### PR TITLE
test(router): replay-contract harness pins adapter request shapes

### DIFF
--- a/crates/openwave-router/tests/fixtures/anthropic/minimal_turn.request.json
+++ b/crates/openwave-router/tests/fixtures/anthropic/minimal_turn.request.json
@@ -1,0 +1,39 @@
+{
+  "body": {
+    "max_tokens": 1024,
+    "messages": [
+      {
+        "content": [
+          {
+            "cache_control": {
+              "type": "ephemeral"
+            },
+            "text": "What changed in this file?",
+            "type": "text"
+          }
+        ],
+        "role": "user"
+      }
+    ],
+    "model": "claude-opus-5",
+    "stream": true,
+    "system": [
+      {
+        "cache_control": {
+          "type": "ephemeral"
+        },
+        "text": "You are a careful assistant.",
+        "type": "text"
+      }
+    ],
+    "temperature": 0.20000000298023224
+  },
+  "headers": {
+    "anthropic-version": "2023-06-01",
+    "content-type": "application/json",
+    "x-api-key": "<redacted>"
+  },
+  "method": "POST",
+  "path": "/v1/messages",
+  "query": null
+}

--- a/crates/openwave-router/tests/fixtures/anthropic/structured_output.request.json
+++ b/crates/openwave-router/tests/fixtures/anthropic/structured_output.request.json
@@ -1,0 +1,69 @@
+{
+  "body": {
+    "max_tokens": 1024,
+    "messages": [
+      {
+        "content": [
+          {
+            "cache_control": {
+              "type": "ephemeral"
+            },
+            "text": "Summarize the incident.",
+            "type": "text"
+          }
+        ],
+        "role": "user"
+      }
+    ],
+    "model": "claude-opus-5",
+    "stream": true,
+    "tool_choice": {
+      "name": "incident_summary",
+      "type": "tool"
+    },
+    "tools": [
+      {
+        "cache_control": {
+          "type": "ephemeral"
+        },
+        "description": "Return the result of this request. Call this once, with the whole answer in its arguments, and write nothing else.",
+        "input_schema": {
+          "additionalProperties": false,
+          "properties": {
+            "affected": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "headline": {
+              "type": "string"
+            },
+            "severity": {
+              "enum": [
+                "low",
+                "high"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "affected",
+            "headline",
+            "severity"
+          ],
+          "type": "object"
+        },
+        "name": "incident_summary"
+      }
+    ]
+  },
+  "headers": {
+    "anthropic-version": "2023-06-01",
+    "content-type": "application/json",
+    "x-api-key": "<redacted>"
+  },
+  "method": "POST",
+  "path": "/v1/messages",
+  "query": null
+}

--- a/crates/openwave-router/tests/fixtures/anthropic/tool_loop_closure.events.json
+++ b/crates/openwave-router/tests/fixtures/anthropic/tool_loop_closure.events.json
@@ -1,0 +1,37 @@
+[
+  {
+    "text": "a.toml is read. ",
+    "type": "text_delta"
+  },
+  {
+    "text": "Retrying b.toml.",
+    "type": "text_delta"
+  },
+  {
+    "id": "toolu_3",
+    "index": 1,
+    "name": "read_file",
+    "type": "tool_call_started"
+  },
+  {
+    "fragment": "{\"path\":",
+    "index": 1,
+    "type": "tool_call_args_delta"
+  },
+  {
+    "fragment": "\"b.toml\"}",
+    "index": 1,
+    "type": "tool_call_args_delta"
+  },
+  {
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 128,
+    "input_tokens": 412,
+    "output_tokens": 37,
+    "type": "usage"
+  },
+  {
+    "reason": "tool_use",
+    "type": "stop"
+  }
+]

--- a/crates/openwave-router/tests/fixtures/anthropic/tool_loop_closure.request.json
+++ b/crates/openwave-router/tests/fixtures/anthropic/tool_loop_closure.request.json
@@ -1,0 +1,108 @@
+{
+  "body": {
+    "max_tokens": 4096,
+    "messages": [
+      {
+        "content": [
+          {
+            "text": "Read both configs.",
+            "type": "text"
+          }
+        ],
+        "role": "user"
+      },
+      {
+        "content": [
+          {
+            "text": "Reading both.",
+            "type": "text"
+          },
+          {
+            "id": "call_1",
+            "input": {
+              "path": "a.toml"
+            },
+            "name": "read_file",
+            "type": "tool_use"
+          },
+          {
+            "id": "call_2",
+            "input": {
+              "path": "b.toml"
+            },
+            "name": "read_file",
+            "type": "tool_use"
+          }
+        ],
+        "role": "assistant"
+      },
+      {
+        "content": [
+          {
+            "content": "retries = 3",
+            "is_error": false,
+            "tool_use_id": "call_1",
+            "type": "tool_result"
+          },
+          {
+            "cache_control": {
+              "type": "ephemeral"
+            },
+            "content": "no such file",
+            "is_error": true,
+            "tool_use_id": "call_2",
+            "type": "tool_result"
+          }
+        ],
+        "role": "user"
+      }
+    ],
+    "model": "claude-opus-5",
+    "output_config": {
+      "effort": "high"
+    },
+    "stream": true,
+    "system": [
+      {
+        "cache_control": {
+          "type": "ephemeral"
+        },
+        "text": "Use the tools.",
+        "type": "text"
+      }
+    ],
+    "thinking": {
+      "display": "summarized",
+      "type": "adaptive"
+    },
+    "tools": [
+      {
+        "cache_control": {
+          "type": "ephemeral"
+        },
+        "description": "Read a file from the workspace.",
+        "input_schema": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "path"
+          ],
+          "type": "object"
+        },
+        "name": "read_file"
+      }
+    ]
+  },
+  "headers": {
+    "anthropic-version": "2023-06-01",
+    "content-type": "application/json",
+    "x-api-key": "<redacted>"
+  },
+  "method": "POST",
+  "path": "/v1/messages",
+  "query": null
+}

--- a/crates/openwave-router/tests/fixtures/anthropic/tool_loop_closure.response.sse
+++ b/crates/openwave-router/tests/fixtures/anthropic/tool_loop_closure.response.sse
@@ -1,0 +1,30 @@
+event: message_start
+data: {"type":"message_start","message":{"usage":{"input_tokens":412,"cache_read_input_tokens":128}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"a.toml is read. "}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Retrying b.toml."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_3","name":"read_file"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"path\":"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\"b.toml\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":37}}
+

--- a/crates/openwave-router/tests/fixtures/anthropic/tool_schema.request.json
+++ b/crates/openwave-router/tests/fixtures/anthropic/tool_schema.request.json
@@ -1,0 +1,98 @@
+{
+  "body": {
+    "max_tokens": 2048,
+    "messages": [
+      {
+        "content": [
+          {
+            "cache_control": {
+              "type": "ephemeral"
+            },
+            "text": "Search for the retry policy.",
+            "type": "text"
+          }
+        ],
+        "role": "user"
+      }
+    ],
+    "model": "claude-opus-5",
+    "stream": true,
+    "system": [
+      {
+        "cache_control": {
+          "type": "ephemeral"
+        },
+        "text": "Use the tool.",
+        "type": "text"
+      }
+    ],
+    "tool_choice": {
+      "name": "search_documents",
+      "type": "tool"
+    },
+    "tools": [
+      {
+        "cache_control": {
+          "type": "ephemeral"
+        },
+        "description": "Search the attached documents.",
+        "input_schema": {
+          "additionalProperties": false,
+          "properties": {
+            "filters": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "field": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "field"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "query": {
+              "description": "What to look for.",
+              "type": "string"
+            },
+            "scope": {
+              "additionalProperties": false,
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "project",
+                    "chat"
+                  ],
+                  "type": "string"
+                },
+                "limit": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "query"
+          ],
+          "type": "object"
+        },
+        "name": "search_documents"
+      }
+    ]
+  },
+  "headers": {
+    "anthropic-version": "2023-06-01",
+    "content-type": "application/json",
+    "x-api-key": "<redacted>"
+  },
+  "method": "POST",
+  "path": "/v1/messages",
+  "query": null
+}

--- a/crates/openwave-router/tests/fixtures/gemini/minimal_turn.request.json
+++ b/crates/openwave-router/tests/fixtures/gemini/minimal_turn.request.json
@@ -1,0 +1,31 @@
+{
+  "body": {
+    "contents": [
+      {
+        "parts": [
+          {
+            "text": "What changed in this file?"
+          }
+        ],
+        "role": "user"
+      }
+    ],
+    "generationConfig": {
+      "maxOutputTokens": 1024
+    },
+    "systemInstruction": {
+      "parts": [
+        {
+          "text": "You are a careful assistant."
+        }
+      ]
+    }
+  },
+  "headers": {
+    "content-type": "application/json",
+    "x-goog-api-key": "<redacted>"
+  },
+  "method": "POST",
+  "path": "/v1beta/models/gemini-3.6-flash:streamGenerateContent",
+  "query": "alt=sse"
+}

--- a/crates/openwave-router/tests/fixtures/gemini/structured_output.request.json
+++ b/crates/openwave-router/tests/fixtures/gemini/structured_output.request.json
@@ -1,0 +1,54 @@
+{
+  "body": {
+    "contents": [
+      {
+        "parts": [
+          {
+            "text": "Summarize the incident."
+          }
+        ],
+        "role": "user"
+      }
+    ],
+    "generationConfig": {
+      "maxOutputTokens": 1024,
+      "responseMimeType": "application/json",
+      "responseSchema": {
+        "properties": {
+          "affected": {
+            "items": {
+              "type": "STRING"
+            },
+            "type": "ARRAY"
+          },
+          "headline": {
+            "type": "STRING"
+          },
+          "severity": {
+            "enum": [
+              "low",
+              "high"
+            ],
+            "type": "STRING"
+          }
+        },
+        "required": [
+          "affected",
+          "headline",
+          "severity"
+        ],
+        "type": "OBJECT"
+      },
+      "thinkingConfig": {
+        "thinkingLevel": "high"
+      }
+    }
+  },
+  "headers": {
+    "content-type": "application/json",
+    "x-goog-api-key": "<redacted>"
+  },
+  "method": "POST",
+  "path": "/v1beta/models/gemini-3.6-flash:streamGenerateContent",
+  "query": "alt=sse"
+}

--- a/crates/openwave-router/tests/fixtures/gemini/tool_loop_closure.events.json
+++ b/crates/openwave-router/tests/fixtures/gemini/tool_loop_closure.events.json
@@ -1,0 +1,32 @@
+[
+  {
+    "text": "a.toml is read. ",
+    "type": "text_delta"
+  },
+  {
+    "text": "Retrying b.toml.",
+    "type": "text_delta"
+  },
+  {
+    "id": "call_3",
+    "index": 0,
+    "name": "read_file",
+    "type": "tool_call_started"
+  },
+  {
+    "fragment": "{\"path\":\"b.toml\"}",
+    "index": 0,
+    "type": "tool_call_args_delta"
+  },
+  {
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 128,
+    "input_tokens": 284,
+    "output_tokens": 49,
+    "type": "usage"
+  },
+  {
+    "reason": "tool_use",
+    "type": "stop"
+  }
+]

--- a/crates/openwave-router/tests/fixtures/gemini/tool_loop_closure.request.json
+++ b/crates/openwave-router/tests/fixtures/gemini/tool_loop_closure.request.json
@@ -1,0 +1,106 @@
+{
+  "body": {
+    "contents": [
+      {
+        "parts": [
+          {
+            "text": "Read both configs."
+          }
+        ],
+        "role": "user"
+      },
+      {
+        "parts": [
+          {
+            "text": "Reading both."
+          },
+          {
+            "functionCall": {
+              "args": {
+                "path": "a.toml"
+              },
+              "name": "read_file"
+            },
+            "thoughtSignature": "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="
+          },
+          {
+            "functionCall": {
+              "args": {
+                "path": "b.toml"
+              },
+              "name": "read_file"
+            }
+          }
+        ],
+        "role": "model"
+      },
+      {
+        "parts": [
+          {
+            "functionResponse": {
+              "name": "read_file",
+              "response": {
+                "output": "retries = 3"
+              }
+            }
+          },
+          {
+            "functionResponse": {
+              "name": "read_file",
+              "response": {
+                "error": "no such file"
+              }
+            }
+          }
+        ],
+        "role": "user"
+      }
+    ],
+    "generationConfig": {
+      "maxOutputTokens": 4096,
+      "thinkingConfig": {
+        "thinkingLevel": "high"
+      }
+    },
+    "systemInstruction": {
+      "parts": [
+        {
+          "text": "Use the tools."
+        }
+      ]
+    },
+    "toolConfig": {
+      "functionCallingConfig": {
+        "mode": "AUTO"
+      }
+    },
+    "tools": [
+      {
+        "functionDeclarations": [
+          {
+            "description": "Read a file from the workspace.",
+            "name": "read_file",
+            "parameters": {
+              "properties": {
+                "path": {
+                  "type": "STRING"
+                }
+              },
+              "required": [
+                "path"
+              ],
+              "type": "OBJECT"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "headers": {
+    "content-type": "application/json",
+    "x-goog-api-key": "<redacted>"
+  },
+  "method": "POST",
+  "path": "/v1beta/models/gemini-3.6-flash:streamGenerateContent",
+  "query": "alt=sse"
+}

--- a/crates/openwave-router/tests/fixtures/gemini/tool_loop_closure.response.sse
+++ b/crates/openwave-router/tests/fixtures/gemini/tool_loop_closure.response.sse
@@ -1,0 +1,6 @@
+data: {"candidates":[{"content":{"parts":[{"text":"a.toml is read. "}]}}]}
+
+data: {"candidates":[{"content":{"parts":[{"text":"Retrying b.toml."},{"functionCall":{"id":"call_3","name":"read_file","args":{"path":"b.toml"}}}]}}]}
+
+data: {"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":412,"cachedContentTokenCount":128,"candidatesTokenCount":37,"thoughtsTokenCount":12}}
+

--- a/crates/openwave-router/tests/fixtures/gemini/tool_schema.request.json
+++ b/crates/openwave-router/tests/fixtures/gemini/tool_schema.request.json
@@ -1,0 +1,93 @@
+{
+  "body": {
+    "contents": [
+      {
+        "parts": [
+          {
+            "text": "Search for the retry policy."
+          }
+        ],
+        "role": "user"
+      }
+    ],
+    "generationConfig": {
+      "maxOutputTokens": 2048
+    },
+    "systemInstruction": {
+      "parts": [
+        {
+          "text": "Use the tool."
+        }
+      ]
+    },
+    "toolConfig": {
+      "functionCallingConfig": {
+        "allowedFunctionNames": [
+          "search_documents"
+        ],
+        "mode": "ANY"
+      }
+    },
+    "tools": [
+      {
+        "functionDeclarations": [
+          {
+            "description": "Search the attached documents.",
+            "name": "search_documents",
+            "parameters": {
+              "properties": {
+                "filters": {
+                  "items": {
+                    "properties": {
+                      "field": {
+                        "type": "STRING"
+                      }
+                    },
+                    "required": [
+                      "field"
+                    ],
+                    "type": "OBJECT"
+                  },
+                  "type": "ARRAY"
+                },
+                "query": {
+                  "description": "What to look for.",
+                  "type": "STRING"
+                },
+                "scope": {
+                  "properties": {
+                    "kind": {
+                      "enum": [
+                        "project",
+                        "chat"
+                      ],
+                      "type": "STRING"
+                    },
+                    "limit": {
+                      "type": "INTEGER"
+                    }
+                  },
+                  "required": [
+                    "kind"
+                  ],
+                  "type": "OBJECT"
+                }
+              },
+              "required": [
+                "query"
+              ],
+              "type": "OBJECT"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "headers": {
+    "content-type": "application/json",
+    "x-goog-api-key": "<redacted>"
+  },
+  "method": "POST",
+  "path": "/v1beta/models/gemini-3.6-flash:streamGenerateContent",
+  "query": "alt=sse"
+}

--- a/crates/openwave-router/tests/fixtures/openai/minimal_turn.request.json
+++ b/crates/openwave-router/tests/fixtures/openai/minimal_turn.request.json
@@ -1,0 +1,36 @@
+{
+  "body": {
+    "input": [
+      {
+        "content": [
+          {
+            "text": "You are a careful assistant.",
+            "type": "input_text"
+          }
+        ],
+        "role": "system"
+      },
+      {
+        "content": [
+          {
+            "text": "What changed in this file?",
+            "type": "input_text"
+          }
+        ],
+        "role": "user"
+      }
+    ],
+    "max_output_tokens": 1024,
+    "model": "gpt-5.6-sol",
+    "store": false,
+    "stream": true,
+    "temperature": 0.20000000298023224
+  },
+  "headers": {
+    "authorization": "<redacted>",
+    "content-type": "application/json"
+  },
+  "method": "POST",
+  "path": "/responses",
+  "query": null
+}

--- a/crates/openwave-router/tests/fixtures/openai/structured_output.request.json
+++ b/crates/openwave-router/tests/fixtures/openai/structured_output.request.json
@@ -1,0 +1,64 @@
+{
+  "body": {
+    "input": [
+      {
+        "content": [
+          {
+            "text": "Summarize the incident.",
+            "type": "input_text"
+          }
+        ],
+        "role": "user"
+      }
+    ],
+    "max_output_tokens": 1024,
+    "model": "gpt-5.6-sol",
+    "reasoning": {
+      "effort": "high",
+      "summary": "auto"
+    },
+    "store": false,
+    "stream": true,
+    "text": {
+      "format": {
+        "name": "incident_summary",
+        "schema": {
+          "additionalProperties": false,
+          "properties": {
+            "affected": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "headline": {
+              "type": "string"
+            },
+            "severity": {
+              "enum": [
+                "low",
+                "high"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "affected",
+            "headline",
+            "severity"
+          ],
+          "type": "object"
+        },
+        "strict": true,
+        "type": "json_schema"
+      }
+    }
+  },
+  "headers": {
+    "authorization": "<redacted>",
+    "content-type": "application/json"
+  },
+  "method": "POST",
+  "path": "/responses",
+  "query": null
+}

--- a/crates/openwave-router/tests/fixtures/openai/tool_loop_closure.events.json
+++ b/crates/openwave-router/tests/fixtures/openai/tool_loop_closure.events.json
@@ -1,0 +1,37 @@
+[
+  {
+    "text": "a.toml is read. ",
+    "type": "text_delta"
+  },
+  {
+    "text": "Retrying b.toml.",
+    "type": "text_delta"
+  },
+  {
+    "id": "call_3",
+    "index": 0,
+    "name": "read_file",
+    "type": "tool_call_started"
+  },
+  {
+    "fragment": "{\"path\":",
+    "index": 0,
+    "type": "tool_call_args_delta"
+  },
+  {
+    "fragment": "\"b.toml\"}",
+    "index": 0,
+    "type": "tool_call_args_delta"
+  },
+  {
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 128,
+    "input_tokens": 284,
+    "output_tokens": 37,
+    "type": "usage"
+  },
+  {
+    "reason": "tool_use",
+    "type": "stop"
+  }
+]

--- a/crates/openwave-router/tests/fixtures/openai/tool_loop_closure.request.json
+++ b/crates/openwave-router/tests/fixtures/openai/tool_loop_closure.request.json
@@ -1,0 +1,85 @@
+{
+  "body": {
+    "input": [
+      {
+        "content": [
+          {
+            "text": "Use the tools.",
+            "type": "input_text"
+          }
+        ],
+        "role": "system"
+      },
+      {
+        "content": [
+          {
+            "text": "Read both configs.",
+            "type": "input_text"
+          }
+        ],
+        "role": "user"
+      },
+      {
+        "content": "Reading both.",
+        "role": "assistant"
+      },
+      {
+        "arguments": "{\"path\":\"a.toml\"}",
+        "call_id": "call_1",
+        "name": "read_file",
+        "type": "function_call"
+      },
+      {
+        "arguments": "{\"path\":\"b.toml\"}",
+        "call_id": "call_2",
+        "name": "read_file",
+        "type": "function_call"
+      },
+      {
+        "call_id": "call_1",
+        "output": "retries = 3",
+        "type": "function_call_output"
+      },
+      {
+        "call_id": "call_2",
+        "output": "Error: the tool call failed.\nno such file",
+        "type": "function_call_output"
+      }
+    ],
+    "max_output_tokens": 4096,
+    "model": "gpt-5.6-sol",
+    "reasoning": {
+      "effort": "high",
+      "summary": "auto"
+    },
+    "store": false,
+    "stream": true,
+    "tools": [
+      {
+        "description": "Read a file from the workspace.",
+        "name": "read_file",
+        "parameters": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "path"
+          ],
+          "type": "object"
+        },
+        "strict": true,
+        "type": "function"
+      }
+    ]
+  },
+  "headers": {
+    "authorization": "<redacted>",
+    "content-type": "application/json"
+  },
+  "method": "POST",
+  "path": "/responses",
+  "query": null
+}

--- a/crates/openwave-router/tests/fixtures/openai/tool_loop_closure.response.sse
+++ b/crates/openwave-router/tests/fixtures/openai/tool_loop_closure.response.sse
@@ -1,0 +1,14 @@
+data: {"type":"response.output_text.delta","delta":"a.toml is read. "}
+
+data: {"type":"response.output_text.delta","delta":"Retrying b.toml."}
+
+data: {"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_3","name":"read_file"}}
+
+data: {"type":"response.function_call_arguments.delta","call_id":"call_3","delta":"{\"path\":"}
+
+data: {"type":"response.function_call_arguments.delta","call_id":"call_3","delta":"\"b.toml\"}"}
+
+data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_3","name":"read_file","arguments":"{\"path\":\"b.toml\"}"}}
+
+data: {"type":"response.completed","response":{"usage":{"input_tokens":412,"input_tokens_details":{"cached_tokens":128},"output_tokens":37}}}
+

--- a/crates/openwave-router/tests/fixtures/openai/tool_schema.request.json
+++ b/crates/openwave-router/tests/fixtures/openai/tool_schema.request.json
@@ -1,0 +1,94 @@
+{
+  "body": {
+    "input": [
+      {
+        "content": [
+          {
+            "text": "Use the tool.",
+            "type": "input_text"
+          }
+        ],
+        "role": "system"
+      },
+      {
+        "content": [
+          {
+            "text": "Search for the retry policy.",
+            "type": "input_text"
+          }
+        ],
+        "role": "user"
+      }
+    ],
+    "max_output_tokens": 2048,
+    "model": "gpt-5.6-sol",
+    "store": false,
+    "stream": true,
+    "tool_choice": {
+      "name": "search_documents",
+      "type": "function"
+    },
+    "tools": [
+      {
+        "description": "Search the attached documents.",
+        "name": "search_documents",
+        "parameters": {
+          "additionalProperties": false,
+          "properties": {
+            "filters": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "field": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "field"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "query": {
+              "description": "What to look for.",
+              "type": "string"
+            },
+            "scope": {
+              "additionalProperties": false,
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "project",
+                    "chat"
+                  ],
+                  "type": "string"
+                },
+                "limit": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "query"
+          ],
+          "type": "object"
+        },
+        "strict": false,
+        "type": "function"
+      }
+    ]
+  },
+  "headers": {
+    "authorization": "<redacted>",
+    "content-type": "application/json"
+  },
+  "method": "POST",
+  "path": "/responses",
+  "query": null
+}

--- a/crates/openwave-router/tests/fixtures/openai_compat/minimal_turn.request.json
+++ b/crates/openwave-router/tests/fixtures/openai_compat/minimal_turn.request.json
@@ -1,0 +1,25 @@
+{
+  "body": {
+    "max_tokens": 1024,
+    "messages": [
+      {
+        "content": "You are a careful assistant.",
+        "role": "system"
+      },
+      {
+        "content": "What changed in this file?",
+        "role": "user"
+      }
+    ],
+    "model": "gpt-5.6-sol",
+    "stream": true,
+    "temperature": 0.20000000298023224
+  },
+  "headers": {
+    "authorization": "<redacted>",
+    "content-type": "application/json"
+  },
+  "method": "POST",
+  "path": "/chat/completions",
+  "query": null
+}

--- a/crates/openwave-router/tests/fixtures/openai_compat/structured_output.request.json
+++ b/crates/openwave-router/tests/fixtures/openai_compat/structured_output.request.json
@@ -1,0 +1,55 @@
+{
+  "body": {
+    "max_completion_tokens": 1024,
+    "messages": [
+      {
+        "content": "Summarize the incident.",
+        "role": "user"
+      }
+    ],
+    "model": "gpt-5.6-sol",
+    "reasoning_effort": "high",
+    "response_format": {
+      "json_schema": {
+        "name": "incident_summary",
+        "schema": {
+          "additionalProperties": false,
+          "properties": {
+            "affected": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "headline": {
+              "type": "string"
+            },
+            "severity": {
+              "enum": [
+                "low",
+                "high"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "affected",
+            "headline",
+            "severity"
+          ],
+          "type": "object"
+        },
+        "strict": true
+      },
+      "type": "json_schema"
+    },
+    "stream": true
+  },
+  "headers": {
+    "authorization": "<redacted>",
+    "content-type": "application/json"
+  },
+  "method": "POST",
+  "path": "/chat/completions",
+  "query": null
+}

--- a/crates/openwave-router/tests/fixtures/openai_compat/tool_loop_closure.events.json
+++ b/crates/openwave-router/tests/fixtures/openai_compat/tool_loop_closure.events.json
@@ -1,0 +1,37 @@
+[
+  {
+    "text": "a.toml is read. ",
+    "type": "text_delta"
+  },
+  {
+    "text": "Retrying b.toml.",
+    "type": "text_delta"
+  },
+  {
+    "id": "call_3",
+    "index": 0,
+    "name": "read_file",
+    "type": "tool_call_started"
+  },
+  {
+    "fragment": "{\"path\":",
+    "index": 0,
+    "type": "tool_call_args_delta"
+  },
+  {
+    "fragment": "\"b.toml\"}",
+    "index": 0,
+    "type": "tool_call_args_delta"
+  },
+  {
+    "reason": "tool_use",
+    "type": "stop"
+  },
+  {
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 128,
+    "input_tokens": 284,
+    "output_tokens": 37,
+    "type": "usage"
+  }
+]

--- a/crates/openwave-router/tests/fixtures/openai_compat/tool_loop_closure.request.json
+++ b/crates/openwave-router/tests/fixtures/openai_compat/tool_loop_closure.request.json
@@ -1,0 +1,79 @@
+{
+  "body": {
+    "max_completion_tokens": 4096,
+    "messages": [
+      {
+        "content": "Use the tools.",
+        "role": "system"
+      },
+      {
+        "content": "Read both configs.",
+        "role": "user"
+      },
+      {
+        "content": "Reading both.",
+        "role": "assistant",
+        "tool_calls": [
+          {
+            "function": {
+              "arguments": "{\"path\":\"a.toml\"}",
+              "name": "read_file"
+            },
+            "id": "call_1",
+            "type": "function"
+          },
+          {
+            "function": {
+              "arguments": "{\"path\":\"b.toml\"}",
+              "name": "read_file"
+            },
+            "id": "call_2",
+            "type": "function"
+          }
+        ]
+      },
+      {
+        "content": "retries = 3",
+        "role": "tool",
+        "tool_call_id": "call_1"
+      },
+      {
+        "content": "Error: the tool call failed.\nno such file",
+        "role": "tool",
+        "tool_call_id": "call_2"
+      }
+    ],
+    "model": "gpt-5.6-sol",
+    "reasoning_effort": "high",
+    "stream": true,
+    "tools": [
+      {
+        "function": {
+          "description": "Read a file from the workspace.",
+          "name": "read_file",
+          "parameters": {
+            "additionalProperties": false,
+            "properties": {
+              "path": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "path"
+            ],
+            "type": "object"
+          },
+          "strict": true
+        },
+        "type": "function"
+      }
+    ]
+  },
+  "headers": {
+    "authorization": "<redacted>",
+    "content-type": "application/json"
+  },
+  "method": "POST",
+  "path": "/chat/completions",
+  "query": null
+}

--- a/crates/openwave-router/tests/fixtures/openai_compat/tool_loop_closure.response.sse
+++ b/crates/openwave-router/tests/fixtures/openai_compat/tool_loop_closure.response.sse
@@ -1,0 +1,14 @@
+data: {"choices":[{"delta":{"content":"a.toml is read. "}}]}
+
+data: {"choices":[{"delta":{"content":"Retrying b.toml."}}]}
+
+data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_3","function":{"name":"read_file","arguments":"{\"path\":"}}]}}]}
+
+data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"b.toml\"}"}}]}}]}
+
+data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}
+
+data: {"choices":[],"usage":{"prompt_tokens":412,"completion_tokens":37,"prompt_tokens_details":{"cached_tokens":128}}}
+
+data: [DONE]
+

--- a/crates/openwave-router/tests/fixtures/openai_compat/tool_schema.request.json
+++ b/crates/openwave-router/tests/fixtures/openai_compat/tool_schema.request.json
@@ -1,0 +1,86 @@
+{
+  "body": {
+    "max_tokens": 2048,
+    "messages": [
+      {
+        "content": "Use the tool.",
+        "role": "system"
+      },
+      {
+        "content": "Search for the retry policy.",
+        "role": "user"
+      }
+    ],
+    "model": "gpt-5.6-sol",
+    "stream": true,
+    "tool_choice": {
+      "function": {
+        "name": "search_documents"
+      },
+      "type": "function"
+    },
+    "tools": [
+      {
+        "function": {
+          "description": "Search the attached documents.",
+          "name": "search_documents",
+          "parameters": {
+            "additionalProperties": false,
+            "properties": {
+              "filters": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "field": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "field"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "query": {
+                "description": "What to look for.",
+                "type": "string"
+              },
+              "scope": {
+                "additionalProperties": false,
+                "properties": {
+                  "kind": {
+                    "enum": [
+                      "project",
+                      "chat"
+                    ],
+                    "type": "string"
+                  },
+                  "limit": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "kind"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "query"
+            ],
+            "type": "object"
+          }
+        },
+        "type": "function"
+      }
+    ]
+  },
+  "headers": {
+    "authorization": "<redacted>",
+    "content-type": "application/json"
+  },
+  "method": "POST",
+  "path": "/chat/completions",
+  "query": null
+}

--- a/crates/openwave-router/tests/replay_contracts.rs
+++ b/crates/openwave-router/tests/replay_contracts.rs
@@ -1,0 +1,484 @@
+//! Replay contracts: what each provider adapter actually puts on the wire.
+//!
+//! Adapters translate one normalized [`ChatRequest`] into four very different
+//! request shapes, and the translation is where provider drift bites: a new
+//! model generation starts rejecting a parameter an older one accepted, and the
+//! first thing anyone sees is a 400 in a user's turn. The unit tests in each
+//! adapter assert on individual fields, which is exactly the coverage that goes
+//! stale — a field can move, vanish, or gain a sibling without any assertion
+//! noticing.
+//!
+//! So these tests run the *real* adapters against a local server that stands in
+//! for the provider, capture the exact outbound request — method, path, headers,
+//! body — and compare the whole thing against a committed fixture. Any change to
+//! a request shape shows up as a readable JSON diff in review rather than as a
+//! silent behavior change.
+//!
+//! The same round trip also feeds a recorded response back through the adapter's
+//! decoder for one scenario per provider, so the fixture pins the normalized
+//! [`ProviderEvent`] sequence the stream produces end to end — SSE framing,
+//! streamed tool-call argument assembly, usage, and stop reason included.
+//!
+//! **When one of these fails**, read the diff first: it is the change you made,
+//! described in the provider's own vocabulary. If the new shape is what you
+//! meant to send, re-record and commit the result:
+//!
+//! ```text
+//! UPDATE_FIXTURES=1 cargo test -p openwave-router --test replay_contracts
+//! git diff crates/openwave-router/tests/fixtures
+//! ```
+//!
+//! The fixtures are hand-reviewable on purpose. A reviewer who cannot tell from
+//! the diff whether a provider would still accept the request is the signal that
+//! the change needs a live check, not a bigger fixture.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use axum::body::Body;
+use axum::extract::{Request, State};
+use axum::response::{IntoResponse, Response};
+use axum::routing::any;
+use futures::StreamExt;
+use openwave_core::model::ReasoningEffort;
+use openwave_core::{
+    ChatMessage, ChatRequest, ContentBlock, MessageReasoning, ModelProvider, ProviderEvent,
+    ResponseFormat, Role, ToolChoice, ToolSpec,
+};
+use openwave_router::{AnthropicProvider, GeminiProvider, OpenAiCompatProvider, OpenAiProvider};
+use serde_json::{json, Value};
+
+/// The credential every adapter is handed. It must never reach a fixture: the
+/// capture redacts credential headers by name, and this value is distinctive
+/// enough that a leak through some *other* header is obvious in review.
+const TEST_API_KEY: &str = "test-provider-key-not-a-secret";
+
+/// Headers that describe the transport rather than the adapter's request. They
+/// vary with the local port and the encoded body length, so pinning them would
+/// make every fixture nondeterministic without adding coverage.
+const TRANSPORT_HEADERS: &[&str] = &[
+    "host",
+    "content-length",
+    "accept",
+    "accept-encoding",
+    "connection",
+    "user-agent",
+];
+
+/// Header names carrying a credential. The name stays in the fixture — a
+/// credential that moves to a different header is a change worth seeing — and
+/// only the value is replaced.
+const CREDENTIAL_HEADERS: &[&str] = &["authorization", "x-api-key", "x-goog-api-key"];
+
+const REDACTED: &str = "<redacted>";
+
+// ---------------------------------------------------------------------------
+// Scenarios
+// ---------------------------------------------------------------------------
+
+/// The canonical requests every adapter is measured against.
+///
+/// One list, shared by all four providers, so a fixture diff reads as "this is
+/// how provider X shapes the same turn" and the scenarios cannot drift apart
+/// per adapter.
+fn scenarios(model: &str) -> Vec<(&'static str, ChatRequest)> {
+    vec![
+        ("minimal_turn", minimal_turn(model)),
+        ("tool_schema", tool_schema(model)),
+        ("tool_loop_closure", tool_loop_closure(model)),
+        ("structured_output", structured_output(model)),
+    ]
+}
+
+/// The smallest real turn: a system prompt, one user message, and the sampling
+/// controls a non-reasoning model takes.
+fn minimal_turn(model: &str) -> ChatRequest {
+    ChatRequest {
+        model: model.to_string(),
+        system: Some("You are a careful assistant.".into()),
+        messages: vec![ChatMessage::text(Role::User, "What changed in this file?")],
+        max_tokens: Some(1024),
+        temperature: Some(0.2),
+        ..Default::default()
+    }
+}
+
+/// A tool whose schema uses the constructs providers disagree about — a nested
+/// object, an enum, an array of objects, an integer bound — plus a forced tool
+/// choice.
+fn tool_schema(model: &str) -> ChatRequest {
+    ChatRequest {
+        model: model.to_string(),
+        system: Some("Use the tool.".into()),
+        messages: vec![ChatMessage::text(
+            Role::User,
+            "Search for the retry policy.",
+        )],
+        tools: vec![search_tool()],
+        tool_choice: Some(ToolChoice::Tool {
+            name: "search_documents".into(),
+        }),
+        max_tokens: Some(2048),
+        ..Default::default()
+    }
+}
+
+/// Closing the loop on two parallel calls: the assistant's step carried text and
+/// two `tool_use` blocks, and the next user message answers both — one of them
+/// with a failure. The step is a reasoning one with tools advertised but not
+/// forced, which is the shape an agentic turn actually has.
+fn tool_loop_closure(model: &str) -> ChatRequest {
+    ChatRequest {
+        model: model.to_string(),
+        system: Some("Use the tools.".into()),
+        messages: vec![
+            ChatMessage::text(Role::User, "Read both configs."),
+            ChatMessage {
+                role: Role::Assistant,
+                content: vec![
+                    ContentBlock::Text {
+                        text: "Reading both.".into(),
+                    },
+                    ContentBlock::ToolUse {
+                        id: "call_1".into(),
+                        name: "read_file".into(),
+                        input: json!({ "path": "a.toml" }),
+                    },
+                    ContentBlock::ToolUse {
+                        id: "call_2".into(),
+                        name: "read_file".into(),
+                        input: json!({ "path": "b.toml" }),
+                    },
+                ],
+                reasoning: MessageReasoning::default(),
+            },
+            ChatMessage {
+                role: Role::User,
+                content: vec![
+                    ContentBlock::ToolResult {
+                        tool_use_id: "call_1".into(),
+                        content: "retries = 3".into(),
+                        is_error: false,
+                    },
+                    ContentBlock::ToolResult {
+                        tool_use_id: "call_2".into(),
+                        content: "no such file".into(),
+                        is_error: true,
+                    },
+                ],
+                reasoning: MessageReasoning::default(),
+            },
+        ],
+        tools: vec![read_file_tool()],
+        reasoning_model: true,
+        reasoning_effort: Some(ReasoningEffort::High),
+        max_tokens: Some(4096),
+        ..Default::default()
+    }
+}
+
+/// A schema-constrained answer from a reasoning model.
+///
+/// The constraint is the interesting part: three adapters express it three ways,
+/// and on Anthropic it is enforced by forcing a tool, which in turn suppresses
+/// the thinking block the same reasoning flags produce in `tool_loop_closure`.
+fn structured_output(model: &str) -> ChatRequest {
+    ChatRequest {
+        model: model.to_string(),
+        messages: vec![ChatMessage::text(Role::User, "Summarize the incident.")],
+        reasoning_model: true,
+        reasoning_effort: Some(ReasoningEffort::High),
+        response_format: Some(ResponseFormat::JsonSchema {
+            name: "incident_summary".into(),
+            schema: json!({
+                "type": "object",
+                "properties": {
+                    "headline": { "type": "string" },
+                    "severity": { "type": "string", "enum": ["low", "high"] },
+                    "affected": { "type": "array", "items": { "type": "string" } }
+                },
+                "required": ["headline", "severity", "affected"],
+                "additionalProperties": false
+            }),
+        }),
+        max_tokens: Some(1024),
+        ..Default::default()
+    }
+}
+
+fn search_tool() -> ToolSpec {
+    ToolSpec {
+        name: "search_documents".into(),
+        description: "Search the attached documents.".into(),
+        input_schema: json!({
+            "type": "object",
+            "properties": {
+                "query": { "type": "string", "description": "What to look for." },
+                "scope": {
+                    "type": "object",
+                    "properties": {
+                        "kind": { "type": "string", "enum": ["project", "chat"] },
+                        "limit": { "type": "integer" }
+                    },
+                    "required": ["kind"],
+                    "additionalProperties": false
+                },
+                "filters": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": { "field": { "type": "string" } },
+                        "required": ["field"],
+                        "additionalProperties": false
+                    }
+                }
+            },
+            "required": ["query"],
+            "additionalProperties": false
+        }),
+    }
+}
+
+fn read_file_tool() -> ToolSpec {
+    ToolSpec {
+        name: "read_file".into(),
+        description: "Read a file from the workspace.".into(),
+        input_schema: json!({
+            "type": "object",
+            "properties": { "path": { "type": "string" } },
+            "required": ["path"],
+            "additionalProperties": false
+        }),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-adapter contracts
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn anthropic_request_contracts() {
+    check_adapter("anthropic", "claude-opus-5", |base_url| {
+        Arc::new(AnthropicProvider::new(TEST_API_KEY).with_base_url(base_url))
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn openai_responses_request_contracts() {
+    check_adapter("openai", "gpt-5.6-sol", |base_url| {
+        Arc::new(OpenAiProvider::new(TEST_API_KEY).with_base_url(base_url))
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn openai_compat_request_contracts() {
+    check_adapter("openai_compat", "gpt-5.6-sol", |base_url| {
+        Arc::new(OpenAiCompatProvider::compatible(TEST_API_KEY, base_url))
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn gemini_request_contracts() {
+    check_adapter("gemini", "gemini-3.6-flash", |base_url| {
+        Arc::new(GeminiProvider::new(TEST_API_KEY).with_base_url(base_url))
+    })
+    .await;
+}
+
+/// Run every scenario through one adapter and compare both directions against
+/// the committed fixtures.
+async fn check_adapter(
+    provider: &str,
+    model: &str,
+    build: impl Fn(&str) -> Arc<dyn ModelProvider>,
+) {
+    for (scenario, request) in scenarios(model) {
+        let recording = recorded_response(provider, scenario);
+        let response_body = recording
+            .clone()
+            .unwrap_or_else(|| terminal_frame(provider).to_string());
+        let (captured, events) = round_trip(&build, request, response_body).await;
+
+        assert_matches_fixture(&format!("{provider}/{scenario}.request.json"), &captured);
+        // A scenario with a recorded response also pins what the decoder makes
+        // of it; the rest are served a bare terminal frame so the adapter has
+        // something to finish on.
+        if recording.is_some() {
+            let events = serde_json::to_value(&events).expect("provider events serialize");
+            assert_matches_fixture(&format!("{provider}/{scenario}.events.json"), &events);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The intercepting transport
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+struct Endpoint {
+    captured: Arc<Mutex<Option<Value>>>,
+    response: Arc<String>,
+}
+
+/// Serve `response` from a local address, point the adapter at it, and return
+/// the request it sent alongside the events it decoded.
+async fn round_trip(
+    build: impl Fn(&str) -> Arc<dyn ModelProvider>,
+    request: ChatRequest,
+    response: String,
+) -> (Value, Vec<ProviderEvent>) {
+    let endpoint = Endpoint {
+        captured: Arc::new(Mutex::new(None)),
+        response: Arc::new(response),
+    };
+    let app = axum::Router::new()
+        .fallback(any(intercept))
+        .with_state(endpoint.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    let provider = build(&format!("http://{address}"));
+    let mut stream = provider
+        .stream(request)
+        .await
+        .expect("the adapter accepted the scenario and the local endpoint answered");
+    let mut events = Vec::new();
+    while let Some(event) = stream.next().await {
+        events.push(event);
+    }
+    server.abort();
+
+    let captured = endpoint
+        .captured
+        .lock()
+        .unwrap()
+        .take()
+        .expect("the adapter sent exactly one request");
+    (captured, events)
+}
+
+async fn intercept(State(endpoint): State<Endpoint>, request: Request) -> Response {
+    let (parts, body) = request.into_parts();
+    let mut headers = BTreeMap::new();
+    for (name, value) in &parts.headers {
+        let name = name.as_str().to_ascii_lowercase();
+        if TRANSPORT_HEADERS.contains(&name.as_str()) {
+            continue;
+        }
+        let value = if CREDENTIAL_HEADERS.contains(&name.as_str()) {
+            REDACTED.to_string()
+        } else {
+            String::from_utf8_lossy(value.as_bytes()).into_owned()
+        };
+        headers.insert(name, Value::String(value));
+    }
+
+    let bytes = axum::body::to_bytes(body, usize::MAX).await.unwrap();
+    let body: Value = serde_json::from_slice(&bytes).expect("adapters send a JSON body");
+
+    let captured = json!({
+        "method": parts.method.as_str(),
+        "path": parts.uri.path(),
+        "query": parts.uri.query(),
+        "headers": Value::Object(headers.into_iter().collect()),
+        "body": body,
+    });
+    *endpoint.captured.lock().unwrap() = Some(captured);
+
+    (
+        [(axum::http::header::CONTENT_TYPE, "text/event-stream")],
+        Body::from(endpoint.response.as_str().to_owned()),
+    )
+        .into_response()
+}
+
+/// The minimum each adapter needs to end a stream cleanly, for scenarios whose
+/// subject is the request rather than the decode path.
+fn terminal_frame(provider: &str) -> &'static str {
+    match provider {
+        "anthropic" => {
+            "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"}}\n\n"
+        }
+        "openai" => "data: {\"type\":\"response.completed\",\"response\":{}}\n\n",
+        "openai_compat" => "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+        "gemini" => "data: {\"candidates\":[{\"finishReason\":\"STOP\"}]}\n\n",
+        other => panic!("no terminal frame for {other}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+fn fixtures_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures")
+}
+
+/// The recorded response body for a scenario, if one is committed.
+fn recorded_response(provider: &str, scenario: &str) -> Option<String> {
+    std::fs::read_to_string(fixtures_dir().join(format!("{provider}/{scenario}.response.sse"))).ok()
+}
+
+fn assert_matches_fixture(relative: &str, actual: &Value) {
+    let path = fixtures_dir().join(relative);
+    let rendered = format!(
+        "{}\n",
+        serde_json::to_string_pretty(actual).expect("the capture serializes")
+    );
+
+    if std::env::var_os("UPDATE_FIXTURES").is_some() {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, rendered).unwrap();
+        return;
+    }
+
+    let expected = std::fs::read_to_string(&path).unwrap_or_else(|_| {
+        panic!("{relative} has no committed fixture.\n{}", RERECORD_HINT);
+    });
+    assert!(
+        rendered == expected,
+        "{relative} no longer matches what the adapter sends.\n\n{}\n{}",
+        diff(&expected, &rendered),
+        RERECORD_HINT
+    );
+}
+
+const RERECORD_HINT: &str = "\
+If the new shape is intended, re-record and review the diff:
+  UPDATE_FIXTURES=1 cargo test -p openwave-router --test replay_contracts
+  git diff crates/openwave-router/tests/fixtures";
+
+/// A line diff, so a failure reads as the change that caused it rather than as
+/// two walls of JSON. Matching leading and trailing lines are trimmed first, so
+/// an inserted field shows up as one added line instead of shifting everything
+/// after it.
+fn diff(expected: &str, actual: &str) -> String {
+    use std::fmt::Write as _;
+
+    let expected: Vec<&str> = expected.lines().collect();
+    let actual: Vec<&str> = actual.lines().collect();
+    let shortest = expected.len().min(actual.len());
+    let leading = (0..shortest)
+        .take_while(|&index| expected[index] == actual[index])
+        .count();
+    let trailing = (0..shortest - leading)
+        .take_while(|&back| expected[expected.len() - 1 - back] == actual[actual.len() - 1 - back])
+        .count();
+
+    let mut out = String::new();
+    for (offset, line) in expected[leading..expected.len() - trailing]
+        .iter()
+        .enumerate()
+    {
+        let _ = writeln!(out, "{:>5} -committed {line}", leading + offset + 1);
+    }
+    for (offset, line) in actual[leading..actual.len() - trailing].iter().enumerate() {
+        let _ = writeln!(out, "{:>5} +sent      {line}", leading + offset + 1);
+    }
+    out
+}


### PR DESCRIPTION
Provider adapters each turn one normalized `ChatRequest` into a different wire request, and that translation is where provider drift lands on us. A new model generation starts rejecting a parameter shape an older one accepted and the first sign of it is a 400 inside a user's turn (#1492), because nothing in CI looks at the request as a whole — the existing unit tests assert on individual fields, so a field can move, vanish, or gain a sibling without any assertion noticing.

This adds `crates/openwave-router/tests/replay_contracts.rs`: the real adapters run against a local server standing in for the provider, and the exact outbound request — method, path, query, headers, body — is captured and compared against a committed, pretty-printed JSON fixture.

Four scenarios, shared across all four adapters so the fixtures read as "here is how each provider shapes the same turn":

- `minimal_turn` — system prompt, one user message, `max_tokens` and `temperature` (Gemini's deliberate temperature drop shows up here).
- `tool_schema` — a tool whose schema uses a nested object, an enum, and an array of objects, with a forced tool choice.
- `tool_loop_closure` — an assistant step with two parallel `tool_use` blocks answered by two results, one of them an error, on a reasoning model with tools advertised but not forced. This is the scenario that pins all four reasoning shapes: Anthropic's `thinking: adaptive` + `output_config.effort`, OpenAI's `reasoning.effort`, Chat Completions' `reasoning_effort`, and Gemini's `thinkingConfig.thinkingLevel`.
- `structured_output` — a schema-constrained answer, which each adapter expresses differently and which on Anthropic forces a tool (and therefore suppresses thinking — visible in that fixture).

The same round trip also replays a recorded SSE response through the adapter's decoder for one scenario per provider, so the fixtures pin the normalized `ProviderEvent` sequence end to end: frame parsing, streamed tool-call argument assembly, usage accounting, and stop reason. That is the second half of the replay layer; the recordings here are hand-composed against the documented stream shapes, the same way the adapters' existing decode tests are. Producing them from real traffic with a provenance manifest is a later slice.

No production code changed — every adapter already accepts a base URL, which is the interception seam.

## What a failing test means, and how to fix it

A failure prints a line diff of the committed fixture against what the adapter now sends:

```
   62 -committed         "thinkingBudget": 4096
   62 +sent              "thinkingLevel": "high"
```

Read it as the change you made, in the provider's vocabulary, and decide whether a provider would still accept the request. If the new shape is intended:

```
UPDATE_FIXTURES=1 cargo test -p openwave-router --test replay_contracts
git diff crates/openwave-router/tests/fixtures
```

Commit the re-recorded fixtures with the change. The point of the fixtures being readable rather than hashed is that the diff is the review artifact; a diff a reviewer can't judge is the signal that the change needs checking against the live API.

Credential headers are redacted by name — the name stays, so a credential moving to a different header still shows up — and transport headers (`host`, `content-length`, `accept*`, `connection`, `user-agent`) are dropped, so the captures are deterministic.

No new dependencies: the harness uses `axum`, `tokio`, and `futures`, which the crate already has.

Part of #1508. Slices 3 and 4 (the Environment-gated live canary lane and the recording provenance manifest) remain open.