### PR TITLE
feat(mcp): curated 'tested with OpenWave' server tier in Connected Apps

### DIFF
--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -32,6 +32,7 @@ import {
   type EgressConfig as WireEgressConfig,
   type CustomModelConfig as WireCustomModelConfig,
   type McpHealth as WireMcpHealth,
+  type McpCuration as WireMcpCuration,
   type McpServerDefinition as WireMcpServerDefinition,
   type McpViewSession,
   type GatewayApps as WireGatewayApps,
@@ -276,6 +277,12 @@ export type McpServerDefinition = WireMcpServerDefinition;
 export type McpServerInfo = WireMcpServerInfo;
 
 export type McpServersInfo = WireMcpServersInfo;
+
+/**
+ * The curated-list entry a configured MCP server matched. Present means
+ * OpenWave has driven the server end to end; absent is the community tier.
+ */
+export type McpCuration = WireMcpCuration;
 
 /** The Connected apps listing: per-kind projections, both kinds. */
 export type ConnectedAppsInfo = WireConnectedAppsInfo;

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -631,6 +631,13 @@ name: string, health: McpHealth, tool_count: number,
  */
 tools: Array<string>, diagnostic: string | null, 
 /**
+ * The curated-list entry this server matched, when OpenWave has
+ * exercised it end to end. `null` is the community tier: mounted and
+ * usable, just not something we have driven ourselves. A label, not
+ * a gate — nothing about the mount changes either way.
+ */
+curated: McpCuration | null, 
+/**
  * The gateway MCP endpoint slug this record mounts, when it is
  * gateway-backed rather than a local stdio/HTTP definition.
  */
@@ -1086,6 +1093,30 @@ allow_local_mcp_servers: boolean, };
 export type ManagedPolicySource = "os" | "provisioned" | "unmanaged";
 
 /**
+ * The curated-registry entry a configured server matched, projected to the
+ * renderer beside the server's health.
+ *
+ * Presence *is* the tier: a server with a curation is "tested", a server
+ * without one is "community". One field cannot disagree with itself the way
+ * a separate boolean and a separate record could.
+ */
+export type McpCuration = { 
+/**
+ * The curated list's own name for the server, which need not match the
+ * namespace the reader configured it under.
+ */
+display_name: string, 
+/**
+ * `YYYY-MM-DD` the entry was last exercised end to end.
+ */
+tested_on: string, 
+/**
+ * One sentence on what was exercised, for the reader deciding how much
+ * the badge is worth.
+ */
+notes: string, };
+
+/**
  * Renderer-safe connection lifecycle.
  */
 export type McpHealth = "initializing" | "healthy" | "degraded" | "reconnecting" | "disabled";
@@ -1138,7 +1169,14 @@ gateway_endpoint: string | null, request_timeout_ms: number, enabled: boolean, }
  * One renderer-safe server projection. Resolved `env_from` values and child
  * process details are intentionally absent.
  */
-export type McpServerInfo = { health: McpHealth, tool_count: number, diagnostic: string | null, name: string, command: string | null, args: Array<string>, 
+export type McpServerInfo = { health: McpHealth, tool_count: number, diagnostic: string | null, 
+/**
+ * The curated-list entry this definition matches, when OpenWave has
+ * exercised the server end to end. `null` means community: mounted and
+ * usable, just not something we have driven ourselves. Derived from the
+ * definition on every read, never stored.
+ */
+curated: McpCuration | null, name: string, command: string | null, args: Array<string>, 
 /**
  * Names of the environment variables this server is given directly. The
  * values live in the secret store under [`env_secret_key`] and never

--- a/crates/openwave-desktop/ui/src/settings/ConnectedAppsPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ConnectedAppsPanel.dom.test.tsx
@@ -29,6 +29,7 @@ const docsServer: McpServerInfo = {
   health: "healthy",
   tool_count: 3,
   diagnostic: null,
+  curated: null,
 };
 
 /** The app-first listing: a gateway-backed record (org apps ride the
@@ -44,6 +45,7 @@ const listing: ConnectedAppsInfo = {
       tool_count: 2,
       tools: ["sentry__proxy_api", "linear__proxy_api"],
       diagnostic: null,
+      curated: null,
       gateway_endpoint: "primary",
       gateway_apps: ["Sentry (org)", "Linear (org)"],
       used_by_app_count: 0,
@@ -56,6 +58,7 @@ const listing: ConnectedAppsInfo = {
       tool_count: 3,
       tools: ["search", "fetch", "list_sources"],
       diagnostic: null,
+      curated: null,
       gateway_endpoint: null,
       gateway_apps: [],
       used_by_app_count: 2,

--- a/crates/openwave-desktop/ui/src/settings/ConnectedAppsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ConnectedAppsPanel.tsx
@@ -19,7 +19,7 @@ import type {
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { McpHealthChip, McpPanel } from "./McpPanel";
+import { McpHealthChip, McpPanel, McpTierChip } from "./McpPanel";
 import {
   SettingsError,
   SettingsField,
@@ -169,6 +169,7 @@ function McpAppEntry({
       <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
         <p className="text-sm font-bold">{mcpTitle(entry)}</p>
         <McpHealthChip health={entry.health} />
+        <McpTierChip curated={entry.curated} />
         {entry.gateway_endpoint !== null && (
           <span className="text-xs text-muted-foreground">
             · via your organization's gateway

--- a/crates/openwave-desktop/ui/src/settings/McpPanel.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/McpPanel.test.tsx
@@ -34,6 +34,7 @@ const healthy: McpServersInfo = {
       health: "healthy",
       tool_count: 2,
       diagnostic: null,
+      curated: null,
     },
   ],
 };
@@ -67,6 +68,7 @@ function gatewayMount(
     health: "healthy",
     tool_count: 3,
     diagnostic: null,
+    curated: null,
     ...overrides,
   };
 }

--- a/crates/openwave-desktop/ui/src/settings/McpPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/McpPanel.tsx
@@ -4,6 +4,7 @@ import { Plus, RefreshCw, Trash2 } from "lucide-react";
 import type {
   ApiClient,
   GatewayApps,
+  McpCuration,
   McpHealth,
   McpServerDefinition,
   McpServerInfo,
@@ -44,6 +45,7 @@ function emptyServer(index: number): McpServerInfo {
     health: "initializing",
     tool_count: 0,
     diagnostic: null,
+    curated: null,
   };
 }
 
@@ -86,6 +88,32 @@ function chipLabel(health: McpHealth): string {
   }
 }
 
+/**
+ * The two-tier honesty label: "Tested" for a server on the curated list,
+ * "Community" for everything else. A label only — both tiers mount, connect,
+ * and call identically. The server decides the tier from the *saved*
+ * definition, so an unsaved edit keeps the previous row's label until Save.
+ */
+export function McpTierChip({ curated }: { curated: McpCuration | null }) {
+  const tested = curated !== null;
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs ${
+        tested
+          ? "border-emerald-600/40 text-emerald-700 dark:border-emerald-400/40 dark:text-emerald-400"
+          : "text-muted-foreground"
+      }`}
+      title={
+        tested
+          ? `${curated.display_name} — exercised end to end on ${curated.tested_on}. ${curated.notes}`
+          : "Not on OpenWave's tested list. It still mounts and runs; we have not driven this server ourselves."
+      }
+    >
+      {tested ? "Tested" : "Community"}
+    </span>
+  );
+}
+
 function transportOf(server: McpServerInfo): Transport {
   if (server.gateway_endpoint !== null) return "gateway";
   return server.url !== null ? "http" : "stdio";
@@ -114,7 +142,13 @@ function transportFields(transport: "stdio" | "http"): Partial<McpServerInfo> {
 }
 
 function definition(server: McpServerInfo): McpServerDefinition {
-  const { health: _, tool_count: __, diagnostic: ___, ...value } = server;
+  const {
+    health: _,
+    tool_count: __,
+    diagnostic: ___,
+    curated: ____,
+    ...value
+  } = server;
   return value;
 }
 
@@ -192,6 +226,7 @@ export function McpPanel({
             health: mount.health,
             tool_count: mount.tool_count,
             diagnostic: mount.diagnostic,
+            curated: mount.curated,
           },
         ];
       });
@@ -584,6 +619,8 @@ export function McpPanel({
                       "Save the configuration to verify this server."
                 }
               />
+
+              <McpTierChip curated={server.curated} />
 
               <div className="flex items-center justify-between gap-4">
                 <div className="flex-1">

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -38,6 +38,7 @@ mod gateway_runtime;
 pub mod logging;
 mod managed_policy;
 mod mcp_config;
+mod mcp_curated;
 mod model_registry;
 mod model_roles;
 /// OpenAPI ingest into the bounded operation catalog a `rest_api` connected

--- a/crates/openwave-server/src/mcp_config.rs
+++ b/crates/openwave-server/src/mcp_config.rs
@@ -27,6 +27,8 @@ use serde::{Deserialize, Serialize};
 use tokio::process::Command;
 use tokio::sync::Mutex;
 
+use crate::mcp_curated::{curation_for, McpCuration};
+
 const CONFIG_ENV: &str = "OPENWAVE_MCP_CONFIG";
 const MAX_CONFIG_BYTES: u64 = 1024 * 1024;
 pub(crate) const MAX_CONFIG_BODY_BYTES: usize = 1024 * 1024;
@@ -565,6 +567,11 @@ pub(crate) struct McpServerInfo {
     pub(crate) health: McpHealth,
     pub(crate) tool_count: usize,
     pub(crate) diagnostic: Option<String>,
+    /// The curated-list entry this definition matches, when OpenWave has
+    /// exercised the server end to end. `null` means community: mounted and
+    /// usable, just not something we have driven ourselves. Derived from the
+    /// definition on every read, never stored.
+    pub(crate) curated: Option<McpCuration>,
 }
 
 #[derive(Debug, Clone, Serialize, ts_rs::TS)]
@@ -1086,7 +1093,6 @@ impl McpRuntime {
                 .map(|definition| {
                     let managed = state.servers.get(&definition.name);
                     McpServerInfo {
-                        definition: definition.clone(),
                         health: managed.map_or(
                             if definition.enabled {
                                 McpHealth::Initializing
@@ -1099,6 +1105,8 @@ impl McpRuntime {
                             .and_then(|server| server.client.as_ref())
                             .map_or(0, |client| client.tools().count()),
                         diagnostic: managed.and_then(|server| server.diagnostic.clone()),
+                        curated: curation(definition),
+                        definition: definition.clone(),
                     }
                 })
                 .collect(),
@@ -1913,17 +1921,31 @@ impl McpRuntime {
                 .map(|definition| {
                     let managed = state.servers.get(&definition.name);
                     McpServerInfo {
-                        definition: definition.clone(),
                         health: managed.map_or(McpHealth::Initializing, |server| server.health),
                         tool_count: managed
                             .and_then(|server| server.client.as_ref())
                             .map_or(0, |client| client.tools().count()),
                         diagnostic: managed.and_then(|server| server.diagnostic.clone()),
+                        curated: curation(definition),
+                        definition: definition.clone(),
                     }
                 })
                 .collect(),
         }
     }
+}
+
+/// The curated-list entry this definition matches, if any.
+///
+/// A gateway mount carries neither a command nor a URL here — the endpoint is
+/// resolved from the session at connect time — so it never matches, which is
+/// the honest answer: the curated list is about servers we drove ourselves.
+fn curation(definition: &McpServerDefinition) -> Option<McpCuration> {
+    curation_for(
+        definition.command.as_deref(),
+        &definition.args,
+        definition.url.as_deref(),
+    )
 }
 
 /// Whether this definition should hold a live connection right now.

--- a/crates/openwave-server/src/mcp_curated.rs
+++ b/crates/openwave-server/src/mcp_curated.rs
@@ -1,0 +1,201 @@
+//! The curated list of MCP servers OpenWave has exercised end to end.
+//!
+//! Any MCP server can be mounted, and nothing here gates one: the list is a
+//! label, not a policy. A configured server that matches an entry is shown as
+//! *tested*; everything else is shown as *community* — usable, honestly
+//! marked. `docs/mcp-tested-servers.md` states what a curated entry claims and
+//! how a server earns one.
+//!
+//! Recognition is deliberately narrow. A stdio entry matches the executable's
+//! file stem plus the leading arguments that select MCP mode, and an HTTP
+//! entry matches the URL's exact `scheme://authority`. Anything looser would
+//! let an unrelated server inherit the badge.
+
+use std::path::Path;
+
+use serde::Serialize;
+
+/// The curated-registry entry a configured server matched, projected to the
+/// renderer beside the server's health.
+///
+/// Presence *is* the tier: a server with a curation is "tested", a server
+/// without one is "community". One field cannot disagree with itself the way
+/// a separate boolean and a separate record could.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
+pub(crate) struct McpCuration {
+    /// The curated list's own name for the server, which need not match the
+    /// namespace the reader configured it under.
+    pub(crate) display_name: String,
+    /// `YYYY-MM-DD` the entry was last exercised end to end.
+    pub(crate) tested_on: String,
+    /// One sentence on what was exercised, for the reader deciding how much
+    /// the badge is worth.
+    pub(crate) notes: String,
+}
+
+/// How a curated entry recognises a stdio definition.
+#[derive(Debug, Clone, Copy)]
+struct CuratedCommand {
+    /// The executable's file stem, compared case-insensitively so a path, a
+    /// bare name, and a Windows `.exe` all land on the same entry.
+    program: &'static str,
+    /// Leading arguments that select the server's MCP mode, compared exactly.
+    /// Empty for a program that speaks MCP and nothing else.
+    args_prefix: &'static [&'static str],
+}
+
+/// One curated server: what we call it, how to recognise it, and when we last
+/// exercised it.
+struct CuratedMcpServer {
+    display_name: &'static str,
+    /// Set when the entry describes a local stdio server.
+    stdio: Option<CuratedCommand>,
+    /// Set when the entry describes a remote HTTP server: the exact
+    /// lowercase `scheme://authority` its URL must carry. Compared whole, so
+    /// a userinfo prefix (`https://curated.example@evil.example/`) cannot
+    /// borrow a curated origin.
+    url_origin: Option<&'static str>,
+    tested_on: &'static str,
+    notes: &'static str,
+}
+
+/// The curated list.
+///
+/// Short on purpose. An entry says a person mounted that server in OpenWave
+/// and drove its auth, tool schemas, streaming, and approval previews — not
+/// that the server is popular or that its vendor is trusted. Adding one is an
+/// editorial act with a date attached; see `docs/mcp-tested-servers.md`.
+const CURATED_MCP_SERVERS: &[CuratedMcpServer] = &[CuratedMcpServer {
+    display_name: "OpenWave workspace tools",
+    stdio: Some(CuratedCommand {
+        program: "openwave",
+        args_prefix: &["mcp"],
+    }),
+    url_origin: None,
+    tested_on: "2026-08-05",
+    notes: "OpenWave's own read-only workspace server over stdio. The \
+            workspace's integration tests mount it through the same \
+            configuration path the desktop uses, so discovery, tool schemas, \
+            and the approval gate are exercised on every run.",
+}];
+
+/// The curated entry this definition matches, if any.
+///
+/// Takes the recognisable parts rather than the definition so the matcher
+/// stays independent of how a definition is spelled.
+pub(crate) fn curation_for(
+    command: Option<&str>,
+    args: &[String],
+    url: Option<&str>,
+) -> Option<McpCuration> {
+    CURATED_MCP_SERVERS
+        .iter()
+        .find(|entry| entry.matches(command, args, url))
+        .map(|entry| McpCuration {
+            display_name: entry.display_name.to_string(),
+            tested_on: entry.tested_on.to_string(),
+            notes: entry.notes.to_string(),
+        })
+}
+
+impl CuratedMcpServer {
+    fn matches(&self, command: Option<&str>, args: &[String], url: Option<&str>) -> bool {
+        self.matches_stdio(command, args) || self.matches_url(url)
+    }
+
+    fn matches_stdio(&self, command: Option<&str>, args: &[String]) -> bool {
+        let (Some(entry), Some(command)) = (self.stdio, command) else {
+            return false;
+        };
+        let Some(stem) = Path::new(command)
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+        else {
+            return false;
+        };
+        stem.eq_ignore_ascii_case(entry.program)
+            && args.len() >= entry.args_prefix.len()
+            && args
+                .iter()
+                .zip(entry.args_prefix)
+                .all(|(configured, expected)| configured == expected)
+    }
+
+    fn matches_url(&self, url: Option<&str>) -> bool {
+        let (Some(origin), Some(url)) = (self.url_origin, url) else {
+            return false;
+        };
+        origin_of(url).is_some_and(|configured| configured == origin)
+    }
+}
+
+/// The lowercase `scheme://authority` of an absolute URL.
+///
+/// Hand-rolled because this surface has no URL parser and needs no more than
+/// the prefix before the path. Scheme and authority are both
+/// case-insensitive; everything after the authority is ignored.
+fn origin_of(url: &str) -> Option<String> {
+    let (scheme, rest) = url.split_once("://")?;
+    let authority = rest.split(['/', '?', '#']).next()?;
+    if authority.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "{}://{}",
+        scheme.to_ascii_lowercase(),
+        authority.to_ascii_lowercase()
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The badge is a claim about a specific server, so an entry that cannot
+    /// recognise one — or recognises one by a pattern too loose to identify
+    /// it — would put "tested" on the wrong row. Every field the matcher and
+    /// the renderer read is checked here because the list is hand-edited and
+    /// nothing else looks at it.
+    #[test]
+    fn every_curated_entry_can_only_match_the_server_it_names() {
+        for entry in CURATED_MCP_SERVERS {
+            let label = entry.display_name;
+            assert!(
+                entry.stdio.is_some() != entry.url_origin.is_some(),
+                "{label} must declare exactly one transport pattern"
+            );
+            if let Some(stdio) = entry.stdio {
+                assert!(!stdio.program.is_empty(), "{label} has an empty program");
+            }
+            if let Some(origin) = entry.url_origin {
+                assert_eq!(
+                    origin_of(origin).as_deref(),
+                    Some(origin),
+                    "{label} must declare a lowercase scheme://authority origin"
+                );
+            }
+            assert!(
+                entry.tested_on.len() == 10
+                    && entry
+                        .tested_on
+                        .chars()
+                        .enumerate()
+                        .all(|(index, character)| if index == 4 || index == 7 {
+                            character == '-'
+                        } else {
+                            character.is_ascii_digit()
+                        }),
+                "{label} must carry a YYYY-MM-DD tested date"
+            );
+            assert!(!entry.notes.is_empty(), "{label} must say what was tested");
+        }
+
+        let args = vec!["mcp".to_string(), "/workspace".to_string()];
+        assert!(curation_for(Some("/usr/local/bin/openwave"), &args, None).is_some());
+        // The subcommand is what makes it an MCP server; `openwave serve` is
+        // the same binary and is not one.
+        assert!(curation_for(Some("openwave"), &["serve".to_string()], None).is_none());
+        assert!(curation_for(Some("openwave-fork"), &args, None).is_none());
+        assert!(curation_for(None, &[], Some("https://example.invalid/mcp")).is_none());
+    }
+}

--- a/crates/openwave-server/src/routes/connected_apps.rs
+++ b/crates/openwave-server/src/routes/connected_apps.rs
@@ -22,6 +22,7 @@ use crate::connected_apps::{
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
 use crate::mcp_config::McpHealth;
+use crate::mcp_curated::McpCuration;
 use crate::openapi_catalog::{
     enumerate_openapi_operations, ingest_openapi_document, sha256_hex, MAX_OPENAPI_DOCUMENT_BYTES,
 };
@@ -65,6 +66,11 @@ pub enum ConnectedAppInfo {
         /// remote-authored descriptions — the consent sheet's posture.
         tools: Vec<String>,
         diagnostic: Option<String>,
+        /// The curated-list entry this server matched, when OpenWave has
+        /// exercised it end to end. `null` is the community tier: mounted and
+        /// usable, just not something we have driven ourselves. A label, not
+        /// a gate — nothing about the mount changes either way.
+        curated: Option<McpCuration>,
         /// The gateway MCP endpoint slug this record mounts, when it is
         /// gateway-backed rather than a local stdio/HTTP definition.
         gateway_endpoint: Option<String>,
@@ -551,6 +557,7 @@ async fn connected_apps_info(state: &AppState) -> Result<ConnectedAppsInfo, Serv
                 health: server.health,
                 tool_count: server.tool_count,
                 diagnostic: server.diagnostic,
+                curated: server.curated,
                 gateway_endpoint,
                 gateway_apps,
                 used_by_app_count: used_by.get(&id).copied().unwrap_or(0),

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -63,6 +63,15 @@ the process boundary. MCP approvals cannot be remembered for the chat. A server
 definition can change behind a stable namespace, so reusing a name-based grant
 would silently widen its authority.
 
+## Tested and community servers
+
+Each configured server carries one of two labels in Settings: **Tested** when
+it matches OpenWave's curated list of servers we have exercised end to end, and
+**Community** otherwise. The label gates nothing — both tiers mount, connect,
+and call identically. See
+[Tested and community MCP servers](mcp-tested-servers.md) for what the tested
+claim covers and how a server earns an entry.
+
 ## Health and refresh
 
 Settings reports `initializing`, `healthy`, `degraded`, `reconnecting`, or

--- a/docs/mcp-tested-servers.md
+++ b/docs/mcp-tested-servers.md
@@ -1,0 +1,78 @@
+# Tested and community MCP servers
+
+Any MCP server can be mounted, and OpenWave treats them all the same at
+runtime: the same discovery bounds, the same approval gate, the same
+namespacing. Server *quality* is not uniform, though, and a badly-schema'd
+server makes the whole agent feel broken rather than the server. So the
+Connected apps surface labels each configured server one of two ways.
+
+- **Tested** — the server matches an entry on OpenWave's curated list. Someone
+  mounted that exact server, drove it, and dated the result.
+- **Community** — everything else. Mounted, connected, and callable, exactly
+  like a tested one. We simply have not driven it ourselves and will not imply
+  otherwise.
+
+**The label gates nothing.** It changes no approval, no tool exposure, and no
+connection behavior. It exists so the two claims stay distinguishable.
+
+## What "tested" claims
+
+An entry means a person ran the server against a real OpenWave profile and
+exercised, at minimum:
+
+- **The auth flow** — whatever the server needs to authenticate (a stdio
+  server's forwarded environment names, or an HTTP server's bearer token
+  variable), configured from Settings and reconnecting cleanly after a
+  restart.
+- **Tool schemas** — discovery completes inside OpenWave's bounds (frame size,
+  tool count, description and schema limits), the mounted names survive the
+  `mcp__{namespace}__{tool}` contract, and the published schemas describe the
+  arguments the server actually accepts.
+- **Streaming** — responses arrive over both the plain-JSON and
+  `text/event-stream` shapes the transport admits, and a long call does not
+  strand the turn.
+- **Approval previews** — the approval card for each tool reads as a sentence a
+  person can decide on, rather than an opaque blob.
+
+It does **not** claim the server is secure, well-maintained, or run by anyone
+we have a relationship with. It is a report on one session, with a date.
+
+## What the list holds
+
+The list lives in `crates/openwave-server/src/mcp_curated.rs`, next to the
+model registry it is modelled on: a static table compiled into the app, no
+network fetch, no background refresh. Each entry carries a display name, the
+pattern that recognises the server, the date it was last exercised, and a
+sentence of notes.
+
+Recognition is deliberately narrow, because a loose pattern would hand the
+badge to a server nobody tested:
+
+- a **stdio** entry matches the executable's file stem — case-insensitively, so
+  a path, a bare name, and a Windows `.exe` all land on the same entry — plus
+  the leading arguments that select the server's MCP mode;
+- an **HTTP** entry matches the URL's exact `scheme://authority`. The whole
+  authority is compared, so `https://curated.example@evil.example/` cannot
+  borrow a curated origin.
+
+A gateway-backed mount matches nothing here: its endpoint is resolved from the
+signed-in gateway session at connect time and no command or URL is stored, so
+the honest answer is the community label.
+
+The tier is computed from the *saved* definition on every read. While a server
+row is being edited and not yet saved, its label still describes the saved
+definition.
+
+## Adding an entry
+
+1. Mount the server in a real profile and work through the four contracts
+   above. If any of them is broken, the outcome is a bug report, not an entry.
+2. Add a row to `CURATED_MCP_SERVERS` with today's date and notes that say what
+   you drove — the notes are shown to the reader deciding how much the badge is
+   worth, so "verified" is not a useful sentence.
+3. Keep the pattern as narrow as it can be while still matching how people
+   normally configure that server.
+
+Re-exercise an entry when the server ships a major version and move the date
+forward, or drop the entry. A stale date is more honest than a fresh label
+nobody re-earned, but an entry no one is willing to re-drive should come out.


### PR DESCRIPTION
Any MCP server can be mounted, and server quality varies enough that a
badly-schema'd server reads as OpenWave being broken rather than the server.
This labels the difference instead of hiding it.

Each configured server in Connected apps now carries one of two labels:
**Tested** when it matches OpenWave's curated list, **Community** otherwise.
The label gates nothing — both tiers mount, connect, discover, and call
identically, and no approval behavior changes.

## The list

`crates/openwave-server/src/mcp_curated.rs`, in the shape of the model
registry: a static table compiled into the app with a display name, a
recognition pattern, the date it was last exercised, and notes.

Recognition is deliberately narrow, since a loose pattern hands the badge to a
server nobody tested. A stdio entry matches the executable's file stem
(case-insensitively, so a path, a bare name, and a Windows `.exe` agree) plus
the leading arguments that select MCP mode. An HTTP entry matches the URL's
exact `scheme://authority`, compared whole so
`https://curated.example@evil.example/` cannot borrow a curated origin. A
gateway-backed mount matches nothing: its endpoint is resolved from the session
at connect time and no command or URL is stored, so community is the honest
answer.

The tier reaches the renderer as the matched entry itself (`curated:
McpCuration | null`) rather than a boolean beside a record, so the label and
the evidence behind it cannot disagree. It is derived from the saved definition
on every read and never stored.

## Seeding

One entry: OpenWave's own `openwave mcp <workspace>` server. That is the only
server this repository actually attests to — the CLI integration tests mount it
through the same boot-configuration path the desktop uses, so its discovery,
tool schemas, and namespacing are exercised on every run. Nothing in `docs/` or
the test fixtures references a third-party server we have driven, so seeding
beyond that would be an assertion rather than a record. Growing the list is
editorial and belongs in follow-up commits, one server per session that
actually ran it.

## Docs

`docs/mcp-tested-servers.md` states what the tested claim covers (auth flow,
tool schemas, streaming, approval previews), what it explicitly does not claim,
how recognition works, and the bar for adding an entry. Linked from
`docs/mcp-servers.md`.

## Verification

`cargo check`/`clippy --all-targets` on `openwave-server`, its `mcp` and
`connected_apps` test modules, the regenerated wire types, and `tsc` plus the
settings vitest suite in the desktop UI. I have not driven the running desktop
app to look at the badge.

One test added, in the curated module: the list is hand-edited and nothing else
reads it, so a malformed entry (no pattern, both patterns, a bad date, an
origin that would over-match) would ship a "tested" label on a row nobody
tested. It also pins that `openwave serve` — the same binary without the `mcp`
subcommand — does not inherit the entry.

Closes #1512