### PR TITLE
fix(server): make same-filename output creation deterministic under concurrency

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -5671,8 +5671,11 @@ mod tests {
     #[tokio::test]
     async fn output_writeback_filename_resolves_to_the_newest_live_output() {
         let (_db, store, chat, turn_id, lease_token) = output_writeback_fixture().await;
+        // A retracted `report.md` frees the name for a later one. Only one live
+        // output can hold it, and that is the one the checkpoint must resolve.
         let older = Utc::now() - chrono::Duration::minutes(10);
-        create_named_output(&store, chat.id, "report.md", older).await;
+        let retracted = create_named_output(&store, chat.id, "report.md", older).await;
+        store.delete_output(retracted, older).await.unwrap();
         let newest = create_named_output(&store, chat.id, "report.md", Utc::now()).await;
 
         let root_id = uuid::Uuid::new_v4();

--- a/crates/openwave-core/src/db/migration/baseline/content.rs
+++ b/crates/openwave-core/src/db/migration/baseline/content.rs
@@ -135,13 +135,27 @@ pub(super) fn output_table() -> TableCreateStatement {
 }
 
 pub(super) fn output_indexes() -> Vec<IndexCreateStatement> {
-    vec![Index::create()
-        .name("idx_output_chat_created")
-        .table(Output::Table)
-        .col(Output::ChatId)
-        .col(Output::CreatedAt)
-        .col(Output::Id)
-        .to_owned()]
+    vec![
+        Index::create()
+            .name("idx_output_chat_created")
+            .table(Output::Table)
+            .col(Output::ChatId)
+            .col(Output::CreatedAt)
+            .col(Output::Id)
+            .to_owned(),
+        // Filename is the identity everything outside the store addresses an
+        // output by, so at most one live output in a conversation may carry a
+        // given name. Retracted outputs are excluded: deleting `report.md` must
+        // leave the name free for a later one.
+        Index::create()
+            .name("idx_output_chat_live_filename")
+            .table(Output::Table)
+            .col(Output::ChatId)
+            .col(Output::Filename)
+            .unique()
+            .and_where(Expr::col(Output::DeletedAt).is_null())
+            .to_owned(),
+    ]
 }
 
 /// One immutable revision of an output: the length and digest of the bytes,

--- a/crates/openwave-core/src/db/ops/output.rs
+++ b/crates/openwave-core/src/db/ops/output.rs
@@ -51,6 +51,20 @@ pub(in crate::db) async fn create_output(
             )))
         };
     }
+    // Filename is the identity everything outside the store addresses an
+    // output by, so the conversation's write lock (held above) plus this check
+    // decide the name's owner exactly once: the first writer keeps it, and a
+    // concurrent scan that lost the race is told which output to revise
+    // instead of publishing a second live record under the same name.
+    if let Some(taken) =
+        find_live_output_by_filename_on(&transaction, request.chat_id, &request.filename).await?
+    {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::OutputFilenameTaken {
+            filename: request.filename.clone(),
+            output_id: taken,
+        });
+    }
     entities::output::ActiveModel {
         id: Set(request.id.0),
         chat_id: Set(request.chat_id.0),
@@ -250,6 +264,25 @@ pub(in crate::db) async fn restore_output(
         // Restoring a live output is the same durable outcome, not a conflict.
         transaction.rollback().await.map_err(store_err)?;
         return Ok(true);
+    }
+    // A retraction frees the filename, so something else may have claimed it in
+    // the meantime. Refuse rather than let two live outputs answer to one name;
+    // the caller can retract the current holder first.
+    if !acquire_chat_write_lock(&transaction, existing.chat_id).await? {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!(
+            "chat {} does not exist",
+            existing.chat_id
+        )));
+    }
+    if let Some(taken) =
+        find_live_output_by_filename_on(&transaction, existing.chat_id, &existing.filename).await?
+    {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::OutputFilenameTaken {
+            filename: existing.filename,
+            output_id: taken,
+        });
     }
     // Clearing the soft-delete is the exact inverse of `delete_output`; the
     // revision history is untouched. Surfacing the restored output as freshly
@@ -452,6 +485,28 @@ where
     find_output_on(conn, id)
         .await?
         .ok_or_else(|| AgentError::Store(format!("output {id} not found")))
+}
+
+/// The live output holding `filename` in `chat_id`, if any.
+///
+/// The partial unique index on the same predicate guarantees there is at most
+/// one, so this reads a single id rather than a list.
+async fn find_live_output_by_filename_on<C>(
+    conn: &C,
+    chat_id: ChatId,
+    filename: &str,
+) -> Result<Option<OutputId>>
+where
+    C: ConnectionTrait,
+{
+    Ok(entities::output::Entity::find()
+        .filter(entities::output::Column::ChatId.eq(chat_id.0))
+        .filter(entities::output::Column::Filename.eq(filename))
+        .filter(entities::output::Column::DeletedAt.is_null())
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .map(|model| OutputId(model.id)))
 }
 
 async fn require_output(store: &DbStore, id: OutputId) -> Result<OutputRecord> {

--- a/crates/openwave-core/src/db/tests/output.rs
+++ b/crates/openwave-core/src/db/tests/output.rs
@@ -690,6 +690,82 @@ mod output_scan {
     }
 
     #[tokio::test]
+    async fn concurrent_scans_of_one_filename_land_on_a_single_output() {
+        let (_dir, store, chat) = store_with_chat().await;
+        let conversation = tempfile::tempdir().unwrap();
+        let store = std::sync::Arc::new(store);
+        let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+
+        // A foreground turn and a background run, each writing `report.md` in
+        // its own workspace and publishing into the same conversation.
+        let mut tasks = Vec::new();
+        for (index, bytes) in [b"# Foreground".as_slice(), b"# Background".as_slice()]
+            .into_iter()
+            .enumerate()
+        {
+            let workspace = tempfile::tempdir().unwrap();
+            write_output_file(workspace.path(), "report.md", bytes);
+            let workspace_dir = open_scratch(workspace.path());
+            let publication = open_scratch(conversation.path());
+            let store = store.clone();
+            let barrier = barrier.clone();
+            tasks.push(tokio::spawn(async move {
+                let _keep = workspace;
+                barrier.wait().await;
+                sync_output_directory(
+                    store.as_ref(),
+                    &workspace_dir,
+                    &publication,
+                    chat.id,
+                    CallId::new(),
+                    RevisionProducer::Turn(TurnId::new()),
+                    at(index as i64),
+                )
+                .await
+                .unwrap()
+            }));
+        }
+        let syncs: Vec<_> = futures::future::join_all(tasks)
+            .await
+            .into_iter()
+            .map(Result::unwrap)
+            .collect();
+
+        // Whoever won, the conversation holds exactly one `report.md`, both
+        // scans addressed it, and the loser's bytes became its second revision
+        // rather than a second live record under the same name.
+        let live = store
+            .find_outputs_by_filename(chat.id, "report.md")
+            .await
+            .unwrap();
+        assert_eq!(live.len(), 1, "concurrent scans forked the filename");
+        let output = &live[0];
+        assert_eq!(output.revision_count, 2);
+        for sync in &syncs {
+            assert!(sync.notes.is_empty(), "{:?}", sync.notes);
+            assert_eq!(sync.entries.len(), 1);
+            assert_eq!(sync.entries[0].output_id, output.id);
+        }
+        let mut statuses: Vec<_> = syncs.iter().map(|sync| sync.entries[0].status).collect();
+        statuses.sort_by_key(|status| format!("{status:?}"));
+        assert_eq!(
+            statuses,
+            vec![OutputSyncStatus::Created, OutputSyncStatus::Updated]
+        );
+
+        // Both revisions' bytes are readable where the record says they are.
+        for revision in store.list_output_revisions(output.id).await.unwrap() {
+            let relative = output_revision_relative_path(output.id, revision.id);
+            assert_eq!(
+                std::fs::read(conversation.path().join(&relative))
+                    .unwrap()
+                    .len() as u64,
+                revision.byte_len
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn unacceptable_files_become_notes_without_failing_the_scan() {
         let (_dir, store, chat) = store_with_chat().await;
         let scratch = tempfile::tempdir().unwrap();

--- a/crates/openwave-core/src/deliverable.rs
+++ b/crates/openwave-core/src/deliverable.rs
@@ -61,7 +61,8 @@ pub struct OutputRecord {
     pub id: OutputId,
     /// Conversation that exclusively owns this output.
     pub chat_id: ChatId,
-    /// Display filename. Not identity, and not unique within a chat.
+    /// Display filename. Not identity, but unique among a conversation's
+    /// live outputs: at most one live record answers to a given name.
     pub filename: String,
     /// Fixed media type set when the output was created: derived from `filename`
     /// for a text deliverable, or the explicit type of an accepted binary

--- a/crates/openwave-core/src/error.rs
+++ b/crates/openwave-core/src/error.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use crate::id::OutputId;
 use crate::ProjectId;
 
 /// Shorthand for results across the core crate.
@@ -77,6 +78,17 @@ pub enum AgentError {
     #[error("project {0} not found")]
     ProjectNotFound(ProjectId),
 
+    /// An output creation lost the race for a filename: another live output in
+    /// the same conversation already carries it. The winner's id is carried so
+    /// the loser can address the same document instead of forking it.
+    #[error("output filename `{filename}` is already live in this conversation as {output_id}")]
+    OutputFilenameTaken {
+        /// The contested display filename.
+        filename: String,
+        /// The live output that already holds the name.
+        output_id: OutputId,
+    },
+
     /// A failure reaching the secret store (keychain / KMS).
     #[error("secret error: {0}")]
     Secret(String),
@@ -140,6 +152,7 @@ impl AgentError {
             Self::MissingCredential(_) => "missing_credential",
             Self::Store(_) => "store",
             Self::ProjectNotFound(_) => "not_found",
+            Self::OutputFilenameTaken { .. } => "conflict",
             Self::Secret(_) => "secret",
             Self::Provider(_) => "provider",
             Self::Authentication(_) => "authentication",

--- a/crates/openwave-core/src/output_scan.rs
+++ b/crates/openwave-core/src/output_scan.rs
@@ -10,6 +10,13 @@
 //! output identities — it just writes files — and deleting a file from
 //! `output/` never deletes the durable record.
 //!
+//! Two scans can run against one conversation at once — a background run
+//! publishes into its parent while the foreground turn is still writing — so
+//! the snapshot a scan takes of the existing outputs can go stale before it
+//! records anything. The store, not the scan, decides who owns a filename: a
+//! creation that lost that race is told which output won and appends to it,
+//! so a name never ends up on two live records.
+//!
 //! The scan is deliberately non-fatal: a file the host cannot accept (too
 //! large, unreadable, over the revision cap) becomes a note for the model
 //! rather than a failed command.
@@ -162,46 +169,24 @@ async fn record_candidate(
         .find(|output| output.filename == candidate.filename);
 
     if let Some(output) = matched {
-        let current = store
-            .get_output_revision(output.current_revision)
-            .await?
-            .ok_or_else(|| AgentError::Store("current revision is missing".into()))?;
-        if current.sha256 == sha256 && current.byte_len == byte_len {
-            return Ok(OutputSyncEntry {
-                filename: candidate.filename.clone(),
-                output_id: output.id,
-                ordinal: current.ordinal,
-                status: OutputSyncStatus::Unchanged,
-            });
-        }
-        let revision_id = OutputRevisionId::for_call_artifact(call_id, &candidate.filename);
-        publish_revision_bytes(publication, output.id, revision_id, &candidate.content).await?;
-        let updated = store
-            .append_output_revision(
-                output.id,
-                &NewOutputRevision {
-                    id: revision_id,
-                    byte_len,
-                    sha256,
-                    turn_id: None,
-                    producing_run_id: None,
-                    created_at: now,
-                }
-                .with_producer(producer),
-            )
-            .await?;
-        return Ok(OutputSyncEntry {
-            filename: candidate.filename.clone(),
-            output_id: updated.id,
-            ordinal: updated.revision_count,
-            status: OutputSyncStatus::Updated,
-        });
+        return revise_output(
+            store,
+            publication,
+            output.id,
+            call_id,
+            producer,
+            now,
+            candidate,
+            sha256,
+            byte_len,
+        )
+        .await;
     }
 
     let output_id = OutputId::for_call_artifact(call_id, &candidate.filename);
     let revision_id = OutputRevisionId::for_call_artifact(call_id, &candidate.filename);
     publish_revision_bytes(publication, output_id, revision_id, &candidate.content).await?;
-    let created = store
+    let created = match store
         .create_output(&CreateOutput {
             id: output_id,
             chat_id,
@@ -217,12 +202,88 @@ async fn record_candidate(
             }
             .with_producer(producer),
         })
-        .await?;
+        .await
+    {
+        Ok(created) => created,
+        // Another scan created this filename between our snapshot and this
+        // write. The store picked the winner; publish onto it rather than
+        // forking a second live output that answers to the same name.
+        Err(AgentError::OutputFilenameTaken { output_id, .. }) => {
+            return revise_output(
+                store,
+                publication,
+                output_id,
+                call_id,
+                producer,
+                now,
+                candidate,
+                sha256,
+                byte_len,
+            )
+            .await;
+        }
+        Err(error) => return Err(error),
+    };
     Ok(OutputSyncEntry {
         filename: candidate.filename.clone(),
         output_id: created.id,
         ordinal: created.revision_count,
         status: OutputSyncStatus::Created,
+    })
+}
+
+/// Land a scanned file on an output that already exists, appending a revision
+/// unless the bytes already match the current one.
+#[allow(clippy::too_many_arguments)]
+async fn revise_output(
+    store: &dyn Store,
+    publication: &Dir,
+    output_id: OutputId,
+    call_id: CallId,
+    producer: RevisionProducer,
+    now: DateTime<Utc>,
+    candidate: &ScanCandidate,
+    sha256: [u8; 32],
+    byte_len: u64,
+) -> Result<OutputSyncEntry> {
+    let output = store
+        .get_output(output_id)
+        .await?
+        .filter(|output| output.deleted_at.is_none())
+        .ok_or_else(|| AgentError::Store(format!("output {output_id} is no longer live")))?;
+    let current = store
+        .get_output_revision(output.current_revision)
+        .await?
+        .ok_or_else(|| AgentError::Store("current revision is missing".into()))?;
+    if current.sha256 == sha256 && current.byte_len == byte_len {
+        return Ok(OutputSyncEntry {
+            filename: candidate.filename.clone(),
+            output_id: output.id,
+            ordinal: current.ordinal,
+            status: OutputSyncStatus::Unchanged,
+        });
+    }
+    let revision_id = OutputRevisionId::for_call_artifact(call_id, &candidate.filename);
+    publish_revision_bytes(publication, output.id, revision_id, &candidate.content).await?;
+    let updated = store
+        .append_output_revision(
+            output.id,
+            &NewOutputRevision {
+                id: revision_id,
+                byte_len,
+                sha256,
+                turn_id: None,
+                producing_run_id: None,
+                created_at: now,
+            }
+            .with_producer(producer),
+        )
+        .await?;
+    Ok(OutputSyncEntry {
+        filename: candidate.filename.clone(),
+        output_id: updated.id,
+        ordinal: updated.revision_count,
+        status: OutputSyncStatus::Updated,
     })
 }
 

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -1667,6 +1667,11 @@ pub trait Store: Send + Sync {
     /// and supplies their exact length and digest. Reusing `request.id` with
     /// identical content returns the original record so an ambiguous store
     /// response can be retried; reusing it with different content is rejected.
+    ///
+    /// At most one live output per conversation may carry a given filename. A
+    /// creation that finds the name already taken fails with
+    /// [`AgentError::OutputFilenameTaken`] naming the output that holds it, so
+    /// the caller can revise that record instead of forking the name.
     async fn create_output(&self, _request: &CreateOutput) -> Result<OutputRecord> {
         output_storage_unavailable()
     }
@@ -1735,6 +1740,10 @@ pub trait Store: Send + Sync {
     /// output is reversible. Returns `false` only when the output does not
     /// exist; restoring a live output is the same durable outcome, not a
     /// conflict. Nothing about the revision history changes.
+    ///
+    /// A retraction frees the output's filename, so restoring fails with
+    /// [`AgentError::OutputFilenameTaken`] when something else has since
+    /// claimed it — the caller retracts the current holder first.
     async fn restore_output(
         &self,
         _id: OutputId,

--- a/crates/openwave-server/src/desktop_schema.rs
+++ b/crates/openwave-server/src/desktop_schema.rs
@@ -25,7 +25,7 @@ const VECTOR_DIRECTORY: &str = "vectors";
 const MAX_MARKER_BYTES: u64 = 1_024;
 
 /// Bump this whenever the pre-v1 schema baseline changes incompatibly.
-const DESKTOP_SCHEMA_EPOCH: u32 = 5;
+const DESKTOP_SCHEMA_EPOCH: u32 = 6;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]


### PR DESCRIPTION
## The race

Filename is the identity everything outside the store addresses an output by, but nothing enforced that a conversation held only one output per name. `sync_output_directory` takes one snapshot of the conversation's live outputs and then decides, per scanned file, whether to create or revise. Two scans running at once — routine now that background runs publish into their parent conversation while the foreground turn is still writing — both see no `report.md`, both derive a distinct `OutputId::for_call_artifact(call_id, filename)`, and both create. The conversation ends up with two live outputs answering to one name, and "newest live match" resolution forks between them with nothing to tell the user which document they are looking at.

A test that runs two scans of `report.md` concurrently reproduces this on `main`: two live outputs, one name.

## Mechanism: serialize creation per conversation, first writer keeps the name

`create_output` already begins a transaction and takes the owning chat's write lock — the same lock `append_output_revision` uses to keep ordinals from colliding. Creation is therefore already serialized per conversation; all that was missing was the check. It now runs inside that transaction, after the lock: if a live output in the chat already carries the filename, the creation is refused with `AgentError::OutputFilenameTaken` naming the winner.

Serializing on the existing lock rather than catching a constraint violation and retrying keeps the whole decision in one place and needs no new transaction structure or backoff. The partial unique index on `(chat_id, filename) WHERE deleted_at IS NULL` is still there, as the schema-level statement of the invariant: no future write path can quietly reintroduce the fork, and the check above can read a single row rather than a list. Retracted outputs are excluded from the index because deleting `report.md` must leave the name free for a later one.

The scan handles the refusal by doing what it would have done had its snapshot been current: it re-reads the winning output and appends its bytes as a revision, publishing them under the winner's id. The create and revise paths were factored into one `revise_output` helper so both reach the store the same way. The loser leaves behind one unreferenced file at its own (never-recorded) revision path in conversation scratch — inert, and only on the racing path.

## Restore

Excluding retracted outputs from the index gives restore a new failure mode: undeleting an output whose filename has since been reclaimed would violate the index. `restore_output` now takes the chat write lock and reports the same `OutputFilenameTaken` conflict, so the caller gets an actionable message instead of a raw constraint error.

## Schema

Baseline edit, so `DESKTOP_SCHEMA_EPOCH` moves 5 -> 6 and pre-v1 local databases are rebuilt, per the pre-v1 lifecycle.

## Still open

This is only the half of #1555 that is wanted under either answer to its product question. **Whether cross-producer filename merging is intended** — one document with many producers, versus producers namespacing their outputs — is untouched and still open. A background run writing `report.md` still appends to the user's foreground `report.md`; that is now deterministic rather than forked, but the UI still says nothing about who produced the head revision. Part of #1555.

## Tests

One added: `concurrent_scans_of_one_filename_land_on_a_single_output` runs two barrier-synchronized scans of the same filename from separate workspaces into one conversation and asserts the conversation holds exactly one live `report.md` with two revisions, that both scans addressed it, and that both revisions' bytes are readable where the record says they are. Verified red on the pre-fix code (two live outputs), green after.

One modified: `output_writeback_filename_resolves_to_the_newest_live_output` seeded two live outputs with one filename to prove filename resolution picks the live record. That state is no longer constructible, so it retracts the first output instead and keeps the same assertion.

## Verification

`cargo test -p openwave-core --locked --lib`, `cargo test -p openwave-server --locked --lib`, `cargo check --workspace --locked --all-targets`, `cargo clippy -p openwave-core -p openwave-server --locked --all-targets`, `cargo fmt --check` — all clean. The partial unique index follows the same `and_where` form as the existing ones in the baseline, so it renders for both backends, but I have not exercised it against PostgreSQL locally.