### PR TITLE
test(server): stop hand-driven turn tests racing the turn worker

### DIFF
--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -1480,6 +1480,32 @@ async fn test_app_with(
     test_app_from_parts(provider, store, dir)
 }
 
+/// The same router with no turn lane behind it.
+///
+/// A test that drives a turn by hand — accepting it and then claiming its
+/// lease straight from the store — has to be that turn's only claimant. A live
+/// `TurnWorker` scans the same queue every few hundred milliseconds, so under
+/// load it can take the queued turn between the accept and the claim, and the
+/// test's claim then finds nothing due. Routes that never run a turn should
+/// use this instead of `test_app`.
+async fn test_app_without_turn_worker() -> (Router, Arc<str>, Arc<dyn Store>, tempfile::TempDir) {
+    let (dir, store) = temp_db_store("t.db").await;
+    let store: Arc<dyn Store> = Arc::new(store);
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let token = state.token.clone();
+    (app(state), token, store, dir)
+}
+
 fn test_app_from_parts(
     provider: Arc<dyn ModelProvider>,
     store: Arc<dyn Store>,
@@ -1612,6 +1638,10 @@ async fn test_app_with_state() -> (
     (app(state.clone()), token, state, store, dir)
 }
 
+/// Admit a background agent run under a turn this test owns outright.
+///
+/// The claim below is a queue scan, so the app under test must not be running
+/// a turn worker — see `test_app_without_turn_worker`.
 async fn admit_sandbox_for_test(
     store: &Arc<dyn Store>,
     chat_id: ChatId,
@@ -1634,7 +1664,7 @@ async fn admit_sandbox_for_test(
         .await
         .unwrap()
         .turn
-        .expect("sandbox test turn should claim");
+        .expect("the hand-driven turn is this test's to claim");
     match store
         .admit_sandbox_agent_run(
             turn.id,

--- a/crates/openwave-server/src/tests/lifecycle.rs
+++ b/crates/openwave-server/src/tests/lifecycle.rs
@@ -1035,6 +1035,12 @@ pub(super) async fn post_native_json(
         .unwrap()
 }
 
+/// Park a turn on a client tool call without running the agent loop.
+///
+/// This and the other `park_*_for_route_test` helpers accept a turn and then
+/// claim it straight from the store, which is a scan over the whole queue. The
+/// app under test must therefore have no turn worker running yet, or the two
+/// race for the same queued turn — see `test_app_without_turn_worker`.
 async fn park_client_wait_for_route_test(
     store: &dyn Store,
     chat_id: ChatId,
@@ -1209,7 +1215,7 @@ async fn resolve_parked_client_call(
 
 #[tokio::test]
 async fn user_question_api_is_renderer_safe_exact_and_not_native_claimable() {
-    let (router, token, store, _dir) = test_app().await;
+    let (router, token, store, _dir) = test_app_without_turn_worker().await;
     let bearer = format!("Bearer {token}");
     let chat = make_chat(&router, &bearer).await;
     let (turn_id, call) = park_user_questions_for_route_test(&*store, chat.id).await;
@@ -1789,7 +1795,7 @@ async fn renderer_pending_client_executions_are_a_closed_folder_consent_projecti
 
 #[tokio::test]
 async fn pending_chat_prompts_are_cross_chat_opaque_summaries() {
-    let (router, token, store, _dir) = test_app().await;
+    let (router, token, store, _dir) = test_app_without_turn_worker().await;
     let bearer = format!("Bearer {token}");
     let question_chat = make_chat(&router, &bearer).await;
     let (_question_turn_id, question_call) =
@@ -1875,7 +1881,7 @@ async fn pending_chat_prompts_are_cross_chat_opaque_summaries() {
 /// aggregation, not any single branch of it.
 #[tokio::test]
 async fn the_inbox_lists_parked_work_until_its_own_route_resolves_it() {
-    let (router, token, store, _dir) = test_app().await;
+    let (router, token, store, _dir) = test_app_without_turn_worker().await;
     let bearer = format!("Bearer {token}");
 
     let question_chat = make_chat(&router, &bearer).await;

--- a/crates/openwave-server/src/tests/sandbox.rs
+++ b/crates/openwave-server/src/tests/sandbox.rs
@@ -94,7 +94,7 @@ async fn create_then_get_and_list() {
 
 #[tokio::test]
 async fn agent_run_snapshots_expose_only_safe_live_sandbox_activity() {
-    let (router, token, store, _dir) = test_app().await;
+    let (router, token, store, _dir) = test_app_without_turn_worker().await;
     let bearer = format!("Bearer {token}");
     let chat: Chat = {
         let response = router
@@ -216,7 +216,7 @@ async fn agent_run_snapshots_expose_only_safe_live_sandbox_activity() {
 
 #[tokio::test]
 async fn agent_run_activity_history_is_ordered_renderer_safe_and_names_submitted_files() {
-    let (router, token, store, _dir) = test_app().await;
+    let (router, token, store, _dir) = test_app_without_turn_worker().await;
     let bearer = format!("Bearer {token}");
     let chat = make_chat(&router, &bearer).await;
     let other_chat = make_chat(&router, &bearer).await;
@@ -1186,7 +1186,7 @@ async fn agent_run_snapshots_expose_only_safe_live_foreground_folder_activity() 
 
 #[tokio::test]
 async fn agent_run_snapshots_omit_persisted_raw_failure_detail() {
-    let (router, token, store, _dir) = test_app().await;
+    let (router, token, store, _dir) = test_app_without_turn_worker().await;
     let bearer = format!("Bearer {token}");
     let response = router
         .clone()


### PR DESCRIPTION
`agent_run_activity_history_is_ordered_renderer_safe_and_names_submitted_files`
intermittently failed on `claim_turn_run` returning `None` inside
`admit_sandbox_for_test`. The suspected cause in #1552 was a clock-granularity
comparison in the claim predicate; it is not that.

`test_app()` spawns a real `TurnWorker` against the same store. The helper
accepts a turn and then claims it with its own lease, and `claim_turn_run` is a
scan over the whole queue, not a claim of a named turn — so the worker's
250ms poll can take the queued turn in the window between the accept and the
helper's claim. Instrumenting the failure confirmed it: at the point of the
panic the turn was already `Running`, `claim_count: 1`, holding a lease token
the test had never issued, stamped ~4ms before the helper's claim time. Nothing
about the store's timestamp handling is involved; `canonical_db_timestamp`
keeps microseconds and the ordering was strictly correct.

Leaving the claim predicate alone is deliberate. Making it tolerate an equal
timestamp would not have helped here, and loosening a durable-queue eligibility
rule to quiet a test would trade a real invariant for a test artifact.

The fix is to stop running a competing claimant in tests that own their turn
outright. That pattern already exists in this file — the tests around
`park_client_wait_for_route_test` build their state and spawn the worker only
after parking — so this gives it a name, `test_app_without_turn_worker`, and
uses it for the six tests that drive a turn by hand from the store and never
need a turn to run: three sandbox snapshot/activity tests and three lifecycle
question/prompt/inbox tests. The helpers that hand-claim now say in a comment
why their app must not have a worker.

Verification: the full `openwave-server` test binary at `--test-threads 32`
failed 4 times across 12 runs before the change (the activity-history test, its
sibling snapshot test, and the inbox test) and 0 times across 15 runs after.

Closes #1552