### PR TITLE
feat(core): plugin manifests group built-in skills into a bundled catalog

### DIFF
--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -23,6 +23,7 @@ pub mod office_render;
 mod output;
 pub mod overlay;
 pub mod package_cache;
+pub mod plugins;
 mod preview;
 mod receipt;
 mod remote;
@@ -52,6 +53,10 @@ pub use overlay::{
 };
 pub use package_cache::{
     PromotionReport, SharedPackageCache, PACKAGE_CACHE_DIR, PACKAGE_CACHE_ENV,
+};
+pub use plugins::{
+    is_valid_plugin_name, is_valid_plugin_router_preamble, load_plugins, parse_plugin_manifest,
+    LoadedPlugin, PluginCategory, PluginPackage, PluginParseError, PLUGIN_MANIFEST_FILE,
 };
 pub use preview::{scan_preview_directory, PreviewScan};
 pub use remote::RemoteSessionPool;

--- a/crates/openwave-code-execution/src/plugins.rs
+++ b/crates/openwave-code-execution/src/plugins.rs
@@ -1,0 +1,576 @@
+//! Plugins: thin manifests that group skills into one installable bundle.
+//!
+//! A skill stays the model's routing unit — the prompt catalog still lists
+//! `(name, description)` lines and the instruction body still reaches the
+//! model only through `read_file` of the staged `SKILL.md`. A plugin adds a
+//! layer above that atom: a directory whose `PLUGIN.md` names a set of member
+//! skills, carries the display identity a UI needs, and may declare one
+//! *router preamble* — a single line emitted above its skills in the catalog
+//! when they are alternatives for the same intent and the model needs help
+//! choosing between them.
+//!
+//! Plugins are packaging, not a prompt concept. A skill claimed by no plugin
+//! keeps working exactly as before, which is what keeps user-authored skills
+//! in the data directory unaffected by this layer.
+//!
+//! Parsing follows `skills.rs` exactly: hand-rolled strict frontmatter, a
+//! closed key set, byte bounds and printability on every emitted string, and
+//! skip-with-warning per package so one bad manifest can never break the
+//! prompt. Membership is validated against the skills that actually loaded, so
+//! a plugin naming a skill that isn't there is skipped whole rather than
+//! advertising a group the catalog cannot render.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use crate::skills::{is_valid_skill_name, LoadedSkill};
+
+/// The manifest file every plugin package is defined by.
+pub const PLUGIN_MANIFEST_FILE: &str = "PLUGIN.md";
+
+const MAX_NAME_BYTES: usize = 64;
+const MAX_DISPLAY_NAME_BYTES: usize = 64;
+const MAX_DESCRIPTION_BYTES: usize = 200;
+const MAX_ROUTER_PREAMBLE_BYTES: usize = 300;
+const MAX_MEMBER_SKILLS: usize = 16;
+
+/// What kind of work a plugin bundles, from a closed vocabulary.
+///
+/// Closed on purpose, like [`crate::HostDep`]: an unknown value rejects the
+/// manifest instead of parsing into a string no grouping or badge can act on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PluginCategory {
+    /// Documents authored for reading: text, fixed-layout, slides.
+    Documents,
+    /// Tabular and structured data work.
+    Data,
+    /// Charts, plots, and other rendered visuals.
+    Visualization,
+    /// Anything the vocabulary above does not describe yet.
+    Other,
+}
+
+impl PluginCategory {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "documents" => Some(Self::Documents),
+            "data" => Some(Self::Data),
+            "visualization" => Some(Self::Visualization),
+            "other" => Some(Self::Other),
+            _ => None,
+        }
+    }
+}
+
+/// Host-derived bundle entry parsed from a plugin manifest's frontmatter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginPackage {
+    /// Kebab-case slug; also the directory name.
+    pub name: String,
+    /// Human-facing name for surfaces that show the bundle.
+    pub display_name: String,
+    /// One printable line describing what the bundle covers.
+    pub description: String,
+    /// What kind of work the bundle is for.
+    pub category: PluginCategory,
+    /// Member skill slugs, in manifest order, each one a loaded skill.
+    pub skills: Vec<String>,
+    /// Optional line emitted above the member skills in the prompt catalog,
+    /// telling the model how to choose among them.
+    pub router_preamble: Option<String>,
+}
+
+/// One validated plugin.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoadedPlugin {
+    /// The parsed manifest this plugin's grouping is derived from.
+    pub package: PluginPackage,
+}
+
+/// Why a plugin manifest was rejected.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("invalid plugin manifest: {0}")]
+pub struct PluginParseError(String);
+
+fn invalid(reason: impl Into<String>) -> PluginParseError {
+    PluginParseError(reason.into())
+}
+
+/// Whether `name` is a well-formed plugin slug: bounded kebab-case with no
+/// empty segments — the same grammar skill names use.
+#[must_use]
+pub fn is_valid_plugin_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= MAX_NAME_BYTES
+        && name
+            .split('-')
+            .all(|segment| !segment.is_empty() && segment.bytes().all(is_slug_byte))
+}
+
+fn is_slug_byte(byte: u8) -> bool {
+    byte.is_ascii_lowercase() || byte.is_ascii_digit()
+}
+
+/// Whether `line` is safe to emit as one bounded prompt or UI line: non-empty,
+/// trimmed, within `limit` bytes, and free of control characters so it cannot
+/// span lines or smuggle a heading.
+fn is_valid_line(line: &str, limit: usize) -> bool {
+    !line.is_empty()
+        && line.len() <= limit
+        && line.trim() == line
+        && !line.chars().any(char::is_control)
+}
+
+/// Whether `preamble` is safe to emit as the plugin's catalog line.
+///
+/// Exported so prompt composition can refuse a forged entry independently of
+/// the parser, the way it re-checks skill names and descriptions.
+#[must_use]
+pub fn is_valid_plugin_router_preamble(preamble: &str) -> bool {
+    is_valid_line(preamble, MAX_ROUTER_PREAMBLE_BYTES)
+}
+
+/// Parse one `PLUGIN.md` source: strict frontmatter between `---` fences.
+///
+/// Recognized keys are exactly `name`, `display-name`, `description`,
+/// `category`, the single-line flow list `skills: ["a", "b"]`, and the
+/// optional `router-preamble`. Anything else — an unknown key, a duplicate, a
+/// member that is not a well-formed skill slug, a control character in a
+/// rendered line — rejects the whole manifest. The body below the frontmatter
+/// is documentation for whoever opens the file; it is never staged and never
+/// reaches the model, so it may be empty.
+pub fn parse_plugin_manifest(source: &str) -> Result<PluginPackage, PluginParseError> {
+    if source.len() > crate::MAX_WORKSPACE_FILE_BYTES {
+        return Err(invalid("manifest exceeds the workspace file limit"));
+    }
+    let rest = source
+        .strip_prefix("---\n")
+        .ok_or_else(|| invalid("missing opening frontmatter fence"))?;
+    let (frontmatter, _body) = rest
+        .split_once("\n---\n")
+        .ok_or_else(|| invalid("missing closing frontmatter fence"))?;
+
+    let mut name = None;
+    let mut display_name = None;
+    let mut description = None;
+    let mut category = None;
+    let mut skills = None;
+    let mut router_preamble = None;
+    for line in frontmatter.lines() {
+        if line.trim().is_empty() {
+            return Err(invalid("blank line inside frontmatter"));
+        }
+        let (key, value) = line
+            .split_once(':')
+            .ok_or_else(|| invalid(format!("frontmatter line without a key: {line:?}")))?;
+        let value = value.trim();
+        match key {
+            "name" => {
+                if name.replace(value).is_some() {
+                    return Err(invalid("duplicate 'name'"));
+                }
+            }
+            "display-name" => {
+                if display_name.replace(value).is_some() {
+                    return Err(invalid("duplicate 'display-name'"));
+                }
+            }
+            "description" => {
+                if description.replace(value).is_some() {
+                    return Err(invalid("duplicate 'description'"));
+                }
+            }
+            "category" => {
+                if category.replace(value).is_some() {
+                    return Err(invalid("duplicate 'category'"));
+                }
+            }
+            "skills" => {
+                if skills.replace(parse_member_skills(value)?).is_some() {
+                    return Err(invalid("duplicate 'skills'"));
+                }
+            }
+            "router-preamble" => {
+                if router_preamble.replace(value).is_some() {
+                    return Err(invalid("duplicate 'router-preamble'"));
+                }
+            }
+            other => return Err(invalid(format!("unknown frontmatter key {other:?}"))),
+        }
+    }
+
+    let name = name.ok_or_else(|| invalid("missing 'name'"))?;
+    if !is_valid_plugin_name(name) {
+        return Err(invalid(format!(
+            "'name' is not a kebab-case slug: {name:?}"
+        )));
+    }
+    let display_name = display_name.ok_or_else(|| invalid("missing 'display-name'"))?;
+    if !is_valid_line(display_name, MAX_DISPLAY_NAME_BYTES) {
+        return Err(invalid("'display-name' is not one bounded printable line"));
+    }
+    let description = description.ok_or_else(|| invalid("missing 'description'"))?;
+    if !is_valid_line(description, MAX_DESCRIPTION_BYTES) {
+        return Err(invalid("'description' is not one bounded printable line"));
+    }
+    let category = category.ok_or_else(|| invalid("missing 'category'"))?;
+    let Some(category) = PluginCategory::parse(category) else {
+        return Err(invalid(format!("unknown 'category': {category:?}")));
+    };
+    let skills = skills.ok_or_else(|| invalid("missing 'skills'"))?;
+    let router_preamble = router_preamble
+        .map(|preamble| {
+            is_valid_plugin_router_preamble(preamble)
+                .then(|| preamble.to_owned())
+                .ok_or_else(|| invalid("'router-preamble' is not one bounded printable line"))
+        })
+        .transpose()?;
+    Ok(PluginPackage {
+        name: name.to_owned(),
+        display_name: display_name.to_owned(),
+        description: description.to_owned(),
+        category,
+        skills,
+        router_preamble,
+    })
+}
+
+/// Parse the single-line flow form `["word-documents", "pdf-documents"]`.
+///
+/// Every item is a double-quoted skill slug; the slug grammar admits neither
+/// `"` nor `]`, so the list cannot be malformed into something that parses.
+fn parse_member_skills(value: &str) -> Result<Vec<String>, PluginParseError> {
+    let malformed = || invalid("'skills' must be `[\"skill-name\", ...]` with at least one member");
+    let items = value
+        .strip_prefix('[')
+        .and_then(|rest| rest.strip_suffix(']'))
+        .ok_or_else(malformed)?
+        .trim();
+    if items.is_empty() {
+        return Err(malformed());
+    }
+    let mut skills: Vec<String> = Vec::new();
+    for item in items.split(',') {
+        let skill = item
+            .trim()
+            .strip_prefix('"')
+            .and_then(|rest| rest.strip_suffix('"'))
+            .ok_or_else(malformed)?;
+        if !is_valid_skill_name(skill) {
+            return Err(invalid(format!(
+                "'skills' member is not a kebab-case slug: {skill:?}"
+            )));
+        }
+        if skills.iter().any(|existing| existing == skill) {
+            return Err(invalid(format!("duplicate 'skills' member: {skill:?}")));
+        }
+        skills.push(skill.to_owned());
+    }
+    if skills.len() > MAX_MEMBER_SKILLS {
+        return Err(invalid("'skills' lists too many members"));
+    }
+    Ok(skills)
+}
+
+/// Load every valid plugin under `source`, one directory per plugin, against
+/// the skills that actually loaded.
+///
+/// A plugin is skipped with a warning — never half-applied — when its manifest
+/// is unreadable or rejected, when the directory name disagrees with the
+/// manifest, when a member skill is not among `skills`, or when a member is
+/// already claimed by another plugin. Claims resolve in name order so the same
+/// tree always produces the same grouping. Skills no plugin claims stay
+/// standalone; that is the supported shape for a bare skill directory, not a
+/// degraded one.
+#[must_use]
+pub fn load_plugins(source: &Path, skills: &[LoadedSkill]) -> Vec<LoadedPlugin> {
+    let entries = match std::fs::read_dir(source) {
+        Ok(entries) => entries,
+        Err(error) => {
+            tracing::warn!(
+                "plugin source directory {} is unreadable: {error}",
+                source.display()
+            );
+            return Vec::new();
+        }
+    };
+    let known: BTreeSet<&str> = skills
+        .iter()
+        .map(|skill| skill.package.name.as_str())
+        .collect();
+    let mut parsed: Vec<PluginPackage> = Vec::new();
+    for entry in entries.flatten() {
+        let Ok(directory_name) = entry.file_name().into_string() else {
+            continue;
+        };
+        let is_directory = entry
+            .path()
+            .symlink_metadata()
+            .is_ok_and(|metadata| metadata.is_dir() && !metadata.file_type().is_symlink());
+        if !is_directory {
+            continue;
+        }
+        let manifest_path = entry.path().join(PLUGIN_MANIFEST_FILE);
+        let regular_file = manifest_path
+            .symlink_metadata()
+            .is_ok_and(|metadata| metadata.is_file() && !metadata.file_type().is_symlink());
+        if !regular_file {
+            tracing::warn!("skipping plugin '{directory_name}': no regular {PLUGIN_MANIFEST_FILE}");
+            continue;
+        }
+        let manifest = match std::fs::read_to_string(&manifest_path) {
+            Ok(manifest) => manifest,
+            Err(error) => {
+                tracing::warn!("skipping plugin '{directory_name}': manifest unreadable: {error}");
+                continue;
+            }
+        };
+        let package = match parse_plugin_manifest(&manifest) {
+            Ok(package) => package,
+            Err(error) => {
+                tracing::warn!("skipping plugin '{directory_name}': {error}");
+                continue;
+            }
+        };
+        if package.name != directory_name {
+            tracing::warn!(
+                "skipping plugin '{directory_name}': manifest names itself {:?}",
+                package.name
+            );
+            continue;
+        }
+        if let Some(missing) = package
+            .skills
+            .iter()
+            .find(|skill| !known.contains(skill.as_str()))
+        {
+            tracing::warn!(
+                "skipping plugin '{directory_name}': member skill {missing:?} did not load"
+            );
+            continue;
+        }
+        parsed.push(package);
+    }
+
+    parsed.sort_by(|a, b| a.name.cmp(&b.name));
+    let mut claimed: BTreeSet<String> = BTreeSet::new();
+    let mut plugins = Vec::new();
+    for package in parsed {
+        if let Some(taken) = package
+            .skills
+            .iter()
+            .find(|skill| claimed.contains(skill.as_str()))
+        {
+            tracing::warn!(
+                "skipping plugin '{}': skill {taken:?} is already claimed by another plugin",
+                package.name
+            );
+            continue;
+        }
+        claimed.extend(package.skills.iter().cloned());
+        plugins.push(LoadedPlugin { package });
+    }
+    plugins
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::skills::{load_skills, SkillOrigin, SKILL_MANIFEST_FILE};
+
+    const VALID: &str = "---\n\
+name: documents\n\
+display-name: Documents\n\
+description: Word, PDF, and slide deliverables.\n\
+category: documents\n\
+skills: [\"word-documents\", \"pdf-documents\"]\n\
+router-preamble: Pick by the file the user needs.\n\
+---\n\
+\n\
+# Documents\n";
+
+    fn write_skill(dir: &Path, name: &str) {
+        let skill = dir.join(name);
+        std::fs::create_dir(&skill).unwrap();
+        std::fs::write(
+            skill.join(SKILL_MANIFEST_FILE),
+            format!("---\nname: {name}\ndescription: Does {name} work.\n---\nBody.\n"),
+        )
+        .unwrap();
+    }
+
+    fn write_plugin(dir: &Path, name: &str, manifest: &str) {
+        let plugin = dir.join(name);
+        std::fs::create_dir(&plugin).unwrap();
+        std::fs::write(plugin.join(PLUGIN_MANIFEST_FILE), manifest).unwrap();
+    }
+
+    #[test]
+    fn valid_manifest_parses_into_its_bundle_entry() {
+        let package = parse_plugin_manifest(VALID).unwrap();
+        assert_eq!(package.name, "documents");
+        assert_eq!(package.display_name, "Documents");
+        assert_eq!(package.category, PluginCategory::Documents);
+        assert_eq!(package.skills, ["word-documents", "pdf-documents"]);
+        assert_eq!(
+            package.router_preamble.as_deref(),
+            Some("Pick by the file the user needs.")
+        );
+
+        // The preamble is optional; everything else is required.
+        let minimal = "---\nname: charts\ndisplay-name: Charts\ndescription: Plots.\n\
+                       category: visualization\nskills: [\"charts\"]\n---\n";
+        assert_eq!(
+            parse_plugin_manifest(minimal).unwrap().router_preamble,
+            None
+        );
+    }
+
+    #[test]
+    fn malformed_manifests_are_rejected_not_half_parsed() {
+        let head = "---\nname: a\ndisplay-name: A\ndescription: b\ncategory: other\n";
+        for (case, source) in [
+            ("no frontmatter", "# Just markdown\n".to_owned()),
+            ("unclosed frontmatter", format!("{head}skills: [\"c\"]\n")),
+            (
+                "missing name",
+                "---\ndisplay-name: A\ndescription: b\ncategory: other\nskills: [\"c\"]\n---\n"
+                    .to_owned(),
+            ),
+            (
+                "missing display-name",
+                "---\nname: a\ndescription: b\ncategory: other\nskills: [\"c\"]\n---\n".to_owned(),
+            ),
+            ("missing skills", format!("{head}---\n")),
+            (
+                "unknown category",
+                "---\nname: a\ndisplay-name: A\ndescription: b\ncategory: wizardry\nskills: [\"c\"]\n---\n".to_owned(),
+            ),
+            ("empty skills list", format!("{head}skills: []\n---\n")),
+            (
+                "non-kebab member",
+                format!("{head}skills: [\"Word Documents\"]\n---\n"),
+            ),
+            (
+                "duplicate member",
+                format!("{head}skills: [\"c\", \"c\"]\n---\n"),
+            ),
+            (
+                "block-style skills",
+                format!("{head}skills:\n  - c\n---\n"),
+            ),
+            (
+                "unknown key",
+                format!("{head}skills: [\"c\"]\nversion: 1\n---\n"),
+            ),
+            (
+                "multi-line preamble",
+                format!("{head}skills: [\"c\"]\nrouter-preamble: one\\nline\n---\n")
+                    .replace("\\n", "\u{0b}"),
+            ),
+            (
+                "oversized preamble",
+                format!("{head}skills: [\"c\"]\nrouter-preamble: {}\n---\n", "x".repeat(301)),
+            ),
+        ] {
+            assert!(
+                parse_plugin_manifest(&source).is_err(),
+                "{case} should be rejected"
+            );
+        }
+    }
+
+    /// Contract: membership is checked against the skills that actually
+    /// loaded, and one skill belongs to at most one plugin — a second
+    /// claimant is skipped whole rather than producing overlapping groups.
+    #[test]
+    fn loader_rejects_dangling_members_and_double_claims() {
+        let skills_dir = tempfile::tempdir().unwrap();
+        for name in ["charts", "pdf-documents", "word-documents"] {
+            write_skill(skills_dir.path(), name);
+        }
+        let skills = load_skills(skills_dir.path(), SkillOrigin::Builtin);
+
+        let plugins_dir = tempfile::tempdir().unwrap();
+        write_plugin(plugins_dir.path(), "documents", VALID);
+        // Claims a skill 'documents' already owns: skipped entirely, so its
+        // uncontested member stays standalone rather than half-grouped.
+        write_plugin(
+            plugins_dir.path(),
+            "zzz-later",
+            "---\nname: zzz-later\ndisplay-name: Later\ndescription: Steals a member.\n\
+             category: other\nskills: [\"charts\", \"pdf-documents\"]\n---\n",
+        );
+        // Names a skill that did not load.
+        write_plugin(
+            plugins_dir.path(),
+            "ghosts",
+            "---\nname: ghosts\ndisplay-name: Ghosts\ndescription: Dangling member.\n\
+             category: other\nskills: [\"spreadsheets\"]\n---\n",
+        );
+        // Directory disagrees with the manifest.
+        write_plugin(plugins_dir.path(), "mislabeled", VALID);
+
+        let plugins = load_plugins(plugins_dir.path(), &skills);
+        assert_eq!(
+            plugins
+                .iter()
+                .map(|plugin| plugin.package.name.as_str())
+                .collect::<Vec<_>>(),
+            ["documents"]
+        );
+        assert_eq!(
+            plugins[0].package.skills,
+            ["word-documents", "pdf-documents"]
+        );
+    }
+
+    /// Contract: every plugin shipped in the repository's `plugins/` tree must
+    /// parse against the bundled skills, and the three of them must cover the
+    /// curated document set exactly — a dropped plugin or a renamed member
+    /// would otherwise show up only as an ungrouped catalog.
+    #[test]
+    fn bundled_plugin_sources_cover_every_bundled_skill() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let skills = load_skills(&root.join("skills"), SkillOrigin::Builtin);
+        let source = root.join("plugins");
+        let directories = std::fs::read_dir(&source)
+            .expect("bundled plugins directory exists")
+            .filter_map(Result::ok)
+            .filter(|entry| entry.path().is_dir())
+            .count();
+        let plugins = load_plugins(&source, &skills);
+        assert_eq!(
+            plugins.len(),
+            directories,
+            "a bundled plugin failed strict loading"
+        );
+        assert_eq!(
+            plugins
+                .iter()
+                .map(|plugin| plugin.package.name.as_str())
+                .collect::<Vec<_>>(),
+            ["charts", "documents", "spreadsheets"]
+        );
+        let mut covered: Vec<&str> = plugins
+            .iter()
+            .flat_map(|plugin| plugin.package.skills.iter().map(String::as_str))
+            .collect();
+        covered.sort_unstable();
+        assert_eq!(
+            covered,
+            skills
+                .iter()
+                .map(|skill| skill.package.name.as_str())
+                .collect::<Vec<_>>(),
+            "every bundled skill must belong to exactly one bundled plugin"
+        );
+        // The document bundle is the one whose members are alternatives for
+        // the same intent, so its routing line is load-bearing.
+        let documents = plugins
+            .iter()
+            .find(|plugin| plugin.package.name == "documents")
+            .unwrap();
+        assert!(documents.package.router_preamble.is_some());
+    }
+}

--- a/crates/openwave-core/src/config.rs
+++ b/crates/openwave-core/src/config.rs
@@ -63,6 +63,12 @@ pub struct Config {
     /// application resources; other embeddings leave it absent.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub exec_skills_dir: Option<PathBuf>,
+    /// Trusted source directory for the built-in plugin manifests that group
+    /// those skills. Desktop resolves this from its signed application
+    /// resources; other embeddings leave it absent and every skill stands
+    /// alone in the catalog.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exec_plugins_dir: Option<PathBuf>,
     /// Whether newly spawned background agent runs may execute inside a local
     /// container when the configured runtime is available. Disabled by default,
     /// so existing installations keep the in-process scheduler path.
@@ -95,6 +101,13 @@ impl Config {
         self.data_dir.join("skills")
     }
 
+    /// The per-install directory user-authored plugins are read from,
+    /// alongside `{data_dir}/skills` and derived the same way.
+    #[must_use]
+    pub fn user_plugins_dir(&self) -> PathBuf {
+        self.data_dir.join("plugins")
+    }
+
     /// A desktop-profile config rooted at `data_dir`.
     pub fn desktop(data_dir: impl Into<PathBuf>) -> Self {
         Self {
@@ -104,6 +117,7 @@ impl Config {
             bundle_id: None,
             exec_scripts_dir: None,
             exec_skills_dir: None,
+            exec_plugins_dir: None,
             container_execution_enabled: false,
             container_image: None,
             auth_tokens_file: None,
@@ -173,6 +187,7 @@ impl Config {
             bundle_id: None,
             exec_scripts_dir: None,
             exec_skills_dir: None,
+            exec_plugins_dir: None,
             container_execution_enabled,
             container_image,
             auth_tokens_file,

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -150,6 +150,12 @@ const REQUIRED_SKILLS: [&str; 5] = [
     "word-documents",
 ];
 
+/// The plugins those skills are grouped into. Boot requires all three: a
+/// plugin that fails to load takes its skills out of the grouped catalog
+/// silently, which is exactly the kind of drift a packaged build should not
+/// ship.
+const REQUIRED_PLUGINS: [&str; 3] = ["charts", "documents", "spreadsheets"];
+
 fn exec_skills_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
     let directory = app
         .path()
@@ -162,6 +168,53 @@ fn exec_skills_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
         }
     }
     Ok(directory)
+}
+
+fn exec_plugins_dir(app: &tauri::AppHandle, skills_dir: &Path) -> Result<PathBuf, String> {
+    let directory = app
+        .path()
+        .resource_dir()
+        .map_err(|error| format!("app resource dir: {error}"))?
+        .join("plugins");
+    verify_required_plugins(skills_dir, &directory)?;
+    Ok(directory)
+}
+
+/// Load both bundled trees the way the server will and check that the required
+/// plugins are present and together cover every required skill.
+///
+/// Loading is what is checked, not file presence: a manifest that parses but
+/// names a skill that did not load is skipped by the loader, and the resulting
+/// gap would otherwise appear only as an ungrouped catalog at runtime.
+fn verify_required_plugins(skills_dir: &Path, plugins_dir: &Path) -> Result<(), String> {
+    let skills = openwave_code_execution::load_skills(
+        skills_dir,
+        openwave_code_execution::SkillOrigin::Builtin,
+    );
+    let plugins = openwave_code_execution::load_plugins(plugins_dir, &skills);
+    let loaded: Vec<&str> = plugins
+        .iter()
+        .map(|plugin| plugin.package.name.as_str())
+        .collect();
+    for name in REQUIRED_PLUGINS {
+        if !loaded.contains(&name) {
+            return Err(format!(
+                "bundled plugin '{name}' is missing or failed to load from {}; loaded: {loaded:?}",
+                plugins_dir.display()
+            ));
+        }
+    }
+    let mut covered: Vec<&str> = plugins
+        .iter()
+        .flat_map(|plugin| plugin.package.skills.iter().map(String::as_str))
+        .collect();
+    covered.sort_unstable();
+    if covered != REQUIRED_SKILLS {
+        return Err(format!(
+            "bundled plugins cover {covered:?}, but the required document skills are {REQUIRED_SKILLS:?}"
+        ));
+    }
+    Ok(())
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -320,6 +373,11 @@ async fn boot_server(
     let mut config = Config::desktop(data_dir.clone());
     config.exec_scripts_dir = Some(exec_scripts_dir(&app)?);
     config.exec_skills_dir = Some(exec_skills_dir(&app)?);
+    let skills_dir = config
+        .exec_skills_dir
+        .clone()
+        .expect("skills dir was just set");
+    config.exec_plugins_dir = Some(exec_plugins_dir(&app, &skills_dir)?);
     // The effective identifier — including the debug-build override — keys
     // the macOS managed-preferences (MDM) domain the server reads policy from.
     config.bundle_id = Some(app.config().identifier.clone());
@@ -401,13 +459,14 @@ async fn boot_server(
 
 #[cfg(test)]
 mod bundle_tests {
-    use super::REQUIRED_SKILLS;
+    use super::{verify_required_plugins, REQUIRED_SKILLS};
 
-    /// Packaged-style skill resolution, pinned at test time: the
-    /// `tauri.conf.json` resource map must stage a skills tree into the app
-    /// bundle, and that tree must yield every skill `exec_skills_dir`
-    /// requires. Dropping the resource line or breaking a manifest would
-    /// otherwise surface only as a packaged-app boot failure.
+    /// Packaged-style skill and plugin resolution, pinned at test time: the
+    /// `tauri.conf.json` resource map must stage both trees into the app
+    /// bundle, that skills tree must yield every skill `exec_skills_dir`
+    /// requires, and the plugins tree must group all of them. Dropping a
+    /// resource line or breaking a manifest would otherwise surface only as a
+    /// packaged-app boot failure.
     #[test]
     fn bundled_resources_carry_all_required_skills() {
         let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -415,16 +474,20 @@ mod bundle_tests {
             &std::fs::read_to_string(manifest_dir.join("tauri.conf.json")).unwrap(),
         )
         .unwrap();
-        let source = conf["bundle"]["resources"]
+        let resources = conf["bundle"]["resources"]
             .as_object()
-            .expect("tauri.conf.json maps bundle resources")
-            .iter()
-            .find_map(|(source, target)| {
-                (target.as_str() == Some("skills/")).then(|| source.clone())
-            })
-            .expect("tauri.conf.json bundles a skills/ resource");
+            .expect("tauri.conf.json maps bundle resources");
+        let resource = |target: &str| {
+            resources
+                .iter()
+                .find_map(|(source, mapped)| {
+                    (mapped.as_str() == Some(target)).then(|| manifest_dir.join(source))
+                })
+                .unwrap_or_else(|| panic!("tauri.conf.json bundles a {target} resource"))
+        };
+        let skills_dir = resource("skills/");
         let skills = openwave_code_execution::load_skills(
-            &manifest_dir.join(source),
+            &skills_dir,
             openwave_code_execution::SkillOrigin::Builtin,
         );
         let names: Vec<&str> = skills
@@ -432,6 +495,7 @@ mod bundle_tests {
             .map(|skill| skill.package.name.as_str())
             .collect();
         assert_eq!(names, REQUIRED_SKILLS);
+        verify_required_plugins(&skills_dir, &resource("plugins/")).unwrap();
     }
 }
 

--- a/crates/openwave-desktop/tauri.conf.json
+++ b/crates/openwave-desktop/tauri.conf.json
@@ -62,7 +62,8 @@
     },
     "resources": {
       "../../scripts/exec-documents/": "exec-scripts/",
-      "../../skills/": "skills/"
+      "../../skills/": "skills/",
+      "../../plugins/": "plugins/"
     },
     "externalBin": [
       "binaries/openwave-host-broker"

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -910,6 +910,10 @@ pub struct ConfiguredCodeExecutionProvider {
     /// staging so an added or edited skill is picked up on the next turn
     /// without a restart. `None` disables user skills entirely.
     user_skills_dir: Option<PathBuf>,
+    /// Built-in plugins validated once at configuration against the built-in
+    /// skills, grouping them in the prompt catalog. Empty when no plugin tree
+    /// is configured, which leaves every skill standalone.
+    plugins: Arc<Vec<openwave_code_execution::LoadedPlugin>>,
     folder_grant_resolver: Option<Arc<dyn ExecFolderGrantResolver>>,
     /// Host-provided office-to-PDF converter feeding the model's visual QA
     /// loop. `None` (headless embeddings) degrades to an honest sync note.
@@ -1111,6 +1115,7 @@ impl ConfiguredCodeExecutionProvider {
             document_scripts_source: None,
             skills: Arc::new(Vec::new()),
             user_skills_dir: None,
+            plugins: Arc::new(Vec::new()),
             folder_grant_resolver: None,
             office_converter: None,
             host_tool_broker: None,
@@ -1179,6 +1184,21 @@ impl ConfiguredCodeExecutionProvider {
         self
     }
 
+    /// Load the built-in plugins that group the built-in skills in the prompt
+    /// catalog. Call after [`Self::with_skills`]: membership is resolved
+    /// against the skills already loaded, and a plugin naming one that is not
+    /// there is skipped (with a warning) rather than grouping nothing.
+    #[must_use]
+    pub fn with_plugins(mut self, source: Option<PathBuf>) -> Self {
+        self.plugins = Arc::new(
+            source
+                .as_deref()
+                .map(|source| openwave_code_execution::load_plugins(source, &self.skills))
+                .unwrap_or_default(),
+        );
+        self
+    }
+
     /// Install the per-install directory user-authored skill packages are
     /// loaded from. The directory is created here (best effort) so the user
     /// has a place to drop a skill; its contents are re-read at each staging,
@@ -1211,6 +1231,15 @@ impl ConfiguredCodeExecutionProvider {
         self.current_skills()
             .into_iter()
             .map(|skill| skill.package)
+            .collect()
+    }
+
+    /// The bundles the catalog groups skills under. User skills are claimed by
+    /// no plugin and stay standalone.
+    pub(crate) fn plugin_catalog(&self) -> Vec<openwave_code_execution::PluginPackage> {
+        self.plugins
+            .iter()
+            .map(|plugin| plugin.package.clone())
             .collect()
     }
 

--- a/crates/openwave-server/src/foreground_prompt.rs
+++ b/crates/openwave-server/src/foreground_prompt.rs
@@ -9,7 +9,7 @@
 use std::collections::BTreeSet;
 use std::fmt::Write;
 
-use openwave_code_execution::{SkillOrigin, SkillPackage};
+use openwave_code_execution::{PluginPackage, SkillOrigin, SkillPackage};
 use openwave_core::{NetworkPolicy, ToolSpec};
 use sha2::{Digest, Sha256};
 
@@ -61,6 +61,7 @@ pub(crate) fn compose(specs: &[ToolSpec]) -> String {
         specs,
         &[],
         &[],
+        &[],
         &NetworkPolicy::default(),
         crate::code_execution::DEFAULT_TIMEOUT_MS,
         false,
@@ -92,6 +93,76 @@ fn render_timeout(timeout_ms: u64) -> String {
     }
 }
 
+/// Render one skill's catalog line.
+///
+/// The catalog is host-derived from strictly parsed skill manifests.
+/// Re-checking the same bounds here keeps a forged name or a multi-line
+/// description from ever composing into a prompt line, mirroring how folder
+/// paths are JSON-quoted elsewhere; an entry that fails is dropped, not
+/// sanitized.
+fn skill_line(skill: &SkillPackage) -> Option<String> {
+    if !openwave_code_execution::is_valid_skill_name(&skill.name)
+        || !openwave_code_execution::is_valid_skill_description(&skill.description)
+    {
+        return None;
+    }
+    // A user-authored skill is attributed so the model knows the instructions
+    // are the user's own conventions. The suffix is host-appended after
+    // validation, never manifest content.
+    let attribution = match skill.origin {
+        SkillOrigin::Builtin => "",
+        SkillOrigin::User => " (yours)",
+    };
+    Some(format!(
+        "- {}: {}{attribution}",
+        skill.name, skill.description
+    ))
+}
+
+/// Render the skill catalog, grouping the skills a plugin bundles under that
+/// plugin's router preamble.
+///
+/// Grouping is presentation only: every line keeps the `- name: description`
+/// shape the model already routes on, and the `read_file` instruction below
+/// the list is unchanged. Members render in manifest order, so a preamble that
+/// names them in a deliberate order reads against the same order. A plugin
+/// whose members are all forged or missing contributes nothing, and a preamble
+/// failing the same bounds check the parser applied is dropped while its
+/// skills still render — a bad line never suppresses a real capability. Skills
+/// no plugin claims follow the grouped ones in catalog order, which is where
+/// user-authored skills land.
+fn skill_catalog_lines(skills: &[SkillPackage], plugins: &[PluginPackage]) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut grouped: BTreeSet<&str> = BTreeSet::new();
+    for plugin in plugins {
+        let members: Vec<&SkillPackage> = plugin
+            .skills
+            .iter()
+            .filter_map(|member| skills.iter().find(|skill| skill.name == *member))
+            .collect();
+        let member_lines: Vec<String> = members.iter().copied().filter_map(skill_line).collect();
+        if member_lines.is_empty() {
+            continue;
+        }
+        if let Some(preamble) = plugin
+            .router_preamble
+            .as_deref()
+            .filter(|preamble| openwave_code_execution::is_valid_plugin_router_preamble(preamble))
+        {
+            lines.push(format!("- {preamble}"));
+        }
+        grouped.extend(members.iter().map(|skill| skill.name.as_str()));
+        lines.extend(member_lines);
+    }
+    lines.extend(
+        skills
+            .iter()
+            .filter(|skill| !grouped.contains(skill.name.as_str()))
+            .filter_map(skill_line),
+    );
+    lines
+}
+
 /// Compose the prompt for one exact tool surface, with a bounded snapshot of
 /// host-resolved local-exec folders, in the chat's current permission
 /// posture. The sandbox profile resolves the folders again per invocation.
@@ -105,6 +176,7 @@ pub(crate) fn compose_for_surface(
     specs: &[ToolSpec],
     exec_folders: &[ResolvedExecFolderGrant],
     skills: &[SkillPackage],
+    plugins: &[PluginPackage],
     network_policy: &NetworkPolicy,
     exec_timeout_ms: u64,
     offline_package_cache: bool,
@@ -460,27 +532,7 @@ pub(crate) fn compose_for_surface(
     }
 
     if has("exec") {
-        // The catalog is host-derived from strictly parsed skill manifests.
-        // Re-checking the same bounds here keeps a forged name or a
-        // multi-line description from ever composing into a prompt line,
-        // mirroring how folder paths are JSON-quoted above.
-        let mut lines: Vec<String> = skills
-            .iter()
-            .filter(|skill| {
-                openwave_code_execution::is_valid_skill_name(&skill.name)
-                    && openwave_code_execution::is_valid_skill_description(&skill.description)
-            })
-            .map(|skill| {
-                // A user-authored skill is attributed so the model knows the
-                // instructions are the user's own conventions. The suffix is
-                // host-appended after validation, never manifest content.
-                let attribution = match skill.origin {
-                    SkillOrigin::Builtin => "",
-                    SkillOrigin::User => " (yours)",
-                };
-                format!("- {}: {}{attribution}", skill.name, skill.description)
-            })
-            .collect();
+        let mut lines = skill_catalog_lines(skills, plugins);
         if !lines.is_empty() {
             lines.push(
                 "- Before producing a kind of document listed above, read `.openwave/skills/<name>/SKILL.md` with `read_file` and follow its instructions."
@@ -691,6 +743,7 @@ mod tests {
             &specs,
             &[],
             &[],
+            &[],
             &NetworkPolicy::default(),
             TIMEOUT,
             false,
@@ -699,6 +752,7 @@ mod tests {
         );
         let normal = compose_for_surface(
             &specs,
+            &[],
             &[],
             &[],
             &NetworkPolicy::default(),
@@ -752,6 +806,7 @@ mod tests {
             &[spec("exec")],
             &folders,
             &[],
+            &[],
             &NetworkPolicy::default(),
             TIMEOUT,
             false,
@@ -781,6 +836,7 @@ mod tests {
                 &[spec("exec")],
                 &[],
                 &[],
+                &[],
                 policy,
                 TIMEOUT,
                 false,
@@ -801,6 +857,7 @@ mod tests {
         // claiming installs are unavailable.
         let off_with_cache = compose_for_surface(
             &[spec("exec")],
+            &[],
             &[],
             &[],
             &NetworkPolicy::Off,
@@ -858,6 +915,7 @@ mod tests {
             &[spec("exec")],
             &[],
             &[],
+            &[],
             &NetworkPolicy::Open,
             1_500,
             false,
@@ -906,6 +964,7 @@ mod tests {
             &[spec("exec")],
             &[],
             &skills,
+            &[],
             &NetworkPolicy::default(),
             TIMEOUT,
             false,
@@ -927,6 +986,7 @@ mod tests {
             &[spec("read_file")],
             &[],
             &skills,
+            &[],
             &NetworkPolicy::default(),
             TIMEOUT,
             false,
@@ -939,6 +999,7 @@ mod tests {
             &[spec("exec")],
             &[],
             &skills[2..],
+            &[],
             &NetworkPolicy::default(),
             TIMEOUT,
             false,
@@ -946,6 +1007,92 @@ mod tests {
             false,
         );
         assert!(!forged_only.contains(DOCUMENT_SKILLS_HEADING));
+    }
+
+    /// Contract: a plugin's skills render under its router preamble, skills no
+    /// plugin claims still render after them, and a forged preamble is dropped
+    /// without taking its skills' lines with it.
+    #[test]
+    fn plugin_grouping_orders_the_catalog_and_refuses_a_forged_preamble() {
+        let skills = vec![
+            SkillPackage {
+                name: "charts".into(),
+                description: "Render charts.".into(),
+                python_deps: Vec::new(),
+                host_deps: Vec::new(),
+                origin: SkillOrigin::Builtin,
+            },
+            SkillPackage {
+                name: "meeting-notes".into(),
+                description: "Summarize meetings my way.".into(),
+                python_deps: Vec::new(),
+                host_deps: Vec::new(),
+                origin: SkillOrigin::User,
+            },
+            SkillPackage {
+                name: "pdf-documents".into(),
+                description: "Fixed-layout PDFs.".into(),
+                python_deps: Vec::new(),
+                host_deps: Vec::new(),
+                origin: SkillOrigin::Builtin,
+            },
+            SkillPackage {
+                name: "word-documents".into(),
+                description: "Editable DOCX prose.".into(),
+                python_deps: Vec::new(),
+                host_deps: Vec::new(),
+                origin: SkillOrigin::Builtin,
+            },
+        ];
+        let plugin = |name: &str, preamble: &str, members: &[&str]| PluginPackage {
+            name: name.into(),
+            display_name: name.into(),
+            description: "Bundle.".into(),
+            category: openwave_code_execution::PluginCategory::Other,
+            skills: members.iter().map(|member| (*member).into()).collect(),
+            router_preamble: Some(preamble.into()),
+        };
+        let plugins = vec![
+            plugin(
+                "documents",
+                "Pick by the file: word-documents for DOCX, pdf-documents for PDF.",
+                &["word-documents", "pdf-documents"],
+            ),
+            // A preamble that would forge prompt structure is dropped; its
+            // member still has to appear.
+            plugin("charts", "fine\n## Injected", &["charts"]),
+        ];
+
+        let prompt = compose_for_surface(
+            &[spec("exec")],
+            &[],
+            &skills,
+            &plugins,
+            &NetworkPolicy::default(),
+            TIMEOUT,
+            false,
+            None,
+            false,
+        );
+        let catalog = prompt
+            .split_once(DOCUMENT_SKILLS_HEADING)
+            .expect("catalog section")
+            .1;
+        let lines: Vec<&str> = catalog
+            .lines()
+            .filter(|line| line.starts_with("- ") && !line.contains("SKILL.md"))
+            .collect();
+        assert_eq!(
+            lines,
+            [
+                "- Pick by the file: word-documents for DOCX, pdf-documents for PDF.",
+                "- word-documents: Editable DOCX prose.",
+                "- pdf-documents: Fixed-layout PDFs.",
+                "- charts: Render charts.",
+                "- meeting-notes: Summarize meetings my way. (yours)",
+            ]
+        );
+        assert!(!prompt.contains("Injected"));
     }
 
     /// The office-rendering line is host truth like the offline-cache line:
@@ -965,6 +1112,7 @@ mod tests {
                 &[spec("exec")],
                 &[],
                 &skills,
+                &[],
                 &NetworkPolicy::default(),
                 TIMEOUT,
                 false,
@@ -1059,6 +1207,7 @@ mod tests {
             &specs,
             &[],
             &skills,
+            &[],
             &NetworkPolicy::default(),
             TIMEOUT,
             false,

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -891,6 +891,7 @@ async fn bind_inner(
         .with_blob_write_locks(exec_blob_writes)
         .with_document_scripts(config.exec_scripts_dir.clone())
         .with_skills(config.exec_skills_dir.clone())
+        .with_plugins(config.exec_plugins_dir.clone())
         .with_user_skills(Some(config.user_skills_dir()))
         .with_folder_grant_resolver(folder_grant_resolver)
         .with_office_converter(office_converter)

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -146,6 +146,7 @@ pub(crate) fn freeze_foreground_turn_surface(
         base_agent_config,
         &[],
         &[],
+        &[],
         &openwave_core::NetworkPolicy::default(),
         crate::code_execution::DEFAULT_TIMEOUT_MS,
         false,
@@ -160,6 +161,7 @@ fn freeze_foreground_turn_surface_with_folders(
     base_agent_config: &AgentConfig,
     exec_folders: &[crate::code_execution::ResolvedExecFolderGrant],
     skills: &[openwave_code_execution::SkillPackage],
+    plugins: &[openwave_code_execution::PluginPackage],
     network_policy: &openwave_core::NetworkPolicy,
     exec_timeout_ms: u64,
     offline_package_cache: bool,
@@ -171,6 +173,7 @@ fn freeze_foreground_turn_surface_with_folders(
         &tools.specs_for_surface(true, plan_mode),
         exec_folders,
         skills,
+        plugins,
         network_policy,
         exec_timeout_ms,
         offline_package_cache,
@@ -597,16 +600,16 @@ impl TurnWorker {
             },
             None => Vec::new(),
         };
-        let skills = match self.exec_folder_context.as_ref() {
+        let (skills, plugins) = match self.exec_folder_context.as_ref() {
             Some(provider) => {
                 // The prompt's skill catalog directs the model to read each
                 // staged SKILL.md before its first exec, so the workspace has
                 // to be staged now — waiting for the first exec to stage it
                 // loses that race and the read fails with not-found.
                 provider.stage_turn_workspace(chat.id).await;
-                provider.skill_catalog()
+                (provider.skill_catalog(), provider.plugin_catalog())
             }
-            None => Vec::new(),
+            None => (Vec::new(), Vec::new()),
         };
         let offline_package_cache = match self.exec_folder_context.as_ref() {
             Some(provider) => provider.offline_package_cache_ready().await,
@@ -625,6 +628,7 @@ impl TurnWorker {
             &self.agent_config,
             &exec_folders,
             &skills,
+            &plugins,
             &chat.network_policy,
             exec_timeout_ms,
             offline_package_cache,

--- a/plugins/charts/PLUGIN.md
+++ b/plugins/charts/PLUGIN.md
@@ -1,0 +1,12 @@
+---
+name: charts
+display-name: Charts
+description: Charts and plots rendered to PNG or SVG, inspected before delivery.
+category: visualization
+skills: ["charts"]
+---
+
+# Charts
+
+Visualization is a distinct intent from authoring a document: a chart is
+usually produced to be embedded in one, or delivered on its own.

--- a/plugins/documents/PLUGIN.md
+++ b/plugins/documents/PLUGIN.md
@@ -1,0 +1,14 @@
+---
+name: documents
+display-name: Documents
+description: Word, PDF, and PowerPoint deliverables, each validated before delivery.
+category: documents
+skills: ["word-documents", "pdf-documents", "presentations"]
+router-preamble: Choose the document skill by the file the user needs: word-documents for editable DOCX prose, pdf-documents for fixed-layout PDFs or edits to existing ones, presentations for slide decks.
+---
+
+# Documents
+
+Groups the three authoring skills whose outputs are read rather than
+calculated. They are alternatives for one intent — "write this up" — so the
+router preamble tells the model how to pick before it reads any `SKILL.md`.

--- a/plugins/spreadsheets/PLUGIN.md
+++ b/plugins/spreadsheets/PLUGIN.md
@@ -1,0 +1,12 @@
+---
+name: spreadsheets
+display-name: Spreadsheets
+description: Excel workbooks with live formulas, number formats, and inspected layout.
+category: data
+skills: ["spreadsheets"]
+---
+
+# Spreadsheets
+
+Tabular work is its own bundle rather than part of Documents: a workbook is a
+calculation surface the user keeps working in, not a document to read.


### PR DESCRIPTION
Introduces the plugin layer from #1570: a directory whose `PLUGIN.md` groups
related skills behind one manifest and one display identity. Skills are
unchanged — the five `skills/<name>/SKILL.md` files, their staging paths, and
the lazy `read_file` instruction are all byte-identical. Plugins are packaging.

## Manifest

`plugins/<slug>/PLUGIN.md`, parsed by the same hand-rolled strict frontmatter
reader `skills.rs` uses (no YAML dependency, no `Cargo.lock` change). Keys are
`name`, `display-name`, `description`, `category` (closed vocabulary:
`documents`, `data`, `visualization`, `other`), a single-line flow list
`skills: ["a", "b"]`, and an optional bounded `router-preamble`. Every rendered
string is byte-bounded and checked for control characters; an unknown key, a
duplicate, a non-slug member, or a duplicated member rejects the whole
manifest. No version field yet — nothing consumes one, and adding it later is
additive. The markdown body is documentation for whoever opens the file; it is
never staged and never reaches the model.

## Loader

`load_plugins(source, &[LoadedSkill])` keeps the skills loader's posture:
strict parse or skip-with-warning per plugin. Membership resolves against the
skills that actually loaded, so a plugin naming a skill that isn't there is
skipped rather than advertising a group the catalog cannot render. A skill
belongs to at most one plugin; claims resolve in name order and a second
claimant is skipped whole, so the same tree always produces the same grouping.
Skills no plugin claims stay standalone — that is the supported shape for a
bare skill directory, which is what keeps user skills in `{data_dir}/skills`
working exactly as before.

## Grouping and rendering

The built-ins regroup into Documents (word-documents, pdf-documents,
presentations, with a router preamble distinguishing when each applies),
Spreadsheets, and Charts. Skill directories did not move.

In the catalog, a plugin's skills render under its preamble in manifest order,
and standalone skills follow in catalog order. The preamble is re-validated at
prompt-build time against the same bounds the parser applied — the
forged-entry defense the catalog already applies to names and descriptions —
and a preamble that fails is dropped without taking its skills' lines with it.

## Boot and packaging

`REQUIRED_SKILLS` gains a required-plugins check: the three manifests must load
against the bundled skills and together cover the same five skills, with the
failure naming the plugin and the directory it was looked for in. The Tauri
resource map ships `plugins/` beside `skills/`, and the bundle test now pins
both resource lines.

## Deferred

User plugins are not wired end to end. `Config::user_plugins_dir()` and
`exec_plugins_dir` are in place, but only the built-in tree loads today: a user
plugin can only group skills the loader can see, and the merge and reservation
rules (built-in names reserved, no shadowing) deserve the same treatment skills
got rather than a rushed second path in this diff. Nothing about the shape here
blocks it. Enable/disable state, capability badges, and UI remain on #1573 and
#1574.

## Tests

Three added, all contracts: the bundled plugin manifests parse and cover every
bundled skill exactly once (mirrors `bundled_skill_sources_all_parse`); the
loader rejects dangling members and double claims; the catalog renders grouped
before standalone and refuses a forged preamble. Existing prompt tests picked
up the new parameter only. No tests removed.

Verified: `cargo fmt --all`, `cargo check --workspace --locked --all-targets`,
clippy on the touched crates, and the test modules for
`openwave-code-execution`, `openwave-core` config, `openwave-server`
(`foreground_prompt`, `code_execution`), and the desktop bundle test. I did not
drive the packaged app, so the resource map is verified by the bundle test
rather than by a real install.

Closes #1572
