### PR TITLE
fix(desktop): scope overlay titlebar config to macOS

### DIFF
--- a/crates/openwave-desktop/tauri.conf.json
+++ b/crates/openwave-desktop/tauri.conf.json
@@ -24,13 +24,7 @@
         "height": 760,
         "minWidth": 720,
         "minHeight": 480,
-        "titleBarStyle": "Overlay",
-        "hiddenTitle": true,
-        "dragDropEnabled": true,
-        "trafficLightPosition": {
-          "x": 16,
-          "y": 17
-        }
+        "dragDropEnabled": true
       }
     ],
     "security": {

--- a/crates/openwave-desktop/tauri.macos.conf.json
+++ b/crates/openwave-desktop/tauri.macos.conf.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "windows": [
+      {
+        "label": "main",
+        "title": "OpenWave",
+        "width": 1100,
+        "height": 760,
+        "minWidth": 720,
+        "minHeight": 480,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true,
+        "dragDropEnabled": true,
+        "trafficLightPosition": {
+          "x": 16,
+          "y": 17
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- keep the shared Tauri window config free of macOS-only titlebar fields so Windows and Linux use standard decorated windows
- move the existing overlay titlebar, hidden title, and traffic-light position into `tauri.macos.conf.json`
- preserve the resolved macOS config exactly as it was before the split

## Verification

- `cargo check -p openwave-desktop --locked`
- `cargo fmt --all --check`
- `node --test scripts/workflow-security.test.mjs`
- compared generated Tauri capability schemas before and after the change; no files changed
- verified the RFC 7396-merged macOS config matches the previous `tauri.conf.json`

Real window behavior on Windows/Linux still needs verification on those hosts.

Closes #1584
