### PR TITLE
feat(server): retire MCP tool bindings for local apps

### DIFF
--- a/crates/openwave-core/src/tools/create_app.rs
+++ b/crates/openwave-core/src/tools/create_app.rs
@@ -3,10 +3,10 @@
 //!
 //! The tool records a profile-scoped app: an untrusted HTML bundle published
 //! write-once under the profile data directory, paired with a trusted manifest
-//! naming the mounted MCP tools the app may call. Identity follows the output
-//! tools' discipline — the app and revision ids derive from the durable call
-//! id, so a retried call lands on the record it already created instead of
-//! forking a second one.
+//! naming the connected-app operations the app may call. Identity follows the
+//! output tools' discipline — the app and revision ids derive from the durable
+//! call id, so a retried call lands on the record it already created instead
+//! of forking a second one.
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -23,8 +23,8 @@ use crate::connected_app::ConnectedAppKind;
 use crate::error::Result;
 use crate::id::{AppId, AppRevisionId, TurnId};
 use crate::local_app::{
-    mounted_tool_under, publish_app_bundle, validate_app_manifest, AppBinding, AppManifest,
-    AppRecord, CreateApp, NewAppRevision, MAX_APP_BUNDLE_BYTES,
+    publish_app_bundle, validate_app_manifest, AppBinding, AppManifest, AppRecord, CreateApp,
+    NewAppRevision, MAX_APP_BUNDLE_BYTES,
 };
 use crate::preview::{ResultEntry, ResultEntryKind};
 use crate::storage::Store;
@@ -49,11 +49,10 @@ pub(super) struct Arguments {
     bundle_html: String,
     #[schemars(description = "The app's manifest: its display name and the exact \
                        capabilities it may call, grouped by connected app. Each \
-                       binding names a connected app by id (the tool description \
-                       lists the configured ids) and either the full mounted MCP \
-                       tool names under it (`tools`, for mcp_server apps) or the \
-                       declared OpenAPI operationIds (`operation_ids`, for \
-                       rest_api apps).")]
+                       binding names a rest_api connected app by id (the tool \
+                       description lists the configured ids) and the declared \
+                       OpenAPI operationIds it may execute (`operation_ids`). \
+                       Mounted MCP tools cannot be bound.")]
     manifest: AppManifest,
     #[serde(default)]
     #[schemars(
@@ -99,11 +98,11 @@ impl CreateAppTool {
             .ok_or_else(|| ToolOutput::error("this call is not recorded in this conversation"))
     }
 
-    /// Check that every manifest binding names a configured connected app of
-    /// the kind its vocabulary requires: tools bindings resolve to an
-    /// `mcp_server` record with each pinned name mounted under its namespace;
-    /// operation bindings resolve to a `rest_api` record with each pinned
-    /// `operationId` declared by its ingested catalog.
+    /// Check that every manifest binding names a configured connected app and
+    /// speaks the one live vocabulary: operation bindings resolve to a
+    /// `rest_api` record with each pinned `operationId` declared by its
+    /// ingested catalog. Tools bindings are refused outright — the vocabulary
+    /// is retired (#1332).
     async fn check_bindings(&self, manifest: &AppManifest) -> std::result::Result<(), String> {
         if manifest.bindings.is_empty() {
             return Ok(());
@@ -134,31 +133,24 @@ impl CreateAppTool {
                 });
             };
             match binding {
-                AppBinding::Tools(binding) => {
-                    if app.kind != ConnectedAppKind::McpServer {
-                        return Err(format!(
-                            "connected app {} ({}) is a {} app; only mcp_server apps \
-                             contribute mounted tools — bind its operations with \
-                             `operation_ids` instead",
-                            app.id, app.name, app.kind
-                        ));
-                    }
-                    for tool in &binding.tools {
-                        if mounted_tool_under(&app.name, tool).is_none() {
-                            return Err(format!(
-                                "tool {tool:?} is not mounted under connected app {} — its \
-                                 tools are named `mcp__{}__{{tool}}`",
-                                app.id, app.name
-                            ));
-                        }
-                    }
+                // The tools vocabulary is retired (#1332): MCP was the only
+                // bindable kind when local apps shipped, and REST operations
+                // replaced it as the app-facing surface. The grammar still
+                // parses `tools` (stored manifests carry it), but nothing new
+                // may pin it — refused here with the alternative spelled out.
+                AppBinding::Tools(_) => {
+                    return Err(format!(
+                        "connected app {} ({}) is bound with `tools`, but local apps \
+                         no longer bind mounted MCP tools; bind a rest_api connected \
+                         app's declared operations with `operation_ids` instead",
+                        app.id, app.name
+                    ));
                 }
                 AppBinding::Operations(binding) => {
                     if app.kind != ConnectedAppKind::RestApi {
                         return Err(format!(
                             "connected app {} ({}) is a {} app; only rest_api apps \
-                             contribute operations — bind its mounted tools with \
-                             `tools` instead",
+                             contribute bindable operations",
                             app.id, app.name, app.kind
                         ));
                     }
@@ -505,9 +497,9 @@ mod tests {
         let mut arguments = json!({
             "bundle_html": "<!doctype html><h1>Triage</h1>",
             "manifest": {
-                "name": "Sentry triage",
+                "name": "Issue triage",
                 "bindings": [
-                    { "app": connected, "tools": ["mcp__sentry__list_issues"] }
+                    { "app": connected, "operation_ids": ["listIssues"] }
                 ],
             },
         });
@@ -524,7 +516,7 @@ mod tests {
 
         let first = fixture
             .tool
-            .execute(&ctx, arguments_bound_to(fixture.sentry, None))
+            .execute(&ctx, arguments_bound_to(fixture.issues, None))
             .await
             .unwrap();
         assert!(!first.is_error, "{}", first.content);
@@ -542,7 +534,7 @@ mod tests {
         // forking a second app or a second revision.
         let retried = fixture
             .tool
-            .execute(&ctx, arguments_bound_to(fixture.sentry, None))
+            .execute(&ctx, arguments_bound_to(fixture.issues, None))
             .await
             .unwrap();
         assert!(!retried.is_error, "{}", retried.content);
@@ -552,7 +544,7 @@ mod tests {
         assert_eq!(record.revision_count, 1);
 
         // The same call id must not be able to publish different content.
-        let mut different = arguments_bound_to(fixture.sentry, None);
+        let mut different = arguments_bound_to(fixture.issues, None);
         different["bundle_html"] = json!("<!doctype html><h1>Changed</h1>");
         let refused = fixture.tool.execute(&ctx, different).await.unwrap();
         assert!(refused.is_error);
@@ -563,7 +555,7 @@ mod tests {
             .tool
             .execute(
                 &append_ctx,
-                arguments_bound_to(fixture.sentry, Some(app_id.0)),
+                arguments_bound_to(fixture.issues, Some(app_id.0)),
             )
             .await
             .unwrap();
@@ -579,7 +571,7 @@ mod tests {
             .tool
             .execute(
                 &wrong_ctx,
-                arguments_bound_to(fixture.sentry, Some(missing_app)),
+                arguments_bound_to(fixture.issues, Some(missing_app)),
             )
             .await
             .unwrap();
@@ -598,17 +590,17 @@ mod tests {
     async fn refusals_are_tool_errors_not_panics() {
         let fixture = fixture().await;
 
-        // A manifest pinning a name that could never match a mounted tool.
+        // A manifest pinning an operation id outside the ingest grammar.
         let (_, ctx) = fixture.recorded_call().await;
-        let mut bad_manifest = arguments_bound_to(fixture.sentry, None);
-        bad_manifest["manifest"]["bindings"][0]["tools"] = json!(["list_issues"]);
+        let mut bad_manifest = arguments_bound_to(fixture.issues, None);
+        bad_manifest["manifest"]["bindings"][0]["operation_ids"] = json!(["not an operation id"]);
         let refused = fixture.tool.execute(&ctx, bad_manifest).await.unwrap();
         assert!(refused.is_error);
         assert!(refused.content.contains("invalid app manifest"));
 
         // An oversized bundle is refused before anything is written.
         let (_, ctx) = fixture.recorded_call().await;
-        let mut oversized = arguments_bound_to(fixture.sentry, None);
+        let mut oversized = arguments_bound_to(fixture.issues, None);
         oversized["bundle_html"] = json!("x".repeat(MAX_APP_BUNDLE_BYTES + 1));
         assert!(
             fixture
@@ -624,7 +616,7 @@ mod tests {
             ToolCtx::without_private_scratch(fixture.chat_id, None).with_call_id(CallId::new());
         let refused = fixture
             .tool
-            .execute(&foreign_ctx, arguments_bound_to(fixture.sentry, None))
+            .execute(&foreign_ctx, arguments_bound_to(fixture.issues, None))
             .await
             .unwrap();
         assert!(refused.is_error);
@@ -686,17 +678,26 @@ mod tests {
             refused.content
         );
 
-        // And the mirror image: a tools binding against the rest_api record.
-        let (_, ctx) = fixture.recorded_call().await;
-        let mut tools_on_rest = arguments_bound_to(fixture.issues, None);
-        tools_on_rest["manifest"]["bindings"][0]["tools"] = json!(["mcp__issues__list"]);
-        let refused = fixture.tool.execute(&ctx, tools_on_rest).await.unwrap();
-        assert!(refused.is_error);
-        assert!(
-            refused.content.contains("only mcp_server apps"),
-            "{}",
-            refused.content
-        );
+        // Tools bindings are retired (#1332): refused at the door no matter
+        // which kind of connected app they name, with the live vocabulary
+        // spelled out.
+        for connected in [fixture.sentry, fixture.issues] {
+            let (_, ctx) = fixture.recorded_call().await;
+            let tools_manifest = json!({
+                "bundle_html": "<!doctype html><h1>Triage</h1>",
+                "manifest": {
+                    "name": "Issue triage",
+                    "bindings": [{ "app": connected, "tools": ["mcp__sentry__list_issues"] }],
+                },
+            });
+            let refused = fixture.tool.execute(&ctx, tools_manifest).await.unwrap();
+            assert!(refused.is_error);
+            assert!(
+                refused.content.contains("no longer bind mounted MCP tools"),
+                "{}",
+                refused.content
+            );
+        }
     }
 
     #[tokio::test]
@@ -705,7 +706,7 @@ mod tests {
         let (_, ctx) = fixture.recorded_call().await;
         let output = fixture
             .tool
-            .execute(&ctx, arguments_bound_to(fixture.sentry, None))
+            .execute(&ctx, arguments_bound_to(fixture.issues, None))
             .await
             .unwrap();
         assert!(!output.is_error, "{}", output.content);
@@ -719,7 +720,7 @@ mod tests {
             panic!("one app row per call");
         };
         assert_eq!(row.kind, ResultEntryKind::App);
-        assert_eq!(row.label, "Sentry triage");
+        assert_eq!(row.label, "Issue triage");
         assert_eq!(row.meta.as_deref(), Some("revision 1"));
         // The app id is the row's navigation target, so the card can open the
         // app it just made.
@@ -730,6 +731,6 @@ mod tests {
         // Renderer-safe: an id and a name, never the bundle or the bindings.
         let json = serde_json::to_string(&preview).unwrap();
         assert!(!json.contains("doctype"));
-        assert!(!json.contains("mcp__sentry__list_issues"));
+        assert!(!json.contains("listIssues"));
     }
 }

--- a/crates/openwave-core/src/tools/definitions.rs
+++ b/crates/openwave-core/src/tools/definitions.rs
@@ -43,17 +43,15 @@ pub(super) fn create_app() -> ToolSpec {
         "Publish a local mini-app the user can reopen from their Apps library: a \
          complete self-contained HTML document plus a manifest naming the app and \
          pinning the exact capabilities it may call through the host. Each \
-         manifest binding names a connected app by its id and lists either full \
-         mounted tool names (`mcp__{namespace}__{tool}`, for mcp_server apps) or \
-         declared OpenAPI operationIds (`operation_ids`, for rest_api apps) under \
-         it; the configured connected apps and their ids are listed at the end of \
-         this description. The app renders in a sandboxed frame with no network \
-         access; pinned capabilities run only after the user grants them. From \
-         inside the frame the bundle calls them by posting JSON-RPC 2.0 to its \
-         parent window: `tools/call` with `{name, arguments}` for pinned tools, \
-         or `operations/call` with `{operation_id, parameters?, body?}` for \
-         pinned REST operations, whose result carries the raw response as \
-         `{status, content_type, body_base64}`. Pass \
+         manifest binding names a rest_api connected app by its id and lists the \
+         declared OpenAPI operationIds it may execute (`operation_ids`); mounted \
+         MCP tools cannot be bound. The configured connected apps and their ids \
+         are listed at the end of this description. The app renders in a \
+         sandboxed frame with no network access; pinned operations run only \
+         after the user grants them. From inside the frame the bundle calls them \
+         by posting JSON-RPC 2.0 to its parent window: `operations/call` with \
+         `{operation_id, parameters?, body?}`, whose result carries the raw \
+         response as `{status, content_type, body_base64}`. Pass \
          the app_id from an earlier create_app result to publish a new revision \
          of that app — revisions append, never overwrite.",
     )

--- a/crates/openwave-server/src/mcp_config.rs
+++ b/crates/openwave-server/src/mcp_config.rs
@@ -625,44 +625,20 @@ pub(crate) struct RestRosterApp {
 }
 
 /// The roster text appended to `create_app`'s description: every configured
-/// connected app with the id a manifest binding names — the namespace an
-/// `mcp_server`'s mounted tools carry, or a bounded sample of a `rest_api`
-/// record's operation ids.
+/// `rest_api` connected app with the id a manifest binding names and a
+/// bounded sample of its declared operation ids.
 ///
-/// A server without a live client (disabled, degraded, locked down) stays
-/// listed — authoring a binding against it is legitimate, and the grant and
-/// invoke gates enforce at call time — but its line says so, instead of
-/// promising mounted tool names that do not currently exist.
-fn connected_app_roster(
-    definitions: &[McpServerDefinition],
-    ids: &BTreeMap<String, ConnectedAppId>,
-    servers: &HashMap<String, ManagedServer>,
-    rest: &[RestRosterApp],
-) -> String {
-    if definitions.is_empty() && rest.is_empty() {
-        return "\n\nNo connected apps are configured, so only manifests with an \
-                empty bindings list can be created."
+/// `mcp_server` records are deliberately absent: mounted-tool bindings are
+/// retired (#1332), so listing them would invite the model to author
+/// manifests the door refuses.
+fn connected_app_roster(rest: &[RestRosterApp]) -> String {
+    if rest.is_empty() {
+        return "\n\nNo rest_api connected apps are configured, so only manifests \
+                with an empty bindings list can be created."
             .to_owned();
     }
     let mut roster =
         String::from("\n\nConfigured connected apps (set each binding's `app` to an id):");
-    for definition in definitions {
-        let Some(id) = ids.get(&definition.name) else {
-            continue;
-        };
-        let unavailable = servers
-            .get(&definition.name)
-            .is_none_or(|server| server.client.is_none());
-        roster.push_str(&format!(
-            "\n- {id} — {name}: tools are named `mcp__{name}__{{tool}}`{status}",
-            name = definition.name,
-            status = if unavailable {
-                " (currently unavailable — configured but not connected)"
-            } else {
-                ""
-            }
-        ));
-    }
     for app in rest {
         let mut listed: Vec<&str> = app
             .operation_ids
@@ -1571,7 +1547,7 @@ impl McpRuntime {
         servers: HashMap<String, ManagedServer>,
     ) {
         let rest = self.rest_roster().await;
-        let registry = self.registry_with(&definitions, &ids, &servers, &rest);
+        let registry = self.registry_with(&servers, &rest);
         let mut state = self.state.lock().await;
         state.definitions = definitions;
         state.ids = ids;
@@ -1636,13 +1612,11 @@ impl McpRuntime {
     /// configuration.
     async fn registry_for(&self, state: &RuntimeState) -> ToolRegistry {
         let rest = self.rest_roster().await;
-        self.registry_with(&state.definitions, &state.ids, &state.servers, &rest)
+        self.registry_with(&state.servers, &rest)
     }
 
     fn registry_with(
         &self,
-        definitions: &[McpServerDefinition],
-        ids: &BTreeMap<String, ConnectedAppId>,
         servers: &HashMap<String, ManagedServer>,
         rest: &[RestRosterApp],
     ) -> ToolRegistry {
@@ -1664,7 +1638,7 @@ impl McpRuntime {
         if let Some(inner) = registry.server_tool(CREATE_APP_TOOL) {
             registry.register(Box::new(CreateAppWithRoster {
                 inner,
-                roster: connected_app_roster(definitions, ids, servers, rest),
+                roster: connected_app_roster(rest),
             }));
         }
         registry
@@ -2928,15 +2902,14 @@ mod tests {
             Some("Sign in to the model gateway to reconnect this server.")
         );
 
-        // The degraded mount stays on the create_app roster, but its line
-        // stops promising mounted tool names it does not have.
+        // MCP mounts never reach the create_app roster — tool bindings are
+        // retired (#1332) — so a configured-but-degraded gateway server reads
+        // as "nothing bindable", not as a bindable app with a caveat.
         let state = runtime.state.lock().await;
-        let roster = connected_app_roster(&state.definitions, &state.ids, &state.servers, &[]);
+        assert!(!state.definitions.is_empty());
+        let roster = connected_app_roster(&[]);
         assert!(
-            roster.contains(
-                "tools are named `mcp__tools__{tool}` \
-                 (currently unavailable — configured but not connected)"
-            ),
+            roster.contains("No rest_api connected apps are configured"),
             "{roster}"
         );
     }
@@ -3170,12 +3143,15 @@ mod tests {
         assert_eq!(info.servers[0].tool_count, 1);
         assert!(runtime.snapshot().get("mcp__gateway__lookup").is_some());
 
-        // A connected server's roster line carries no availability caveat.
+        // Even a healthy, connected server contributes nothing bindable to
+        // the create_app roster: tool bindings are retired (#1332).
         {
-            let state = runtime.state.lock().await;
-            let roster = connected_app_roster(&state.definitions, &state.ids, &state.servers, &[]);
-            assert!(roster.contains("tools are named `mcp__gateway__{tool}`"));
-            assert!(!roster.contains("currently unavailable"), "{roster}");
+            let roster = connected_app_roster(&[]);
+            assert!(!roster.contains("mcp__gateway__"), "{roster}");
+            assert!(
+                roster.contains("No rest_api connected apps are configured"),
+                "{roster}"
+            );
         }
 
         // The declared view was prefetched at connect and is served from

--- a/crates/openwave-server/src/routes/app_grant.rs
+++ b/crates/openwave-server/src/routes/app_grant.rs
@@ -17,11 +17,10 @@ use axum::http::StatusCode;
 use chrono::Utc;
 use serde::Serialize;
 
-use openwave_core::connected_app::ConnectedAppKind;
 use openwave_core::id::{AppId, ConnectedAppId};
 use openwave_core::local_app::{
-    mounted_tool_under, AppBinding, AppGrant, AppGrantBinding, AppManifest,
-    AppOperationsGrantBinding, AppRecord, AppRevision, AppToolsGrantBinding,
+    AppBinding, AppGrant, AppGrantBinding, AppManifest, AppOperationsGrantBinding, AppRecord,
+    AppRevision,
 };
 
 use crate::connected_apps::{current_app_fingerprints, current_rest_definitions, AppFingerprint};
@@ -115,34 +114,18 @@ pub async fn post_app_grant(
             )));
         };
         match binding {
-            AppBinding::Tools(binding) => {
-                if app_fingerprint.kind != ConnectedAppKind::McpServer {
-                    return Err(ServerError::conflict(format!(
-                        "connected app {:?} is a {} app, so its tools binding cannot \
-                         be granted",
-                        app_fingerprint.name, app_fingerprint.kind
-                    )));
-                }
-                // Nor is there anything coherent when a pinned name is not
-                // under the app's current namespace (the record was renamed
-                // after authoring): the grant would name tools that cannot
-                // exist under this app.
-                if let Some(tool) = binding
-                    .tools
-                    .iter()
-                    .find(|tool| mounted_tool_under(&app_fingerprint.name, tool).is_none())
-                {
-                    return Err(ServerError::conflict(format!(
-                        "tool {tool:?} is not mounted under connected app {:?}, so this \
-                         app cannot be granted",
-                        app_fingerprint.name
-                    )));
-                }
-                bindings.push(AppGrantBinding::Tools(AppToolsGrantBinding {
-                    app: binding.app,
-                    tools: binding.tools.clone(),
-                    fingerprint: app_fingerprint.fingerprint,
-                }));
+            // Mounted-tool bindings are retired: MCP was the only bindable
+            // kind when local apps shipped, and the REST vocabulary has since
+            // replaced it as the app-facing surface (#1332). A manifest still
+            // pinning tools cannot be granted — the failure direction is
+            // "revise the app", never "grant the legacy surface".
+            AppBinding::Tools(_) => {
+                return Err(ServerError::conflict(format!(
+                    "connected app {:?} is bound by mounted MCP tools, which local \
+                     apps no longer support; publish a revision binding a rest_api \
+                     connected app's operations instead",
+                    app_fingerprint.name
+                )));
             }
             AppBinding::Operations(binding) => {
                 // Every pinned operation must exist in the record's current
@@ -242,13 +225,12 @@ async fn current_live_app(
 /// Whether a granted binding covers everything a current-manifest binding
 /// pins, in the same vocabulary. A grant kept under the other vocabulary
 /// covers nothing: consent named tools or operations, never "whatever the
-/// record now speaks".
+/// record now speaks". A tools binding is never covered — the vocabulary is
+/// retired (#1332), so a grant recorded before the retirement reads as
+/// ungranted rather than keeping the legacy surface invokable.
 fn binding_covered(pinned: &AppBinding, granted: &AppGrantBinding) -> bool {
     match (pinned, granted) {
-        (AppBinding::Tools(pinned), AppGrantBinding::Tools(granted)) => pinned
-            .tools
-            .iter()
-            .all(|tool| granted.tools.iter().any(|held| held == tool)),
+        (AppBinding::Tools(_), _) => false,
         (AppBinding::Operations(pinned), AppGrantBinding::Operations(granted)) => pinned
             .operation_ids
             .iter()

--- a/crates/openwave-server/src/routes/app_invoke.rs
+++ b/crates/openwave-server/src/routes/app_invoke.rs
@@ -1,16 +1,18 @@
 //! `POST /apps/{id}/invoke` — out-of-turn invocation of a local app's pinned
-//! capabilities: mounted MCP tools and declared REST operations.
+//! capabilities: declared REST operations of `rest_api` connected apps.
 //!
 //! The first tool execution outside a model turn: the sandboxed app frame
 //! posts a call to the trusted renderer, the renderer forwards it here on its
-//! bearer, and the server performs the same dispatch a turn would — registry
-//! snapshot and `Tool::execute` for a mounted MCP tool, the governed REST
-//! executor for a declared operation — minus the turn. Enforcement is
-//! entirely server-side and fails closed, in a fixed order: the app must
-//! exist with a current revision, the requested capability must be pinned in
-//! that revision's manifest bindings, and a live app grant must cover the
-//! call — including that every granted connected app's current definition
-//! still matches the fingerprint recorded at consent.
+//! bearer, and the server executes the pinned operation through the governed
+//! REST executor — minus the turn. The `tool` surface still parses (stored
+//! manifests may pin mounted MCP tools) but refuses before dispatch: tool
+//! bindings are retired (#1332), and REST operations are the one invocable
+//! surface. Enforcement is entirely server-side and fails closed, in a fixed
+//! order: the app must exist with a current revision, the requested
+//! capability must be pinned in that revision's manifest bindings, and a live
+//! app grant must cover the call — including that every granted connected
+//! app's current definition still matches the fingerprint recorded at
+//! consent.
 //!
 //! Chat approval gates, permission modes, and plan mode deliberately do not
 //! apply: there is no chat. The app grant is the whole policy.
@@ -386,6 +388,19 @@ async fn require_app_grant(
 ) -> Result<(), AppInvokeError> {
     let consent_required =
         |message: String| AppInvokeError::refused(AppInvokeRefusalKind::ConsentRequired, message);
+    // Mounted-tool bindings are retired (#1332): the consent route no longer
+    // grants them, and a grant recorded before the retirement must not keep
+    // the legacy surface invokable. Refusing here — before the grant is even
+    // read — is what makes the retirement hold for pre-existing grants, and
+    // `consent_required` is deliberate: it routes the user to the sheet,
+    // whose refusal explains what the app must be revised to bind.
+    if let Pinned::Tool(_) = pinned {
+        return Err(consent_required(
+            "mounted MCP tools are no longer invokable from apps; this app must be \
+             revised to bind a rest_api connected app's operations"
+                .into(),
+        ));
+    }
     let Some(grant) = state.store.get_app_grant(app.id).await? else {
         return Err(consent_required(format!(
             "no live app grant covers {}",

--- a/crates/openwave-server/src/tests/app_grant.rs
+++ b/crates/openwave-server/src/tests/app_grant.rs
@@ -68,8 +68,10 @@ async fn create_app_bound_to(
 /// executable, arguments, literal environment values, selected environment
 /// names — must never appear in any grant response, asserted on the raw
 /// serialized JSON rather than a parsed projection so nothing can hide in an
-/// unmodeled field. Also pins the 404 for an unknown app and the conflict for
-/// a binding whose server is not configured (nothing coherent to consent to).
+/// unmodeled field. Consent itself now conflicts — tool bindings are retired
+/// (#1332) — and the refusal must be just as leak-free as the projection.
+/// Also pins the 404 for an unknown app and the conflict for a binding whose
+/// server is not configured (nothing coherent to consent to).
 #[tokio::test]
 async fn grant_responses_carry_names_only_never_definitions_or_env_values() {
     let (router, token, store, _dir) = test_app().await;
@@ -108,15 +110,20 @@ async fn grant_responses_carry_names_only_never_definitions_or_env_values() {
     let state = grant_request(&router, &bearer, "GET", app_id).await;
     assert_eq!(state.status(), StatusCode::OK);
     responses.push(("GET", body_string(state).await));
-    let consented = grant_request(&router, &bearer, "POST", app_id).await;
-    assert_eq!(consented.status(), StatusCode::OK);
-    responses.push(("POST", body_string(consented).await));
+    // Tool bindings are retired: there is nothing grantable behind this
+    // manifest, so consent conflicts instead of recording a grant.
+    let refused = grant_request(&router, &bearer, "POST", app_id).await;
+    assert_eq!(refused.status(), StatusCode::CONFLICT);
+    responses.push(("POST", body_string(refused).await));
 
+    // The sheet still names the server and its pinned tools, so it can say
+    // what the manifest asked for and why it cannot be granted.
+    assert!(
+        responses[0].1.contains("\"cmd\"") && responses[0].1.contains("mcp__cmd__doit"),
+        "GET: the sheet needs server and tool names: {}",
+        responses[0].1
+    );
     for (method, body) in &responses {
-        assert!(
-            body.contains("\"cmd\"") && body.contains("mcp__cmd__doit"),
-            "{method}: the sheet needs server and tool names: {body}"
-        );
         for leaked in [
             "secret-location",
             "docs-mcp",
@@ -133,8 +140,6 @@ async fn grant_responses_carry_names_only_never_definitions_or_env_values() {
     }
     let before: serde_json::Value = serde_json::from_str(&responses[0].1).unwrap();
     assert_eq!(before["granted"], json!(false));
-    let after: serde_json::Value = serde_json::from_str(&responses[1].1).unwrap();
-    assert_eq!(after["granted"], json!(true));
 
     // An unknown app is 404 on the whole surface.
     let missing = grant_request(&router, &bearer, "GET", AppId::new()).await;
@@ -150,6 +155,107 @@ async fn grant_responses_carry_names_only_never_definitions_or_env_values() {
     .await;
     let refused = grant_request(&router, &bearer, "POST", unbound).await;
     assert_eq!(refused.status(), StatusCode::CONFLICT);
+}
+
+/// The `rest_api` side of the same projection contract: consent still grants,
+/// and neither the base URL, the document hash, nor the credential reference
+/// behind the record ever reaches the renderer — the sheet gets the record's
+/// display name and the pinned operation ids, nothing else.
+#[tokio::test]
+async fn rest_grant_responses_grant_and_carry_names_only() {
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let connected = openwave_core::id::ConnectedAppId::new();
+    let catalog = crate::openapi_catalog::ingest_openapi_document(
+        json!({
+            "openapi": "3.0.3",
+            "info": { "title": "Issues", "version": "1" },
+            "paths": {
+                "/issues": { "get": { "operationId": "listIssues" } }
+            }
+        })
+        .to_string()
+        .as_bytes(),
+        None,
+    )
+    .unwrap();
+    store
+        .replace_connected_apps(
+            openwave_core::connected_app::ConnectedAppKind::RestApi,
+            &[openwave_core::connected_app::ConnectedApp {
+                id: connected,
+                name: "issues".into(),
+                kind: openwave_core::connected_app::ConnectedAppKind::RestApi,
+                definition: json!({
+                    "base_url": "https://internal.example.com/secret-mount/v2",
+                    "catalog": &catalog,
+                    "credential": {
+                        "secret_name": "issues-credential-reference",
+                        "placement": "bearer"
+                    },
+                }),
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            }],
+        )
+        .await
+        .unwrap();
+
+    let app_id = AppId::new();
+    store
+        .create_app(&CreateApp {
+            id: app_id,
+            revision: NewAppRevision {
+                id: AppRevisionId::new(),
+                manifest: AppManifest {
+                    name: "Grant fixture".into(),
+                    bindings: vec![AppBinding::Operations(
+                        openwave_core::local_app::AppOperationsBinding {
+                            app: connected,
+                            operation_ids: vec!["listIssues".into()],
+                        },
+                    )],
+                },
+                byte_len: 1,
+                sha256: [0; 32],
+                turn_id: None,
+                producing_run_id: None,
+                chat_id: None,
+                created_at: chrono::Utc::now(),
+            },
+        })
+        .await
+        .unwrap();
+
+    let mut responses = Vec::new();
+    let state = grant_request(&router, &bearer, "GET", app_id).await;
+    assert_eq!(state.status(), StatusCode::OK);
+    responses.push(("GET", body_string(state).await));
+    let consented = grant_request(&router, &bearer, "POST", app_id).await;
+    assert_eq!(consented.status(), StatusCode::OK);
+    responses.push(("POST", body_string(consented).await));
+
+    for (method, body) in &responses {
+        assert!(
+            body.contains("\"issues\"") && body.contains("listIssues"),
+            "{method}: the sheet needs the record and operation names: {body}"
+        );
+        for leaked in [
+            "internal.example.com",
+            "secret-mount",
+            "issues-credential-reference",
+            &catalog.document_sha256,
+        ] {
+            assert!(
+                !body.contains(leaked),
+                "{method}: {leaked:?} must not reach the renderer: {body}"
+            );
+        }
+    }
+    let before: serde_json::Value = serde_json::from_str(&responses[0].1).unwrap();
+    assert_eq!(before["granted"], json!(false));
+    let after: serde_json::Value = serde_json::from_str(&responses[1].1).unwrap();
+    assert_eq!(after["granted"], json!(true));
 }
 
 async fn body_string(response: axum::response::Response) -> String {

--- a/crates/openwave-server/src/tests/app_invoke.rs
+++ b/crates/openwave-server/src/tests/app_invoke.rs
@@ -1,10 +1,12 @@
-//! `POST /apps/{id}/invoke`: server-side enforcement and MCP dispatch.
+//! `POST /apps/{id}/invoke`: server-side enforcement, the retired MCP tool
+//! surface, and governed REST dispatch.
 
 use super::*;
 
 use openwave_core::id::{AppId, AppRevisionId};
 use openwave_core::local_app::{
-    AppBinding, AppManifest, AppToolsBinding, CreateApp, NewAppRevision,
+    AppBinding, AppGrant, AppGrantBinding, AppManifest, AppToolsBinding, AppToolsGrantBinding,
+    CreateApp, NewAppRevision,
 };
 use serde_json::json;
 
@@ -200,11 +202,12 @@ async fn invoke(
         .unwrap()
 }
 
-/// The route's whole enforcement ladder, fail-closed at every rung: a missing
-/// or deleted app is 404, an unpinned or non-MCP name is refused before the
-/// gate, and — the fail-closed default — even a perfectly pinned tool on a
-/// mounted, healthy server is refused with `consent_required` until the user
-/// consents, and the external server never sees a `tools/call`.
+/// The route's whole enforcement ladder for the retired tool surface,
+/// fail-closed at every rung: a missing or deleted app is 404, an unpinned or
+/// non-MCP name is refused before the gate, and a pinned tool refuses with
+/// `consent_required` no matter what — including under a tools grant recorded
+/// before the retirement (#1332) — so the external server never sees a
+/// `tools/call`.
 #[tokio::test]
 async fn every_invoke_is_refused_before_dispatch_without_a_grant() {
     let log = Arc::new(ToolServerLog::default());
@@ -234,8 +237,8 @@ async fn every_invoke_is_refused_before_dispatch_without_a_grant() {
             json!({"tool": "read_file"}),
             refusal(StatusCode::FORBIDDEN, "not_pinned"),
         ),
-        // Pinned, mounted, healthy — still refused, because the user never
-        // consented. No grant, no call.
+        // Pinned, mounted, healthy — still refused: the tool surface is
+        // retired, and no consent can open it.
         (
             app_id,
             json!({"tool": "mcp__srv__viewer", "arguments": {"q": "open"}}),
@@ -248,6 +251,34 @@ async fn every_invoke_is_refused_before_dispatch_without_a_grant() {
         let info: AgentErrorInfo = json_body(response).await;
         assert_eq!(info.kind, kind, "{body}");
     }
+
+    // A tools grant recorded before the retirement — planted directly with
+    // the definition's current fingerprint, since the consent route refuses
+    // to record one now — must not keep the legacy surface invokable.
+    let fingerprint =
+        crate::mcp_config::definition_fingerprint(&tool_server_config(address).servers[0]);
+    store
+        .put_app_grant(&AppGrant {
+            app_id,
+            bindings: vec![AppGrantBinding::Tools(AppToolsGrantBinding {
+                app: connected_app_id(&store, "srv").await,
+                tools: vec!["mcp__srv__viewer".into()],
+                fingerprint,
+            })],
+            created_at: chrono::Utc::now(),
+        })
+        .await
+        .unwrap();
+    let response = invoke(
+        &router,
+        &bearer,
+        app_id,
+        json!({"tool": "mcp__srv__viewer"}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let info: AgentErrorInfo = json_body(response).await;
+    assert_eq!(info.kind, "consent_required");
 
     // A soft-deleted app refuses identically to a missing one.
     store.delete_app(app_id, chrono::Utc::now()).await.unwrap();
@@ -265,191 +296,6 @@ async fn every_invoke_is_refused_before_dispatch_without_a_grant() {
         0,
         "no refusal path may reach the external server"
     );
-}
-
-/// The grant lifecycle end to end over the API: consent opens the gate and a
-/// granted invoke round-trips to the external server; revocation closes it on
-/// the very next invoke, and the refusal is `consent_required` — a re-prompt,
-/// not an error.
-#[tokio::test]
-async fn consent_opens_the_gate_and_revocation_closes_it() {
-    let log = Arc::new(ToolServerLog::default());
-    let address = spawn_tool_server(log.clone(), "ok".into(), json!({})).await;
-    let (router, token, store, _dir) = test_app().await;
-    let bearer = format!("Bearer {token}");
-    put_srv(&router, &bearer, address).await;
-    let app_id = create_pinned_app(&store, &["mcp__srv__viewer"]).await;
-
-    consent(&router, &bearer, app_id).await;
-    let response = invoke(
-        &router,
-        &bearer,
-        app_id,
-        json!({"tool": "mcp__srv__viewer", "arguments": {"q": "open"}}),
-    )
-    .await;
-    assert_eq!(response.status(), StatusCode::OK);
-    let result: serde_json::Value = json_body(response).await;
-    assert_eq!(result["content"], json!("ok"));
-    assert_eq!(log.calls.load(Ordering::SeqCst), 1);
-
-    let revoked = grant_request(&router, &bearer, "DELETE", app_id).await;
-    assert_eq!(revoked.status(), StatusCode::NO_CONTENT);
-    let response = invoke(
-        &router,
-        &bearer,
-        app_id,
-        json!({"tool": "mcp__srv__viewer"}),
-    )
-    .await;
-    assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    let info: AgentErrorInfo = json_body(response).await;
-    assert_eq!(info.kind, "consent_required");
-    assert_eq!(
-        log.calls.load(Ordering::SeqCst),
-        1,
-        "a revoked grant must stop the next call before dispatch"
-    );
-}
-
-/// The property that makes MCP approvals per-call in chats, preserved here
-/// without per-call friction: a Settings edit can swap the process behind a
-/// stable server name, so a reconfigured definition invalidates the grant. The
-/// granted invoke works; after the definition changes the same invoke refuses
-/// with `consent_required` and the state projection flags the server as
-/// changed; a fresh consent re-pins to the new definition.
-#[tokio::test]
-async fn reconfiguring_a_bound_server_invalidates_the_grant() {
-    let log = Arc::new(ToolServerLog::default());
-    let address = spawn_tool_server(log.clone(), "first".into(), json!({})).await;
-    let swapped_log = Arc::new(ToolServerLog::default());
-    let swapped = spawn_tool_server(swapped_log.clone(), "second".into(), json!({})).await;
-    let (router, token, store, _dir) = test_app().await;
-    let bearer = format!("Bearer {token}");
-    put_srv(&router, &bearer, address).await;
-    let app_id = create_pinned_app(&store, &["mcp__srv__viewer"]).await;
-
-    consent(&router, &bearer, app_id).await;
-    let response = invoke(
-        &router,
-        &bearer,
-        app_id,
-        json!({"tool": "mcp__srv__viewer"}),
-    )
-    .await;
-    assert_eq!(response.status(), StatusCode::OK);
-
-    // The same name now resolves to a different process.
-    put_srv(&router, &bearer, swapped).await;
-    let response = invoke(
-        &router,
-        &bearer,
-        app_id,
-        json!({"tool": "mcp__srv__viewer"}),
-    )
-    .await;
-    assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    let info: AgentErrorInfo = json_body(response).await;
-    assert_eq!(info.kind, "consent_required");
-    assert_eq!(
-        swapped_log.calls.load(Ordering::SeqCst),
-        0,
-        "the swapped-in server must not be reached under the stale grant"
-    );
-    let state = grant_request(&router, &bearer, "GET", app_id).await;
-    let state: serde_json::Value = json_body(state).await;
-    assert_eq!(state["granted"], json!(false));
-    assert_eq!(state["bindings"][0]["definition_changed"], json!(true));
-
-    consent(&router, &bearer, app_id).await;
-    let response = invoke(
-        &router,
-        &bearer,
-        app_id,
-        json!({"tool": "mcp__srv__viewer"}),
-    )
-    .await;
-    assert_eq!(response.status(), StatusCode::OK);
-    assert_eq!(swapped_log.calls.load(Ordering::SeqCst), 1);
-}
-
-/// A revision that widens the manifest exceeds the grant by construction: the
-/// new tool refuses with `consent_required` while the already-granted tool
-/// keeps working, with no widening-specific mechanism anywhere. Re-consent is
-/// computed from the server's current state — the renderer's bare "yes"
-/// cannot name tools — so afterwards the new tool is invokable.
-#[tokio::test]
-async fn a_widened_manifest_requires_fresh_consent_for_the_new_tools() {
-    let log = Arc::new(ToolServerLog::default());
-    let address = spawn_tool_server(log.clone(), "ok".into(), json!({})).await;
-    let (router, token, store, _dir) = test_app().await;
-    let bearer = format!("Bearer {token}");
-    put_srv(&router, &bearer, address).await;
-    let app_id = create_pinned_app(&store, &["mcp__srv__viewer"]).await;
-    consent(&router, &bearer, app_id).await;
-
-    store
-        .append_app_revision(
-            app_id,
-            &NewAppRevision {
-                id: AppRevisionId::new(),
-                manifest: AppManifest {
-                    name: "Invoke fixture".into(),
-                    bindings: vec![AppBinding::Tools(AppToolsBinding {
-                        app: connected_app_id(&store, "srv").await,
-                        tools: vec!["mcp__srv__viewer".into(), "mcp__srv__unpinned".into()],
-                    })],
-                },
-                byte_len: 1,
-                sha256: [0; 32],
-                turn_id: None,
-                producing_run_id: None,
-                chat_id: None,
-                created_at: chrono::Utc::now(),
-            },
-        )
-        .await
-        .unwrap();
-
-    let response = invoke(
-        &router,
-        &bearer,
-        app_id,
-        json!({"tool": "mcp__srv__unpinned"}),
-    )
-    .await;
-    assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    let info: AgentErrorInfo = json_body(response).await;
-    assert_eq!(info.kind, "consent_required");
-    let response = invoke(
-        &router,
-        &bearer,
-        app_id,
-        json!({"tool": "mcp__srv__viewer"}),
-    )
-    .await;
-    assert_eq!(
-        response.status(),
-        StatusCode::OK,
-        "tools within the granted set stay invokable"
-    );
-    let state = grant_request(&router, &bearer, "GET", app_id).await;
-    let state: serde_json::Value = json_body(state).await;
-    assert_eq!(
-        state["granted"],
-        json!(false),
-        "the widened manifest must re-prompt on next open"
-    );
-
-    consent(&router, &bearer, app_id).await;
-    let response = invoke(
-        &router,
-        &bearer,
-        app_id,
-        json!({"tool": "mcp__srv__unpinned"}),
-    )
-    .await;
-    assert_eq!(response.status(), StatusCode::OK);
 }
 
 async fn dispatch_state(
@@ -917,4 +763,123 @@ async fn consent_conflicts_when_a_pinned_operation_left_the_catalog() {
     assert_eq!(response.status(), StatusCode::CONFLICT);
     let info: AgentErrorInfo = json_body(response).await;
     assert!(info.message.contains("retiredOp"), "{}", info.message);
+}
+
+/// Revocation closes the gate on the very next invoke, and the refusal is
+/// `consent_required` — a re-prompt, not an error.
+#[tokio::test]
+async fn revocation_closes_the_gate_on_the_next_invoke() {
+    let log = Arc::new(RestCallLog::default());
+    let (router, bearer, store, _dir) = rest_test_app(log.clone()).await;
+    let connected = ConnectedAppId::new();
+    seed_rest_record(&store, connected, "https://api.example.com/v2").await;
+    let app_id = create_operation_app(&store, connected, &["listIssues"]).await;
+
+    consent(&router, &bearer, app_id).await;
+    let response = invoke(
+        &router,
+        &bearer,
+        app_id,
+        json!({"operation_id": "listIssues"}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(log.calls.load(Ordering::SeqCst), 1);
+
+    let revoked = grant_request(&router, &bearer, "DELETE", app_id).await;
+    assert_eq!(revoked.status(), StatusCode::NO_CONTENT);
+    let response = invoke(
+        &router,
+        &bearer,
+        app_id,
+        json!({"operation_id": "listIssues"}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let info: AgentErrorInfo = json_body(response).await;
+    assert_eq!(info.kind, "consent_required");
+    assert_eq!(
+        log.calls.load(Ordering::SeqCst),
+        1,
+        "a revoked grant must stop the next call before dispatch"
+    );
+}
+
+/// A revision that widens the manifest exceeds the grant by construction: the
+/// new operation refuses with `consent_required` while the already-granted
+/// one keeps working, with no widening-specific mechanism anywhere.
+/// Re-consent is computed from the server's current state — the renderer's
+/// bare "yes" cannot name operations — so afterwards the new operation is
+/// invokable.
+#[tokio::test]
+async fn a_widened_manifest_requires_fresh_consent_for_the_new_operations() {
+    let log = Arc::new(RestCallLog::default());
+    let (router, bearer, store, _dir) = rest_test_app(log.clone()).await;
+    let connected = ConnectedAppId::new();
+    seed_rest_record(&store, connected, "https://api.example.com/v2").await;
+    let app_id = create_operation_app(&store, connected, &["listIssues"]).await;
+    consent(&router, &bearer, app_id).await;
+
+    store
+        .append_app_revision(
+            app_id,
+            &NewAppRevision {
+                id: AppRevisionId::new(),
+                manifest: AppManifest {
+                    name: "REST fixture".into(),
+                    bindings: vec![AppBinding::Operations(AppOperationsBinding {
+                        app: connected,
+                        operation_ids: vec!["listIssues".into(), "getIssue".into()],
+                    })],
+                },
+                byte_len: 1,
+                sha256: [0; 32],
+                turn_id: None,
+                producing_run_id: None,
+                chat_id: None,
+                created_at: chrono::Utc::now(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let response = invoke(
+        &router,
+        &bearer,
+        app_id,
+        json!({"operation_id": "getIssue", "parameters": {"id": "7"}}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let info: AgentErrorInfo = json_body(response).await;
+    assert_eq!(info.kind, "consent_required");
+    let response = invoke(
+        &router,
+        &bearer,
+        app_id,
+        json!({"operation_id": "listIssues"}),
+    )
+    .await;
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "operations within the granted set stay invokable"
+    );
+    let state = grant_request(&router, &bearer, "GET", app_id).await;
+    let state: serde_json::Value = json_body(state).await;
+    assert_eq!(
+        state["granted"],
+        json!(false),
+        "the widened manifest must re-prompt on next open"
+    );
+
+    consent(&router, &bearer, app_id).await;
+    let response = invoke(
+        &router,
+        &bearer,
+        app_id,
+        json!({"operation_id": "getIssue", "parameters": {"id": "7"}}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
 }

--- a/crates/openwave-server/src/tests/app_library.rs
+++ b/crates/openwave-server/src/tests/app_library.rs
@@ -4,7 +4,7 @@ use super::*;
 
 use openwave_core::id::{AppId, AppRevisionId};
 use openwave_core::local_app::{
-    AppBinding, AppManifest, AppToolsBinding, CreateApp, NewAppRevision,
+    AppBinding, AppManifest, AppOperationsBinding, CreateApp, NewAppRevision,
 };
 use serde_json::json;
 
@@ -17,29 +17,39 @@ async fn library_lists_grant_verdicts_and_deletion_removes_the_row() {
     let (router, token, store, _dir) = test_app().await;
     let bearer = format!("Bearer {token}");
 
-    // A disabled stdio server never spawns but still carries a definition
-    // fingerprint, which is all a grant pins.
-    let put = router
-        .clone()
-        .oneshot(
-            Request::builder()
-                .method("PUT")
-                .uri("/mcp/servers")
-                .header("authorization", &bearer)
-                .header("content-type", "application/json")
-                .body(Body::from(
-                    json!({"servers": [{
-                        "name": "cmd",
-                        "command": "/usr/local/bin/fixture-mcp",
-                        "enabled": false
-                    }]})
-                    .to_string(),
-                ))
-                .unwrap(),
+    // A configured rest_api record carries a definition fingerprint, which is
+    // all a grant pins — no live endpoint is needed to consent.
+    let connected = openwave_core::id::ConnectedAppId::new();
+    let catalog = crate::openapi_catalog::ingest_openapi_document(
+        json!({
+            "openapi": "3.0.3",
+            "info": { "title": "Issues", "version": "1" },
+            "paths": {
+                "/issues": { "get": { "operationId": "listIssues" } }
+            }
+        })
+        .to_string()
+        .as_bytes(),
+        None,
+    )
+    .unwrap();
+    store
+        .replace_connected_apps(
+            openwave_core::connected_app::ConnectedAppKind::RestApi,
+            &[openwave_core::connected_app::ConnectedApp {
+                id: connected,
+                name: "issues".into(),
+                kind: openwave_core::connected_app::ConnectedAppKind::RestApi,
+                definition: json!({
+                    "base_url": "https://api.example.com/v2",
+                    "catalog": &catalog,
+                }),
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            }],
         )
         .await
         .unwrap();
-    assert_eq!(put.status(), StatusCode::OK);
 
     let app_id = AppId::new();
     store
@@ -49,9 +59,9 @@ async fn library_lists_grant_verdicts_and_deletion_removes_the_row() {
                 id: AppRevisionId::new(),
                 manifest: AppManifest {
                     name: "Library fixture".into(),
-                    bindings: vec![AppBinding::Tools(AppToolsBinding {
-                        app: connected_app_id(&store, "cmd").await,
-                        tools: vec!["mcp__cmd__doit".into()],
+                    bindings: vec![AppBinding::Operations(AppOperationsBinding {
+                        app: connected,
+                        operation_ids: vec!["listIssues".into()],
                     })],
                 },
                 byte_len: 1,
@@ -82,7 +92,7 @@ async fn library_lists_grant_verdicts_and_deletion_removes_the_row() {
     assert_eq!(listed.status(), StatusCode::OK);
     let body = body_string(listed).await;
     assert!(
-        !body.contains("bindings") && !body.contains("mcp__cmd__doit"),
+        !body.contains("bindings") && !body.contains("listIssues"),
         "the listing must not carry manifest bindings: {body}"
     );
     let library: serde_json::Value = serde_json::from_str(&body).unwrap();

--- a/docs/connected-apps.md
+++ b/docs/connected-apps.md
@@ -60,22 +60,25 @@ profiles do not get it (below).
 
 ## Bindings key off the app
 
-A local app's manifest binds capabilities of connected apps. The end-state
-vocabulary is app-first:
+A local app's manifest binds capabilities of connected apps. The vocabulary
+is app-first, and since the tool-binding retirement (#1332) it has exactly
+one live kind:
 
-- `{ app, tools[] }` for `mcp_server` apps — today's `{ server, tools[] }`
-  is the legacy spelling of this, keyed by namespace instead of record id.
 - `{ app, operation_ids[] }` for `rest_api` apps.
+- `{ app, tools[] }` for `mcp_server` apps existed as the founding
+  vocabulary — the only one available when local apps shipped — and is
+  retired: `create_app` refuses to author it, consent conflicts instead of
+  granting it, and the invoke route refuses the tool surface even under a
+  pre-retirement grant. Stored manifests still parse and read as
+  ungrantable. MCP was app-bindable only because it predated REST bindings;
+  once REST landed there was no remaining app-shaped use for a vocabulary
+  whose consentable universe included local stdio processes.
 
 Grants, the consent sheet, the invoke route's refusal ladder, and live
-fingerprint invalidation carry over unchanged; only the pinned vocabulary
-and the per-kind fingerprint differ:
-
-- `mcp_server`: the existing canonical definition form (`v:1`, fields not
-  storage — see below).
-- `rest_api`: SHA-256 over base URL + OpenAPI document hash + credential
-  *reference* + placement. Rotating the credential value behind the same
-  reference does not invalidate consent; repointing the reference does.
+fingerprint invalidation carry over unchanged; the `rest_api` fingerprint is
+SHA-256 over base URL + OpenAPI document hash + credential *reference* +
+placement. Rotating the credential value behind the same reference does not
+invalidate consent; repointing the reference does.
 
 The consent sheet leads with the app's display name ("Sentry") and lists
 pinned capabilities under it — a legibility improvement over leading with
@@ -138,5 +141,7 @@ so this is mechanical.
 - OAuth-brokered kinds (Drive/Box-style source connectors) — the reserved
   `openwave-connectors` scaffold; a future kind, not part of this epic.
 - Filesystem bindings and their consent posture — #1331.
-- Narrowing which MCP transports are app-bindable — #1332, decided once
-  REST bindings exist.
+- ~~Narrowing which MCP transports are app-bindable — #1332, decided once
+  REST bindings exist.~~ Decided and done: rather than narrowing by
+  transport, MCP tool bindings were retired entirely (see "Bindings key off
+  the app" above).

--- a/docs/local-apps.md
+++ b/docs/local-apps.md
@@ -76,9 +76,9 @@ call identity exists; it is only *invocation* that happens outside one.
 ## Invocation and consent
 
 Invocation is new host surface: the first tool execution outside a model turn.
-The route (`POST /apps/{id}/invoke`, renderer bearer) resolves the current
-tool registry snapshot and executes the named tool — mechanically the same
-dispatch a turn performs, minus the turn.
+The route (`POST /apps/{id}/invoke`, renderer bearer) executes the named
+capability through the host's governed dispatch — mechanically the same
+execution a turn performs, minus the turn.
 
 What it deliberately does **not** reuse is the chat approval gate. That gate
 is enforced inside the foreground agent loop, scoped to a chat and its
@@ -88,10 +88,11 @@ standing grant would silently widen. None of that maps onto a profile-scoped
 app driven by a human click. Local apps therefore get their own consent
 object, designed against the same threat:
 
-- An **app grant** records, per app: the granted `(app, tools[])` set — keyed
-  by connected-app record id — and a **fingerprint of each bound app's
-  definition** (namespace, command, args, cwd, selected env names, URL —
-  whatever the transport carries).
+- An **app grant** records, per app: the granted `(app, capabilities[])` set —
+  keyed by connected-app record id — and a **fingerprint of each bound app's
+  definition** (whatever the kind carries: base URL, document hash, and
+  credential reference for `rest_api`; namespace, command, args, cwd,
+  selected env names, URL for the retired `mcp_server` vocabulary).
 - The grant is created by explicit user consent on a sheet that lists every
   binding. It is revocable from the Apps library.
 - Every invoke checks, live: the tool is in the current revision's manifest,
@@ -135,37 +136,35 @@ The frame's opaque origin means an app has no storage of its own. v1 apps are
 stateless: they refetch through their tools on open. A state primitive is a
 deliberate non-goal until something real needs it.
 
-## Acting on gateway-backed servers
+## Tool bindings are retired
 
-Bindings name mounted servers of any transport — local stdio, remote HTTP,
-or gateway endpoints — uniformly. When a binding resolves to a gateway
-endpoint, calls carry the user's per-endpoint `mcp:<slug>` bearer, so the
-gateway authenticates the person: its live entitlement checks apply, its
-audit and content-free usage ledgers attribute the call to that user, and the
-client name rides as `openwave`. Local apps are already governed and
-attributed for gateway-backed bindings with zero gateway-side work.
-
-One boundary follows from the gateway's design rather than ours:
-gateway-attested endpoints refuse session-token calls that lack a
-model-emitted observation, so local apps can act only on Direct endpoints
-today. Promotion (below) is what lifts that, because a promoted app's calls
-are brokered by the gateway itself.
-
-Local stdio and HTTP servers run under whatever authority the user configured
-them with. That is the existing local trust model, unchanged — an app adds no
-authority to a server the user already mounted.
-
-## Beyond MCP bindings
-
-Mounted MCP tools are the first binding vocabulary, not the last. The
-accepted next step ([connected-apps.md](connected-apps.md), tracked by
-#1330) makes MCP servers one *kind* of a broader connected-app record and
-adds a `rest_api` kind — a base URL, an ingested OpenAPI catalog, and a
-secret-store credential — executed through a governed local egress layer.
-App manifests then gain a sibling binding kind, `{ app, operation_ids[] }`,
-with the grant, consent-sheet, and invoke machinery on this page carried
-over unchanged. Until that lands, MCP tools remain the only callable
+Mounted MCP tools were the first binding vocabulary — the only one available
+when local apps shipped — and are no longer bindable (#1332). The
+connected-apps epic ([connected-apps.md](connected-apps.md), #1330) made MCP
+servers one *kind* of connected app and added the `rest_api` kind — a base
+URL, an ingested OpenAPI catalog, and a secret-store credential, executed
+through a governed local egress layer. App manifests bind
+`{ app, operation_ids[] }`, with the grant, consent-sheet, and invoke
+machinery on this page carried over unchanged. That is now the one callable
 surface.
+
+With REST in place, tool bindings had no remaining use their vocabulary
+covered better, and their consentable universe was the wrong shape for apps:
+a manifest could pin tools of *any* mounted transport — local stdio, remote
+HTTP, or gateway endpoints — putting "run a local process on this machine"
+inside the app-grantable world, while gateway-attested endpoints refused
+app-driven session-token calls regardless. The doors now refuse the
+vocabulary end to end: `create_app` refuses to author a `tools` binding, the
+consent route conflicts instead of granting one, and the invoke route
+refuses the tool surface even under a grant recorded before the retirement —
+the failure direction is re-ask, never widen. The grammar still parses
+stored manifests, which read as ungrantable on every surface; full removal
+of the vocabulary (types, wire shapes, the frame bridge's `tools/call` verb)
+is a separate mechanical change.
+
+Mounted MCP servers themselves are unchanged: chats keep their full tool
+surface. The retirement narrows what an *app manifest* may pin, nothing
+else.
 
 ## The authorization gate
 
@@ -183,11 +182,13 @@ where a team-scoped copy is stored, served, and brokered by the gateway under
 each viewer's own entitlements. Three properties keep that door open without
 building anything now:
 
-- **The binding vocabulary maps.** A gateway-endpoint binding translates
-  mechanically to the gateway's manifest vocabulary (endpoint slug, proxied
-  operation set). Promotion walks the bindings and refuses with a precise
-  list when any binding is not gateway-resolvable — an app bound to a local
-  stdio server cannot promote, by construction.
+- **The binding vocabulary maps.** An operation binding against a
+  gateway-hosted API translates mechanically to the gateway's manifest
+  vocabulary (endpoint slug, proxied operation set). Promotion walks the
+  bindings and refuses with a precise list when any binding is not
+  gateway-resolvable — an app bound to a purely local API cannot promote, by
+  construction. (Retiring tool bindings, above, removed the widest class of
+  unpromotable bindings outright.)
 - **Revision identity carries.** Digests, ordinals, and producer provenance
   become the published revision's provenance.
 - **Attestation flips from limitation to benefit.** Once the gateway brokers


### PR DESCRIPTION
## What

Local apps no longer bind mounted MCP tools. `{ app, operation_ids[] }` on `rest_api` connected apps is the one live binding vocabulary; the `tools` vocabulary is refused at every door while remaining parseable, so stored manifests read as ungrantable rather than unreadable.

## Why

MCP was app-bindable only because it was the sole connected-app kind when local apps shipped (#1254–#1284); REST bindings (#1330) have since replaced it as the surface apps are meant to speak. The tools vocabulary's consentable universe was the wrong shape for apps — a manifest could pin tools of **any** mounted transport, putting "run a local process on this machine" inside the app-grantable world — and gateway-attested endpoints refuse app-driven session-token calls regardless, so the surviving legitimate surface was thin. #1332 asked for transport narrowing; per discussion the decision went one step further and retired the vocabulary. Grants pin fingerprints and remain ~zero in the wild, so now is the cheapest this ever gets.

## Enforcement points

- **Authoring** — `create_app` refuses a `tools` binding with the `operation_ids` alternative spelled out; its description and roster now speak rest_api only, so the model is never invited to author what the door refuses.
- **Consent** — `POST /apps/{id}/grant` conflicts (409) on a tools binding; `binding_covered` reports one as never covered, so a legacy app presents its sheet (whose refusal explains the revision needed) instead of a granted frame.
- **Invoke** — `require_app_grant` refuses the tool surface with `consent_required` before the grant is even read, so a grant recorded pre-retirement cannot keep the surface invokable; the external server is never reached.

No wire-type or UI changes; the frame bridge's `tools/call` verb now always surfaces the server's refusal. Full removal (types, wire shapes, bridge verb, manifest-stripping migration) is #1589.

## Test changes

- The invoke ladder test converts into the retirement pin, including a planted pre-retirement tools grant (with a correct live fingerprint) that still refuses before dispatch.
- `consent_opens_the_gate_and_revocation_closes_it` and `a_widened_manifest_requires_fresh_consent_for_the_new_tools` are converted to REST fixtures (revocation and by-construction widening were only covered via MCP).
- `reconfiguring_a_bound_server_invalidates_the_grant` is **removed as duplicate coverage**: the REST ladder test already exercises definition-swap staleness, the `definition_changed` projection, and re-consent re-pinning.
- The grant projection leak test keeps its secret-shaped stdio fixture (GET + the new 409 must both stay leak-free) and gains a rest_api sibling asserting consent still grants and never leaks base URL, document hash, or credential reference.
- Roster tests now assert MCP mounts never appear on the `create_app` roster.

Closes #1332

🤖 Generated with [Claude Code](https://claude.com/claude-code)