### PR TITLE
fix(desktop): disclose cloud execution on unsupported hosts

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -384,6 +384,7 @@ export function ChatView({
           onRetryTurn={onRetryTurn}
           hydrated={hydrated}
           imageClient={client}
+          executionConfigClient={client}
           changeClient={client}
         />
         <button

--- a/crates/openwave-desktop/ui/src/CodeExecutionDisclosure.ts
+++ b/crates/openwave-desktop/ui/src/CodeExecutionDisclosure.ts
@@ -1,0 +1,19 @@
+import type { CodeExecutionConfigInfo } from "./api";
+
+export const MANAGED_EXECUTION_DISCLOSURE =
+  "Code execution runs in an E2B or Daytona cloud sandbox on this device. Files staged for a run leave this machine and are uploaded to that provider.";
+
+/**
+ * Whether this host has no native execution path and therefore must use a
+ * managed provider. The server owns the platform decision; the renderer only
+ * interprets its structured Local-provider capability row.
+ */
+export function requiresManagedExecutionDisclosure(
+  providers: CodeExecutionConfigInfo["providers"] | null | undefined,
+): boolean {
+  const local = providers?.find((row) => row.provider === "local");
+  return (
+    local?.available === false &&
+    local.unavailable_reason === "unsupported_platform"
+  );
+}

--- a/crates/openwave-desktop/ui/src/HomeRoute.tsx
+++ b/crates/openwave-desktop/ui/src/HomeRoute.tsx
@@ -292,7 +292,10 @@ export function HomeRoute() {
           {/* The same null state an empty conversation shows: home is where a
               chat starts, so it greets the same way. Picking a starter prompt
               fills the composer rather than sending, the way it does in a chat. */}
-          <WelcomeState onSelectPrompt={setDraft} />
+          <WelcomeState
+            onSelectPrompt={setDraft}
+            executionConfigClient={client}
+          />
         </div>
 
         <div className="z-10 mx-auto w-full max-w-3xl pb-2">

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -239,6 +239,7 @@ type MessageListProps = {
   onRetryTurn?: (turn: RetryableTurn) => void;
   hydrated?: boolean;
   imageClient?: Pick<ApiClient, "getChatImageAttachment">;
+  executionConfigClient?: Pick<ApiClient, "getCodeExecutionConfig">;
   changeClient?: Pick<
     ApiClient,
     "getFileChangePreview" | "undoFileChange" | "undoTurnFileChanges"
@@ -291,6 +292,7 @@ export function MessageList({
   onRetryTurn,
   hydrated = true,
   imageClient,
+  executionConfigClient,
   changeClient,
 }: MessageListProps) {
   // Stable identity between renders so memoized rows only re-render when the
@@ -339,7 +341,10 @@ export function MessageList({
   if (isEmpty) {
     return (
       <div className="messages is-empty" ref={scrollRef} onScroll={onScroll}>
-        <WelcomeState onSelectPrompt={onSelectPrompt} />
+        <WelcomeState
+          onSelectPrompt={onSelectPrompt}
+          executionConfigClient={executionConfigClient}
+        />
       </div>
     );
   }

--- a/crates/openwave-desktop/ui/src/WelcomeState.test.tsx
+++ b/crates/openwave-desktop/ui/src/WelcomeState.test.tsx
@@ -1,23 +1,89 @@
-import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it, vi } from "vitest";
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  ApiClient,
+  CodeExecutionConfigInfo,
+} from "./api";
 import { WelcomeState } from "./WelcomeState";
+
+afterEach(cleanup);
+
+function executionClient(
+  providers: CodeExecutionConfigInfo["providers"],
+): Pick<ApiClient, "getCodeExecutionConfig"> {
+  return {
+    getCodeExecutionConfig: vi.fn().mockResolvedValue({
+      providers,
+    } as CodeExecutionConfigInfo),
+  };
+}
 
 describe("WelcomeState", () => {
   it("renders the greeting and starter prompts when a handler is provided", () => {
-    const markup = renderToStaticMarkup(
-      <WelcomeState onSelectPrompt={vi.fn()} />,
-    );
+    render(<WelcomeState onSelectPrompt={vi.fn()} />);
 
-    expect(markup).toContain("How can I help?");
-    expect(markup).toContain("What can you help me with?");
-    expect(markup).toContain("Draft a plan");
-    expect(markup).toContain('aria-label="Start a chat"');
+    expect(
+      screen.getByRole("heading", { name: "How can I help?" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("What can you help me with?")).toBeInTheDocument();
+    expect(screen.getByText("Draft a plan")).toBeInTheDocument();
+    expect(
+      screen.getByRole("region", { name: "Start a chat" }),
+    ).toBeInTheDocument();
   });
 
   it("omits the starter prompts when no handler is provided", () => {
-    const markup = renderToStaticMarkup(<WelcomeState />);
+    const { container } = render(<WelcomeState />);
 
-    expect(markup).toContain("How can I help?");
-    expect(markup).not.toContain("welcome-prompt");
+    expect(
+      screen.getByRole("heading", { name: "How can I help?" }),
+    ).toBeInTheDocument();
+    expect(container.querySelector(".welcome-prompts")).toBeNull();
+  });
+
+  it("discloses cloud execution and staged-file uploads when Local is unsupported", async () => {
+    render(
+      <WelcomeState
+        executionConfigClient={executionClient([
+          {
+            provider: "local",
+            available: false,
+            unavailable_reason: "unsupported_platform",
+          },
+          {
+            provider: "e2b",
+            available: false,
+            unavailable_reason: "missing_credential",
+          },
+          {
+            provider: "daytona",
+            available: false,
+            unavailable_reason: "missing_credential",
+          },
+        ])}
+      />,
+    );
+
+    expect(
+      await screen.findByText(/Files staged for a run leave this machine/i),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the macOS welcome copy unchanged when Local is available", async () => {
+    const client = executionClient([
+      { provider: "local", available: true },
+      { provider: "e2b", available: true },
+      { provider: "daytona", available: true },
+    ]);
+    render(<WelcomeState executionConfigClient={client} />);
+
+    await waitFor(() =>
+      expect(client.getCodeExecutionConfig).toHaveBeenCalled(),
+    );
+    expect(
+      screen.queryByText(/Files staged for a run leave this machine/i),
+    ).toBeNull();
   });
 });

--- a/crates/openwave-desktop/ui/src/WelcomeState.tsx
+++ b/crates/openwave-desktop/ui/src/WelcomeState.tsx
@@ -1,4 +1,10 @@
+import { useEffect, useState } from "react";
 import { FileSearch, ListChecks, MessageCircle, Sparkles } from "lucide-react";
+import type { ApiClient, CodeExecutionConfigInfo } from "./api";
+import {
+  MANAGED_EXECUTION_DISCLOSURE,
+  requiresManagedExecutionDisclosure,
+} from "./CodeExecutionDisclosure";
 import { Logomark } from "./Logomark";
 
 type StarterPrompt = {
@@ -32,9 +38,41 @@ const STARTER_PROMPTS: StarterPrompt[] = [
 
 export function WelcomeState({
   onSelectPrompt,
+  executionConfigClient,
 }: {
   onSelectPrompt?: (prompt: string) => void;
+  executionConfigClient?: Pick<ApiClient, "getCodeExecutionConfig">;
 }) {
+  const [executionProviders, setExecutionProviders] = useState<
+    CodeExecutionConfigInfo["providers"] | null
+  >(null);
+
+  useEffect(() => {
+    if (
+      !executionConfigClient ||
+      typeof executionConfigClient.getCodeExecutionConfig !== "function"
+    ) {
+      return;
+    }
+    let cancelled = false;
+    setExecutionProviders(null);
+    void executionConfigClient
+      .getCodeExecutionConfig()
+      .then((config) => {
+        if (!cancelled) setExecutionProviders(config.providers);
+      })
+      // A missing disclosure is safer than inventing platform facts when the
+      // capability report cannot be read.
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [executionConfigClient]);
+
+  const managedExecutionOnly = requiresManagedExecutionDisclosure(
+    executionProviders,
+  );
+
   return (
     <section className="welcome" aria-label="Start a chat">
       <span className="welcome-mark" aria-hidden="true">
@@ -45,6 +83,7 @@ export function WelcomeState({
         <p>
           Ask a question, search attached sources, or start a task.
         </p>
+        {managedExecutionOnly && <p>{MANAGED_EXECUTION_DISCLOSURE}</p>}
       </div>
       {onSelectPrompt && (
         <div className="welcome-prompts">

--- a/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.dom.test.tsx
@@ -159,6 +159,9 @@ describe("CodeExecutionPanel", () => {
     expect(
       putCodeExecutionCredential.mock.invocationCallOrder[0],
     ).toBeLessThan(putCodeExecutionConfig.mock.invocationCallOrder[0]);
+    expect(
+      screen.queryByText(/Files staged for a run leave this machine/i),
+    ).toBeNull();
   });
 
   it("removes one provider's saved key without touching the other", async () => {
@@ -312,6 +315,9 @@ describe("CodeExecutionPanel", () => {
     // The headline states the host has nothing, and each row says what would
     // change it — a missing key must be readable here, not archaeological.
     await screen.findByText(/No execution provider configured/i);
+    expect(
+      screen.getByText(/Files staged for a run leave this machine/i),
+    ).toBeInTheDocument();
     expect(
       screen.getByText(/Not supported on this operating system/i),
     ).toBeInTheDocument();

--- a/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
@@ -6,6 +6,10 @@ import type {
   CodeExecutionCredentialReadiness,
   CodeExecutionProviderKind,
 } from "../api";
+import {
+  MANAGED_EXECUTION_DISCLOSURE,
+  requiresManagedExecutionDisclosure,
+} from "../CodeExecutionDisclosure";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -156,6 +160,14 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
             label={state.label}
             description={state.description}
           />
+
+          {requiresManagedExecutionDisclosure(config.providers) && (
+            <SettingsSection title="Where code runs">
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                {MANAGED_EXECUTION_DISCLOSURE}
+              </p>
+            </SettingsSection>
+          )}
 
           <SettingsSection
             title="Cloud sandbox keys"


### PR DESCRIPTION
## Summary

- derive the cloud-only execution disclosure from the structured Local-provider capability report, specifically its `unsupported_platform` reason
- show the disclosure in the welcome/onboarding state and Code execution settings
- state plainly that execution uses E2B or Daytona and files staged for a run leave the machine
- leave the macOS copy unchanged when Local is reported available

## Verification

- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run src/WelcomeState.test.tsx src/settings/CodeExecutionPanel.dom.test.tsx` (11 passed)
- `pnpm test` (109 files, 730 tests passed)

I did not drive the desktop app to visually verify the macOS Local-provider path. Automated coverage asserts the new disclosure is absent when the capability report says Local is available.

Closes #1583
