### PR TITLE
feat(server): plugin enable state and derived capability badges

### DIFF
--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -55,8 +55,9 @@ pub use package_cache::{
     PromotionReport, SharedPackageCache, PACKAGE_CACHE_DIR, PACKAGE_CACHE_ENV,
 };
 pub use plugins::{
-    is_valid_plugin_name, is_valid_plugin_router_preamble, load_plugins, parse_plugin_manifest,
-    LoadedPlugin, PluginCategory, PluginPackage, PluginParseError, PLUGIN_MANIFEST_FILE,
+    derived_capabilities, is_valid_plugin_name, is_valid_plugin_router_preamble, load_plugins,
+    parse_plugin_manifest, LoadedPlugin, PluginCapability, PluginCategory, PluginPackage,
+    PluginParseError, PLUGIN_MANIFEST_FILE,
 };
 pub use preview::{scan_preview_directory, PreviewScan};
 pub use remote::RemoteSessionPool;

--- a/crates/openwave-code-execution/src/plugins.rs
+++ b/crates/openwave-code-execution/src/plugins.rs
@@ -19,11 +19,15 @@
 //! prompt. Membership is validated against the skills that actually loaded, so
 //! a plugin naming a skill that isn't there is skipped whole rather than
 //! advertising a group the catalog cannot render.
+//!
+//! Capability badges follow the same posture from the other direction: they
+//! are derived from what the member skills actually declare, and the closed
+//! key set means a manifest cannot state them at all.
 
 use std::collections::BTreeSet;
 use std::path::Path;
 
-use crate::skills::{is_valid_skill_name, LoadedSkill};
+use crate::skills::{is_valid_skill_name, LoadedSkill, SkillPackage};
 
 /// The manifest file every plugin package is defined by.
 pub const PLUGIN_MANIFEST_FILE: &str = "PLUGIN.md";
@@ -38,7 +42,8 @@ const MAX_MEMBER_SKILLS: usize = 16;
 ///
 /// Closed on purpose, like [`crate::HostDep`]: an unknown value rejects the
 /// manifest instead of parsing into a string no grouping or badge can act on.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, ts_rs::TS)]
+#[serde(rename_all = "snake_case")]
 pub enum PluginCategory {
     /// Documents authored for reading: text, fixed-layout, slides.
     Documents,
@@ -60,6 +65,87 @@ impl PluginCategory {
             _ => None,
         }
     }
+}
+
+/// What a plugin can actually do, from a closed vocabulary.
+///
+/// A badge is **derived by the host from the plugin's contents** and is never
+/// read from a manifest: there is no `capabilities` key, and the parser's
+/// closed key set rejects one outright, so a bundle cannot understate what it
+/// carries or claim reach it does not have. This is the same honesty invariant
+/// the model registry enforces on modality flags.
+///
+/// Badges have two consumers. A UI shows them on a plugin's detail view, and
+/// the permission layer keys install/enable confirmation on the heavier ones —
+/// which is what keeps day-to-day skill invocation prompt-free.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    serde::Serialize,
+    serde::Deserialize,
+    ts_rs::TS,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum PluginCapability {
+    /// Produces deliverables in the workspace. Every skill teaches `exec`
+    /// work that saves files, so any bundle with a member carries this.
+    WriteFiles,
+    /// Reaches the network while running. Today that is the sandbox `pip`
+    /// install a declared Python dependency implies.
+    Network,
+    /// Needs a host-managed install outside the sandbox (a declared
+    /// [`crate::HostDep`], e.g. the LibreOffice converter).
+    HostInstall,
+    /// Drives a live surface — a running document, a browser, a device.
+    ///
+    /// No component kind derives this yet: it is reserved for the live-control
+    /// components the plugin format is meant to grow into, and is listed here
+    /// so the vocabulary a UI and the permission layer render against is
+    /// closed and complete from the start rather than widening later.
+    LiveControl,
+    /// Bundles an MCP server, and so whatever that server exposes.
+    ///
+    /// Like [`Self::LiveControl`], nothing derives this yet — plugins bundle
+    /// only skills today. It lands when MCPB-backed components do.
+    Mcp,
+}
+
+/// The badges `plugin` earns from what it actually contains.
+///
+/// `members` is any set of loaded skill packages; only those the plugin
+/// actually claims are considered, so a caller may pass the whole catalog.
+/// The result is deduplicated and sorted, so the same bundle always renders
+/// the same badge row.
+#[must_use]
+pub fn derived_capabilities(
+    plugin: &PluginPackage,
+    members: &[&SkillPackage],
+) -> Vec<PluginCapability> {
+    let members: Vec<&SkillPackage> = members
+        .iter()
+        .copied()
+        .filter(|skill| plugin.skills.contains(&skill.name))
+        .collect();
+    let mut capabilities = BTreeSet::new();
+    if !members.is_empty() {
+        // A skill is instructions for producing a deliverable through `exec`;
+        // one member is enough for the bundle to write files.
+        capabilities.insert(PluginCapability::WriteFiles);
+    }
+    if members.iter().any(|skill| !skill.python_deps.is_empty()) {
+        // Declared Python deps are installed with `pip` inside the sandbox,
+        // which is a network reach under the current install flow.
+        capabilities.insert(PluginCapability::Network);
+    }
+    if members.iter().any(|skill| !skill.host_deps.is_empty()) {
+        capabilities.insert(PluginCapability::HostInstall);
+    }
+    capabilities.into_iter().collect()
 }
 
 /// Host-derived bundle entry parsed from a plugin manifest's frontmatter.
@@ -377,6 +463,7 @@ pub fn load_plugins(source: &Path, skills: &[LoadedSkill]) -> Vec<LoadedPlugin> 
 mod tests {
     use super::*;
     use crate::skills::{load_skills, SkillOrigin, SKILL_MANIFEST_FILE};
+    use crate::HostDep;
 
     const VALID: &str = "---\n\
 name: documents\n\
@@ -523,6 +610,95 @@ router-preamble: Pick by the file the user needs.\n\
             plugins[0].package.skills,
             ["word-documents", "pdf-documents"]
         );
+    }
+
+    /// Contract: a badge row is a function of what the member skills declare,
+    /// and a manifest cannot state one — the closed key set is what enforces
+    /// that, so the rejection is asserted here beside the derivation it
+    /// protects.
+    #[test]
+    fn capabilities_derive_from_member_deps_and_never_from_the_manifest() {
+        let skill = |name: &str, python: &[&str], host: &[HostDep]| SkillPackage {
+            name: name.to_owned(),
+            description: "Does work.".to_owned(),
+            python_deps: python.iter().map(|dep| (*dep).to_owned()).collect(),
+            host_deps: host.to_vec(),
+            origin: SkillOrigin::Builtin,
+        };
+        let plain = skill("plain", &[], &[]);
+        let pip = skill("pip", &["python-docx==1.2.0"], &[]);
+        let hosted = skill("hosted", &[], &[HostDep::LibreOffice]);
+        let both = skill("both", &["python-pptx==1.0.2"], &[HostDep::LibreOffice]);
+        // Not a member of any plugin under test: a caller may pass the whole
+        // catalog, and a non-member must never contribute a badge.
+        let outsider = skill("outsider", &["numpy==2.3.4"], &[HostDep::LibreOffice]);
+
+        for (case, members, expected) in [
+            ("no members", vec![], vec![]),
+            (
+                "instructions only",
+                vec![&plain],
+                vec![PluginCapability::WriteFiles],
+            ),
+            (
+                "python deps imply the pip install's network reach",
+                vec![&pip],
+                vec![PluginCapability::WriteFiles, PluginCapability::Network],
+            ),
+            (
+                "host deps imply a managed install outside the sandbox",
+                vec![&hosted],
+                vec![PluginCapability::WriteFiles, PluginCapability::HostInstall],
+            ),
+            (
+                "one member is enough for each badge",
+                vec![&plain, &both],
+                vec![
+                    PluginCapability::WriteFiles,
+                    PluginCapability::Network,
+                    PluginCapability::HostInstall,
+                ],
+            ),
+        ] {
+            let plugin = PluginPackage {
+                name: "bundle".to_owned(),
+                display_name: "Bundle".to_owned(),
+                description: "A bundle.".to_owned(),
+                category: PluginCategory::Other,
+                skills: members.iter().map(|skill| skill.name.clone()).collect(),
+                router_preamble: None,
+            };
+            let mut passed: Vec<&SkillPackage> = members;
+            passed.push(&outsider);
+            let mut expected = expected;
+            expected.sort_unstable();
+            assert_eq!(
+                derived_capabilities(&plugin, &passed),
+                expected,
+                "{case} should derive exactly these badges"
+            );
+        }
+
+        // `live-control` and `mcp` exist in the vocabulary with no deriving
+        // source yet; nothing a plugin can contain today produces them.
+        let everything = PluginPackage {
+            name: "bundle".to_owned(),
+            display_name: "Bundle".to_owned(),
+            description: "A bundle.".to_owned(),
+            category: PluginCategory::Other,
+            skills: vec!["both".to_owned()],
+            router_preamble: None,
+        };
+        let derived = derived_capabilities(&everything, &[&both]);
+        assert!(!derived.contains(&PluginCapability::LiveControl));
+        assert!(!derived.contains(&PluginCapability::Mcp));
+
+        // A manifest that tries to declare its own badges is rejected whole.
+        assert!(parse_plugin_manifest(
+            "---\nname: a\ndisplay-name: A\ndescription: b\ncategory: other\n\
+             skills: [\"c\"]\ncapabilities: [\"network\"]\n---\n"
+        )
+        .is_err());
     }
 
     /// Contract: every plugin shipped in the repository's `plugins/` tree must

--- a/crates/openwave-code-execution/src/skills.rs
+++ b/crates/openwave-code-execution/src/skills.rs
@@ -67,7 +67,8 @@ impl HostDep {
 /// Origin is host-derived from the load path, never from manifest content, so
 /// a user package cannot claim to be built-in. The prompt catalog uses it to
 /// attribute user-authored entries.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, ts_rs::TS)]
+#[serde(rename_all = "snake_case")]
 pub enum SkillOrigin {
     /// Shipped with the application from a trusted resource directory.
     Builtin,

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1412,6 +1412,93 @@ export type PermissionMode = "plan" | "ask" | "auto" | "allow";
 export type PlanDecisionChoice = "accept" | "reject";
 
 /**
+ * What a plugin can actually do, from a closed vocabulary.
+ *
+ * A badge is **derived by the host from the plugin's contents** and is never
+ * read from a manifest: there is no `capabilities` key, and the parser's
+ * closed key set rejects one outright, so a bundle cannot understate what it
+ * carries or claim reach it does not have. This is the same honesty invariant
+ * the model registry enforces on modality flags.
+ *
+ * Badges have two consumers. A UI shows them on a plugin's detail view, and
+ * the permission layer keys install/enable confirmation on the heavier ones —
+ * which is what keeps day-to-day skill invocation prompt-free.
+ */
+export type PluginCapability = "write-files" | "network" | "host-install" | "live-control" | "mcp";
+
+/**
+ * Everything this installation has, in the state it is in.
+ */
+export type PluginCatalog = { 
+/**
+ * Bundles in load order (by slug), each with its members.
+ */
+plugins: Array<PluginInfo>, 
+/**
+ * Skills no bundle claims — user-authored packages land here.
+ */
+skills: Array<PluginSkillInfo>, };
+
+/**
+ * What kind of work a plugin bundles, from a closed vocabulary.
+ *
+ * Closed on purpose, like [`crate::HostDep`]: an unknown value rejects the
+ * manifest instead of parsing into a string no grouping or badge can act on.
+ */
+export type PluginCategory = "documents" | "data" | "visualization" | "other";
+
+/**
+ * Body of `PUT /plugins/enabled`. Absent names are left alone.
+ */
+export type PluginEnableUpdate = { 
+/**
+ * Bundle flags to set, by slug.
+ */
+plugins: { [key in string]: boolean }, 
+/**
+ * Skill flags to set, by slug. Setting one inside a disabled bundle is
+ * allowed and remembered; it takes effect when the bundle comes back.
+ */
+skills: { [key in string]: boolean }, };
+
+/**
+ * One bundle, as a management surface renders it.
+ */
+export type PluginInfo = { 
+/**
+ * The slug the toggle route addresses it by.
+ */
+name: string, display_name: string, description: string, category: PluginCategory, 
+/**
+ * What the bundle can do, derived by the host from what it contains.
+ * Never self-declared: a manifest has no key for this.
+ */
+capabilities: Array<PluginCapability>, 
+/**
+ * Whether the bundle is on. Off gates every member regardless of the
+ * member's own flag, which the member entries still report unchanged.
+ */
+enabled: boolean, 
+/**
+ * Member skills in manifest order.
+ */
+skills: Array<PluginSkillInfo>, };
+
+/**
+ * One skill, inside a bundle or standing alone.
+ */
+export type PluginSkillInfo = { name: string, description: string, 
+/**
+ * Where the package was loaded from; host-derived, never claimed.
+ */
+origin: SkillOrigin, 
+/**
+ * The skill's *own* flag, independent of any owning bundle's — so a UI
+ * can show the member choices that come back when a bundle is re-enabled.
+ */
+enabled: boolean, };
+
+/**
  * An optional grouping of chats that share project context and a document
  * corpus. A chat may belong to a project or stand alone — unlike some designs
  * that make a project mandatory, OpenWave keeps loose, projectless chats.
@@ -1712,6 +1799,15 @@ max_active_background_agents: number, };
  * Renderer-safe progress of the current sign-in attempt.
  */
 export type SignInProgress = { "state": "idle" } | { "state": "pending", authorization_url: string, } | { "state": "failed", message: string, };
+
+/**
+ * Which source a validated skill package was loaded from.
+ *
+ * Origin is host-derived from the load path, never from manifest content, so
+ * a user package cannot claim to be built-in. The prompt catalog uses it to
+ * attribute user-authored entries.
+ */
+export type SkillOrigin = "builtin" | "user";
 
 /**
  * What a document declares, for the configuration form's operation picker.

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -1217,18 +1217,69 @@ impl ConfiguredCodeExecutionProvider {
         self
     }
 
-    /// The built-in skills merged with a fresh read of the user skills
+    /// Every installed skill, before the install's enable flags apply: the
+    /// built-in packages merged with a fresh read of the user skills
     /// directory. Built-ins were validated once at configuration; user
-    /// packages go through the same strict loader here, so one staging and
-    /// the catalog derived from it always agree. The read is a handful of
-    /// small files at most.
-    fn current_skills(&self) -> Vec<openwave_code_execution::LoadedSkill> {
+    /// packages go through the same strict loader here. The read is a handful
+    /// of small files at most.
+    ///
+    /// This is what a management surface lists — it has to show a disabled
+    /// component in order to offer turning it back on. Everything the model
+    /// or a sandbox sees goes through [`Self::current_skills`] instead.
+    pub(crate) fn installed_skills(&self) -> Vec<openwave_code_execution::LoadedSkill> {
         openwave_code_execution::merged_skills(&self.skills, self.user_skills_dir.as_deref())
     }
 
+    /// Every installed bundle, before the install's enable flags apply.
+    pub(crate) fn installed_plugins(&self) -> Vec<openwave_code_execution::PluginPackage> {
+        self.plugins
+            .iter()
+            .map(|plugin| plugin.package.clone())
+            .collect()
+    }
+
+    /// The bundle that claims `skill`, if any.
+    fn owning_plugin(&self, skill: &str) -> Option<&str> {
+        self.plugins
+            .iter()
+            .find(|plugin| plugin.package.skills.iter().any(|member| member == skill))
+            .map(|plugin| plugin.package.name.as_str())
+    }
+
+    /// The install's plugin and skill enable flags.
+    pub(crate) async fn enable_state(&self) -> crate::plugin_state::PluginEnableState {
+        crate::plugin_state::read_plugin_enable_state(&*self.store).await
+    }
+
+    /// The skills this install actually runs: installed, minus anything the
+    /// user switched off — either directly or by disabling the bundle that
+    /// claims it.
+    ///
+    /// One filtered read backs both consumers, so a disabled skill is absent
+    /// from the staged workspace *and* from the prompt catalog; the model is
+    /// never told about instructions the sandbox will not have.
+    async fn current_skills(&self) -> Vec<openwave_code_execution::LoadedSkill> {
+        self.enabled_skills(self.installed_skills()).await
+    }
+
+    /// Narrow an installed set to what the install's flags leave on.
+    async fn enabled_skills(
+        &self,
+        installed: Vec<openwave_code_execution::LoadedSkill>,
+    ) -> Vec<openwave_code_execution::LoadedSkill> {
+        let state = self.enable_state().await;
+        installed
+            .into_iter()
+            .filter(|skill| {
+                state.skill_enabled(&skill.package.name, self.owning_plugin(&skill.package.name))
+            })
+            .collect()
+    }
+
     /// The host-derived (name, description) catalog for prompt composition.
-    pub(crate) fn skill_catalog(&self) -> Vec<openwave_code_execution::SkillPackage> {
+    pub(crate) async fn skill_catalog(&self) -> Vec<openwave_code_execution::SkillPackage> {
         self.current_skills()
+            .await
             .into_iter()
             .map(|skill| skill.package)
             .collect()
@@ -1236,9 +1287,11 @@ impl ConfiguredCodeExecutionProvider {
 
     /// The bundles the catalog groups skills under. User skills are claimed by
     /// no plugin and stay standalone.
-    pub(crate) fn plugin_catalog(&self) -> Vec<openwave_code_execution::PluginPackage> {
+    pub(crate) async fn plugin_catalog(&self) -> Vec<openwave_code_execution::PluginPackage> {
+        let state = self.enable_state().await;
         self.plugins
             .iter()
+            .filter(|plugin| state.plugin_enabled(&plugin.package.name))
             .map(|plugin| plugin.package.clone())
             .collect()
     }
@@ -1254,10 +1307,15 @@ impl ConfiguredCodeExecutionProvider {
     /// `execute` re-prepares (with the provider-correct mirroring flag)
     /// before any command runs.
     pub(crate) async fn stage_turn_workspace(&self, chat_id: ChatId) {
-        let skills = self.current_skills();
-        if skills.is_empty() {
+        // A configuration with no skills at all — a headless embedding — has
+        // no workspace to prepare. An install that has *disabled* every skill
+        // is a different case: a workspace may already hold staged copies, and
+        // the pass below is what takes them back out.
+        let installed = self.installed_skills();
+        if installed.is_empty() {
             return;
         }
+        let skills = self.enabled_skills(installed).await;
         // Warm the staged skills' declared host tools while the turn runs:
         // `ensure` is fire-and-forget with the broker's own discipline
         // (serialized installs, remembered failures), so a declaration in a
@@ -1295,7 +1353,7 @@ impl ConfiguredCodeExecutionProvider {
     /// is the truth: only a tool that resolves right now counts, so a prompt
     /// never promises a converter that is mid-download or failed to install.
     pub(crate) async fn office_rendering_available(&self) -> Option<bool> {
-        let declared = self.current_skills().iter().any(|skill| {
+        let declared = self.current_skills().await.iter().any(|skill| {
             skill
                 .package
                 .host_deps
@@ -1871,7 +1929,7 @@ impl ConfiguredCodeExecutionProvider {
         degradation_chat: ChatId,
     ) -> std::result::Result<CodeExecutionResponse, CodeExecutionError> {
         let host_dir = self.scratch_root.join(request.workspace_id.as_str());
-        let skills = self.current_skills();
+        let skills = self.current_skills().await;
         prepare_execution_directories(
             &host_dir,
             kind != CodeExecutionProviderKind::Local,
@@ -2376,7 +2434,8 @@ async fn prepare_execution_directories(
 
 /// Stage the validated skills (built-in and user-authored) into
 /// `.openwave/skills/<name>/`: the manifest, plus any helper files the package
-/// carries under `scripts/`.
+/// carries under `scripts/`. Anything already staged under a name that is not
+/// in `skills` is removed, so the staged tree is exactly the enabled set.
 ///
 /// Each destination is resolved a component at a time for the same reason the
 /// helper install is: `.openwave/` is writable by local exec, so a planted
@@ -2386,6 +2445,33 @@ async fn install_skills(
     skills: &[openwave_code_execution::LoadedSkill],
     host_dir: &std::path::Path,
 ) -> std::result::Result<(), CodeExecutionError> {
+    let root = resolve_scratch_directory(host_dir, openwave_code_execution::SKILLS_DIR, true)
+        .await
+        .ok_or_else(|| {
+            CodeExecutionError::Sandbox("the staged skills directory is unavailable".into())
+        })?;
+    // Staging is the whole set, not an accumulation. A skill the install has
+    // switched off — or one the user deleted — must leave a workspace that
+    // staged it on an earlier turn, or the model could still `read_file`
+    // instructions the catalog no longer advertises. Removal is best effort:
+    // a leftover directory is untidy, but failing the command over it would
+    // take working execution down with it.
+    for entry in root.entries().await.unwrap_or_default() {
+        if skills.iter().any(|skill| skill.package.name == entry.name) {
+            continue;
+        }
+        let removed = match entry.kind {
+            openwave_code_execution::ScratchEntryKind::Directory => {
+                root.remove_dir_all(&entry.name).await
+            }
+            kind => root.remove(&entry.name, kind).await,
+        };
+        if let Err(error) = removed {
+            tracing::warn!(
+                "a skill no longer staged could not be removed from the workspace: {error}"
+            );
+        }
+    }
     for skill in skills {
         let name = &skill.package.name;
         let destination = resolve_scratch_directory(
@@ -3100,6 +3186,7 @@ mod tests {
         assert_eq!(
             provider
                 .skill_catalog()
+                .await
                 .iter()
                 .map(|skill| (skill.name.as_str(), skill.origin))
                 .collect::<Vec<_>>(),
@@ -3118,6 +3205,88 @@ mod tests {
         let bare_chat = ChatId::new();
         bare.stage_turn_workspace(bare_chat).await;
         assert!(!scratch_root.path().join(bare_chat.to_string()).exists());
+    }
+
+    /// Contract: switching a component off has to bite in both places at once
+    /// — the staged workspace and the prompt catalog derived from it. A skill
+    /// the model is still told about but whose `SKILL.md` is gone is the exact
+    /// inconsistency the single filtered read exists to prevent.
+    #[tokio::test]
+    async fn disabling_drops_a_component_from_staging_and_the_catalog() {
+        let (store, _database) = test_store().await;
+        let store = Arc::new(store);
+        let scratch_root = tempfile::tempdir().unwrap();
+        let skills_dir = tempfile::tempdir().unwrap();
+        for name in ["charts", "word-documents"] {
+            let dir = skills_dir.path().join(name);
+            std::fs::create_dir(&dir).unwrap();
+            std::fs::write(
+                dir.join(openwave_code_execution::SKILL_MANIFEST_FILE),
+                format!("---\nname: {name}\ndescription: Does {name} work.\n---\nBody.\n"),
+            )
+            .unwrap();
+        }
+        let plugins_dir = tempfile::tempdir().unwrap();
+        let plugin = plugins_dir.path().join("documents");
+        std::fs::create_dir(&plugin).unwrap();
+        std::fs::write(
+            plugin.join(openwave_code_execution::PLUGIN_MANIFEST_FILE),
+            "---\nname: documents\ndisplay-name: Documents\ndescription: Deliverables.\n\
+             category: documents\nskills: [\"word-documents\"]\n---\n",
+        )
+        .unwrap();
+
+        let provider = ConfiguredCodeExecutionProvider::new(
+            store.clone(),
+            Arc::new(NoSecrets),
+            scratch_root.path(),
+        )
+        .with_skills(Some(skills_dir.path().to_owned()))
+        .with_plugins(Some(plugins_dir.path().to_owned()));
+        let chat_id = ChatId::new();
+        let staged = |name: &str| {
+            scratch_root
+                .path()
+                .join(chat_id.to_string())
+                .join(openwave_code_execution::SKILLS_DIR)
+                .join(name)
+                .join(openwave_code_execution::SKILL_MANIFEST_FILE)
+        };
+
+        provider.stage_turn_workspace(chat_id).await;
+        assert!(staged("charts").exists());
+        assert!(staged("word-documents").exists());
+
+        // Disabling the bundle takes its member out of both; the standalone
+        // skill is untouched, and the bundle leaves the plugin catalog.
+        let mut flags = provider.enable_state().await;
+        flags.set_plugin("documents", false);
+        crate::plugin_state::write_plugin_enable_state(&*store, &flags)
+            .await
+            .unwrap();
+        provider.stage_turn_workspace(chat_id).await;
+        assert!(!staged("word-documents").exists());
+        assert!(staged("charts").exists());
+        assert_eq!(
+            provider
+                .skill_catalog()
+                .await
+                .iter()
+                .map(|skill| skill.name.clone())
+                .collect::<Vec<_>>(),
+            ["charts"]
+        );
+        assert!(provider.plugin_catalog().await.is_empty());
+
+        // Disabling a standalone skill needs no bundle to go through.
+        let mut flags = provider.enable_state().await;
+        flags.set_skill("charts", false);
+        crate::plugin_state::write_plugin_enable_state(&*store, &flags)
+            .await
+            .unwrap();
+        provider.stage_turn_workspace(chat_id).await;
+        assert!(!staged("charts").exists());
+        assert!(provider.skill_catalog().await.is_empty());
     }
 
     /// The declaration-driven host-tool contract: staging a skill that

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -45,6 +45,7 @@ mod model_roles;
 /// app stores and the governed REST executor validates against.
 pub mod openapi_catalog;
 mod pairing;
+mod plugin_state;
 mod principal;
 mod provider;
 mod providers;
@@ -323,6 +324,13 @@ pub fn app(state: AppState) -> Router {
                 .layer(DefaultBodyLimit::max(mcp_config::MAX_CONFIG_BODY_BYTES)),
         )
         .route("/connected-apps", get(routes::get_connected_apps))
+        // The installed skill/plugin catalog and its enable flags.
+        .route("/plugins", get(routes::get_plugins))
+        .route(
+            "/plugins/enabled",
+            axum::routing::put(routes::put_plugins_enabled)
+                .layer(DefaultBodyLimit::max(routes::MAX_PLUGIN_ENABLE_BODY_BYTES)),
+        )
         .route(
             "/connected-apps/rest/{id}",
             axum::routing::put(routes::put_rest_connected_app)
@@ -932,6 +940,9 @@ async fn bind_inner(
     // root-attachment mutations stay off — matching `AppState::new`.
     state.root_attachment_routes_enabled = client_executor_id.is_some();
     state.blobs = blobs;
+    // The plugin management routes list what the provider actually loaded, so
+    // they read the same instance staging and prompt composition use.
+    state.code_execution = Some(code_execution.clone());
     // The bus is built with the app state, after the exec provider it belongs
     // to; handing it over here is what lets a first-run image pull reach the
     // chat that is waiting on it.

--- a/crates/openwave-server/src/plugin_state.rs
+++ b/crates/openwave-server/src/plugin_state.rs
@@ -1,0 +1,153 @@
+//! Install-wide enable flags for plugins and the skills they bundle.
+//!
+//! State is global, not per-chat: turning a bundle off is a statement about
+//! this installation, and a later slice can add per-chat overrides on top of
+//! it. It rides the same `setting` key-value row every other install-wide
+//! preference uses (the chat model, the background-agent ceiling), because a
+//! handful of booleans does not earn a table of its own.
+//!
+//! Everything defaults to enabled, so only a *disabled* component is
+//! persisted. That keeps the row proportional to what the user actually turned
+//! off, and it gives the plugin gate the behavior the product wants for free:
+//! a plugin's flag is a gate *over* its members' own flags rather than a
+//! rewrite of them, so re-enabling a bundle restores exactly the member
+//! choices that were in place when it was switched off.
+//!
+//! A disabled component must actually bite, which means both consumers read
+//! this: the workspace staging pass never writes it into a sandbox, and the
+//! prompt catalog never advertises it. Both come from the one filtered read in
+//! [`crate::code_execution`], so the two can't disagree.
+
+use std::collections::BTreeMap;
+
+use openwave_core::Store;
+use serde::{Deserialize, Serialize};
+
+/// The `setting` row the flags live in.
+pub(crate) const PLUGIN_ENABLE_STATE_SETTING: &str = "plugins.enable_state";
+
+/// How many disabled components one install may record, per kind. A bound, not
+/// a product limit: nothing legitimate approaches it, and it stops a client
+/// from growing the settings row without end.
+pub(crate) const MAX_DISABLED_COMPONENTS: usize = 512;
+
+/// Which plugins and skills this installation has switched off.
+///
+/// Absent means enabled, so a fresh install and an install that has never
+/// touched a toggle are the same state.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct PluginEnableState {
+    /// Plugin slugs the user turned off. Only `false` entries are kept.
+    #[serde(default)]
+    plugins: BTreeMap<String, bool>,
+    /// Skill slugs the user turned off, whether the skill belongs to a plugin
+    /// or stands alone. Kept independently of the plugin flag above.
+    #[serde(default)]
+    skills: BTreeMap<String, bool>,
+}
+
+impl PluginEnableState {
+    /// Whether the bundle itself is on.
+    pub(crate) fn plugin_enabled(&self, plugin: &str) -> bool {
+        self.plugins.get(plugin).copied().unwrap_or(true)
+    }
+
+    /// Whether the skill's own flag is on, ignoring any owning plugin.
+    pub(crate) fn skill_flag(&self, skill: &str) -> bool {
+        self.skills.get(skill).copied().unwrap_or(true)
+    }
+
+    /// Whether the skill is live: its own flag is on *and* the bundle that
+    /// claims it, if any, is on. A skill no plugin claims is gated only by its
+    /// own flag.
+    pub(crate) fn skill_enabled(&self, skill: &str, owner: Option<&str>) -> bool {
+        self.skill_flag(skill) && owner.is_none_or(|plugin| self.plugin_enabled(plugin))
+    }
+
+    /// Record a plugin's flag. Enabling drops the row rather than storing
+    /// `true`, since absent already means enabled.
+    pub(crate) fn set_plugin(&mut self, plugin: &str, enabled: bool) {
+        set(&mut self.plugins, plugin, enabled);
+    }
+
+    /// Record a skill's own flag, independent of any owning plugin's.
+    pub(crate) fn set_skill(&mut self, skill: &str, enabled: bool) {
+        set(&mut self.skills, skill, enabled);
+    }
+
+    /// Whether the state is within the recorded-flag bound.
+    pub(crate) fn within_bounds(&self) -> bool {
+        self.plugins.len() <= MAX_DISABLED_COMPONENTS
+            && self.skills.len() <= MAX_DISABLED_COMPONENTS
+    }
+}
+
+fn set(flags: &mut BTreeMap<String, bool>, name: &str, enabled: bool) {
+    if enabled {
+        flags.remove(name);
+    } else {
+        flags.insert(name.to_owned(), false);
+    }
+}
+
+/// Read the install's flags.
+///
+/// Unreadable or malformed state degrades to "everything enabled" with a
+/// warning rather than failing the caller: this gates prompt composition and
+/// workspace staging on every turn, and a bad settings row must not take the
+/// skill system down or, worse, silently disable it.
+pub(crate) async fn read_plugin_enable_state(store: &dyn Store) -> PluginEnableState {
+    let value = match store.get_setting(PLUGIN_ENABLE_STATE_SETTING).await {
+        Ok(value) => value,
+        Err(error) => {
+            tracing::warn!("plugin enable state is unreadable ({error}); treating all as enabled");
+            return PluginEnableState::default();
+        }
+    };
+    let Some(value) = value else {
+        return PluginEnableState::default();
+    };
+    match serde_json::from_value(value) {
+        Ok(state) => state,
+        Err(error) => {
+            tracing::warn!("plugin enable state is malformed ({error}); treating all as enabled");
+            PluginEnableState::default()
+        }
+    }
+}
+
+/// Persist the install's flags.
+pub(crate) async fn write_plugin_enable_state(
+    store: &dyn Store,
+    state: &PluginEnableState,
+) -> openwave_core::Result<()> {
+    let value = serde_json::to_value(state)
+        .map_err(|error| openwave_core::AgentError::config(error.to_string()))?;
+    store.set_setting(PLUGIN_ENABLE_STATE_SETTING, &value).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Contract: a plugin's flag gates its members without overwriting them,
+    /// so switching a bundle off and back on restores the member choices that
+    /// were in place — the reason the two maps are stored independently.
+    #[test]
+    fn the_plugin_flag_gates_member_flags_without_replacing_them() {
+        let mut state = PluginEnableState::default();
+        // Default: nothing recorded, everything on.
+        assert!(state.plugin_enabled("documents"));
+        assert!(state.skill_enabled("word-documents", Some("documents")));
+
+        state.set_skill("pdf-documents", false);
+        state.set_plugin("documents", false);
+        assert!(!state.skill_enabled("word-documents", Some("documents")));
+        // A standalone skill is untouched by another bundle's gate.
+        assert!(state.skill_enabled("meeting-notes", None));
+
+        state.set_plugin("documents", true);
+        assert!(state.skill_enabled("word-documents", Some("documents")));
+        assert!(!state.skill_enabled("pdf-documents", Some("documents")));
+    }
+}

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -67,6 +67,7 @@ mod document;
 pub(crate) mod image_attachment;
 mod inbox;
 mod plans;
+mod plugins;
 mod root_attachment;
 mod user_questions;
 pub use app_grant::*;
@@ -79,6 +80,7 @@ pub use document::*;
 pub use image_attachment::*;
 pub use inbox::*;
 pub use plans::*;
+pub use plugins::*;
 pub use root_attachment::*;
 pub use user_questions::*;
 

--- a/crates/openwave-server/src/routes/plugins.rs
+++ b/crates/openwave-server/src/routes/plugins.rs
@@ -1,0 +1,180 @@
+//! `/plugins` — the install-wide plugin and skill management surface.
+//!
+//! One read route projects everything installed: each bundle with its display
+//! identity, its host-derived capability badges, and its member skills with
+//! their own enable state, plus the skills no bundle claims. A disabled
+//! component is still listed — a management surface that hid it would offer no
+//! way to turn it back on — with `enabled: false` saying so.
+//!
+//! One write route sets flags. It is a merge patch, not a replacement: a body
+//! names only the components it means to change, so two clients toggling
+//! different bundles do not clobber each other. The flags themselves live in
+//! [`crate::plugin_state`]; what is enforced here is that a name is a
+//! well-formed slug and that the recorded set stays bounded.
+
+use axum::extract::State;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+use openwave_code_execution::{
+    derived_capabilities, is_valid_plugin_name, is_valid_skill_name, PluginCapability,
+    PluginCategory, SkillOrigin, SkillPackage,
+};
+
+use crate::error::ServerError;
+use crate::extract::Json;
+use crate::plugin_state::{read_plugin_enable_state, write_plugin_enable_state};
+use crate::state::AppState;
+
+/// Body bound for the toggle route: a merge patch over slug-keyed booleans,
+/// so even a body naming every recordable component is small.
+pub const MAX_PLUGIN_ENABLE_BODY_BYTES: usize = 64 * 1024;
+
+/// Everything this installation has, in the state it is in.
+#[derive(Debug, Serialize, ts_rs::TS)]
+pub struct PluginCatalog {
+    /// Bundles in load order (by slug), each with its members.
+    pub plugins: Vec<PluginInfo>,
+    /// Skills no bundle claims — user-authored packages land here.
+    pub skills: Vec<PluginSkillInfo>,
+}
+
+/// One bundle, as a management surface renders it.
+#[derive(Debug, Serialize, ts_rs::TS)]
+pub struct PluginInfo {
+    /// The slug the toggle route addresses it by.
+    pub name: String,
+    pub display_name: String,
+    pub description: String,
+    pub category: PluginCategory,
+    /// What the bundle can do, derived by the host from what it contains.
+    /// Never self-declared: a manifest has no key for this.
+    pub capabilities: Vec<PluginCapability>,
+    /// Whether the bundle is on. Off gates every member regardless of the
+    /// member's own flag, which the member entries still report unchanged.
+    pub enabled: bool,
+    /// Member skills in manifest order.
+    pub skills: Vec<PluginSkillInfo>,
+}
+
+/// One skill, inside a bundle or standing alone.
+#[derive(Debug, Serialize, ts_rs::TS)]
+pub struct PluginSkillInfo {
+    pub name: String,
+    pub description: String,
+    /// Where the package was loaded from; host-derived, never claimed.
+    pub origin: SkillOrigin,
+    /// The skill's *own* flag, independent of any owning bundle's — so a UI
+    /// can show the member choices that come back when a bundle is re-enabled.
+    pub enabled: bool,
+}
+
+/// Body of `PUT /plugins/enabled`. Absent names are left alone.
+#[derive(Debug, Default, Deserialize, ts_rs::TS)]
+pub struct PluginEnableUpdate {
+    /// Bundle flags to set, by slug.
+    #[serde(default)]
+    pub plugins: BTreeMap<String, bool>,
+    /// Skill flags to set, by slug. Setting one inside a disabled bundle is
+    /// allowed and remembered; it takes effect when the bundle comes back.
+    #[serde(default)]
+    pub skills: BTreeMap<String, bool>,
+}
+
+/// `GET /plugins` — the installed catalog with its current enable state.
+pub async fn get_plugins(
+    State(state): State<AppState>,
+) -> Result<Json<PluginCatalog>, ServerError> {
+    let flags = read_plugin_enable_state(&*state.store).await;
+    let Some(exec) = state.code_execution.as_ref() else {
+        // An embedding with no code execution stages no skills and advertises
+        // none; an empty catalog is the honest answer, not an error.
+        return Ok(Json(PluginCatalog {
+            plugins: Vec::new(),
+            skills: Vec::new(),
+        }));
+    };
+    let installed: Vec<SkillPackage> = exec
+        .installed_skills()
+        .into_iter()
+        .map(|skill| skill.package)
+        .collect();
+    let by_name = |name: &str| installed.iter().find(|skill| skill.name == name);
+
+    let mut claimed: Vec<&str> = Vec::new();
+    let mut plugins = Vec::new();
+    for plugin in exec.installed_plugins() {
+        let members: Vec<&SkillPackage> = plugin
+            .skills
+            .iter()
+            .filter_map(|member| by_name(member))
+            .collect();
+        claimed.extend(members.iter().map(|skill| skill.name.as_str()));
+        plugins.push(PluginInfo {
+            capabilities: derived_capabilities(&plugin, &members),
+            enabled: flags.plugin_enabled(&plugin.name),
+            skills: members
+                .into_iter()
+                .map(|skill| skill_info(skill, &flags))
+                .collect(),
+            name: plugin.name,
+            display_name: plugin.display_name,
+            description: plugin.description,
+            category: plugin.category,
+        });
+    }
+    let skills = installed
+        .iter()
+        .filter(|skill| !claimed.contains(&skill.name.as_str()))
+        .map(|skill| skill_info(skill, &flags))
+        .collect();
+    Ok(Json(PluginCatalog { plugins, skills }))
+}
+
+fn skill_info(
+    skill: &SkillPackage,
+    flags: &crate::plugin_state::PluginEnableState,
+) -> PluginSkillInfo {
+    PluginSkillInfo {
+        name: skill.name.clone(),
+        description: skill.description.clone(),
+        origin: skill.origin,
+        enabled: flags.skill_flag(&skill.name),
+    }
+}
+
+/// `PUT /plugins/enabled` — set the named flags, returning the fresh catalog.
+///
+/// Names are checked against the slug grammar rather than against what is
+/// installed: a flag for a bundle that is not present today is a legitimate
+/// thing to record — reinstalling it should not silently re-enable it — while
+/// an unbounded or malformed name is not.
+pub async fn put_plugins_enabled(
+    State(state): State<AppState>,
+    Json(body): Json<PluginEnableUpdate>,
+) -> Result<Json<PluginCatalog>, ServerError> {
+    let mut flags = read_plugin_enable_state(&*state.store).await;
+    for (plugin, enabled) in &body.plugins {
+        if !is_valid_plugin_name(plugin) {
+            return Err(ServerError::bad_request(format!(
+                "not a plugin name: {plugin:?}"
+            )));
+        }
+        flags.set_plugin(plugin, *enabled);
+    }
+    for (skill, enabled) in &body.skills {
+        if !is_valid_skill_name(skill) {
+            return Err(ServerError::bad_request(format!(
+                "not a skill name: {skill:?}"
+            )));
+        }
+        flags.set_skill(skill, *enabled);
+    }
+    if !flags.within_bounds() {
+        return Err(ServerError::bad_request(
+            "too many components are switched off",
+        ));
+    }
+    write_plugin_enable_state(&*state.store, &flags).await?;
+    get_plugins(State(state)).await
+}

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -187,6 +187,14 @@ pub struct AppState {
     /// Coordinates durable Sensitive-tool decisions and low-latency wakeups.
     pub approvals: Arc<ApprovalBroker>,
     pub(crate) local_voice: Arc<dyn LocalVoiceRunner>,
+    /// The configured code-execution provider, when this embedding has one.
+    ///
+    /// Installed after assembly, like the blob store: the provider is built
+    /// before the state that carries its event bus. Only the plugin
+    /// management routes read it — they list what is installed, which is the
+    /// provider's own load — so an embedding without one (tests, headless)
+    /// simply has nothing to manage.
+    pub(crate) code_execution: Option<Arc<crate::code_execution::ConfiguredCodeExecutionProvider>>,
 }
 
 impl AppState {
@@ -331,6 +339,7 @@ impl AppState {
             events: Arc::new(EventBus::default()),
             approvals: Arc::new(ApprovalBroker::new(store)),
             local_voice: Arc::new(UnavailableLocalVoiceRunner),
+            code_execution: None,
         })
     }
 

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -2623,3 +2623,174 @@ async fn a_superseded_gateway_session_never_reads_usable() {
     .await
     .unwrap());
 }
+
+/// A router whose state carries a code-execution provider loaded from the
+/// repository's own bundled skills and plugins, over `store`.
+///
+/// The catalog routes are only interesting against a real load: what they
+/// project is exactly what staging and prompt composition read.
+fn plugin_app(store: Arc<dyn Store>, data_dir: &std::path::Path) -> (Router, Arc<str>) {
+    let secrets = Arc::new(MemSecrets::default());
+    let mut state = AppState::new(
+        Config::desktop(data_dir),
+        store.clone(),
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        secrets.clone(),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    state.code_execution = Some(Arc::new(
+        crate::code_execution::ConfiguredCodeExecutionProvider::new(
+            store,
+            secrets,
+            data_dir.join("scratch"),
+        )
+        .with_skills(Some(root.join("skills")))
+        .with_plugins(Some(root.join("plugins"))),
+    ));
+    let token = state.token.clone();
+    (app(state), token)
+}
+
+async fn get_plugins(router: &Router, bearer: &str) -> serde_json::Value {
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/plugins")
+                .header(header::AUTHORIZATION, bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    json_body(response).await
+}
+
+async fn put_plugins_enabled(
+    router: &Router,
+    bearer: &str,
+    body: serde_json::Value,
+) -> axum::response::Response {
+    router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/plugins/enabled")
+                .header(header::AUTHORIZATION, bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+/// Contract: the catalog reports host-derived badges and enable state,
+/// toggles are a merge patch that survives a restart, and a disabled bundle
+/// gates its members without erasing their own flags — so re-enabling it
+/// restores the member choices that were in place.
+#[tokio::test]
+async fn the_plugin_catalog_reports_badges_and_persists_toggles() {
+    let (dir, store) = temp_db_store("plugins.db").await;
+    let store: Arc<dyn Store> = Arc::new(store);
+    let (router, token) = plugin_app(store.clone(), dir.path());
+    let bearer = format!("Bearer {token}");
+
+    let catalog = get_plugins(&router, &bearer).await;
+    let documents = catalog["plugins"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|plugin| plugin["name"] == "documents")
+        .expect("the bundled document plugin is listed")
+        .clone();
+    assert_eq!(documents["enabled"], true);
+    // Its members declare pinned Python deps and LibreOffice, so the badges
+    // are derived rather than absent — no manifest states any of this.
+    assert_eq!(
+        documents["capabilities"],
+        serde_json::json!(["write-files", "network", "host-install"])
+    );
+
+    // Turn the bundle off and one member off, in one merge patch.
+    let response = put_plugins_enabled(
+        &router,
+        &bearer,
+        serde_json::json!({
+            "plugins": {"documents": false},
+            "skills": {"pdf-documents": false}
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // A second server over the same store sees both, so the state is durable
+    // rather than process-local.
+    let (reloaded, token) = plugin_app(store.clone(), dir.path());
+    let bearer = format!("Bearer {token}");
+    let catalog = get_plugins(&reloaded, &bearer).await;
+    let documents = catalog["plugins"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|plugin| plugin["name"] == "documents")
+        .unwrap()
+        .clone();
+    assert_eq!(documents["enabled"], false);
+    let member = |name: &str| {
+        documents["skills"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|skill| skill["name"] == name)
+            .unwrap()["enabled"]
+            .clone()
+    };
+    // The bundle's gate did not rewrite the members: one is off because the
+    // patch said so, the others are untouched.
+    assert_eq!(member("pdf-documents"), serde_json::json!(false));
+    assert_eq!(member("word-documents"), serde_json::json!(true));
+
+    // Re-enabling the bundle brings back exactly those choices.
+    let restored = put_plugins_enabled(
+        &reloaded,
+        &bearer,
+        serde_json::json!({"plugins": {"documents": true}}),
+    )
+    .await;
+    assert_eq!(restored.status(), StatusCode::OK);
+    let catalog: serde_json::Value = json_body(restored).await;
+    let documents = catalog["plugins"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|plugin| plugin["name"] == "documents")
+        .unwrap()
+        .clone();
+    assert_eq!(documents["enabled"], true);
+    assert_eq!(
+        documents["skills"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|skill| skill["name"] == "pdf-documents")
+            .unwrap()["enabled"],
+        false
+    );
+
+    // A name that is not a slug is refused rather than recorded.
+    let refused = put_plugins_enabled(
+        &reloaded,
+        &bearer,
+        serde_json::json!({"skills": {"Not A Slug": false}}),
+    )
+    .await;
+    assert_eq!(refused.status(), StatusCode::BAD_REQUEST);
+}

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -607,7 +607,10 @@ impl TurnWorker {
                 // to be staged now — waiting for the first exec to stage it
                 // loses that race and the read fails with not-found.
                 provider.stage_turn_workspace(chat.id).await;
-                (provider.skill_catalog(), provider.plugin_catalog())
+                (
+                    provider.skill_catalog().await,
+                    provider.plugin_catalog().await,
+                )
             }
             None => (Vec::new(), Vec::new()),
         };

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -360,6 +360,10 @@ mod tests {
             &cfg, &mut out,
         );
         generate::collect_from::<crate::mcp_config::McpServersInfo>(&cfg, &mut out);
+        // The installed plugin/skill catalog, its host-derived capability
+        // badges, and the toggle body the management surface sends back.
+        generate::collect_from::<crate::routes::PluginCatalog>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::PluginEnableUpdate>(&cfg, &mut out);
         // The Connected apps settings listing: per-kind health/catalog
         // projections and credential *status* — never definitions or values.
         generate::collect_from::<crate::routes::ConnectedAppsInfo>(&cfg, &mut out);


### PR DESCRIPTION
Closes #1573. Part of #1570, on top of #1581 and #1582.

## Derived capability badges

`PluginCapability` is a closed vocabulary — `write-files`, `network`, `host-install`, `live-control`, `mcp` — and `derived_capabilities(plugin, members)` computes a plugin's row from what it actually contains:

- at least one member skill ⇒ `write-files` (a skill is instructions for producing a deliverable through `exec`)
- any member with declared Python deps ⇒ `network` (the sandbox pip install under the current flow)
- any member with declared host deps ⇒ `host-install`

The result is deduplicated and sorted, so a bundle always renders the same row. `live-control` and `mcp` have no deriving source yet; they are documented as reserved for the component kinds the format is meant to grow into, so the vocabulary a UI and the permission layer render against is closed and complete rather than widening later.

Derivation is never read from a manifest. There is no `capabilities` key, and the parser's closed key set rejects one outright — asserted beside the derivation it protects.

## Enable state

Install-wide, in the existing `setting` key-value row (`plugins.enable_state`) rather than a new table — a handful of booleans does not earn one, and this is where the chat model and the background-agent ceiling already live. No schema change, so no epoch bump.

Only *disabled* components are persisted. That keeps the row proportional to what the user turned off, and it gives the plugin gate the behavior the product wants for free: the plugin flag gates its members' own flags rather than rewriting them, so re-enabling a bundle restores exactly the member choices that were in place.

Disabling bites in both places at once. `ConfiguredCodeExecutionProvider::current_skills` is the single filtered read backing workspace staging *and* the prompt catalog, so a disabled component cannot be advertised to the model while missing from the sandbox. Filtering happens where the catalog inputs are assembled, not in prompt composition — `foreground_prompt.rs` is untouched. Staging now prunes as well as writes: a workspace that staged a skill on an earlier turn does not keep serving its `SKILL.md` after the skill is switched off. Removal is best effort so a leftover directory cannot fail a command.

## API

- `GET /plugins` — the installed catalog: plugins with display metadata, derived badges, and per-member skill state, plus the skills no bundle claims. Disabled components are still listed (with `enabled: false`); hiding them would leave no way to turn them back on.
- `PUT /plugins/enabled` — a merge patch over slug-keyed booleans, returning the fresh catalog. Absent names are left alone, so two clients toggling different bundles do not clobber each other. Names are validated against the slug grammar rather than against what is installed: recording a flag for a bundle that is not present today is legitimate (reinstalling should not silently re-enable it), a malformed or unbounded one is not.

`AppState` gained an optional handle to the configured code-execution provider, installed after assembly like the blob store, so the management routes list the same load staging and prompt composition read. Wire types are generated; `wire.ts` regenerated with `UPDATE_WIRE_TYPES=1 cargo test -p openwave-server`.

## Tests

Four, no new scaffolding beyond one router helper:

- capability derivation, table-driven over dep shapes, including that a non-member never contributes a badge and that a `capabilities:` manifest key rejects
- the plugin flag gates member flags without replacing them (the reason the two maps are stored independently)
- disabling drops a component from the staged workspace *and* the catalog — extends the existing staging coverage
- the catalog route reports badges and enable state, and a toggle survives a second server over the same store

## Not in this slice

- The UI (#1574) — this is the API it consumes.
- Any permission linkage. Badges are where install/enable confirmation belongs, but nothing keys on them yet.
- Per-chat overrides; the issue scopes this to global state first.

Verified with `cargo fmt --all`, `cargo check --workspace --locked` (no lockfile change), clippy `-D warnings` on both touched crates, and the full `openwave-server` and `openwave-code-execution` lib suites. Not driven in the running app.