### PR TITLE
test(server): stop the container worker test counting sweep destroys

### DIFF
--- a/crates/openwave-server/src/sandbox_container_run/tests.rs
+++ b/crates/openwave-server/src/sandbox_container_run/tests.rs
@@ -470,11 +470,20 @@ async fn container_worker_service_drives_queued_work_over_loopback() {
         .expect("the explicitly enabled service is constructed");
         let task = tokio::spawn(worker.run());
 
+        // Wait for the run's committed result and a discharged teardown
+        // obligation. The service's maintenance cadence drives pending
+        // teardowns too, so it can issue a directed destroy for the very handle
+        // the driver is already tearing down — destroy is idempotent at the
+        // backend and the sweep is built to run beside live drivers, so the
+        // destroy call count is not a fixed number here. What the service owes
+        // is that the container it provisioned is gone and its obligation is
+        // discharged; the runner-level tests pin the exactly-once destroy on
+        // the drive path, where nothing else is sweeping.
         loop {
             let run = store.get_agent_run(run_id).await.unwrap().unwrap();
-            if run.status == AgentRunStatus::Completed
-                && backend.destroys.load(Ordering::SeqCst) == 1
-            {
+            let torn_down = backend.destroys.load(Ordering::SeqCst) >= 1
+                && store.list_sandbox_teardowns().await.unwrap().is_empty();
+            if run.status == AgentRunStatus::Completed && torn_down {
                 break;
             }
             tokio::time::sleep(Duration::from_millis(10)).await;
@@ -482,8 +491,9 @@ async fn container_worker_service_drives_queued_work_over_loopback() {
 
         task.abort();
         assert!(task.await.unwrap_err().is_cancelled());
+        // Exactly one container was created for the run, whatever the sweep did
+        // alongside the driver's own teardown.
         assert_eq!(backend.provisions.load(Ordering::SeqCst), 1);
-        assert_eq!(backend.destroys.load(Ordering::SeqCst), 1);
     })
     .await
     .expect("service drive completed within its time bound");


### PR DESCRIPTION
`container_worker_service_drives_queued_work_over_loopback` intermittently timed
out at its 30s bound under `--test-threads 32`. Instrumenting the timeout showed
the drive itself was fine every time: the run reached `Completed`, one container
was provisioned, no error was recorded — and `destroys` was **2**, not 1.

The second destroy comes from the worker's own maintenance lane. The driver's
teardown persists the obligation before the first destroy attempt and marks it
done only after a confirmed destroy. The maintenance cadence — 25ms in this
test's config — lists pending teardowns and issues a directed destroy for any
obligation carrying a committed handle. Under load the driver's window between
enqueue and complete widens far enough for a cadence pass to land inside it, and
both paths destroy the same handle.

That is what the sweep is designed to do; it is documented as safe to run beside
live drivers precisely because destroy is idempotent at the backend. The test's
wait loop, though, breaks only on `destroys == 1`, so once the count reached 2 it
could never break and the run's own success was invisible to it — the 30s
timeout was the first thing to fire.

So the fix is to stop asserting a number the service does not owe. The loop now
waits for the committed result plus a discharged teardown obligation — the
container is gone and the durable obligation is cleared — and the test still
pins that exactly one container was provisioned for the run. Exactly-once
destroy on the drive path stays covered by the runner-level tests
(`drives_a_container_run_end_to_end_over_loopback` and its siblings), which drive
`SandboxContainerRunner` directly with nothing else sweeping.

Verification: the full `openwave-server` test binary at `--test-threads 32`
failed this test twice across 26 runs before the change, and 0 times across 16
runs after. Two other tests flaked during those runs and are unrelated to this
one; they are filed separately.

Closes #1580
