### PR TITLE
feat(desktop): plugins rail destination with enable toggles and capability badges

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -36,6 +36,7 @@ import type { RetryableTurn } from "./MessageList";
 import type { TranscriptFileAttachment } from "./TranscriptFileAttachments";
 import type { TranscriptImageAttachment } from "./ImageAttachments";
 import { AppsPanel } from "./apps/AppsPanel";
+import { PluginsPanel } from "./plugins/PluginsPanel";
 import { BackgroundAgentPanel } from "./BackgroundAgentPanel";
 import { OutputDetailRoot } from "./outputs/OutputDetailRoot";
 import { OutputsView } from "./outputs/OutputsView";
@@ -678,6 +679,8 @@ export function ChatRoute({ chatId }: { chatId: string }) {
         );
       case "apps":
         return <AppsPanel panel={panel} position={side} />;
+      case "plugins":
+        return <PluginsPanel panel={panel} position={side} />;
       case "agent":
         return (
           <BackgroundAgentPanel

--- a/crates/openwave-desktop/ui/src/HomeRoute.tsx
+++ b/crates/openwave-desktop/ui/src/HomeRoute.tsx
@@ -27,6 +27,7 @@ import { ModelMenu } from "./ModelMenu";
 import { modelForSelection } from "./ModelSelection";
 import { effectiveNewChatSettings, useNewChatSettings } from "./NewChatSettings";
 import { AppsPanel } from "./apps/AppsPanel";
+import { PluginsPanel } from "./plugins/PluginsPanel";
 import { PanelLayout } from "./panel/PanelLayout";
 import type { LayoutState, PanelContent } from "./panel/panelTypes";
 import { useLayoutState } from "./panel/usePanelNav";
@@ -267,9 +268,10 @@ export function HomeRoute() {
       : undefined;
 
   // Home hosts panels the way a conversation does, but only the ones that
-  // mean something outside a chat — today, the Apps library. Anything else in
-  // the URL collapses back to home alone rather than rendering a panel whose
-  // content is scoped to a conversation this route does not have.
+  // mean something outside a chat — the Apps library and the Plugins library.
+  // Anything else in the URL collapses back to home alone rather than
+  // rendering a panel whose content is scoped to a conversation this route
+  // does not have.
   const layout = homeLayout(useLayoutState());
 
   function renderPanel(
@@ -278,6 +280,9 @@ export function HomeRoute() {
   ) {
     if (panel.type === "apps" && position !== "chat") {
       return <AppsPanel panel={panel} position={position} />;
+    }
+    if (panel.type === "plugins" && position !== "chat") {
+      return <PluginsPanel panel={panel} position={position} />;
     }
     return homeContent();
   }
@@ -387,14 +392,14 @@ export function HomeRoute() {
 }
 
 /**
- * The layouts home is willing to host: itself alone, or itself beside the
- * Apps library. A URL naming any conversation-scoped panel is a stale or
- * hand-edited link; it lands on plain home rather than an empty panel.
+ * The layouts home is willing to host: itself alone, or itself beside one of
+ * the install-wide libraries. A URL naming any conversation-scoped panel is a
+ * stale or hand-edited link; it lands on plain home rather than an empty panel.
  */
 function homeLayout(layout: LayoutState): LayoutState {
   if (layout.mode === "single") return { mode: "single", panel: { type: "chat" } };
   const supported = (panel: PanelContent) =>
-    panel.type === "chat" || panel.type === "apps";
+    panel.type === "chat" || panel.type === "apps" || panel.type === "plugins";
   if (!supported(layout.left) || !supported(layout.right)) {
     return { mode: "single", panel: { type: "chat" } };
   }

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -55,6 +55,13 @@ import {
   type ProviderInfo as WireProviderInfo,
   type ProviderKind as WireProviderKind,
   type PermissionMode as WirePermissionMode,
+  type PluginCapability as WirePluginCapability,
+  type PluginCatalog as WirePluginCatalog,
+  type PluginCategory as WirePluginCategory,
+  type PluginEnableUpdate as WirePluginEnableUpdate,
+  type PluginInfo as WirePluginInfo,
+  type PluginSkillInfo as WirePluginSkillInfo,
+  type SkillOrigin as WireSkillOrigin,
   type NetworkPolicy as WireNetworkPolicy,
   type ReasoningEffort as WireReasoningEffort,
   type Settings,
@@ -518,6 +525,27 @@ export type McpAppPayload = {
   structured_content?: unknown;
   is_error: boolean;
 };
+
+/** Everything installed, bundle by bundle, in the enable state it is in. */
+export type PluginCatalog = WirePluginCatalog;
+
+/** One bundle: its identity, its host-derived badges, and its members. */
+export type PluginInfo = WirePluginInfo;
+
+/** One skill, inside a bundle or standing alone. */
+export type PluginSkillInfo = WirePluginSkillInfo;
+
+/** What a bundle can do, derived by the host from what it contains. */
+export type PluginCapability = WirePluginCapability;
+
+/** What kind of work a bundle is for. */
+export type PluginCategory = WirePluginCategory;
+
+/** A merge patch over enable flags: absent names are left alone. */
+export type PluginEnableUpdate = WirePluginEnableUpdate;
+
+/** Where a skill package was loaded from; host-derived, never claimed. */
+export type SkillOrigin = WireSkillOrigin;
 
 /** The Apps library listing: every live local app, newest activity first. */
 export type AppLibrary = WireAppLibrary;
@@ -1153,6 +1181,25 @@ export class ApiClient {
 
   listApps(): Promise<AppLibrary> {
     return this.json("/apps", { headers: this.headers() });
+  }
+
+  listPlugins(): Promise<PluginCatalog> {
+    return this.json("/plugins", { headers: this.headers() });
+  }
+
+  /**
+   * Set the named enable flags, and take the fresh catalog back.
+   *
+   * A merge patch: the body names only what is changing, and the response is
+   * the authority on what the whole catalog now looks like — which is what
+   * lets a surface toggle optimistically and reconcile from one round trip.
+   */
+  setPluginsEnabled(update: PluginEnableUpdate): Promise<PluginCatalog> {
+    return this.json("/plugins/enabled", {
+      method: "PUT",
+      headers: this.headers(true),
+      body: JSON.stringify(update),
+    });
   }
 
   getApp(appId: string): Promise<AppDetail> {

--- a/crates/openwave-desktop/ui/src/panel/panelTypes.ts
+++ b/crates/openwave-desktop/ui/src/panel/panelTypes.ts
@@ -17,6 +17,11 @@ export type PanelContent =
   /** The Apps library; an app id turns the list into that app's detail. */
   | { type: "apps"; appId?: string }
   /**
+   * The Plugins library; a plugin slug turns the list into that bundle's
+   * detail, with its member skills and their own switches.
+   */
+  | { type: "plugins"; pluginId?: string }
+  /**
    * One background agent run, opened from its row in the transcript's agent
    * list. There is no bare agent catalog — the transcript is the list — so the
    * run id is always present.
@@ -56,6 +61,7 @@ export function isContentPanel(panel: PanelContent): boolean {
     case "chat":
     case "folders":
     case "apps":
+    case "plugins":
       return false;
     case "outputs":
       // The outputs list is navigation; a single opened output is the thing

--- a/crates/openwave-desktop/ui/src/panel/panelUrl.test.ts
+++ b/crates/openwave-desktop/ui/src/panel/panelUrl.test.ts
@@ -15,6 +15,11 @@ describe("panel URLs", () => {
     expect(parsePanelSegment("folders")).toEqual({ type: "folders" });
     expect(parsePanelSegment("apps")).toEqual({ type: "apps" });
     expect(parsePanelSegment("apps.app-1")).toEqual({ type: "apps", appId: "app-1" });
+    expect(parsePanelSegment("plugins")).toEqual({ type: "plugins" });
+    expect(parsePanelSegment("plugins.documents")).toEqual({
+      type: "plugins",
+      pluginId: "documents",
+    });
     expect(parsePanelSegment("agent.run-1")).toEqual({ type: "agent", runId: "run-1" });
     expect(parsePanelSegment("agent")).toBeNull();
     expect(parsePanelSegment("document.doc-1")).toEqual({
@@ -52,6 +57,8 @@ describe("panel URLs", () => {
       { type: "outputs" },
       { type: "outputs", outputId: "output-1" },
       { type: "folders" },
+      { type: "plugins" },
+      { type: "plugins", pluginId: "documents" },
       { type: "agent", runId: "run-1" },
     ] as const) {
       expect(parsePanelSegment(encodePanelSegment(panel))).toEqual(panel);

--- a/crates/openwave-desktop/ui/src/panel/panelUrl.ts
+++ b/crates/openwave-desktop/ui/src/panel/panelUrl.ts
@@ -21,6 +21,8 @@ import {
  *   folders
  *   apps
  *   apps.{appId}
+ *   plugins
+ *   plugins.{pluginSlug}
  *   agent.{runId}
  *
  * Only the first separator picks the panel type; what follows is read by that
@@ -48,6 +50,8 @@ export function parsePanelSegment(segment: string): PanelContent | null {
       return id ? { type: "outputs", outputId: id } : { type: "outputs" };
     case "apps":
       return id ? { type: "apps", appId: id } : { type: "apps" };
+    case "plugins":
+      return id ? { type: "plugins", pluginId: id } : { type: "plugins" };
     case "agent":
       // A run id is the whole address; there is no bare agent panel.
       return id ? { type: "agent", runId: id } : null;
@@ -83,6 +87,8 @@ export function encodePanelSegment(panel: PanelContent): string {
       return panel.outputId ? `outputs.${panel.outputId}` : "outputs";
     case "apps":
       return panel.appId ? `apps.${panel.appId}` : "apps";
+    case "plugins":
+      return panel.pluginId ? `plugins.${panel.pluginId}` : "plugins";
     case "agent":
       return `agent.${panel.runId}`;
   }

--- a/crates/openwave-desktop/ui/src/plugins/PluginDetailView.tsx
+++ b/crates/openwave-desktop/ui/src/plugins/PluginDetailView.tsx
@@ -1,0 +1,140 @@
+import { ChevronLeft } from "lucide-react";
+
+import { PanelSecondaryHeader } from "@/components/PanelHeader";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { capabilityLabel, categoryIcon, categoryLabel } from "./pluginVocabulary";
+import type { PluginCatalogState } from "./usePluginCatalog";
+
+/**
+ * One bundle, as the panel addressed `plugins.{slug}`: what it is for, what it
+ * can do, and which of its skills are on.
+ *
+ * A member's switch is gated while the bundle itself is off, because a member
+ * of a disabled bundle cannot run whatever its own flag says. It is gated
+ * rather than cleared: the server keeps member flags independently, so the
+ * choices made here come back exactly as they were when the bundle does.
+ */
+export function PluginDetailView({
+  pluginId,
+  state,
+  onBack,
+}: {
+  pluginId: string;
+  state: PluginCatalogState;
+  /** Return to the `plugins` list panel. */
+  onBack: () => void;
+}) {
+  const { catalog, loading, error, setEnabled } = state;
+  const plugin = catalog?.plugins.find((entry) => entry.name === pluginId) ?? null;
+  const Icon = plugin ? categoryIcon(plugin.category) : null;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <PanelSecondaryHeader showBorder={false} className="pr-1 pl-2">
+        <Button variant="ghost" size="icon-sm" onClick={onBack}>
+          <ChevronLeft className="size-4" />
+          <span className="sr-only">Back to plugins</span>
+        </Button>
+        <h1 className="min-w-0 truncate text-lg font-medium">
+          {plugin?.display_name ?? "Plugin"}
+        </h1>
+      </PanelSecondaryHeader>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto pt-4 pb-4">
+        {error && (
+          <p className="text-critical mx-4 text-sm" role="alert">
+            {error}
+          </p>
+        )}
+        {!error && loading && !catalog && (
+          <p className="text-muted-foreground mx-4 text-sm" role="status">
+            Loading plugin…
+          </p>
+        )}
+        {!error && catalog && !plugin && (
+          <p className="text-muted-foreground mx-4 text-sm" role="status">
+            That plugin is not installed.
+          </p>
+        )}
+
+        {plugin && (
+          <>
+            <section className="mx-4 flex flex-col gap-3" aria-label="About">
+              <div className="flex items-start gap-3">
+                <div className="flex min-w-0 flex-1 flex-col gap-1">
+                  <div className="text-muted-foreground flex items-center gap-1.5 text-xs">
+                    {Icon && <Icon className="size-3.5 shrink-0" aria-hidden="true" />}
+                    <span>{categoryLabel(plugin.category)}</span>
+                  </div>
+                  <p className="text-sm">{plugin.description}</p>
+                </div>
+                <Switch
+                  aria-label={`Enable ${plugin.display_name}`}
+                  checked={plugin.enabled}
+                  onCheckedChange={(enabled) =>
+                    setEnabled({ plugins: { [plugin.name]: enabled }, skills: {} })
+                  }
+                />
+              </div>
+
+              {plugin.capabilities.length > 0 && (
+                <div className="flex flex-wrap gap-1.5">
+                  {plugin.capabilities.map((capability) => (
+                    <Badge key={capability} variant="outline" size="sm">
+                      {capabilityLabel(capability)}
+                    </Badge>
+                  ))}
+                </div>
+              )}
+            </section>
+
+            <section className="mx-4 flex flex-col gap-2" aria-label="Skills">
+              <div className="flex flex-col gap-0.5">
+                <h2 className="text-sm font-medium">Skills</h2>
+                {!plugin.enabled && (
+                  <p className="text-muted-foreground text-xs">
+                    Turn the plugin on to change which of its skills are
+                    available. Your choices are kept while it is off.
+                  </p>
+                )}
+              </div>
+              <ul className="flex flex-col gap-1" aria-label="Member skills">
+                {plugin.skills.map((skill) => (
+                  <li key={skill.name} className="flex items-center gap-3 rounded-md p-2">
+                    <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                      <span
+                        className={`truncate text-sm font-medium${
+                          plugin.enabled ? "" : " text-muted-foreground"
+                        }`}
+                      >
+                        {skill.name}
+                      </span>
+                      <span className="text-muted-foreground line-clamp-2 text-xs">
+                        {skill.description}
+                      </span>
+                    </div>
+                    <Switch
+                      aria-label={`Enable ${skill.name}`}
+                      checked={skill.enabled}
+                      disabled={!plugin.enabled}
+                      onCheckedChange={(enabled) =>
+                        setEnabled({ plugins: {}, skills: { [skill.name]: enabled } })
+                      }
+                    />
+                  </li>
+                ))}
+              </ul>
+              {plugin.skills.length === 0 && (
+                <p className="text-muted-foreground text-sm">
+                  This plugin bundles no skills.
+                </p>
+              )}
+            </section>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/crates/openwave-desktop/ui/src/plugins/Plugins.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/plugins/Plugins.dom.test.tsx
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { PluginCatalog } from "@/api";
+import { PluginDetailView } from "./PluginDetailView";
+import type { PluginsApis } from "./pluginsApis";
+import { PluginsView } from "./PluginsView";
+import { usePluginCatalog } from "./usePluginCatalog";
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn() } }));
+
+const CATALOG: PluginCatalog = {
+  plugins: [
+    {
+      name: "documents",
+      display_name: "Documents",
+      description: "Write and revise Word documents.",
+      category: "documents",
+      capabilities: ["write-files", "host-install"],
+      enabled: false,
+      skills: [
+        {
+          name: "docx",
+          description: "Author a Word document.",
+          origin: "builtin",
+          enabled: true,
+        },
+        {
+          name: "pdf",
+          description: "Author a PDF.",
+          origin: "builtin",
+          enabled: false,
+        },
+      ],
+    },
+  ],
+  skills: [
+    {
+      name: "my-notes",
+      description: "How I like meeting notes written.",
+      origin: "user",
+      enabled: true,
+    },
+  ],
+};
+
+function catalogWith(
+  plugins: Partial<Record<string, boolean>>,
+): PluginCatalog {
+  return {
+    ...CATALOG,
+    plugins: CATALOG.plugins.map((plugin) => ({
+      ...plugin,
+      enabled: plugins[plugin.name] ?? plugin.enabled,
+    })),
+  };
+}
+
+/** Drives the real catalog hook so a toggle exercises the whole round trip. */
+function ListHarness({ apis }: { apis: PluginsApis }) {
+  const state = usePluginCatalog(apis);
+  return <PluginsView state={state} onOpen={() => {}} />;
+}
+
+function DetailHarness({ apis }: { apis: PluginsApis }) {
+  const state = usePluginCatalog(apis);
+  return (
+    <PluginDetailView pluginId="documents" state={state} onBack={() => {}} />
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("Plugins library", () => {
+  it("gates a disabled plugin's member switches without clearing their own flags", async () => {
+    const apis: PluginsApis = {
+      list: vi.fn().mockResolvedValue(CATALOG),
+      setEnabled: vi.fn(),
+    };
+    render(<DetailHarness apis={apis} />);
+
+    // The bundle is off, so no member can run whatever its own flag says —
+    // but the flags are still what the server holds, so the switches show the
+    // choices that come back when the bundle does.
+    const docx = await screen.findByRole("switch", { name: "Enable docx" });
+    const pdf = screen.getByRole("switch", { name: "Enable pdf" });
+    expect(docx).toBeDisabled();
+    expect(pdf).toBeDisabled();
+    expect(docx).toBeChecked();
+    expect(pdf).not.toBeChecked();
+
+    // Capability badges read as sentences on the detail view.
+    expect(screen.getByText("Writes files")).toBeInTheDocument();
+    expect(screen.getByText("Installs host software")).toBeInTheDocument();
+  });
+
+  it("ungates the members once the plugin's own toggle round trip lands", async () => {
+    const apis: PluginsApis = {
+      list: vi.fn().mockResolvedValue(CATALOG),
+      setEnabled: vi.fn().mockResolvedValue(catalogWith({ documents: true })),
+    };
+    render(<DetailHarness apis={apis} />);
+
+    fireEvent.click(
+      await screen.findByRole("switch", { name: "Enable Documents" }),
+    );
+    expect(apis.setEnabled).toHaveBeenCalledWith({
+      plugins: { documents: true },
+      skills: {},
+    });
+    await waitFor(() =>
+      expect(screen.getByRole("switch", { name: "Enable docx" })).toBeEnabled(),
+    );
+  });
+
+  it("reconciles a list toggle from the catalog the server returns", async () => {
+    // The server answers with more than the toggle asked for — the user skill
+    // comes back off too — and the surface takes that as the truth rather than
+    // keeping its optimistic guess.
+    const reconciled: PluginCatalog = {
+      ...catalogWith({ documents: true }),
+      skills: [{ ...CATALOG.skills[0]!, enabled: false }],
+    };
+    const apis: PluginsApis = {
+      list: vi.fn().mockResolvedValue(CATALOG),
+      setEnabled: vi.fn().mockResolvedValue(reconciled),
+    };
+    render(<ListHarness apis={apis} />);
+
+    const bundle = await screen.findByRole("switch", { name: "Enable Documents" });
+    fireEvent.click(bundle);
+    // Optimistic: the switch is on before the request resolves.
+    expect(bundle).toBeChecked();
+    await waitFor(() =>
+      expect(
+        screen.getByRole("switch", { name: "Enable my-notes" }),
+      ).not.toBeChecked(),
+    );
+    expect(bundle).toBeChecked();
+  });
+
+  it("puts a failed toggle back where it was", async () => {
+    const apis: PluginsApis = {
+      list: vi.fn().mockResolvedValue(CATALOG),
+      setEnabled: vi.fn().mockRejectedValue(new Error("offline")),
+    };
+    render(<ListHarness apis={apis} />);
+
+    const skill = await screen.findByRole("switch", { name: "Enable my-notes" });
+    expect(skill).toBeChecked();
+    fireEvent.click(skill);
+    // Optimistic first, then back where it was once the write fails: the
+    // surface never keeps claiming a state the server did not record.
+    expect(skill).not.toBeChecked();
+    await waitFor(() => expect(skill).toBeChecked());
+    expect(apis.setEnabled).toHaveBeenCalledWith({
+      plugins: {},
+      skills: { "my-notes": false },
+    });
+  });
+
+  it("explains an installation with nothing in it", async () => {
+    const apis: PluginsApis = {
+      list: vi.fn().mockResolvedValue({ plugins: [], skills: [] }),
+      setEnabled: vi.fn(),
+    };
+    render(<ListHarness apis={apis} />);
+
+    expect(await screen.findByText("No plugins installed")).toBeInTheDocument();
+    // The user-skills section is absent rather than empty when there are none.
+    expect(screen.queryByLabelText("Your skills")).not.toBeInTheDocument();
+  });
+});

--- a/crates/openwave-desktop/ui/src/plugins/PluginsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/plugins/PluginsPanel.tsx
@@ -1,0 +1,45 @@
+import { useMemo } from "react";
+
+import { useApp } from "@/AppContext";
+import { PanelFrame } from "@/panel/PanelFrame";
+import type { PanelContent } from "@/panel/panelTypes";
+import { usePanelNav } from "@/panel/usePanelNav";
+import { PluginDetailView } from "./PluginDetailView";
+import { pluginsApisFromClient } from "./pluginsApis";
+import { PluginsView } from "./PluginsView";
+import { usePluginCatalog } from "./usePluginCatalog";
+
+/**
+ * The `plugins` panel: the library list, or — addressed `plugins.{slug}` — one
+ * bundle's detail. Both read the catalog this panel owns, so a switch flipped
+ * on the list is already flipped when the detail opens.
+ */
+export function PluginsPanel({
+  panel,
+  position,
+}: {
+  panel: Extract<PanelContent, { type: "plugins" }>;
+  position: "left" | "right";
+}) {
+  const { client } = useApp();
+  const { openPanel } = usePanelNav();
+  const apis = useMemo(() => pluginsApisFromClient(client), [client]);
+  const state = usePluginCatalog(apis);
+
+  return (
+    <PanelFrame position={position} spaceBetween>
+      {panel.pluginId ? (
+        <PluginDetailView
+          pluginId={panel.pluginId}
+          state={state}
+          onBack={() => openPanel({ type: "plugins" })}
+        />
+      ) : (
+        <PluginsView
+          state={state}
+          onOpen={(pluginId) => openPanel({ type: "plugins", pluginId })}
+        />
+      )}
+    </PanelFrame>
+  );
+}

--- a/crates/openwave-desktop/ui/src/plugins/PluginsView.tsx
+++ b/crates/openwave-desktop/ui/src/plugins/PluginsView.tsx
@@ -1,0 +1,236 @@
+import { ChevronRight, Puzzle } from "lucide-react";
+import type { ReactNode } from "react";
+
+import type { PluginInfo, PluginSkillInfo } from "@/api";
+import { PanelSecondaryHeader } from "@/components/PanelHeader";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import { Switch } from "@/components/ui/switch";
+import { capabilityShortLabel, categoryIcon } from "./pluginVocabulary";
+import type { PluginCatalogState } from "./usePluginCatalog";
+
+/**
+ * The Plugins library, as the panel addressed `plugins`.
+ *
+ * Install-wide rather than conversation-scoped — a bundle being on is a
+ * property of this installation, not of the chat you happened to be in when
+ * you switched it — which is why this hangs off the home rail beside the Apps
+ * library. Picking a row opens `plugins.{slug}`: the bundle's description, its
+ * badges, and its member skills with their own switches.
+ *
+ * The origin split is the catalog's own: bundles first, then the skills no
+ * bundle claims, with anything the user wrote themselves called out as theirs.
+ */
+export function PluginsView({
+  state,
+  onOpen,
+}: {
+  state: PluginCatalogState;
+  /** Navigate to the `plugins.{slug}` panel contract. */
+  onOpen: (pluginId: string) => void;
+}) {
+  const { catalog, loading, error, reload, setEnabled } = state;
+  const yourSkills = catalog?.skills.filter((skill) => skill.origin === "user") ?? [];
+  const otherSkills =
+    catalog?.skills.filter((skill) => skill.origin !== "user") ?? [];
+  const isEmpty =
+    catalog !== null && catalog.plugins.length === 0 && catalog.skills.length === 0;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <PanelSecondaryHeader showBorder={false} className="pr-1 pl-4">
+        <h1 className="text-lg font-medium">Plugins</h1>
+      </PanelSecondaryHeader>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto pt-4 pb-4">
+        {error && (
+          <div
+            className="mx-4 flex shrink-0 items-center justify-between gap-3 rounded-md bg-critical-background px-3 py-2 text-sm text-critical-foreground-muted"
+            role="alert"
+          >
+            <span>{error}</span>
+            <Button variant="outline" size="xs" className="shrink-0" onClick={reload}>
+              Try again
+            </Button>
+          </div>
+        )}
+
+        {loading && !catalog && (
+          <p className="text-muted-foreground px-4 text-sm" role="status">
+            Loading your plugins…
+          </p>
+        )}
+
+        {isEmpty && (
+          <Empty>
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <Puzzle />
+              </EmptyMedia>
+              <EmptyTitle>No plugins installed</EmptyTitle>
+              <EmptyDescription>
+                Plugins bundle the skills OpenWave can use in a conversation.
+                This installation has none available — the ones that ship with
+                the app appear here once code execution is set up.
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        )}
+
+        {catalog && catalog.plugins.length > 0 && (
+          <Section title="Plugins">
+            <ul className="flex flex-col gap-1" aria-label="Plugins">
+              {catalog.plugins.map((plugin) => (
+                <li key={plugin.name}>
+                  <PluginRow
+                    plugin={plugin}
+                    onOpen={() => onOpen(plugin.name)}
+                    onToggle={(enabled) =>
+                      setEnabled({ plugins: { [plugin.name]: enabled }, skills: {} })
+                    }
+                  />
+                </li>
+              ))}
+            </ul>
+          </Section>
+        )}
+
+        {yourSkills.length > 0 && (
+          <Section
+            title="Your skills"
+            description="Skills you wrote, loaded from your data directory. They stand on their own rather than belonging to a bundle."
+          >
+            <SkillList skills={yourSkills} setEnabled={setEnabled} label="Your skills" />
+          </Section>
+        )}
+
+        {otherSkills.length > 0 && (
+          <Section
+            title="Other skills"
+            description="Installed skills that no bundle claims."
+          >
+            <SkillList skills={otherSkills} setEnabled={setEnabled} label="Other skills" />
+          </Section>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="mx-3 flex flex-col gap-2" aria-label={title}>
+      <div className="flex flex-col gap-0.5 px-1">
+        <h2 className="text-sm font-medium">{title}</h2>
+        {description && (
+          <p className="text-muted-foreground text-xs">{description}</p>
+        )}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+/**
+ * A bundle's row: the whole row opens the detail, and the switch — which is
+ * not inside that button — turns the bundle on and off without leaving the
+ * list.
+ */
+function PluginRow({
+  plugin,
+  onOpen,
+  onToggle,
+}: {
+  plugin: PluginInfo;
+  onOpen: () => void;
+  onToggle: (enabled: boolean) => void;
+}) {
+  const Icon = categoryIcon(plugin.category);
+  return (
+    <div className="hover:bg-muted flex items-center gap-3 rounded-md p-2 transition-colors">
+      <button
+        type="button"
+        className="flex min-w-0 flex-1 items-start gap-3 text-left"
+        onClick={onOpen}
+      >
+        <Icon className="text-muted-foreground mt-0.5 size-4 shrink-0" aria-hidden="true" />
+        <span className="flex min-w-0 flex-1 flex-col gap-1">
+          <span className="flex min-w-0 items-center gap-1.5">
+            <span className="truncate text-sm font-medium">{plugin.display_name}</span>
+            <ChevronRight
+              className="text-muted-foreground size-3.5 shrink-0"
+              aria-hidden="true"
+            />
+          </span>
+          <span className="text-muted-foreground line-clamp-2 text-xs">
+            {plugin.description}
+          </span>
+          {plugin.capabilities.length > 0 && (
+            <span className="flex flex-wrap gap-1 pt-0.5">
+              {plugin.capabilities.map((capability) => (
+                <Badge key={capability} variant="outline" size="sm">
+                  {capabilityShortLabel(capability)}
+                </Badge>
+              ))}
+            </span>
+          )}
+        </span>
+      </button>
+      <Switch
+        aria-label={`Enable ${plugin.display_name}`}
+        checked={plugin.enabled}
+        onCheckedChange={onToggle}
+      />
+    </div>
+  );
+}
+
+function SkillList({
+  skills,
+  setEnabled,
+  label,
+}: {
+  skills: PluginSkillInfo[];
+  setEnabled: PluginCatalogState["setEnabled"];
+  label: string;
+}) {
+  return (
+    <ul className="flex flex-col gap-1" aria-label={label}>
+      {skills.map((skill) => (
+        <li
+          key={skill.name}
+          className="flex items-center gap-3 rounded-md p-2 transition-colors"
+        >
+          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+            <span className="truncate text-sm font-medium">{skill.name}</span>
+            <span className="text-muted-foreground line-clamp-2 text-xs">
+              {skill.description}
+            </span>
+          </div>
+          <Switch
+            aria-label={`Enable ${skill.name}`}
+            checked={skill.enabled}
+            onCheckedChange={(enabled) =>
+              setEnabled({ plugins: {}, skills: { [skill.name]: enabled } })
+            }
+          />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/crates/openwave-desktop/ui/src/plugins/pluginVocabulary.ts
+++ b/crates/openwave-desktop/ui/src/plugins/pluginVocabulary.ts
@@ -1,0 +1,64 @@
+import { BarChart3, FileText, Package, Table2 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+import type { PluginCapability, PluginCategory } from "@/api";
+
+/**
+ * A short, human reading of one derived badge.
+ *
+ * The vocabulary is closed server-side, so this table is total: a capability
+ * the host can derive always has words here rather than falling back to the
+ * wire slug. `live-control` and `mcp` are not derived by anything today; they
+ * are named anyway because the surface renders whatever comes back, and the
+ * day a bundle earns one it should read like the others.
+ */
+const CAPABILITY_LABELS: Record<PluginCapability, string> = {
+  "write-files": "Writes files",
+  network: "Installs packages over the network",
+  "host-install": "Installs host software",
+  "live-control": "Controls a live surface",
+  mcp: "Bundles an MCP server",
+};
+
+export function capabilityLabel(capability: PluginCapability): string {
+  return CAPABILITY_LABELS[capability];
+}
+
+/**
+ * The short form for a list row, where a badge sits beside a name rather than
+ * on a detail page with room to explain itself.
+ */
+const CAPABILITY_SHORT_LABELS: Record<PluginCapability, string> = {
+  "write-files": "Files",
+  network: "Network",
+  "host-install": "Host install",
+  "live-control": "Live control",
+  mcp: "MCP",
+};
+
+export function capabilityShortLabel(capability: PluginCapability): string {
+  return CAPABILITY_SHORT_LABELS[capability];
+}
+
+const CATEGORY_LABELS: Record<PluginCategory, string> = {
+  documents: "Documents",
+  data: "Data",
+  visualization: "Visualization",
+  other: "Other",
+};
+
+export function categoryLabel(category: PluginCategory): string {
+  return CATEGORY_LABELS[category];
+}
+
+/** A plugin has no icon of its own yet, so its category stands in for one. */
+const CATEGORY_ICONS: Record<PluginCategory, LucideIcon> = {
+  documents: FileText,
+  data: Table2,
+  visualization: BarChart3,
+  other: Package,
+};
+
+export function categoryIcon(category: PluginCategory): LucideIcon {
+  return CATEGORY_ICONS[category];
+}

--- a/crates/openwave-desktop/ui/src/plugins/pluginsApis.ts
+++ b/crates/openwave-desktop/ui/src/plugins/pluginsApis.ts
@@ -1,0 +1,19 @@
+import type { ApiClient, PluginCatalog, PluginEnableUpdate } from "@/api";
+
+/**
+ * Everything the Plugins library calls on the server, as one injectable
+ * object — the {@link import("@/apps/appsApis").AppsApis} pattern, so the list,
+ * the detail, and the toggle round trip are drivable in tests without a
+ * network.
+ */
+export type PluginsApis = {
+  list(): Promise<PluginCatalog>;
+  setEnabled(update: PluginEnableUpdate): Promise<PluginCatalog>;
+};
+
+export function pluginsApisFromClient(client: ApiClient): PluginsApis {
+  return {
+    list: () => client.listPlugins(),
+    setEnabled: (update) => client.setPluginsEnabled(update),
+  };
+}

--- a/crates/openwave-desktop/ui/src/plugins/usePluginCatalog.ts
+++ b/crates/openwave-desktop/ui/src/plugins/usePluginCatalog.ts
@@ -1,0 +1,125 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+
+import type {
+  PluginCatalog,
+  PluginEnableUpdate,
+  PluginSkillInfo,
+} from "@/api";
+import type { PluginsApis } from "./pluginsApis";
+
+/**
+ * The catalog as it would read if `update` had already been accepted.
+ *
+ * Applied to the current catalog so a switch moves under the finger rather
+ * than after the round trip. It is deliberately the same merge-patch shape the
+ * route takes — a name the update omits is left exactly as it was — so this
+ * and the server can never disagree about what a body meant. A member skill's
+ * own flag is set wherever it appears: inside its bundle, or standing alone.
+ */
+export function applyEnableUpdate(
+  catalog: PluginCatalog,
+  update: PluginEnableUpdate,
+): PluginCatalog {
+  const applySkill = (skill: PluginSkillInfo): PluginSkillInfo => {
+    const next = update.skills[skill.name];
+    return next === undefined ? skill : { ...skill, enabled: next };
+  };
+  return {
+    plugins: catalog.plugins.map((plugin) => {
+      const next = update.plugins[plugin.name];
+      return {
+        ...plugin,
+        enabled: next === undefined ? plugin.enabled : next,
+        skills: plugin.skills.map(applySkill),
+      };
+    }),
+    skills: catalog.skills.map(applySkill),
+  };
+}
+
+export type PluginCatalogState = {
+  catalog: PluginCatalog | null;
+  loading: boolean;
+  /** A failed *load*; a failed toggle reverts and speaks through a toast. */
+  error: string | null;
+  reload: () => void;
+  /** Toggle optimistically, then reconcile from what the server returns. */
+  setEnabled: (update: PluginEnableUpdate) => void;
+};
+
+/**
+ * The Plugins library's one piece of state, owned above both views so the list
+ * and a bundle's detail are never two catalogs disagreeing about the same
+ * switch.
+ *
+ * Toggling is optimistic and reconciled: the response to `PUT /plugins/enabled`
+ * is the whole catalog, so it is taken as the truth rather than merged into a
+ * local guess. A failure puts back the catalog the toggle started from — the
+ * switch snaps back and says why, instead of leaving the surface claiming a
+ * state the server never recorded.
+ */
+export function usePluginCatalog(apis: PluginsApis): PluginCatalogState {
+  const [catalog, setCatalog] = useState<PluginCatalog | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  // Bumped by every load and every write, so a slow response that has been
+  // overtaken — by a reload, an unmount, or a later toggle — is dropped rather
+  // than reinstating a catalog the reader has already moved past.
+  const generationRef = useRef(0);
+
+  const reload = useCallback(() => {
+    const generation = ++generationRef.current;
+    setLoading(true);
+    setError(null);
+    void (async () => {
+      try {
+        const loaded = await apis.list();
+        if (generation !== generationRef.current) return;
+        setCatalog(loaded);
+      } catch (caught) {
+        if (generation !== generationRef.current) return;
+        setError(friendlyPluginError(caught, "Could not load your plugins."));
+      } finally {
+        if (generation === generationRef.current) setLoading(false);
+      }
+    })();
+  }, [apis]);
+
+  useEffect(() => {
+    reload();
+    return () => {
+      generationRef.current += 1;
+    };
+  }, [reload]);
+
+  const setEnabled = useCallback(
+    (update: PluginEnableUpdate) => {
+      const previous = catalog;
+      if (!previous) return;
+      const generation = ++generationRef.current;
+      setCatalog(applyEnableUpdate(previous, update));
+      void (async () => {
+        try {
+          const fresh = await apis.setEnabled(update);
+          if (generation !== generationRef.current) return;
+          setCatalog(fresh);
+        } catch (caught) {
+          if (generation !== generationRef.current) return;
+          setCatalog(previous);
+          toast.error(
+            friendlyPluginError(caught, "Could not save that change."),
+          );
+        }
+      })();
+    },
+    [apis, catalog],
+  );
+
+  return { catalog, loading, error, reload, setEnabled };
+}
+
+export function friendlyPluginError(error: unknown, fallback: string): string {
+  const message = String(error).replace(/^Error:\s*/, "").trim();
+  return message && message.length <= 240 ? message : fallback;
+}

--- a/crates/openwave-desktop/ui/src/sidebar/HomeSidebar.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/HomeSidebar.tsx
@@ -1,5 +1,5 @@
 import { useNavigate, useRouterState, useSearch } from "@tanstack/react-router";
-import { LayoutGrid, MessagesSquare } from "lucide-react";
+import { LayoutGrid, MessagesSquare, Puzzle } from "lucide-react";
 
 import { useApp } from "@/AppContext";
 import { useChatListStore } from "@/ChatListStore";
@@ -35,6 +35,13 @@ export function HomeSidebar() {
     segment === "apps" || segment?.startsWith("apps.") === true;
   const appsOpen =
     pathname === "/" && (holdsApps(search.left) || holdsApps(search.right));
+
+  // Plugins read the same way: install-wide, hosted on home, current whichever
+  // slot holds the list or one bundle's detail.
+  const holdsPlugins = (segment: string | undefined) =>
+    segment === "plugins" || segment?.startsWith("plugins.") === true;
+  const pluginsOpen =
+    pathname === "/" && (holdsPlugins(search.left) || holdsPlugins(search.right));
 
   return (
     <SidebarFrame>
@@ -75,7 +82,8 @@ export function HomeSidebar() {
       </div>
 
       {/* Apps are profile-scoped — they outlive every conversation — so their
-          library belongs on the chat-free rail, opening as a panel on home. */}
+          library belongs on the chat-free rail, opening as a panel on home.
+          Plugins are install-wide for the same reason and sit beside them. */}
       <SidebarSectionTitle className="mt-4">Library</SidebarSectionTitle>
       <SidebarButton
         aria-current={appsOpen ? "page" : undefined}
@@ -85,6 +93,15 @@ export function HomeSidebar() {
       >
         <LayoutGrid />
         <span>Apps</span>
+      </SidebarButton>
+      <SidebarButton
+        aria-current={pluginsOpen ? "page" : undefined}
+        data-active={pluginsOpen || undefined}
+        className="data-[active]:bg-muted"
+        onClick={() => void navigate({ to: "/", search: { left: "plugins" } })}
+      >
+        <Puzzle />
+        <span>Plugins</span>
       </SidebarButton>
     </SidebarFrame>
   );


### PR DESCRIPTION
A Plugins destination in the home rail, beside the Apps library and for the same reason: what is installed and what is switched on is a property of this installation, not of the conversation you happened to be in.

## Routing and layout

Plugins is a panel addressed by the URL like every other — `plugins` for the library, `plugins.{slug}` for one bundle's detail — so a layout with the library open survives a reload and can be linked at. It is a navigation panel, so it settles on the left and leaves whatever is in the other slot alone. Home hosts it (the rail entry lands there), and the chat route renders it too, so opening it from beside a conversation keeps the conversation.

The catalog is owned by the panel and passed to both views, so the list and a bundle's detail are never two catalogs disagreeing about the same switch.

## The surfaces

The list shows each bundle with a category glyph, its description, short capability badges and its own switch, then the skills no bundle claims — split so anything the user wrote is attributed to them, and absent entirely when there are none. An installation with nothing in it (headless, or before code execution is set up) gets an explanatory empty state rather than a bare list.

The detail view spells the badges out in full sentences ("Installs host software" rather than "Host install"), shows the category, and gives every member skill a switch. A member's switch is gated while its bundle is off, but never cleared: the server keeps member flags independently, so the choices made there come back exactly as they were when the bundle comes back. The capability table is total over the closed wire vocabulary, including the two nothing derives yet, so the day a bundle earns one it reads like the others.

## State

Toggling is optimistic, then reconciled from the whole catalog `PUT /plugins/enabled` returns rather than merged into a local guess. Requests are generation-guarded, so an overtaken response cannot reinstate a state the reader has moved past. A failed write puts back the catalog the toggle started from and says why through the existing toast, so the surface never keeps claiming a state the server did not record.

## Scope

Installed-set management only — no marketplace or browse surface, and no composer `/` reach. UI-only diff; no Rust touched.

## Tests

Five component tests over the two views driving the real catalog hook: member switches gated (and their own flags intact) under a disabled bundle, ungating once the bundle's round trip lands, reconciliation taking the server's catalog over the optimistic guess, a failed write reverting, and the empty state. The panel-URL round-trip test gains the two new segments.

`pnpm exec tsc --noEmit`, `pnpm test` (110 files, 733 tests) and `pnpm build` all pass locally.

I could not drive the running app, so the visual result is unverified beyond following the existing Apps library's structure and the shared shadcn/oklch primitives.

Closes #1574