### PR TITLE
feat(sandbox): steer a live sandbox-resident agent mid-run

### DIFF
--- a/crates/openwave-sandbox-agent/src/agent.rs
+++ b/crates/openwave-sandbox-agent/src/agent.rs
@@ -25,6 +25,16 @@
 //! back for the next step; any other completion is the final answer. The host
 //! (or, in tests, a mock host model) is what decides the directive, so the loop
 //! is genuinely driven from the model over the reverse channel.
+//!
+//! # Steering
+//!
+//! The run is not fire-and-forget once it starts. At every step boundary the
+//! loop takes whatever the host has
+//! [steered](openwave_sandbox_protocol::steer) over the live connection and
+//! appends it to the transcript as user-authored guidance, so a mid-run
+//! instruction changes what the next completion is asked for. Guidance that
+//! arrives while a model call is in flight lands on the following step; nothing
+//! interrupts a step already underway.
 
 use std::path::PathBuf;
 
@@ -36,6 +46,10 @@ use crate::tools::sandbox_tool_registry;
 
 /// The prefix a model completion uses to request a local tool call.
 const TOOL_DIRECTIVE: &str = "use-tool:";
+
+/// How a host-sent steering instruction is labelled in the transcript, so the
+/// model reads it as guidance from the user rather than as tool output.
+pub const STEERING_PREFIX: &str = "Steering from the user: ";
 
 /// Bound on model steps, so a model that never finishes cannot loop forever.
 const MAX_STEPS: usize = 8;
@@ -105,6 +119,19 @@ async fn run_loop(
 
     let mut transcript = format!("Task: {task}\n");
     for _step in 0..MAX_STEPS {
+        // Fold in whatever the host has steered since the last step. Steering is
+        // applied at the step boundary, as user-authored guidance appended to the
+        // transcript the next completion is asked for — the loop reads it exactly
+        // as it reads the task, so late guidance can redirect the run without
+        // restarting it. Each one is echoed on the event stream so the host's
+        // journal shows when an instruction took effect, not merely that it was
+        // sent.
+        for instruction in run.take_steering() {
+            let _ = run
+                .emit_progress(format!("applying steering: {instruction}"))
+                .await;
+            transcript.push_str(&format!("{STEERING_PREFIX}{instruction}\n"));
+        }
         // Each model step is its own durable operation, so a re-issue after a
         // reconnect is answered from the host's recorded outcome.
         let completion = model

--- a/crates/openwave-sandbox-agent/src/lib.rs
+++ b/crates/openwave-sandbox-agent/src/lib.rs
@@ -41,7 +41,7 @@ pub mod model;
 pub mod supervisor;
 pub mod tools;
 
-pub use agent::{run_agent, AgentRunError};
+pub use agent::{run_agent, AgentRunError, STEERING_PREFIX};
 pub use egress::{EgressProxy, EgressProxyConfig};
 pub use exec::{ExecTool, EXEC_TOOL};
 pub use fs::{

--- a/crates/openwave-sandbox-protocol/src/lib.rs
+++ b/crates/openwave-sandbox-protocol/src/lib.rs
@@ -62,6 +62,7 @@ pub mod protocol;
 pub mod provisioning;
 pub mod reference;
 pub mod reverse;
+pub mod steer;
 pub mod wire;
 
 pub use host::{CapabilityHost, ReverseWaiter};
@@ -82,8 +83,9 @@ pub use reverse::{
     ModelInferenceResult, RequestFrame, ReverseEnvelope, ReverseRequest, ReverseResponseEnvelope,
     ReverseResult, RunProvenance,
 };
+pub use steer::{SteerMessage, MAX_PENDING_STEERS, MAX_STEER_BYTES};
 pub use wire::sandbox::serve_connection;
 pub use wire::{
     host::ConnectError, read_frame, write_frame, FrameError, HostConnection, ReverseOutcome,
-    SandboxRun, WireClient, WireFrame,
+    SandboxRun, SteerError, WireClient, WireFrame,
 };

--- a/crates/openwave-sandbox-protocol/src/protocol.rs
+++ b/crates/openwave-sandbox-protocol/src/protocol.rs
@@ -20,9 +20,16 @@ use crate::provisioning::TransportSecret;
 /// negotiation window across versions.
 ///
 /// Version 2 added authenticated attach, version 3 added run initialization,
-/// and version 4 adds sandbox acknowledgement of consumed reverse responses so
-/// the host can evict replay bodies safely.
-pub const PROTOCOL_VERSION: u32 = 4;
+/// version 4 added sandbox acknowledgement of consumed reverse responses so the
+/// host can evict replay bodies safely, and version 5 adds host -> sandbox
+/// [steering](crate::steer) of a live run.
+///
+/// A new frame is an incompatible change here even though it is additive: the
+/// wire envelope names a closed set of lanes and refuses an unknown one rather
+/// than skipping it, so a peer that has never heard of a lane must be turned
+/// away at the handshake — where the refusal is legible — instead of dropping a
+/// frame it cannot parse mid-run.
+pub const PROTOCOL_VERSION: u32 = 5;
 
 /// Largest single reverse-RPC or event frame a conforming transport accepts,
 /// so a peer cannot force unbounded buffering with one enormous frame.

--- a/crates/openwave-sandbox-protocol/src/steer.rs
+++ b/crates/openwave-sandbox-protocol/src/steer.rs
@@ -1,0 +1,91 @@
+//! Host -> sandbox steering: mid-run guidance for a live agent loop.
+//!
+//! A background run is otherwise fire-and-join — the host delivers a task at
+//! [init](crate::init::RunInit) and then only reads events. Steering is the one
+//! host-originated instruction that reaches a *running* loop: the host sends a
+//! [`SteerMessage`] over the live connection and the sandbox folds its text into
+//! the agent's next model step.
+//!
+//! # Attached-only, and deliberately not queued
+//!
+//! A steer is delivered over the connection the host holds; there is no durable
+//! queue behind it. A host with no live connection cannot steer, and learns so
+//! immediately rather than parking an instruction that may never be read. The
+//! sandbox likewise buffers only a bounded number of un-consumed steers
+//! ([`MAX_PENDING_STEERS`]) so a host that steers faster than the loop steps
+//! cannot grow sandbox memory without bound.
+//!
+//! # Ordering
+//!
+//! Steering is carried on the reserved control lane, which the writer drains
+//! ahead of the request lane, so an instruction is not stuck behind a reverse
+//! response or a replay backlog. It is applied at a step boundary, never
+//! mid-step: the loop consumes what has arrived when it composes its next
+//! prompt, so a steer sent while a model call is in flight lands on the step
+//! after it.
+
+use serde::{Deserialize, Serialize};
+
+/// Largest UTF-8 payload one steer message may carry.
+///
+/// Well under the frame bound: an instruction is a sentence or a paragraph, not
+/// a document, and a host that wants to hand the sandbox a document has the
+/// filesystem for it.
+pub const MAX_STEER_BYTES: usize = 8 * 1024;
+
+/// Largest number of steer messages the sandbox holds for a loop that has not
+/// reached its next step boundary. Past it the oldest pending instruction is
+/// dropped: the newest guidance is the guidance the user meant.
+pub const MAX_PENDING_STEERS: usize = 16;
+
+/// One mid-run instruction the host sends to a live sandbox-resident agent.
+///
+/// The sandbox folds [`text`](Self::text) into the agent's next model step as
+/// user-authored guidance. It is host-originated and never echoed back; the
+/// sandbox reports what it did with it on its own event stream.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SteerMessage {
+    /// The instruction, bounded by [`MAX_STEER_BYTES`].
+    pub text: String,
+}
+
+impl SteerMessage {
+    /// A steer carrying `text`.
+    #[must_use]
+    pub fn new(text: impl Into<String>) -> Self {
+        Self { text: text.into() }
+    }
+
+    /// Whether the instruction is within its declared bound.
+    ///
+    /// Checked by the sender before it writes the frame and by the sandbox
+    /// before it queues one: an over-bound steer is refused, not truncated,
+    /// because a half-instruction is worse guidance than none.
+    #[must_use]
+    pub fn within_bounds(&self) -> bool {
+        self.text.len() <= MAX_STEER_BYTES
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn steer_roundtrips_and_is_bounded() {
+        let message = SteerMessage::new("prefer the smaller refactor");
+        let encoded = serde_json::to_string(&message).unwrap();
+        assert_eq!(
+            serde_json::from_str::<SteerMessage>(&encoded).unwrap(),
+            message
+        );
+        assert!(message.within_bounds());
+        assert!(!SteerMessage::new("x".repeat(MAX_STEER_BYTES + 1)).within_bounds());
+    }
+
+    #[test]
+    fn unknown_fields_are_rejected() {
+        assert!(serde_json::from_str::<SteerMessage>(r#"{"text":"hi","urgent":true}"#).is_err());
+    }
+}

--- a/crates/openwave-sandbox-protocol/src/wire/host.rs
+++ b/crates/openwave-sandbox-protocol/src/wire/host.rs
@@ -54,6 +54,18 @@ pub enum ConnectError {
     Transport(#[from] FrameError),
 }
 
+/// Why steering a live run did not reach the sandbox.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum SteerError {
+    /// The instruction exceeded [`MAX_STEER_BYTES`](crate::steer::MAX_STEER_BYTES).
+    #[error("the steering instruction exceeded its size bound")]
+    TooLarge,
+    /// The connection closed; an unattached run cannot be steered, and nothing
+    /// is queued for it.
+    #[error("the run is not attached")]
+    Disconnected,
+}
+
 /// The host's live connection to a sandbox.
 ///
 /// Holds the accepted handshake, a receiver for the sandbox's event stream, and
@@ -240,6 +252,33 @@ impl HostConnection {
             .await;
     }
 
+    /// Steer the live run: hand the sandbox one mid-run instruction to fold into
+    /// its agent loop's next model step.
+    ///
+    /// Attached-only by construction — this is a method on a live connection, so
+    /// there is nowhere to leave an instruction for a run that is not attached,
+    /// and nothing is queued on the host's behalf. It rides the reserved control
+    /// lane, so it is not stuck behind a reverse response or a replay backlog.
+    ///
+    /// Acceptance means the instruction was handed to a connection that was live
+    /// when it was written, not that the agent has read it: a connection that
+    /// drops in the same instant loses it, and the caller steers again.
+    ///
+    /// # Errors
+    /// [`SteerError::TooLarge`] past [`MAX_STEER_BYTES`](crate::steer::MAX_STEER_BYTES)
+    /// — refused rather than truncated — or [`SteerError::Disconnected`] once the
+    /// connection has closed.
+    pub async fn send_steer(&self, message: crate::steer::SteerMessage) -> Result<(), SteerError> {
+        if !message.within_bounds() {
+            return Err(SteerError::TooLarge);
+        }
+        self.outbound
+            .control
+            .send(WireFrame::Steer(message))
+            .await
+            .map_err(|_| SteerError::Disconnected)
+    }
+
     /// Start sending host-ownership keepalives over the reserved control lane.
     ///
     /// The first keepalive is immediate, then one is sent every `interval` until
@@ -344,13 +383,15 @@ async fn read_loop<R>(
                     Err(TrySendError::Full(_) | TrySendError::Closed(_)) => break,
                 }
             }
-            // The host answers requests; it never receives responses or another
-            // handshake mid-connection. Ignore rather than trust peer input.
+            // The host answers requests; it never receives responses, another
+            // handshake mid-connection, or its own host -> sandbox frames.
+            // Ignore rather than trust peer input.
             WireFrame::Request(RequestFrame::Response(_))
             | WireFrame::Attach(_)
             | WireFrame::Handshake(_)
             | WireFrame::EventAck { .. }
-            | WireFrame::Init(_) => {}
+            | WireFrame::Init(_)
+            | WireFrame::Steer(_) => {}
         }
     }
 }

--- a/crates/openwave-sandbox-protocol/src/wire/mod.rs
+++ b/crates/openwave-sandbox-protocol/src/wire/mod.rs
@@ -54,7 +54,7 @@ use crate::{
     reverse::{ControlFrame, RequestFrame},
 };
 
-pub use host::{HostConnection, WireClient};
+pub use host::{HostConnection, SteerError, WireClient};
 pub use sandbox::{serve_connection, ReverseOutcome, SandboxRun};
 
 /// How long either side waits for the handshake frame it is owed before it drops
@@ -76,10 +76,18 @@ pub const MAX_FRAME_BYTES: usize = crate::protocol::MAX_FRAME_BYTES;
 
 /// One framed unit on the wire.
 ///
-/// The variants name the four lanes the connection multiplexes plus the two
+/// The variants name the lanes the connection multiplexes plus the two
 /// handshake frames that open it. Each carries one of the protocol's existing
 /// types verbatim; this envelope does not fork their shapes, it only tags which
 /// lane the payload belongs to.
+///
+/// The set is closed, and `deny_unknown_fields` means an unrecognized lane fails
+/// to decode rather than being skipped. That is deliberate: a peer must never
+/// half-understand a connection. Adding a variant is therefore an incompatible
+/// change that bumps [`PROTOCOL_VERSION`](crate::protocol::PROTOCOL_VERSION), and
+/// the exact-equality attach handshake turns a skew into a legible refusal
+/// carrying the peer's own version — an older sandbox image is turned away at
+/// attach, never handed a frame it would drop.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(
     tag = "lane",
@@ -114,6 +122,11 @@ pub enum WireFrame {
     /// once the handle has committed on the host. Redelivered on every attach;
     /// the sandbox keeps the first and ignores the rest.
     Init(crate::init::RunInit),
+    /// Host -> sandbox: one mid-run [steering](crate::steer) instruction for a
+    /// live agent loop. Written onto the reserved control queue, so guidance is
+    /// never stuck behind a response or replay backlog, and applied by the
+    /// sandbox at its next step boundary.
+    Steer(crate::steer::SteerMessage),
 }
 
 /// Why a framed read or write stopped.

--- a/crates/openwave-sandbox-protocol/src/wire/sandbox.rs
+++ b/crates/openwave-sandbox-protocol/src/wire/sandbox.rs
@@ -15,7 +15,7 @@
 //! to attachment: a `call` with no attached host waits for the host to attach.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, VecDeque},
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc, Mutex,
@@ -99,6 +99,9 @@ struct RunInner {
     init: watch::Sender<Option<crate::init::RunInit>>,
     /// Monotonic activity generation observed by the sandbox idle watchdog.
     activity: watch::Sender<u64>,
+    /// Host-sent steering instructions the agent loop has not consumed yet,
+    /// oldest first and bounded by [`MAX_PENDING_STEERS`].
+    steering: Mutex<VecDeque<String>>,
 }
 
 /// One run-scoped, cloneable sandbox. Every clone shares one event buffer and one
@@ -159,6 +162,7 @@ impl SandboxRun {
                 conn,
                 init,
                 activity,
+                steering: Mutex::new(VecDeque::new()),
             }),
         }
     }
@@ -203,6 +207,37 @@ impl SandboxRun {
             *slot = Some(init);
             true
         });
+    }
+
+    /// Take every host [steering](crate::steer) instruction that has arrived and
+    /// not yet been consumed, oldest first, leaving the queue empty.
+    ///
+    /// The agent loop calls this at a step boundary and folds what it gets into
+    /// the next model step, so an instruction that arrives mid-step lands on the
+    /// step after it. Steering is attached-only: nothing is queued while the host
+    /// is away, and a run nobody steered returns an empty vector.
+    #[must_use]
+    pub fn take_steering(&self) -> Vec<String> {
+        self.inner
+            .steering
+            .lock()
+            .expect("steering lock")
+            .drain(..)
+            .collect()
+    }
+
+    /// Queue one host steering instruction for the agent loop's next step.
+    ///
+    /// Bounded at [`MAX_PENDING_STEERS`](crate::steer::MAX_PENDING_STEERS): a host
+    /// that steers faster than the loop steps drops its *oldest* pending
+    /// instruction rather than growing sandbox memory, because the newest
+    /// guidance is the guidance the user meant.
+    fn deliver_steer(&self, text: String) {
+        let mut steering = self.inner.steering.lock().expect("steering lock");
+        while steering.len() >= crate::steer::MAX_PENDING_STEERS {
+            steering.pop_front();
+        }
+        steering.push_back(text);
     }
 
     /// Emit a bounded progress line, returning its assigned sequence.
@@ -557,6 +592,19 @@ where
                 run.mark_activity();
                 run.deliver_init(init);
             }
+            // Mid-run steering, likewise only over an authenticated connection,
+            // and only from the connection currently installed as the run's live
+            // peer: a superseded socket must not inject guidance for a host that
+            // has already been replaced. An over-bound instruction is dropped
+            // rather than truncated — a conforming host checks the bound before
+            // it writes, so this is a non-conforming peer, and half an
+            // instruction is worse guidance than none.
+            WireFrame::Steer(message) => {
+                if run.is_live(&closed) && message.within_bounds() {
+                    run.mark_activity();
+                    run.deliver_steer(message.text);
+                }
+            }
             // The sandbox originates cancels and requests; it never receives
             // them. Pong is liveness only. Ignore rather than trust peer input.
             WireFrame::Control(
@@ -598,6 +646,7 @@ mod tests {
     use crate::{
         ids::RunId,
         protocol::{AttachRequest, HandshakeResponse},
+        steer::{SteerMessage, MAX_PENDING_STEERS, MAX_STEER_BYTES},
     };
 
     fn run_with(secret: &TransportSecret) -> SandboxRun {
@@ -656,6 +705,71 @@ mod tests {
             "a peer that never attached must not be installed"
         );
         drop(host_side);
+    }
+
+    /// Steering is bounded on the way in and keeps the newest guidance: an
+    /// over-bound instruction is refused rather than truncated, and a host that
+    /// steers faster than the loop steps loses its oldest pending instruction,
+    /// never sandbox memory.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn steering_is_bounded_and_keeps_the_newest_instructions() {
+        let secret = TransportSecret::new("steer-bounds-test");
+        let run = run_with(&secret);
+        let (host_side, sandbox_side) = tokio::io::duplex(128 * 1024);
+        tokio::spawn(super::serve_connection(sandbox_side, run.clone()));
+        let (mut reader, mut writer) = attach(host_side, &secret, EventCursor::START).await;
+
+        let over_bound = "x".repeat(MAX_STEER_BYTES + 1);
+        write_frame(
+            &mut writer,
+            &WireFrame::Steer(SteerMessage::new(over_bound.clone())),
+        )
+        .await
+        .expect("send an over-bound steer");
+        for index in 0..MAX_PENDING_STEERS + 2 {
+            write_frame(
+                &mut writer,
+                &WireFrame::Steer(SteerMessage::new(format!("step {index}"))),
+            )
+            .await
+            .expect("send a steer");
+        }
+        // A ping behind them, answered on the same connection, proves every
+        // steer above was processed before the assertions read the queue.
+        write_frame(
+            &mut writer,
+            &WireFrame::Control(ControlFrame::Ping { nonce: 7 }),
+        )
+        .await
+        .expect("send ping");
+        let pong = tokio::time::timeout(std::time::Duration::from_secs(5), read_frame(&mut reader))
+            .await
+            .expect("the connection is served")
+            .expect("pong");
+        assert!(matches!(
+            pong,
+            WireFrame::Control(ControlFrame::Pong { nonce: 7 })
+        ));
+
+        let taken = run.take_steering();
+        assert_eq!(
+            taken.len(),
+            MAX_PENDING_STEERS,
+            "the pending queue is capped, got {taken:?}"
+        );
+        assert!(
+            !taken.contains(&over_bound),
+            "an over-bound instruction must be refused, not carried"
+        );
+        assert_eq!(
+            taken.first().map(String::as_str),
+            Some("step 2"),
+            "the oldest pending instructions are what a full queue drops"
+        );
+        assert!(
+            run.take_steering().is_empty(),
+            "taking steering leaves the queue empty"
+        );
     }
 
     /// A superseded peer — still draining its socket after the host reconnected —

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -456,6 +456,10 @@ pub fn app(state: AppState) -> Router {
             post(routes::post_agent_run_cancel),
         )
         .route(
+            "/chats/{chat_id}/agent-runs/{run_id}/steer",
+            post(routes::post_agent_run_steer),
+        )
+        .route(
             "/settings/api-key",
             axum::routing::put(routes::put_api_key).delete(routes::delete_api_key),
         )
@@ -1040,6 +1044,7 @@ async fn bind_inner(
             sandbox_container_admission.backend,
             state.resolver.clone(),
             state.agent_run_wake.clone(),
+            state.sandbox_steering.clone(),
             enabled,
             sandbox_container_run::SandboxContainerRunConfig::default(),
             sandbox_container_run_worker::SandboxContainerRunWorkerConfig::default(),

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -47,7 +47,7 @@ use crate::mcp_config::{McpServersConfig, McpServersInfo};
 use crate::model_roles::{self, ModelRole};
 use crate::providers::{self, ProviderCredential, ProviderInfo, ProviderKind, ProviderUpdate};
 use crate::scoped_store::ScopedStore;
-use crate::state::AppState;
+use crate::state::{AppState, SandboxSteerRefusal};
 use crate::view_frames::ViewFrameSource;
 use crate::voice_transcription::{self, VoiceTranscriptionInfo, VoiceTranscriptionUpdate};
 use crate::web_search::{
@@ -2675,6 +2675,62 @@ pub async fn post_agent_run_cancel(
         StatusCode::ACCEPTED,
         Json(AgentRunCancellationSnapshot { id: run.id, status }),
     ))
+}
+
+/// Body of `POST /chats/{chat_id}/agent-runs/{run_id}/steer`.
+#[derive(Debug, Deserialize)]
+pub struct AgentRunSteerBody {
+    /// The instruction to hand the running sandbox agent.
+    pub content: String,
+}
+
+/// `POST /chats/{chat_id}/agent-runs/{run_id}/steer` — hand one mid-run
+/// instruction to a sandbox-resident child that is running right now.
+///
+/// Unlike turn steering, this is **attached-only and not durable**: the
+/// instruction travels over the connection the container driver is holding, and
+/// the sandbox folds it into its next model step. A run this process holds no
+/// connection to is refused with `409` and nothing is queued, so a caller is
+/// never told an instruction was accepted that no agent will ever read.
+/// `202 Accepted` means a live connection took it. Foreground, wrong-chat, and
+/// terminal runs are rejected without exposing executor details.
+pub async fn post_agent_run_steer(
+    State(state): State<AppState>,
+    store: ScopedStore,
+    Path((chat_id, run_id)): Path<(ChatId, openwave_core::AgentRunId)>,
+    Json(body): Json<AgentRunSteerBody>,
+) -> Result<StatusCode, ServerError> {
+    let content = body.content.trim().to_owned();
+    if content.is_empty()
+        || content.contains('\0')
+        || content.len() > openwave_sandbox_protocol::steer::MAX_STEER_BYTES
+    {
+        return Err(ServerError::bad_request(
+            "steering content must be non-empty, contain no NUL characters, and fit the size limit",
+        ));
+    }
+    store.require_chat(chat_id).await?;
+    let run = store
+        .get_agent_run(run_id)
+        .await?
+        .filter(|run| run.chat_id == chat_id && run.tier == AgentRunTier::Background);
+    let Some(run) = run else {
+        return Err(ServerError::not_found(format!(
+            "agent run {run_id} not found"
+        )));
+    };
+    if run.status != AgentRunStatus::Running {
+        return Err(ServerError::conflict("sandbox run is not steerable"));
+    }
+    match state.sandbox_steering.steer(run_id, content) {
+        Ok(()) => Ok(StatusCode::ACCEPTED),
+        Err(SandboxSteerRefusal::NotAttached) => Err(ServerError::conflict(
+            "sandbox run is not attached; steering is not queued",
+        )),
+        Err(SandboxSteerRefusal::Backlogged) => Err(ServerError::conflict(
+            "sandbox run has not consumed its pending steering yet",
+        )),
+    }
 }
 
 /// Best-effort local acceleration after a sandbox cancellation has committed.

--- a/crates/openwave-server/src/sandbox_container_run.rs
+++ b/crates/openwave-server/src/sandbox_container_run.rs
@@ -54,6 +54,7 @@ use openwave_sandbox_protocol::{
         Capability, CapabilityResponder, GrantSet, ModelInferenceResult, ReverseRequest,
         ReverseResult, RunProvenance,
     },
+    steer::SteerMessage,
     AttachRequest, BackendError, CapabilityHost, ConnectError, ProvisionRequest, SandboxAddress,
     SandboxBackend, SandboxHandle, SandboxNetworkPolicy, SandboxTag, WireClient,
 };
@@ -65,6 +66,7 @@ use crate::resolver::ProviderResolver;
 use crate::sandbox_admission::{evaluate_detached_admission, DetachedPreconditions};
 use crate::sandbox_docker::DEFAULT_IDLE_TIMEOUT_SECS;
 use crate::scoped_model_token::{GatewayScopedTokenIssuer, ScopedModelTokenIssuer};
+use crate::state::SandboxSteerGuard;
 
 /// The provider attribution stamped on reverse operations from a local
 /// container. Untrusted attribution rendered on consent prompts, never a claim
@@ -74,6 +76,13 @@ const CONTAINER_PROVENANCE_PROVIDER: &str = "local-container";
 /// comfortably below it. Kept together so the safety margin is reviewable and
 /// testable instead of existing only in matching comments across crates.
 const SANDBOX_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(30);
+
+/// How many steering instructions the host holds for one attached run before it
+/// refuses new ones. Steering is applied at the sandbox's step boundary, so a
+/// small backlog covers a burst arriving mid-step; past it the caller is told to
+/// retry rather than the host growing an unbounded queue for a run that may
+/// never read it.
+const STEER_BACKLOG: usize = 8;
 
 const _: () = assert!(
     SANDBOX_KEEPALIVE_INTERVAL.as_secs() * 2 < DEFAULT_IDLE_TIMEOUT_SECS,
@@ -280,6 +289,10 @@ pub struct SandboxContainerRunner {
     /// `scoped_model_token_available` input. Defaults to the gateway position
     /// — unavailable, fail-closed — until the gateway can mint for real.
     token_issuer: Arc<dyn ScopedModelTokenIssuer>,
+    /// Where this driver publishes the steering sink of every connection it
+    /// holds, so an API caller can reach a live run. A driver assembled without
+    /// one (a test that never steers) publishes into its own empty guard.
+    steering: Arc<SandboxSteerGuard>,
 }
 
 impl SandboxContainerRunner {
@@ -298,7 +311,16 @@ impl SandboxContainerRunner {
             resolver,
             config,
             token_issuer: Arc::new(GatewayScopedTokenIssuer),
+            steering: Arc::new(SandboxSteerGuard::default()),
         }
+    }
+
+    /// Publish this driver's live-connection steering sinks into `steering`, the
+    /// same guard the server's steer route resolves a run against.
+    #[must_use]
+    pub(crate) fn with_steering(mut self, steering: Arc<SandboxSteerGuard>) -> Self {
+        self.steering = steering;
+        self
     }
 
     /// Replace the scoped-token issuer — the seam tests and future
@@ -673,7 +695,22 @@ impl SandboxContainerRunner {
         // heartbeat the run is failed out from under a container that is still
         // working and still spending. The whole drive is additionally bounded by
         // the run's absolute deadline, so no path can wait forever.
-        let drive = self.drive_events(run_id, protocol_run_id, handle, &host, &init);
+        // The steering channel outlives any single connection: an instruction
+        // accepted just as a connection drops is carried to the reattach rather
+        // than lost. It is *not* a durable queue — it dies with this drive, and
+        // nothing accepts steering while the run is unattached, because the
+        // guard entry exists only while a connection is live.
+        let (steer_tx, mut steer_rx) = tokio::sync::mpsc::channel::<String>(STEER_BACKLOG);
+        let drive = self.drive_events(
+            run_id,
+            protocol_run_id,
+            handle,
+            &host,
+            &init,
+            lease_token,
+            &steer_tx,
+            &mut steer_rx,
+        );
         tokio::pin!(drive);
         let mut heartbeat = tokio::time::interval(self.config.heartbeat);
         heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -818,6 +855,7 @@ impl SandboxContainerRunner {
 
     /// Attach and drain the container's event stream until it reports a terminal
     /// event, reattaching across unplanned disconnects within the budget.
+    #[allow(clippy::too_many_arguments)]
     async fn drive_events(
         &self,
         run_id: AgentRunId,
@@ -825,12 +863,25 @@ impl SandboxContainerRunner {
         handle: &SandboxHandle,
         host: &CapabilityHost,
         init: &RunInit,
+        lease_token: Uuid,
+        steer_tx: &tokio::sync::mpsc::Sender<String>,
+        steer_rx: &mut tokio::sync::mpsc::Receiver<String>,
     ) -> DriveEnd {
         let mut cursor = EventCursor::START;
         let mut attempt = 0u32;
         loop {
             match self
-                .drain_connection(run_id, protocol_run_id, handle, host, init, &mut cursor)
+                .drain_connection(
+                    run_id,
+                    protocol_run_id,
+                    handle,
+                    host,
+                    init,
+                    &mut cursor,
+                    lease_token,
+                    steer_tx,
+                    steer_rx,
+                )
                 .await
             {
                 DrainOutcome::Result(text) => return DriveEnd::Result(text),
@@ -862,6 +913,9 @@ impl SandboxContainerRunner {
         host: &CapabilityHost,
         init: &RunInit,
         cursor: &mut EventCursor,
+        lease_token: Uuid,
+        steer_tx: &tokio::sync::mpsc::Sender<String>,
+        steer_rx: &mut tokio::sync::mpsc::Receiver<String>,
     ) -> DrainOutcome {
         let address = match self.backend.address(handle).await {
             Ok(address) => address,
@@ -908,40 +962,62 @@ impl SandboxContainerRunner {
         // Deliver the run init on every attach; the sandbox keeps the first
         // and ignores redeliveries, so a reattach is idempotent.
         conn.send_init(init.clone()).await;
+        // Publish this connection's steering sink for exactly as long as the
+        // connection lives, so the API can tell "attached, instruction taken"
+        // from "not attached, nothing queued" by whether an entry exists. A
+        // registration refused (an identity already published) means a
+        // superseded attempt still holds it; drive on rather than displacing it.
+        let _attached = self
+            .steering
+            .register(run_id, lease_token, steer_tx.clone());
         // Drain events, committing the cursor by acknowledging each, until a
-        // terminal event arrives or the connection closes. Both terminal events
-        // end the drive: the supervisor keeps serving after its agent loop
-        // returns, so waiting only for a result would hang on an open socket and
-        // leak the container.
-        while let Some(event) = conn.next_event().await {
-            let payload = event.payload.clone();
-            *cursor = EventCursor::committed(event.sequence);
-            conn.acknowledge(*cursor).await;
-            match payload {
-                EventPayload::Result(text) => return DrainOutcome::Result(text),
-                EventPayload::Failed(detail) => return DrainOutcome::AgentFailed(detail),
-                // Progress is observation, published so a reader can watch the
-                // run without waiting for its result. The sandbox's own event
-                // sequence keys the append, so a reattach that redelivers a
-                // batch leaves one line rather than two, and a failure to
-                // publish is dropped rather than allowed to end the drive.
-                EventPayload::Progress(text) => {
-                    if let Err(error) = self
-                        .store
-                        .append_agent_run_progress(
-                            run_id,
-                            &format!("event:{}", event.sequence.get()),
-                            &text,
-                        )
-                        .await
-                    {
-                        eprintln!("openwave: could not publish progress for run {run_id}: {error}");
+        // terminal event arrives or the connection closes, while forwarding any
+        // steering the host accepted onto the reserved control lane. Both
+        // terminal events end the drive: the supervisor keeps serving after its
+        // agent loop returns, so waiting only for a result would hang on an open
+        // socket and leak the container.
+        loop {
+            tokio::select! {
+                event = conn.next_event() => {
+                    let Some(event) = event else { return DrainOutcome::Disconnected };
+                    let payload = event.payload.clone();
+                    *cursor = EventCursor::committed(event.sequence);
+                    conn.acknowledge(*cursor).await;
+                    match payload {
+                        EventPayload::Result(text) => return DrainOutcome::Result(text),
+                        EventPayload::Failed(detail) => return DrainOutcome::AgentFailed(detail),
+                        // Progress is observation, published so a reader can watch the
+                        // run without waiting for its result. The sandbox's own event
+                        // sequence keys the append, so a reattach that redelivers a
+                        // batch leaves one line rather than two, and a failure to
+                        // publish is dropped rather than allowed to end the drive.
+                        EventPayload::Progress(text) => {
+                            if let Err(error) = self
+                                .store
+                                .append_agent_run_progress(
+                                    run_id,
+                                    &format!("event:{}", event.sequence.get()),
+                                    &text,
+                                )
+                                .await
+                            {
+                                eprintln!("openwave: could not publish progress for run {run_id}: {error}");
+                            }
+                        }
+                        _ => {}
                     }
                 }
-                _ => {}
+                Some(instruction) = steer_rx.recv() => {
+                    if let Err(error) = conn.send_steer(SteerMessage::new(instruction)).await {
+                        // The connection went away under the instruction. The
+                        // drive reattaches; the instruction is not re-sent,
+                        // because guidance the run never saw is the caller's to
+                        // repeat, not the host's to replay later out of context.
+                        eprintln!("openwave: a steering instruction was not delivered: {error}");
+                    }
+                }
             }
         }
-        DrainOutcome::Disconnected
     }
 
     /// Connect a TCP stream to the container's loopback address.

--- a/crates/openwave-server/src/sandbox_container_run/tests.rs
+++ b/crates/openwave-server/src/sandbox_container_run/tests.rs
@@ -26,7 +26,7 @@ use openwave_core::{
     AgentRunStatus, CallId, Chat, ChatId, ChatRequest, DbStore, ModelProvider, ProviderEvent,
     ProviderId, Result, StopReason, Store,
 };
-use openwave_sandbox_agent::run_agent;
+use openwave_sandbox_agent::{run_agent, STEERING_PREFIX};
 use openwave_sandbox_protocol::{
     ids::{OperationId, RunId, SandboxTag},
     protocol::{Response, PROTOCOL_VERSION},
@@ -53,6 +53,7 @@ use crate::sandbox_container_run_worker::{
     SandboxContainerRunWorker, SandboxContainerRunWorkerConfig,
 };
 use crate::scoped_model_token::{MintedScopedToken, ScopedModelTokenIssuer};
+use crate::state::{SandboxSteerGuard, SandboxSteerRefusal};
 
 // --- Mock host model (the resolver the driver proxies inference through) ------
 
@@ -60,6 +61,15 @@ use crate::scoped_model_token::{MintedScopedToken, ScopedModelTokenIssuer};
 /// many completions it is asked for. Drives the real in-container loop: the first
 /// completion tells the sandbox to run a filesystem tool, the second is the
 /// final result the sandbox submits.
+/// Holds the sandbox's first model step open so a test can act while the run is
+/// genuinely attached and working: the provider announces the step on `started`
+/// and answers only once the test signals `release`.
+#[derive(Default)]
+struct StepGate {
+    started: Notify,
+    release: Notify,
+}
+
 struct ScriptedProvider {
     completions: Mutex<Vec<String>>,
     calls: AtomicUsize,
@@ -70,6 +80,8 @@ struct ScriptedProvider {
     /// How long each completion stalls, so a test can hold a drive open across
     /// several lease periods.
     delay: Duration,
+    /// When set, the first completion is held at this gate.
+    gate: Option<Arc<StepGate>>,
 }
 
 impl ScriptedProvider {
@@ -79,6 +91,15 @@ impl ScriptedProvider {
             calls: AtomicUsize::new(0),
             prompts: Mutex::new(Vec::new()),
             delay: Duration::ZERO,
+            gate: None,
+        }
+    }
+
+    /// The same provider, but holding its first completion at `gate`.
+    fn gated(completions: Vec<String>, gate: Arc<StepGate>) -> Self {
+        Self {
+            gate: Some(gate),
+            ..Self::new(completions)
         }
     }
 
@@ -109,6 +130,12 @@ impl ModelProvider for ScriptedProvider {
 
     async fn stream(&self, request: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
         let index = self.calls.fetch_add(1, Ordering::SeqCst);
+        if index == 0 {
+            if let Some(gate) = &self.gate {
+                gate.started.notify_one();
+                gate.release.notified().await;
+            }
+        }
         for message in &request.messages {
             for block in &message.content {
                 if let openwave_core::ContentBlock::Text { text } = block {
@@ -463,6 +490,7 @@ async fn container_worker_service_drives_queued_work_over_loopback() {
             backend.clone(),
             Arc::new(FixedResolver(provider)),
             Arc::new(Notify::new()),
+            Arc::new(SandboxSteerGuard::default()),
             true,
             fast_config(),
             fast_worker_config(),
@@ -513,6 +541,7 @@ async fn container_worker_service_cadence_completes_pending_teardown() {
             backend.clone(),
             Arc::new(FixedResolver(provider)),
             Arc::new(Notify::new()),
+            Arc::new(SandboxSteerGuard::default()),
             true,
             fast_config(),
             fast_worker_config(),
@@ -1700,6 +1729,101 @@ async fn an_attached_cancellation_is_acknowledged_and_torn_down() {
         assert_eq!(cancelled.status, AgentRunStatus::Cancelled);
         // The container did not outlive the cancellation.
         assert_eq!(backend.destroys.load(Ordering::SeqCst), 1);
+    })
+    .await
+    .expect("test completed within its time bound");
+}
+
+/// Steering a live sandbox-resident run: an instruction the host sends while the
+/// container is mid-run reaches the agent's *next* model step, and a run nobody
+/// is attached to refuses the instruction instead of queueing it.
+///
+/// This is the whole contract of the feature across the real stack — the host
+/// API, the wire frame over a loopback socket, and the in-container loop folding
+/// the text into its transcript — so it is driven end to end rather than
+/// asserted on the frame in isolation.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn steering_a_live_container_run_reaches_the_agents_next_model_step() {
+    tokio::time::timeout(Duration::from_secs(30), async {
+        const INSTRUCTION: &str = "stop listing files and report what you have";
+        let (_dir, store, chat) = store().await;
+        let run_id = admit_container_run(&store, chat.id, "inspect the workspace").await;
+
+        let backend = MockBackend::spawning();
+        let gate = Arc::new(StepGate::default());
+        // Two tool steps then a final answer, so the run is still working when
+        // the instruction arrives and has a later step to apply it on.
+        let provider = Arc::new(ScriptedProvider::gated(
+            vec![
+                "use-tool:list_dir:{\"path\":\".\"}".to_owned(),
+                "use-tool:list_dir:{\"path\":\".\"}".to_owned(),
+                "nothing but an empty workspace".to_owned(),
+            ],
+            gate.clone(),
+        ));
+        let steering = Arc::new(SandboxSteerGuard::default());
+        let runner = Arc::new(
+            SandboxContainerRunner::new(
+                store.clone(),
+                backend.clone(),
+                Arc::new(FixedResolver(provider.clone())),
+                fast_config(),
+            )
+            .with_steering(steering.clone()),
+        );
+
+        // Nothing is attached yet: the instruction is refused outright rather
+        // than parked for a connection that may never exist.
+        assert_eq!(
+            steering.steer(run_id, "too early to steer".to_owned()),
+            Err(SandboxSteerRefusal::NotAttached),
+        );
+
+        let drive = tokio::spawn({
+            let runner = runner.clone();
+            async move { runner.drive(run_id).await }
+        });
+
+        // The first model step proves the container is attached and working, so
+        // the instruction below is genuinely mid-run.
+        gate.started.notified().await;
+        steering
+            .steer(run_id, INSTRUCTION.to_owned())
+            .expect("a live attached run accepts steering");
+        // Let the frame cross the socket while the sandbox is parked on its
+        // model call, then release the step it was waiting on.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        gate.release.notify_one();
+
+        let outcome = drive
+            .await
+            .unwrap()
+            .expect("driving succeeds")
+            .expect("the container run is claimable");
+        assert_eq!(outcome, SandboxContainerRunOutcome::Completed(run_id));
+
+        // The sandbox folded the instruction into a later step's transcript: the
+        // host proxied a prompt carrying it, which the first prompt did not.
+        let prompts = provider.prompts.lock().unwrap().clone();
+        let steered = format!("{STEERING_PREFIX}{INSTRUCTION}");
+        assert!(
+            !prompts[0].contains(&steered),
+            "the instruction cannot appear before it was sent"
+        );
+        assert!(
+            prompts
+                .iter()
+                .skip(1)
+                .any(|prompt| prompt.contains(&steered)),
+            "a step after the instruction must carry it, got prompts: {prompts:?}"
+        );
+
+        // The run is over, so its connection is gone and steering is refused
+        // again — the registration lives exactly as long as the attachment.
+        assert_eq!(
+            steering.steer(run_id, "too late to steer".to_owned()),
+            Err(SandboxSteerRefusal::NotAttached),
+        );
     })
     .await
     .expect("test completed within its time bound");

--- a/crates/openwave-server/src/sandbox_container_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_container_run_worker.rs
@@ -13,6 +13,7 @@ use tokio::sync::Notify;
 
 use crate::resolver::ProviderResolver;
 use crate::sandbox_container_run::{SandboxContainerRunConfig, SandboxContainerRunner};
+use crate::state::SandboxSteerGuard;
 
 /// Service-level polling and maintenance tunables.
 #[derive(Debug, Clone, Copy)]
@@ -62,6 +63,7 @@ impl SandboxContainerRunWorker {
         backend: Arc<dyn SandboxBackend>,
         resolver: Arc<dyn ProviderResolver>,
         wake: Arc<Notify>,
+        steering: Arc<SandboxSteerGuard>,
         enabled: bool,
         runner_config: SandboxContainerRunConfig,
         config: SandboxContainerRunWorkerConfig,
@@ -75,12 +77,12 @@ impl SandboxContainerRunWorker {
         assert!(!config.maintenance_interval.is_zero());
         assert!(config.candidate_limit > 0);
         assert!(config.max_concurrency > 0);
-        let runner = Arc::new(SandboxContainerRunner::new(
-            store.clone(),
-            backend,
-            resolver,
-            runner_config,
-        ));
+        let runner = Arc::new(
+            SandboxContainerRunner::new(store.clone(), backend, resolver, runner_config)
+                // The same guard the steer route resolves a run against, so an
+                // instruction reaches the connection this worker's driver holds.
+                .with_steering(steering),
+        );
         Some(Self {
             store,
             runner,

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -11,7 +11,7 @@ use openwave_core::{
     AgentConfig, AgentError, AgentRunId, BlobStore, CallId, CancelToken, ChatId, Config,
     FsBlobStore, Profile, Result, SecretProvider, SteerInbox, Store, ToolRegistry, TurnId,
 };
-use tokio::sync::{Notify, Semaphore};
+use tokio::sync::{mpsc, Notify, Semaphore};
 use uuid::Uuid;
 
 use crate::approvals::ApprovalBroker;
@@ -182,6 +182,12 @@ pub struct AppState {
     /// only let an authenticated cancellation request promptly drop provider
     /// futures owned by this server process.
     pub(crate) sandbox_attempts: Arc<SandboxAttemptGuard>,
+    /// Process-local steering sinks for sandbox-resident runs attached here.
+    ///
+    /// Mid-run steering is delivered over the connection the container driver
+    /// holds, so a run this process is not attached to cannot be steered and
+    /// the request is refused rather than queued.
+    pub(crate) sandbox_steering: Arc<SandboxSteerGuard>,
     /// Live fan-out of turn events to connected WebSocket clients.
     pub events: Arc<EventBus>,
     /// Coordinates durable Sensitive-tool decisions and low-latency wakeups.
@@ -336,6 +342,7 @@ impl AppState {
             root_attachment_routes_enabled: true,
             active_turns: Arc::new(TurnGuard::default()),
             sandbox_attempts: Arc::new(SandboxAttemptGuard::default()),
+            sandbox_steering: Arc::new(SandboxSteerGuard::default()),
             events: Arc::new(EventBus::default()),
             approvals: Arc::new(ApprovalBroker::new(store)),
             local_voice: Arc::new(UnavailableLocalVoiceRunner),
@@ -436,6 +443,104 @@ impl SandboxAttemptGuard {
             return true;
         }
         false
+    }
+}
+
+/// Steering handles for sandbox-resident runs this process currently holds a
+/// live connection to.
+///
+/// Steering a background run is attached-only: the instruction rides the
+/// connection the container driver is holding right now, and there is no durable
+/// queue behind it. Registration is therefore exactly as long as one attached
+/// connection — the driver registers after its attach handshake is accepted and
+/// the RAII handle deregisters when that connection ends — so an absent entry
+/// means "nobody can carry this instruction", which is what the API reports.
+/// Like [`SandboxAttemptGuard`], this map is process-local and never
+/// participates in admission or terminal decisions.
+#[derive(Default)]
+pub(crate) struct SandboxSteerGuard {
+    attached: Mutex<HashMap<(AgentRunId, Uuid), mpsc::Sender<String>>>,
+}
+
+/// Why one steering instruction could not be handed to a live run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SandboxSteerRefusal {
+    /// No connection to the run is live in this process, so nothing can carry
+    /// the instruction. Nothing was queued.
+    NotAttached,
+    /// The run is attached but has not consumed the instructions already sent;
+    /// the caller retries rather than growing an unbounded backlog.
+    Backlogged,
+}
+
+impl SandboxSteerGuard {
+    /// Register the live connection's steering sink for one exact run and lease.
+    ///
+    /// Returns `None` when that identity is already registered, so a superseded
+    /// registration can never displace the live one.
+    pub(crate) fn register(
+        self: &Arc<Self>,
+        agent_run_id: AgentRunId,
+        lease_token: Uuid,
+        sink: mpsc::Sender<String>,
+    ) -> Option<AttachedSandboxRun> {
+        let mut attached = self.attached.lock().unwrap();
+        let identity = (agent_run_id, lease_token);
+        if attached.contains_key(&identity) {
+            return None;
+        }
+        attached.insert(identity, sink);
+        Some(AttachedSandboxRun {
+            guard: Arc::clone(self),
+            agent_run_id,
+            lease_token,
+        })
+    }
+
+    /// Hand `text` to the run's live connection.
+    ///
+    /// Acceptance means a live connection took the instruction, not that the
+    /// agent has read it; the run's own event stream reports when it is applied.
+    ///
+    /// # Errors
+    /// [`SandboxSteerRefusal::NotAttached`] when no connection to the run is
+    /// live here, or [`SandboxSteerRefusal::Backlogged`] when the live one has
+    /// not drained what it was already given.
+    pub(crate) fn steer(
+        &self,
+        agent_run_id: AgentRunId,
+        text: String,
+    ) -> std::result::Result<(), SandboxSteerRefusal> {
+        let attached = self.attached.lock().unwrap();
+        // At most one connection per run is live, but it is keyed by the exact
+        // lease that owns it, which the caller does not (and should not) name.
+        let sink = attached
+            .iter()
+            .find(|((run, _lease), _sink)| *run == agent_run_id)
+            .map(|(_identity, sink)| sink.clone())
+            .ok_or(SandboxSteerRefusal::NotAttached)?;
+        drop(attached);
+        sink.try_send(text).map_err(|error| match error {
+            mpsc::error::TrySendError::Full(_) => SandboxSteerRefusal::Backlogged,
+            mpsc::error::TrySendError::Closed(_) => SandboxSteerRefusal::NotAttached,
+        })
+    }
+}
+
+/// The registration of one attached sandbox-resident run, deregistered on drop.
+pub(crate) struct AttachedSandboxRun {
+    guard: Arc<SandboxSteerGuard>,
+    agent_run_id: AgentRunId,
+    lease_token: Uuid,
+}
+
+impl Drop for AttachedSandboxRun {
+    fn drop(&mut self) {
+        self.guard
+            .attached
+            .lock()
+            .unwrap()
+            .remove(&(self.agent_run_id, self.lease_token));
     }
 }
 


### PR DESCRIPTION
Background runs are fire-and-join today: the host delivers a task in the run init and then only reads events, so there is no way to redirect a container that is already working. This adds steering — the host hands a running sandbox-resident agent one instruction over the connection it is already holding, and the agent folds it into its next model step.

## The frame

`WireFrame::Steer(SteerMessage)` is a host → sandbox lane carrying bounded text (`MAX_STEER_BYTES`, 8 KiB, refused rather than truncated). It is written onto the reserved control queue, so guidance is never stuck behind a reverse response or a resume replay, and the sandbox queues at most `MAX_PENDING_STEERS` un-consumed instructions, dropping the oldest — the newest guidance is what the user meant.

The wire envelope names a closed set of lanes and `deny_unknown_fields` refuses an unrecognized one, so a new frame is an incompatible change even though it is additive. `PROTOCOL_VERSION` therefore goes to 5, and the exact-equality attach handshake turns a skew into a legible `AttachRefused` carrying the peer's own version: an older sandbox image is turned away at attach rather than handed a frame it would drop mid-run. The version constant's doc now says this explicitly so the next frame follows the same path.

## Attached-only, not queued

`HostConnection::send_steer` is a method on a live connection, so there is nowhere to leave an instruction for a run nobody is attached to. The container driver publishes its steering sink into a process-local guard for exactly as long as one connection lives — registered after the attach handshake is accepted, deregistered by an RAII handle when the connection ends — keyed by the exact run and lease, in the same shape as the existing sandbox cancellation guard. An absent entry means "nothing can carry this", which is what the API reports; nothing is persisted and nothing is retried later out of context.

`POST /chats/{chat_id}/agent-runs/{run_id}/steer` is the surface: `202` when a live connection took the instruction, `409` when the run is not attached (or has not drained what it was already given), `400` for empty, oversized, or NUL-bearing content, `404` for a missing or foreground run. Acceptance means a live connection took it, not that the agent has read it — the run's own event stream reports when it is applied.

## Agent side

The in-container loop drains pending steering at each step boundary and appends it to the transcript as user-authored guidance, so the next completion is asked for something different without restarting the run. Each applied instruction is echoed as a progress event, so the host's journal shows when guidance took effect rather than only that it was sent. Nothing interrupts a step already in flight; an instruction that arrives mid-call lands on the following step.

## Tests

- A loopback test in the existing container-driver style — the real in-container agent and transport server over a real socket, only Docker and the host model mocked — steers a run while it is genuinely mid-step and asserts the instruction shows up in a later proxied prompt but not the first, and that the same run refuses steering before it attaches and after it finishes.
- A transport test that an over-bound instruction is refused rather than truncated and that a full pending queue drops its oldest entry.
- Round-trip and unknown-field coverage for the new wire type, matching how the other frames are pinned.

Labelled `full-ci`: this changes the wire contract and its version across the protocol crate, the sandbox agent, and the server, which is exactly the boundary where the fast gate's skips are not the coverage I want before merge.

## Deferred

- No chat-tool surface for steering. Letting an agent steer its own children raises approval-class questions — who may redirect whose run, and how that is recorded — that belong in their own change; the internal API and route are what this lands.
- No durable queueing. Steering an unattached run is refused, not parked; a durable inbox for background runs needs its own delivery and dedupe semantics.

Closes #951
