### PR TITLE
feat(server): live progress read model for background agent runs

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -703,6 +703,27 @@ pub mod agent_run_result {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+pub mod agent_run_progress {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "agent_run_progress")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub agent_run_id: Uuid,
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub sequence: i64,
+        pub source_key: String,
+        pub text: String,
+        pub created_at: DateTimeUtc,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub mod agent_run_cancellation {
     use sea_orm::entity::prelude::*;
 

--- a/crates/openwave-core/src/db/migration/baseline/agent_run.rs
+++ b/crates/openwave-core/src/db/migration/baseline/agent_run.rs
@@ -472,6 +472,73 @@ pub(super) fn agent_run_result_indexes() -> Vec<IndexCreateStatement> {
         .to_owned()]
 }
 
+/// The bounded, ordered progress stream one background run publishes while it
+/// works.
+///
+/// This is observation, not correctness state: nothing reads it to decide what
+/// a run may do next, and losing a line only leaves a gap in what an observer
+/// sees. Its ordering contract is the per-run `sequence`, which is what lets a
+/// reader resume from a cursor instead of re-reading the whole stream.
+///
+/// `source_key` is the producer's own identity for the line — a sandbox
+/// protocol event sequence, or the durable checkpoint a model preamble belongs
+/// to. It makes an append idempotent, so a reattached container that redelivers
+/// events, or a worker that retries an ambiguous commit, cannot duplicate a
+/// line the reader already has.
+pub(super) fn agent_run_progress_table() -> TableCreateStatement {
+    Table::create()
+        .table(AgentRunProgress::Table)
+        .col(
+            ColumnDef::new(AgentRunProgress::AgentRunId)
+                .uuid()
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(AgentRunProgress::Sequence)
+                .big_integer()
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(AgentRunProgress::SourceKey)
+                .string_len(96)
+                .not_null(),
+        )
+        .col(ColumnDef::new(AgentRunProgress::Text).text().not_null())
+        .col(
+            ColumnDef::new(AgentRunProgress::CreatedAt)
+                .timestamp_with_time_zone()
+                .not_null(),
+        )
+        .primary_key(
+            Index::create()
+                .col(AgentRunProgress::AgentRunId)
+                .col(AgentRunProgress::Sequence),
+        )
+        .foreign_key(
+            ForeignKey::create()
+                .name("fk_agent_run_progress_run")
+                .from(AgentRunProgress::Table, AgentRunProgress::AgentRunId)
+                .to(AgentRun::Table, AgentRun::Id)
+                .on_delete(ForeignKeyAction::Cascade),
+        )
+        .check(Expr::col(AgentRunProgress::Sequence).gte(1))
+        .check(
+            Func::char_length(Expr::col(AgentRunProgress::Text))
+                .between(1, crate::model::AgentRunProgressEntry::MAX_TEXT_LEN as i32),
+        )
+        .to_owned()
+}
+
+pub(super) fn agent_run_progress_indexes() -> Vec<IndexCreateStatement> {
+    vec![Index::create()
+        .name("idx_agent_run_progress_source")
+        .table(AgentRunProgress::Table)
+        .col(AgentRunProgress::AgentRunId)
+        .col(AgentRunProgress::SourceKey)
+        .unique()
+        .to_owned()]
+}
+
 /// A cancellation request against a live run, recorded under the lease it
 /// interrupts so a stale worker cannot observe someone else's request.
 pub(super) fn agent_run_cancellation_table() -> TableCreateStatement {

--- a/crates/openwave-core/src/db/migration/baseline/mod.rs
+++ b/crates/openwave-core/src/db/migration/baseline/mod.rs
@@ -87,6 +87,10 @@ pub(super) fn tables() -> Vec<BaselineTable> {
             agent_run::agent_run_cancellation_table(),
             agent_run::agent_run_cancellation_indexes(),
         ),
+        entry(
+            agent_run::agent_run_progress_table(),
+            agent_run::agent_run_progress_indexes(),
+        ),
         // Turn runs and the journal.
         entry(turn::turn_run_table(), turn::turn_run_indexes()),
         entry(chat::event_table(), chat::event_indexes()),

--- a/crates/openwave-core/src/db/migration/idens.rs
+++ b/crates/openwave-core/src/db/migration/idens.rs
@@ -275,6 +275,16 @@ pub(crate) enum AgentRunResult {
 }
 
 #[derive(DeriveIden)]
+pub(crate) enum AgentRunProgress {
+    Table,
+    AgentRunId,
+    Sequence,
+    SourceKey,
+    Text,
+    CreatedAt,
+}
+
+#[derive(DeriveIden)]
 pub(crate) enum AgentRunCancellation {
     Table,
     AgentRunId,

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -1081,6 +1081,24 @@ impl Store for DbStore {
         ops::agent_run::get_agent_run_result(self, id).await
     }
 
+    async fn append_agent_run_progress(
+        &self,
+        run_id: AgentRunId,
+        source_key: &str,
+        text: &str,
+    ) -> Result<()> {
+        ops::agent_run::progress::append(self, run_id, source_key, text).await
+    }
+
+    async fn list_agent_run_progress(
+        &self,
+        run_id: AgentRunId,
+        after_sequence: i64,
+        limit: u64,
+    ) -> Result<Vec<crate::model::AgentRunProgressEntry>> {
+        ops::agent_run::progress::list(self, run_id, after_sequence, limit).await
+    }
+
     async fn claim_agent_run(
         &self,
         lease_token: uuid::Uuid,

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -30,6 +30,8 @@ pub(in crate::db) use cancellation::{
     unsettled_sandbox_children_for_origin_turn_on,
 };
 
+pub(in crate::db) mod progress;
+
 pub(in crate::db) async fn insert_foreground_agent_run_on<C>(
     conn: &C,
     chat_id: ChatId,

--- a/crates/openwave-core/src/db/ops/agent_run/progress.rs
+++ b/crates/openwave-core/src/db/ops/agent_run/progress.rs
@@ -1,0 +1,145 @@
+//! The ordered progress stream a background run publishes while it works.
+//!
+//! This is the one part of the agent-run tier that is not correctness state.
+//! Nothing reads it to decide what a run may do next, so the append does not
+//! take a lease, does not fence, and is deliberately allowed to fail without
+//! disturbing the transition that produced the line. What it does guarantee is
+//! ordering and idempotency: a per-run sequence a reader can resume from, and a
+//! producer-supplied `source_key` that makes redelivering a line a no-op.
+
+use chrono::Utc;
+use sea_orm::sea_query::OnConflict;
+use sea_orm::{
+    ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, Set,
+    TransactionTrait,
+};
+
+use crate::error::Result;
+use crate::id::AgentRunId;
+use crate::model::AgentRunProgressEntry;
+
+use super::super::super::{entities, store_err, DbStore};
+
+/// How many times to retry a sequence assignment that lost a race. Only one
+/// producer publishes a run's progress at a time, so this is defence against an
+/// overlapping handoff rather than an expected path.
+const ASSIGNMENT_ATTEMPTS: u32 = 3;
+
+pub(in crate::db) async fn append(
+    store: &DbStore,
+    run_id: AgentRunId,
+    source_key: &str,
+    text: &str,
+) -> Result<()> {
+    let text = truncate_on_char_boundary(text.trim(), AgentRunProgressEntry::MAX_TEXT_LEN);
+    if text.is_empty() {
+        return Ok(());
+    }
+    let source_key =
+        truncate_on_char_boundary(source_key, AgentRunProgressEntry::MAX_SOURCE_KEY_LEN);
+
+    for _ in 0..ASSIGNMENT_ATTEMPTS {
+        let transaction = store.conn.begin().await.map_err(store_err)?;
+        let highest: Option<i64> = entities::agent_run_progress::Entity::find()
+            .filter(entities::agent_run_progress::Column::AgentRunId.eq(*run_id.as_uuid()))
+            .select_only()
+            .column_as(entities::agent_run_progress::Column::Sequence.max(), "max")
+            .into_tuple()
+            .one(&transaction)
+            .await
+            .map_err(store_err)?
+            .flatten();
+        let sequence = highest.unwrap_or(0).saturating_add(1);
+
+        // The unique `(run_id, source_key)` index is what makes a redelivered
+        // line a no-op, and the composite primary key is what refuses a
+        // sequence two producers assigned at once. Both resolve to "do nothing"
+        // here; only the second is worth retrying, and the loop bound keeps
+        // even that from spinning.
+        let inserted = entities::agent_run_progress::Entity::insert(
+            entities::agent_run_progress::ActiveModel {
+                agent_run_id: Set(*run_id.as_uuid()),
+                sequence: Set(sequence),
+                source_key: Set(source_key.clone()),
+                text: Set(text.clone()),
+                created_at: Set(Utc::now()),
+            },
+        )
+        .on_conflict(OnConflict::new().do_nothing().to_owned())
+        .exec_without_returning(&transaction)
+        .await;
+
+        match inserted {
+            Ok(0) => {
+                // Either the key is already published or the sequence was taken.
+                // Distinguish them: an existing key is done, a taken sequence
+                // wants another assignment.
+                let published = entities::agent_run_progress::Entity::find()
+                    .filter(entities::agent_run_progress::Column::AgentRunId.eq(*run_id.as_uuid()))
+                    .filter(entities::agent_run_progress::Column::SourceKey.eq(source_key.clone()))
+                    .count(&transaction)
+                    .await
+                    .map_err(store_err)?;
+                transaction.rollback().await.map_err(store_err)?;
+                if published > 0 {
+                    return Ok(());
+                }
+                continue;
+            }
+            Ok(_) => {}
+            Err(_) => {
+                transaction.rollback().await.map_err(store_err)?;
+                continue;
+            }
+        }
+
+        // Retention: this stream is disposable observation, and a run that
+        // narrates for an hour must not grow the journal without bound.
+        let oldest_retained = sequence.saturating_sub(AgentRunProgressEntry::RETAINED_PER_RUN);
+        if oldest_retained > 0 {
+            entities::agent_run_progress::Entity::delete_many()
+                .filter(entities::agent_run_progress::Column::AgentRunId.eq(*run_id.as_uuid()))
+                .filter(entities::agent_run_progress::Column::Sequence.lte(oldest_retained))
+                .exec(&transaction)
+                .await
+                .map_err(store_err)?;
+        }
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(());
+    }
+    Ok(())
+}
+
+pub(in crate::db) async fn list(
+    store: &DbStore,
+    run_id: AgentRunId,
+    after_sequence: i64,
+    limit: u64,
+) -> Result<Vec<AgentRunProgressEntry>> {
+    let limit = limit.clamp(1, AgentRunProgressEntry::MAX_PAGE);
+    let rows = entities::agent_run_progress::Entity::find()
+        .filter(entities::agent_run_progress::Column::AgentRunId.eq(*run_id.as_uuid()))
+        .filter(entities::agent_run_progress::Column::Sequence.gt(after_sequence.max(0)))
+        .order_by_asc(entities::agent_run_progress::Column::Sequence)
+        .limit(limit)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(rows
+        .into_iter()
+        .map(|row| AgentRunProgressEntry {
+            run_id: AgentRunId(row.agent_run_id),
+            sequence: row.sequence,
+            text: row.text,
+            created_at: row.created_at,
+        })
+        .collect())
+}
+
+/// Truncate to at most `limit` characters, never splitting one.
+fn truncate_on_char_boundary(text: &str, limit: usize) -> String {
+    if text.chars().count() <= limit {
+        return text.to_owned();
+    }
+    text.chars().take(limit).collect()
+}

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -152,8 +152,8 @@ pub use image::{
 pub use keychain::KeychainSecretProvider;
 pub use model::{
     exec_attachment_file_name, AgentRun, AgentRunCancellationReason, AgentRunCancellationSignal,
-    AgentRunExecutionLocation, AgentRunInboxEntry, AgentRunInboxStatus, AgentRunResult,
-    AgentRunResultPayload, AgentRunStatus, AgentRunSubmittedOutput, AgentRunTier,
+    AgentRunExecutionLocation, AgentRunInboxEntry, AgentRunInboxStatus, AgentRunProgressEntry,
+    AgentRunResult, AgentRunResultPayload, AgentRunStatus, AgentRunSubmittedOutput, AgentRunTier,
     AgentRunWaitCondition, AgentRunWaitSetCandidate, AgentRunWaitSetCheckpointRequest,
     BeginRootAttachmentChange, BlobRetirement, BlobRetirementStatus, Chat, ChatRootAttachment,
     ClientToolCallRequest, DelegatedFileReadClaim, DocumentListCursor, DocumentRecord,

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1374,6 +1374,44 @@ impl AgentRun {
     pub const MAX_RESULT_LEN: usize = 65_536;
 }
 
+/// One durable, ordered line of live progress published by a background run.
+///
+/// A background run is otherwise only observable at its edges — the state it is
+/// in, the checkpoint it currently sits on, and the result it eventually
+/// submits. This is the stream in between: bounded prose the run itself
+/// produced, ordered by a per-run [`sequence`](Self::sequence) so a reader can
+/// resume from what it already has rather than re-reading everything.
+///
+/// It is deliberately not correctness state. No transition reads it, and a
+/// dropped line costs an observer one gap, never a wrong decision.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentRunProgressEntry {
+    pub run_id: crate::id::AgentRunId,
+    /// Monotonic per-run ordering, starting at one. Gaps are possible once
+    /// retention trims the oldest lines; order never is.
+    pub sequence: i64,
+    pub text: String,
+    pub created_at: DateTime<Utc>,
+}
+
+impl AgentRunProgressEntry {
+    /// Maximum persisted characters in one line. A progress line is a sentence
+    /// of narration, not a transcript; anything longer is truncated on the way
+    /// in rather than rejected, because losing the line entirely would be the
+    /// worse outcome for an observer.
+    pub const MAX_TEXT_LEN: usize = 2_048;
+    /// Lines retained per run. A long-running child can narrate indefinitely,
+    /// and this stream is disposable observation, so the oldest lines are
+    /// dropped rather than allowed to grow the journal without bound.
+    pub const RETAINED_PER_RUN: i64 = 200;
+    /// Maximum lines one read may return.
+    pub const MAX_PAGE: u64 = 200;
+    /// Lines one read returns when the caller does not ask for a bound.
+    pub const DEFAULT_PAGE: u64 = 50;
+    /// Maximum length of a producer's own identity for a line.
+    pub const MAX_SOURCE_KEY_LEN: usize = 96;
+}
+
 /// Immutable ownership receipt for one admitted sandbox child.
 ///
 /// The origin turn is intentionally distinct from the long-lived foreground

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -36,15 +36,15 @@ use crate::id::{
 use crate::image::ImageRef;
 use crate::local_app::{AppGrant, AppRecord, AppRevision, CreateApp, NewAppRevision};
 use crate::model::{
-    AgentRun, AgentRunInboxEntry, AgentRunResult, AgentRunTier, AgentRunWaitSetCandidate,
-    BeginRootAttachmentChange, BlobRetirement, BlobRetirementStatus, Chat, ClientToolCallRequest,
-    DocumentListCursor, DocumentRecord, DocumentScope, DocumentSourceBlob, DocumentSourceUpsert,
-    DocumentSummaryRecord, DocumentUpsert, ExecFileRejection, ExecFileRejectionRecord,
-    ExecFileSnapshot, ExecFileSnapshotRecord, Message, MessageAttachment,
-    MessageDocumentAttachment, NetworkPolicy, OwnerId, PermissionMode, Project, ReasoningEffort,
-    RootAttachmentChange, RootAttachmentChangeTerminal, ToolCallRecord, ToolCallResolution,
-    TurnAgentRunWaitSet, TurnCheckpointProgress, TurnClientWait, TurnFailureReceipt,
-    TurnFailureRetry, TurnRun, TurnSteer,
+    AgentRun, AgentRunInboxEntry, AgentRunProgressEntry, AgentRunResult, AgentRunTier,
+    AgentRunWaitSetCandidate, BeginRootAttachmentChange, BlobRetirement, BlobRetirementStatus,
+    Chat, ClientToolCallRequest, DocumentListCursor, DocumentRecord, DocumentScope,
+    DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert,
+    ExecFileRejection, ExecFileRejectionRecord, ExecFileSnapshot, ExecFileSnapshotRecord, Message,
+    MessageAttachment, MessageDocumentAttachment, NetworkPolicy, OwnerId, PermissionMode, Project,
+    ReasoningEffort, RootAttachmentChange, RootAttachmentChangeTerminal, ToolCallRecord,
+    ToolCallResolution, TurnAgentRunWaitSet, TurnCheckpointProgress, TurnClientWait,
+    TurnFailureReceipt, TurnFailureRetry, TurnRun, TurnSteer,
 };
 use crate::provider::{RefusalOutcome, StopReason, Usage};
 use crate::semantic_checkpoint::{ContextCheckpoint, SaveContextCheckpointOutcome};
@@ -2224,6 +2224,42 @@ pub trait Store: Send + Sync {
 
     /// Fetch the immutable terminal receipt for one agent run, if it exists.
     async fn get_agent_run_result(&self, _id: AgentRunId) -> Result<Option<AgentRunResult>> {
+        agent_run_storage_unavailable()
+    }
+
+    /// Append one bounded progress line to a background run's ordered stream,
+    /// assigning it the next per-run sequence.
+    ///
+    /// `source_key` is the producer's own identity for the line — a sandbox
+    /// protocol event sequence, or the durable checkpoint a model preamble
+    /// belongs to. Re-appending a key that already exists is a no-op, so a
+    /// reattached container redelivering events and a worker retrying an
+    /// ambiguous commit both leave one line rather than two.
+    ///
+    /// Text longer than [`AgentRunProgressEntry::MAX_TEXT_LEN`] is truncated on
+    /// a character boundary rather than refused; a line is observation, and a
+    /// truncated one still tells the reader more than a dropped one. Retention
+    /// bounds the stream to [`AgentRunProgressEntry::RETAINED_PER_RUN`] lines.
+    async fn append_agent_run_progress(
+        &self,
+        _run_id: AgentRunId,
+        _source_key: &str,
+        _text: &str,
+    ) -> Result<()> {
+        agent_run_storage_unavailable()
+    }
+
+    /// Read one run's progress lines strictly newer than `after_sequence`, in
+    /// ascending order, bounded by `limit`.
+    ///
+    /// A cursor of zero starts at the beginning of whatever retention still
+    /// holds. This is a read model: it takes no lease and never mutates.
+    async fn list_agent_run_progress(
+        &self,
+        _run_id: AgentRunId,
+        _after_sequence: i64,
+        _limit: u64,
+    ) -> Result<Vec<AgentRunProgressEntry>> {
         agent_run_storage_unavailable()
     }
 

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -14,6 +14,7 @@ import {
   type PendingApprovalSnapshot,
   type AgentActivitySnapshot,
   type AgentActivityHistoryItem,
+  type AgentRunProgressLine,
   type AgentActivityKind,
   type AgentActivityOutcome,
   type AgentRunCancellationSnapshot,
@@ -407,6 +408,22 @@ export type AgentActivity = AgentActivitySnapshot;
  * inputs, queries, results, identities, paths, leases, or diagnostics.
  */
 export type AgentActivityHistoryEntry = AgentActivityHistoryItem;
+
+/**
+ * One line of live progress a background run published.
+ *
+ * The text is the run's own bounded narration, the same class of prose the
+ * terminal result carries. `sequence` is the resume cursor: order is the
+ * contract, and gaps are possible once the server's retention trims the
+ * oldest lines.
+ */
+export type AgentRunProgressEntry = AgentRunProgressLine;
+
+/** A page of live progress plus the cursor to resume from. */
+export type AgentRunProgress = {
+  entries: AgentRunProgressEntry[];
+  nextSequence: number;
+};
 
 
 
@@ -1662,6 +1679,30 @@ export class ApiClient {
     return parseAgentActivityHistory(body);
   }
 
+  /**
+   * One resumable page of a background run's live progress.
+   *
+   * Poll with the previous page's `nextSequence` to receive only what the run
+   * has published since. A wrong-chat, foreground, or missing run answers
+   * `404`, which surfaces as a thrown error.
+   */
+  async listAgentRunProgress(
+    chatId: string,
+    runId: string,
+    afterSequence = 0,
+    limit?: number,
+  ): Promise<AgentRunProgress> {
+    const query = new URLSearchParams({
+      after_sequence: String(afterSequence),
+    });
+    if (limit !== undefined) query.set("limit", String(limit));
+    const body = await this.json<unknown>(
+      `/chats/${encodeURIComponent(chatId)}/agent-runs/${encodeURIComponent(runId)}/progress?${query}`,
+      { headers: this.headers() },
+    );
+    return parseAgentRunProgress(body, afterSequence);
+  }
+
   async cancelAgentRun(
     chatId: string,
     runId: string,
@@ -2319,6 +2360,42 @@ export function parseAgentActivityHistory(
       },
     ];
   });
+}
+
+/**
+ * Keep only well-formed progress lines, in server order.
+ *
+ * A line without a finite sequence, non-empty text, and a timestamp is dropped
+ * rather than rendered. The cursor falls back to what the caller asked for, so
+ * a malformed page re-reads rather than silently skipping ahead.
+ */
+export function parseAgentRunProgress(
+  value: unknown,
+  requestedAfter = 0,
+): AgentRunProgress {
+  if (!isRecord(value) || !Array.isArray(value.entries)) {
+    return { entries: [], nextSequence: requestedAfter };
+  }
+  const entries = value.entries.flatMap((entry): AgentRunProgressEntry[] => {
+    if (
+      !isRecord(entry) ||
+      typeof entry.sequence !== "number" ||
+      !Number.isFinite(entry.sequence) ||
+      typeof entry.text !== "string" ||
+      entry.text.length === 0 ||
+      typeof entry.at !== "string" ||
+      entry.at.length === 0
+    ) {
+      return [];
+    }
+    return [{ sequence: entry.sequence, text: entry.text, at: entry.at }];
+  });
+  const nextSequence =
+    typeof value.next_sequence === "number" &&
+    Number.isFinite(value.next_sequence)
+      ? value.next_sequence
+      : requestedAfter;
+  return { entries, nextSequence };
 }
 
 export function parseSandboxAgentCancellation(

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -72,6 +72,35 @@ export type AgentRunExecutionLocation = "in_process" | "container";
 export type AgentRunId = string;
 
 /**
+ * One line of live progress a background run published, as the renderer sees
+ * it.
+ *
+ * The text is the run's own bounded narration — the same class of prose the
+ * terminal `terminal_text` already carries, published while the run is still
+ * working instead of only at the end. It is not a tool trace: tool arguments,
+ * queries, results, folder and file identities, host paths, provider
+ * identities, executor leases, and raw diagnostics stay server-side, exactly as
+ * they do for the activity projections.
+ */
+export type AgentRunProgressLine = { 
+/**
+ * Monotonic per-run ordering. Pass the page's `next_sequence` back as
+ * `after_sequence` to read only what has arrived since.
+ */
+sequence: number, text: string, at: string, };
+
+/**
+ * One resumable page of a background run's live progress.
+ */
+export type AgentRunProgressPage = { entries: Array<AgentRunProgressLine>, 
+/**
+ * The cursor to resume from: the highest sequence in this page, or the
+ * requested cursor when the page is empty. A reader that polls with this
+ * value never re-reads a line it already has.
+ */
+next_sequence: number, };
+
+/**
  * Renderer-safe state for one agent run.
  *
  * Worker lease tokens, scheduling budgets, and other executor-facing fields

--- a/crates/openwave-server/src/desktop_schema.rs
+++ b/crates/openwave-server/src/desktop_schema.rs
@@ -25,7 +25,7 @@ const VECTOR_DIRECTORY: &str = "vectors";
 const MAX_MARKER_BYTES: u64 = 1_024;
 
 /// Bump this whenever the pre-v1 schema baseline changes incompatibly.
-const DESKTOP_SCHEMA_EPOCH: u32 = 6;
+const DESKTOP_SCHEMA_EPOCH: u32 = 7;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -448,6 +448,10 @@ pub fn app(state: AppState) -> Router {
             get(routes::list_agent_run_activity),
         )
         .route(
+            "/chats/{chat_id}/agent-runs/{run_id}/progress",
+            get(routes::list_agent_run_progress),
+        )
+        .route(
             "/chats/{chat_id}/agent-runs/{run_id}/cancel",
             post(routes::post_agent_run_cancel),
         )

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -2501,6 +2501,96 @@ pub async fn list_agent_run_activity(
     Ok(Json(sandbox_activity_history(&calls)))
 }
 
+/// One line of live progress a background run published, as the renderer sees
+/// it.
+///
+/// The text is the run's own bounded narration — the same class of prose the
+/// terminal `terminal_text` already carries, published while the run is still
+/// working instead of only at the end. It is not a tool trace: tool arguments,
+/// queries, results, folder and file identities, host paths, provider
+/// identities, executor leases, and raw diagnostics stay server-side, exactly as
+/// they do for the activity projections.
+#[derive(Debug, Clone, Serialize, ts_rs::TS)]
+pub struct AgentRunProgressLine {
+    /// Monotonic per-run ordering. Pass the page's `next_sequence` back as
+    /// `after_sequence` to read only what has arrived since.
+    pub sequence: i64,
+    pub text: String,
+    pub at: chrono::DateTime<Utc>,
+}
+
+/// One resumable page of a background run's live progress.
+#[derive(Debug, Serialize, ts_rs::TS)]
+pub struct AgentRunProgressPage {
+    pub entries: Vec<AgentRunProgressLine>,
+    /// The cursor to resume from: the highest sequence in this page, or the
+    /// requested cursor when the page is empty. A reader that polls with this
+    /// value never re-reads a line it already has.
+    pub next_sequence: i64,
+}
+
+/// Query for `GET /chats/{chat_id}/agent-runs/{run_id}/progress`.
+#[derive(Debug, Deserialize)]
+pub struct AgentRunProgressQuery {
+    /// Return only lines strictly newer than this sequence; `0` (the default)
+    /// starts from the oldest line retention still holds.
+    #[serde(default)]
+    pub after_sequence: i64,
+    /// Maximum lines to return, clamped to the read model's own bound.
+    pub limit: Option<u64>,
+}
+
+/// `GET /chats/{chat_id}/agent-runs/{run_id}/progress` — the resumable live
+/// progress stream for one background run.
+///
+/// The run snapshot says what state a child is in and the activity projections
+/// say which step it is on; neither says what the child is actually doing. This
+/// is that: the ordered lines the run itself published, readable while it is
+/// still running rather than only once it submits a result. Because each line
+/// carries a monotonic sequence, an observer polls with the cursor it last saw
+/// and receives only what is new.
+///
+/// Read-only, and bound to the exact chat: a missing, wrong-chat, or foreground
+/// run returns `404` rather than revealing whether an unrelated run identifier
+/// exists.
+pub async fn list_agent_run_progress(
+    store: ScopedStore,
+    Path((chat_id, run_id)): Path<(ChatId, openwave_core::AgentRunId)>,
+    Query(query): Query<AgentRunProgressQuery>,
+) -> Result<Json<AgentRunProgressPage>, ServerError> {
+    store.require_chat(chat_id).await?;
+    let run = store
+        .get_agent_run(run_id)
+        .await?
+        .filter(|run| run.chat_id == chat_id && run.tier == AgentRunTier::Background);
+    if run.is_none() {
+        return Err(ServerError::not_found(format!(
+            "agent run {run_id} not found"
+        )));
+    }
+    let after_sequence = query.after_sequence.max(0);
+    let limit = query
+        .limit
+        .unwrap_or(openwave_core::AgentRunProgressEntry::DEFAULT_PAGE);
+    let entries = store
+        .list_agent_run_progress(run_id, after_sequence, limit)
+        .await?;
+    let next_sequence = entries
+        .last()
+        .map_or(after_sequence, |entry| entry.sequence);
+    Ok(Json(AgentRunProgressPage {
+        entries: entries
+            .into_iter()
+            .map(|entry| AgentRunProgressLine {
+                sequence: entry.sequence,
+                text: entry.text,
+                at: entry.created_at,
+            })
+            .collect(),
+        next_sequence,
+    }))
+}
+
 /// Closed renderer-safe acknowledgement for sandbox cancellation.
 #[derive(Debug, Serialize, ts_rs::TS)]
 pub struct AgentRunCancellationSnapshot {

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -508,59 +508,69 @@ impl SandboxAgentRunWorker {
                 .acknowledge_cancellation_or_lease_loss(run.id, lease_token)
                 .await;
         };
-        match completion_result {
-            Ok(SandboxCompletion::Final(text)) => self.submit_result(&run, lease_token, text).await,
-            Ok(SandboxCompletion::WebSearch {
+        let step = match completion_result {
+            Ok(step) => step,
+            Err(error) => return self.record_failure(&run, lease_token, error).await,
+        };
+        let SandboxStep {
+            narration,
+            completion,
+        } = step;
+        match completion {
+            SandboxCompletion::Final(text) => self.submit_result(&run, lease_token, text).await,
+            SandboxCompletion::WebSearch {
                 provider_id,
                 arguments,
-            }) => {
+            } => {
                 self.park_sandbox_tool_call(
                     run,
                     lease_token,
                     provider_id,
                     openwave_core::SANDBOX_WEB_SEARCH_TOOL,
                     arguments,
+                    &narration,
                     "sandbox web-search checkpoint identity conflict",
                 )
                 .await
             }
-            Ok(SandboxCompletion::Exec {
+            SandboxCompletion::Exec {
                 provider_id,
                 arguments,
-            }) => {
+            } => {
                 self.park_sandbox_tool_call(
                     run,
                     lease_token,
                     provider_id,
                     SANDBOX_EXEC_TOOL,
                     arguments,
+                    &narration,
                     "sandbox exec checkpoint identity conflict",
                 )
                 .await
             }
-            Ok(SandboxCompletion::Done { outputs, summary }) => {
+            SandboxCompletion::Done { outputs, summary } => {
                 self.submit_submission(&run, lease_token, &outputs, &summary)
                     .await
             }
-            Ok(SandboxCompletion::FolderAccessProposal { request }) => {
+            SandboxCompletion::FolderAccessProposal { request } => {
                 self.submit_folder_access_proposal(run.id, lease_token, request)
                     .await
             }
-            Ok(SandboxCompletion::DelegatedFileRead {
+            SandboxCompletion::DelegatedFileRead {
                 provider_id,
                 arguments,
-            }) => {
+            } => {
                 self.park_sandbox_tool_call(
                     run,
                     lease_token,
                     provider_id,
                     openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL,
                     arguments,
+                    &narration,
                     "sandbox delegated-file checkpoint identity conflict",
                 )
                 .await
             }
-            Err(error) => self.record_failure(&run, lease_token, error).await,
         }
     }
 
@@ -817,6 +827,7 @@ impl SandboxAgentRunWorker {
     /// tool name and the conflict message differ — so they share this body
     /// rather than each carrying its own copy of the crash-recovery reasoning
     /// below.
+    #[allow(clippy::too_many_arguments)]
     async fn park_sandbox_tool_call(
         &self,
         run: AgentRun,
@@ -824,6 +835,7 @@ impl SandboxAgentRunWorker {
         provider_id: String,
         name: &str,
         arguments: serde_json::Value,
+        narration: &str,
         conflict_message: &str,
     ) -> Result<SandboxAgentRunWorkerOutcome> {
         let call = SandboxToolCallRequest {
@@ -857,6 +869,7 @@ impl SandboxAgentRunWorker {
                             && existing.arguments == call.arguments
                     });
                 if let Some(call) = recovered {
+                    self.publish_progress(run.id, call.id, narration).await;
                     self.wake.notify_one();
                     return Ok(SandboxAgentRunWorkerOutcome::ToolCheckpointed(call.id));
                 }
@@ -866,6 +879,7 @@ impl SandboxAgentRunWorker {
         match outcome {
             ParkSandboxToolCallOutcome::Parked { call, .. }
             | ParkSandboxToolCallOutcome::Existing { call, .. } => {
+                self.publish_progress(run.id, call.id, narration).await;
                 // This shared wake is only a latency hint; the dedicated
                 // executor's durable candidate scan remains the recovery path.
                 self.wake.notify_one();
@@ -887,6 +901,32 @@ impl SandboxAgentRunWorker {
                 self.acknowledge_cancellation_or_lease_loss(run.id, lease_token)
                     .await
             }
+        }
+    }
+
+    /// Publish what the model said before it checkpointed, so an observer can
+    /// see what the run is doing between steps.
+    ///
+    /// This is observation, not correctness state. It is written after the
+    /// checkpoint has already committed under a proven lease, keyed by that
+    /// checkpoint's durable identity so a retried commit republishes nothing,
+    /// and a failure here is reported and dropped rather than allowed to
+    /// disturb a transition that already succeeded.
+    async fn publish_progress(
+        &self,
+        run_id: openwave_core::AgentRunId,
+        call_id: CallId,
+        narration: &str,
+    ) {
+        if narration.trim().is_empty() {
+            return;
+        }
+        if let Err(error) = self
+            .store
+            .append_agent_run_progress(run_id, &format!("call:{call_id}"), narration)
+            .await
+        {
+            eprintln!("openwave: could not publish progress for run {run_id}: {error}");
         }
     }
 
@@ -1055,6 +1095,20 @@ async fn sandbox_request(
     })
 }
 
+/// One completed model step: the tool checkpoint or terminal outcome it
+/// produced, plus whatever the model said on the way there.
+#[derive(Debug)]
+struct SandboxStep {
+    /// Text the model produced before checkpointing on a tool.
+    ///
+    /// This is the run's own account of what it is about to do, and between
+    /// checkpoints it is the only thing an observer could see. A step that ends
+    /// the run carries nothing here — its result text already says it.
+    narration: String,
+    completion: SandboxCompletion,
+}
+
+#[derive(Debug)]
 enum SandboxCompletion {
     Final(String),
     /// The run's own files, offered as the deliverables for the task.
@@ -1083,7 +1137,7 @@ enum SandboxCompletion {
 async fn complete_sandbox_task(
     provider: Arc<dyn ModelProvider>,
     request: ChatRequest,
-) -> Result<SandboxCompletion> {
+) -> Result<SandboxStep> {
     let web_search_advertised = request
         .tools
         .iter()
@@ -1167,9 +1221,12 @@ async fn complete_sandbox_task(
                         let arguments = serde_json::from_str(&arguments).map_err(|_| {
                             AgentError::msg("sandbox agent emitted invalid web-search arguments")
                         })?;
-                        return Ok(SandboxCompletion::WebSearch {
-                            provider_id,
-                            arguments,
+                        return Ok(SandboxStep {
+                            narration: text,
+                            completion: SandboxCompletion::WebSearch {
+                                provider_id,
+                                arguments,
+                            },
                         });
                     }
                     if name == SANDBOX_EXEC_TOOL && exec_advertised {
@@ -1181,9 +1238,12 @@ async fn complete_sandbox_task(
                                 "sandbox agent emitted invalid exec arguments",
                             ));
                         }
-                        return Ok(SandboxCompletion::Exec {
-                            provider_id,
-                            arguments,
+                        return Ok(SandboxStep {
+                            narration: text,
+                            completion: SandboxCompletion::Exec {
+                                provider_id,
+                                arguments,
+                            },
                         });
                     }
                     if name == openwave_core::SANDBOX_DONE_TOOL && done_advertised {
@@ -1201,9 +1261,12 @@ async fn complete_sandbox_task(
                                 .map_err(|_| {
                                     AgentError::msg("sandbox agent emitted invalid done arguments")
                                 })?;
-                        return Ok(SandboxCompletion::Done {
-                            outputs: arguments.outputs,
-                            summary: arguments.summary,
+                        return Ok(SandboxStep {
+                            narration: String::new(),
+                            completion: SandboxCompletion::Done {
+                                outputs: arguments.outputs,
+                                summary: arguments.summary,
+                            },
                         });
                     }
                     if name == openwave_core::REQUEST_FOLDER_ACCESS_TOOL
@@ -1218,7 +1281,10 @@ async fn complete_sandbox_task(
                                 "sandbox agent emitted invalid folder-access proposal",
                             ));
                         }
-                        return Ok(SandboxCompletion::FolderAccessProposal { request });
+                        return Ok(SandboxStep {
+                            narration: String::new(),
+                            completion: SandboxCompletion::FolderAccessProposal { request },
+                        });
                     }
                     if name == openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL
                         && delegated_file_advertised
@@ -1233,9 +1299,12 @@ async fn complete_sandbox_task(
                                 "sandbox agent emitted invalid delegated-file arguments",
                             ));
                         }
-                        return Ok(SandboxCompletion::DelegatedFileRead {
-                            provider_id,
-                            arguments,
+                        return Ok(SandboxStep {
+                            narration: text,
+                            completion: SandboxCompletion::DelegatedFileRead {
+                                provider_id,
+                                arguments,
+                            },
                         });
                     }
                     return Err(AgentError::msg(
@@ -1252,7 +1321,10 @@ async fn complete_sandbox_task(
                         "sandbox agent produced an empty final result",
                     ));
                 }
-                return Ok(SandboxCompletion::Final(text));
+                return Ok(SandboxStep {
+                    narration: String::new(),
+                    completion: SandboxCompletion::Final(text),
+                });
             }
             ProviderEvent::Refusal { details } => {
                 let category = details
@@ -1893,6 +1965,20 @@ mod tests {
             store.get_agent_run(id).await.unwrap().unwrap().status,
             AgentRunStatus::Waiting
         );
+        // The narration the model produced before checkpointing is published as
+        // live progress, so the run is observable while it is still parked
+        // rather than only once it submits a result.
+        let progress = store.list_agent_run_progress(id, 0, 50).await.unwrap();
+        assert_eq!(progress.len(), 1);
+        assert_eq!(progress[0].sequence, 1);
+        assert_eq!(progress[0].text, "I’ll research that now.");
+        // Reading past the cursor the observer already holds returns nothing,
+        // which is what makes polling cheap.
+        assert!(store
+            .list_agent_run_progress(id, progress[0].sequence, 50)
+            .await
+            .unwrap()
+            .is_empty());
         let executor_lease = uuid::Uuid::new_v4();
         store
             .claim_sandbox_tool_call(call_id, executor_lease, chrono::Duration::minutes(1))
@@ -2171,6 +2257,7 @@ mod tests {
                     "search_1".into(),
                     openwave_core::SANDBOX_WEB_SEARCH_TOOL,
                     serde_json::json!({"query":"OpenWave"}),
+                    "",
                     "sandbox web-search checkpoint identity conflict",
                 )
                 .await
@@ -2996,7 +3083,7 @@ mod tests {
             },
         ]));
         assert!(matches!(
-            complete_sandbox_task(provider, request).await.unwrap(),
+            complete_sandbox_task(provider, request).await.unwrap().completion,
             SandboxCompletion::DelegatedFileRead { arguments, .. }
                 if arguments == serde_json::json!({})
         ));

--- a/crates/openwave-server/src/sandbox_container_run.rs
+++ b/crates/openwave-server/src/sandbox_container_run.rs
@@ -673,7 +673,7 @@ impl SandboxContainerRunner {
         // heartbeat the run is failed out from under a container that is still
         // working and still spending. The whole drive is additionally bounded by
         // the run's absolute deadline, so no path can wait forever.
-        let drive = self.drive_events(protocol_run_id, handle, &host, &init);
+        let drive = self.drive_events(run_id, protocol_run_id, handle, &host, &init);
         tokio::pin!(drive);
         let mut heartbeat = tokio::time::interval(self.config.heartbeat);
         heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -820,6 +820,7 @@ impl SandboxContainerRunner {
     /// event, reattaching across unplanned disconnects within the budget.
     async fn drive_events(
         &self,
+        run_id: AgentRunId,
         protocol_run_id: RunId,
         handle: &SandboxHandle,
         host: &CapabilityHost,
@@ -829,7 +830,7 @@ impl SandboxContainerRunner {
         let mut attempt = 0u32;
         loop {
             match self
-                .drain_connection(protocol_run_id, handle, host, init, &mut cursor)
+                .drain_connection(run_id, protocol_run_id, handle, host, init, &mut cursor)
                 .await
             {
                 DrainOutcome::Result(text) => return DriveEnd::Result(text),
@@ -852,8 +853,10 @@ impl SandboxContainerRunner {
 
     /// Dial the container, attach, and drain its event stream over one
     /// connection until it delivers a result or drops.
+    #[allow(clippy::too_many_arguments)]
     async fn drain_connection(
         &self,
+        run_id: AgentRunId,
         protocol_run_id: RunId,
         handle: &SandboxHandle,
         host: &CapabilityHost,
@@ -917,6 +920,24 @@ impl SandboxContainerRunner {
             match payload {
                 EventPayload::Result(text) => return DrainOutcome::Result(text),
                 EventPayload::Failed(detail) => return DrainOutcome::AgentFailed(detail),
+                // Progress is observation, published so a reader can watch the
+                // run without waiting for its result. The sandbox's own event
+                // sequence keys the append, so a reattach that redelivers a
+                // batch leaves one line rather than two, and a failure to
+                // publish is dropped rather than allowed to end the drive.
+                EventPayload::Progress(text) => {
+                    if let Err(error) = self
+                        .store
+                        .append_agent_run_progress(
+                            run_id,
+                            &format!("event:{}", event.sequence.get()),
+                            &text,
+                        )
+                        .await
+                    {
+                        eprintln!("openwave: could not publish progress for run {run_id}: {error}");
+                    }
+                }
                 _ => {}
             }
         }

--- a/crates/openwave-server/src/scoped_store.rs
+++ b/crates/openwave-server/src/scoped_store.rs
@@ -271,6 +271,18 @@ impl ScopedStore {
         self.store.request_agent_run_cancellation(id).await
     }
 
+    /// [`Store::list_agent_run_progress`].
+    pub async fn list_agent_run_progress(
+        &self,
+        run_id: AgentRunId,
+        after_sequence: i64,
+        limit: u64,
+    ) -> Result<Vec<openwave_core::AgentRunProgressEntry>> {
+        self.store
+            .list_agent_run_progress(run_id, after_sequence, limit)
+            .await
+    }
+
     /// [`Store::list_sandbox_tool_calls_for_agent_run`].
     pub async fn list_sandbox_tool_calls_for_agent_run(
         &self,

--- a/crates/openwave-server/src/tests/sandbox.rs
+++ b/crates/openwave-server/src/tests/sandbox.rs
@@ -405,6 +405,99 @@ async fn agent_run_activity_history_is_ordered_renderer_safe_and_names_submitted
 }
 
 #[tokio::test]
+async fn agent_run_progress_is_ordered_resumable_and_bound_to_its_chat() {
+    let (router, token, store, _dir) = test_app_without_turn_worker().await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let other_chat = make_chat(&router, &bearer).await;
+    let run = admit_sandbox_for_test(&store, chat.id, "research").await;
+
+    let read = |after: Option<i64>| {
+        let router = router.clone();
+        let bearer = bearer.clone();
+        let chat_id = chat.id;
+        let run_id = run.id;
+        async move {
+            let query = after.map_or_else(String::new, |after| format!("?after_sequence={after}"));
+            let response = router
+                .oneshot(
+                    Request::builder()
+                        .uri(format!(
+                            "/chats/{chat_id}/agent-runs/{run_id}/progress{query}"
+                        ))
+                        .header(header::AUTHORIZATION, &bearer)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            json_body::<serde_json::Value>(response).await
+        }
+    };
+
+    // A run that has published nothing reads as an empty page whose cursor is
+    // the one the caller asked for, so a poller does not skip ahead.
+    let empty = read(None).await;
+    assert_eq!(empty["entries"], serde_json::json!([]));
+    assert_eq!(empty["next_sequence"], serde_json::json!(0));
+
+    store
+        .append_agent_run_progress(run.id, "call:one", "Reading the filings.")
+        .await
+        .unwrap();
+    store
+        .append_agent_run_progress(run.id, "call:two", "Writing the summary.")
+        .await
+        .unwrap();
+    // The same producer identity republished is the reattach case: one line,
+    // not two.
+    store
+        .append_agent_run_progress(run.id, "call:one", "Reading the filings.")
+        .await
+        .unwrap();
+
+    let page = read(None).await;
+    let entries = page["entries"].as_array().unwrap();
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0]["sequence"], serde_json::json!(1));
+    assert_eq!(
+        entries[0]["text"],
+        serde_json::json!("Reading the filings.")
+    );
+    assert_eq!(entries[1]["sequence"], serde_json::json!(2));
+    assert_eq!(page["next_sequence"], serde_json::json!(2));
+    assert!(entries[0]["at"].is_string());
+
+    // Resuming from the cursor returns only what arrived after it.
+    let resumed = read(Some(1)).await;
+    let resumed_entries = resumed["entries"].as_array().unwrap();
+    assert_eq!(resumed_entries.len(), 1);
+    assert_eq!(
+        resumed_entries[0]["text"],
+        serde_json::json!("Writing the summary.")
+    );
+    assert_eq!(resumed["next_sequence"], serde_json::json!(2));
+    assert_eq!(read(Some(2)).await["entries"], serde_json::json!([]));
+
+    // Binding to the wrong chat must not reveal that the run exists.
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/chats/{}/agent-runs/{}/progress",
+                    other_chat.id, run.id
+                ))
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
 async fn delegated_file_routes_are_native_only_and_expose_only_exact_broker_authority() {
     let (router, token, _state, store, _dir) = test_app_with_state().await;
     let bearer = format!("Bearer {token}");

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -386,6 +386,9 @@ mod tests {
         // A separate endpoint root: the ordered activity history is returned by
         // its own route, so the snapshot walk never reaches it.
         generate::collect_from::<crate::routes::AgentActivityHistoryItem>(&cfg, &mut out);
+        // Likewise its own endpoint root: the live progress stream is paged by
+        // its own route rather than embedded in a snapshot.
+        generate::collect_from::<crate::routes::AgentRunProgressPage>(&cfg, &mut out);
         out
     }
 

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -333,6 +333,36 @@ the exact chat and run, a pending or retryable error state is held until
 polling confirms the durable transition, and no worker lease or direct
 scheduler control ever crosses the boundary.
 
+Those surfaces answer *what state* a child is in and *which step* it is on.
+Neither answers what the child is actually doing, which until it submits a
+result is the only thing a reader wants to know.
+`GET /chats/{chat_id}/agent-runs/{run_id}/progress` is that stream: the bounded
+lines the run itself published, each stamped with a monotonic per-run sequence.
+A reader polls with the cursor it last saw and receives only what has arrived
+since, which is what makes watching a long child cheap. A missing, wrong-chat,
+or foreground run answers `404`, exactly as the activity history does.
+
+Two producers write it, and neither is trusted to write it correctly for the
+stream to stay usable. A container-located run's progress comes from the
+sandbox protocol's own sequenced event stream; an in-process run's comes from
+the text its model produced before it checkpointed on a tool. Each line carries
+its producer's identity for that line — an event sequence, or the durable
+checkpoint the narration belongs to — so a reattached container redelivering a
+batch, or a worker retrying an ambiguous commit, leaves one line rather than
+two.
+
+The stream is deliberately outside the correctness contract. No transition
+reads it; the append takes no lease and commits separately from the transition
+that produced the line; a failure to publish is reported and dropped rather
+than allowed to disturb a checkpoint that already committed. Retention bounds
+it, so a run that narrates for an hour costs a bounded number of rows and an
+observer that stops reading may find the oldest lines gone. What it does
+guarantee is order, and that a line already delivered is never delivered twice.
+The text is the run's own prose — the same class the terminal result already
+carries — and nothing else: no tool arguments, queries, results, folder or file
+identities, host paths, provider identities, executor leases, or raw
+diagnostics.
+
 ## Reliability contract
 
 The agent hierarchy preserves the runtime's existing rules:


### PR DESCRIPTION
A background run is observable only at its edges today: the state it is in (`GET /chats/{id}/agent-runs`), the checkpoint it currently sits on (the snapshot's `activity` and the activity history route), and the result it eventually submits. Between those there is nothing to read, so a parent or the desktop watching a long child sees a static "running" row until the run terminates. Durable join tells you when a child is done; nothing tells you what it is doing.

This adds the stream in between.

## The read model

`GET /chats/{chat_id}/agent-runs/{run_id}/progress?after_sequence=N&limit=M` returns a page of the bounded lines a background run published, each stamped with a monotonic per-run sequence, plus the cursor to resume from. A reader polls with the cursor it last held and receives only what has arrived since. A missing, wrong-chat, or foreground run answers `404` without revealing whether an unrelated run identifier exists — the same posture the activity history route already takes.

## Where the lines come from

Two producers, matching the two execution adapters:

- A container-located run's progress comes from the sandbox protocol's own resumable, sequenced event stream. The driver was already draining it and committing its cursor; `EventPayload::Progress` fell through a `_ => {}` and was discarded.
- An in-process run's progress comes from the text its model produced before checkpointing on a tool — the run's own account of what it is about to do. `complete_sandbox_task` was dropping it on the tool-use path.

Each line carries its producer's identity for that line: a protocol event sequence, or the durable checkpoint the narration belongs to. A unique `(run_id, source_key)` index makes republishing a no-op, so a reattached container redelivering a batch and a worker retrying an ambiguous commit both leave one line rather than two.

## Posture

The stream is deliberately outside the correctness contract. Nothing reads it to decide what a run may do next. The append takes no lease and commits separately from the transition that produced the line — it runs only after that checkpoint has already committed under a proven lease — and a failure to publish is reported and dropped rather than allowed to disturb a transition that succeeded. Retention bounds the table to a fixed number of lines per run, so a child that narrates for an hour costs a bounded number of rows and a reader that stops polling may find the oldest lines trimmed; order is the guarantee, not completeness.

Only the run's own prose crosses the boundary — the same class of text the terminal result already carries. Tool arguments, queries, results, folder and file identities, host paths, provider identities, executor leases, and raw diagnostics all stay server-side, exactly as they do for the activity projections.

## What is not here

The desktop consumption point is split out as #1604, so this PR is the server contract plus the typed client and defensive parser the UI slice will build on. The transcript rows and the background-agent panel still render state and activity only.

## Tests

Two, both behavioral:

- `agent_run_progress_is_ordered_resumable_and_bound_to_its_chat` drives the route: an empty run reads as an empty page whose cursor does not advance, republishing a producer key leaves one line, resuming from a cursor returns only what followed it, and the wrong chat answers `404`.
- The existing `checkpoints_web_search_after_a_text_preamble_and_rebuilds_its_receipt` worker test gains assertions that the preamble it already produces is published as progress and that reading past the cursor returns nothing — the write path, exercised where a real run produces it, rather than a second fixture.

Schema epoch bumped for the new table.

Closes #954.