### PR TITLE
fix(desktop): floor the sidebar rail width so open panels can't squash it

### DIFF
--- a/crates/openwave-desktop/ui/src/panel/PanelLayout.tsx
+++ b/crates/openwave-desktop/ui/src/panel/PanelLayout.tsx
@@ -72,7 +72,12 @@ export function PanelLayout({
     <PanelGroup
       ref={groupRef}
       direction="horizontal"
-      className={cn("content-container min-h-0 w-full max-w-full flex-1 overflow-clip")}
+      className={cn(
+        // min-w-0 stops the group's content-driven min-content width from
+        // pushing the row wider than its flex basis, which is what let panel
+        // content squeeze the sidebar rail beside it.
+        "content-container min-h-0 w-full max-w-full min-w-0 flex-1 overflow-clip",
+      )}
       data-dragging={dragging || undefined}
     >
       <Panel

--- a/crates/openwave-desktop/ui/src/sidebar/primitives.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/primitives.tsx
@@ -39,6 +39,11 @@ export function Sidebar({ className, children, ...props }: ComponentProps<"div">
         )}
         style={{
           flex: isCompact ? "0 0 calc(var(--spacing) * 14)" : "var(--sidebar-expanded-flex)",
+          // Above 1600px, --sidebar-expanded-flex sets flex-shrink to 1 so the
+          // rail can grow with the window. Without a min-width floor, that same
+          // shrink lets a second open content panel squeeze the rail down to a
+          // sliver instead of taking space from the panels themselves.
+          minWidth: isCompact ? "calc(var(--spacing) * 14)" : "var(--sidebar-expanded-min)",
         }}
         data-sidebar={width}
       >

--- a/mockups/codex-shell-mockup-v2.html
+++ b/mockups/codex-shell-mockup-v2.html
@@ -1,0 +1,654 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>OpenWave — Codex-style shell mockup v2 (tabbed right panel)</title>
+<style>
+  /* ---- OpenWave tokens (from ui/src/styles.css) ---- */
+  :root {
+    --background: oklch(1 0 0);
+    --foreground: oklch(0 0 0);
+    --page-background: oklch(98.2% 0 0);
+    --border: oklch(0.92 0.004 286.32);
+    --primary: oklch(0.21 0.006 285.885);
+    --primary-foreground: oklch(0.967 0.001 286.375);
+    --secondary: oklch(0.924 0.001 0);
+    --muted: oklch(0.924 0.001 0);
+    --muted-foreground: oklch(0.552 0.016 285.938);
+    --accent: oklch(0.924 0.001 0);
+    --card: oklch(0.985 0 0);
+    --popover: oklch(1 0 0);
+    --success: oklch(0.627 0.194 149.214);
+    --warning: oklch(0.666 0.179 58.318);
+    --critical: oklch(0.577 0.245 27.325);
+    --info: oklch(0.588 0.158 241.966);
+    --radius: 0.5rem;
+    --container-margin: 0.5rem;
+    --shadow: 0 0px 8px 0px oklch(0 0 0 / 0.07);
+    --shadow-lg: 0 4px 24px 0px oklch(0 0 0 / 0.13);
+    --sans: "Inter", "Segoe UI", system-ui, sans-serif;
+    --mono: "SF Mono", ui-monospace, Menlo, monospace;
+    color-scheme: light;
+  }
+  .dark {
+    --background: oklch(0.21 0.008 262);
+    --foreground: oklch(0.95 0 0);
+    --page-background: oklch(0.12 0.005 262);
+    --border: oklch(0.31 0.009 262);
+    --primary: oklch(0.95 0 0);
+    --primary-foreground: oklch(0.12 0.005 262);
+    --secondary: oklch(0.27 0.009 262);
+    --muted: oklch(0.27 0.009 262);
+    --muted-foreground: oklch(0.68 0.006 262);
+    --accent: oklch(0.27 0.009 262);
+    --card: oklch(0.16 0.006 262);
+    --popover: oklch(0.14 0.006 262);
+    --success: oklch(0.792 0.209 151.711);
+    --warning: oklch(0.828 0.189 84.429);
+    --critical: oklch(0.704 0.191 22.216);
+    --info: oklch(0.746 0.16 232.661);
+    --shadow: 0 0px 8px 0px oklch(0 0 0 / 0.3);
+    --shadow-lg: 0 4px 24px 0px oklch(0 0 0 / 0.45);
+    color-scheme: dark;
+  }
+
+  * { box-sizing: border-box; margin: 0; }
+  html, body { height: 100%; }
+  body {
+    font-family: var(--sans);
+    font-size: 14px;
+    line-height: 1.45;
+    color: var(--foreground);
+    background: var(--page-background);
+    overflow: hidden;
+  }
+  button { font: inherit; color: inherit; background: none; border: none; cursor: pointer; }
+
+  .shell { display: flex; height: 100vh; }
+
+  /* =========================================================
+     SIDEBAR — chats only, fixed width, out of the panel split.
+     ========================================================= */
+  .sidebar {
+    flex: 0 0 248px;
+    min-width: 248px;
+    display: flex;
+    flex-direction: column;
+    padding: 10px 8px 8px;
+    gap: 2px;
+    overflow-y: auto;
+  }
+  .sidebar-head { display: flex; align-items: center; gap: 8px; padding: 4px 8px 10px; }
+  .logomark {
+    width: 22px; height: 22px; border-radius: 6px;
+    background: var(--primary); color: var(--primary-foreground);
+    display: grid; place-items: center; font-weight: 700; font-size: 12px;
+  }
+  .sidebar-head .wordmark { font-weight: 600; font-size: 13px; }
+  .sidebar-head .spacer { flex: 1; }
+  .icon-btn {
+    width: 26px; height: 26px; border-radius: 6px;
+    display: grid; place-items: center; color: var(--muted-foreground);
+  }
+  .icon-btn:hover { background: var(--accent); color: var(--foreground); }
+
+  .nav-item {
+    display: flex; align-items: center; gap: 9px;
+    padding: 6px 8px; border-radius: 6px;
+    color: var(--foreground); font-size: 13px;
+    width: 100%; text-align: left;
+  }
+  .nav-item svg { width: 15px; height: 15px; color: var(--muted-foreground); flex: none; }
+  .nav-item:hover { background: var(--accent); }
+  .nav-item .count { margin-left: auto; font-size: 11px; color: var(--muted-foreground); }
+
+  .section-label {
+    padding: 14px 8px 4px; font-size: 11px; font-weight: 500;
+    color: var(--muted-foreground); letter-spacing: 0.02em;
+  }
+  .chat-item {
+    display: block; width: 100%; text-align: left;
+    padding: 5px 8px; border-radius: 6px; font-size: 13px;
+    color: var(--foreground);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  .chat-item:hover { background: var(--accent); }
+  .chat-item.active { background: var(--accent); font-weight: 500; }
+  .chat-item .dot {
+    display: inline-block; width: 6px; height: 6px; border-radius: 50%;
+    background: var(--success); margin-right: 7px; vertical-align: 1px;
+  }
+  .chat-item.attention .dot { background: var(--warning); }
+  .project-group .chat-item { padding-left: 30px; }
+  .sidebar-foot { margin-top: auto; padding-top: 10px; border-top: 1px solid var(--border); }
+
+  /* =========================================================
+     MAIN CARD
+     ========================================================= */
+  .main {
+    flex: 1 1 0;
+    min-width: 0;
+    margin: var(--container-margin) var(--container-margin) var(--container-margin) 0;
+    background: var(--background);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    box-shadow: var(--shadow);
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .main-header {
+    flex: none;
+    display: flex; align-items: center; gap: 10px;
+    padding: 8px 14px;
+    border-bottom: 1px solid var(--border);
+  }
+  .breadcrumb { display: flex; align-items: center; gap: 6px; font-size: 13px; min-width: 0; }
+  .breadcrumb .crumb { color: var(--muted-foreground); }
+  .breadcrumb .sep { color: var(--muted-foreground); opacity: 0.5; }
+  .breadcrumb .current { font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .header-actions { margin-left: auto; display: flex; align-items: center; gap: 6px; }
+
+  /* Always-visible chat status chip: permission mode + agent activity.
+     This is the collapsed face of the details dropdown. */
+  .status-chip {
+    display: inline-flex; align-items: center; gap: 7px;
+    font-size: 12px; padding: 4px 10px; border-radius: 999px;
+    border: 1px solid var(--border); color: var(--muted-foreground);
+  }
+  .status-chip:hover { background: var(--accent); color: var(--foreground); }
+  .status-chip .mode { color: var(--warning); font-weight: 500; }
+  .status-chip .dots { display: inline-flex; gap: 3px; }
+
+  /* =========================================================
+     PANELS — chat pinned left, tabbed panel on the right.
+     ========================================================= */
+  .panels { flex: 1; display: flex; min-height: 0; }
+  .panel { min-width: 320px; display: flex; flex-direction: column; min-height: 0; }
+  .panel.transcript { flex: 1.3 1 0; }
+  .panel.side { flex: 1 1 0; border-left: 1px solid var(--border); }
+  .panel.side.hidden { display: none; }
+
+  /* Tab strip */
+  .tabstrip {
+    flex: none; display: flex; align-items: center; gap: 2px;
+    padding: 6px 8px 0; border-bottom: 1px solid var(--border);
+  }
+  .tab {
+    display: inline-flex; align-items: center; gap: 7px;
+    font-size: 12.5px; padding: 6px 12px 7px;
+    border-radius: 8px 8px 0 0;
+    color: var(--muted-foreground);
+    border: 1px solid transparent; border-bottom: none;
+    position: relative; top: 1px;
+    max-width: 180px;
+  }
+  .tab .label { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .tab:hover { color: var(--foreground); background: var(--accent); }
+  .tab.active {
+    color: var(--foreground); font-weight: 500;
+    background: var(--background);
+    border-color: var(--border);
+  }
+  .tab .status-dot { width: 6px; height: 6px; }
+  .tab .badge-n {
+    font-size: 10.5px; padding: 0 5px; border-radius: 999px;
+    background: var(--secondary); color: var(--muted-foreground);
+  }
+  .tabstrip .strip-spacer { flex: 1; }
+  .tabstrip .icon-btn { width: 24px; height: 24px; margin-bottom: 3px; }
+
+  .tabpage { flex: 1; overflow-y: auto; padding: 16px 18px; display: none; }
+  .tabpage.active { display: block; }
+
+  .panel-body { flex: 1; overflow-y: auto; padding: 18px 22px; }
+
+  /* transcript bits */
+  .msg-user {
+    background: var(--secondary); border-radius: 14px;
+    padding: 9px 14px; max-width: 78%; margin-left: auto; margin-bottom: 18px;
+    font-size: 13.5px;
+  }
+  .msg-assistant { margin-bottom: 18px; font-size: 13.5px; max-width: 46rem; }
+  .agent-card {
+    border: 1px solid var(--border); border-radius: 10px;
+    background: var(--card); margin: 10px 0; max-width: 46rem;
+    font-size: 12.5px;
+  }
+  .agent-card .row { display: flex; align-items: center; gap: 8px; padding: 8px 12px; }
+  .agent-card .row + .row { border-top: 1px solid var(--border); }
+  .status-dot { width: 7px; height: 7px; border-radius: 50%; flex: none; }
+  .status-dot.run { background: var(--success); }
+  .status-dot.retry { background: var(--warning); }
+  .status-dot.done { background: var(--muted-foreground); }
+  .agent-card .task { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .agent-card .meta { color: var(--muted-foreground); font-size: 11.5px; flex: none; }
+  .chip {
+    font-size: 11px; padding: 2px 8px; border-radius: 999px;
+    border: 1px solid var(--border); color: var(--muted-foreground); flex: none;
+  }
+
+  .composer-wrap { flex: none; padding: 12px 22px 16px; }
+  .composer {
+    max-width: 46rem; margin: 0 auto;
+    border: 1px solid var(--border); border-radius: 14px;
+    background: var(--background); box-shadow: var(--shadow);
+    padding: 10px 12px 8px;
+  }
+  .composer .input { color: var(--muted-foreground); font-size: 13.5px; padding: 2px 4px 10px; }
+  .composer .bar { display: flex; align-items: center; gap: 8px; }
+  .composer .bar .spacer { flex: 1; }
+  .pill-btn {
+    display: inline-flex; align-items: center; gap: 6px;
+    font-size: 12px; padding: 4px 10px; border-radius: 999px;
+    color: var(--muted-foreground);
+  }
+  .pill-btn:hover { background: var(--accent); color: var(--foreground); }
+  .send-btn {
+    width: 28px; height: 28px; border-radius: 50%;
+    background: var(--primary); color: var(--primary-foreground);
+    display: grid; place-items: center;
+  }
+
+  /* --- Agents tab --- */
+  .agent-list-item {
+    display: flex; align-items: center; gap: 9px; width: 100%; text-align: left;
+    padding: 8px 10px; border-radius: 8px; font-size: 12.5px;
+  }
+  .agent-list-item:hover { background: var(--accent); }
+  .agent-list-item.selected { background: var(--accent); }
+  .agent-list-item .task { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .agent-list-item .meta { color: var(--muted-foreground); font-size: 11px; flex: none; }
+  .agent-detail {
+    margin-top: 14px; padding-top: 14px; border-top: 1px solid var(--border);
+  }
+  .task-title { font-weight: 600; font-size: 13px; margin-bottom: 3px; }
+  .task-sub { color: var(--muted-foreground); font-size: 12px; margin-bottom: 12px; }
+  .badge {
+    font-size: 11px; padding: 2px 8px; border-radius: 999px; font-weight: 500;
+    background: color-mix(in oklch, var(--success) 18%, transparent);
+    color: var(--success);
+  }
+  .timeline { font-size: 12.5px; color: var(--muted-foreground); display: grid; gap: 8px; }
+  .timeline .t-row { display: flex; gap: 8px; align-items: baseline; }
+  .timeline .t-time { font-family: var(--mono); font-size: 11px; flex: none; width: 34px; }
+
+  /* --- Outputs tab --- */
+  .output-row {
+    display: flex; align-items: center; gap: 10px; width: 100%; text-align: left;
+    padding: 9px 10px; border-radius: 8px; font-size: 12.5px;
+  }
+  .output-row:hover { background: var(--accent); }
+  .file-icon {
+    width: 28px; height: 28px; border-radius: 6px; flex: none;
+    display: grid; place-items: center; font-size: 10px; font-weight: 700;
+    background: var(--secondary); color: var(--muted-foreground);
+  }
+  .file-icon.xlsx { background: color-mix(in oklch, var(--success) 16%, transparent); color: var(--success); }
+  .file-icon.png  { background: color-mix(in oklch, var(--info) 16%, transparent); color: var(--info); }
+  .file-icon.docx { background: color-mix(in oklch, var(--warning) 16%, transparent); color: var(--warning); }
+  .output-row .name { flex: 1; min-width: 0; }
+  .output-row .fname { font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .output-row .fmeta { color: var(--muted-foreground); font-size: 11px; }
+  .vbadge {
+    font-size: 10.5px; font-family: var(--mono); padding: 1px 6px;
+    border-radius: 999px; border: 1px solid var(--border);
+    color: var(--muted-foreground); flex: none;
+  }
+
+  /* --- Preview tab --- */
+  .preview-frame {
+    border: 1px solid var(--border); border-radius: 8px; overflow: hidden;
+    background: var(--card);
+  }
+  .preview-frame table { border-collapse: collapse; width: 100%; font-size: 11.5px; font-family: var(--mono); }
+  .preview-frame th, .preview-frame td {
+    border: 1px solid var(--border); padding: 4px 8px; text-align: left;
+    white-space: nowrap; color: var(--muted-foreground);
+  }
+  .preview-frame th { background: var(--secondary); color: var(--foreground); font-weight: 600; }
+  .preview-caption { font-size: 11.5px; color: var(--muted-foreground); margin-top: 8px; }
+
+  /* =========================================================
+     DETAILS DROPDOWN — anchored to the status chip, closed by
+     default, click-outside dismiss. Chat settings only; the
+     scalable lists (agents, outputs) live in tabs instead.
+     ========================================================= */
+  .dropdown {
+    position: absolute; top: 44px; right: 12px; z-index: 30;
+    width: 280px;
+    background: var(--popover);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    box-shadow: var(--shadow-lg);
+    overflow: hidden;
+    font-size: 13px;
+    padding: 6px 0;
+    display: none;
+  }
+  .dropdown.open { display: block; }
+  .prow {
+    display: flex; align-items: center; gap: 9px;
+    padding: 7px 12px; width: 100%; text-align: left; font-size: 12.5px;
+  }
+  .prow:hover { background: var(--accent); }
+  .prow svg { width: 14px; height: 14px; color: var(--muted-foreground); flex: none; }
+  .prow .label { flex: 1; }
+  .prow .value { color: var(--muted-foreground); font-size: 12px; flex: none; }
+  .prow .chev { color: var(--muted-foreground); flex: none; }
+
+  svg { display: block; }
+  .hint {
+    position: fixed; bottom: 10px; left: 50%; transform: translateX(-50%);
+    font-size: 11px; color: var(--muted-foreground);
+    background: var(--popover); border: 1px solid var(--border);
+    border-radius: 999px; padding: 4px 12px; box-shadow: var(--shadow);
+    white-space: nowrap; z-index: 40;
+  }
+  .hint b { font-weight: 600; }
+</style>
+</head>
+<body>
+<div class="shell">
+
+  <!-- ============ SIDEBAR: chats only ============ -->
+  <nav class="sidebar">
+    <div class="sidebar-head">
+      <div class="logomark">OW</div>
+      <span class="wordmark">OpenWave</span>
+      <span class="spacer"></span>
+      <button class="icon-btn" title="Search">
+        <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>
+      </button>
+      <button class="icon-btn" id="themeToggle" title="Toggle theme">
+        <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4m11.4-11.4 1.4-1.4"/></svg>
+      </button>
+    </div>
+
+    <button class="nav-item">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>
+      New chat
+    </button>
+    <button class="nav-item">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 12h-6l-2 3h-4l-2-3H2"/><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/></svg>
+      Inbox <span class="count">3</span>
+    </button>
+    <button class="nav-item">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+      Folders
+    </button>
+    <button class="nav-item">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+      Apps
+    </button>
+
+    <div class="section-label">Projects</div>
+    <div class="project-group">
+      <button class="nav-item">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+        Q3 planning
+      </button>
+      <button class="chat-item"><span class="dot"></span>Budget model rebuild</button>
+      <button class="chat-item">Headcount scenarios</button>
+    </div>
+    <div class="project-group">
+      <button class="nav-item">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+        Vendor research
+      </button>
+      <button class="chat-item">CRM comparison matrix</button>
+    </div>
+
+    <div class="section-label">Recents</div>
+    <button class="chat-item active"><span class="dot"></span>Test: spawn background agents</button>
+    <button class="chat-item attention"><span class="dot"></span>Quarterly deck draft</button>
+    <button class="chat-item">Summarize customer interviews</button>
+    <button class="chat-item">Fix conversion table formulas</button>
+    <button class="chat-item">Draft onboarding doc</button>
+    <button class="chat-item">Analyze churn cohort CSV</button>
+    <button class="chat-item">Rename exported files</button>
+
+    <div class="sidebar-foot">
+      <button class="nav-item">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M12 1v3m0 16v3m11-11h-3M4 12H1m18.4-7.4-2.2 2.2M6.8 17.2l-2.2 2.2m14.8 0-2.2-2.2M6.8 6.8 4.6 4.6"/></svg>
+        Settings
+      </button>
+    </div>
+  </nav>
+
+  <!-- ============ MAIN CARD ============ -->
+  <main class="main">
+    <header class="main-header">
+      <div class="breadcrumb">
+        <span class="crumb">Chats</span><span class="sep">/</span>
+        <span class="current">Test: spawn background agents</span>
+      </div>
+      <div class="header-actions">
+        <!-- Always-visible status: permission mode + live agent dots.
+             Clicking opens the chat-details dropdown. -->
+        <button class="status-chip" id="statusChip">
+          <span class="mode">Allow all</span>
+          <span class="dots">
+            <span class="status-dot run"></span>
+            <span class="status-dot run"></span>
+            <span class="status-dot retry"></span>
+          </span>
+        </button>
+        <button class="icon-btn" id="panelToggle" title="Toggle right panel">
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M14 4v16"/></svg>
+        </button>
+      </div>
+    </header>
+
+    <div class="panels">
+      <!-- ===== CHAT: always the left panel ===== -->
+      <section class="panel transcript">
+        <div class="panel-body">
+          <div class="msg-user">Test: spawn a few background agents to work on sample deliverables of various types</div>
+          <div class="msg-assistant">I'll spawn three background agents, each on a different deliverable type, then collect their results.</div>
+
+          <div class="agent-card">
+            <div class="row">
+              <span class="status-dot run"></span>
+              <span class="task">Task: produce a small sample spreadsheet deliverable. Build a single-sheet…</span>
+              <span class="meta">Working · 39s</span>
+              <span class="chip">Stop</span>
+            </div>
+            <div class="row">
+              <span class="status-dot run"></span>
+              <span class="task">Task: produce a small sample chart deliverable. Create a PNG chart…</span>
+              <span class="meta">Working · 32s</span>
+              <span class="chip">Stop</span>
+            </div>
+            <div class="row">
+              <span class="status-dot retry"></span>
+              <span class="task">Task: produce a small sample Word document deliverable. Create an editable…</span>
+              <span class="meta">Waiting to retry</span>
+              <span class="chip">Stop</span>
+            </div>
+          </div>
+
+          <div class="msg-assistant">Three agents are running in parallel (spreadsheet, chart, Word doc). Waiting for results.</div>
+        </div>
+        <div class="composer-wrap">
+          <div class="composer">
+            <div class="input">Guide the active response…</div>
+            <div class="bar">
+              <button class="pill-btn">＋</button>
+              <button class="pill-btn">✳ Default</button>
+              <span class="spacer"></span>
+              <button class="send-btn">
+                <svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor"><rect x="6" y="6" width="12" height="12" rx="2"/></svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===== RIGHT PANEL: tabbed workspace ===== -->
+      <section class="panel side" id="sidePanel">
+        <div class="tabstrip">
+          <button class="tab active" data-tab="agents">
+            <span class="status-dot run"></span>
+            <span class="label">Agents</span>
+            <span class="badge-n">3</span>
+          </button>
+          <button class="tab" data-tab="outputs">
+            <span class="label">Outputs</span>
+            <span class="badge-n">3</span>
+          </button>
+          <button class="tab" data-tab="preview">
+            <span class="label">sample.xlsx</span>
+          </button>
+          <span class="strip-spacer"></span>
+          <button class="icon-btn" title="Close panel" onclick="document.getElementById('sidePanel').classList.add('hidden')">
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12"/></svg>
+          </button>
+        </div>
+
+        <!-- Agents tab: list on top, selected agent's detail below -->
+        <div class="tabpage active" id="tab-agents">
+          <button class="agent-list-item selected">
+            <span class="status-dot run"></span>
+            <span class="task">Spreadsheet deliverable — sample.xlsx</span>
+            <span class="meta">39s</span>
+          </button>
+          <button class="agent-list-item">
+            <span class="status-dot run"></span>
+            <span class="task">Chart deliverable — churn-chart.png</span>
+            <span class="meta">32s</span>
+          </button>
+          <button class="agent-list-item">
+            <span class="status-dot retry"></span>
+            <span class="task">Word doc deliverable — report.docx</span>
+            <span class="meta">retrying</span>
+          </button>
+
+          <div class="agent-detail">
+            <div style="display:flex; align-items:center; gap:8px; margin-bottom:4px;">
+              <div class="task-title" style="margin:0; flex:1;">Spreadsheet deliverable</div>
+              <span class="badge">Running</span>
+              <span class="chip">Stop</span>
+            </div>
+            <div class="task-sub">Build a single-sheet Excel workbook named `sample.xlsx` · Working in the background · 39s</div>
+            <div class="timeline">
+              <div class="t-row"><span class="t-time">0:02</span><span>Started sandbox, staged skill `xlsx`</span></div>
+              <div class="t-row"><span class="t-time">0:11</span><span>Wrote build_workbook.py</span></div>
+              <div class="t-row"><span class="t-time">0:24</span><span>Running openpyxl to generate sheet…</span></div>
+              <div class="t-row"><span class="t-time">0:39</span><span>Validating output/sample.xlsx</span></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Outputs tab: versioned files, filename identity -->
+        <div class="tabpage" id="tab-outputs">
+          <button class="output-row">
+            <span class="file-icon xlsx">XLS</span>
+            <span class="name">
+              <div class="fname">sample.xlsx</div>
+              <div class="fmeta">Updated 39s ago · agent: spreadsheet deliverable</div>
+            </span>
+            <span class="vbadge">v2</span>
+            <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" style="color:var(--muted-foreground)"><path d="M12 8v4l2.5 2.5"/><circle cx="12" cy="12" r="9"/></svg>
+          </button>
+          <button class="output-row">
+            <span class="file-icon png">PNG</span>
+            <span class="name">
+              <div class="fname">churn-chart.png</div>
+              <div class="fmeta">Created 1m ago · agent: chart deliverable</div>
+            </span>
+            <span class="vbadge">v1</span>
+            <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" style="color:var(--muted-foreground)"><path d="M12 8v4l2.5 2.5"/><circle cx="12" cy="12" r="9"/></svg>
+          </button>
+          <button class="output-row" style="opacity:0.55">
+            <span class="file-icon docx">DOC</span>
+            <span class="name">
+              <div class="fname">report.docx</div>
+              <div class="fmeta">Pending · agent retrying</div>
+            </span>
+            <span class="vbadge">—</span>
+          </button>
+        </div>
+
+        <!-- Preview tab: an open document, as its own tab -->
+        <div class="tabpage" id="tab-preview">
+          <div class="preview-frame">
+            <table>
+              <tr><th></th><th>A</th><th>B</th><th>C</th><th>D</th></tr>
+              <tr><th>1</th><td>Month</td><td>Revenue</td><td>Costs</td><td>Net</td></tr>
+              <tr><th>2</th><td>Apr</td><td>128,400</td><td>91,200</td><td>37,200</td></tr>
+              <tr><th>3</th><td>May</td><td>131,900</td><td>93,750</td><td>38,150</td></tr>
+              <tr><th>4</th><td>Jun</td><td>140,220</td><td>95,010</td><td>45,210</td></tr>
+              <tr><th>5</th><td>Total</td><td>400,520</td><td>279,960</td><td>120,560</td></tr>
+            </table>
+          </div>
+          <div class="preview-caption">sample.xlsx · v2 · updated 39s ago · <u>History</u> · <u>Open in Excel</u></div>
+        </div>
+      </section>
+    </div>
+
+    <!-- ============ CHAT DETAILS DROPDOWN ============ -->
+    <aside class="dropdown" id="dropdown">
+      <button class="prow">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 8V4H8"/><rect x="4" y="8" width="16" height="12" rx="2"/><path d="M2 14h2m16 0h2M9 13v2m6-2v2"/></svg>
+        <span class="label">Model</span>
+        <span class="value">Sonnet 5 · Default</span>
+        <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 18 6-6-6-6"/></svg>
+      </button>
+      <button class="prow">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+        <span class="label">Permissions</span>
+        <span class="value">Allow all</span>
+        <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 18 6-6-6-6"/></svg>
+      </button>
+      <button class="prow">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+        <span class="label">Folders</span>
+        <span class="value">~/Documents/q3 · rw</span>
+      </button>
+      <button class="prow">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v12m0 0 4-4m-4 4-4-4"/><path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2"/></svg>
+        <span class="label">Move to project</span>
+        <span class="value">—</span>
+        <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 18 6-6-6-6"/></svg>
+      </button>
+    </aside>
+  </main>
+</div>
+
+<div class="hint">
+  <b>Try:</b> switch right-panel tabs · status chip opens chat details · ▯ toggles the panel · ☀ theme
+</div>
+
+<script>
+  // Tabs
+  document.querySelectorAll('.tab').forEach(tab => {
+    tab.addEventListener('click', () => {
+      document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+      document.querySelectorAll('.tabpage').forEach(p => p.classList.remove('active'));
+      tab.classList.add('active');
+      document.getElementById('tab-' + tab.dataset.tab).classList.add('active');
+    });
+  });
+
+  // Details dropdown: anchored, click-outside dismiss
+  const dropdown = document.getElementById('dropdown');
+  const chip = document.getElementById('statusChip');
+  chip.addEventListener('click', (e) => {
+    e.stopPropagation();
+    dropdown.classList.toggle('open');
+  });
+  document.addEventListener('click', (e) => {
+    if (!dropdown.contains(e.target)) dropdown.classList.remove('open');
+  });
+
+  document.getElementById('panelToggle').addEventListener('click', () =>
+    document.getElementById('sidePanel').classList.toggle('hidden'));
+  document.getElementById('themeToggle').addEventListener('click', () =>
+    document.documentElement.classList.toggle('dark'));
+</script>
+</body>
+</html>

--- a/mockups/codex-shell-mockup.html
+++ b/mockups/codex-shell-mockup.html
@@ -1,0 +1,505 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>OpenWave — Codex-style shell mockup</title>
+<style>
+  /* ---- OpenWave tokens (from ui/src/styles.css) ---- */
+  :root {
+    --background: oklch(1 0 0);
+    --foreground: oklch(0 0 0);
+    --page-background: oklch(98.2% 0 0);
+    --border: oklch(0.92 0.004 286.32);
+    --primary: oklch(0.21 0.006 285.885);
+    --primary-foreground: oklch(0.967 0.001 286.375);
+    --secondary: oklch(0.924 0.001 0);
+    --muted: oklch(0.924 0.001 0);
+    --muted-foreground: oklch(0.552 0.016 285.938);
+    --accent: oklch(0.924 0.001 0);
+    --card: oklch(0.985 0 0);
+    --popover: oklch(1 0 0);
+    --success: oklch(0.627 0.194 149.214);
+    --warning: oklch(0.666 0.179 58.318);
+    --critical: oklch(0.577 0.245 27.325);
+    --info: oklch(0.588 0.158 241.966);
+    --radius: 0.5rem;
+    --container-margin: 0.5rem;
+    --shadow: 0 0px 8px 0px oklch(0 0 0 / 0.07);
+    --shadow-lg: 0 4px 24px 0px oklch(0 0 0 / 0.13);
+    --sans: "Inter", "Segoe UI", system-ui, sans-serif;
+    --mono: "SF Mono", ui-monospace, Menlo, monospace;
+    color-scheme: light;
+  }
+  .dark {
+    --background: oklch(0.21 0.008 262);
+    --foreground: oklch(0.95 0 0);
+    --page-background: oklch(0.12 0.005 262);
+    --border: oklch(0.31 0.009 262);
+    --primary: oklch(0.95 0 0);
+    --primary-foreground: oklch(0.12 0.005 262);
+    --secondary: oklch(0.27 0.009 262);
+    --muted: oklch(0.27 0.009 262);
+    --muted-foreground: oklch(0.68 0.006 262);
+    --accent: oklch(0.27 0.009 262);
+    --card: oklch(0.16 0.006 262);
+    --popover: oklch(0.14 0.006 262);
+    --success: oklch(0.792 0.209 151.711);
+    --warning: oklch(0.828 0.189 84.429);
+    --critical: oklch(0.704 0.191 22.216);
+    --info: oklch(0.746 0.16 232.661);
+    --shadow: 0 0px 8px 0px oklch(0 0 0 / 0.3);
+    --shadow-lg: 0 4px 24px 0px oklch(0 0 0 / 0.45);
+    color-scheme: dark;
+  }
+
+  * { box-sizing: border-box; margin: 0; }
+  html, body { height: 100%; }
+  body {
+    font-family: var(--sans);
+    font-size: 14px;
+    line-height: 1.45;
+    color: var(--foreground);
+    background: var(--page-background);
+    overflow: hidden;
+  }
+  button { font: inherit; color: inherit; background: none; border: none; cursor: pointer; }
+
+  .shell { display: flex; height: 100vh; }
+
+  /* =========================================================
+     SIDEBAR — chats only, fixed width, never squashed.
+     Panels divide the *remaining* space; sidebar is flex: 0 0.
+     ========================================================= */
+  .sidebar {
+    flex: 0 0 248px;
+    min-width: 248px;
+    display: flex;
+    flex-direction: column;
+    padding: 10px 8px 8px;
+    gap: 2px;
+    overflow-y: auto;
+  }
+  .sidebar-head { display: flex; align-items: center; gap: 8px; padding: 4px 8px 10px; }
+  .logomark {
+    width: 22px; height: 22px; border-radius: 6px;
+    background: var(--primary); color: var(--primary-foreground);
+    display: grid; place-items: center; font-weight: 700; font-size: 12px;
+  }
+  .sidebar-head .wordmark { font-weight: 600; font-size: 13px; }
+  .sidebar-head .spacer { flex: 1; }
+  .icon-btn {
+    width: 26px; height: 26px; border-radius: 6px;
+    display: grid; place-items: center; color: var(--muted-foreground);
+  }
+  .icon-btn:hover { background: var(--accent); color: var(--foreground); }
+
+  .nav-item {
+    display: flex; align-items: center; gap: 9px;
+    padding: 6px 8px; border-radius: 6px;
+    color: var(--foreground); font-size: 13px;
+    width: 100%; text-align: left;
+  }
+  .nav-item svg { width: 15px; height: 15px; color: var(--muted-foreground); flex: none; }
+  .nav-item:hover { background: var(--accent); }
+  .nav-item.active { background: var(--accent); font-weight: 500; }
+  .nav-item .count { margin-left: auto; font-size: 11px; color: var(--muted-foreground); }
+
+  .section-label {
+    padding: 14px 8px 4px; font-size: 11px; font-weight: 500;
+    color: var(--muted-foreground); letter-spacing: 0.02em;
+  }
+  .chat-item {
+    display: block; width: 100%; text-align: left;
+    padding: 5px 8px; border-radius: 6px; font-size: 13px;
+    color: var(--foreground);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  .chat-item:hover { background: var(--accent); }
+  .chat-item.active { background: var(--accent); font-weight: 500; }
+  .chat-item .dot {
+    display: inline-block; width: 6px; height: 6px; border-radius: 50%;
+    background: var(--success); margin-right: 7px; vertical-align: 1px;
+  }
+  .chat-item.attention .dot { background: var(--warning); }
+  .project-group .chat-item { padding-left: 30px; }
+
+  .sidebar-foot { margin-top: auto; padding-top: 10px; border-top: 1px solid var(--border); }
+
+  /* =========================================================
+     MAIN — one floating card on the page background,
+     matching the existing container-margin chrome.
+     ========================================================= */
+  .main {
+    flex: 1 1 0;
+    min-width: 0;
+    margin: var(--container-margin) var(--container-margin) var(--container-margin) 0;
+    background: var(--background);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    box-shadow: var(--shadow);
+    display: flex;
+    flex-direction: column;
+    position: relative;   /* anchor for the floating popup */
+    overflow: hidden;
+  }
+
+  .main-header {
+    flex: none;
+    display: flex; align-items: center; gap: 10px;
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--border);
+  }
+  .breadcrumb { display: flex; align-items: center; gap: 6px; font-size: 13px; min-width: 0; }
+  .breadcrumb .crumb { color: var(--muted-foreground); }
+  .breadcrumb .sep { color: var(--muted-foreground); opacity: 0.5; }
+  .breadcrumb .current { font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .header-actions { margin-left: auto; display: flex; align-items: center; gap: 4px; }
+
+  /* Two content panels split the card; each has a real min-width so
+     opening the second one can never crush anything else. */
+  .panels { flex: 1; display: flex; min-height: 0; }
+  .panel { min-width: 320px; display: flex; flex-direction: column; min-height: 0; }
+  .panel.transcript { flex: 1.4 1 0; }
+  .panel.side { flex: 1 1 0; border-left: 1px solid var(--border); }
+  .panel.side.hidden { display: none; }
+
+  .panel-header {
+    flex: none; display: flex; align-items: center; gap: 8px;
+    padding: 9px 12px; border-bottom: 1px solid var(--border);
+    font-size: 13px; font-weight: 500;
+  }
+  .panel-body { flex: 1; overflow-y: auto; padding: 18px 22px; }
+
+  /* transcript bits */
+  .msg-user {
+    background: var(--secondary); border-radius: 14px;
+    padding: 9px 14px; max-width: 78%; margin-left: auto; margin-bottom: 18px;
+    font-size: 13.5px;
+  }
+  .msg-assistant { margin-bottom: 18px; font-size: 13.5px; max-width: 46rem; }
+  .agent-card {
+    border: 1px solid var(--border); border-radius: 10px;
+    background: var(--card); margin: 10px 0; max-width: 46rem;
+    font-size: 12.5px;
+  }
+  .agent-card .row {
+    display: flex; align-items: center; gap: 8px; padding: 8px 12px;
+  }
+  .agent-card .row + .row { border-top: 1px solid var(--border); }
+  .status-dot { width: 7px; height: 7px; border-radius: 50%; flex: none; }
+  .status-dot.run { background: var(--success); }
+  .status-dot.retry { background: var(--warning); }
+  .agent-card .task { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .agent-card .meta { color: var(--muted-foreground); font-size: 11.5px; flex: none; }
+  .chip {
+    font-size: 11px; padding: 2px 8px; border-radius: 999px;
+    border: 1px solid var(--border); color: var(--muted-foreground); flex: none;
+  }
+
+  .composer-wrap { flex: none; padding: 12px 22px 16px; }
+  .composer {
+    max-width: 46rem; margin: 0 auto;
+    border: 1px solid var(--border); border-radius: 14px;
+    background: var(--background); box-shadow: var(--shadow);
+    padding: 10px 12px 8px;
+  }
+  .composer .input { color: var(--muted-foreground); font-size: 13.5px; padding: 2px 4px 10px; }
+  .composer .bar { display: flex; align-items: center; gap: 8px; }
+  .composer .bar .spacer { flex: 1; }
+  .pill-btn {
+    display: inline-flex; align-items: center; gap: 6px;
+    font-size: 12px; padding: 4px 10px; border-radius: 999px;
+    color: var(--muted-foreground);
+  }
+  .pill-btn:hover { background: var(--accent); color: var(--foreground); }
+  .send-btn {
+    width: 28px; height: 28px; border-radius: 50%;
+    background: var(--primary); color: var(--primary-foreground);
+    display: grid; place-items: center;
+  }
+
+  /* side panel content */
+  .side .task-title { font-weight: 600; font-size: 13.5px; margin-bottom: 4px; }
+  .side .task-sub { color: var(--muted-foreground); font-size: 12.5px; margin-bottom: 14px; }
+  .badge {
+    font-size: 11px; padding: 2px 8px; border-radius: 999px; font-weight: 500;
+    background: color-mix(in oklch, var(--success) 18%, transparent);
+    color: var(--success);
+  }
+  .timeline { font-size: 12.5px; color: var(--muted-foreground); display: grid; gap: 8px; }
+  .timeline .t-row { display: flex; gap: 8px; align-items: baseline; }
+  .timeline .t-time { font-family: var(--mono); font-size: 11px; flex: none; width: 34px; }
+
+  /* =========================================================
+     FLOATING POPUP — top-right, collapsible. All the chat-scoped
+     "stuff" that used to be panels/sidebar chrome lives here.
+     ========================================================= */
+  .popup {
+    position: absolute; top: 52px; right: 14px; z-index: 30;
+    width: 300px;
+    background: var(--popover);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    box-shadow: var(--shadow-lg);
+    overflow: hidden;
+    font-size: 13px;
+  }
+  .popup-header {
+    display: flex; align-items: center; gap: 8px;
+    padding: 10px 12px; cursor: pointer; user-select: none;
+  }
+  .popup-header .title { font-weight: 600; font-size: 12.5px; }
+  .popup-header .spacer { flex: 1; }
+  .popup-body { border-top: 1px solid var(--border); padding: 4px 0 8px; }
+  .popup.collapsed { width: auto; }
+  .popup.collapsed .popup-body { display: none; }
+  .popup.collapsed .popup-header { padding: 7px 12px; }
+
+  .prow {
+    display: flex; align-items: center; gap: 9px;
+    padding: 7px 12px; width: 100%; text-align: left; font-size: 12.5px;
+  }
+  .prow:hover { background: var(--accent); }
+  .prow svg { width: 14px; height: 14px; color: var(--muted-foreground); flex: none; }
+  .prow .label { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .prow .value { color: var(--muted-foreground); font-size: 12px; flex: none; }
+  .prow .value.pos { color: var(--success); font-family: var(--mono); font-size: 11.5px; }
+  .prow .chev { color: var(--muted-foreground); flex: none; }
+  .popup-divider { height: 1px; background: var(--border); margin: 6px 0; }
+  .popup-section-label {
+    padding: 6px 12px 2px; font-size: 10.5px; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted-foreground);
+  }
+  .agent-mini { padding: 5px 12px; display: flex; align-items: center; gap: 8px; font-size: 12px; }
+  .agent-mini .task { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: var(--foreground); }
+  .agent-mini .t { color: var(--muted-foreground); font-family: var(--mono); font-size: 10.5px; flex: none; }
+
+  svg { display: block; }
+  .hint {
+    position: fixed; bottom: 10px; left: 50%; transform: translateX(-50%);
+    font-size: 11px; color: var(--muted-foreground);
+    background: var(--popover); border: 1px solid var(--border);
+    border-radius: 999px; padding: 4px 12px; box-shadow: var(--shadow);
+    white-space: nowrap; z-index: 40;
+  }
+  .hint b { font-weight: 600; }
+</style>
+</head>
+<body>
+<div class="shell">
+
+  <!-- ============ SIDEBAR: chats only ============ -->
+  <nav class="sidebar">
+    <div class="sidebar-head">
+      <div class="logomark">OW</div>
+      <span class="wordmark">OpenWave</span>
+      <span class="spacer"></span>
+      <button class="icon-btn" title="Search">
+        <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>
+      </button>
+      <button class="icon-btn" id="themeToggle" title="Toggle theme">
+        <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4m11.4-11.4 1.4-1.4"/></svg>
+      </button>
+    </div>
+
+    <button class="nav-item">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>
+      New chat
+    </button>
+    <button class="nav-item">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 12h-6l-2 3h-4l-2-3H2"/><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/></svg>
+      Inbox <span class="count">3</span>
+    </button>
+    <button class="nav-item">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+      Folders
+    </button>
+    <button class="nav-item">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+      Apps
+    </button>
+
+    <div class="section-label">Projects</div>
+    <div class="project-group">
+      <button class="nav-item">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+        Q3 planning
+      </button>
+      <button class="chat-item"><span class="dot"></span>Budget model rebuild</button>
+      <button class="chat-item">Headcount scenarios</button>
+    </div>
+    <div class="project-group">
+      <button class="nav-item">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+        Vendor research
+      </button>
+      <button class="chat-item">CRM comparison matrix</button>
+    </div>
+
+    <div class="section-label">Recents</div>
+    <button class="chat-item active"><span class="dot"></span>Test: spawn background agents</button>
+    <button class="chat-item attention"><span class="dot"></span>Quarterly deck draft</button>
+    <button class="chat-item">Summarize customer interviews</button>
+    <button class="chat-item">Fix conversion table formulas</button>
+    <button class="chat-item">Draft onboarding doc</button>
+    <button class="chat-item">Analyze churn cohort CSV</button>
+    <button class="chat-item">Rename exported files</button>
+
+    <div class="sidebar-foot">
+      <button class="nav-item">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M12 1v3m0 16v3m11-11h-3M4 12H1m18.4-7.4-2.2 2.2M6.8 17.2l-2.2 2.2m14.8 0-2.2-2.2M6.8 6.8 4.6 4.6"/></svg>
+        Settings
+      </button>
+    </div>
+  </nav>
+
+  <!-- ============ MAIN CARD ============ -->
+  <main class="main">
+    <header class="main-header">
+      <div class="breadcrumb">
+        <span class="crumb">Chats</span><span class="sep">/</span>
+        <span class="current">Test: spawn background agents</span>
+      </div>
+      <div class="header-actions">
+        <button class="icon-btn" id="panelToggle" title="Toggle agent panel">
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M14 4v16"/></svg>
+        </button>
+        <button class="icon-btn" id="popupToggle" title="Chat details">
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 8h.01M11 12h1v4h1"/></svg>
+        </button>
+      </div>
+    </header>
+
+    <div class="panels">
+      <!-- transcript panel -->
+      <section class="panel transcript">
+        <div class="panel-body">
+          <div class="msg-user">Test: spawn a few background agents to work on sample deliverables of various types</div>
+          <div class="msg-assistant">I'll spawn three background agents, each on a different deliverable type, then collect their results.</div>
+
+          <div class="agent-card">
+            <div class="row">
+              <span class="status-dot run"></span>
+              <span class="task">Task: produce a small sample spreadsheet deliverable. Build a single-sheet…</span>
+              <span class="meta">Working · 39s</span>
+              <span class="chip">Stop</span>
+            </div>
+            <div class="row">
+              <span class="status-dot run"></span>
+              <span class="task">Task: produce a small sample chart deliverable. Create a PNG chart…</span>
+              <span class="meta">Working · 32s</span>
+              <span class="chip">Stop</span>
+            </div>
+            <div class="row">
+              <span class="status-dot retry"></span>
+              <span class="task">Task: produce a small sample Word document deliverable. Create an editable…</span>
+              <span class="meta">Waiting to retry</span>
+              <span class="chip">Stop</span>
+            </div>
+          </div>
+
+          <div class="msg-assistant">Three agents are running in parallel (spreadsheet, chart, Word doc). Waiting for results.</div>
+        </div>
+        <div class="composer-wrap">
+          <div class="composer">
+            <div class="input">Guide the active response…</div>
+            <div class="bar">
+              <button class="pill-btn">＋</button>
+              <button class="pill-btn">✳ Default</button>
+              <span class="spacer"></span>
+              <button class="pill-btn">⚡ Allow all</button>
+              <button class="send-btn">
+                <svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor"><rect x="6" y="6" width="12" height="12" rx="2"/></svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- second panel: agent detail -->
+      <section class="panel side" id="sidePanel">
+        <div class="panel-header">
+          Agent
+          <span class="spacer" style="flex:1"></span>
+          <span class="badge">Running</span>
+          <button class="icon-btn" title="Close panel" onclick="document.getElementById('sidePanel').classList.add('hidden')">
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12"/></svg>
+          </button>
+        </div>
+        <div class="panel-body">
+          <div class="task-title">Task: produce a small sample spreadsheet deliverable</div>
+          <div class="task-sub">Build a single-sheet Excel workbook named `sample.xlsx` · Working in the background · 39s</div>
+          <div class="timeline">
+            <div class="t-row"><span class="t-time">0:02</span><span>Started sandbox, staged skill `xlsx`</span></div>
+            <div class="t-row"><span class="t-time">0:11</span><span>Wrote build_workbook.py</span></div>
+            <div class="t-row"><span class="t-time">0:24</span><span>Running openpyxl to generate sheet…</span></div>
+            <div class="t-row"><span class="t-time">0:39</span><span>Validating output/sample.xlsx</span></div>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <!-- ============ FLOATING CHAT-DETAILS POPUP ============ -->
+    <aside class="popup" id="popup">
+      <div class="popup-header" onclick="togglePopup()">
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" style="color: var(--muted-foreground)"><path d="M12 3 2 8l10 5 10-5-10-5zM2 13l10 5 10-5"/></svg>
+        <span class="title">Chat details</span>
+        <span class="spacer"></span>
+        <span class="value pos" style="font-family: var(--mono); font-size: 11.5px; color: var(--success)">+87 −0</span>
+        <svg id="popupChevron" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" style="color: var(--muted-foreground)"><path d="m6 9 6 6 6-6"/></svg>
+      </div>
+      <div class="popup-body">
+        <button class="prow">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 8V4H8"/><rect x="4" y="8" width="16" height="12" rx="2"/><path d="M2 14h2m16 0h2M9 13v2m6-2v2"/></svg>
+          <span class="label">Model</span>
+          <span class="value">Sonnet 5 · Default</span>
+          <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 18 6-6-6-6"/></svg>
+        </button>
+        <button class="prow">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+          <span class="label">Permissions</span>
+          <span class="value">Allow all</span>
+          <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 18 6-6-6-6"/></svg>
+        </button>
+        <button class="prow">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+          <span class="label">Folders</span>
+          <span class="value">~/Documents/q3 · read-write</span>
+        </button>
+        <button class="prow">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/></svg>
+          <span class="label">Outputs</span>
+          <span class="value">3 files · v2</span>
+          <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 18 6-6-6-6"/></svg>
+        </button>
+
+        <div class="popup-divider"></div>
+        <div class="popup-section-label">Background agents · 3</div>
+        <div class="agent-mini"><span class="status-dot run"></span><span class="task">Spreadsheet deliverable</span><span class="t">39s</span></div>
+        <div class="agent-mini"><span class="status-dot run"></span><span class="task">PNG chart deliverable</span><span class="t">32s</span></div>
+        <div class="agent-mini"><span class="status-dot retry"></span><span class="task">Word doc deliverable</span><span class="t">retrying</span></div>
+      </div>
+    </aside>
+  </main>
+</div>
+
+<div class="hint">
+  <b>Try:</b> collapse the popup (click its header) · toggle the second panel (▯ button) · theme (☀)
+</div>
+
+<script>
+  function togglePopup() {
+    const p = document.getElementById('popup');
+    p.classList.toggle('collapsed');
+    document.getElementById('popupChevron').style.transform =
+      p.classList.contains('collapsed') ? 'rotate(180deg)' : '';
+  }
+  document.getElementById('popupToggle').addEventListener('click', () => togglePopup());
+  document.getElementById('panelToggle').addEventListener('click', () =>
+    document.getElementById('sidePanel').classList.toggle('hidden'));
+  document.getElementById('themeToggle').addEventListener('click', () =>
+    document.documentElement.classList.toggle('dark'));
+</script>
+</body>
+</html>


### PR DESCRIPTION
With two content panels open on a viewport wider than 1600px, the sidebar rail collapsed to a sliver. At that breakpoint `--sidebar-expanded-flex` switches to `flex: 0 1 clamp(...)` so the rail can grow with the window — but flex-shrink 1 with no min-width floor also lets panel content shrink the rail arbitrarily when the row runs out of space.

- Give the rail a `min-width` floor (expanded and compact) so overflow pressure lands on the panel region, which is already clamped by `.main`'s `minmax(0, 1fr)` track.
- Defensively add `min-w-0` to the `PanelGroup` container so panel min-content can't push the row wider from one level below the grid clamp.

Verified with tsc and the AppShell + panel vitest files.