### PR TITLE
feat(core): folder-binding vocabulary for local apps

### DIFF
--- a/crates/openwave-core/src/id.rs
+++ b/crates/openwave-core/src/id.rs
@@ -509,6 +509,18 @@ impl schemars::JsonSchema for ConnectedAppId {
     }
 }
 
+/// Schema for the other id the model writes: `create_app` manifests bind
+/// connected folders by broker root id.
+impl schemars::JsonSchema for HostRootId {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "HostRootId".into()
+    }
+
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        <Uuid as schemars::JsonSchema>::json_schema(generator)
+    }
+}
+
 id_type!(
     /// Identifies one immutable revision of a local app.
     AppRevisionId

--- a/crates/openwave-core/src/local_app.rs
+++ b/crates/openwave-core/src/local_app.rs
@@ -16,7 +16,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::deliverable::RevisionProducer;
-use crate::id::{AgentRunId, AppId, AppRevisionId, ChatId, ConnectedAppId, TurnId};
+use crate::id::{AgentRunId, AppId, AppRevisionId, ChatId, ConnectedAppId, HostRootId, TurnId};
 
 /// Stable name of the foreground tool that creates and revises local apps.
 ///
@@ -233,15 +233,19 @@ pub enum AppGrantBinding {
     Tools(AppToolsGrantBinding),
     /// `{ app, operation_ids[], fingerprint }` — granted REST operations.
     Operations(AppOperationsGrantBinding),
+    /// `{ folder, access, fingerprint }` — granted folder access.
+    Folder(AppFolderGrantBinding),
 }
 
 impl AppGrantBinding {
-    /// The connected app the grant binding names.
+    /// The connected app the grant binding names, when it names one — a
+    /// folder grant binding names a broker root instead.
     #[must_use]
-    pub fn app(&self) -> ConnectedAppId {
+    pub fn app(&self) -> Option<ConnectedAppId> {
         match self {
-            Self::Tools(binding) => binding.app,
-            Self::Operations(binding) => binding.app,
+            Self::Tools(binding) => Some(binding.app),
+            Self::Operations(binding) => Some(binding.app),
+            Self::Folder(_) => None,
         }
     }
 
@@ -251,6 +255,7 @@ impl AppGrantBinding {
         match self {
             Self::Tools(binding) => binding.fingerprint,
             Self::Operations(binding) => binding.fingerprint,
+            Self::Folder(binding) => binding.fingerprint,
         }
     }
 }
@@ -285,6 +290,22 @@ pub struct AppOperationsGrantBinding {
     /// consent time — for a `rest_api` record, over the base URL, document
     /// hash, and credential *reference* and placement, never a credential
     /// value. Persisted as lowercase hex.
+    #[serde(with = "hex_fingerprint")]
+    pub fingerprint: [u8; 32],
+}
+
+/// The granted access to one connected folder.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AppFolderGrantBinding {
+    /// Broker root the consent names, matching the manifest binding it
+    /// covers.
+    pub folder: HostRootId,
+    /// The granted access level.
+    pub access: FolderAccess,
+    /// SHA-256 fingerprint over the folder grant's canonical form — the root
+    /// id and access level, never a path or display name. Persisted as
+    /// lowercase hex.
     #[serde(with = "hex_fingerprint")]
     pub fingerprint: [u8; 32],
 }
@@ -326,12 +347,17 @@ mod hex_fingerprint {
 /// validator would have refused.
 pub fn validate_app_grant(grant: &AppGrant) -> Result<serde_json::Value, String> {
     validate_binding_set(grant.bindings.iter().map(|binding| match binding {
-        AppGrantBinding::Tools(binding) => {
-            (binding.app, BindingCapabilities::Tools(&binding.tools))
-        }
+        AppGrantBinding::Tools(binding) => (
+            BindingKey::App(binding.app),
+            BindingCapabilities::Tools(&binding.tools),
+        ),
         AppGrantBinding::Operations(binding) => (
-            binding.app,
+            BindingKey::App(binding.app),
             BindingCapabilities::Operations(&binding.operation_ids),
+        ),
+        AppGrantBinding::Folder(binding) => (
+            BindingKey::Folder(binding.folder),
+            BindingCapabilities::Folder(binding.access),
         ),
     }))?;
     serde_json::to_value(&grant.bindings).map_err(|error| format!("unencodable app grant: {error}"))
@@ -355,13 +381,13 @@ pub struct AppManifest {
     pub bindings: Vec<AppBinding>,
 }
 
-/// The capabilities one connected app contributes to a local app: mounted MCP
-/// tools for an `mcp_server` record, declared REST operations for a
-/// `rest_api` record.
+/// The capabilities one binding contributes to a local app: declared REST
+/// operations of a `rest_api` connected app, bounded access to a connected
+/// folder, or — retired (#1332) but still parseable — mounted MCP tools.
 ///
-/// Untagged and closed: the two shapes are distinguished by their one
-/// differing field (`tools` vs `operation_ids`), each variant refuses unknown
-/// fields, and a body carrying both fields matches neither.
+/// Untagged and closed: the shapes are distinguished by their differing
+/// field names, each variant refuses unknown fields, and a body mixing
+/// fields from two shapes matches none.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(untagged)]
 pub enum AppBinding {
@@ -370,15 +396,19 @@ pub enum AppBinding {
     /// `{ app, operation_ids[] }` — declared operations of a `rest_api`
     /// record.
     Operations(AppOperationsBinding),
+    /// `{ folder, access }` — bounded access to a connected folder.
+    Folder(AppFolderBinding),
 }
 
 impl AppBinding {
-    /// The connected app the binding names.
+    /// The connected app the binding names, when it names one — a folder
+    /// binding names a broker root instead.
     #[must_use]
-    pub fn app(&self) -> ConnectedAppId {
+    pub fn app(&self) -> Option<ConnectedAppId> {
         match self {
-            Self::Tools(binding) => binding.app,
-            Self::Operations(binding) => binding.app,
+            Self::Tools(binding) => Some(binding.app),
+            Self::Operations(binding) => Some(binding.app),
+            Self::Folder(_) => None,
         }
     }
 }
@@ -417,6 +447,52 @@ pub struct AppOperationsBinding {
     pub operation_ids: Vec<String>,
 }
 
+/// Bounded access to one connected folder, by broker root id.
+///
+/// The folder is not a connected app: its identity is the host broker's
+/// registration, established through the trusted native picker, and the
+/// binding names it by the same opaque root id every other product surface
+/// uses. See `docs/folder-bindings.md`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AppFolderBinding {
+    /// Root id of the connected folder. The available ids are listed in the
+    /// `create_app` tool description.
+    #[schemars(description = "Root id of the approved connected folder.")]
+    pub folder: HostRootId,
+    /// The access level the app requests over the folder.
+    #[schemars(description = "Access the app requests: \"read\" for listing and \
+                       bounded reads, \"read_write\" to also write files. Write \
+                       access is a louder consent — request it only when the app \
+                       needs it.")]
+    pub access: FolderAccess,
+}
+
+/// The access level of a folder binding.
+///
+/// Consent-bearing: the level is part of what the user grants and part of
+/// the binding's fingerprint, so widening `read` to `read_write` always
+/// re-prompts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FolderAccess {
+    /// Listing and bounded reads.
+    Read,
+    /// Listing, bounded reads, and bounded writes.
+    ReadWrite,
+}
+
+impl FolderAccess {
+    /// Stable wire spelling, for canonical forms and display.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Read => "read",
+            Self::ReadWrite => "read_write",
+        }
+    }
+}
+
 /// Validate an app manifest structurally and return the JSON to store.
 ///
 /// Checks the display name, the mounted-tool grammar of every binding, and the
@@ -427,10 +503,17 @@ pub struct AppOperationsBinding {
 pub fn validate_app_manifest(manifest: &AppManifest) -> Result<serde_json::Value, String> {
     validate_app_name(&manifest.name)?;
     validate_binding_set(manifest.bindings.iter().map(|binding| match binding {
-        AppBinding::Tools(binding) => (binding.app, BindingCapabilities::Tools(&binding.tools)),
+        AppBinding::Tools(binding) => (
+            BindingKey::App(binding.app),
+            BindingCapabilities::Tools(&binding.tools),
+        ),
         AppBinding::Operations(binding) => (
-            binding.app,
+            BindingKey::App(binding.app),
             BindingCapabilities::Operations(&binding.operation_ids),
+        ),
+        AppBinding::Folder(binding) => (
+            BindingKey::Folder(binding.folder),
+            BindingCapabilities::Folder(binding.access),
         ),
     }))?;
     let json =
@@ -444,16 +527,26 @@ pub fn validate_app_manifest(manifest: &AppManifest) -> Result<serde_json::Value
     Ok(json)
 }
 
+/// One binding's identity for the duplicate check: the connected app it
+/// binds, or the folder root it binds.
+#[derive(PartialEq, Eq, Hash)]
+enum BindingKey {
+    App(ConnectedAppId),
+    Folder(HostRootId),
+}
+
 /// One binding's capability list, by vocabulary, for the shared grammar check.
 enum BindingCapabilities<'a> {
     Tools(&'a [String]),
     Operations(&'a [String]),
+    Folder(FolderAccess),
 }
 
 /// The binding grammar shared by manifests and grants: no duplicate connected
-/// apps (one binding per record, whichever vocabulary), every tool shaped
-/// like a full mounted name, and every operation id within the ingest
-/// module's `operationId` grammar.
+/// apps or folders (one binding per record or root, whichever vocabulary),
+/// every tool shaped like a full mounted name, and every operation id within
+/// the ingest module's `operationId` grammar. A folder binding has no list to
+/// validate — its access level is closed by type.
 ///
 /// A namespace may itself contain `_`, so a mounted name cannot be split
 /// unambiguously without knowing the namespace — and the bound record lives
@@ -463,13 +556,23 @@ enum BindingCapabilities<'a> {
 /// belongs to the host layers that resolve ids (the `create_app` door, grant
 /// computation, the invoke gate).
 fn validate_binding_set<'a>(
-    bindings: impl Iterator<Item = (ConnectedAppId, BindingCapabilities<'a>)>,
+    bindings: impl Iterator<Item = (BindingKey, BindingCapabilities<'a>)>,
 ) -> Result<(), String> {
-    let mut apps = std::collections::HashSet::new();
-    for (app, capabilities) in bindings {
-        if !apps.insert(app) {
-            return Err(format!("duplicate binding for connected app {app}"));
+    let mut keys = std::collections::HashSet::new();
+    for (key, capabilities) in bindings {
+        match &key {
+            BindingKey::App(app) => {
+                if keys.contains(&key) {
+                    return Err(format!("duplicate binding for connected app {app}"));
+                }
+            }
+            BindingKey::Folder(folder) => {
+                if keys.contains(&key) {
+                    return Err(format!("duplicate binding for folder {folder}"));
+                }
+            }
         }
+        keys.insert(key);
         match capabilities {
             BindingCapabilities::Tools(binding_tools) => {
                 let mut tools = std::collections::HashSet::new();
@@ -506,6 +609,9 @@ fn validate_binding_set<'a>(
                     }
                 }
             }
+            // A folder binding carries no capability list; the access level
+            // is closed by type and consent-bearing rather than grammatical.
+            BindingCapabilities::Folder(_) => {}
         }
     }
     Ok(())
@@ -747,6 +853,91 @@ mod tests {
         assert_eq!(granted.fingerprint(), [0xab; 32]);
         assert!(serde_json::from_value::<AppGrantBinding>(
             json!({ "app": app, "tools": [], "operation_ids": [], "fingerprint": fingerprint })
+        )
+        .is_err());
+    }
+
+    /// The folder vocabulary joins the same untagged, closed grammar: its
+    /// shape parses, its access levels are a closed set, mixing it with an
+    /// app-keyed shape matches nothing, and one binding per root holds like
+    /// one binding per connected app.
+    #[test]
+    fn folder_bindings_parse_closed_and_dedupe_by_root() {
+        use serde_json::json;
+
+        let app = ConnectedAppId::new();
+        let folder = HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap();
+        let read: AppBinding =
+            serde_json::from_value(json!({ "folder": folder, "access": "read" })).unwrap();
+        let AppBinding::Folder(binding) = &read else {
+            panic!("a folder shape must parse as a folder binding");
+        };
+        assert_eq!(binding.access, FolderAccess::Read);
+        assert!(read.app().is_none());
+        let write: AppBinding =
+            serde_json::from_value(json!({ "folder": folder, "access": "read_write" })).unwrap();
+        assert!(matches!(
+            write,
+            AppBinding::Folder(AppFolderBinding {
+                access: FolderAccess::ReadWrite,
+                ..
+            })
+        ));
+
+        // Closed on every edge: an open-ended access value, a mixed shape,
+        // an unknown field, and a nil root id all refuse.
+        for body in [
+            json!({ "folder": folder, "access": "write" }),
+            json!({ "folder": folder, "access": "read", "app": app }),
+            json!({ "folder": folder, "access": "read", "extra": true }),
+            json!({ "folder": folder }),
+            json!({ "folder": uuid::Uuid::nil(), "access": "read" }),
+        ] {
+            assert!(
+                serde_json::from_value::<AppBinding>(body.clone()).is_err(),
+                "{body}"
+            );
+        }
+
+        // One binding per folder root; a folder and a connected app never
+        // collide on the duplicate check.
+        let folder_binding =
+            |access: FolderAccess| AppBinding::Folder(AppFolderBinding { folder, access });
+        assert!(validate_app_manifest(&AppManifest {
+            name: "Files".into(),
+            bindings: vec![
+                folder_binding(FolderAccess::Read),
+                AppBinding::Operations(AppOperationsBinding {
+                    app,
+                    operation_ids: vec!["listIssues".into()],
+                }),
+            ],
+        })
+        .is_ok());
+        assert!(
+            validate_app_manifest(&AppManifest {
+                name: "Files".into(),
+                bindings: vec![
+                    folder_binding(FolderAccess::Read),
+                    folder_binding(FolderAccess::ReadWrite),
+                ],
+            })
+            .is_err(),
+            "duplicate folder bindings are refused across access levels"
+        );
+
+        // The grant twin round-trips with its pinned fingerprint and keeps
+        // the untagged discrimination.
+        let fingerprint = "cd".repeat(32);
+        let granted: AppGrantBinding = serde_json::from_value(
+            json!({ "folder": folder, "access": "read_write", "fingerprint": fingerprint }),
+        )
+        .unwrap();
+        assert!(matches!(granted, AppGrantBinding::Folder(_)));
+        assert!(granted.app().is_none());
+        assert_eq!(granted.fingerprint(), [0xcd; 32]);
+        assert!(serde_json::from_value::<AppGrantBinding>(
+            json!({ "folder": folder, "access": "read" })
         )
         .is_err());
     }

--- a/crates/openwave-core/src/tools/create_app.rs
+++ b/crates/openwave-core/src/tools/create_app.rs
@@ -113,26 +113,37 @@ impl CreateAppTool {
             .await
             .map_err(|_| "could not read the configured connected apps".to_owned())?;
         for binding in &manifest.bindings {
-            let Some(app) = connected.iter().find(|app| app.id == binding.app()) else {
+            // Folder bindings have a vocabulary but no dispatch yet: the door
+            // stays closed until the host-folder seam ships (see
+            // docs/folder-bindings.md), so nothing half-works in between.
+            let Some(binding_app) = binding.app() else {
+                return Err(
+                    "folder bindings are not yet available; bind a rest_api connected \
+                     app's operations with `operation_ids` instead"
+                        .to_owned(),
+                );
+            };
+            let Some(app) = connected.iter().find(|app| app.id == binding_app) else {
                 let configured: Vec<String> = connected
                     .iter()
                     .map(|app| format!("{} ({}, {})", app.id, app.name, app.kind))
                     .collect();
                 return Err(if configured.is_empty() {
                     format!(
-                        "connected app {} is not configured, and no connected apps \
-                         are; only an empty bindings list is valid",
-                        binding.app()
+                        "connected app {binding_app} is not configured, and no connected \
+                         apps are; only an empty bindings list is valid"
                     )
                 } else {
                     format!(
-                        "connected app {} is not configured; bind one of: {}",
-                        binding.app(),
+                        "connected app {binding_app} is not configured; bind one of: {}",
                         configured.join(", ")
                     )
                 });
             };
             match binding {
+                // Refused before app resolution above — a folder binding has
+                // no connected app to resolve.
+                AppBinding::Folder(_) => {}
                 // The tools vocabulary is retired (#1332): MCP was the only
                 // bindable kind when local apps shipped, and REST operations
                 // replaced it as the app-facing surface. The grammar still
@@ -698,6 +709,29 @@ mod tests {
                 refused.content
             );
         }
+    }
+
+    /// Folder bindings parse but the authoring door stays closed until the
+    /// host-folder seam ships (docs/folder-bindings.md) — nothing may publish
+    /// a manifest the consent route cannot yet grant.
+    #[tokio::test]
+    async fn folder_bindings_are_refused_at_the_door_until_dispatch_exists() {
+        let fixture = fixture().await;
+        let (_, ctx) = fixture.recorded_call().await;
+        let manifest = json!({
+            "bundle_html": "<!doctype html><h1>Files</h1>",
+            "manifest": {
+                "name": "File browser",
+                "bindings": [{ "folder": Uuid::new_v4(), "access": "read" }],
+            },
+        });
+        let refused = fixture.tool.execute(&ctx, manifest).await.unwrap();
+        assert!(refused.is_error);
+        assert!(
+            refused.content.contains("not yet available"),
+            "{}",
+            refused.content
+        );
     }
 
     #[tokio::test]

--- a/crates/openwave-server/src/routes/app_grant.rs
+++ b/crates/openwave-server/src/routes/app_grant.rs
@@ -104,16 +104,26 @@ pub async fn post_app_grant(
     let rest_definitions = current_rest_definitions(&state).await?;
     let mut bindings = Vec::with_capacity(revision.manifest.bindings.len());
     for binding in &revision.manifest.bindings {
+        // Folder bindings have a vocabulary but no grant computation yet
+        // (docs/folder-bindings.md): the consent door stays closed until the
+        // host-folder seam ships, so no half-granted state can exist.
+        let Some(binding_app) = binding.app() else {
+            return Err(ServerError::conflict(
+                "folder bindings are not yet grantable".to_owned(),
+            ));
+        };
         // A binding whose connected app is not configured cannot be pinned to
         // a definition, so there is nothing coherent to consent to. An
         // unparseable rest_api definition reads the same way, by design.
-        let Some(app_fingerprint) = current.get(&binding.app()) else {
+        let Some(app_fingerprint) = current.get(&binding_app) else {
             return Err(ServerError::conflict(format!(
-                "connected app {} is not configured, so this app cannot be granted",
-                binding.app()
+                "connected app {binding_app} is not configured, so this app cannot \
+                 be granted"
             )));
         };
         match binding {
+            // Refused before app resolution above.
+            AppBinding::Folder(_) => {}
             // Mounted-tool bindings are retired: MCP was the only bindable
             // kind when local apps shipped, and the REST vocabulary has since
             // replaced it as the app-facing surface (#1332). A manifest still
@@ -175,14 +185,18 @@ pub async fn post_app_grant(
 }
 
 /// Whether one granted binding still pins the definition its connected app
-/// carries right now. A missing record is a mismatch, never a match.
+/// carries right now. A missing record is a mismatch, never a match, and a
+/// folder grant binding has no current fingerprint to match until the
+/// host-folder seam ships — it reads stale, failing closed to re-consent.
 fn fingerprint_current(
     binding: &AppGrantBinding,
     current: &BTreeMap<ConnectedAppId, AppFingerprint>,
 ) -> bool {
-    current
-        .get(&binding.app())
-        .is_some_and(|app| app.fingerprint == binding.fingerprint())
+    binding.app().is_some_and(|app| {
+        current
+            .get(&app)
+            .is_some_and(|candidate| candidate.fingerprint == binding.fingerprint())
+    })
 }
 
 /// `DELETE /apps/{id}/grant` — revoke consent.
@@ -245,20 +259,30 @@ fn binding_covered(pinned: &AppBinding, granted: &AppGrantBinding) -> bool {
 /// manifest: `granted` is true exactly when every pinned capability would
 /// pass the gate right now. Shared with the library listing so its granted
 /// badge is this verdict rather than a reimplementation of it.
+///
+/// Folder bindings are not yet projected (docs/folder-bindings.md): a
+/// manifest carrying one lists its app-keyed bindings and reads ungranted
+/// overall, matching the consent route's refusal, so the sheet shows and its
+/// affirmative conflicts with the explanation.
 pub(crate) fn grant_state(
     manifest: &AppManifest,
     grant: Option<&AppGrant>,
     current: &BTreeMap<ConnectedAppId, AppFingerprint>,
 ) -> AppGrantState {
+    let has_folder_binding = manifest
+        .bindings
+        .iter()
+        .any(|binding| matches!(binding, AppBinding::Folder(_)));
     let bindings: Vec<AppGrantBindingState> = manifest
         .bindings
         .iter()
-        .map(|binding| {
+        .filter_map(|binding| {
+            let binding_app = binding.app()?;
             let granted_binding = grant.and_then(|grant| {
                 grant
                     .bindings
                     .iter()
-                    .find(|candidate| candidate.app() == binding.app())
+                    .find(|candidate| candidate.app() == Some(binding_app))
             });
             let covered = granted_binding.is_some_and(|granted| binding_covered(binding, granted));
             let definition_changed =
@@ -266,26 +290,28 @@ pub(crate) fn grant_state(
             let (tools, operation_ids) = match binding {
                 AppBinding::Tools(binding) => (Some(binding.tools.clone()), None),
                 AppBinding::Operations(binding) => (None, Some(binding.operation_ids.clone())),
+                AppBinding::Folder(_) => return None,
             };
-            AppGrantBindingState {
-                app: binding.app(),
-                name: current.get(&binding.app()).map(|app| app.name.clone()),
+            Some(AppGrantBindingState {
+                app: binding_app,
+                name: current.get(&binding_app).map(|app| app.name.clone()),
                 tools,
                 operation_ids,
                 granted: covered
                     && granted_binding.is_some_and(|granted| fingerprint_current(granted, current)),
                 definition_changed,
-            }
+            })
         })
         .collect();
     // The invoke gate also pins connected apps the grant names beyond the
     // current manifest, so the overall verdict does too.
-    let granted = grant.is_some_and(|grant| {
-        bindings.iter().all(|binding| binding.granted)
-            && grant
-                .bindings
-                .iter()
-                .all(|binding| fingerprint_current(binding, current))
-    });
+    let granted = !has_folder_binding
+        && grant.is_some_and(|grant| {
+            bindings.iter().all(|binding| binding.granted)
+                && grant
+                    .bindings
+                    .iter()
+                    .all(|binding| fingerprint_current(binding, current))
+        });
     AppGrantState { granted, bindings }
 }

--- a/crates/openwave-server/src/routes/app_invoke.rs
+++ b/crates/openwave-server/src/routes/app_invoke.rs
@@ -312,7 +312,7 @@ fn require_pinned_tool(revision: &AppRevision, tool: &str) -> Result<(), AppInvo
         .iter()
         .any(|binding| match binding {
             AppBinding::Tools(binding) => binding.tools.iter().any(|pinned| pinned == tool),
-            AppBinding::Operations(_) => false,
+            AppBinding::Operations(_) | AppBinding::Folder(_) => false,
         });
     if pinned {
         return Ok(());
@@ -337,7 +337,7 @@ fn require_pinned_operation(
                 .operation_ids
                 .iter()
                 .any(|pinned| pinned == operation_id),
-            AppBinding::Tools(_) => false,
+            AppBinding::Tools(_) | AppBinding::Folder(_) => false,
         });
     if pinned {
         return Ok(());
@@ -409,7 +409,8 @@ async fn require_app_grant(
     };
     // The pin check has already passed, so exactly one current-manifest
     // binding names this capability; its connected app is the record the
-    // grant must cover the capability under.
+    // grant must cover the capability under. (Folder bindings answer to a
+    // different surface and never resolve here.)
     let connected_app = revision
         .manifest
         .bindings
@@ -424,7 +425,7 @@ async fn require_app_grant(
                 .any(|held| held == operation_id),
             _ => false,
         })
-        .map(AppBinding::app);
+        .and_then(AppBinding::app);
     let covered = connected_app.is_some_and(|connected_app| {
         grant
             .bindings
@@ -452,14 +453,24 @@ async fn require_app_grant(
     }
     let current = current_app_fingerprints(state).await?;
     for binding in &grant.bindings {
-        let matches = current
-            .get(&binding.app())
-            .is_some_and(|app| app.fingerprint == binding.fingerprint());
+        // A folder grant binding has no current fingerprint to compare until
+        // the host-folder seam ships; it reads stale, failing the whole grant
+        // closed to re-consent exactly like a deleted record.
+        let matches = binding.app().is_some_and(|app| {
+            current
+                .get(&app)
+                .is_some_and(|candidate| candidate.fingerprint == binding.fingerprint())
+        });
         if !matches {
-            return Err(consent_required(format!(
-                "connected app {} was reconfigured after consent; the grant is stale",
-                binding.app()
-            )));
+            return Err(consent_required(match binding.app() {
+                Some(app) => format!(
+                    "connected app {app} was reconfigured after consent; the grant is \
+                     stale"
+                ),
+                None => {
+                    "a granted folder binding cannot be verified; the grant is stale".to_owned()
+                }
+            }));
         }
     }
     Ok(())

--- a/crates/openwave-server/src/routes/connected_apps.rs
+++ b/crates/openwave-server/src/routes/connected_apps.rs
@@ -513,7 +513,10 @@ async fn connected_apps_info(state: &AppState) -> Result<ConnectedAppsInfo, Serv
         std::collections::BTreeMap::new();
     for grant in state.store.list_live_app_grants().await? {
         for binding in &grant.bindings {
-            *used_by.entry(binding.app()).or_default() += 1;
+            // Folder grant bindings name broker roots, not connected apps.
+            if let Some(app) = binding.app() {
+                *used_by.entry(app).or_default() += 1;
+            }
         }
     }
     // Org-app display names by endpoint slug, so gateway-backed entries can

--- a/crates/openwave-server/src/tests/app_grant.rs
+++ b/crates/openwave-server/src/tests/app_grant.rs
@@ -262,3 +262,53 @@ async fn body_string(response: axum::response::Response) -> String {
     let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     String::from_utf8(bytes.to_vec()).unwrap()
 }
+
+/// A manifest carrying a folder binding reads ungranted and cannot be
+/// granted: the vocabulary landed ahead of its dispatch
+/// (docs/folder-bindings.md), so the consent door stays closed and no
+/// half-granted state can exist.
+#[tokio::test]
+async fn folder_bindings_read_ungranted_and_conflict_on_consent() {
+    use openwave_core::local_app::{AppFolderBinding, FolderAccess};
+
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let app_id = AppId::new();
+    store
+        .create_app(&CreateApp {
+            id: app_id,
+            revision: NewAppRevision {
+                id: AppRevisionId::new(),
+                manifest: AppManifest {
+                    name: "Files fixture".into(),
+                    bindings: vec![AppBinding::Folder(AppFolderBinding {
+                        folder: openwave_core::id::HostRootId::from_uuid(uuid::Uuid::new_v4())
+                            .unwrap(),
+                        access: FolderAccess::Read,
+                    })],
+                },
+                byte_len: 1,
+                sha256: [0; 32],
+                turn_id: None,
+                producing_run_id: None,
+                chat_id: None,
+                created_at: chrono::Utc::now(),
+            },
+        })
+        .await
+        .unwrap();
+
+    let state = grant_request(&router, &bearer, "GET", app_id).await;
+    assert_eq!(state.status(), StatusCode::OK);
+    let state: serde_json::Value = serde_json::from_str(&body_string(state).await).unwrap();
+    assert_eq!(state["granted"], json!(false));
+
+    let refused = grant_request(&router, &bearer, "POST", app_id).await;
+    assert_eq!(refused.status(), StatusCode::CONFLICT);
+    let info: AgentErrorInfo = json_body(refused).await;
+    assert!(
+        info.message.contains("not yet grantable"),
+        "{}",
+        info.message
+    );
+}


### PR DESCRIPTION
Slice 1 of docs/folder-bindings.md (#1331), stacked on #1607 (the design contract).

App manifests and grants learn the `{ folder, access }` vocabulary: an untagged third binding shape naming an approved connected folder by broker root id at `read` or `read_write` access, with the shared grammar deduplicating across both id spaces (a folder and a connected app can never collide on the duplicate check) and the grant twin pinning the standard lowercase-hex fingerprint. `HostRootId` gains the same manual `JsonSchema` impl `ConnectedAppId` has, since the model authors it through `create_app`.

**Every door stays deliberately closed until dispatch exists**, so no half-granted state can appear in between:

- `create_app` refuses to author a folder binding ("not yet available").
- The consent route conflicts on one ("not yet grantable"), and the grant-state projection reads such a manifest as ungranted overall, so the sheet shows and its affirmative conflicts with the explanation.
- A folder grant binding (none can exist yet) would read stale at the invoke gate, failing the whole grant closed exactly like a deleted record.

Each refusal points at the design doc so the later slices (server seam, desktop/broker surface, invoke + bridge) open the doors consciously. `AppBinding::app()` / `AppGrantBinding::app()` become `Option<ConnectedAppId>` — a folder binding names a root, not a record — which is most of the mechanical diff.

No wire-type or UI changes; the grant projection is unchanged on the wire.

Refs #1331

🤖 Generated with [Claude Code](https://claude.com/claude-code)
