### PR TITLE
feat(desktop): restyle background-agent detail with markdown result and tool timeline

### DIFF
--- a/crates/openwave-desktop/ui/src/AgentActivityTimeline.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/AgentActivityTimeline.dom.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  AgentActivityTimeline,
+  type AgentActivityState,
+} from "./AgentActivityTimeline";
+
+afterEach(cleanup);
+
+const state: AgentActivityState = {
+  loading: false,
+  error: false,
+  loaded: true,
+  items: [
+    {
+      kind: "read_delegated_file",
+      outcome: "completed",
+      at: "2026-08-05T18:36:00Z",
+    },
+    {
+      kind: "exec",
+      outcome: "failed",
+      at: "2026-08-05T18:37:00Z",
+    },
+    {
+      kind: "web_search",
+      outcome: "completed",
+      at: "2026-08-05T18:38:00Z",
+    },
+  ],
+};
+
+describe("AgentActivityTimeline", () => {
+  it("follows the run by default and preserves an explicit user toggle", () => {
+    const { rerender } = render(
+      <AgentActivityTimeline state={state} active />,
+    );
+
+    const summary = screen.getByRole("button", {
+      name: "Ran 3 tool calls · 1 failed",
+    });
+    expect(summary.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByRole("list")).toBeTruthy();
+
+    rerender(<AgentActivityTimeline state={state} active={false} />);
+    expect(summary.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByRole("list")).toBeNull();
+
+    fireEvent.click(summary);
+    expect(summary.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByRole("list")).toBeTruthy();
+
+    rerender(<AgentActivityTimeline state={state} active />);
+    rerender(<AgentActivityTimeline state={state} active={false} />);
+    expect(summary.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByRole("list")).toBeTruthy();
+  });
+});

--- a/crates/openwave-desktop/ui/src/AgentActivityTimeline.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/AgentActivityTimeline.dom.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
@@ -26,35 +26,40 @@ const state: AgentActivityState = {
     },
     {
       kind: "web_search",
-      outcome: "completed",
+      outcome: "waiting",
       at: "2026-08-05T18:38:00Z",
     },
   ],
 };
 
 describe("AgentActivityTimeline", () => {
-  it("follows the run by default and preserves an explicit user toggle", () => {
+  it("shows the latest live activity without presenting waiting as running", () => {
     const { rerender } = render(
-      <AgentActivityTimeline state={state} active />,
+      <AgentActivityTimeline
+        state={state}
+        active
+        activeLabel="Waiting to search the web"
+      />,
     );
 
-    const summary = screen.getByRole("button", {
+    const liveTrigger = screen.getByRole("button", {
+      name: "Waiting to search the web",
+    });
+    expect(liveTrigger.getAttribute("aria-expanded")).toBe("true");
+    expect(liveTrigger.querySelector(".animate-pulse")).toBeNull();
+
+    const waitingRow = within(screen.getByRole("list"))
+      .getByText("Waiting to search the web")
+      .closest("li");
+    expect(waitingRow?.querySelector(".lucide-clock")).toBeTruthy();
+    expect(waitingRow?.querySelector(".animate-spin")).toBeNull();
+    expect(waitingRow?.querySelector(".animate-pulse")).toBeNull();
+
+    rerender(<AgentActivityTimeline state={state} active={false} />);
+    const settledTrigger = screen.getByRole("button", {
       name: "Ran 3 tool calls · 1 failed",
     });
-    expect(summary.getAttribute("aria-expanded")).toBe("true");
-    expect(screen.getByRole("list")).toBeTruthy();
-
-    rerender(<AgentActivityTimeline state={state} active={false} />);
-    expect(summary.getAttribute("aria-expanded")).toBe("false");
+    expect(settledTrigger.getAttribute("aria-expanded")).toBe("false");
     expect(screen.queryByRole("list")).toBeNull();
-
-    fireEvent.click(summary);
-    expect(summary.getAttribute("aria-expanded")).toBe("true");
-    expect(screen.getByRole("list")).toBeTruthy();
-
-    rerender(<AgentActivityTimeline state={state} active />);
-    rerender(<AgentActivityTimeline state={state} active={false} />);
-    expect(summary.getAttribute("aria-expanded")).toBe("true");
-    expect(screen.getByRole("list")).toBeTruthy();
   });
 });

--- a/crates/openwave-desktop/ui/src/AgentActivityTimeline.tsx
+++ b/crates/openwave-desktop/ui/src/AgentActivityTimeline.tsx
@@ -78,17 +78,21 @@ export function summarizeAgentActivity(
 export function AgentActivityTimeline({
   state,
   active,
+  activeLabel,
+  expanded: controlledExpanded,
+  onExpandedChange,
 }: {
   state: AgentActivityState;
   active: boolean;
+  activeLabel?: string;
+  expanded?: boolean;
+  onExpandedChange?: (expanded: boolean) => void;
 }) {
   const contentId = useId();
-  const [expanded, setExpanded] = useState(active);
-  const [userToggled, setUserToggled] = useState(false);
-
-  useEffect(() => {
-    if (!userToggled) setExpanded(active);
-  }, [active, userToggled]);
+  const [expandedPreference, setExpandedPreference] = useState<boolean | null>(
+    null,
+  );
+  const expanded = controlledExpanded ?? expandedPreference ?? active;
 
   if (state.error) {
     return (
@@ -108,6 +112,10 @@ export function AgentActivityTimeline({
   }
 
   const summary = summarizeAgentActivity(state.items);
+  const latest = state.items[state.items.length - 1]!;
+  const triggerLabel = active
+    ? (activeLabel ?? agentActivityHistoryLabel(latest))
+    : agentActivitySummaryLabel(summary);
 
   return (
     <div className="flex flex-col gap-0.5">
@@ -118,15 +126,16 @@ export function AgentActivityTimeline({
         aria-expanded={expanded}
         aria-controls={contentId}
         onClick={() => {
-          setUserToggled(true);
-          setExpanded((current) => !current);
+          const next = !expanded;
+          if (onExpandedChange) onExpandedChange(next);
+          else setExpandedPreference(next);
         }}
       >
         <ChevronRight
           className={cn("size-3 transition-transform", expanded && "rotate-90")}
           aria-hidden="true"
         />
-        {agentActivitySummaryLabel(summary)}
+        <span>{triggerLabel}</span>
       </Button>
       {expanded && (
         <ol
@@ -188,6 +197,7 @@ function activityOutcomeTone(
 ): ToolTone {
   switch (outcome) {
     case "waiting":
+      return "waiting_approval";
     case "running":
       return "running";
     case "completed":

--- a/crates/openwave-desktop/ui/src/AgentActivityTimeline.tsx
+++ b/crates/openwave-desktop/ui/src/AgentActivityTimeline.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
+import { ChevronRight } from "lucide-react";
 
 import type { AgentActivityHistoryEntry } from "./api";
-import {
-  agentActivityHistoryLabel,
-  getAgentActivityOutcomeDotClass,
-} from "./AgentRunDisplay";
+import { agentActivityHistoryLabel } from "./AgentRunDisplay";
+import { ToolIcon } from "./ToolIcon";
+import { ToolStatusIcon, type ToolTone } from "./ToolStatusIcon";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 export type AgentActivityState = {
@@ -56,8 +57,39 @@ export function useAgentRunActivity(
   return activity;
 }
 
-/** The ordered timeline itself: one dot, phrase, and time per recorded step. */
-export function AgentActivityTimeline({ state }: { state: AgentActivityState }) {
+export type AgentActivitySummary = {
+  toolCalls: number;
+  failed: number;
+};
+
+export function summarizeAgentActivity(
+  items: readonly AgentActivityHistoryEntry[],
+): AgentActivitySummary {
+  return {
+    toolCalls: items.length,
+    failed: items.filter((entry) => entry.outcome === "failed").length,
+  };
+}
+
+/**
+ * The ordered timeline itself: the same collapsible rail foreground tool calls
+ * use, reduced to the renderer-safe label, outcome, and time the history owns.
+ */
+export function AgentActivityTimeline({
+  state,
+  active,
+}: {
+  state: AgentActivityState;
+  active: boolean;
+}) {
+  const contentId = useId();
+  const [expanded, setExpanded] = useState(active);
+  const [userToggled, setUserToggled] = useState(false);
+
+  useEffect(() => {
+    if (!userToggled) setExpanded(active);
+  }, [active, userToggled]);
+
   if (state.error) {
     return (
       <p className="text-xs text-muted-foreground" role="status">
@@ -74,27 +106,97 @@ export function AgentActivityTimeline({ state }: { state: AgentActivityState }) 
       </p>
     );
   }
+
+  const summary = summarizeAgentActivity(state.items);
+
   return (
-    <ol className="flex flex-col gap-2 border-l-2 border-border py-0.5 pl-3" role="list">
-      {state.items.map((entry, index) => (
-        <li key={`${entry.at}:${index}`} className="flex items-center gap-2 text-xs">
-          <span
-            className={cn(
-              "size-1.5 shrink-0 rounded-full",
-              getAgentActivityOutcomeDotClass(entry.outcome),
-            )}
-            aria-hidden="true"
-          />
-          <span className="min-w-0 flex-1 truncate text-foreground">
-            {agentActivityHistoryLabel(entry)}
-          </span>
-          <time className="shrink-0 text-muted-foreground" dateTime={entry.at}>
-            {formatActivityTime(entry.at)}
-          </time>
-        </li>
-      ))}
-    </ol>
+    <div className="flex flex-col gap-0.5">
+      <Button
+        type="button"
+        variant="link"
+        className="h-auto w-fit gap-1.5 px-0 py-0.5 text-xs text-muted-foreground"
+        aria-expanded={expanded}
+        aria-controls={contentId}
+        onClick={() => {
+          setUserToggled(true);
+          setExpanded((current) => !current);
+        }}
+      >
+        <ChevronRight
+          className={cn("size-3 transition-transform", expanded && "rotate-90")}
+          aria-hidden="true"
+        />
+        {agentActivitySummaryLabel(summary)}
+      </Button>
+      {expanded && (
+        <ol
+          id={contentId}
+          className="relative ml-1.5 flex flex-col gap-3 border-l-2 border-border py-1 pl-4 text-sm"
+          role="list"
+        >
+          {state.items.map((entry, index) => {
+            const tone = activityOutcomeTone(entry.outcome);
+            return (
+              <li
+                key={`${entry.at}:${index}`}
+                className="flex min-w-0 items-center gap-1.5"
+              >
+                <div
+                  className="absolute -left-px -translate-x-1/2 bg-background py-0.5 text-muted-foreground [&_svg]:size-4"
+                  aria-hidden="true"
+                >
+                  <ToolIcon name={entry.kind} />
+                </div>
+                <ToolStatusIcon
+                  tone={tone}
+                  className={cn(
+                    "size-4 shrink-0",
+                    tone === "failed" && "text-critical",
+                  )}
+                />
+                <span
+                  className={cn(
+                    "min-w-0 flex-1 truncate font-medium text-foreground",
+                    tone === "running" && "animate-pulse",
+                  )}
+                >
+                  {agentActivityHistoryLabel(entry)}
+                </span>
+                <time
+                  className="ml-auto shrink-0 text-xs tabular-nums text-muted-foreground"
+                  dateTime={entry.at}
+                >
+                  {formatActivityTime(entry.at)}
+                </time>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </div>
   );
+}
+
+function agentActivitySummaryLabel(summary: AgentActivitySummary): string {
+  const toolCalls = `${summary.toolCalls} tool ${summary.toolCalls === 1 ? "call" : "calls"}`;
+  const failures = summary.failed > 0 ? ` · ${summary.failed} failed` : "";
+  return `Ran ${toolCalls}${failures}`;
+}
+
+function activityOutcomeTone(
+  outcome: AgentActivityHistoryEntry["outcome"],
+): ToolTone {
+  switch (outcome) {
+    case "waiting":
+    case "running":
+      return "running";
+    case "completed":
+      return "completed";
+    case "failed":
+      return "failed";
+    case "cancelled":
+      return "cancelled";
+  }
 }
 
 function formatActivityTime(at: string): string {

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.dom.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { AgentActivityHistoryEntry, AgentRun } from "./api";
+import { BackgroundAgentList } from "./BackgroundAgentList";
+
+afterEach(cleanup);
+
+function run(status: AgentRun["status"]): AgentRun {
+  return {
+    id: "run-1",
+    parent_id: "foreground",
+    spawn_call_id: "spawn-call",
+    tier: "background",
+    execution_location: "in_process",
+    status,
+    task: "Prepare the report",
+    started_at: "2026-08-05T18:35:00Z",
+    finished_at: status === "completed" ? "2026-08-05T18:37:00Z" : null,
+    last_error_code: null,
+    activity:
+      status === "running" ? { kind: "exec", status: "running" } : null,
+    submitted_outputs: [],
+    terminal_text: status === "completed" ? "Report complete" : null,
+    created_at: "2026-08-05T18:35:00Z",
+    updated_at:
+      status === "completed"
+        ? "2026-08-05T18:37:00Z"
+        : "2026-08-05T18:36:00Z",
+  };
+}
+
+describe("BackgroundAgentList activity disclosure", () => {
+  it("preserves the row and rail preferences when polling moves a run between groups", async () => {
+    let activity: AgentActivityHistoryEntry[] = [
+      {
+        kind: "exec",
+        outcome: "running",
+        at: "2026-08-05T18:36:00Z",
+      },
+    ];
+    const loadActivity = async () => activity;
+    const list = (agentRun: AgentRun) => (
+      <BackgroundAgentList
+        spawns={[{ callId: "spawn-call", status: "completed" }]}
+        runs={[agentRun]}
+        loading={false}
+        error={null}
+        onRetry={() => undefined}
+        onCancel={async () => undefined}
+        onLoadActivity={loadActivity}
+      />
+    );
+
+    const { rerender } = render(list(run("running")));
+    fireEvent.click(screen.getByRole("button", { name: "Show activity" }));
+
+    const liveTrigger = await screen.findByRole("button", {
+      name: "Running a command",
+    });
+    expect(liveTrigger.getAttribute("aria-expanded")).toBe("true");
+
+    // End on an explicit open preference: the terminal default is closed, so
+    // losing this choice during the status-group remount fails the assertion.
+    fireEvent.click(liveTrigger);
+    fireEvent.click(liveTrigger);
+    expect(liveTrigger.getAttribute("aria-expanded")).toBe("true");
+
+    activity = [
+      {
+        kind: "exec",
+        outcome: "completed",
+        at: "2026-08-05T18:37:00Z",
+      },
+    ];
+    rerender(list(run("completed")));
+
+    expect(
+      screen.getByRole("button", { name: "Hide activity" }),
+    ).toBeTruthy();
+    const settledTrigger = await screen.findByRole("button", {
+      name: "Ran 1 tool call",
+    });
+    expect(settledTrigger.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByRole("list")).toBeTruthy();
+  });
+});

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
@@ -54,6 +54,12 @@ export function BackgroundAgentList({
   onOpenOutput,
 }: BackgroundAgentListProps) {
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
+  // Rows move between keyed status groups as polling advances. Keep both
+  // disclosures here, keyed by run, so that remount does not erase a choice.
+  const [expandedRunIds, setExpandedRunIds] = useState<Set<string>>(new Set());
+  const [activityExpandedByRunId, setActivityExpandedByRunId] = useState<
+    Map<string, boolean>
+  >(new Map());
   const sandboxRuns = runs.filter((run) => run.tier === "background");
   const matchedRuns = sandboxRuns.filter((run) =>
     spawns.some(
@@ -84,6 +90,23 @@ export function BackgroundAgentList({
       const next = new Set(current);
       if (next.has(id)) next.delete(id);
       else next.add(id);
+      return next;
+    });
+  };
+
+  const setRunExpanded = (runId: string, expanded: boolean) => {
+    setExpandedRunIds((current) => {
+      const next = new Set(current);
+      if (expanded) next.add(runId);
+      else next.delete(runId);
+      return next;
+    });
+  };
+
+  const setActivityExpanded = (runId: string, expanded: boolean) => {
+    setActivityExpandedByRunId((current) => {
+      const next = new Map(current);
+      next.set(runId, expanded);
       return next;
     });
   };
@@ -144,6 +167,14 @@ export function BackgroundAgentList({
                         onLoadActivity={onLoadActivity}
                         onOpen={onOpen}
                         onOpenOutput={onOpenOutput}
+                        expanded={expandedRunIds.has(run.id)}
+                        onExpandedChange={(expanded) =>
+                          setRunExpanded(run.id, expanded)
+                        }
+                        activityExpanded={activityExpandedByRunId.get(run.id)}
+                        onActivityExpandedChange={(expanded) =>
+                          setActivityExpanded(run.id, expanded)
+                        }
                       />
                     ))}
                   </div>
@@ -179,14 +210,21 @@ function BackgroundAgentRow({
   onLoadActivity,
   onOpen,
   onOpenOutput,
+  expanded,
+  onExpandedChange,
+  activityExpanded,
+  onActivityExpandedChange,
 }: {
   run: AgentRun;
   onCancel: (runId: string) => Promise<void>;
   onLoadActivity: (runId: string) => Promise<AgentActivityHistoryEntry[]>;
   onOpen?: (runId: string) => void;
   onOpenOutput?: (outputId: string) => void;
+  expanded: boolean;
+  onExpandedChange: (expanded: boolean) => void;
+  activityExpanded?: boolean;
+  onActivityExpandedChange: (expanded: boolean) => void;
 }) {
-  const [expanded, setExpanded] = useState(false);
   const [stopping, setStopping] = useState(false);
   const activity = useAgentRunActivity(
     run.id,
@@ -227,7 +265,7 @@ function BackgroundAgentRow({
         <button
           type="button"
           className="shrink-0"
-          onClick={() => setExpanded((open) => !open)}
+          onClick={() => onExpandedChange(!expanded)}
           aria-expanded={expanded}
           aria-controls={contentId}
           aria-label={expanded ? "Hide activity" : "Show activity"}
@@ -244,7 +282,7 @@ function BackgroundAgentRow({
           type="button"
           className="flex min-w-0 flex-1 items-center gap-2 text-left"
           onClick={() =>
-            onOpen ? onOpen(run.id) : setExpanded((open) => !open)
+            onOpen ? onOpen(run.id) : onExpandedChange(!expanded)
           }
         >
           <span
@@ -285,6 +323,11 @@ function BackgroundAgentRow({
           <AgentActivityTimeline
             state={activity}
             active={RUNNING_AGENT_STATUSES.has(run.status)}
+            activeLabel={agentRunStatusDetail(run)}
+            expanded={
+              activityExpanded ?? RUNNING_AGENT_STATUSES.has(run.status)
+            }
+            onExpandedChange={onActivityExpandedChange}
           />
         </div>
       )}

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
@@ -282,7 +282,10 @@ function BackgroundAgentRow({
       )}
       {expanded && (
         <div id={contentId} className="mt-2 pl-5">
-          <AgentActivityTimeline state={activity} />
+          <AgentActivityTimeline
+            state={activity}
+            active={RUNNING_AGENT_STATUSES.has(run.status)}
+          />
         </div>
       )}
     </div>

--- a/crates/openwave-desktop/ui/src/BackgroundAgentPanel.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentPanel.tsx
@@ -174,7 +174,12 @@ function BackgroundAgentDetail({
         )}
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto p-4" aria-live="polite">
-        <AgentActivityTimeline key={run.id} state={activity} active={live} />
+        <AgentActivityTimeline
+          key={run.id}
+          state={activity}
+          active={live}
+          activeLabel={agentRunStatusDetail(run)}
+        />
         {run.terminal_text && (
           <section className="mt-4 border-t pt-3.5">
             <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">

--- a/crates/openwave-desktop/ui/src/BackgroundAgentPanel.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentPanel.tsx
@@ -1,10 +1,15 @@
 import { useEffect, useState } from "react";
-import { Bot, Square } from "lucide-react";
+import { Bot, Check, Clock, Square, X } from "lucide-react";
 
 import { useApp } from "./AppContext";
-import { AgentActivityTimeline, useAgentRunActivity } from "./AgentActivityTimeline";
+import {
+  AgentActivityTimeline,
+  summarizeAgentActivity,
+  useAgentRunActivity,
+} from "./AgentActivityTimeline";
 import { agentRunStatusDetail, RUNNING_AGENT_STATUSES } from "./AgentRunDisplay";
 import type { AgentRun } from "./api";
+import { MessageMarkdown } from "./MessageMarkdown";
 import { SubmittedOutputPills } from "./SubmittedOutputPills";
 import { useAgentRuns } from "./useAgentRuns";
 import { PanelBreadcrumb } from "@/components/PanelHeader";
@@ -13,6 +18,7 @@ import { usePanelNav } from "@/panel/usePanelNav";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Spinner } from "@/components/ui/spinner";
 
 /**
  * One background run, opened beside the conversation from its row in the
@@ -122,23 +128,39 @@ function BackgroundAgentDetail({
   const live = RUNNING_AGENT_STATUSES.has(run.status);
   const now = useNowWhile(live);
   const elapsed = elapsedLabel(run, now);
+  const activitySummary =
+    activity.loaded && activity.items.length > 0
+      ? summarizeAgentActivity(activity.items)
+      : null;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
       <div className="shrink-0 px-4 pt-4">
-        <div className="flex items-center gap-2">
-          <Bot className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-          <h2 className="min-w-0 flex-1 truncate text-base font-medium">
-            {run.task ?? "Background agent"}
-          </h2>
-          <AgentRunStatusBadge status={run.status} />
+        <div className="flex items-start gap-2.5">
+          <div className="grid size-7 shrink-0 place-items-center rounded-lg border bg-muted text-muted-foreground">
+            <Bot className="size-4" aria-hidden="true" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h2 className="line-clamp-2 text-sm font-semibold leading-5">
+              {run.task ?? "Background agent"}
+            </h2>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {agentRunStatusDetail(run)}
+              {elapsed && <> · {elapsed}</>}
+              {activitySummary && (
+                <>
+                  {" · "}
+                  {agentActivityMetaLabel(activitySummary)}
+                </>
+              )}
+            </p>
+          </div>
+          <div className="mt-0.5 shrink-0">
+            <AgentRunStatusBadge status={run.status} />
+          </div>
         </div>
-        <p className="mt-1 text-sm text-muted-foreground">
-          {agentRunStatusDetail(run)}
-          {elapsed && <> · {elapsed}</>}
-        </p>
         {run.status === "failed" && run.last_error_code && (
-          <p className="mt-1 font-mono text-xs text-critical">
+          <p className="ml-9 mt-1 font-mono text-xs text-critical">
             {run.last_error_code}
           </p>
         )}
@@ -152,17 +174,17 @@ function BackgroundAgentDetail({
         )}
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto p-4" aria-live="polite">
+        <AgentActivityTimeline key={run.id} state={activity} active={live} />
         {run.terminal_text && (
-          <div className="mb-4 rounded-md border bg-muted/40 px-3 py-2.5">
-            <p className="text-xs font-medium text-muted-foreground">
-              {run.status === "failed" ? "Error" : "Result"}
+          <section className="mt-4 border-t pt-3.5">
+            <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+              Result
             </p>
-            <p className="mt-1 text-sm break-words whitespace-pre-wrap text-foreground">
-              {run.terminal_text}
-            </p>
-          </div>
+            <div className="break-words text-foreground [&_.message-markdown]:text-sm">
+              <MessageMarkdown>{run.terminal_text}</MessageMarkdown>
+            </div>
+          </section>
         )}
-        <AgentActivityTimeline state={activity} />
       </div>
     </div>
   );
@@ -171,21 +193,59 @@ function BackgroundAgentDetail({
 function AgentRunStatusBadge({ status }: { status: AgentRun["status"] }) {
   switch (status) {
     case "completed":
-      return <Badge variant="success" size="sm">Complete</Badge>;
+      return (
+        <Badge variant="success" size="sm">
+          <Check className="size-3" aria-hidden="true" />
+          Complete
+        </Badge>
+      );
     case "failed":
-      return <Badge variant="critical" size="sm">Failed</Badge>;
+      return (
+        <Badge variant="critical" size="sm">
+          <X className="size-3" aria-hidden="true" />
+          Failed
+        </Badge>
+      );
     case "cancelled":
-      return <Badge variant="critical" size="sm">Stopped</Badge>;
+      return (
+        <Badge variant="critical" size="sm">
+          <X className="size-3" aria-hidden="true" />
+          Stopped
+        </Badge>
+      );
     case "cancelling":
-      return <Badge variant="outline" size="sm">Stopping</Badge>;
+      return (
+        <Badge variant="outline" size="sm">
+          <Spinner className="size-3" aria-hidden="true" />
+          Stopping
+        </Badge>
+      );
     case "waiting":
     case "retry_wait":
-      return <Badge variant="warning" size="sm">Waiting</Badge>;
+      return (
+        <Badge variant="warning" size="sm">
+          <Clock className="size-3" aria-hidden="true" />
+          Waiting
+        </Badge>
+      );
     case "active":
     case "queued":
     case "running":
-      return <Badge variant="info" size="sm">Running</Badge>;
+      return (
+        <Badge variant="info" size="sm">
+          <Spinner className="size-3" aria-hidden="true" />
+          Running
+        </Badge>
+      );
   }
+}
+
+function agentActivityMetaLabel({
+  toolCalls,
+  failed,
+}: ReturnType<typeof summarizeAgentActivity>): string {
+  const count = `${toolCalls} tool ${toolCalls === 1 ? "call" : "calls"}`;
+  return failed > 0 ? `${count}, ${failed} failed` : count;
 }
 
 /** The current second, ticking only while something on screen depends on it. */


### PR DESCRIPTION
This restyles the background-agent detail panel to use the same visual language as foreground tool calls. The task header now includes icon-backed status badges and history counts, activity renders as a collapsible icon rail with outcome states, and terminal results render as markdown beneath a divider instead of raw text in a muted box.

The activity rail defaults open while work is active and closed after the run settles, while preserving an explicit user toggle. A focused DOM test covers that transition.

Typed per-step previews such as command text and exit codes require additional server data and remain a follow-up server slice.

Verification:
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run src/AgentActivityTimeline.dom.test.tsx src/BackgroundAgentList.test.tsx src/AgentRunDisplay.test.ts src/MessageMarkdown.test.tsx src/MessageMarkdown.dom.test.tsx`
- `pnpm build`