### PR TITLE
ci: prove SQLite profile migrations and Credential Manager on the Windows lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,7 +383,10 @@ jobs:
     # always check every crate that currently contains Windows-gated code.
     if: ${{ needs.changes.outputs.rust == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')) }}
     runs-on: windows-latest
-    timeout-minutes: 20
+    # The persistence steps below compile openwave-server's test target, which
+    # is the heaviest codegen this lane pays; leave headroom over the
+    # check-plus-broker baseline.
+    timeout-minutes: 30
     env:
       CARGO_INCREMENTAL: 0
       CARGO_PROFILE_DEV_DEBUG: 0
@@ -432,6 +435,20 @@ jobs:
       # native host, not a second copy of the workspace suite.
       - name: Host broker Windows tests
         run: cargo test -p openwave-host-broker --locked
+      # Boot-critical persistence, proven on the OS that ships it: the desktop
+      # profile's SQLite open/migrate lifecycle (openwave-server's
+      # desktop_schema module, including the Windows MoveFileExW marker swap)
+      # and a Credential Manager set/get/delete round trip through the keyring
+      # crate's windows-native backend. Targeted filters on two crates — not a
+      # second copy of the workspace suite.
+      - name: SQLite profile open and migrations
+        run: cargo test -p openwave-server --lib desktop_schema --locked
+      # `-- --ignored` runs the native round trip alone, so the process-global
+      # in-memory keyring mock installed by the ordinary unit test never
+      # activates and the test reaches the real Credential Manager available
+      # under the hosted runner session.
+      - name: Credential Manager round trip
+        run: cargo test -p openwave-core --lib keychain --locked -- --ignored
 
   test:
     name: test

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -112,6 +112,16 @@ impl DbStore {
             .map_err(store_err)?;
         Ok(Self { conn })
     }
+
+    /// Close the connection pool, releasing every database file handle before
+    /// returning. Dropping the store closes connections asynchronously, which
+    /// is fine at process exit — but a caller that deletes or replaces the
+    /// SQLite files next (restart simulations, the pre-v1 reset lifecycle)
+    /// must close explicitly: Windows refuses to delete a file another handle
+    /// still has open or memory-mapped.
+    pub async fn close(self) -> Result<()> {
+        self.conn.close().await.map_err(store_err)
+    }
 }
 
 impl DbStore {

--- a/crates/openwave-core/src/keychain.rs
+++ b/crates/openwave-core/src/keychain.rs
@@ -135,4 +135,39 @@ mod tests {
         // Deleting is a no-op when nothing is persisted (mock is per-entry).
         secrets.delete_secret(key).await.unwrap();
     }
+
+    /// Round-trips a secret through the real OS credential store — Credential
+    /// Manager on Windows, Keychain on macOS — via the platform `keyring`
+    /// backend, the boot-critical path every stored API key takes. Ignored by
+    /// default so ordinary test runs never write to a developer's credential
+    /// store; the Windows CI lane runs it explicitly with `-- --ignored`,
+    /// which also keeps the process-global in-memory mock (set by the test
+    /// above) out of this process.
+    #[tokio::test]
+    #[ignore = "writes to the real OS credential store; the Windows CI lane runs it explicitly"]
+    async fn native_credential_store_round_trip() {
+        assert!(
+            !MOCK_INIT.is_completed(),
+            "the in-memory keyring mock is active in this process; \
+             run this test alone (`-- --ignored`) so it reaches the real backend"
+        );
+        let secrets = KeychainSecretProvider::with_service("openwave-ci-probe");
+        let key = format!("credential-round-trip-{}", uuid::Uuid::new_v4());
+
+        assert_eq!(secrets.get_secret(&key).await.unwrap(), None);
+        secrets.set_secret(&key, "first").await.unwrap();
+        assert_eq!(
+            secrets.get_secret(&key).await.unwrap().as_deref(),
+            Some("first")
+        );
+        secrets.set_secret(&key, "second").await.unwrap();
+        assert_eq!(
+            secrets.get_secret(&key).await.unwrap().as_deref(),
+            Some("second")
+        );
+        secrets.delete_secret(&key).await.unwrap();
+        assert_eq!(secrets.get_secret(&key).await.unwrap(), None);
+        // Deleting an absent entry is a no-op, not an error.
+        secrets.delete_secret(&key).await.unwrap();
+    }
 }

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -3394,7 +3394,8 @@ mod tests {
 
     /// Local exec is confined to the scratch directory but can create entries
     /// in it, including a symlink aimed at the host. Both preparation writes
-    /// run on that directory before the next command, unsandboxed.    #[cfg(unix)]
+    /// run on that directory before the next command, unsandboxed.
+    #[cfg(unix)]
     #[tokio::test]
     async fn preparation_does_not_write_through_a_planted_symlink() {
         let outside = tempfile::tempdir().unwrap();

--- a/crates/openwave-server/src/desktop_schema.rs
+++ b/crates/openwave-server/src/desktop_schema.rs
@@ -356,7 +356,9 @@ mod tests {
             .await
             .unwrap();
         legacy.create_chat(&chat()).await.unwrap();
-        drop(legacy);
+        // An explicit close, not a drop: the reset below deletes and rewrites
+        // the SQLite files, which Windows refuses while a handle is open.
+        legacy.close().await.unwrap();
 
         let blob = dir.path().join("blobs").join("keep-me");
         std::fs::create_dir_all(blob.parent().unwrap()).unwrap();
@@ -424,7 +426,9 @@ mod tests {
         let config = Config::desktop(dir.path());
         let first = connect(&config).await.unwrap();
         first.create_chat(&chat()).await.unwrap();
-        drop(first);
+        // An explicit close, not a drop: the epoch reset below deletes the
+        // SQLite files, which Windows refuses while a handle is open.
+        first.close().await.unwrap();
         std::fs::write(
             dir.path().join(MARKER_FILE),
             serde_json::to_vec(&SchemaMarker {


### PR DESCRIPTION
## Summary

The Windows lane (#1592) checks the Windows-gated crates and runs the host-broker suite natively, but nothing proved the boot-critical persistence services on the OS that ships them. This extends the lane with two targeted steps, reusing existing coverage wherever it exists:

- **SQLite profile open and migrations** — runs the existing `desktop_schema` module in openwave-server (`cargo test -p openwave-server --lib desktop_schema --locked`). Those 13 tests already cover the whole boot contract: opening the profile database, running migrations through `DbStore::connect`, the pre-v1 epoch reset lifecycle, and fail-closed marker handling — including the Windows-specific `MoveFileExW` marker replacement, which until now was never compiled by a test lane on Windows.
- **Credential Manager round trip** — one new ignored test in openwave-core's `keychain` module that set/get/overwrite/deletes a secret through the real OS credential store via the `keyring` crate's platform backend (windows-native on this lane). The lane runs it with `cargo test -p openwave-core --lib keychain --locked -- --ignored`; running only ignored tests keeps the process-global in-memory keyring mock (installed by the ordinary unit test) out of the process, and `#[ignore]` keeps ordinary developer runs from writing to a real credential store. Hosted `windows-latest` runners provide a usable Credential Manager under the runner session, so the full set/get/delete contract is proven there — nothing is left needing an interactive session.

Both steps are targeted `cargo test -p <crate> <filter>` invocations, not a second copy of the workspace suite. The lane timeout goes from 20 to 30 minutes because compiling openwave-server's test target is the heaviest codegen the lane now pays.

Also fixes a latent bug this lane exposed: in `code_execution.rs`, the `#[cfg(unix)]` gate on `preparation_does_not_write_through_a_planted_symlink` had been glued onto the end of its doc comment, making the attribute inert text — the unix-only test (it calls `std::os::unix::fs::symlink`) would have broken openwave-server's test-target compile on Windows.

Closes #1601

## Test plan

- [x] `cargo test -p openwave-server --lib desktop_schema` plus the re-gated symlink test pass on the host (14 tests)
- [x] `cargo test -p openwave-core --lib keychain` passes on the host; the native test is correctly ignored by default
- [x] `cargo check -p openwave-core -p openwave-server --locked` with no lock drift; `cargo fmt --check` clean
- [ ] Windows lane green on this PR with `full-ci` (the point of the change)

Made with [Cursor](https://cursor.com)