### PR TITLE
feat(desktop): pin the conversation and host open panels as tabs

### DIFF
--- a/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
@@ -341,7 +341,7 @@ describe("app shell", () => {
     expect(await screen.findByTestId("transcript")).toBeInTheDocument();
   });
 
-  it("arranges panels beside the conversation from the sidebar", async () => {
+  it("opens panels as tabs beside the conversation, from the sidebar", async () => {
     const user = userEvent.setup();
     const { router } = await mountApp({ at: "/c/chat-1" });
     await screen.findByTestId("transcript");
@@ -351,17 +351,25 @@ describe("app shell", () => {
     expect(await screen.findByTestId("folders")).toBeInTheDocument();
     // The conversation stays mounted beside it rather than being replaced.
     expect(screen.getByTestId("transcript")).toBeInTheDocument();
-    await waitFor(() =>
-      expect(router.state.location.search).toEqual({ left: "folders", right: "chat" }),
-    );
+    await waitFor(() => expect(router.state.location.search).toEqual({ tabs: "folders" }));
 
-    // The Library entry reaches the app catalog without leaving the chat.
+    // The Library entry reaches the app catalog without closing what is open:
+    // it joins the strip and comes forward.
     await user.click(screen.getByRole("button", { name: "Apps" }));
 
     expect(await screen.findByTestId("apps")).toBeInTheDocument();
     await waitFor(() =>
-      expect(router.state.location.search).toEqual({ left: "apps", right: "chat" }),
+      expect(router.state.location.search).toEqual({
+        tabs: "folders,apps",
+        active: "apps",
+      }),
     );
+    expect(screen.queryByTestId("folders")).not.toBeInTheDocument();
+
+    // The tab it displaced is still there to go back to.
+    await user.click(screen.getByRole("tab", { name: "Folders" }));
+    expect(await screen.findByTestId("folders")).toBeInTheDocument();
+    await waitFor(() => expect(router.state.location.search).toEqual({ tabs: "folders,apps" }));
   });
 
   it("closes a panel back to the conversation alone", async () => {
@@ -378,6 +386,15 @@ describe("app shell", () => {
   });
 
   it("restores the arrangement a deep link describes", async () => {
+    await mountApp({ at: "/c/chat-2?tabs=folders,outputs&active=outputs" });
+
+    expect(await screen.findByTestId("outputs")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Folders" })).toBeInTheDocument();
+  });
+
+  // Windows left open across the change, and links shared before it, still
+  // carry the retired pair-of-slots grammar.
+  it("restores a link written in the retired layout grammar", async () => {
     await mountApp({ at: "/c/chat-2?left=outputs&right=chat" });
 
     expect(await screen.findByTestId("outputs")).toBeInTheDocument();

--- a/crates/openwave-desktop/ui/src/BackgroundAgentPanel.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentPanel.tsx
@@ -9,7 +9,6 @@ import { SubmittedOutputPills } from "./SubmittedOutputPills";
 import { useAgentRuns } from "./useAgentRuns";
 import { PanelBreadcrumb } from "@/components/PanelHeader";
 import { PanelFrame } from "@/panel/PanelFrame";
-import type { PanelPosition } from "@/panel/panelTypes";
 import { usePanelNav } from "@/panel/usePanelNav";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -28,11 +27,9 @@ import { Skeleton } from "@/components/ui/skeleton";
 export function BackgroundAgentPanel({
   chatId,
   runId,
-  position,
 }: {
   chatId: string;
   runId: string;
-  position: PanelPosition;
 }) {
   const { client } = useApp();
   const { openPanel } = usePanelNav();
@@ -77,7 +74,6 @@ export function BackgroundAgentPanel({
 
   return (
     <PanelFrame
-      position={position}
       breadcrumb={<PanelBreadcrumb firstPart="Agent" />}
       headerRightSlot={stopButton}
       showBorder

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -541,110 +541,108 @@ export function ChatRoute({ chatId }: { chatId: string }) {
     );
   }
 
-  function renderPanel(panel: PanelContent, position: "left" | "right" | "chat", visible: boolean) {
-    if (panel.type === "chat") {
-      // Only the levels the selected model accepts are offerable, and a model
-      // that accepts none gets no selector at all.
-      const efforts =
-        modelForSelection(models, chat!.model)?.reasoning_efforts ?? [];
-      return (
-        <TranscriptVisibilityProvider value={visible}>
-          <ChatView
-            client={client}
-            chat={chat!}
-            hydrated={hydrated}
-            nativeHost={nativeHost}
-            deletingChat={deletingChatId !== null}
-            draftRef={draftRef}
-            attachError={attachError}
-            files={{
-              items: files,
-              attaching,
-              onAttach: hasNativeHost() ? onAttach : undefined,
-              onRemove: (documentId) =>
-                setComposerFiles((current) =>
-                  current.filter((file) => file.documentId !== documentId),
-                ),
-            }}
-            folders={{
-              items: folders.items,
-              working: folders.working,
-              error: folders.error,
-              onAttach: nativeHost ? folders.attach : undefined,
-              onRemove: folders.remove,
-            }}
-            voice={{
-              available: voice.available,
-              state: voice.state,
-              error: voice.error,
-              onStart: () => void voice.start(),
-              onStop: voice.stop,
-            }}
-            nativeDropTarget={
-              <DocumentDropTarget
-                chatId={chatId}
-                onAttached={adoptAttached}
-                onError={(error) => setAttachError(friendlyAttachError(error))}
-              />
-            }
-            composerImages={{
-              items: images.attachments,
-              error: images.error,
-              unsupportedModel: textOnlyModelLabel(models, chat!.model),
-              onAttachFiles: (selected) => {
-                if (
-                  images.attachments.length + files.length + selected.length >
-                  MAX_IMAGE_ATTACHMENTS
-                ) {
-                  setAttachError(
-                    `A message can carry at most ${MAX_IMAGE_ATTACHMENTS} attachments.`,
-                  );
-                  return;
-                }
-                images.attachFiles(selected);
-              },
-              onRemove: images.remove,
-              onRetry: images.retry,
-            }}
-            composerModelMenu={
-              <ModelMenu
-                models={models}
-                value={chat!.model}
-                defaultKey={defaultModelKey}
-                disabled={deletingChatId !== null}
-                onChange={onModelChange}
-              />
-            }
-            composerPermissionMenu={
-              <PermissionModeMenu
-                value={chat!.permission_mode}
-                disabled={deletingChatId !== null}
-                onChange={onPermissionModeChange}
-              />
-            }
-            composerReasoning={{
-              levels: efforts,
-              value: chat!.reasoning_effort,
-              disabled: deletingChatId !== null,
-              onChange: onReasoningEffortChange,
-            }}
-            composerNetwork={{
-              value: chat!.network_policy,
-              disabled: deletingChatId !== null,
-              onChange: onNetworkPolicyChange,
-            }}
-            onDraftChange={setComposerDraft}
-            onSelectPrompt={setComposerDraft}
-            onSend={onSend}
-            onRetryTurn={retryTurn}
-            onOpenAgentPanel={(runId) => openPanel({ type: "agent", runId })}
-            onOpenOutput={(outputId) => openPanel({ type: "outputs", outputId })}
-          />
-        </TranscriptVisibilityProvider>
-      );
-    }
+  function renderChat(visible: boolean) {
+    // Only the levels the selected model accepts are offerable, and a model
+    // that accepts none gets no selector at all.
+    const efforts = modelForSelection(models, chat!.model)?.reasoning_efforts ?? [];
+    return (
+      <TranscriptVisibilityProvider value={visible}>
+        <ChatView
+          client={client}
+          chat={chat!}
+          hydrated={hydrated}
+          nativeHost={nativeHost}
+          deletingChat={deletingChatId !== null}
+          draftRef={draftRef}
+          attachError={attachError}
+          files={{
+            items: files,
+            attaching,
+            onAttach: hasNativeHost() ? onAttach : undefined,
+            onRemove: (documentId) =>
+              setComposerFiles((current) =>
+                current.filter((file) => file.documentId !== documentId),
+              ),
+          }}
+          folders={{
+            items: folders.items,
+            working: folders.working,
+            error: folders.error,
+            onAttach: nativeHost ? folders.attach : undefined,
+            onRemove: folders.remove,
+          }}
+          voice={{
+            available: voice.available,
+            state: voice.state,
+            error: voice.error,
+            onStart: () => void voice.start(),
+            onStop: voice.stop,
+          }}
+          nativeDropTarget={
+            <DocumentDropTarget
+              chatId={chatId}
+              onAttached={adoptAttached}
+              onError={(error) => setAttachError(friendlyAttachError(error))}
+            />
+          }
+          composerImages={{
+            items: images.attachments,
+            error: images.error,
+            unsupportedModel: textOnlyModelLabel(models, chat!.model),
+            onAttachFiles: (selected) => {
+              if (
+                images.attachments.length + files.length + selected.length >
+                MAX_IMAGE_ATTACHMENTS
+              ) {
+                setAttachError(
+                  `A message can carry at most ${MAX_IMAGE_ATTACHMENTS} attachments.`,
+                );
+                return;
+              }
+              images.attachFiles(selected);
+            },
+            onRemove: images.remove,
+            onRetry: images.retry,
+          }}
+          composerModelMenu={
+            <ModelMenu
+              models={models}
+              value={chat!.model}
+              defaultKey={defaultModelKey}
+              disabled={deletingChatId !== null}
+              onChange={onModelChange}
+            />
+          }
+          composerPermissionMenu={
+            <PermissionModeMenu
+              value={chat!.permission_mode}
+              disabled={deletingChatId !== null}
+              onChange={onPermissionModeChange}
+            />
+          }
+          composerReasoning={{
+            levels: efforts,
+            value: chat!.reasoning_effort,
+            disabled: deletingChatId !== null,
+            onChange: onReasoningEffortChange,
+          }}
+          composerNetwork={{
+            value: chat!.network_policy,
+            disabled: deletingChatId !== null,
+            onChange: onNetworkPolicyChange,
+          }}
+          onDraftChange={setComposerDraft}
+          onSelectPrompt={setComposerDraft}
+          onSend={onSend}
+          onRetryTurn={retryTurn}
+          onOpenAgentPanel={(runId) => openPanel({ type: "agent", runId })}
+          onOpenOutput={(outputId) => openPanel({ type: "outputs", outputId })}
+        />
+      </TranscriptVisibilityProvider>
+    );
+  }
 
-    const side = position === "right" ? "right" : "left";
+  function renderPanel(panel: PanelContent) {
     switch (panel.type) {
       case "document":
         return (
@@ -652,19 +650,14 @@ export function ChatRoute({ chatId }: { chatId: string }) {
             chatId={chatId}
             documentID={panel.documentId}
             citationId={panel.citationId}
-            position={side}
           />
         );
       case "outputs":
         // An output id turns the list into the reader for that one output.
         return panel.outputId ? (
-          <OutputDetailRoot
-            chatId={chatId}
-            outputId={panel.outputId}
-            position={side}
-          />
+          <OutputDetailRoot chatId={chatId} outputId={panel.outputId} />
         ) : (
-          <PanelFrame position={side} spaceBetween>
+          <PanelFrame spaceBetween>
             <OutputsView
               chatId={chatId}
               onOpen={(outputId) => openPanel({ type: "outputs", outputId })}
@@ -673,22 +666,16 @@ export function ChatRoute({ chatId }: { chatId: string }) {
         );
       case "folders":
         return (
-          <PanelFrame position={side} spaceBetween>
+          <PanelFrame spaceBetween>
             <FoldersView chat={chat!} />
           </PanelFrame>
         );
       case "apps":
-        return <AppsPanel panel={panel} position={side} />;
+        return <AppsPanel panel={panel} />;
       case "plugins":
-        return <PluginsPanel panel={panel} position={side} />;
+        return <PluginsPanel panel={panel} />;
       case "agent":
-        return (
-          <BackgroundAgentPanel
-            chatId={chatId}
-            runId={panel.runId}
-            position={side}
-          />
-        );
+        return <BackgroundAgentPanel chatId={chatId} runId={panel.runId} />;
     }
   }
 
@@ -701,7 +688,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
       {/* Citations live in the transcript but open into the panel beside it,
           so the way there is provided above both slots. */}
       <SourceNavProvider value={sourceNav}>
-        <PanelLayout layout={layout} renderPanel={renderPanel} />
+        <PanelLayout layout={layout} renderChat={renderChat} renderPanel={renderPanel} />
       </SourceNavProvider>
     </div>
     </RouteFrame>

--- a/crates/openwave-desktop/ui/src/HomeRoute.tsx
+++ b/crates/openwave-desktop/ui/src/HomeRoute.tsx
@@ -29,7 +29,7 @@ import { effectiveNewChatSettings, useNewChatSettings } from "./NewChatSettings"
 import { AppsPanel } from "./apps/AppsPanel";
 import { PluginsPanel } from "./plugins/PluginsPanel";
 import { PanelLayout } from "./panel/PanelLayout";
-import type { LayoutState, PanelContent } from "./panel/panelTypes";
+import { EMPTY_LAYOUT, type LayoutState, type PanelContent } from "./panel/panelTypes";
 import { useLayoutState } from "./panel/usePanelNav";
 import { PermissionModeMenu } from "./PermissionModeMenu";
 import { RouteFrame } from "./RouteFrame";
@@ -274,17 +274,10 @@ export function HomeRoute() {
   // does not have.
   const layout = homeLayout(useLayoutState());
 
-  function renderPanel(
-    panel: PanelContent,
-    position: "left" | "right" | "chat",
-  ) {
-    if (panel.type === "apps" && position !== "chat") {
-      return <AppsPanel panel={panel} position={position} />;
-    }
-    if (panel.type === "plugins" && position !== "chat") {
-      return <PluginsPanel panel={panel} position={position} />;
-    }
-    return homeContent();
+  function renderPanel(panel: PanelContent) {
+    if (panel.type === "apps") return <AppsPanel panel={panel} />;
+    if (panel.type === "plugins") return <PluginsPanel panel={panel} />;
+    return null;
   }
 
   function homeContent() {
@@ -388,23 +381,27 @@ export function HomeRoute() {
   return (
     <RouteFrame sidebar={<HomeSidebar />}>
       <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-        <PanelLayout layout={layout} renderPanel={renderPanel} />
+        <PanelLayout
+          layout={layout}
+          renderChat={() => homeContent()}
+          renderPanel={renderPanel}
+        />
       </div>
     </RouteFrame>
   );
 }
 
 /**
- * The layouts home is willing to host: itself alone, or itself beside one of
- * the install-wide libraries. A URL naming any conversation-scoped panel is a
- * stale or hand-edited link; it lands on plain home rather than an empty panel.
+ * The tabs home is willing to host: only the install-wide libraries. A URL
+ * naming any conversation-scoped panel is a stale or hand-edited link, and
+ * that tab is dropped rather than opened onto content this route cannot fetch.
  */
 function homeLayout(layout: LayoutState): LayoutState {
-  if (layout.mode === "single") return { mode: "single", panel: { type: "chat" } };
   const supported = (panel: PanelContent) =>
-    panel.type === "chat" || panel.type === "apps" || panel.type === "plugins";
-  if (!supported(layout.left) || !supported(layout.right)) {
-    return { mode: "single", panel: { type: "chat" } };
-  }
-  return layout;
+    panel.type === "apps" || panel.type === "plugins";
+  const active = layout.tabs[layout.activeIndex];
+  const tabs = layout.tabs.filter(supported);
+  if (tabs.length === 0) return EMPTY_LAYOUT;
+  const activeIndex = active && supported(active) ? tabs.indexOf(active) : 0;
+  return { ...layout, tabs, activeIndex: Math.max(activeIndex, 0) };
 }

--- a/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
@@ -889,7 +889,7 @@ describe("actionable tool results", () => {
     await user.click(screen.getByRole("button", { name: "Open output deck.pptx" }));
     await waitFor(() => {
       expect(router.state.location.search).toMatchObject({
-        right: "outputs.output-1",
+        tabs: "outputs.output-1",
       });
     });
   });
@@ -951,7 +951,7 @@ describe("actionable tool results", () => {
       screen.getByRole("button", { name: "Open app Sentry triage" }),
     );
     await waitFor(() => {
-      expect(router.state.location.search).toMatchObject({ left: "apps.app-1" });
+      expect(router.state.location.search).toMatchObject({ tabs: "apps.app-1" });
     });
   });
 

--- a/crates/openwave-desktop/ui/src/apps/AppsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppsPanel.tsx
@@ -16,17 +16,15 @@ import { appsApisFromClient } from "./appsApis";
  */
 export function AppsPanel({
   panel,
-  position,
 }: {
   panel: Extract<PanelContent, { type: "apps" }>;
-  position: "left" | "right";
 }) {
   const { client } = useApp();
   const { openPanel } = usePanelNav();
   const apis = useMemo(() => appsApisFromClient(client), [client]);
 
   return (
-    <PanelFrame position={position} spaceBetween>
+    <PanelFrame spaceBetween>
       {panel.appId ? (
         <AppDetailView
           appId={panel.appId}

--- a/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
@@ -112,7 +112,6 @@ async function openPanel(
       <DocumentDetailRoot
         chatId="chat-1"
         documentID="doc-1"
-        position="left"
         download={download}
         canDownload
       />
@@ -129,7 +128,7 @@ async function openFailingPanel(rejection: unknown) {
   };
   const rendered = await renderWithRouter(
     <AppContextProvider value={{ client } as unknown as AppContextValue}>
-      <DocumentDetailRoot chatId="chat-1" documentID="doc-1" position="left" />
+      <DocumentDetailRoot chatId="chat-1" documentID="doc-1" />
     </AppContextProvider>,
     { initialUrl: "/c/chat-1?left=sources.doc-1&right=chat" },
   );
@@ -177,7 +176,6 @@ async function openCitation(
         chatId="chat-1"
         documentID="doc-1"
         citationId={citationId}
-        position="left"
       />
     </AppContextProvider>,
     { initialUrl: `/c/chat-1?left=sources.doc-1.${citationId}&right=chat` },
@@ -212,7 +210,6 @@ async function openCitationThenAnother(
           chatId="chat-1"
           documentID="doc-1"
           citationId={citationId}
-          position="left"
         />
       </AppContextProvider>
     );

--- a/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.tsx
+++ b/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.tsx
@@ -16,7 +16,6 @@ import {
 import { exportLibraryDocument } from "@/documents";
 import { hasNativeHost } from "@/host";
 import { PanelFrame } from "@/panel/PanelFrame";
-import type { PanelPosition } from "@/panel/panelTypes";
 import { useCitationPlacement } from "./citationPlacement";
 import {
   DocumentDetailActions,
@@ -26,7 +25,6 @@ import {
 type Props = {
   chatId: string;
   documentID: string;
-  position: PanelPosition;
   /**
    * The citation this panel was opened from, as the third part of its address.
    * It names a place inside the document: the passage to highlight, and the
@@ -45,7 +43,6 @@ type Props = {
 export function DocumentDetailRoot({
   chatId,
   documentID,
-  position,
   citationId,
   download = exportLibraryDocument,
   canDownload = hasNativeHost(),
@@ -158,7 +155,6 @@ export function DocumentDetailRoot({
 
   return (
     <PanelFrame
-      position={position}
       showBorder
       breadcrumb={
         <DocumentDetailBreadcrumb

--- a/crates/openwave-desktop/ui/src/outputs/OutputDetailRoot.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/outputs/OutputDetailRoot.dom.test.tsx
@@ -96,8 +96,8 @@ function detailApis(overrides: Partial<OutputDetailApis> = {}): OutputDetailApis
 
 async function openOutput(apis: OutputDetailApis, id = outputId) {
   return renderWithRouter(
-    <OutputDetailRoot chatId="chat-1" outputId={id} position="left" apis={apis} />,
-    { initialUrl: `/c/chat-1?left=outputs.${id}&right=chat` },
+    <OutputDetailRoot chatId="chat-1" outputId={id} apis={apis} />,
+    { initialUrl: `/c/chat-1?tabs=outputs.${id}` },
   );
 }
 
@@ -124,7 +124,7 @@ describe("OutputDetailRoot", () => {
 
     await user.click(screen.getByRole("button", { name: "Outputs" }));
     await waitFor(() =>
-      expect(router.state.location.search).toEqual({ left: "outputs", right: "chat" }),
+      expect(router.state.location.search).toEqual({ tabs: "outputs" }),
     );
   });
 

--- a/crates/openwave-desktop/ui/src/outputs/OutputDetailRoot.tsx
+++ b/crates/openwave-desktop/ui/src/outputs/OutputDetailRoot.tsx
@@ -25,7 +25,6 @@ import {
   useNativePickerLatch,
 } from "@/NativePickerLatch";
 import { PanelFrame } from "@/panel/PanelFrame";
-import type { PanelPosition } from "@/panel/panelTypes";
 import { usePanelNav } from "@/panel/usePanelNav";
 import { OutputContent } from "./OutputContent";
 import { outputTypeLabel } from "./outputFormat";
@@ -80,12 +79,10 @@ function producedByLabel(revision: OutputRevisionInfo): string {
 export function OutputDetailRoot({
   chatId,
   outputId,
-  position,
   apis = defaultApis,
 }: {
   chatId: string;
   outputId: string;
-  position: PanelPosition;
   apis?: OutputDetailApis;
 }) {
   const { openPanel } = usePanelNav();
@@ -221,7 +218,6 @@ export function OutputDetailRoot({
 
   return (
     <PanelFrame
-      position={position}
       showBorder
       breadcrumb={
         <PanelBreadcrumb

--- a/crates/openwave-desktop/ui/src/panel/PanelFrame.tsx
+++ b/crates/openwave-desktop/ui/src/panel/PanelFrame.tsx
@@ -3,33 +3,33 @@ import { useState, type ReactNode } from "react";
 import { PanelPrimaryHeader } from "@/components/PanelHeader";
 import { PopoverCollisionBoundaryProvider } from "@/components/ui/popover";
 import { usePanelNav } from "./usePanelNav";
-import type { PanelPosition } from "./panelTypes";
 
 /**
  * The chrome every panel wears, and the box it lives in.
  *
  * The frame is also the collision boundary for popovers opened inside it, so a
  * menu near the edge of a narrow panel stays within its own panel instead of
- * flipping out over the one beside it.
+ * flipping out over the conversation beside it.
+ *
+ * Only the tab showing is mounted, so the close control here is that tab's:
+ * closing it hands focus to its neighbour, or back to the conversation when it
+ * was the last one open.
  */
 export function PanelFrame({
-  position,
   breadcrumb,
   headerRightSlot,
   spaceBetween,
   showBorder,
   children,
 }: {
-  position: PanelPosition;
   breadcrumb?: ReactNode;
   headerRightSlot?: ReactNode;
   spaceBetween?: boolean;
   showBorder?: boolean;
   children: ReactNode;
 }) {
-  const { layout, closePanel, toggleFullscreen } = usePanelNav();
+  const { layout, closeTab, toggleFullscreen } = usePanelNav();
   const [boundary, setBoundary] = useState<HTMLElement | null>(null);
-  const isFullscreen = layout.mode === "split" && layout.fullscreen === position;
 
   return (
     <PopoverCollisionBoundaryProvider boundary={boundary}>
@@ -39,9 +39,9 @@ export function PanelFrame({
           rightSlot={headerRightSlot}
           spaceBetween={spaceBetween}
           showBorder={showBorder}
-          isFullscreen={isFullscreen}
-          onToggleFullscreen={() => toggleFullscreen(position)}
-          onClose={() => closePanel(position)}
+          isFullscreen={layout.fullscreen}
+          onToggleFullscreen={() => toggleFullscreen()}
+          onClose={() => closeTab()}
         />
         {children}
       </div>

--- a/crates/openwave-desktop/ui/src/panel/PanelLayout.tsx
+++ b/crates/openwave-desktop/ui/src/panel/PanelLayout.tsx
@@ -3,70 +3,67 @@ import { Panel, PanelGroup, type ImperativePanelGroupHandle } from "react-resiza
 
 import { cn } from "@/lib/utils";
 import { PanelDragHandle } from "./PanelDragHandle";
-import type { LayoutState, PanelContent } from "./panelTypes";
+import { PanelTabs } from "./PanelTabs";
+import { activePanel, type LayoutState, type PanelContent } from "./panelTypes";
+import { usePanelNav } from "./usePanelNav";
 
 const MIN_PANEL_SIZE = 25;
 const MAX_PANEL_SIZE = 75;
 
 /**
- * Three slots — left, conversation, right — of which any may be empty.
+ * Two regions: the conversation, and the panels open beside it.
+ *
+ * The conversation is always mounted and never displaced — a panel expanded
+ * over it only takes the width, because its pollers for pending approvals and
+ * questions have to keep running behind it.
  *
  * Sizes are driven imperatively rather than through `defaultSize`, because the
- * arrangement is a function of the URL and the panels have to follow it even
- * when the reader has since dragged them somewhere else. Panels take a dynamic
- * `minSize` of zero while hidden instead of being `collapsible`, so a drag can
- * never squeeze one out of existence — only closing it can.
+ * arrangement is a function of the URL and the regions have to follow it even
+ * when the reader has since dragged them somewhere else. A hidden region takes
+ * a dynamic `minSize` of zero instead of being `collapsible`, so a drag can
+ * never squeeze one out of existence — only closing the tabs can.
  *
- * The whole arrangement is applied in one `setLayout` rather than resizing each
- * panel in turn: sequential resizes are each clamped by the others' current
- * bounds, so an intermediate step can be rejected and leave the group somewhere
- * nobody asked for.
+ * The whole arrangement is applied in one `setLayout` rather than resizing
+ * each region in turn: sequential resizes are each clamped by the other's
+ * current bounds, so an intermediate step can be rejected and leave the group
+ * somewhere nobody asked for.
  */
 export function PanelLayout({
   layout,
+  renderChat,
   renderPanel,
 }: {
   layout: LayoutState;
   /**
-   * `visible` is false for a slot that has been sized out of the arrangement.
-   * The conversation is rendered either way — its pollers for pending approvals
-   * and questions have to keep running while a panel is expanded over it — so
-   * the body is told rather than unmounted.
+   * `visible` is false while a panel is expanded over the conversation. The
+   * conversation is rendered either way, so the body is told rather than
+   * unmounted.
    */
-  renderPanel: (
-    panel: PanelContent,
-    position: "left" | "right" | "chat",
-    visible: boolean,
-  ) => ReactNode;
+  renderChat: (visible: boolean) => ReactNode;
+  /** Only the tab showing is rendered; the rest are addresses, not mounts. */
+  renderPanel: (panel: PanelContent) => ReactNode;
 }) {
   const groupRef = useRef<ImperativePanelGroupHandle>(null);
   const [dragging, setDragging] = useState(false);
+  const { focusTab, closeTab } = usePanelNav();
 
-  const isSplit = layout.mode === "split";
-  const fullscreen = isSplit ? layout.fullscreen : undefined;
-  const leftPanel = isSplit && layout.left.type !== "chat" ? layout.left : null;
-  const rightPanel = isSplit && layout.right.type !== "chat" ? layout.right : null;
-  const bothOpen = Boolean(leftPanel && rightPanel);
+  const hasTabs = layout.tabs.length > 0;
+  const fullscreen = hasTabs && layout.fullscreen;
+  const panel = activePanel(layout);
 
   useEffect(() => {
     const group = groupRef.current;
-    // Before the group has registered its panels there is no layout to replace,
-    // and handing it one is rejected outright. The panels' own defaults already
-    // describe the arrangement at that point.
+    // Before the group has registered its regions there is no layout to
+    // replace, and handing it one is rejected outright. The regions' own
+    // defaults already describe the arrangement at that point.
     if (!group || group.getLayout().length === 0) return;
-    group.setLayout(
-      panelSizes({ isSplit, fullscreen, hasLeft: Boolean(leftPanel), hasRight: Boolean(rightPanel) }),
-    );
-  }, [isSplit, fullscreen, leftPanel, rightPanel]);
+    group.setLayout(panelSizes({ hasTabs, fullscreen }));
+  }, [hasTabs, fullscreen]);
 
-  const initialSizesRef = useRef(
-    panelSizes({ isSplit, fullscreen, hasLeft: Boolean(leftPanel), hasRight: Boolean(rightPanel) }),
-  );
+  const initialSizesRef = useRef(panelSizes({ hasTabs, fullscreen }));
   const initialSizes = initialSizesRef.current;
 
-  const showLeft = isSplit && Boolean(leftPanel);
-  const showChat = !isSplit || (!fullscreen && !bothOpen);
-  const showRight = isSplit && Boolean(rightPanel);
+  const showChat = !fullscreen;
 
   return (
     <PanelGroup
@@ -82,63 +79,55 @@ export function PanelLayout({
     >
       <Panel
         order={1}
-        minSize={showLeft && !fullscreen ? MIN_PANEL_SIZE : 0}
-        maxSize={showLeft && !fullscreen ? MAX_PANEL_SIZE : 100}
+        minSize={showChat ? (hasTabs ? MIN_PANEL_SIZE : 100) : 0}
+        maxSize={showChat ? (hasTabs ? MAX_PANEL_SIZE : 100) : 0}
         defaultSize={initialSizes[0]}
         className="panel-animated"
       >
-        {showLeft && leftPanel && renderPanel(leftPanel, "left", true)}
+        {renderChat(showChat)}
       </Panel>
 
-      <PanelDragHandle disabled={!showLeft || (!bothOpen && !showChat)} onDragging={setDragging} />
+      <PanelDragHandle disabled={!hasTabs || Boolean(fullscreen)} onDragging={setDragging} />
 
       <Panel
         order={2}
-        minSize={showChat ? MIN_PANEL_SIZE : 0}
-        maxSize={showChat ? 100 : 0}
+        minSize={hasTabs && !fullscreen ? MIN_PANEL_SIZE : 0}
+        maxSize={hasTabs ? 100 : 0}
         defaultSize={initialSizes[1]}
         className="panel-animated"
       >
-        {renderPanel({ type: "chat" }, "chat", showChat)}
-      </Panel>
-
-      <PanelDragHandle disabled={!showRight || bothOpen || !showChat} onDragging={setDragging} />
-
-      <Panel
-        order={3}
-        minSize={showRight && !fullscreen ? MIN_PANEL_SIZE : 0}
-        maxSize={showRight && !fullscreen ? MAX_PANEL_SIZE : 100}
-        defaultSize={initialSizes[2]}
-        className="panel-animated"
-      >
-        {showRight && rightPanel && renderPanel(rightPanel, "right", true)}
+        {panel && (
+          <div className="flex h-full w-full min-w-0 flex-col overflow-clip">
+            <div className="shrink-0 px-1 pt-1">
+              <PanelTabs
+                tabs={layout.tabs}
+                activeIndex={layout.activeIndex}
+                onSelect={focusTab}
+                onClose={closeTab}
+              />
+            </div>
+            <div className="flex min-h-0 flex-1 flex-col">{renderPanel(panel)}</div>
+          </div>
+        )}
       </Panel>
     </PanelGroup>
   );
 }
 
 /**
- * The share each slot takes, as `[left, chat, right]`.
+ * The share each region takes, as `[chat, panels]`.
  *
- * Two panels open leaves the conversation nothing: half a panel each is
- * readable, three columns is not.
+ * Nothing open leaves the conversation the window; anything open splits it,
+ * and an expanded panel takes all of it.
  */
 export function panelSizes({
-  isSplit,
+  hasTabs,
   fullscreen,
-  hasLeft,
-  hasRight,
 }: {
-  isSplit: boolean;
-  fullscreen?: "left" | "right";
-  hasLeft: boolean;
-  hasRight: boolean;
-}): [number, number, number] {
-  if (!isSplit) return [0, 100, 0];
-  if (fullscreen === "left") return [100, 0, 0];
-  if (fullscreen === "right") return [0, 0, 100];
-  if (hasLeft && hasRight) return [50, 0, 50];
-  if (hasLeft) return [50, 50, 0];
-  if (hasRight) return [0, 50, 50];
-  return [0, 100, 0];
+  hasTabs: boolean;
+  fullscreen?: boolean;
+}): [number, number] {
+  if (!hasTabs) return [100, 0];
+  if (fullscreen) return [0, 100];
+  return [50, 50];
 }

--- a/crates/openwave-desktop/ui/src/panel/PanelTabs.tsx
+++ b/crates/openwave-desktop/ui/src/panel/PanelTabs.tsx
@@ -1,0 +1,113 @@
+import { Bot, FileText, FolderOpen, LayoutGrid, Package, Shapes, X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { panelKey, type PanelContent } from "./panelTypes";
+
+/**
+ * What a tab says it is.
+ *
+ * Nothing here fetches: the strip has to be right the moment a panel opens,
+ * before the panel behind it has loaded anything, so a tab names the kind of
+ * thing it holds rather than the title of the particular one. The panel's own
+ * header carries the title once it has it.
+ */
+function panelTabLabel(panel: PanelContent): string {
+  switch (panel.type) {
+    case "document":
+      return "Document";
+    case "outputs":
+      return panel.outputId ? "Output" : "Outputs";
+    case "folders":
+      return "Folders";
+    case "apps":
+      return "Apps";
+    case "plugins":
+      return "Plugins";
+    case "agent":
+      return "Agent";
+  }
+}
+
+function PanelTabIcon({ panel }: { panel: PanelContent }) {
+  const className = "size-3.5 shrink-0";
+  switch (panel.type) {
+    case "document":
+      return <FileText className={className} />;
+    case "outputs":
+      return <Package className={className} />;
+    case "folders":
+      return <FolderOpen className={className} />;
+    case "apps":
+      return <LayoutGrid className={className} />;
+    case "plugins":
+      return <Shapes className={className} />;
+    case "agent":
+      return <Bot className={className} />;
+  }
+}
+
+/**
+ * The strip above the region: one tab per open panel, the active one lifted
+ * out of the muted trough the way the in-panel view switchers are.
+ *
+ * The close control is a sibling of the tab button rather than nested inside
+ * it — a button inside a button is not valid markup, and clicking the ✕ should
+ * not first select the tab it is about to remove.
+ */
+export function PanelTabs({
+  tabs,
+  activeIndex,
+  onSelect,
+  onClose,
+}: {
+  tabs: PanelContent[];
+  activeIndex: number;
+  onSelect: (index: number) => void;
+  onClose: (index: number) => void;
+}) {
+  if (tabs.length === 0) return null;
+
+  return (
+    <div
+      role="tablist"
+      aria-label="Open panels"
+      className="flex shrink-0 items-center gap-1 overflow-x-auto rounded-lg bg-muted p-1"
+    >
+      {tabs.map((panel, index) => {
+        const active = index === activeIndex;
+        const label = panelTabLabel(panel);
+        return (
+          <div
+            key={panelKey(panel)}
+            className={cn(
+              "group flex min-w-0 shrink-0 items-center rounded-md pr-1 transition-colors",
+              active ? "bg-background shadow-sm" : "hover:bg-background/50",
+            )}
+          >
+            <button
+              type="button"
+              role="tab"
+              aria-selected={active}
+              onClick={() => onSelect(index)}
+              className={cn(
+                "flex min-w-0 cursor-pointer items-center gap-1.5 rounded-md py-1 pl-2 pr-1 text-xs font-medium whitespace-nowrap transition-colors",
+                active ? "text-foreground" : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <PanelTabIcon panel={panel} />
+              <span className="max-w-40 truncate">{label}</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => onClose(index)}
+              className="grid size-4 shrink-0 cursor-pointer place-items-center rounded-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <X className="size-3" />
+              <span className="sr-only">{`Close ${label}`}</span>
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/crates/openwave-desktop/ui/src/panel/panelSizes.test.ts
+++ b/crates/openwave-desktop/ui/src/panel/panelSizes.test.ts
@@ -2,42 +2,18 @@ import { describe, expect, it } from "vitest";
 
 import { panelSizes } from "./PanelLayout";
 
-const NOTHING_OPEN = { isSplit: false, hasLeft: false, hasRight: false };
-
 describe("panelSizes", () => {
-  it("gives the conversation everything when nothing else is open", () => {
-    expect(panelSizes(NOTHING_OPEN)).toEqual([0, 100, 0]);
+  it("gives the conversation the window when nothing is open beside it", () => {
+    expect(panelSizes({ hasTabs: false })).toEqual([100, 0]);
+    // Expanding is meaningless with nothing to expand.
+    expect(panelSizes({ hasTabs: false, fullscreen: true })).toEqual([100, 0]);
   });
 
-  it("splits evenly with one panel open", () => {
-    expect(panelSizes({ isSplit: true, hasLeft: true, hasRight: false })).toEqual([50, 50, 0]);
-    expect(panelSizes({ isSplit: true, hasLeft: false, hasRight: true })).toEqual([0, 50, 50]);
+  it("splits evenly with panels open", () => {
+    expect(panelSizes({ hasTabs: true })).toEqual([50, 50]);
   });
 
-  it("steps the conversation out when both slots are taken", () => {
-    // Three columns in a desktop window is not a readable transcript.
-    expect(panelSizes({ isSplit: true, hasLeft: true, hasRight: true })).toEqual([50, 0, 50]);
-  });
-
-  it("gives a fullscreen panel the whole width", () => {
-    expect(
-      panelSizes({ isSplit: true, hasLeft: true, hasRight: true, fullscreen: "left" }),
-    ).toEqual([100, 0, 0]);
-    expect(
-      panelSizes({ isSplit: true, hasLeft: true, hasRight: true, fullscreen: "right" }),
-    ).toEqual([0, 0, 100]);
-  });
-
-  it("always totals a full width", () => {
-    for (const fullscreen of [undefined, "left", "right"] as const) {
-      for (const hasLeft of [false, true]) {
-        for (const hasRight of [false, true]) {
-          for (const isSplit of [false, true]) {
-            const sizes = panelSizes({ isSplit, fullscreen, hasLeft, hasRight });
-            expect(sizes.reduce((total, size) => total + size, 0)).toBe(100);
-          }
-        }
-      }
-    }
+  it("hands the window to an expanded panel", () => {
+    expect(panelSizes({ hasTabs: true, fullscreen: true })).toEqual([0, 100]);
   });
 });

--- a/crates/openwave-desktop/ui/src/panel/panelTypes.ts
+++ b/crates/openwave-desktop/ui/src/panel/panelTypes.ts
@@ -1,11 +1,9 @@
 /**
- * The workspace is a pair of slots either side of the conversation, and a panel
- * is whatever is in one of them. Chat is a panel like any other rather than the
- * frame the others hang off — that is what lets a chat with a project and a
- * chat without one share a single layout.
+ * The workspace is the conversation and, beside it, a region of open panels.
+ * The conversation is always there — it is the frame, not a panel — and
+ * everything else opens as a tab in the region to its right.
  */
 export type PanelContent =
-  | { type: "chat" }
   /**
    * `citationId` is where in the document to open: the citation it names
    * carries the cited span and page. It only means anything alongside the
@@ -30,45 +28,39 @@ export type PanelContent =
 
 export type PanelType = PanelContent["type"];
 
-export type PanelPosition = "left" | "right";
+/**
+ * The open panels, which one is showing, and whether the region has taken the
+ * whole window. No tabs is the bare URL: the conversation alone.
+ */
+export type LayoutState = {
+  tabs: PanelContent[];
+  activeIndex: number;
+  fullscreen: boolean;
+};
+
+export const EMPTY_LAYOUT: LayoutState = { tabs: [], activeIndex: 0, fullscreen: false };
 
 /**
- * Either the conversation alone, or two slots with the conversation possibly
- * squeezed out between them. `single` is the bare URL with no search params, so
- * the common case leaves no trail.
+ * What makes two panels the same tab.
+ *
+ * A library and the item drilled into from it are one panel showing something
+ * else, not two — the Apps list and an app's detail share a tab, and clicking
+ * Folders again lands on the tab already open. Documents and agent runs are
+ * addressed by identity instead, so two documents are two tabs while
+ * re-opening one at a different citation moves within the tab it already has.
  */
-export type LayoutState =
-  | { mode: "single"; panel: PanelContent }
-  | {
-      mode: "split";
-      left: PanelContent;
-      right: PanelContent;
-      fullscreen?: PanelPosition;
-    };
-
-export function areSamePanelType(a: PanelContent, b: PanelContent): boolean {
-  return a.type === b.type;
+export function panelKey(panel: PanelContent): string {
+  switch (panel.type) {
+    case "document":
+      return `document:${panel.documentId}`;
+    case "agent":
+      return `agent:${panel.runId}`;
+    default:
+      return panel.type;
+  }
 }
 
-/**
- * Navigation panels are lists you pick from; content panels are the thing you
- * picked. Navigation settles on the left, content on the right, and closing a
- * panel returns whatever is left to its own side rather than leaving it
- * stranded where the other panel happened to put it.
- */
-export function isContentPanel(panel: PanelContent): boolean {
-  switch (panel.type) {
-    case "chat":
-    case "folders":
-    case "apps":
-    case "plugins":
-      return false;
-    case "outputs":
-      // The outputs list is navigation; a single opened output is the thing
-      // you picked, and reads on the content side like a document does.
-      return panel.outputId !== undefined;
-    case "document":
-    case "agent":
-      return true;
-  }
+/** The panel currently showing in the region, or `null` when nothing is open. */
+export function activePanel(layout: LayoutState): PanelContent | null {
+  return layout.tabs[layout.activeIndex] ?? null;
 }

--- a/crates/openwave-desktop/ui/src/panel/panelUrl.test.ts
+++ b/crates/openwave-desktop/ui/src/panel/panelUrl.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 
 import {
   encodePanelSegment,
-  isValidLayout,
   layoutFromSearch,
   parsePanelSegment,
   searchFromLayout,
@@ -10,27 +9,26 @@ import {
 
 describe("panel URLs", () => {
   it("reads navigation panels and addressed document viewers", () => {
-    expect(parsePanelSegment("chat")).toEqual({ type: "chat" });
     expect(parsePanelSegment("outputs")).toEqual({ type: "outputs" });
     expect(parsePanelSegment("folders")).toEqual({ type: "folders" });
-    expect(parsePanelSegment("apps")).toEqual({ type: "apps" });
     expect(parsePanelSegment("apps.app-1")).toEqual({ type: "apps", appId: "app-1" });
-    expect(parsePanelSegment("plugins")).toEqual({ type: "plugins" });
     expect(parsePanelSegment("plugins.documents")).toEqual({
       type: "plugins",
       pluginId: "documents",
     });
     expect(parsePanelSegment("agent.run-1")).toEqual({ type: "agent", runId: "run-1" });
     expect(parsePanelSegment("agent")).toBeNull();
-    expect(parsePanelSegment("document.doc-1")).toEqual({
-      type: "document",
-      documentId: "doc-1",
-    });
     expect(parsePanelSegment("document.doc-1.cite-1")).toEqual({
       type: "document",
       documentId: "doc-1",
       citationId: "cite-1",
     });
+  });
+
+  // The conversation holds its own region now; a URL still naming it as a
+  // panel is describing a tab that does not exist.
+  it("no longer reads the conversation as a panel", () => {
+    expect(parsePanelSegment("chat")).toBeNull();
   });
 
   it("keeps historical source detail links but retires the bare catalog", () => {
@@ -51,13 +49,12 @@ describe("panel URLs", () => {
 
   it("round-trips every current panel shape", () => {
     for (const panel of [
-      { type: "chat" },
       { type: "document", documentId: "doc-1" },
       { type: "document", documentId: "doc-1", citationId: "cite-1" },
       { type: "outputs" },
       { type: "outputs", outputId: "output-1" },
       { type: "folders" },
-      { type: "plugins" },
+      { type: "apps" },
       { type: "plugins", pluginId: "documents" },
       { type: "agent", runId: "run-1" },
     ] as const) {
@@ -67,50 +64,88 @@ describe("panel URLs", () => {
 });
 
 describe("layout URLs", () => {
-  const single = { mode: "single", panel: { type: "chat" } } as const;
+  const alone = { tabs: [], activeIndex: 0, fullscreen: false };
 
   it("uses a bare URL for the conversation alone", () => {
-    expect(layoutFromSearch({})).toEqual(single);
-    expect(searchFromLayout(single)).toEqual({
+    expect(layoutFromSearch({})).toEqual(alone);
+    expect(searchFromLayout(alone)).toEqual({
+      tabs: undefined,
+      active: undefined,
+      fullscreen: undefined,
       left: undefined,
       right: undefined,
-      fullscreen: undefined,
     });
   });
 
-  it("fills the unnamed side with the conversation", () => {
-    expect(layoutFromSearch({ right: "document.doc-1" })).toEqual({
-      mode: "split",
-      left: { type: "chat" },
-      right: { type: "document", documentId: "doc-1" },
-      fullscreen: undefined,
-    });
-  });
-
-  it("falls back rather than opening a stale bare sources panel", () => {
-    expect(layoutFromSearch({ left: "sources" })).toEqual(single);
-    expect(layoutFromSearch({ left: "chat", right: "chat" })).toEqual(single);
-  });
-
-  it("round-trips a split document layout", () => {
+  it("round-trips a strip of tabs with one of them showing", () => {
     const layout = {
-      mode: "split",
-      left: { type: "chat" },
-      right: { type: "document", documentId: "doc-1" },
-      fullscreen: "right",
-    } as const;
+      tabs: [
+        { type: "folders" as const },
+        { type: "document" as const, documentId: "doc-1", citationId: "cite-2" },
+      ],
+      activeIndex: 1,
+      fullscreen: true,
+    };
+
+    expect(searchFromLayout(layout)).toMatchObject({
+      tabs: "folders,document.doc-1.cite-2",
+      active: "document.doc-1.cite-2",
+      fullscreen: "1",
+    });
     expect(layoutFromSearch(searchFromLayout(layout))).toEqual(layout);
   });
 
-  it("refuses two document viewers in one layout", () => {
+  it("falls back to the first tab when nothing usable is named active", () => {
+    expect(layoutFromSearch({ tabs: "folders,outputs", active: "apps" }).activeIndex).toBe(0);
+    expect(layoutFromSearch({ tabs: "folders,outputs" }).activeIndex).toBe(0);
+  });
+
+  it("drops segments that address nothing, and the conversation with them", () => {
+    expect(layoutFromSearch({ tabs: "chat,folders,nonsense" })).toEqual({
+      tabs: [{ type: "folders" }],
+      activeIndex: 0,
+      fullscreen: false,
+    });
+    expect(layoutFromSearch({ tabs: "chat" })).toEqual(alone);
+  });
+
+  it("reads one tab per panel however often the URL names it", () => {
+    // Both segments address the same document, which is one tab open at one
+    // of the two places in it.
+    expect(layoutFromSearch({ tabs: "document.doc-1,document.doc-1.cite-2" }).tabs).toEqual([
+      { type: "document", documentId: "doc-1" },
+    ]);
+  });
+
+  it("restores a link written in the retired pair-of-slots grammar", () => {
+    expect(layoutFromSearch({ left: "folders", right: "document.doc-1" })).toEqual({
+      tabs: [{ type: "folders" }, { type: "document", documentId: "doc-1" }],
+      activeIndex: 0,
+      fullscreen: false,
+    });
+    // The conversation used to fill the slot it was not sharing.
+    expect(layoutFromSearch({ left: "chat", right: "outputs.out-9" })).toEqual({
+      tabs: [{ type: "outputs", outputId: "out-9" }],
+      activeIndex: 0,
+      fullscreen: false,
+    });
+    expect(layoutFromSearch({ left: "chat", right: "chat" })).toEqual(alone);
+  });
+
+  it("carries a legacy expanded panel over, but not an expanded conversation", () => {
     expect(
-      isValidLayout(
-        { type: "document", documentId: "a" },
-        { type: "document", documentId: "b" },
-      ),
-    ).toBe(false);
+      layoutFromSearch({ left: "chat", right: "document.doc-1", fullscreen: "right" }),
+    ).toMatchObject({ fullscreen: true });
     expect(
-      isValidLayout({ type: "document", documentId: "a" }, { type: "chat" }),
-    ).toBe(true);
+      layoutFromSearch({ left: "chat", right: "document.doc-1", fullscreen: "left" }),
+    ).toMatchObject({ fullscreen: false });
+  });
+
+  it("clears the retired params whenever it writes a layout", () => {
+    expect(searchFromLayout(layoutFromSearch({ left: "folders" }))).toMatchObject({
+      tabs: "folders",
+      left: undefined,
+      right: undefined,
+    });
   });
 });

--- a/crates/openwave-desktop/ui/src/panel/panelUrl.ts
+++ b/crates/openwave-desktop/ui/src/panel/panelUrl.ts
@@ -1,9 +1,4 @@
-import {
-  areSamePanelType,
-  type LayoutState,
-  type PanelContent,
-  type PanelPosition,
-} from "./panelTypes";
+import { EMPTY_LAYOUT, panelKey, type LayoutState, type PanelContent } from "./panelTypes";
 
 /**
  * Panels are addressed by the URL, so a layout can be restored, gone back to,
@@ -13,7 +8,6 @@ import {
  * The grammar is `{type}` or `{type}.{id}`, with one document panel taking a
  * second identifier:
  *
- *   chat
  *   document.{documentId}
  *   document.{documentId}.{citationId}
  *   outputs
@@ -29,6 +23,9 @@ import {
  * panel and nothing else. Output navigation carries the durable opaque output
  * identity rather than a display filename. A source identifier is followed by
  * the citation to open it at, when the reader arrived from one.
+ *
+ * The conversation has no segment: it is beside the region rather than in it,
+ * so it is not something the URL has to say.
  */
 export function parsePanelSegment(segment: string): PanelContent | null {
   const separator = segment.indexOf(".");
@@ -36,8 +33,6 @@ export function parsePanelSegment(segment: string): PanelContent | null {
   const id = separator === -1 ? "" : segment.slice(separator + 1);
 
   switch (type) {
-    case "chat":
-      return id ? null : { type: "chat" };
     case "folders":
       return id ? null : { type: "folders" };
     case "document":
@@ -75,8 +70,6 @@ function parseDocumentTarget(id: string): PanelContent | null {
 
 export function encodePanelSegment(panel: PanelContent): string {
   switch (panel.type) {
-    case "chat":
-      return "chat";
     case "folders":
       return "folders";
     case "document":
@@ -94,51 +87,96 @@ export function encodePanelSegment(panel: PanelContent): string {
   }
 }
 
-export function parseFullscreenParam(value: string | undefined): PanelPosition | undefined {
-  return value === "left" || value === "right" ? value : undefined;
-}
-
-/** The same panel on both sides is not a layout anyone asked for. */
-export function isValidLayout(left: PanelContent, right: PanelContent): boolean {
-  return !areSamePanelType(left, right);
-}
-
 export type PanelSearch = {
+  /** The open tabs, in strip order, as a comma-separated list of segments. */
+  tabs?: string;
+  /** The segment of the tab showing; absent means the first one. */
+  active?: string;
+  /** `"1"` when the region has taken the whole window. */
+  fullscreen?: string;
+  /**
+   * The retired pair-of-slots grammar. Read on the way in so older links and
+   * already-open windows still land somewhere; never written back out.
+   */
   left?: string;
   right?: string;
-  fullscreen?: string;
 };
 
+const TAB_SEPARATOR = ",";
+
 /**
- * Read a layout out of the URL, falling back to the conversation alone whenever
- * the search params do not describe a usable one. A hand-edited or stale URL
- * should land the reader somewhere sensible rather than on an error.
+ * Read a layout out of the URL, falling back to the conversation alone
+ * whenever the search params do not describe a usable one. A hand-edited or
+ * stale URL should land the reader somewhere sensible rather than on an error.
  */
 export function layoutFromSearch(search: PanelSearch): LayoutState {
-  const single: LayoutState = { mode: "single", panel: { type: "chat" } };
-  if (!search.left && !search.right) return single;
+  const segments =
+    search.tabs !== undefined
+      ? search.tabs.split(TAB_SEPARATOR)
+      : // The old grammar named one panel per side; left came first on screen,
+        // so it comes first in the strip. `chat` was a slot filler and parses
+        // as nothing, which is what drops it here.
+        [search.left, search.right].filter((value): value is string => Boolean(value));
 
-  const left = search.left ? parsePanelSegment(search.left) : { type: "chat" as const };
-  const right = search.right ? parsePanelSegment(search.right) : { type: "chat" as const };
-  if (!left || !right || !isValidLayout(left, right)) return single;
-  if (left.type === "chat" && right.type === "chat") return single;
+  const tabs: PanelContent[] = [];
+  const seen = new Set<string>();
+  for (const segment of segments) {
+    const panel = parsePanelSegment(segment.trim());
+    if (!panel) continue;
+    const key = panelKey(panel);
+    // A URL naming the same panel twice describes one tab, not two.
+    if (seen.has(key)) continue;
+    seen.add(key);
+    tabs.push(panel);
+  }
+  if (tabs.length === 0) return EMPTY_LAYOUT;
 
   return {
-    mode: "split",
-    left,
-    right,
-    fullscreen: parseFullscreenParam(search.fullscreen),
+    tabs,
+    activeIndex: activeIndexFromSearch(search, tabs),
+    fullscreen: isFullscreenParam(search),
   };
 }
 
-/** The inverse of {@link layoutFromSearch}: `single` clears the params entirely. */
-export function searchFromLayout(layout: LayoutState): PanelSearch {
-  if (layout.mode === "single") {
-    return { left: undefined, right: undefined, fullscreen: undefined };
+function activeIndexFromSearch(search: PanelSearch, tabs: PanelContent[]): number {
+  const named = search.active ? parsePanelSegment(search.active) : null;
+  if (named) {
+    const index = tabs.findIndex((tab) => panelKey(tab) === panelKey(named));
+    if (index !== -1) return index;
   }
+  // In a legacy link the expanded side is the one the reader was looking at.
+  if (search.tabs === undefined && search.fullscreen === "right" && tabs.length > 1) {
+    return tabs.length - 1;
+  }
+  return 0;
+}
+
+function isFullscreenParam(search: PanelSearch): boolean {
+  if (search.tabs !== undefined) return search.fullscreen === "1";
+  // The old grammar named the expanded side. Only a side that actually held a
+  // panel survives as fullscreen — an expanded conversation is now just the
+  // conversation with nothing beside it.
+  const expanded = search.fullscreen === "left" ? search.left : search.right;
+  if (search.fullscreen !== "left" && search.fullscreen !== "right") return false;
+  return Boolean(expanded && parsePanelSegment(expanded));
+}
+
+/**
+ * The inverse of {@link layoutFromSearch}. No tabs clears the params entirely,
+ * and the retired slot params are always cleared, so a legacy URL is rewritten
+ * the first time the layout changes.
+ */
+export function searchFromLayout(layout: LayoutState): PanelSearch {
+  const cleared = { left: undefined, right: undefined };
+  if (layout.tabs.length === 0) {
+    return { ...cleared, tabs: undefined, active: undefined, fullscreen: undefined };
+  }
+  const active = layout.tabs[layout.activeIndex];
   return {
-    left: encodePanelSegment(layout.left),
-    right: encodePanelSegment(layout.right),
-    fullscreen: layout.fullscreen,
+    ...cleared,
+    tabs: layout.tabs.map(encodePanelSegment).join(TAB_SEPARATOR),
+    // The first tab is the default, so naming it would only lengthen the URL.
+    active: layout.activeIndex > 0 && active ? encodePanelSegment(active) : undefined,
+    fullscreen: layout.fullscreen ? "1" : undefined,
   };
 }

--- a/crates/openwave-desktop/ui/src/panel/usePanelNav.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/panel/usePanelNav.dom.test.tsx
@@ -10,22 +10,23 @@ import { usePanelNav } from "./usePanelNav";
 afterEach(cleanup);
 
 function Harness() {
-  const { openPanel, closePanel, toggleFullscreen } = usePanelNav();
+  const { layout, openPanel, closeTab, closeAllPanels, toggleFullscreen } = usePanelNav();
   const sourceNav = useStableSourceNav(openPanel);
   return (
     <div>
       <button onClick={() => openPanel({ type: "folders" })}>open folders</button>
       <button onClick={() => openPanel({ type: "outputs" })}>open outputs</button>
+      <button onClick={() => openPanel({ type: "apps", appId: "app-1" })}>open app</button>
       <button
-        onClick={() =>
-          sourceNav.openCitation({ documentId: "doc-2", citationId: "cite-1" })
-        }
+        onClick={() => sourceNav.openCitation({ documentId: "doc-2", citationId: "cite-1" })}
       >
         open citation
       </button>
-      <button onClick={() => closePanel("left")}>close left</button>
-      <button onClick={() => closePanel("right")}>close right</button>
-      <button onClick={() => toggleFullscreen("left")}>fullscreen left</button>
+      <button onClick={() => closeTab()}>close active</button>
+      <button onClick={() => closeTab({ type: "folders" })}>close folders</button>
+      <button onClick={() => closeAllPanels()}>close all</button>
+      <button onClick={() => toggleFullscreen()}>fullscreen</button>
+      <output>{`${layout.tabs.length}:${layout.activeIndex}`}</output>
     </div>
   );
 }
@@ -35,92 +36,109 @@ async function mount(initialUrl: string) {
 }
 
 describe("usePanelNav", () => {
-  it("opens a navigation panel on the left, leaving the conversation beside it", async () => {
+  it("appends each newly opened panel and shows it", async () => {
     const user = userEvent.setup();
     const { router } = await mount("/c/chat-1");
 
     await user.click(screen.getByText("open folders"));
-
-    await waitFor(() =>
-      expect(router.state.location.search).toEqual({ left: "folders", right: "chat" }),
-    );
-  });
-
-  it("replaces a panel that belongs on the same side", async () => {
-    const user = userEvent.setup();
-    const { router } = await mount("/c/chat-1?left=folders&right=chat");
+    await waitFor(() => expect(router.state.location.search).toEqual({ tabs: "folders" }));
 
     await user.click(screen.getByText("open outputs"));
-
     await waitFor(() =>
-      expect(router.state.location.search).toEqual({ left: "outputs", right: "chat" }),
+      expect(router.state.location.search).toEqual({
+        tabs: "folders,outputs",
+        active: "outputs",
+      }),
     );
   });
 
-  // A citation is clicked in the transcript, which in a split layout is one of
-  // the two slots. The document has to arrive beside it: replacing the
-  // conversation with the source it cites takes away the thing being read.
-  it("opens a citation beside the conversation rather than over it", async () => {
+  it("brings an open panel forward rather than opening it twice", async () => {
     const user = userEvent.setup();
-    // Another source is already open, and the conversation is fullscreen — the
-    // reader is reading it, and the citation they clicked is in it.
-    const { router } = await mount(
-      "/c/chat-1?left=chat&right=document.doc-1&fullscreen=left",
+    const { router } = await mount("/c/chat-1?tabs=folders,outputs&active=outputs");
+
+    await user.click(screen.getByText("open folders"));
+
+    await waitFor(() =>
+      expect(router.state.location.search).toEqual({ tabs: "folders,outputs" }),
     );
+  });
+
+  // A library and the item drilled into from it are one panel showing
+  // something else, so opening the detail moves the tab rather than adding one.
+  it("updates the tab in place when the panel it holds is addressed again", async () => {
+    const user = userEvent.setup();
+    const { router } = await mount("/c/chat-1?tabs=apps");
+
+    await user.click(screen.getByText("open app"));
+
+    await waitFor(() => expect(router.state.location.search).toEqual({ tabs: "apps.app-1" }));
+  });
+
+  it("opens a citation beside the conversation, keeping what was already open", async () => {
+    const user = userEvent.setup();
+    const { router } = await mount("/c/chat-1?tabs=document.doc-1");
 
     await user.click(screen.getByText("open citation"));
 
     await waitFor(() =>
       expect(router.state.location.search).toEqual({
-        left: "chat",
-        right: "document.doc-2.cite-1",
+        tabs: "document.doc-1,document.doc-2.cite-1",
+        active: "document.doc-2.cite-1",
       }),
     );
   });
 
-  it("collapses to the bare URL when the survivor is the conversation", async () => {
+  it("hands focus to the neighbour on the left when the open tab closes", async () => {
     const user = userEvent.setup();
-    const { router } = await mount("/c/chat-1?left=folders&right=chat");
+    const { router } = await mount("/c/chat-1?tabs=folders,outputs&active=outputs");
 
-    await user.click(screen.getByText("close left"));
+    await user.click(screen.getByText("close active"));
+
+    await waitFor(() => expect(router.state.location.search).toEqual({ tabs: "folders" }));
+  });
+
+  it("keeps showing the same panel when a tab beside it closes", async () => {
+    const user = userEvent.setup();
+    const { router } = await mount("/c/chat-1?tabs=folders,outputs&active=outputs");
+
+    await user.click(screen.getByText("close folders"));
+
+    await waitFor(() => expect(router.state.location.search).toEqual({ tabs: "outputs" }));
+  });
+
+  it("returns to the conversation alone when the last tab closes", async () => {
+    const user = userEvent.setup();
+    const { router } = await mount("/c/chat-1?tabs=folders");
+
+    await user.click(screen.getByText("close active"));
 
     await waitFor(() => expect(router.state.location.search).toEqual({}));
   });
 
-  it("returns the survivor to its own side rather than leaving it stranded", async () => {
+  it("closes every panel at once", async () => {
     const user = userEvent.setup();
-    // Folders sits on the right here, which is not where a navigation panel
-    // belongs; closing the other slot should move it home.
-    const { router } = await mount("/c/chat-1?left=outputs&right=folders");
+    const { router } = await mount("/c/chat-1?tabs=folders,outputs&fullscreen=1");
 
-    await user.click(screen.getByText("close left"));
+    await user.click(screen.getByText("close all"));
 
-    await waitFor(() =>
-      expect(router.state.location.search).toEqual({ left: "folders", right: "chat" }),
-    );
+    await waitFor(() => expect(router.state.location.search).toEqual({}));
   });
 
-  it("toggles fullscreen on and back off", async () => {
+  it("toggles fullscreen on and back off, and not at all with nothing open", async () => {
     const user = userEvent.setup();
-    const { router } = await mount("/c/chat-1?left=folders&right=chat");
+    const { router } = await mount("/c/chat-1?tabs=folders");
 
-    await user.click(screen.getByText("fullscreen left"));
+    await user.click(screen.getByText("fullscreen"));
     await waitFor(() =>
-      expect(router.state.location.search).toMatchObject({ fullscreen: "left" }),
+      expect(router.state.location.search).toEqual({ tabs: "folders", fullscreen: "1" }),
     );
 
-    await user.click(screen.getByText("fullscreen left"));
-    await waitFor(() =>
-      expect(router.state.location.search).toEqual({ left: "folders", right: "chat" }),
-    );
-  });
+    await user.click(screen.getByText("fullscreen"));
+    await waitFor(() => expect(router.state.location.search).toEqual({ tabs: "folders" }));
 
-  it("does nothing on a conversation with no panels open", async () => {
-    const user = userEvent.setup();
-    const { router } = await mount("/c/chat-1");
-
-    await user.click(screen.getByText("fullscreen left"));
-
+    await user.click(screen.getByText("close active"));
+    await waitFor(() => expect(router.state.location.search).toEqual({}));
+    await user.click(screen.getByText("fullscreen"));
     expect(router.state.location.search).toEqual({});
   });
 });

--- a/crates/openwave-desktop/ui/src/panel/usePanelNav.ts
+++ b/crates/openwave-desktop/ui/src/panel/usePanelNav.ts
@@ -1,23 +1,23 @@
 import { useMemo } from "react";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 
-import { isContentPanel, type LayoutState, type PanelContent, type PanelPosition } from "./panelTypes";
-import { isValidLayout, layoutFromSearch, searchFromLayout, type PanelSearch } from "./panelUrl";
+import { EMPTY_LAYOUT, panelKey, type LayoutState, type PanelContent } from "./panelTypes";
+import { layoutFromSearch, searchFromLayout, type PanelSearch } from "./panelUrl";
 
 /** The layout the URL currently describes. */
 export function useLayoutState(): LayoutState {
   const search = useSearch({ strict: false }) as PanelSearch;
   return useMemo(
     () => layoutFromSearch(search),
-    [search.left, search.right, search.fullscreen],
+    [search.tabs, search.active, search.fullscreen, search.left, search.right],
   );
 }
 
 /**
- * Opening, closing, and expanding panels — all of it by navigation, because the
- * URL is where the layout lives. Every helper preserves the other slot, so
- * opening sources from a conversation leaves the conversation beside it rather
- * than replacing it.
+ * Opening, closing, and expanding panels — all of it by navigation, because
+ * the URL is where the layout lives. The conversation is never one of them: it
+ * holds its own region and cannot be displaced, so every helper here only
+ * rearranges the tabs beside it.
  */
 export function usePanelNav() {
   const navigate = useNavigate();
@@ -27,7 +27,7 @@ export function usePanelNav() {
   function go(next: LayoutState) {
     // Panels live beside a conversation when there is one; outside any
     // conversation the home route hosts them (the Apps library), and its bare
-    // URL is the single-layout collapse the same way a chat's is.
+    // URL is the no-tabs collapse the same way a chat's is.
     if (chatId) {
       void navigate({
         to: "/c/$chatId",
@@ -39,59 +39,79 @@ export function usePanelNav() {
     }
   }
 
+  function indexOf(panel: PanelContent): number {
+    const key = panelKey(panel);
+    return layout.tabs.findIndex((tab) => panelKey(tab) === key);
+  }
+
   return {
     layout,
 
-    /** Show `panel` on the side it belongs, keeping whatever the other side holds. */
+    /**
+     * Show `panel` in the region beside the conversation.
+     *
+     * A panel already open is brought forward rather than opened twice, and
+     * takes on whatever the new request carries — clicking a second citation
+     * into an open document moves that tab to the new position instead of
+     * stacking another copy of the document beside it.
+     */
     openPanel(panel: PanelContent) {
-      const side: PanelPosition = isContentPanel(panel) ? "right" : "left";
-      const chat: PanelContent = { type: "chat" };
-      const other =
-        layout.mode === "split" ? (side === "left" ? layout.right : layout.left) : chat;
-
-      let left = side === "left" ? panel : other;
-      let right = side === "left" ? other : panel;
-      // The slot we are not filling already holds this kind of panel; it has
-      // been superseded, so hand that side back to the conversation.
-      if (!isValidLayout(left, right)) {
-        if (side === "left") right = chat;
-        else left = chat;
+      const existing = indexOf(panel);
+      if (existing !== -1) {
+        const tabs = layout.tabs.slice();
+        tabs[existing] = panel;
+        go({ ...layout, tabs, activeIndex: existing });
+        return;
       }
-      go({ mode: "split", left, right, fullscreen: undefined });
+      go({
+        ...layout,
+        tabs: [...layout.tabs, panel],
+        activeIndex: layout.tabs.length,
+      });
+    },
+
+    /**
+     * Close one tab — by default the one showing.
+     *
+     * Focus falls to the tab on its left, which is where the reader was before
+     * they opened this one, and the last tab closing leaves the conversation
+     * alone at the bare URL.
+     */
+    closeTab(target?: PanelContent | number) {
+      const index =
+        typeof target === "number" ? target : target ? indexOf(target) : layout.activeIndex;
+      if (index < 0 || index >= layout.tabs.length) return;
+
+      const tabs = layout.tabs.filter((_, at) => at !== index);
+      if (tabs.length === 0) {
+        go(EMPTY_LAYOUT);
+        return;
+      }
+      let activeIndex = layout.activeIndex;
+      if (index < activeIndex) activeIndex -= 1;
+      else if (index === activeIndex) activeIndex = index - 1;
+      go({
+        ...layout,
+        tabs,
+        activeIndex: Math.min(Math.max(activeIndex, 0), tabs.length - 1),
+      });
+    },
+
+    /** Bring one of the open tabs forward. */
+    focusTab(index: number) {
+      if (index < 0 || index >= layout.tabs.length || index === layout.activeIndex) return;
+      go({ ...layout, activeIndex: index });
     },
 
     /** Collapse back to the conversation alone. */
     closeAllPanels() {
-      go({ mode: "single", panel: { type: "chat" } });
+      go(EMPTY_LAYOUT);
     },
 
-    /**
-     * Closing one slot returns the survivor to its own side, with the
-     * conversation filling the slot it vacated. A lone conversation collapses
-     * to the bare URL.
-     */
-    closePanel(position: PanelPosition) {
-      if (layout.mode !== "split") {
-        go({ mode: "single", panel: { type: "chat" } });
-        return;
-      }
-      const survivor = position === "left" ? layout.right : layout.left;
-      if (survivor.type === "chat") {
-        go({ mode: "single", panel: { type: "chat" } });
-        return;
-      }
-      const chat: PanelContent = { type: "chat" };
-      go({
-        mode: "split",
-        left: isContentPanel(survivor) ? chat : survivor,
-        right: isContentPanel(survivor) ? survivor : chat,
-        fullscreen: undefined,
-      });
-    },
-
-    toggleFullscreen(position: PanelPosition) {
-      if (layout.mode !== "split") return;
-      go({ ...layout, fullscreen: layout.fullscreen === position ? undefined : position });
+    /** Hand the window to the region, or give the conversation its share back. */
+    toggleFullscreen() {
+      if (layout.tabs.length === 0) return;
+      go({ ...layout, fullscreen: !layout.fullscreen });
     },
   };
 }

--- a/crates/openwave-desktop/ui/src/plugins/PluginsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/plugins/PluginsPanel.tsx
@@ -16,10 +16,8 @@ import { usePluginCatalog } from "./usePluginCatalog";
  */
 export function PluginsPanel({
   panel,
-  position,
 }: {
   panel: Extract<PanelContent, { type: "plugins" }>;
-  position: "left" | "right";
 }) {
   const { client } = useApp();
   const { openPanel } = usePanelNav();
@@ -27,7 +25,7 @@ export function PluginsPanel({
   const state = usePluginCatalog(apis);
 
   return (
-    <PanelFrame position={position} spaceBetween>
+    <PanelFrame spaceBetween>
       {panel.pluginId ? (
         <PluginDetailView
           pluginId={panel.pluginId}

--- a/crates/openwave-desktop/ui/src/router.tsx
+++ b/crates/openwave-desktop/ui/src/router.tsx
@@ -27,17 +27,30 @@ const rootRoute = createRootRoute({ component: AppShell });
  */
 type ChatSearch = PanelSearch & { focus?: string };
 
+/**
+ * The layout params, kept as strings for the panel parser to make sense of.
+ * `left` and `right` are the retired grammar, read so an older link or an
+ * already-open window still restores; the router rewrites them to `tabs` the
+ * first time the layout changes.
+ */
+function panelSearchFrom(search: Record<string, unknown>): PanelSearch {
+  const text = (value: unknown) => (typeof value === "string" ? value : undefined);
+  return {
+    tabs: text(search.tabs),
+    active: text(search.active),
+    fullscreen: text(search.fullscreen),
+    left: text(search.left),
+    right: text(search.right),
+  };
+}
+
 const homeRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/",
   // Home hosts panels the way a conversation does — the Apps library opens
   // beside the composer — so it reads the same layout params. Which panel
   // types home actually accepts is decided by HomeRoute, not the URL parser.
-  validateSearch: (search: Record<string, unknown>): PanelSearch => ({
-    left: typeof search.left === "string" ? search.left : undefined,
-    right: typeof search.right === "string" ? search.right : undefined,
-    fullscreen: typeof search.fullscreen === "string" ? search.fullscreen : undefined,
-  }),
+  validateSearch: (search: Record<string, unknown>): PanelSearch => panelSearchFrom(search),
   component: HomeRoute,
 });
 
@@ -85,9 +98,7 @@ const chatRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/c/$chatId",
   validateSearch: (search: Record<string, unknown>): ChatSearch => ({
-    left: typeof search.left === "string" ? search.left : undefined,
-    right: typeof search.right === "string" ? search.right : undefined,
-    fullscreen: typeof search.fullscreen === "string" ? search.fullscreen : undefined,
+    ...panelSearchFrom(search),
     // Where a deep link is pointing: the parked call to reveal once the
     // transcript is up. It rides beside the layout params because it is
     // addressing state like they are, and it is dropped from the URL as soon

--- a/crates/openwave-desktop/ui/src/sidebar/ChatSidebar.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/ChatSidebar.tsx
@@ -41,10 +41,7 @@ export function ChatSidebar({ chat }: { chat: Chat }) {
     (state) => state.chatIdsWithPendingPrompts,
   );
 
-  const openPanelTypes: Set<PanelType> =
-    layout.mode === "split"
-      ? new Set([layout.left.type, layout.right.type])
-      : new Set<PanelType>(["chat"]);
+  const openPanelTypes: Set<PanelType> = new Set(layout.tabs.map((tab) => tab.type));
 
   // The recent list carries per-row markers, but a chat past its cut can still
   // park a turn on a question. The way back doubles as where that is reported.


### PR DESCRIPTION
Reworks the panel layout model so the conversation is always visible on the left and the region beside it hosts every open panel as a tab, replacing the two-slot split that squeezed the conversation to 0% when both slots filled.

- `LayoutState` becomes `{tabs, activeIndex, fullscreen}`; chat is no longer a panel and cannot be displaced.
- URL grammar is now `?tabs=<seg>,<seg>&active=<seg>&fullscreen=1` over the unchanged per-panel segment grammar. Legacy `left`/`right`/`fullscreen=side` links are still read (left first, chat segments dropped) and rewritten on the first layout change.
- `usePanelNav`: `openPanel` focuses an existing tab of the same identity (updating it in place, e.g. a new citation into an open document) or appends; `closeTab` focuses the left neighbour; fullscreen expands the region.
- New `PanelTabs` strip: type icon + label + close per tab, active tab lifted out of the muted trough like the existing in-panel switchers. Only the active tab's panel renders; the conversation stays mounted as before.
- `PanelLayout` drops to two resizable regions ([100,0] / [50,50] / [0,100]) with the same 25–75 drag bounds.

Tests: panelUrl/usePanelNav/panelSizes rewritten for the new model (incl. legacy-link mapping); AppShell deep-link tests cover both new- and legacy-shape URLs. Full UI suite 740 passed; tsc and vite build clean.

Follow-ups deliberately left: real titles in tab labels (needs a title cache), tab reordering/overflow menu.