### PR TITLE
feat(release): package and publish unsigned Windows x86_64 installers

### DIFF
--- a/.github/workflows/cache-macos.yml
+++ b/.github/workflows/cache-macos.yml
@@ -51,7 +51,7 @@ jobs:
       matrix:
         # Apple Silicon only while the product is in active development; see
         # docs/releases.md. Restoring Intel means adding its row back here, to
-        # the two release matrices, and to MACOS_ARCHITECTURES.
+        # the two macOS release matrices, and to RELEASE_PLATFORMS.
         include:
           - arch: aarch64
             target: aarch64-apple-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
-name: Publish macOS release
+name: Publish desktop release
 
 run-name: >-
   ${{ github.event_name == 'release'
-    && format('Dispatch macOS {0}', github.event.release.tag_name)
-    || format('Publish macOS {0}', inputs.release_tag) }}
+    && format('Dispatch desktop {0}', github.event.release.tag_name)
+    || format('Publish desktop {0}', inputs.release_tag) }}
 
 on:
   release:
@@ -24,8 +24,8 @@ concurrency:
   # Serialize production builds so two tags cannot race mutable latest.json.
   group: >-
     ${{ github.event_name == 'release'
-      && format('openwave-macos-release-dispatch-{0}', github.run_id)
-      || 'openwave-macos-production-release' }}
+      && format('openwave-desktop-release-dispatch-{0}', github.run_id)
+      || 'openwave-desktop-production-release' }}
   cancel-in-progress: false
 
 jobs:
@@ -711,9 +711,344 @@ jobs:
           [[ -z "${APPLE_CERTIFICATE_PATH:-}" ]] \
             || rm -f "$APPLE_CERTIFICATE_PATH"
 
+  prepare_windows:
+    name: prepare unsigned Windows · ${{ matrix.arch }}
+    needs: [validate, inspect_hosted]
+    if: ${{ needs.inspect_hosted.outputs.exists != 'true' }}
+    runs-on: windows-latest
+    timeout-minutes: 90
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        # x86_64 only for the first unsigned Windows releases; see
+        # docs/releases.md.
+        include:
+          - arch: x86_64
+            target: x86_64-pc-windows-msvc
+    env:
+      CARGO_INCREMENTAL: 0
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_RW_MODE: READ_ONLY
+      OPENWAVE_VERSION: ${{ needs.validate.outputs.version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.validate.outputs.sha }}
+
+      - name: Install Rust target
+        run: |
+          rustup show
+          rustup target add "${{ matrix.target }}"
+
+      - name: Restore unsigned Rust build cache
+        id: rust-build-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            target/release/.cargo-lock
+            target/release/.fingerprint
+            target/release/build
+            target/release/deps
+            target/${{ matrix.target }}/release/.cargo-lock
+            target/${{ matrix.target }}/release/.fingerprint
+            target/${{ matrix.target }}/release/build
+            target/${{ matrix.target }}/release/deps
+            target/${{ matrix.target }}/release/openwave-desktop.exe
+            target/${{ matrix.target }}/release/openwave-host-broker.exe
+            target/${{ matrix.target }}/release/openwave_desktop_lib.*
+            crates/openwave-desktop/binaries/openwave-host-broker-${{ matrix.target }}.exe
+          key: windows-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
+          restore-keys: |
+            windows-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
+            windows-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
+
+      - name: Set up compiler cache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.16.0
+
+      - name: Cache Cargo downloads
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: windows-release-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
+          add-job-id-key: "false"
+          add-rust-environment-hash-key: "false"
+          cache-bin: false
+          cache-targets: false
+          # No cache-warming workflow exists for Windows, so this
+          # credential-free prerequisite is the registry cache's single writer.
+          save-if: true
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        with:
+          version: 10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: crates/openwave-desktop/ui/pnpm-lock.yaml
+      - name: Install UI dependencies
+        working-directory: crates/openwave-desktop/ui
+        run: pnpm install --frozen-lockfile
+
+      - name: Compile without production credentials or bundles
+        id: compile
+        continue-on-error: true
+        uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1
+        with:
+          projectPath: crates/openwave-desktop
+          args: --target ${{ matrix.target }} --no-bundle --ci
+
+      - name: Save release-specific unsigned Rust build cache
+        if: ${{ !cancelled() && steps.rust-build-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            target/release/.cargo-lock
+            target/release/.fingerprint
+            target/release/build
+            target/release/deps
+            target/${{ matrix.target }}/release/.cargo-lock
+            target/${{ matrix.target }}/release/.fingerprint
+            target/${{ matrix.target }}/release/build
+            target/${{ matrix.target }}/release/deps
+            target/${{ matrix.target }}/release/openwave-desktop.exe
+            target/${{ matrix.target }}/release/openwave-host-broker.exe
+            target/${{ matrix.target }}/release/openwave_desktop_lib.*
+            crates/openwave-desktop/binaries/openwave-host-broker-${{ matrix.target }}.exe
+          key: ${{ steps.rust-build-cache.outputs.cache-primary-key }}
+
+      - name: Require a successful unsigned compilation
+        if: ${{ steps.compile.outcome != 'success' }}
+        run: exit 1
+
+  build_windows:
+    name: Windows · ${{ matrix.arch }}
+    needs: [validate, inspect_hosted, prepare_windows]
+    if: >-
+      ${{
+        always()
+        && needs.validate.result == 'success'
+        && needs.inspect_hosted.result == 'success'
+        && needs.inspect_hosted.outputs.exists != 'true'
+        && needs.prepare_windows.result == 'success'
+      }}
+    runs-on: windows-latest
+    timeout-minutes: 90
+    environment:
+      name: desktop-production
+      url: https://downloads.brightwave.io/openwave/manifest.json
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        # x86_64 only for the first unsigned Windows releases; see
+        # docs/releases.md.
+        include:
+          - arch: x86_64
+            target: x86_64-pc-windows-msvc
+    env:
+      # Reuse compiler outputs across trusted release runs without caching the
+      # bundled installers or the updater signing material.
+      CARGO_INCREMENTAL: 0
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_RW_MODE: READ_ONLY
+      # Rust code that reports or gates on the product version reads this value.
+      # Cargo package versions remain development metadata and are not released.
+      OPENWAVE_VERSION: ${{ needs.validate.outputs.version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # Build the immutable commit resolved from the validated release tag.
+          ref: ${{ needs.validate.outputs.sha }}
+
+      # This restore-only step runs before the updater-signing secret is
+      # loaded. The matching cache is written by a credential-free prerequisite
+      # job, and every restorable key pins at minimum the Cargo.lock and
+      # toolchain hashes. The path list must stay byte-identical to the writing
+      # job's — `actions/cache` folds it into the cache version. The next step
+      # deletes the linked products the archive carries, so only compiler
+      # intermediates survive into the packaged build.
+      - name: Restore unsigned Rust build cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            target/release/.cargo-lock
+            target/release/.fingerprint
+            target/release/build
+            target/release/deps
+            target/${{ matrix.target }}/release/.cargo-lock
+            target/${{ matrix.target }}/release/.fingerprint
+            target/${{ matrix.target }}/release/build
+            target/${{ matrix.target }}/release/deps
+            target/${{ matrix.target }}/release/openwave-desktop.exe
+            target/${{ matrix.target }}/release/openwave-host-broker.exe
+            target/${{ matrix.target }}/release/openwave_desktop_lib.*
+            crates/openwave-desktop/binaries/openwave-host-broker-${{ matrix.target }}.exe
+          key: windows-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
+          restore-keys: |
+            windows-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
+            windows-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
+
+      # A restore extracts the whole archive, including the linked products a
+      # prerequisite run left in it. Delete them and let this build relink them
+      # from the tag's own sources; the compiler intermediates that make the
+      # reuse worthwhile stay. The sidecar matters most: Tauri copies it into
+      # the installer verbatim, with no Cargo fingerprint governing it.
+      - name: Discard restored product binaries
+        env:
+          RELEASE_TARGET: ${{ matrix.target }}
+        run: |
+          rm -rf \
+            "target/$RELEASE_TARGET/release/openwave-desktop.exe" \
+            "target/$RELEASE_TARGET/release/openwave-host-broker.exe" \
+            "target/$RELEASE_TARGET/release/"openwave_desktop_lib.* \
+            "crates/openwave-desktop/binaries/openwave-host-broker-$RELEASE_TARGET.exe"
+
+      # Authenticode code signing is deliberately absent: v1 Windows releases
+      # ship unsigned installers. The Tauri updater key still signs the
+      # artifact bytes for latest.json — that is artifact authenticity, not
+      # Windows code signing.
+      - name: Validate updater signing configuration
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          missing=()
+          for name in \
+            TAURI_SIGNING_PRIVATE_KEY \
+            TAURI_SIGNING_PRIVATE_KEY_PASSWORD; do
+            [[ -n "${!name:-}" ]] || missing+=("$name")
+          done
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing desktop-production updater-signing configuration: %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+      - name: Install Rust target
+        run: |
+          rustup show
+          rustup target add "${{ matrix.target }}"
+
+      - name: Set up compiler cache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.16.0
+
+      - name: Cache Cargo downloads
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: windows-release-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
+          add-job-id-key: "false"
+          add-rust-environment-hash-key: "false"
+          cache-bin: false
+          # Installers, updater signatures, and signing material remain outside
+          # both the Cargo download cache and the restore-only build cache. The
+          # credential-free prerequisite is the single registry-cache writer.
+          cache-targets: false
+          save-if: false
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        with:
+          version: 10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: crates/openwave-desktop/ui/pnpm-lock.yaml
+      - name: Install UI dependencies
+        working-directory: crates/openwave-desktop/ui
+        run: pnpm install --frozen-lockfile
+
+      - name: Write tag-derived Tauri configuration
+        env:
+          RELEASE_CONFIG: ${{ runner.temp }}/openwave-release.json
+        run: |
+          node -e '
+            const fs = require("node:fs");
+            fs.writeFileSync(process.env.RELEASE_CONFIG, JSON.stringify({
+              version: process.env.OPENWAVE_VERSION,
+              // One installer format for v1: NSIS supports per-user installs
+              // without elevation and needs no WiX configuration.
+              bundle: { targets: ["nsis"] },
+              // Release bundles register only the real scheme, mirroring the
+              // macOS release configuration: a release binary refuses
+              // openwave-dev:// links by design, so registering the dev scheme
+              // would shadow whatever debug build should answer it.
+              plugins: { "deep-link": { desktop: { schemes: ["openwave"] } } }
+            }));
+          '
+
+      - name: Build the Tauri app without Windows code signing
+        id: tauri
+        uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1
+        with:
+          projectPath: crates/openwave-desktop
+          args: >-
+            --target ${{ matrix.target }}
+            --config ${{ runner.temp }}/openwave-release.json
+            --bundles nsis
+
+      - name: Verify and collect unsigned artifacts
+        env:
+          RELEASE_ARCH: ${{ matrix.arch }}
+          RELEASE_TARGET: ${{ matrix.target }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          target_dir="$(cygpath -u "$(cargo metadata --format-version 1 --no-deps | jq -r .target_directory)")"
+          bundle_dir="$target_dir/$RELEASE_TARGET/release/bundle"
+          setup_paths=("$bundle_dir"/nsis/*-setup.exe)
+          (( ${#setup_paths[@]} == 1 )) && [[ -f "${setup_paths[0]}" ]] || {
+            echo "Expected exactly one NSIS installer in $bundle_dir/nsis" >&2
+            exit 1
+          }
+          setup_path="${setup_paths[0]}"
+
+          # Tauri copies the target-named sidecar into the installer verbatim;
+          # require the executable the bundling step consumed.
+          sidecar="crates/openwave-desktop/binaries/openwave-host-broker-$RELEASE_TARGET.exe"
+          [[ -s "$sidecar" ]] || {
+            echo "Missing target-named host broker sidecar: $sidecar" >&2
+            exit 1
+          }
+
+          # Windows updates install from the NSIS installer itself, so the
+          # updater signature for latest.json covers those exact bytes.
+          updater_path="$setup_path"
+          signature_path="${updater_path}.sig"
+          rm -f "$signature_path"
+          tauri signer sign "$updater_path"
+          [[ -s "$signature_path" ]] || {
+            echo "Tauri updater signature is empty: $signature_path" >&2
+            exit 1
+          }
+
+          output_dir="dist/windows/$RELEASE_ARCH"
+          base_name="OpenWave_${OPENWAVE_VERSION}_${RELEASE_ARCH}"
+          mkdir -p "$output_dir"
+          cp "$setup_path" "$output_dir/${base_name}-setup.exe"
+          cp "$signature_path" "$output_dir/${base_name}-setup.exe.sig"
+          find "$output_dir" -type f -print
+
+      - name: Upload verified Windows artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: openwave-windows-${{ matrix.arch }}-${{ needs.validate.outputs.version }}
+          path: dist/windows/${{ matrix.arch }}/
+          if-no-files-found: error
+          retention-days: 7
+
   publish:
     name: publish downloads.brightwave.io
-    needs: [validate, inspect_hosted, build_macos]
+    needs: [validate, inspect_hosted, build_macos, build_windows]
     if: >-
       ${{
         always()
@@ -721,7 +1056,10 @@ jobs:
         && needs.inspect_hosted.result == 'success'
         && (
           needs.inspect_hosted.outputs.exists == 'true'
-          || needs.build_macos.result == 'success'
+          || (
+            needs.build_macos.result == 'success'
+            && needs.build_windows.result == 'success'
+          )
         )
       }}
     runs-on: ubuntu-latest
@@ -775,6 +1113,13 @@ jobs:
         with:
           name: openwave-macos-aarch64-${{ needs.validate.outputs.version }}
           path: dist/macos/aarch64
+
+      - name: Download Windows artifacts
+        if: ${{ needs.inspect_hosted.outputs.exists != 'true' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: openwave-windows-x86_64-${{ needs.validate.outputs.version }}
+          path: dist/windows/x86_64
 
       - name: Create release manifests and checksums
         if: ${{ needs.inspect_hosted.outputs.exists != 'true' }}
@@ -832,6 +1177,7 @@ jobs:
             case "$1" in
               *.json) echo application/json ;;
               *.dmg) echo application/x-apple-diskimage ;;
+              *.exe) echo application/vnd.microsoft.portable-executable ;;
               *.zip) echo application/zip ;;
               *.tar.gz) echo application/gzip ;;
               *.sig|*.sha256) echo text/plain ;;
@@ -928,7 +1274,7 @@ jobs:
       # The hosted release is the only source of artifact bytes. Re-downloading
       # it here keeps the GitHub assets a verified copy of what the CDN serves,
       # and works the same whether this run built the release or resumed one.
-      - name: Download the published disk images
+      - name: Download the published installers
         run: |
           mkdir -p downloads
           manifest="$RUNNER_TEMP/manifest.json"
@@ -936,10 +1282,11 @@ jobs:
             "$RELEASE_BASE_URL/releases/v$OPENWAVE_VERSION/manifest.json" \
             --output "$manifest"
 
-          while IFS=$'\t' read -r arch url digest; do
-            case "$arch" in
-              aarch64) name="OpenWave-macos-apple-silicon.dmg" ;;
-              *) echo "Unsupported release architecture: $arch" >&2; exit 1 ;;
+          while IFS=$'\t' read -r platform arch url digest; do
+            case "$platform/$arch" in
+              macos/aarch64) name="OpenWave-macos-apple-silicon.dmg" ;;
+              windows/x86_64) name="OpenWave-windows-x86_64-setup.exe" ;;
+              *) echo "Unsupported release platform: $platform/$arch" >&2; exit 1 ;;
             esac
             curl --fail --silent --show-error --location "$url" \
               --output "downloads/$name"
@@ -947,19 +1294,21 @@ jobs:
             (cd downloads && sha256sum --check --strict "$name.sha256")
           done < <(jq -r \
             '.artifacts[]
-             | select(.platform == "macos" and .format == "dmg")
-             | [.arch, .url, .sha256] | @tsv' \
+             | select((.platform == "macos" and .format == "dmg")
+                 or (.platform == "windows" and .format == "nsis"))
+             | [.platform, .arch, .url, .sha256] | @tsv' \
             "$manifest")
 
           dmg_count="$(find downloads -name '*.dmg' -type f | wc -l)"
-          (( dmg_count == 1 )) || {
-            echo "Expected one macOS disk image, found $dmg_count." >&2
+          exe_count="$(find downloads -name '*.exe' -type f | wc -l)"
+          (( dmg_count == 1 && exe_count == 1 )) || {
+            echo "Expected one macOS disk image and one Windows installer, found $dmg_count and $exe_count." >&2
             exit 1
           }
 
       # Version-free asset names give the README permanent one-click download
       # links through GitHub's /releases/latest/download/ redirect.
-      - name: Attach the disk images to the GitHub Release
+      - name: Attach the installers to the GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: >-

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -138,38 +138,42 @@ automatic.
    prereleases, drafts, or commits outside `main`, and pins all later jobs to
    the resolved commit SHA.
 5. The dispatched workflow first checks whether that exact tag, commit, and
-   publication date already have a complete immutable release on S3. A
-   credential-free prerequisite otherwise compiles the tag with its product
-   version and saves unsigned Cargo outputs before any signing or notarization
-   can fail.
-6. The production job reuses those prepared compiler outputs — every cache key
-   it can restore names the release commit or, at minimum, the `Cargo.lock` and
-   toolchain hashes, and it deletes the linked binaries the archive carries so
-   the products it signs are always linked from the tag's own sources. It then
-   signs the app with the Developer ID identity, notarizes and staples the app
-   and DMG, verifies them with Apple tooling, and creates a signed Tauri updater
-   archive.
+   publication date already have a complete immutable release on S3.
+   Credential-free prerequisites — one per platform — otherwise compile the tag
+   with its product version and save unsigned Cargo outputs before any signing
+   or notarization can fail.
+6. The production jobs reuse those prepared compiler outputs — every cache key
+   they can restore names the release commit or, at minimum, the `Cargo.lock`
+   and toolchain hashes, and they delete the linked binaries the archive
+   carries so the products they package are always linked from the tag's own
+   sources. The macOS job then signs the app with the Developer ID identity,
+   notarizes and staples the app and DMG, verifies them with Apple tooling, and
+   creates a signed Tauri updater archive. The parallel Windows job packages
+   one unsigned NSIS installer — Authenticode signing is deliberately not
+   performed yet — and signs the installer bytes with the same Tauri updater
+   key, which is artifact authenticity rather than Windows code signing.
 7. Only after the build passes does the publisher upload immutable versioned
    files, advance the public manifests, invalidate their CDN paths, and
    smoke-test the hosted release. If a prior attempt already uploaded the
    complete immutable prefix, a new dispatch validates and reuses those bytes,
    skips the desktop build, and resumes only mutable metadata publication,
    CDN invalidation, and smoke testing.
-8. A final job downloads the notarized disk image back from the CDN, checks it
-   against the immutable manifest digests, and attaches it to the GitHub
-   Release as `OpenWave-macos-apple-silicon.dmg` with a `.sha256` sidecar. It
-   holds no signing or AWS credentials. The name omits the version so that
+8. A final job downloads the notarized disk image and the Windows installer
+   back from the CDN, checks them against the immutable manifest digests, and
+   attaches them to the GitHub Release as `OpenWave-macos-apple-silicon.dmg`
+   and `OpenWave-windows-x86_64-setup.exe` with `.sha256` sidecars. It holds no
+   signing or AWS credentials. The names omit the version so that
    `https://github.com/brightwave-inc/openwave/releases/latest/download/<name>`
    stays a permanent download link for the README; the release page and the
    app's own version string identify which build it is.
 
 Publishing the native draft is the only release boundary. Merging ordinary PRs
 updates the draft but never builds or ships a desktop version. A published
-GitHub Release is considered shipped only when its dispatched **Publish macOS
-release** build completes successfully; the initial dispatch run is not the
-shipping signal.
+GitHub Release is considered shipped only when its dispatched **Publish
+desktop release** build completes successfully; the initial dispatch run is
+not the shipping signal.
 
-## Public macOS delivery
+## Public desktop delivery
 
 ### Apple Silicon only, for now
 
@@ -180,18 +184,38 @@ identical crate set — about 18 minutes against 7 on a recent release — so th
 Intel job, not the one anybody installs, set the length of every release and
 cache-warm run. No one on the team or in early testing uses an Intel Mac.
 
-`MACOS_ARCHITECTURES` in `scripts/create-release-manifests.mjs` is the single
+`RELEASE_PLATFORMS` in `scripts/create-release-manifests.mjs` is the single
 source of truth for what a release contains: it drives the manifest, the
 `latest.json` platform keys, and the immutable prefix below. Restoring Intel
-means adding `x86_64` there and adding its row back to the two `release.yml`
-build matrices and the `cache-macos.yml` warm matrix.
+means adding `x86_64` to the macOS entry there and adding its row back to the
+two macOS `release.yml` build matrices and the `cache-macos.yml` warm matrix.
 
-Two consequences worth knowing. `latest.json` advertises only
-`darwin-aarch64`, so an Intel install finds no update rather than a broken one.
-And the preflight that resumes an already-hosted release validates it against
-the current architecture set, so a release published before this change cannot
-be re-dispatched; it fails on the artifact count instead of silently
-republishing.
+Two consequences worth knowing. `latest.json` advertises only the platforms in
+that table, so an unsupported install finds no update rather than a broken
+one. And the preflight that resumes an already-hosted release validates it
+against the current platform set, so a release published before a platform
+change cannot be re-dispatched; it fails on the artifact count instead of
+silently republishing.
+
+### Windows: unsigned x86_64, for now
+
+A release ships one `x86_64` Windows build as a single NSIS `-setup.exe`
+installer. NSIS is the one installer format for v1 because Tauri bundles it
+with no additional configuration and it installs per-user without elevation.
+The installer is deliberately **not** Authenticode-signed yet, so Windows
+SmartScreen will warn on first run; code signing is tracked separately and
+must not be confused with the Tauri updater signature the release does carry.
+That updater signature covers the exact installer bytes and feeds
+`latest.json`'s `windows-x86_64` entry — Tauri v2 installs updates from the
+installer itself, so no separate updater archive exists on Windows. Packaged
+apps currently run the update loop only on macOS; the Windows metadata is
+published so updater-enabled Windows builds can adopt it without a manifest
+change.
+
+Unlike macOS, no cache-warming workflow exists for Windows: the credential-free
+`prepare_windows` job compiles the tag from scratch (or from an earlier
+release's prepared cache) and is the single writer of the Windows Cargo
+registry and prepared-build caches.
 
 The public download contract is rooted at:
 
@@ -204,13 +228,17 @@ Each release has an immutable prefix:
 ```text
 openwave/releases/vMAJOR.MINOR.PATCH/
 ├── manifest.json
-└── macos/
-    └── aarch64/
+├── macos/
+│   └── aarch64/
+└── windows/
+    └── x86_64/
 ```
 
-Each architecture directory contains a notarized DMG, a zip of the notarized
-app, a signed `.app.tar.gz` updater archive, its signature, and SHA-256 files.
-The root `manifest.json` and Tauri-compatible `latest.json` are the only mutable
+Each macOS architecture directory contains a notarized DMG, a zip of the
+notarized app, a signed `.app.tar.gz` updater archive, its signature, and
+SHA-256 files. Each Windows architecture directory contains an unsigned NSIS
+installer, its Tauri updater signature, and SHA-256 files. The root
+`manifest.json` and Tauri-compatible `latest.json` are the only mutable
 objects. The workflow refuses to overwrite a versioned object with different
 bytes or move `latest.json` to an older version.
 
@@ -283,8 +311,9 @@ the configured distribution. No long-lived AWS access key belongs in GitHub.
 
 Before the first public release, protect the environment as appropriate, verify
 all configuration values, and exercise the workflow with the intended first
-tag. The workflow references Apple signing secrets only in the macOS jobs;
-publishing uses short-lived AWS credentials obtained through OIDC.
+tag. The workflow references Apple signing secrets only in the macOS jobs; the
+Windows jobs receive only the Tauri updater key, and publishing uses
+short-lived AWS credentials obtained through OIDC.
 
 ### Release CI and cache security
 

--- a/scripts/create-release-manifests.mjs
+++ b/scripts/create-release-manifests.mjs
@@ -12,14 +12,30 @@ import { pathToFileURL } from "node:url";
 
 import { parseReleaseTag } from "./check-release-tag.mjs";
 
-// The architectures a release ships. Apple Silicon only while the product is
-// in active development; see docs/releases.md.
-export const MACOS_ARCHITECTURES = ["aarch64"];
-
-const ARTIFACT_FORMATS = [
-  { extension: ".dmg", format: "dmg" },
-  { extension: ".app.zip", format: "app.zip" },
-  { extension: ".app.tar.gz", format: "app.tar.gz", updater: true },
+// The platforms, architectures, and artifact formats a release ships. This is
+// the single source of truth for what a release contains: it drives the
+// manifest, the `latest.json` platform keys, and the immutable hosting prefix.
+// macOS is Apple Silicon only while the product is in active development; see
+// docs/releases.md. Windows ships one unsigned NSIS installer, which is also
+// its Tauri updater artifact (Tauri v2 installs updates from the installer
+// itself, so the `.sig` covers those exact bytes).
+export const RELEASE_PLATFORMS = [
+  {
+    platform: "macos",
+    updaterPlatform: "darwin",
+    architectures: ["aarch64"],
+    formats: [
+      { extension: ".dmg", format: "dmg" },
+      { extension: ".app.zip", format: "app.zip" },
+      { extension: ".app.tar.gz", format: "app.tar.gz", updater: true },
+    ],
+  },
+  {
+    platform: "windows",
+    updaterPlatform: "windows",
+    architectures: ["x86_64"],
+    formats: [{ extension: "-setup.exe", format: "nsis", updater: true }],
+  },
 ];
 
 function requiredOption(options, name) {
@@ -60,36 +76,47 @@ function requireFile(file) {
 
 export function createLatestDocument({ version, publishedAt, artifacts }) {
   const updaterArtifacts = new Map();
-  for (const artifact of artifacts) {
-    if (artifact.platform !== "macos" || artifact.format !== "app.tar.gz") {
-      continue;
+  for (const descriptor of RELEASE_PLATFORMS) {
+    const updaterFormat = descriptor.formats.find((format) => format.updater);
+    for (const artifact of artifacts) {
+      if (
+        artifact.platform !== descriptor.platform ||
+        artifact.format !== updaterFormat.format
+      ) {
+        continue;
+      }
+      if (
+        !descriptor.architectures.includes(artifact.arch) ||
+        typeof artifact.signature !== "string" ||
+        !artifact.signature
+      ) {
+        throw new Error(
+          `invalid ${descriptor.platform} updater artifact in release manifest`,
+        );
+      }
+      updaterArtifacts.set(
+        `${descriptor.updaterPlatform}-${artifact.arch}`,
+        artifact,
+      );
     }
-    if (
-      !MACOS_ARCHITECTURES.includes(artifact.arch) ||
-      typeof artifact.signature !== "string" ||
-      !artifact.signature
-    ) {
-      throw new Error("invalid macOS updater artifact in release manifest");
-    }
-    updaterArtifacts.set(artifact.arch, artifact);
   }
 
   return {
     version,
     pub_date: publishedAt,
     platforms: Object.fromEntries(
-      MACOS_ARCHITECTURES.map((arch) => {
-        const artifact = updaterArtifacts.get(arch);
-        if (!artifact) {
-          throw new Error(
-            `missing ${arch} updater artifact in release manifest`,
-          );
-        }
-        return [
-          `darwin-${arch}`,
-          { signature: artifact.signature, url: artifact.url },
-        ];
-      }),
+      RELEASE_PLATFORMS.flatMap((descriptor) =>
+        descriptor.architectures.map((arch) => {
+          const key = `${descriptor.updaterPlatform}-${arch}`;
+          const artifact = updaterArtifacts.get(key);
+          if (!artifact) {
+            throw new Error(
+              `missing ${key} updater artifact in release manifest`,
+            );
+          }
+          return [key, { signature: artifact.signature, url: artifact.url }];
+        }),
+      ),
     ),
   };
 }
@@ -124,59 +151,69 @@ export function createReleaseManifests({
   const distPath = path.resolve(dist);
   const artifacts = [];
 
-  for (const arch of MACOS_ARCHITECTURES) {
-    const directory = path.join(distPath, "macos", arch);
-    const baseName = `OpenWave_${version}_${arch}`;
+  for (const platformDescriptor of RELEASE_PLATFORMS) {
+    for (const arch of platformDescriptor.architectures) {
+      const directory = path.join(distPath, platformDescriptor.platform, arch);
+      const baseName = `OpenWave_${version}_${arch}`;
 
-    for (const descriptor of ARTIFACT_FORMATS) {
-      const filename = `${baseName}${descriptor.extension}`;
-      const file = path.join(directory, filename);
-      requireFile(file);
+      for (const descriptor of platformDescriptor.formats) {
+        const filename = `${baseName}${descriptor.extension}`;
+        const file = path.join(directory, filename);
+        requireFile(file);
 
-      const digest = sha256(file);
-      writeFileSync(`${file}.sha256`, `${digest}  ${filename}\n`);
-      const relativeFilename = path.posix.join("macos", arch, filename);
-      const checksumFilename = `${relativeFilename}.sha256`;
-      const artifact = {
-        platform: "macos",
-        arch,
-        format: descriptor.format,
-        filename: relativeFilename,
-        url: publicUrl(normalizedBaseUrl, version, relativeFilename),
-        size: statSync(file).size,
-        sha256: digest,
-        checksum_filename: checksumFilename,
-        checksum_url: publicUrl(normalizedBaseUrl, version, checksumFilename),
-      };
+        const digest = sha256(file);
+        writeFileSync(`${file}.sha256`, `${digest}  ${filename}\n`);
+        const relativeFilename = path.posix.join(
+          platformDescriptor.platform,
+          arch,
+          filename,
+        );
+        const checksumFilename = `${relativeFilename}.sha256`;
+        const artifact = {
+          platform: platformDescriptor.platform,
+          arch,
+          format: descriptor.format,
+          filename: relativeFilename,
+          url: publicUrl(normalizedBaseUrl, version, relativeFilename),
+          size: statSync(file).size,
+          sha256: digest,
+          checksum_filename: checksumFilename,
+          checksum_url: publicUrl(
+            normalizedBaseUrl,
+            version,
+            checksumFilename,
+          ),
+        };
 
-      if (descriptor.updater) {
-        const signatureFile = `${file}.sig`;
-        requireFile(signatureFile);
-        const signature = readFileSync(signatureFile, "utf8").trim();
-        if (!signature) {
-          throw new Error(`empty updater signature: ${signatureFile}`);
+        if (descriptor.updater) {
+          const signatureFile = `${file}.sig`;
+          requireFile(signatureFile);
+          const signature = readFileSync(signatureFile, "utf8").trim();
+          if (!signature) {
+            throw new Error(`empty updater signature: ${signatureFile}`);
+          }
+          const signatureDigest = sha256(signatureFile);
+          writeFileSync(
+            `${signatureFile}.sha256`,
+            `${signatureDigest}  ${path.basename(signatureFile)}\n`,
+          );
+          artifact.signature = signature;
+          artifact.signature_filename = `${relativeFilename}.sig`;
+          artifact.signature_url = publicUrl(
+            normalizedBaseUrl,
+            version,
+            artifact.signature_filename,
+          );
+          artifact.signature_sha256 = signatureDigest;
+          artifact.signature_checksum_url = publicUrl(
+            normalizedBaseUrl,
+            version,
+            `${artifact.signature_filename}.sha256`,
+          );
         }
-        const signatureDigest = sha256(signatureFile);
-        writeFileSync(
-          `${signatureFile}.sha256`,
-          `${signatureDigest}  ${path.basename(signatureFile)}\n`,
-        );
-        artifact.signature = signature;
-        artifact.signature_filename = `${relativeFilename}.sig`;
-        artifact.signature_url = publicUrl(
-          normalizedBaseUrl,
-          version,
-          artifact.signature_filename,
-        );
-        artifact.signature_sha256 = signatureDigest;
-        artifact.signature_checksum_url = publicUrl(
-          normalizedBaseUrl,
-          version,
-          `${artifact.signature_filename}.sha256`,
-        );
-      }
 
-      artifacts.push(artifact);
+        artifacts.push(artifact);
+      }
     }
   }
 

--- a/scripts/create-release-manifests.test.mjs
+++ b/scripts/create-release-manifests.test.mjs
@@ -6,26 +6,34 @@ import test from "node:test";
 
 import {
   createReleaseManifests,
-  MACOS_ARCHITECTURES,
+  RELEASE_PLATFORMS,
 } from "./create-release-manifests.mjs";
 import { preparePublishedRelease } from "./prepare-published-release.mjs";
 
+const EXPECTED_ARTIFACT_COUNT = RELEASE_PLATFORMS.reduce(
+  (count, descriptor) =>
+    count + descriptor.architectures.length * descriptor.formats.length,
+  0,
+);
+
 function releaseFixture() {
   const dist = mkdtempSync(path.join(tmpdir(), "openwave-release-"));
-  for (const arch of MACOS_ARCHITECTURES) {
-    const directory = path.join(dist, "macos", arch);
-    mkdirSync(directory, { recursive: true });
-    const baseName = `OpenWave_0.4.2_${arch}`;
-    writeFileSync(path.join(directory, `${baseName}.dmg`), `dmg-${arch}`);
-    writeFileSync(path.join(directory, `${baseName}.app.zip`), `zip-${arch}`);
-    writeFileSync(
-      path.join(directory, `${baseName}.app.tar.gz`),
-      `updater-${arch}`,
-    );
-    writeFileSync(
-      path.join(directory, `${baseName}.app.tar.gz.sig`),
-      `signature-${arch}\n`,
-    );
+  for (const descriptor of RELEASE_PLATFORMS) {
+    for (const arch of descriptor.architectures) {
+      const directory = path.join(dist, descriptor.platform, arch);
+      mkdirSync(directory, { recursive: true });
+      const baseName = `OpenWave_0.4.2_${arch}`;
+      for (const format of descriptor.formats) {
+        const file = path.join(directory, `${baseName}${format.extension}`);
+        writeFileSync(file, `${format.format}-${descriptor.platform}-${arch}`);
+        if (format.updater) {
+          writeFileSync(
+            `${file}.sig`,
+            `signature-${descriptor.platform}-${arch}\n`,
+          );
+        }
+      }
+    }
   }
   return dist;
 }
@@ -42,15 +50,26 @@ test("creates a complete manifest and Tauri updater document", () => {
   const dist = releaseFixture();
   const { manifest, latest } = createReleaseManifests({ dist, ...RELEASE });
 
-  assert.equal(manifest.artifacts.length, MACOS_ARCHITECTURES.length * 3);
-  assert.deepEqual(Object.keys(latest.platforms), ["darwin-aarch64"]);
+  assert.equal(manifest.artifacts.length, EXPECTED_ARTIFACT_COUNT);
+  assert.deepEqual(Object.keys(latest.platforms), [
+    "darwin-aarch64",
+    "windows-x86_64",
+  ]);
   assert.match(
     latest.platforms["darwin-aarch64"].url,
     /releases\/v0\.4\.2\/macos\/aarch64\/OpenWave_0\.4\.2_aarch64\.app\.tar\.gz$/,
   );
   assert.equal(
     latest.platforms["darwin-aarch64"].signature,
-    "signature-aarch64",
+    "signature-macos-aarch64",
+  );
+  assert.match(
+    latest.platforms["windows-x86_64"].url,
+    /releases\/v0\.4\.2\/windows\/x86_64\/OpenWave_0\.4\.2_x86_64-setup\.exe$/,
+  );
+  assert.equal(
+    latest.platforms["windows-x86_64"].signature,
+    "signature-windows-x86_64",
   );
 
   const diskManifest = JSON.parse(

--- a/scripts/prepare-published-release.mjs
+++ b/scripts/prepare-published-release.mjs
@@ -6,14 +6,8 @@ import { pathToFileURL } from "node:url";
 
 import {
   createLatestDocument,
-  MACOS_ARCHITECTURES,
+  RELEASE_PLATFORMS,
 } from "./create-release-manifests.mjs";
-
-const ARTIFACT_FORMATS = [
-  { extension: ".dmg", format: "dmg" },
-  { extension: ".app.zip", format: "app.zip" },
-  { extension: ".app.tar.gz", format: "app.tar.gz", updater: true },
-];
 
 function requiredOption(options, name) {
   const value = options.get(name);
@@ -63,14 +57,20 @@ export function validatePublishedReleaseManifest({
 
   const normalizedBaseUrl = baseUrl.replace(/\/+$/, "");
   const expected = new Map();
-  for (const arch of MACOS_ARCHITECTURES) {
-    for (const descriptor of ARTIFACT_FORMATS) {
-      const filename = path.posix.join(
-        "macos",
-        arch,
-        `OpenWave_${version}_${arch}${descriptor.extension}`,
-      );
-      expected.set(filename, { arch, ...descriptor });
+  for (const platformDescriptor of RELEASE_PLATFORMS) {
+    for (const arch of platformDescriptor.architectures) {
+      for (const descriptor of platformDescriptor.formats) {
+        const filename = path.posix.join(
+          platformDescriptor.platform,
+          arch,
+          `OpenWave_${version}_${arch}${descriptor.extension}`,
+        );
+        expected.set(filename, {
+          platform: platformDescriptor.platform,
+          arch,
+          ...descriptor,
+        });
+      }
     }
   }
 
@@ -89,7 +89,7 @@ export function validatePublishedReleaseManifest({
     }
     seen.add(artifact.filename);
 
-    requireExact(artifact.platform, "macos", "artifact platform");
+    requireExact(artifact.platform, descriptor.platform, "artifact platform");
     requireExact(artifact.arch, descriptor.arch, "artifact architecture");
     requireExact(artifact.format, descriptor.format, "artifact format");
     if (!Number.isSafeInteger(artifact.size) || artifact.size <= 0) {

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -427,7 +427,7 @@ test("cache warming cannot access production credentials or publish", () => {
     for (const step of downloadCaches) {
       assert.match(
         step,
-        /shared-key: macos-release-cargo-registry-v2-\$\{\{ hashFiles\('Cargo\.lock'\) \}\}/,
+        /shared-key: (?:macos-release-cargo-registry-v2|windows-release-cargo-registry-v1)-\$\{\{ hashFiles\('Cargo\.lock'\) \}\}/,
       );
       assert.match(step, /add-rust-environment-hash-key: "false"/);
       assert.match(step, /cache-targets: false/);

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -604,6 +604,98 @@ test("release caches restore only credential-free compiler products", () => {
   );
 });
 
+test("Windows release jobs mirror the credential-free prepare/build split", () => {
+  const release = workflows["release.yml"];
+  const prepareJob = workflowJob(release, "prepare_windows");
+  const buildJob = workflowJob(release, "build_windows");
+  const prepareCacheSave = prepareJob.match(
+    /- name: Save release-specific unsigned Rust build cache[\s\S]*?(?=\n\s+- name:)/,
+  )?.[0];
+  const buildCacheRestore = buildJob.match(
+    /- name: Restore unsigned Rust build cache[\s\S]*?(?=\n\s+- name:)/,
+  )?.[0];
+  assert.ok(prepareCacheSave);
+  assert.ok(buildCacheRestore);
+
+  // The prerequisite compiles without any production credential and never
+  // uploads what it built; only the cache carries its outputs forward.
+  assert.match(prepareJob, /SCCACHE_GHA_RW_MODE: READ_ONLY/);
+  assert.match(prepareJob, /--no-bundle --ci/);
+  assert.match(prepareJob, /continue-on-error: true/);
+  assert.doesNotMatch(prepareJob, /^    environment:/m);
+  assert.doesNotMatch(prepareJob, /secrets\./);
+  assert.doesNotMatch(
+    prepareJob,
+    /APPLE_|TAURI_SIGNING|AWS_|DOWNLOADS_|actions\/upload-artifact/,
+  );
+  assert.ok(
+    prepareJob.indexOf("Save release-specific unsigned Rust build cache") <
+      prepareJob.indexOf("Require a successful unsigned compilation"),
+    "release compiler outputs must be saved before a failed compile is reported",
+  );
+
+  // The packaging job is restore-only and loads the updater key only after
+  // the credential-free cache restore.
+  assert.doesNotMatch(buildJob, /actions\/cache\/save/);
+  assert.ok(
+    buildJob.indexOf("Restore unsigned Rust build cache") <
+      buildJob.indexOf("Validate updater signing configuration"),
+    "the build cache must be restored before the updater secret is loaded",
+  );
+
+  // Identical path lists keep the cache version shared between the writing
+  // and restoring jobs; every restorable key pins at least the lockfile and
+  // toolchain hashes.
+  const cachedPaths = (step) =>
+    step.match(/path: \|\n([\s\S]*?)\n\s+key:/)?.[1];
+  assert.ok(cachedPaths(buildCacheRestore));
+  assert.equal(cachedPaths(buildCacheRestore), cachedPaths(prepareCacheSave));
+  const restorableKeys = buildCacheRestore
+    .split("\n")
+    .map((line) => line.trim().replace(/^key: /, ""))
+    .filter((line) => line.startsWith("windows-release-"));
+  assert.ok(restorableKeys.length >= 3);
+  for (const key of restorableKeys) {
+    assert.ok(
+      key.includes("hashFiles('Cargo.lock',"),
+      `restorable Windows cache key does not pin the source: ${key}`,
+    );
+  }
+
+  // Whatever a restore extracts, the products that get packaged are relinked
+  // from the tag's own sources.
+  const discardProducts = buildJob.match(
+    /- name: Discard restored product binaries[\s\S]*?(?=\n\s+- name:)/,
+  )?.[0];
+  assert.ok(discardProducts);
+  for (const product of [
+    /release\/openwave-desktop\.exe/,
+    /release\/openwave-host-broker\.exe/,
+    /openwave_desktop_lib\./,
+    /binaries\/openwave-host-broker-\$RELEASE_TARGET\.exe/,
+  ]) {
+    assert.match(discardProducts, product);
+  }
+  assert.ok(
+    buildJob.indexOf("Discard restored product binaries") >
+      buildJob.indexOf("Restore unsigned Rust build cache") &&
+      buildJob.indexOf("Discard restored product binaries") <
+        buildJob.indexOf("Build the Tauri app without Windows code signing"),
+    "restored product binaries must be discarded before the packaged build",
+  );
+
+  // v1 ships unsigned Windows artifacts: no Authenticode configuration may
+  // creep in, no Apple credential reaches the Windows jobs, and the updater
+  // private key stays out of the Tauri build step.
+  assert.doesNotMatch(release, /certificateThumbprint|signCommand/);
+  assert.doesNotMatch(buildJob, /APPLE_|AWS_|DOWNLOADS_/);
+  const buildStep = buildJob.match(
+    /- name: Build the Tauri app without Windows code signing[\s\S]*?(?=\n\s+- name:)/,
+  )?.[0];
+  assert.ok(buildStep);
+  assert.doesNotMatch(buildStep, /TAURI_SIGNING_PRIVATE_KEY/);
+});
+
 test("an existing immutable release resumes without rebuilding or overwriting", () => {
   const release = workflows["release.yml"];
   const inspectJob = workflowJob(release, "inspect_hosted");
@@ -618,6 +710,14 @@ test("an existing immutable release resumes without rebuilding or overwriting", 
   assert.match(prepareJob, /needs\.inspect_hosted\.outputs\.exists != 'true'/);
   assert.match(
     signedBuildJob,
+    /needs\.inspect_hosted\.outputs\.exists != 'true'/,
+  );
+  assert.match(
+    workflowJob(release, "prepare_windows"),
+    /needs\.inspect_hosted\.outputs\.exists != 'true'/,
+  );
+  assert.match(
+    workflowJob(release, "build_windows"),
     /needs\.inspect_hosted\.outputs\.exists != 'true'/,
   );
   assert.match(
@@ -652,6 +752,7 @@ test("GitHub release downloads are copied from the hosted release", () => {
   assert.match(attachJob, /releases\/v\$OPENWAVE_VERSION\/manifest\.json/);
   assert.match(attachJob, /sha256sum --check --strict/);
   assert.match(attachJob, /OpenWave-macos-apple-silicon\.dmg/);
+  assert.match(attachJob, /OpenWave-windows-x86_64-setup\.exe/);
   assert.match(attachJob, /gh release upload "\$RELEASE_TAG"/);
 
   assert.match(


### PR DESCRIPTION
**Stacked on #1615** (the release-policy lane runs the base branch's `workflow-security.test.mjs` against this PR's workflows, so the Windows Cargo-registry cache namespace must be admitted by the base first). Retarget this PR to `main` and rebase once #1615 lands.

Closes #1602. Part of #1527; item 11 of the ordered plan in #1503.

## What changed

`.github/workflows/release.yml` was macOS-specific throughout. This adds unsigned Windows packaging as parallel jobs, leaving the Apple signing path untouched:

- **`prepare_windows`** (windows-latest, credential-free): checks out the validated tag SHA, installs UI deps (Node 22 + pnpm 10, matching the existing lanes), compiles the `x86_64-pc-windows-msvc` desktop and `openwave-host-broker.exe` sidecar with `--no-bundle --ci`, and saves an unsigned build cache keyed `windows-release-prepared-v1-{arch}-{hash(Cargo.lock, rust-toolchain.toml)}-{sha}-{version}`, mirroring the macOS pattern (save-before-failure ordering included). It has no environment, secrets, or artifact upload.
- **`build_windows`** (windows-latest, `desktop-production`): restore-only cache whose path list is byte-identical to the prepare job's save (enforced by test), restored *before* the updater secret is loaded; deletes the restored linked products (`openwave-desktop.exe`, `openwave-host-broker.exe`, `openwave_desktop_lib.*`, the target-named sidecar) exactly like the macOS job; runs `tauri build --target x86_64-pc-windows-msvc` with a tag-derived config overlay (version, `targets: ["nsis"]`, release-only `openwave://` deep-link scheme). No Authenticode configuration exists anywhere in the workflow — the installer ships unsigned.
- **Updater signature**: the workflow already wires the Tauri updater key for macOS, so the Windows job signs the installer bytes with the same `tauri signer sign` mechanism. Tauri v2 installs Windows updates from the NSIS installer itself, so the `-setup.exe` doubles as the updater artifact; no separate archive exists. `latest.json` gains a `windows-x86_64` entry. (This is artifact authenticity, separate from Authenticode; the in-app update loop is still macOS-gated in `updater.rs`.)
- **Manifest/publish/attach**: `scripts/create-release-manifests.mjs` and `scripts/prepare-published-release.mjs` are generalized around a `RELEASE_PLATFORMS` table (the previous `MACOS_ARCHITECTURES` export folded into it). The immutable manifest now carries `platform: windows`, `arch: x86_64`, `format: nsis`, size/sha256/checksum URLs, and updater signature fields in exactly the macOS artifact shape. The publish job downloads the Windows artifact, uploads with a proper `.exe` content type, and the attach job adds the version-free asset `OpenWave-windows-x86_64-setup.exe` (+`.sha256`) next to the macOS DMG.
- Workflow name, run-name, and concurrency groups renamed from `macos` to `desktop`; `docs/releases.md` updated to match.

## Why NSIS and not MSI

`tauri.conf.json` sets `bundle.targets: "all"` with zero Windows-specific configuration, so both formats are equally "configured" — the tie-breaks all favor NSIS: it is Tauri's recommended Windows target, installs per-user without elevation out of the box (no WiX upgrade-code or language decisions to make and freeze), the bundler fetches NSIS itself on the runner, and the Tauri v2 updater installs directly from the `-setup.exe`. MSI adds WiX surface area for no v1 benefit.

## Tests

- `create-release-manifests.test.mjs`: fixtures generalized to the platform table; asserts the `windows-x86_64` latest.json entry and URL/signature shape alongside the existing macOS assertions. No coverage removed.
- `workflow-security.test.mjs`: one new test pins the Windows credential-free prepare/build split (no secrets in prepare, restore-before-secret ordering, identical cache path lists, lockfile-pinned restore keys, product discard between restore and build, no `certificateThumbprint`/`signCommand`, updater key kept out of the Tauri build step). Existing macOS assertions untouched; the Cargo-downloads shared-key assertion now accepts the Windows registry key namespace.

## Consequences worth knowing

- A release published **before** this change cannot be re-dispatched afterwards: the resume preflight validates the hosted manifest against the current platform set and fails on artifact count instead of silently republishing (same behavior documented for architecture changes).
- The README has no Windows download link/badge yet; adding one only makes sense once the first Windows-bearing release exists, so it is left as a follow-up.
- No cache-warming workflow exists for Windows; `prepare_windows` is the single writer of the Windows registry and prepared-build caches, so the first tag run compiles cold.

## What a real tag dry-run still needs to prove (verification here is static only)

- The NSIS installer actually contains the app, the **target-named sidecar** (`openwave-host-broker-x86_64-pc-windows-msvc.exe`), and the bundled resources (exec-scripts, skills, plugins).
- `tauri build --target x86_64-pc-windows-msvc --bundles nsis` succeeds on `windows-latest` end to end, including the NSIS toolchain download and the `tauri` CLI being on PATH for `tauri signer sign` (the macOS job relies on the same tauri-action behavior).
- Install → clean profile boot → uninstall on a real Windows machine, including SmartScreen behavior for the unsigned binary and the `openwave://` deep-link registration.
- Updater metadata correctness: the `windows-x86_64` `latest.json` entry, and that a future updater-enabled Windows build accepts the signature over the installer bytes.
- Cache behavior across the prepare/build pair on `windows-latest` (glob paths like `openwave_desktop_lib.*` restoring as expected), and the Git-Bash steps (`cygpath`, `jq`, globbing) on the real runner image.
- Publish/attach paths for the new artifact: S3 content type, CDN smoke test, and the `OpenWave-windows-x86_64-setup.exe` GitHub asset.

Made with [Cursor](https://cursor.com)