### PR TITLE
ci: admit a Windows Cargo-registry namespace in the release cache policy

### DIFF
--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -427,7 +427,7 @@ test("cache warming cannot access production credentials or publish", () => {
     for (const step of downloadCaches) {
       assert.match(
         step,
-        /shared-key: macos-release-cargo-registry-v2-\$\{\{ hashFiles\('Cargo\.lock'\) \}\}/,
+        /shared-key: (?:macos-release-cargo-registry-v2|windows-release-cargo-registry-v1)-\$\{\{ hashFiles\('Cargo\.lock'\) \}\}/,
       );
       assert.match(step, /add-rust-environment-hash-key: "false"/);
       assert.match(step, /cache-targets: false/);


### PR DESCRIPTION
Prerequisite slice for #1602 (unsigned Windows release packaging).

The `release policy` lane deliberately runs the **base branch's** copy of `scripts/workflow-security.test.mjs` against a pull request's workflows, so a single PR cannot both relax a policy and introduce the workflow that relies on the relaxation. The Windows prepare/build jobs need their own Cargo-registry cache namespace (`windows-release-cargo-registry-v1-...`) — Cargo homes are per-runner-OS, and reusing the macOS-labeled key would be misleading at best.

This PR widens exactly one assertion: every `Cache Cargo downloads` step in `release.yml` / `cache-macos.yml` must use either the existing trusted macOS shared key or the new Windows one, still pinned to `hashFiles('Cargo.lock')` and still required to carry `add-rust-environment-hash-key: "false"` and `cache-targets: false`. Nothing currently on `main` uses the new namespace, so this test change passes against unchanged workflows.

The Windows packaging PR (#1614) stacks on this branch and will be retargeted to `main` once this lands.

Made with [Cursor](https://cursor.com)