### PR TITLE
feat(desktop): the broker and desktop implement the host-folder seam

### DIFF
--- a/crates/openwave-desktop/src/host_access.rs
+++ b/crates/openwave-desktop/src/host_access.rs
@@ -4,8 +4,9 @@ use std::path::PathBuf;
 
 use openwave_core::{ChatId, Store};
 use openwave_host_broker::{
-    Capability, ControlRequest, ControlResult, ExecutionContext, GrantSubject, OperationEnvelope,
-    OperationRequest, OperationResult, ResolveExecRootsRequest, RootId, RootSummary,
+    AppFolderPathRequest, AppFolderWriteRequest, Capability, ControlRequest, ControlResult,
+    ExecutionContext, GrantSubject, OperationEnvelope, OperationRequest, OperationResult,
+    RelativePath, ResolveExecRootsRequest, RootId, RootSummary, WriteFileMode,
 };
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager, State};
@@ -188,6 +189,189 @@ impl openwave_server::code_execution::ExecFolderGrantResolver for DesktopExecFol
                 })
             })
             .collect()
+    }
+}
+
+/// The desktop's host-folder surface for local-app folder bindings: the
+/// server's optional seam (docs/folder-bindings.md), implemented over the
+/// broker sidecar's app-folder control surface.
+///
+/// The server has already enforced the app grant — pin, coverage, access
+/// level, fingerprint — before any call lands here; this bridge carries
+/// opaque root ids and folder-relative paths to the broker, which owns the
+/// host-level half (live registration, pinned descriptors, byte bounds).
+pub(crate) struct DesktopHostFolders {
+    app: AppHandle,
+}
+
+impl DesktopHostFolders {
+    pub(crate) fn new(app: AppHandle) -> Self {
+        Self { app }
+    }
+
+    fn broker(&self) -> State<'_, HostAccess> {
+        self.app.state::<HostAccess>()
+    }
+}
+
+/// The broker's safe error vocabulary folded into the seam's closed one —
+/// codes only, never broker message text, so nothing host-shaped can reach
+/// an app frame.
+fn folder_op_error(
+    error: crate::broker::BrokerClientError,
+) -> openwave_server::host_folders::FolderOpError {
+    use openwave_server::host_folders::FolderOpError;
+
+    match error {
+        crate::broker::BrokerClientError::Broker { code, .. } => match code {
+            openwave_host_broker::ErrorCode::Denied
+            | openwave_host_broker::ErrorCode::InvalidRoot => FolderOpError::NotConnected,
+            openwave_host_broker::ErrorCode::NotFound => FolderOpError::NotFound,
+            openwave_host_broker::ErrorCode::InvalidRequest => FolderOpError::InvalidPath,
+            openwave_host_broker::ErrorCode::TooLarge => FolderOpError::TooLarge,
+            openwave_host_broker::ErrorCode::AlreadyExists => FolderOpError::WrongMode,
+            _ => FolderOpError::Failed,
+        },
+        _ => FolderOpError::Failed,
+    }
+}
+
+fn folder_relative_path(
+    path: &str,
+) -> Result<RelativePath, openwave_server::host_folders::FolderOpError> {
+    RelativePath::parse(path).map_err(|_| openwave_server::host_folders::FolderOpError::InvalidPath)
+}
+
+#[async_trait::async_trait]
+impl openwave_server::host_folders::HostFolders for DesktopHostFolders {
+    async fn approved_roots(
+        &self,
+    ) -> openwave_core::Result<Vec<openwave_server::host_folders::ApprovedFolder>> {
+        let result = self
+            .broker()
+            .broker
+            .control(ControlRequest::ListApprovedRoots)
+            .await
+            .map_err(|error| openwave_core::AgentError::config(error.to_string()))?;
+        let ControlResult::ListApprovedRoots { roots } = result else {
+            return Err(openwave_core::AgentError::config(
+                "host broker returned an invalid folder listing",
+            ));
+        };
+        Ok(roots
+            .into_iter()
+            .filter_map(|root| {
+                let root_id = openwave_core::HostRootId::from_uuid(root.root_id.as_uuid()).ok()?;
+                Some(openwave_server::host_folders::ApprovedFolder {
+                    root_id,
+                    display_name: root.display_name,
+                })
+            })
+            .collect())
+    }
+
+    async fn list_folder(
+        &self,
+        root: openwave_core::HostRootId,
+        path: &str,
+    ) -> Result<
+        Vec<openwave_server::host_folders::FolderEntry>,
+        openwave_server::host_folders::FolderOpError,
+    > {
+        use openwave_server::host_folders::FolderOpError;
+
+        let root_id =
+            RootId::from_uuid(*root.as_uuid()).map_err(|_| FolderOpError::NotConnected)?;
+        let path = folder_relative_path(path)?;
+        let result = self
+            .broker()
+            .broker
+            .control(ControlRequest::ListAppFolder(AppFolderPathRequest {
+                root_id,
+                path,
+            }))
+            .await
+            .map_err(folder_op_error)?;
+        let ControlResult::ListAppFolder { entries } = result else {
+            return Err(FolderOpError::Failed);
+        };
+        Ok(entries
+            .into_iter()
+            .map(|entry| openwave_server::host_folders::FolderEntry {
+                name: entry.name,
+                directory: matches!(entry.kind, openwave_host_broker::EntryKind::Directory),
+            })
+            .collect())
+    }
+
+    async fn read_file(
+        &self,
+        root: openwave_core::HostRootId,
+        path: &str,
+    ) -> Result<Vec<u8>, openwave_server::host_folders::FolderOpError> {
+        use base64::Engine as _;
+
+        use openwave_server::host_folders::FolderOpError;
+
+        let root_id =
+            RootId::from_uuid(*root.as_uuid()).map_err(|_| FolderOpError::NotConnected)?;
+        let path = folder_relative_path(path)?;
+        let result = self
+            .broker()
+            .broker
+            .control(ControlRequest::ReadAppFolderFile(AppFolderPathRequest {
+                root_id,
+                path,
+            }))
+            .await
+            .map_err(folder_op_error)?;
+        let ControlResult::ReadAppFolderFile(result) = result else {
+            return Err(FolderOpError::Failed);
+        };
+        base64::engine::general_purpose::STANDARD
+            .decode(result.content_base64)
+            .map_err(|_| FolderOpError::Failed)
+    }
+
+    async fn write_file(
+        &self,
+        root: openwave_core::HostRootId,
+        path: &str,
+        content: &[u8],
+        replace: bool,
+    ) -> Result<
+        openwave_server::host_folders::FolderWriteReceipt,
+        openwave_server::host_folders::FolderOpError,
+    > {
+        use base64::Engine as _;
+        use sha2::Digest as _;
+
+        use openwave_server::host_folders::FolderOpError;
+
+        let root_id =
+            RootId::from_uuid(*root.as_uuid()).map_err(|_| FolderOpError::NotConnected)?;
+        let path = folder_relative_path(path)?;
+        let result = self
+            .broker()
+            .broker
+            .control(ControlRequest::WriteAppFolderFile(AppFolderWriteRequest {
+                root_id,
+                path,
+                mode: if replace {
+                    WriteFileMode::Replace
+                } else {
+                    WriteFileMode::Create
+                },
+                content_base64: base64::engine::general_purpose::STANDARD.encode(content),
+                bytes: content.len(),
+                sha256: sha2::Sha256::digest(content).into(),
+            }))
+            .await
+            .map_err(folder_op_error)?;
+        let ControlResult::WriteAppFolderFile { bytes, replaced } = result else {
+            return Err(FolderOpError::Failed);
+        };
+        Ok(openwave_server::host_folders::FolderWriteReceipt { bytes, replaced })
     }
 }
 

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -407,6 +407,7 @@ async fn boot_server(
         Some(office_converter),
         Some(host_tool_broker),
         Some(local_voice),
+        Some(Arc::new(host_access::DesktopHostFolders::new(app.clone()))),
     )
     .await
     .map_err(|e| e.to_string())?;

--- a/crates/openwave-host-broker/src/broker.rs
+++ b/crates/openwave-host-broker/src/broker.rs
@@ -32,15 +32,15 @@ use crate::{
     },
     path_policy::RootIdentity,
     protocol::{
-        ControlEnvelope, ControlRequest, ControlResponseEnvelope, ControlResult, DirectoryEntry,
-        EntryKind, ErrorCode, ErrorResponse, GrantRootCapabilityRequest, GrantRootCapabilityResult,
-        GrantStatementSummary, HelloResult, LookupRegisterRootReceiptRequest,
-        LookupRegisterRootReceiptResult, LookupRootAttachmentReceiptRequest,
-        LookupRootAttachmentReceiptResult, OperationEnvelope, OperationRequest,
-        OperationResponseEnvelope, OperationResult, PathRequest, ReadFileBinaryResult,
-        ReadFileResult, RegisterRootReceipt, RegisterRootRequest, RegisterRootResult,
-        ResolveExecRootsRequest, ResolvedExecRoot, Response, ResponseEnvelope, RevokeGrantRequest,
-        RevokeGrantResult, RevokeRootRequest, RevokeRootResult, RootAccess,
+        AppFolderWriteRequest, ControlEnvelope, ControlRequest, ControlResponseEnvelope,
+        ControlResult, DirectoryEntry, EntryKind, ErrorCode, ErrorResponse,
+        GrantRootCapabilityRequest, GrantRootCapabilityResult, GrantStatementSummary, HelloResult,
+        LookupRegisterRootReceiptRequest, LookupRegisterRootReceiptResult,
+        LookupRootAttachmentReceiptRequest, LookupRootAttachmentReceiptResult, OperationEnvelope,
+        OperationRequest, OperationResponseEnvelope, OperationResult, PathRequest,
+        ReadFileBinaryResult, ReadFileResult, RegisterRootReceipt, RegisterRootRequest,
+        RegisterRootResult, ResolveExecRootsRequest, ResolvedExecRoot, Response, ResponseEnvelope,
+        RevokeGrantRequest, RevokeGrantResult, RevokeRootRequest, RevokeRootResult, RootAccess,
         RootAttachmentMutationKind, RootAttachmentMutationReceipt, RootAttachmentMutationRequest,
         RootAttachmentMutationResult, RootSummary, UnavailableRootReason, UnavailableRootSummary,
         WriteFileMode, WriteFileRequest, WriteFileResult, MAX_READ_FILE_BINARY_BYTES,
@@ -334,6 +334,16 @@ impl ControlAudit {
             | ControlRequest::ListApprovedRoots
             | ControlRequest::ListGrantStatements
             | ControlRequest::ListUnavailableRoots => None,
+            // The app-folder trio is consented and recorded server-side: the
+            // app grant names the folder and access level, and dispatch is
+            // admitted there before the broker is reached. The broker-side
+            // audit vocabulary is subject-keyed and local apps have no grant
+            // subject; auditing these under a borrowed subject would
+            // misattribute them. An app-actor audit kind is the recorded
+            // follow-up (docs/folder-bindings.md).
+            ControlRequest::ListAppFolder(_)
+            | ControlRequest::ReadAppFolderFile(_)
+            | ControlRequest::WriteAppFolderFile(_) => None,
             ControlRequest::ResolveExecRoots(request) => Some(Self {
                 actor: AuditActor::Control {
                     subject: match request.context.project_id() {
@@ -741,6 +751,37 @@ impl Controller {
             ControlRequest::GrantRootCapability(request) => self
                 .grant_root_capability(request)
                 .map(ControlResult::GrantRootCapability),
+            ControlRequest::ListAppFolder(request) => {
+                let root = {
+                    let state = self.lock_state().map_err(error_response)?;
+                    app_folder_root(&state, request.root_id).map_err(error_response)?
+                };
+                match list_directory(&root, &request.path).map_err(error_response)? {
+                    OperationResult::ListDirectory { entries } => {
+                        Ok(ControlResult::ListAppFolder { entries })
+                    }
+                    _ => Err(error_response(BrokerError::Denied)),
+                }
+            }
+            ControlRequest::ReadAppFolderFile(request) => {
+                let root = {
+                    let state = self.lock_state().map_err(error_response)?;
+                    app_folder_root(&state, request.root_id).map_err(error_response)?
+                };
+                match read_file_binary(&root, &request.path).map_err(error_response)? {
+                    OperationResult::ReadFileBinary(result) => {
+                        Ok(ControlResult::ReadAppFolderFile(result))
+                    }
+                    _ => Err(error_response(BrokerError::Denied)),
+                }
+            }
+            ControlRequest::WriteAppFolderFile(request) => {
+                let root = {
+                    let state = self.lock_state().map_err(error_response)?;
+                    app_folder_root(&state, request.root_id).map_err(error_response)?
+                };
+                write_app_folder_file(&root, request).map_err(error_response)
+            }
         }
     }
 
@@ -2363,6 +2404,65 @@ fn has_physical_root_alias(state: &State, root_id: RootId) -> bool {
         .roots
         .iter()
         .any(|(candidate_id, root)| *candidate_id != root_id && root.root.identity() == identity)
+}
+
+/// The pinned directory of one live registration, for the app-folder trio.
+///
+/// Trusted-host surface: no conversation attachment and no grant lookup
+/// apply — the server-side app grant is the consent gate
+/// (`docs/folder-bindings.md`) — but only a *live* registration answers. A
+/// set-aside or forgotten root is denied, and I/O through the pinned
+/// descriptor means a renamed-and-replaced directory cannot answer either.
+fn app_folder_root(state: &State, root_id: RootId) -> Result<Dir, BrokerError> {
+    state
+        .roots
+        .get(&root_id)
+        .ok_or(BrokerError::Denied)?
+        .root
+        .directory()
+        .try_clone()
+        .map_err(BrokerError::from)
+}
+
+/// One bounded app-folder write, atomic and digest-bound like the agent
+/// write operation, minus its approval and idempotency machinery: there is
+/// no chat to park an approval on, and the server-side dispatch does not
+/// replay — a same-content retry reconciles via the destination check.
+fn write_app_folder_file(
+    root: &Dir,
+    request: AppFolderWriteRequest,
+) -> Result<ControlResult, BrokerError> {
+    let probe = WriteFileRequest {
+        operation_id: OperationId::from_uuid(Uuid::new_v4())
+            .expect("a random v4 uuid is never nil"),
+        root_id: request.root_id,
+        path: request.path.clone(),
+        mode: request.mode,
+        approval: None,
+        content_base64: request.content_base64.clone(),
+        bytes: request.bytes,
+        sha256: request.sha256,
+    };
+    let content = decode_write_content(&probe)?;
+    match atomic_write_connected_file(
+        root,
+        &request.path,
+        &content,
+        request.mode,
+        probe.operation_id,
+    ) {
+        Ok(replaced) => Ok(ControlResult::WriteAppFolderFile {
+            bytes: request.bytes,
+            replaced,
+        }),
+        Err(_error) if destination_matches(root, &request.path, request.bytes, request.sha256) => {
+            Ok(ControlResult::WriteAppFolderFile {
+                bytes: request.bytes,
+                replaced: matches!(request.mode, WriteFileMode::Replace),
+            })
+        }
+        Err(error) => Err(error),
+    }
 }
 
 fn list_approved_roots(state: &State) -> Result<Vec<RootSummary>, ErrorResponse> {

--- a/crates/openwave-host-broker/src/broker/tests.rs
+++ b/crates/openwave-host-broker/src/broker/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::WriteApproval;
+use crate::{AppFolderPathRequest, WriteApproval};
 
 #[derive(Default)]
 struct CollectingAudit {
@@ -3585,4 +3585,133 @@ fn pending_write_recovery_never_replays_an_ambiguous_native_result() {
             })
         ));
     }
+}
+
+/// The app-folder trio (docs/folder-bindings.md in the product repo) is a
+/// trusted-host surface with the broker's host-level half intact: only a
+/// live registration answers, transfers keep the byte bounds, and writes are
+/// digest-bound and mode-checked — while no conversation context applies at
+/// all, because consent lives in the caller's app grant.
+#[test]
+fn app_folder_trio_serves_live_registrations_and_dies_with_the_registration() {
+    let (_temp, broker, root) = setup();
+    let controller = broker.controller();
+    let conversation = Uuid::new_v4();
+    let registered = register(
+        &controller,
+        GrantSubject::conversation(conversation).unwrap(),
+        conversation,
+        root,
+        OperationId::new(),
+    );
+    let root_id = registered.root.root_id;
+    let control = |request: ControlRequest| {
+        unwrap_response(controller.handle(ControlEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: crate::RequestId::new(),
+            request,
+        }))
+    };
+
+    // Listing the root and reading a file need no conversation context.
+    let ControlResult::ListAppFolder { entries } =
+        control(ControlRequest::ListAppFolder(AppFolderPathRequest {
+            root_id,
+            path: RelativePath::root(),
+        }))
+        .unwrap()
+    else {
+        panic!("unexpected control result")
+    };
+    assert!(entries
+        .iter()
+        .any(|entry| entry.name == "note.txt" && entry.kind == EntryKind::File));
+    assert!(entries
+        .iter()
+        .any(|entry| entry.name == "reports" && entry.kind == EntryKind::Directory));
+
+    let ControlResult::ReadAppFolderFile(read) =
+        control(ControlRequest::ReadAppFolderFile(AppFolderPathRequest {
+            root_id,
+            path: RelativePath::parse("note.txt").unwrap(),
+        }))
+        .unwrap()
+    else {
+        panic!("unexpected control result")
+    };
+    assert_eq!(
+        BASE64.decode(read.content_base64).unwrap(),
+        b"hello from broker"
+    );
+
+    // Writes are digest-bound and mode-checked: create lands, a same-content
+    // create retry reconciles, a different-content create refuses, and
+    // replace replaces.
+    let write = |mode: WriteFileMode, bytes: &[u8]| {
+        control(ControlRequest::WriteAppFolderFile(AppFolderWriteRequest {
+            root_id,
+            path: RelativePath::parse("app-state.json").unwrap(),
+            mode,
+            content_base64: BASE64.encode(bytes),
+            bytes: bytes.len(),
+            sha256: Sha256::digest(bytes).into(),
+        }))
+    };
+    let ControlResult::WriteAppFolderFile { bytes, replaced } =
+        write(WriteFileMode::Create, b"{\"cards\":1}").unwrap()
+    else {
+        panic!("unexpected control result")
+    };
+    assert_eq!((bytes, replaced), (11, false));
+    let ControlResult::WriteAppFolderFile { replaced, .. } =
+        write(WriteFileMode::Create, b"{\"cards\":1}").unwrap()
+    else {
+        panic!("unexpected control result")
+    };
+    assert!(!replaced, "a same-content create retry reconciles");
+    assert_eq!(
+        write(WriteFileMode::Create, b"{\"cards\":2}")
+            .unwrap_err()
+            .code,
+        ErrorCode::AlreadyExists
+    );
+    let ControlResult::WriteAppFolderFile { replaced, .. } =
+        write(WriteFileMode::Replace, b"{\"cards\":2}").unwrap()
+    else {
+        panic!("unexpected control result")
+    };
+    assert!(replaced);
+
+    // A mismatched digest refuses before any I/O.
+    assert_eq!(
+        control(ControlRequest::WriteAppFolderFile(AppFolderWriteRequest {
+            root_id,
+            path: RelativePath::parse("tampered.json").unwrap(),
+            mode: WriteFileMode::Create,
+            content_base64: BASE64.encode(b"x"),
+            bytes: 1,
+            sha256: [0; 32],
+        }))
+        .unwrap_err()
+        .code,
+        ErrorCode::InvalidRequest
+    );
+
+    // Revoking the registration closes the whole surface: the registration
+    // is the host-level gate, and nothing else answers for it.
+    revoke(
+        &controller,
+        OperationId::new(),
+        GrantSubject::conversation(conversation).unwrap(),
+        root_id,
+    );
+    assert_eq!(
+        control(ControlRequest::ReadAppFolderFile(AppFolderPathRequest {
+            root_id,
+            path: RelativePath::parse("note.txt").unwrap(),
+        }))
+        .unwrap_err()
+        .code,
+        ErrorCode::Denied
+    );
 }

--- a/crates/openwave-host-broker/src/lib.rs
+++ b/crates/openwave-host-broker/src/lib.rs
@@ -30,17 +30,18 @@ pub use id::{
 };
 pub use path_policy::{RootPolicy, RootPolicyError, ValidatedRoot};
 pub use protocol::{
-    ControlEnvelope, ControlRequest, ControlResponseEnvelope, ControlResult, DirectoryEntry,
-    EntryKind, ErrorCode, ErrorResponse, GrantRootCapabilityRequest, GrantRootCapabilityResult,
-    GrantStatementSummary, HelloResult, LookupRegisterRootReceiptRequest,
-    LookupRegisterRootReceiptResult, LookupRootAttachmentReceiptRequest,
-    LookupRootAttachmentReceiptResult, OperationEnvelope, OperationRequest,
-    OperationResponseEnvelope, OperationResult, PathRequest, ReadFileBinaryResult, ReadFileResult,
-    RegisterRootReceipt, RegisterRootRequest, RegisterRootResult, ResolveExecRootsRequest,
-    ResolvedExecRoot, Response, ResponseEnvelope, RevokeGrantRequest, RevokeGrantResult,
-    RevokeRootRequest, RevokeRootResult, RootAccess, RootAttachmentMutationKind,
-    RootAttachmentMutationReceipt, RootAttachmentMutationRequest, RootAttachmentMutationResult,
-    RootSummary, UnavailableRootReason, UnavailableRootSummary, WriteApproval, WriteFileMode,
-    WriteFileRequest, WriteFileResult, MAX_READ_FILE_BINARY_BYTES, PROTOCOL_VERSION,
+    AppFolderPathRequest, AppFolderWriteRequest, ControlEnvelope, ControlRequest,
+    ControlResponseEnvelope, ControlResult, DirectoryEntry, EntryKind, ErrorCode, ErrorResponse,
+    GrantRootCapabilityRequest, GrantRootCapabilityResult, GrantStatementSummary, HelloResult,
+    LookupRegisterRootReceiptRequest, LookupRegisterRootReceiptResult,
+    LookupRootAttachmentReceiptRequest, LookupRootAttachmentReceiptResult, OperationEnvelope,
+    OperationRequest, OperationResponseEnvelope, OperationResult, PathRequest,
+    ReadFileBinaryResult, ReadFileResult, RegisterRootReceipt, RegisterRootRequest,
+    RegisterRootResult, ResolveExecRootsRequest, ResolvedExecRoot, Response, ResponseEnvelope,
+    RevokeGrantRequest, RevokeGrantResult, RevokeRootRequest, RevokeRootResult, RootAccess,
+    RootAttachmentMutationKind, RootAttachmentMutationReceipt, RootAttachmentMutationRequest,
+    RootAttachmentMutationResult, RootSummary, UnavailableRootReason, UnavailableRootSummary,
+    WriteApproval, WriteFileMode, WriteFileRequest, WriteFileResult, MAX_READ_FILE_BINARY_BYTES,
+    PROTOCOL_VERSION,
 };
 pub use relative_path::{RelativePath, RelativePathError};

--- a/crates/openwave-host-broker/src/protocol.rs
+++ b/crates/openwave-host-broker/src/protocol.rs
@@ -122,6 +122,29 @@ pub enum ControlRequest {
     /// panel. No operation id — an equivalent live grant makes a retry observe
     /// `granted: false`, so nothing can be minted twice.
     GrantRootCapability(GrantRootCapabilityRequest),
+    /// List one approved root's directory for a local-app folder binding.
+    ///
+    /// The app-folder trio (`ListAppFolder`, `ReadAppFolderFile`,
+    /// `WriteAppFolderFile`) is a trusted-host surface for local apps
+    /// (`docs/folder-bindings.md`): the desktop calls it only after the
+    /// server's app grant admitted the invoke, so consent lives in the app
+    /// grant, not here. The broker still owns the host-level half — the root
+    /// must be a live registration (never a set-aside one), paths are
+    /// re-parsed into the relative grammar, I/O goes through the pinned
+    /// descriptor so a renamed-and-replaced directory cannot answer, and
+    /// every transfer respects the same byte bounds as agent operations.
+    /// No conversation attachment applies: an app is profile-scoped.
+    ListAppFolder(AppFolderPathRequest),
+    /// Read one file under an approved root for a local-app folder binding,
+    /// as bounded opaque bytes. See [`ControlRequest::ListAppFolder`].
+    ReadAppFolderFile(AppFolderPathRequest),
+    /// Write one file under an approved root for a local-app folder binding.
+    ///
+    /// Unlike the agent write operation there is no per-replacement approval
+    /// object: the standing `read_write` app grant is the write consent, at
+    /// folder granularity, checked server-side before dispatch. See
+    /// [`ControlRequest::ListAppFolder`].
+    WriteAppFolderFile(AppFolderWriteRequest),
 }
 
 /// Strict payload for a native-picker root registration.
@@ -135,6 +158,41 @@ pub struct RegisterRootRequest {
     pub conversation_id: Uuid,
     pub path: PathBuf,
     pub consent_method: ConsentMethod,
+}
+
+/// One approved root and a path under it, for the app-folder read surfaces.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AppFolderPathRequest {
+    pub root_id: RootId,
+    pub path: RelativePath,
+}
+
+/// One bounded app-folder write: content bound to its digest, like the agent
+/// write operation, minus the approval object (the app grant is the standing
+/// consent, enforced server-side).
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AppFolderWriteRequest {
+    pub root_id: RootId,
+    pub path: RelativePath,
+    pub mode: WriteFileMode,
+    pub content_base64: String,
+    pub bytes: usize,
+    pub sha256: [u8; 32],
+}
+
+impl std::fmt::Debug for AppFolderWriteRequest {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AppFolderWriteRequest")
+            .field("root_id", &self.root_id)
+            .field("path", &self.path)
+            .field("mode", &self.mode)
+            .field("content_base64", &"[redacted]")
+            .field("bytes", &self.bytes)
+            .finish()
+    }
 }
 
 /// Trusted product projection to intersect with live broker authority.
@@ -387,6 +445,9 @@ pub enum ControlResult {
     RevokeRoot(RevokeRootResult),
     RevokeGrant(RevokeGrantResult),
     GrantRootCapability(GrantRootCapabilityResult),
+    ListAppFolder { entries: Vec<DirectoryEntry> },
+    ReadAppFolderFile(ReadFileBinaryResult),
+    WriteAppFolderFile { bytes: usize, replaced: bool },
 }
 
 /// One currently authorized host root for native local execution.

--- a/crates/openwave-server/src/host_folders.rs
+++ b/crates/openwave-server/src/host_folders.rs
@@ -16,18 +16,97 @@ use openwave_core::local_app::FolderAccess;
 /// One host-approved connected folder, projected renderer-safe: the stable
 /// broker root id and its display name, never a path.
 #[derive(Debug, Clone)]
-pub(crate) struct ApprovedFolder {
-    pub(crate) root_id: HostRootId,
-    pub(crate) display_name: String,
+pub struct ApprovedFolder {
+    pub root_id: HostRootId,
+    pub display_name: String,
+}
+
+/// One directory entry under an approved folder.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FolderEntry {
+    /// Entry name — a single path segment, never a path.
+    pub name: String,
+    /// Whether the entry is itself a directory.
+    pub directory: bool,
+}
+
+/// The outcome of one bounded app-folder write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FolderWriteReceipt {
+    /// Bytes written.
+    pub bytes: usize,
+    /// Whether an existing file was replaced.
+    pub replaced: bool,
+}
+
+/// The closed failure vocabulary of app-folder operations.
+///
+/// Renderer-facing: each variant's display text is what an app frame may see,
+/// so no variant ever carries a path, an OS error, or broker internals.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FolderOpError {
+    /// The folder is no longer a live registration.
+    NotConnected,
+    /// The path does not name an existing entry.
+    NotFound,
+    /// The path grammar refused (absolute, traversal, or malformed).
+    InvalidPath,
+    /// The file or listing exceeds the host's transfer bound.
+    TooLarge,
+    /// A create found an existing file, or a replace found none.
+    WrongMode,
+    /// Anything else — the host refused or failed, with no detail an app
+    /// frame is entitled to.
+    Failed,
+}
+
+impl std::fmt::Display for FolderOpError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::NotConnected => "the folder is no longer connected",
+            Self::NotFound => "no such file or folder",
+            Self::InvalidPath => "the path is not a valid folder-relative path",
+            Self::TooLarge => "the content exceeds the folder transfer bound",
+            Self::WrongMode => "the file already exists, or there is nothing to replace",
+            Self::Failed => "the folder operation failed",
+        })
+    }
 }
 
 /// The host-folder surface for local-app folder bindings.
+///
+/// Implementations sit over the host broker's app-folder control surface,
+/// which owns the host-level half — live-registration checks, pinned
+/// descriptors, byte bounds. The caller owns the consent half: nothing here
+/// is dispatched until the app grant admitted the invoke.
 #[async_trait]
-pub(crate) trait HostFolders: Send + Sync {
+pub trait HostFolders: Send + Sync {
     /// Every host-approved connected folder, read live per request — never
     /// cached across one — so grant enforcement always judges the
     /// registration a root id resolves to *now*.
     async fn approved_roots(&self) -> openwave_core::Result<Vec<ApprovedFolder>>;
+
+    /// List one directory under an approved folder, within the host's
+    /// listing bounds.
+    async fn list_folder(
+        &self,
+        root: HostRootId,
+        path: &str,
+    ) -> Result<Vec<FolderEntry>, FolderOpError>;
+
+    /// Read one file under an approved folder as bounded opaque bytes.
+    async fn read_file(&self, root: HostRootId, path: &str) -> Result<Vec<u8>, FolderOpError>;
+
+    /// Write one file under an approved folder, atomically, within the
+    /// host's write bound. `replace` selects the create-vs-replace mode; the
+    /// caller has already enforced the grant's access level.
+    async fn write_file(
+        &self,
+        root: HostRootId,
+        path: &str,
+        content: &[u8],
+        replace: bool,
+    ) -> Result<FolderWriteReceipt, FolderOpError>;
 }
 
 /// SHA-256 fingerprint of one folder binding's canonical form, the value an

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -35,7 +35,7 @@ mod exec_write_snapshot;
 mod extract;
 mod foreground_prompt;
 mod gateway_runtime;
-mod host_folders;
+pub mod host_folders;
 pub mod logging;
 mod managed_policy;
 mod mcp_config;
@@ -723,6 +723,7 @@ pub async fn bind(config: Config) -> Result<Server> {
         None,
         None,
         None,
+        None,
     )
     .await
 }
@@ -733,7 +734,7 @@ pub async fn bind(config: Config) -> Result<Server> {
 /// to use [`bind`] when process-environment configuration is undesirable.
 pub async fn bind_configured(config: Config) -> Result<Server> {
     let mcp_servers = mcp_config::ConfiguredMcpServers::from_env()?;
-    bind_inner(config, None, mcp_servers, None, None, None, None).await
+    bind_inner(config, None, mcp_servers, None, None, None, None, None).await
 }
 
 /// Bind the API with a stable app-private native executor identity.
@@ -751,6 +752,7 @@ pub async fn bind_with_desktop_executor(
         config,
         Some(client_executor_id),
         mcp_config::ConfiguredMcpServers::default(),
+        None,
         None,
         None,
         None,
@@ -777,14 +779,16 @@ pub async fn bind_configured_with_desktop_executor(
         None,
         None,
         None,
+        None,
     )
     .await
 }
 
 /// Desktop binding with the native bridges only the product app can provide:
 /// the resolver that turns connected folders into per-invocation local
-/// sandbox grants, and the office-to-PDF converter that renders office
-/// outputs for the model's visual QA loop.
+/// sandbox grants, the office-to-PDF converter that renders office
+/// outputs for the model's visual QA loop, and the host-folder surface
+/// local-app folder bindings dispatch through.
 pub async fn bind_configured_with_desktop_executor_and_folder_grants(
     config: Config,
     client_executor_id: Uuid,
@@ -792,6 +796,7 @@ pub async fn bind_configured_with_desktop_executor_and_folder_grants(
     office_converter: Option<Arc<dyn openwave_code_execution::HostOfficeConverter>>,
     host_tool_broker: Option<Arc<dyn openwave_code_execution::HostToolBroker>>,
     local_voice: Option<Arc<dyn LocalVoiceRunner>>,
+    host_folders: Option<Arc<dyn host_folders::HostFolders>>,
 ) -> Result<Server> {
     if client_executor_id.is_nil() {
         return Err(AgentError::config("client executor id must not be nil"));
@@ -805,6 +810,7 @@ pub async fn bind_configured_with_desktop_executor_and_folder_grants(
         office_converter,
         host_tool_broker,
         local_voice,
+        host_folders,
     )
     .await
 }
@@ -846,6 +852,7 @@ async fn bind_inner(
     office_converter: Option<Arc<dyn openwave_code_execution::HostOfficeConverter>>,
     host_tool_broker: Option<Arc<dyn openwave_code_execution::HostToolBroker>>,
     local_voice: Option<Arc<dyn LocalVoiceRunner>>,
+    host_folders: Option<Arc<dyn host_folders::HostFolders>>,
 ) -> Result<Server> {
     // Desktop live delivery remains process-local. Turns, steering, and tool
     // approvals are durable, while one process still owns the complete data
@@ -962,6 +969,10 @@ async fn bind_inner(
     if let Some(local_voice) = local_voice {
         state.set_local_voice_runner(local_voice);
     }
+    // The host-folder surface local-app folder bindings dispatch through;
+    // absent everywhere but the desktop, where folder bindings then refuse
+    // to grant (docs/folder-bindings.md).
+    state.host_folders = host_folders;
     state.mcp.initialize(mcp_servers).await?;
     let token = state.token.clone();
     let client_executor_token = state.client_executor_token.clone();

--- a/crates/openwave-server/src/tests/app_grant.rs
+++ b/crates/openwave-server/src/tests/app_grant.rs
@@ -333,6 +333,36 @@ async fn folder_bindings_grant_and_fail_closed_when_the_folder_disconnects() {
         async fn approved_roots(&self) -> openwave_core::Result<Vec<ApprovedFolder>> {
             Ok(self.0.lock().unwrap().clone())
         }
+
+        // The consent surface never dispatches I/O; a fake that fails loudly
+        // if it ever does keeps this test about the grant object.
+        async fn list_folder(
+            &self,
+            _root: openwave_core::id::HostRootId,
+            _path: &str,
+        ) -> Result<Vec<crate::host_folders::FolderEntry>, crate::host_folders::FolderOpError>
+        {
+            panic!("the grant surface must not dispatch folder I/O")
+        }
+
+        async fn read_file(
+            &self,
+            _root: openwave_core::id::HostRootId,
+            _path: &str,
+        ) -> Result<Vec<u8>, crate::host_folders::FolderOpError> {
+            panic!("the grant surface must not dispatch folder I/O")
+        }
+
+        async fn write_file(
+            &self,
+            _root: openwave_core::id::HostRootId,
+            _path: &str,
+            _content: &[u8],
+            _replace: bool,
+        ) -> Result<crate::host_folders::FolderWriteReceipt, crate::host_folders::FolderOpError>
+        {
+            panic!("the grant surface must not dispatch folder I/O")
+        }
     }
 
     let (dir, store) = temp_db_store("folder-grant.db").await;


### PR DESCRIPTION
Fourth PR in the folder-bindings stack (#1331), stacked on #1612: the seam the consent surface reads — and dispatch will call — becomes real on the desktop.

- **Broker**: an app-folder trio on the trusted control channel (`ListAppFolder`, `ReadAppFolderFile`, `WriteAppFolderFile`). No conversation attachment or grant lookup applies — consent lives in the server-side app grant, checked before dispatch — while the broker keeps the host-level half: only a **live registration** answers (set-aside and revoked roots deny), paths re-parse into the relative grammar, I/O goes through the **pinned descriptor** (a renamed-and-replaced directory can't answer), transfers keep the existing byte bounds (64 KiB text / 8 MiB binary reads, 512 KiB writes, listing caps), and writes are digest-bound, mode-checked, and atomic with same-content-retry reconciliation. One test drives the whole trio end to end including revocation closing the surface.
- **Broker audit**: deliberately absent for these three for now — the audit vocabulary is subject-keyed and apps have no grant subject; borrowing one would misattribute. An app-actor audit kind is the recorded follow-up (noted in the design doc and the code).
- **Server**: `HostFolders` grows `list_folder`/`read_file`/`write_file` with a closed, renderer-safe failure vocabulary (`FolderOpError` — codes only, no paths, no OS errors, no broker message text), and threads through `bind_inner` so embeddings opt in explicitly; every existing embedding passes `None`.
- **Desktop**: `DesktopHostFolders` implements the trait over the broker sidecar client (the `DesktopExecFolderGrantResolver` pattern) and installs it at bind — folder consent over real approved folders becomes live on the desktop with this PR.

The invoke surface and `fs/*` bridge verbs that consume the dispatch half are the final slice.

Refs #1331

🤖 Generated with [Claude Code](https://claude.com/claude-code)
