### PR TITLE
feat(server): typed previews in background-agent activity history

### DIFF
--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -184,8 +184,9 @@ pub use plan_mode::{
     MAX_PLAN_FEEDBACK_CHARS, MAX_PLAN_TITLE_CHARS, MIN_PLAN_CONTENT_CHARS,
 };
 pub use preview::{
-    format_bytes, ExecDegradation, ResultEntry, ResultEntryKind, ResultFailure, ToolActionPreview,
-    ToolResultPreview, MAX_RESULT_ENTRIES, MAX_RESULT_ENTRY_CHARS,
+    format_bytes, AgentActivityDetail, ExecDegradation, ResultEntry, ResultEntryKind,
+    ResultFailure, ToolActionPreview, ToolResultPreview, MAX_RESULT_ENTRIES,
+    MAX_RESULT_ENTRY_CHARS,
 };
 pub use provider::{
     ChatMessage, ChatRequest, ContentBlock, MessageReasoning, ModelProvider, ProviderEvent,

--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -1,8 +1,10 @@
 //! Closed renderer projections of what a tool will do, and what it did.
 //!
-//! The renderer boundary carries no tool arguments and no tool output. These
-//! types are the deliberate exceptions: a tool may opt in to showing a human
-//! the action under review and the result it produced, field by field.
+//! The renderer boundary carries neither raw argument objects nor raw tool
+//! output. These types are the deliberate exceptions: a tool may opt in to
+//! showing a human selected fields, one by one. Model-authored strings remain
+//! untrusted text and may repeat information the model already saw; the
+//! boundary guarantee is about which stored and host-owned fields are copied.
 //!
 //! They are not passthroughs. Each variant enumerates exactly what a person
 //! needs in order to consent to an action or to understand its outcome, values
@@ -34,6 +36,101 @@ pub const MAX_RESULT_ENTRY_CHARS: usize = 200;
 
 /// Most rows a result preview lists before it counts the rest instead.
 pub const MAX_RESULT_ENTRIES: usize = 50;
+
+/// A bounded headline for one background-agent activity step.
+///
+/// This is deliberately smaller than [`ToolActionPreview`]. The command,
+/// arguments, and query are model-authored text: they are bounded for safe
+/// single-line presentation, but may repeat any information the background
+/// agent already saw and are therefore outside the host-field non-disclosure
+/// guarantee. The projection never copies stored result text or host-only
+/// broker identity directly. Its only host-derived values are a typed numeric
+/// exit code and the leaf name of the canonically admitted delegated file.
+///
+/// Command and search fields use the foreground approval-card projection so
+/// both surfaces share the same sanitization.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AgentActivityDetail {
+    /// The argument vector a background command ran and its settled exit code,
+    /// when the immutable receipt recorded one.
+    Exec {
+        command: String,
+        args: Vec<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        exit_code: Option<i32>,
+    },
+    /// One public-web query, trimmed and bounded like its approval preview.
+    Search { query: String },
+    /// The bounded leaf name of the one canonically admitted delegated file.
+    File { name: String },
+}
+
+impl AgentActivityDetail {
+    /// Project the headline fields admitted for one tool call.
+    ///
+    /// Only the two model-authored call shapes reached by background history
+    /// are admitted here. Malformed or unrecognized arguments project no
+    /// detail instead of falling back to raw JSON. Both are first projected
+    /// through [`ToolActionPreview::build`], reusing its sanitization exactly.
+    #[must_use]
+    pub fn build(tool_name: &str, arguments: &Value) -> Option<Self> {
+        match ToolActionPreview::build(tool_name, arguments) {
+            Some(ToolActionPreview::Exec { command, args, .. }) => {
+                return Some(Self::Exec {
+                    command,
+                    args,
+                    exit_code: None,
+                });
+            }
+            Some(ToolActionPreview::WebSearch { query, .. }) => {
+                return Some(Self::Search { query });
+            }
+            _ => None,
+        }
+    }
+
+    /// Project the one file delegated to a background run by base name only.
+    ///
+    /// The admission carries a root-relative path because the trusted broker
+    /// needs it; the activity headline needs only the final display name.
+    #[must_use]
+    pub fn delegated_file(relative_path: &str) -> Option<Self> {
+        let name = std::path::Path::new(relative_path).file_name()?.to_str()?;
+        Some(Self::File {
+            name: clamp(name, MAX_ACTION_FIELD_CHARS)?,
+        })
+    }
+
+    /// Attach an exec exit code from the immutable receipt's first line.
+    ///
+    /// A live call has no receipt, a signal is recorded as `exit: signal`, and
+    /// setup failures carry no `exit:` line; all three keep the field absent.
+    #[must_use]
+    pub fn with_exec_result(self, result: &str) -> Self {
+        let exit_code = result
+            .lines()
+            .next()
+            .and_then(|line| line.strip_prefix("exit: "))
+            .and_then(|code| code.parse::<i32>().ok());
+        match (self, exit_code) {
+            (
+                Self::Exec {
+                    command,
+                    args,
+                    exit_code: _,
+                },
+                Some(exit_code),
+            ) => Self::Exec {
+                command,
+                args,
+                exit_code: Some(exit_code),
+            },
+            (detail, _) => detail,
+        }
+    }
+}
 
 /// The action a call will take, in a form a human can inspect.
 ///
@@ -822,15 +919,15 @@ fn search_query(arguments: &Value) -> Option<String> {
     )
 }
 
-/// Bound one optional single-line preview field, dropping control characters
-/// that could forge card structure. An absent, empty, or all-control field is
-/// not presentable.
+/// Bound one optional single-line preview field, dropping control characters,
+/// Unicode separators, and directional formatting that could forge card
+/// structure. An absent, empty, or entirely-forbidden field is not presentable.
 fn clamped_field(value: Option<&Value>) -> Option<String> {
     clamp(value?.as_str()?, MAX_ACTION_FIELD_CHARS)
 }
 
-/// Bound a list of single-line preview fields: surplus entries elided,
-/// unreadable ones dropped.
+/// Bound a list of single-line preview fields: surplus entries are elided and
+/// unreadable or entirely-forbidden ones are dropped.
 fn clamped_list(value: Option<&Value>) -> Vec<String> {
     value
         .and_then(Value::as_array)
@@ -896,14 +993,26 @@ fn list_survives_clamp(value: Option<&Value>) -> bool {
 /// nothing.
 fn survives_clamp(value: &str) -> bool {
     !value.is_empty()
-        && !value.chars().any(char::is_control)
+        && !value.chars().any(preview_formatting_character)
         && value.chars().count() <= MAX_ACTION_FIELD_CHARS
+}
+
+/// Characters that can break a one-line preview or spoof its visual order.
+///
+/// This clamp is shared by foreground approval previews and background
+/// activity details, so extending it hardens both renderer surfaces together.
+fn preview_formatting_character(character: char) -> bool {
+    character.is_control()
+        || matches!(
+            character,
+            '\u{2028}' | '\u{2029}' | '\u{202a}'..='\u{202e}' | '\u{2066}'..='\u{2069}'
+        )
 }
 
 fn clamp(value: &str, max_chars: usize) -> Option<String> {
     let cleaned: String = value
         .chars()
-        .filter(|character| !character.is_control())
+        .filter(|character| !preview_formatting_character(*character))
         .take(max_chars)
         .collect();
     (!cleaned.is_empty()).then_some(cleaned)
@@ -1054,6 +1163,123 @@ mod tests {
                 files: Vec::new(),
             })
         );
+    }
+
+    #[test]
+    fn agent_activity_detail_bounds_hostile_text_and_parses_only_a_first_line_exit() {
+        let long_command = "x".repeat(MAX_ACTION_FIELD_CHARS + 8);
+        let many_args = (0..MAX_ACTION_ARGS + 2)
+            .map(|index| format!("arg-{index}"))
+            .collect::<Vec<_>>();
+        let cases: Vec<(&str, &str, serde_json::Value, Option<AgentActivityDetail>)> = vec![
+            (
+                "ASCII controls are removed",
+                crate::SANDBOX_EXEC_TOOL,
+                json!({"command": "py\nthon", "args": ["safe\u{0}arg"]}),
+                Some(AgentActivityDetail::Exec {
+                    command: "python".into(),
+                    args: vec!["safearg".into()],
+                    exit_code: None,
+                }),
+            ),
+            (
+                "Unicode separators are removed",
+                crate::SANDBOX_WEB_SEARCH_TOOL,
+                json!({"query": "first\u{2028}second\u{2029}third"}),
+                Some(AgentActivityDetail::Search {
+                    query: "firstsecondthird".into(),
+                }),
+            ),
+            (
+                "directional formatting is removed",
+                crate::SANDBOX_EXEC_TOOL,
+                json!({"command": "python3", "args": ["report\u{202e}cod\u{2067}.exe"]}),
+                Some(AgentActivityDetail::Exec {
+                    command: "python3".into(),
+                    args: vec!["reportcod.exe".into()],
+                    exit_code: None,
+                }),
+            ),
+            (
+                "absolute-looking model text remains model text",
+                crate::SANDBOX_EXEC_TOOL,
+                json!({"command": "cat", "args": ["/Users/alice/private.txt"]}),
+                Some(AgentActivityDetail::Exec {
+                    command: "cat".into(),
+                    args: vec!["/Users/alice/private.txt".into()],
+                    exit_code: None,
+                }),
+            ),
+            (
+                "connected-folder paths are not an admitted detail source",
+                crate::READ_CONNECTED_FILE_TOOL,
+                json!({"path": "/Users/alice/private.txt"}),
+                None,
+            ),
+            (
+                "fields and argument counts are clamped",
+                crate::SANDBOX_EXEC_TOOL,
+                json!({"command": long_command, "args": many_args}),
+                Some(AgentActivityDetail::Exec {
+                    command: "x".repeat(MAX_ACTION_FIELD_CHARS),
+                    args: (0..MAX_ACTION_ARGS)
+                        .map(|index| format!("arg-{index}"))
+                        .collect(),
+                    exit_code: None,
+                }),
+            ),
+        ];
+        for (case, tool, arguments, expected) in cases {
+            assert_eq!(
+                AgentActivityDetail::build(tool, &arguments),
+                expected,
+                "{case}"
+            );
+        }
+
+        // The same predicate guards foreground exact-action previews: a value
+        // needing separator or bidi sanitization must not create a narrow grant.
+        for command in ["line\u{2028}break", "right\u{202e}left"] {
+            assert!(!ToolActionPreview::describes_exactly(
+                "exec",
+                &json!({"command": command})
+            ));
+        }
+
+        // An invalid legacy admission can expose at most its leaf, never the
+        // absolute path it arrived with.
+        assert_eq!(
+            AgentActivityDetail::delegated_file("/Users/alice/private.txt"),
+            Some(AgentActivityDetail::File {
+                name: "private.txt".into(),
+            })
+        );
+
+        let base = AgentActivityDetail::Exec {
+            command: "python3".into(),
+            args: vec!["report.py".into()],
+            exit_code: None,
+        };
+        for (case, result, exit_code) in [
+            ("numeric first line", "exit: 17\nexit: 99", Some(17)),
+            ("numeric second line", "duration_ms: 1\nexit: 17", None),
+            ("signal", "exit: signal\nduration_ms: 1", None),
+            (
+                "setup failure",
+                "The command could not be run in this task's workspace.",
+                None,
+            ),
+        ] {
+            assert_eq!(
+                base.clone().with_exec_result(result),
+                AgentActivityDetail::Exec {
+                    command: "python3".into(),
+                    args: vec!["report.py".into()],
+                    exit_code,
+                },
+                "{case}"
+            );
+        }
     }
 
     /// The exec card lists the durable outputs the command published. Only

--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -1183,24 +1183,6 @@ mod tests {
                 }),
             ),
             (
-                "Unicode separators are removed",
-                crate::SANDBOX_WEB_SEARCH_TOOL,
-                json!({"query": "first\u{2028}second\u{2029}third"}),
-                Some(AgentActivityDetail::Search {
-                    query: "firstsecondthird".into(),
-                }),
-            ),
-            (
-                "directional formatting is removed",
-                crate::SANDBOX_EXEC_TOOL,
-                json!({"command": "python3", "args": ["report\u{202e}cod\u{2067}.exe"]}),
-                Some(AgentActivityDetail::Exec {
-                    command: "python3".into(),
-                    args: vec!["reportcod.exe".into()],
-                    exit_code: None,
-                }),
-            ),
-            (
                 "absolute-looking model text remains model text",
                 crate::SANDBOX_EXEC_TOOL,
                 json!({"command": "cat", "args": ["/Users/alice/private.txt"]}),
@@ -1237,13 +1219,36 @@ mod tests {
             );
         }
 
-        // The same predicate guards foreground exact-action previews: a value
-        // needing separator or bidi sanitization must not create a narrow grant.
-        for command in ["line\u{2028}break", "right\u{202e}left"] {
-            assert!(!ToolActionPreview::describes_exactly(
-                "exec",
-                &json!({"command": command})
-            ));
+        // Every separator and bidi-formatting code point guarded by the shared
+        // predicate is exercised through both consumers: background detail is
+        // sanitized, while a foreground exact-action grant is refused.
+        for (case, character) in [
+            ("U+2028", '\u{2028}'),
+            ("U+2029", '\u{2029}'),
+            ("U+202A", '\u{202a}'),
+            ("U+202B", '\u{202b}'),
+            ("U+202C", '\u{202c}'),
+            ("U+202D", '\u{202d}'),
+            ("U+202E", '\u{202e}'),
+            ("U+2066", '\u{2066}'),
+            ("U+2067", '\u{2067}'),
+            ("U+2068", '\u{2068}'),
+            ("U+2069", '\u{2069}'),
+        ] {
+            let arguments = json!({"command": format!("left{character}right")});
+            assert_eq!(
+                AgentActivityDetail::build(crate::SANDBOX_EXEC_TOOL, &arguments),
+                Some(AgentActivityDetail::Exec {
+                    command: "leftright".into(),
+                    args: Vec::new(),
+                    exit_code: None,
+                }),
+                "background detail did not reject {case}"
+            );
+            assert!(
+                !ToolActionPreview::describes_exactly("exec", &arguments),
+                "foreground exactness accepted {case}"
+            );
         }
 
         // An invalid legacy admission can expose at most its leaf, never the

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -403,9 +403,9 @@ export type AgentActivity = AgentActivitySnapshot;
 /**
  * One settled or live step in a background run's ordered activity history.
  *
- * Same closed vocabulary and posture as {@link AgentActivity}: the server
- * sends only a fixed kind, a coarse outcome, and a timestamp — never tool
- * inputs, queries, results, identities, paths, leases, or diagnostics.
+ * The wire may also carry an additive typed `detail`. This server-only slice
+ * intentionally discards it in {@link parseAgentActivityHistory}; preserving it
+ * waits for the renderer slice's closed, bounded, kind-matched validator.
  */
 export type AgentActivityHistoryEntry = AgentActivityHistoryItem;
 

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -9,15 +9,37 @@
 // which a type can express. See docs/wire-types.md.
 
 /**
+ * A bounded headline for one background-agent activity step.
+ *
+ * This is deliberately smaller than [`ToolActionPreview`]. The command,
+ * arguments, and query are model-authored text: they are bounded for safe
+ * single-line presentation, but may repeat any information the background
+ * agent already saw and are therefore outside the host-field non-disclosure
+ * guarantee. The projection never copies stored result text or host-only
+ * broker identity directly. Its only host-derived values are a typed numeric
+ * exit code and the leaf name of the canonically admitted delegated file.
+ *
+ * Command and search fields use the foreground approval-card projection so
+ * both surfaces share the same sanitization.
+ */
+export type AgentActivityDetail = { "kind": "exec", command: string, args: Array<string>, exit_code?: number, } | { "kind": "search", query: string, } | { "kind": "file", name: string, };
+
+/**
  * One renderer-safe entry in a background run's ordered activity history.
  *
- * Built from durable sandbox tool calls, but it carries only the fixed
- * [`AgentActivityKind`] vocabulary, a coarse lifecycle, and a timestamp. Tool
- * arguments, queries, results, folder and file identities, host paths,
- * provider identities, executor leases, and raw diagnostics all remain
- * server-side, exactly as they do for the live `activity` projection.
+ * Built on read from durable sandbox tool calls and their immutable receipts.
+ * `detail` admits bounded model-authored command/argument/query text, which may
+ * repeat anything the child already saw and is not covered by the host-field
+ * non-disclosure guarantee. The only host-derived values are the numeric exit
+ * code parsed from a receipt's first line and the delegated file's leaf name.
+ * Stored result text, full broker paths and root identities, provider
+ * identities, executor leases, and diagnostics are never copied directly.
+ *
+ * No separate activity-history shape is persisted. The optional field keeps
+ * the wire additive for older clients and lets calls without derivable detail
+ * retain the original `{kind, outcome, at}` shape.
  */
-export type AgentActivityHistoryItem = { kind: AgentActivityKind, outcome: AgentActivityOutcome, at: string, };
+export type AgentActivityHistoryItem = { kind: AgentActivityKind, outcome: AgentActivityOutcome, at: string, detail?: AgentActivityDetail, };
 
 /**
  * Fixed, renderer-safe names for supported live work.
@@ -77,10 +99,10 @@ export type AgentRunId = string;
  *
  * The text is the run's own bounded narration — the same class of prose the
  * terminal `terminal_text` already carries, published while the run is still
- * working instead of only at the end. It is not a tool trace: tool arguments,
- * queries, results, folder and file identities, host paths, provider
- * identities, executor leases, and raw diagnostics stay server-side, exactly as
- * they do for the activity projections.
+ * working instead of only at the end. It is model-authored and may repeat
+ * information the run already saw. Stored tool records and host-owned fields
+ * are not copied directly into it. Typed activity headlines are projected
+ * separately.
  */
 export type AgentRunProgressLine = { 
 /**

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -2250,7 +2250,7 @@ pub struct SubmittedOutputSnapshot {
 ///
 /// Adding a durable tool does not automatically expose it to a renderer: it
 /// must be deliberately admitted here with a safe label.
-#[derive(Debug, Clone, Copy, Serialize, ts_rs::TS)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentActivityKind {
     Exec,
@@ -2311,7 +2311,7 @@ fn sandbox_activity(calls: &[SandboxToolCall]) -> Option<AgentActivitySnapshot> 
 /// admits the three terminal outcomes so a settled step can be shown in an
 /// ordered timeline. It carries no failure detail: a failed step is only
 /// "failed", never why.
-#[derive(Debug, Clone, Copy, Serialize, ts_rs::TS)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentActivityOutcome {
     Waiting,
@@ -2323,16 +2323,25 @@ pub enum AgentActivityOutcome {
 
 /// One renderer-safe entry in a background run's ordered activity history.
 ///
-/// Built from durable sandbox tool calls, but it carries only the fixed
-/// [`AgentActivityKind`] vocabulary, a coarse lifecycle, and a timestamp. Tool
-/// arguments, queries, results, folder and file identities, host paths,
-/// provider identities, executor leases, and raw diagnostics all remain
-/// server-side, exactly as they do for the live `activity` projection.
-#[derive(Debug, Clone, Copy, Serialize, ts_rs::TS)]
+/// Built on read from durable sandbox tool calls and their immutable receipts.
+/// `detail` admits bounded model-authored command/argument/query text, which may
+/// repeat anything the child already saw and is not covered by the host-field
+/// non-disclosure guarantee. The only host-derived values are the numeric exit
+/// code parsed from a receipt's first line and the delegated file's leaf name.
+/// Stored result text, full broker paths and root identities, provider
+/// identities, executor leases, and diagnostics are never copied directly.
+///
+/// No separate activity-history shape is persisted. The optional field keeps
+/// the wire additive for older clients and lets calls without derivable detail
+/// retain the original `{kind, outcome, at}` shape.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 pub struct AgentActivityHistoryItem {
     pub kind: AgentActivityKind,
     pub outcome: AgentActivityOutcome,
     pub at: chrono::DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub detail: Option<openwave_core::AgentActivityDetail>,
 }
 
 /// Project a background run's durable sandbox tool calls into an ordered,
@@ -2341,14 +2350,26 @@ pub struct AgentActivityHistoryItem {
 /// The store returns calls in durable creation order, so the projection keeps
 /// that order. Tool names outside the admitted vocabulary are executor data,
 /// not a renderer contract, and are skipped rather than leaked as raw labels.
-fn sandbox_activity_history(calls: &[SandboxToolCall]) -> Vec<AgentActivityHistoryItem> {
+/// `delegated_file` is the run's one admission-delegated file identity, when it
+/// had one; only its base name may reach a `read_delegated_file` entry. The
+/// receipt map contains only terminal exec receipts, used solely to recover the
+/// typed exit code from their first line.
+fn sandbox_activity_history(
+    calls: &[SandboxToolCall],
+    delegated_file: Option<&str>,
+    receipts: &std::collections::HashMap<CallId, openwave_core::SandboxToolCallReceipt>,
+) -> Vec<AgentActivityHistoryItem> {
     calls
         .iter()
-        .filter_map(sandbox_activity_history_item)
+        .filter_map(|call| sandbox_activity_history_item(call, delegated_file, receipts))
         .collect()
 }
 
-fn sandbox_activity_history_item(call: &SandboxToolCall) -> Option<AgentActivityHistoryItem> {
+fn sandbox_activity_history_item(
+    call: &SandboxToolCall,
+    delegated_file: Option<&str>,
+    receipts: &std::collections::HashMap<CallId, openwave_core::SandboxToolCallReceipt>,
+) -> Option<AgentActivityHistoryItem> {
     let kind = match call.name.as_str() {
         openwave_core::SANDBOX_EXEC_TOOL => AgentActivityKind::Exec,
         "web_search" => AgentActivityKind::WebSearch,
@@ -2380,7 +2401,26 @@ fn sandbox_activity_history_item(call: &SandboxToolCall) -> Option<AgentActivity
         // state is executor data, not a renderer contract.
         _ => return None,
     };
-    Some(AgentActivityHistoryItem { kind, outcome, at })
+    // The delegated read is argument-free, so its headline comes from the
+    // admission rather than from model-authored arguments. Every other detail
+    // is a bounded projection of the durable call and optional receipt.
+    let detail = match call.name.as_str() {
+        openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL => {
+            delegated_file.and_then(openwave_core::AgentActivityDetail::delegated_file)
+        }
+        _ => openwave_core::AgentActivityDetail::build(&call.name, &call.arguments).map(|detail| {
+            match receipts.get(&call.id) {
+                Some(receipt) => detail.with_exec_result(&receipt.result),
+                None => detail,
+            }
+        }),
+    };
+    Some(AgentActivityHistoryItem {
+        kind,
+        outcome,
+        at,
+        detail,
+    })
 }
 
 fn foreground_activity(
@@ -2479,10 +2519,14 @@ pub async fn list_agent_runs(
 /// This is the durable companion to the live `activity` field on a run
 /// snapshot: where that field names only the single current checkpoint, this
 /// returns every admitted step in order, each with a coarse terminal outcome
-/// and timestamp. It keeps the same posture — no tool arguments, queries,
-/// results, identities, leases, or diagnostics cross the boundary. A missing,
-/// wrong-chat, or foreground run returns `404` rather than revealing whether an
-/// unrelated run identifier exists.
+/// and timestamp. Each entry may add a bounded typed headline — the command and
+/// exit status a settled exec recorded, the query a web search asked, or the
+/// base name of the run's one delegated file. Command, argument, and query text
+/// is model-authored and may repeat information the child already saw; the
+/// boundary guarantee is narrower: stored results and host-only fields are not
+/// copied directly, apart from the typed exit code and admitted leaf name. A
+/// missing, wrong-chat, or foreground run returns `404` rather than revealing
+/// whether an unrelated run identifier exists.
 pub async fn list_agent_run_activity(
     store: ScopedStore,
     Path((chat_id, run_id)): Path<(ChatId, openwave_core::AgentRunId)>,
@@ -2498,7 +2542,37 @@ pub async fn list_agent_run_activity(
         )));
     };
     let calls = store.list_sandbox_tool_calls_for_agent_run(run.id).await?;
-    Ok(Json(sandbox_activity_history(&calls)))
+    // The run's one delegated file identity is needed only for its argument-free
+    // read call. A missing admission leaves that entry in the original
+    // detail-free shape rather than dropping the history.
+    let delegated_file = if calls
+        .iter()
+        .any(|call| call.name == openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL)
+    {
+        store
+            .get_sandbox_agent_admission(run.id)
+            .await?
+            .and_then(|admission| admission.resource)
+            .map(|resource| resource.relative_path)
+    } else {
+        None
+    };
+    // Exit status lives on the immutable receipts, not the call rows. A
+    // missing receipt — a live step, or a call settled before receipts were
+    // kept — leaves the detail without an exit code rather than failing.
+    let mut receipts = std::collections::HashMap::new();
+    for call in &calls {
+        if call.name == openwave_core::SANDBOX_EXEC_TOOL && call.status.is_terminal() {
+            if let Some(receipt) = store.get_sandbox_tool_call_receipt(call.id).await? {
+                receipts.insert(call.id, receipt);
+            }
+        }
+    }
+    Ok(Json(sandbox_activity_history(
+        &calls,
+        delegated_file.as_deref(),
+        &receipts,
+    )))
 }
 
 /// One line of live progress a background run published, as the renderer sees
@@ -2506,10 +2580,10 @@ pub async fn list_agent_run_activity(
 ///
 /// The text is the run's own bounded narration — the same class of prose the
 /// terminal `terminal_text` already carries, published while the run is still
-/// working instead of only at the end. It is not a tool trace: tool arguments,
-/// queries, results, folder and file identities, host paths, provider
-/// identities, executor leases, and raw diagnostics stay server-side, exactly as
-/// they do for the activity projections.
+/// working instead of only at the end. It is model-authored and may repeat
+/// information the run already saw. Stored tool records and host-owned fields
+/// are not copied directly into it. Typed activity headlines are projected
+/// separately.
 #[derive(Debug, Clone, Serialize, ts_rs::TS)]
 pub struct AgentRunProgressLine {
     /// Monotonic per-run ordering. Pass the page's `next_sequence` back as

--- a/crates/openwave-server/src/scoped_store.rs
+++ b/crates/openwave-server/src/scoped_store.rs
@@ -31,8 +31,8 @@ use openwave_core::{
     DocumentListCursor, DocumentRecord, DocumentScope, DocumentSourceUpsert, DocumentSummaryRecord,
     ImageRef, JournaledTurnOutcome, NetworkPolicy, OwnerId, PermissionMode, Project, ProjectId,
     ReasoningEffort, RequestAgentRunCancellationOutcome, RequestTurnCancellationOutcome, Result,
-    SandboxToolCall, SequencedEvent, Store, ToolApproval, ToolCallRecord, TurnId, TurnRun,
-    TurnSteerId,
+    SandboxAgentAdmission, SandboxToolCall, SandboxToolCallReceipt, SequencedEvent, Store,
+    ToolApproval, ToolCallRecord, TurnId, TurnRun, TurnSteerId,
 };
 
 use crate::error::ServerError;
@@ -291,6 +291,22 @@ impl ScopedStore {
         self.store
             .list_sandbox_tool_calls_for_agent_run(agent_run_id)
             .await
+    }
+
+    /// [`Store::get_sandbox_agent_admission`].
+    pub async fn get_sandbox_agent_admission(
+        &self,
+        agent_run_id: AgentRunId,
+    ) -> Result<Option<SandboxAgentAdmission>> {
+        self.store.get_sandbox_agent_admission(agent_run_id).await
+    }
+
+    /// [`Store::get_sandbox_tool_call_receipt`].
+    pub async fn get_sandbox_tool_call_receipt(
+        &self,
+        call_id: CallId,
+    ) -> Result<Option<SandboxToolCallReceipt>> {
+        self.store.get_sandbox_tool_call_receipt(call_id).await
     }
 
     /// [`Store::list_pending_client_tool_calls`].

--- a/crates/openwave-server/src/tests/sandbox.rs
+++ b/crates/openwave-server/src/tests/sandbox.rs
@@ -215,7 +215,7 @@ async fn agent_run_snapshots_expose_only_safe_live_sandbox_activity() {
 }
 
 #[tokio::test]
-async fn agent_run_activity_history_is_ordered_renderer_safe_and_names_submitted_files() {
+async fn agent_run_activity_history_is_ordered_typed_and_names_submitted_files() {
     let (router, token, store, _dir) = test_app_without_turn_worker().await;
     let bearer = format!("Bearer {token}");
     let chat = make_chat(&router, &bearer).await;
@@ -233,28 +233,28 @@ async fn agent_run_activity_history_is_ordered_renderer_safe_and_names_submitted
         run.id
     );
 
-    let checkpoint = SandboxToolCallRequest {
+    let exec = SandboxToolCallRequest {
         id: CallId::new(),
         agent_run_id: run.id,
         chat_id: chat.id,
-        provider_id: "provider-call-identity".into(),
-        name: "web_search".into(),
+        provider_id: "private-exec-provider-identity".into(),
+        name: openwave_core::SANDBOX_EXEC_TOOL.into(),
         arguments: serde_json::json!({
-            "query": "private query that must not reach the renderer",
-            "api_key": "secret-value"
+            "command": "python3",
+            "args": ["report.py", "--format", "md"]
         }),
     };
     assert!(matches!(
         store
-            .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &checkpoint)
+            .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &exec)
             .await
             .unwrap(),
         ParkSandboxToolCallOutcome::Parked { .. }
     ));
-    let executor_lease = uuid::Uuid::new_v4();
+    let exec_lease = uuid::Uuid::new_v4();
     assert!(matches!(
         store
-            .claim_sandbox_tool_call(checkpoint.id, executor_lease, chrono::Duration::minutes(5))
+            .claim_sandbox_tool_call(exec.id, exec_lease, chrono::Duration::minutes(5))
             .await
             .unwrap(),
         openwave_core::ClaimSandboxToolCallOutcome::Claimed(_)
@@ -262,10 +262,12 @@ async fn agent_run_activity_history_is_ordered_renderer_safe_and_names_submitted
     assert!(matches!(
         store
             .resolve_sandbox_tool_call(
-                checkpoint.id,
-                executor_lease,
-                &ToolCallResolution::Completed {
-                    result: "private result that must not reach the renderer".into(),
+                exec.id,
+                exec_lease,
+                &ToolCallResolution::Failed {
+                    result: "exit: 17\nduration_ms: 42\n\nstderr:\nprivate output".into(),
+                    error_code: "exec_command_failed".into(),
+                    error_detail: Some("private executor detail".into()),
                 },
             )
             .await
@@ -273,12 +275,64 @@ async fn agent_run_activity_history_is_ordered_renderer_safe_and_names_submitted
         openwave_core::ResolveSandboxToolCallOutcome::Resolved
     ));
 
-    // Resolving the checkpoint hands the run back for continuation; take it and
-    // submit a file, which is what a produced result is.
-    let continuation_lease = uuid::Uuid::new_v4();
+    // Continue through a second checkpoint so the endpoint also proves durable
+    // ordering and the query-only search projection.
+    let search_worker_lease = uuid::Uuid::new_v4();
     assert_eq!(
         store
-            .claim_agent_run(continuation_lease, chrono::Duration::minutes(5), 4, 4)
+            .claim_agent_run(search_worker_lease, chrono::Duration::minutes(5), 4, 4)
+            .await
+            .unwrap()
+            .unwrap()
+            .id,
+        run.id
+    );
+    let search = SandboxToolCallRequest {
+        id: CallId::new(),
+        agent_run_id: run.id,
+        chat_id: chat.id,
+        provider_id: "private-search-provider-identity".into(),
+        name: openwave_core::SANDBOX_WEB_SEARCH_TOOL.into(),
+        arguments: serde_json::json!({
+            "query": "OpenWave release notes",
+            "api_key": "secret-value"
+        }),
+    };
+    assert!(matches!(
+        store
+            .park_agent_run_for_sandbox_tool_call(run.id, search_worker_lease, &search)
+            .await
+            .unwrap(),
+        ParkSandboxToolCallOutcome::Parked { .. }
+    ));
+    let search_lease = uuid::Uuid::new_v4();
+    assert!(matches!(
+        store
+            .claim_sandbox_tool_call(search.id, search_lease, chrono::Duration::minutes(5))
+            .await
+            .unwrap(),
+        openwave_core::ClaimSandboxToolCallOutcome::Claimed(_)
+    ));
+    assert!(matches!(
+        store
+            .resolve_sandbox_tool_call(
+                search.id,
+                search_lease,
+                &ToolCallResolution::Completed {
+                    result: "private search result".into(),
+                },
+            )
+            .await
+            .unwrap(),
+        openwave_core::ResolveSandboxToolCallOutcome::Resolved
+    ));
+
+    // Resolving the second checkpoint hands the run back for completion; submit
+    // a file, which remains the run's durable produced result.
+    let completion_lease = uuid::Uuid::new_v4();
+    assert_eq!(
+        store
+            .claim_agent_run(completion_lease, chrono::Duration::minutes(5), 4, 4)
             .await
             .unwrap()
             .unwrap()
@@ -306,7 +360,7 @@ async fn agent_run_activity_history_is_ordered_renderer_safe_and_names_submitted
     store
         .submit_agent_run_submission(
             run.id,
-            continuation_lease,
+            completion_lease,
             &[openwave_core::AgentRunSubmittedOutput {
                 output_id: submitted,
                 filename: "Q3 revenue.md".into(),
@@ -363,25 +417,59 @@ async fn agent_run_activity_history_is_ordered_renderer_safe_and_names_submitted
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
     let history: Vec<serde_json::Value> = json_body(response).await;
-    assert_eq!(history.len(), 1);
+    assert_eq!(history.len(), 2);
+    assert_eq!(history[0].get("kind"), Some(&serde_json::json!("exec")));
     assert_eq!(
-        history[0].get("kind"),
+        history[0].get("outcome"),
+        Some(&serde_json::json!("failed"))
+    );
+    assert_eq!(
+        history[0].get("detail"),
+        Some(&serde_json::json!({
+            "kind": "exec",
+            "command": "python3",
+            "args": ["report.py", "--format", "md"],
+            "exit_code": 17,
+        }))
+    );
+    assert_eq!(
+        history[1].get("kind"),
         Some(&serde_json::json!("web_search"))
     );
     assert_eq!(
-        history[0].get("outcome"),
+        history[1].get("outcome"),
         Some(&serde_json::json!("completed"))
     );
-    assert!(history[0].get("at").is_some_and(|at| at.is_string()));
+    assert_eq!(
+        history[1].get("detail"),
+        Some(&serde_json::json!({
+            "kind": "search",
+            "query": "OpenWave release notes",
+        }))
+    );
+    assert!(history
+        .iter()
+        .all(|entry| entry.get("at").is_some_and(|at| at.is_string())));
+
+    // The field is additive: an entry serialized before typed detail existed
+    // still deserializes with no detail.
+    let mut old_entry = history[0].clone();
+    old_entry.as_object_mut().unwrap().remove("detail");
+    let old_entry: crate::routes::AgentActivityHistoryItem =
+        serde_json::from_value(old_entry).expect("the old history shape still deserializes");
+    assert_eq!(old_entry.detail, None);
 
     let encoded = serde_json::to_string(&history).unwrap();
     for forbidden in [
-        "private query that must not reach the renderer",
-        "private result that must not reach the renderer",
+        "private output",
+        "private executor detail",
+        "private search result",
         "secret-value",
-        "provider-call-identity",
+        "private-exec-provider-identity",
+        "private-search-provider-identity",
         "arguments",
         "lease_token",
+        "duration_ms",
         "result",
     ] {
         assert!(!encoded.contains(forbidden), "history leaked {forbidden}");
@@ -754,6 +842,39 @@ async fn delegated_file_routes_are_native_only_and_expose_only_exact_broker_auth
         "private delegated task",
     ] {
         assert!(!encoded.contains(forbidden), "receipt leaked {forbidden}");
+    }
+
+    // Activity names only the delegated file's bounded leaf name. The broker
+    // root and parent path remain native-only even though the durable admission
+    // retains both for authorization.
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/chats/{}/agent-runs/{}/activity",
+                    chat.id, child.id
+                ))
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let history: Vec<serde_json::Value> = json_body(response).await;
+    assert_eq!(history.len(), 1);
+    assert_eq!(
+        history[0]["detail"],
+        serde_json::json!({"kind": "file", "name": "private-summary.md"})
+    );
+    let encoded = serde_json::to_string(&history).unwrap();
+    for forbidden in [
+        resource.relative_path.as_str(),
+        &root_id.to_string(),
+        "private-read-provider-id",
+        "private delegated task",
+    ] {
+        assert!(!encoded.contains(forbidden), "activity leaked {forbidden}");
     }
 }
 

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -324,6 +324,20 @@ provider identifiers, executor leases, and raw failures remain server-side.
 New tools are invisible to the renderer until they receive their own safe
 activity projection.
 
+`GET /chats/{chat_id}/agent-runs/{run_id}/activity` rebuilds the background
+run's ordered history from those durable checkpoints. Each item keeps the fixed
+kind, coarse outcome, and timestamp, and may add one typed headline: the bounded
+command vector and recorded exit code, the bounded public-web query, or the leaf
+name of the one delegated file. Command, argument, and query strings are
+model-authored: the display clamp bounds and de-spoofs them, but they may repeat
+anything the child already saw and are outside the host-field non-disclosure
+guarantee. The server does not directly copy stored stdout, stderr, search
+results, full broker paths, opaque root identities, provider identities,
+executor leases, or raw diagnostics. The only host-derived detail is the typed
+numeric exit code and delegated leaf name. The detail key is optional, so a call
+without a derivable headline retains the original three-field shape; no separate
+activity-history payload or database migration is involved.
+
 The desktop consumes that projection in two places. The transcript renders one
 status row per spawned child beside the delegation it came from, correlated by
 the snapshot's spawn-call id, and a background-agent panel renders the same
@@ -359,9 +373,9 @@ it, so a run that narrates for an hour costs a bounded number of rows and an
 observer that stops reading may find the oldest lines gone. What it does
 guarantee is order, and that a line already delivered is never delivered twice.
 The text is the run's own prose — the same class the terminal result already
-carries — and nothing else: no tool arguments, queries, results, folder or file
-identities, host paths, provider identities, executor leases, or raw
-diagnostics.
+carries. It may repeat information the run already saw, so the boundary promise
+is about provenance rather than content: the progress path does not directly
+copy stored tool arguments/results or host-owned identities into the stream.
 
 ## Reliability contract
 


### PR DESCRIPTION
## Summary

Adds an optional tagged `detail` preview to background-agent activity history so clients can render the command argv and exit code, public-web query, or delegated-file display name for each durable step. The projection reuses the foreground action-preview sanitization for commands and searches, and reads exec exit status from the immutable sandbox receipt.

The preview stays headline-level by design: stdout, stderr, search results, raw arguments, host paths, opaque root identities, provider identities, executor leases, and diagnostics remain server-side. Captured output needs its own retention contract and is intentionally outside this change.

Activity history is still rebuilt on read from existing sandbox call and receipt rows; no new persisted history shape or migration is introduced. `detail` is optional and omitted when it cannot be derived, so older three-field entries continue to deserialize and older clients can ignore the additive field. The generated TypeScript wire contract and agent-run documentation are updated accordingly.

## Verification

- `cargo check -p openwave-core -p openwave-server --locked`
- `cargo test -p openwave-core preview::tests --locked`
- `cargo test -p openwave-server tests::sandbox --locked`
- `cargo test -p openwave-server wire_types --locked`