### PR TITLE
feat(desktop): chat-header status chip with details popover

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -12,6 +12,7 @@ import type {
 import { useApp } from "./AppContext";
 import { AssistantSourceMarkerStreamScrubber } from "./AssistantSourceMarkerStream";
 import { ChatHeaderTitle } from "./ChatHeaderTitle";
+import { ChatStatusChip } from "./ChatStatusChip";
 import { reconcilePendingApprovalCards } from "./ApprovalHistory";
 import { loadChatApprovalHydration } from "./ChatApprovalHydration";
 import { useChatListStore } from "./ChatListStore";
@@ -684,6 +685,18 @@ export function ChatRoute({ chatId }: { chatId: string }) {
     <div className="mr-2 flex min-h-0 min-w-0 flex-1 flex-col">
       <header className="mt-2 flex h-9 w-full shrink-0 items-center justify-between gap-2 pl-4 pr-1">
         <ChatHeaderTitle chat={chat} />
+        <ChatStatusChip
+          client={client}
+          chat={chat}
+          models={models}
+          defaultModelKey={defaultModelKey}
+          folders={folders.items}
+          disabled={deletingChatId !== null}
+          onModelChange={onModelChange}
+          onPermissionModeChange={onPermissionModeChange}
+          onOpenFolders={() => openPanel({ type: "folders" })}
+          onOpenAgent={(runId) => openPanel({ type: "agent", runId })}
+        />
       </header>
       {/* Citations live in the transcript but open into the panel beside it,
           so the way there is provided above both slots. */}

--- a/crates/openwave-desktop/ui/src/ChatStatusChip.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ChatStatusChip.dom.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+import type { AgentRun, ApiClient, Chat, ModelInfo } from "./api";
+import { ChatStatusChip } from "./ChatStatusChip";
+import { useChatSessionStore } from "./ChatSessionStore";
+import type { ChatFolderAccess } from "./useChatFolderAttachments";
+
+const chat = {
+  id: "chat-1",
+  title: "Roadmap",
+  project_id: null,
+  model: "sonnet",
+  permission_mode: "auto",
+} as unknown as Chat;
+
+const models = [
+  { id: "sonnet", display_name: "Claude Sonnet", provider: "anthropic", available: true },
+] as unknown as ModelInfo[];
+
+const folder = {
+  rootId: "root-1",
+  displayName: "Notes",
+  status: "connected",
+  statements: [],
+} as unknown as ChatFolderAccess;
+
+function runningRun(id: string, status: AgentRun["status"]): AgentRun {
+  return {
+    id,
+    parent_id: null,
+    tier: "background",
+    status,
+    spawn_call_id: `call-${id}`,
+  } as unknown as AgentRun;
+}
+
+function renderChip(runs: AgentRun[] = []) {
+  const client = {
+    listAgentRuns: vi.fn().mockResolvedValue(runs),
+  } as unknown as ApiClient;
+  const onOpenFolders = vi.fn();
+  const onOpenAgent = vi.fn();
+  render(
+    <ChatStatusChip
+      client={client}
+      chat={chat}
+      models={models}
+      defaultModelKey={null}
+      folders={[folder]}
+      onModelChange={vi.fn()}
+      onPermissionModeChange={vi.fn()}
+      onOpenFolders={onOpenFolders}
+      onOpenAgent={onOpenAgent}
+    />,
+  );
+  return { onOpenFolders, onOpenAgent };
+}
+
+beforeEach(() => {
+  useChatSessionStore.getState().reset();
+});
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+it("names the chat's permission mode and opens its details", async () => {
+  const { onOpenFolders } = renderChip();
+
+  const chip = screen.getByRole("button", { name: "Chat status: Auto" });
+  expect(chip).toHaveTextContent("Auto");
+
+  await userEvent.click(chip);
+  expect(await screen.findByText("Model")).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /^Model:/ })).toHaveTextContent(
+    "Claude Sonnet",
+  );
+  expect(screen.getByRole("button", { name: "Permissions: Auto" })).toBeInTheDocument();
+
+  await userEvent.click(screen.getByText("Notes · No access"));
+  expect(onOpenFolders).toHaveBeenCalled();
+});
+
+/**
+ * The dots are the whole reason the chip is persistent: background work is
+ * invisible from a scrolled-away transcript otherwise.
+ */
+it("counts live background runs and opens the newest one", async () => {
+  useChatSessionStore.getState().update((session) => ({
+    ...session,
+    messages: [
+      {
+        id: "m1",
+        role: "tool",
+        name: "spawn_sandbox_agent",
+        callId: "call-run-1",
+        status: "completed",
+      },
+      {
+        id: "m2",
+        role: "tool",
+        name: "spawn_sandbox_agent",
+        callId: "call-run-2",
+        status: "completed",
+      },
+    ] as never,
+  }));
+  const { onOpenAgent } = renderChip([
+    runningRun("run-1", "running"),
+    runningRun("run-2", "retry_wait"),
+  ]);
+
+  const chip = await screen.findByRole("button", {
+    name: "Chat status: Auto, 2 running",
+  });
+  await userEvent.click(chip);
+  await userEvent.click(screen.getByText("2 background agents"));
+  expect(onOpenAgent).toHaveBeenCalledWith("run-2");
+});

--- a/crates/openwave-desktop/ui/src/ChatStatusChip.tsx
+++ b/crates/openwave-desktop/ui/src/ChatStatusChip.tsx
@@ -1,0 +1,215 @@
+import { useMemo, useState } from "react";
+import { Bot, ChevronDown, FolderOpen } from "lucide-react";
+
+import type {
+  AgentRun,
+  ApiClient,
+  Chat,
+  ModelInfo,
+  ModelSelectionKey,
+  PermissionMode,
+} from "./api";
+import { RUNNING_AGENT_STATUSES } from "./AgentRunDisplay";
+import { useChatSessionStore } from "./ChatSessionStore";
+import { folderAccessLabel, folderReach } from "./FolderAccess";
+import { ModelMenu } from "./ModelMenu";
+import { permissionModeOption, PermissionModeMenu } from "./PermissionModeMenu";
+import { backgroundAgentSpawnKeys, useAgentRuns } from "./useAgentRuns";
+import type { ChatFolderAccess } from "./useChatFolderAttachments";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+/** Past this many dots the chip counts the rest rather than growing. */
+const MAX_STATUS_DOTS = 3;
+
+/**
+ * Live work reads in two colours, matching how the agent rows phrase it:
+ * green while a run is making progress, amber while it is parked — waiting on
+ * something, or backing off before another attempt.
+ */
+function liveRunDotClass(status: AgentRun["status"]): string {
+  switch (status) {
+    case "waiting":
+    case "retry_wait":
+    case "cancelling":
+      return "bg-warning";
+    default:
+      return "bg-success";
+  }
+}
+
+export type ChatStatusChipProps = {
+  client: ApiClient;
+  chat: Chat;
+  models: ModelInfo[];
+  defaultModelKey: string | null;
+  folders: readonly ChatFolderAccess[];
+  disabled?: boolean;
+  onModelChange: (key: ModelSelectionKey | null) => void | Promise<void>;
+  onPermissionModeChange: (mode: PermissionMode) => void | Promise<void>;
+  /** Bring the Folders panel forward. */
+  onOpenFolders: () => void;
+  /** Bring one background run's panel forward. */
+  onOpenAgent: (runId: string) => void;
+};
+
+/**
+ * The chat's standing state, always in the header: which permission mode new
+ * turns run under, and whether anything is still working in the background.
+ *
+ * The composer keeps its own controls — this is the answer to "what is this
+ * conversation set to right now" from anywhere in the transcript, plus a way
+ * to change it without scrolling back down. The menus behind it are the same
+ * components the composer uses, so a mode or model can only be described one
+ * way in the app.
+ */
+export function ChatStatusChip({
+  client,
+  chat,
+  models,
+  defaultModelKey,
+  folders,
+  disabled,
+  onModelChange,
+  onPermissionModeChange,
+  onOpenFolders,
+  onOpenAgent,
+}: ChatStatusChipProps) {
+  const [open, setOpen] = useState(false);
+
+  // Subscribed as a joined key rather than the message list: the header must
+  // not re-render on every streamed token, and the set of spawn steps changes
+  // only when one appears or resolves.
+  const spawnKey = useChatSessionStore((session) =>
+    backgroundAgentSpawnKeys(session.messages).join(","),
+  );
+  const spawnKeys = useMemo(
+    () => (spawnKey ? spawnKey.split(",") : []),
+    [spawnKey],
+  );
+  const { runs } = useAgentRuns(client, chat.id, spawnKeys);
+
+  const matched = runs.filter(
+    (run) =>
+      run.tier === "background" &&
+      spawnKeys.some((key) => run.id === key || run.spawn_call_id === key),
+  );
+  const liveRuns = matched.filter((run) => RUNNING_AGENT_STATUSES.has(run.status));
+  const overflowRuns = Math.max(0, liveRuns.length - MAX_STATUS_DOTS);
+
+  const mode = permissionModeOption(chat.permission_mode);
+
+  const folderSummary =
+    folders.length === 0
+      ? "No folders"
+      : folders.length === 1
+        ? `${folders[0].displayName} · ${folderAccessLabel(folderReach(folders[0].statements))}`
+        : `${folders.length} folders`;
+
+  // The run a reader most likely means by "show me": the newest one still
+  // working, or — once everything has settled — the newest run there is.
+  const focusRun = liveRuns.at(-1) ?? matched.at(-1) ?? null;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "flex h-7 shrink-0 cursor-pointer items-center gap-1.5 rounded-full border border-border px-2.5 text-xs whitespace-nowrap transition-colors hover:bg-accent hover:text-foreground",
+            mode.elevated ? "text-warning-foreground" : "text-muted-foreground",
+          )}
+          aria-label={
+            liveRuns.length > 0
+              ? `Chat status: ${mode.label}, ${liveRuns.length} running`
+              : `Chat status: ${mode.label}`
+          }
+        >
+          <span>{mode.label}</span>
+          {liveRuns.length > 0 && (
+            <span className="flex items-center gap-1" aria-hidden="true">
+              {liveRuns.slice(0, MAX_STATUS_DOTS).map((run) => (
+                <span
+                  key={run.id}
+                  className={cn(
+                    "size-1.5 rounded-full",
+                    liveRunDotClass(run.status),
+                  )}
+                />
+              ))}
+              {overflowRuns > 0 && (
+                <span className="text-[0.65rem] leading-none">{`+${overflowRuns}`}</span>
+              )}
+            </span>
+          )}
+          <ChevronDown className="size-3.5 opacity-50" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        className="w-80 p-1"
+        // The rows open their own menus, which are portalled outside this
+        // content. Dismissing on those clicks would take the popover down
+        // underneath the menu the reader is still using.
+        onPointerDownOutside={(event) => {
+          if ((event.target as Element | null)?.closest?.("[role='menu']")) {
+            event.preventDefault();
+          }
+        }}
+      >
+        <div className="flex items-center justify-between gap-2 px-2 py-1">
+          <span className="text-xs text-muted-foreground">Model</span>
+          <ModelMenu
+            models={models}
+            value={chat.model}
+            defaultKey={defaultModelKey}
+            disabled={disabled}
+            onChange={onModelChange}
+          />
+        </div>
+        <div className="flex items-center justify-between gap-2 px-2 py-1">
+          <span className="text-xs text-muted-foreground">Permissions</span>
+          <PermissionModeMenu
+            value={chat.permission_mode}
+            disabled={disabled}
+            onChange={onPermissionModeChange}
+          />
+        </div>
+        <button
+          type="button"
+          className="flex w-full cursor-pointer items-center justify-between gap-2 rounded-md px-2 py-2 text-left transition-colors hover:bg-accent"
+          onClick={() => {
+            setOpen(false);
+            onOpenFolders();
+          }}
+        >
+          <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <FolderOpen className="size-3.5" aria-hidden="true" />
+            Folders
+          </span>
+          <span className="min-w-0 truncate text-xs">{folderSummary}</span>
+        </button>
+        {focusRun && (
+          <button
+            type="button"
+            className="flex w-full cursor-pointer items-center justify-between gap-2 rounded-md px-2 py-2 text-left transition-colors hover:bg-accent"
+            onClick={() => {
+              setOpen(false);
+              onOpenAgent(focusRun.id);
+            }}
+          >
+            <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <Bot className="size-3.5" aria-hidden="true" />
+              Agents
+            </span>
+            <span className="text-xs">
+              {matched.length === 1
+                ? "1 background agent"
+                : `${matched.length} background agents`}
+            </span>
+          </button>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -32,7 +32,10 @@ import { useStreamStalled } from "./useStreamStalled";
 import { useTurnControls } from "./useTurnControls";
 import { usePlanApprovals } from "./usePlanApprovals";
 import { useUserQuestions } from "./useUserQuestions";
-import { useAgentRuns } from "./useAgentRuns";
+import {
+  backgroundAgentSpawnKeys as spawnKeysOf,
+  useAgentRuns,
+} from "./useAgentRuns";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { ArrowDown } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -118,14 +121,7 @@ export function ChatView({
   const lastSeq = useChatSessionStore((session) => session.lastSeq);
   const streamStalled = useStreamStalled(busy, lastSeq);
   const backgroundAgentSpawnKeys = useMemo(
-    () =>
-      messages.flatMap((message) =>
-        message.role === "tool" && message.name === "spawn_sandbox_agent"
-          && message.status !== "failed"
-          && message.status !== "cancelled"
-          ? [message.backgroundAgentRunId ?? message.callId]
-          : [],
-      ),
+    () => spawnKeysOf(messages),
     [messages],
   );
   const agentRuns = useAgentRuns(client, chat.id, backgroundAgentSpawnKeys);

--- a/crates/openwave-desktop/ui/src/useAgentRuns.ts
+++ b/crates/openwave-desktop/ui/src/useAgentRuns.ts
@@ -2,8 +2,28 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { AgentActivityHistoryEntry, AgentRun, ApiClient } from "./api";
 import { RUNNING_AGENT_STATUSES } from "./AgentRunDisplay";
+import type { ChatMessage } from "./MessageList";
 
 const LIVE_POLL_INTERVAL_MS = 5_000;
+
+/**
+ * The spawn steps in a transcript worth observing, by the key each one is
+ * matched on: the run it resolved to, or — until it has one — the call that
+ * asked for it. A spawn that failed or was cancelled never produced a durable
+ * child, so nothing is waiting on it.
+ */
+export function backgroundAgentSpawnKeys(
+  messages: readonly ChatMessage[],
+): string[] {
+  return messages.flatMap((message) =>
+    message.role === "tool" &&
+    message.name === "spawn_sandbox_agent" &&
+    message.status !== "failed" &&
+    message.status !== "cancelled"
+      ? [message.backgroundAgentRunId ?? message.callId]
+      : [],
+  );
+}
 
 export type AgentRuns = {
   runs: AgentRun[];


### PR DESCRIPTION
Adds a persistent status chip to the chat header: the chat's permission mode (amber when elevated — Auto / Allow all — matching the permission menu's own rule) plus live background-agent status dots (green running, amber waiting/retrying, capped at 3 with +N).

Clicking it opens an anchored popover with the chat's working state in one place:
- Model — the real ModelMenu, same props as the composer's.
- Permissions — the real PermissionModeMenu.
- Folders — attached-folder summary; opens the Folders tab.
- Agents — N background agents; opens the newest live run's tab. Hidden when there are none.

The header subscribes to spawn keys as a joined string so streaming tokens don't re-render it; agent runs reuse the existing useAgentRuns poller (only polls while something is live). Composer controls are untouched — the chip is additive; consolidating the composer menus can follow once the chip has proven itself.

Tests: 2 behavior tests (mode + rows, live dots); full UI suite 742 passed; tsc clean.