### PR TITLE
feat(desktop): make the status-chip popover the home for chat-scoped places

### DIFF
--- a/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
@@ -341,12 +341,14 @@ describe("app shell", () => {
     expect(await screen.findByTestId("transcript")).toBeInTheDocument();
   });
 
-  it("opens panels as tabs beside the conversation, from the sidebar", async () => {
+  it("opens panels as tabs beside the conversation", async () => {
     const user = userEvent.setup();
     const { router } = await mountApp({ at: "/c/chat-1" });
     await screen.findByTestId("transcript");
 
-    await user.click(screen.getByRole("button", { name: "Folders" }));
+    // Chat-scoped places open from the chat's own chip, not the rail.
+    await user.click(screen.getByRole("button", { name: /^Chat status:/ }));
+    await user.click(await screen.findByRole("button", { name: /Folders/ }));
 
     expect(await screen.findByTestId("folders")).toBeInTheDocument();
     // The conversation stays mounted beside it rather than being replaced.
@@ -376,13 +378,13 @@ describe("app shell", () => {
     const user = userEvent.setup();
     const { router } = await mountApp({ at: "/c/chat-1" });
     await screen.findByTestId("transcript");
-    await user.click(screen.getByRole("button", { name: "Folders" }));
-    await screen.findByTestId("folders");
+    await user.click(screen.getByRole("button", { name: "Apps" }));
+    await screen.findByTestId("apps");
 
-    await user.click(screen.getByRole("button", { name: "Close" }));
+    await user.click(screen.getByRole("button", { name: "Close Apps" }));
 
     await waitFor(() => expect(router.state.location.search).toEqual({}));
-    expect(screen.queryByTestId("folders")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("apps")).not.toBeInTheDocument();
   });
 
   it("restores the arrangement a deep link describes", async () => {
@@ -425,24 +427,22 @@ describe("app shell", () => {
     },
   );
 
-  it("gives each route only the controls that route can act on", async () => {
-    const conversationOnly = ["Outputs", "Folders"];
-
+  it("keeps chat-scoped places behind the chat's own chip", async () => {
     await mountApp();
     await screen.findByText("How can I help?");
-    // Not disabled — absent. Home has no conversation for these to describe,
-    // and offering them here is what let the rail navigate into whichever
-    // chat happened to have been open last.
-    for (const label of conversationOnly) {
-      expect(screen.queryByRole("button", { name: label })).not.toBeInTheDocument();
-    }
+    // Not disabled — absent. Home has no conversation for the chip to
+    // describe, and the rail itself carries nothing chat-scoped anymore.
+    expect(
+      screen.queryByRole("button", { name: /^Chat status:/ }),
+    ).not.toBeInTheDocument();
     cleanup();
 
+    const user = userEvent.setup();
     await mountApp({ at: "/c/chat-1" });
     await screen.findByTestId("transcript");
-    for (const label of conversationOnly) {
-      expect(screen.getByRole("button", { name: label })).toBeEnabled();
-    }
+    await user.click(screen.getByRole("button", { name: /^Chat status:/ }));
+    expect(await screen.findByRole("button", { name: /Outputs/ })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /Folders/ })).toBeEnabled();
   });
 
   it("switches to another conversation from inside one", async () => {

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -688,12 +688,8 @@ export function ChatRoute({ chatId }: { chatId: string }) {
         <ChatStatusChip
           client={client}
           chat={chat}
-          models={models}
-          defaultModelKey={defaultModelKey}
           folders={folders.items}
-          disabled={deletingChatId !== null}
-          onModelChange={onModelChange}
-          onPermissionModeChange={onPermissionModeChange}
+          onOpenOutputs={() => openPanel({ type: "outputs" })}
           onOpenFolders={() => openPanel({ type: "folders" })}
           onOpenAgent={(runId) => openPanel({ type: "agent", runId })}
         />

--- a/crates/openwave-desktop/ui/src/ChatStatusChip.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ChatStatusChip.dom.test.tsx
@@ -3,10 +3,16 @@ import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 
-import type { AgentRun, ApiClient, Chat, ModelInfo } from "./api";
+import type { AgentRun, ApiClient, Chat } from "./api";
 import { ChatStatusChip } from "./ChatStatusChip";
 import { useChatSessionStore } from "./ChatSessionStore";
 import type { ChatFolderAccess } from "./useChatFolderAttachments";
+
+vi.mock("./deliverables", () => ({
+  listDeliverables: vi.fn().mockResolvedValue({
+    deliverables: [{ id: "out-1" }, { id: "out-2" }],
+  }),
+}));
 
 const chat = {
   id: "chat-1",
@@ -15,10 +21,6 @@ const chat = {
   model: "sonnet",
   permission_mode: "auto",
 } as unknown as Chat;
-
-const models = [
-  { id: "sonnet", display_name: "Claude Sonnet", provider: "anthropic", available: true },
-] as unknown as ModelInfo[];
 
 const folder = {
   rootId: "root-1",
@@ -41,22 +43,20 @@ function renderChip(runs: AgentRun[] = []) {
   const client = {
     listAgentRuns: vi.fn().mockResolvedValue(runs),
   } as unknown as ApiClient;
+  const onOpenOutputs = vi.fn();
   const onOpenFolders = vi.fn();
   const onOpenAgent = vi.fn();
   render(
     <ChatStatusChip
       client={client}
       chat={chat}
-      models={models}
-      defaultModelKey={null}
       folders={[folder]}
-      onModelChange={vi.fn()}
-      onPermissionModeChange={vi.fn()}
+      onOpenOutputs={onOpenOutputs}
       onOpenFolders={onOpenFolders}
       onOpenAgent={onOpenAgent}
     />,
   );
-  return { onOpenFolders, onOpenAgent };
+  return { onOpenOutputs, onOpenFolders, onOpenAgent };
 }
 
 beforeEach(() => {
@@ -67,20 +67,18 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-it("names the chat's permission mode and opens its details", async () => {
-  const { onOpenFolders } = renderChip();
+it("names the chat's permission mode and opens its chat-scoped places", async () => {
+  const { onOpenOutputs, onOpenFolders } = renderChip();
 
   const chip = screen.getByRole("button", { name: "Chat status: Auto" });
   expect(chip).toHaveTextContent("Auto");
 
   await userEvent.click(chip);
-  expect(await screen.findByText("Model")).toBeInTheDocument();
-  expect(screen.getByRole("button", { name: /^Model:/ })).toHaveTextContent(
-    "Claude Sonnet",
-  );
-  expect(screen.getByRole("button", { name: "Permissions: Auto" })).toBeInTheDocument();
+  await userEvent.click(await screen.findByText("2 outputs"));
+  expect(onOpenOutputs).toHaveBeenCalled();
 
-  await userEvent.click(screen.getByText("Notes · No access"));
+  await userEvent.click(chip);
+  await userEvent.click(await screen.findByText("Notes · No access"));
   expect(onOpenFolders).toHaveBeenCalled();
 });
 

--- a/crates/openwave-desktop/ui/src/ChatStatusChip.tsx
+++ b/crates/openwave-desktop/ui/src/ChatStatusChip.tsx
@@ -1,19 +1,13 @@
-import { useMemo, useState } from "react";
-import { Bot, ChevronDown, FolderOpen } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Bot, ChevronDown, FolderOpen, Shapes } from "lucide-react";
 
-import type {
-  AgentRun,
-  ApiClient,
-  Chat,
-  ModelInfo,
-  ModelSelectionKey,
-  PermissionMode,
-} from "./api";
+import type { AgentRun, ApiClient, Chat } from "./api";
 import { RUNNING_AGENT_STATUSES } from "./AgentRunDisplay";
 import { useChatSessionStore } from "./ChatSessionStore";
+import { listDeliverables } from "./deliverables";
 import { folderAccessLabel, folderReach } from "./FolderAccess";
-import { ModelMenu } from "./ModelMenu";
-import { permissionModeOption, PermissionModeMenu } from "./PermissionModeMenu";
+import { permissionModeOption } from "./PermissionModeMenu";
+import { useRefreshSignals } from "./RefreshSignals";
 import { backgroundAgentSpawnKeys, useAgentRuns } from "./useAgentRuns";
 import type { ChatFolderAccess } from "./useChatFolderAttachments";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -41,12 +35,9 @@ function liveRunDotClass(status: AgentRun["status"]): string {
 export type ChatStatusChipProps = {
   client: ApiClient;
   chat: Chat;
-  models: ModelInfo[];
-  defaultModelKey: string | null;
   folders: readonly ChatFolderAccess[];
-  disabled?: boolean;
-  onModelChange: (key: ModelSelectionKey | null) => void | Promise<void>;
-  onPermissionModeChange: (mode: PermissionMode) => void | Promise<void>;
+  /** Bring the Outputs panel forward. */
+  onOpenOutputs: () => void;
   /** Bring the Folders panel forward. */
   onOpenFolders: () => void;
   /** Bring one background run's panel forward. */
@@ -57,21 +48,17 @@ export type ChatStatusChipProps = {
  * The chat's standing state, always in the header: which permission mode new
  * turns run under, and whether anything is still working in the background.
  *
- * The composer keeps its own controls — this is the answer to "what is this
- * conversation set to right now" from anywhere in the transcript, plus a way
- * to change it without scrolling back down. The menus behind it are the same
- * components the composer uses, so a mode or model can only be described one
- * way in the app.
+ * Behind it, the places that describe only this conversation — its outputs,
+ * its folders, its background agents. The composer already owns changing the
+ * model and the mode; repeating those controls here would leave two switches
+ * for one setting, so this popover only holds what has nowhere else to live
+ * now that the rail is the chat list.
  */
 export function ChatStatusChip({
   client,
   chat,
-  models,
-  defaultModelKey,
   folders,
-  disabled,
-  onModelChange,
-  onPermissionModeChange,
+  onOpenOutputs,
   onOpenFolders,
   onOpenAgent,
 }: ChatStatusChipProps) {
@@ -98,6 +85,7 @@ export function ChatStatusChip({
   const overflowRuns = Math.max(0, liveRuns.length - MAX_STATUS_DOTS);
 
   const mode = permissionModeOption(chat.permission_mode);
+  const outputCount = useOutputCount(chat.id);
 
   const folderSummary =
     folders.length === 0
@@ -145,71 +133,101 @@ export function ChatStatusChip({
           <ChevronDown className="size-3.5 opacity-50" />
         </button>
       </PopoverTrigger>
-      <PopoverContent
-        align="end"
-        className="w-80 p-1"
-        // The rows open their own menus, which are portalled outside this
-        // content. Dismissing on those clicks would take the popover down
-        // underneath the menu the reader is still using.
-        onPointerDownOutside={(event) => {
-          if ((event.target as Element | null)?.closest?.("[role='menu']")) {
-            event.preventDefault();
+      <PopoverContent align="end" className="w-80 p-1">
+        <DetailRow
+          icon={<Shapes className="size-3.5" aria-hidden="true" />}
+          label="Outputs"
+          value={
+            outputCount === 0
+              ? "No outputs yet"
+              : outputCount === 1
+                ? "1 output"
+                : `${outputCount} outputs`
           }
-        }}
-      >
-        <div className="flex items-center justify-between gap-2 px-2 py-1">
-          <span className="text-xs text-muted-foreground">Model</span>
-          <ModelMenu
-            models={models}
-            value={chat.model}
-            defaultKey={defaultModelKey}
-            disabled={disabled}
-            onChange={onModelChange}
-          />
-        </div>
-        <div className="flex items-center justify-between gap-2 px-2 py-1">
-          <span className="text-xs text-muted-foreground">Permissions</span>
-          <PermissionModeMenu
-            value={chat.permission_mode}
-            disabled={disabled}
-            onChange={onPermissionModeChange}
-          />
-        </div>
-        <button
-          type="button"
-          className="flex w-full cursor-pointer items-center justify-between gap-2 rounded-md px-2 py-2 text-left transition-colors hover:bg-accent"
+          onClick={() => {
+            setOpen(false);
+            onOpenOutputs();
+          }}
+        />
+        <DetailRow
+          icon={<FolderOpen className="size-3.5" aria-hidden="true" />}
+          label="Folders"
+          value={folderSummary}
           onClick={() => {
             setOpen(false);
             onOpenFolders();
           }}
-        >
-          <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-            <FolderOpen className="size-3.5" aria-hidden="true" />
-            Folders
-          </span>
-          <span className="min-w-0 truncate text-xs">{folderSummary}</span>
-        </button>
+        />
         {focusRun && (
-          <button
-            type="button"
-            className="flex w-full cursor-pointer items-center justify-between gap-2 rounded-md px-2 py-2 text-left transition-colors hover:bg-accent"
+          <DetailRow
+            icon={<Bot className="size-3.5" aria-hidden="true" />}
+            label="Agents"
+            value={
+              matched.length === 1
+                ? "1 background agent"
+                : `${matched.length} background agents`
+            }
             onClick={() => {
               setOpen(false);
               onOpenAgent(focusRun.id);
             }}
-          >
-            <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-              <Bot className="size-3.5" aria-hidden="true" />
-              Agents
-            </span>
-            <span className="text-xs">
-              {matched.length === 1
-                ? "1 background agent"
-                : `${matched.length} background agents`}
-            </span>
-          </button>
+          />
         )}
       </PopoverContent>
     </Popover>
   );
+}
+
+function DetailRow({
+  icon,
+  label,
+  value,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="flex w-full cursor-pointer items-center justify-between gap-2 rounded-md px-2 py-2 text-left transition-colors hover:bg-accent"
+      onClick={onClick}
+    >
+      <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        {icon}
+        {label}
+      </span>
+      <span className="min-w-0 truncate text-xs">{value}</span>
+    </button>
+  );
+}
+
+/**
+ * How many outputs this conversation has produced. Fetched on mount and again
+ * whenever a refresh signal says the number could have moved; errors are
+ * swallowed, leaving the last known count, because a stale number in a summary
+ * row is better than an error state in one.
+ */
+function useOutputCount(chatId: string): number {
+  const [count, setCount] = useState(0);
+  const outputWritebacks = useRefreshSignals((s) => s.outputWritebacks);
+
+  useEffect(() => {
+    let cancelled = false;
+    listDeliverables(chatId).then(
+      (catalog) => {
+        if (!cancelled) setCount(catalog.deliverables.length);
+      },
+      () => {
+        /* swallow — stale count is acceptable */
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [chatId, outputWritebacks]);
+
+  return count;
 }

--- a/crates/openwave-desktop/ui/src/sidebar/AppSidebar.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/AppSidebar.tsx
@@ -1,42 +1,28 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { type ReactNode } from "react";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
-import {
-  CircleAlert,
-  FolderOpen,
-  LayoutGrid,
-  MessagesSquare,
-  Puzzle,
-  Shapes,
-} from "lucide-react";
+import { CircleAlert, LayoutGrid, MessagesSquare, Puzzle } from "lucide-react";
 
 import type { Chat } from "@/api";
 import { useApp } from "@/AppContext";
 import { useChatAttention } from "@/ChatAttention";
 import { useChatListStore } from "@/ChatListStore";
-import { Badge } from "@/components/ui/badge";
-import { listDeliverables, type DeliverablesCatalog } from "@/deliverables";
 import type { PanelType } from "@/panel/panelTypes";
 import { usePanelNav } from "@/panel/usePanelNav";
-import { useRefreshSignals } from "@/RefreshSignals";
 import { ChatsSection } from "./ChatsSection";
 import { InboxButton } from "./InboxButton";
 import { NewChatButton } from "./NewChatButton";
 import { SidebarButton, SidebarSectionTitle } from "./primitives";
 import { SidebarFrame } from "./SidebarFrame";
 
-// Module scope, not an inline arrow: the count effect keys on the extractor's
-// identity, and this rail re-renders on every composer keystroke.
-const countDeliverables = (catalog: DeliverablesCatalog) =>
-  catalog.deliverables.length;
-
 /**
  * The one navigation rail, used by every route that is not settings.
  *
- * Its subject is the chat list: a slim block of actions at the top, and the
- * conversations filling everything below it. Home and a conversation see the
- * same rail so that moving between them does not rearrange the furniture —
- * what a conversation adds is the two panels that only mean something when
- * there is one to act on, Outputs and Folders.
+ * Its subject is the chat list: a slim block of install-wide destinations at
+ * the top, and the conversations filling everything below it. Home and a
+ * conversation see the same rail so that moving between them does not
+ * rearrange the furniture. Everything that describes one conversation —
+ * outputs, folders, agents — lives in the chat header's status chip instead,
+ * beside the conversation it describes.
  *
  * `chat` is the conversation the route is showing, when it is showing one.
  */
@@ -71,27 +57,6 @@ export function AppSidebar({ chat }: { chat?: Chat }) {
 
       <div className="mt-2 flex shrink-0 flex-col gap-0.5">
         <InboxButton />
-
-        {/* Outputs and Folders describe one conversation, so they exist only
-            where there is one. Offering them on home is what let the rail
-            navigate into whichever chat happened to have been open last. */}
-        {chat && (
-          <>
-            <PanelButton
-              label="Outputs"
-              icon={<Shapes />}
-              active={openPanelTypes.has("outputs")}
-              onClick={() => openPanel({ type: "outputs" })}
-              badge={<OutputCountBadge chatId={chat.id} />}
-            />
-            <PanelButton
-              label="Folders"
-              icon={<FolderOpen />}
-              active={openPanelTypes.has("folders")}
-              onClick={() => openPanel({ type: "folders" })}
-            />
-          </>
-        )}
 
         {/* Apps and plugins are install-wide — they outlive every conversation
             — so they open the same way from anywhere: as a panel beside the
@@ -152,13 +117,11 @@ function PanelButton({
   label,
   icon,
   active,
-  badge,
   onClick,
 }: {
   label: string;
   icon: ReactNode;
   active: boolean;
-  badge?: ReactNode;
   onClick: () => void;
 }) {
   return (
@@ -170,45 +133,6 @@ function PanelButton({
     >
       {icon}
       <span>{label}</span>
-      {badge}
     </SidebarButton>
   );
-}
-
-/** How many outputs this conversation has produced, or nothing while it has none. */
-function OutputCountBadge({ chatId }: { chatId: string }) {
-  const count = useSidebarCount(chatId, listDeliverables, countDeliverables);
-  if (count === 0) return null;
-  return (
-    <Badge variant="outline" className="-my-0.5">
-      {count}
-    </Badge>
-  );
-}
-
-/**
- * Fetch a count on mount and whenever the refresh-signal store ticks any of the
- * targets that could change the number (folder access for sources, output
- * writebacks for deliverables). Errors are swallowed — the badge simply stays at
- * its last known value or zero.
- */
-function useSidebarCount<T>(
-  chatId: string,
-  fetcher: (chatId: string) => Promise<T>,
-  extract: (result: T) => number,
-): number {
-  const [count, setCount] = useState(0);
-  const folderAccess = useRefreshSignals((s) => s.folderAccess);
-  const outputWritebacks = useRefreshSignals((s) => s.outputWritebacks);
-
-  useEffect(() => {
-    let cancelled = false;
-    fetcher(chatId).then(
-      (result) => { if (!cancelled) setCount(extract(result)); },
-      () => { /* swallow — stale count is acceptable */ },
-    );
-    return () => { cancelled = true; };
-  }, [chatId, folderAccess, outputWritebacks, fetcher, extract]);
-
-  return count;
 }


### PR DESCRIPTION
Follow-up to #1620/#1621 correcting what lives where: the composer already owns changing the model and permission mode, so repeating those controls in the header popover left two switches for one setting. And with the rail now being the chat list, the chat-scoped destinations needed a home beside the conversation they describe.

- The status-chip popover now holds exactly the chat-scoped places: Outputs (with live count), Folders (attached summary), Agents (count, opens the newest run) — each opening its tab. Model/Permissions rows removed.
- The chip face is unchanged: permission mode + live agent dots.
- The sidebar drops its Outputs/Folders rows entirely — it's New chat, Inbox, Apps, Plugins, then chats. The output-count fetch moved from the rail badge into the popover row.

Tests updated in place: panel-open flows drive the chip popover (Folders) and the rail (Apps); the route-scoped-controls test now pins that home has no chip and a chat's chip offers Outputs/Folders. Full UI suite 745 passed; tsc clean.