### PR TITLE
feat(desktop): show typed activity previews in the background-agent timeline

### DIFF
--- a/crates/openwave-desktop/ui/src/AgentActivityTimeline.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/AgentActivityTimeline.dom.test.tsx
@@ -72,13 +72,12 @@ describe("AgentActivityTimeline", () => {
   it("distinguishes a failed command by its own headline and exit status", () => {
     render(<AgentActivityTimeline state={state} active={false} expanded />);
 
-    const commandRow = within(screen.getByRole("list"))
-      .getByText("pip install matplotlib")
-      .closest("li");
-    expect(commandRow).toBeTruthy();
-    expect(
-      commandRow?.querySelector(".font-mono")?.textContent,
-    ).toBe("pip install matplotlib");
-    expect(within(commandRow!).getByText("Exit 1")).toBeTruthy();
+    const commandRow = within(screen.getByRole("list")).getAllByRole(
+      "listitem",
+    )[1]!;
+    expect(commandRow.querySelector(".font-mono")?.textContent).toBe(
+      "pip install matplotlib",
+    );
+    expect(within(commandRow).getByText("Exit 1")).toBeTruthy();
   });
 });

--- a/crates/openwave-desktop/ui/src/AgentActivityTimeline.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/AgentActivityTimeline.dom.test.tsx
@@ -23,6 +23,12 @@ const state: AgentActivityState = {
       kind: "exec",
       outcome: "failed",
       at: "2026-08-05T18:37:00Z",
+      detail: {
+        kind: "exec",
+        command: "pip",
+        args: ["install", "matplotlib"],
+        exit_code: 1,
+      },
     },
     {
       kind: "web_search",
@@ -61,5 +67,18 @@ describe("AgentActivityTimeline", () => {
     });
     expect(settledTrigger.getAttribute("aria-expanded")).toBe("false");
     expect(screen.queryByRole("list")).toBeNull();
+  });
+
+  it("distinguishes a failed command by its own headline and exit status", () => {
+    render(<AgentActivityTimeline state={state} active={false} expanded />);
+
+    const commandRow = within(screen.getByRole("list"))
+      .getByText("pip install matplotlib")
+      .closest("li");
+    expect(commandRow).toBeTruthy();
+    expect(
+      commandRow?.querySelector(".font-mono")?.textContent,
+    ).toBe("pip install matplotlib");
+    expect(within(commandRow!).getByText("Exit 1")).toBeTruthy();
   });
 });

--- a/crates/openwave-desktop/ui/src/AgentActivityTimeline.tsx
+++ b/crates/openwave-desktop/ui/src/AgentActivityTimeline.tsx
@@ -4,6 +4,7 @@ import { ChevronRight } from "lucide-react";
 import type { AgentActivityHistoryEntry } from "./api";
 import { agentActivityHistoryLabel } from "./AgentRunDisplay";
 import { ToolIcon } from "./ToolIcon";
+import { execCommandHeadline } from "./ToolPreview";
 import { ToolStatusIcon, type ToolTone } from "./ToolStatusIcon";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -145,6 +146,8 @@ export function AgentActivityTimeline({
         >
           {state.items.map((entry, index) => {
             const tone = activityOutcomeTone(entry.outcome);
+            const headline = activityHeadline(entry.detail);
+            const exitCode = failedExitCode(entry);
             return (
               <li
                 key={`${entry.at}:${index}`}
@@ -165,12 +168,28 @@ export function AgentActivityTimeline({
                 />
                 <span
                   className={cn(
-                    "min-w-0 flex-1 truncate font-medium text-foreground",
+                    "min-w-0 truncate font-medium text-foreground",
+                    headline === null ? "flex-1" : "shrink-0",
                     tone === "running" && "animate-pulse",
                   )}
                 >
                   {agentActivityHistoryLabel(entry)}
                 </span>
+                {headline !== null && (
+                  <span
+                    className={cn(
+                      "min-w-0 flex-1 truncate text-xs text-muted-foreground",
+                      headline.monospace && "font-mono",
+                    )}
+                  >
+                    {headline.text}
+                  </span>
+                )}
+                {exitCode !== null && (
+                  <span className="shrink-0 text-xs font-medium text-destructive">
+                    Exit {exitCode}
+                  </span>
+                )}
                 <time
                   className="ml-auto shrink-0 text-xs tabular-nums text-muted-foreground"
                   dateTime={entry.at}
@@ -184,6 +203,43 @@ export function AgentActivityTimeline({
       )}
     </div>
   );
+}
+
+/**
+ * The step's own headline, next to the generic label.
+ *
+ * "Ran a command" is the same sentence whichever command ran, so the validated
+ * detail is what tells the steps apart. It stays a truncated single line: this
+ * row is all the renderer has, because no output is retained for a background
+ * run's calls.
+ */
+function activityHeadline(
+  detail: AgentActivityHistoryEntry["detail"],
+): { text: string; monospace: boolean } | null {
+  if (detail === undefined) return null;
+  switch (detail.kind) {
+    case "exec":
+      return {
+        text: execCommandHeadline(detail.command, detail.args),
+        monospace: true,
+      };
+    case "search":
+      return { text: detail.query, monospace: false };
+    case "file":
+      return { text: detail.name, monospace: false };
+  }
+}
+
+/**
+ * The exit status of a command that failed, when the receipt recorded one. A
+ * non-zero exit is the most specific thing the timeline can say about a failed
+ * step, the same way the foreground badge prefers it over "failed".
+ */
+function failedExitCode(entry: AgentActivityHistoryEntry): number | null {
+  if (entry.outcome !== "failed") return null;
+  const detail = entry.detail;
+  if (detail?.kind !== "exec" || detail.exit_code === undefined) return null;
+  return detail.exit_code;
 }
 
 function agentActivitySummaryLabel(summary: AgentActivitySummary): string {

--- a/crates/openwave-desktop/ui/src/AgentActivityTimeline.tsx
+++ b/crates/openwave-desktop/ui/src/AgentActivityTimeline.tsx
@@ -169,7 +169,7 @@ export function AgentActivityTimeline({
                 <span
                   className={cn(
                     "min-w-0 truncate font-medium text-foreground",
-                    headline === null ? "flex-1" : "shrink-0",
+                    headline === null && "flex-1",
                     tone === "running" && "animate-pulse",
                   )}
                 >
@@ -180,13 +180,14 @@ export function AgentActivityTimeline({
                     className={cn(
                       "min-w-0 flex-1 truncate text-xs text-muted-foreground",
                       headline.monospace && "font-mono",
+                      tone === "running" && "animate-pulse",
                     )}
                   >
                     {headline.text}
                   </span>
                 )}
                 {exitCode !== null && (
-                  <span className="shrink-0 text-xs font-medium text-destructive">
+                  <span className="shrink-0 text-xs font-medium text-critical">
                     Exit {exitCode}
                   </span>
                 )}

--- a/crates/openwave-desktop/ui/src/ToolPreview.tsx
+++ b/crates/openwave-desktop/ui/src/ToolPreview.tsx
@@ -71,9 +71,7 @@ export function toolPreviewPresentation(
     ].join("\n");
     return { headline, detail };
   }
-  const headline = [preview.command, ...preview.args]
-    .map(quoteArgument)
-    .join(" ");
+  const headline = execCommandHeadline(preview.command, preview.args);
   // Everything below the command is a fact *about* it, so it reads as a
   // comment rather than as something a shell would run. There is no shell here
   // at all — this is an argument vector.
@@ -92,6 +90,20 @@ export function toolPreviewPresentation(
     .filter((line): line is string => typeof line === "string")
     .join("\n");
   return { headline, detail };
+}
+
+/**
+ * The one-line form of a command and its argument vector.
+ *
+ * Shared so a command reads identically wherever it is shown: the foreground
+ * approval and result cards, and the background run's activity timeline, which
+ * has only this headline and no card to open.
+ */
+export function execCommandHeadline(
+  command: string,
+  args: readonly string[],
+): string {
+  return [command, ...args].map(quoteArgument).join(" ");
 }
 
 /**

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -853,6 +853,31 @@ describe("parseAgentActivityHistory", () => {
           at: "2026-08-05T18:41:00Z",
           detail: { kind: "file", name: "brief.md", root_id: "private" },
         },
+        // An argument vector the projection could not have produced: one
+        // element is not a string, so the whole headline would misdescribe
+        // what ran.
+        {
+          kind: "exec",
+          outcome: "completed",
+          at: "2026-08-05T18:42:00Z",
+          detail: { kind: "exec", command: "python3", args: ["run.py", 7] },
+        },
+        // A bidirectional override would let the headline read in an order
+        // other than the one that ran.
+        {
+          kind: "exec",
+          outcome: "completed",
+          at: "2026-08-05T18:43:00Z",
+          detail: { kind: "exec", command: "rm", args: ["\u202egnp.txt"] },
+        },
+        // An exit status no process produced costs only itself: the command
+        // is still the useful part of the row.
+        {
+          kind: "exec",
+          outcome: "failed",
+          at: "2026-08-05T18:44:00Z",
+          detail: { kind: "exec", command: "make", args: [], exit_code: 1.5 },
+        },
       ]),
     ).toEqual([
       {
@@ -873,6 +898,14 @@ describe("parseAgentActivityHistory", () => {
         kind: "read_delegated_file",
         outcome: "completed",
         at: "2026-08-05T18:41:00Z",
+      },
+      { kind: "exec", outcome: "completed", at: "2026-08-05T18:42:00Z" },
+      { kind: "exec", outcome: "completed", at: "2026-08-05T18:43:00Z" },
+      {
+        kind: "exec",
+        outcome: "failed",
+        at: "2026-08-05T18:44:00Z",
+        detail: { kind: "exec", command: "make", args: [] },
       },
     ]);
   });

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   ApiClient,
+  parseAgentActivityHistory,
   parseFolderAccessRequest,
   parseInboxItem,
   parsePendingChatPrompt,
@@ -806,6 +807,74 @@ describe("code-execution configuration API", () => {
         }),
       }),
     );
+  });
+});
+
+describe("parseAgentActivityHistory", () => {
+  it("keeps an entry whose typed detail it cannot vouch for, without the detail", () => {
+    expect(
+      parseAgentActivityHistory([
+        {
+          kind: "exec",
+          outcome: "failed",
+          at: "2026-08-05T18:37:00Z",
+          detail: {
+            kind: "exec",
+            command: "pip",
+            args: ["install", "matplotlib"],
+            exit_code: 1,
+          },
+        },
+        // A search headline on a command step: the tag is known, but it would
+        // describe an action other than the one that ran.
+        {
+          kind: "exec",
+          outcome: "completed",
+          at: "2026-08-05T18:38:00Z",
+          detail: { kind: "search", query: "quarterly revenue" },
+        },
+        // A headline the server's own projection would never emit: an unknown
+        // tag, a control character, and an extra key it does not admit.
+        {
+          kind: "web_search",
+          outcome: "completed",
+          at: "2026-08-05T18:39:00Z",
+          detail: { kind: "host_path", path: "/Users/someone" },
+        },
+        {
+          kind: "web_search",
+          outcome: "completed",
+          at: "2026-08-05T18:40:00Z",
+          detail: { kind: "search", query: "quarterly\nrevenue" },
+        },
+        {
+          kind: "read_delegated_file",
+          outcome: "completed",
+          at: "2026-08-05T18:41:00Z",
+          detail: { kind: "file", name: "brief.md", root_id: "private" },
+        },
+      ]),
+    ).toEqual([
+      {
+        kind: "exec",
+        outcome: "failed",
+        at: "2026-08-05T18:37:00Z",
+        detail: {
+          kind: "exec",
+          command: "pip",
+          args: ["install", "matplotlib"],
+          exit_code: 1,
+        },
+      },
+      { kind: "exec", outcome: "completed", at: "2026-08-05T18:38:00Z" },
+      { kind: "web_search", outcome: "completed", at: "2026-08-05T18:39:00Z" },
+      { kind: "web_search", outcome: "completed", at: "2026-08-05T18:40:00Z" },
+      {
+        kind: "read_delegated_file",
+        outcome: "completed",
+        at: "2026-08-05T18:41:00Z",
+      },
+    ]);
   });
 });
 

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -14,6 +14,7 @@ import {
   type PendingApprovalSnapshot,
   type AgentActivitySnapshot,
   type AgentActivityHistoryItem,
+  type AgentActivityDetail,
   type AgentRunProgressLine,
   type AgentActivityKind,
   type AgentActivityOutcome,
@@ -403,9 +404,10 @@ export type AgentActivity = AgentActivitySnapshot;
 /**
  * One settled or live step in a background run's ordered activity history.
  *
- * The wire may also carry an additive typed `detail`. This server-only slice
- * intentionally discards it in {@link parseAgentActivityHistory}; preserving it
- * waits for the renderer slice's closed, bounded, kind-matched validator.
+ * The wire may also carry an additive typed `detail`, kept only when
+ * {@link parseAgentActivityHistory} can validate it as a bounded headline whose
+ * tag matches the entry's own kind. An entry whose detail fails that check is
+ * still rendered, without the headline.
  */
 export type AgentActivityHistoryEntry = AgentActivityHistoryItem;
 
@@ -2301,9 +2303,18 @@ function onlyKeys<Wire>(
 }
 
 function nonEmptyBounded(value: unknown, maxChars: number): value is string {
+  return bounded(value, maxChars) && value.trim().length > 0;
+}
+
+/**
+ * A string within `maxChars` characters and free of control characters, which
+ * would otherwise let a projected field rewrite the line it is rendered on.
+ * Unlike {@link nonEmptyBounded} an empty string passes: an empty command
+ * argument is a real element of an argument vector.
+ */
+function bounded(value: unknown, maxChars: number): value is string {
   return (
     typeof value === "string" &&
-    value.trim().length > 0 &&
     Array.from(value).length <= maxChars &&
     !Array.from(value).some((character) => {
       const code = character.codePointAt(0) ?? 0;
@@ -2331,6 +2342,108 @@ const AGENT_ACTIVITY_OUTCOMES = new Set<AgentActivityOutcome>([
 ]);
 
 /**
+ * The bounds one activity headline may carry: the server projects each field
+ * through the same caps the approval preview uses, so a longer field or a
+ * larger vector is a payload it would not have produced.
+ */
+const ACTIVITY_DETAIL_FIELD_CHARS = 512;
+const ACTIVITY_DETAIL_ARGS = 32;
+
+/** Largest exit status a signed 32-bit exit code can carry. */
+const ACTIVITY_EXIT_CODE_LIMIT = 2 ** 31;
+
+/**
+ * The kinds a `file` headline may accompany: those that name a single file or
+ * folder. `list_connected_folders` names nothing in particular, so a file
+ * headline arriving on it is a mismatch rather than an extra fact.
+ */
+const ACTIVITY_FILE_DETAIL_KINDS = new Set<AgentActivityKind>([
+  "read_delegated_file",
+  "list_folder",
+  "read_connected_file",
+  "import_connected_file",
+]);
+
+/**
+ * Validate one entry's optional headline against the entry's own kind.
+ *
+ * The detail is model-authored text on a surface that otherwise renders only a
+ * closed vocabulary, so the check is closed on every axis: an unknown tag, an
+ * extra key, an unbounded or control-character field, an oversized argument
+ * vector, or a tag that does not belong to this activity kind all yield no
+ * detail. Failing that way costs the reader a headline; keeping a mismatched
+ * one would let a `search` payload describe a command that ran.
+ */
+function parseAgentActivityDetail(
+  kind: AgentActivityKind,
+  value: unknown,
+): AgentActivityDetail | undefined {
+  if (!isRecord(value)) return undefined;
+  if (value.kind === "exec") {
+    if (
+      kind !== "exec" ||
+      !onlyKeys<Extract<AgentActivityDetail, { kind: "exec" }>>(value, [
+        "kind",
+        "command",
+        "args",
+        "exit_code",
+      ]) ||
+      !nonEmptyBounded(value.command, ACTIVITY_DETAIL_FIELD_CHARS) ||
+      !Array.isArray(value.args) ||
+      value.args.length > ACTIVITY_DETAIL_ARGS ||
+      !(
+        value.exit_code === undefined ||
+        (typeof value.exit_code === "number" &&
+          Number.isInteger(value.exit_code) &&
+          Math.abs(value.exit_code) < ACTIVITY_EXIT_CODE_LIMIT)
+      )
+    ) {
+      return undefined;
+    }
+    const args: string[] = [];
+    for (const arg of value.args) {
+      if (!bounded(arg, ACTIVITY_DETAIL_FIELD_CHARS)) return undefined;
+      args.push(arg);
+    }
+    return value.exit_code === undefined
+      ? { kind: "exec", command: value.command, args }
+      : {
+          kind: "exec",
+          command: value.command,
+          args,
+          exit_code: value.exit_code,
+        };
+  }
+  if (value.kind === "search") {
+    if (
+      kind !== "web_search" ||
+      !onlyKeys<Extract<AgentActivityDetail, { kind: "search" }>>(value, [
+        "kind",
+        "query",
+      ]) ||
+      !nonEmptyBounded(value.query, ACTIVITY_DETAIL_FIELD_CHARS)
+    ) {
+      return undefined;
+    }
+    return { kind: "search", query: value.query };
+  }
+  if (value.kind === "file") {
+    if (
+      !ACTIVITY_FILE_DETAIL_KINDS.has(kind) ||
+      !onlyKeys<Extract<AgentActivityDetail, { kind: "file" }>>(value, [
+        "kind",
+        "name",
+      ]) ||
+      !nonEmptyBounded(value.name, ACTIVITY_DETAIL_FIELD_CHARS)
+    ) {
+      return undefined;
+    }
+    return { kind: "file", name: value.name };
+  }
+  return undefined;
+}
+
+/**
  * Keep only well-formed history entries in their server order. An entry whose
  * kind or outcome falls outside the closed vocabulary, or whose timestamp is
  * missing, is dropped rather than rendered — the same defensive discipline the
@@ -2352,11 +2465,14 @@ export function parseAgentActivityHistory(
     ) {
       return [];
     }
+    const kind = entry.kind as AgentActivityKind;
+    const detail = parseAgentActivityDetail(kind, entry.detail);
     return [
       {
-        kind: entry.kind as AgentActivityKind,
+        kind,
         outcome: entry.outcome as AgentActivityOutcome,
         at: entry.at,
+        ...(detail === undefined ? {} : { detail }),
       },
     ];
   });

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -2307,10 +2307,18 @@ function nonEmptyBounded(value: unknown, maxChars: number): value is string {
 }
 
 /**
- * A string within `maxChars` characters and free of control characters, which
- * would otherwise let a projected field rewrite the line it is rendered on.
- * Unlike {@link nonEmptyBounded} an empty string passes: an empty command
- * argument is a real element of an argument vector.
+ * A string within `maxChars` characters and free of any character that could
+ * break the one line it is rendered on or spoof its visual order: C0/C1
+ * controls, the line and paragraph separators, and the bidirectional
+ * overrides and isolates. This mirrors the projection's own clamp
+ * (`preview_formatting_character` in `openwave-core`), because the renderer
+ * validates what it is about to draw rather than trusting that the sender
+ * already did.
+ *
+ * Unlike {@link nonEmptyBounded} an empty string passes. Nothing on this wire
+ * is expected to be empty — the projection drops a field that clamps away —
+ * so this only avoids rejecting a whole payload over a field whose emptiness
+ * says nothing about its trustworthiness.
  */
 function bounded(value: unknown, maxChars: number): value is string {
   return (
@@ -2318,7 +2326,14 @@ function bounded(value: unknown, maxChars: number): value is string {
     Array.from(value).length <= maxChars &&
     !Array.from(value).some((character) => {
       const code = character.codePointAt(0) ?? 0;
-      return code < 32 || (code >= 127 && code <= 159);
+      return (
+        code < 32 ||
+        (code >= 127 && code <= 159) ||
+        code === 0x2028 ||
+        code === 0x2029 ||
+        (code >= 0x202a && code <= 0x202e) ||
+        (code >= 0x2066 && code <= 0x2069)
+      );
     })
   );
 }
@@ -2349,19 +2364,17 @@ const AGENT_ACTIVITY_OUTCOMES = new Set<AgentActivityOutcome>([
 const ACTIVITY_DETAIL_FIELD_CHARS = 512;
 const ACTIVITY_DETAIL_ARGS = 32;
 
-/** Largest exit status a signed 32-bit exit code can carry. */
-const ACTIVITY_EXIT_CODE_LIMIT = 2 ** 31;
+/** The half-open range of a signed 32-bit exit code, as the wire type spells it. */
+const ACTIVITY_EXIT_CODE_MIN = -(2 ** 31);
+const ACTIVITY_EXIT_CODE_MAX = 2 ** 31;
 
 /**
- * The kinds a `file` headline may accompany: those that name a single file or
- * folder. `list_connected_folders` names nothing in particular, so a file
- * headline arriving on it is a mismatch rather than an extra fact.
+ * The kinds a `file` headline may accompany. The server pairs one only with the
+ * delegated read today, and the cross-check is worth exactly as much as it is
+ * narrow: widen this when a folder tool starts naming a file, not before.
  */
 const ACTIVITY_FILE_DETAIL_KINDS = new Set<AgentActivityKind>([
   "read_delegated_file",
-  "list_folder",
-  "read_connected_file",
-  "import_connected_file",
 ]);
 
 /**
@@ -2369,10 +2382,11 @@ const ACTIVITY_FILE_DETAIL_KINDS = new Set<AgentActivityKind>([
  *
  * The detail is model-authored text on a surface that otherwise renders only a
  * closed vocabulary, so the check is closed on every axis: an unknown tag, an
- * extra key, an unbounded or control-character field, an oversized argument
- * vector, or a tag that does not belong to this activity kind all yield no
- * detail. Failing that way costs the reader a headline; keeping a mismatched
- * one would let a `search` payload describe a command that ran.
+ * extra key, an unbounded field or one carrying formatting characters, an
+ * oversized argument vector, or a tag that does not belong to this activity
+ * kind all yield no detail. Failing that way costs the reader a headline;
+ * keeping a mismatched one would let a `search` payload describe a command
+ * that ran.
  */
 function parseAgentActivityDetail(
   kind: AgentActivityKind,
@@ -2390,13 +2404,7 @@ function parseAgentActivityDetail(
       ]) ||
       !nonEmptyBounded(value.command, ACTIVITY_DETAIL_FIELD_CHARS) ||
       !Array.isArray(value.args) ||
-      value.args.length > ACTIVITY_DETAIL_ARGS ||
-      !(
-        value.exit_code === undefined ||
-        (typeof value.exit_code === "number" &&
-          Number.isInteger(value.exit_code) &&
-          Math.abs(value.exit_code) < ACTIVITY_EXIT_CODE_LIMIT)
-      )
+      value.args.length > ACTIVITY_DETAIL_ARGS
     ) {
       return undefined;
     }
@@ -2405,13 +2413,16 @@ function parseAgentActivityDetail(
       if (!bounded(arg, ACTIVITY_DETAIL_FIELD_CHARS)) return undefined;
       args.push(arg);
     }
-    return value.exit_code === undefined
+    // The exit status is decoration next to the command itself, so an
+    // unusable one costs only itself: the reader still sees what ran.
+    const exitCode = activityExitCode(value.exit_code);
+    return exitCode === undefined
       ? { kind: "exec", command: value.command, args }
       : {
           kind: "exec",
           command: value.command,
           args,
-          exit_code: value.exit_code,
+          exit_code: exitCode,
         };
   }
   if (value.kind === "search") {
@@ -2441,6 +2452,23 @@ function parseAgentActivityDetail(
     return { kind: "file", name: value.name };
   }
   return undefined;
+}
+
+/**
+ * The recorded exit status, when it is one a process could actually have
+ * produced: the server parses it as an `i32`, so anything fractional or outside
+ * that range did not come from a receipt.
+ */
+function activityExitCode(value: unknown): number | undefined {
+  if (
+    typeof value !== "number" ||
+    !Number.isInteger(value) ||
+    value < ACTIVITY_EXIT_CODE_MIN ||
+    value >= ACTIVITY_EXIT_CODE_MAX
+  ) {
+    return undefined;
+  }
+  return value;
 }
 
 /**


### PR DESCRIPTION
A background run's activity timeline showed only the generic label for each
step, so five commands in a row all read "Ran a command" and the reader had no
way to tell them apart. The wire already carries an optional typed `detail` per
entry — a bounded exec command/args (plus an exit code when the receipt
recorded one), a search query, or a delegated file's leaf name — which the
desktop was discarding pending a validator.

This adds that validator and renders the result.

`parseAgentActivityHistory` now keeps `detail`, but only when it can vouch for
it, and the check is closed on every axis: the tag must be one of the three
known kinds, it must match the entry's own activity kind (an exec headline only
on an exec step, a search headline only on `web_search`, a file headline only on
the kinds that name one file or folder), keys outside the admitted set are
rejected, string fields are length-bounded and free of control characters, and
an exit code must be an integer in signed 32-bit range. Anything else drops the
headline and keeps the entry, so a step never disappears from the timeline and a
mismatched payload can never describe an action other than the one that ran.
The detail is model-authored text on a surface that otherwise renders a closed
vocabulary, which is why it gets this treatment rather than a shape check.

In the timeline, each row now carries a truncated muted headline next to its
label: monospace for a command — formatted by the same argument-vector helper
the foreground approval and result cards use, now shared out of `ToolPreview` —
and plain text for a query or file name. A failed command with a recorded exit
code surfaces `Exit N` in destructive text, matching how the foreground status
badge prefers the specific exit over the generic outcome word.

Deferred: the expandable command/output cards from the panel design need
server-side output retention for background runs, which does not exist — no
output is stored for a delegated run's calls, so there is nothing to put behind
a tab yet.

Verified with `tsc --noEmit`, the touched vitest files, and `pnpm build`.