### PR TITLE
feat(desktop): plugin detail page with skill instruction dialogs

### DIFF
--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -64,6 +64,7 @@ import {
   type PluginInfo as WirePluginInfo,
   type PluginSkillInfo as WirePluginSkillInfo,
   type SkillOrigin as WireSkillOrigin,
+  type SkillInstructions as WireSkillInstructions,
   type NetworkPolicy as WireNetworkPolicy,
   type ReasoningEffort as WireReasoningEffort,
   type Settings,
@@ -565,6 +566,9 @@ export type PluginEnableUpdate = WirePluginEnableUpdate;
 
 /** Where a skill package was loaded from; host-derived, never claimed. */
 export type SkillOrigin = WireSkillOrigin;
+
+/** One skill's instruction body, fetched on demand for its detail view. */
+export type SkillInstructions = WireSkillInstructions;
 
 /** The Apps library listing: every live local app, newest activity first. */
 export type AppLibrary = WireAppLibrary;
@@ -1219,6 +1223,13 @@ export class ApiClient {
 
   listPlugins(): Promise<PluginCatalog> {
     return this.json("/plugins", { headers: this.headers() });
+  }
+
+  /** One skill's full instruction body — what the model is taught by it. */
+  getSkillInstructions(name: string): Promise<SkillInstructions> {
+    return this.json(`/plugins/skills/${encodeURIComponent(name)}/instructions`, {
+      headers: this.headers(),
+    });
   }
 
   /**

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1880,6 +1880,20 @@ max_active_background_agents: number, };
 export type SignInProgress = { "state": "idle" } | { "state": "pending", authorization_url: string, } | { "state": "failed", message: string, };
 
 /**
+ * One skill's instruction body, for the management surface's detail view.
+ *
+ * Its own route rather than a catalog field on purpose: a body is kilobytes
+ * where a catalog row is bytes, and the catalog is fetched far more often
+ * than any one skill is read.
+ */
+export type SkillInstructions = { name: string, 
+/**
+ * The `SKILL.md` markdown body, with the frontmatter removed — what the
+ * model is taught when the skill is staged, shown to the reader verbatim.
+ */
+instructions: string, };
+
+/**
  * Which source a validated skill package was loaded from.
  *
  * Origin is host-derived from the load path, never from manifest content, so

--- a/crates/openwave-desktop/ui/src/plugins/PluginDetailView.tsx
+++ b/crates/openwave-desktop/ui/src/plugins/PluginDetailView.tsx
@@ -1,34 +1,51 @@
-import { ChevronLeft } from "lucide-react";
+import { useState } from "react";
+import { ChevronLeft, Sparkles } from "lucide-react";
+import type { ReactNode } from "react";
 
+import type { PluginSkillInfo } from "@/api";
 import { PanelSecondaryHeader } from "@/components/PanelHeader";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
+import type { PluginsApis } from "./pluginsApis";
 import { capabilityLabel, categoryIcon, categoryLabel } from "./pluginVocabulary";
+import { SkillDialog } from "./SkillDialog";
 import type { PluginCatalogState } from "./usePluginCatalog";
 
 /**
- * One bundle, as the panel addressed `plugins.{slug}`: what it is for, what it
- * can do, and which of its skills are on.
+ * One bundle's page: identity up top, its member skills, and the facts the
+ * host derives about it.
  *
  * A member's switch is gated while the bundle itself is off, because a member
  * of a disabled bundle cannot run whatever its own flag says. It is gated
  * rather than cleared: the server keeps member flags independently, so the
  * choices made here come back exactly as they were when the bundle does.
+ *
+ * A skill row opens the skill itself — its full instruction body — in a
+ * dialog, so what a skill actually teaches the model is one click away from
+ * the switch that turns it on.
  */
 export function PluginDetailView({
   pluginId,
   state,
+  loadInstructions,
   onBack,
 }: {
   pluginId: string;
   state: PluginCatalogState;
-  /** Return to the `plugins` list panel. */
+  loadInstructions: PluginsApis["instructions"];
+  /** Return to the plugins list. */
   onBack: () => void;
 }) {
   const { catalog, loading, error, setEnabled } = state;
   const plugin = catalog?.plugins.find((entry) => entry.name === pluginId) ?? null;
   const Icon = plugin ? categoryIcon(plugin.category) : null;
+  const [openSkill, setOpenSkill] = useState<PluginSkillInfo | null>(null);
+  // The dialog re-reads its skill from the fresh catalog, so its switch moves
+  // with the toggle round trip instead of freezing at the row that opened it.
+  const shownSkill = openSkill
+    ? (plugin?.skills.find((skill) => skill.name === openSkill.name) ?? openSkill)
+    : null;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -37,104 +54,152 @@ export function PluginDetailView({
           <ChevronLeft className="size-4" />
           <span className="sr-only">Back to plugins</span>
         </Button>
-        <h1 className="min-w-0 truncate text-lg font-medium">
-          {plugin?.display_name ?? "Plugin"}
-        </h1>
       </PanelSecondaryHeader>
 
-      <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto pt-4 pb-4">
-        {error && (
-          <p className="text-critical mx-4 text-sm" role="alert">
-            {error}
-          </p>
-        )}
-        {!error && loading && !catalog && (
-          <p className="text-muted-foreground mx-4 text-sm" role="status">
-            Loading plugin…
-          </p>
-        )}
-        {!error && catalog && !plugin && (
-          <p className="text-muted-foreground mx-4 text-sm" role="status">
-            That plugin is not installed.
-          </p>
-        )}
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-6 pt-2 pb-8">
+          {error && (
+            <p className="text-critical text-sm" role="alert">
+              {error}
+            </p>
+          )}
+          {!error && loading && !catalog && (
+            <p className="text-muted-foreground text-sm" role="status">
+              Loading plugin…
+            </p>
+          )}
+          {!error && catalog && !plugin && (
+            <p className="text-muted-foreground text-sm" role="status">
+              That plugin is not installed.
+            </p>
+          )}
 
-        {plugin && (
-          <>
-            <section className="mx-4 flex flex-col gap-3" aria-label="About">
-              <div className="flex items-start gap-3">
-                <div className="flex min-w-0 flex-1 flex-col gap-1">
-                  <div className="text-muted-foreground flex items-center gap-1.5 text-xs">
-                    {Icon && <Icon className="size-3.5 shrink-0" aria-hidden="true" />}
-                    <span>{categoryLabel(plugin.category)}</span>
+          {plugin && (
+            <>
+              <section className="flex flex-col gap-3" aria-label="About">
+                {Icon && (
+                  <div className="grid size-14 place-items-center rounded-xl border bg-muted text-muted-foreground">
+                    <Icon className="size-7" aria-hidden="true" />
                   </div>
-                  <p className="text-sm">{plugin.description}</p>
+                )}
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex min-w-0 flex-col gap-1">
+                    <h1 className="text-xl font-semibold">{plugin.display_name}</h1>
+                    <p className="text-muted-foreground text-sm">{plugin.description}</p>
+                  </div>
+                  <Switch
+                    aria-label={`Enable ${plugin.display_name}`}
+                    checked={plugin.enabled}
+                    onCheckedChange={(enabled) =>
+                      setEnabled({ plugins: { [plugin.name]: enabled }, skills: {} })
+                    }
+                  />
                 </div>
-                <Switch
-                  aria-label={`Enable ${plugin.display_name}`}
-                  checked={plugin.enabled}
-                  onCheckedChange={(enabled) =>
-                    setEnabled({ plugins: { [plugin.name]: enabled }, skills: {} })
-                  }
-                />
-              </div>
+              </section>
 
-              {plugin.capabilities.length > 0 && (
-                <div className="flex flex-wrap gap-1.5">
-                  {plugin.capabilities.map((capability) => (
-                    <Badge key={capability} variant="outline" size="sm">
-                      {capabilityLabel(capability)}
-                    </Badge>
-                  ))}
+              <section className="flex flex-col gap-1" aria-label="Skills">
+                <div className="flex items-baseline gap-2 border-b pb-2">
+                  <h2 className="text-base font-semibold">Skills</h2>
+                  <span className="text-muted-foreground text-sm">
+                    {plugin.skills.length}
+                  </span>
                 </div>
-              )}
-            </section>
-
-            <section className="mx-4 flex flex-col gap-2" aria-label="Skills">
-              <div className="flex flex-col gap-0.5">
-                <h2 className="text-sm font-medium">Skills</h2>
-                {!plugin.enabled && (
-                  <p className="text-muted-foreground text-xs">
+                {!plugin.enabled && plugin.skills.length > 0 && (
+                  <p className="text-muted-foreground pt-1 text-xs">
                     Turn the plugin on to change which of its skills are
                     available. Your choices are kept while it is off.
                   </p>
                 )}
-              </div>
-              <ul className="flex flex-col gap-1" aria-label="Member skills">
-                {plugin.skills.map((skill) => (
-                  <li key={skill.name} className="flex items-center gap-3 rounded-md p-2">
-                    <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-                      <span
-                        className={`truncate text-sm font-medium${
-                          plugin.enabled ? "" : " text-muted-foreground"
-                        }`}
+                <ul className="flex flex-col" aria-label="Member skills">
+                  {plugin.skills.map((skill) => (
+                    <li
+                      key={skill.name}
+                      className="hover:bg-muted/60 -mx-2 flex items-center gap-3 rounded-md px-2 py-2.5 transition-colors"
+                    >
+                      <button
+                        type="button"
+                        className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 text-left"
+                        onClick={() => setOpenSkill(skill)}
                       >
-                        {skill.name}
+                        <span className="grid size-8 shrink-0 place-items-center rounded-lg border bg-muted text-muted-foreground">
+                          <Sparkles className="size-4" aria-hidden="true" />
+                        </span>
+                        <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                          <span
+                            className={`truncate text-sm font-medium${
+                              plugin.enabled ? "" : " text-muted-foreground"
+                            }`}
+                          >
+                            {skill.name}
+                          </span>
+                          <span className="text-muted-foreground line-clamp-2 text-xs">
+                            {skill.description}
+                          </span>
+                        </span>
+                      </button>
+                      <Switch
+                        aria-label={`Enable ${skill.name}`}
+                        checked={skill.enabled}
+                        disabled={!plugin.enabled}
+                        onCheckedChange={(enabled) =>
+                          setEnabled({ plugins: {}, skills: { [skill.name]: enabled } })
+                        }
+                      />
+                    </li>
+                  ))}
+                </ul>
+                {plugin.skills.length === 0 && (
+                  <p className="text-muted-foreground pt-1 text-sm">
+                    This plugin bundles no skills.
+                  </p>
+                )}
+              </section>
+
+              <section className="flex flex-col gap-1" aria-label="Information">
+                <h2 className="border-b pb-2 text-base font-semibold">Information</h2>
+                <dl className="grid grid-cols-[8rem_1fr] gap-x-4 gap-y-2 pt-2 text-sm">
+                  <InfoRow label="Category">{categoryLabel(plugin.category)}</InfoRow>
+                  <InfoRow label="Capabilities">
+                    {plugin.capabilities.length === 0 ? (
+                      <span className="text-muted-foreground">None derived</span>
+                    ) : (
+                      <span className="flex flex-wrap gap-1.5">
+                        {plugin.capabilities.map((capability) => (
+                          <Badge key={capability} variant="outline" size="sm">
+                            {capabilityLabel(capability)}
+                          </Badge>
+                        ))}
                       </span>
-                      <span className="text-muted-foreground line-clamp-2 text-xs">
-                        {skill.description}
-                      </span>
-                    </div>
-                    <Switch
-                      aria-label={`Enable ${skill.name}`}
-                      checked={skill.enabled}
-                      disabled={!plugin.enabled}
-                      onCheckedChange={(enabled) =>
-                        setEnabled({ plugins: {}, skills: { [skill.name]: enabled } })
-                      }
-                    />
-                  </li>
-                ))}
-              </ul>
-              {plugin.skills.length === 0 && (
-                <p className="text-muted-foreground text-sm">
-                  This plugin bundles no skills.
-                </p>
-              )}
-            </section>
-          </>
-        )}
+                    )}
+                  </InfoRow>
+                  <InfoRow label="Skills">{String(plugin.skills.length)}</InfoRow>
+                </dl>
+              </section>
+            </>
+          )}
+        </div>
       </div>
+
+      <SkillDialog
+        skill={shownSkill}
+        gated={plugin !== null && !plugin.enabled}
+        onOpenChange={(open) => {
+          if (!open) setOpenSkill(null);
+        }}
+        onToggle={(skill, enabled) =>
+          setEnabled({ plugins: {}, skills: { [skill.name]: enabled } })
+        }
+        loadInstructions={loadInstructions}
+      />
     </div>
+  );
+}
+
+function InfoRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <>
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="min-w-0">{children}</dd>
+    </>
   );
 }

--- a/crates/openwave-desktop/ui/src/plugins/Plugins.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/plugins/Plugins.dom.test.tsx
@@ -57,16 +57,36 @@ function catalogWith(
   };
 }
 
+const SKILL_BODY = "Use this skill when authoring Word documents.";
+
+function apisWith(overrides: Partial<PluginsApis> = {}): PluginsApis {
+  return {
+    list: vi.fn().mockResolvedValue(CATALOG),
+    setEnabled: vi.fn(),
+    instructions: vi
+      .fn()
+      .mockImplementation(async (name: string) => ({ name, instructions: SKILL_BODY })),
+    ...overrides,
+  };
+}
+
 /** Drives the real catalog hook so a toggle exercises the whole round trip. */
 function ListHarness({ apis }: { apis: PluginsApis }) {
   const state = usePluginCatalog(apis);
-  return <PluginsView state={state} onOpen={() => {}} />;
+  return (
+    <PluginsView state={state} loadInstructions={apis.instructions} onOpen={() => {}} />
+  );
 }
 
 function DetailHarness({ apis }: { apis: PluginsApis }) {
   const state = usePluginCatalog(apis);
   return (
-    <PluginDetailView pluginId="documents" state={state} onBack={() => {}} />
+    <PluginDetailView
+      pluginId="documents"
+      state={state}
+      loadInstructions={apis.instructions}
+      onBack={() => {}}
+    />
   );
 }
 
@@ -77,10 +97,7 @@ afterEach(() => {
 
 describe("Plugins library", () => {
   it("gates a disabled plugin's member switches without clearing their own flags", async () => {
-    const apis: PluginsApis = {
-      list: vi.fn().mockResolvedValue(CATALOG),
-      setEnabled: vi.fn(),
-    };
+    const apis = apisWith();
     render(<DetailHarness apis={apis} />);
 
     // The bundle is off, so no member can run whatever its own flag says —
@@ -99,10 +116,9 @@ describe("Plugins library", () => {
   });
 
   it("ungates the members once the plugin's own toggle round trip lands", async () => {
-    const apis: PluginsApis = {
-      list: vi.fn().mockResolvedValue(CATALOG),
+    const apis = apisWith({
       setEnabled: vi.fn().mockResolvedValue(catalogWith({ documents: true })),
-    };
+    });
     render(<DetailHarness apis={apis} />);
 
     fireEvent.click(
@@ -125,10 +141,7 @@ describe("Plugins library", () => {
       ...catalogWith({ documents: true }),
       skills: [{ ...CATALOG.skills[0]!, enabled: false }],
     };
-    const apis: PluginsApis = {
-      list: vi.fn().mockResolvedValue(CATALOG),
-      setEnabled: vi.fn().mockResolvedValue(reconciled),
-    };
+    const apis = apisWith({ setEnabled: vi.fn().mockResolvedValue(reconciled) });
     render(<ListHarness apis={apis} />);
 
     const bundle = await screen.findByRole("switch", { name: "Enable Documents" });
@@ -144,10 +157,9 @@ describe("Plugins library", () => {
   });
 
   it("puts a failed toggle back where it was", async () => {
-    const apis: PluginsApis = {
-      list: vi.fn().mockResolvedValue(CATALOG),
+    const apis = apisWith({
       setEnabled: vi.fn().mockRejectedValue(new Error("offline")),
-    };
+    });
     render(<ListHarness apis={apis} />);
 
     const skill = await screen.findByRole("switch", { name: "Enable my-notes" });
@@ -163,11 +175,25 @@ describe("Plugins library", () => {
     });
   });
 
+  it("opens a skill's own instructions from its row", async () => {
+    const apis = apisWith();
+    render(<DetailHarness apis={apis} />);
+
+    // The row body — not the switch beside it — opens the skill.
+    fireEvent.click(await screen.findByRole("button", { name: /docx/ }));
+
+    // The dialog shows the staged instruction body, fetched on open.
+    expect(await screen.findByText(SKILL_BODY)).toBeInTheDocument();
+    expect(apis.instructions).toHaveBeenCalledWith("docx");
+    // Its switch is the same gated control the row has: the bundle is off.
+    // (The modal hides the page behind it, so this is the dialog's own.)
+    expect(screen.getByRole("switch", { name: "Enable docx" })).toBeDisabled();
+  });
+
   it("explains an installation with nothing in it", async () => {
-    const apis: PluginsApis = {
+    const apis = apisWith({
       list: vi.fn().mockResolvedValue({ plugins: [], skills: [] }),
-      setEnabled: vi.fn(),
-    };
+    });
     render(<ListHarness apis={apis} />);
 
     expect(await screen.findByText("No plugins installed")).toBeInTheDocument();

--- a/crates/openwave-desktop/ui/src/plugins/PluginsPage.tsx
+++ b/crates/openwave-desktop/ui/src/plugins/PluginsPage.tsx
@@ -31,11 +31,13 @@ export function PluginsPage({ pluginId }: { pluginId?: string }) {
           <PluginDetailView
             pluginId={pluginId}
             state={state}
+            loadInstructions={apis.instructions}
             onBack={() => void navigate({ to: "/plugins" })}
           />
         ) : (
           <PluginsView
             state={state}
+            loadInstructions={apis.instructions}
             onOpen={(id) =>
               void navigate({ to: "/plugins/$pluginId", params: { pluginId: id } })
             }

--- a/crates/openwave-desktop/ui/src/plugins/PluginsView.tsx
+++ b/crates/openwave-desktop/ui/src/plugins/PluginsView.tsx
@@ -1,5 +1,5 @@
-import { ChevronRight, Puzzle } from "lucide-react";
-import type { ReactNode } from "react";
+import { ChevronRight, Puzzle, Sparkles } from "lucide-react";
+import { useState, type ReactNode } from "react";
 
 import type { PluginInfo, PluginSkillInfo } from "@/api";
 import { PanelSecondaryHeader } from "@/components/PanelHeader";
@@ -13,7 +13,9 @@ import {
   EmptyTitle,
 } from "@/components/ui/empty";
 import { Switch } from "@/components/ui/switch";
+import type { PluginsApis } from "./pluginsApis";
 import { capabilityShortLabel, categoryIcon } from "./pluginVocabulary";
+import { SkillDialog } from "./SkillDialog";
 import type { PluginCatalogState } from "./usePluginCatalog";
 
 /**
@@ -30,18 +32,26 @@ import type { PluginCatalogState } from "./usePluginCatalog";
  */
 export function PluginsView({
   state,
+  loadInstructions,
   onOpen,
 }: {
   state: PluginCatalogState;
-  /** Navigate to the `plugins.{slug}` panel contract. */
+  loadInstructions: PluginsApis["instructions"];
+  /** Navigate to the bundle's own page. */
   onOpen: (pluginId: string) => void;
 }) {
   const { catalog, loading, error, reload, setEnabled } = state;
+  const [openSkill, setOpenSkill] = useState<PluginSkillInfo | null>(null);
   const yourSkills = catalog?.skills.filter((skill) => skill.origin === "user") ?? [];
   const otherSkills =
     catalog?.skills.filter((skill) => skill.origin !== "user") ?? [];
   const isEmpty =
     catalog !== null && catalog.plugins.length === 0 && catalog.skills.length === 0;
+  // The dialog re-reads its skill from the fresh catalog, so its switch moves
+  // with the toggle round trip instead of freezing at the row that opened it.
+  const shownSkill = openSkill
+    ? (catalog?.skills.find((skill) => skill.name === openSkill.name) ?? openSkill)
+    : null;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -107,7 +117,12 @@ export function PluginsView({
             title="Your skills"
             description="Skills you wrote, loaded from your data directory. They stand on their own rather than belonging to a bundle."
           >
-            <SkillList skills={yourSkills} setEnabled={setEnabled} label="Your skills" />
+            <SkillList
+              skills={yourSkills}
+              setEnabled={setEnabled}
+              label="Your skills"
+              onOpenSkill={setOpenSkill}
+            />
           </Section>
         )}
 
@@ -116,10 +131,27 @@ export function PluginsView({
             title="Other skills"
             description="Installed skills that no bundle claims."
           >
-            <SkillList skills={otherSkills} setEnabled={setEnabled} label="Other skills" />
+            <SkillList
+              skills={otherSkills}
+              setEnabled={setEnabled}
+              label="Other skills"
+              onOpenSkill={setOpenSkill}
+            />
           </Section>
         )}
       </div>
+
+      <SkillDialog
+        skill={shownSkill}
+        gated={false}
+        onOpenChange={(open) => {
+          if (!open) setOpenSkill(null);
+        }}
+        onToggle={(skill, enabled) =>
+          setEnabled({ plugins: {}, skills: { [skill.name]: enabled } })
+        }
+        loadInstructions={loadInstructions}
+      />
     </div>
   );
 }
@@ -204,24 +236,35 @@ function SkillList({
   skills,
   setEnabled,
   label,
+  onOpenSkill,
 }: {
   skills: PluginSkillInfo[];
   setEnabled: PluginCatalogState["setEnabled"];
   label: string;
+  onOpenSkill: (skill: PluginSkillInfo) => void;
 }) {
   return (
     <ul className="flex flex-col gap-1" aria-label={label}>
       {skills.map((skill) => (
         <li
           key={skill.name}
-          className="flex items-center gap-3 rounded-md p-2 transition-colors"
+          className="hover:bg-muted flex items-center gap-3 rounded-md p-2 transition-colors"
         >
-          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-            <span className="truncate text-sm font-medium">{skill.name}</span>
-            <span className="text-muted-foreground line-clamp-2 text-xs">
-              {skill.description}
+          <button
+            type="button"
+            className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 text-left"
+            onClick={() => onOpenSkill(skill)}
+          >
+            <span className="text-muted-foreground grid size-7 shrink-0 place-items-center rounded-md border bg-muted">
+              <Sparkles className="size-3.5" aria-hidden="true" />
             </span>
-          </div>
+            <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+              <span className="truncate text-sm font-medium">{skill.name}</span>
+              <span className="text-muted-foreground line-clamp-2 text-xs">
+                {skill.description}
+              </span>
+            </span>
+          </button>
           <Switch
             aria-label={`Enable ${skill.name}`}
             checked={skill.enabled}

--- a/crates/openwave-desktop/ui/src/plugins/SkillDialog.tsx
+++ b/crates/openwave-desktop/ui/src/plugins/SkillDialog.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from "react";
+import { Sparkles } from "lucide-react";
+
+import type { PluginSkillInfo } from "@/api";
+import { MessageMarkdown } from "@/MessageMarkdown";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
+
+/**
+ * One skill, up close: its identity, its own switch, and the instruction body
+ * it stages — the exact markdown the model is taught, shown to the reader
+ * verbatim rather than summarized.
+ *
+ * The body is fetched when the dialog opens, not carried in the catalog: a
+ * body is kilobytes where a catalog row is bytes.
+ */
+export function SkillDialog({
+  skill,
+  gated,
+  onOpenChange,
+  onToggle,
+  loadInstructions,
+}: {
+  /** The skill showing, or `null` while the dialog is closed. */
+  skill: PluginSkillInfo | null;
+  /** True while an owning bundle is off, which gates the switch here too. */
+  gated: boolean;
+  onOpenChange: (open: boolean) => void;
+  onToggle: (skill: PluginSkillInfo, enabled: boolean) => void;
+  loadInstructions: (name: string) => Promise<{ instructions: string }>;
+}) {
+  const name = skill?.name ?? null;
+  const [body, setBody] = useState<
+    { state: "loading" } | { state: "failed" } | { state: "ready"; text: string }
+  >({ state: "loading" });
+
+  useEffect(() => {
+    if (!name) return;
+    let cancelled = false;
+    setBody({ state: "loading" });
+    loadInstructions(name).then(
+      ({ instructions }) => {
+        if (!cancelled) setBody({ state: "ready", text: instructions });
+      },
+      () => {
+        if (!cancelled) setBody({ state: "failed" });
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [name, loadInstructions]);
+
+  return (
+    <Dialog open={skill !== null} onOpenChange={onOpenChange}>
+      {skill && (
+        <DialogContent className="flex max-h-[85vh] max-w-2xl flex-col gap-4">
+          {/* The switch sits with the chrome, clear of the close button. */}
+          <div className="absolute top-2 right-12">
+            <Switch
+              aria-label={`Enable ${skill.name}`}
+              checked={skill.enabled}
+              disabled={gated}
+              onCheckedChange={(enabled) => onToggle(skill, enabled)}
+            />
+          </div>
+
+          <div className="flex flex-col gap-2 pr-20">
+            <div className="grid size-10 place-items-center rounded-lg border bg-muted text-muted-foreground">
+              <Sparkles className="size-5" aria-hidden="true" />
+            </div>
+            <DialogTitle className="flex items-baseline gap-2">
+              {skill.name}
+              <span className="text-muted-foreground text-base font-normal">Skill</span>
+            </DialogTitle>
+            <DialogDescription>{skill.description}</DialogDescription>
+          </div>
+
+          <div className="bg-muted/50 min-h-0 flex-1 overflow-y-auto rounded-lg border p-4">
+            {body.state === "loading" && (
+              <div className="flex flex-col gap-2" role="status" aria-label="Loading skill">
+                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-2/3" />
+              </div>
+            )}
+            {body.state === "failed" && (
+              <p className="text-sm" role="alert">
+                Could not load this skill's instructions.
+              </p>
+            )}
+            {body.state === "ready" && (
+              <div className="[&_.message-markdown]:text-sm">
+                <MessageMarkdown>{body.text}</MessageMarkdown>
+              </div>
+            )}
+          </div>
+
+          <p className="text-muted-foreground text-xs">
+            {skill.origin === "user"
+              ? "Installed by you, from your data directory."
+              : "Bundled with OpenWave."}
+            {gated && " Its plugin is off, so the skill cannot run right now."}
+          </p>
+        </DialogContent>
+      )}
+    </Dialog>
+  );
+}

--- a/crates/openwave-desktop/ui/src/plugins/pluginsApis.ts
+++ b/crates/openwave-desktop/ui/src/plugins/pluginsApis.ts
@@ -1,4 +1,9 @@
-import type { ApiClient, PluginCatalog, PluginEnableUpdate } from "@/api";
+import type {
+  ApiClient,
+  PluginCatalog,
+  PluginEnableUpdate,
+  SkillInstructions,
+} from "@/api";
 
 /**
  * Everything the Plugins library calls on the server, as one injectable
@@ -9,11 +14,14 @@ import type { ApiClient, PluginCatalog, PluginEnableUpdate } from "@/api";
 export type PluginsApis = {
   list(): Promise<PluginCatalog>;
   setEnabled(update: PluginEnableUpdate): Promise<PluginCatalog>;
+  /** One skill's instruction body, fetched when its detail opens. */
+  instructions(name: string): Promise<SkillInstructions>;
 };
 
 export function pluginsApisFromClient(client: ApiClient): PluginsApis {
   return {
     list: () => client.listPlugins(),
     setEnabled: (update) => client.setPluginsEnabled(update),
+    instructions: (name) => client.getSkillInstructions(name),
   };
 }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -333,6 +333,10 @@ pub fn app(state: AppState) -> Router {
                 .layer(DefaultBodyLimit::max(routes::MAX_PLUGIN_ENABLE_BODY_BYTES)),
         )
         .route(
+            "/plugins/skills/{name}/instructions",
+            get(routes::get_skill_instructions),
+        )
+        .route(
             "/connected-apps/rest/{id}",
             axum::routing::put(routes::put_rest_connected_app)
                 .delete(routes::delete_rest_connected_app)

--- a/crates/openwave-server/src/routes/plugins.rs
+++ b/crates/openwave-server/src/routes/plugins.rs
@@ -12,7 +12,7 @@
 //! [`crate::plugin_state`]; what is enforced here is that a name is a
 //! well-formed slug and that the recorded set stays bounded.
 
-use axum::extract::State;
+use axum::extract::{Path, State};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -141,6 +141,55 @@ fn skill_info(
         origin: skill.origin,
         enabled: flags.skill_flag(&skill.name),
     }
+}
+
+/// One skill's instruction body, for the management surface's detail view.
+///
+/// Its own route rather than a catalog field on purpose: a body is kilobytes
+/// where a catalog row is bytes, and the catalog is fetched far more often
+/// than any one skill is read.
+#[derive(Debug, Serialize, ts_rs::TS)]
+pub struct SkillInstructions {
+    pub name: String,
+    /// The `SKILL.md` markdown body, with the frontmatter removed — what the
+    /// model is taught when the skill is staged, shown to the reader verbatim.
+    pub instructions: String,
+}
+
+/// `GET /plugins/skills/{name}/instructions`.
+pub async fn get_skill_instructions(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Result<Json<SkillInstructions>, ServerError> {
+    if !is_valid_skill_name(&name) {
+        return Err(ServerError::bad_request(format!(
+            "not a skill name: {name:?}"
+        )));
+    }
+    let skill = state
+        .code_execution
+        .as_ref()
+        .and_then(|exec| {
+            exec.installed_skills()
+                .into_iter()
+                .find(|skill| skill.package.name == name)
+        })
+        .ok_or_else(|| ServerError::not_found(format!("no skill named {name:?}")))?;
+    Ok(Json(SkillInstructions {
+        name,
+        instructions: manifest_body(&skill.manifest).to_owned(),
+    }))
+}
+
+/// The manifest with its frontmatter fences removed. Every staged manifest
+/// parsed on the way in, so the split always succeeds; falling back to the
+/// whole source keeps a malformed one readable rather than blank.
+fn manifest_body(manifest: &str) -> &str {
+    manifest
+        .strip_prefix("---\n")
+        .and_then(|rest| rest.split_once("\n---\n"))
+        .map_or(manifest, |(_, body)| body)
+        .trim()
 }
 
 /// `PUT /plugins/enabled` — set the named flags, returning the fresh catalog.

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -364,6 +364,9 @@ mod tests {
         // badges, and the toggle body the management surface sends back.
         generate::collect_from::<crate::routes::PluginCatalog>(&cfg, &mut out);
         generate::collect_from::<crate::routes::PluginEnableUpdate>(&cfg, &mut out);
+        // Its own endpoint root: a skill's instruction body is fetched on
+        // demand rather than carried in the catalog.
+        generate::collect_from::<crate::routes::SkillInstructions>(&cfg, &mut out);
         // The Connected apps settings listing: per-kind health/catalog
         // projections and credential *status* — never definitions or values.
         generate::collect_from::<crate::routes::ConnectedAppsInfo>(&cfg, &mut out);


### PR DESCRIPTION
Replaces #1627, which GitHub auto-closed when its stacked base branch was deleted on merge; same change, rebased onto `main`.

## Plugin page
The bundle detail was a cramped panel list; it is now a real page: icon tile, name and tagline beside the enable switch, a counted **Skills** section, and an **Information** section carrying the host-derived facts (category, capability badges, skill count). Nothing invented — no developer/version rows, because manifests don't declare them.

## Skill dialogs
Clicking a skill row (in a bundle, or a standalone skill on the library page) opens the skill in a dialog: identity, its own enable switch — gated the same way the row's is while the bundle is off — its origin (bundled vs. user-installed), and the staged `SKILL.md` instruction body rendered as markdown. The reader sees exactly what the model is taught, verbatim.

## Server
New `GET /plugins/skills/{name}/instructions` returning `{ name, instructions }`, the manifest body with frontmatter stripped. Its own route rather than a catalog field on purpose: bodies are kilobytes where catalog rows are bytes, and the catalog is fetched far more often. Wire types regenerated.

## Tests
Existing plugin toggle/gating round-trip tests updated for the new props; one new test drives row → dialog → fetched body → gated switch. Verified with `tsc`, `vitest run` (748 passing), `vite build`, `cargo check -p openwave-server --locked`, and the wire-type staleness test.