### PR TITLE
fix(desktop): settle a declined background-agent spawn

### DIFF
--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.test.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.test.tsx
@@ -137,6 +137,23 @@ describe("BackgroundAgentList", () => {
     expect(markup).toEqual("");
   });
 
+  it("settles a declined spawn instead of waiting for a run that cannot arrive", () => {
+    const markup = renderToStaticMarkup(
+      <BackgroundAgentList
+        spawns={[{ callId: "call-denied", status: "denied" }]}
+        runs={[]}
+        loading={false}
+        error={null}
+        onRetry={() => undefined}
+        onCancel={noop}
+        onLoadActivity={noActivity}
+      />,
+    );
+
+    expect(markup).toContain("Declined");
+    expect(markup).not.toContain("Waiting for background agent");
+  });
+
   it("offers Stop on a cancellable run", () => {
     const markup = renderToStaticMarkup(
       <BackgroundAgentList

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
@@ -182,15 +182,34 @@ export function BackgroundAgentList({
               </div>
             );
           })}
-          {unresolvedSpawns.map((spawn) => (
-            <div key={spawn.callId} className="flex min-w-0 items-center gap-2 border-t border-border px-3 py-2.5">
-              <Skeleton className="size-2 shrink-0 rounded-full bg-muted-foreground" aria-hidden="true" />
-              <Skeleton className="h-4 w-28" aria-hidden="true" />
-              <span className="text-sm text-muted-foreground">
-                {loading ? "Starting background agent" : "Waiting for background agent"}
-              </span>
-            </div>
-          ))}
+          {unresolvedSpawns.map((spawn) =>
+            spawn.status === "denied" ? (
+              // A declined spawn never reaches the sandbox, so no durable run
+              // will ever arrive to replace this row. Settle it here: the
+              // placeholder would otherwise read as work still on its way.
+              <div
+                key={spawn.callId}
+                className="flex min-w-0 items-center gap-2 border-t border-border px-3 py-2.5"
+              >
+                <span
+                  className={cn("size-2 shrink-0 rounded-full", getAgentRunDotClass("cancelled"))}
+                  aria-hidden="true"
+                />
+                <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+                  Background agent
+                </span>
+                <span className="shrink-0 text-xs text-muted-foreground">Declined</span>
+              </div>
+            ) : (
+              <div key={spawn.callId} className="flex min-w-0 items-center gap-2 border-t border-border px-3 py-2.5">
+                <Skeleton className="size-2 shrink-0 rounded-full bg-muted-foreground" aria-hidden="true" />
+                <Skeleton className="h-4 w-28" aria-hidden="true" />
+                <span className="text-sm text-muted-foreground">
+                  {loading ? "Starting background agent" : "Waiting for background agent"}
+                </span>
+              </div>
+            ),
+          )}
         </div>
       )}
     </section>


### PR DESCRIPTION
Declining the approval for `spawn_sandbox_agent` sets the tool call to `denied`, and no durable run will ever arrive behind it. `BackgroundAgentList` only treated `failed` and `cancelled` spawns as settled, so a declined one fell through to the placeholder branch and shimmered "Waiting for background agent" for the rest of the transcript.

A declined spawn now renders as its own settled row — destructive dot, "Background agent", and a right-aligned "Declined" — matching how a real run row reads.

It stays in the list rather than being dropped the way a failed spawn is, because `MessageList` strips `spawn_sandbox_agent` from the activity rail whenever the agent list is present; hiding it here as well would erase the decline from the conversation entirely.

One test added: a declined spawn renders "Declined" and no longer renders the waiting placeholder.

Verified with `tsc --noEmit` and the desktop UI's `BackgroundAgentList`, `BackgroundAgentList.dom`, and `MessageList` suites. Not driven in the running app.