### PR TITLE
fix(desktop): align the skill dialog switch with the close button

### DIFF
--- a/crates/openwave-desktop/ui/src/plugins/SkillDialog.tsx
+++ b/crates/openwave-desktop/ui/src/plugins/SkillDialog.tsx
@@ -61,8 +61,9 @@ export function SkillDialog({
     <Dialog open={skill !== null} onOpenChange={onOpenChange}>
       {skill && (
         <DialogContent className="flex max-h-[85vh] max-w-2xl flex-col gap-4">
-          {/* The switch sits with the chrome, clear of the close button. */}
-          <div className="absolute top-2 right-12">
+          {/* Vertically centered on the close button's size-10 hit area, with a
+              comfortable gap to its left. */}
+          <div className="absolute top-4 right-14">
             <Switch
               aria-label={`Enable ${skill.name}`}
               checked={skill.enabled}
@@ -71,7 +72,7 @@ export function SkillDialog({
             />
           </div>
 
-          <div className="flex flex-col gap-2 pr-20">
+          <div className="flex flex-col gap-2 pr-28">
             <div className="grid size-10 place-items-center rounded-lg border bg-muted text-muted-foreground">
               <Sparkles className="size-5" aria-hidden="true" />
             </div>


### PR DESCRIPTION
## Summary
- The skill dialog's enable switch was pinned at `top-2 right-12`, independent of the close button's own position (`top-2 right-2`, size-10 hit area), so it sat too high and crowded the close button.
- Position the switch relative to the close button's actual box: `top-4` centers the 24px-tall switch within the 40px close button, and `right-14` gives it a clean gap to the button's left edge.
- Widen the neighboring `pr-20` to `pr-28` so the header content clears the switch's new, slightly wider footprint.

## Test plan
- [x] `pnpm exec tsc --noEmit` in `crates/openwave-desktop/ui`
- [x] `pnpm vitest run src/plugins/Plugins.dom.test.tsx`