### PR TITLE
feat(desktop): plugins section in the composer tools menu

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -32,6 +32,7 @@ import { useStreamStalled } from "./useStreamStalled";
 import { useTurnControls } from "./useTurnControls";
 import { usePlanApprovals } from "./usePlanApprovals";
 import { useUserQuestions } from "./useUserQuestions";
+import { useComposerPlugins } from "./plugins/useComposerPlugins";
 import {
   backgroundAgentSpawnKeys as spawnKeysOf,
   useAgentRuns,
@@ -105,6 +106,7 @@ export function ChatView({
   // viewer that re-renders per keystroke is one unstable dependency away from
   // reloading its engine mid-typing.
   const draft = useComposerDraft(chat.id);
+  const composerPlugins = useComposerPlugins(client);
   const folderAccess = useFolderAccessRequests(client, chat.id);
   const outputWritebacks = useOutputWritebackRequests(client, chat.id);
   const userQuestions = useUserQuestions(client, chat.id);
@@ -413,6 +415,7 @@ export function ChatView({
           permissionMenu={composerPermissionMenu}
           network={composerNetwork}
           reasoning={composerReasoning}
+          plugins={composerPlugins}
           images={composerImages}
           files={files}
           folders={folders}

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -20,6 +20,7 @@ import { MAX_STEER_CHARACTERS } from "./ActiveTurnSteer";
 import {
   ComposerToolsMenu,
   type ComposerNetwork,
+  type ComposerPlugins,
   type ComposerReasoning,
 } from "./ComposerToolsMenu";
 import {
@@ -36,6 +37,7 @@ import { WithTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { documentIcon } from "@/documentIcon";
 import type { ImportedDocument } from "@/documents";
+import type { PluginInfo } from "./api";
 import { folderAccessLabel, folderReach } from "./FolderAccess";
 import type { ChatFolderAccess } from "./useChatFolderAttachments";
 
@@ -100,6 +102,33 @@ function resizeComposerTextarea(textarea: HTMLTextAreaElement): void {
     verticalInsets,
   )}px`;
   textarea.style.overflowY = textarea.scrollHeight > maximum ? "auto" : "hidden";
+}
+
+/**
+ * The sentence that engages a plugin, and where the caret lands after it.
+ *
+ * There is no directive the backend parses: an enabled bundle's skills are in
+ * the model's system prompt, so asking for one in plain words is what makes it
+ * happen. The text goes in at the caret, with a space in front of it when it
+ * would otherwise run into what is already written.
+ */
+export function insertPluginDirective(
+  draft: string,
+  directive: string,
+  selectionStart: number,
+  selectionEnd: number,
+): { text: string; caret: number } {
+  const before = draft.slice(0, selectionStart);
+  const after = draft.slice(selectionEnd);
+  const gap = before && !/\s$/.test(before) ? " " : "";
+  return {
+    text: `${before}${gap}${directive}${after}`,
+    caret: before.length + gap.length + directive.length,
+  };
+}
+
+export function pluginDirective(displayName: string): string {
+  return `Use the ${displayName} plugin: `;
 }
 
 /**
@@ -168,6 +197,7 @@ export type ComposerProps = {
   permissionMenu?: ReactNode;
   network?: ComposerNetwork;
   reasoning?: ComposerReasoning;
+  plugins?: ComposerPlugins;
   images?: ComposerImages;
   files?: ComposerFiles;
   folders?: ComposerFolders;
@@ -195,6 +225,7 @@ export function Composer({
   permissionMenu,
   network,
   reasoning,
+  plugins,
   images,
   files,
   folders,
@@ -216,6 +247,7 @@ export function Composer({
   // dragenter and dragleave fire for every descendant the pointer crosses, so a
   // boolean flickers the drop hint on and off while the file is held still.
   const dragDepthRef = useRef(0);
+  const selectionRef = useRef<{ start: number; end: number } | null>(null);
   const [dragging, setDragging] = useState(false);
   const { confirm, dialog: confirmDialog } = useConfirm();
   const inputDisabled = disabled;
@@ -241,6 +273,12 @@ export function Composer({
     if (textarea) resizeComposerTextarea(textarea);
   }, [draft, resetKey]);
 
+  // A different conversation is a different draft: the caret from the last one
+  // means nothing in it.
+  useLayoutEffect(() => {
+    selectionRef.current = null;
+  }, [resetKey]);
+
   async function submit(): Promise<void> {
     if (!canSubmit) return;
     const submissionKey = resetKey;
@@ -264,7 +302,47 @@ export function Composer({
   }
 
   function onChange(event: ChangeEvent<HTMLTextAreaElement>) {
+    rememberSelection(event.target);
     onDraftChange(event.target.value);
+  }
+
+  /** Where the reader last had the caret, for text inserted from a menu. */
+  function rememberSelection(textarea: HTMLTextAreaElement) {
+    selectionRef.current = {
+      start: textarea.selectionStart,
+      end: textarea.selectionEnd,
+    };
+  }
+
+  /**
+   * Turn the bundle on, then say so in the message being written.
+   *
+   * The caret is restored after the insertion so the reader carries on typing
+   * their request where the sentence left off, rather than at the end of a
+   * draft they may have been editing in the middle of. A draft nobody has put
+   * a caret in yet — a starter prompt, a transcript — is appended to.
+   */
+  function engagePlugin(plugin: PluginInfo) {
+    plugins?.onSelect(plugin);
+    const remembered = selectionRef.current;
+    const start = Math.min(remembered?.start ?? draft.length, draft.length);
+    const end = Math.min(remembered?.end ?? draft.length, draft.length);
+    const { text, caret } = insertPluginDirective(
+      draft,
+      pluginDirective(plugin.display_name),
+      start,
+      end,
+    );
+    selectionRef.current = { start: caret, end: caret };
+    onDraftChange(text);
+    // After the menu has closed and the new value has been painted; focusing
+    // while the menu is still up hands focus straight back to the trigger.
+    window.requestAnimationFrame(() => {
+      const field = textareaRef.current;
+      if (!field || field.disabled) return;
+      field.focus();
+      field.setSelectionRange(caret, caret);
+    });
   }
 
   function endDrag() {
@@ -409,6 +487,7 @@ export function Composer({
         data-composer-input=""
         disabled={inputDisabled}
         onChange={onChange}
+        onSelect={(event) => rememberSelection(event.currentTarget)}
         onPaste={onPaste}
         onKeyDown={(event) => {
           if (!shouldSubmitComposerKey(event.nativeEvent)) return;
@@ -432,6 +511,11 @@ export function Composer({
             }
             network={network}
             reasoning={reasoning}
+            plugins={
+              plugins
+                ? { items: plugins.items, onSelect: engagePlugin }
+                : undefined
+            }
           />
           {modelMenu}
         </div>

--- a/crates/openwave-desktop/ui/src/ComposerPlugins.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerPlugins.dom.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, expect, it, vi } from "vitest";
+
+import { Composer, insertPluginDirective } from "./Composer";
+import type { PluginInfo } from "./api";
+
+afterEach(cleanup);
+
+const DOCUMENTS: PluginInfo = {
+  name: "documents",
+  display_name: "Documents",
+  description: "Writes Word, Excel, and PowerPoint files.",
+  category: "documents",
+  capabilities: [],
+  enabled: false,
+  skills: [],
+};
+
+it("engages a plugin from the tools menu and says so in the draft", async () => {
+  const onSelect = vi.fn();
+  const onDraftChange = vi.fn();
+  const user = userEvent.setup();
+  render(
+    <Composer
+      activeTurnId={null}
+      busy={false}
+      cancelError={null}
+      cancelPending={false}
+      disabled={false}
+      draft="Summarize the report"
+      plugins={{ items: [DOCUMENTS], onSelect }}
+      onDraftChange={onDraftChange}
+      onSend={vi.fn(async () => {})}
+      onSteer={vi.fn(async () => {})}
+      onStop={vi.fn(async () => {})}
+      resetKey="chat-1"
+      steerError={null}
+      steerPending={false}
+      steerStatus={null}
+    />,
+  );
+
+  await user.click(screen.getByRole("button", { name: "Tools" }));
+  await user.click(screen.getByRole("menuitem", { name: /Documents/ }));
+
+  expect(onSelect).toHaveBeenCalledWith(DOCUMENTS);
+  expect(onDraftChange).toHaveBeenCalledWith(
+    "Summarize the report Use the Documents plugin: ",
+  );
+});
+
+it("puts the directive at the caret without running words together", () => {
+  expect(insertPluginDirective("", "Use it: ", 0, 0)).toEqual({
+    text: "Use it: ",
+    caret: 8,
+  });
+  // Mid-draft, over a selection, and after text that already ends in a space.
+  expect(insertPluginDirective("draft here", "Use it: ", 5, 10)).toEqual({
+    text: "draft Use it: ",
+    caret: 14,
+  });
+  expect(insertPluginDirective("draft ", "Use it: ", 6, 6)).toEqual({
+    text: "draft Use it: ",
+    caret: 14,
+  });
+});

--- a/crates/openwave-desktop/ui/src/ComposerToolsMenu.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerToolsMenu.dom.test.tsx
@@ -4,10 +4,24 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, expect, it, vi } from "vitest";
 
 import { ComposerToolsMenu } from "./ComposerToolsMenu";
+import type { PluginInfo } from "./api";
 
 afterEach(cleanup);
 
 const LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
+
+function plugin(overrides: Partial<PluginInfo> = {}): PluginInfo {
+  return {
+    name: "documents",
+    display_name: "Documents",
+    description: "Writes Word, Excel, and PowerPoint files.",
+    category: "documents",
+    capabilities: [],
+    enabled: false,
+    skills: [],
+    ...overrides,
+  };
+}
 
 function open() {
   return userEvent.setup().click(screen.getByRole("button", { name: "Tools" }));
@@ -83,4 +97,38 @@ it("opens the network policy in a dialog the menu does not clip", async () => {
 it("renders nothing when the surface offers none of its actions", () => {
   const { container } = render(<ComposerToolsMenu disabled={false} />);
   expect(container).toBeEmptyDOMElement();
+});
+
+it("offers the installed plugins under the turn's setup actions", async () => {
+  const onSelect = vi.fn();
+  render(
+    <ComposerToolsMenu
+      disabled={false}
+      attachFiles={{ attaching: false, onAttach: vi.fn() }}
+      plugins={{ items: [plugin()], onSelect }}
+    />,
+  );
+
+  await open();
+  const rows = screen.getAllByRole("menuitem");
+  expect(rows.map((row) => row.textContent)).toEqual([
+    "Attach files",
+    "DocumentsWrites Word, Excel, and PowerPoint files.",
+  ]);
+
+  await userEvent.setup().click(rows[1]);
+  expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ name: "documents" }));
+});
+
+it("keeps the plugins section off a catalog that is empty or unread", async () => {
+  render(
+    <ComposerToolsMenu
+      disabled={false}
+      attachFiles={{ attaching: false, onAttach: vi.fn() }}
+      plugins={{ items: [], onSelect: vi.fn() }}
+    />,
+  );
+
+  await open();
+  expect(screen.queryByText("Plugins")).not.toBeInTheDocument();
 });

--- a/crates/openwave-desktop/ui/src/ComposerToolsMenu.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerToolsMenu.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { FolderPlus, LoaderCircle, Paperclip, Plus } from "lucide-react";
 
-import type { NetworkPolicy, ReasoningEffort } from "./api";
+import type { NetworkPolicy, PluginInfo, ReasoningEffort } from "./api";
 import { ReasoningEffortSubMenu } from "./ModelMenu";
 import {
   NetworkPolicyDialog,
@@ -12,11 +12,14 @@ import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { categoryIcon } from "@/plugins/pluginVocabulary";
 import { WithTooltip } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
 
 export type ComposerNetwork = {
   value: NetworkPolicy;
@@ -31,12 +34,25 @@ export type ComposerReasoning = {
   onChange: (effort: ReasoningEffort | null) => void | Promise<void>;
 };
 
+/**
+ * The installed bundles, offered as something to reach for on this message.
+ *
+ * Presentational: the menu lists what it is given and reports the pick. Turning
+ * the bundle on and saying so in the draft belong to whoever owns the catalog
+ * and the draft.
+ */
+export type ComposerPlugins = {
+  items: readonly PluginInfo[];
+  onSelect: (plugin: PluginInfo) => void;
+};
+
 export type ComposerToolsMenuProps = {
   disabled: boolean;
   attachFiles?: { attaching: boolean; onAttach: () => void };
   attachFolder?: { working: boolean; onAttach: () => void };
   network?: ComposerNetwork;
   reasoning?: ComposerReasoning;
+  plugins?: ComposerPlugins;
 };
 
 /**
@@ -47,6 +63,10 @@ export type ComposerToolsMenuProps = {
  * rather than a place to write. These actions are all things you reach for
  * occasionally and then forget about, so they collapse into one menu and leave
  * the bar to the model, the permission mode, and sending.
+ *
+ * Installed plugins sit at the bottom for the same reason: picking one is
+ * preparation for this message, not a place to manage the library — that stays
+ * on the Plugins page.
  */
 export function ComposerToolsMenu({
   disabled,
@@ -54,6 +74,7 @@ export function ComposerToolsMenu({
   attachFolder,
   network,
   reasoning,
+  plugins,
 }: ComposerToolsMenuProps) {
   // The dialog is a sibling of the menu, not a child: selecting the row closes
   // the menu, and a dialog rendered inside the menu's content would be torn
@@ -62,7 +83,11 @@ export function ComposerToolsMenu({
 
   const hasAttachments = Boolean(attachFiles || attachFolder);
   const hasSettings = Boolean(network || reasoning);
-  if (!hasAttachments && !hasSettings) return null;
+  // A catalog that is empty or never loaded simply has no section. The menu is
+  // not the place to report that the plugin library could not be read.
+  const pluginItems = plugins?.items ?? [];
+  const hasPlugins = pluginItems.length > 0;
+  if (!hasAttachments && !hasSettings && !hasPlugins) return null;
 
   const NetworkIcon = network ? networkPolicyIcon(network.value) : null;
 
@@ -82,7 +107,13 @@ export function ComposerToolsMenu({
             </Button>
           </DropdownMenuTrigger>
         </WithTooltip>
-        <DropdownMenuContent align="start" side="top" className="w-60">
+        <DropdownMenuContent
+          align="start"
+          side="top"
+          // Plugin rows carry a description under the name, so the menu widens
+          // to give one a readable line rather than truncating it to nothing.
+          className={cn(hasPlugins ? "w-72" : "w-60")}
+        >
           {attachFiles && (
             <DropdownMenuItem
               disabled={disabled || attachFiles.attaching}
@@ -136,6 +167,39 @@ export function ComposerToolsMenu({
                 {networkPolicyLabel(network.value)}
               </span>
             </DropdownMenuItem>
+          )}
+
+          {hasPlugins && plugins && (
+            <>
+              {(hasAttachments || hasSettings) && <DropdownMenuSeparator />}
+              <p className="text-muted-foreground px-2 py-1.5 text-xs font-medium">
+                Plugins
+              </p>
+              <DropdownMenuGroup aria-label="Plugins">
+                {pluginItems.map((plugin) => {
+                  const Icon = categoryIcon(plugin.category);
+                  return (
+                    <DropdownMenuItem
+                      key={plugin.name}
+                      className="items-start"
+                      disabled={disabled}
+                      onSelect={() => plugins.onSelect(plugin)}
+                    >
+                      <Icon
+                        className="text-muted-foreground mt-0.5 size-4 shrink-0"
+                        aria-hidden="true"
+                      />
+                      <span className="flex min-w-0 flex-col">
+                        <span className="truncate">{plugin.display_name}</span>
+                        <span className="text-muted-foreground truncate text-xs">
+                          {plugin.description}
+                        </span>
+                      </span>
+                    </DropdownMenuItem>
+                  );
+                })}
+              </DropdownMenuGroup>
+            </>
           )}
         </DropdownMenuContent>
       </DropdownMenu>

--- a/crates/openwave-desktop/ui/src/HomeRoute.tsx
+++ b/crates/openwave-desktop/ui/src/HomeRoute.tsx
@@ -27,6 +27,7 @@ import { ModelMenu } from "./ModelMenu";
 import { modelForSelection } from "./ModelSelection";
 import { effectiveNewChatSettings, useNewChatSettings } from "./NewChatSettings";
 import { PermissionModeMenu } from "./PermissionModeMenu";
+import { useComposerPlugins } from "./plugins/useComposerPlugins";
 import { RouteFrame } from "./RouteFrame";
 import { AppSidebar } from "./sidebar/AppSidebar";
 import { WelcomeState } from "./WelcomeState";
@@ -50,6 +51,7 @@ export function HomeRoute() {
   const { client, models, defaultModelKey } = useApp();
   const creatingChat = useChatListStore((state) => state.creatingChat);
   const draft = useComposerDraft(HOME_DRAFT_KEY);
+  const composerPlugins = useComposerPlugins(client);
   const setDraft = (text: string) =>
     composerDraftActions.setDraft(HOME_DRAFT_KEY, text);
   const voice = useVoiceComposer(
@@ -291,6 +293,7 @@ export function HomeRoute() {
             cancelPending={false}
             disabled={creatingChat}
             draft={draft}
+            plugins={composerPlugins}
             images={composerImages}
             voice={{
               available: voice.available,

--- a/crates/openwave-desktop/ui/src/plugins/useComposerPlugins.ts
+++ b/crates/openwave-desktop/ui/src/plugins/useComposerPlugins.ts
@@ -1,0 +1,32 @@
+import { useMemo } from "react";
+
+import type { ApiClient } from "@/api";
+import type { ComposerPlugins } from "@/ComposerToolsMenu";
+import { pluginsApisFromClient } from "./pluginsApis";
+import { usePluginCatalog } from "./usePluginCatalog";
+
+/**
+ * The installed bundles, as the composer's tools menu wants them.
+ *
+ * Picking one from the composer is a shortcut, not a per-chat setting: a
+ * bundle being on is still a property of this installation, so engaging a
+ * bundle that is off turns it on the same way its switch on the Plugins page
+ * would. Nothing is returned while the catalog is loading or after it failed —
+ * the menu shows no section rather than reporting on a library the reader did
+ * not ask about.
+ */
+export function useComposerPlugins(
+  client: ApiClient,
+): ComposerPlugins | undefined {
+  const apis = useMemo(() => pluginsApisFromClient(client), [client]);
+  const { catalog, setEnabled } = usePluginCatalog(apis);
+  const plugins = catalog?.plugins ?? [];
+  if (plugins.length === 0) return undefined;
+  return {
+    items: plugins,
+    onSelect: (plugin) => {
+      if (plugin.enabled) return;
+      setEnabled({ plugins: { [plugin.name]: true }, skills: {} });
+    },
+  };
+}


### PR DESCRIPTION
The composer's "+" menu now has a Plugins section under the attachment and
turn-setup rows, listing the installed bundles with their category icon and a
one-line description. Picking one enables the bundle if it was off and inserts
`Use the <name> plugin: ` into the draft at the caret, then focuses the
composer so the reader carries on writing the request from there.

Engaging a plugin this way is deliberately plain: there is no per-chat plugin
state and no directive the backend parses. An enabled bundle's skills are in
the model's system prompt, so naming one in the message is what makes it
happen; the only state involved is the same install-wide switch the Plugins
page shows.

`ComposerToolsMenu` stays presentational — it takes a list and reports the
pick. The catalog fetch lives in a small hook over the existing plugin catalog
state, used by both composer parents (chat and home), and the insertion lives
in `Composer`, which owns the textarea. A catalog that is empty or failed to
load renders no section rather than putting error chrome in a menu that was
opened for something else. The menu widens to `w-72` only when it has plugin
rows to show.

Per-chat plugin selection remains deferred (#1573); this is the composer-menu
follow-up #1597 left open.

Verified locally: `tsc --noEmit`, the full UI vitest suite (113 files), and
`pnpm build`. New tests cover the section rendering from a catalog and staying
absent for an empty one, the select path enabling plus inserting, and the
insertion helper's spacing and caret placement.