### PR TITLE
feat(desktop): surface background exec output in the activity timeline

### DIFF
--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -1,10 +1,19 @@
 //! Closed renderer projections of what a tool will do, and what it did.
 //!
 //! The renderer boundary carries neither raw argument objects nor raw tool
-//! output. These types are the deliberate exceptions: a tool may opt in to
-//! showing a human selected fields, one by one. Model-authored strings remain
-//! untrusted text and may repeat information the model already saw; the
-//! boundary guarantee is about which stored and host-owned fields are copied.
+//! output, with one deliberate exception noted below. These types are the
+//! opt-in surface: a tool may show a human selected fields, one by one.
+//! Model-authored strings remain untrusted text and may repeat information the
+//! model already saw; the boundary guarantee is about which stored and
+//! host-owned fields are copied.
+//!
+//! The exception is a settled `exec` receipt's bounded tail on
+//! [`AgentActivityDetail::Exec`]. A sandbox command runs in a private,
+//! initially-empty workspace holding only what the run itself staged, so its
+//! stdout and stderr are the child's own text rather than host- or
+//! user-derived content — and without it a failed background command is
+//! unreadable. It does not generalize: web-search and delegated-file results
+//! carry material the run was handed, and are still never projected.
 //!
 //! They are not passthroughs. Each variant enumerates exactly what a person
 //! needs in order to consent to an action or to understand its outcome, values
@@ -37,29 +46,45 @@ pub const MAX_RESULT_ENTRY_CHARS: usize = 200;
 /// Most rows a result preview lists before it counts the rest instead.
 pub const MAX_RESULT_ENTRIES: usize = 50;
 
+/// Longest exec receipt tail one background activity step carries.
+///
+/// Much smaller than [`MAX_RESULT_STREAM_CHARS`] because the cost is paid
+/// differently: the activity endpoint returns a run's *whole* history in one
+/// response and the panel re-fetches it on every update, so this bound is
+/// multiplied by every settled command a long run ever ran. A tail of the last
+/// couple of thousand characters is where a failure's message almost always
+/// is; the full receipt stays server-side.
+pub const MAX_ACTIVITY_EXEC_OUTPUT_CHARS: usize = 2_000;
+
 /// A bounded headline for one background-agent activity step.
 ///
 /// This is deliberately smaller than [`ToolActionPreview`]. The command,
 /// arguments, and query are model-authored text: they are bounded for safe
 /// single-line presentation, but may repeat any information the background
 /// agent already saw and are therefore outside the host-field non-disclosure
-/// guarantee. The projection never copies stored result text or host-only
-/// broker identity directly. Its only host-derived values are a typed numeric
-/// exit code and the leaf name of the canonically admitted delegated file.
+/// guarantee. The projection copies no stored result text except a settled
+/// `exec` receipt's bounded tail — see [`Self::with_exec_result`] — and never
+/// copies host-only broker identity directly. Its only other host-derived
+/// values are a typed numeric exit code and the leaf name of the canonically
+/// admitted delegated file.
 ///
 /// Command and search fields use the foreground approval-card projection so
 /// both surfaces share the same sanitization.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum AgentActivityDetail {
-    /// The argument vector a background command ran and its settled exit code,
-    /// when the immutable receipt recorded one.
+    /// The argument vector a background command ran, its settled exit code,
+    /// and the tail of what it printed, when the immutable receipt recorded
+    /// them.
     Exec {
         command: String,
         args: Vec<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         #[ts(optional)]
         exit_code: Option<i32>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        output: Option<String>,
     },
     /// One public-web query, trimmed and bounded like its approval preview.
     Search { query: String },
@@ -82,6 +107,7 @@ impl AgentActivityDetail {
                     command,
                     args,
                     exit_code: None,
+                    output: None,
                 });
             }
             Some(ToolActionPreview::WebSearch { query, .. }) => {
@@ -103,33 +129,55 @@ impl AgentActivityDetail {
         })
     }
 
-    /// Attach an exec exit code from the immutable receipt's first line.
+    /// Attach what a settled exec recorded: its exit code and a readable tail
+    /// of the receipt.
     ///
-    /// A live call has no receipt, a signal is recorded as `exit: signal`, and
-    /// setup failures carry no `exit:` line; all three keep the field absent.
+    /// The exit code is parsed from the receipt's first line. A live call has
+    /// no receipt, a signal is recorded as `exit: signal`, and setup failures
+    /// carry no `exit:` line; all three keep the field absent.
+    ///
+    /// The output is the tail of the *whole* receipt, headers included, not
+    /// the section after a `stdout:` marker. A command can print those markers
+    /// itself, so splitting on them would let it choose what the card shows;
+    /// carrying the receipt verbatim means the card shows what the host wrote.
+    /// The tail is preferred over the head because the receipt's own tail is
+    /// already the tail of the streams, which is where a failure's message
+    /// almost always is. Control characters other than newlines and tabs are
+    /// dropped so the pane cannot be redrawn or reordered by what a command
+    /// printed, and the bound is applied in characters, so the result is never
+    /// split mid-codepoint.
     #[must_use]
     pub fn with_exec_result(self, result: &str) -> Self {
+        let Self::Exec { command, args, .. } = self else {
+            return self;
+        };
         let exit_code = result
             .lines()
             .next()
             .and_then(|line| line.strip_prefix("exit: "))
             .and_then(|code| code.parse::<i32>().ok());
-        match (self, exit_code) {
-            (
-                Self::Exec {
-                    command,
-                    args,
-                    exit_code: _,
-                },
-                Some(exit_code),
-            ) => Self::Exec {
-                command,
-                args,
-                exit_code: Some(exit_code),
-            },
-            (detail, _) => detail,
+        Self::Exec {
+            command,
+            args,
+            exit_code,
+            output: receipt_tail(result, MAX_ACTIVITY_EXEC_OUTPUT_CHARS),
         }
     }
+}
+
+/// Keep the last `max_chars` readable characters of a receipt, or nothing when
+/// it had none.
+fn receipt_tail(result: &str, max_chars: usize) -> Option<String> {
+    let readable: Vec<char> = result
+        .chars()
+        .filter(|character| {
+            !preview_formatting_character(*character) || matches!(character, '\n' | '\t')
+        })
+        .collect();
+    let start = readable.len().saturating_sub(max_chars);
+    let tail: String = readable[start..].iter().collect();
+    let trimmed = tail.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_owned())
 }
 
 /// The action a call will take, in a form a human can inspect.
@@ -1180,6 +1228,7 @@ mod tests {
                     command: "python".into(),
                     args: vec!["safearg".into()],
                     exit_code: None,
+                    output: None,
                 }),
             ),
             (
@@ -1190,6 +1239,7 @@ mod tests {
                     command: "cat".into(),
                     args: vec!["/Users/alice/private.txt".into()],
                     exit_code: None,
+                    output: None,
                 }),
             ),
             (
@@ -1208,6 +1258,7 @@ mod tests {
                         .map(|index| format!("arg-{index}"))
                         .collect(),
                     exit_code: None,
+                    output: None,
                 }),
             ),
         ];
@@ -1242,6 +1293,7 @@ mod tests {
                     command: "leftright".into(),
                     args: Vec::new(),
                     exit_code: None,
+                    output: None,
                 }),
                 "background detail did not reject {case}"
             );
@@ -1264,6 +1316,7 @@ mod tests {
             command: "python3".into(),
             args: vec!["report.py".into()],
             exit_code: None,
+            output: None,
         };
         for (case, result, exit_code) in [
             ("numeric first line", "exit: 17\nexit: 99", Some(17)),
@@ -1281,10 +1334,60 @@ mod tests {
                     command: "python3".into(),
                     args: vec!["report.py".into()],
                     exit_code,
+                    output: Some(result.into()),
                 },
                 "{case}"
             );
         }
+    }
+
+    /// The receipt tail is what makes a settled background command readable,
+    /// so what it carries is bounded and de-spoofed rather than trusted: an
+    /// oversized receipt keeps its end, multi-byte text is never split
+    /// mid-codepoint, terminal control sequences are dropped, and a receipt
+    /// with nothing readable in it carries no output at all.
+    #[test]
+    fn exec_activity_output_keeps_a_bounded_despoofed_tail() {
+        let base = AgentActivityDetail::Exec {
+            command: "python3".into(),
+            args: Vec::new(),
+            exit_code: None,
+            output: None,
+        };
+        let output = |result: &str| match base.clone().with_exec_result(result) {
+            AgentActivityDetail::Exec { output, .. } => output,
+            other => panic!("exec detail became {other:?}"),
+        };
+
+        // An overlong receipt keeps its end, where a failure's message is.
+        let long = format!(
+            "exit: 1\n{}\nTraceback: the part that matters",
+            "x".repeat(MAX_ACTIVITY_EXEC_OUTPUT_CHARS * 2)
+        );
+        let tail = output(&long).expect("an overlong receipt still carries a tail");
+        assert_eq!(tail.chars().count(), MAX_ACTIVITY_EXEC_OUTPUT_CHARS);
+        assert!(tail.ends_with("Traceback: the part that matters"));
+        assert!(!tail.contains("exit: 1"));
+
+        // Cutting a multi-byte tail lands on a character boundary, because the
+        // bound counts characters rather than bytes.
+        let multibyte = "é".repeat(MAX_ACTIVITY_EXEC_OUTPUT_CHARS + 40);
+        assert_eq!(
+            output(&multibyte),
+            Some("é".repeat(MAX_ACTIVITY_EXEC_OUTPUT_CHARS))
+        );
+
+        // Escape sequences and bidi overrides cannot redraw or reorder the
+        // pane; newlines and tabs survive because output without them is not
+        // readable.
+        assert_eq!(
+            output("exit: 0\n\u{1b}[2Jcol\ta\u{202e}drowssap\nline"),
+            Some("exit: 0\n[2Jcol\tadrowssap\nline".into())
+        );
+
+        // A receipt with nothing readable left carries no output rather than
+        // an empty pane.
+        assert_eq!(output("  \n\u{1b}\n "), None);
     }
 
     /// The exec card lists the durable outputs the command published. Only

--- a/crates/openwave-desktop/ui/src/AgentActivityTimeline.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/AgentActivityTimeline.dom.test.tsx
@@ -28,6 +28,7 @@ const state: AgentActivityState = {
         command: "pip",
         args: ["install", "matplotlib"],
         exit_code: 1,
+        output: "exit: 1\n\nstderr:\nERROR: no matching distribution",
       },
     },
     {
@@ -69,8 +70,10 @@ describe("AgentActivityTimeline", () => {
     expect(screen.queryByRole("list")).toBeNull();
   });
 
-  it("gives a failed command an open card with its headline and exit status", () => {
-    render(<AgentActivityTimeline state={state} active={false} expanded />);
+  it("gives a failed command an open card with its headline, exit status, and captured output", () => {
+    const { rerender } = render(
+      <AgentActivityTimeline state={state} active={false} expanded />,
+    );
 
     const commandRow = within(screen.getByRole("list")).getAllByRole(
       "listitem",
@@ -83,5 +86,26 @@ describe("AgentActivityTimeline", () => {
       "pip install matplotlib",
     );
     expect(within(commandRow).getByText("Exit 1")).toBeTruthy();
+    expect(
+      within(commandRow).getByText(/ERROR: no matching distribution/),
+    ).toBeTruthy();
+
+    // A settled command that printed nothing says so, rather than leaving the
+    // reader to wonder whether the pane failed to load.
+    const withoutOutput: AgentActivityState = {
+      ...state,
+      items: state.items.map((item, index) =>
+        index === 1
+          ? {
+              ...item,
+              detail: { kind: "exec", command: "pip", args: [], exit_code: 0 },
+            }
+          : item,
+      ),
+    };
+    rerender(
+      <AgentActivityTimeline state={withoutOutput} active={false} expanded />,
+    );
+    expect(screen.getByText("No output captured.")).toBeTruthy();
   });
 });

--- a/crates/openwave-desktop/ui/src/AgentActivityTimeline.tsx
+++ b/crates/openwave-desktop/ui/src/AgentActivityTimeline.tsx
@@ -240,9 +240,10 @@ type ExecActivityDetail = Extract<
 
 /**
  * A command step's card: the same collapsed chrome a foreground exec card
- * uses — monospace command, outcome pill, chevron. The body holds only the
- * full unelided command line, because a background run's output is not
- * retained; a failed card starts open so the reader lands on what failed.
+ * uses — monospace command, outcome pill, chevron. The body holds the full
+ * unelided command line and, once the step has settled, the tail of what the
+ * command printed; a failed card starts open so the reader lands on what
+ * failed.
  */
 function ExecActivityCard({
   detail,
@@ -253,6 +254,8 @@ function ExecActivityCard({
 }) {
   const headline = execCommandHeadline(detail.command, detail.args);
   const failed = outcome === "failed";
+  const settled =
+    outcome === "completed" || outcome === "failed" || outcome === "cancelled";
   return (
     <ToolCardShell
       icon={<Terminal className="size-3.5 shrink-0" aria-hidden="true" />}
@@ -267,9 +270,20 @@ function ExecActivityCard({
         <pre className="bg-muted text-muted-foreground rounded-md p-2 text-xs break-words whitespace-pre-wrap">
           {headline}
         </pre>
-        <p className="text-muted-foreground px-0.5 text-[11px]">
-          Output isn't retained for background runs.
-        </p>
+        {detail.output ? (
+          <pre className="bg-muted text-muted-foreground rounded-md p-2 text-xs break-words whitespace-pre-wrap">
+            {detail.output}
+          </pre>
+        ) : (
+          // Only a settled step can be said to have printed nothing. While it
+          // is still running, an empty pane would read as a finished command
+          // that said nothing.
+          settled && (
+            <p className="text-muted-foreground px-0.5 text-[11px]">
+              No output captured.
+            </p>
+          )
+        )}
       </div>
     </ToolCardShell>
   );

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -878,6 +878,32 @@ describe("parseAgentActivityHistory", () => {
           at: "2026-08-05T18:44:00Z",
           detail: { kind: "exec", command: "make", args: [], exit_code: 1.5 },
         },
+        // The captured tail is drawn as a block, so its line breaks are
+        // structure rather than spoofing.
+        {
+          kind: "exec",
+          outcome: "completed",
+          at: "2026-08-05T18:45:00Z",
+          detail: {
+            kind: "exec",
+            command: "make",
+            args: [],
+            output: "exit: 0\n\nstdout:\nbuilt 3 charts",
+          },
+        },
+        // An escape sequence in that block could repaint the pane, so the
+        // output is dropped while the row it describes survives.
+        {
+          kind: "exec",
+          outcome: "completed",
+          at: "2026-08-05T18:46:00Z",
+          detail: {
+            kind: "exec",
+            command: "make",
+            args: [],
+            output: "\u001b[2Jexit: 0",
+          },
+        },
       ]),
     ).toEqual([
       {
@@ -905,6 +931,23 @@ describe("parseAgentActivityHistory", () => {
         kind: "exec",
         outcome: "failed",
         at: "2026-08-05T18:44:00Z",
+        detail: { kind: "exec", command: "make", args: [] },
+      },
+      {
+        kind: "exec",
+        outcome: "completed",
+        at: "2026-08-05T18:45:00Z",
+        detail: {
+          kind: "exec",
+          command: "make",
+          args: [],
+          output: "exit: 0\n\nstdout:\nbuilt 3 charts",
+        },
+      },
+      {
+        kind: "exec",
+        outcome: "completed",
+        at: "2026-08-05T18:46:00Z",
         detail: { kind: "exec", command: "make", args: [] },
       },
     ]);

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -2371,17 +2371,39 @@ function bounded(value: unknown, maxChars: number): value is string {
   return (
     typeof value === "string" &&
     Array.from(value).length <= maxChars &&
-    !Array.from(value).some((character) => {
-      const code = character.codePointAt(0) ?? 0;
-      return (
-        code < 32 ||
-        (code >= 127 && code <= 159) ||
-        code === 0x2028 ||
-        code === 0x2029 ||
-        (code >= 0x202a && code <= 0x202e) ||
-        (code >= 0x2066 && code <= 0x2069)
-      );
-    })
+    !Array.from(value).some(forbiddenPreviewCharacter)
+  );
+}
+
+/**
+ * The same clamp for a field that is drawn as a block rather than a line, so
+ * line breaks and tabs are structure rather than spoofing. Everything else
+ * {@link bounded} rejects is still rejected: an escape sequence or a
+ * bidirectional override in a pane of command output could still redraw or
+ * reorder what the reader sees.
+ */
+function boundedBlock(value: unknown, maxChars: number): value is string {
+  return (
+    typeof value === "string" &&
+    Array.from(value).length <= maxChars &&
+    !Array.from(value).some(
+      (character) =>
+        forbiddenPreviewCharacter(character) &&
+        character !== "\n" &&
+        character !== "\t",
+    )
+  );
+}
+
+function forbiddenPreviewCharacter(character: string): boolean {
+  const code = character.codePointAt(0) ?? 0;
+  return (
+    code < 32 ||
+    (code >= 127 && code <= 159) ||
+    code === 0x2028 ||
+    code === 0x2029 ||
+    (code >= 0x202a && code <= 0x202e) ||
+    (code >= 0x2066 && code <= 0x2069)
   );
 }
 
@@ -2410,6 +2432,13 @@ const AGENT_ACTIVITY_OUTCOMES = new Set<AgentActivityOutcome>([
  */
 const ACTIVITY_DETAIL_FIELD_CHARS = 512;
 const ACTIVITY_DETAIL_ARGS = 32;
+
+/**
+ * The exec output tail's cap, with slack over the server's own 2,000-character
+ * bound: the point of checking is to reject a payload orders of magnitude
+ * larger than the projection can emit, not to re-derive its arithmetic.
+ */
+const ACTIVITY_DETAIL_OUTPUT_CHARS = 4_000;
 
 /** The half-open range of a signed 32-bit exit code, as the wire type spells it. */
 const ACTIVITY_EXIT_CODE_MIN = -(2 ** 31);
@@ -2448,6 +2477,7 @@ function parseAgentActivityDetail(
         "command",
         "args",
         "exit_code",
+        "output",
       ]) ||
       !nonEmptyBounded(value.command, ACTIVITY_DETAIL_FIELD_CHARS) ||
       !Array.isArray(value.args) ||
@@ -2461,16 +2491,23 @@ function parseAgentActivityDetail(
       args.push(arg);
     }
     // The exit status is decoration next to the command itself, so an
-    // unusable one costs only itself: the reader still sees what ran.
+    // unusable one costs only itself: the reader still sees what ran. The
+    // captured tail is treated the same way — a payload the projection could
+    // not have produced is dropped, not rendered, and not fatal to the row.
     const exitCode = activityExitCode(value.exit_code);
-    return exitCode === undefined
-      ? { kind: "exec", command: value.command, args }
-      : {
-          kind: "exec",
-          command: value.command,
-          args,
-          exit_code: exitCode,
-        };
+    const output =
+      value.output !== undefined &&
+      boundedBlock(value.output, ACTIVITY_DETAIL_OUTPUT_CHARS) &&
+      value.output.trim().length > 0
+        ? value.output
+        : undefined;
+    return {
+      kind: "exec",
+      command: value.command,
+      args,
+      ...(exitCode === undefined ? {} : { exit_code: exitCode }),
+      ...(output === undefined ? {} : { output }),
+    };
   }
   if (value.kind === "search") {
     if (

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -15,14 +15,16 @@
  * arguments, and query are model-authored text: they are bounded for safe
  * single-line presentation, but may repeat any information the background
  * agent already saw and are therefore outside the host-field non-disclosure
- * guarantee. The projection never copies stored result text or host-only
- * broker identity directly. Its only host-derived values are a typed numeric
- * exit code and the leaf name of the canonically admitted delegated file.
+ * guarantee. The projection copies no stored result text except a settled
+ * `exec` receipt's bounded tail — see [`Self::with_exec_result`] — and never
+ * copies host-only broker identity directly. Its only other host-derived
+ * values are a typed numeric exit code and the leaf name of the canonically
+ * admitted delegated file.
  *
  * Command and search fields use the foreground approval-card projection so
  * both surfaces share the same sanitization.
  */
-export type AgentActivityDetail = { "kind": "exec", command: string, args: Array<string>, exit_code?: number, } | { "kind": "search", query: string, } | { "kind": "file", name: string, };
+export type AgentActivityDetail = { "kind": "exec", command: string, args: Array<string>, exit_code?: number, output?: string, } | { "kind": "search", query: string, } | { "kind": "file", name: string, };
 
 /**
  * One renderer-safe entry in a background run's ordered activity history.
@@ -30,10 +32,14 @@ export type AgentActivityDetail = { "kind": "exec", command: string, args: Array
  * Built on read from durable sandbox tool calls and their immutable receipts.
  * `detail` admits bounded model-authored command/argument/query text, which may
  * repeat anything the child already saw and is not covered by the host-field
- * non-disclosure guarantee. The only host-derived values are the numeric exit
- * code parsed from a receipt's first line and the delegated file's leaf name.
- * Stored result text, full broker paths and root identities, provider
- * identities, executor leases, and diagnostics are never copied directly.
+ * non-disclosure guarantee. Stored result text is copied in one place only: a
+ * settled `exec` step carries its receipt's bounded tail, because that text is
+ * the command's own output from a private workspace and is what makes a failed
+ * step readable. Web-search and delegated-file results stay server-side. The
+ * other host-derived values are the numeric exit code parsed from a receipt's
+ * first line and the delegated file's leaf name. Full broker paths and root
+ * identities, provider identities, executor leases, and diagnostics are never
+ * copied.
  *
  * No separate activity-history shape is persisted. The optional field keeps
  * the wire additive for older clients and lets calls without derivable detail

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -2326,10 +2326,14 @@ pub enum AgentActivityOutcome {
 /// Built on read from durable sandbox tool calls and their immutable receipts.
 /// `detail` admits bounded model-authored command/argument/query text, which may
 /// repeat anything the child already saw and is not covered by the host-field
-/// non-disclosure guarantee. The only host-derived values are the numeric exit
-/// code parsed from a receipt's first line and the delegated file's leaf name.
-/// Stored result text, full broker paths and root identities, provider
-/// identities, executor leases, and diagnostics are never copied directly.
+/// non-disclosure guarantee. Stored result text is copied in one place only: a
+/// settled `exec` step carries its receipt's bounded tail, because that text is
+/// the command's own output from a private workspace and is what makes a failed
+/// step readable. Web-search and delegated-file results stay server-side. The
+/// other host-derived values are the numeric exit code parsed from a receipt's
+/// first line and the delegated file's leaf name. Full broker paths and root
+/// identities, provider identities, executor leases, and diagnostics are never
+/// copied.
 ///
 /// No separate activity-history shape is persisted. The optional field keeps
 /// the wire additive for older clients and lets calls without derivable detail
@@ -2352,8 +2356,9 @@ pub struct AgentActivityHistoryItem {
 /// not a renderer contract, and are skipped rather than leaked as raw labels.
 /// `delegated_file` is the run's one admission-delegated file identity, when it
 /// had one; only its base name may reach a `read_delegated_file` entry. The
-/// receipt map contains only terminal exec receipts, used solely to recover the
-/// typed exit code from their first line.
+/// receipt map contains only terminal exec receipts, used to recover the typed
+/// exit code from their first line and a bounded tail of what the command
+/// printed.
 fn sandbox_activity_history(
     calls: &[SandboxToolCall],
     delegated_file: Option<&str>,
@@ -2519,14 +2524,16 @@ pub async fn list_agent_runs(
 /// This is the durable companion to the live `activity` field on a run
 /// snapshot: where that field names only the single current checkpoint, this
 /// returns every admitted step in order, each with a coarse terminal outcome
-/// and timestamp. Each entry may add a bounded typed headline — the command and
-/// exit status a settled exec recorded, the query a web search asked, or the
-/// base name of the run's one delegated file. Command, argument, and query text
-/// is model-authored and may repeat information the child already saw; the
-/// boundary guarantee is narrower: stored results and host-only fields are not
-/// copied directly, apart from the typed exit code and admitted leaf name. A
-/// missing, wrong-chat, or foreground run returns `404` rather than revealing
-/// whether an unrelated run identifier exists.
+/// and timestamp. Each entry may add a bounded typed headline — the command,
+/// exit status, and output tail a settled exec recorded, the query a web search
+/// asked, or the base name of the run's one delegated file. Command, argument,
+/// and query text is model-authored and may repeat information the child
+/// already saw. The exec output tail is the one stored result the projection
+/// copies: it is the command's own text from a private workspace. Web-search
+/// and delegated-file results and host-only fields are not copied, apart from
+/// the typed exit code and admitted leaf name. A missing, wrong-chat, or
+/// foreground run returns `404` rather than revealing whether an unrelated run
+/// identifier exists.
 pub async fn list_agent_run_activity(
     store: ScopedStore,
     Path((chat_id, run_id)): Path<(ChatId, openwave_core::AgentRunId)>,
@@ -2557,9 +2564,9 @@ pub async fn list_agent_run_activity(
     } else {
         None
     };
-    // Exit status lives on the immutable receipts, not the call rows. A
-    // missing receipt — a live step, or a call settled before receipts were
-    // kept — leaves the detail without an exit code rather than failing.
+    // Exit status and the printed tail live on the immutable receipts, not the
+    // call rows. A missing receipt — a live step, or a call settled before
+    // receipts were kept — leaves the detail without them rather than failing.
     let mut receipts = std::collections::HashMap::new();
     for call in &calls {
         if call.name == openwave_core::SANDBOX_EXEC_TOOL && call.status.is_terminal() {

--- a/crates/openwave-server/src/tests/sandbox.rs
+++ b/crates/openwave-server/src/tests/sandbox.rs
@@ -265,7 +265,7 @@ async fn agent_run_activity_history_is_ordered_typed_and_names_submitted_files()
                 exec.id,
                 exec_lease,
                 &ToolCallResolution::Failed {
-                    result: "exit: 17\nduration_ms: 42\n\nstderr:\nprivate output".into(),
+                    result: "exit: 17\nduration_ms: 42\n\nstderr:\nthe command's own stderr".into(),
                     error_code: "exec_command_failed".into(),
                     error_detail: Some("private executor detail".into()),
                 },
@@ -430,6 +430,7 @@ async fn agent_run_activity_history_is_ordered_typed_and_names_submitted_files()
             "command": "python3",
             "args": ["report.py", "--format", "md"],
             "exit_code": 17,
+            "output": "exit: 17\nduration_ms: 42\n\nstderr:\nthe command's own stderr",
         }))
     );
     assert_eq!(
@@ -459,9 +460,12 @@ async fn agent_run_activity_history_is_ordered_typed_and_names_submitted_files()
         serde_json::from_value(old_entry).expect("the old history shape still deserializes");
     assert_eq!(old_entry.detail, None);
 
+    // A settled exec's receipt tail is the one stored result the projection
+    // carries, asserted exactly above. Nothing else crosses: not the search
+    // result, not the executor's own failure detail, not the arguments a
+    // search was called with, and not the durable row's other columns.
     let encoded = serde_json::to_string(&history).unwrap();
     for forbidden in [
-        "private output",
         "private executor detail",
         "private search result",
         "secret-value",
@@ -469,8 +473,6 @@ async fn agent_run_activity_history_is_ordered_typed_and_names_submitted_files()
         "private-search-provider-identity",
         "arguments",
         "lease_token",
-        "duration_ms",
-        "result",
     ] {
         assert!(!encoded.contains(forbidden), "history leaked {forbidden}");
     }

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -327,16 +327,32 @@ activity projection.
 `GET /chats/{chat_id}/agent-runs/{run_id}/activity` rebuilds the background
 run's ordered history from those durable checkpoints. Each item keeps the fixed
 kind, coarse outcome, and timestamp, and may add one typed headline: the bounded
-command vector and recorded exit code, the bounded public-web query, or the leaf
-name of the one delegated file. Command, argument, and query strings are
-model-authored: the display clamp bounds and de-spoofs them, but they may repeat
-anything the child already saw and are outside the host-field non-disclosure
-guarantee. The server does not directly copy stored stdout, stderr, search
-results, full broker paths, opaque root identities, provider identities,
-executor leases, or raw diagnostics. The only host-derived detail is the typed
-numeric exit code and delegated leaf name. The detail key is optional, so a call
-without a derivable headline retains the original three-field shape; no separate
-activity-history payload or database migration is involved.
+command vector, recorded exit code, and captured output tail of a settled `exec`
+step; the bounded public-web query; or the leaf name of the one delegated file.
+Command, argument, and query strings are model-authored: the display clamp
+bounds and de-spoofs them, but they may repeat anything the child already saw
+and are outside the host-field non-disclosure guarantee.
+
+A settled `exec` step's output tail is the one deliberate exception to the rule
+that stored results stay server-side. A sandbox command runs in a private,
+initially-empty workspace containing only what the run itself staged, so what it
+printed is the command's own text rather than host- or user-derived content, and
+without it a failed background command is unreadable. The tail is bounded to
+2,000 characters, carried only for terminal steps, and taken from the whole
+receipt rather than from the section after a `stdout:` marker, so a command
+cannot choose what the card shows by printing that marker itself; control
+characters other than newlines and tabs are dropped. It is bounded that
+tightly because the endpoint returns a run's entire history in one response and
+the panel re-fetches on update. The exception does not extend to web-search
+results or delegated-file contents, which carry material the run was handed and
+are still never projected.
+
+The server does not directly copy any other stored result, nor full broker
+paths, opaque root identities, provider identities, executor leases, or raw
+diagnostics. The other host-derived details are the typed numeric exit code and
+delegated leaf name. The detail key is optional, so a call without a derivable
+headline retains the original three-field shape; no separate activity-history
+payload or database migration is involved.
 
 The desktop consumes that projection in two places. The transcript renders one
 status row per spawned child beside the delegation it came from, correlated by


### PR DESCRIPTION
Background exec steps in the agent activity timeline told the reader that "Output isn't retained for background runs." That was never true: the sandbox exec worker builds a bounded receipt — exit code, duration, published outputs, and 3 KB tails of stdout and stderr — and persists it immutably. The activity projection just parsed the first line for the exit code and discarded the rest, so a failed background command showed up in the panel as a command line and a pill, with no way to see why it failed.

`AgentActivityDetail::Exec` now carries an optional `output`: a 2,000-character tail of the settled receipt. The card renders it in the same monospace pane the command line uses. The notice is gone, and a settled step whose receipt had nothing readable says "No output captured." instead. No schema change — the receipt was already stored.

Two details worth review:

- The tail comes from the whole receipt, headers included, not from the section after its `stdout:` marker. A command can print that marker itself, so splitting on it would let the command choose what the card shows; carrying the receipt verbatim means the card shows what the host wrote. It is the tail rather than the head because the receipt's tail is already the tail of the streams, which is where a failure's message almost always is.
- Control characters other than newlines and tabs are dropped, and the bound is applied in characters so a multi-byte tail is never split mid-codepoint. The renderer re-validates with the same rule rather than trusting the sender, as the other activity fields already do.

The bound is deliberately small — 2 KB against the 40 KB a foreground result preview may carry — and attached only to terminal steps. The activity endpoint returns a run's entire history in one response and the panel re-fetches it on every update, so this cost is multiplied by every command a long run ever ran. That tradeoff is stated at the constant.

## The policy amendment

The projection's non-disclosure rule was written in three places (the `preview` module doc, the route and type comments in `openwave-server`, and `docs/agent-runs.md`) and said stored result text never crosses. This narrows that to name one exception: a settled exec step's output tail.

The reasoning is that a sandbox command runs in a private, initially-empty workspace containing only what the run itself staged, so its stdout and stderr are the child's own text, not host- or user-derived content. That does not generalize, and the amendment says so: web-search results and delegated-file contents carry material the run was handed, and remain server-side. The guard test in `tests/sandbox.rs` still asserts that a search result, the executor's raw failure detail, provider identities, and lease tokens never appear in the activity payload; what it no longer forbids is the exec receipt text the response now carries by design, which the same test pins exactly.

## Tests

One new unit test in `preview.rs` covers the tail: an oversized receipt keeps its end, a multi-byte tail is cut on a character boundary, escape sequences and bidi overrides are dropped while newlines and tabs survive, and a receipt with nothing readable carries no output. The existing exit-code cases and the DOM and validator tests were extended in place rather than duplicated. No tests removed.

Verified: `cargo check --workspace --locked --all-targets` (no lockfile diff), `cargo test -p openwave-core` and `-p openwave-server` in full, `tsc --noEmit`, and the full `pnpm vitest run` suite. The wire types were regenerated with `UPDATE_WIRE_TYPES=1`. I did not drive the running app.