### PR TITLE
feat(core): reusable prompts as a plugin member kind and user prompt library

### DIFF
--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -25,6 +25,7 @@ pub mod overlay;
 pub mod package_cache;
 pub mod plugins;
 mod preview;
+pub mod prompts;
 mod receipt;
 mod remote;
 pub mod sbpl;
@@ -60,6 +61,10 @@ pub use plugins::{
     PluginParseError, PLUGIN_MANIFEST_FILE,
 };
 pub use preview::{scan_preview_directory, PreviewScan};
+pub use prompts::{
+    is_valid_prompt_name, load_prompts, merged_prompts, parse_prompt_manifest, LoadedPrompt,
+    PromptOrigin, PromptPackage, PromptParseError, MAX_PROMPT_BODY_BYTES, PROMPT_MANIFEST_FILE,
+};
 pub use remote::RemoteSessionPool;
 pub use skills::{
     is_valid_skill_description, is_valid_skill_name, load_skills, merged_skills,

--- a/crates/openwave-code-execution/src/plugins.rs
+++ b/crates/openwave-code-execution/src/plugins.rs
@@ -1,4 +1,5 @@
-//! Plugins: thin manifests that group skills into one installable bundle.
+//! Plugins: thin manifests that group skills and prompts into one installable
+//! bundle.
 //!
 //! A skill stays the model's routing unit — the prompt catalog still lists
 //! `(name, description)` lines and the instruction body still reaches the
@@ -8,6 +9,13 @@
 //! *router preamble* — a single line emitted above its skills in the catalog
 //! when they are alternatives for the same intent and the model needs help
 //! choosing between them.
+//!
+//! A bundle may also claim member **prompts** (see [`crate::prompts`]), which
+//! are the opposite kind of thing: inert user-side text a person inserts into
+//! the composer, with no catalog line and no staged bytes. They are members
+//! here only so a bundle can ship the starting messages that go with its
+//! skills, and so switching the bundle off takes them out of the library
+//! together. A bundle may carry skills, prompts, or both.
 //!
 //! Plugins are packaging, not a prompt concept. A skill claimed by no plugin
 //! keeps working exactly as before, which is what keeps user-authored skills
@@ -27,6 +35,7 @@
 use std::collections::BTreeSet;
 use std::path::Path;
 
+use crate::prompts::{is_valid_prompt_name, LoadedPrompt};
 use crate::skills::{is_valid_skill_name, LoadedSkill, SkillPackage};
 
 /// The manifest file every plugin package is defined by.
@@ -37,6 +46,7 @@ const MAX_DISPLAY_NAME_BYTES: usize = 64;
 const MAX_DESCRIPTION_BYTES: usize = 200;
 const MAX_ROUTER_PREAMBLE_BYTES: usize = 300;
 const MAX_MEMBER_SKILLS: usize = 16;
+const MAX_MEMBER_PROMPTS: usize = 32;
 
 /// What kind of work a plugin bundles, from a closed vocabulary.
 ///
@@ -161,6 +171,9 @@ pub struct PluginPackage {
     pub category: PluginCategory,
     /// Member skill slugs, in manifest order, each one a loaded skill.
     pub skills: Vec<String>,
+    /// Member prompt slugs, in manifest order, each one a loaded prompt.
+    /// Empty for a skills-only bundle, which is every bundle we ship.
+    pub prompts: Vec<String>,
     /// Optional line emitted above the member skills in the prompt catalog,
     /// telling the model how to choose among them.
     pub router_preamble: Option<String>,
@@ -219,12 +232,13 @@ pub fn is_valid_plugin_router_preamble(preamble: &str) -> bool {
 /// Parse one `PLUGIN.md` source: strict frontmatter between `---` fences.
 ///
 /// Recognized keys are exactly `name`, `display-name`, `description`,
-/// `category`, the single-line flow list `skills: ["a", "b"]`, and the
-/// optional `router-preamble`. Anything else — an unknown key, a duplicate, a
-/// member that is not a well-formed skill slug, a control character in a
-/// rendered line — rejects the whole manifest. The body below the frontmatter
-/// is documentation for whoever opens the file; it is never staged and never
-/// reaches the model, so it may be empty.
+/// `category`, the single-line flow lists `skills: ["a", "b"]` and
+/// `prompts: ["c"]`, and the optional `router-preamble`. Either member list
+/// may be omitted, but a bundle that claims nothing is rejected. Anything
+/// else — an unknown key, a duplicate, a member that is not a well-formed
+/// slug, a control character in a rendered line — rejects the whole manifest.
+/// The body below the frontmatter is documentation for whoever opens the file;
+/// it is never staged and never reaches the model, so it may be empty.
 pub fn parse_plugin_manifest(source: &str) -> Result<PluginPackage, PluginParseError> {
     if source.len() > crate::MAX_WORKSPACE_FILE_BYTES {
         return Err(invalid("manifest exceeds the workspace file limit"));
@@ -241,6 +255,7 @@ pub fn parse_plugin_manifest(source: &str) -> Result<PluginPackage, PluginParseE
     let mut description = None;
     let mut category = None;
     let mut skills = None;
+    let mut prompts = None;
     let mut router_preamble = None;
     for line in frontmatter.lines() {
         if line.trim().is_empty() {
@@ -272,8 +287,17 @@ pub fn parse_plugin_manifest(source: &str) -> Result<PluginPackage, PluginParseE
                 }
             }
             "skills" => {
-                if skills.replace(parse_member_skills(value)?).is_some() {
+                let members =
+                    parse_members(value, "skills", MAX_MEMBER_SKILLS, is_valid_skill_name)?;
+                if skills.replace(members).is_some() {
                     return Err(invalid("duplicate 'skills'"));
+                }
+            }
+            "prompts" => {
+                let members =
+                    parse_members(value, "prompts", MAX_MEMBER_PROMPTS, is_valid_prompt_name)?;
+                if prompts.replace(members).is_some() {
+                    return Err(invalid("duplicate 'prompts'"));
                 }
             }
             "router-preamble" => {
@@ -303,7 +327,13 @@ pub fn parse_plugin_manifest(source: &str) -> Result<PluginPackage, PluginParseE
     let Some(category) = PluginCategory::parse(category) else {
         return Err(invalid(format!("unknown 'category': {category:?}")));
     };
-    let skills = skills.ok_or_else(|| invalid("missing 'skills'"))?;
+    // Either list alone is a legitimate bundle — a skills-only one is what we
+    // ship — but a manifest claiming neither describes nothing.
+    let skills = skills.unwrap_or_default();
+    let prompts = prompts.unwrap_or_default();
+    if skills.is_empty() && prompts.is_empty() {
+        return Err(invalid("bundle claims no 'skills' and no 'prompts'"));
+    }
     let router_preamble = router_preamble
         .map(|preamble| {
             is_valid_plugin_router_preamble(preamble)
@@ -317,16 +347,28 @@ pub fn parse_plugin_manifest(source: &str) -> Result<PluginPackage, PluginParseE
         description: description.to_owned(),
         category,
         skills,
+        prompts,
         router_preamble,
     })
 }
 
 /// Parse the single-line flow form `["word-documents", "pdf-documents"]`.
 ///
-/// Every item is a double-quoted skill slug; the slug grammar admits neither
-/// `"` nor `]`, so the list cannot be malformed into something that parses.
-fn parse_member_skills(value: &str) -> Result<Vec<String>, PluginParseError> {
-    let malformed = || invalid("'skills' must be `[\"skill-name\", ...]` with at least one member");
+/// Every item is a double-quoted slug checked by `valid`; the slug grammar
+/// admits neither `"` nor `]`, so the list cannot be malformed into something
+/// that parses. An empty list is rejected rather than treated as absent: it
+/// reads as an intent the manifest does not express.
+fn parse_members(
+    value: &str,
+    key: &str,
+    limit: usize,
+    valid: fn(&str) -> bool,
+) -> Result<Vec<String>, PluginParseError> {
+    let malformed = || {
+        invalid(format!(
+            "'{key}' must be `[\"name\", ...]` with at least one member"
+        ))
+    };
     let items = value
         .strip_prefix('[')
         .and_then(|rest| rest.strip_suffix(']'))
@@ -335,41 +377,45 @@ fn parse_member_skills(value: &str) -> Result<Vec<String>, PluginParseError> {
     if items.is_empty() {
         return Err(malformed());
     }
-    let mut skills: Vec<String> = Vec::new();
+    let mut members: Vec<String> = Vec::new();
     for item in items.split(',') {
-        let skill = item
+        let member = item
             .trim()
             .strip_prefix('"')
             .and_then(|rest| rest.strip_suffix('"'))
             .ok_or_else(malformed)?;
-        if !is_valid_skill_name(skill) {
+        if !valid(member) {
             return Err(invalid(format!(
-                "'skills' member is not a kebab-case slug: {skill:?}"
+                "'{key}' member is not a kebab-case slug: {member:?}"
             )));
         }
-        if skills.iter().any(|existing| existing == skill) {
-            return Err(invalid(format!("duplicate 'skills' member: {skill:?}")));
+        if members.iter().any(|existing| existing == member) {
+            return Err(invalid(format!("duplicate '{key}' member: {member:?}")));
         }
-        skills.push(skill.to_owned());
+        members.push(member.to_owned());
     }
-    if skills.len() > MAX_MEMBER_SKILLS {
-        return Err(invalid("'skills' lists too many members"));
+    if members.len() > limit {
+        return Err(invalid(format!("'{key}' lists too many members")));
     }
-    Ok(skills)
+    Ok(members)
 }
 
 /// Load every valid plugin under `source`, one directory per plugin, against
-/// the skills that actually loaded.
+/// the skills and prompts that actually loaded.
 ///
 /// A plugin is skipped with a warning — never half-applied — when its manifest
 /// is unreadable or rejected, when the directory name disagrees with the
-/// manifest, when a member skill is not among `skills`, or when a member is
-/// already claimed by another plugin. Claims resolve in name order so the same
-/// tree always produces the same grouping. Skills no plugin claims stay
-/// standalone; that is the supported shape for a bare skill directory, not a
-/// degraded one.
+/// manifest, when a member is not among `skills` or `prompts`, or when a
+/// member is already claimed by another plugin. Claims resolve in name order
+/// so the same tree always produces the same grouping. Members no plugin
+/// claims stay standalone; that is the supported shape for a bare skill or
+/// prompt directory, not a degraded one.
 #[must_use]
-pub fn load_plugins(source: &Path, skills: &[LoadedSkill]) -> Vec<LoadedPlugin> {
+pub fn load_plugins(
+    source: &Path,
+    skills: &[LoadedSkill],
+    prompts: &[LoadedPrompt],
+) -> Vec<LoadedPlugin> {
     let entries = match std::fs::read_dir(source) {
         Ok(entries) => entries,
         Err(error) => {
@@ -380,9 +426,13 @@ pub fn load_plugins(source: &Path, skills: &[LoadedSkill]) -> Vec<LoadedPlugin> 
             return Vec::new();
         }
     };
-    let known: BTreeSet<&str> = skills
+    let known_skills: BTreeSet<&str> = skills
         .iter()
         .map(|skill| skill.package.name.as_str())
+        .collect();
+    let known_prompts: BTreeSet<&str> = prompts
+        .iter()
+        .map(|prompt| prompt.package.name.as_str())
         .collect();
     let mut parsed: Vec<PluginPackage> = Vec::new();
     for entry in entries.flatten() {
@@ -428,10 +478,20 @@ pub fn load_plugins(source: &Path, skills: &[LoadedSkill]) -> Vec<LoadedPlugin> 
         if let Some(missing) = package
             .skills
             .iter()
-            .find(|skill| !known.contains(skill.as_str()))
+            .find(|skill| !known_skills.contains(skill.as_str()))
         {
             tracing::warn!(
                 "skipping plugin '{directory_name}': member skill {missing:?} did not load"
+            );
+            continue;
+        }
+        if let Some(missing) = package
+            .prompts
+            .iter()
+            .find(|prompt| !known_prompts.contains(prompt.as_str()))
+        {
+            tracing::warn!(
+                "skipping plugin '{directory_name}': member prompt {missing:?} did not load"
             );
             continue;
         }
@@ -439,13 +499,14 @@ pub fn load_plugins(source: &Path, skills: &[LoadedSkill]) -> Vec<LoadedPlugin> 
     }
 
     parsed.sort_by(|a, b| a.name.cmp(&b.name));
-    let mut claimed: BTreeSet<String> = BTreeSet::new();
+    let mut claimed_skills: BTreeSet<String> = BTreeSet::new();
+    let mut claimed_prompts: BTreeSet<String> = BTreeSet::new();
     let mut plugins = Vec::new();
     for package in parsed {
         if let Some(taken) = package
             .skills
             .iter()
-            .find(|skill| claimed.contains(skill.as_str()))
+            .find(|skill| claimed_skills.contains(skill.as_str()))
         {
             tracing::warn!(
                 "skipping plugin '{}': skill {taken:?} is already claimed by another plugin",
@@ -453,7 +514,19 @@ pub fn load_plugins(source: &Path, skills: &[LoadedSkill]) -> Vec<LoadedPlugin> 
             );
             continue;
         }
-        claimed.extend(package.skills.iter().cloned());
+        if let Some(taken) = package
+            .prompts
+            .iter()
+            .find(|prompt| claimed_prompts.contains(prompt.as_str()))
+        {
+            tracing::warn!(
+                "skipping plugin '{}': prompt {taken:?} is already claimed by another plugin",
+                package.name
+            );
+            continue;
+        }
+        claimed_skills.extend(package.skills.iter().cloned());
+        claimed_prompts.extend(package.prompts.iter().cloned());
         plugins.push(LoadedPlugin { package });
     }
     plugins
@@ -462,6 +535,7 @@ pub fn load_plugins(source: &Path, skills: &[LoadedSkill]) -> Vec<LoadedPlugin> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::prompts::{load_prompts, PromptOrigin, PROMPT_MANIFEST_FILE};
     use crate::skills::{load_skills, SkillOrigin, SKILL_MANIFEST_FILE};
     use crate::HostDep;
 
@@ -486,6 +560,16 @@ router-preamble: Pick by the file the user needs.\n\
         .unwrap();
     }
 
+    fn write_prompt(dir: &Path, name: &str) {
+        let prompt = dir.join(name);
+        std::fs::create_dir(&prompt).unwrap();
+        std::fs::write(
+            prompt.join(PROMPT_MANIFEST_FILE),
+            format!("---\nname: {name}\ndescription: Starts a {name}.\n---\nBody.\n"),
+        )
+        .unwrap();
+    }
+
     fn write_plugin(dir: &Path, name: &str, manifest: &str) {
         let plugin = dir.join(name);
         std::fs::create_dir(&plugin).unwrap();
@@ -499,6 +583,7 @@ router-preamble: Pick by the file the user needs.\n\
         assert_eq!(package.display_name, "Documents");
         assert_eq!(package.category, PluginCategory::Documents);
         assert_eq!(package.skills, ["word-documents", "pdf-documents"]);
+        assert_eq!(package.prompts, [""; 0]);
         assert_eq!(
             package.router_preamble.as_deref(),
             Some("Pick by the file the user needs.")
@@ -511,6 +596,14 @@ router-preamble: Pick by the file the user needs.\n\
             parse_plugin_manifest(minimal).unwrap().router_preamble,
             None
         );
+
+        // Either member list alone is a bundle: prompts-only is as valid as
+        // the skills-only shape we ship.
+        let prompts_only = "---\nname: writing\ndisplay-name: Writing\ndescription: Starters.\n\
+                            category: other\nprompts: [\"weekly-update\"]\n---\n";
+        let package = parse_plugin_manifest(prompts_only).unwrap();
+        assert_eq!(package.skills, [""; 0]);
+        assert_eq!(package.prompts, ["weekly-update"]);
     }
 
     #[test]
@@ -528,7 +621,15 @@ router-preamble: Pick by the file the user needs.\n\
                 "missing display-name",
                 "---\nname: a\ndescription: b\ncategory: other\nskills: [\"c\"]\n---\n".to_owned(),
             ),
-            ("missing skills", format!("{head}---\n")),
+            ("no members at all", format!("{head}---\n")),
+            (
+                "empty prompts list",
+                format!("{head}skills: [\"c\"]\nprompts: []\n---\n"),
+            ),
+            (
+                "non-kebab prompt member",
+                format!("{head}prompts: [\"Weekly Update\"]\n---\n"),
+            ),
             (
                 "unknown category",
                 "---\nname: a\ndisplay-name: A\ndescription: b\ncategory: wizardry\nskills: [\"c\"]\n---\n".to_owned(),
@@ -567,9 +668,11 @@ router-preamble: Pick by the file the user needs.\n\
         }
     }
 
-    /// Contract: membership is checked against the skills that actually
-    /// loaded, and one skill belongs to at most one plugin — a second
+    /// Contract: membership is checked against the skills and prompts that
+    /// actually loaded, and a member belongs to at most one plugin — a second
     /// claimant is skipped whole rather than producing overlapping groups.
+    /// Prompts are members on exactly those terms, so both rules are asserted
+    /// against them too.
     #[test]
     fn loader_rejects_dangling_members_and_double_claims() {
         let skills_dir = tempfile::tempdir().unwrap();
@@ -577,9 +680,19 @@ router-preamble: Pick by the file the user needs.\n\
             write_skill(skills_dir.path(), name);
         }
         let skills = load_skills(skills_dir.path(), SkillOrigin::Builtin);
+        let prompts_dir = tempfile::tempdir().unwrap();
+        write_prompt(prompts_dir.path(), "weekly-update");
+        let prompts = load_prompts(prompts_dir.path(), PromptOrigin::Builtin);
 
         let plugins_dir = tempfile::tempdir().unwrap();
-        write_plugin(plugins_dir.path(), "documents", VALID);
+        write_plugin(
+            plugins_dir.path(),
+            "documents",
+            &VALID.replace(
+                "router-preamble:",
+                "prompts: [\"weekly-update\"]\nrouter-preamble:",
+            ),
+        );
         // Claims a skill 'documents' already owns: skipped entirely, so its
         // uncontested member stays standalone rather than half-grouped.
         write_plugin(
@@ -588,6 +701,13 @@ router-preamble: Pick by the file the user needs.\n\
             "---\nname: zzz-later\ndisplay-name: Later\ndescription: Steals a member.\n\
              category: other\nskills: [\"charts\", \"pdf-documents\"]\n---\n",
         );
+        // Claims a prompt 'documents' already owns.
+        write_plugin(
+            plugins_dir.path(),
+            "zzz-writing",
+            "---\nname: zzz-writing\ndisplay-name: Writing\ndescription: Steals a prompt.\n\
+             category: other\nprompts: [\"weekly-update\"]\n---\n",
+        );
         // Names a skill that did not load.
         write_plugin(
             plugins_dir.path(),
@@ -595,10 +715,17 @@ router-preamble: Pick by the file the user needs.\n\
             "---\nname: ghosts\ndisplay-name: Ghosts\ndescription: Dangling member.\n\
              category: other\nskills: [\"spreadsheets\"]\n---\n",
         );
+        // Names a prompt that did not load.
+        write_plugin(
+            plugins_dir.path(),
+            "phantoms",
+            "---\nname: phantoms\ndisplay-name: Phantoms\ndescription: Dangling prompt.\n\
+             category: other\nprompts: [\"standup\"]\n---\n",
+        );
         // Directory disagrees with the manifest.
         write_plugin(plugins_dir.path(), "mislabeled", VALID);
 
-        let plugins = load_plugins(plugins_dir.path(), &skills);
+        let plugins = load_plugins(plugins_dir.path(), &skills, &prompts);
         assert_eq!(
             plugins
                 .iter()
@@ -610,6 +737,7 @@ router-preamble: Pick by the file the user needs.\n\
             plugins[0].package.skills,
             ["word-documents", "pdf-documents"]
         );
+        assert_eq!(plugins[0].package.prompts, ["weekly-update"]);
     }
 
     /// Contract: a badge row is a function of what the member skills declare,
@@ -666,6 +794,7 @@ router-preamble: Pick by the file the user needs.\n\
                 description: "A bundle.".to_owned(),
                 category: PluginCategory::Other,
                 skills: members.iter().map(|skill| skill.name.clone()).collect(),
+                prompts: Vec::new(),
                 router_preamble: None,
             };
             let mut passed: Vec<&SkillPackage> = members;
@@ -687,6 +816,7 @@ router-preamble: Pick by the file the user needs.\n\
             description: "A bundle.".to_owned(),
             category: PluginCategory::Other,
             skills: vec!["both".to_owned()],
+            prompts: Vec::new(),
             router_preamble: None,
         };
         let derived = derived_capabilities(&everything, &[&both]);
@@ -715,7 +845,7 @@ router-preamble: Pick by the file the user needs.\n\
             .filter_map(Result::ok)
             .filter(|entry| entry.path().is_dir())
             .count();
-        let plugins = load_plugins(&source, &skills);
+        let plugins = load_plugins(&source, &skills, &[]);
         assert_eq!(
             plugins.len(),
             directories,

--- a/crates/openwave-code-execution/src/prompts.rs
+++ b/crates/openwave-code-execution/src/prompts.rs
@@ -1,0 +1,399 @@
+//! Reusable prompts: saved starting messages the user can insert.
+//!
+//! A prompt is a directory whose `PROMPT.md` carries a name, a one-line tip,
+//! and a markdown body. The body is the text a surface drops into the
+//! composer when the user picks it — nothing else. That is the whole feature,
+//! and the narrowness is deliberate: a prompt is **user-side content**. It
+//! never enters the operating prompt, is never staged into an exec workspace,
+//! and has no catalog line, so nothing here is reachable by the model except
+//! by the user choosing to send it.
+//!
+//! That is what separates a prompt from a skill. A skill is instructions the
+//! model routes on, so `skills.rs` bounds every string that reaches the prompt
+//! and stages files into the sandbox. A prompt has neither reach, so it needs
+//! only the checks that keep a management surface honest: a well-formed slug
+//! for addressing, a bounded printable description for the card, and a bounded
+//! body so a stray file cannot become a multi-megabyte fetch.
+//!
+//! Prompts come from the same two sources skills do — packages shipped with
+//! the application, and user-authored directories under a per-install path —
+//! and follow the same rules: one strict parser for both, a name collision
+//! resolving in the built-in's favor, and skip-with-warning per package so one
+//! bad file cannot take out the library.
+
+use std::path::Path;
+
+/// The manifest file every prompt package is defined by.
+pub const PROMPT_MANIFEST_FILE: &str = "PROMPT.md";
+
+const MAX_NAME_BYTES: usize = 64;
+const MAX_DESCRIPTION_BYTES: usize = 200;
+
+/// Bound on the insertable body.
+///
+/// A prompt is a starting message a person wrote, so this is generous by two
+/// orders of magnitude for the real cases; it exists so a file that wandered
+/// into the prompts directory cannot become an unbounded response body.
+pub const MAX_PROMPT_BODY_BYTES: usize = 16 * 1024;
+
+/// Which source a validated prompt package was loaded from.
+///
+/// Host-derived from the load path, never from manifest content, so a user
+/// package cannot claim to be built-in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, ts_rs::TS)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptOrigin {
+    /// Shipped with the application from a trusted resource directory.
+    Builtin,
+    /// Authored by the user in the per-install prompts directory.
+    User,
+}
+
+/// Host-derived library entry parsed from a prompt manifest's frontmatter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PromptPackage {
+    /// Kebab-case slug; also the directory name and the route's address.
+    pub name: String,
+    /// One printable line: the tip a card or popover shows.
+    pub description: String,
+    /// Where the package was loaded from.
+    pub origin: PromptOrigin,
+}
+
+/// One validated prompt: its library entry plus the text to insert.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoadedPrompt {
+    /// The parsed frontmatter a library listing is built from.
+    pub package: PromptPackage,
+    /// The markdown below the frontmatter, inserted into the composer verbatim.
+    pub body: String,
+}
+
+/// Why a prompt manifest was rejected.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("invalid prompt manifest: {0}")]
+pub struct PromptParseError(String);
+
+fn invalid(reason: impl Into<String>) -> PromptParseError {
+    PromptParseError(reason.into())
+}
+
+/// Whether `name` is a well-formed prompt slug: bounded kebab-case with no
+/// empty segments — the same grammar skill and plugin names use.
+#[must_use]
+pub fn is_valid_prompt_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= MAX_NAME_BYTES
+        && name
+            .split('-')
+            .all(|segment| !segment.is_empty() && segment.bytes().all(is_slug_byte))
+}
+
+fn is_slug_byte(byte: u8) -> bool {
+    byte.is_ascii_lowercase() || byte.is_ascii_digit()
+}
+
+/// Parse one `PROMPT.md` source: strict frontmatter between `---` fences, then
+/// a non-empty markdown body. `origin` records which source the caller is
+/// loading from; it never comes from the manifest itself.
+///
+/// Recognized keys are exactly `name` and `description`, both required. A
+/// duplicate, a name that is not a slug, a description that is not one bounded
+/// printable line, an empty body, or a body past
+/// [`MAX_PROMPT_BODY_BYTES`] rejects the manifest regardless of origin.
+///
+/// Unknown keys split by origin exactly as skill manifests do: a built-in is a
+/// package we ship, so an unrecognized key there is a defect worth failing on,
+/// while a user manifest may carry fields from whatever editor wrote it and
+/// those are ignored with a warning, along with the indented lines belonging
+/// to them.
+pub fn parse_prompt_manifest(
+    source: &str,
+    origin: PromptOrigin,
+) -> Result<LoadedPrompt, PromptParseError> {
+    let rest = source
+        .strip_prefix("---\n")
+        .ok_or_else(|| invalid("missing opening frontmatter fence"))?;
+    let (frontmatter, body) = rest
+        .split_once("\n---\n")
+        .ok_or_else(|| invalid("missing closing frontmatter fence"))?;
+
+    let mut name = None;
+    let mut description = None;
+    let tolerant = matches!(origin, PromptOrigin::User);
+    // An ignored key's value may continue over following lines. Those lines
+    // carry no key of their own, so tolerating them is what makes ignoring the
+    // key mean ignoring the whole entry.
+    let mut inside_ignored_value = false;
+    for line in frontmatter.lines() {
+        if line.trim().is_empty() {
+            return Err(invalid("blank line inside frontmatter"));
+        }
+        let Some((key, value)) = line.split_once(':') else {
+            if tolerant && inside_ignored_value {
+                continue;
+            }
+            return Err(invalid(format!("frontmatter line without a key: {line:?}")));
+        };
+        let value = value.trim();
+        inside_ignored_value = false;
+        match key {
+            "name" => {
+                if name.replace(value).is_some() {
+                    return Err(invalid("duplicate 'name'"));
+                }
+            }
+            "description" => {
+                if description.replace(value).is_some() {
+                    return Err(invalid("duplicate 'description'"));
+                }
+            }
+            other => {
+                if !tolerant {
+                    return Err(invalid(format!("unknown frontmatter key {other:?}")));
+                }
+                tracing::warn!("ignoring unknown frontmatter key {other:?} in a user prompt");
+                inside_ignored_value = true;
+            }
+        }
+    }
+
+    let name = name.ok_or_else(|| invalid("missing 'name'"))?;
+    if !is_valid_prompt_name(name) {
+        return Err(invalid(format!(
+            "'name' is not a kebab-case slug: {name:?}"
+        )));
+    }
+    let description = description.ok_or_else(|| invalid("missing 'description'"))?;
+    if description.is_empty()
+        || description.len() > MAX_DESCRIPTION_BYTES
+        || description.trim() != description
+        || description.chars().any(char::is_control)
+    {
+        return Err(invalid("'description' is not one bounded printable line"));
+    }
+    let body = body.trim();
+    if body.is_empty() {
+        return Err(invalid("empty prompt body"));
+    }
+    if body.len() > MAX_PROMPT_BODY_BYTES {
+        return Err(invalid("prompt body exceeds the insertable limit"));
+    }
+    Ok(LoadedPrompt {
+        package: PromptPackage {
+            name: name.to_owned(),
+            description: description.to_owned(),
+            origin,
+        },
+        body: body.to_owned(),
+    })
+}
+
+/// Load every valid prompt package under `source`, one directory per prompt,
+/// tagging each with `origin`.
+///
+/// A malformed package — an unreadable manifest, frontmatter the parser
+/// rejects, or a directory whose name disagrees with its manifest — is skipped
+/// with a warning so one bad file can never break the library. The result is
+/// sorted by name for a deterministic listing.
+#[must_use]
+pub fn load_prompts(source: &Path, origin: PromptOrigin) -> Vec<LoadedPrompt> {
+    let mut prompts = Vec::new();
+    let entries = match std::fs::read_dir(source) {
+        Ok(entries) => entries,
+        Err(error) => {
+            tracing::warn!(
+                "prompt source directory {} is unreadable: {error}",
+                source.display()
+            );
+            return prompts;
+        }
+    };
+    for entry in entries.flatten() {
+        let Ok(directory_name) = entry.file_name().into_string() else {
+            continue;
+        };
+        let is_directory = entry
+            .path()
+            .symlink_metadata()
+            .is_ok_and(|metadata| metadata.is_dir() && !metadata.file_type().is_symlink());
+        if !is_directory {
+            continue;
+        }
+        let manifest_path = entry.path().join(PROMPT_MANIFEST_FILE);
+        let regular_file = manifest_path
+            .symlink_metadata()
+            .is_ok_and(|metadata| metadata.is_file() && !metadata.file_type().is_symlink());
+        if !regular_file {
+            tracing::warn!("skipping prompt '{directory_name}': no regular {PROMPT_MANIFEST_FILE}");
+            continue;
+        }
+        let manifest = match std::fs::read_to_string(&manifest_path) {
+            Ok(manifest) => manifest,
+            Err(error) => {
+                tracing::warn!("skipping prompt '{directory_name}': manifest unreadable: {error}");
+                continue;
+            }
+        };
+        let prompt = match parse_prompt_manifest(&manifest, origin) {
+            Ok(prompt) => prompt,
+            Err(error) => {
+                tracing::warn!("skipping prompt '{directory_name}': {error}");
+                continue;
+            }
+        };
+        if prompt.package.name != directory_name {
+            tracing::warn!(
+                "skipping prompt '{directory_name}': manifest names itself {:?}",
+                prompt.package.name
+            );
+            continue;
+        }
+        prompts.push(prompt);
+    }
+    prompts.sort_by(|a, b| a.package.name.cmp(&b.package.name));
+    prompts
+}
+
+/// The built-in prompts plus the user-authored packages under `user_dir`,
+/// merged into one deterministic library.
+///
+/// User prompts go through the same parser as built-ins. A user package whose
+/// name collides with a built-in is dropped with a warning, so a curated
+/// prompt can never be shadowed by a local file of the same name. A missing
+/// user directory is simply an empty user set.
+#[must_use]
+pub fn merged_prompts(builtins: &[LoadedPrompt], user_dir: Option<&Path>) -> Vec<LoadedPrompt> {
+    let mut prompts = builtins.to_vec();
+    if let Some(dir) = user_dir.filter(|dir| dir.is_dir()) {
+        for user_prompt in load_prompts(dir, PromptOrigin::User) {
+            let name = &user_prompt.package.name;
+            if builtins.iter().any(|prompt| prompt.package.name == *name) {
+                tracing::warn!("skipping user prompt '{name}': a built-in prompt owns that name");
+                continue;
+            }
+            prompts.push(user_prompt);
+        }
+        prompts.sort_by(|a, b| a.package.name.cmp(&b.package.name));
+    }
+    prompts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID: &str = "---\n\
+name: weekly-update\n\
+description: Draft this week's status update.\n\
+---\n\
+\n\
+Write a status update covering what shipped, what slipped, and what is next.\n";
+
+    /// Contract: the manifest splits into the library entry and the exact text
+    /// a composer inserts, and everything that would make either dishonest —
+    /// a missing key, a name that cannot address a route, an unbounded body —
+    /// rejects the package instead of half-loading it.
+    #[test]
+    fn manifests_parse_into_an_entry_and_a_body_or_are_rejected() {
+        let prompt = parse_prompt_manifest(VALID, PromptOrigin::Builtin).unwrap();
+        assert_eq!(prompt.package.name, "weekly-update");
+        assert_eq!(
+            prompt.package.description,
+            "Draft this week's status update."
+        );
+        assert_eq!(
+            prompt.body,
+            "Write a status update covering what shipped, what slipped, and what is next."
+        );
+
+        let oversized = format!(
+            "---\nname: a\ndescription: b\n---\n{}\n",
+            "x".repeat(MAX_PROMPT_BODY_BYTES + 1)
+        );
+        for (case, source) in [
+            ("no frontmatter", "# Just markdown\n".to_owned()),
+            ("unclosed frontmatter", "---\nname: a\n".to_owned()),
+            (
+                "missing description",
+                "---\nname: a\n---\nBody.\n".to_owned(),
+            ),
+            (
+                "non-kebab name",
+                "---\nname: Weekly Update\ndescription: b\n---\nBody.\n".to_owned(),
+            ),
+            (
+                "control character in description",
+                "---\nname: a\ndescription: b\u{7}c\n---\nBody.\n".to_owned(),
+            ),
+            (
+                "unknown key in a built-in",
+                "---\nname: a\ndescription: b\nauthor: c\n---\nBody.\n".to_owned(),
+            ),
+            (
+                "empty body",
+                "---\nname: a\ndescription: b\n---\n  \n".to_owned(),
+            ),
+            ("oversized body", oversized),
+        ] {
+            assert!(
+                parse_prompt_manifest(&source, PromptOrigin::Builtin).is_err(),
+                "{case} should be rejected"
+            );
+        }
+
+        // A user-authored file may carry keys from whatever wrote it; the same
+        // manifest is still a defect in a package we ship.
+        let extra = "---\nname: a\ndescription: b\nauthor: someone\ntags:\n  - one\n---\nBody.\n";
+        assert!(parse_prompt_manifest(extra, PromptOrigin::User).is_ok());
+        assert!(parse_prompt_manifest(extra, PromptOrigin::Builtin).is_err());
+    }
+
+    /// Contract: a user package goes through the same loader, carries its
+    /// origin, and can never shadow a built-in name.
+    #[test]
+    fn user_prompts_merge_after_builtins_without_shadowing() {
+        let write = |dir: &Path, name: &str, source: &str| {
+            let prompt = dir.join(name);
+            std::fs::create_dir(&prompt).unwrap();
+            std::fs::write(prompt.join(PROMPT_MANIFEST_FILE), source).unwrap();
+        };
+
+        let builtin_dir = tempfile::tempdir().unwrap();
+        write(builtin_dir.path(), "weekly-update", VALID);
+        // Parses, but the directory disagrees with the manifest.
+        write(builtin_dir.path(), "mislabeled", VALID);
+        let builtins = load_prompts(builtin_dir.path(), PromptOrigin::Builtin);
+        assert_eq!(builtins.len(), 1);
+
+        let user_dir = tempfile::tempdir().unwrap();
+        write(
+            user_dir.path(),
+            "weekly-update",
+            "---\nname: weekly-update\ndescription: Impostor.\n---\nImpostor body.\n",
+        );
+        write(
+            user_dir.path(),
+            "standup",
+            "---\nname: standup\ndescription: My standup format.\n---\nYesterday, today, blockers.\n",
+        );
+        write(user_dir.path(), "broken", "no frontmatter\n");
+
+        let merged = merged_prompts(&builtins, Some(user_dir.path()));
+        assert_eq!(
+            merged
+                .iter()
+                .map(|prompt| (prompt.package.name.as_str(), prompt.package.origin))
+                .collect::<Vec<_>>(),
+            [
+                ("standup", PromptOrigin::User),
+                ("weekly-update", PromptOrigin::Builtin),
+            ]
+        );
+        assert!(merged[1].body.starts_with("Write a status update"));
+
+        // A missing user directory is an empty user set, not an error.
+        let missing = user_dir.path().join("does-not-exist");
+        assert_eq!(merged_prompts(&builtins, Some(&missing)).len(), 1);
+    }
+}

--- a/crates/openwave-core/src/config.rs
+++ b/crates/openwave-core/src/config.rs
@@ -69,6 +69,12 @@ pub struct Config {
     /// alone in the catalog.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub exec_plugins_dir: Option<PathBuf>,
+    /// Trusted source directory for built-in reusable prompt packages. Prompts
+    /// are user-side text, never staged and never advertised to the model, so
+    /// an embedding that leaves this absent simply has no curated prompts —
+    /// user-authored ones still load from the data directory.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exec_prompts_dir: Option<PathBuf>,
     /// Whether newly spawned background agent runs may execute inside a local
     /// container when the configured runtime is available. Disabled by default,
     /// so existing installations keep the in-process scheduler path.
@@ -108,6 +114,14 @@ impl Config {
         self.data_dir.join("plugins")
     }
 
+    /// The per-install directory user-authored prompt packages are read from
+    /// (`{data_dir}/prompts/<name>/PROMPT.md`), derived the same way as
+    /// [`Config::user_skills_dir`].
+    #[must_use]
+    pub fn user_prompts_dir(&self) -> PathBuf {
+        self.data_dir.join("prompts")
+    }
+
     /// A desktop-profile config rooted at `data_dir`.
     pub fn desktop(data_dir: impl Into<PathBuf>) -> Self {
         Self {
@@ -118,6 +132,7 @@ impl Config {
             exec_scripts_dir: None,
             exec_skills_dir: None,
             exec_plugins_dir: None,
+            exec_prompts_dir: None,
             container_execution_enabled: false,
             container_image: None,
             auth_tokens_file: None,
@@ -188,6 +203,7 @@ impl Config {
             exec_scripts_dir: None,
             exec_skills_dir: None,
             exec_plugins_dir: None,
+            exec_prompts_dir: None,
             container_execution_enabled,
             container_image,
             auth_tokens_file,

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -191,7 +191,9 @@ fn verify_required_plugins(skills_dir: &Path, plugins_dir: &Path) -> Result<(), 
         skills_dir,
         openwave_code_execution::SkillOrigin::Builtin,
     );
-    let plugins = openwave_code_execution::load_plugins(plugins_dir, &skills);
+    // The bundle ships no built-in prompts; a manifest claiming one would be
+    // skipped, which this check would then see as a missing plugin.
+    let plugins = openwave_code_execution::load_plugins(plugins_dir, &skills, &[]);
     let loaded: Vec<&str> = plugins
         .iter()
         .map(|plugin| plugin.package.name.as_str())

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1516,7 +1516,15 @@ plugins: Array<PluginInfo>,
 /**
  * Skills no bundle claims — user-authored packages land here.
  */
-skills: Array<PluginSkillInfo>, };
+skills: Array<PluginSkillInfo>, 
+/**
+ * Every installed prompt, bundled or standalone, in one flat list.
+ *
+ * Flat rather than nested under its bundle because the consumer is a
+ * picker over the whole library; a plugin's members are the entries whose
+ * `plugin` names it.
+ */
+prompts: Array<PluginPromptInfo>, };
 
 /**
  * What kind of work a plugin bundles, from a closed vocabulary.
@@ -1564,6 +1572,37 @@ enabled: boolean,
 skills: Array<PluginSkillInfo>, };
 
 /**
+ * One reusable prompt, as a picker or a management surface renders it.
+ *
+ * Deliberately without a body: the text is fetched from
+ * [`get_prompt_body`] when the user actually picks one, so the catalog stays
+ * bytes per entry no matter how long the prompts are.
+ */
+export type PluginPromptInfo = { 
+/**
+ * The slug the body route addresses it by.
+ */
+name: string, 
+/**
+ * The tip a card or popover shows.
+ */
+description: string, 
+/**
+ * Where the package was loaded from; host-derived, never claimed.
+ */
+origin: PromptOrigin, 
+/**
+ * The bundle that claims this prompt, if any. `None` is a standalone
+ * package — every user-authored prompt is one.
+ */
+plugin: string | null, 
+/**
+ * Whether the prompt is offered. A prompt has no flag of its own: a
+ * bundled one follows its bundle, and a standalone one is always on.
+ */
+enabled: boolean, };
+
+/**
  * One skill, inside a bundle or standing alone.
  */
 export type PluginSkillInfo = { name: string, description: string, 
@@ -1609,6 +1648,28 @@ created_at: string, };
  * Identifies a project: an optional grouping a chat may belong to.
  */
 export type ProjectId = string;
+
+/**
+ * One prompt's insertable text, fetched when the user picks it.
+ *
+ * Its own route for the same reason skill instructions have one: the catalog
+ * is fetched far more often than any one prompt is inserted.
+ */
+export type PromptBody = { name: string, 
+/**
+ * The `PROMPT.md` markdown below the frontmatter — exactly what goes into
+ * the composer. It is never composed into the model's operating prompt;
+ * it reaches a model only if the user sends the message.
+ */
+body: string, };
+
+/**
+ * Which source a validated prompt package was loaded from.
+ *
+ * Host-derived from the load path, never from manifest content, so a user
+ * package cannot claim to be built-in.
+ */
+export type PromptOrigin = "builtin" | "user";
 
 /**
  * Public view of a provider — never includes the credential itself.

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -910,6 +910,13 @@ pub struct ConfiguredCodeExecutionProvider {
     /// staging so an added or edited skill is picked up on the next turn
     /// without a restart. `None` disables user skills entirely.
     user_skills_dir: Option<PathBuf>,
+    /// Built-in reusable prompts validated once at configuration. Unlike
+    /// skills, nothing here reaches the model or a sandbox: a prompt is text
+    /// the user inserts, so this exists only to be listed and fetched.
+    prompts: Arc<Vec<openwave_code_execution::LoadedPrompt>>,
+    /// Per-install directory of user-authored prompt packages, re-read on each
+    /// listing so an added or edited prompt appears without a restart.
+    user_prompts_dir: Option<PathBuf>,
     /// Built-in plugins validated once at configuration against the built-in
     /// skills, grouping them in the prompt catalog. Empty when no plugin tree
     /// is configured, which leaves every skill standalone.
@@ -1115,6 +1122,8 @@ impl ConfiguredCodeExecutionProvider {
             document_scripts_source: None,
             skills: Arc::new(Vec::new()),
             user_skills_dir: None,
+            prompts: Arc::new(Vec::new()),
+            user_prompts_dir: None,
             plugins: Arc::new(Vec::new()),
             folder_grant_resolver: None,
             office_converter: None,
@@ -1184,6 +1193,42 @@ impl ConfiguredCodeExecutionProvider {
         self
     }
 
+    /// Load and install the built-in reusable prompt packages. Call before
+    /// [`Self::with_plugins`]: a bundle's `prompts:` members are resolved
+    /// against the prompts already loaded.
+    #[must_use]
+    pub fn with_prompts(mut self, source: Option<PathBuf>) -> Self {
+        self.prompts = Arc::new(
+            source
+                .as_deref()
+                .map(|source| {
+                    openwave_code_execution::load_prompts(
+                        source,
+                        openwave_code_execution::PromptOrigin::Builtin,
+                    )
+                })
+                .unwrap_or_default(),
+        );
+        self
+    }
+
+    /// Install the per-install directory user-authored prompt packages are
+    /// loaded from. The directory is created here (best effort) so the user
+    /// has a place to drop a prompt; its contents are re-read on each listing.
+    #[must_use]
+    pub fn with_user_prompts(mut self, source: Option<PathBuf>) -> Self {
+        if let Some(source) = source.as_deref() {
+            if let Err(error) = std::fs::create_dir_all(source) {
+                tracing::warn!(
+                    "user prompts directory {} could not be created: {error}",
+                    source.display()
+                );
+            }
+        }
+        self.user_prompts_dir = source;
+        self
+    }
+
     /// Load the built-in plugins that group the built-in skills in the prompt
     /// catalog. Call after [`Self::with_skills`]: membership is resolved
     /// against the skills already loaded, and a plugin naming one that is not
@@ -1193,7 +1238,9 @@ impl ConfiguredCodeExecutionProvider {
         self.plugins = Arc::new(
             source
                 .as_deref()
-                .map(|source| openwave_code_execution::load_plugins(source, &self.skills))
+                .map(|source| {
+                    openwave_code_execution::load_plugins(source, &self.skills, &self.prompts)
+                })
                 .unwrap_or_default(),
         );
         self
@@ -1236,6 +1283,16 @@ impl ConfiguredCodeExecutionProvider {
             .iter()
             .map(|plugin| plugin.package.clone())
             .collect()
+    }
+
+    /// Every installed prompt, before the install's enable flags apply: the
+    /// built-in packages merged with a fresh read of the user prompts
+    /// directory, exactly as [`Self::installed_skills`] does.
+    ///
+    /// There is no filtered counterpart. A prompt is never staged and never
+    /// advertised, so this one listing is the whole consumer surface.
+    pub(crate) fn installed_prompts(&self) -> Vec<openwave_code_execution::LoadedPrompt> {
+        openwave_code_execution::merged_prompts(&self.prompts, self.user_prompts_dir.as_deref())
     }
 
     /// The bundle that claims `skill`, if any.

--- a/crates/openwave-server/src/foreground_prompt.rs
+++ b/crates/openwave-server/src/foreground_prompt.rs
@@ -1050,6 +1050,7 @@ mod tests {
             description: "Bundle.".into(),
             category: openwave_code_execution::PluginCategory::Other,
             skills: members.iter().map(|member| (*member).into()).collect(),
+            prompts: Vec::new(),
             router_preamble: Some(preamble.into()),
         };
         let plugins = vec![

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -336,6 +336,7 @@ pub fn app(state: AppState) -> Router {
             "/plugins/skills/{name}/instructions",
             get(routes::get_skill_instructions),
         )
+        .route("/plugins/prompts/{name}/body", get(routes::get_prompt_body))
         .route(
             "/connected-apps/rest/{id}",
             axum::routing::put(routes::put_rest_connected_app)
@@ -923,8 +924,10 @@ async fn bind_inner(
         .with_blob_write_locks(exec_blob_writes)
         .with_document_scripts(config.exec_scripts_dir.clone())
         .with_skills(config.exec_skills_dir.clone())
+        .with_prompts(config.exec_prompts_dir.clone())
         .with_plugins(config.exec_plugins_dir.clone())
         .with_user_skills(Some(config.user_skills_dir()))
+        .with_user_prompts(Some(config.user_prompts_dir()))
         .with_folder_grant_resolver(folder_grant_resolver)
         .with_office_converter(office_converter)
         .with_host_tool_broker(host_tool_broker),

--- a/crates/openwave-server/src/routes/plugins.rs
+++ b/crates/openwave-server/src/routes/plugins.rs
@@ -1,10 +1,16 @@
-//! `/plugins` — the install-wide plugin and skill management surface.
+//! `/plugins` — the install-wide plugin, skill, and prompt management surface.
 //!
 //! One read route projects everything installed: each bundle with its display
 //! identity, its host-derived capability badges, and its member skills with
 //! their own enable state, plus the skills no bundle claims. A disabled
 //! component is still listed — a management surface that hid it would offer no
 //! way to turn it back on — with `enabled: false` saying so.
+//!
+//! Reusable prompts ride the same read route as a flat list. They are
+//! user-side text with no catalog line and no staged bytes, so there is
+//! nothing to gate per prompt: a bundled one follows its bundle's flag and a
+//! standalone one is always offered. Bodies come from their own route, fetched
+//! when a prompt is actually picked.
 //!
 //! One write route sets flags. It is a merge patch, not a replacement: a body
 //! names only the components it means to change, so two clients toggling
@@ -17,8 +23,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 use openwave_code_execution::{
-    derived_capabilities, is_valid_plugin_name, is_valid_skill_name, PluginCapability,
-    PluginCategory, SkillOrigin, SkillPackage,
+    derived_capabilities, is_valid_plugin_name, is_valid_prompt_name, is_valid_skill_name,
+    PluginCapability, PluginCategory, PromptOrigin, PromptPackage, SkillOrigin, SkillPackage,
 };
 
 use crate::error::ServerError;
@@ -37,6 +43,12 @@ pub struct PluginCatalog {
     pub plugins: Vec<PluginInfo>,
     /// Skills no bundle claims — user-authored packages land here.
     pub skills: Vec<PluginSkillInfo>,
+    /// Every installed prompt, bundled or standalone, in one flat list.
+    ///
+    /// Flat rather than nested under its bundle because the consumer is a
+    /// picker over the whole library; a plugin's members are the entries whose
+    /// `plugin` names it.
+    pub prompts: Vec<PluginPromptInfo>,
 }
 
 /// One bundle, as a management surface renders it.
@@ -69,6 +81,27 @@ pub struct PluginSkillInfo {
     pub enabled: bool,
 }
 
+/// One reusable prompt, as a picker or a management surface renders it.
+///
+/// Deliberately without a body: the text is fetched from
+/// [`get_prompt_body`] when the user actually picks one, so the catalog stays
+/// bytes per entry no matter how long the prompts are.
+#[derive(Debug, Serialize, ts_rs::TS)]
+pub struct PluginPromptInfo {
+    /// The slug the body route addresses it by.
+    pub name: String,
+    /// The tip a card or popover shows.
+    pub description: String,
+    /// Where the package was loaded from; host-derived, never claimed.
+    pub origin: PromptOrigin,
+    /// The bundle that claims this prompt, if any. `None` is a standalone
+    /// package — every user-authored prompt is one.
+    pub plugin: Option<String>,
+    /// Whether the prompt is offered. A prompt has no flag of its own: a
+    /// bundled one follows its bundle, and a standalone one is always on.
+    pub enabled: bool,
+}
+
 /// Body of `PUT /plugins/enabled`. Absent names are left alone.
 #[derive(Debug, Default, Deserialize, ts_rs::TS)]
 pub struct PluginEnableUpdate {
@@ -92,6 +125,7 @@ pub async fn get_plugins(
         return Ok(Json(PluginCatalog {
             plugins: Vec::new(),
             skills: Vec::new(),
+            prompts: Vec::new(),
         }));
     };
     let installed: Vec<SkillPackage> = exec
@@ -103,6 +137,10 @@ pub async fn get_plugins(
 
     let mut claimed: Vec<&str> = Vec::new();
     let mut plugins = Vec::new();
+    // Which bundle claims each prompt, and whether that bundle is on. Built
+    // while walking the bundles so the flat prompt list below can attribute
+    // and gate each entry without a second pass over the manifests.
+    let mut prompt_owners: BTreeMap<String, (String, bool)> = BTreeMap::new();
     for plugin in exec.installed_plugins() {
         let members: Vec<&SkillPackage> = plugin
             .skills
@@ -110,9 +148,13 @@ pub async fn get_plugins(
             .filter_map(|member| by_name(member))
             .collect();
         claimed.extend(members.iter().map(|skill| skill.name.as_str()));
+        let plugin_enabled = flags.plugin_enabled(&plugin.name);
+        for prompt in &plugin.prompts {
+            prompt_owners.insert(prompt.clone(), (plugin.name.clone(), plugin_enabled));
+        }
         plugins.push(PluginInfo {
             capabilities: derived_capabilities(&plugin, &members),
-            enabled: flags.plugin_enabled(&plugin.name),
+            enabled: plugin_enabled,
             skills: members
                 .into_iter()
                 .map(|skill| skill_info(skill, &flags))
@@ -128,7 +170,31 @@ pub async fn get_plugins(
         .filter(|skill| !claimed.contains(&skill.name.as_str()))
         .map(|skill| skill_info(skill, &flags))
         .collect();
-    Ok(Json(PluginCatalog { plugins, skills }))
+    let prompts = exec
+        .installed_prompts()
+        .into_iter()
+        .map(|prompt| prompt_info(&prompt.package, &prompt_owners))
+        .collect();
+    Ok(Json(PluginCatalog {
+        plugins,
+        skills,
+        prompts,
+    }))
+}
+
+fn prompt_info(
+    prompt: &PromptPackage,
+    owners: &BTreeMap<String, (String, bool)>,
+) -> PluginPromptInfo {
+    let owner = owners.get(&prompt.name);
+    PluginPromptInfo {
+        name: prompt.name.clone(),
+        description: prompt.description.clone(),
+        origin: prompt.origin,
+        plugin: owner.map(|(plugin, _)| plugin.clone()),
+        // A standalone prompt has nothing that could switch it off yet.
+        enabled: owner.is_none_or(|(_, enabled)| *enabled),
+    }
 }
 
 fn skill_info(
@@ -190,6 +256,44 @@ fn manifest_body(manifest: &str) -> &str {
         .and_then(|rest| rest.split_once("\n---\n"))
         .map_or(manifest, |(_, body)| body)
         .trim()
+}
+
+/// One prompt's insertable text, fetched when the user picks it.
+///
+/// Its own route for the same reason skill instructions have one: the catalog
+/// is fetched far more often than any one prompt is inserted.
+#[derive(Debug, Serialize, ts_rs::TS)]
+pub struct PromptBody {
+    pub name: String,
+    /// The `PROMPT.md` markdown below the frontmatter — exactly what goes into
+    /// the composer. It is never composed into the model's operating prompt;
+    /// it reaches a model only if the user sends the message.
+    pub body: String,
+}
+
+/// `GET /plugins/prompts/{name}/body`.
+pub async fn get_prompt_body(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Result<Json<PromptBody>, ServerError> {
+    if !is_valid_prompt_name(&name) {
+        return Err(ServerError::bad_request(format!(
+            "not a prompt name: {name:?}"
+        )));
+    }
+    let prompt = state
+        .code_execution
+        .as_ref()
+        .and_then(|exec| {
+            exec.installed_prompts()
+                .into_iter()
+                .find(|prompt| prompt.package.name == name)
+        })
+        .ok_or_else(|| ServerError::not_found(format!("no prompt named {name:?}")))?;
+    Ok(Json(PromptBody {
+        name,
+        body: prompt.body,
+    }))
 }
 
 /// `PUT /plugins/enabled` — set the named flags, returning the fresh catalog.

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -2794,3 +2794,138 @@ async fn the_plugin_catalog_reports_badges_and_persists_toggles() {
     .await;
     assert_eq!(refused.status(), StatusCode::BAD_REQUEST);
 }
+
+/// Contract: reusable prompts reach the client as one flat, attributed list
+/// whose entries a bundle's flag gates, and their bodies come from their own
+/// route. Both halves are wire shape a composer depends on, and the gating is
+/// the only behavior a prompt has — a bundled prompt surviving its bundle
+/// being switched off would be invisible until someone read the catalog JSON.
+#[tokio::test]
+async fn the_catalog_lists_prompts_and_serves_their_bodies() {
+    let (dir, store) = temp_db_store("prompts.db").await;
+    let store: Arc<dyn Store> = Arc::new(store);
+
+    let trees = tempfile::tempdir().unwrap();
+    let write = |kind: &str, name: &str, source: String| {
+        let package = trees.path().join(kind).join(name);
+        std::fs::create_dir_all(&package).unwrap();
+        let manifest = match kind {
+            "skills" => "SKILL.md",
+            "prompts" => "PROMPT.md",
+            _ => "PLUGIN.md",
+        };
+        std::fs::write(package.join(manifest), source).unwrap();
+    };
+    write(
+        "skills",
+        "charts",
+        "---\nname: charts\ndescription: Plots.\n---\nBody.\n".to_owned(),
+    );
+    write(
+        "prompts",
+        "weekly-update",
+        "---\nname: weekly-update\ndescription: Draft this week's update.\n---\n\
+         Cover what shipped, what slipped, and what is next.\n"
+            .to_owned(),
+    );
+    write(
+        "plugins",
+        "reporting",
+        "---\nname: reporting\ndisplay-name: Reporting\ndescription: Status reporting.\n\
+         category: other\nskills: [\"charts\"]\nprompts: [\"weekly-update\"]\n---\n"
+            .to_owned(),
+    );
+    // A user-authored prompt, from the per-install directory rather than the
+    // bundled tree, claimed by no plugin.
+    std::fs::create_dir_all(dir.path().join("prompts/standup")).unwrap();
+    std::fs::write(
+        dir.path().join("prompts/standup/PROMPT.md"),
+        "---\nname: standup\ndescription: My standup format.\n---\nYesterday, today, blockers.\n",
+    )
+    .unwrap();
+
+    let secrets = Arc::new(MemSecrets::default());
+    let mut state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        secrets.clone(),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    state.code_execution = Some(Arc::new(
+        crate::code_execution::ConfiguredCodeExecutionProvider::new(
+            store,
+            secrets,
+            dir.path().join("scratch"),
+        )
+        .with_skills(Some(trees.path().join("skills")))
+        .with_prompts(Some(trees.path().join("prompts")))
+        .with_plugins(Some(trees.path().join("plugins")))
+        .with_user_prompts(Some(dir.path().join("prompts"))),
+    ));
+    let token = state.token.clone();
+    let router = app(state);
+    let bearer = format!("Bearer {token}");
+
+    let prompt = |catalog: &serde_json::Value, name: &str| {
+        catalog["prompts"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|prompt| prompt["name"] == name)
+            .unwrap_or_else(|| panic!("{name} is listed"))
+            .clone()
+    };
+    let catalog = get_plugins(&router, &bearer).await;
+    let bundled = prompt(&catalog, "weekly-update");
+    assert_eq!(bundled["plugin"], "reporting");
+    assert_eq!(bundled["origin"], "builtin");
+    assert_eq!(bundled["enabled"], true);
+    let standalone = prompt(&catalog, "standup");
+    assert_eq!(standalone["plugin"], serde_json::Value::Null);
+    assert_eq!(standalone["origin"], "user");
+    assert_eq!(standalone["enabled"], true);
+
+    // The bundle's flag is the only thing that gates a prompt.
+    let response = put_plugins_enabled(
+        &router,
+        &bearer,
+        serde_json::json!({"plugins": {"reporting": false}}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let catalog: serde_json::Value = json_body(response).await;
+    assert_eq!(prompt(&catalog, "weekly-update")["enabled"], false);
+    assert_eq!(prompt(&catalog, "standup")["enabled"], true);
+
+    let body = |name: &str| {
+        let router = router.clone();
+        let bearer = bearer.clone();
+        let uri = format!("/plugins/prompts/{name}/body");
+        async move {
+            router
+                .oneshot(
+                    Request::builder()
+                        .uri(uri)
+                        .header(header::AUTHORIZATION, bearer)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+        }
+    };
+    let response = body("standup").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let fetched: serde_json::Value = json_body(response).await;
+    assert_eq!(fetched["body"], "Yesterday, today, blockers.");
+    assert_eq!(body("does-not-exist").await.status(), StatusCode::NOT_FOUND);
+    assert_eq!(
+        body("Not%20A%20Slug").await.status(),
+        StatusCode::BAD_REQUEST
+    );
+}

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -367,6 +367,8 @@ mod tests {
         // Its own endpoint root: a skill's instruction body is fetched on
         // demand rather than carried in the catalog.
         generate::collect_from::<crate::routes::SkillInstructions>(&cfg, &mut out);
+        // Likewise for a reusable prompt's insertable text.
+        generate::collect_from::<crate::routes::PromptBody>(&cfg, &mut out);
         // The Connected apps settings listing: per-kind health/catalog
         // projections and credential *status* — never definitions or values.
         generate::collect_from::<crate::routes::ConnectedAppsInfo>(&cfg, &mut out);


### PR DESCRIPTION
Part of #772 / #1570.

Adds reusable prompts: a saved starting message — name, one-line tip, markdown
body — that a surface drops into the composer. This slice is the capability
only; the composer popover and home cards are separate slices, and nothing but
regenerated wire types touches the desktop UI.

A prompt is deliberately far narrower than a skill. It is user-side content: it
never enters the operating prompt, is never staged into an exec workspace, and
has no catalog line. It is inert text that reaches a model only if the user
sends the message. So the parser bounds what a management surface needs to be
honest — a slug for addressing, a bounded printable description for the card,
a bounded body so a stray file cannot become a multi-megabyte fetch — and
nothing more.

**`PROMPT.md`** (`openwave-code-execution/src/prompts.rs`) follows `skills.rs`
package for package: strict hand-rolled frontmatter with `name` and
`description` required, a non-empty body below the fences, directory name must
agree with the manifest, skip-with-warning per package, and the same
origin-split on unknown keys — rejected in a built-in we ship, ignored with a
warning in a user-authored one.

**Plugin membership.** `PLUGIN.md` gains an optional `prompts:` list alongside
`skills:`, same single-line flow form, same closed key set. Either list may be
omitted but a bundle claiming neither is now rejected, which makes a
prompts-only bundle a legitimate shape. Members resolve against the prompts
that actually loaded and one prompt belongs to at most one bundle, exactly as
skills do; `load_plugins` therefore takes the loaded prompts as a third
argument. Capability badges are unchanged — inert text derives nothing, and the
closed key set still means a manifest cannot state a badge.

**Sources.** Built-ins come from a new `exec_prompts_dir`, user-authored ones
from `{data_dir}/prompts/<name>/PROMPT.md`, merged by `merged_prompts` with the
built-in winning a name collision. No built-in prompts ship in this change: the
bundled plugins keep skills-only manifests, and the desktop leaves
`exec_prompts_dir` unset.

**Wire surface.** `GET /plugins` gains a flat `prompts` list — name,
description, host-derived origin, the bundle that claims it (or `null`), and
whether it is offered. Flat rather than nested because the consumer is a picker
over the whole library; a bundle's members are the entries naming it. There is
no per-prompt toggle in this slice: a bundled prompt follows its bundle's flag
and a standalone one is always on. `GET /plugins/prompts/{name}/body` serves
the text on demand, mirroring the skill-instructions route so the catalog stays
bytes per entry. Generated TypeScript regenerated with
`UPDATE_WIRE_TYPES=1 cargo test -p openwave-server`.

Tests, three added and one widened:

- `prompts::manifests_parse_into_an_entry_and_a_body_or_are_rejected` — the
  parse contract, including the origin split on unknown keys, since a tolerant
  built-in parser would let a shipped typo through silently.
- `prompts::user_prompts_merge_after_builtins_without_shadowing` — the
  shadowing rule and origin attribution; a local file quietly replacing a
  curated prompt is exactly the failure this prevents.
- `plugins::loader_rejects_dangling_members_and_double_claims` widened to cover
  prompt members on both rules, rather than adding a parallel test.
- `the_catalog_lists_prompts_and_serves_their_bodies` — the catalog wire shape
  and the body route end to end. Gating is the only behavior a prompt has, so a
  bundled prompt surviving its bundle being switched off would otherwise be
  visible only to someone reading the catalog JSON.

Verified with `cargo check --workspace --locked` (no lockfile change), the full
`openwave-code-execution`, `openwave-server`, `openwave-core`, and
`openwave-desktop` suites, and clippy on the touched crates. Not verified by
driving the running app — there is no UI for prompts yet.
