### PR TITLE
feat(desktop): pinned outputs summary in the chat view

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -62,6 +62,7 @@ import {
   PICKER_HOLDERS,
   useNativePickerLatch,
 } from "./NativePickerLatch";
+import { PinnedOutputsStrip } from "./PinnedOutputsStrip";
 import { PanelFrame } from "./panel/PanelFrame";
 import { PanelLayout } from "./panel/PanelLayout";
 import type { PanelContent } from "./panel/panelTypes";
@@ -745,6 +746,13 @@ export function ChatRoute({ chatId }: { chatId: string }) {
           onOpenAgents={() => openPanel({ type: "agents" })}
         />
       </header>
+      <PinnedOutputsStrip
+        chatId={chatId}
+        outputs={deliverables}
+        panelOpen={layout.tabs.length > 0}
+        onOpenOutput={(outputId) => openPanel({ type: "outputs", outputId })}
+        onOpenOutputs={() => openPanel({ type: "outputs" })}
+      />
       {/* Citations live in the transcript but open into the panel beside it,
           so the way there is provided above both slots. */}
       <SourceNavProvider value={sourceNav}>

--- a/crates/openwave-desktop/ui/src/PinnedOutputsStrip.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/PinnedOutputsStrip.dom.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+import type { DeliverableSummary } from "./deliverables";
+import { PinnedOutputsStrip, useOutputsStripStore } from "./PinnedOutputsStrip";
+
+function output(outputId: string, filename: string, updatedAt: string): DeliverableSummary {
+  return {
+    outputId,
+    filename,
+    mediaType: "text/markdown",
+    sizeBytes: 12,
+    revisionCount: 1,
+    updatedAt,
+    producingRunId: null,
+  };
+}
+
+const outputs = [
+  output("out-1", "plan.md", "2026-08-01T10:00:00Z"),
+  output("out-2", "summary.md", "2026-08-02T10:00:00Z"),
+];
+
+function renderStrip({ panelOpen = false } = {}) {
+  const onOpenOutput = vi.fn();
+  const onOpenOutputs = vi.fn();
+  render(
+    <PinnedOutputsStrip
+      chatId="chat-1"
+      outputs={outputs}
+      panelOpen={panelOpen}
+      onOpenOutput={onOpenOutput}
+      onOpenOutputs={onOpenOutputs}
+    />,
+  );
+  return { onOpenOutput, onOpenOutputs };
+}
+
+beforeEach(() => {
+  window.sessionStorage.clear();
+  useOutputsStripStore.setState({ collapsed: {} });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+it("names the outputs by default and opens the one clicked", async () => {
+  const { onOpenOutput } = renderStrip();
+
+  // Newest first — the file the last turn wrote is the one being looked for.
+  const chips = screen.getAllByRole("button", { name: /^Open output/ });
+  expect(chips.map((chip) => chip.textContent)).toEqual(["summary.md", "plan.md"]);
+
+  await userEvent.click(chips[1]!);
+  expect(onOpenOutput).toHaveBeenCalledWith("out-1");
+});
+
+/** The panel supersedes the strip: two copies of the outputs is just chrome. */
+it("stays out of the way while a panel is open", () => {
+  renderStrip({ panelOpen: true });
+  expect(screen.queryByRole("region", { name: "Outputs" })).toBeNull();
+});
+
+it("remembers being collapsed across a remount of the chat route", async () => {
+  const first = renderStrip();
+  await userEvent.click(screen.getByRole("button", { name: "Hide outputs" }));
+  expect(screen.queryByRole("button", { name: /^Open output/ })).toBeNull();
+  expect(first.onOpenOutputs).not.toHaveBeenCalled();
+
+  cleanup();
+  renderStrip();
+  expect(screen.queryByRole("button", { name: /^Open output/ })).toBeNull();
+  expect(screen.getByRole("button", { name: "Show outputs" })).toBeTruthy();
+});

--- a/crates/openwave-desktop/ui/src/PinnedOutputsStrip.tsx
+++ b/crates/openwave-desktop/ui/src/PinnedOutputsStrip.tsx
@@ -1,0 +1,183 @@
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { create } from "zustand";
+
+import type { DeliverableSummary } from "./deliverables";
+import { documentIcon } from "./documentIcon";
+import { cn } from "@/lib/utils";
+
+/** Past this many the rest collapse into a count rather than wrapping on. */
+const MAX_VISIBLE_OUTPUTS = 4;
+
+const COLLAPSED_PREFIX = "outputs_strip_collapsed_";
+
+function readStoredCollapsed(): Record<string, boolean> {
+  const collapsed: Record<string, boolean> = {};
+  try {
+    const storage = window.sessionStorage;
+    for (let index = 0; index < storage.length; index += 1) {
+      const name = storage.key(index);
+      if (!name?.startsWith(COLLAPSED_PREFIX)) continue;
+      if (storage.getItem(name) === "true") {
+        collapsed[name.slice(COLLAPSED_PREFIX.length)] = true;
+      }
+    }
+  } catch {
+    // A strip with no memory still works; an unreadable store is not fatal.
+  }
+  return collapsed;
+}
+
+function writeStoredCollapsed(chatId: string, collapsed: boolean): void {
+  try {
+    if (collapsed) {
+      window.sessionStorage.setItem(`${COLLAPSED_PREFIX}${chatId}`, "true");
+    } else {
+      window.sessionStorage.removeItem(`${COLLAPSED_PREFIX}${chatId}`);
+    }
+  } catch {
+    // Persisting the preference is best-effort.
+  }
+}
+
+/**
+ * Which conversations the reader has folded the strip away in.
+ *
+ * The chat route is remounted per conversation, so this cannot live in the
+ * component: folding the strip away and glancing at another chat would unfold
+ * it again on the way back. Session storage rather than local — collapsing is a
+ * "not now", not a setting, and a fresh launch should show the outputs again.
+ */
+type OutputsStripStore = {
+  collapsed: Record<string, boolean>;
+  setCollapsed: (chatId: string, collapsed: boolean) => void;
+};
+
+export function createOutputsStripStore() {
+  return create<OutputsStripStore>()((set) => ({
+    collapsed: readStoredCollapsed(),
+    setCollapsed: (chatId, collapsed) => {
+      writeStoredCollapsed(chatId, collapsed);
+      set((state) => {
+        const next = { ...state.collapsed };
+        if (collapsed) next[chatId] = true;
+        else delete next[chatId];
+        return { collapsed: next };
+      });
+    },
+  }));
+}
+
+export const useOutputsStripStore = createOutputsStripStore();
+
+export type PinnedOutputsStripProps = {
+  chatId: string;
+  outputs: readonly DeliverableSummary[];
+  /** True while a panel is open beside the conversation. */
+  panelOpen: boolean;
+  /** Open one output in the panel region. */
+  onOpenOutput: (outputId: string) => void;
+  /** Bring the whole outputs list forward. */
+  onOpenOutputs: () => void;
+};
+
+/**
+ * What this conversation has produced, pinned above the transcript.
+ *
+ * The header chip counts outputs but is easy to read past, and the files are
+ * the point of most conversations that make any — so they get named where the
+ * reader is already looking, from the first one onwards.
+ *
+ * It yields to the panel region: once a panel is open the outputs are either
+ * already on screen or one tab away, and a second copy of them above the
+ * transcript is just chrome. Collapsing is the reader's own call and outlives
+ * the panel, so it is remembered per conversation.
+ */
+export function PinnedOutputsStrip({
+  chatId,
+  outputs,
+  panelOpen,
+  onOpenOutput,
+  onOpenOutputs,
+}: PinnedOutputsStripProps) {
+  const collapsed = useOutputsStripStore((state) => state.collapsed[chatId] ?? false);
+  const setCollapsed = useOutputsStripStore((state) => state.setCollapsed);
+
+  if (panelOpen || outputs.length === 0) return null;
+
+  // Newest first: the file the last turn wrote is the one being looked for.
+  const ordered = [...outputs].sort(
+    (a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt),
+  );
+  const visible = ordered.slice(0, MAX_VISIBLE_OUTPUTS);
+  const hidden = ordered.length - visible.length;
+  const label = outputs.length === 1 ? "1 output" : `${outputs.length} outputs`;
+
+  return (
+    <section
+      className="mt-1 flex shrink-0 flex-wrap items-center gap-x-2 gap-y-1 px-4 py-1"
+      aria-label="Outputs"
+    >
+      <button
+        type="button"
+        className="cursor-pointer text-xs text-muted-foreground transition-colors hover:text-foreground"
+        onClick={onOpenOutputs}
+      >
+        {label}
+      </button>
+      {!collapsed &&
+        visible.map((output) => (
+          <OutputChip
+            key={output.outputId}
+            output={output}
+            onOpen={() => onOpenOutput(output.outputId)}
+          />
+        ))}
+      {!collapsed && hidden > 0 && (
+        <button
+          type="button"
+          className="cursor-pointer text-xs text-muted-foreground transition-colors hover:text-foreground"
+          onClick={onOpenOutputs}
+        >
+          {`+${hidden} more`}
+        </button>
+      )}
+      <button
+        type="button"
+        className="ml-auto inline-flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+        aria-label={collapsed ? "Show outputs" : "Hide outputs"}
+        aria-expanded={!collapsed}
+        onClick={() => setCollapsed(chatId, !collapsed)}
+      >
+        {collapsed ? (
+          <ChevronDown className="size-3.5" aria-hidden="true" />
+        ) : (
+          <ChevronUp className="size-3.5" aria-hidden="true" />
+        )}
+      </button>
+    </section>
+  );
+}
+
+function OutputChip({
+  output,
+  onOpen,
+}: {
+  output: DeliverableSummary;
+  onOpen: () => void;
+}) {
+  const Icon = documentIcon(output.mediaType);
+  return (
+    <button
+      type="button"
+      className={cn(
+        "bg-background inline-flex max-w-56 min-w-0 cursor-pointer items-center gap-1.5",
+        "rounded-md border px-2 py-0.5 text-xs transition-colors hover:bg-accent",
+      )}
+      onClick={onOpen}
+      aria-label={`Open output ${output.filename}`}
+    >
+      <Icon className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+      <span className="min-w-0 truncate">{output.filename}</span>
+    </button>
+  );
+}


### PR DESCRIPTION
The chat header counts a conversation's outputs in the status chip, but the pill
reads as chrome and people miss it — and the files a chat produced are often the
point of it.

This pins a summary of them above the transcript instead, shown by default as
soon as the chat has an output: the count, then one chip per output with its
filename and doc-type icon, newest first. A chip opens that output in the panel
region; the count and the `+N more` overflow open the outputs list. Four chips
are shown before the rest fold into the overflow, so the strip stays one line.

The strip yields to the panel region — while any panel is open the outputs are
either already on screen or one tab away, and a second copy above the transcript
is noise. Collapsing it is the reader's own call and outlives the panel, so it
folds to just the count and is remembered per conversation in session storage.
The chat route is remounted per conversation, so component state would unfold it
again on the way back to a chat; a fresh launch does show it again, since
collapsing reads as "not now" rather than a setting.

`ChatStatusChip` is unchanged.

Tests: three behavior tests on the strip — that it names the outputs newest-first
and opens the one clicked, that it renders nothing while a panel is open, and
that a collapse survives a remount of the route.

Verified locally: `tsc --noEmit`, the full `vitest` suite (113 files, 752 tests),
and `pnpm build`. Not driven in the running app.
