### PR TITLE
feat(server): let a turn explicitly invoke skills by name

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -13119,6 +13119,7 @@ mod image_hydration_tests {
                 "what is in this screenshot?",
                 &[image],
                 &[],
+                &[],
             )
             .await
             .unwrap();
@@ -13155,7 +13156,15 @@ mod image_hydration_tests {
         let pixels = b"pixels".to_vec();
         let image = image_ref(uuid::Uuid::from_u128(9), &pixels);
         store
-            .accept_turn_with_attachments(TurnId::new(), chat.id, "fake", "look", &[image], &[])
+            .accept_turn_with_attachments(
+                TurnId::new(),
+                chat.id,
+                "fake",
+                "look",
+                &[image],
+                &[],
+                &[],
+            )
             .await
             .unwrap();
 
@@ -13192,6 +13201,7 @@ mod image_hydration_tests {
                     "fake",
                     &format!("image {index}"),
                     &[image_ref(blob_id, &pixels)],
+                    &[],
                     &[],
                 )
                 .await

--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -920,6 +920,8 @@ pub mod turn_run {
         pub input_message_id: Uuid,
         pub output_message_id: Option<Uuid>,
         pub model: String,
+        #[sea_orm(column_type = "JsonBinary")]
+        pub invoked_skills: Json,
         pub status: String,
         pub attempt_count: i32,
         pub max_attempts: i32,

--- a/crates/openwave-core/src/db/migration/baseline/turn.rs
+++ b/crates/openwave-core/src/db/migration/baseline/turn.rs
@@ -223,6 +223,14 @@ pub(super) fn turn_run_table() -> TableCreateStatement {
                 .string_len(crate::model::TurnRun::MAX_MODEL_LEN as u32)
                 .not_null(),
         )
+        // The skills the user named for this turn, as a JSON array of slugs.
+        // Empty is the common case and the default, so an accepted turn always
+        // has an honest value rather than a null standing in for "none".
+        .col(
+            ColumnDef::new(TurnRun::InvokedSkills)
+                .json_binary()
+                .not_null(),
+        )
         .col(
             ColumnDef::new(TurnRun::Status)
                 .string_len(32)

--- a/crates/openwave-core/src/db/migration/idens.rs
+++ b/crates/openwave-core/src/db/migration/idens.rs
@@ -538,6 +538,7 @@ pub(crate) enum TurnRun {
     InputMessageId,
     OutputMessageId,
     Model,
+    InvokedSkills,
     Status,
     AttemptCount,
     MaxAttempts,

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -1357,7 +1357,7 @@ impl Store for DbStore {
         model: &str,
         content: &str,
     ) -> Result<AcceptTurnOutcome> {
-        ops::turn::accept_turn(self, id, chat_id, model, content, &[], &[]).await
+        ops::turn::accept_turn(self, id, chat_id, model, content, &[], &[], &[]).await
     }
 
     async fn accept_turn_with_attachments(
@@ -1368,8 +1368,19 @@ impl Store for DbStore {
         content: &str,
         images: &[ImageRef],
         documents: &[DocumentId],
+        invoked_skills: &[String],
     ) -> Result<AcceptTurnOutcome> {
-        ops::turn::accept_turn(self, id, chat_id, model, content, images, documents).await
+        ops::turn::accept_turn(
+            self,
+            id,
+            chat_id,
+            model,
+            content,
+            images,
+            documents,
+            invoked_skills,
+        )
+        .await
     }
 
     async fn claim_turn_run(

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -824,6 +824,7 @@ where
             }
             _ => continue,
         };
+        let invoked_skills = super::turn::invoked_skills_from_model(&turn)?;
         index_of.insert(turn.id, snapshots.len());
         snapshots.push(ChatTerminalTurnSnapshot {
             turn_id: TurnId(turn.id),
@@ -834,6 +835,7 @@ where
             refusal: None,
             failure_kind: turn.last_error_code,
             model: turn.model,
+            invoked_skills,
             finished_at,
         });
     }

--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -104,6 +104,7 @@ pub(in crate::db) async fn recover_exact_terminal_event(
     }))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(in crate::db) async fn accept_turn(
     store: &DbStore,
     id: TurnId,
@@ -112,8 +113,9 @@ pub(in crate::db) async fn accept_turn(
     content: &str,
     images: &[ImageRef],
     documents: &[DocumentId],
+    invoked_skills: &[String],
 ) -> Result<AcceptTurnOutcome> {
-    validate_turn_input(id, model, content)?;
+    validate_turn_input(id, model, content, invoked_skills)?;
     message_attachment_ops::validate(images)?;
     message_document_attachment_ops::validate_count(images.len(), documents)?;
 
@@ -139,6 +141,7 @@ pub(in crate::db) async fn accept_turn(
             content,
             images,
             documents,
+            invoked_skills,
         )
         .await?;
         transaction.commit().await.map_err(store_err)?;
@@ -221,6 +224,7 @@ pub(in crate::db) async fn accept_turn(
         input_message_id: Set(input_message_id.0),
         output_message_id: Set(None),
         model: Set(model.into()),
+        invoked_skills: Set(serde_json::json!(invoked_skills)),
         status: Set(TurnRunStatus::Queued.as_str().into()),
         attempt_count: Set(0),
         max_attempts: Set(TurnRun::DEFAULT_MAX_ATTEMPTS),
@@ -260,6 +264,7 @@ pub(in crate::db) async fn accept_turn(
                     content,
                     images,
                     documents,
+                    invoked_skills,
                 )
                 .await;
             }
@@ -946,7 +951,12 @@ fn turn_run_due_order(
         .then_with(|| left.id.cmp(&right.id))
 }
 
-fn validate_turn_input(id: TurnId, model: &str, content: &str) -> Result<()> {
+fn validate_turn_input(
+    id: TurnId,
+    model: &str,
+    content: &str,
+    invoked_skills: &[String],
+) -> Result<()> {
     if id.0.is_nil() {
         return Err(AgentError::Store("turn id must not be nil".into()));
     }
@@ -963,6 +973,22 @@ fn validate_turn_input(id: TurnId, model: &str, content: &str) -> Result<()> {
         return Err(AgentError::Store(
             "turn content must be non-empty and contain no NUL characters".into(),
         ));
+    }
+    if invoked_skills.len() > TurnRun::MAX_INVOKED_SKILLS {
+        return Err(AgentError::Store(format!(
+            "a turn may invoke at most {} skills",
+            TurnRun::MAX_INVOKED_SKILLS
+        )));
+    }
+    if invoked_skills.iter().any(|skill| {
+        skill.trim().is_empty()
+            || skill.len() > TurnRun::MAX_INVOKED_SKILL_NAME_LEN
+            || skill.chars().any(char::is_control)
+    }) {
+        return Err(AgentError::Store(format!(
+            "an invoked skill name must be 1 to {} characters with no control characters",
+            TurnRun::MAX_INVOKED_SKILL_NAME_LEN
+        )));
     }
     Ok(())
 }
@@ -1001,6 +1027,7 @@ async fn exact_accepted_turn_on<C>(
     content: &str,
     images: &[ImageRef],
     documents: &[DocumentId],
+    invoked_skills: &[String],
 ) -> Result<AcceptTurnOutcome>
 where
     C: ConnectionTrait,
@@ -1039,7 +1066,8 @@ where
         && existing.model == model
         && message.content == content
         && accepted_images == images
-        && accepted_documents == documents;
+        && accepted_documents == documents
+        && invoked_skills_from_model(&existing)? == invoked_skills;
     Ok(if exact {
         AcceptTurnOutcome::Existing(turn_run_from_model(existing)?)
     } else {
@@ -1049,6 +1077,7 @@ where
 
 pub(in crate::db) fn turn_run_from_model(model: entities::turn_run::Model) -> Result<TurnRun> {
     let usage = usage_from_turn_model(&model)?;
+    let invoked_skills = invoked_skills_from_model(&model)?;
     Ok(TurnRun {
         id: TurnId(model.id),
         chat_id: ChatId(model.chat_id),
@@ -1056,6 +1085,7 @@ pub(in crate::db) fn turn_run_from_model(model: entities::turn_run::Model) -> Re
         input_message_id: MessageId(model.input_message_id),
         output_message_id: model.output_message_id.map(MessageId),
         model: model.model,
+        invoked_skills,
         status: turn_run_status_from_db(&model.status)?,
         attempt_count: model.attempt_count,
         max_attempts: model.max_attempts,
@@ -1073,6 +1103,22 @@ pub(in crate::db) fn turn_run_from_model(model: entities::turn_run::Model) -> Re
         last_steer_applied_at: model.last_steer_applied_at,
         created_at: model.created_at,
         updated_at: model.updated_at,
+    })
+}
+
+/// Read back the skills the user invoked when the turn was accepted.
+///
+/// A row whose value is not an array of strings is corrupt rather than merely
+/// unusual: the turn's accepted input can no longer be described honestly, so
+/// this fails instead of degrading to "no skills were invoked".
+pub(in crate::db) fn invoked_skills_from_model(
+    model: &entities::turn_run::Model,
+) -> Result<Vec<String>> {
+    serde_json::from_value(model.invoked_skills.clone()).map_err(|error| {
+        AgentError::Store(format!(
+            "turn {} has unreadable invoked skills: {error}",
+            TurnId(model.id)
+        ))
     })
 }
 

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -2175,6 +2175,7 @@ async fn make_queued_turn(
         input_message_id: Set(input_message_id.0),
         output_message_id: Set(None),
         model: Set(model.into()),
+        invoked_skills: Set(serde_json::json!([])),
         status: Set(TurnRunStatus::Queued.as_str().into()),
         attempt_count: Set(0),
         max_attempts: Set(crate::model::TurnRun::DEFAULT_MAX_ATTEMPTS),
@@ -6167,6 +6168,7 @@ async fn running_turn_cancellation_holds_the_chat_until_exact_worker_acknowledge
             refusal: None,
             failure_kind: None,
             model: "gpt-5".into(),
+            invoked_skills: Vec::new(),
             finished_at: acknowledged_at,
         }]
     );

--- a/crates/openwave-core/src/db/tests/message_attachment.rs
+++ b/crates/openwave-core/src/db/tests/message_attachment.rs
@@ -22,7 +22,7 @@ async fn accept_turn_with_images(
     images: &[ImageRef],
 ) -> TurnRun {
     match store
-        .accept_turn_with_attachments(TurnId::new(), chat_id, "gpt-5", content, images, &[])
+        .accept_turn_with_attachments(TurnId::new(), chat_id, "gpt-5", content, images, &[], &[])
         .await
         .unwrap()
     {
@@ -119,7 +119,15 @@ async fn file_attachments_persist_with_the_message_and_join_its_idempotency_proo
     let turn_id = TurnId::new();
     let documents = [first.id, second.id];
     let accepted = store
-        .accept_turn_with_attachments(turn_id, chat.id, "gpt-5", "compare these", &[], &documents)
+        .accept_turn_with_attachments(
+            turn_id,
+            chat.id,
+            "gpt-5",
+            "compare these",
+            &[],
+            &documents,
+            &[],
+        )
         .await
         .unwrap();
     assert!(matches!(accepted, AcceptTurnOutcome::Accepted(_)));
@@ -165,6 +173,7 @@ async fn file_attachments_persist_with_the_message_and_join_its_idempotency_proo
                 "compare these",
                 &[],
                 &documents,
+                &[],
             )
             .await
             .unwrap(),
@@ -179,6 +188,7 @@ async fn file_attachments_persist_with_the_message_and_join_its_idempotency_proo
                 "compare these",
                 &[],
                 &[second.id, first.id],
+                &[],
             )
             .await
             .unwrap(),
@@ -196,7 +206,7 @@ async fn attachments_join_the_turn_idempotency_proof() {
     let other = image_for(b"a different attachment", 640, 480);
 
     let accepted = match store
-        .accept_turn_with_attachments(turn_id, chat.id, "gpt-5", "describe", &[image], &[])
+        .accept_turn_with_attachments(turn_id, chat.id, "gpt-5", "describe", &[image], &[], &[])
         .await
         .unwrap()
     {
@@ -207,7 +217,7 @@ async fn attachments_join_the_turn_idempotency_proof() {
     // A byte-identical retry re-references the same blob instead of recording
     // the attachment twice.
     let existing = match store
-        .accept_turn_with_attachments(turn_id, chat.id, "gpt-5", "describe", &[image], &[])
+        .accept_turn_with_attachments(turn_id, chat.id, "gpt-5", "describe", &[image], &[], &[])
         .await
         .unwrap()
     {
@@ -224,7 +234,7 @@ async fn attachments_join_the_turn_idempotency_proof() {
     // acceptance of the first submission's attachments.
     assert!(matches!(
         store
-            .accept_turn_with_attachments(turn_id, chat.id, "gpt-5", "describe", &[other], &[])
+            .accept_turn_with_attachments(turn_id, chat.id, "gpt-5", "describe", &[other], &[], &[])
             .await
             .unwrap(),
         AcceptTurnOutcome::IdentityConflict
@@ -237,6 +247,7 @@ async fn attachments_join_the_turn_idempotency_proof() {
                 "gpt-5",
                 "describe",
                 &[image, other],
+                &[],
                 &[],
             )
             .await
@@ -265,7 +276,15 @@ async fn attachment_bounds_are_rejected_before_any_row_is_written() {
         .map(|index| image_for(format!("attachment {index}").as_bytes(), 16, 16))
         .collect();
     assert!(store
-        .accept_turn_with_attachments(TurnId::new(), chat.id, "gpt-5", "too many", &oversized, &[],)
+        .accept_turn_with_attachments(
+            TurnId::new(),
+            chat.id,
+            "gpt-5",
+            "too many",
+            &oversized,
+            &[],
+            &[]
+        )
         .await
         .is_err());
 
@@ -280,6 +299,7 @@ async fn attachment_bounds_are_rejected_before_any_row_is_written() {
             "gpt-5",
             "degenerate",
             &[degenerate],
+            &[],
             &[],
         )
         .await
@@ -296,6 +316,7 @@ async fn attachment_bounds_are_rejected_before_any_row_is_written() {
             "gpt-5",
             "nil blob",
             &[nil_blob],
+            &[],
             &[],
         )
         .await

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1926,6 +1926,14 @@ pub struct TurnRun {
     pub output_message_id: Option<MessageId>,
     /// Model selected when the turn was accepted.
     pub model: String,
+    /// Skills the user explicitly invoked for this turn, in submitted order.
+    ///
+    /// Empty for an ordinary turn, where the model routes on the prompt's skill
+    /// catalog by itself. A non-empty list is a user instruction captured with
+    /// the turn, exactly like the model selection above, so a reloaded
+    /// transcript still shows what the turn was told to use.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub invoked_skills: Vec<String>,
     /// Durable delivery state.
     pub status: TurnRunStatus,
     /// Failure attempts already started. Client-execution resumptions stay
@@ -1976,6 +1984,15 @@ impl TurnRun {
     pub const DEFAULT_MAX_ATTEMPTS: i32 = 5;
     /// Maximum persisted model identifier length.
     pub const MAX_MODEL_LEN: usize = 512;
+    /// Maximum skills one turn may explicitly invoke.
+    ///
+    /// A bound, not a product limit: a user picks a couple of skills for a
+    /// turn, and this keeps one accepted turn's persisted instruction finite.
+    pub const MAX_INVOKED_SKILLS: usize = 8;
+    /// Maximum persisted invoked skill name length. Matches the skill parser's
+    /// own name bound, so a name that could never name a staged skill is
+    /// refused before it reaches storage.
+    pub const MAX_INVOKED_SKILL_NAME_LEN: usize = 64;
     /// Maximum persisted machine-readable error code length.
     pub const MAX_ERROR_CODE_LEN: usize = 128;
     /// Maximum persisted diagnostic detail length.

--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -102,17 +102,13 @@ impl AgentActivityDetail {
     #[must_use]
     pub fn build(tool_name: &str, arguments: &Value) -> Option<Self> {
         match ToolActionPreview::build(tool_name, arguments) {
-            Some(ToolActionPreview::Exec { command, args, .. }) => {
-                return Some(Self::Exec {
-                    command,
-                    args,
-                    exit_code: None,
-                    output: None,
-                });
-            }
-            Some(ToolActionPreview::WebSearch { query, .. }) => {
-                return Some(Self::Search { query });
-            }
+            Some(ToolActionPreview::Exec { command, args, .. }) => Some(Self::Exec {
+                command,
+                args,
+                exit_code: None,
+                output: None,
+            }),
+            Some(ToolActionPreview::WebSearch { query, .. }) => Some(Self::Search { query }),
             _ => None,
         }
     }

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -117,6 +117,9 @@ pub struct ChatTerminalTurnSnapshot {
     pub failure_kind: Option<String>,
     /// Provider-qualified model selection captured when the turn was accepted.
     pub model: String,
+    /// Skills the user explicitly invoked when the turn was accepted, in
+    /// submitted order. Empty for a turn that named none.
+    pub invoked_skills: Vec<String>,
     pub finished_at: chrono::DateTime<chrono::Utc>,
 }
 
@@ -2585,7 +2588,7 @@ pub trait Store: Send + Sync {
         model: &str,
         content: &str,
     ) -> Result<AcceptTurnOutcome> {
-        self.accept_turn_with_attachments(id, chat_id, model, content, &[], &[])
+        self.accept_turn_with_attachments(id, chat_id, model, content, &[], &[], &[])
             .await
     }
 
@@ -2598,10 +2601,18 @@ pub trait Store: Send + Sync {
     /// recorded at its position in its media-specific list, which is the order
     /// a reloaded transcript replays it in.
     ///
+    /// `invoked_skills` names the skills the user explicitly asked this turn to
+    /// use. It is accepted input like the model and the attachments, so it is
+    /// part of the same idempotency proof: a retry naming different skills is a
+    /// conflict rather than a silent acceptance of the first submission's list.
+    /// Whether each name is a live skill is the caller's decision; storage only
+    /// bounds the list and the shape of each name.
+    ///
     /// Recording an attachment makes its blob live: any queued retirement for
     /// that blob is cancelled in the same transaction. Because blob ids are
     /// content-derived, re-submitting identical bytes re-references the existing
     /// blob rather than storing a second copy.
+    #[allow(clippy::too_many_arguments)]
     async fn accept_turn_with_attachments(
         &self,
         _id: TurnId,
@@ -2610,6 +2621,7 @@ pub trait Store: Send + Sync {
         _content: &str,
         _images: &[ImageRef],
         _documents: &[DocumentId],
+        _invoked_skills: &[String],
     ) -> Result<AcceptTurnOutcome> {
         turn_storage_unavailable()
     }

--- a/crates/openwave-desktop/src/chat_debug.rs
+++ b/crates/openwave-desktop/src/chat_debug.rs
@@ -807,6 +807,7 @@ mod tests {
                 input_message_id: MessageId(uuid(5)),
                 output_message_id: None,
                 model: "claude-sonnet-4-5".to_owned(),
+                invoked_skills: Vec::new(),
                 status: TurnRunStatus::Failed,
                 attempt_count: 5,
                 max_attempts: 5,

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -482,7 +482,12 @@ origin: RootAttachmentOrigin, };
  * cancelled turns have no message, but remain first-class transcript entries
  * carrying the partial prose and reasoning the reader already saw live.
  */
-export type ChatTerminalTurnSnapshot = { turn_id: TurnId, message_id?: MessageId, status: ChatTerminalTurnStatus, partial_content: string, reasoning?: string, refusal?: RendererRefusal, failure_category?: TurnFailureCategory, failure_model?: RendererModelIdentity, file_changes: Array<ExecFileChangeSummary>, finished_at: string, };
+export type ChatTerminalTurnSnapshot = { turn_id: TurnId, message_id?: MessageId, status: ChatTerminalTurnStatus, partial_content: string, reasoning?: string, refusal?: RendererRefusal, failure_category?: TurnFailureCategory, failure_model?: RendererModelIdentity, file_changes: Array<ExecFileChangeSummary>, 
+/**
+ * Skills the user explicitly invoked for this turn, in submitted order.
+ * Absent for the ordinary turn that invoked none.
+ */
+invoked_skills?: Array<string>, finished_at: string, };
 
 export type ChatTerminalTurnStatus = "completed" | "failed" | "cancelled";
 

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -3075,6 +3075,7 @@ mod tests {
                 "inspect these",
                 &[],
                 &[first_id, second_id, oversized_id],
+                &[],
             )
             .await
             .unwrap();

--- a/crates/openwave-server/src/desktop_schema.rs
+++ b/crates/openwave-server/src/desktop_schema.rs
@@ -25,7 +25,7 @@ const VECTOR_DIRECTORY: &str = "vectors";
 const MAX_MARKER_BYTES: u64 = 1_024;
 
 /// Bump this whenever the pre-v1 schema baseline changes incompatibly.
-const DESKTOP_SCHEMA_EPOCH: u32 = 7;
+const DESKTOP_SCHEMA_EPOCH: u32 = 8;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/openwave-server/src/foreground_prompt.rs
+++ b/crates/openwave-server/src/foreground_prompt.rs
@@ -67,6 +67,7 @@ pub(crate) fn compose(specs: &[ToolSpec]) -> String {
         false,
         None,
         false,
+        &[],
     )
 }
 
@@ -182,6 +183,9 @@ pub(crate) fn compose_for_surface(
     offline_package_cache: bool,
     office_rendering: Option<bool>,
     plan_mode: bool,
+    // Skills the user explicitly invoked for this exact turn. Empty is the
+    // ordinary case and composes byte-identically to a turn that named none.
+    invoked_skills: &[String],
 ) -> String {
     let names = specs
         .iter()
@@ -553,6 +557,24 @@ pub(crate) fn compose_for_surface(
                 ),
                 None => {}
             }
+            // The user's own routing decision, so it follows the catalog it
+            // overrides rather than becoming a section of its own. Names are
+            // re-checked against the same bounds the catalog lines pass: the
+            // list arrives from a request, and one that could never name a
+            // staged skill must not compose into a prompt line. The route
+            // refuses an unknown name before the turn is accepted, so a name
+            // dropped here would already have been rejected upstream.
+            let invoked: Vec<&str> = invoked_skills
+                .iter()
+                .map(String::as_str)
+                .filter(|name| openwave_code_execution::is_valid_skill_name(name))
+                .collect();
+            if !invoked.is_empty() {
+                lines.push(format!(
+                    "- The user explicitly invoked these skills for this turn: {}. Read each one's `.openwave/skills/<name>/SKILL.md` before doing the work and follow it — these are instructions for this turn, not optional catalog entries.",
+                    invoked.join(", ")
+                ));
+            }
             push_section(&mut prompt, DOCUMENT_SKILLS_HEADING, &lines);
         }
     }
@@ -749,6 +771,7 @@ mod tests {
             false,
             None,
             true,
+            &[],
         );
         let normal = compose_for_surface(
             &specs,
@@ -760,6 +783,7 @@ mod tests {
             false,
             None,
             false,
+            &[],
         );
 
         assert!(plan.contains(PLAN_MODE_HEADING));
@@ -812,6 +836,7 @@ mod tests {
             false,
             None,
             false,
+            &[],
         );
 
         assert!(prompt.contains(
@@ -842,6 +867,7 @@ mod tests {
                 false,
                 None,
                 false,
+                &[],
             )
         };
         let pip_line = "python3 -m pip install --user";
@@ -865,6 +891,7 @@ mod tests {
             true,
             None,
             false,
+            &[],
         );
         assert!(off_with_cache.contains("no outbound network access"));
         assert!(off_with_cache.contains("--no-index --find-links \"$OPENWAVE_PACKAGE_CACHE\""));
@@ -921,6 +948,7 @@ mod tests {
             false,
             None,
             false,
+            &[],
         );
         assert!(odd.contains("killed by the host after 1500 milliseconds"));
     }
@@ -970,6 +998,7 @@ mod tests {
             false,
             None,
             false,
+            &[],
         );
         assert!(prompt.contains(DOCUMENT_SKILLS_HEADING));
         assert!(prompt.contains("- pdf-documents: Generate and manipulate PDF documents."));
@@ -992,6 +1021,7 @@ mod tests {
             false,
             None,
             false,
+            &[],
         );
         assert!(!without_exec.contains(DOCUMENT_SKILLS_HEADING));
         // Nothing but forged entries composes no section at all.
@@ -1005,8 +1035,62 @@ mod tests {
             false,
             None,
             false,
+            &[],
         );
         assert!(!forged_only.contains(DOCUMENT_SKILLS_HEADING));
+    }
+
+    /// Contract: naming skills for a turn adds one explicit instruction to the
+    /// catalog section and changes nothing else, so an ordinary turn composes
+    /// exactly the prompt it composed before invocation existed.
+    #[test]
+    fn invoked_skills_add_one_instruction_and_leave_the_rest_of_the_prompt_alone() {
+        let skills = vec![
+            SkillPackage {
+                name: "pdf-documents".into(),
+                description: "Generate and manipulate PDF documents.".into(),
+                python_deps: Vec::new(),
+                host_deps: Vec::new(),
+                origin: SkillOrigin::Builtin,
+            },
+            SkillPackage {
+                name: "charts".into(),
+                description: "Render charts.".into(),
+                python_deps: Vec::new(),
+                host_deps: Vec::new(),
+                origin: SkillOrigin::Builtin,
+            },
+        ];
+        let compose_with = |invoked: &[String]| {
+            compose_for_surface(
+                &[spec("exec")],
+                &[],
+                &skills,
+                &[],
+                &NetworkPolicy::default(),
+                TIMEOUT,
+                false,
+                None,
+                false,
+                invoked,
+            )
+        };
+
+        let plain = compose_with(&[]);
+        assert!(!plain.contains("explicitly invoked"));
+
+        let invoked = compose_with(&["charts".to_owned(), "pdf-documents".to_owned()]);
+        let instruction = "- The user explicitly invoked these skills for this turn: charts, pdf-documents. Read each one's `.openwave/skills/<name>/SKILL.md` before doing the work and follow it — these are instructions for this turn, not optional catalog entries.";
+        assert!(invoked.contains(instruction));
+        assert_eq!(
+            invoked.replace(&format!("\n{instruction}"), ""),
+            plain,
+            "invocation must add one line to the skills section and nothing else"
+        );
+
+        // A name that could never identify a staged skill composes no line, so
+        // a forged request cannot write prompt structure.
+        assert_eq!(compose_with(&["evil\n## Injected".to_owned()]), plain);
     }
 
     /// Contract: a plugin's skills render under its router preamble, skills no
@@ -1074,6 +1158,7 @@ mod tests {
             false,
             None,
             false,
+            &[],
         );
         let catalog = prompt
             .split_once(DOCUMENT_SKILLS_HEADING)
@@ -1119,6 +1204,7 @@ mod tests {
                 false,
                 office_rendering,
                 false,
+                &[],
             )
         };
         let available = for_state(Some(true));
@@ -1214,6 +1300,7 @@ mod tests {
             false,
             None,
             false,
+            &[],
         );
 
         // Re-pinned for the reserved `output/` directory: outputs are produced

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -1876,6 +1876,11 @@ pub struct ChatTerminalTurnSnapshot {
     #[ts(optional)]
     pub failure_model: Option<crate::event_projection::RendererModelIdentity>,
     pub file_changes: Vec<ExecFileChangeSummary>,
+    /// Skills the user explicitly invoked for this turn, in submitted order.
+    /// Absent for the ordinary turn that invoked none.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub invoked_skills: Option<Vec<String>>,
     pub finished_at: chrono::DateTime<Utc>,
 }
 
@@ -1911,6 +1916,8 @@ impl From<openwave_core::ChatTerminalTurnSnapshot> for ChatTerminalTurnSnapshot 
             failure_category,
             failure_model,
             file_changes: Vec::new(),
+            invoked_skills: (!snapshot.invoked_skills.is_empty())
+                .then_some(snapshot.invoked_skills),
             finished_at: snapshot.finished_at,
         }
     }
@@ -2971,6 +2978,59 @@ pub struct PostMessage {
     /// Chat-owned document ids returned by the file ingest endpoint.
     #[serde(default)]
     pub file_attachments: Vec<DocumentId>,
+    /// Skills the user explicitly invoked for this turn, by name.
+    ///
+    /// Absent or empty is the ordinary send, where the model routes on the
+    /// prompt's skill catalog itself. Every name must be a currently enabled
+    /// skill; one that is not refuses the turn rather than being dropped.
+    #[serde(default)]
+    pub invoked_skills: Vec<String>,
+}
+
+/// Refuse a turn that invokes a skill the install cannot actually run.
+///
+/// The catalog the user picked from and the catalog this turn will stage are
+/// read at different moments, and a skill can be disabled or uninstalled in
+/// between. Honouring the rest of the list would send the turn with an
+/// instruction to read a manifest that is not there, so an unknown or disabled
+/// name refuses the whole submission before any model call — the same posture
+/// as a turn carrying images a model cannot see. The refusal names the skill
+/// so a client can drop it and resubmit.
+async fn require_invocable_skills(state: &AppState, invoked: &[String]) -> Result<(), ServerError> {
+    if invoked.is_empty() {
+        return Ok(());
+    }
+    if invoked.len() > openwave_core::TurnRun::MAX_INVOKED_SKILLS {
+        return Err(ServerError::bad_request_kind(
+            "too_many_invoked_skills",
+            format!(
+                "a turn may invoke at most {} skills",
+                openwave_core::TurnRun::MAX_INVOKED_SKILLS
+            ),
+        ));
+    }
+    let mut distinct = std::collections::HashSet::with_capacity(invoked.len());
+    for name in invoked {
+        if !distinct.insert(name.as_str()) {
+            return Err(ServerError::bad_request_kind(
+                "duplicate_invoked_skill",
+                format!("skill `{name}` was invoked more than once"),
+            ));
+        }
+    }
+    let available = match state.code_execution.as_ref() {
+        Some(exec) => exec.skill_catalog().await,
+        None => Vec::new(),
+    };
+    for name in invoked {
+        if !available.iter().any(|skill| skill.name == *name) {
+            return Err(ServerError::bad_request_kind(
+                "invoked_skill_unavailable",
+                format!("skill `{name}` is not installed or is not enabled"),
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Resolve published attachment ids into authoritative image identity.
@@ -3196,6 +3256,7 @@ pub async fn post_message(
         };
         validate_model_selection(&state, &selected, true).await?
     };
+    require_invocable_skills(&state, &body.invoked_skills).await?;
     let images = resolve_message_attachments(&state, &body.attachments).await?;
     let documents = resolve_file_attachments(&store, id, &body.file_attachments).await?;
     if images.len().saturating_add(documents.len()) > openwave_core::MAX_MESSAGE_ATTACHMENTS {
@@ -3211,7 +3272,15 @@ pub async fn post_message(
         require_image_capable_model(&state, &model).await?;
     }
     match store
-        .accept_turn_with_attachments(body.turn_id, id, &model, &body.content, &images, &documents)
+        .accept_turn_with_attachments(
+            body.turn_id,
+            id,
+            &model,
+            &body.content,
+            &images,
+            &documents,
+            &body.invoked_skills,
+        )
         .await?
     {
         AcceptTurnOutcome::Accepted(_) | AcceptTurnOutcome::Existing(_) => {
@@ -3238,6 +3307,7 @@ pub async fn post_message(
                             &body.content,
                             &images,
                             &documents,
+                            &body.invoked_skills,
                         )
                         .await?,
                     AcceptTurnOutcome::Existing(_)

--- a/crates/openwave-server/src/scoped_store.rs
+++ b/crates/openwave-server/src/scoped_store.rs
@@ -209,6 +209,7 @@ impl ScopedStore {
     }
 
     /// [`Store::accept_turn_with_attachments`].
+    #[allow(clippy::too_many_arguments)]
     pub async fn accept_turn_with_attachments(
         &self,
         id: TurnId,
@@ -217,9 +218,18 @@ impl ScopedStore {
         content: &str,
         images: &[ImageRef],
         documents: &[DocumentId],
+        invoked_skills: &[String],
     ) -> Result<AcceptTurnOutcome> {
         self.store
-            .accept_turn_with_attachments(id, chat_id, model, content, images, documents)
+            .accept_turn_with_attachments(
+                id,
+                chat_id,
+                model,
+                content,
+                images,
+                documents,
+                invoked_skills,
+            )
             .await
     }
 

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -904,13 +904,22 @@ impl Store for PauseTerminalStore {
         content: &str,
         images: &[openwave_core::ImageRef],
         documents: &[openwave_core::DocumentId],
+        invoked_skills: &[String],
     ) -> Result<openwave_core::AcceptTurnOutcome> {
         if self.pause_accept.swap(false, Ordering::SeqCst) {
             self.entered.notify_one();
             self.release.notified().await;
         }
         self.inner
-            .accept_turn_with_attachments(id, chat_id, model, content, images, documents)
+            .accept_turn_with_attachments(
+                id,
+                chat_id,
+                model,
+                content,
+                images,
+                documents,
+                invoked_skills,
+            )
             .await
     }
     async fn accept_turn_steer(

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -2929,3 +2929,85 @@ async fn the_catalog_lists_prompts_and_serves_their_bodies() {
         StatusCode::BAD_REQUEST
     );
 }
+
+/// POST a message that explicitly invokes skills by name, returning the raw
+/// response so a refusal's typed kind can be read.
+async fn send_message_invoking(
+    router: &Router,
+    bearer: &str,
+    chat: ChatId,
+    invoked: &[&str],
+) -> axum::response::Response {
+    router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/chats/{chat}/messages"))
+                .header(header::AUTHORIZATION, bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "turn_id": TurnId::new(),
+                        "content": "build the deck",
+                        "invoked_skills": invoked,
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+/// Contract: a turn may name the skills it must use, and the names are checked
+/// against the catalog the turn will actually stage. A skill the install has
+/// switched off is not a live capability, so invoking it refuses the whole
+/// submission rather than sending a turn told to read a manifest that staging
+/// has already removed.
+#[tokio::test]
+async fn an_invoked_skill_must_be_enabled_or_the_turn_is_refused() {
+    let (dir, store) = temp_db_store("invoked-skills.db").await;
+    let store: Arc<dyn Store> = Arc::new(store);
+    let (router, token) = plugin_app(store.clone(), dir.path());
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+
+    let accepted = send_message_invoking(&router, &bearer, chat.id, &["presentations"]).await;
+    assert_eq!(accepted.status(), StatusCode::ACCEPTED);
+    let turns = store.list_turn_runs(chat.id).await.unwrap();
+    assert_eq!(
+        turns
+            .iter()
+            .map(|turn| turn.invoked_skills.clone())
+            .collect::<Vec<_>>(),
+        [vec!["presentations".to_owned()]],
+        "the invocation is captured with the turn, not just used to build a prompt"
+    );
+
+    // Switching the skill off makes the same submission a refusal.
+    let toggled = put_plugins_enabled(
+        &router,
+        &bearer,
+        serde_json::json!({"skills": {"presentations": false}}),
+    )
+    .await;
+    assert_eq!(toggled.status(), StatusCode::OK);
+
+    let refused = send_message_invoking(&router, &bearer, chat.id, &["presentations"]).await;
+    assert_eq!(refused.status(), StatusCode::BAD_REQUEST);
+    let error: AgentErrorInfo = json_body(refused).await;
+    assert_eq!(error.kind, "invoked_skill_unavailable");
+
+    let unknown = send_message_invoking(&router, &bearer, chat.id, &["no-such-skill"]).await;
+    assert_eq!(unknown.status(), StatusCode::BAD_REQUEST);
+    let error: AgentErrorInfo = json_body(unknown).await;
+    assert_eq!(error.kind, "invoked_skill_unavailable");
+
+    // Refused, not partially honoured: one bad name in a list that is otherwise
+    // live takes the whole turn down, and neither submission was recorded.
+    let mixed =
+        send_message_invoking(&router, &bearer, chat.id, &["charts", "no-such-skill"]).await;
+    assert_eq!(mixed.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(store.list_turn_runs(chat.id).await.unwrap().len(), 1);
+}

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -152,6 +152,7 @@ pub(crate) fn freeze_foreground_turn_surface(
         false,
         None,
         false,
+        &[],
     )
 }
 
@@ -167,6 +168,7 @@ fn freeze_foreground_turn_surface_with_folders(
     offline_package_cache: bool,
     office_rendering: Option<bool>,
     plan_mode: bool,
+    invoked_skills: &[String],
 ) -> ForegroundTurnSurface {
     let mut agent_config = base_agent_config.clone();
     agent_config.system_prompt = Some(crate::foreground_prompt::compose_for_surface(
@@ -179,6 +181,7 @@ fn freeze_foreground_turn_surface_with_folders(
         offline_package_cache,
         office_rendering,
         plan_mode,
+        invoked_skills,
     ));
     ForegroundTurnSurface {
         tools,
@@ -640,6 +643,7 @@ impl TurnWorker {
                 chat.permission_mode,
                 Some(openwave_core::PermissionMode::Plan)
             ),
+            &turn.invoked_skills,
         );
         if let Some(prompt) = surface.agent_config.system_prompt.as_deref() {
             eprintln!(


### PR DESCRIPTION
Skills reach the model as a `(name, description)` catalog in the operating prompt, and the model decides on its own whether to read a skill's `SKILL.md`. There was no way for the user to say "use this skill for this turn". This adds the server side of that: the wire field, its validation, its effect on the prompt, and its persistence. The composer that sends it is a separate change.

`POST /chats/{id}/messages` takes an optional `invoked_skills: [String]`. Absent or empty behaves exactly as before — the composed prompt is byte-identical, which one of the tests asserts directly rather than by inspection.

A name must be in the catalog the turn will actually stage, which is the install's *enabled* set: the plugin/skill enable flags gate it the same way staging and the catalog lines do. An unknown or disabled name refuses the whole submission with `400 invoked_skill_unavailable` before any model call — the same posture as a turn carrying images its model cannot see. Partially honouring the list would send a turn instructed to read a manifest that staging has already removed. Duplicates and a list past the bound are refused too (`duplicate_invoked_skill`, `too_many_invoked_skills`).

When names are present, the Document skills section gains one line after the catalog telling the model the user invoked those skills for this turn and it must read each one's `.openwave/skills/<name>/SKILL.md` and follow it. The names are re-checked against the skill parser's own bounds before composing, for the same reason catalog lines are: the list arrives from a request and must not be able to write prompt structure.

The invocation rides the catalog section, so a surface with no `exec` renders neither — the same gate the catalog already has. Staging is not a new assumption: `stage_turn_workspace` runs at turn start for exactly the enabled set, so a validated name's manifest is on disk before the first model call. It is best-effort, as it already was for the catalog itself.

Persistence follows the model selection, which is the existing per-turn snapshot of a user choice: a `turn_run.invoked_skills` column captured at acceptance, part of the same idempotency proof as the model and the attachments, so a retry naming different skills is a conflict rather than a silent acceptance of the first list. It flows to the turn worker for prompt composition and out through the terminal-turn transcript projection, so a reloaded chat can show what a turn was told to use. Schema epoch bumped for the new column; wire types regenerated.

Tests:
- `invoked_skills_add_one_instruction_and_leave_the_rest_of_the_prompt_alone` — the invoked prompt is the plain prompt plus exactly one line, and a forged name composes nothing.
- `an_invoked_skill_must_be_enabled_or_the_turn_is_refused` — over the real bundled skill/plugin load: an enabled name is accepted and recorded on the turn, the same name refuses once switched off, an unknown name refuses, and one bad name in an otherwise live list takes the whole turn down.

`full-ci` because the new column is a jsonb column on the Postgres turn-state lane, which does not run locally.

Part of #772

The clippy lane also carries two `needless_return` removals in `preview.rs`. They are unrelated to this change and predate it — a newer clippy started rejecting them, and the same lint fails on `main` — but this PR's lane cannot go green without them.
