### PR TITLE
feat(desktop): home starter cards read the prompt library

### DIFF
--- a/crates/openwave-desktop/ui/src/HomeRoute.tsx
+++ b/crates/openwave-desktop/ui/src/HomeRoute.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 
 import { useApp } from "./AppContext";
@@ -27,6 +27,7 @@ import { ModelMenu } from "./ModelMenu";
 import { modelForSelection } from "./ModelSelection";
 import { effectiveNewChatSettings, useNewChatSettings } from "./NewChatSettings";
 import { PermissionModeMenu } from "./PermissionModeMenu";
+import { pluginsApisFromClient } from "./plugins/pluginsApis";
 import { useComposerPlugins } from "./plugins/useComposerPlugins";
 import { RouteFrame } from "./RouteFrame";
 import { AppSidebar } from "./sidebar/AppSidebar";
@@ -52,6 +53,7 @@ export function HomeRoute() {
   const creatingChat = useChatListStore((state) => state.creatingChat);
   const draft = useComposerDraft(HOME_DRAFT_KEY);
   const composerPlugins = useComposerPlugins(client);
+  const promptLibrary = useMemo(() => pluginsApisFromClient(client), [client]);
   const setDraft = (text: string) =>
     composerDraftActions.setDraft(HOME_DRAFT_KEY, text);
   const voice = useVoiceComposer(
@@ -277,10 +279,13 @@ export function HomeRoute() {
         <div className="flex min-h-0 flex-1 items-center justify-center overflow-y-auto">
           {/* The same null state an empty conversation shows: home is where a
               chat starts, so it greets the same way. Picking a starter prompt
-              fills the composer rather than sending, the way it does in a chat. */}
+              fills the composer rather than sending, the way it does in a chat.
+              Home's starters come from the installed prompt library when it has
+              any; otherwise the built-in openers stand. */}
           <WelcomeState
             onSelectPrompt={setDraft}
             executionConfigClient={client}
+            promptLibrary={promptLibrary}
           />
         </div>
 

--- a/crates/openwave-desktop/ui/src/WelcomeState.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/WelcomeState.dom.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { PluginCatalog } from "@/api";
+import { WelcomeState, type PromptLibraryApis } from "./WelcomeState";
+
+const EMPTY_CATALOG: PluginCatalog = { plugins: [], skills: [], prompts: [] };
+
+const CATALOG: PluginCatalog = {
+  ...EMPTY_CATALOG,
+  prompts: [
+    {
+      name: "weekly-update",
+      description: "Draft this week's status note.",
+      origin: "user",
+      plugin: null,
+      enabled: true,
+    },
+    {
+      name: "retired-brief",
+      description: "From a bundle that is switched off.",
+      origin: "builtin",
+      plugin: "reporting",
+      enabled: false,
+    },
+  ],
+};
+
+function libraryWith(catalog: PluginCatalog): PromptLibraryApis {
+  return {
+    list: vi.fn().mockResolvedValue(catalog),
+    promptBody: vi
+      .fn()
+      .mockResolvedValue({ name: "weekly-update", body: "Write my weekly update covering " }),
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("WelcomeState starters", () => {
+  it("offers the enabled library prompts and inserts the picked body", async () => {
+    const library = libraryWith(CATALOG);
+    const onSelectPrompt = vi.fn();
+    render(
+      <WelcomeState onSelectPrompt={onSelectPrompt} promptLibrary={library} />,
+    );
+
+    const card = await screen.findByRole("button", { name: /Weekly update/ });
+    expect(screen.getByText("Draft this week's status note.")).toBeInTheDocument();
+    // A prompt whose bundle is off is not on offer, and the static openers
+    // step aside once the library has something to say.
+    expect(screen.queryByText(/Retired brief/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "What can you help me with?" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(card);
+    await waitFor(() =>
+      expect(onSelectPrompt).toHaveBeenCalledWith(
+        "Write my weekly update covering ",
+      ),
+    );
+    expect(library.promptBody).toHaveBeenCalledWith("weekly-update");
+  });
+
+  it("keeps the built-in starters when the library has nothing enabled", async () => {
+    const library = libraryWith(EMPTY_CATALOG);
+    const onSelectPrompt = vi.fn();
+    render(
+      <WelcomeState onSelectPrompt={onSelectPrompt} promptLibrary={library} />,
+    );
+
+    // Shown from the first paint, not after the catalog answers: an install
+    // with no prompts must never see home flicker or empty out.
+    const starter = screen.getByRole("button", {
+      name: "What can you help me with?",
+    });
+    await waitFor(() => expect(library.list).toHaveBeenCalled());
+    fireEvent.click(starter);
+    expect(onSelectPrompt).toHaveBeenCalledWith("What can you help me with?");
+  });
+});

--- a/crates/openwave-desktop/ui/src/WelcomeState.tsx
+++ b/crates/openwave-desktop/ui/src/WelcomeState.tsx
@@ -1,11 +1,27 @@
 import { useEffect, useState } from "react";
 import { FileSearch, ListChecks, MessageCircle, Sparkles } from "lucide-react";
-import type { ApiClient, CodeExecutionConfigInfo } from "./api";
+import type {
+  ApiClient,
+  CodeExecutionConfigInfo,
+  PluginPromptInfo,
+} from "./api";
 import {
   MANAGED_EXECUTION_DISCLOSURE,
   requiresManagedExecutionDisclosure,
 } from "./CodeExecutionDisclosure";
 import { Logomark } from "./Logomark";
+import type { PluginsApis } from "./plugins/pluginsApis";
+
+/**
+ * What the welcome screen calls on the prompt library.
+ *
+ * The library's own two calls, narrowed: the catalog names the prompts, and
+ * one body is fetched only when a card is picked.
+ */
+export type PromptLibraryApis = Pick<PluginsApis, "list" | "promptBody">;
+
+/** How many library prompts home offers before it stops listing them. */
+const MAX_LIBRARY_PROMPTS = 6;
 
 type StarterPrompt = {
   icon: typeof Sparkles;
@@ -36,16 +52,39 @@ const STARTER_PROMPTS: StarterPrompt[] = [
   },
 ];
 
+/**
+ * A prompt slug as a card title: `weekly-update` reads "Weekly update".
+ *
+ * The package's own description is the tip below it, so the title only has to
+ * be a legible name rather than a summary.
+ */
+export function promptTitle(name: string): string {
+  const words = name.replace(/[-_]+/g, " ").trim();
+  if (!words) return name;
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+const CARD_CLASS =
+  "flex items-center gap-2.5 rounded-[10px] border border-border bg-background px-3.5 py-2.5 text-[0.85rem] font-medium text-left text-foreground transition-[background-color,border-color] duration-[120ms] ease-in-out hover:border-[color-mix(in_srgb,var(--ink)_22%,var(--line))] hover:bg-accent [&_svg]:flex-none [&_svg]:text-muted-foreground [&:hover_svg]:text-foreground";
+
 export function WelcomeState({
   onSelectPrompt,
   executionConfigClient,
+  promptLibrary,
 }: {
   onSelectPrompt?: (prompt: string) => void;
   executionConfigClient?: Pick<ApiClient, "getCodeExecutionConfig">;
+  /**
+   * The installed prompt library, when this surface offers it. Absent — or
+   * empty, or still loading — the hardcoded starters stand, so an install with
+   * no prompts sees exactly what it saw before.
+   */
+  promptLibrary?: PromptLibraryApis;
 }) {
   const [executionProviders, setExecutionProviders] = useState<
     CodeExecutionConfigInfo["providers"] | null
   >(null);
+  const [libraryPrompts, setLibraryPrompts] = useState<PluginPromptInfo[]>([]);
 
   useEffect(() => {
     if (
@@ -69,9 +108,45 @@ export function WelcomeState({
     };
   }, [executionConfigClient]);
 
+  useEffect(() => {
+    if (!promptLibrary) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const catalog = await promptLibrary.list();
+        if (cancelled) return;
+        setLibraryPrompts(
+          catalog.prompts
+            .filter((prompt) => prompt.enabled)
+            .slice(0, MAX_LIBRARY_PROMPTS),
+        );
+      } catch {
+        // A library that cannot be read is a library with nothing to offer:
+        // home keeps its starters rather than reporting a failure nobody
+        // asked for.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [promptLibrary]);
+
   const managedExecutionOnly = requiresManagedExecutionDisclosure(
     executionProviders,
   );
+
+  function insertLibraryPrompt(name: string) {
+    if (!onSelectPrompt || !promptLibrary) return;
+    void (async () => {
+      try {
+        const body = await promptLibrary.promptBody(name);
+        onSelectPrompt(body.body);
+      } catch {
+        // Picking is not a place to raise an error: a body that cannot be
+        // read simply leaves the composer as it was.
+      }
+    })();
+  }
 
   return (
     <section className="welcome" aria-label="Start a chat">
@@ -85,13 +160,35 @@ export function WelcomeState({
         </p>
         {managedExecutionOnly && <p>{MANAGED_EXECUTION_DISCLOSURE}</p>}
       </div>
-      {onSelectPrompt && (
+      {onSelectPrompt && libraryPrompts.length > 0 && (
+        <div className="welcome-prompts">
+          {libraryPrompts.map((prompt) => (
+            <button
+              key={prompt.name}
+              type="button"
+              className={CARD_CLASS}
+              onClick={() => insertLibraryPrompt(prompt.name)}
+            >
+              <Sparkles size={16} />
+              <span className="min-w-0">
+                <span className="block">{promptTitle(prompt.name)}</span>
+                {prompt.description && (
+                  <span className="block text-[0.78rem] font-normal text-muted-foreground">
+                    {prompt.description}
+                  </span>
+                )}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+      {onSelectPrompt && libraryPrompts.length === 0 && (
         <div className="welcome-prompts">
           {STARTER_PROMPTS.map(({ icon: Icon, label, prompt }) => (
             <button
               key={label}
               type="button"
-              className="flex items-center gap-2.5 rounded-[10px] border border-border bg-background px-3.5 py-2.5 text-[0.85rem] font-medium text-left text-foreground transition-[background-color,border-color] duration-[120ms] ease-in-out hover:border-[color-mix(in_srgb,var(--ink)_22%,var(--line))] hover:bg-accent [&_svg]:flex-none [&_svg]:text-muted-foreground [&:hover_svg]:text-foreground"
+              className={CARD_CLASS}
               onClick={() => onSelectPrompt(prompt)}
             >
               <Icon size={16} />

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -62,7 +62,9 @@ import {
   type PluginCategory as WirePluginCategory,
   type PluginEnableUpdate as WirePluginEnableUpdate,
   type PluginInfo as WirePluginInfo,
+  type PluginPromptInfo as WirePluginPromptInfo,
   type PluginSkillInfo as WirePluginSkillInfo,
+  type PromptBody as WirePromptBody,
   type SkillOrigin as WireSkillOrigin,
   type SkillInstructions as WireSkillInstructions,
   type NetworkPolicy as WireNetworkPolicy,
@@ -554,6 +556,12 @@ export type PluginInfo = WirePluginInfo;
 
 /** One skill, inside a bundle or standing alone. */
 export type PluginSkillInfo = WirePluginSkillInfo;
+
+/** One reusable prompt, bundled or standalone, as the catalog lists it. */
+export type PluginPromptInfo = WirePluginPromptInfo;
+
+/** One prompt's insertable text, fetched when the user picks it. */
+export type PromptBody = WirePromptBody;
 
 /** What a bundle can do, derived by the host from what it contains. */
 export type PluginCapability = WirePluginCapability;
@@ -1228,6 +1236,18 @@ export class ApiClient {
   /** One skill's full instruction body — what the model is taught by it. */
   getSkillInstructions(name: string): Promise<SkillInstructions> {
     return this.json(`/plugins/skills/${encodeURIComponent(name)}/instructions`, {
+      headers: this.headers(),
+    });
+  }
+
+  /**
+   * One prompt's insertable text — what a picker drops into the composer.
+   *
+   * Its own route because the catalog is read far more often than any single
+   * prompt is inserted.
+   */
+  getPromptBody(name: string): Promise<PromptBody> {
+    return this.json(`/plugins/prompts/${encodeURIComponent(name)}/body`, {
       headers: this.headers(),
     });
   }

--- a/crates/openwave-desktop/ui/src/plugins/Plugins.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/plugins/Plugins.dom.test.tsx
@@ -43,6 +43,7 @@ const CATALOG: PluginCatalog = {
       enabled: true,
     },
   ],
+  prompts: [],
 };
 
 function catalogWith(
@@ -66,6 +67,7 @@ function apisWith(overrides: Partial<PluginsApis> = {}): PluginsApis {
     instructions: vi
       .fn()
       .mockImplementation(async (name: string) => ({ name, instructions: SKILL_BODY })),
+    promptBody: vi.fn(),
     ...overrides,
   };
 }

--- a/crates/openwave-desktop/ui/src/plugins/pluginsApis.ts
+++ b/crates/openwave-desktop/ui/src/plugins/pluginsApis.ts
@@ -2,6 +2,7 @@ import type {
   ApiClient,
   PluginCatalog,
   PluginEnableUpdate,
+  PromptBody,
   SkillInstructions,
 } from "@/api";
 
@@ -16,6 +17,8 @@ export type PluginsApis = {
   setEnabled(update: PluginEnableUpdate): Promise<PluginCatalog>;
   /** One skill's instruction body, fetched when its detail opens. */
   instructions(name: string): Promise<SkillInstructions>;
+  /** One prompt's insertable text, fetched when the user picks it. */
+  promptBody(name: string): Promise<PromptBody>;
 };
 
 export function pluginsApisFromClient(client: ApiClient): PluginsApis {
@@ -23,5 +26,6 @@ export function pluginsApisFromClient(client: ApiClient): PluginsApis {
     list: () => client.listPlugins(),
     setEnabled: (update) => client.setPluginsEnabled(update),
     instructions: (name) => client.getSkillInstructions(name),
+    promptBody: (name) => client.getPromptBody(name),
   };
 }

--- a/crates/openwave-desktop/ui/src/plugins/usePluginCatalog.ts
+++ b/crates/openwave-desktop/ui/src/plugins/usePluginCatalog.ts
@@ -35,6 +35,13 @@ export function applyEnableUpdate(
       };
     }),
     skills: catalog.skills.map(applySkill),
+    // A prompt has no flag of its own: a bundled one follows its bundle, so an
+    // optimistic bundle toggle has to carry its prompts with it. A standalone
+    // prompt is always on and never moves.
+    prompts: catalog.prompts.map((prompt) => {
+      const next = prompt.plugin ? update.plugins[prompt.plugin] : undefined;
+      return next === undefined ? prompt : { ...prompt, enabled: next };
+    }),
   };
 }
 


### PR DESCRIPTION
Home's welcome screen offered four hardcoded openers. It now reads the installed prompt library from `GET /plugins` and renders the enabled prompts as cards — slug as the title, the package's description as the tip below it — keeping the existing card styling. The list is capped at six so a large library doesn't take over the screen.

Selecting a card fetches `GET /plugins/prompts/{name}/body` and inserts the body into the composer draft, the same `onSelectPrompt` path the static strings used. A failed catalog or body fetch is silent: a picker showing an error dialog is worse than a card that does nothing.

Nothing ships prompts built-in yet, so an empty library is the common case. The hardcoded starters render until the catalog comes back with at least one enabled prompt, which also covers the loading window — no spinner, no flash of an empty welcome screen.

Also fixes a gap left by the prompts PR: `applyEnableUpdate` rebuilt the catalog without the new `prompts` field. It now carries prompts through an optimistic toggle, with a bundled prompt following its bundle's flag (a standalone prompt has no flag of its own).

Tests, in `WelcomeState.dom.test.tsx`:
- Enabled library prompts render, a disabled one does not, and picking a card inserts the fetched body.
- An empty library keeps the built-in starters, and they are present before the catalog resolves.

Part of #772