### PR TITLE
feat(desktop): composer slash popover invokes skills and inserts prompts

### DIFF
--- a/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
@@ -326,6 +326,7 @@ describe("app shell", () => {
         "summarise the filing",
         [],
         [],
+        [],
       ),
     );
     expect(

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -173,7 +173,14 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   useEffect(() => {
     if (!chat || !hydrated) return;
     const pending = firstMessageActions.take(chatId);
-    if (pending) void sendMessage(pending.text, pending.images, pending.files);
+    if (pending) {
+      void sendMessage(
+        pending.text,
+        pending.images,
+        pending.files,
+        pending.skills,
+      );
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chat, chatId, hydrated]);
 
@@ -357,6 +364,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
     content: string,
     imageItems: readonly ImageAttachment[] = images.attachments,
     fileItems: readonly ImportedDocument[] = files,
+    skillNames: readonly string[] = invokedSkills(),
   ) {
     await postTurn({
       content,
@@ -368,8 +376,18 @@ export function ChatRoute({ chatId }: { chatId: string }) {
         name: file.displayName,
         mediaType: file.mediaType,
       })),
+      invokedSkills: skillNames,
       fromComposer: true,
     });
+  }
+
+  /**
+   * The skills the composer is holding, read outside a render: the route does
+   * not subscribe to the draft, so a pill picked in the pane below has to be
+   * read from the store at the moment the turn is posted.
+   */
+  function invokedSkills(): readonly string[] {
+    return useComposerDrafts.getState().attachments[chatId]?.skills ?? [];
   }
 
   /**
@@ -389,6 +407,10 @@ export function ChatRoute({ chatId }: { chatId: string }) {
       transcriptImages: [...turn.images],
       documentIds: turn.files.map((file) => file.documentId),
       transcriptFiles: [...turn.files],
+      // A retry resends what the transcript holds, and the transcript does not
+      // yet carry the skills a turn was invoked with — so a retried turn is the
+      // ordinary send, with the composer's own pills left out of it.
+      invokedSkills: [],
       fromComposer: false,
     });
   }
@@ -404,6 +426,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
     transcriptImages,
     documentIds,
     transcriptFiles,
+    invokedSkills: skillNames,
     fromComposer,
   }: {
     content: string;
@@ -411,6 +434,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
     transcriptImages: readonly TranscriptImageAttachment[];
     documentIds: readonly string[];
     transcriptFiles: readonly TranscriptFileAttachment[];
+    invokedSkills: readonly string[];
     fromComposer: boolean;
   }) {
     if (!chat || !content || busy || deletingChatId !== null) return;
@@ -442,15 +466,18 @@ export function ChatRoute({ chatId }: { chatId: string }) {
         content,
         attachments,
         documentIds,
+        skillNames,
       );
       // Only once the turn is durably accepted, and only for what the composer
       // actually contributed. A refused send — an image the selected model
-      // cannot read, say — must leave the attachments where the reader can fix
-      // the problem and try again; a retry must not throw away attachments the
-      // reader has queued for their *next* message.
+      // cannot read, or a skill this install can no longer run — must leave the
+      // attachments and the pills where the reader can fix the problem and try
+      // again; a retry must not throw away attachments the reader has queued
+      // for their *next* message.
       if (fromComposer) {
         images.clear();
         setComposerFiles(() => []);
+        composerDraftActions.setSkills(chatId, []);
       }
     } catch (err) {
       // Nothing was accepted, so the message has to go back to where it can be

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -10,8 +10,11 @@ import {
 import type { ApiClient, Chat } from "./api";
 import { followScrollBehavior, isNearBottom, scrollToLatest } from "./ChatScroll";
 import { useChatSessionStore } from "./ChatSessionStore";
-import { useComposerDraft } from "./ComposerDrafts";
 import {
+  useComposerAttachments,
+  useComposerDraft,
+  useComposerDrafts,
+} from "./ComposerDrafts";import {
   Composer,
   type ComposerFiles,
   type ComposerFolders,
@@ -107,6 +110,7 @@ export function ChatView({
   // reloading its engine mid-typing.
   const draft = useComposerDraft(chat.id);
   const composerPlugins = useComposerPlugins(client);
+  const invokedSkills = useComposerAttachments(chat.id).skills;
   const folderAccess = useFolderAccessRequests(client, chat.id);
   const outputWritebacks = useOutputWritebackRequests(client, chat.id);
   const userQuestions = useUserQuestions(client, chat.id);
@@ -415,7 +419,23 @@ export function ChatView({
           permissionMenu={composerPermissionMenu}
           network={composerNetwork}
           reasoning={composerReasoning}
-          plugins={composerPlugins}
+          plugins={composerPlugins.plugins}
+          slash={{
+            options: composerPlugins.slashOptions,
+            invoked: invokedSkills,
+            onInvoke: (name) =>
+              useComposerDrafts
+                .getState()
+                .setSkills(chat.id, [...invokedSkills, name]),
+            onRemove: (name) =>
+              useComposerDrafts
+                .getState()
+                .setSkills(
+                  chat.id,
+                  invokedSkills.filter((skill) => skill !== name),
+                ),
+            loadPromptBody: composerPlugins.loadPromptBody,
+          }}
           images={composerImages}
           files={files}
           folders={folders}

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -14,9 +14,18 @@ import {
   Image as ImageIcon,
   Mic,
   Square,
+  Sparkles,
+  Wand2,
   X,
 } from "lucide-react";
 import { MAX_STEER_CHARACTERS } from "./ActiveTurnSteer";
+import {
+  activeSlashQuery,
+  filterSlashOptions,
+  replaceSlashToken,
+  MAX_INVOKED_SKILLS,
+  type SlashOption,
+} from "./ComposerSlash";
 import {
   ComposerToolsMenu,
   type ComposerNetwork,
@@ -173,6 +182,23 @@ export type ComposerVoice = {
   onStop: () => void;
 };
 
+/**
+ * What typing `/` reaches, and which skills the next message will invoke.
+ *
+ * The composer owns the token and the list; the surface above it owns the
+ * catalog and the invoked names, because those have to survive this component
+ * — the chat route reads them again when it posts the turn.
+ */
+export type ComposerSlash = {
+  options: readonly SlashOption[];
+  /** Skill names invoked for the next send, in the order they were picked. */
+  invoked: readonly string[];
+  onInvoke: (name: string) => void;
+  onRemove: (name: string) => void;
+  /** One prompt's insertable text. A rejection leaves the draft as it was. */
+  loadPromptBody: (name: string) => Promise<string>;
+};
+
 /** Whether attached images stop this turn from being sent, and why. */
 export function imageSendBlocker(images: ComposerImages | undefined): string | null {
   if (!images || images.items.length === 0) return null;
@@ -198,6 +224,7 @@ export type ComposerProps = {
   network?: ComposerNetwork;
   reasoning?: ComposerReasoning;
   plugins?: ComposerPlugins;
+  slash?: ComposerSlash;
   images?: ComposerImages;
   files?: ComposerFiles;
   folders?: ComposerFolders;
@@ -226,6 +253,7 @@ export function Composer({
   network,
   reasoning,
   plugins,
+  slash,
   images,
   files,
   folders,
@@ -249,6 +277,14 @@ export function Composer({
   const dragDepthRef = useRef(0);
   const selectionRef = useRef<{ start: number; end: number } | null>(null);
   const [dragging, setDragging] = useState(false);
+  // The `/` token under the caret, as a piece of state rather than a derived
+  // value: the caret moves without the draft changing, and a ref would leave
+  // the list open over a caret that has walked away from the token.
+  const [slashToken, setSlashToken] = useState<{
+    start: number;
+    query: string;
+  } | null>(null);
+  const [slashHighlight, setSlashHighlight] = useState(0);
   const { confirm, dialog: confirmDialog } = useConfirm();
   const inputDisabled = disabled;
   const active = busy && activeTurnId !== null;
@@ -277,7 +313,125 @@ export function Composer({
   // means nothing in it.
   useLayoutEffect(() => {
     selectionRef.current = null;
+    setSlashToken(null);
   }, [resetKey]);
+
+  const invokedSkills = slash?.invoked ?? [];
+  const atSkillCap = invokedSkills.length >= MAX_INVOKED_SKILLS;
+  /**
+   * What this `/` can still reach.
+   *
+   * A skill already on the message is not offered again — the server refuses a
+   * duplicate — and neither is any skill once the turn's cap is reached, or
+   * while a turn is running: steering carries no invocation, so a pill picked
+   * there would silently apply to some later message. Prompts are text and stay
+   * available throughout.
+   */
+  const slashOptions = (slash?.options ?? []).filter((option) => {
+    if (option.kind === "prompt") return true;
+    if (active || atSkillCap) return false;
+    return !invokedSkills.includes(option.name);
+  });
+  const slashMatches = slashToken
+    ? filterSlashOptions(slashOptions, slashToken.query)
+    : [];
+  // Skills vanish from the list at the cap, which would otherwise read as a
+  // catalog that has lost them. The note says which bound was reached.
+  const slashCapNote = slashToken !== null && !active && atSkillCap;
+  // An open list with nothing in it is a panel over the draft saying nothing.
+  const slashOpen =
+    slashToken !== null && (slashMatches.length > 0 || slashCapNote);
+  const slashIndex = Math.min(slashHighlight, slashMatches.length - 1);
+
+  /** Re-read whether the caret sits inside a `/` token, and reset the cursor. */
+  function syncSlashToken(value: string, caret: number) {
+    const token = slash ? activeSlashQuery(value, caret) : null;
+    setSlashToken(token);
+    setSlashHighlight(0);
+  }
+
+  /**
+   * Take the `/query` out of the draft, and do what the row promised.
+   *
+   * A skill leaves a pill behind: the name travels beside the message rather
+   * than inside it, so nothing has to be parsed back out of prose. A prompt is
+   * text, so its body replaces the token — fetched only now, because the
+   * catalog deliberately carries no bodies.
+   */
+  function selectSlashOption(option: SlashOption) {
+    const token = slashToken;
+    if (!slash || !token) return;
+    const caret = token.start + 1 + token.query.length;
+    setSlashToken(null);
+    if (option.kind === "skill") {
+      applySlashReplacement(draft, token.start, caret, "");
+      slash.onInvoke(option.name);
+      return;
+    }
+    void (async () => {
+      let body: string;
+      try {
+        body = await slash.loadPromptBody(option.name);
+      } catch {
+        // Picking is not a place to raise an error: a body that cannot be read
+        // leaves the draft exactly as the reader typed it, `/` token and all.
+        return;
+      }
+      applySlashReplacement(draft, token.start, caret, body);
+    })();
+  }
+
+  function applySlashReplacement(
+    source: string,
+    start: number,
+    caret: number,
+    replacement: string,
+  ) {
+    const next = replaceSlashToken(source, start, caret, replacement);
+    selectionRef.current = { start: next.caret, end: next.caret };
+    onDraftChange(next.text);
+    window.requestAnimationFrame(() => {
+      const field = textareaRef.current;
+      if (!field || field.disabled) return;
+      field.focus();
+      field.setSelectionRange(next.caret, next.caret);
+    });
+  }
+
+  /** The list's own keys, taken before the textarea's send-on-Enter sees them. */
+  function handleSlashKey(event: KeyboardEvent<HTMLTextAreaElement>): boolean {
+    if (event.key === "Escape") {
+      // Only claimed when there is a list to close, so Escape keeps whatever
+      // meaning the surrounding surface gives it the rest of the time.
+      if (slashToken === null) return false;
+      setSlashToken(null);
+      return true;
+    }
+    if (!slashOpen) return false;
+    // A list showing only the cap note has nothing to move through or pick, so
+    // Enter stays what it always is: send.
+    if (slashMatches.length === 0) return false;
+    if (event.key === "ArrowDown") {
+      setSlashHighlight((current) => (current + 1) % slashMatches.length);
+      return true;
+    }
+    if (event.key === "ArrowUp") {
+      setSlashHighlight(
+        (current) =>
+          (Math.min(current, slashMatches.length - 1) +
+            slashMatches.length -
+            1) %
+          slashMatches.length,
+      );
+      return true;
+    }
+    if (event.key === "Enter" || event.key === "Tab") {
+      const option = slashMatches[slashIndex];
+      if (option) selectSlashOption(option);
+      return true;
+    }
+    return false;
+  }
 
   async function submit(): Promise<void> {
     if (!canSubmit) return;
@@ -303,6 +457,7 @@ export function Composer({
 
   function onChange(event: ChangeEvent<HTMLTextAreaElement>) {
     rememberSelection(event.target);
+    syncSlashToken(event.target.value, event.target.selectionStart);
     onDraftChange(event.target.value);
   }
 
@@ -465,6 +620,78 @@ export function Composer({
           ))}
         </ul>
       )}
+      {slash && invokedSkills.length > 0 && (
+        <ul
+          className="m-0 flex list-none flex-wrap gap-2 p-0"
+          aria-label="Invoked skills"
+        >
+          {invokedSkills.map((name) => (
+            <InvokedSkillChip
+              key={name}
+              label={skillLabel(slash.options, name)}
+              onRemove={() => slash.onRemove(name)}
+            />
+          ))}
+        </ul>
+      )}
+      {slashOpen && (
+        // In flow above the field rather than floating over it: the composer
+        // clips its own overflow to keep its rounded edge, so a panel anchored
+        // above the box would be cut off at the border.
+        <ul
+          id="composer-slash-list"
+          role="listbox"
+          aria-label="Skills and prompts"
+          className="m-0 max-h-56 list-none overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md"
+        >
+          {slashMatches.map((option, index) => (
+            <li key={`${option.kind}:${option.name}`}>
+              <button
+                type="button"
+                id={`composer-slash-option-${index}`}
+                role="option"
+                aria-selected={index === slashIndex}
+                className={cn(
+                  "flex w-full items-start gap-2 rounded-sm px-2 py-1.5 text-left text-sm",
+                  index === slashIndex && "bg-accent text-accent-foreground",
+                )}
+                // Taken on mousedown so the field never loses the caret the
+                // insertion is about to be made at.
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => selectSlashOption(option)}
+              >
+                {option.kind === "skill" ? (
+                  <Wand2
+                    className="mt-0.5 size-4 shrink-0 text-muted-foreground"
+                    aria-hidden="true"
+                  />
+                ) : (
+                  <Sparkles
+                    className="mt-0.5 size-4 shrink-0 text-muted-foreground"
+                    aria-hidden="true"
+                  />
+                )}
+                <span className="flex min-w-0 flex-col">
+                  <span className="truncate">{option.label}</span>
+                  {option.description && (
+                    <span className="truncate text-xs text-muted-foreground">
+                      {option.description}
+                    </span>
+                  )}
+                </span>
+                <span className="ml-auto shrink-0 pl-2 text-[0.68rem] text-muted-foreground">
+                  {option.kind === "skill" ? "Skill" : "Prompt"}
+                </span>
+              </button>
+            </li>
+          ))}
+          {slashCapNote && (
+            <li className="px-2 py-1.5 text-xs text-muted-foreground">
+              {`A message can invoke at most ${MAX_INVOKED_SKILLS} skills.`}
+            </li>
+          )}
+        </ul>
+      )}
       <textarea
         ref={textareaRef}
         className={cn(
@@ -482,14 +709,29 @@ export function Composer({
                 : "Message OpenWave…"
         }
         aria-label="Message"
+        aria-controls={slashOpen ? "composer-slash-list" : undefined}
+        aria-activedescendant={
+          slashOpen ? `composer-slash-option-${slashIndex}` : undefined
+        }
         // A stable hook for the shell's focus-composer shortcut, which has to
         // find the field without a ref threaded up through every route.
         data-composer-input=""
         disabled={inputDisabled}
         onChange={onChange}
-        onSelect={(event) => rememberSelection(event.currentTarget)}
+        onSelect={(event) => {
+          rememberSelection(event.currentTarget);
+          syncSlashToken(
+            event.currentTarget.value,
+            event.currentTarget.selectionStart,
+          );
+        }}
+        onBlur={() => setSlashToken(null)}
         onPaste={onPaste}
         onKeyDown={(event) => {
+          if (handleSlashKey(event)) {
+            event.preventDefault();
+            return;
+          }
           if (!shouldSubmitComposerKey(event.nativeEvent)) return;
           event.preventDefault();
           void submit();
@@ -672,6 +914,54 @@ export function Composer({
       )}
       {confirmDialog}
     </form>
+  );
+}
+
+/** What the catalog calls a skill, falling back to its slug if it has gone. */
+function skillLabel(options: readonly SlashOption[], name: string): string {
+  const option = options.find(
+    (candidate) => candidate.kind === "skill" && candidate.name === name,
+  );
+  return option?.label ?? name;
+}
+
+/**
+ * One skill this message will invoke.
+ *
+ * A pill rather than words in the draft: the invocation is a field on the
+ * message, so it has to be visible and removable as one thing, not as text the
+ * reader could half-delete.
+ */
+function InvokedSkillChip({
+  label,
+  onRemove,
+}: {
+  label: string;
+  onRemove: () => void;
+}) {
+  return (
+    <li className="relative flex min-w-0 max-w-full items-center gap-2 rounded-lg border border-border bg-muted/50 py-1.5 pl-2 pr-7 text-muted-foreground">
+      <span className="inline-flex size-9 shrink-0 items-center justify-center rounded-md bg-background">
+        <Wand2 size={16} aria-hidden="true" />
+      </span>
+      <span className="grid min-w-0 gap-px">
+        <strong
+          className="max-w-[12rem] truncate text-xs font-semibold text-foreground"
+          title={label}
+        >
+          {label}
+        </strong>
+        <small className="text-[0.68rem]">Skill</small>
+      </span>
+      <button
+        type="button"
+        className="absolute right-0.5 top-0.5 inline-flex items-center justify-center rounded-full border-0 bg-transparent p-0.5 text-inherit hover:bg-accent hover:text-foreground"
+        aria-label={`Remove ${label}`}
+        onClick={onRemove}
+      >
+        <X size={14} aria-hidden="true" />
+      </button>
+    </li>
   );
 }
 

--- a/crates/openwave-desktop/ui/src/ComposerDrafts.ts
+++ b/crates/openwave-desktop/ui/src/ComposerDrafts.ts
@@ -58,12 +58,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 export type ComposerAttachmentDraft = {
   images: ImageAttachment[];
   files: ImportedDocument[];
+  /** Skills the next message will invoke, by catalog name, in pick order. */
+  skills: string[];
   pendingChatId: string | null;
 };
 
 export const EMPTY_ATTACHMENT_DRAFT: ComposerAttachmentDraft = {
   images: [],
   files: [],
+  skills: [],
   pendingChatId: null,
 };
 
@@ -71,6 +74,7 @@ function isEmptyAttachmentDraft(draft: ComposerAttachmentDraft): boolean {
   return (
     draft.images.length === 0 &&
     draft.files.length === 0 &&
+    draft.skills.length === 0 &&
     draft.pendingChatId === null
   );
 }
@@ -91,6 +95,7 @@ function storableDraft(
       .filter((image) => image.status === "ready" && image.attachmentId !== null)
       .map((image) => ({ ...image, previewUrl: null })),
     files: draft.files,
+    skills: draft.skills,
     pendingChatId: draft.pendingChatId,
   };
 }
@@ -116,6 +121,9 @@ function parseStoredAttachmentDraft(value: string): ComposerAttachmentDraft | nu
     return {
       images,
       files,
+      skills: (Array.isArray(parsed.skills) ? parsed.skills : []).filter(
+        (skill): skill is string => typeof skill === "string",
+      ),
       pendingChatId:
         typeof parsed.pendingChatId === "string" ? parsed.pendingChatId : null,
     };
@@ -187,6 +195,7 @@ export type ComposerDraftStore = {
   clearDraft: (key: string) => void;
   setImages: (key: string, images: ImageAttachment[]) => void;
   setFiles: (key: string, files: ImportedDocument[]) => void;
+  setSkills: (key: string, skills: string[]) => void;
   setPendingChatId: (key: string, chatId: string | null) => void;
 };
 
@@ -230,6 +239,8 @@ export function createComposerDraftStore() {
         updateAttachments(key, (current) => ({ ...current, images })),
       setFiles: (key, files) =>
         updateAttachments(key, (current) => ({ ...current, files })),
+      setSkills: (key, skills) =>
+        updateAttachments(key, (current) => ({ ...current, skills })),
       setPendingChatId: (key, chatId) =>
         updateAttachments(key, (current) => ({
           ...current,

--- a/crates/openwave-desktop/ui/src/ComposerSlash.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerSlash.dom.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+import { useState } from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, expect, it, vi } from "vitest";
+
+import { Composer, type ComposerSlash } from "./Composer";
+import type { SlashOption } from "./ComposerSlash";
+
+afterEach(cleanup);
+
+const OPTIONS: SlashOption[] = [
+  {
+    kind: "skill",
+    name: "pptx",
+    label: "Pptx",
+    description: "Builds slide decks.",
+  },
+  {
+    kind: "skill",
+    name: "xlsx",
+    label: "Xlsx",
+    description: "Builds spreadsheets.",
+  },
+  {
+    kind: "prompt",
+    name: "weekly-update",
+    label: "Weekly update",
+    description: "The Monday note.",
+  },
+];
+
+function slash(overrides: Partial<ComposerSlash> = {}): ComposerSlash {
+  return {
+    options: OPTIONS,
+    invoked: [],
+    onInvoke: vi.fn(),
+    onRemove: vi.fn(),
+    loadPromptBody: vi.fn(async () => "Write this week's update covering:"),
+    ...overrides,
+  };
+}
+
+/**
+ * A composer whose draft is real state, so typing behaves the way it does in a
+ * route: the `/` token the list reads is whatever has actually been typed.
+ */
+function ComposerHarness({
+  slash: menu,
+  onDraftChange,
+}: {
+  slash: ComposerSlash;
+  onDraftChange?: (draft: string) => void;
+}) {
+  const [draft, setDraft] = useState("");
+  return (
+    <Composer
+      activeTurnId={null}
+      busy={false}
+      cancelError={null}
+      cancelPending={false}
+      disabled={false}
+      draft={draft}
+      slash={menu}
+      onDraftChange={(next) => {
+        setDraft(next);
+        onDraftChange?.(next);
+      }}
+      onSend={vi.fn(async () => {})}
+      onSteer={vi.fn(async () => {})}
+      onStop={vi.fn(async () => {})}
+      resetKey="chat-1"
+      steerError={null}
+      steerPending={false}
+      steerStatus={null}
+    />
+  );
+}
+
+it("opens on a leading slash, narrows to what is typed, and closes on escape", async () => {
+  const user = userEvent.setup();
+  render(<ComposerHarness slash={slash()} />);
+
+  await user.click(screen.getByRole("textbox", { name: "Message" }));
+  await user.keyboard("/");
+  expect(screen.getAllByRole("option")).toHaveLength(3);
+
+  await user.keyboard("ppt");
+  const narrowed = screen.getAllByRole("option");
+  expect(narrowed).toHaveLength(1);
+  expect(narrowed[0]).toHaveAccessibleName(/Pptx/);
+
+  await user.keyboard("{Escape}");
+  expect(screen.queryByRole("option")).toBeNull();
+});
+
+it("leaves a slash inside ordinary text alone", async () => {
+  const user = userEvent.setup();
+  render(<ComposerHarness slash={slash()} />);
+
+  const field = screen.getByRole("textbox", { name: "Message" });
+  await user.click(field);
+  // Mid-word: a path is not someone reaching for the library.
+  await user.keyboard("read src/pptx");
+  expect(screen.queryByRole("option")).toBeNull();
+
+  // And a space ends the token: by then the reader is writing prose again.
+  await user.clear(field);
+  await user.keyboard("/pptx and");
+  expect(screen.queryByRole("option")).toBeNull();
+});
+
+it("replaces the token with the prompt body it fetches", async () => {
+  const user = userEvent.setup();
+  const menu = slash();
+  const onDraftChange = vi.fn();
+  render(<ComposerHarness slash={menu} onDraftChange={onDraftChange} />);
+
+  await user.click(screen.getByRole("textbox", { name: "Message" }));
+  await user.keyboard("draft the /weekly");
+  await user.click(screen.getByRole("option", { name: /Weekly update/ }));
+
+  expect(menu.loadPromptBody).toHaveBeenCalledWith("weekly-update");
+  expect(onDraftChange).toHaveBeenLastCalledWith(
+    "draft the Write this week's update covering:",
+  );
+  // A prompt is text, not an invocation: nothing is pinned to the message.
+  expect(menu.onInvoke).not.toHaveBeenCalled();
+});
+
+it("invokes a picked skill and shows it as a chip the reader can drop", async () => {
+  const user = userEvent.setup();
+  const onInvoke = vi.fn();
+  const onDraftChange = vi.fn();
+  render(
+    <ComposerHarness slash={slash({ onInvoke })} onDraftChange={onDraftChange} />,
+  );
+
+  await user.click(screen.getByRole("textbox", { name: "Message" }));
+  await user.keyboard("make slides /pptx");
+  await user.click(screen.getByRole("option", { name: /Pptx/ }));
+
+  expect(onInvoke).toHaveBeenCalledWith("pptx");
+  // The token comes out of the prose; the invocation travels beside it.
+  expect(onDraftChange).toHaveBeenLastCalledWith("make slides ");
+
+  cleanup();
+  const onRemove = vi.fn();
+  render(<ComposerHarness slash={slash({ invoked: ["pptx"], onRemove })} />);
+  await user.click(screen.getByRole("button", { name: "Remove Pptx" }));
+  expect(onRemove).toHaveBeenCalledWith("pptx");
+});

--- a/crates/openwave-desktop/ui/src/ComposerSlash.ts
+++ b/crates/openwave-desktop/ui/src/ComposerSlash.ts
@@ -1,0 +1,138 @@
+import type { PluginCatalog } from "./api";
+import { promptTitle } from "./WelcomeState";
+
+/** The server's bound on how many skills one turn may invoke. */
+export const MAX_INVOKED_SKILLS = 8;
+
+/**
+ * One thing a `/` can reach: a skill to invoke, or a prompt to insert.
+ *
+ * Both live in one flat list because the reader is looking for a name, not
+ * deciding which library it came from. `kind` is what the composer acts on:
+ * picking a skill leaves a pill behind, picking a prompt writes text.
+ */
+export type SlashOption = {
+  kind: "skill" | "prompt";
+  /** The catalog slug — what the wire and the pill are keyed by. */
+  name: string;
+  label: string;
+  description: string;
+};
+
+/**
+ * The `/` token being typed, if the caret is inside one.
+ *
+ * A `/` only opens the list at the start of the draft or after whitespace, so
+ * ordinary text — a path, a date, an and/or — never raises a popover over what
+ * someone is writing. Whitespace ends the token: once a space is typed the
+ * reader has moved on to prose, and nothing in either catalog is addressed by
+ * a name with a space in it.
+ */
+export function activeSlashQuery(
+  draft: string,
+  caret: number,
+): { start: number; query: string } | null {
+  const upToCaret = draft.slice(0, caret);
+  const start = upToCaret.lastIndexOf("/");
+  if (start < 0) return null;
+  const preceding = start === 0 ? "" : draft[start - 1];
+  if (preceding && !/\s/.test(preceding)) return null;
+  const query = upToCaret.slice(start + 1);
+  if (/\s/.test(query)) return null;
+  return { start, query };
+}
+
+/**
+ * The options a query names, best match first.
+ *
+ * Substring rather than fuzzy: the reader is completing a name they mostly
+ * know, and a fuzzy match over two libraries returns rows nobody typed toward.
+ * A name that starts with the query sorts above one that merely contains it,
+ * and a description-only match sorts last — it is the weakest evidence that
+ * this is the row being reached for.
+ */
+export function filterSlashOptions(
+  options: readonly SlashOption[],
+  query: string,
+): SlashOption[] {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return [...options];
+  const ranked: { option: SlashOption; rank: number }[] = [];
+  for (const option of options) {
+    const name = option.name.toLowerCase();
+    const label = option.label.toLowerCase();
+    const rank = name.startsWith(needle) || label.startsWith(needle)
+      ? 0
+      : name.includes(needle) || label.includes(needle)
+        ? 1
+        : option.description.toLowerCase().includes(needle)
+          ? 2
+          : -1;
+    if (rank >= 0) ranked.push({ option, rank });
+  }
+  return ranked
+    .sort((left, right) => left.rank - right.rank)
+    .map((entry) => entry.option);
+}
+
+/**
+ * The draft with the `/query` token taken out and `replacement` put in its
+ * place, and where the caret lands after it.
+ */
+export function replaceSlashToken(
+  draft: string,
+  start: number,
+  caret: number,
+  replacement: string,
+): { text: string; caret: number } {
+  const before = draft.slice(0, start);
+  const after = draft.slice(caret);
+  return {
+    text: `${before}${replacement}${after}`,
+    caret: before.length + replacement.length,
+  };
+}
+
+/**
+ * What the catalog offers a `/` today: every enabled skill, bundled or
+ * standing alone, and every enabled prompt.
+ *
+ * A member skill is offered only when its bundle is on as well as itself —
+ * a skill inside a disabled bundle is not staged for a turn, so offering it
+ * would produce a send the server refuses.
+ */
+export function slashOptionsFromCatalog(
+  catalog: PluginCatalog | null,
+): SlashOption[] {
+  if (!catalog) return [];
+  const skills: SlashOption[] = [];
+  const seen = new Set<string>();
+  const addSkill = (skill: { name: string; description: string }) => {
+    if (seen.has(skill.name)) return;
+    seen.add(skill.name);
+    skills.push({
+      kind: "skill",
+      name: skill.name,
+      label: promptTitle(skill.name),
+      description: skill.description,
+    });
+  };
+  for (const plugin of catalog.plugins) {
+    if (!plugin.enabled) continue;
+    for (const skill of plugin.skills) {
+      if (skill.enabled) addSkill(skill);
+    }
+  }
+  for (const skill of catalog.skills) {
+    if (skill.enabled) addSkill(skill);
+  }
+  const prompts: SlashOption[] = catalog.prompts
+    .filter((prompt) => prompt.enabled)
+    .map((prompt) => ({
+      kind: "prompt",
+      name: prompt.name,
+      label: promptTitle(prompt.name),
+      description: prompt.description,
+    }));
+  return [...skills, ...prompts];
+}

--- a/crates/openwave-desktop/ui/src/FirstMessage.test.ts
+++ b/crates/openwave-desktop/ui/src/FirstMessage.test.ts
@@ -7,6 +7,7 @@ describe("first message handover", () => {
     text: "summarise the filing",
     images: [],
     files: [],
+    skills: [],
   };
 
   it("hands the message and attachments to the chat they were written for", () => {

--- a/crates/openwave-desktop/ui/src/FirstMessage.ts
+++ b/crates/openwave-desktop/ui/src/FirstMessage.ts
@@ -6,6 +6,8 @@ export type PendingFirstMessage = {
   text: string;
   images: ImageAttachment[];
   files: ImportedDocument[];
+  /** Skills picked on home, which only the chat route can actually post. */
+  skills: string[];
 };
 
 /**

--- a/crates/openwave-desktop/ui/src/HomeRoute.tsx
+++ b/crates/openwave-desktop/ui/src/HomeRoute.tsx
@@ -94,6 +94,7 @@ export function HomeRoute() {
   const pendingChatId = attachments.pendingChatId;
   const pendingImages = attachments.images;
   const pendingFiles = attachments.files;
+  const pendingSkills = attachments.skills;
   const [attaching, setAttaching] = useState(false);
   const [attachError, setAttachError] = useState<string | null>(null);
 
@@ -239,6 +240,7 @@ export function HomeRoute() {
         text: content,
         images: pendingImages,
         files: pendingFiles,
+        skills: pendingSkills,
       });
       // Clear the home draft only once navigation has committed. If it throws,
       // the message lives only in the FirstMessage store with no composer
@@ -298,7 +300,22 @@ export function HomeRoute() {
             cancelPending={false}
             disabled={creatingChat}
             draft={draft}
-            plugins={composerPlugins}
+            plugins={composerPlugins.plugins}
+            slash={{
+              options: composerPlugins.slashOptions,
+              invoked: pendingSkills,
+              onInvoke: (name) =>
+                composerDraftActions.setSkills(HOME_DRAFT_KEY, [
+                  ...pendingSkills,
+                  name,
+                ]),
+              onRemove: (name) =>
+                composerDraftActions.setSkills(
+                  HOME_DRAFT_KEY,
+                  pendingSkills.filter((skill) => skill !== name),
+                ),
+              loadPromptBody: composerPlugins.loadPromptBody,
+            }}
             images={composerImages}
             voice={{
               available: voice.available,

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -559,6 +559,33 @@ describe("parseToolActionPreview", () => {
   });
 });
 
+describe("sending a message", () => {
+  it("carries the invoked skills beside the prose the reader typed", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new ApiClient("http://127.0.0.1", "token");
+
+    await client.postMessage(
+      "chat-1",
+      "turn-1",
+      "make the deck",
+      [],
+      ["doc-1"],
+      ["pptx"],
+    );
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://127.0.0.1/chats/chat-1/messages");
+    expect(JSON.parse(String(init.body))).toEqual({
+      turn_id: "turn-1",
+      content: "make the deck",
+      attachments: [],
+      file_attachments: ["doc-1"],
+      invoked_skills: ["pptx"],
+    });
+  });
+});
+
 describe("active turn steering", () => {
   it("posts an interrupt against the exact chat, turn, and stable identity", async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 202 }));

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -1795,6 +1795,10 @@ export class ApiClient {
    * `attachments` names images already published for this chat, in the order
    * they should be shown to the model. Only identity crosses: the server
    * re-derives every attachment's format and dimensions from the stored bytes.
+   *
+   * `invokedSkills` names the skills the reader explicitly reached for. A name
+   * the install cannot run refuses the whole turn rather than being dropped, so
+   * the caller must be ready to show the refusal.
    */
   postMessage(
     chatId: string,
@@ -1802,6 +1806,7 @@ export class ApiClient {
     content: string,
     attachments: readonly string[] = [],
     fileAttachments: readonly string[] = [],
+    invokedSkills: readonly string[] = [],
   ): Promise<void> {
     return this.json(`/chats/${chatId}/messages`, {
       method: "POST",
@@ -1811,6 +1816,7 @@ export class ApiClient {
         content,
         attachments,
         file_attachments: fileAttachments,
+        invoked_skills: invokedSkills,
       }),
     });
   }

--- a/crates/openwave-desktop/ui/src/plugins/useComposerPlugins.ts
+++ b/crates/openwave-desktop/ui/src/plugins/useComposerPlugins.ts
@@ -1,32 +1,59 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
 import type { ApiClient } from "@/api";
 import type { ComposerPlugins } from "@/ComposerToolsMenu";
+import { slashOptionsFromCatalog, type SlashOption } from "@/ComposerSlash";
 import { pluginsApisFromClient } from "./pluginsApis";
 import { usePluginCatalog } from "./usePluginCatalog";
 
 /**
- * The installed bundles, as the composer's tools menu wants them.
+ * Everything a composer draws from the plugin library: the bundles its tools
+ * menu offers, and the skills and prompts a `/` reaches.
  *
- * Picking one from the composer is a shortcut, not a per-chat setting: a
- * bundle being on is still a property of this installation, so engaging a
- * bundle that is off turns it on the same way its switch on the Plugins page
- * would. Nothing is returned while the catalog is loading or after it failed —
- * the menu shows no section rather than reporting on a library the reader did
+ * One hook over one catalog on purpose — the two surfaces are the same
+ * installation read two ways, and a second hook would mean a second
+ * `GET /plugins` on every chat view for a list already in hand.
+ */
+export type ComposerPluginLibrary = {
+  /** Absent while loading, after a failed load, or when nothing is installed. */
+  plugins: ComposerPlugins | undefined;
+  /** Enabled skills and prompts, flat, for the `/` list. */
+  slashOptions: SlashOption[];
+  loadPromptBody: (name: string) => Promise<string>;
+};
+
+/**
+ * Picking a bundle from the composer is a shortcut, not a per-chat setting: a
+ * bundle being on is still a property of this installation, so engaging one
+ * that is off turns it on the same way its switch on the Plugins page would.
+ * Nothing is offered while the catalog is loading or after it failed — the
+ * composer shows no section rather than reporting on a library the reader did
  * not ask about.
  */
-export function useComposerPlugins(
-  client: ApiClient,
-): ComposerPlugins | undefined {
+export function useComposerPlugins(client: ApiClient): ComposerPluginLibrary {
   const apis = useMemo(() => pluginsApisFromClient(client), [client]);
   const { catalog, setEnabled } = usePluginCatalog(apis);
   const plugins = catalog?.plugins ?? [];
-  if (plugins.length === 0) return undefined;
+  const slashOptions = useMemo(
+    () => slashOptionsFromCatalog(catalog),
+    [catalog],
+  );
+  const loadPromptBody = useCallback(
+    async (name: string) => (await apis.promptBody(name)).body,
+    [apis],
+  );
   return {
-    items: plugins,
-    onSelect: (plugin) => {
-      if (plugin.enabled) return;
-      setEnabled({ plugins: { [plugin.name]: true }, skills: {} });
-    },
+    plugins:
+      plugins.length === 0
+        ? undefined
+        : {
+            items: plugins,
+            onSelect: (plugin) => {
+              if (plugin.enabled) return;
+              setEnabled({ plugins: { [plugin.name]: true }, skills: {} });
+            },
+          },
+    slashOptions,
+    loadPromptBody,
   };
 }


### PR DESCRIPTION
Part of #772.

Typing `/` at the start of the draft or after whitespace opens a flat list of
the enabled skills and prompts the install has, filtered by whatever follows
the slash. A `/` anywhere else — a path, a mid-word slash — is left alone, and
a space ends the token, so the list never appears over ordinary prose.

Picking a prompt fetches its body from `GET /plugins/prompts/{name}/body` and
puts the text where the token was; a body that cannot be read leaves the draft
untouched rather than raising an error at someone who was only browsing.
Picking a skill removes the token and pins a dismissible chip beside the
attachment chips instead: the invocation is a field on the message, so it has
to be one thing to remove rather than words a reader could half-delete. The
chips travel to the server as `invoked_skills` on the message POST, and are
cleared with the attachments once the turn is accepted — a refused send leaves
them in place with the server's reason in the transcript, which is what the
`invoked_skill_unavailable` refusal is for.

Skills are withheld from the list once eight are pinned (the server's bound,
with a line saying so), while a turn is running (steering carries no
invocation), and for names already pinned. Prompts stay available throughout.

The list is in flow above the field rather than floating over it: the composer
clips its own overflow for its rounded edge, so an anchored panel would be cut
off at the border.

Both composers reach the same catalog `useComposerPlugins` already loads for
the tools menu, so nothing here adds a request. The invoked names live in the
composer draft store beside the attachments, which is what lets the chat route
read them synchronously when it posts and lets a pick made on home survive the
navigation into the conversation it opens.

Tests:

- `/` opens on a leading slash, narrows as the query is typed, and closes on Escape.
- A slash mid-word, and a token followed by a space, leave the list closed.
- Picking a prompt fetches the body and replaces the token with it, pinning nothing.
- Picking a skill invokes it, takes the token out of the draft, and leaves a chip that can be dismissed.
- `postMessage` carries `invoked_skills` beside the prose (api).