### PR TITLE
fix(desktop): show one provider-required card per turn

### DIFF
--- a/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
@@ -995,6 +995,59 @@ describe("actionable tool results", () => {
       expect(router.state.location.pathname).toBe("/settings/web-search");
     });
   });
+
+  it("stands the provider-required card up once per turn", async () => {
+    await renderWithRouter(
+      <MessageList
+        messages={[
+          // Two searches issued in parallel, both refused for the same missing
+          // provider, then a fresh turn that hits the wall again.
+          {
+            id: "web-search-1",
+            role: "tool",
+            callId: "call-1",
+            name: "web_search",
+            status: "failed",
+            result: { tool: "web_search_provider_required" },
+          },
+          {
+            id: "web-search-2",
+            role: "tool",
+            callId: "call-2",
+            name: "web_search",
+            status: "failed",
+            result: { tool: "web_search_provider_required" },
+          },
+          { id: "user-2", role: "user", text: "Try again" },
+          {
+            id: "web-search-3",
+            role: "tool",
+            callId: "call-3",
+            name: "web_search",
+            status: "failed",
+            result: { tool: "web_search_provider_required" },
+          },
+        ]}
+        folderAccessRequests={[]}
+        nativeHost={false}
+        nativeBusy={false}
+        resolvingFolderCalls={new Set()}
+        folderAccessErrors={{}}
+        decidingApprovalCalls={new Set()}
+        approvalErrors={{}}
+        busy={false}
+        scrollRef={{ current: null }}
+        onScroll={noop}
+        onApproval={noop}
+        onFolderAccessDecision={noop}
+        onFolderAccessCancel={noop}
+      />,
+    );
+
+    expect(
+      screen.getAllByRole("heading", { name: "Web search needs a provider" }),
+    ).toHaveLength(2);
+  });
 });
 
 describe("citation anchors", () => {

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -560,6 +560,12 @@ export function groupMessageItems(
   // caller lift the last exchange into a pinned wrapper without re-deriving the
   // turn boundary. Stays -1 for a transcript that opens on activity alone.
   let lastTurnStart = -1;
+  // Cards whose whole content is the situation, not the call — a standing
+  // call-to-action the reader answers once. Parallel calls that all fail the
+  // same way would otherwise stack identical copies of it. The claim is per
+  // turn, not per transcript: the next turn hitting the same wall is a live
+  // prompt again, so a user message clears it.
+  let standingCardKeys = new Set<string>();
   let index = 0;
   let groupIndex = 0;
   let streamingAssistantId: string | undefined;
@@ -584,7 +590,10 @@ export function groupMessageItems(
     const message = messages[index];
 
     if (!isActivityMessage(message)) {
-      if (message.role === "user") lastTurnStart = items.length;
+      if (message.role === "user") {
+        lastTurnStart = items.length;
+        standingCardKeys = new Set<string>();
+      }
       items.push(
         <MessageBubble
           key={message.id}
@@ -628,6 +637,7 @@ export function groupMessageItems(
     const cards = surfacedCards(
       phase,
       parked,
+      standingCardKeys,
       onApproval,
       approvalState,
       chatId,
@@ -739,6 +749,12 @@ function isolatedCard(
 /** What deciding a card needs beyond the entry it is deciding about. */
 type CardContext = {
   parked: Set<string>;
+  /**
+   * Keys of the standing call-to-action cards already shown this turn, so the
+   * second call that fails the same way adds a rail row and nothing else.
+   * Written through by {@link surfacedCard} as it claims a key.
+   */
+  standingCardKeys: Set<string>;
   onApproval: (
     callId: string,
     decision: "approve" | "reject",
@@ -771,6 +787,7 @@ type CardContext = {
 function surfacedCards(
   phase: ChatMessage[],
   parked: Set<string>,
+  standingCardKeys: Set<string>,
   onApproval: (
     callId: string,
     decision: "approve" | "reject",
@@ -786,6 +803,7 @@ function surfacedCards(
 ): ReactNode[] {
   const context: CardContext = {
     parked,
+    standingCardKeys,
     onApproval,
     approvalState,
     chatId,
@@ -855,7 +873,14 @@ function surfacedAppCards(entry: ChatMessage): ReactNode {
 
 /** The card one entry earns, or `null` when it earns none. */
 function surfacedCard(entry: ChatMessage, context: CardContext): ReactNode {
-  const { parked, onApproval, approvalState, chatId, imageClient } = context;
+  const {
+    parked,
+    standingCardKeys,
+    onApproval,
+    approvalState,
+    chatId,
+    imageClient,
+  } = context;
   if (entry.role === "approval") {
     if (entry.resolved) return null;
     return isolatedCard(
@@ -884,6 +909,13 @@ function surfacedCard(entry: ChatMessage, context: CardContext): ReactNode {
     entry.result?.tool === "web_search_provider_required" &&
     !parked.has(entry.callId)
   ) {
+    // The card says nothing about the call that produced it — it asks the
+    // reader to configure a provider. Parallel searches all fail this way at
+    // once, so only the first of them stands the card up; the rest are already
+    // accounted for on the rail. A parked call renders no card at all and so
+    // never claims the turn's slot.
+    if (standingCardKeys.has("web_search_provider_required")) return null;
+    standingCardKeys.add("web_search_provider_required");
     return isolatedCard(entry.id, "", <WebSearchProviderRequiredCard />);
   }
   // An MCP App view is keyed on the *result*: the tool has no action


### PR DESCRIPTION
Parallel `web_search` calls made while no provider is configured each return a `web_search_provider_required` result, and the transcript stacked one identical "Web search needs a provider" card per call. The card carries no per-call data, so the extra copies were pure noise.

`groupMessageItems` now owns a per-turn set of standing card keys, cleared at each user message and threaded into the card context. The first unparked provider-required result claims the key and renders the card; later results in the same turn (including in later phases) render only their rail row, and a call parked on approval still renders nothing and does not consume the slot. A new turn that hits the same wall shows the card again, since it is a live call to action.

Verified with `pnpm vitest run src/MessageList.dom.test.tsx` and `pnpm exec tsc --noEmit`; the added dom test renders two parallel failures plus a second turn and asserts exactly two cards.