### PR TITLE
feat(server): curate Claude Fable 5

### DIFF
--- a/crates/openwave-server/src/model_registry.rs
+++ b/crates/openwave-server/src/model_registry.rs
@@ -155,6 +155,20 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         // because a model on the adaptive block always reasons.
         reasoning_efforts: EFFORT_LOW_TO_MAX,
     },
+    // Second, not first: the built-in default is this provider's first curated
+    // row, and the default stays Opus 5.
+    ModelSpec {
+        id: "claude-fable-5",
+        display_name: "Claude Fable 5",
+        provider: ProviderKind::Anthropic,
+        verification: VerificationTier::Verified,
+        context_window: 1_000_000,
+        max_output_tokens: 128_000,
+        input_modalities: TEXT_AND_IMAGE,
+        supports_reasoning: true,
+        // Same adaptive-thinking generation as Opus 5 and Sonnet 5.
+        reasoning_efforts: EFFORT_LOW_TO_MAX,
+    },
     ModelSpec {
         id: "claude-sonnet-5",
         display_name: "Claude Sonnet 5",


### PR DESCRIPTION
Claude Fable 5 was missing from the curated model registry, so it could
only ever reach the picker as an unverified custom or gateway row: text
only, no reasoning effort, generic branding.

This adds the registry row — 1M context window, 128K max output, image
input, and the `low`..`max` adaptive-thinking effort range shared with
Opus 5 and Sonnet 5.

The row is placed second among the Anthropic entries deliberately. The
built-in default resolves to a provider's first curated row, and this
change is not meant to move the default off Opus 5; a comment on the row
records that.

No new tests: the existing registry invariant tests (unique keys,
well-formed capabilities, verification tier present, Anthropic effort
range) already cover a new row.

Verified with `cargo test -p openwave-server model_registry` (11 passed)
and `cargo fmt --check`.