### PR TITLE
refactor: remove the retired local-app tools binding vocabulary end to end

### DIFF
--- a/crates/openwave-core/src/db/tests/app.rs
+++ b/crates/openwave-core/src/db/tests/app.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::id::{AgentRunId, AppId, AppRevisionId, ConnectedAppId};
 use crate::local_app::{
-    AppBinding, AppManifest, AppToolsBinding, CreateApp, NewAppRevision, MAX_APP_BUNDLE_BYTES,
+    AppBinding, AppManifest, AppOperationsBinding, CreateApp, NewAppRevision, MAX_APP_BUNDLE_BYTES,
     MAX_APP_REVISIONS,
 };
 
@@ -16,9 +16,9 @@ fn digest(seed: u8) -> [u8; 32] {
 fn manifest(name: &str) -> AppManifest {
     AppManifest {
         name: name.to_owned(),
-        bindings: vec![AppBinding::Tools(AppToolsBinding {
+        bindings: vec![AppBinding::Operations(AppOperationsBinding {
             app: ConnectedAppId(uuid::Uuid::from_u128(1)),
-            tools: vec!["mcp__sentry__list_issues".into()],
+            operation_ids: vec!["listIssues".into()],
         })],
     }
 }
@@ -178,14 +178,14 @@ async fn a_revision_records_one_producer_and_dangling_conversation_provenance() 
 async fn malformed_manifests_and_out_of_bounds_bundles_are_refused() {
     let (_dir, store) = temp_store().await;
 
-    // A pinned name that is not shaped like a mounted tool can never match
-    // one, so the store refuses it at the door.
-    let mut bare_tool = create_request(1);
-    bare_tool.revision.manifest.bindings[0] = AppBinding::Tools(AppToolsBinding {
+    // A pinned id outside the operationId grammar can never match a declared
+    // operation, so the store refuses it at the door.
+    let mut bare_operation = create_request(1);
+    bare_operation.revision.manifest.bindings[0] = AppBinding::Operations(AppOperationsBinding {
         app: ConnectedAppId(uuid::Uuid::from_u128(1)),
-        tools: vec!["list_issues".into()],
+        operation_ids: vec!["not an operation id".into()],
     });
-    assert!(store.create_app(&bare_tool).await.is_err());
+    assert!(store.create_app(&bare_operation).await.is_err());
 
     let mut empty_bundle = create_request(1);
     empty_bundle.revision.byte_len = 0;
@@ -199,9 +199,9 @@ async fn malformed_manifests_and_out_of_bounds_bundles_are_refused() {
     let mut oversized_manifest = create_request(1);
     oversized_manifest.revision.manifest.bindings = (0..2_000)
         .map(|index| {
-            AppBinding::Tools(AppToolsBinding {
+            AppBinding::Operations(AppOperationsBinding {
                 app: ConnectedAppId::new(),
-                tools: vec![format!("mcp__server_{index:04}__tool_padding_padding")],
+                operation_ids: vec![format!("operation_{index:04}_padding_padding")],
             })
         })
         .collect();

--- a/crates/openwave-core/src/local_app.rs
+++ b/crates/openwave-core/src/local_app.rs
@@ -8,7 +8,7 @@
 //!
 //! Each revision pairs an untrusted HTML bundle (bytes on disk, recorded here
 //! as length + digest) with a trusted, structurally validated manifest naming
-//! the mounted MCP tools the app may call.
+//! the connected-app operations and folders the app may call.
 
 use std::path::PathBuf;
 
@@ -43,9 +43,6 @@ pub const MAX_APP_MANIFEST_BYTES: usize = 64 * 1024;
 pub const MAX_APP_REVISIONS: u32 = 100;
 /// Largest app display name accepted by the manifest.
 pub const MAX_APP_NAME_CHARS: usize = 120;
-/// Provider-safe bound every mounted tool name already obeys, reused verbatim
-/// for manifest bindings so a pinned name can always match a mounted one.
-pub const MAX_MOUNTED_TOOL_NAME_BYTES: usize = 64;
 /// Largest `operationId` a `rest_api` binding may pin, in bytes.
 ///
 /// A deliberate mirror of the OpenAPI ingest module's bound
@@ -131,7 +128,7 @@ pub struct AppRevision {
     pub app_id: AppId,
     /// One-based position in the app's revision history.
     pub ordinal: u32,
-    /// The trusted manifest: display name and pinned tool bindings.
+    /// The trusted manifest: display name and pinned capability bindings.
     pub manifest: AppManifest,
     /// Exact byte length of the revision's bundle.
     pub byte_len: u64,
@@ -199,9 +196,9 @@ pub struct CreateApp {
 }
 
 /// The durable consent object for one app: the granted binding set —
-/// `(app, tools[])` or `(app, operation_ids[])` per bound connected app —
-/// with each bound connected app pinned to a fingerprint of its definition as
-/// it was configured at consent time.
+/// `(app, operation_ids[])` per bound connected app, or `(folder, access)`
+/// per bound folder — with each bound connected app pinned to a fingerprint
+/// of its definition as it was configured at consent time.
 ///
 /// One grant per app, replaced wholesale by a fresh consent and deleted by
 /// revocation. The fingerprint is what keeps consent honest: a Settings edit
@@ -229,8 +226,6 @@ pub struct AppGrant {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum AppGrantBinding {
-    /// `{ app, tools[], fingerprint }` — granted mounted MCP tools.
-    Tools(AppToolsGrantBinding),
     /// `{ app, operation_ids[], fingerprint }` — granted REST operations.
     Operations(AppOperationsGrantBinding),
     /// `{ folder, access, fingerprint }` — granted folder access.
@@ -243,7 +238,6 @@ impl AppGrantBinding {
     #[must_use]
     pub fn app(&self) -> Option<ConnectedAppId> {
         match self {
-            Self::Tools(binding) => Some(binding.app),
             Self::Operations(binding) => Some(binding.app),
             Self::Folder(_) => None,
         }
@@ -253,28 +247,10 @@ impl AppGrantBinding {
     #[must_use]
     pub fn fingerprint(&self) -> [u8; 32] {
         match self {
-            Self::Tools(binding) => binding.fingerprint,
             Self::Operations(binding) => binding.fingerprint,
             Self::Folder(binding) => binding.fingerprint,
         }
     }
-}
-
-/// The granted mounted tools under one `mcp_server` connected app.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct AppToolsGrantBinding {
-    /// Connected app the consent names, matching the manifest binding it
-    /// covers.
-    pub app: ConnectedAppId,
-    /// Full mounted tool names (`mcp__{namespace}__{tool}`) the grant covers.
-    pub tools: Vec<String>,
-    /// SHA-256 fingerprint of the connected app's definition as configured at
-    /// consent time, computed by the host over a canonical serialization that
-    /// carries configuration *names and structure* only — never environment
-    /// or token values. Persisted as lowercase hex.
-    #[serde(with = "hex_fingerprint")]
-    pub fingerprint: [u8; 32],
 }
 
 /// The granted declared operations under one `rest_api` connected app.
@@ -347,10 +323,6 @@ mod hex_fingerprint {
 /// validator would have refused.
 pub fn validate_app_grant(grant: &AppGrant) -> Result<serde_json::Value, String> {
     validate_binding_set(grant.bindings.iter().map(|binding| match binding {
-        AppGrantBinding::Tools(binding) => (
-            BindingKey::App(binding.app),
-            BindingCapabilities::Tools(&binding.tools),
-        ),
         AppGrantBinding::Operations(binding) => (
             BindingKey::App(binding.app),
             BindingCapabilities::Operations(&binding.operation_ids),
@@ -363,8 +335,8 @@ pub fn validate_app_grant(grant: &AppGrant) -> Result<serde_json::Value, String>
     serde_json::to_value(&grant.bindings).map_err(|error| format!("unencodable app grant: {error}"))
 }
 
-/// The trusted half of an app revision: a display name and the exact mounted
-/// tools the app may call.
+/// The trusted half of an app revision: a display name and the exact
+/// capabilities the app may call.
 ///
 /// The manifest — not the bundle — is what the user consents to and what the
 /// host enforces per call, so its shape is closed (`deny_unknown_fields`) and
@@ -377,13 +349,13 @@ pub fn validate_app_grant(grant: &AppGrant) -> Result<serde_json::Value, String>
 pub struct AppManifest {
     /// Display name shown in the transcript card and the Apps library.
     pub name: String,
-    /// Pinned tool bindings, grouped by connected app.
+    /// Pinned capability bindings, grouped by connected app or folder.
     pub bindings: Vec<AppBinding>,
 }
 
 /// The capabilities one binding contributes to a local app: declared REST
-/// operations of a `rest_api` connected app, bounded access to a connected
-/// folder, or — retired (#1332) but still parseable — mounted MCP tools.
+/// operations of a `rest_api` connected app, or bounded access to a
+/// connected folder.
 ///
 /// Untagged and closed: the shapes are distinguished by their differing
 /// field names, each variant refuses unknown fields, and a body mixing
@@ -391,8 +363,6 @@ pub struct AppManifest {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(untagged)]
 pub enum AppBinding {
-    /// `{ app, tools[] }` — mounted MCP tools of an `mcp_server` record.
-    Tools(AppToolsBinding),
     /// `{ app, operation_ids[] }` — declared operations of a `rest_api`
     /// record.
     Operations(AppOperationsBinding),
@@ -406,29 +376,10 @@ impl AppBinding {
     #[must_use]
     pub fn app(&self) -> Option<ConnectedAppId> {
         match self {
-            Self::Tools(binding) => Some(binding.app),
             Self::Operations(binding) => Some(binding.app),
             Self::Folder(_) => None,
         }
     }
-}
-
-/// The mounted tools one `mcp_server` connected app contributes to a local
-/// app.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
-#[serde(deny_unknown_fields)]
-pub struct AppToolsBinding {
-    /// Id of the connected app the tools belong to. The available ids are
-    /// listed in the `create_app` tool description.
-    #[schemars(description = "Id of the mcp_server connected app these tools belong to.")]
-    pub app: ConnectedAppId,
-    /// Full mounted tool names, each `mcp__{namespace}__{tool}` under the
-    /// bound connected app's namespace.
-    #[schemars(
-        description = "Full mounted tool names (`mcp__{namespace}__{tool}`), all \
-                       under the bound connected app's namespace."
-    )]
-    pub tools: Vec<String>,
 }
 
 /// The declared operations one `rest_api` connected app contributes to a
@@ -532,18 +483,11 @@ pub trait ApprovedFolderSource: Send + Sync {
 
 /// Validate an app manifest structurally and return the JSON to store.
 ///
-/// Checks the display name, the mounted-tool grammar of every binding, and the
-/// serialized size bound. Tool names must be full mounted names under the
-/// binding's server namespace and fit the provider-safe 64-byte
-/// `[A-Za-z0-9_-]` contract every mounted tool already obeys, so a pinned name
-/// that could never match a mounted tool is refused at the door.
+/// Checks the display name, the grammar of every binding, and the serialized
+/// size bound.
 pub fn validate_app_manifest(manifest: &AppManifest) -> Result<serde_json::Value, String> {
     validate_app_name(&manifest.name)?;
     validate_binding_set(manifest.bindings.iter().map(|binding| match binding {
-        AppBinding::Tools(binding) => (
-            BindingKey::App(binding.app),
-            BindingCapabilities::Tools(&binding.tools),
-        ),
         AppBinding::Operations(binding) => (
             BindingKey::App(binding.app),
             BindingCapabilities::Operations(&binding.operation_ids),
@@ -574,24 +518,19 @@ enum BindingKey {
 
 /// One binding's capability list, by vocabulary, for the shared grammar check.
 enum BindingCapabilities<'a> {
-    Tools(&'a [String]),
     Operations(&'a [String]),
     Folder,
 }
 
 /// The binding grammar shared by manifests and grants: no duplicate connected
 /// apps or folders (one binding per record or root, whichever vocabulary),
-/// every tool shaped like a full mounted name, and every operation id within
-/// the ingest module's `operationId` grammar. A folder binding has no list to
-/// validate — its access level is closed by type.
+/// and every operation id within the ingest module's `operationId` grammar. A
+/// folder binding has no list to validate — its access level is closed by
+/// type.
 ///
-/// A namespace may itself contain `_`, so a mounted name cannot be split
-/// unambiguously without knowing the namespace — and the bound record lives
-/// behind the store. The grammar here is therefore structural only; the exact
-/// `mcp__{namespace}__` cross-check against the bound connected app's
-/// configuration — and the catalog membership check for operation ids —
-/// belongs to the host layers that resolve ids (the `create_app` door, grant
-/// computation, the invoke gate).
+/// The grammar here is structural only; the catalog membership check for
+/// operation ids belongs to the host layers that resolve ids (the
+/// `create_app` door, grant computation, the invoke gate).
 fn validate_binding_set<'a>(
     bindings: impl Iterator<Item = (BindingKey, BindingCapabilities<'a>)>,
 ) -> Result<(), String> {
@@ -611,24 +550,6 @@ fn validate_binding_set<'a>(
         }
         keys.insert(key);
         match capabilities {
-            BindingCapabilities::Tools(binding_tools) => {
-                let mut tools = std::collections::HashSet::new();
-                for tool in binding_tools {
-                    if tool.len() > MAX_MOUNTED_TOOL_NAME_BYTES || !is_mounted_name_charset(tool) {
-                        return Err(format!(
-                            "tool {tool:?} must be at most {MAX_MOUNTED_TOOL_NAME_BYTES} bytes of [A-Za-z0-9_-]"
-                        ));
-                    }
-                    if !is_mounted_name_shape(tool) {
-                        return Err(format!(
-                            "tool {tool:?} is not a mounted `mcp__{{namespace}}__{{tool}}` name"
-                        ));
-                    }
-                    if !tools.insert(tool.as_str()) {
-                        return Err(format!("duplicate tool {tool:?}"));
-                    }
-                }
-            }
             BindingCapabilities::Operations(binding_operations) => {
                 let mut operations = std::collections::HashSet::new();
                 for operation_id in binding_operations {
@@ -654,31 +575,6 @@ fn validate_binding_set<'a>(
     Ok(())
 }
 
-/// Whether a name is shaped like `mcp__{namespace}__{tool}` with a non-empty
-/// namespace and tool segment under *some* split — the namespace itself may
-/// contain `_`, so the exact split is only decidable against a configured
-/// record.
-fn is_mounted_name_shape(name: &str) -> bool {
-    let Some(qualified) = name.strip_prefix("mcp__") else {
-        return false;
-    };
-    qualified
-        .match_indices("__")
-        .any(|(index, _)| index > 0 && index + 2 < qualified.len())
-}
-
-/// The bare tool segment of `name` when it is mounted under exactly
-/// `namespace` — the host-side half of the binding grammar, shared by the
-/// `create_app` door, grant computation, and the invoke gate so every layer
-/// applies the same exact-prefix reading.
-#[must_use]
-pub fn mounted_tool_under<'a>(namespace: &str, name: &'a str) -> Option<&'a str> {
-    name.strip_prefix("mcp__")?
-        .strip_prefix(namespace)?
-        .strip_prefix("__")
-        .filter(|tool| !tool.is_empty())
-}
-
 fn validate_app_name(name: &str) -> Result<(), String> {
     if name.is_empty() || name.chars().count() > MAX_APP_NAME_CHARS {
         return Err(format!(
@@ -692,11 +588,6 @@ fn validate_app_name(name: &str) -> Result<(), String> {
         return Err("app name may not contain control characters".into());
     }
     Ok(())
-}
-
-fn is_mounted_name_charset(name: &str) -> bool {
-    name.bytes()
-        .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-')
 }
 
 /// The ingest module's `operationId` charset, mirrored (see
@@ -739,62 +630,13 @@ mod tests {
     }
 
     #[test]
-    fn manifests_enforce_the_mounted_tool_grammar() {
-        let app = ConnectedAppId::new();
-        let manifest = |tools: &[&str]| AppManifest {
-            name: "Sentry triage".into(),
-            bindings: vec![AppBinding::Tools(AppToolsBinding {
-                app,
-                tools: tools.iter().map(|tool| (*tool).to_owned()).collect(),
-            })],
-        };
-
-        assert!(validate_app_manifest(&manifest(&[
-            "mcp__sentry__list_issues",
-            "mcp__sentry__get_issue"
-        ]))
-        .is_ok());
-        // Bindings may be empty: a static app pins no tools.
+    fn manifests_enforce_the_name_grammar() {
+        // Bindings may be empty: a static app pins no capabilities.
         assert!(validate_app_manifest(&AppManifest {
             name: "Static".into(),
             bindings: Vec::new(),
         })
         .is_ok());
-
-        for tool in [
-            "list_issues",                               // bare name, not mounted
-            "mcp__sentry__",                             // empty tool segment
-            "mcp____tool",                               // empty namespace segment
-            "mcp__sentry__bad name",                     // charset
-            &format!("mcp__sentry__{}", "x".repeat(64)), // over the 64-byte bound
-        ] {
-            assert!(validate_app_manifest(&manifest(&[tool])).is_err(), "{tool}");
-        }
-        assert!(
-            validate_app_manifest(&manifest(&[
-                "mcp__sentry__list_issues",
-                "mcp__sentry__list_issues"
-            ]))
-            .is_err(),
-            "duplicate pins are refused"
-        );
-        assert!(
-            validate_app_manifest(&AppManifest {
-                name: "Twice".into(),
-                bindings: vec![
-                    AppBinding::Tools(AppToolsBinding {
-                        app,
-                        tools: Vec::new()
-                    }),
-                    AppBinding::Tools(AppToolsBinding {
-                        app,
-                        tools: Vec::new()
-                    }),
-                ],
-            })
-            .is_err(),
-            "duplicate connected-app bindings are refused"
-        );
 
         for name in ["", " padded ", "line\nbreak", &"x".repeat(121)] {
             assert!(
@@ -835,15 +677,15 @@ mod tests {
             validate_app_manifest(&manifest(&["listIssues", "listIssues"])).is_err(),
             "duplicate pins are refused"
         );
-        // One binding per connected app holds across vocabularies: the same
-        // record cannot be bound once for tools and once for operations.
+        // One binding per connected app: the same record cannot be bound
+        // twice.
         assert!(
             validate_app_manifest(&AppManifest {
                 name: "Twice".into(),
                 bindings: vec![
-                    AppBinding::Tools(AppToolsBinding {
+                    AppBinding::Operations(AppOperationsBinding {
                         app,
-                        tools: Vec::new()
+                        operation_ids: Vec::new()
                     }),
                     AppBinding::Operations(AppOperationsBinding {
                         app,
@@ -852,7 +694,7 @@ mod tests {
                 ],
             })
             .is_err(),
-            "duplicate connected-app bindings are refused across binding kinds"
+            "duplicate connected-app bindings are refused"
         );
     }
 
@@ -861,17 +703,16 @@ mod tests {
         use serde_json::json;
 
         let app = ConnectedAppId::new();
-        let tools: AppBinding =
-            serde_json::from_value(json!({ "app": app, "tools": ["mcp__srv__viewer"] })).unwrap();
-        assert!(matches!(tools, AppBinding::Tools(_)));
         let operations: AppBinding =
             serde_json::from_value(json!({ "app": app, "operation_ids": ["listIssues"] })).unwrap();
         assert!(matches!(operations, AppBinding::Operations(_)));
-        // Both vocabularies in one binding, or any unknown field, match
-        // neither closed variant.
+        // The retired tools vocabulary (#1332, removed in #1589), a binding
+        // mixing vocabularies, any unknown field, and a bare app all match no
+        // closed variant.
         for body in [
+            json!({ "app": app, "tools": ["mcp__srv__viewer"] }),
             json!({ "app": app, "tools": [], "operation_ids": [] }),
-            json!({ "app": app, "tools": [], "extra": true }),
+            json!({ "app": app, "operation_ids": [], "extra": true }),
             json!({ "app": app }),
         ] {
             assert!(
@@ -888,10 +729,16 @@ mod tests {
         .unwrap();
         assert!(matches!(granted, AppGrantBinding::Operations(_)));
         assert_eq!(granted.fingerprint(), [0xab; 32]);
-        assert!(serde_json::from_value::<AppGrantBinding>(
-            json!({ "app": app, "tools": [], "operation_ids": [], "fingerprint": fingerprint })
-        )
-        .is_err());
+        // A pre-removal tools grant reads as unparseable, not as any variant.
+        for body in [
+            json!({ "app": app, "tools": ["mcp__srv__viewer"], "fingerprint": fingerprint }),
+            json!({ "app": app, "tools": [], "operation_ids": [], "fingerprint": fingerprint }),
+        ] {
+            assert!(
+                serde_json::from_value::<AppGrantBinding>(body.clone()).is_err(),
+                "{body}"
+            );
+        }
     }
 
     /// The folder vocabulary joins the same untagged, closed grammar: its
@@ -977,20 +824,5 @@ mod tests {
             json!({ "folder": folder, "access": "read" })
         )
         .is_err());
-    }
-
-    #[test]
-    fn the_exact_namespace_reading_is_prefix_anchored() {
-        // A namespace may contain `_`, so only the exact-prefix reading is
-        // sound — this is the check the host layers apply once the bound
-        // record's namespace is known.
-        assert_eq!(
-            mounted_tool_under("my_server", "mcp__my_server__tool"),
-            Some("tool")
-        );
-        assert_eq!(mounted_tool_under("my", "mcp__my_server__tool"), None);
-        assert_eq!(mounted_tool_under("sentry", "mcp__github__list"), None);
-        assert_eq!(mounted_tool_under("sentry", "mcp__sentry__"), None);
-        assert_eq!(mounted_tool_under("sentry", "sentry__tool"), None);
     }
 }

--- a/crates/openwave-core/src/tools/create_app.rs
+++ b/crates/openwave-core/src/tools/create_app.rs
@@ -116,11 +116,10 @@ impl CreateAppTool {
             .ok_or_else(|| ToolOutput::error("this call is not recorded in this conversation"))
     }
 
-    /// Check that every manifest binding names a configured connected app and
-    /// speaks the one live vocabulary: operation bindings resolve to a
-    /// `rest_api` record with each pinned `operationId` declared by its
-    /// ingested catalog. Tools bindings are refused outright — the vocabulary
-    /// is retired (#1332).
+    /// Check that every manifest binding names a configured connected app or
+    /// approved folder and speaks a live vocabulary: operation bindings
+    /// resolve to a `rest_api` record with each pinned `operationId` declared
+    /// by its ingested catalog.
     async fn check_bindings(&self, manifest: &AppManifest) -> std::result::Result<(), String> {
         if manifest.bindings.is_empty() {
             return Ok(());
@@ -189,19 +188,6 @@ impl CreateAppTool {
                 // Handled above — a folder binding has no connected app to
                 // resolve.
                 AppBinding::Folder(_) => {}
-                // The tools vocabulary is retired (#1332): MCP was the only
-                // bindable kind when local apps shipped, and REST operations
-                // replaced it as the app-facing surface. The grammar still
-                // parses `tools` (stored manifests carry it), but nothing new
-                // may pin it — refused here with the alternative spelled out.
-                AppBinding::Tools(_) => {
-                    return Err(format!(
-                        "connected app {} ({}) is bound with `tools`, but local apps \
-                         no longer bind mounted MCP tools; bind a rest_api connected \
-                         app's declared operations with `operation_ids` instead",
-                        app.id, app.name
-                    ));
-                }
                 AppBinding::Operations(binding) => {
                     if app.kind != ConnectedAppKind::RestApi {
                         return Err(format!(
@@ -734,9 +720,9 @@ mod tests {
             refused.content
         );
 
-        // Tools bindings are retired (#1332): refused at the door no matter
-        // which kind of connected app they name, with the live vocabulary
-        // spelled out.
+        // The tools vocabulary is removed (#1332, #1589): a manifest pinning
+        // `tools` no longer parses as any binding shape, and the refusal
+        // carries the live schema so the model sees what is bindable.
         for connected in [fixture.sentry, fixture.issues] {
             let (_, ctx) = fixture.recorded_call().await;
             let tools_manifest = json!({
@@ -749,7 +735,7 @@ mod tests {
             let refused = fixture.tool.execute(&ctx, tools_manifest).await.unwrap();
             assert!(refused.is_error);
             assert!(
-                refused.content.contains("no longer bind mounted MCP tools"),
+                refused.content.contains("invalid arguments"),
                 "{}",
                 refused.content
             );

--- a/crates/openwave-desktop/ui/src/McpAppBridge.test.ts
+++ b/crates/openwave-desktop/ui/src/McpAppBridge.test.ts
@@ -14,7 +14,7 @@ const PAYLOAD: McpAppPayload = {
 
 function harness(
   theme: "light" | "dark" = "dark",
-  invokeTool?: Parameters<typeof createMcpAppBridge>[0]["invokeTool"],
+  invokeOperation?: Parameters<typeof createMcpAppBridge>[0]["invokeOperation"],
 ) {
   const postMessage = vi.fn();
   const frame = { postMessage } as unknown as Window;
@@ -24,7 +24,7 @@ function harness(
     frame: () => frame,
     theme: () => currentTheme,
     onHeight,
-    invokeTool,
+    invokeOperation,
   });
   const fromView = (data: unknown, source: unknown = frame) =>
     bridge.handleMessage({ data, source } as MessageEvent);
@@ -123,29 +123,37 @@ describe("createMcpAppBridge", () => {
     expect(sent()).toHaveLength(1);
   });
 
-  it("refuses tools/call without an invoker, and undeclared methods with one", () => {
-    // The transcript card wires no invoker: tools/call stays method-not-found
-    // there, exactly as before the app-open flow existed.
+  it("refuses operations/call without an invoker, and undeclared methods with one", () => {
+    // The transcript card wires no invoker: operations/call stays
+    // method-not-found there.
     const bare = harness();
     bare.fromView({
       jsonrpc: "2.0",
       id: 1,
-      method: "tools/call",
-      params: { name: "mcp__cmd__doit", arguments: {} },
+      method: "operations/call",
+      params: { operation_id: "listIssues" },
     });
     expect(bare.sent()).toEqual([
       { jsonrpc: "2.0", id: 1, error: { code: -32601, message: "Method not found" } },
     ]);
 
-    // Wiring the invoker declares tools/call and nothing else: any other
-    // method still fails closed rather than acquiring a handler by accident.
-    const invokeTool = vi.fn();
-    const wired = harness("dark", invokeTool);
+    // Wiring the invoker declares operations/call and nothing else: any
+    // other method — including the removed tools/call verb — still fails
+    // closed rather than acquiring a handler by accident.
+    const invokeOperation = vi.fn();
+    const wired = harness("dark", invokeOperation);
     wired.fromView({ jsonrpc: "2.0", id: 2, method: "resources/read", params: {} });
+    wired.fromView({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: { name: "mcp__cmd__doit", arguments: {} },
+    });
     expect(wired.sent()).toEqual([
       { jsonrpc: "2.0", id: 2, error: { code: -32601, message: "Method not found" } },
+      { jsonrpc: "2.0", id: 3, error: { code: -32601, message: "Method not found" } },
     ]);
-    expect(invokeTool).not.toHaveBeenCalled();
+    expect(invokeOperation).not.toHaveBeenCalled();
   });
 
   it("answers ping and clamps size-changed heights", () => {

--- a/crates/openwave-desktop/ui/src/McpAppBridge.ts
+++ b/crates/openwave-desktop/ui/src/McpAppBridge.ts
@@ -20,7 +20,6 @@ export const MCP_APPS_PROTOCOL_VERSION = "2026-01-26";
 
 import {
   AppInvokeRefusalError,
-  type AppInvokeResult,
   type AppFolderInvokeResult,
   type AppRestInvokeResult,
   type McpAppPayload,
@@ -29,21 +28,13 @@ import {
 export type { McpAppPayload };
 
 /**
- * Executes one tool call on the embedded view's behalf. Local-app hosts wire
- * this to `POST /apps/{id}/invoke`; both the arguments and the result are
- * opaque passthrough the bridge forwards without interpreting. A rejection
- * becomes a JSON-RPC error reply — a typed [`AppInvokeRefusalError`] keeps
- * its machine-readable kind in `error.data` (the refusal envelope is
- * host-authored, so surfacing it is not interpretation).
- */
-export type AppToolInvoker = (tool: string, args: unknown) => Promise<AppInvokeResult>;
-
-/**
- * Executes one granted REST operation on the embedded view's behalf — the
- * `operations/call` sibling of [`AppToolInvoker`], wired to the same invoke
- * route. Parameters, body, and the `{status, content_type, body_base64}`
- * result are opaque passthrough in both directions; rejections map to
- * JSON-RPC errors exactly as tool-call rejections do.
+ * Executes one granted REST operation on the embedded view's behalf,
+ * wired to `POST /apps/{id}/invoke`. Parameters, body, and the
+ * `{status, content_type, body_base64}` result are opaque passthrough in
+ * both directions; a rejection becomes a JSON-RPC error reply — a typed
+ * [`AppInvokeRefusalError`] keeps its machine-readable kind in `error.data`
+ * (the refusal envelope is host-authored, so surfacing it is not
+ * interpretation).
  */
 export type AppOperationInvoker = (
   operationId: string,
@@ -53,9 +44,9 @@ export type AppOperationInvoker = (
 
 /**
  * Executes one granted folder operation on the embedded view's behalf — the
- * `fs/*` sibling of the other two invokers, wired to the same invoke route.
+ * `fs/*` sibling of the operation invoker, wired to the same invoke route.
  * Content crosses base64-encoded in both directions; rejections map to
- * JSON-RPC errors exactly as tool- and operation-call rejections do.
+ * JSON-RPC errors exactly as operation-call rejections do.
  */
 export type AppFolderInvoker = (
   folder: string,
@@ -85,17 +76,10 @@ export function createMcpAppBridge(options: {
   theme: () => "light" | "dark";
   onHeight?: (height: number) => void;
   /**
-   * When present, the view may call `tools/call` and the bridge forwards it
-   * here. Absent — the MCP App transcript card — `tools/call` refuses with
-   * method-not-found exactly as before: a view only gets the methods its
-   * host deliberately declared.
-   */
-  invokeTool?: AppToolInvoker;
-  /**
    * When present, the view may call `operations/call` and the bridge
-   * forwards it here — the REST sibling of `invokeTool`, under the same
-   * rule: absent, the method refuses with method-not-found, so a view only
-   * gets the methods its host deliberately declared.
+   * forwards it here. Absent — the MCP App transcript card —
+   * `operations/call` refuses with method-not-found: a view only gets the
+   * methods its host deliberately declared.
    */
   invokeOperation?: AppOperationInvoker;
   /**
@@ -170,58 +154,6 @@ export function createMcpAppBridge(options: {
         case "ping":
           post({ jsonrpc: "2.0", id, result: {} });
           break;
-        case "tools/call": {
-          const invoke = options.invokeTool;
-          if (!invoke) {
-            post({
-              jsonrpc: "2.0",
-              id,
-              error: { code: -32601, message: "Method not found" },
-            });
-            break;
-          }
-          const params = isRecord(message.params) ? message.params : {};
-          const tool = typeof params.name === "string" ? params.name : null;
-          if (!tool) {
-            post({
-              jsonrpc: "2.0",
-              id,
-              error: { code: -32602, message: "tools/call needs a string name" },
-            });
-            break;
-          }
-          // The reply is asynchronous; `post` already refuses after dispose,
-          // so a result landing after unmount goes nowhere.
-          void invoke(tool, params.arguments).then(
-            (result) =>
-              post({
-                jsonrpc: "2.0",
-                id,
-                result: {
-                  content: [{ type: "text", text: result.content }],
-                  ...(result.structured_content === undefined ||
-                  result.structured_content === null
-                    ? {}
-                    : { structuredContent: result.structured_content }),
-                  isError: result.is_error,
-                },
-              }),
-            (error: unknown) =>
-              post({
-                jsonrpc: "2.0",
-                id,
-                error:
-                  error instanceof AppInvokeRefusalError
-                    ? {
-                        code: -32000,
-                        message: error.message,
-                        data: { kind: error.kind },
-                      }
-                    : { code: -32000, message: String(error) },
-              }),
-          );
-          break;
-        }
         case "operations/call": {
           const invoke = options.invokeOperation;
           if (!invoke) {

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -594,21 +594,12 @@ export type AppGrantState = WireAppGrantState;
 export type AppViewSessionInfo = AppViewSession;
 
 /**
- * Result of a granted app invoke, forwarded verbatim to the sandboxed frame.
+ * Result of a granted REST-operation invoke, forwarded verbatim to the
+ * sandboxed frame.
  *
  * Hand-written on purpose, like [`McpAppPayload`] and for the same reason:
- * `structured_content` is opaque passthrough the renderer never interprets,
- * which the wire-type generator's precision guard refuses.
- */
-export type AppInvokeResult = {
-  content: string;
-  structured_content?: unknown;
-  is_error: boolean;
-};
-
-/**
- * Result of a granted REST-operation invoke — {@link AppInvokeResult}'s
- * sibling for `rest_api` bindings, hand-written for the same reason.
+ * the response is opaque passthrough the renderer never interprets, which
+ * the wire-type generator's precision guard refuses.
  *
  * An executed operation is opaque passthrough: whatever HTTP status the API
  * answered (4xx/5xx included) with `is_error: false` and the raw response
@@ -1315,27 +1306,12 @@ export class ApiClient {
   }
 
   /**
-   * Execute one of an app's pinned tools outside any turn. `args` and the
-   * result are opaque passthrough between the sandboxed frame and the server;
-   * a typed refusal surfaces as {@link AppInvokeRefusalError} so the caller
-   * can branch on `consent_required` without string-matching prose.
-   */
-  async invokeApp(
-    appId: string,
-    tool: string,
-    args: unknown,
-  ): Promise<AppInvokeResult> {
-    return (await this.postAppInvoke(appId, {
-      tool,
-      arguments: args,
-    })) as AppInvokeResult;
-  }
-
-  /**
-   * Execute one of an app's pinned REST operations outside any turn — the
-   * `operation_id` sibling of {@link invokeApp}, with the same opaque
-   * passthrough and refusal contract. The response body crosses base64-
-   * encoded in `body_base64` (see {@link AppRestInvokeResult}).
+   * Execute one of an app's pinned REST operations outside any turn.
+   * `parameters`, `body`, and the result are opaque passthrough between the
+   * sandboxed frame and the server; a typed refusal surfaces as
+   * {@link AppInvokeRefusalError} so the caller can branch on
+   * `consent_required` without string-matching prose. The response body
+   * crosses base64-encoded in `body_base64` (see {@link AppRestInvokeResult}).
    */
   async invokeAppOperation(
     appId: string,
@@ -1351,9 +1327,10 @@ export class ApiClient {
 
   /**
    * Execute one folder operation of an app's granted folder binding — the
-   * `folder` sibling of {@link invokeApp}, with the same refusal contract.
-   * File content crosses base64-encoded in both directions; failures come
-   * back as `is_error` results in the host's closed vocabulary.
+   * `folder` sibling of {@link invokeAppOperation}, with the same refusal
+   * contract. File content crosses base64-encoded in both directions;
+   * failures come back as `is_error` results in the host's closed
+   * vocabulary.
    */
   async invokeAppFolder(
     appId: string,

--- a/crates/openwave-desktop/ui/src/apps/AppConsentSheet.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppConsentSheet.tsx
@@ -5,7 +5,6 @@ import {
   ShieldAlert,
   ShieldCheck,
   TriangleAlert,
-  Wrench,
 } from "lucide-react";
 
 import type { AppGrantState } from "@/api";
@@ -110,15 +109,6 @@ export function AppConsentSheet({
                 </div>
               )}
               <ul className="flex flex-col gap-0.5">
-                {(binding.tools ?? []).map((tool) => (
-                  <li
-                    key={tool}
-                    className="text-muted-foreground flex items-center gap-1.5 pl-1 text-xs"
-                  >
-                    <Wrench className="size-3 shrink-0" aria-hidden="true" />
-                    <span className="truncate font-mono">{tool}</span>
-                  </li>
-                ))}
                 {(binding.operation_ids ?? []).map((operationId) => (
                   <li
                     key={operationId}

--- a/crates/openwave-desktop/ui/src/apps/AppDetailView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppDetailView.dom.test.tsx
@@ -22,12 +22,11 @@ const GRANTED: AppGrantState = {
   granted: true,
   bindings: [
     {
-      app: "11111111-1111-4111-8111-111111111111",
+      app: "22222222-2222-4222-8222-222222222222",
       folder: null,
       access: null,
-      name: "cmd",
-      tools: ["mcp__cmd__doit"],
-      operation_ids: null,
+      name: "issues",
+      operation_ids: ["listIssues"],
       granted: true,
       definition_changed: false,
     },
@@ -42,8 +41,7 @@ const STALE: AppGrantState = {
       folder: null,
       access: null,
       name: "cmd",
-      tools: ["mcp__cmd__doit"],
-      operation_ids: null,
+      operation_ids: ["doThing"],
       granted: false,
       definition_changed: true,
     },
@@ -52,7 +50,6 @@ const STALE: AppGrantState = {
       folder: null,
       access: null,
       name: "issues",
-      tools: null,
       operation_ids: ["listIssues"],
       granted: false,
       definition_changed: false,
@@ -72,13 +69,6 @@ function apisWith(grant: AppGrantState): AppsApis {
     viewSession: vi
       .fn()
       .mockResolvedValue({ frame_path: "/apps/view-frames/token-1" }),
-    invoke: vi
-      .fn()
-      .mockResolvedValue({
-        content: '{"ok":true}',
-        structured_content: { ok: true },
-        is_error: false,
-      }),
     invokeOperation: vi.fn().mockResolvedValue({
       status: 200,
       content_type: "application/json",
@@ -98,7 +88,7 @@ afterEach(() => {
 });
 
 describe("AppDetailView", () => {
-  it("opens a granted app and drives one invoke round trip through the bridge", async () => {
+  it("opens a granted app and drives one REST operation round trip through the bridge", async () => {
     const apis = apisWith(GRANTED);
     render(<AppDetailView appId="app-1" apis={apis} onBack={() => {}} />);
 
@@ -114,51 +104,12 @@ describe("AppDetailView", () => {
     expect(frame).toHaveAttribute("sandbox", "allow-scripts");
     expect(frame.getAttribute("sandbox")).not.toContain("allow-same-origin");
 
-    // The frame asks for a tool call; the parent forwards it to the invoke
-    // route and posts the result back — both directions opaque passthrough.
-    const contentWindow = frame.contentWindow!;
-    const posted = vi.spyOn(contentWindow, "postMessage");
-    window.dispatchEvent(
-      new MessageEvent("message", {
-        data: {
-          jsonrpc: "2.0",
-          id: 3,
-          method: "tools/call",
-          params: { name: "mcp__cmd__doit", arguments: { q: 1 } },
-        },
-        source: contentWindow,
-      }),
-    );
-    await waitFor(() => expect(posted).toHaveBeenCalled());
-    expect(apis.invoke).toHaveBeenCalledWith("app-1", "mcp__cmd__doit", {
-      q: 1,
-    });
-    expect(posted).toHaveBeenCalledWith(
-      {
-        jsonrpc: "2.0",
-        id: 3,
-        result: {
-          content: [{ type: "text", text: '{"ok":true}' }],
-          structuredContent: { ok: true },
-          isError: false,
-        },
-      },
-      "*",
-    );
-  });
-
-  it("drives one REST operation round trip through the bridge", async () => {
-    const apis = apisWith(GRANTED);
-    render(<AppDetailView appId="app-1" apis={apis} onBack={() => {}} />);
-
-    const frame = (await screen.findByTitle(
-      "App: Fixture app",
-    )) as HTMLIFrameElement;
     const contentWindow = frame.contentWindow!;
     const posted = vi.spyOn(contentWindow, "postMessage");
 
     // The frame asks for a REST operation; the parent forwards it to the
-    // same invoke route and posts the REST result back verbatim.
+    // invoke route and posts the REST result back verbatim — both
+    // directions opaque passthrough.
     window.dispatchEvent(
       new MessageEvent("message", {
         data: {
@@ -301,10 +252,10 @@ describe("AppDetailView", () => {
     render(<AppDetailView appId="app-1" apis={apis} onBack={() => {}} />);
 
     // The sheet renders the server projection: the connected app's display
-    // name and tools, and the marker for a
+    // name and operation ids, and the marker for a
     // definition that changed since the previous consent.
-    expect(await screen.findByText("mcp__cmd__doit")).toBeInTheDocument();
-    // A rest_api binding renders its operation ids in the same list.
+    expect(await screen.findByText("doThing")).toBeInTheDocument();
+    // The second rest_api binding renders its operation ids in the same list.
     expect(screen.getByText("listIssues")).toBeInTheDocument();
     expect(
       screen.getByText("Reconfigured since you agreed"),
@@ -328,7 +279,6 @@ describe("AppDetailView", () => {
           folder: "33333333-3333-4333-8333-333333333333",
           access: "read_write",
           name: "Tax documents",
-          tools: null,
           operation_ids: null,
           granted: false,
           definition_changed: false,
@@ -338,7 +288,6 @@ describe("AppDetailView", () => {
           folder: null,
           access: null,
           name: "issues",
-          tools: null,
           operation_ids: ["listIssues"],
           granted: false,
           definition_changed: false,

--- a/crates/openwave-desktop/ui/src/apps/AppDetailView.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppDetailView.tsx
@@ -158,7 +158,6 @@ export function AppDetailView({
                     Allowed to use{" "}
                     {grant.bindings
                       .flatMap((binding) => [
-                        ...(binding.tools ?? []),
                         ...(binding.operation_ids ?? []),
                         ...(binding.folder !== null
                           ? [

--- a/crates/openwave-desktop/ui/src/apps/AppFrame.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppFrame.tsx
@@ -9,8 +9,8 @@ import type { AppsApis } from "./appsApis";
  * The running app: one stored revision in the same sandbox the MCP App card
  * uses — `sandbox="allow-scripts"` without `allow-same-origin`, so the bundle
  * runs with an opaque origin and no reach into OpenWave's DOM, storage, or
- * bearer — plus the host bridge with both invoke legs wired in. The frame
- * posts `tools/call` or `operations/call`; the bridge forwards either to the
+ * bearer — plus the host bridge with the invoke legs wired in. The frame
+ * posts `operations/call` or `fs/*`; the bridge forwards either to the
  * bearer-authenticated invoke route and posts the result back, both
  * directions opaque passthrough.
  *
@@ -55,19 +55,6 @@ export function AppFrame({
       frame: () => frameRef.current?.contentWindow ?? null,
       theme: () => themeRef.current,
       onHeight: setFrameHeight,
-      invokeTool: async (tool, args) => {
-        try {
-          return await apis.invoke(appId, tool, args);
-        } catch (error) {
-          if (
-            error instanceof AppInvokeRefusalError &&
-            error.kind === "consent_required"
-          ) {
-            onConsentRequiredRef.current?.();
-          }
-          throw error;
-        }
-      },
       invokeOperation: async (operationId, parameters, body) => {
         try {
           return await apis.invokeOperation(appId, operationId, parameters, body);

--- a/crates/openwave-desktop/ui/src/apps/appsApis.ts
+++ b/crates/openwave-desktop/ui/src/apps/appsApis.ts
@@ -2,7 +2,6 @@ import type {
   ApiClient,
   AppDetail,
   AppGrantState,
-  AppInvokeResult,
   AppLibrary,
   AppFolderInvokeResult,
   AppRestInvokeResult,
@@ -25,7 +24,6 @@ export type AppsApis = {
   consent(appId: string): Promise<AppGrantState>;
   revoke(appId: string): Promise<void>;
   viewSession(appId: string): Promise<AppViewSessionInfo>;
-  invoke(appId: string, tool: string, args: unknown): Promise<AppInvokeResult>;
   invokeOperation(
     appId: string,
     operationId: string,
@@ -52,7 +50,6 @@ export function appsApisFromClient(client: ApiClient): AppsApis {
     consent: (appId) => client.consentAppGrant(appId),
     revoke: (appId) => client.revokeAppGrant(appId),
     viewSession: (appId) => client.createAppViewFrame(appId),
-    invoke: (appId, tool, args) => client.invokeApp(appId, tool, args),
     invokeOperation: (appId, operationId, parameters, body) =>
       client.invokeAppOperation(appId, operationId, parameters, body),
     invokeFolder: (appId, folder, op, path, contentBase64, replace) =>

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -204,11 +204,10 @@ revisions: Array<AppRevisionSummary>, };
  * One current-manifest binding, projected for the consent sheet.
  *
  * Exactly one of `app` and `folder` is present, matching what the binding
- * names. An app-keyed row carries `tools` or `operation_ids` per its
- * vocabulary; a folder row carries `access`. The sheet derives the
- * combined-consent exfiltration warning (docs/folder-bindings.md) from the
- * rows themselves: a manifest with both a folder row and an operations row
- * can read files and reach the network.
+ * names. An app-keyed row carries `operation_ids`; a folder row carries
+ * `access`. The sheet derives the combined-consent exfiltration warning
+ * (docs/folder-bindings.md) from the rows themselves: a manifest with both a
+ * folder row and an operations row can read files and reach the network.
  */
 export type AppGrantBindingState = { 
 /**
@@ -231,11 +230,6 @@ access: FolderAccess | null,
  * instead of showing a raw id alone.
  */
 name: string | null, 
-/**
- * Full mounted tool names the current manifest pins under this app, for
- * an `mcp_server` binding.
- */
-tools: Array<string> | null, 
 /**
  * Catalog `operationId`s the current manifest pins under this app, for a
  * `rest_api` binding.

--- a/crates/openwave-server/src/connected_apps.rs
+++ b/crates/openwave-server/src/connected_apps.rs
@@ -206,10 +206,6 @@ impl CurrentFingerprints {
     /// match.
     pub(crate) fn grant_binding_current(&self, binding: &AppGrantBinding) -> bool {
         match binding {
-            AppGrantBinding::Tools(binding) => self
-                .apps
-                .get(&binding.app)
-                .is_some_and(|app| app.fingerprint == binding.fingerprint),
             AppGrantBinding::Operations(binding) => self
                 .apps
                 .get(&binding.app)

--- a/crates/openwave-server/src/desktop_schema.rs
+++ b/crates/openwave-server/src/desktop_schema.rs
@@ -25,7 +25,7 @@ const VECTOR_DIRECTORY: &str = "vectors";
 const MAX_MARKER_BYTES: u64 = 1_024;
 
 /// Bump this whenever the pre-v1 schema baseline changes incompatibly.
-const DESKTOP_SCHEMA_EPOCH: u32 = 8;
+const DESKTOP_SCHEMA_EPOCH: u32 = 9;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/openwave-server/src/routes/app_grant.rs
+++ b/crates/openwave-server/src/routes/app_grant.rs
@@ -6,7 +6,7 @@
 //! manifest and the connected-app definitions and folder registrations
 //! *current* at that moment, so a stale sheet can never grant capabilities
 //! the manifest no longer pins or pin a definition that has since changed.
-//! State (`GET`) is renderer-safe metadata: connected-app, folder, tool, and
+//! State (`GET`) is renderer-safe metadata: connected-app, folder, and
 //! operation *names* with coverage/staleness booleans, never definitions,
 //! never paths, and never environment or credential values.
 
@@ -48,11 +48,10 @@ pub struct AppGrantState {
 /// One current-manifest binding, projected for the consent sheet.
 ///
 /// Exactly one of `app` and `folder` is present, matching what the binding
-/// names. An app-keyed row carries `tools` or `operation_ids` per its
-/// vocabulary; a folder row carries `access`. The sheet derives the
-/// combined-consent exfiltration warning (docs/folder-bindings.md) from the
-/// rows themselves: a manifest with both a folder row and an operations row
-/// can read files and reach the network.
+/// names. An app-keyed row carries `operation_ids`; a folder row carries
+/// `access`. The sheet derives the combined-consent exfiltration warning
+/// (docs/folder-bindings.md) from the rows themselves: a manifest with both a
+/// folder row and an operations row can read files and reach the network.
 #[derive(Debug, Serialize, ts_rs::TS)]
 pub struct AppGrantBindingState {
     /// Connected app the manifest binds, by record id, for an app-keyed
@@ -67,9 +66,6 @@ pub struct AppGrantBindingState {
     /// nothing configured or approved answers to the id — the sheet says so
     /// instead of showing a raw id alone.
     pub name: Option<String>,
-    /// Full mounted tool names the current manifest pins under this app, for
-    /// an `mcp_server` binding.
-    pub tools: Option<Vec<String>>,
     /// Catalog `operationId`s the current manifest pins under this app, for a
     /// `rest_api` binding.
     pub operation_ids: Option<Vec<String>>,
@@ -131,22 +127,6 @@ pub async fn post_app_grant(
                     access: binding.access,
                     fingerprint: folder_fingerprint(binding.folder, binding.access),
                 }));
-            }
-            // Mounted-tool bindings are retired: MCP was the only bindable
-            // kind when local apps shipped, and the REST vocabulary has since
-            // replaced it as the app-facing surface (#1332). A manifest still
-            // pinning tools cannot be granted — the failure direction is
-            // "revise the app", never "grant the legacy surface".
-            AppBinding::Tools(binding) => {
-                let name = current
-                    .apps
-                    .get(&binding.app)
-                    .map_or_else(|| binding.app.to_string(), |app| app.name.clone());
-                return Err(ServerError::conflict(format!(
-                    "connected app {name:?} is bound by mounted MCP tools, which local \
-                     apps no longer support; publish a revision binding a rest_api \
-                     connected app's operations instead"
-                )));
             }
             AppBinding::Operations(binding) => {
                 // A binding whose connected app is not configured cannot be
@@ -246,15 +226,11 @@ async fn current_live_app(
 /// Whether a granted binding covers everything a current-manifest binding
 /// pins, in the same vocabulary. A grant kept under another vocabulary
 /// covers nothing: consent named operations or a folder at an access level,
-/// never "whatever the target now speaks". A tools binding is never covered —
-/// the vocabulary is retired (#1332), so a grant recorded before the
-/// retirement reads as ungranted rather than keeping the legacy surface
-/// invokable. A `read_write` folder grant covers a `read` pin: a revision
-/// that narrows its access stays granted, mirroring how a narrowed operation
-/// set stays covered.
+/// never "whatever the target now speaks". A `read_write` folder grant
+/// covers a `read` pin: a revision that narrows its access stays granted,
+/// mirroring how a narrowed operation set stays covered.
 fn binding_covered(pinned: &AppBinding, granted: &AppGrantBinding) -> bool {
     match (pinned, granted) {
-        (AppBinding::Tools(_), _) => false,
         (AppBinding::Operations(pinned), AppGrantBinding::Operations(granted)) => pinned
             .operation_ids
             .iter()
@@ -303,12 +279,9 @@ pub(crate) fn grant_state(
             let covered = granted_binding.is_some_and(|granted| binding_covered(binding, granted));
             let target_current =
                 granted_binding.is_some_and(|granted| current.grant_binding_current(granted));
-            let (tools, operation_ids, access) = match binding {
-                AppBinding::Tools(binding) => (Some(binding.tools.clone()), None, None),
-                AppBinding::Operations(binding) => {
-                    (None, Some(binding.operation_ids.clone()), None)
-                }
-                AppBinding::Folder(binding) => (None, None, Some(binding.access)),
+            let (operation_ids, access) = match binding {
+                AppBinding::Operations(binding) => (Some(binding.operation_ids.clone()), None),
+                AppBinding::Folder(binding) => (None, Some(binding.access)),
             };
             let name = match binding {
                 AppBinding::Folder(binding) => current.folders.get(&binding.folder).cloned(),
@@ -325,7 +298,6 @@ pub(crate) fn grant_state(
                 },
                 access,
                 name,
-                tools,
                 operation_ids,
                 granted: covered && target_current,
                 definition_changed: granted_binding.is_some() && !target_current,

--- a/crates/openwave-server/src/routes/app_invoke.rs
+++ b/crates/openwave-server/src/routes/app_invoke.rs
@@ -4,15 +4,12 @@
 //! The first tool execution outside a model turn: the sandboxed app frame
 //! posts a call to the trusted renderer, the renderer forwards it here on its
 //! bearer, and the server executes the pinned operation through the governed
-//! REST executor — minus the turn. The `tool` surface still parses (stored
-//! manifests may pin mounted MCP tools) but refuses before dispatch: tool
-//! bindings are retired (#1332), and REST operations are the one invocable
-//! surface. Enforcement is entirely server-side and fails closed, in a fixed
-//! order: the app must exist with a current revision, the requested
-//! capability must be pinned in that revision's manifest bindings, and a live
-//! app grant must cover the call — including that every granted connected
-//! app's current definition still matches the fingerprint recorded at
-//! consent.
+//! REST executor — minus the turn. Enforcement is entirely server-side and
+//! fails closed, in a fixed order: the app must exist with a current
+//! revision, the requested capability must be pinned in that revision's
+//! manifest bindings, and a live app grant must cover the call — including
+//! that every granted connected app's current definition still matches the
+//! fingerprint recorded at consent.
 //!
 //! Chat approval gates, permission modes, and plan mode deliberately do not
 //! apply: there is no chat. The app grant is the whole policy.
@@ -25,7 +22,7 @@ use serde::{Deserialize, Serialize};
 
 use openwave_core::id::AppId;
 use openwave_core::local_app::{AppBinding, AppGrantBinding, AppRecord, AppRevision};
-use openwave_core::{AgentError, ChatId, ToolCtx};
+use openwave_core::AgentError;
 
 use crate::connected_apps::{current_fingerprints, current_rest_definitions};
 use crate::error::ServerError;
@@ -34,28 +31,23 @@ use crate::rest_executor::{RestExecuteError, RestOperationRequest};
 use crate::state::AppState;
 
 /// Body bound for an invoke request: a capability name plus its opaque
-/// arguments. Generous for a tool call, far below the MCP client's own 2 MiB
-/// JSON-RPC frame bound so an admitted request can always be forwarded, and
-/// exactly the governed REST executor's request-body cap.
+/// arguments. Far below the governed REST executor's request-body cap, and
+/// exactly that cap.
 pub(crate) const MAX_APP_INVOKE_BODY_BYTES: usize = 256 * 1024;
 
-/// Body of `POST /apps/{id}/invoke` — one of the two invocable surfaces.
+/// Body of `POST /apps/{id}/invoke` — one of the invocable surfaces.
 ///
-/// Either `tool` (with optional `arguments`) for a mounted MCP tool, or
-/// `operation_id` (with optional `parameters`/`body`) for a declared REST
-/// operation — never both, never neither. The passthrough halves
-/// (`arguments`, `parameters`, `body`) are opaque JSON authored inside the
-/// sandboxed app frame; the server hands them to the executor verbatim and
-/// the renderer never interprets them, so — like [`super::McpAppPayload`] —
-/// this request has a hand-written TS twin rather than a generated wire type:
-/// the generator's precision guard rightly refuses `any`-shaped fields.
+/// Either `operation_id` (with optional `parameters`/`body`) for a declared
+/// REST operation, or `folder` (with `op` and its fields) for a connected
+/// folder — never both, never neither. The passthrough halves (`parameters`,
+/// `body`) are opaque JSON authored inside the sandboxed app frame; the
+/// server hands them to the executor verbatim and the renderer never
+/// interprets them, so — like [`super::McpAppPayload`] — this request has a
+/// hand-written TS twin rather than a generated wire type: the generator's
+/// precision guard rightly refuses `any`-shaped fields.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AppInvokeRequest {
-    /// Full mounted name (`mcp__{server}__{tool}`) of the pinned tool to run.
-    pub tool: Option<String>,
-    /// Opaque arguments for the tool, passed through untouched.
-    pub arguments: Option<serde_json::Value>,
     /// Catalog `operationId` of the pinned REST operation to execute.
     pub operation_id: Option<String>,
     /// Declared parameter values for the operation, name → JSON scalar.
@@ -76,27 +68,9 @@ pub struct AppInvokeRequest {
     pub replace: Option<bool>,
 }
 
-/// Result of a granted MCP-tool invoke, packaged for the sandboxed app frame.
-///
-/// Deliberately not a generated wire type, for the same reason as the
-/// request: `structured_content` is opaque passthrough the renderer forwards
-/// to the frame without reading. Both halves have already crossed the MCP
-/// client's result clamp, so nothing here exceeds the 1 MiB call-result bound.
-#[derive(Debug, PartialEq, Serialize)]
-pub struct AppInvokeResult {
-    /// The call result's text content, clamped by the MCP client.
-    pub content: String,
-    /// The call's structured content, absent when the server sent none or the
-    /// clamp dropped an oversized payload (the text then carries a marker).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub structured_content: Option<serde_json::Value>,
-    /// Whether the external tool reported its own failure.
-    pub is_error: bool,
-}
-
 /// Result of a granted REST-operation invoke, packaged for the sandboxed app
-/// frame — [`AppInvokeResult`]'s sibling for the `rest_api` surface, and a
-/// hand-written TS twin for the same reason.
+/// frame — a hand-written TS twin rather than a generated wire type, for the
+/// same passthrough reason as the request.
 ///
 /// An executed operation crosses as opaque passthrough: whatever status the
 /// API answered (including 4xx/5xx and unfollowed redirects) with
@@ -141,8 +115,8 @@ pub enum AppInvokeRefusalKind {
     NotPinned,
     /// The pinned capability is not covered by a live app grant.
     ConsentRequired,
-    /// The pinned name does not resolve to a mounted MCP tool or a declared
-    /// catalog operation right now.
+    /// The pinned name does not resolve to a declared catalog operation or an
+    /// available connected folder right now.
     UnknownTool,
 }
 
@@ -201,10 +175,6 @@ impl IntoResponse for AppInvokeError {
 
 /// Which surface one admitted request names.
 enum InvokeSurface {
-    Tool {
-        tool: String,
-        arguments: serde_json::Value,
-    },
     Operation(RestOperationRequest),
     Folder {
         folder: openwave_core::id::HostRootId,
@@ -237,25 +207,9 @@ fn requested_surface(request: AppInvokeRequest) -> Result<InvokeSurface, AppInvo
             message,
         ))
     };
-    match (request.tool, request.operation_id, request.folder) {
-        (Some(tool), None, None) => {
-            if request.parameters.is_some()
-                || request.body.is_some()
-                || request.op.is_some()
-                || request.path.is_some()
-                || request.content_base64.is_some()
-                || request.replace.is_some()
-            {
-                return Err(invalid("a tool invoke takes arguments and nothing else"));
-            }
-            Ok(InvokeSurface::Tool {
-                tool,
-                arguments: request.arguments.unwrap_or_default(),
-            })
-        }
-        (None, Some(operation_id), None) => {
-            if request.arguments.is_some()
-                || request.op.is_some()
+    match (request.operation_id, request.folder) {
+        (Some(operation_id), None) => {
+            if request.op.is_some()
                 || request.path.is_some()
                 || request.content_base64.is_some()
                 || request.replace.is_some()
@@ -272,9 +226,8 @@ fn requested_surface(request: AppInvokeRequest) -> Result<InvokeSurface, AppInvo
                 body: request.body,
             }))
         }
-        (None, None, Some(folder)) => {
-            if request.arguments.is_some() || request.parameters.is_some() || request.body.is_some()
-            {
+        (None, Some(folder)) => {
+            if request.parameters.is_some() || request.body.is_some() {
                 return Err(invalid(
                     "a folder invoke takes op, path, content_base64, and replace \
                      and nothing else",
@@ -314,7 +267,7 @@ fn requested_surface(request: AppInvokeRequest) -> Result<InvokeSurface, AppInvo
             Ok(InvokeSurface::Folder { folder, path, op })
         }
         _ => Err(invalid(
-            "exactly one of tool, operation_id, or folder must be provided",
+            "exactly one of operation_id or folder must be provided",
         )),
     }
 }
@@ -334,13 +287,6 @@ pub async fn post_app_invoke(
     let surface = requested_surface(request)?;
     let (app, revision) = current_app_revision(&state, app_id).await?;
     match surface {
-        InvokeSurface::Tool { tool, arguments } => {
-            require_pinned_tool(&revision, &tool)?;
-            require_app_grant(&state, &app, &revision, &Pinned::Tool(&tool)).await?;
-            dispatch_mounted_tool(&state, &tool, arguments)
-                .await
-                .map(|result| Json(result).into_response())
-        }
         InvokeSurface::Operation(request) => {
             require_pinned_operation(&revision, &request.operation_id)?;
             require_app_grant(
@@ -401,25 +347,6 @@ async fn current_app_revision(
     Ok((app, revision))
 }
 
-/// Refuse any tool the current revision's manifest does not pin.
-fn require_pinned_tool(revision: &AppRevision, tool: &str) -> Result<(), AppInvokeError> {
-    let pinned = revision
-        .manifest
-        .bindings
-        .iter()
-        .any(|binding| match binding {
-            AppBinding::Tools(binding) => binding.tools.iter().any(|pinned| pinned == tool),
-            AppBinding::Operations(_) | AppBinding::Folder(_) => false,
-        });
-    if pinned {
-        return Ok(());
-    }
-    Err(AppInvokeError::refused(
-        AppInvokeRefusalKind::NotPinned,
-        format!("{tool:?} is not pinned in this app's current manifest"),
-    ))
-}
-
 /// Refuse any operation the current revision's manifest does not pin.
 fn require_pinned_operation(
     revision: &AppRevision,
@@ -434,7 +361,7 @@ fn require_pinned_operation(
                 .operation_ids
                 .iter()
                 .any(|pinned| pinned == operation_id),
-            AppBinding::Tools(_) | AppBinding::Folder(_) => false,
+            AppBinding::Folder(_) => false,
         });
     if pinned {
         return Ok(());
@@ -463,7 +390,7 @@ fn require_pinned_folder(
                     && (!writes
                         || binding.access == openwave_core::local_app::FolderAccess::ReadWrite)
             }
-            AppBinding::Tools(_) | AppBinding::Operations(_) => false,
+            AppBinding::Operations(_) => false,
         });
     if pinned {
         return Ok(());
@@ -480,7 +407,6 @@ fn require_pinned_folder(
 
 /// The invoked capability, for the grant gate.
 enum Pinned<'a> {
-    Tool(&'a str),
     Operation(&'a str),
     Folder {
         folder: openwave_core::id::HostRootId,
@@ -491,7 +417,6 @@ enum Pinned<'a> {
 impl Pinned<'_> {
     fn description(&self) -> String {
         match self {
-            Self::Tool(tool) => format!("{tool:?}"),
             Self::Operation(operation_id) => format!("operation {operation_id:?}"),
             Self::Folder { folder, writes } => {
                 if *writes {
@@ -529,19 +454,6 @@ async fn require_app_grant(
 ) -> Result<(), AppInvokeError> {
     let consent_required =
         |message: String| AppInvokeError::refused(AppInvokeRefusalKind::ConsentRequired, message);
-    // Mounted-tool bindings are retired (#1332): the consent route no longer
-    // grants them, and a grant recorded before the retirement must not keep
-    // the legacy surface invokable. Refusing here — before the grant is even
-    // read — is what makes the retirement hold for pre-existing grants, and
-    // `consent_required` is deliberate: it routes the user to the sheet,
-    // whose refusal explains what the app must be revised to bind.
-    if let Pinned::Tool(_) = pinned {
-        return Err(consent_required(
-            "mounted MCP tools are no longer invokable from apps; this app must be \
-             revised to bind a rest_api connected app's operations"
-                .into(),
-        ));
-    }
     let Some(grant) = state.store.get_app_grant(app.id).await? else {
         return Err(consent_required(format!(
             "no live app grant covers {}",
@@ -571,9 +483,6 @@ async fn require_app_grant(
                 .bindings
                 .iter()
                 .find(|binding| match (binding, pinned) {
-                    (AppBinding::Tools(binding), Pinned::Tool(tool)) => {
-                        binding.tools.iter().any(|held| held == tool)
-                    }
                     (AppBinding::Operations(binding), Pinned::Operation(operation_id)) => binding
                         .operation_ids
                         .iter()
@@ -586,10 +495,6 @@ async fn require_app_grant(
                     .bindings
                     .iter()
                     .any(|binding| match (binding, pinned) {
-                        (AppGrantBinding::Tools(binding), Pinned::Tool(tool)) => {
-                            binding.app == connected_app
-                                && binding.tools.iter().any(|granted| granted == tool)
-                        }
                         (AppGrantBinding::Operations(binding), Pinned::Operation(operation_id)) => {
                             binding.app == connected_app
                                 && binding
@@ -626,46 +531,6 @@ async fn require_app_grant(
         }
     }
     Ok(())
-}
-
-/// Resolve a pinned name against the current MCP snapshot and execute it.
-///
-/// This path invokes mounted MCP tools only. The name must carry the mounted
-/// `mcp__{server}__{tool}` shape — which no built-in server tool does — and
-/// must resolve to a server-executed registration; a client-executed contract
-/// has no executor here and refuses. The execution context is deliberately
-/// inert: no chat owns this call and no scratch is attached, so nothing
-/// dispatched from here could reach a workspace capability. The synthetic
-/// chat id is process-stable rather than per-call: gateway tools resolve a
-/// per-chat call credential from it, and a fresh id per invoke would mint a
-/// fresh gateway attestation context per invoke — pure token churn, since an
-/// app invoke has no model emission to attest and gateway-attested tools
-/// refuse it regardless (the recorded Direct-endpoints-only limitation).
-/// Results cross back through the MCP client's own 1 MiB call-result clamp.
-pub(crate) async fn dispatch_mounted_tool(
-    state: &AppState,
-    tool_name: &str,
-    arguments: serde_json::Value,
-) -> Result<AppInvokeResult, AppInvokeError> {
-    let unknown = || {
-        AppInvokeError::refused(
-            AppInvokeRefusalKind::UnknownTool,
-            format!("{tool_name:?} is not a mounted MCP tool"),
-        )
-    };
-    if !is_mounted_mcp_name(tool_name) {
-        return Err(unknown());
-    }
-    let registry = state.mcp.snapshot();
-    let tool = registry.get(tool_name).ok_or_else(unknown)?;
-    static APP_INVOKE_CHAT: std::sync::LazyLock<ChatId> = std::sync::LazyLock::new(ChatId::new);
-    let ctx = ToolCtx::without_private_scratch(*APP_INVOKE_CHAT, None);
-    let output = tool.execute(&ctx, arguments).await?;
-    Ok(AppInvokeResult {
-        content: output.content,
-        structured_content: output.data,
-        is_error: output.is_error,
-    })
 }
 
 /// Resolve the pinned operation's `rest_api` record and run the governed
@@ -850,16 +715,5 @@ async fn dispatch_folder_op(
                 Err(error) => AppFolderInvokeResult::failure(error),
             }
         }
-    })
-}
-
-/// Whether a name has the mounted `mcp__{server}__{tool}` shape.
-///
-/// The same grammar the manifest validator enforces on pins; repeated here so
-/// dispatch is independently safe when driven without the pin check.
-fn is_mounted_mcp_name(name: &str) -> bool {
-    name.strip_prefix("mcp__").is_some_and(|rest| {
-        rest.split_once("__")
-            .is_some_and(|(server, tool)| !server.is_empty() && !tool.is_empty())
     })
 }

--- a/crates/openwave-server/src/tests/app_grant.rs
+++ b/crates/openwave-server/src/tests/app_grant.rs
@@ -9,7 +9,7 @@ use super::*;
 
 use openwave_core::id::{AppId, AppRevisionId};
 use openwave_core::local_app::{
-    AppBinding, AppManifest, AppToolsBinding, CreateApp, NewAppRevision,
+    AppBinding, AppManifest, AppOperationsBinding, CreateApp, NewAppRevision,
 };
 use serde_json::json;
 
@@ -36,7 +36,7 @@ async fn grant_request(
 async fn create_app_bound_to(
     store: &Arc<dyn Store>,
     app: openwave_core::id::ConnectedAppId,
-    tools: &[&str],
+    operation_ids: &[&str],
 ) -> AppId {
     let app_id = AppId::new();
     store
@@ -46,9 +46,9 @@ async fn create_app_bound_to(
                 id: AppRevisionId::new(),
                 manifest: AppManifest {
                     name: "Grant fixture".into(),
-                    bindings: vec![AppBinding::Tools(AppToolsBinding {
+                    bindings: vec![AppBinding::Operations(AppOperationsBinding {
                         app,
-                        tools: tools.iter().map(|tool| (*tool).to_owned()).collect(),
+                        operation_ids: operation_ids.iter().map(|id| (*id).to_owned()).collect(),
                     })],
                 },
                 byte_len: 1,
@@ -64,103 +64,39 @@ async fn create_app_bound_to(
     app_id
 }
 
-/// The consent surface carries names only. A command server's definition —
-/// executable, arguments, literal environment values, selected environment
-/// names — must never appear in any grant response, asserted on the raw
-/// serialized JSON rather than a parsed projection so nothing can hide in an
-/// unmodeled field. Consent itself now conflicts — tool bindings are retired
-/// (#1332) — and the refusal must be just as leak-free as the projection.
-/// Also pins the 404 for an unknown app and the conflict for a binding whose
-/// server is not configured (nothing coherent to consent to).
+/// The surface's refusal edges: an unknown app is 404 everywhere, and a
+/// binding to a connected app that is not configured cannot be granted —
+/// there is no definition to pin the consent to.
 #[tokio::test]
-async fn grant_responses_carry_names_only_never_definitions_or_env_values() {
+async fn unknown_apps_and_unconfigured_bindings_refuse_on_the_grant_surface() {
     let (router, token, store, _dir) = test_app().await;
     let bearer = format!("Bearer {token}");
-    // A disabled stdio server never spawns, so the definition can carry
-    // conspicuously secret-shaped configuration for the leak assertions.
-    let put = router
-        .clone()
-        .oneshot(
-            Request::builder()
-                .method("PUT")
-                .uri("/mcp/servers")
-                .header("authorization", &bearer)
-                .header("content-type", "application/json")
-                .body(Body::from(
-                    json!({"servers": [{
-                        "name": "cmd",
-                        "command": "/opt/secret-location/docs-mcp",
-                        "args": ["--secret-flag"],
-                        "env": ["LITERAL_NAME"],
-                        "env_values": {"LITERAL_NAME": "literal-value-hunter2"},
-                        "env_from": ["PARENT_SECRET_NAME"],
-                        "enabled": false
-                    }]})
-                    .to_string(),
-                ))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(put.status(), StatusCode::OK);
-    let cmd = connected_app_id(&store, "cmd").await;
-    let app_id = create_app_bound_to(&store, cmd, &["mcp__cmd__doit"]).await;
-
-    let mut responses = Vec::new();
-    let state = grant_request(&router, &bearer, "GET", app_id).await;
-    assert_eq!(state.status(), StatusCode::OK);
-    responses.push(("GET", body_string(state).await));
-    // Tool bindings are retired: there is nothing grantable behind this
-    // manifest, so consent conflicts instead of recording a grant.
-    let refused = grant_request(&router, &bearer, "POST", app_id).await;
-    assert_eq!(refused.status(), StatusCode::CONFLICT);
-    responses.push(("POST", body_string(refused).await));
-
-    // The sheet still names the server and its pinned tools, so it can say
-    // what the manifest asked for and why it cannot be granted.
-    assert!(
-        responses[0].1.contains("\"cmd\"") && responses[0].1.contains("mcp__cmd__doit"),
-        "GET: the sheet needs server and tool names: {}",
-        responses[0].1
-    );
-    for (method, body) in &responses {
-        for leaked in [
-            "secret-location",
-            "docs-mcp",
-            "--secret-flag",
-            "literal-value-hunter2",
-            "LITERAL_NAME",
-            "PARENT_SECRET_NAME",
-        ] {
-            assert!(
-                !body.contains(leaked),
-                "{method}: {leaked:?} must not reach the renderer: {body}"
-            );
-        }
-    }
-    let before: serde_json::Value = serde_json::from_str(&responses[0].1).unwrap();
-    assert_eq!(before["granted"], json!(false));
 
     // An unknown app is 404 on the whole surface.
     let missing = grant_request(&router, &bearer, "GET", AppId::new()).await;
     assert_eq!(missing.status(), StatusCode::NOT_FOUND);
 
-    // A binding to a connected app that is not configured cannot be granted:
-    // there is no definition to pin the consent to.
+    // A binding to a connected app that is not configured reads ungranted
+    // and conflicts on consent.
     let unbound = create_app_bound_to(
         &store,
         openwave_core::id::ConnectedAppId::new(),
-        &["mcp__ghost__walk"],
+        &["listIssues"],
     )
     .await;
+    let state = grant_request(&router, &bearer, "GET", unbound).await;
+    assert_eq!(state.status(), StatusCode::OK);
+    let state: serde_json::Value = serde_json::from_str(&body_string(state).await).unwrap();
+    assert_eq!(state["granted"], json!(false));
     let refused = grant_request(&router, &bearer, "POST", unbound).await;
     assert_eq!(refused.status(), StatusCode::CONFLICT);
 }
 
-/// The `rest_api` side of the same projection contract: consent still grants,
-/// and neither the base URL, the document hash, nor the credential reference
-/// behind the record ever reaches the renderer — the sheet gets the record's
-/// display name and the pinned operation ids, nothing else.
+/// The projection contract: consent grants, and neither the base URL, the
+/// document hash, nor the credential reference behind the record ever reaches
+/// the renderer — the sheet gets the record's display name and the pinned
+/// operation ids, nothing else. Asserted on the raw serialized JSON rather
+/// than a parsed projection so nothing can hide in an unmodeled field.
 #[tokio::test]
 async fn rest_grant_responses_grant_and_carry_names_only() {
     let (router, token, store, _dir) = test_app().await;

--- a/crates/openwave-server/src/tests/app_invoke.rs
+++ b/crates/openwave-server/src/tests/app_invoke.rs
@@ -1,156 +1,11 @@
-//! `POST /apps/{id}/invoke`: server-side enforcement, the retired MCP tool
-//! surface, and governed REST dispatch.
+//! `POST /apps/{id}/invoke`: server-side enforcement and governed REST
+//! dispatch.
 
 use super::*;
 
 use openwave_core::id::{AppId, AppRevisionId};
-use openwave_core::local_app::{
-    AppBinding, AppGrant, AppGrantBinding, AppManifest, AppToolsBinding, AppToolsGrantBinding,
-    CreateApp, NewAppRevision,
-};
+use openwave_core::local_app::{AppBinding, AppManifest, CreateApp, NewAppRevision};
 use serde_json::json;
-
-/// The MCP client's call-result bound and the marker its clamp leaves.
-const CALL_RESULT_CLAMP_BYTES: usize = 1024 * 1024;
-const CLAMP_MARKER: &str = "[truncated: MCP result exceeded 1 MiB]";
-
-/// What one invoke against the fake external server observed.
-#[derive(Default)]
-struct ToolServerLog {
-    calls: AtomicUsize,
-    last_arguments: Mutex<Option<serde_json::Value>>,
-}
-
-/// A loopback Streamable-HTTP MCP server mounting `viewer` and `unpinned`,
-/// whose `tools/call` answers with the given content and structured payload.
-async fn spawn_tool_server(
-    log: Arc<ToolServerLog>,
-    content: String,
-    structured: serde_json::Value,
-) -> std::net::SocketAddr {
-    use axum::routing::post as axum_post;
-
-    let handler = move |body: String| {
-        let log = log.clone();
-        let content = content.clone();
-        let structured = structured.clone();
-        async move {
-            let request: serde_json::Value = serde_json::from_str(&body).unwrap();
-            let id = request.get("id").cloned().unwrap_or_default();
-            let result = match request["method"].as_str().unwrap_or_default() {
-                "initialize" => json!({
-                    "protocolVersion": openwave_mcp::PROTOCOL_VERSION,
-                    "capabilities": {"tools": {}},
-                    "serverInfo": {"name": "invoke-fixture", "version": "1"}
-                }),
-                "tools/list" => json!({
-                    "tools": [
-                        {
-                            "name": "viewer",
-                            "description": "The pinned tool",
-                            "inputSchema": {"type": "object"}
-                        },
-                        {
-                            "name": "unpinned",
-                            "description": "Mounted but never pinned",
-                            "inputSchema": {"type": "object"}
-                        }
-                    ]
-                }),
-                "tools/call" => {
-                    log.calls.fetch_add(1, Ordering::SeqCst);
-                    *log.last_arguments.lock().unwrap() =
-                        Some(request["params"]["arguments"].clone());
-                    json!({
-                        "content": [{"type": "text", "text": content}],
-                        "structuredContent": structured,
-                        "isError": false
-                    })
-                }
-                _ => json!({}),
-            };
-            (
-                [("content-type", "application/json")],
-                json!({"jsonrpc": "2.0", "id": id, "result": result}).to_string(),
-            )
-        }
-    };
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let address = listener.local_addr().unwrap();
-    tokio::spawn(async move {
-        axum::serve(listener, Router::new().route("/mcp", axum_post(handler)))
-            .await
-            .unwrap();
-    });
-    address
-}
-
-fn tool_server_config(address: std::net::SocketAddr) -> crate::mcp_config::McpServersConfig {
-    serde_json::from_value(json!({
-        "servers": [{
-            "name": "srv",
-            "url": format!("http://{address}/mcp"),
-            "request_timeout_ms": 30_000,
-            "enabled": true
-        }]
-    }))
-    .unwrap()
-}
-
-/// Create an app whose current manifest pins exactly `tools` under the
-/// connected app the configured `srv` server became.
-async fn create_pinned_app(store: &Arc<dyn Store>, tools: &[&str]) -> AppId {
-    let app_id = AppId::new();
-    store
-        .create_app(&CreateApp {
-            id: app_id,
-            revision: NewAppRevision {
-                id: AppRevisionId::new(),
-                manifest: AppManifest {
-                    name: "Invoke fixture".into(),
-                    bindings: vec![AppBinding::Tools(AppToolsBinding {
-                        app: connected_app_id(store, "srv").await,
-                        tools: tools.iter().map(|tool| (*tool).to_owned()).collect(),
-                    })],
-                },
-                byte_len: 1,
-                sha256: [0; 32],
-                turn_id: None,
-                producing_run_id: None,
-                chat_id: None,
-                created_at: chrono::Utc::now(),
-            },
-        })
-        .await
-        .unwrap();
-    app_id
-}
-
-/// Configure the mounted server set to one `srv` at `address` over the API.
-async fn put_srv(router: &Router, bearer: &str, address: std::net::SocketAddr) {
-    let response = router
-        .clone()
-        .oneshot(
-            Request::builder()
-                .method("PUT")
-                .uri("/mcp/servers")
-                .header("authorization", bearer)
-                .header("content-type", "application/json")
-                .body(Body::from(
-                    json!({"servers": [{
-                        "name": "srv",
-                        "url": format!("http://{address}/mcp"),
-                        "request_timeout_ms": 30_000,
-                        "enabled": true
-                    }]})
-                    .to_string(),
-                ))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(response.status(), StatusCode::OK);
-}
 
 /// Send one of the body-less grant requests (`GET`, `POST` consent, `DELETE`).
 async fn grant_request(
@@ -200,233 +55,6 @@ async fn invoke(
         )
         .await
         .unwrap()
-}
-
-/// The route's whole enforcement ladder for the retired tool surface,
-/// fail-closed at every rung: a missing or deleted app is 404, an unpinned or
-/// non-MCP name is refused before the gate, and a pinned tool refuses with
-/// `consent_required` no matter what — including under a tools grant recorded
-/// before the retirement (#1332) — so the external server never sees a
-/// `tools/call`.
-#[tokio::test]
-async fn every_invoke_is_refused_before_dispatch_without_a_grant() {
-    let log = Arc::new(ToolServerLog::default());
-    let address = spawn_tool_server(log.clone(), "ok".into(), json!({})).await;
-    let (router, token, store, _dir) = test_app().await;
-    let bearer = format!("Bearer {token}");
-    put_srv(&router, &bearer, address).await;
-    let app_id = create_pinned_app(&store, &["mcp__srv__viewer"]).await;
-
-    let refusal = |status: StatusCode, kind: &str| (status, kind.to_owned());
-    let cases = [
-        // No such app: refused before anything is inspected.
-        (
-            AppId::new(),
-            json!({"tool": "mcp__srv__viewer"}),
-            refusal(StatusCode::NOT_FOUND, "app_not_found"),
-        ),
-        // Mounted and healthy, but the manifest never pinned it.
-        (
-            app_id,
-            json!({"tool": "mcp__srv__unpinned"}),
-            refusal(StatusCode::FORBIDDEN, "not_pinned"),
-        ),
-        // A non-MCP name can never be pinned by a validated manifest.
-        (
-            app_id,
-            json!({"tool": "read_file"}),
-            refusal(StatusCode::FORBIDDEN, "not_pinned"),
-        ),
-        // Pinned, mounted, healthy — still refused: the tool surface is
-        // retired, and no consent can open it.
-        (
-            app_id,
-            json!({"tool": "mcp__srv__viewer", "arguments": {"q": "open"}}),
-            refusal(StatusCode::FORBIDDEN, "consent_required"),
-        ),
-    ];
-    for (target, body, (status, kind)) in cases {
-        let response = invoke(&router, &bearer, target, body.clone()).await;
-        assert_eq!(response.status(), status, "{body}");
-        let info: AgentErrorInfo = json_body(response).await;
-        assert_eq!(info.kind, kind, "{body}");
-    }
-
-    // A tools grant recorded before the retirement — planted directly with
-    // the definition's current fingerprint, since the consent route refuses
-    // to record one now — must not keep the legacy surface invokable.
-    let fingerprint =
-        crate::mcp_config::definition_fingerprint(&tool_server_config(address).servers[0]);
-    store
-        .put_app_grant(&AppGrant {
-            app_id,
-            bindings: vec![AppGrantBinding::Tools(AppToolsGrantBinding {
-                app: connected_app_id(&store, "srv").await,
-                tools: vec!["mcp__srv__viewer".into()],
-                fingerprint,
-            })],
-            created_at: chrono::Utc::now(),
-        })
-        .await
-        .unwrap();
-    let response = invoke(
-        &router,
-        &bearer,
-        app_id,
-        json!({"tool": "mcp__srv__viewer"}),
-    )
-    .await;
-    assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    let info: AgentErrorInfo = json_body(response).await;
-    assert_eq!(info.kind, "consent_required");
-
-    // A soft-deleted app refuses identically to a missing one.
-    store.delete_app(app_id, chrono::Utc::now()).await.unwrap();
-    let response = invoke(
-        &router,
-        &bearer,
-        app_id,
-        json!({"tool": "mcp__srv__viewer"}),
-    )
-    .await;
-    assert_eq!(response.status(), StatusCode::NOT_FOUND);
-
-    assert_eq!(
-        log.calls.load(Ordering::SeqCst),
-        0,
-        "no refusal path may reach the external server"
-    );
-}
-
-async fn dispatch_state(
-    base: ToolRegistry,
-    address: std::net::SocketAddr,
-) -> (AppState, tempfile::TempDir) {
-    let (dir, store) = temp_db_store("app-invoke.db").await;
-    let store: Arc<dyn Store> = Arc::new(store);
-    let state = AppState::new(
-        Config::desktop(dir.path()),
-        store,
-        Arc::new(FixedResolver(Arc::new(FakeProvider))),
-        Arc::new(MemSecrets::default()),
-        Arc::new(base),
-        AgentConfig {
-            model: "fake".into(),
-            ..AgentConfig::default()
-        },
-    );
-    state
-        .mcp
-        .replace(tool_server_config(address))
-        .await
-        .unwrap();
-    (state, dir)
-}
-
-/// With the consent gate out of the way (dispatch driven directly, which is
-/// exactly what a granted invoke will do), a pinned name round-trips to the
-/// external server: arguments pass through verbatim, the oversized text comes
-/// back clamped with the client's marker, and the structured payload crosses
-/// as untouched passthrough JSON.
-#[tokio::test]
-async fn gate_opened_dispatch_round_trips_clamped_opaque_results() {
-    let log = Arc::new(ToolServerLog::default());
-    let structured = json!({"rows": [{"id": 7, "status": "open"}]});
-    let address = spawn_tool_server(
-        log.clone(),
-        "x".repeat(CALL_RESULT_CLAMP_BYTES + 64),
-        structured.clone(),
-    )
-    .await;
-    let (state, _dir) = dispatch_state(ToolRegistry::new(), address).await;
-
-    let arguments = json!({"q": "open", "nested": {"limit": 3}});
-    let result =
-        crate::routes::dispatch_mounted_tool(&state, "mcp__srv__viewer", arguments.clone())
-            .await
-            .unwrap();
-
-    assert_eq!(log.calls.load(Ordering::SeqCst), 1);
-    assert_eq!(
-        log.last_arguments.lock().unwrap().clone(),
-        Some(arguments),
-        "arguments must cross to the server verbatim"
-    );
-    assert!(result.content.len() <= CALL_RESULT_CLAMP_BYTES);
-    assert!(
-        result.content.ends_with(CLAMP_MARKER),
-        "the clamp marker must survive to the invoke result"
-    );
-    assert_eq!(
-        result.structured_content,
-        Some(structured),
-        "structured content is opaque passthrough"
-    );
-    assert!(!result.is_error);
-}
-
-/// Even driven with the gate open, dispatch executes mounted MCP tools only:
-/// a built-in server tool, a client-executed contract (including one hiding
-/// under a mounted-looking name), and an unmounted name are all refused.
-#[tokio::test]
-async fn gate_opened_dispatch_refuses_every_non_mcp_surface() {
-    struct BaseTool;
-
-    #[async_trait]
-    impl Tool for BaseTool {
-        fn spec(&self) -> ToolSpec {
-            ToolSpec {
-                name: "innocent_tool".into(),
-                description: "a built-in server tool".into(),
-                input_schema: json!({"type": "object"}),
-            }
-        }
-        fn approval_class(&self) -> ApprovalClass {
-            ApprovalClass::ReadOnly
-        }
-        async fn execute(
-            &self,
-            _ctx: &ToolCtx,
-            _args: serde_json::Value,
-        ) -> openwave_core::Result<ToolOutput> {
-            panic!("the invoke route must never execute a built-in tool");
-        }
-    }
-
-    let log = Arc::new(ToolServerLog::default());
-    let address = spawn_tool_server(log.clone(), "ok".into(), json!({})).await;
-    let mut base = ToolRegistry::new();
-    base.register(Box::new(BaseTool));
-    base.register_client(
-        ToolSpec {
-            name: "mcp__srv__client_owned".into(),
-            description: "client-executed contract".into(),
-            input_schema: json!({"type": "object"}),
-        },
-        ApprovalClass::ReadOnly,
-    );
-    let (state, _dir) = dispatch_state(base, address).await;
-
-    for name in [
-        "innocent_tool",
-        "mcp__srv__client_owned",
-        "mcp__srv__missing",
-        "mcp____tool",
-        "mcp__srv__",
-    ] {
-        let error = crate::routes::dispatch_mounted_tool(&state, name, json!({}))
-            .await
-            .expect_err(name);
-        match error {
-            crate::routes::AppInvokeError::Refused(refusal) => assert_eq!(
-                refusal.kind,
-                crate::routes::AppInvokeRefusalKind::UnknownTool,
-                "{name}"
-            ),
-            other => panic!("{name}: expected a typed refusal, got {other:?}"),
-        }
-    }
-    assert_eq!(log.calls.load(Ordering::SeqCst), 0);
 }
 
 // --- REST operation bindings ---
@@ -620,6 +248,8 @@ async fn rest_invokes_walk_the_ladder_and_round_trip_through_the_governed_execut
     let app_id = create_operation_app(&store, connected, &["listIssues"]).await;
 
     // Fail-closed before consent, and on every malformed or unpinned shape.
+    // A body carrying the removed `tools` vocabulary's `tool` field no longer
+    // parses at all (#1332, #1589).
     let refusals = [
         (
             json!({"operation_id": "listIssues"}),
@@ -633,8 +263,8 @@ async fn rest_invokes_walk_the_ladder_and_round_trip_through_the_governed_execut
         ),
         (
             json!({"operation_id": "listIssues", "tool": "mcp__srv__viewer"}),
-            StatusCode::UNPROCESSABLE_ENTITY,
-            "invalid_invoke_request",
+            StatusCode::BAD_REQUEST,
+            "bad_request",
         ),
         (
             json!({}),
@@ -642,7 +272,7 @@ async fn rest_invokes_walk_the_ladder_and_round_trip_through_the_governed_execut
             "invalid_invoke_request",
         ),
         (
-            json!({"operation_id": "listIssues", "arguments": {"q": "open"}}),
+            json!({"operation_id": "listIssues", "op": "list"}),
             StatusCode::UNPROCESSABLE_ENTITY,
             "invalid_invoke_request",
         ),
@@ -653,6 +283,17 @@ async fn rest_invokes_walk_the_ladder_and_round_trip_through_the_governed_execut
         let info: AgentErrorInfo = json_body(response).await;
         assert_eq!(info.kind, kind, "{body}");
     }
+    // No such app: refused before anything is inspected.
+    let response = invoke(
+        &router,
+        &bearer,
+        AppId::new(),
+        json!({"operation_id": "listIssues"}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let info: AgentErrorInfo = json_body(response).await;
+    assert_eq!(info.kind, "app_not_found");
     assert_eq!(log.calls.load(Ordering::SeqCst), 0);
 
     // Consent projects the operation vocabulary under the app's display name.
@@ -662,7 +303,11 @@ async fn rest_invokes_walk_the_ladder_and_round_trip_through_the_governed_execut
     assert_eq!(state["granted"], json!(true));
     assert_eq!(state["bindings"][0]["name"], json!("issues"));
     assert_eq!(state["bindings"][0]["operation_ids"], json!(["listIssues"]));
-    assert_eq!(state["bindings"][0]["tools"], json!(null));
+    assert_eq!(
+        state["bindings"][0].get("tools"),
+        None,
+        "the removed tools vocabulary must not reappear in the projection"
+    );
 
     // A granted invoke round-trips: the executor assembled the declared URL,
     // injected the referenced credential, and the response crosses as opaque
@@ -746,6 +391,17 @@ async fn rest_invokes_walk_the_ladder_and_round_trip_through_the_governed_execut
         .as_deref()
         .unwrap()
         .starts_with("https://api.elsewhere.example/v2/issues"));
+
+    // A soft-deleted app refuses identically to a missing one.
+    store.delete_app(app_id, chrono::Utc::now()).await.unwrap();
+    let response = invoke(
+        &router,
+        &bearer,
+        app_id,
+        json!({"operation_id": "listIssues"}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 /// Consent has nothing coherent to record when a pinned operation is not in

--- a/docs/local-apps.md
+++ b/docs/local-apps.md
@@ -2,9 +2,9 @@
 
 Agent-generated mini-apps that live in the profile: a bounded HTML document
 rendered in the sandboxed view-frame machinery, plus a manifest that pins the
-exact mounted MCP tools the app may call. The user asks for "a Sentry triage
-view" once; the result is a durable, revisable surface they can reopen from the
-sidebar instead of a conversation they re-run.
+exact connected-app operations and folders the app may call. The user asks
+for "a Sentry triage view" once; the result is a durable, revisable surface
+they can reopen from the sidebar instead of a conversation they re-run.
 
 This page is the design overview for the local-first slice. Sharing is
 deliberately out of scope: the eventual sharing plane is a model gateway
@@ -13,15 +13,16 @@ deliberately out of scope: the eventual sharing plane is a model gateway
 ## Product flow
 
 1. In a conversation, the foreground agent calls `create_app` with a name, an
-   HTML bundle, and a manifest naming the tools the app uses. The transcript
-   shows an app card; revisions of the same app append, never overwrite.
+   HTML bundle, and a manifest naming the capabilities the app uses. The
+   transcript shows an app card; revisions of the same app append, never
+   overwrite.
 2. The user opens the app — from the card or from an **Apps** library on the
-   home sidebar. First open (and any open after the app's tool needs change)
-   presents a consent sheet listing exactly which servers and tools the app may
-   call. Consent is per-app, durable, and revocable from the library.
-3. The app renders in a sandboxed frame and drives its pinned tools through the
-   host. Results render however the app likes; the app never holds a
-   credential and has no network of its own.
+   home sidebar. First open (and any open after the app's capability needs
+   change) presents a consent sheet listing exactly what the app may call.
+   Consent is per-app, durable, and revocable from the library.
+3. The app renders in a sandboxed frame and drives its pinned capabilities
+   through the host. Results render however the app likes; the app never
+   holds a credential and has no network of its own.
 
 ## Two parts, two trust levels
 
@@ -31,10 +32,11 @@ An app revision is an untrusted **bundle** and a trusted **manifest**:
   prefetched MCP view). It is assumed hostile: prompt injection anywhere in a
   conversation can author it.
 - The manifest is small, structural JSON: a display name and
-  `bindings: [{ app, tools[] }]` naming mounted tool names under the
+  `bindings: [{ app, operation_ids[] }]` naming declared operations under the
   connected-app records ([connected-apps.md](connected-apps.md)) that
-  contribute them. The manifest — not the bundle — is what the user consents
-  to and what the host enforces per call.
+  contribute them, or `{ folder, access }` naming a connected folder. The
+  manifest — not the bundle — is what the user consents to and what the host
+  enforces per call.
 
 The containment story is inherited from MCP App views and unchanged: the frame
 is served by the host with its own strict CSP (`default-src 'none'`,
@@ -153,14 +155,12 @@ covered better, and their consentable universe was the wrong shape for apps:
 a manifest could pin tools of *any* mounted transport — local stdio, remote
 HTTP, or gateway endpoints — putting "run a local process on this machine"
 inside the app-grantable world, while gateway-attested endpoints refused
-app-driven session-token calls regardless. The doors now refuse the
-vocabulary end to end: `create_app` refuses to author a `tools` binding, the
-consent route conflicts instead of granting one, and the invoke route
-refuses the tool surface even under a grant recorded before the retirement —
-the failure direction is re-ask, never widen. The grammar still parses
-stored manifests, which read as ungrantable on every surface; full removal
-of the vocabulary (types, wire shapes, the frame bridge's `tools/call` verb)
-is a separate mechanical change.
+app-driven session-token calls regardless. #1332 first refused the vocabulary
+at every door (authoring, consent, invoke) while keeping stored manifests
+parseable; #1589 then removed it end to end — the types, the shared binding
+grammar's tools arm, the invoke route's tool surface, the frame bridge's
+`tools/call` verb, and the wire shapes are gone, and the pre-v1 schema epoch
+was bumped so profiles carrying the old vocabulary are rebuilt.
 
 Mounted MCP servers themselves are unchanged: chats keep their full tool
 surface. The retirement narrows what an *app manifest* may pin, nothing


### PR DESCRIPTION
Follow-up to #1332, which retired MCP tool bindings for local apps by refusing them at every door while deliberately keeping the vocabulary parseable. This is the mechanical removal pass. Closes #1589.

## What changed

- **Core**: `AppBinding::Tools` / `AppGrantBinding::Tools` and their structs are gone from `openwave-core::local_app`, along with the tools arm of the shared binding grammar and the mounted-name helpers (`mounted_tool_under`, shape/charset checks, `MAX_MOUNTED_TOOL_NAME_BYTES`) that had no remaining callers. A manifest or grant carrying `tools` now fails to deserialize instead of reading as ungrantable. The `create_app` door's explicit tools refusal is gone with it — the schema itself now refuses, with the live vocabulary in the error.
- **Server**: the invoke route loses its tool surface (`tool`/`arguments` body fields, `require_pinned_tool`, `dispatch_mounted_tool`, `AppInvokeResult`, the `Pinned::Tool` grant-gate arms, `is_mounted_mcp_name`); the grant projection loses its `tools` field and the consent route its tools-conflict arm; `CurrentFingerprints` loses the tools match arm.
- **Migration story**: the issue predates the baseline squash (#1542), so there is no migration chain to strip manifests in. Instead `DESKTOP_SCHEMA_EPOCH` bumps 8 → 9: stored pre-v1 profiles whose manifests or grants may still carry the removed vocabulary are rebuilt, the sanctioned hard-cut path of the disposable pre-v1 lifecycle.
- **Desktop UI**: the frame bridge's `tools/call` verb, `AppToolInvoker`, and `invokeTool` wiring are removed (`McpAppBridge.ts`, `AppFrame.tsx`, `api.ts` `invokeApp`, `appsApis.ts`), as are the consent sheet's and detail view's tools-list renderings. `wire.ts` regenerated — `AppGrantBindingState` loses `tools`.
- **Docs**: `docs/local-apps.md` retirement section updated to record the removal instead of promising it.

## Removed tests, one line each

- `local_app::manifests_enforce_the_mounted_tool_grammar` — exercised the removed mounted-name grammar; its surviving concerns (name grammar, empty bindings, duplicate bindings) moved into `manifests_enforce_the_name_grammar` and the operation-id test, and `bindings_deserialize_untagged_and_closed` now pins that the retired vocabulary refuses to parse.
- `local_app::the_exact_namespace_reading_is_prefix_anchored` — tested `mounted_tool_under`, which is removed.
- `app_invoke::every_invoke_is_refused_before_dispatch_without_a_grant` — the retired-surface enforcement ladder; the parts that outlive the surface (404 for unknown app, soft-delete refusal, stale-vocabulary body refusal) are folded into the REST ladder test.
- `app_invoke::gate_opened_dispatch_round_trips_clamped_opaque_results` and `…refuses_every_non_mcp_surface` — drove `dispatch_mounted_tool` directly, which is removed, along with the fake MCP tool server they needed.
- `app_grant::grant_responses_carry_names_only_never_definitions_or_env_values` — its fixture bound an `mcp_server` record, which is no longer bindable at all; the surviving edges (404, unconfigured-binding conflict) live in `unknown_apps_and_unconfigured_bindings_refuse_on_the_grant_surface`, and the leak-freedom contract stays pinned by `rest_grant_responses_grant_and_carry_names_only`.
- UI: the `tools/call` round-trip dom test folded into the REST round-trip test (which now also carries the sandbox-attribute assertions); the bridge's capability-by-presence test now asserts `operations/call`, including that the removed `tools/call` verb is method-not-found even with an invoker wired.

## Verification

- `cargo test -p openwave-core -p openwave-server` (app/local-app/grant/invoke modules), `cargo check --workspace --locked`, `cargo clippy -p openwave-core -p openwave-server --all-targets`, `cargo fmt` — all clean.
- `pnpm test` (763 tests) and `pnpm build` in the desktop UI — clean.
- `UPDATE_WIRE_TYPES=1` regeneration produced exactly the `tools` field removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)