### PR TITLE
feat(desktop): shadcn-styled markdown tables with copy

### DIFF
--- a/crates/openwave-desktop/ui/src/ClipboardCopyButton.tsx
+++ b/crates/openwave-desktop/ui/src/ClipboardCopyButton.tsx
@@ -4,6 +4,8 @@ import { WithTooltip } from "@/components/ui/tooltip";
 
 export type ClipboardWriter = {
   writeText(text: string): Promise<void>;
+  /** Present only where the richer, multi-flavour clipboard API exists. */
+  write?(items: ClipboardItem[]): Promise<void>;
 };
 
 type CopyState = "idle" | "copied" | "failed";
@@ -14,17 +16,24 @@ type TimerApi = {
 };
 
 type ClipboardCopyButtonProps = {
-  value: string;
   label: string;
   copiedAnnouncement: string;
   failedAnnouncement: string;
   className?: string;
-};
+} & (
+  | { value: string; copy?: never }
+  /**
+   * Produce and write the payload at click time — for a control whose content
+   * is only known from the rendered DOM, or that writes more than plain text.
+   */
+  | { value?: never; copy: () => Promise<void> }
+);
 
 export const COPY_STATE_RESET_MS = 3_000;
 
 export function ClipboardCopyButton({
   value,
+  copy,
   label,
   copiedAnnouncement,
   failedAnnouncement,
@@ -39,7 +48,8 @@ export function ClipboardCopyButton({
 
   async function onCopy() {
     try {
-      await copyPlainText(value);
+      if (copy) await copy();
+      else await copyPlainText(value ?? "");
       setCopyState("copied");
     } catch {
       setCopyState("failed");
@@ -86,6 +96,36 @@ export async function copyPlainText(
     throw new Error("Clipboard access is unavailable");
   }
   await clipboard.writeText(text);
+}
+
+/**
+ * Write one selection under two flavours, so the paste target picks the one it
+ * understands: `text/html` for a rich editor, `text/plain` for an editor, a
+ * terminal, or a spreadsheet reading tab-separated cells.
+ *
+ * Falls back to the plain flavour alone wherever the multi-flavour API is
+ * missing or refuses the write, which is the payload every target accepts.
+ */
+export async function copyRichText(
+  html: string,
+  text: string,
+  clipboard: ClipboardWriter | undefined = globalThis.navigator?.clipboard,
+  item: typeof ClipboardItem | undefined = globalThis.ClipboardItem,
+): Promise<void> {
+  if (clipboard?.write && item) {
+    try {
+      await clipboard.write([
+        new item({
+          "text/plain": new Blob([text], { type: "text/plain" }),
+          "text/html": new Blob([html], { type: "text/html" }),
+        }),
+      ]);
+      return;
+    } catch {
+      // Fall through: a browser that rejects the richer write still takes text.
+    }
+  }
+  await copyPlainText(text, clipboard);
 }
 
 export function scheduleCopyStateReset(

--- a/crates/openwave-desktop/ui/src/MessageMarkdown.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageMarkdown.dom.test.tsx
@@ -21,6 +21,21 @@ describe("code block copy", () => {
   });
 });
 
+describe("table copy", () => {
+  it("copies the rendered cells as tab-separated rows", async () => {
+    const user = userEvent.setup();
+    render(
+      <MessageMarkdown>
+        {"| Name | Value |\n| --- | --- |\n| Alpha | **1** |"}
+      </MessageMarkdown>,
+    );
+    await user.click(screen.getByRole("button", { name: "Copy table" }));
+    expect(await window.navigator.clipboard.readText()).toBe(
+      "Name\tValue\nAlpha\t1",
+    );
+  });
+});
+
 const DOCUMENT = "0b2b1f2c-9d3e-4a5b-8c7d-6e5f4a3b2c1d";
 const OLD_CITATION = "3f7c8a91-2b4d-4e6f-9a1b-5c7d8e9f0a1b";
 

--- a/crates/openwave-desktop/ui/src/MessageMarkdown.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageMarkdown.test.tsx
@@ -76,19 +76,18 @@ describe("MessageMarkdown", () => {
     expect(markup).not.toContain("javascript:");
   });
 
-  it("renders a plain table without a frame or copy footer", () => {
+  it("renders a table through the table primitive, with a copy control", () => {
     const markup = renderToStaticMarkup(
       <MessageMarkdown>
         {"| Name | Value |\n| --- | --- |\n| Alpha | **1** |"}
       </MessageMarkdown>,
     );
 
-    expect(markup).toContain("<table>");
+    expect(markup).toContain('data-slot="table"');
+    expect(markup).toContain('data-slot="table-head"');
     expect(markup).toContain("Alpha");
     expect(markup).toContain("<strong>1</strong>");
-    // Chat tables are plain: no framing wrapper, no copy control.
-    expect(markup).not.toContain("Copy table contents");
-    expect(markup).not.toContain("markdown-table-frame");
+    expect(markup).toContain('aria-label="Copy table"');
   });
 
   it("renders display math through KaTeX rather than as literal source", () => {

--- a/crates/openwave-desktop/ui/src/MessageMarkdown.tsx
+++ b/crates/openwave-desktop/ui/src/MessageMarkdown.tsx
@@ -1,4 +1,10 @@
-import { isValidElement, memo, useMemo, type ReactNode } from "react";
+import {
+  isValidElement,
+  memo,
+  useMemo,
+  useRef,
+  type ReactNode,
+} from "react";
 import ReactMarkdown, {
   type Components,
   type Options,
@@ -7,7 +13,16 @@ import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import rehypeHighlight from "rehype-highlight";
 import rehypeKatex from "rehype-katex";
-import { ClipboardCopyButton } from "./ClipboardCopyButton";
+import { ClipboardCopyButton, copyRichText } from "./ClipboardCopyButton";
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import {
   CITATION_DOCUMENT_PROPERTY,
   CITATION_LOCATOR_PROPERTY,
@@ -128,6 +143,58 @@ export function safeMarkdownUrl(url: string | undefined): string | undefined {
   }
 }
 
+/**
+ * The tab-separated form of a rendered table — what a spreadsheet, an editor,
+ * or a terminal receives when the table is copied.
+ *
+ * Read off the DOM rather than the Markdown source: what the reader sees is
+ * already the resolved cell text, inline formatting and citations included,
+ * and re-parsing the source would be a second renderer to keep in agreement
+ * with this one.
+ */
+export function tableClipboardText(table: HTMLTableElement): string {
+  return Array.from(table.rows)
+    .map((row) =>
+      Array.from(row.cells)
+        .map((cell) => (cell.textContent ?? "").replace(/\s+/g, " ").trim())
+        .join("\t"),
+    )
+    .join("\n");
+}
+
+async function copyTable(table: HTMLTableElement | null): Promise<void> {
+  if (!table) throw new Error("No table to copy");
+  await copyRichText(table.outerHTML, tableClipboardText(table));
+}
+
+/**
+ * A Markdown table, in its own horizontal scroll container so a wide table
+ * scrolls instead of crushing its columns below the message width, with a copy
+ * control that yields the table in both a rich and a plain flavour.
+ *
+ * The control reads the table out of a ref at click time, so this stays a pure
+ * render with no effect that would assume a complete table — the block is
+ * re-rendered on every streaming tick, half-parsed rows and all.
+ */
+function MarkdownTable({ children }: { children?: ReactNode }) {
+  const container = useRef<HTMLDivElement>(null);
+
+  return (
+    <div className="group/markdown-table relative my-5">
+      <ClipboardCopyButton
+        copy={() => copyTable(container.current?.querySelector("table") ?? null)}
+        label="Copy table"
+        copiedAnnouncement="Table copied"
+        failedAnnouncement="Copy failed"
+        className="border-border bg-background text-muted-foreground hover:text-foreground absolute top-0 right-0 z-10 inline-flex items-center rounded-md border p-1 opacity-0 shadow-sm transition-opacity group-hover/markdown-table:opacity-100 focus-visible:opacity-100"
+      />
+      <div ref={container} className="w-full overflow-x-auto">
+        <Table>{children}</Table>
+      </div>
+    </div>
+  );
+}
+
 const components: Components = {
   p: ({ children }) => <p>{children}</p>,
   h1: ({ children }) => <h1>{children}</h1>,
@@ -176,6 +243,15 @@ const components: Components = {
     );
   },
   blockquote: ({ children }) => <blockquote>{children}</blockquote>,
+  table: ({ children }) => <MarkdownTable>{children}</MarkdownTable>,
+  thead: ({ children }) => <TableHeader>{children}</TableHeader>,
+  tbody: ({ children }) => <TableBody>{children}</TableBody>,
+  tr: ({ children }) => <TableRow>{children}</TableRow>,
+  // GFM column alignment arrives as an inline text-align style; forwarding it
+  // is what keeps a right-aligned numeric column right-aligned.
+  th: ({ children, style }) => <TableHead style={style}>{children}</TableHead>,
+  td: ({ children, style }) => <TableCell style={style}>{children}</TableCell>,
+  caption: ({ children }) => <TableCaption>{children}</TableCaption>,
   // Most spans in a rendered message are syntax-highlighting tokens and pass
   // straight through; the ones {@link rehypeCitationDirectives} built carry the
   // citation they cite and become the phrase a reader can open.

--- a/crates/openwave-desktop/ui/src/components/ui/table.tsx
+++ b/crates/openwave-desktop/ui/src/components/ui/table.tsx
@@ -1,0 +1,90 @@
+import { cn } from "@/lib/utils";
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <table
+      data-slot="table"
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  );
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  );
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "border-border hover:bg-muted/40 border-b transition-colors",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "text-muted-foreground h-9 px-2.5 text-left align-middle font-medium whitespace-nowrap",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn("px-2.5 py-2 align-top", className)}
+      {...props}
+    />
+  );
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("text-muted-foreground mt-3 text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+  TableCaption,
+};

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -962,7 +962,8 @@ body {
 
 /* Paragraphs carry no margin of their own — the message column and the line
    height give the prose its rhythm — while the block elements keep the
-   typographic default gap around them. */
+   typographic default gap around them. Tables set their own margin on the
+   wrapper the `Table` primitive renders into. */
 .message-markdown p {
   margin: 0;
 }
@@ -970,8 +971,7 @@ body {
 .message-markdown ul,
 .message-markdown ol,
 .message-markdown pre,
-.message-markdown blockquote,
-.message-markdown table {
+.message-markdown blockquote {
   margin: 1.25em 0;
 }
 
@@ -1174,33 +1174,6 @@ body {
   margin: 1rem 0;
   border: 0;
   border-top: 1px solid var(--line);
-}
-
-/* ---------- Tables ---------- */
-
-/* A chat table is plain prose, not a framed widget. `display: block` turns the
-   table into its own horizontal scroll container so a wide table overflows and
-   scrolls instead of crushing its columns below the message width. */
-.message-markdown table {
-  display: block;
-  max-width: 100%;
-  overflow-x: auto;
-  border-collapse: collapse;
-  font-size: 0.92em;
-}
-
-.message-markdown th,
-.message-markdown td {
-  border-bottom: 1px solid var(--line);
-  padding: 0.35rem 0.45rem;
-  text-align: left;
-  vertical-align: top;
-  overflow-wrap: normal;
-  word-break: normal;
-}
-
-.message-markdown th {
-  font-weight: 600;
 }
 
 .markdown-image-omitted {


### PR DESCRIPTION
Chat Markdown tables rendered as bare `<table>` elements styled by a few global
rules in `styles.css`, separate from the primitives the rest of the interface is
built from. This routes them through a vendored `Table` primitive
(`components/ui/table.tsx`, in the same hand-vendored style as the others) and
wraps each table in its own horizontally scrollable container, so a wide table
scrolls instead of crushing its columns below the message width.

Each table also gets a copy control, revealed on hover the way the code-fence one
is. It writes the selection under two flavours: `text/html` from the rendered
table and `text/plain` as tab-separated rows. A paste therefore arrives as a real
table in a rich editor and as cells in a spreadsheet, rather than as a line of
pipes. Where the multi-flavour clipboard API is missing or rejects the write, it
falls back to writing the tab-separated text alone.

Both payloads are built from the DOM at click time via a ref, not by parsing the
Markdown a second time — the cell text a reader sees is already resolved, and a
second renderer would be one more thing to keep in agreement. The override stays
a pure render with no effects, which is what streaming needs: blocks re-render
every tick, half-parsed tables included.

The same rendering path backs Markdown output previews, so those get the upgraded
tables too. The now-redundant global `table`/`th`/`td` rules are removed; nothing
else selected them. GFM column alignment is forwarded through as an inline
`text-align`, so right-aligned numeric columns stay right-aligned.

Verified with `tsc --noEmit`, `pnpm test` (116 files, 765 tests), and `pnpm build`.
