### PR TITLE
feat(core): recognize native chart deliverables by the .chart.json suffix

### DIFF
--- a/crates/openwave-core/src/deliverable.rs
+++ b/crates/openwave-core/src/deliverable.rs
@@ -34,6 +34,17 @@ pub const MAX_BINARY_DELIVERABLE_BYTES: usize = 16 * 1024 * 1024;
 pub const MAX_DELIVERABLE_NAME_CHARS: usize = 120;
 /// Largest declared media type accepted for a binary workspace artifact.
 pub const MAX_DELIVERABLE_MEDIA_TYPE_CHARS: usize = 127;
+/// Media type of a native chart deliverable: JSON describing one figure rather
+/// than an opaque data document, so a renderer can draw it instead of showing
+/// its source.
+pub const CHART_MEDIA_TYPE: &str = "application/vnd.openwave.chart+json";
+/// Compound filename suffix that selects [`CHART_MEDIA_TYPE`].
+///
+/// A compound suffix rather than a bare extension keeps a chart file ordinary
+/// JSON on disk — anything that reads `.json` still reads it — while giving the
+/// catalog an unambiguous signal that the bytes describe a figure. Only the full
+/// suffix qualifies: `chart.json` on its own is plain `application/json`.
+pub const CHART_FILENAME_SUFFIX: &str = ".chart.json";
 /// Largest number of revisions one output retains.
 ///
 /// Reaching the bound is a product decision rather than a storage failure: the
@@ -290,12 +301,17 @@ fn is_media_type_token(token: &str) -> bool {
 }
 
 /// Whether a media type is one of the curated text types whose outputs use the
-/// text size ceiling.
+/// text size ceiling and the bounded text preview.
 #[must_use]
 pub fn media_type_is_text(media_type: &str) -> bool {
     matches!(
         media_type,
-        "text/markdown" | "text/plain" | "text/csv" | "application/json" | "text/html"
+        "text/markdown"
+            | "text/plain"
+            | "text/csv"
+            | "application/json"
+            | "text/html"
+            | CHART_MEDIA_TYPE
     )
 }
 
@@ -312,10 +328,18 @@ pub fn revision_byte_ceiling(media_type: &str) -> usize {
 }
 
 /// Return the fixed media type for one supported deliverable filename.
+///
+/// The compound suffix [`CHART_FILENAME_SUFFIX`] is matched before the plain
+/// extension, so `revenue.chart.json` is a chart while `data.json` — and the
+/// bare name `chart.json`, which does not carry the leading dot — stay
+/// `application/json`. Matching is case-insensitive.
 #[must_use]
 pub fn deliverable_media_type(name: &str) -> Option<&'static str> {
-    let extension = name.rsplit_once('.')?.1.to_ascii_lowercase();
-    match extension.as_str() {
+    let lowercased = name.to_ascii_lowercase();
+    if lowercased.ends_with(CHART_FILENAME_SUFFIX) {
+        return Some(CHART_MEDIA_TYPE);
+    }
+    match lowercased.rsplit_once('.')?.1 {
         "md" => Some("text/markdown"),
         "txt" => Some("text/plain"),
         "csv" => Some("text/csv"),
@@ -416,6 +440,27 @@ mod tests {
         assert_eq!(deliverable_media_type("brief.MD"), Some("text/markdown"));
         assert_eq!(deliverable_media_type("table.csv"), Some("text/csv"));
         assert_eq!(deliverable_media_type("archive.zip"), None);
+        // The chart suffix is compound, and only the full suffix qualifies.
+        assert_eq!(
+            deliverable_media_type("sales.chart.json"),
+            Some(CHART_MEDIA_TYPE)
+        );
+        assert_eq!(
+            deliverable_media_type("Q3.CHART.JSON"),
+            Some(CHART_MEDIA_TYPE)
+        );
+        assert_eq!(
+            deliverable_media_type("chart.json"),
+            Some("application/json")
+        );
+        assert_eq!(
+            deliverable_media_type("data.json"),
+            Some("application/json")
+        );
+        // A chart is a curated text type, so it is refused as a binary artifact
+        // and reaches the text preview and ceiling.
+        assert!(validate_deliverable_media_type(CHART_MEDIA_TYPE).is_ok());
+        assert!(validate_binary_deliverable("figure.bin", CHART_MEDIA_TYPE).is_err());
     }
 
     #[test]
@@ -462,6 +507,10 @@ mod tests {
         );
         assert_eq!(
             revision_byte_ceiling("application/json"),
+            MAX_DELIVERABLE_BYTES
+        );
+        assert_eq!(
+            revision_byte_ceiling(CHART_MEDIA_TYPE),
             MAX_DELIVERABLE_BYTES
         );
         assert_eq!(

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -130,9 +130,9 @@ pub use deliverable::{
     output_revision_relative_path, revision_byte_ceiling, validate_binary_deliverable,
     validate_deliverable_media_type, validate_deliverable_name, validate_portable_filename,
     CreateOutput, DeliverableKind, NewOutputRevision, OutputRecord, OutputRevision,
-    RevisionProducer, MAX_BINARY_DELIVERABLE_BYTES, MAX_DELIVERABLE_BYTES,
-    MAX_DELIVERABLE_MEDIA_TYPE_CHARS, MAX_DELIVERABLE_NAME_CHARS, MAX_OUTPUT_REVISIONS,
-    OUTPUTS_DIRECTORY,
+    RevisionProducer, CHART_FILENAME_SUFFIX, CHART_MEDIA_TYPE, MAX_BINARY_DELIVERABLE_BYTES,
+    MAX_DELIVERABLE_BYTES, MAX_DELIVERABLE_MEDIA_TYPE_CHARS, MAX_DELIVERABLE_NAME_CHARS,
+    MAX_OUTPUT_REVISIONS, OUTPUTS_DIRECTORY,
 };
 #[cfg(feature = "tools")]
 pub use deliverable_acceptance::{

--- a/crates/openwave-desktop/ui/src/deliverables.ts
+++ b/crates/openwave-desktop/ui/src/deliverables.ts
@@ -61,7 +61,8 @@ export type TextDeliverableMediaType =
   | "text/plain"
   | "text/csv"
   | "application/json"
-  | "text/html";
+  | "text/html"
+  | "application/vnd.openwave.chart+json";
 
 const MAX_DELIVERABLES = 100;
 const MAX_FILENAME_CHARACTERS = 120;
@@ -80,6 +81,7 @@ export function isTextDeliverableMediaType(
     "text/csv",
     "application/json",
     "text/html",
+    "application/vnd.openwave.chart+json",
   ].includes(value);
 }
 

--- a/crates/openwave-desktop/ui/src/outputs/CodeViewer.tsx
+++ b/crates/openwave-desktop/ui/src/outputs/CodeViewer.tsx
@@ -17,6 +17,7 @@ function fence(language: string, content: string): string {
 export function codeLanguageForMediaType(mediaType: string): string {
   switch (mediaType.split(";", 1)[0]!.trim().toLowerCase()) {
     case "application/json":
+    case "application/vnd.openwave.chart+json":
       return "json";
     case "text/html":
       return "xml";

--- a/crates/openwave-desktop/ui/src/outputs/outputFormat.ts
+++ b/crates/openwave-desktop/ui/src/outputs/outputFormat.ts
@@ -9,6 +9,8 @@ export function outputTypeLabel(mediaType: string): string {
       return "CSV";
     case "application/json":
       return "JSON";
+    case "application/vnd.openwave.chart+json":
+      return "Chart";
     case "text/html":
       return "HTML";
     case "text/plain":


### PR DESCRIPTION
The desktop app is gaining a native chart viewer, and it needs to tell a chart
figure apart from an ordinary data file. Both are JSON, so the extension alone
cannot carry the distinction — a `.json` output should keep its source view.

This adds a curated text media type, `application/vnd.openwave.chart+json`,
selected by the compound filename suffix `.chart.json`. A chart is written as
Plotly figure JSON (`{data, layout}`), so the file stays readable by anything
that reads JSON while the catalog gets an unambiguous signal about what the
bytes are.

`deliverable_media_type` checks the compound suffix before the plain extension
match, case-insensitively. Only the full suffix qualifies: `revenue.chart.json`
is a chart, while `data.json` and the bare name `chart.json` remain
`application/json`. The new type joins `media_type_is_text`, so charts get the
512 KiB text ceiling and the bounded text preview rather than the binary path,
and are refused as a declared type for a binary artifact. The existing media
type validator already accepts `+` in a subtype token, so it needed no change.

Every other caller derives its answer through `deliverable_media_type`,
`media_type_is_text`, or `revision_byte_ceiling`, so the scan, acceptance,
store, and preview paths pick this up without edits. The desktop UI keeps its
own mirror of the curated list; it is updated to match, with the type labelled
"Chart" in the outputs table and rendered as JSON source until the viewer
lands.

Tests: the media-type derivation test covers the three suffix cases and
case-insensitivity, and the ceiling test covers the new type. No new test
functions.