### PR TITLE
fix(desktop): give the UI production build enough heap for its largest chunk

### DIFF
--- a/crates/openwave-desktop/ui/package.json
+++ b/crates/openwave-desktop/ui/package.json
@@ -5,10 +5,10 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && node --max-old-space-size=4096 node_modules/vite/bin/vite.js build",
     "test": "vitest run",
     "before-tauri-dev": "node ../scripts/prepare-sidecar.mjs && vite",
-    "before-tauri-build": "node ../scripts/prepare-sidecar.mjs --release && tsc && vite build",
+    "before-tauri-build": "node ../scripts/prepare-sidecar.mjs --release && tsc && node --max-old-space-size=4096 node_modules/vite/bin/vite.js build",
     "preview": "vite preview",
     "tauri": "cargo tauri"
   },


### PR DESCRIPTION
Since the interactive chart viewer landed (#1649), the production UI build carries plotly as a ~4.8 MB lazy chunk, and rendering it pushes rollup past Node's default heap ceiling on CI runners. Main's `desktop UI` lane and the macOS release-cache warm both die with `FATAL ERROR: Reached heap limit` during `rendering chunks...`; local machines with more RAM pass because Node scales its default ceiling with system memory.

Run `vite build` through `node --max-old-space-size=4096` in the two UI build scripts, so every consumer of the build — the CI lane's `pnpm build`, `tauri build`'s `before-tauri-build`, and local builds — gets the same headroom. A script-level flag rather than workflow-level `NODE_OPTIONS` keeps the fix in one place and platform-neutral.

Verified locally: `pnpm build` completes through the wrapped invocation (21.9s, plotly chunk emitted as before).