### PR TITLE
feat(desktop): render chart outputs inline in the conversation

### DIFF
--- a/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
@@ -5,9 +5,27 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { ApprovalCard } from "./ApprovalCard";
 import { AppContextProvider, type AppContextValue } from "./AppContext";
 import type { ApiClient } from "./api";
+import { readDeliverable } from "./deliverables";
 import { MessageBubble, MessageList, type ChatMessage } from "./MessageList";
 import { SourceNavProvider } from "./panel/SourceNav";
 import { renderWithRouter } from "./test/router";
+import Plotly from "plotly.js-dist-min";
+
+// The chart card reads the output it draws, and draws it with the plotting
+// engine — neither of which a transcript test has any business really doing.
+vi.mock("./deliverables", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./deliverables")>()),
+  readDeliverable: vi.fn(),
+}));
+vi.mock("plotly.js-dist-min", () => ({
+  default: {
+    react: vi.fn(() => Promise.resolve()),
+    purge: vi.fn(),
+    Plots: { resize: vi.fn() },
+  },
+}));
+
+const CHART_MEDIA_TYPE = "application/vnd.openwave.chart+json";
 
 const noop = () => undefined;
 
@@ -38,7 +56,10 @@ const REMEMBER = "2.Yes, and don't ask again in this chat";
 const REMEMBER_IN_PROJECT = "2.Yes, and don't ask again in this project";
 const MORE = "More options";
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
 
 describe("approval card interactions", () => {
   it("propagates each decision with the grant it names", async () => {
@@ -831,6 +852,42 @@ describe("mcp app views", () => {
 });
 
 describe("actionable tool results", () => {
+  /** One exec call that published a chart output. */
+  function chartExecMessage(): ChatMessage {
+    return {
+      id: "exec-chart",
+      role: "tool",
+      callId: "call-2",
+      name: "exec",
+      status: "completed",
+      preview: {
+        tool: "exec",
+        command: "python3",
+        args: ["plot.py"],
+        cwd: ".",
+        files: [],
+      },
+      result: {
+        tool: "exec",
+        exitCode: 0,
+        timedOut: false,
+        outputTruncated: false,
+        stdout: "",
+        stderr: "",
+        outputs: [
+          {
+            kind: "output",
+            label: "revenue.chart.json",
+            detail: null,
+            meta: "v1 · created",
+            mediaType: CHART_MEDIA_TYPE,
+            targetId: "output-2",
+          },
+        ],
+      },
+    };
+  }
+
   it("opens a published output in the content panel from its card", async () => {
     const user = userEvent.setup();
     const { router } = await renderWithRouter(
@@ -892,6 +949,97 @@ describe("actionable tool results", () => {
         tabs: "outputs.output-1",
       });
     });
+  });
+
+  /**
+   * A chart is only worth anything as a picture, so its card draws the figure
+   * where the turn produced it — and still goes to the output panel, which is
+   * where versions, export and the source view live.
+   */
+  it("draws a chart output inline and still opens it in the panel", async () => {
+    const user = userEvent.setup();
+    vi.mocked(readDeliverable).mockResolvedValue({
+      outputId: "output-2",
+      filename: "revenue.chart.json",
+      mediaType: CHART_MEDIA_TYPE,
+      revisionCount: 1,
+      revisionId: "rev-1",
+      content: JSON.stringify({
+        data: [{ type: "bar", x: ["Q1"], y: [3] }],
+        layout: { title: "Revenue" },
+      }),
+      truncated: false,
+    });
+
+    const { router } = await renderWithRouter(
+      <MessageList
+        messages={[chartExecMessage()]}
+        folderAccessRequests={[]}
+        nativeHost={false}
+        nativeBusy={false}
+        resolvingFolderCalls={new Set()}
+        folderAccessErrors={{}}
+        decidingApprovalCalls={new Set()}
+        approvalErrors={{}}
+        busy={false}
+        scrollRef={{ current: null }}
+        onScroll={noop}
+        onApproval={noop}
+        onFolderAccessDecision={noop}
+        onFolderAccessCancel={noop}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(Plotly.react).toHaveBeenCalled();
+    });
+    expect(vi.mocked(Plotly.react).mock.calls[0]![1]).toEqual([
+      { type: "bar", x: ["Q1"], y: [3] },
+    ]);
+
+    await user.click(
+      screen.getByRole("button", { name: "Open output revenue.chart.json" }),
+    );
+    await waitFor(() => {
+      expect(router.state.location.search).toMatchObject({
+        tabs: "outputs.output-2",
+      });
+    });
+  });
+
+  /** Bytes that are not a figure leave the ordinary output card behind. */
+  it("falls back to the plain card when the chart cannot be read", async () => {
+    vi.mocked(readDeliverable).mockRejectedValue(new Error("gone"));
+    vi.spyOn(console, "error").mockImplementation(noop);
+
+    await renderWithRouter(
+      <MessageList
+        messages={[chartExecMessage()]}
+        folderAccessRequests={[]}
+        nativeHost={false}
+        nativeBusy={false}
+        resolvingFolderCalls={new Set()}
+        folderAccessErrors={{}}
+        decidingApprovalCalls={new Set()}
+        approvalErrors={{}}
+        busy={false}
+        scrollRef={{ current: null }}
+        onScroll={noop}
+        onApproval={noop}
+        onFolderAccessDecision={noop}
+        onFolderAccessCancel={noop}
+      />,
+    );
+
+    // The card the reader is left with is the ordinary output card — not the
+    // chart frame still holding its placeholder open.
+    await waitFor(() => {
+      expect(document.querySelector(".animate-pulse")).toBeNull();
+    });
+    expect(
+      screen.getByRole("button", { name: "Open output revenue.chart.json" }),
+    ).toBeInTheDocument();
+    expect(Plotly.react).not.toHaveBeenCalled();
   });
 
   it("opens the app the turn just created, from a card outside the accordion", async () => {

--- a/crates/openwave-desktop/ui/src/OutputCard.tsx
+++ b/crates/openwave-desktop/ui/src/OutputCard.tsx
@@ -1,16 +1,34 @@
+import { lazy, Suspense, useEffect, useRef, useState } from "react";
+
 import type { ResultEntry } from "@/api";
 import { DocumentIcon } from "@/components/document-table/DocumentIcon";
+import { Skeleton } from "@/components/ui/skeleton";
+import { readDeliverable, type DeliverablePreview } from "@/deliverables";
+import { parseChartFigure } from "@/outputs/chartFigure";
 import { usePanelNav } from "@/panel/usePanelNav";
+import { useActiveChatId } from "@/useActiveChatId";
+
+// The plotting engine is a large dependency and most conversations never make a
+// chart, so it is fetched from the app bundle on first use — the same lazy
+// viewer the outputs panel draws a chart output with.
+const ChartViewer = lazy(() => import("@/outputs/ChartViewer"));
+
+const CHART_MEDIA_TYPE = "application/vnd.openwave.chart+json";
+/** Matches the viewer's own default, so the placeholder holds the right space. */
+const DEFAULT_CHART_HEIGHT = 400;
+
+function normalizeMediaType(mediaType: string): string {
+  return mediaType.split(";", 1)[0]!.trim().toLowerCase();
+}
 
 /**
  * The cards a phase hangs under itself for the outputs it published.
  *
- * Mirrors Brightwave's deliverable cards at the end of a turn: one bordered
- * card per created or updated output — type icon in a tinted chip, filename,
- * version line — and a click opens the output in the content panel, where the
- * document viewers (Univer for spreadsheets and docs, pdf.js for PDFs) take
- * over. The exec card's collapsed rail still names the command; these cards
- * carry the thing the reader actually came for.
+ * One bordered card per created or updated output — type icon in a tinted chip,
+ * filename, version line — and a click opens the output in the content panel,
+ * where the document viewers (Univer for spreadsheets and docs, pdf.js for
+ * PDFs) take over. The exec card's collapsed rail still names the command;
+ * these cards carry the thing the reader actually came for.
  */
 export function OutputCardList({ outputs }: { outputs: ResultEntry[] }) {
   if (outputs.length === 0) return null;
@@ -23,15 +41,31 @@ export function OutputCardList({ outputs }: { outputs: ResultEntry[] }) {
   );
 }
 
-/**
- * One published output. Clickable only when the projection carries the durable
- * output id; rows rehydrated from journals written before the id crossed still
- * render, as the same card without a destination.
- */
-function OutputCard({ entry }: { entry: ResultEntry }) {
+const CARD_FRAME =
+  "bg-background inline-flex max-w-full min-w-0 items-center gap-3 rounded-lg border px-4 py-3 text-left shadow-sm";
+
+function OpenOutputCard({
+  entry,
+  outputId,
+}: {
+  entry: ResultEntry;
+  outputId: string;
+}) {
   const { openPanel } = usePanelNav();
-  const outputId = entry.targetId;
-  const body = (
+  return (
+    <button
+      type="button"
+      className={`${CARD_FRAME} hover:bg-muted/40 cursor-pointer transition-colors`}
+      onClick={() => openPanel({ type: "outputs", outputId })}
+      aria-label={`Open output ${entry.label}`}
+    >
+      <OutputCardBody entry={entry} />
+    </button>
+  );
+}
+
+function OutputCardBody({ entry }: { entry: ResultEntry }) {
+  return (
     <>
       <span className="bg-muted rounded-md p-2" aria-hidden="true">
         <DocumentIcon mediaType={entry.mediaType} className="size-5" />
@@ -46,19 +80,150 @@ function OutputCard({ entry }: { entry: ResultEntry }) {
       </span>
     </>
   );
-  const frame =
-    "bg-background inline-flex max-w-full min-w-0 items-center gap-3 rounded-lg border px-4 py-3 text-left shadow-sm";
+}
+
+/**
+ * One published output. Clickable only when the projection carries the durable
+ * output id; rows rehydrated from journals written before the id crossed still
+ * render, as the same card without a destination.
+ */
+function OutputCard({ entry }: { entry: ResultEntry }) {
+  const outputId = entry.targetId;
+
   if (outputId === null) {
-    return <div className={frame}>{body}</div>;
+    return (
+      <div className={CARD_FRAME}>
+        <OutputCardBody entry={entry} />
+      </div>
+    );
   }
-  return (
+
+  if (normalizeMediaType(entry.mediaType ?? "") === CHART_MEDIA_TYPE) {
+    return <ChartOutputCard entry={entry} outputId={outputId} />;
+  }
+
+  return <OpenOutputCard entry={entry} outputId={outputId} />;
+}
+
+/**
+ * Reads the output's current revision once the card is on screen.
+ *
+ * The transcript can hold many of these, and a figure the reader has scrolled
+ * past is not worth a round trip, so the fetch waits for the card to come into
+ * view. Where there is no observer to ask, it simply reads on mount.
+ */
+function useVisiblePreview(
+  chatId: string | null,
+  outputId: string,
+): { ref: React.RefObject<HTMLDivElement | null>; preview: DeliverablePreview | null; failed: boolean } {
+  const ref = useRef<HTMLDivElement>(null);
+  const [visible, setVisible] = useState(typeof IntersectionObserver !== "function");
+  const [preview, setPreview] = useState<DeliverablePreview | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    if (visible) return;
+    const element = ref.current;
+    if (!element) return;
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some((entry) => entry.isIntersecting)) setVisible(true);
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [visible]);
+
+  useEffect(() => {
+    if (!visible) return;
+    if (!chatId) {
+      setFailed(true);
+      return;
+    }
+    let cancelled = false;
+    void readDeliverable(chatId, outputId)
+      .then((next) => {
+        if (!cancelled) setPreview(next);
+      })
+      .catch((error) => {
+        // A chart that cannot be read is not an error worth a banner in the
+        // transcript — the card still opens the output, which reports properly.
+        console.error("inline chart could not be read", error);
+        if (!cancelled) setFailed(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [chatId, outputId, visible]);
+
+  return { ref, preview, failed };
+}
+
+/**
+ * A chart output drawn where the turn produced it.
+ *
+ * A chart is only worth anything as a picture, so the transcript shows it
+ * rather than a filename to click. The header still goes to the output panel,
+ * which is where versions, export and the source view live. The current
+ * revision is what gets drawn: the card names the version the turn wrote, and a
+ * later turn that revises the same file is the one whose card shows the change.
+ *
+ * Anything that is not a drawable figure — an unreadable read, a truncated
+ * file, bytes that are not a figure at all — falls back to the plain output
+ * card, which is what every other output type shows here.
+ */
+function ChartOutputCard({
+  entry,
+  outputId,
+}: {
+  entry: ResultEntry;
+  outputId: string;
+}) {
+  const chatId = useActiveChatId();
+  const { openPanel } = usePanelNav();
+  const { ref, preview, failed } = useVisiblePreview(chatId, outputId);
+
+  const figure =
+    preview && !preview.truncated ? parseChartFigure(preview.content) : null;
+
+  const header = (
     <button
       type="button"
-      className={`${frame} hover:bg-muted/40 cursor-pointer transition-colors`}
+      className="hover:bg-muted/40 flex w-full min-w-0 cursor-pointer items-center gap-3 rounded-t-lg px-4 py-3 text-left transition-colors"
       onClick={() => openPanel({ type: "outputs", outputId })}
       aria-label={`Open output ${entry.label}`}
     >
-      {body}
+      <OutputCardBody entry={entry} />
     </button>
+  );
+
+  if (failed || (preview && !figure)) {
+    return (
+      <div ref={ref}>
+        <OpenOutputCard entry={entry} outputId={outputId} />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={ref}
+      className="bg-background w-full max-w-2xl min-w-0 rounded-lg border shadow-sm"
+    >
+      {header}
+      <div className="px-4 pb-4">
+        {preview ? (
+          <Suspense fallback={<ChartPlaceholder />}>
+            <ChartViewer preview={preview} />
+          </Suspense>
+        ) : (
+          <ChartPlaceholder />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ChartPlaceholder() {
+  return (
+    <Skeleton className="w-full" style={{ height: DEFAULT_CHART_HEIGHT }} />
   );
 }


### PR DESCRIPTION
A chart output is only worth anything as a picture, but until now a turn that
produced one left a filename in the transcript and made the reader click into
the outputs panel to see what was drawn.

The output cards a turn hangs under its exec call now draw the figure for chart
outputs (`application/vnd.openwave.chart+json`). The card keeps its header —
icon, filename, version line — and clicking it still opens the same output
detail panel it did before, which is where versions, export and the source view
live.

Details:

- The figure is drawn by the existing lazy `ChartViewer`, so the plotting
  engine stays out of the startup bundle and is fetched on first use. The
  preview comes from `readDeliverable`, the same read the outputs panel makes.
- The read waits for the card to intersect the viewport, so scrolling back
  through a long conversation does not fetch every chart it ever produced.
  Without an `IntersectionObserver` it reads on mount.
- Anything that is not a drawable figure — a failed read, a truncated file,
  bytes that are not a figure — falls back to the ordinary output card, which
  is what every other output type shows there. The card is never blank and the
  destination is unchanged.
- The card draws the output's current revision. A later turn that revises the
  same file gets its own card, which is the one showing the change.

The pinned outputs summary above the transcript is untouched.

Tests: two cases added to the existing output-card group in
`MessageList.dom.test.tsx` — a chart card draws its traces and still navigates
to the output panel, and an unreadable chart leaves the plain card behind.

Verified with `tsc --noEmit`, `vitest run` (769 tests) and `pnpm build`; the
running app was not driven.