### PR TITLE
feat(core): model-level vendor web search capability plumbing

### DIFF
--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -191,7 +191,7 @@ pub use preview::{
 pub use provider::{
     ChatMessage, ChatRequest, ContentBlock, MessageReasoning, ModelProvider, ProviderEvent,
     ProviderId, ReasoningOrigin, RefusalDetails, RefusalOutcome, ResponseFormat, StopReason,
-    ToolChoice, Usage,
+    ToolChoice, Usage, VendorWebSearch,
 };
 pub use renderer_tool::RendererToolName;
 pub use secret_cache::CachingSecretProvider;

--- a/crates/openwave-core/src/provider.rs
+++ b/crates/openwave-core/src/provider.rs
@@ -238,6 +238,32 @@ pub enum ToolChoice {
     },
 }
 
+/// Ask the routing adapter to enable the provider's own server-side web search
+/// tool for this request.
+///
+/// The search runs on the provider's infrastructure: OpenWave advertises no
+/// tool for it, never sees the fetch, and makes no egress of its own, so none
+/// of the host's network policy applies to it. Present means the host decided
+/// the turn may search; absent means it may not.
+///
+/// Adapters that cannot express a vendor search — a route whose endpoint
+/// OpenWave does not control, or a provider with no such tool — must ignore
+/// this and send the request unchanged. Failing the turn over a control the
+/// host offered as an enhancement would trade a working answer for an error.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VendorWebSearch {
+    /// Upper bound on searches the provider may run in one turn.
+    pub max_uses: u32,
+}
+
+impl VendorWebSearch {
+    /// Search budget for a turn when the host has no reason to pick another.
+    ///
+    /// Enough for a question that needs following up on its first results,
+    /// while still bounding what one turn can spend.
+    pub const DEFAULT_MAX_USES: u32 = 5;
+}
+
 /// A request for one streamed model completion.
 ///
 /// The struct is constructed as a literal rather than through a builder, so it
@@ -298,6 +324,11 @@ pub struct ChatRequest {
     /// output constraint is the stronger promise.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_choice: Option<ToolChoice>,
+    /// Whether the provider's own web search tool is enabled for this request,
+    /// and the budget it may spend. Absent, the model has no vendor search and
+    /// reaches the web only through the tools OpenWave advertises.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vendor_web_search: Option<VendorWebSearch>,
     /// Pixels for the [`ContentBlock::Image`] blocks in `messages`.
     ///
     /// Hydrated from the blob store for exactly this request. Skipped by serde

--- a/crates/openwave-server/src/model_registry.rs
+++ b/crates/openwave-server/src/model_registry.rs
@@ -111,6 +111,15 @@ pub struct ModelSpec {
     pub input_modalities: &'static [InputModality],
     /// Whether the model can produce an internal reasoning stream.
     pub supports_reasoning: bool,
+    /// Whether a turn on this model may enable the provider's own server-side
+    /// web search tool instead of OpenWave's client-side one.
+    ///
+    /// Like the other capability flags, this gates behavior rather than
+    /// display: setting it asserts that the routing adapter for this row's
+    /// provider emits the vendor tool on the request, not merely that the
+    /// vendor documents one. Gateway and custom compatible routes cannot make
+    /// that promise, and the invariant below holds them to it.
+    pub supports_vendor_web_search: bool,
     /// The reasoning-effort levels this model accepts, ascending.
     ///
     /// A single flag cannot describe the range: a model may take `high` and
@@ -149,6 +158,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         // request format. The capability guard below keeps that promise honest.
         input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
+        supports_vendor_web_search: true,
         // Claude 4.6 and later reason on an adaptive thinking block, and the
         // Anthropic adapter sends one along with the chat's chosen effort. That
         // generation onward takes `low` through `max`; there is no `none`,
@@ -166,6 +176,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
+        supports_vendor_web_search: true,
         // Same adaptive-thinking generation as Opus 5 and Sonnet 5.
         reasoning_efforts: EFFORT_LOW_TO_MAX,
     },
@@ -178,6 +189,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
+        supports_vendor_web_search: true,
         reasoning_efforts: EFFORT_LOW_TO_MAX,
     },
     ModelSpec {
@@ -189,6 +201,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 64_000,
         input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
+        supports_vendor_web_search: true,
         // Haiku 4.5 predates the adaptive switch: it rejects the effort
         // control, so the adapter leaves both off and the picker hides it.
         reasoning_efforts: EFFORT_UNSUPPORTED,
@@ -202,6 +215,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
+        supports_vendor_web_search: true,
         reasoning_efforts: EFFORT_LOW_TO_MAX,
     },
     ModelSpec {
@@ -213,6 +227,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
+        supports_vendor_web_search: true,
         reasoning_efforts: EFFORT_LOW_TO_MAX,
     },
     ModelSpec {
@@ -224,6 +239,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
+        supports_vendor_web_search: true,
         reasoning_efforts: EFFORT_LOW_TO_MAX,
     },
     ModelSpec {
@@ -235,6 +251,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
+        supports_vendor_web_search: true,
         reasoning_efforts: EFFORT_LOW_TO_MAX,
     },
     ModelSpec {
@@ -246,6 +263,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
+        supports_vendor_web_search: false,
         // The whole GPT-5 line reasons on a caller-selected effort, which the
         // OpenAI-compatible adapter already sends alongside
         // `max_completion_tokens`. Only the 5.6 generation added `max`.
@@ -260,6 +278,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
+        supports_vendor_web_search: false,
         reasoning_efforts: EFFORT_NONE_TO_MAX,
     },
     ModelSpec {
@@ -271,6 +290,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
+        supports_vendor_web_search: false,
         reasoning_efforts: EFFORT_NONE_TO_MAX,
     },
     ModelSpec {
@@ -282,6 +302,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
+        supports_vendor_web_search: false,
         reasoning_efforts: EFFORT_NONE_TO_XHIGH,
     },
     ModelSpec {
@@ -293,6 +314,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
+        supports_vendor_web_search: false,
         reasoning_efforts: EFFORT_NONE_TO_XHIGH,
     },
     ModelSpec {
@@ -304,6 +326,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
+        supports_vendor_web_search: false,
         reasoning_efforts: EFFORT_NONE_TO_XHIGH,
     },
     // Gemini rows are intentionally limited to ids currently published by
@@ -319,6 +342,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 65_536,
         input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
+        supports_vendor_web_search: false,
         reasoning_efforts: EFFORT_NONE_TO_HIGH,
     },
     ModelSpec {
@@ -330,6 +354,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 65_536,
         input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
+        supports_vendor_web_search: false,
         reasoning_efforts: EFFORT_NONE_TO_HIGH,
     },
     ModelSpec {
@@ -341,6 +366,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 65_536,
         input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
+        supports_vendor_web_search: false,
         reasoning_efforts: EFFORT_NONE_TO_HIGH,
     },
     ModelSpec {
@@ -352,6 +378,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 65_536,
         input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
+        supports_vendor_web_search: false,
         reasoning_efforts: EFFORT_NONE_TO_HIGH,
     },
 ];
@@ -625,6 +652,22 @@ mod tests {
             find("gpt-5.4-nano").unwrap().reasoning_efforts,
             EFFORT_NONE_TO_XHIGH
         );
+    }
+
+    #[test]
+    fn no_pass_through_route_claims_the_vendor_web_search_tool() {
+        for spec in MODEL_REGISTRY {
+            assert!(
+                !spec.supports_vendor_web_search
+                    || !matches!(
+                        spec.provider,
+                        ProviderKind::OpenaiCompatible | ProviderKind::ModelGateway
+                    ),
+                "{} claims a provider-executed web search under `{}`, whose endpoint OpenWave cannot assume implements one",
+                spec.id,
+                spec.provider
+            );
+        }
     }
 
     #[test]

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -3185,6 +3185,7 @@ mod image_capability_tests {
         max_output_tokens: 64_000,
         input_modalities: &[InputModality::Text],
         supports_reasoning: false,
+        supports_vendor_web_search: false,
         reasoning_efforts: &[],
     };
 


### PR DESCRIPTION
Some providers run web search themselves, on their own infrastructure, as a
server-side tool the model calls — OpenWave advertises nothing, executes
nothing, and makes no egress of its own. Turning that on for a turn needs two
pieces of state that no adapter should invent for itself: whether the resolved
model's route can actually emit the vendor tool, and whether the host decided
this request may search and with what budget.

`ModelSpec` gains `supports_vendor_web_search`. Like the other capability
flags it gates behavior rather than display: setting it asserts that the
route's adapter emits the vendor tool, not merely that the vendor documents
one. It is set on the curated Anthropic rows and left off everywhere else. A
new registry invariant holds custom-compatible and gateway rows to that
promise — OpenWave does not control what those endpoints implement, so they
cannot claim a provider-executed search.

`ChatRequest` gains an optional `vendor_web_search` carrying the per-turn
search budget. `ChatRequest` derives `Default` and callers spread it, so this
reaches the adapters without touching any construction site. Adapters that
cannot express a vendor search must ignore the field and send the request
unchanged rather than fail a turn over a control the host offered as an
enhancement.

Nothing reads either field yet. The Anthropic adapter that emits the tool, and
the server side that decides when a turn sets the request field, follow in
stacked changes.
