### PR TITLE
docs: make result-card doc comments self-contained

### DIFF
--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -514,12 +514,10 @@ impl ResultEntry {
 ///
 /// A batch tool succeeds and fails in the same breath — five files import, two
 /// do not — and a card that lists only what worked is not reporting, it is
-/// flattering. Every one of Brightwave's local-file results carries a parallel
-/// failures list for exactly this reason.
+/// flattering. So every local-file result carries a parallel failures list.
 ///
-/// Two fields because that is what a failure row reads as, and it is what
-/// Brightwave's own card normalizes its three failure shapes down to before
-/// rendering them: the thing that failed, and why.
+/// Two fields because that is what a failure row reads as: the thing that
+/// failed, and why.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 pub struct ResultFailure {
     /// What failed, when the tool can name it. `None` when the tool cannot —
@@ -566,8 +564,8 @@ impl ResultFailure {
 
 /// A byte count as a card should read it.
 ///
-/// Ported from Brightwave's local-file result rows, which is where this reads
-/// as "12.4 KB" rather than as a number nobody scans.
+/// Local-file result rows show "12.4 KB" rather than a raw number nobody
+/// scans.
 #[must_use]
 pub fn format_bytes(bytes: u64) -> String {
     if bytes < 1024 {

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -838,8 +838,7 @@ function surfacedCards(
  *
  * Separate from {@link surfacedCard} because they are additive: the command
  * card says what ran, and these say what it produced — one clickable card per
- * created or updated output, the way Brightwave surfaces deliverables at the
- * end of a turn.
+ * created or updated output, surfaced at the end of the turn.
  */
 function surfacedOutputCards(entry: ChatMessage): ReactNode {
   if (entry.role !== "tool" || entry.result?.tool !== "exec") return null;

--- a/crates/openwave-desktop/ui/src/ToolEntriesList.tsx
+++ b/crates/openwave-desktop/ui/src/ToolEntriesList.tsx
@@ -60,8 +60,8 @@ const LIST_VERBS: Readonly<Partial<Record<string, string>>> = {
 /**
  * The list of things a call found, read, or wrote, inside the activity rail.
  *
- * The shape follows Brightwave's tool-call document list: a bordered card led
- * by a muted count line, over one hoverable row per thing. It renders inside
+ * A bordered card led by a muted count line, over one hoverable row per thing.
+ * It renders inside
  * the expanded phase rather than as a standing card — collapsed, a phase is
  * one line of text, and what each call found is one click away.
  *

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1886,12 +1886,10 @@ export type ResultEntryKind = "file" | "folder" | "source" | "passage" | "link" 
  *
  * A batch tool succeeds and fails in the same breath — five files import, two
  * do not — and a card that lists only what worked is not reporting, it is
- * flattering. Every one of Brightwave's local-file results carries a parallel
- * failures list for exactly this reason.
+ * flattering. So every local-file result carries a parallel failures list.
  *
- * Two fields because that is what a failure row reads as, and it is what
- * Brightwave's own card normalizes its three failure shapes down to before
- * rendering them: the thing that failed, and why.
+ * Two fields because that is what a failure row reads as: the thing that
+ * failed, and why.
  */
 export type ResultFailure = { 
 /**


### PR DESCRIPTION
A few doc comments on the tool-result cards and preview types explained their design by pointing at another product's UI instead of stating the rationale directly. The reasoning belongs in the comment itself: batch results carry a parallel failures list because success-only reporting flatters, a failure row is a thing plus a why, byte counts render human-readable, and output cards surface per turn.

Comment-only change; `ui/src/generated/wire.ts` is the regenerated mirror of the `preview.rs` doc comments (via `UPDATE_WIRE_TYPES=1 cargo test -p openwave-server`, staleness check passes).