### PR TITLE
feat(server): match gateway models to curated ids via upstream ids

### DIFF
--- a/crates/openwave-connectors/src/gateway.rs
+++ b/crates/openwave-connectors/src/gateway.rs
@@ -149,6 +149,12 @@ pub struct GatewayIdentity {
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct GatewayModel {
     pub id: String,
+    /// The provider-side id this deployment routes to, when it differs from
+    /// `id` — a deployment alias such as `us.anthropic.claude-opus-5` behind
+    /// the gateway id `anthropic-us-claude-opus-5`. Optional because gateways
+    /// older than this field simply omit it.
+    #[serde(default)]
+    pub upstream_id: Option<String>,
     pub name: String,
     pub context_window: Option<i64>,
     pub max_output_tokens: Option<i64>,

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -843,6 +843,15 @@ id: string,
  */
 display_name?: string | null, 
 /**
+ * The provider-side id a managed gateway routes this model to, when the
+ * gateway reports one that differs from `id`.
+ *
+ * Populated only by gateway model sync — a user-entered custom model
+ * leaves it unset, and nothing in the settings UI offers it. It exists so
+ * a deployment-aliased id can still be recognized as a curated model.
+ */
+upstream_id?: string | null, 
+/**
  * Context limit used by OpenWave's reducer.
  */
 context_window: number, 

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -546,6 +546,9 @@ impl GatewayRuntime {
             .map(|model| CustomModelConfig {
                 id: model.id,
                 display_name: Some(model.name),
+                // Carried so a deployment-aliased id can still be matched to
+                // its curated row; gateways older than the field send none.
+                upstream_id: model.upstream_id,
                 context_window: clamp_u32(model.context_window, 32_768),
                 max_output_tokens: clamp_u32(model.max_output_tokens, 4_096),
             })
@@ -1143,8 +1146,10 @@ mod tests {
     /// A gateway that serves a model under its upstream id is serving that
     /// curated model over a different route, so the row inherits the curated
     /// capabilities instead of being presented as an anonymous unverified
-    /// endpoint. The deployment's own limits still win, and an id the registry
-    /// does not carry keeps the conservative treatment.
+    /// endpoint — whether the gateway id is itself the curated id or a
+    /// deployment alias whose reported upstream id resolves to one. The
+    /// deployment's own limits still win, and a row the registry can be matched
+    /// to by neither route keeps the conservative treatment.
     #[tokio::test]
     async fn a_gateway_model_matching_a_curated_id_inherits_its_capabilities() {
         let address = serve(Arc::new(FakeGateway::default())).await;
@@ -1158,12 +1163,21 @@ mod tests {
                 models: vec![
                     CustomModelConfig {
                         id: "claude-opus-5".to_string(),
+                        upstream_id: None,
                         display_name: Some("Opus (gateway)".to_string()),
                         context_window: 200_000,
                         max_output_tokens: 32_000,
                     },
                     CustomModelConfig {
                         id: "anthropic-us-claude-opus-5".to_string(),
+                        upstream_id: Some("us.anthropic.claude-opus-5".to_string()),
+                        display_name: None,
+                        context_window: 200_000,
+                        max_output_tokens: 32_000,
+                    },
+                    CustomModelConfig {
+                        id: "acme-inhouse-llm".to_string(),
+                        upstream_id: None,
                         display_name: None,
                         context_window: 200_000,
                         max_output_tokens: 32_000,
@@ -1203,14 +1217,43 @@ mod tests {
         assert_eq!(matched.context_window, 200_000);
         assert_eq!(matched.max_output_tokens, 32_000);
 
-        let unmatched = providers::resolve_model_policy(
+        let aliased = providers::resolve_model_policy(
             &*store,
             "model_gateway::anthropic-us-claude-opus-5",
             false,
         )
         .await
         .unwrap()
-        .expect("the unmatched gateway row still resolves");
+        .expect("the aliased gateway row resolves");
+        assert_eq!(
+            aliased.provider,
+            crate::providers::ProviderKind::ModelGateway,
+            "matching by upstream id must not re-route the request"
+        );
+        assert_eq!(
+            aliased.id, "anthropic-us-claude-opus-5",
+            "the gateway's own id is what the request carries"
+        );
+        assert_eq!(
+            aliased.vendor,
+            Some(crate::providers::ProviderKind::Anthropic)
+        );
+        assert_eq!(aliased.display_name, "Claude Opus 5");
+        assert_eq!(
+            aliased.verification,
+            crate::model_registry::VerificationTier::Verified
+        );
+        assert!(aliased
+            .input_modalities
+            .contains(&crate::model_registry::InputModality::Image));
+        assert!(aliased.supports_reasoning);
+        assert_eq!(aliased.context_window, 200_000);
+
+        let unmatched =
+            providers::resolve_model_policy(&*store, "model_gateway::acme-inhouse-llm", false)
+                .await
+                .unwrap()
+                .expect("the unmatched gateway row still resolves");
         assert_eq!(unmatched.vendor, None);
         assert_eq!(
             unmatched.verification,
@@ -1990,6 +2033,7 @@ mod tests {
                 vertex_location: None,
                 models: vec![CustomModelConfig {
                     id: "legacy-model".to_string(),
+                    upstream_id: None,
                     display_name: None,
                     context_window: 32_768,
                     max_output_tokens: 4_096,
@@ -2103,6 +2147,7 @@ mod tests {
             vertex_location: None,
             models: vec![CustomModelConfig {
                 id: id.to_string(),
+                upstream_id: None,
                 display_name: None,
                 context_window: 32_768,
                 max_output_tokens: 4_096,
@@ -2179,6 +2224,7 @@ mod tests {
                 vertex_location: None,
                 models: vec![CustomModelConfig {
                     id: "foreign-model".to_string(),
+                    upstream_id: None,
                     display_name: None,
                     context_window: 32_768,
                     max_output_tokens: 4_096,
@@ -2230,6 +2276,7 @@ mod tests {
                 vertex_location: None,
                 models: vec![CustomModelConfig {
                     id: "legacy-model".to_string(),
+                    upstream_id: None,
                     display_name: None,
                     context_window: 32_768,
                     max_output_tokens: 4_096,

--- a/crates/openwave-server/src/model_roles.rs
+++ b/crates/openwave-server/src/model_roles.rs
@@ -447,12 +447,14 @@ mod tests {
                 models: vec![
                     CustomModelConfig {
                         id: "gateway-flagship".to_string(),
+                        upstream_id: None,
                         display_name: Some("Gateway Flagship".to_string()),
                         context_window: 1_000_000,
                         max_output_tokens: 64_000,
                     },
                     CustomModelConfig {
                         id: "gateway-haiku".to_string(),
+                        upstream_id: None,
                         display_name: Some("Gateway Haiku".to_string()),
                         context_window: 200_000,
                         max_output_tokens: 8_192,

--- a/crates/openwave-server/src/pairing.rs
+++ b/crates/openwave-server/src/pairing.rs
@@ -613,6 +613,7 @@ mod tests {
                 gateway_url: "https://old.gateway.test/".to_string(),
                 models: vec![providers::CustomModelConfig {
                     id: "stale-model".into(),
+                    upstream_id: None,
                     display_name: None,
                     context_window: 32_768,
                     max_output_tokens: 4_096,

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -450,6 +450,14 @@ pub struct CustomModelConfig {
     /// Optional human-facing label.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
+    /// The provider-side id a managed gateway routes this model to, when the
+    /// gateway reports one that differs from `id`.
+    ///
+    /// Populated only by gateway model sync — a user-entered custom model
+    /// leaves it unset, and nothing in the settings UI offers it. It exists so
+    /// a deployment-aliased id can still be recognized as a curated model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upstream_id: Option<String>,
     /// Context limit used by OpenWave's reducer.
     #[serde(default = "default_custom_context_window")]
     pub context_window: u32,
@@ -517,11 +525,21 @@ impl ResolvedModelPolicy {
     /// reported context and output caps are authoritative for that deployment,
     /// which may be narrower than the upstream model's.
     ///
-    /// An id with no exact curated match keeps the conservative custom
-    /// treatment.
+    /// Deployments also alias their ids (`anthropic-us-claude-opus-5` for an
+    /// upstream `us.anthropic.claude-opus-5`), which no exact match can see.
+    /// When the gateway reports the upstream id, it is tried next — exactly,
+    /// then with the deployment decoration stripped by
+    /// [`curated_id_candidate`].
+    ///
+    /// An id that matches no curated row either way keeps the conservative
+    /// custom treatment.
     fn gateway_for(model: &CustomModelConfig) -> Self {
         let mut policy = Self::custom_for(ProviderKind::ModelGateway, model);
-        let Some(spec) = model_registry::find(&model.id) else {
+        let Some(spec) = model_registry::find(&model.id).or_else(|| {
+            let upstream = model.upstream_id.as_deref()?;
+            model_registry::find(upstream)
+                .or_else(|| model_registry::find(&curated_id_candidate(upstream)))
+        }) else {
             return policy;
         };
         policy.display_name = spec.display_name.to_owned();
@@ -560,10 +578,61 @@ impl ResolvedModelPolicy {
             &CustomModelConfig {
                 id: id.to_owned(),
                 display_name: None,
+                upstream_id: None,
                 context_window: default_custom_context_window(),
                 max_output_tokens: default_custom_max_output_tokens(),
             },
         )
+    }
+}
+
+/// Strip the deployment decoration a hosted provider adds to a curated model
+/// id, so `us.anthropic.claude-opus-5` can be recognized as `claude-opus-5`.
+///
+/// Deliberately narrow: one leading region prefix, then one leading vendor
+/// prefix, then one trailing version suffix — nothing else. Anything broader
+/// would start collapsing distinct curated ids into each other, and a wrong
+/// match here silently attributes another model's capabilities. The result is
+/// only ever *offered* to the registry; a miss keeps the conservative
+/// treatment.
+fn curated_id_candidate(upstream_id: &str) -> String {
+    const REGION_PREFIXES: [&str; 5] = ["us.", "eu.", "apac.", "jp.", "global."];
+    const VENDOR_PREFIXES: [&str; 1] = ["anthropic."];
+
+    let mut candidate = upstream_id;
+    for prefix in REGION_PREFIXES {
+        if let Some(rest) = candidate.strip_prefix(prefix) {
+            candidate = rest;
+            break;
+        }
+    }
+    for prefix in VENDOR_PREFIXES {
+        if let Some(rest) = candidate.strip_prefix(prefix) {
+            candidate = rest;
+            break;
+        }
+    }
+    strip_version_suffix(candidate).to_owned()
+}
+
+/// Drop a trailing `-v<digits>` or `-v<digits>:<digits>` — Bedrock's revision
+/// marker. Left alone when the tail is not exactly that shape.
+fn strip_version_suffix(id: &str) -> &str {
+    let Some((head, tail)) = id.rsplit_once("-v") else {
+        return id;
+    };
+    if head.is_empty() {
+        return id;
+    }
+    let numeric = |part: &str| !part.is_empty() && part.chars().all(|c| c.is_ascii_digit());
+    let matches = match tail.split_once(':') {
+        Some((major, minor)) => numeric(major) && numeric(minor),
+        None => numeric(tail),
+    };
+    if matches {
+        head
+    } else {
+        id
     }
 }
 
@@ -1529,6 +1598,7 @@ mod tests {
     fn an_unset_display_name_is_absent_rather_than_null() {
         let unset = CustomModelConfig {
             id: "local/model".into(),
+            upstream_id: None,
             display_name: None,
             context_window: 32_768,
             max_output_tokens: 4_096,
@@ -1554,10 +1624,36 @@ mod tests {
         assert_eq!(explicit_null, unset);
     }
 
+    /// The candidate the registry is offered for a deployment-aliased upstream
+    /// id. The risk here is over-stripping: every extra rule is another way to
+    /// hand one model another model's capabilities, and curated ids contain
+    /// dots and digits of their own.
+    #[test]
+    fn upstream_ids_are_normalized_only_by_region_vendor_and_version() {
+        assert_eq!(
+            curated_id_candidate("us.anthropic.claude-opus-5"),
+            "claude-opus-5"
+        );
+        assert_eq!(
+            curated_id_candidate("anthropic.claude-sonnet-4-5-v1:0"),
+            "claude-sonnet-4-5"
+        );
+        // Not a region prefix, not a version suffix: left exactly as reported.
+        assert_eq!(curated_id_candidate("gpt-5.6-sol"), "gpt-5.6-sol");
+        assert_eq!(curated_id_candidate("acme.llm-v"), "acme.llm-v");
+        assert_eq!(
+            curated_id_candidate("us.acme.private-model"),
+            "acme.private-model"
+        );
+        // One region prefix, not repeated stripping.
+        assert_eq!(curated_id_candidate("us.eu.model"), "eu.model");
+    }
+
     #[test]
     fn custom_model_validation_is_conservative_and_rejects_duplicates() {
         let valid = CustomModelConfig {
             id: "local/model".into(),
+            upstream_id: None,
             display_name: Some("Local Model".into()),
             context_window: 32_768,
             max_output_tokens: 4_096,
@@ -1571,6 +1667,7 @@ mod tests {
         );
         assert!(validate_custom_models(&[CustomModelConfig {
             id: "bad model".into(),
+            upstream_id: None,
             display_name: None,
             context_window: 32_768,
             max_output_tokens: 4_096,
@@ -1578,6 +1675,7 @@ mod tests {
         .is_err());
         assert!(validate_custom_models(&[CustomModelConfig {
             id: "bad".into(),
+            upstream_id: None,
             display_name: None,
             context_window: 1_000,
             max_output_tokens: 4_096,
@@ -1634,6 +1732,7 @@ mod tests {
             ProviderKind::OpenaiCompatible,
             &CustomModelConfig {
                 id: "local-model".into(),
+                upstream_id: None,
                 display_name: None,
                 context_window: 32_768,
                 max_output_tokens: 4_096,

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -1684,12 +1684,14 @@ async fn model_roles_resolve_at_read_time_and_honor_an_explicit_pin() {
             models: vec![
                 providers::CustomModelConfig {
                     id: "gateway-flagship".to_string(),
+                    upstream_id: None,
                     display_name: Some("Gateway Flagship".to_string()),
                     context_window: 1_000_000,
                     max_output_tokens: 64_000,
                 },
                 providers::CustomModelConfig {
                     id: "gateway-haiku".to_string(),
+                    upstream_id: None,
                     display_name: Some("Gateway Haiku".to_string()),
                     context_window: 200_000,
                     max_output_tokens: 8_192,

--- a/crates/openwave-server/src/tests/image_attachment.rs
+++ b/crates/openwave-server/src/tests/image_attachment.rs
@@ -652,6 +652,7 @@ async fn a_turn_carrying_images_against_a_text_only_model_is_refused() {
             vertex_location: None,
             models: vec![providers::CustomModelConfig {
                 id: "vendor/model".into(),
+                upstream_id: None,
                 display_name: Some("Vendor Model".into()),
                 context_window: 65_536,
                 max_output_tokens: 8_192,


### PR DESCRIPTION
Gateway-synced models inherit curated capabilities (#1648) only on an exact
`model_registry::find(&model.id)` hit. Deployments alias their ids, so a
gateway id like `anthropic-us-claude-opus-5` fronting an upstream
`us.anthropic.claude-opus-5` never matched, and the row was presented as an
anonymous unverified endpoint with no image input and no reasoning.

The gateway's `GET /api/v1/cli/models` now reports an upstream id per model.
This carries it through:

- `GatewayModel.upstream_id` on the connectors wire type, `serde(default)` so
  gateways older than the field still parse.
- `CustomModelConfig.upstream_id`, populated by gateway sync only. It is not
  user-enterable and the settings UI neither renders nor sends it;
  `validate_custom_models` needs no new rule because the field is never taken
  from a client body — every non-sync construction site passes `None`.
- `gateway_for` falls back on an exact-id miss: the reported upstream id
  exactly, then a normalized candidate. Normalization strips one leading
  region prefix (`us.`, `eu.`, `apac.`, `jp.`, `global.`), then one leading
  `anthropic.`, then a trailing `-v<n>` or `-v<n>:<n>` — nothing else. Every
  extra rule is another way to hand one model another model's capabilities,
  and curated ids carry dots and digits of their own (`gpt-5.6-sol` must
  survive untouched). Inheritance still requires the registry to return a row,
  which already means the id is unambiguous.

Everything else about gateway resolution is unchanged: provider stays
`ModelGateway`, the request carries the gateway's own id, and the
deployment's reported limits win over the curated row's.

## Snapshot compatibility

`CustomModelConfig` is `deny_unknown_fields` and is persisted in the
`gateway.models_v1` snapshot. Forward is fine — a new binary reading an old
snapshot sees the field absent and defaults it to `None`.

Downgrading is worth stating plainly: an older binary reading a snapshot
written by this one hits the unknown key, and `read_gateway_snapshot` swallows
the parse error (`serde_json::from_value(...).ok()`), yielding `None`. The
profile behaves as if it had never synced — the model picker is empty until
the next sync (the background loop's first attempt is immediate on boot, so in
practice that is the next launch, not a manual Refresh). Not fixed here: a
correct fix is deciding whether the snapshot should tolerate unknown keys at
all, which is a separate call from this change.

## Tests

`a_gateway_model_matching_a_curated_id_inherits_its_capabilities` now covers
all three cases in one pass: the exact-id row, an aliased row carrying
`upstream_id` (asserted to inherit vendor, tier, modalities and reasoning
while keeping the gateway route, its own id, and the deployment's limits), and
an unrelated in-house id with no upstream id that still gets the conservative
treatment. One new unit test pins the normalizer, which is where an
over-eager rule would do damage.

Wire fixtures are deliberately left without the field so the `serde(default)`
path is what the existing gateway tests exercise.

The generated `wire.ts` picks up the optional field (regenerated, not
hand-edited); no UI source changes.

Closes #1650
