### PR TITLE
feat(desktop): fill the app detail view with the frame, inline the footer

### DIFF
--- a/crates/openwave-desktop/ui/src/apps/AppDetailView.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppDetailView.tsx
@@ -10,6 +10,24 @@ import { friendlyAppsError, updatedLabel } from "./AppsView";
 import type { AppsApis } from "./appsApis";
 
 /**
+ * The footer's one-line revision readout: the current revision and its date,
+ * with a total when history has more than one entry. The full list lives in
+ * the element's `title`.
+ */
+function revisionSummary(detail: AppDetail): string {
+  const current = detail.revisions.find(
+    (revision) => revision.id === detail.current_revision,
+  );
+  const count =
+    detail.revisions.length === 1
+      ? null
+      : `${detail.revisions.length} revisions`;
+  if (!current) return count ?? "1 revision";
+  const label = `Revision ${current.ordinal} · ${updatedLabel(current.created_at)}`;
+  return count ? `${label} · ${count}` : label;
+}
+
+/**
  * One app, as the panel addressed `apps.{appId}`: the running frame (behind
  * its consent gate), the grant controls, the revision history, and deletion.
  *
@@ -92,7 +110,9 @@ export function AppDetailView({
     try {
       setGrant(await apis.grantState(appId));
     } catch {
-      setGrant((current) => (current ? { ...current, granted: false } : current));
+      setGrant((current) =>
+        current ? { ...current, granted: false } : current,
+      );
     }
   }
 
@@ -150,73 +170,75 @@ export function AppDetailView({
               />
             )}
 
-            {grant.granted && (
-              <section className="mx-4 flex flex-col gap-2" aria-label="Access">
-                <div className="text-muted-foreground flex items-center gap-1.5 text-xs">
-                  <ShieldCheck className="size-3.5 shrink-0" aria-hidden="true" />
-                  <span>
-                    Allowed to use{" "}
-                    {grant.bindings
-                      .flatMap((binding) => [
-                        ...(binding.operation_ids ?? []),
-                        ...(binding.folder !== null
-                          ? [
-                              `${binding.name ?? "a folder"} (${
-                                binding.access === "read_write"
-                                  ? "read & write"
-                                  : "read"
-                              })`,
-                            ]
-                          : []),
-                      ])
-                      .join(", ") || "no tools"}
-                  </span>
-                </div>
-                {actionError && (
-                  <p className="text-critical text-sm" role="alert">
-                    {actionError}
-                  </p>
-                )}
-                <div>
-                  <Button
-                    variant="outline"
-                    size="xs"
-                    disabled={busy}
-                    onClick={() => void onRevoke()}
-                  >
-                    Revoke access
-                  </Button>
-                </div>
-              </section>
+            {grant.granted && actionError && (
+              <p className="text-critical mx-4 text-sm" role="alert">
+                {actionError}
+              </p>
             )}
 
-            <section className="mx-4 flex flex-col gap-1" aria-label="Revisions">
-              <h2 className="text-sm font-medium">
-                {detail.revisions.length === 1
-                  ? "1 revision"
-                  : `${detail.revisions.length} revisions`}
-              </h2>
-              <ul className="flex flex-col gap-0.5">
-                {detail.revisions.map((revision) => (
-                  <li
-                    key={revision.id}
-                    className="text-muted-foreground flex items-center gap-2 text-xs"
-                  >
-                    <span className="tabular-nums">
-                      Revision {revision.ordinal}
-                    </span>
-                    <span>{updatedLabel(revision.created_at)}</span>
-                    {revision.id === detail.current_revision && (
-                      <span className="text-foreground">current</span>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            </section>
+            <footer className="mx-4 flex flex-wrap items-center gap-x-4 gap-y-2">
+              <div
+                className="flex min-w-0 flex-1 items-center gap-3"
+                aria-label="Access"
+              >
+                {grant.granted && (
+                  <>
+                    <div className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-xs">
+                      <ShieldCheck
+                        className="size-3.5 shrink-0"
+                        aria-hidden="true"
+                      />
+                      <span className="truncate">
+                        Allowed to use{" "}
+                        {grant.bindings
+                          .flatMap((binding) => [
+                            ...(binding.operation_ids ?? []),
+                            ...(binding.folder !== null
+                              ? [
+                                  `${binding.name ?? "a folder"} (${
+                                    binding.access === "read_write"
+                                      ? "read & write"
+                                      : "read"
+                                  })`,
+                                ]
+                              : []),
+                          ])
+                          .join(", ") || "no tools"}
+                      </span>
+                    </div>
+                    <Button
+                      variant="outline"
+                      size="xs"
+                      disabled={busy}
+                      onClick={() => void onRevoke()}
+                    >
+                      Revoke access
+                    </Button>
+                  </>
+                )}
+              </div>
 
-            <section className="mx-4" aria-label="Delete app">
+              <p
+                className="text-muted-foreground text-xs"
+                aria-label="Revisions"
+                title={detail.revisions
+                  .map(
+                    (revision) =>
+                      `Revision ${revision.ordinal} · ${updatedLabel(
+                        revision.created_at,
+                      )}${
+                        revision.id === detail.current_revision
+                          ? " (current)"
+                          : ""
+                      }`,
+                  )
+                  .join("\n")}
+              >
+                {revisionSummary(detail)}{" "}
+              </p>
+
               <Button
-                variant="outline"
+                variant="destructive"
                 size="xs"
                 disabled={busy}
                 onClick={() => void onDelete()}
@@ -224,7 +246,7 @@ export function AppDetailView({
                 <Trash2 className="size-3.5" aria-hidden="true" />
                 Delete app
               </Button>
-            </section>
+            </footer>
           </>
         )}
       </div>

--- a/crates/openwave-desktop/ui/src/apps/AppFrame.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppFrame.tsx
@@ -17,13 +17,15 @@ import type { AppsApis } from "./appsApis";
  * A `consent_required` refusal mid-session (revoked, or a server reconfigured
  * while the app was open) is reported upward so the host can re-present the
  * consent sheet; the frame itself just sees a rejected call.
+ *
+ * Unlike the inline MCP App card, this frame fills whatever space the panel
+ * gives it — the bridge's app-reported height is ignored and tall content
+ * scrolls inside the sandbox.
  */
 type FrameState =
   | { kind: "loading" }
   | { kind: "unavailable" }
   | { kind: "ready"; url: string };
-
-const DEFAULT_FRAME_HEIGHT = 384;
 
 export function AppFrame({
   appId,
@@ -39,7 +41,6 @@ export function AppFrame({
 }) {
   const { resolved: resolvedTheme } = useTheme();
   const [state, setState] = useState<FrameState>({ kind: "loading" });
-  const [frameHeight, setFrameHeight] = useState(DEFAULT_FRAME_HEIGHT);
   const frameRef = useRef<HTMLIFrameElement | null>(null);
   const bridgeRef = useRef<McpAppBridge | null>(null);
 
@@ -54,10 +55,14 @@ export function AppFrame({
     const bridge = createMcpAppBridge({
       frame: () => frameRef.current?.contentWindow ?? null,
       theme: () => themeRef.current,
-      onHeight: setFrameHeight,
       invokeOperation: async (operationId, parameters, body) => {
         try {
-          return await apis.invokeOperation(appId, operationId, parameters, body);
+          return await apis.invokeOperation(
+            appId,
+            operationId,
+            parameters,
+            body,
+          );
         } catch (error) {
           if (
             error instanceof AppInvokeRefusalError &&
@@ -118,14 +123,14 @@ export function AppFrame({
   }, [apis, appId]);
 
   return (
-    <div className="bg-background mx-4 overflow-hidden rounded-lg border">
+    <div className="bg-background mx-4 flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border">
       {state.kind === "loading" && (
         <p className="text-muted-foreground p-3 text-xs">Opening app…</p>
       )}
       {state.kind === "unavailable" && (
         <p className="text-muted-foreground p-3 text-xs">
-          This app could not be opened. Its stored revision may be missing —
-          try again, or delete the app.
+          This app could not be opened. Its stored revision may be missing — try
+          again, or delete the app.
         </p>
       )}
       {state.kind === "ready" && (
@@ -135,8 +140,7 @@ export function AppFrame({
           src={state.url}
           sandbox="allow-scripts"
           referrerPolicy="no-referrer"
-          className="w-full border-0"
-          style={{ height: frameHeight }}
+          className="w-full flex-1 border-0"
         />
       )}
     </div>


### PR DESCRIPTION
The local app frame sized itself to the app-reported height (default 384px), so a tall app was cut off while the grant, revision, and delete sections stacked below it.

- `AppFrame` now flexes to fill the panel; the bridge's app-reported height is ignored in the detail view and tall content scrolls inside the sandbox.
- The controls below the frame collapse into a single footer row: access summary + **Revoke access** on the left, a one-line revision readout in the middle (current revision + date, count when there are several; the full history is in the element's `title`), and **Delete app** on the right, now using the destructive button variant.

Verified with `pnpm test` (apps suites, 24 passing), `tsc --noEmit`, and `pnpm build`. I did not drive the running app, so the new proportions haven't been eyeballed in a real window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)