### PR TITLE
fix(desktop): remove trailing provider dropdown chevron

### DIFF
--- a/crates/openwave-desktop/ui/src/components/ui/select.tsx
+++ b/crates/openwave-desktop/ui/src/components/ui/select.tsx
@@ -56,10 +56,16 @@ const SelectScrollDownButton = React.forwardRef<
 ));
 SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName;
 
+type SelectContentProps = React.ComponentPropsWithoutRef<
+  typeof SelectPrimitive.Content
+> & {
+  scrollButtons?: boolean;
+};
+
 const SelectContent = React.forwardRef<
   React.ComponentRef<typeof SelectPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = "popper", ...props }, ref) => (
+  SelectContentProps
+>(({ className, children, position = "popper", scrollButtons = true, ...props }, ref) => (
   <SelectPrimitive.Portal>
     <SelectPrimitive.Content
       ref={ref}
@@ -72,7 +78,7 @@ const SelectContent = React.forwardRef<
       position={position}
       {...props}
     >
-      <SelectScrollUpButton />
+      {scrollButtons && <SelectScrollUpButton />}
       <SelectPrimitive.Viewport
         className={cn(
           "p-1",
@@ -82,7 +88,7 @@ const SelectContent = React.forwardRef<
       >
         {children}
       </SelectPrimitive.Viewport>
-      <SelectScrollDownButton />
+      {scrollButtons && <SelectScrollDownButton />}
     </SelectPrimitive.Content>
   </SelectPrimitive.Portal>
 ));

--- a/crates/openwave-desktop/ui/src/settings/ProviderFields.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProviderFields.tsx
@@ -119,7 +119,7 @@ export function ActiveProviderField<Kind extends string>({
         <SelectTrigger aria-label="Provider">
           <SelectValue />
         </SelectTrigger>
-        <SelectContent>
+        <SelectContent scrollButtons={false}>
           <SelectItem value={NO_PROVIDER}>Disabled</SelectItem>
           {options.map((option) => (
             <SelectItem key={option.kind} value={option.kind}>


### PR DESCRIPTION
## Summary

- let the shared select content omit scroll buttons for fixed short lists
- disable the misleading scroll affordance in the provider picker
- preserve scroll controls for longer dropdowns elsewhere

## Verification

- `pnpm exec tsc --noEmit --incremental false`
- `pnpm test` (117 files, 769 tests)
- `pnpm exec vite build`