### PR TITLE
feat(desktop): one plugins panel behind both the slash and the composer menu

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -423,10 +423,10 @@ export function ChatView({
           slash={{
             options: composerPlugins.slashOptions,
             invoked: invokedSkills,
-            onInvoke: (name) =>
+            onInvoke: (names) =>
               useComposerDrafts
                 .getState()
-                .setSkills(chat.id, [...invokedSkills, name]),
+                .setSkills(chat.id, [...invokedSkills, ...names]),
             onRemove: (name) =>
               useComposerDrafts
                 .getState()

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -14,24 +14,33 @@ import {
   Image as ImageIcon,
   Mic,
   Square,
-  Sparkles,
   Wand2,
   X,
 } from "lucide-react";
 import { MAX_STEER_CHARACTERS } from "./ActiveTurnSteer";
 import {
   activeSlashQuery,
+  availableSlashOptions,
   filterSlashOptions,
+  nextOptionHighlight,
   replaceSlashToken,
+  skillsToInvoke,
   MAX_INVOKED_SKILLS,
   type SlashOption,
 } from "./ComposerSlash";
 import {
   ComposerToolsMenu,
   type ComposerNetwork,
-  type ComposerPlugins,
   type ComposerReasoning,
 } from "./ComposerToolsMenu";
+import {
+  optionIcon,
+  pluginOptionRows,
+  PluginsPanel,
+  PLUGINS_PANEL_LABEL,
+  skillCapNote,
+} from "@/plugins/PluginsPanel";
+import { OptionListbox, optionElementId } from "@/components/OptionListbox";
 import {
   describeImageAttachment,
   imageFilesFrom,
@@ -52,6 +61,8 @@ import type { ChatFolderAccess } from "./useChatFolderAttachments";
 
 const MIN_COMPOSER_LINES = 1;
 export const MAX_COMPOSER_LINES = 6;
+
+const SLASH_LIST_ID = "composer-slash-list";
 
 type ComposerKeyEvent = Pick<
   KeyboardEvent<HTMLTextAreaElement>["nativeEvent"],
@@ -114,31 +125,17 @@ function resizeComposerTextarea(textarea: HTMLTextAreaElement): void {
 }
 
 /**
- * The sentence that engages a plugin, and where the caret lands after it.
+ * The installed bundles, and how one is turned on.
  *
- * There is no directive the backend parses: an enabled bundle's skills are in
- * the model's system prompt, so asking for one in plain words is what makes it
- * happen. The text goes in at the caret, with a space in front of it when it
- * would otherwise run into what is already written.
+ * A bundle being on is a property of the installation rather than of this
+ * message, so engaging one that is off turns it on the same way its switch on
+ * the Plugins page would. What the pick then puts on the message is the
+ * composer's business.
  */
-export function insertPluginDirective(
-  draft: string,
-  directive: string,
-  selectionStart: number,
-  selectionEnd: number,
-): { text: string; caret: number } {
-  const before = draft.slice(0, selectionStart);
-  const after = draft.slice(selectionEnd);
-  const gap = before && !/\s$/.test(before) ? " " : "";
-  return {
-    text: `${before}${gap}${directive}${after}`,
-    caret: before.length + gap.length + directive.length,
-  };
-}
-
-export function pluginDirective(displayName: string): string {
-  return `Use the ${displayName} plugin: `;
-}
+export type ComposerPlugins = {
+  items: readonly PluginInfo[];
+  onSelect: (plugin: PluginInfo) => void;
+};
 
 /**
  * Everything the composer needs to present attached images.
@@ -183,17 +180,22 @@ export type ComposerVoice = {
 };
 
 /**
- * What typing `/` reaches, and which skills the next message will invoke.
+ * What the plugins panel reaches, and which skills the next message will
+ * invoke.
  *
- * The composer owns the token and the list; the surface above it owns the
- * catalog and the invoked names, because those have to survive this component
- * — the chat route reads them again when it posts the turn.
+ * The composer owns the token, the panel, and its highlight; the surface above
+ * it owns the catalog and the invoked names, because those have to survive this
+ * component — the chat route reads them again when it posts the turn.
  */
 export type ComposerSlash = {
   options: readonly SlashOption[];
   /** Skill names invoked for the next send, in the order they were picked. */
   invoked: readonly string[];
-  onInvoke: (name: string) => void;
+  /**
+   * Add these skills to the message, in order. A list rather than one name
+   * because a bundle stands for its members and they all arrive at once.
+   */
+  onInvoke: (names: readonly string[]) => void;
   onRemove: (name: string) => void;
   /** One prompt's insertable text. A rejection leaves the draft as it was. */
   loadPromptBody: (name: string) => Promise<string>;
@@ -285,6 +287,9 @@ export function Composer({
     query: string;
   } | null>(null);
   const [slashHighlight, setSlashHighlight] = useState(0);
+  // The same list, opened from the tools menu instead of from a `/`. Its query
+  // is its own: there is no token in the draft to read one from.
+  const [panelQuery, setPanelQuery] = useState<string | null>(null);
   const { confirm, dialog: confirmDialog } = useConfirm();
   const inputDisabled = disabled;
   const active = busy && activeTurnId !== null;
@@ -318,26 +323,17 @@ export function Composer({
 
   const invokedSkills = slash?.invoked ?? [];
   const atSkillCap = invokedSkills.length >= MAX_INVOKED_SKILLS;
-  /**
-   * What this `/` can still reach.
-   *
-   * A skill already on the message is not offered again — the server refuses a
-   * duplicate — and neither is any skill once the turn's cap is reached, or
-   * while a turn is running: steering carries no invocation, so a pill picked
-   * there would silently apply to some later message. Prompts are text and stay
-   * available throughout.
-   */
-  const slashOptions = (slash?.options ?? []).filter((option) => {
-    if (option.kind === "prompt") return true;
-    if (active || atSkillCap) return false;
-    return !invokedSkills.includes(option.name);
+  /** What a pick can still reach, given what this message already carries. */
+  const slashOptions = availableSlashOptions(slash?.options ?? [], invokedSkills, {
+    steering: active,
   });
   const slashMatches = slashToken
     ? filterSlashOptions(slashOptions, slashToken.query)
     : [];
   // Skills vanish from the list at the cap, which would otherwise read as a
   // catalog that has lost them. The note says which bound was reached.
-  const slashCapNote = slashToken !== null && !active && atSkillCap;
+  const capNote = !active && atSkillCap;
+  const slashCapNote = slashToken !== null && capNote;
   // An open list with nothing in it is a panel over the draft saying nothing.
   const slashOpen =
     slashToken !== null && (slashMatches.length > 0 || slashCapNote);
@@ -351,34 +347,43 @@ export function Composer({
   }
 
   /**
-   * Take the `/query` out of the draft, and do what the row promised.
+   * Do what the row promised, and take the `/query` out of the draft when the
+   * pick came from one.
    *
    * A skill leaves a pill behind: the name travels beside the message rather
-   * than inside it, so nothing has to be parsed back out of prose. A prompt is
-   * text, so its body replaces the token — fetched only now, because the
-   * catalog deliberately carries no bodies.
+   * than inside it, so nothing has to be parsed back out of prose. A bundle
+   * leaves one per member skill, and turns itself on first if it was off. A
+   * prompt is text, so its body goes into the draft — fetched only now, because
+   * the catalog deliberately carries no bodies.
    */
-  function selectSlashOption(option: SlashOption) {
-    const token = slashToken;
-    if (!slash || !token) return;
-    const caret = token.start + 1 + token.query.length;
-    setSlashToken(null);
-    if (option.kind === "skill") {
-      applySlashReplacement(draft, token.start, caret, "");
-      slash.onInvoke(option.name);
+  function pickOption(
+    option: SlashOption,
+    token: { start: number; query: string } | null,
+  ) {
+    if (!slash) return;
+    const caret = token ? token.start + 1 + token.query.length : 0;
+    if (option.kind === "prompt") {
+      void (async () => {
+        let body: string;
+        try {
+          body = await slash.loadPromptBody(option.name);
+        } catch {
+          // Picking is not a place to raise an error: a body that cannot be
+          // read leaves the draft exactly as the reader typed it, token and all.
+          return;
+        }
+        if (token) applySlashReplacement(draft, token.start, caret, body);
+        else insertAtSelection(body);
+      })();
       return;
     }
-    void (async () => {
-      let body: string;
-      try {
-        body = await slash.loadPromptBody(option.name);
-      } catch {
-        // Picking is not a place to raise an error: a body that cannot be read
-        // leaves the draft exactly as the reader typed it, `/` token and all.
-        return;
-      }
-      applySlashReplacement(draft, token.start, caret, body);
-    })();
+    if (token) applySlashReplacement(draft, token.start, caret, "");
+    if (option.kind === "plugin") {
+      const plugin = plugins?.items.find((item) => item.name === option.name);
+      if (plugin) plugins?.onSelect(plugin);
+    }
+    const names = skillsToInvoke(option, invokedSkills);
+    if (names.length > 0) slash.onInvoke(names);
   }
 
   function applySlashReplacement(
@@ -388,13 +393,32 @@ export function Composer({
     replacement: string,
   ) {
     const next = replaceSlashToken(source, start, caret, replacement);
-    selectionRef.current = { start: next.caret, end: next.caret };
-    onDraftChange(next.text);
+    moveCaret(next.text, next.caret);
+  }
+
+  /** Text put in where the reader last had the caret, without running words together. */
+  function insertAtSelection(text: string) {
+    const remembered = selectionRef.current;
+    const start = Math.min(remembered?.start ?? draft.length, draft.length);
+    const end = Math.min(remembered?.end ?? draft.length, draft.length);
+    const before = draft.slice(0, start);
+    const gap = before && !/\s$/.test(before) ? " " : "";
+    moveCaret(
+      `${before}${gap}${text}${draft.slice(end)}`,
+      before.length + gap.length + text.length,
+    );
+  }
+
+  function moveCaret(text: string, caret: number) {
+    selectionRef.current = { start: caret, end: caret };
+    onDraftChange(text);
+    // After the panel or menu has closed and the new value has been painted;
+    // focusing while either is still up hands focus straight back to it.
     window.requestAnimationFrame(() => {
       const field = textareaRef.current;
       if (!field || field.disabled) return;
       field.focus();
-      field.setSelectionRange(next.caret, next.caret);
+      field.setSelectionRange(caret, caret);
     });
   }
 
@@ -411,23 +435,17 @@ export function Composer({
     // A list showing only the cap note has nothing to move through or pick, so
     // Enter stays what it always is: send.
     if (slashMatches.length === 0) return false;
-    if (event.key === "ArrowDown") {
-      setSlashHighlight((current) => (current + 1) % slashMatches.length);
-      return true;
-    }
-    if (event.key === "ArrowUp") {
-      setSlashHighlight(
-        (current) =>
-          (Math.min(current, slashMatches.length - 1) +
-            slashMatches.length -
-            1) %
-          slashMatches.length,
-      );
+    const moved = nextOptionHighlight(event.key, slashIndex, slashMatches.length);
+    if (moved !== null) {
+      setSlashHighlight(moved);
       return true;
     }
     if (event.key === "Enter" || event.key === "Tab") {
       const option = slashMatches[slashIndex];
-      if (option) selectSlashOption(option);
+      if (option) {
+        setSlashToken(null);
+        pickOption(option, slashToken);
+      }
       return true;
     }
     return false;
@@ -467,37 +485,6 @@ export function Composer({
       start: textarea.selectionStart,
       end: textarea.selectionEnd,
     };
-  }
-
-  /**
-   * Turn the bundle on, then say so in the message being written.
-   *
-   * The caret is restored after the insertion so the reader carries on typing
-   * their request where the sentence left off, rather than at the end of a
-   * draft they may have been editing in the middle of. A draft nobody has put
-   * a caret in yet — a starter prompt, a transcript — is appended to.
-   */
-  function engagePlugin(plugin: PluginInfo) {
-    plugins?.onSelect(plugin);
-    const remembered = selectionRef.current;
-    const start = Math.min(remembered?.start ?? draft.length, draft.length);
-    const end = Math.min(remembered?.end ?? draft.length, draft.length);
-    const { text, caret } = insertPluginDirective(
-      draft,
-      pluginDirective(plugin.display_name),
-      start,
-      end,
-    );
-    selectionRef.current = { start: caret, end: caret };
-    onDraftChange(text);
-    // After the menu has closed and the new value has been painted; focusing
-    // while the menu is still up hands focus straight back to the trigger.
-    window.requestAnimationFrame(() => {
-      const field = textareaRef.current;
-      if (!field || field.disabled) return;
-      field.focus();
-      field.setSelectionRange(caret, caret);
-    });
   }
 
   function endDrag() {
@@ -628,69 +615,49 @@ export function Composer({
           {invokedSkills.map((name) => (
             <InvokedSkillChip
               key={name}
-              label={skillLabel(slash.options, name)}
+              option={skillOption(slash.options, name)}
+              name={name}
+              // Steering carries no invocation, so a chip is set aside for as
+              // long as a turn is running rather than silently applying later.
+              inactive={active}
               onRemove={() => slash.onRemove(name)}
             />
           ))}
         </ul>
       )}
+      {panelQuery !== null && slash && (
+        <PluginsPanel
+          options={slashOptions}
+          query={panelQuery}
+          capNote={capNote}
+          onQueryChange={setPanelQuery}
+          onPick={(option) => {
+            setPanelQuery(null);
+            pickOption(option, null);
+          }}
+          onClose={() => setPanelQuery(null)}
+        />
+      )}
       {slashOpen && (
         // In flow above the field rather than floating over it: the composer
         // clips its own overflow to keep its rounded edge, so a panel anchored
         // above the box would be cut off at the border.
-        <ul
-          id="composer-slash-list"
-          role="listbox"
-          aria-label="Skills and prompts"
-          className="m-0 max-h-56 list-none overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md"
-        >
-          {slashMatches.map((option, index) => (
-            <li key={`${option.kind}:${option.name}`}>
-              <button
-                type="button"
-                id={`composer-slash-option-${index}`}
-                role="option"
-                aria-selected={index === slashIndex}
-                className={cn(
-                  "flex w-full items-start gap-2 rounded-sm px-2 py-1.5 text-left text-sm",
-                  index === slashIndex && "bg-accent text-accent-foreground",
-                )}
-                // Taken on mousedown so the field never loses the caret the
-                // insertion is about to be made at.
-                onMouseDown={(event) => event.preventDefault()}
-                onClick={() => selectSlashOption(option)}
-              >
-                {option.kind === "skill" ? (
-                  <Wand2
-                    className="mt-0.5 size-4 shrink-0 text-muted-foreground"
-                    aria-hidden="true"
-                  />
-                ) : (
-                  <Sparkles
-                    className="mt-0.5 size-4 shrink-0 text-muted-foreground"
-                    aria-hidden="true"
-                  />
-                )}
-                <span className="flex min-w-0 flex-col">
-                  <span className="truncate">{option.label}</span>
-                  {option.description && (
-                    <span className="truncate text-xs text-muted-foreground">
-                      {option.description}
-                    </span>
-                  )}
-                </span>
-                <span className="ml-auto shrink-0 pl-2 text-[0.68rem] text-muted-foreground">
-                  {option.kind === "skill" ? "Skill" : "Prompt"}
-                </span>
-              </button>
-            </li>
-          ))}
-          {slashCapNote && (
-            <li className="px-2 py-1.5 text-xs text-muted-foreground">
-              {`A message can invoke at most ${MAX_INVOKED_SKILLS} skills.`}
-            </li>
-          )}
-        </ul>
+        <div className="rounded-md border border-border bg-popover text-popover-foreground shadow-md">
+          <OptionListbox
+            listId={SLASH_LIST_ID}
+            label={PLUGINS_PANEL_LABEL}
+            rows={pluginOptionRows(slashMatches)}
+            activeIndex={slashIndex}
+            note={slashCapNote ? skillCapNote() : null}
+            onPick={(index) => {
+              const option = slashMatches[index];
+              if (!option) return;
+              setSlashToken(null);
+              pickOption(option, slashToken);
+            }}
+            onHighlight={setSlashHighlight}
+          />
+        </div>
       )}
       <textarea
         ref={textareaRef}
@@ -709,9 +676,9 @@ export function Composer({
                 : "Message OpenWave…"
         }
         aria-label="Message"
-        aria-controls={slashOpen ? "composer-slash-list" : undefined}
+        aria-controls={slashOpen ? SLASH_LIST_ID : undefined}
         aria-activedescendant={
-          slashOpen ? `composer-slash-option-${slashIndex}` : undefined
+          slashOpen ? optionElementId(SLASH_LIST_ID, slashIndex) : undefined
         }
         // A stable hook for the shell's focus-composer shortcut, which has to
         // find the field without a ref threaded up through every route.
@@ -754,8 +721,13 @@ export function Composer({
             network={network}
             reasoning={reasoning}
             plugins={
-              plugins
-                ? { items: plugins.items, onSelect: engagePlugin }
+              slash && slash.options.length > 0
+                ? {
+                    onOpen: () => {
+                      setSlashToken(null);
+                      setPanelQuery("");
+                    },
+                  }
                 : undefined
             }
           />
@@ -917,12 +889,14 @@ export function Composer({
   );
 }
 
-/** What the catalog calls a skill, falling back to its slug if it has gone. */
-function skillLabel(options: readonly SlashOption[], name: string): string {
-  const option = options.find(
+/** What the catalog calls a skill, or nothing if the catalog has lost it. */
+function skillOption(
+  options: readonly SlashOption[],
+  name: string,
+): SlashOption | undefined {
+  return options.find(
     (candidate) => candidate.kind === "skill" && candidate.name === name,
   );
-  return option?.label ?? name;
 }
 
 /**
@@ -930,36 +904,48 @@ function skillLabel(options: readonly SlashOption[], name: string): string {
  *
  * A pill rather than words in the draft: the invocation is a field on the
  * message, so it has to be visible and removable as one thing, not as text the
- * reader could half-delete.
+ * reader could half-delete. It carries the icon of the library it came from,
+ * which is what makes the several a bundle leaves behind read as one pick.
  */
 function InvokedSkillChip({
-  label,
+  option,
+  name,
+  inactive,
   onRemove,
 }: {
-  label: string;
+  option: SlashOption | undefined;
+  name: string;
+  inactive: boolean;
   onRemove: () => void;
 }) {
+  const label = option?.label ?? name;
+  const Icon = option ? optionIcon(option) : Wand2;
   return (
-    <li className="relative flex min-w-0 max-w-full items-center gap-2 rounded-lg border border-border bg-muted/50 py-1.5 pl-2 pr-7 text-muted-foreground">
-      <span className="inline-flex size-9 shrink-0 items-center justify-center rounded-md bg-background">
-        <Wand2 size={16} aria-hidden="true" />
+    <li
+      className={cn(
+        "relative flex min-w-0 max-w-full items-center gap-2 rounded-full border border-border bg-muted/50 py-1 pl-2 pr-7 text-muted-foreground",
+        inactive && "opacity-60",
+      )}
+    >
+      <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-background">
+        <Icon size={14} aria-hidden="true" />
       </span>
-      <span className="grid min-w-0 gap-px">
-        <strong
-          className="max-w-[12rem] truncate text-xs font-semibold text-foreground"
-          title={label}
-        >
-          {label}
-        </strong>
-        <small className="text-[0.68rem]">Skill</small>
+      <span
+        className="max-w-[12rem] truncate text-xs font-semibold text-foreground"
+        title={label}
+      >
+        {label}
       </span>
+      <small className="text-[0.68rem]">
+        {inactive ? "Next message" : "Skill"}
+      </small>
       <button
         type="button"
-        className="absolute right-0.5 top-0.5 inline-flex items-center justify-center rounded-full border-0 bg-transparent p-0.5 text-inherit hover:bg-accent hover:text-foreground"
+        className="absolute right-1 top-1/2 inline-flex -translate-y-1/2 items-center justify-center rounded-full border-0 bg-transparent p-0.5 text-inherit hover:bg-accent hover:text-foreground"
         aria-label={`Remove ${label}`}
         onClick={onRemove}
       >
-        <X size={14} aria-hidden="true" />
+        <X size={13} aria-hidden="true" />
       </button>
     </li>
   );

--- a/crates/openwave-desktop/ui/src/ComposerPlugins.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerPlugins.dom.test.tsx
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
+import { useState } from "react";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, expect, it, vi } from "vitest";
 
-import { Composer, insertPluginDirective } from "./Composer";
+import { Composer, type ComposerSlash } from "./Composer";
+import type { SlashOption } from "./ComposerSlash";
 import type { PluginInfo } from "./api";
 
 afterEach(cleanup);
@@ -18,20 +20,54 @@ const DOCUMENTS: PluginInfo = {
   skills: [],
 };
 
-it("engages a plugin from the tools menu and says so in the draft", async () => {
-  const onSelect = vi.fn();
-  const onDraftChange = vi.fn();
-  const user = userEvent.setup();
-  render(
+const OPTIONS: SlashOption[] = [
+  {
+    kind: "plugin",
+    name: "documents",
+    label: "Documents",
+    description: "Writes Word, Excel, and PowerPoint files.",
+    category: "documents",
+    skills: ["docx", "pptx"],
+  },
+  {
+    kind: "skill",
+    name: "docx",
+    label: "Docx",
+    description: "Writes documents.",
+    category: "documents",
+  },
+  {
+    kind: "prompt",
+    name: "weekly-update",
+    label: "Weekly update",
+    description: "The Monday note.",
+  },
+];
+
+function ComposerHarness({
+  slash,
+  onDraftChange,
+  onSelect = vi.fn(),
+}: {
+  slash: ComposerSlash;
+  onDraftChange?: (draft: string) => void;
+  onSelect?: (plugin: PluginInfo) => void;
+}) {
+  const [draft, setDraft] = useState("Summarize the report");
+  return (
     <Composer
       activeTurnId={null}
       busy={false}
       cancelError={null}
       cancelPending={false}
       disabled={false}
-      draft="Summarize the report"
+      draft={draft}
       plugins={{ items: [DOCUMENTS], onSelect }}
-      onDraftChange={onDraftChange}
+      slash={slash}
+      onDraftChange={(next) => {
+        setDraft(next);
+        onDraftChange?.(next);
+      }}
       onSend={vi.fn(async () => {})}
       onSteer={vi.fn(async () => {})}
       onStop={vi.fn(async () => {})}
@@ -39,30 +75,90 @@ it("engages a plugin from the tools menu and says so in the draft", async () => 
       steerError={null}
       steerPending={false}
       steerStatus={null}
+    />
+  );
+}
+
+function slash(overrides: Partial<ComposerSlash> = {}): ComposerSlash {
+  return {
+    options: OPTIONS,
+    invoked: [],
+    onInvoke: vi.fn(),
+    onRemove: vi.fn(),
+    loadPromptBody: vi.fn(async () => "Write this week's update covering:"),
+    ...overrides,
+  };
+}
+
+async function openPanel() {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: "Tools" }));
+  await user.click(screen.getByRole("menuitem", { name: "Plugins" }));
+  return user;
+}
+
+it("opens the library from the tools menu with everything a slash reaches", async () => {
+  render(<ComposerHarness slash={slash()} />);
+
+  await openPanel();
+  const rows = await screen.findAllByRole("option");
+  expect(rows.map((row) => row.textContent)).toEqual([
+    "Documents" + DOCUMENTS.description + "Plugin",
+    "DocxWrites documents.Skill",
+    "Weekly updateThe Monday note.Prompt",
+  ]);
+});
+
+it("engages a picked bundle and invokes its skills without touching the draft", async () => {
+  const onSelect = vi.fn();
+  const onInvoke = vi.fn();
+  const onDraftChange = vi.fn();
+  render(
+    <ComposerHarness
+      slash={slash({ onInvoke })}
+      onDraftChange={onDraftChange}
+      onSelect={onSelect}
     />,
   );
 
-  await user.click(screen.getByRole("button", { name: "Tools" }));
-  await user.click(screen.getByRole("menuitem", { name: /Documents/ }));
+  const user = await openPanel();
+  await user.click(await screen.findByRole("option", { name: /Documents/ }));
 
+  // The bundle is turned on, and stands for its members on the message.
   expect(onSelect).toHaveBeenCalledWith(DOCUMENTS);
-  expect(onDraftChange).toHaveBeenCalledWith(
-    "Summarize the report Use the Documents plugin: ",
-  );
+  expect(onInvoke).toHaveBeenCalledWith(["docx", "pptx"]);
+  // Never a sentence in the message the reader is writing.
+  expect(onDraftChange).not.toHaveBeenCalled();
 });
 
-it("puts the directive at the caret without running words together", () => {
-  expect(insertPluginDirective("", "Use it: ", 0, 0)).toEqual({
-    text: "Use it: ",
-    caret: 8,
+it("narrows the panel from its own field and picks with the keyboard", async () => {
+  const onInvoke = vi.fn();
+  render(<ComposerHarness slash={slash({ onInvoke })} />);
+
+  const user = await openPanel();
+  const search = await screen.findByRole("textbox", {
+    name: "Search the plugin library",
   });
-  // Mid-draft, over a selection, and after text that already ends in a space.
-  expect(insertPluginDirective("draft here", "Use it: ", 5, 10)).toEqual({
-    text: "draft Use it: ",
-    caret: 14,
-  });
-  expect(insertPluginDirective("draft ", "Use it: ", 6, 6)).toEqual({
-    text: "draft Use it: ",
-    caret: 14,
-  });
+  await user.type(search, "docx");
+  expect(screen.getAllByRole("option")).toHaveLength(1);
+
+  await user.keyboard("{Enter}");
+  expect(onInvoke).toHaveBeenCalledWith(["docx"]);
+  expect(screen.queryByRole("option")).toBeNull();
+});
+
+it("drops what this message already carries from what the panel offers", async () => {
+  render(<ComposerHarness slash={slash({ invoked: ["docx"] })} />);
+
+  await openPanel();
+  const rows = await screen.findAllByRole("option");
+  // The bundle stays: it still has a member left to invoke. The invoked skill
+  // is gone, and its chip says what the message carries instead.
+  expect(rows.map((row) => row.textContent)).toEqual([
+    "Documents" + DOCUMENTS.description + "Plugin",
+    "Weekly updateThe Monday note.Prompt",
+  ]);
+  expect(
+    screen.getByRole("button", { name: "Remove Docx" }),
+  ).toBeInTheDocument();
 });

--- a/crates/openwave-desktop/ui/src/ComposerSlash.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerSlash.dom.test.tsx
@@ -140,7 +140,7 @@ it("invokes a picked skill and shows it as a chip the reader can drop", async ()
   await user.keyboard("make slides /pptx");
   await user.click(screen.getByRole("option", { name: /Pptx/ }));
 
-  expect(onInvoke).toHaveBeenCalledWith("pptx");
+  expect(onInvoke).toHaveBeenCalledWith(["pptx"]);
   // The token comes out of the prose; the invocation travels beside it.
   expect(onDraftChange).toHaveBeenLastCalledWith("make slides ");
 

--- a/crates/openwave-desktop/ui/src/ComposerSlash.test.ts
+++ b/crates/openwave-desktop/ui/src/ComposerSlash.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  availableSlashOptions,
+  skillsToInvoke,
+  slashOptionsFromCatalog,
+  MAX_INVOKED_SKILLS,
+  type SlashOption,
+} from "./ComposerSlash";
+import type { PluginCatalog } from "./api";
+
+const CATALOG: PluginCatalog = {
+  plugins: [
+    {
+      name: "documents",
+      display_name: "Documents",
+      description: "Writes Word, Excel, and PowerPoint files.",
+      category: "documents",
+      capabilities: [],
+      enabled: true,
+      skills: [
+        { name: "docx", description: "Documents.", origin: "builtin", enabled: true },
+        { name: "pptx", description: "Decks.", origin: "builtin", enabled: false },
+      ],
+    },
+    {
+      name: "charts",
+      display_name: "Charts",
+      description: "Plots data.",
+      category: "visualization",
+      capabilities: [],
+      enabled: false,
+      skills: [
+        { name: "charts", description: "Plots.", origin: "builtin", enabled: true },
+      ],
+    },
+  ],
+  skills: [
+    { name: "notes", description: "Takes notes.", origin: "user", enabled: true },
+  ],
+  prompts: [
+    {
+      name: "weekly-update",
+      description: "The Monday note.",
+      origin: "user",
+      plugin: null,
+      enabled: true,
+    },
+  ],
+};
+
+describe("slashOptionsFromCatalog", () => {
+  it("offers a bundle for its enabled members, and members only once the bundle is on", () => {
+    const options = slashOptionsFromCatalog(CATALOG);
+    expect(
+      options.map((option) => [option.kind, option.name, option.skills]),
+    ).toEqual([
+      ["plugin", "documents", ["docx"]],
+      ["plugin", "charts", ["charts"]],
+      // `pptx` is off on its own, and `charts` is inside a bundle that is off.
+      ["skill", "docx", undefined],
+      ["skill", "notes", undefined],
+      ["prompt", "weekly-update", undefined],
+    ]);
+    // A member skill wears its bundle's category, which is what its chip draws.
+    expect(options.find((option) => option.name === "docx")?.category).toBe(
+      "documents",
+    );
+  });
+});
+
+describe("skillsToInvoke", () => {
+  const bundle: SlashOption = {
+    kind: "plugin",
+    name: "documents",
+    label: "Documents",
+    description: "",
+    skills: ["docx", "pptx", "xlsx"],
+  };
+
+  it("stands for its members, skipping what the message already carries", () => {
+    expect(skillsToInvoke(bundle, ["pptx"])).toEqual(["docx", "xlsx"]);
+  });
+
+  it("fills the room the cap leaves rather than refusing the pick", () => {
+    const taken = Array.from(
+      { length: MAX_INVOKED_SKILLS - 1 },
+      (_, index) => `taken-${index}`,
+    );
+    expect(skillsToInvoke(bundle, taken)).toEqual(["docx"]);
+    expect(skillsToInvoke(bundle, [...taken, "one-more"])).toEqual([]);
+  });
+});
+
+describe("availableSlashOptions", () => {
+  const options = slashOptionsFromCatalog(CATALOG);
+
+  it("keeps prompts and drops invocations while a turn is running", () => {
+    expect(
+      availableSlashOptions(options, [], { steering: true }).map((o) => o.name),
+    ).toEqual(["weekly-update"]);
+  });
+
+  it("drops a bundle only once every member it could add is on the message", () => {
+    expect(
+      availableSlashOptions(options, ["docx"], { steering: false }).map(
+        (option) => option.name,
+      ),
+    ).toEqual(["charts", "notes", "weekly-update"]);
+  });
+});

--- a/crates/openwave-desktop/ui/src/ComposerSlash.ts
+++ b/crates/openwave-desktop/ui/src/ComposerSlash.ts
@@ -1,46 +1,65 @@
-import type { PluginCatalog } from "./api";
+import type { PluginCatalog, PluginCategory } from "./api";
 import { promptTitle } from "./WelcomeState";
 
 /** The server's bound on how many skills one turn may invoke. */
 export const MAX_INVOKED_SKILLS = 8;
 
 /**
- * One thing a `/` can reach: a skill to invoke, or a prompt to insert.
+ * One thing the plugins panel can reach: a skill to invoke, a bundle of them,
+ * or a prompt to insert.
  *
- * Both live in one flat list because the reader is looking for a name, not
+ * All three live in one flat list because the reader is looking for a name, not
  * deciding which library it came from. `kind` is what the composer acts on:
- * picking a skill leaves a pill behind, picking a prompt writes text.
+ * picking a skill leaves a pill behind, picking a bundle leaves one per member
+ * skill, and picking a prompt writes text.
  */
 export type SlashOption = {
-  kind: "skill" | "prompt";
+  kind: "skill" | "prompt" | "plugin";
   /** The catalog slug — what the wire and the pill are keyed by. */
   name: string;
   label: string;
   description: string;
+  /** The owning bundle's category, where one is known, standing in for an icon. */
+  category?: PluginCategory;
+  /** A bundle row's invocable member skills, in manifest order. */
+  skills?: readonly string[];
 };
 
 /**
- * The `/` token being typed, if the caret is inside one.
+ * The trigger token being typed, if the caret is inside one.
  *
- * A `/` only opens the list at the start of the draft or after whitespace, so
- * ordinary text — a path, a date, an and/or — never raises a popover over what
- * someone is writing. Whitespace ends the token: once a space is typed the
- * reader has moved on to prose, and nothing in either catalog is addressed by
- * a name with a space in it.
+ * A trigger only opens a list at the start of the draft or after whitespace, so
+ * ordinary text — a path, a date, an and/or, an email address — never raises a
+ * popover over what someone is writing. Whitespace ends the token: once a space
+ * is typed the reader has moved on to prose, and nothing any of these lists
+ * offers is addressed by a name with a space in it.
+ *
+ * The character is a parameter because the draft has more than one thing to
+ * reach for; `/` is the plugin library.
  */
+export function activeTokenQuery(
+  draft: string,
+  caret: number,
+  trigger: string,
+): { start: number; query: string } | null {
+  const upToCaret = draft.slice(0, caret);
+  const start = upToCaret.lastIndexOf(trigger);
+  if (start < 0) return null;
+  const preceding = start === 0 ? "" : draft[start - 1];
+  if (preceding && !/\s/.test(preceding)) return null;
+  const query = upToCaret.slice(start + trigger.length);
+  if (/\s/.test(query)) return null;
+  return { start, query };
+}
+
+/** The `/` token under the caret: the way into the plugin library. */
 export function activeSlashQuery(
   draft: string,
   caret: number,
 ): { start: number; query: string } | null {
-  const upToCaret = draft.slice(0, caret);
-  const start = upToCaret.lastIndexOf("/");
-  if (start < 0) return null;
-  const preceding = start === 0 ? "" : draft[start - 1];
-  if (preceding && !/\s/.test(preceding)) return null;
-  const query = upToCaret.slice(start + 1);
-  if (/\s/.test(query)) return null;
-  return { start, query };
+  return activeTokenQuery(draft, caret, "/");
 }
+
 
 /**
  * The options a query names, best match first.
@@ -94,20 +113,28 @@ export function replaceSlashToken(
 }
 
 /**
- * What the catalog offers a `/` today: every enabled skill, bundled or
- * standing alone, and every enabled prompt.
+ * What the catalog offers the panel: every enabled skill, bundled or standing
+ * alone; every installed bundle that carries one; and every enabled prompt.
  *
- * A member skill is offered only when its bundle is on as well as itself —
- * a skill inside a disabled bundle is not staged for a turn, so offering it
- * would produce a send the server refuses.
+ * A member skill is offered on its own only when its bundle is on as well as
+ * itself — a skill inside a disabled bundle is not staged for a turn, so
+ * offering it would produce a send the server refuses. The bundle row is
+ * offered either way: picking one turns it on and then invokes its members, so
+ * the row is how a reader reaches a library they have installed but not
+ * enabled. A bundle carrying no enabled skill has no row — turning it on would
+ * leave nothing on the message to see.
  */
 export function slashOptionsFromCatalog(
   catalog: PluginCatalog | null,
 ): SlashOption[] {
   if (!catalog) return [];
+  const plugins: SlashOption[] = [];
   const skills: SlashOption[] = [];
   const seen = new Set<string>();
-  const addSkill = (skill: { name: string; description: string }) => {
+  const addSkill = (
+    skill: { name: string; description: string },
+    category?: PluginCategory,
+  ) => {
     if (seen.has(skill.name)) return;
     seen.add(skill.name);
     skills.push({
@@ -115,12 +142,26 @@ export function slashOptionsFromCatalog(
       name: skill.name,
       label: promptTitle(skill.name),
       description: skill.description,
+      category,
     });
   };
   for (const plugin of catalog.plugins) {
+    const members = plugin.skills
+      .filter((skill) => skill.enabled)
+      .map((skill) => skill.name);
+    if (members.length > 0) {
+      plugins.push({
+        kind: "plugin",
+        name: plugin.name,
+        label: plugin.display_name,
+        description: plugin.description,
+        category: plugin.category,
+        skills: members,
+      });
+    }
     if (!plugin.enabled) continue;
     for (const skill of plugin.skills) {
-      if (skill.enabled) addSkill(skill);
+      if (skill.enabled) addSkill(skill, plugin.category);
     }
   }
   for (const skill of catalog.skills) {
@@ -134,5 +175,69 @@ export function slashOptionsFromCatalog(
       label: promptTitle(prompt.name),
       description: prompt.description,
     }));
-  return [...skills, ...prompts];
+  return [...plugins, ...skills, ...prompts];
+}
+
+/**
+ * The skills a pick would put on the message.
+ *
+ * A bundle stands for its members, so picking one is picking each of them: the
+ * chips it leaves are the chips those skills would have left individually. What
+ * is already on the message is skipped rather than repeated — the server
+ * refuses a duplicate — and the turn's cap truncates rather than rejects, so a
+ * large bundle fills the remaining room instead of doing nothing.
+ */
+export function skillsToInvoke(
+  option: SlashOption,
+  invoked: readonly string[],
+): string[] {
+  const names =
+    option.kind === "plugin"
+      ? (option.skills ?? [])
+      : option.kind === "skill"
+        ? [option.name]
+        : [];
+  const picked: string[] = [];
+  for (const name of names) {
+    if (invoked.length + picked.length >= MAX_INVOKED_SKILLS) break;
+    if (invoked.includes(name) || picked.includes(name)) continue;
+    picked.push(name);
+  }
+  return picked;
+}
+
+/**
+ * What the panel can still reach, given what this message already carries.
+ *
+ * A skill already on the message is not offered again, and neither is anything
+ * that invokes once the turn's cap is reached, or while a turn is running:
+ * steering carries no invocation, so a pill picked there would silently apply
+ * to some later message. Prompts are text and stay available throughout.
+ */
+export function availableSlashOptions(
+  options: readonly SlashOption[],
+  invoked: readonly string[],
+  { steering }: { steering: boolean },
+): SlashOption[] {
+  return options.filter((option) => {
+    if (option.kind === "prompt") return true;
+    if (steering || invoked.length >= MAX_INVOKED_SKILLS) return false;
+    return skillsToInvoke(option, invoked).length > 0;
+  });
+}
+
+/**
+ * Where an arrow key moves the highlight, or `null` when the key is not the
+ * list's to take. Shared so every popover the composer raises moves alike.
+ */
+export function nextOptionHighlight(
+  key: string,
+  current: number,
+  count: number,
+): number | null {
+  if (count === 0) return null;
+  const bounded = Math.min(Math.max(current, 0), count - 1);
+  if (key === "ArrowDown") return (bounded + 1) % count;
+  if (key === "ArrowUp") return (bounded + count - 1) % count;
+  return null;
 }

--- a/crates/openwave-desktop/ui/src/ComposerToolsMenu.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerToolsMenu.dom.test.tsx
@@ -4,24 +4,10 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, expect, it, vi } from "vitest";
 
 import { ComposerToolsMenu } from "./ComposerToolsMenu";
-import type { PluginInfo } from "./api";
 
 afterEach(cleanup);
 
 const LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
-
-function plugin(overrides: Partial<PluginInfo> = {}): PluginInfo {
-  return {
-    name: "documents",
-    display_name: "Documents",
-    description: "Writes Word, Excel, and PowerPoint files.",
-    category: "documents",
-    capabilities: [],
-    enabled: false,
-    skills: [],
-    ...overrides,
-  };
-}
 
 function open() {
   return userEvent.setup().click(screen.getByRole("button", { name: "Tools" }));
@@ -99,13 +85,13 @@ it("renders nothing when the surface offers none of its actions", () => {
   expect(container).toBeEmptyDOMElement();
 });
 
-it("offers the installed plugins under the turn's setup actions", async () => {
-  const onSelect = vi.fn();
+it("offers the plugin library as one row under the turn's setup actions", async () => {
+  const onOpen = vi.fn();
   render(
     <ComposerToolsMenu
       disabled={false}
       attachFiles={{ attaching: false, onAttach: vi.fn() }}
-      plugins={{ items: [plugin()], onSelect }}
+      plugins={{ onOpen }}
     />,
   );
 
@@ -113,19 +99,18 @@ it("offers the installed plugins under the turn's setup actions", async () => {
   const rows = screen.getAllByRole("menuitem");
   expect(rows.map((row) => row.textContent)).toEqual([
     "Attach files",
-    "DocumentsWrites Word, Excel, and PowerPoint files.",
+    "Plugins",
   ]);
 
   await userEvent.setup().click(rows[1]);
-  expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ name: "documents" }));
+  await waitFor(() => expect(onOpen).toHaveBeenCalledOnce());
 });
 
-it("keeps the plugins section off a catalog that is empty or unread", async () => {
+it("keeps the plugins row off a surface with no library to reach", async () => {
   render(
     <ComposerToolsMenu
       disabled={false}
       attachFiles={{ attaching: false, onAttach: vi.fn() }}
-      plugins={{ items: [], onSelect: vi.fn() }}
     />,
   );
 

--- a/crates/openwave-desktop/ui/src/ComposerToolsMenu.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerToolsMenu.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
-import { FolderPlus, LoaderCircle, Paperclip, Plus } from "lucide-react";
+import { FolderPlus, LoaderCircle, Package, Paperclip, Plus } from "lucide-react";
 
-import type { NetworkPolicy, PluginInfo, ReasoningEffort } from "./api";
+import type { NetworkPolicy, ReasoningEffort } from "./api";
 import { ReasoningEffortSubMenu } from "./ModelMenu";
 import {
   NetworkPolicyDialog,
@@ -12,14 +12,11 @@ import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { categoryIcon } from "@/plugins/pluginVocabulary";
 import { WithTooltip } from "@/components/ui/tooltip";
-import { cn } from "@/lib/utils";
 
 export type ComposerNetwork = {
   value: NetworkPolicy;
@@ -35,15 +32,14 @@ export type ComposerReasoning = {
 };
 
 /**
- * The installed bundles, offered as something to reach for on this message.
+ * The way into the plugin library from the menu.
  *
- * Presentational: the menu lists what it is given and reports the pick. Turning
- * the bundle on and saying so in the draft belong to whoever owns the catalog
- * and the draft.
+ * Presentational: the menu reports that the row was chosen. What the library
+ * holds, and what picking one of its rows does, belongs to the composer that
+ * owns the draft and the message's invocations.
  */
-export type ComposerPlugins = {
-  items: readonly PluginInfo[];
-  onSelect: (plugin: PluginInfo) => void;
+export type ComposerPluginsEntry = {
+  onOpen: () => void;
 };
 
 export type ComposerToolsMenuProps = {
@@ -52,7 +48,7 @@ export type ComposerToolsMenuProps = {
   attachFolder?: { working: boolean; onAttach: () => void };
   network?: ComposerNetwork;
   reasoning?: ComposerReasoning;
-  plugins?: ComposerPlugins;
+  plugins?: ComposerPluginsEntry;
 };
 
 /**
@@ -64,8 +60,9 @@ export type ComposerToolsMenuProps = {
  * occasionally and then forget about, so they collapse into one menu and leave
  * the bar to the model, the permission mode, and sending.
  *
- * Installed plugins sit at the bottom for the same reason: picking one is
- * preparation for this message, not a place to manage the library — that stays
+ * The library sits at the bottom as a single row rather than a bundle per line:
+ * it is the same list `/` reaches, and duplicating it here left two pickers
+ * that looked alike and behaved differently. Managing the library still lives
  * on the Plugins page.
  */
 export function ComposerToolsMenu({
@@ -83,10 +80,9 @@ export function ComposerToolsMenu({
 
   const hasAttachments = Boolean(attachFiles || attachFolder);
   const hasSettings = Boolean(network || reasoning);
-  // A catalog that is empty or never loaded simply has no section. The menu is
-  // not the place to report that the plugin library could not be read.
-  const pluginItems = plugins?.items ?? [];
-  const hasPlugins = pluginItems.length > 0;
+  // A catalog that is empty or never loaded simply has no row. The menu is not
+  // the place to report that the plugin library could not be read.
+  const hasPlugins = Boolean(plugins);
   if (!hasAttachments && !hasSettings && !hasPlugins) return null;
 
   const NetworkIcon = network ? networkPolicyIcon(network.value) : null;
@@ -107,13 +103,7 @@ export function ComposerToolsMenu({
             </Button>
           </DropdownMenuTrigger>
         </WithTooltip>
-        <DropdownMenuContent
-          align="start"
-          side="top"
-          // Plugin rows carry a description under the name, so the menu widens
-          // to give one a readable line rather than truncating it to nothing.
-          className={cn(hasPlugins ? "w-72" : "w-60")}
-        >
+        <DropdownMenuContent align="start" side="top" className="w-60">
           {attachFiles && (
             <DropdownMenuItem
               disabled={disabled || attachFiles.attaching}
@@ -172,33 +162,17 @@ export function ComposerToolsMenu({
           {hasPlugins && plugins && (
             <>
               {(hasAttachments || hasSettings) && <DropdownMenuSeparator />}
-              <p className="text-muted-foreground px-2 py-1.5 text-xs font-medium">
-                Plugins
-              </p>
-              <DropdownMenuGroup aria-label="Plugins">
-                {pluginItems.map((plugin) => {
-                  const Icon = categoryIcon(plugin.category);
-                  return (
-                    <DropdownMenuItem
-                      key={plugin.name}
-                      className="items-start"
-                      disabled={disabled}
-                      onSelect={() => plugins.onSelect(plugin)}
-                    >
-                      <Icon
-                        className="text-muted-foreground mt-0.5 size-4 shrink-0"
-                        aria-hidden="true"
-                      />
-                      <span className="flex min-w-0 flex-col">
-                        <span className="truncate">{plugin.display_name}</span>
-                        <span className="text-muted-foreground truncate text-xs">
-                          {plugin.description}
-                        </span>
-                      </span>
-                    </DropdownMenuItem>
-                  );
-                })}
-              </DropdownMenuGroup>
+              <DropdownMenuItem
+                disabled={disabled}
+                onSelect={() => {
+                  // Opened once the menu has gone: the panel takes focus for
+                  // its search field, which the closing menu would take back.
+                  window.requestAnimationFrame(plugins.onOpen);
+                }}
+              >
+                <Package className="size-4 text-muted-foreground" aria-hidden="true" />
+                <span>Plugins</span>
+              </DropdownMenuItem>
             </>
           )}
         </DropdownMenuContent>

--- a/crates/openwave-desktop/ui/src/HomeRoute.tsx
+++ b/crates/openwave-desktop/ui/src/HomeRoute.tsx
@@ -304,10 +304,10 @@ export function HomeRoute() {
             slash={{
               options: composerPlugins.slashOptions,
               invoked: pendingSkills,
-              onInvoke: (name) =>
+              onInvoke: (names) =>
                 composerDraftActions.setSkills(HOME_DRAFT_KEY, [
                   ...pendingSkills,
-                  name,
+                  ...names,
                 ]),
               onRemove: (name) =>
                 composerDraftActions.setSkills(

--- a/crates/openwave-desktop/ui/src/components/OptionListbox.tsx
+++ b/crates/openwave-desktop/ui/src/components/OptionListbox.tsx
@@ -1,0 +1,106 @@
+import type { LucideIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * One row of a composer popover, as the list needs it.
+ *
+ * Deliberately not a plugin, a file, or anything else the composer can reach:
+ * the popover is the same widget whichever trigger opened it — `/` for the
+ * plugin library today — so it takes rows and reports the pick, and each
+ * consumer keeps its own vocabulary on its own side of that line.
+ */
+export type OptionRow = {
+  /** Stable across renders and unique within the list. */
+  key: string;
+  label: string;
+  description?: string;
+  icon: LucideIcon;
+  /** A word on the right saying what picking this row will do. */
+  hint?: string;
+};
+
+/**
+ * A listbox driven from somewhere else's keyboard.
+ *
+ * The field with focus — the draft textarea for `/`, the panel's own search box
+ * when a menu opened it — keeps the keys and points at the active row through
+ * `aria-activedescendant`, which is why the highlight is a prop rather than
+ * this component's own state.
+ */
+export function OptionListbox({
+  listId,
+  label,
+  rows,
+  activeIndex,
+  note,
+  onPick,
+  onHighlight,
+}: {
+  listId: string;
+  label: string;
+  rows: readonly OptionRow[];
+  activeIndex: number;
+  /** A line under the rows explaining a list that is short for a reason. */
+  note?: string | null;
+  onPick: (index: number) => void;
+  onHighlight: (index: number) => void;
+}) {
+  return (
+    <ul
+      id={listId}
+      role="listbox"
+      aria-label={label}
+      className="m-0 max-h-56 list-none overflow-y-auto p-1"
+    >
+      {rows.map((row, index) => {
+        const Icon = row.icon;
+        return (
+          <li key={row.key}>
+            <button
+              type="button"
+              id={optionElementId(listId, index)}
+              role="option"
+              aria-selected={index === activeIndex}
+              className={cn(
+                "flex w-full items-start gap-2 rounded-sm px-2 py-1.5 text-left text-sm",
+                index === activeIndex && "bg-accent text-accent-foreground",
+              )}
+              // Taken on mousedown so the field never loses the caret the
+              // insertion is about to be made at.
+              onMouseDown={(event) => event.preventDefault()}
+              onMouseEnter={() => onHighlight(index)}
+              onClick={() => onPick(index)}
+            >
+              <Icon
+                className="mt-0.5 size-4 shrink-0 text-muted-foreground"
+                aria-hidden="true"
+              />
+              <span className="flex min-w-0 flex-col">
+                <span className="truncate">{row.label}</span>
+                {row.description && (
+                  <span className="truncate text-xs text-muted-foreground">
+                    {row.description}
+                  </span>
+                )}
+              </span>
+              {row.hint && (
+                <span className="ml-auto shrink-0 pl-2 text-[0.68rem] text-muted-foreground">
+                  {row.hint}
+                </span>
+              )}
+            </button>
+          </li>
+        );
+      })}
+      {note && (
+        <li className="px-2 py-1.5 text-xs text-muted-foreground">{note}</li>
+      )}
+    </ul>
+  );
+}
+
+/** The id a field's `aria-activedescendant` points at. */
+export function optionElementId(listId: string, index: number): string {
+  return `${listId}-option-${index}`;
+}

--- a/crates/openwave-desktop/ui/src/plugins/PluginsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/plugins/PluginsPanel.tsx
@@ -1,0 +1,168 @@
+import { type KeyboardEvent, useEffect, useRef, useState } from "react";
+import { Search, Sparkles, Wand2 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+import {
+  filterSlashOptions,
+  nextOptionHighlight,
+  MAX_INVOKED_SKILLS,
+  type SlashOption,
+} from "@/ComposerSlash";
+import { categoryIcon } from "./pluginVocabulary";
+import { OptionListbox, optionElementId, type OptionRow } from "@/components/OptionListbox";
+
+/**
+ * The library, as one list.
+ *
+ * Both ways into it — typing `/` in the draft and picking Plugins from the
+ * tools menu — render these same rows and pick with the same code, so a bundle
+ * reached one way behaves exactly as it does the other. A flat list rather than
+ * a section per kind: the reader is looking for a name, and the kind only
+ * decides what picking does, which the row says on its right.
+ */
+export function pluginOptionRows(
+  options: readonly SlashOption[],
+): OptionRow[] {
+  return options.map((option) => ({
+    key: `${option.kind}:${option.name}`,
+    label: option.label,
+    description: option.description,
+    icon: optionIcon(option),
+    hint: optionKindLabel(option),
+  }));
+}
+
+/** The line under the rows when the turn's cap has taken the skills away. */
+export function skillCapNote(): string {
+  return `A message can invoke at most ${MAX_INVOKED_SKILLS} skills.`;
+}
+
+/**
+ * The same list opened from the tools menu, with a field to narrow it.
+ *
+ * The `/` list is already being typed into, so it needs no field of its own;
+ * this one is opened by a pointer and would otherwise have nowhere to type. It
+ * sits in the composer's flow above the draft rather than floating: the
+ * composer clips its own overflow to keep its rounded edge, so a panel anchored
+ * over the box would be cut off at the border.
+ */
+export function PluginsPanel({
+  options,
+  query,
+  capNote = false,
+  onQueryChange,
+  onPick,
+  onClose,
+}: {
+  options: readonly SlashOption[];
+  query: string;
+  capNote?: boolean;
+  onQueryChange: (query: string) => void;
+  onPick: (option: SlashOption) => void;
+  onClose: () => void;
+}) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [highlight, setHighlight] = useState(0);
+  const matches = filterSlashOptions(options, query);
+  const index = Math.min(highlight, matches.length - 1);
+
+  // Opened from a menu the pointer has just left: focus goes to the field so
+  // the list can be driven by the keyboard from the moment it appears.
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  function onKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      onClose();
+      return;
+    }
+    const moved = nextOptionHighlight(event.key, index, matches.length);
+    if (moved !== null) {
+      event.preventDefault();
+      setHighlight(moved);
+      return;
+    }
+    if (event.key === "Enter" || event.key === "Tab") {
+      const option = matches[index];
+      if (!option) return;
+      event.preventDefault();
+      onPick(option);
+    }
+  }
+
+  return (
+    <div className="rounded-md border border-border bg-popover text-popover-foreground shadow-md">
+      <div className="flex items-center gap-2 border-b border-border px-2 py-1.5">
+        <Search
+          className="size-4 shrink-0 text-muted-foreground"
+          aria-hidden="true"
+        />
+        <input
+          ref={inputRef}
+          type="text"
+          className="w-full border-none bg-transparent text-sm placeholder:text-muted-foreground focus-visible:outline-none"
+          placeholder="Search plugins, skills, and prompts…"
+          aria-label="Search the plugin library"
+          aria-controls={PLUGINS_PANEL_LIST_ID}
+          aria-activedescendant={
+            matches.length > 0
+              ? optionElementId(PLUGINS_PANEL_LIST_ID, index)
+              : undefined
+          }
+          value={query}
+          onChange={(event) => {
+            onQueryChange(event.target.value);
+            setHighlight(0);
+          }}
+          // A click on a row is taken on mousedown, which never moves focus, so
+          // a blur here is the reader leaving the panel for good.
+          onBlur={onClose}
+          onKeyDown={onKeyDown}
+        />
+      </div>
+      {matches.length === 0 && !capNote ? (
+        <p className="px-3 py-2 text-xs text-muted-foreground">
+          Nothing matches.
+        </p>
+      ) : (
+        <OptionListbox
+          listId={PLUGINS_PANEL_LIST_ID}
+          label={PLUGINS_PANEL_LABEL}
+          rows={pluginOptionRows(matches)}
+          activeIndex={index}
+          note={capNote ? skillCapNote() : null}
+          onPick={(picked) => {
+            const option = matches[picked];
+            if (option) onPick(option);
+          }}
+          onHighlight={setHighlight}
+        />
+      )}
+    </div>
+  );
+}
+
+export const PLUGINS_PANEL_LABEL = "Plugins, skills, and prompts";
+
+const PLUGINS_PANEL_LIST_ID = "composer-plugins-list";
+
+/**
+ * A bundle has no icon of its own, so the category stands in for one — for the
+ * bundle and for the skills inside it, which is what makes a chip recognisable
+ * as having come from a particular library.
+ */
+export function optionIcon(option: SlashOption): LucideIcon {
+  if (option.kind === "prompt") return Sparkles;
+  if (option.category) return categoryIcon(option.category);
+  return Wand2;
+}
+
+function optionKindLabel(option: SlashOption): string {
+  return option.kind === "plugin"
+    ? "Plugin"
+    : option.kind === "skill"
+      ? "Skill"
+      : "Prompt";
+}

--- a/crates/openwave-desktop/ui/src/plugins/useComposerPlugins.ts
+++ b/crates/openwave-desktop/ui/src/plugins/useComposerPlugins.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from "react";
 
 import type { ApiClient } from "@/api";
-import type { ComposerPlugins } from "@/ComposerToolsMenu";
+import type { ComposerPlugins } from "@/Composer";
 import { slashOptionsFromCatalog, type SlashOption } from "@/ComposerSlash";
 import { pluginsApisFromClient } from "./pluginsApis";
 import { usePluginCatalog } from "./usePluginCatalog";
@@ -17,7 +17,7 @@ import { usePluginCatalog } from "./usePluginCatalog";
 export type ComposerPluginLibrary = {
   /** Absent while loading, after a failed load, or when nothing is installed. */
   plugins: ComposerPlugins | undefined;
-  /** Enabled skills and prompts, flat, for the `/` list. */
+  /** Enabled bundles, skills, and prompts, flat, for the composer's panel. */
   slashOptions: SlashOption[];
   loadPromptBody: (name: string) => Promise<string>;
 };


### PR DESCRIPTION
The composer had two ways into the plugin library and they behaved differently.
Typing `/` opened a list of skills and prompts: picking a skill left a chip and
recorded the invocation on the next turn, picking a prompt inserted its text.
The tools menu listed installed bundles instead, and picking one enabled the
bundle and then wrote a sentence into the draft — no chip, no invocation, and a
line of prose the reader then had to edit around.

Both triggers now open the same list, with one row renderer, one filter, one
keyboard model, and one pick path:

- `/` in the draft opens it against the typed token, as before.
- The tools menu's plugin rows are replaced by a single **Plugins** row that
  opens the same list above the composer with its own search field. Everything
  else in that menu is unchanged.

Bundles are rows in that list rather than a separate section, so picking one
turns it on if it was off and invokes each of its enabled member skills —
leaving exactly the chips those skills would have left individually, subject to
the turn's cap. A single-skill bundle behaves like picking the skill. A bundle
is dropped from the list only once every member it could still add is already on
the message.

The draft-insertion path for plugins is deleted: nothing but a prompt writes
into the message. Invoked-skill chips are now rounded, carry the icon of the
library the skill came from, and go muted while a turn is running, since
steering carries no invocation — the chips still apply to the next message,
which they now say.

`ComposerSlash.onInvoke` takes a list of names rather than one, because a bundle
adds several at once and the routes append them in a single store write.

The listbox is deliberately trigger-agnostic groundwork: it takes rows and
reports a pick rather than knowing about plugins, and token detection takes the
trigger character as a parameter. Inline `@` context attachment (#1631) can
reuse both instead of growing a second popover; no `@` behavior is implemented
here.

## Tests

- New `ComposerSlash.test.ts` covers the parts a bug would hide in: which rows a
  catalog produces, what a bundle pick expands to against the cap and against
  what the message already carries, and what the list withholds while a turn
  runs.
- `ComposerPlugins.dom.test.tsx` rewritten from the directive-insertion
  assertions it can no longer make: it now drives the menu to the panel and
  asserts the bundle is enabled, its skills invoked, and the draft untouched.
- `ComposerToolsMenu.dom.test.tsx`: the two plugin-section tests now assert the
  single row and its absence, matching the menu's new shape.

`pnpm exec tsc --noEmit`, the full `pnpm exec vitest run` (776 tests), and
`pnpm build` all pass locally. Not driven in the running app.