### PR TITLE
feat(desktop): composer @ popover attaches files and folders inline

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -527,6 +527,33 @@ export function ChatRoute({ chatId }: { chatId: string }) {
     }
   }
 
+  /**
+   * Put a file this conversation already carries back on the next message.
+   *
+   * Nothing is imported: the document is already in the chat's library, so the
+   * message only has to name it again. That is why no size comes with it — the
+   * transcript records what a document is, not how many bytes it was.
+   */
+  function onReattachFile(file: TranscriptFileAttachment) {
+    if (files.some((current) => current.documentId === file.documentId)) return;
+    if (images.attachments.length + files.length >= MAX_IMAGE_ATTACHMENTS) {
+      setAttachError(
+        `A message can carry at most ${MAX_IMAGE_ATTACHMENTS} attachments.`,
+      );
+      return;
+    }
+    setAttachError(null);
+    setComposerFiles((current) => [
+      ...current,
+      {
+        documentId: file.documentId,
+        displayName: file.name,
+        mediaType: file.mediaType,
+        byteLen: 0,
+      },
+    ]);
+  }
+
   function adoptAttached(attached: AttachedFiles) {
     const seenDocumentIds = new Set(files.map((file) => file.documentId));
     const imported =
@@ -619,6 +646,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
             items: files,
             attaching,
             onAttach: hasNativeHost() ? onAttach : undefined,
+            onReattach: onReattachFile,
             onRemove: (documentId) =>
               setComposerFiles((current) =>
                 current.filter((file) => file.documentId !== documentId),
@@ -626,9 +654,11 @@ export function ChatRoute({ chatId }: { chatId: string }) {
           }}
           folders={{
             items: folders.items,
+            approved: folders.approved,
             working: folders.working,
             error: folders.error,
             onAttach: nativeHost ? folders.attach : undefined,
+            onConnect: nativeHost ? folders.connectApproved : undefined,
             onRemove: folders.remove,
           }}
           voice={{

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -36,6 +36,7 @@ import { useTurnControls } from "./useTurnControls";
 import { usePlanApprovals } from "./usePlanApprovals";
 import { useUserQuestions } from "./useUserQuestions";
 import { useComposerPlugins } from "./plugins/useComposerPlugins";
+import { recentChatFiles } from "./ComposerMentions";
 import {
   backgroundAgentSpawnKeys as spawnKeysOf,
   useAgentRuns,
@@ -133,6 +134,22 @@ export function ChatView({
     [messages],
   );
   const agentRuns = useAgentRuns(client, chat.id, backgroundAgentSpawnKeys);
+  // The files already on this conversation, so `@` can name one instead of
+  // sending the reader back to the picker for a document we are already
+  // holding. Read from the transcript rather than fetched: these are the
+  // attachments of the messages on screen.
+  const composerFiles = useMemo(
+    () => ({
+      ...files,
+      recent: recentChatFiles(
+        messages.flatMap((message) =>
+          message.role === "user" ? [message] : [],
+        ),
+        files.items,
+      ),
+    }),
+    [files, messages],
+  );
 
   const navigate = useNavigate();
   const focusCallId = (useSearch({ strict: false }) as { focus?: string }).focus;
@@ -440,7 +457,7 @@ export function ChatView({
             loadPromptBody: composerPlugins.loadPromptBody,
           }}
           images={composerImages}
-          files={files}
+          files={composerFiles}
           folders={folders}
           voice={voice}
           nativeDropTarget={nativeDropTarget}

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -29,6 +29,17 @@ import {
   type SlashOption,
 } from "./ComposerSlash";
 import {
+  activeMentionQuery,
+  attachableFiles,
+  attachableFolders,
+  mentionOptionRows,
+  mentionRows,
+  MENTION_LIST_LABEL,
+  type MentionAction,
+  type MentionCandidate,
+  type MentionRow,
+} from "./ComposerMentions";
+import {
   ComposerToolsMenu,
   type ComposerNetwork,
   type ComposerReasoning,
@@ -57,12 +68,15 @@ import { documentIcon } from "@/documentIcon";
 import type { ImportedDocument } from "@/documents";
 import type { PluginInfo } from "./api";
 import { folderAccessLabel, folderReach } from "./FolderAccess";
+import type { ConnectedFolder } from "./host";
+import type { TranscriptFileAttachment } from "./TranscriptFileAttachments";
 import type { ChatFolderAccess } from "./useChatFolderAttachments";
 
 const MIN_COMPOSER_LINES = 1;
 export const MAX_COMPOSER_LINES = 6;
 
 const SLASH_LIST_ID = "composer-slash-list";
+const MENTION_LIST_ID = "composer-mention-list";
 
 type ComposerKeyEvent = Pick<
   KeyboardEvent<HTMLTextAreaElement>["nativeEvent"],
@@ -158,16 +172,32 @@ export type ComposerImages = {
 
 export type ComposerFiles = {
   items: ImportedDocument[];
+  /**
+   * Files this conversation already carries, newest first — what `@` offers
+   * before the reader has typed anything. Absent on a surface with no
+   * transcript to read them from.
+   */
+  recent?: readonly TranscriptFileAttachment[];
   attaching: boolean;
   onAttach?: () => void;
+  /** Put one of `recent` back on the next message. */
+  onReattach?: (file: TranscriptFileAttachment) => void;
   onRemove: (documentId: string) => void;
 };
 
 export type ComposerFolders = {
   items: ChatFolderAccess[];
+  /**
+   * Folders approved on this device but not attached here. Approval outlives
+   * the chat it was granted in, so these are reachable by name rather than
+   * through the picker.
+   */
+  approved?: readonly ConnectedFolder[];
   working: boolean;
   error: string | null;
   onAttach?: () => void;
+  /** Attach one of `approved` to this conversation. */
+  onConnect?: (rootId: string) => void;
   onRemove: (rootId: string) => void;
 };
 
@@ -290,6 +320,13 @@ export function Composer({
     query: string;
   } | null>(null);
   const [slashHighlight, setSlashHighlight] = useState(0);
+  // The `@` token, kept apart from the `/` one so neither list can inherit the
+  // other's highlight or be closed by the other's Escape.
+  const [mentionToken, setMentionToken] = useState<{
+    start: number;
+    query: string;
+  } | null>(null);
+  const [mentionHighlight, setMentionHighlight] = useState(0);
   // The same list, opened from the tools menu instead of from a `/`. Its query
   // is its own: there is no token in the draft to read one from.
   const [panelQuery, setPanelQuery] = useState<string | null>(null);
@@ -322,6 +359,7 @@ export function Composer({
   useLayoutEffect(() => {
     selectionRef.current = null;
     setSlashToken(null);
+    setMentionToken(null);
   }, [resetKey]);
 
   const invokedSkills = slash?.invoked ?? [];
@@ -342,11 +380,98 @@ export function Composer({
     slashToken !== null && (slashMatches.length > 0 || slashCapNote);
   const slashIndex = Math.min(slashHighlight, slashMatches.length - 1);
 
+  /**
+   * What `@` can reach: the files this conversation already carries, the
+   * folders already approved on this device, and the two pickers behind the
+   * tools menu.
+   *
+   * Every candidate is something the app can already see — a document in this
+   * chat's library, a root the broker holds an approval for. Nothing here
+   * reaches into the filesystem on its own; a file that has never been given to
+   * OpenWave is still reached through the picker, which is what the last rows
+   * are for.
+   */
+  const mentionCandidates: MentionCandidate[] = [
+    ...attachableFiles(files?.recent ?? []),
+    ...attachableFolders(folders?.approved ?? [], folders?.items ?? []),
+  ];
+  const mentionActions: MentionAction[] = [
+    ...(files?.onAttach ? (["browse-files"] as const) : []),
+    ...(folders?.onAttach ? (["connect-folder"] as const) : []),
+  ];
+  const mentionMatches = mentionToken
+    ? mentionRows(mentionCandidates, mentionActions, mentionToken.query)
+    : [];
+  // The `/` list has the caret when both tokens somehow resolve: it is the
+  // older affordance, and two popovers over one draft is one too many.
+  const mentionOpen =
+    mentionToken !== null && !slashOpen && mentionMatches.length > 0;
+  const mentionIndex = Math.min(mentionHighlight, mentionMatches.length - 1);
+
   /** Re-read whether the caret sits inside a `/` token, and reset the cursor. */
   function syncSlashToken(value: string, caret: number) {
     const token = slash ? activeSlashQuery(value, caret) : null;
     setSlashToken(token);
     setSlashHighlight(0);
+    setMentionToken(activeMentionQuery(value, caret));
+    setMentionHighlight(0);
+  }
+
+  /**
+   * Attach what the row named, and take the `@query` out of the draft.
+   *
+   * The pick goes through the same callbacks the tools menu's own items use, so
+   * a mention leaves exactly the chip an attachment leaves — and a refusal
+   * (a cap reached, a folder the broker cannot reopen) is reported wherever
+   * that path already reports it.
+   */
+  function pickMention(
+    row: MentionRow,
+    token: { start: number; query: string },
+  ) {
+    applySlashReplacement(draft, token.start, token.start + 1 + token.query.length, "");
+    if (row.kind === "action") {
+      if (row.action === "browse-files") files?.onAttach?.();
+      else folders?.onAttach?.();
+      return;
+    }
+    const { candidate } = row;
+    if (candidate.kind === "folder") {
+      folders?.onConnect?.(candidate.id);
+      return;
+    }
+    const file = files?.recent?.find(
+      (recent) => recent.documentId === candidate.id,
+    );
+    if (file) files?.onReattach?.(file);
+  }
+
+  /** The `@` list's keys. Only reached when the `/` list did not claim them. */
+  function handleMentionKey(event: KeyboardEvent<HTMLTextAreaElement>): boolean {
+    if (event.key === "Escape") {
+      if (mentionToken === null) return false;
+      setMentionToken(null);
+      return true;
+    }
+    if (!mentionOpen) return false;
+    const moved = nextOptionHighlight(
+      event.key,
+      mentionIndex,
+      mentionMatches.length,
+    );
+    if (moved !== null) {
+      setMentionHighlight(moved);
+      return true;
+    }
+    if (event.key === "Enter" || event.key === "Tab") {
+      const row = mentionMatches[mentionIndex];
+      if (row && mentionToken) {
+        setMentionToken(null);
+        pickMention(row, mentionToken);
+      }
+      return true;
+    }
+    return false;
   }
 
   /**
@@ -662,6 +787,24 @@ export function Composer({
           />
         </div>
       )}
+      {mentionOpen && (
+        <div className="rounded-md border border-border bg-popover text-popover-foreground shadow-md">
+          <OptionListbox
+            listId={MENTION_LIST_ID}
+            label={MENTION_LIST_LABEL}
+            rows={mentionOptionRows(mentionMatches)}
+            activeIndex={mentionIndex}
+            onPick={(index) => {
+              const row = mentionMatches[index];
+              if (!row || !mentionToken) return;
+              const token = mentionToken;
+              setMentionToken(null);
+              pickMention(row, token);
+            }}
+            onHighlight={setMentionHighlight}
+          />
+        </div>
+      )}
       <textarea
         ref={textareaRef}
         className={cn(
@@ -679,9 +822,15 @@ export function Composer({
                 : "Message OpenWave…"
         }
         aria-label="Message"
-        aria-controls={slashOpen ? SLASH_LIST_ID : undefined}
+        aria-controls={
+          slashOpen ? SLASH_LIST_ID : mentionOpen ? MENTION_LIST_ID : undefined
+        }
         aria-activedescendant={
-          slashOpen ? optionElementId(SLASH_LIST_ID, slashIndex) : undefined
+          slashOpen
+            ? optionElementId(SLASH_LIST_ID, slashIndex)
+            : mentionOpen
+              ? optionElementId(MENTION_LIST_ID, mentionIndex)
+              : undefined
         }
         // A stable hook for the shell's focus-composer shortcut, which has to
         // find the field without a ref threaded up through every route.
@@ -695,10 +844,13 @@ export function Composer({
             event.currentTarget.selectionStart,
           );
         }}
-        onBlur={() => setSlashToken(null)}
+        onBlur={() => {
+          setSlashToken(null);
+          setMentionToken(null);
+        }}
         onPaste={onPaste}
         onKeyDown={(event) => {
-          if (handleSlashKey(event)) {
+          if (handleSlashKey(event) || handleMentionKey(event)) {
             event.preventDefault();
             return;
           }
@@ -728,6 +880,7 @@ export function Composer({
                 ? {
                     onOpen: () => {
                       setSlashToken(null);
+                      setMentionToken(null);
                       setPanelQuery("");
                     },
                   }
@@ -1013,7 +1166,12 @@ function FileAttachmentChip({
         >
           {file.displayName}
         </strong>
-        <small className="text-[0.68rem]">{formatBytes(file.byteLen)}</small>
+        {/* A file put back on the message by name carries its identity, not its
+            size — the transcript records what a document is, not how big it
+            was. An unknown size is left unsaid rather than reported as zero. */}
+        {file.byteLen > 0 && (
+          <small className="text-[0.68rem]">{formatBytes(file.byteLen)}</small>
+        )}
       </span>
       <button
         type="button"

--- a/crates/openwave-desktop/ui/src/ComposerMentions.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerMentions.dom.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+import { useState } from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, expect, it, vi } from "vitest";
+
+import {
+  Composer,
+  type ComposerFiles,
+  type ComposerFolders,
+} from "./Composer";
+
+afterEach(cleanup);
+
+const RECENT = [
+  { documentId: "doc-1", name: "Budget.xlsx", mediaType: "text/csv" },
+];
+
+function ComposerHarness({
+  files,
+  folders,
+  onDraftChange,
+}: {
+  files: ComposerFiles;
+  folders?: ComposerFolders;
+  onDraftChange?: (draft: string) => void;
+}) {
+  const [draft, setDraft] = useState("");
+  return (
+    <Composer
+      activeTurnId={null}
+      busy={false}
+      cancelError={null}
+      cancelPending={false}
+      disabled={false}
+      draft={draft}
+      files={files}
+      folders={folders}
+      onDraftChange={(next) => {
+        setDraft(next);
+        onDraftChange?.(next);
+      }}
+      onSend={vi.fn(async () => {})}
+      onSteer={vi.fn(async () => {})}
+      onStop={vi.fn(async () => {})}
+      resetKey="chat-1"
+      steerError={null}
+      steerPending={false}
+      steerStatus={null}
+    />
+  );
+}
+
+function composerFiles(overrides: Partial<ComposerFiles> = {}): ComposerFiles {
+  return {
+    items: [],
+    recent: RECENT,
+    attaching: false,
+    onAttach: vi.fn(),
+    onReattach: vi.fn(),
+    onRemove: vi.fn(),
+    ...overrides,
+  };
+}
+
+function composerFolders(
+  overrides: Partial<ComposerFolders> = {},
+): ComposerFolders {
+  return {
+    items: [],
+    approved: [
+      { rootId: "root-1", displayName: "Reports", status: "connected" },
+    ],
+    working: false,
+    error: null,
+    onAttach: vi.fn(),
+    onConnect: vi.fn(),
+    onRemove: vi.fn(),
+    ...overrides,
+  };
+}
+
+it("attaches a file by name and takes the token back out of the draft", async () => {
+  const user = userEvent.setup();
+  const onReattach = vi.fn();
+  const onDraftChange = vi.fn();
+  render(
+    <ComposerHarness
+      files={composerFiles({ onReattach })}
+      folders={composerFolders()}
+      onDraftChange={onDraftChange}
+    />,
+  );
+
+  await user.click(screen.getByRole("textbox", { name: "Message" }));
+  await user.keyboard("compare against @budg");
+  await user.click(screen.getByRole("option", { name: /Budget.xlsx/ }));
+
+  expect(onReattach).toHaveBeenCalledWith(RECENT[0]);
+  expect(onDraftChange).toHaveBeenLastCalledWith("compare against ");
+});
+
+it("attaches an approved folder from the keyboard alone", async () => {
+  const user = userEvent.setup();
+  const onConnect = vi.fn();
+  render(
+    <ComposerHarness
+      files={composerFiles()}
+      folders={composerFolders({ onConnect })}
+    />,
+  );
+
+  await user.click(screen.getByRole("textbox", { name: "Message" }));
+  await user.keyboard("@repor{Enter}");
+
+  expect(onConnect).toHaveBeenCalledWith("root-1");
+});
+
+it("leaves an at-sign inside ordinary text alone, and closes on escape", async () => {
+  const user = userEvent.setup();
+  render(
+    <ComposerHarness files={composerFiles()} folders={composerFolders()} />,
+  );
+
+  const field = screen.getByRole("textbox", { name: "Message" });
+  await user.click(field);
+  // Mid-word: an email address is not someone reaching for an attachment.
+  await user.keyboard("write to ada@example.com");
+  expect(screen.queryByRole("option")).toBeNull();
+
+  await user.clear(field);
+  await user.keyboard("@");
+  expect(screen.getAllByRole("option").length).toBeGreaterThan(0);
+  await user.keyboard("{Escape}");
+  expect(screen.queryByRole("option")).toBeNull();
+});
+
+it("falls back to the pickers when nothing is within reach", async () => {
+  const user = userEvent.setup();
+  const onAttach = vi.fn();
+  render(
+    <ComposerHarness files={composerFiles({ recent: [], onAttach })} />,
+  );
+
+  await user.click(screen.getByRole("textbox", { name: "Message" }));
+  await user.keyboard("@");
+  await user.click(screen.getByRole("option", { name: /Browse files/ }));
+
+  expect(onAttach).toHaveBeenCalled();
+});

--- a/crates/openwave-desktop/ui/src/ComposerMentions.test.ts
+++ b/crates/openwave-desktop/ui/src/ComposerMentions.test.ts
@@ -1,0 +1,84 @@
+import { expect, it } from "vitest";
+
+import {
+  attachableFolders,
+  mentionRows,
+  recentChatFiles,
+  MAX_MENTION_ROWS,
+  type MentionCandidate,
+} from "./ComposerMentions";
+
+const CANDIDATES: MentionCandidate[] = [
+  { kind: "file", id: "doc-1", label: "Budget.xlsx", mediaType: "text/csv" },
+  { kind: "file", id: "doc-2", label: "Q3 budget notes.md", mediaType: "text/markdown" },
+  { kind: "folder", id: "root-1", label: "Reports" },
+];
+
+function file(documentId: string, name: string) {
+  return { documentId, name, mediaType: "application/pdf" };
+}
+
+it("ranks a prefix above a mid-name hit", () => {
+  const rows = mentionRows(CANDIDATES, ["browse-files", "connect-folder"], "budget");
+
+  // The pickers are named too, so a query that misses them drops them: an `@`
+  // list should answer what was typed, not always end in the same two rows.
+  expect(rows.map(describe)).toEqual(["file:doc-1", "file:doc-2"]);
+});
+
+it("drops candidates a query does not name, and the pickers with them", () => {
+  // Ordinary prose after an `@` must not leave a popover standing over the
+  // draft: with nothing matched the composer has no rows and closes the list.
+  expect(mentionRows(CANDIDATES, ["browse-files"], "nobody")).toEqual([]);
+});
+
+it("offers the pickers when nothing has been typed yet", () => {
+  const rows = mentionRows(CANDIDATES, ["browse-files"], "");
+
+  expect(rows).toHaveLength(4);
+  expect(describe(rows[3]!)).toBe("action:browse-files");
+});
+
+it("names each transcript file once, newest first, minus what is already attached", () => {
+  const messages = [
+    { files: [file("doc-1", "First.pdf")] },
+    { files: [file("doc-2", "Second.pdf"), file("doc-3", "Third.pdf")] },
+    // The same document referenced again later is still one row.
+    { files: [file("doc-1", "First.pdf")] },
+    {},
+  ];
+
+  const recent = recentChatFiles(messages, [
+    { documentId: "doc-3", displayName: "Third.pdf", mediaType: "application/pdf", byteLen: 12 },
+  ]);
+
+  expect(recent.map((entry) => entry.documentId)).toEqual([
+    "doc-1",
+    "doc-2",
+  ]);
+});
+
+it("bounds the transcript scan at the list's size", () => {
+  const messages = Array.from({ length: MAX_MENTION_ROWS + 5 }, (_, index) => ({
+    files: [file(`doc-${index}`, `File ${index}.pdf`)],
+  }));
+
+  expect(recentChatFiles(messages, [])).toHaveLength(MAX_MENTION_ROWS);
+});
+
+it("offers only approved folders this conversation has not attached", () => {
+  const approved = [
+    { rootId: "root-1", displayName: "Reports", status: "connected" as const },
+    { rootId: "root-2", displayName: "Contracts", status: "connected" as const },
+  ];
+
+  expect(attachableFolders(approved, [{ rootId: "root-1" }])).toEqual([
+    { kind: "folder", id: "root-2", label: "Contracts" },
+  ]);
+});
+
+function describe(row: ReturnType<typeof mentionRows>[number]): string {
+  return row.kind === "action"
+    ? `action:${row.action}`
+    : `${row.candidate.kind}:${row.candidate.id}`;
+}

--- a/crates/openwave-desktop/ui/src/ComposerMentions.ts
+++ b/crates/openwave-desktop/ui/src/ComposerMentions.ts
@@ -1,0 +1,181 @@
+import { FolderOpen, FolderPlus, Paperclip } from "lucide-react";
+
+import { activeTokenQuery } from "./ComposerSlash";
+import { documentIcon } from "./documentIcon";
+import type { OptionRow } from "@/components/OptionListbox";
+import type { ConnectedFolder } from "./host";
+import type { ImportedDocument } from "./documents";
+import type { TranscriptFileAttachment } from "./TranscriptFileAttachments";
+
+export const MENTION_LIST_LABEL = "Attach context";
+
+/**
+ * How many candidates one list offers.
+ *
+ * The popover sits over the draft, so it is a shortlist rather than a browser:
+ * past this many rows the reader is scrolling a panel instead of typing a name,
+ * and the query is the faster way to the row they want.
+ */
+export const MAX_MENTION_ROWS = 20;
+
+/** Something already within reach that `@` can put on the next message. */
+export type MentionCandidate =
+  | {
+      kind: "file";
+      /** The library document id — the identity the message carries. */
+      id: string;
+      label: string;
+      mediaType: string;
+    }
+  | { kind: "folder"; /** The broker's root id. */ id: string; label: string };
+
+/** A row that hands off to the picker the tools menu opens. */
+export type MentionAction = "browse-files" | "connect-folder";
+
+export type MentionRow =
+  | { kind: "candidate"; candidate: MentionCandidate }
+  | { kind: "action"; action: MentionAction };
+
+/** The `@` token under the caret: the way into attaching context. */
+export function activeMentionQuery(
+  draft: string,
+  caret: number,
+): { start: number; query: string } | null {
+  return activeTokenQuery(draft, caret, "@");
+}
+
+/**
+ * The files this conversation already carries, newest first and each named
+ * once.
+ *
+ * Read off the transcript the renderer is already holding rather than fetched:
+ * these are the attachments of messages on screen, so the list can never name a
+ * document this chat does not own. A file the composer is already carrying is
+ * left out — attaching it twice would put one document on the message twice.
+ */
+export function recentChatFiles(
+  messages: readonly { files?: readonly TranscriptFileAttachment[] }[],
+  attached: readonly ImportedDocument[],
+): TranscriptFileAttachment[] {
+  const seen = new Set(attached.map((file) => file.documentId));
+  const recent: TranscriptFileAttachment[] = [];
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    for (const file of messages[index]?.files ?? []) {
+      if (seen.has(file.documentId)) continue;
+      seen.add(file.documentId);
+      recent.push(file);
+      if (recent.length >= MAX_MENTION_ROWS) return recent;
+    }
+  }
+  return recent;
+}
+
+/**
+ * What a query names, best match first, with the pickers last.
+ *
+ * Matched on the name alone: every candidate is something the reader has
+ * already seen by name — a file they attached, a folder they approved — so a
+ * name is what they are completing. A prefix sorts above a mid-word hit.
+ *
+ * The picker rows are ranked the same way but always sort after the candidates,
+ * because they are the slower path: reaching one of these names without leaving
+ * the keyboard is the whole point of the list. They are also what keeps `@` from
+ * being a dead end in a conversation that has nothing to offer yet.
+ */
+export function mentionRows(
+  candidates: readonly MentionCandidate[],
+  actions: readonly MentionAction[],
+  query: string,
+): MentionRow[] {
+  const matched = rank(candidates, (candidate) => candidate.label, query)
+    .slice(0, MAX_MENTION_ROWS)
+    .map((candidate): MentionRow => ({ kind: "candidate", candidate }));
+  const offered = rank(actions, actionLabel, query).map(
+    (action): MentionRow => ({ kind: "action", action }),
+  );
+  return [...matched, ...offered];
+}
+
+function rank<T>(
+  items: readonly T[],
+  nameOf: (item: T) => string,
+  query: string,
+): T[] {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return [...items];
+  const ranked: { item: T; rank: number }[] = [];
+  for (const item of items) {
+    const name = nameOf(item).toLowerCase();
+    const rank = name.startsWith(needle) ? 0 : name.includes(needle) ? 1 : -1;
+    if (rank >= 0) ranked.push({ item, rank });
+  }
+  return ranked
+    .sort((left, right) => left.rank - right.rank)
+    .map((entry) => entry.item);
+}
+
+function actionLabel(action: MentionAction): string {
+  return action === "browse-files" ? "Browse files…" : "Connect a folder…";
+}
+
+/** The listbox's view of the rows: an icon, a name, and what a pick will do. */
+export function mentionOptionRows(rows: readonly MentionRow[]): OptionRow[] {
+  return rows.map((row) => {
+    if (row.kind === "action") {
+      return {
+        key: `action:${row.action}`,
+        label: actionLabel(row.action),
+        icon: row.action === "browse-files" ? Paperclip : FolderPlus,
+        hint: "Browse",
+      };
+    }
+    const { candidate } = row;
+    return candidate.kind === "file"
+      ? {
+          key: `file:${candidate.id}`,
+          label: candidate.label,
+          icon: documentIcon(candidate.mediaType),
+          hint: "File",
+        }
+      : {
+          key: `folder:${candidate.id}`,
+          label: candidate.label,
+          icon: FolderOpen,
+          hint: "Folder",
+        };
+  });
+}
+
+/**
+ * The folders `@` can attach: everything approved on this device that is not
+ * already on this conversation.
+ *
+ * Approval is what makes a folder reachable without a picker, and it outlives
+ * the chat it was granted in — so the second conversation to want a folder can
+ * name it instead of finding it on disk again.
+ */
+export function attachableFolders(
+  approved: readonly ConnectedFolder[],
+  attached: readonly { rootId: string }[],
+): MentionCandidate[] {
+  const already = new Set(attached.map((folder) => folder.rootId));
+  return approved
+    .filter((folder) => !already.has(folder.rootId))
+    .map((folder) => ({
+      kind: "folder",
+      id: folder.rootId,
+      label: folder.displayName,
+    }));
+}
+
+/** The files `@` can attach, as candidates. */
+export function attachableFiles(
+  recent: readonly TranscriptFileAttachment[],
+): MentionCandidate[] {
+  return recent.map((file) => ({
+    kind: "file",
+    id: file.documentId,
+    label: file.name,
+    mediaType: file.mediaType,
+  }));
+}

--- a/crates/openwave-desktop/ui/src/useChatFolderAttachments.test.tsx
+++ b/crates/openwave-desktop/ui/src/useChatFolderAttachments.test.tsx
@@ -10,8 +10,10 @@ import { useRefreshSignals } from "./RefreshSignals";
 import { useChatFolderAttachments } from "./useChatFolderAttachments";
 
 vi.mock("./host", () => ({
+  connectApprovedFolder: vi.fn(),
   connectFolder: vi.fn(),
   disconnectFolder: vi.fn(),
+  listApprovedFolders: vi.fn(),
   listCapabilityConsents: vi.fn(),
   listConnectedFolders: vi.fn(),
 }));
@@ -57,6 +59,7 @@ afterEach(() => {
 
 it("connects and revokes a chat folder through the existing host flow", async () => {
   vi.mocked(host.listCapabilityConsents).mockResolvedValue([]);
+  vi.mocked(host.listApprovedFolders).mockResolvedValue([]);
   vi.mocked(host.listConnectedFolders)
     .mockResolvedValueOnce([])
     .mockResolvedValueOnce([

--- a/crates/openwave-desktop/ui/src/useChatFolderAttachments.ts
+++ b/crates/openwave-desktop/ui/src/useChatFolderAttachments.ts
@@ -2,8 +2,10 @@ import { useEffect, useRef, useState } from "react";
 
 import type { Chat } from "./api";
 import {
+  connectApprovedFolder,
   connectFolder,
   disconnectFolder,
+  listApprovedFolders,
   listCapabilityConsents,
   listConnectedFolders,
   type ConnectedFolder,
@@ -28,9 +30,17 @@ export type ChatFolderAccess = ConnectedFolder & {
 
 export type ChatFolderAttachments = {
   items: ChatFolderAccess[];
+  /**
+   * Every folder approved on this device, attached here or not. The composer's
+   * `@` list draws the unattached ones from it: an approval outlives the chat
+   * it was granted in, so a second conversation can reach the folder by name
+   * instead of finding it on disk again.
+   */
+  approved: ConnectedFolder[];
   working: boolean;
   error: string | null;
   attach: () => void;
+  connectApproved: (rootId: string) => void;
   remove: (rootId: string) => void;
 };
 
@@ -44,6 +54,7 @@ export function useChatFolderAttachments(
   nativeHost: boolean,
 ): ChatFolderAttachments {
   const [items, setItems] = useState<ChatFolderAccess[]>([]);
+  const [approved, setApproved] = useState<ConnectedFolder[]>([]);
   const [working, setWorking] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const refreshGeneration = useRef(0);
@@ -53,13 +64,19 @@ export function useChatFolderAttachments(
     const generation = ++refreshGeneration.current;
     if (!chat || !nativeHost) {
       setItems([]);
+      setApproved([]);
       setError(null);
       return;
     }
     setError(null);
-    void Promise.all([listConnectedFolders(chat), listCapabilityConsents()]).then(
-      ([folders, consents]) => {
+    void Promise.all([
+      listConnectedFolders(chat),
+      listCapabilityConsents(),
+      listApprovedFolders(),
+    ]).then(
+      ([folders, consents, approvedFolders]) => {
         if (generation !== refreshGeneration.current) return;
+        setApproved(approvedFolders);
         setItems(
           folders
             // The composer chips are working controls for the current turn;
@@ -102,6 +119,30 @@ export function useChatFolderAttachments(
     }
   }
 
+  /**
+   * Attach a folder this device already approved.
+   *
+   * No picker: the host confirms the re-attachment natively and the broker
+   * re-checks the approval, so the renderer never names a place on disk. The
+   * grant is the host's to make either way — this only spares the reader
+   * finding a folder they have already chosen once.
+   */
+  async function connectApproved(rootId: string) {
+    if (!chat || !nativeHost || working) return;
+    setWorking(true);
+    setError(null);
+    try {
+      const connected = await connectApprovedFolder(chat, rootId);
+      if (connected) {
+        useRefreshSignals.getState().signal("folderAccess");
+      }
+    } catch (reason) {
+      setError(String(reason));
+    } finally {
+      setWorking(false);
+    }
+  }
+
   async function remove(rootId: string) {
     if (!chat || !nativeHost || working) return;
     setWorking(true);
@@ -118,9 +159,11 @@ export function useChatFolderAttachments(
 
   return {
     items,
+    approved,
     working,
     error,
     attach: () => void attach(),
+    connectApproved: (rootId) => void connectApproved(rootId),
     remove: (rootId) => void remove(rootId),
   };
 }


### PR DESCRIPTION
Typing `@` at a token boundary in the composer opens a caret-anchored list of context the conversation can already reach. Attaching a file or a folder no longer means leaving the keyboard for the tools menu.

The list draws on two sources, both of which the app already has in hand:

- **Files this chat already carries.** Read off the transcript the renderer is already holding, newest first and each named once, minus whatever the composer is currently carrying. Picking one names the document again on the next message — nothing is imported, because the document is already in the chat's library.
- **Folders approved on this device but not attached here.** An approval outlives the chat it was granted in, so the second conversation to want a folder can name it instead of finding it on disk again. Picking one goes through `connect_approved_folder`, which is the existing no-picker path: the host confirms natively and the broker re-checks the approval.

Both picks go through the same callbacks the tools menu's "Attach files" and "Attach folder" items use, so a mention leaves exactly the chip an attachment leaves, respects the same attachment cap, and reports a refusal wherever that path already reports one. There is no second attachment path.

Nothing here reaches into the filesystem on its own. Every candidate is something OpenWave has already been given, and a file it has not been given is still reached through the picker — which is what the last two rows of the list are for, and what keeps `@` from being a dead end in a conversation with nothing to offer yet. Those rows are matched against the query like any other, so `@` followed by ordinary prose closes the list instead of leaving a popover standing over the draft.

The popover reuses the listbox, the token reader, and the arrow-key mover the `/` list already uses; the keyboard behaves identically. The two tokens keep separate state so neither list can inherit the other's highlight or be closed by the other's Escape, and `/` takes the caret if both ever resolve. `/` behavior is otherwise untouched.

One presentation change comes with this: a file put back on the message by name carries its identity but no size, because the transcript records what a document is rather than how many bytes it was. The chip leaves the size unsaid rather than reporting zero.

Searching *inside* a connected folder is not here. It would need two new confined Tauri commands — a root-scoped directory listing and a root-scoped attach-by-path — and both are worth reviewing on their own rather than behind a UI slice. Filed as #1663.

Tests: five unit tests over the new pure logic (ranking, the transcript scan and its bound, the approved-folder filter, and the empty-list case that keeps `@` from standing open over prose), and four DOM tests driving the real composer for a file pick, a folder pick from the keyboard alone, the leave-prose-alone/Escape case, and the picker fallback.

Verified from `crates/openwave-desktop/ui`: `tsc --noEmit`, `vitest run` (786 tests), and `pnpm build` all pass. No Rust changed.

Closes #1631
