### PR TITLE
feat(core): load user-authored plugins from the data directory

### DIFF
--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -57,8 +57,8 @@ pub use package_cache::{
 };
 pub use plugins::{
     derived_capabilities, is_valid_plugin_name, is_valid_plugin_router_preamble, load_plugins,
-    parse_plugin_manifest, LoadedPlugin, PluginCapability, PluginCategory, PluginPackage,
-    PluginParseError, PLUGIN_MANIFEST_FILE,
+    merged_plugins, parse_plugin_manifest, LoadedPlugin, PluginCapability, PluginCategory,
+    PluginOrigin, PluginPackage, PluginParseError, PLUGIN_MANIFEST_FILE,
 };
 pub use preview::{scan_preview_directory, PreviewScan};
 pub use prompts::{

--- a/crates/openwave-code-execution/src/plugins.rs
+++ b/crates/openwave-code-execution/src/plugins.rs
@@ -28,6 +28,10 @@
 //! a plugin naming a skill that isn't there is skipped whole rather than
 //! advertising a group the catalog cannot render.
 //!
+//! User-authored bundles under the data directory load through that same
+//! parser and merge behind the built-in tree — see [`merged_plugins`] for the
+//! precedence rules, which mirror the ones user skills already follow.
+//!
 //! Capability badges follow the same posture from the other direction: they
 //! are derived from what the member skills actually declare, and the closed
 //! key set means a manifest cannot state them at all.
@@ -158,6 +162,21 @@ pub fn derived_capabilities(
     capabilities.into_iter().collect()
 }
 
+/// Which source a validated plugin package was loaded from.
+///
+/// Origin is host-derived from the load path, never from manifest content —
+/// the closed key set has no `origin` key at all — so a user bundle cannot
+/// claim to ship with the app. A management surface uses it to attribute the
+/// bundles the user wrote themselves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, ts_rs::TS)]
+#[serde(rename_all = "snake_case")]
+pub enum PluginOrigin {
+    /// Shipped with the application from a trusted resource directory.
+    Builtin,
+    /// Authored by the user in the per-install plugins directory.
+    User,
+}
+
 /// Host-derived bundle entry parsed from a plugin manifest's frontmatter.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PluginPackage {
@@ -177,6 +196,8 @@ pub struct PluginPackage {
     /// Optional line emitted above the member skills in the prompt catalog,
     /// telling the model how to choose among them.
     pub router_preamble: Option<String>,
+    /// Where the package was loaded from.
+    pub origin: PluginOrigin,
 }
 
 /// One validated plugin.
@@ -239,7 +260,15 @@ pub fn is_valid_plugin_router_preamble(preamble: &str) -> bool {
 /// slug, a control character in a rendered line — rejects the whole manifest.
 /// The body below the frontmatter is documentation for whoever opens the file;
 /// it is never staged and never reaches the model, so it may be empty.
-pub fn parse_plugin_manifest(source: &str) -> Result<PluginPackage, PluginParseError> {
+///
+/// `origin` is supplied by the caller from the path the manifest was read
+/// from. Parsing itself is identical for both origins: a user bundle is held
+/// to exactly the built-in manifest grammar, so a plugin that loads here is one
+/// the catalog can render whoever wrote it.
+pub fn parse_plugin_manifest(
+    source: &str,
+    origin: PluginOrigin,
+) -> Result<PluginPackage, PluginParseError> {
     if source.len() > crate::MAX_WORKSPACE_FILE_BYTES {
         return Err(invalid("manifest exceeds the workspace file limit"));
     }
@@ -349,6 +378,7 @@ pub fn parse_plugin_manifest(source: &str) -> Result<PluginPackage, PluginParseE
         skills,
         prompts,
         router_preamble,
+        origin,
     })
 }
 
@@ -401,7 +431,7 @@ fn parse_members(
 }
 
 /// Load every valid plugin under `source`, one directory per plugin, against
-/// the skills and prompts that actually loaded.
+/// the skills and prompts that actually loaded, tagging each with `origin`.
 ///
 /// A plugin is skipped with a warning — never half-applied — when its manifest
 /// is unreadable or rejected, when the directory name disagrees with the
@@ -415,6 +445,7 @@ pub fn load_plugins(
     source: &Path,
     skills: &[LoadedSkill],
     prompts: &[LoadedPrompt],
+    origin: PluginOrigin,
 ) -> Vec<LoadedPlugin> {
     let entries = match std::fs::read_dir(source) {
         Ok(entries) => entries,
@@ -461,7 +492,7 @@ pub fn load_plugins(
                 continue;
             }
         };
-        let package = match parse_plugin_manifest(&manifest) {
+        let package = match parse_plugin_manifest(&manifest, origin) {
             Ok(package) => package,
             Err(error) => {
                 tracing::warn!("skipping plugin '{directory_name}': {error}");
@@ -532,6 +563,75 @@ pub fn load_plugins(
     plugins
 }
 
+/// The built-in plugins plus the user-authored bundles under `user_dir`,
+/// merged into one deterministic catalog.
+///
+/// User bundles go through the same strict loader and the same membership
+/// checks as built-ins, resolved against `skills` and `prompts` — which should
+/// be the *merged* sets, so a user bundle may group the skills the user wrote.
+/// Three rules give the built-in tree the floor, each one a skip-with-warning
+/// so one bad bundle never takes the catalog down:
+///
+/// * a built-in name is reserved: a user bundle claiming it is dropped rather
+///   than shadowing curated grouping;
+/// * a skill a built-in bundle already claims cannot be re-claimed;
+/// * neither can a prompt.
+///
+/// A member that belongs to no built-in bundle is fair game, which is what
+/// lets a user bundle group their own skills. A missing user directory is an
+/// empty user set, not an error. The result is sorted by name.
+#[must_use]
+pub fn merged_plugins(
+    builtins: &[LoadedPlugin],
+    user_dir: Option<&Path>,
+    skills: &[LoadedSkill],
+    prompts: &[LoadedPrompt],
+) -> Vec<LoadedPlugin> {
+    let mut plugins = builtins.to_vec();
+    let Some(dir) = user_dir.filter(|dir| dir.is_dir()) else {
+        return plugins;
+    };
+    let builtin_skills: BTreeSet<&str> = builtins
+        .iter()
+        .flat_map(|plugin| plugin.package.skills.iter().map(String::as_str))
+        .collect();
+    let builtin_prompts: BTreeSet<&str> = builtins
+        .iter()
+        .flat_map(|plugin| plugin.package.prompts.iter().map(String::as_str))
+        .collect();
+    for user_plugin in load_plugins(dir, skills, prompts, PluginOrigin::User) {
+        let package = &user_plugin.package;
+        let name = &package.name;
+        if builtins.iter().any(|plugin| plugin.package.name == *name) {
+            tracing::warn!("skipping user plugin '{name}': a built-in plugin owns that name");
+            continue;
+        }
+        if let Some(taken) = package
+            .skills
+            .iter()
+            .find(|skill| builtin_skills.contains(skill.as_str()))
+        {
+            tracing::warn!(
+                "skipping user plugin '{name}': skill {taken:?} is claimed by a built-in plugin"
+            );
+            continue;
+        }
+        if let Some(taken) = package
+            .prompts
+            .iter()
+            .find(|prompt| builtin_prompts.contains(prompt.as_str()))
+        {
+            tracing::warn!(
+                "skipping user plugin '{name}': prompt {taken:?} is claimed by a built-in plugin"
+            );
+            continue;
+        }
+        plugins.push(user_plugin);
+    }
+    plugins.sort_by(|a, b| a.package.name.cmp(&b.package.name));
+    plugins
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -578,7 +678,7 @@ router-preamble: Pick by the file the user needs.\n\
 
     #[test]
     fn valid_manifest_parses_into_its_bundle_entry() {
-        let package = parse_plugin_manifest(VALID).unwrap();
+        let package = parse_plugin_manifest(VALID, PluginOrigin::Builtin).unwrap();
         assert_eq!(package.name, "documents");
         assert_eq!(package.display_name, "Documents");
         assert_eq!(package.category, PluginCategory::Documents);
@@ -593,7 +693,9 @@ router-preamble: Pick by the file the user needs.\n\
         let minimal = "---\nname: charts\ndisplay-name: Charts\ndescription: Plots.\n\
                        category: visualization\nskills: [\"charts\"]\n---\n";
         assert_eq!(
-            parse_plugin_manifest(minimal).unwrap().router_preamble,
+            parse_plugin_manifest(minimal, PluginOrigin::Builtin)
+                .unwrap()
+                .router_preamble,
             None
         );
 
@@ -601,7 +703,7 @@ router-preamble: Pick by the file the user needs.\n\
         // the skills-only shape we ship.
         let prompts_only = "---\nname: writing\ndisplay-name: Writing\ndescription: Starters.\n\
                             category: other\nprompts: [\"weekly-update\"]\n---\n";
-        let package = parse_plugin_manifest(prompts_only).unwrap();
+        let package = parse_plugin_manifest(prompts_only, PluginOrigin::Builtin).unwrap();
         assert_eq!(package.skills, [""; 0]);
         assert_eq!(package.prompts, ["weekly-update"]);
     }
@@ -662,7 +764,7 @@ router-preamble: Pick by the file the user needs.\n\
             ),
         ] {
             assert!(
-                parse_plugin_manifest(&source).is_err(),
+                parse_plugin_manifest(&source, PluginOrigin::Builtin).is_err(),
                 "{case} should be rejected"
             );
         }
@@ -725,7 +827,7 @@ router-preamble: Pick by the file the user needs.\n\
         // Directory disagrees with the manifest.
         write_plugin(plugins_dir.path(), "mislabeled", VALID);
 
-        let plugins = load_plugins(plugins_dir.path(), &skills, &prompts);
+        let plugins = load_plugins(plugins_dir.path(), &skills, &prompts, PluginOrigin::Builtin);
         assert_eq!(
             plugins
                 .iter()
@@ -738,6 +840,77 @@ router-preamble: Pick by the file the user needs.\n\
             ["word-documents", "pdf-documents"]
         );
         assert_eq!(plugins[0].package.prompts, ["weekly-update"]);
+    }
+
+    /// Contract: the built-in tree has the floor when user-authored bundles
+    /// merge in. Every rule here is a skip-with-warning that is easy to reverse
+    /// by accident — a shadowed name or a re-claimed member would silently
+    /// re-group curated skills — and origin is host-derived from the load path,
+    /// which is what a management surface attributes the user's own bundles by.
+    #[test]
+    fn user_plugins_merge_behind_the_builtin_tree() {
+        let skills_dir = tempfile::tempdir().unwrap();
+        for name in ["charts", "word-documents", "pdf-documents"] {
+            write_skill(skills_dir.path(), name);
+        }
+        let user_skills_dir = tempfile::tempdir().unwrap();
+        write_skill(user_skills_dir.path(), "meeting-notes");
+        let mut skills = load_skills(skills_dir.path(), SkillOrigin::Builtin);
+        skills.extend(load_skills(user_skills_dir.path(), SkillOrigin::User));
+
+        let builtin_dir = tempfile::tempdir().unwrap();
+        write_plugin(builtin_dir.path(), "documents", VALID);
+        let builtins = load_plugins(builtin_dir.path(), &skills, &[], PluginOrigin::Builtin);
+
+        let user_dir = tempfile::tempdir().unwrap();
+        // Groups the user's own skill: the supported shape, and the only one
+        // that survives here.
+        write_plugin(
+            user_dir.path(),
+            "notes",
+            "---\nname: notes\ndisplay-name: My notes\ndescription: How I take notes.\n\
+             category: other\nskills: [\"meeting-notes\"]\n---\n",
+        );
+        // Reserved: a built-in bundle owns this name.
+        write_plugin(
+            user_dir.path(),
+            "documents",
+            "---\nname: documents\ndisplay-name: Mine\ndescription: Shadows the built-in.\n\
+             category: other\nskills: [\"charts\"]\n---\n",
+        );
+        // Re-claims a skill the built-in 'documents' bundle already owns.
+        write_plugin(
+            user_dir.path(),
+            "poaching",
+            "---\nname: poaching\ndisplay-name: Poaching\ndescription: Steals a member.\n\
+             category: other\nskills: [\"pdf-documents\"]\n---\n",
+        );
+        // Invalid manifests never take the catalog down with them.
+        write_plugin(user_dir.path(), "broken", "not frontmatter at all\n");
+
+        let merged = merged_plugins(&builtins, Some(user_dir.path()), &skills, &[]);
+        assert_eq!(
+            merged
+                .iter()
+                .map(|plugin| (plugin.package.name.as_str(), plugin.package.origin))
+                .collect::<Vec<_>>(),
+            [
+                ("documents", PluginOrigin::Builtin),
+                ("notes", PluginOrigin::User),
+            ]
+        );
+        // The built-in bundle kept both of its members.
+        assert_eq!(
+            merged[0].package.skills,
+            ["word-documents", "pdf-documents"]
+        );
+
+        // A missing user directory is an empty user set, not an error.
+        let missing = user_dir.path().join("does-not-exist");
+        assert_eq!(
+            merged_plugins(&builtins, Some(&missing), &skills, &[]).len(),
+            1
+        );
     }
 
     /// Contract: a badge row is a function of what the member skills declare,
@@ -796,6 +969,7 @@ router-preamble: Pick by the file the user needs.\n\
                 skills: members.iter().map(|skill| skill.name.clone()).collect(),
                 prompts: Vec::new(),
                 router_preamble: None,
+                origin: PluginOrigin::Builtin,
             };
             let mut passed: Vec<&SkillPackage> = members;
             passed.push(&outsider);
@@ -818,6 +992,7 @@ router-preamble: Pick by the file the user needs.\n\
             skills: vec!["both".to_owned()],
             prompts: Vec::new(),
             router_preamble: None,
+            origin: PluginOrigin::Builtin,
         };
         let derived = derived_capabilities(&everything, &[&both]);
         assert!(!derived.contains(&PluginCapability::LiveControl));
@@ -826,7 +1001,8 @@ router-preamble: Pick by the file the user needs.\n\
         // A manifest that tries to declare its own badges is rejected whole.
         assert!(parse_plugin_manifest(
             "---\nname: a\ndisplay-name: A\ndescription: b\ncategory: other\n\
-             skills: [\"c\"]\ncapabilities: [\"network\"]\n---\n"
+             skills: [\"c\"]\ncapabilities: [\"network\"]\n---\n",
+            PluginOrigin::Builtin,
         )
         .is_err());
     }
@@ -845,7 +1021,7 @@ router-preamble: Pick by the file the user needs.\n\
             .filter_map(Result::ok)
             .filter(|entry| entry.path().is_dir())
             .count();
-        let plugins = load_plugins(&source, &skills, &[]);
+        let plugins = load_plugins(&source, &skills, &[], PluginOrigin::Builtin);
         assert_eq!(
             plugins.len(),
             directories,

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -193,7 +193,12 @@ fn verify_required_plugins(skills_dir: &Path, plugins_dir: &Path) -> Result<(), 
     );
     // The bundle ships no built-in prompts; a manifest claiming one would be
     // skipped, which this check would then see as a missing plugin.
-    let plugins = openwave_code_execution::load_plugins(plugins_dir, &skills, &[]);
+    let plugins = openwave_code_execution::load_plugins(
+        plugins_dir,
+        &skills,
+        &[],
+        openwave_code_execution::PluginOrigin::Builtin,
+    );
     let loaded: Vec<&str> = plugins
         .iter()
         .map(|plugin| plugin.package.name.as_str())

--- a/crates/openwave-desktop/ui/src/ComposerPlugins.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerPlugins.dom.test.tsx
@@ -13,6 +13,7 @@ const DOCUMENTS: PluginInfo = {
   display_name: "Documents",
   description: "Writes Word, Excel, and PowerPoint files.",
   category: "documents",
+  origin: "builtin",
   capabilities: [],
   enabled: false,
   skills: [],

--- a/crates/openwave-desktop/ui/src/ComposerToolsMenu.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerToolsMenu.dom.test.tsx
@@ -16,6 +16,7 @@ function plugin(overrides: Partial<PluginInfo> = {}): PluginInfo {
     display_name: "Documents",
     description: "Writes Word, Excel, and PowerPoint files.",
     category: "documents",
+    origin: "builtin",
     capabilities: [],
     enabled: false,
     skills: [],

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1578,6 +1578,10 @@ export type PluginInfo = {
  */
 name: string, display_name: string, description: string, category: PluginCategory, 
 /**
+ * Where the bundle was loaded from; host-derived, never claimed.
+ */
+origin: PluginOrigin, 
+/**
  * What the bundle can do, derived by the host from what it contains.
  * Never self-declared: a manifest has no key for this.
  */
@@ -1591,6 +1595,16 @@ enabled: boolean,
  * Member skills in manifest order.
  */
 skills: Array<PluginSkillInfo>, };
+
+/**
+ * Which source a validated plugin package was loaded from.
+ *
+ * Origin is host-derived from the load path, never from manifest content —
+ * the closed key set has no `origin` key at all — so a user bundle cannot
+ * claim to ship with the app. A management surface uses it to attribute the
+ * bundles the user wrote themselves.
+ */
+export type PluginOrigin = "builtin" | "user";
 
 /**
  * One reusable prompt, as a picker or a management surface renders it.

--- a/crates/openwave-desktop/ui/src/plugins/Plugins.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/plugins/Plugins.dom.test.tsx
@@ -17,6 +17,7 @@ const CATALOG: PluginCatalog = {
       display_name: "Documents",
       description: "Write and revise Word documents.",
       category: "documents",
+      origin: "builtin",
       capabilities: ["write-files", "host-install"],
       enabled: false,
       skills: [

--- a/crates/openwave-desktop/ui/src/plugins/PluginsView.tsx
+++ b/crates/openwave-desktop/ui/src/plugins/PluginsView.tsx
@@ -28,7 +28,8 @@ import type { PluginCatalogState } from "./usePluginCatalog";
  * badges, and its member skills with their own switches.
  *
  * The origin split is the catalog's own: bundles first, then the skills no
- * bundle claims, with anything the user wrote themselves called out as theirs.
+ * bundle claims, with anything the user wrote themselves — bundle or skill —
+ * called out as theirs.
  */
 export function PluginsView({
   state,
@@ -42,6 +43,9 @@ export function PluginsView({
 }) {
   const { catalog, loading, error, reload, setEnabled } = state;
   const [openSkill, setOpenSkill] = useState<PluginSkillInfo | null>(null);
+  const yourPlugins = catalog?.plugins.filter((plugin) => plugin.origin === "user") ?? [];
+  const otherPlugins =
+    catalog?.plugins.filter((plugin) => plugin.origin !== "user") ?? [];
   const yourSkills = catalog?.skills.filter((skill) => skill.origin === "user") ?? [];
   const otherSkills =
     catalog?.skills.filter((skill) => skill.origin !== "user") ?? [];
@@ -94,21 +98,28 @@ export function PluginsView({
           </Empty>
         )}
 
-        {catalog && catalog.plugins.length > 0 && (
+        {otherPlugins.length > 0 && (
           <Section title="Plugins">
-            <ul className="flex flex-col gap-1" aria-label="Plugins">
-              {catalog.plugins.map((plugin) => (
-                <li key={plugin.name}>
-                  <PluginRow
-                    plugin={plugin}
-                    onOpen={() => onOpen(plugin.name)}
-                    onToggle={(enabled) =>
-                      setEnabled({ plugins: { [plugin.name]: enabled }, skills: {} })
-                    }
-                  />
-                </li>
-              ))}
-            </ul>
+            <PluginList
+              plugins={otherPlugins}
+              label="Plugins"
+              onOpen={onOpen}
+              setEnabled={setEnabled}
+            />
+          </Section>
+        )}
+
+        {yourPlugins.length > 0 && (
+          <Section
+            title="Your plugins"
+            description="Plugins you wrote, loaded from your data directory."
+          >
+            <PluginList
+              plugins={yourPlugins}
+              label="Your plugins"
+              onOpen={onOpen}
+              setEnabled={setEnabled}
+            />
           </Section>
         )}
 
@@ -175,6 +186,34 @@ function Section({
       </div>
       {children}
     </section>
+  );
+}
+
+function PluginList({
+  plugins,
+  label,
+  onOpen,
+  setEnabled,
+}: {
+  plugins: PluginInfo[];
+  label: string;
+  onOpen: (pluginId: string) => void;
+  setEnabled: PluginCatalogState["setEnabled"];
+}) {
+  return (
+    <ul className="flex flex-col gap-1" aria-label={label}>
+      {plugins.map((plugin) => (
+        <li key={plugin.name}>
+          <PluginRow
+            plugin={plugin}
+            onOpen={() => onOpen(plugin.name)}
+            onToggle={(enabled) =>
+              setEnabled({ plugins: { [plugin.name]: enabled }, skills: {} })
+            }
+          />
+        </li>
+      ))}
+    </ul>
   );
 }
 

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -921,6 +921,10 @@ pub struct ConfiguredCodeExecutionProvider {
     /// skills, grouping them in the prompt catalog. Empty when no plugin tree
     /// is configured, which leaves every skill standalone.
     plugins: Arc<Vec<openwave_code_execution::LoadedPlugin>>,
+    /// Per-install directory of user-authored plugin packages, re-read
+    /// alongside the user skills and prompts they group so an added or edited
+    /// bundle appears without a restart. `None` disables user plugins.
+    user_plugins_dir: Option<PathBuf>,
     folder_grant_resolver: Option<Arc<dyn ExecFolderGrantResolver>>,
     /// Host-provided office-to-PDF converter feeding the model's visual QA
     /// loop. `None` (headless embeddings) degrades to an honest sync note.
@@ -1125,6 +1129,7 @@ impl ConfiguredCodeExecutionProvider {
             prompts: Arc::new(Vec::new()),
             user_prompts_dir: None,
             plugins: Arc::new(Vec::new()),
+            user_plugins_dir: None,
             folder_grant_resolver: None,
             office_converter: None,
             host_tool_broker: None,
@@ -1239,10 +1244,33 @@ impl ConfiguredCodeExecutionProvider {
             source
                 .as_deref()
                 .map(|source| {
-                    openwave_code_execution::load_plugins(source, &self.skills, &self.prompts)
+                    openwave_code_execution::load_plugins(
+                        source,
+                        &self.skills,
+                        &self.prompts,
+                        openwave_code_execution::PluginOrigin::Builtin,
+                    )
                 })
                 .unwrap_or_default(),
         );
+        self
+    }
+
+    /// Install the per-install directory user-authored plugin packages are
+    /// loaded from. The directory is created here (best effort) so the user has
+    /// a place to drop a bundle; its contents are re-read on each listing,
+    /// against the user skills and prompts a bundle may claim.
+    #[must_use]
+    pub fn with_user_plugins(mut self, source: Option<PathBuf>) -> Self {
+        if let Some(source) = source.as_deref() {
+            if let Err(error) = std::fs::create_dir_all(source) {
+                tracing::warn!(
+                    "user plugins directory {} could not be created: {error}",
+                    source.display()
+                );
+            }
+        }
+        self.user_plugins_dir = source;
         self
     }
 
@@ -1277,12 +1305,33 @@ impl ConfiguredCodeExecutionProvider {
         openwave_code_execution::merged_skills(&self.skills, self.user_skills_dir.as_deref())
     }
 
-    /// Every installed bundle, before the install's enable flags apply.
+    /// Every installed bundle, before the install's enable flags apply: the
+    /// built-in bundles merged with a fresh read of the user plugins
+    /// directory, exactly as [`Self::installed_skills`] does.
     pub(crate) fn installed_plugins(&self) -> Vec<openwave_code_execution::PluginPackage> {
-        self.plugins
-            .iter()
-            .map(|plugin| plugin.package.clone())
-            .collect()
+        self.merged_plugins(&self.installed_skills(), &self.installed_prompts())
+    }
+
+    /// The same merge against sets the caller has already read.
+    ///
+    /// Membership is resolved against the *installed* skills and prompts, not
+    /// the enabled ones: a bundle whose member the user switched off is still
+    /// the bundle they installed, and dropping it would take the switch that
+    /// turns the member back on off the surface with it.
+    fn merged_plugins(
+        &self,
+        skills: &[openwave_code_execution::LoadedSkill],
+        prompts: &[openwave_code_execution::LoadedPrompt],
+    ) -> Vec<openwave_code_execution::PluginPackage> {
+        openwave_code_execution::merged_plugins(
+            &self.plugins,
+            self.user_plugins_dir.as_deref(),
+            skills,
+            prompts,
+        )
+        .into_iter()
+        .map(|plugin| plugin.package)
+        .collect()
     }
 
     /// Every installed prompt, before the install's enable flags apply: the
@@ -1296,11 +1345,14 @@ impl ConfiguredCodeExecutionProvider {
     }
 
     /// The bundle that claims `skill`, if any.
-    fn owning_plugin(&self, skill: &str) -> Option<&str> {
-        self.plugins
+    fn owning_plugin<'a>(
+        plugins: &'a [openwave_code_execution::PluginPackage],
+        skill: &str,
+    ) -> Option<&'a str> {
+        plugins
             .iter()
-            .find(|plugin| plugin.package.skills.iter().any(|member| member == skill))
-            .map(|plugin| plugin.package.name.as_str())
+            .find(|plugin| plugin.skills.iter().any(|member| member == skill))
+            .map(|plugin| plugin.name.as_str())
     }
 
     /// The install's plugin and skill enable flags.
@@ -1320,15 +1372,22 @@ impl ConfiguredCodeExecutionProvider {
     }
 
     /// Narrow an installed set to what the install's flags leave on.
+    ///
+    /// Ownership is resolved against the merged bundles, so a user bundle
+    /// gates the user skills it claims exactly as a built-in one does.
     async fn enabled_skills(
         &self,
         installed: Vec<openwave_code_execution::LoadedSkill>,
     ) -> Vec<openwave_code_execution::LoadedSkill> {
         let state = self.enable_state().await;
+        let plugins = self.merged_plugins(&installed, &self.installed_prompts());
         installed
             .into_iter()
             .filter(|skill| {
-                state.skill_enabled(&skill.package.name, self.owning_plugin(&skill.package.name))
+                state.skill_enabled(
+                    &skill.package.name,
+                    Self::owning_plugin(&plugins, &skill.package.name),
+                )
             })
             .collect()
     }
@@ -1342,14 +1401,13 @@ impl ConfiguredCodeExecutionProvider {
             .collect()
     }
 
-    /// The bundles the catalog groups skills under. User skills are claimed by
-    /// no plugin and stay standalone.
+    /// The bundles the catalog groups skills under, built-in and user-authored
+    /// alike. A skill no bundle claims stays standalone.
     pub(crate) async fn plugin_catalog(&self) -> Vec<openwave_code_execution::PluginPackage> {
         let state = self.enable_state().await;
-        self.plugins
-            .iter()
-            .filter(|plugin| state.plugin_enabled(&plugin.package.name))
-            .map(|plugin| plugin.package.clone())
+        self.installed_plugins()
+            .into_iter()
+            .filter(|plugin| state.plugin_enabled(&plugin.name))
             .collect()
     }
 

--- a/crates/openwave-server/src/foreground_prompt.rs
+++ b/crates/openwave-server/src/foreground_prompt.rs
@@ -1136,6 +1136,7 @@ mod tests {
             skills: members.iter().map(|member| (*member).into()).collect(),
             prompts: Vec::new(),
             router_preamble: Some(preamble.into()),
+            origin: openwave_code_execution::PluginOrigin::Builtin,
         };
         let plugins = vec![
             plugin(

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -928,6 +928,7 @@ async fn bind_inner(
         .with_plugins(config.exec_plugins_dir.clone())
         .with_user_skills(Some(config.user_skills_dir()))
         .with_user_prompts(Some(config.user_prompts_dir()))
+        .with_user_plugins(Some(config.user_plugins_dir()))
         .with_folder_grant_resolver(folder_grant_resolver)
         .with_office_converter(office_converter)
         .with_host_tool_broker(host_tool_broker),

--- a/crates/openwave-server/src/routes/plugins.rs
+++ b/crates/openwave-server/src/routes/plugins.rs
@@ -24,7 +24,8 @@ use std::collections::BTreeMap;
 
 use openwave_code_execution::{
     derived_capabilities, is_valid_plugin_name, is_valid_prompt_name, is_valid_skill_name,
-    PluginCapability, PluginCategory, PromptOrigin, PromptPackage, SkillOrigin, SkillPackage,
+    PluginCapability, PluginCategory, PluginOrigin, PromptOrigin, PromptPackage, SkillOrigin,
+    SkillPackage,
 };
 
 use crate::error::ServerError;
@@ -59,6 +60,8 @@ pub struct PluginInfo {
     pub display_name: String,
     pub description: String,
     pub category: PluginCategory,
+    /// Where the bundle was loaded from; host-derived, never claimed.
+    pub origin: PluginOrigin,
     /// What the bundle can do, derived by the host from what it contains.
     /// Never self-declared: a manifest has no key for this.
     pub capabilities: Vec<PluginCapability>,
@@ -163,6 +166,7 @@ pub async fn get_plugins(
             display_name: plugin.display_name,
             description: plugin.description,
             category: plugin.category,
+            origin: plugin.origin,
         });
     }
     let skills = installed

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -2797,6 +2797,171 @@ async fn the_plugin_catalog_reports_badges_and_persists_toggles() {
     assert_eq!(refused.status(), StatusCode::BAD_REQUEST);
 }
 
+/// Contract: a bundle the user wrote in their data directory reaches the
+/// catalog attributed as theirs, the built-in tree keeps the floor when the
+/// two collide, and a flag set against a user bundle outlives the bundle
+/// itself — reinstalling one the user switched off must not quietly switch it
+/// back on.
+#[tokio::test]
+async fn user_plugins_load_from_the_data_directory_and_keep_their_flags() {
+    let (dir, store) = temp_db_store("user-plugins.db").await;
+    let store: Arc<dyn Store> = Arc::new(store);
+
+    let builtin = tempfile::tempdir().unwrap();
+    let write = |root: &std::path::Path, kind: &str, name: &str, manifest: &str, source: String| {
+        let package = root.join(kind).join(name);
+        std::fs::create_dir_all(&package).unwrap();
+        std::fs::write(package.join(manifest), source).unwrap();
+    };
+    write(
+        builtin.path(),
+        "skills",
+        "charts",
+        "SKILL.md",
+        "---\nname: charts\ndescription: Plots.\n---\nBody.\n".to_owned(),
+    );
+    write(
+        builtin.path(),
+        "plugins",
+        "reporting",
+        "PLUGIN.md",
+        "---\nname: reporting\ndisplay-name: Reporting\ndescription: Status reporting.\n\
+         category: other\nskills: [\"charts\"]\n---\n"
+            .to_owned(),
+    );
+    // The user's own skill, and the bundle that groups it.
+    write(
+        dir.path(),
+        "skills",
+        "meeting-notes",
+        "SKILL.md",
+        "---\nname: meeting-notes\ndescription: How I take notes.\n---\nBody.\n".to_owned(),
+    );
+    let write_notes_bundle = || {
+        write(
+            dir.path(),
+            "plugins",
+            "notes",
+            "PLUGIN.md",
+            "---\nname: notes\ndisplay-name: My notes\ndescription: Notes the way I like them.\n\
+             category: other\nskills: [\"meeting-notes\"]\n---\n"
+                .to_owned(),
+        );
+    };
+    write_notes_bundle();
+    // Shadows a built-in name, and re-claims a skill a built-in bundle owns.
+    // Both are skipped; neither takes the rest of the tree down with it.
+    write(
+        dir.path(),
+        "plugins",
+        "reporting",
+        "PLUGIN.md",
+        "---\nname: reporting\ndisplay-name: Mine\ndescription: Shadows the built-in.\n\
+         category: other\nskills: [\"meeting-notes\"]\n---\n"
+            .to_owned(),
+    );
+    write(
+        dir.path(),
+        "plugins",
+        "poaching",
+        "PLUGIN.md",
+        "---\nname: poaching\ndisplay-name: Poaching\ndescription: Steals a member.\n\
+         category: other\nskills: [\"charts\"]\n---\n"
+            .to_owned(),
+    );
+
+    let user_plugin_app = || {
+        let secrets = Arc::new(MemSecrets::default());
+        let mut state = AppState::new(
+            Config::desktop(dir.path()),
+            store.clone(),
+            Arc::new(FixedResolver(Arc::new(FakeProvider))),
+            secrets.clone(),
+            Arc::new(ToolRegistry::new()),
+            AgentConfig {
+                model: "fake".into(),
+                ..AgentConfig::default()
+            },
+        );
+        state.code_execution = Some(Arc::new(
+            crate::code_execution::ConfiguredCodeExecutionProvider::new(
+                store.clone(),
+                secrets,
+                dir.path().join("scratch"),
+            )
+            .with_skills(Some(builtin.path().join("skills")))
+            .with_plugins(Some(builtin.path().join("plugins")))
+            .with_user_skills(Some(dir.path().join("skills")))
+            .with_user_plugins(Some(dir.path().join("plugins"))),
+        ));
+        let token = state.token.clone();
+        (app(state), format!("Bearer {token}"))
+    };
+    let listed = |catalog: &serde_json::Value| {
+        catalog["plugins"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|plugin| {
+                (
+                    plugin["name"].as_str().unwrap().to_owned(),
+                    plugin["origin"].as_str().unwrap().to_owned(),
+                    plugin["enabled"].as_bool().unwrap(),
+                )
+            })
+            .collect::<Vec<_>>()
+    };
+
+    let (router, bearer) = user_plugin_app();
+    let catalog = get_plugins(&router, &bearer).await;
+    assert_eq!(
+        listed(&catalog),
+        [
+            ("notes".to_owned(), "user".to_owned(), true),
+            ("reporting".to_owned(), "builtin".to_owned(), true),
+        ],
+        "the user bundle is listed as theirs; neither collision shadows the built-in one"
+    );
+    // Its member is grouped under it rather than left standalone, and the
+    // built-in bundle kept the skill the user tried to re-claim.
+    let notes = &catalog["plugins"].as_array().unwrap()[0];
+    assert_eq!(notes["skills"][0]["name"], "meeting-notes");
+    assert!(catalog["skills"].as_array().unwrap().is_empty());
+
+    // Switch the user bundle off, then uninstall it.
+    let response = put_plugins_enabled(
+        &router,
+        &bearer,
+        serde_json::json!({"plugins": {"notes": false}}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    std::fs::remove_dir_all(dir.path().join("plugins/notes")).unwrap();
+
+    let (router, bearer) = user_plugin_app();
+    let catalog = get_plugins(&router, &bearer).await;
+    assert_eq!(
+        listed(&catalog),
+        [("reporting".to_owned(), "builtin".to_owned(), true)],
+        "an uninstalled user bundle is gone from the catalog"
+    );
+    // The skill it used to claim is standalone again rather than lost.
+    assert_eq!(catalog["skills"][0]["name"], "meeting-notes");
+
+    // Reinstalling it does not silently re-enable it: the flag was recorded
+    // against the name, not against the package that happened to be present.
+    write_notes_bundle();
+    let (router, bearer) = user_plugin_app();
+    let catalog = get_plugins(&router, &bearer).await;
+    assert_eq!(
+        listed(&catalog),
+        [
+            ("notes".to_owned(), "user".to_owned(), false),
+            ("reporting".to_owned(), "builtin".to_owned(), true),
+        ]
+    );
+}
+
 /// Contract: reusable prompts reach the client as one flat, attributed list
 /// whose entries a bundle's flag gates, and their bodies come from their own
 /// route. Both halves are wire shape a composer depends on, and the gating is


### PR DESCRIPTION
`Config::user_plugins_dir()` was already derived and the directory already
created, but only the bundled `plugins/` tree ever loaded — a `PLUGIN.md` the
user wrote in `{data_dir}/plugins/<name>/` was silently ignored.

User bundles now load through the same strict manifest parser as built-ins
(`load_plugins` takes the origin; parsing itself is identical for both, so a
user bundle is held to exactly the built-in grammar) and merge behind them via
a new `merged_plugins`, mirroring `merged_skills`/`merged_prompts`.

Merge rules, all skip-with-warning so one bad bundle never fails the catalog:

- a built-in bundle's name is reserved — a user bundle claiming it is dropped
  rather than shadowing curated grouping;
- a skill a built-in bundle already claims cannot be re-claimed, and neither
  can a prompt;
- membership resolves against the *merged* skill and prompt sets, so a user
  bundle can group the skills the user wrote; a member that belongs to no
  built-in bundle is fair game;
- within the user tree itself, `load_plugins`' existing single-claim rule
  applies unchanged (name order, deterministic).

Membership is resolved against *installed* rather than enabled skills: a bundle
whose member is switched off is still the bundle you installed, and dropping it
would take the switch that turns the member back on off the surface with it.

`installed_plugins()` and the prompt-composition `plugin_catalog()` now both go
through the merge, so a user bundle groups its skills in the operating prompt
and its flag gates its members exactly as a built-in one does — `owning_plugin`
resolves against the merged set instead of the built-in slice.

Enable state needed no change: flags are recorded against the name, so a user
bundle switched off, uninstalled, and reinstalled comes back off.

`PluginInfo` gains a host-derived `origin` (there is no manifest key for it),
regenerated into `wire.ts`. The library splits the bundle list the same way it
already splits skills, so bundles the user wrote appear under "Your plugins".

Tests: two added. One in the loader for the merge/reserved-name/re-claim rules
and origin attribution — each is a one-line invariant that a refactor could
reverse without any other test noticing. One in the server for the `GET
/plugins` origin contract and enable-state survival across
remove-and-reinstall, which is the behavior a user would notice breaking and
which no unit test can reach. Three UI fixtures gained the new required field;
none removed.

Verified locally: `cargo check --locked --all-targets` and `cargo clippy` on the
touched crates, the full `openwave-code-execution` suite, the server's plugin
tests, `cargo fmt`, and the UI's `tsc` + `pnpm test`. Not verified: driving the
running app.

Closes #1599
