### PR TITLE
feat(server): route web search through the model provider when configured

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -615,6 +615,30 @@ pub struct AgentConfig {
     /// Model for background maintenance calls this turn may make. `None` means
     /// the host has none, and that work is skipped.
     pub utility_model: Option<UtilityModel>,
+    /// How this turn reaches the web.
+    pub web_search: TurnWebSearch,
+}
+
+/// Which web search, if any, a turn is allowed to use.
+///
+/// One decision rather than two flags, because the two effects are inseparable:
+/// the vendor's tool and the host's carry the same name, so whichever one the
+/// turn gets, the other must not be advertised.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum TurnWebSearch {
+    /// The registry decides, as it always has: a registered `web_search` tool
+    /// is advertised and executed on this host. The default, and what every
+    /// turn did before the vendor route existed.
+    #[default]
+    Host,
+    /// The provider searches on its own infrastructure under this budget. The
+    /// host tool is withheld — the searches are already done by the time the
+    /// step's blocks arrive, and nothing dispatches them.
+    Vendor(crate::provider::VendorWebSearch),
+    /// No web search at all this turn: no vendor budget, and the host tool is
+    /// not advertised, so the model is not offered a capability the host has
+    /// turned off.
+    Off,
 }
 
 /// Default context window: 200k tokens (Claude Opus/Sonnet).
@@ -656,6 +680,7 @@ impl Default for AgentConfig {
             context_window: DEFAULT_CONTEXT_WINDOW,
             tool_scratch: None,
             utility_model: None,
+            web_search: TurnWebSearch::Host,
         }
     }
 }
@@ -1091,6 +1116,54 @@ fn call_action_preview(call: &PendingCall) -> Option<ToolActionPreview> {
     serde_json::from_str(&call.args)
         .ok()
         .and_then(|args| ToolActionPreview::build(&call.name, &args))
+}
+
+/// Project the rows of a provider-executed search result into activity entries.
+///
+/// The adapter normalizes its vendor output to the shape the host tool of the
+/// same name produces, so the card the reader sees is built from the same
+/// fields whichever route ran the search. Anything that does not carry that
+/// shape simply contributes no rows.
+fn provider_executed_entries(output: &Value) -> Vec<crate::ResultEntry> {
+    output
+        .get("results")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default()
+        .iter()
+        .map(|result| {
+            let entry = crate::ResultEntry::new(
+                crate::ResultEntryKind::Link,
+                result.get("title").and_then(Value::as_str).unwrap_or(""),
+            );
+            match result
+                .get("url")
+                .and_then(Value::as_str)
+                .and_then(result_host)
+            {
+                Some(host) => entry.with_detail(host),
+                None => entry,
+            }
+        })
+        .collect()
+}
+
+/// The bare host of a result URL, for the secondary line of its row.
+///
+/// Deliberately a display projection rather than a parse: nothing routes on the
+/// answer, and a URL this cannot read simply shows no host.
+fn result_host(url: &str) -> Option<String> {
+    let host = url
+        .split_once("://")?
+        .1
+        .split(['/', '?', '#'])
+        .next()?
+        .rsplit('@')
+        .next()?
+        .split(':')
+        .next()?
+        .trim_start_matches("www.");
+    (!host.is_empty()).then(|| host.to_owned())
 }
 
 struct AssistantCandidate {
@@ -1546,14 +1619,32 @@ impl Agent {
                         tools: if wrap_up {
                             Vec::new()
                         } else {
-                            self.tools.specs_for_surface(
+                            let mut specs = self.tools.specs_for_surface(
                                 self.agent_orchestration_active(),
                                 matches!(chat.permission_mode, Some(PermissionMode::Plan)),
-                            )
+                            );
+                            // The host tool and the provider's own search are
+                            // one capability with one name. Advertising both
+                            // would offer the model two `web_search` tools —
+                            // a request most providers reject outright — so
+                            // the registered one is withheld for exactly the
+                            // turns the host routed elsewhere or turned off.
+                            if self.config.web_search != TurnWebSearch::Host {
+                                specs.retain(|spec| spec.name != crate::WEB_SEARCH_TOOL);
+                            }
+                            specs
                         },
                         max_tokens: self.config.max_tokens,
                         temperature: self.config.temperature,
                         reasoning_effort: self.config.reasoning_effort,
+                        // The wrap-up call is the turn writing its answer from
+                        // what it already has. Leaving the vendor budget on it
+                        // would let the provider start fresh research inside
+                        // the step whose whole purpose is to stop.
+                        vendor_web_search: match self.config.web_search {
+                            TurnWebSearch::Vendor(vendor) if !wrap_up => Some(vendor),
+                            _ => None,
+                        },
                         images,
                         ..Default::default()
                     };
@@ -1782,7 +1873,7 @@ impl Agent {
             // it, and a stale segment must neither commit nor replay an effect a
             // later attempt now owns. Terminal completion is left to the worker's
             // own lease compare-and-swap, so only fence the tool-bearing path.
-            if !calls.is_empty() {
+            if !calls.is_empty() || !provider_executed.is_empty() {
                 self.ensure_durable_lease_current(turn_id).await?;
             }
 
@@ -1800,6 +1891,14 @@ impl Agent {
             // Searches the provider ran on its own infrastructure during this
             // step. They sit between the prose and the calls the loop is about
             // to make, which is where they happened. Nothing dispatches them.
+            //
+            // They are persisted here, before the step's own calls are
+            // admitted, so the journal and a rebuilt transcript both keep them
+            // in the order they occurred.
+            for block in &provider_executed {
+                self.record_provider_executed_call(chat.id, turn_id, block, events)
+                    .await?;
+            }
             blocks.extend(provider_executed);
             for call in &calls {
                 // The transcript block stays the coerced value: it goes back
@@ -2337,6 +2436,97 @@ impl Agent {
         self.tools
             .get(&call.name)
             .is_some_and(|tool| tool.approval_class() == ApprovalClass::ReadOnly)
+    }
+
+    /// Persist one call the provider already ran, and announce it.
+    ///
+    /// The work is finished before OpenWave sees it, so the row is written and
+    /// resolved back to back rather than admitted pending. Everything after
+    /// that is deliberately identical to a host tool call of the same name: the
+    /// journal carries the same started/completed pair, the activity card is
+    /// built by the same projection, and a later turn rebuilds it as an
+    /// ordinary `ToolUse`/`ToolResult` pair, because it is an ordinary row.
+    ///
+    /// A row that cannot be written is not a reason to fail the turn — the
+    /// search already happened and the model already has its results — so the
+    /// step continues without it.
+    async fn record_provider_executed_call(
+        &self,
+        chat_id: ChatId,
+        turn_id: TurnId,
+        block: &ContentBlock,
+        events: &EventSink<'_>,
+    ) -> Result<()> {
+        let ContentBlock::ProviderExecutedToolCall {
+            name,
+            input,
+            output,
+            is_error,
+        } = block
+        else {
+            return Ok(());
+        };
+        let call_id = CallId::new();
+        let result = output.to_string();
+        let tool_output = if *is_error {
+            ToolOutput::error(result.clone())
+        } else {
+            ToolOutput::text(result.clone()).with_entries(provider_executed_entries(output))
+        };
+        let preview = ToolResultPreview::build(name, &tool_output);
+        let record = ToolCallRecord {
+            id: call_id,
+            chat_id,
+            turn_id,
+            // No client loop ever answers this call, so the id only has to be
+            // unique and stable for the row it identifies.
+            provider_id: format!("provider_executed_{call_id}"),
+            name: name.clone(),
+            arguments: input.clone(),
+            raw_arguments: None,
+            execution: ToolCallExecution::Server,
+            status: ToolCallStatus::Pending,
+            result: None,
+            result_preview: None,
+            error_code: None,
+            error_detail: None,
+            client_executor_id: None,
+            client_lease_expires_at: None,
+            created_at: Utc::now(),
+            resolved_at: None,
+        };
+        events.send(AgentEvent::ToolCallStarted {
+            call_id,
+            name: name.clone(),
+        });
+        if !matches!(
+            self.accept_server_call_retry(&record).await?,
+            AcceptedServerCall::Accepted
+        ) {
+            return Ok(());
+        }
+        let resolution = if *is_error {
+            ToolCallResolution::Failed {
+                result,
+                error_code: output
+                    .get("error_code")
+                    .and_then(Value::as_str)
+                    .unwrap_or(ToolErrorCategory::ToolFailed.as_str())
+                    .to_owned(),
+                error_detail: None,
+            }
+        } else {
+            ToolCallResolution::Completed { result }
+        };
+        self.resolve_server_call_retry(chat_id, turn_id, call_id, &resolution, preview.as_ref())
+            .await?;
+        events.send(AgentEvent::ToolCallCompleted {
+            call_id,
+            output: tool_output,
+            action: ToolActionPreview::build(name, input),
+            result: preview,
+        });
+        Ok(())
     }
 
     /// Admit one server-executed call to the durable record before it runs, so
@@ -5052,6 +5242,7 @@ mod tests {
     use crate::id::{ChatId, ProjectId};
     use crate::model::Project;
     use crate::provider::ProviderId;
+    use crate::provider::VendorWebSearch;
     use crate::tools::{ListDir, ReadFile, WriteFile};
 
     fn tool_scratch(path: &std::path::Path) -> ToolScratch {
@@ -6588,6 +6779,178 @@ mod tests {
         let content = found.expect("the resumed transcript replays the result");
         assert!(content.len() < oversized.len());
         assert!(content.contains("[truncated:"));
+    }
+
+    /// The host's own `web_search`. Registered so the turn has one to withhold,
+    /// and never expected to run.
+    struct HostWebSearch;
+
+    #[async_trait]
+    impl Tool for HostWebSearch {
+        fn spec(&self) -> ToolSpec {
+            crate::web_search_tool_spec()
+        }
+        fn approval_class(&self) -> ApprovalClass {
+            ApprovalClass::Sensitive
+        }
+        async fn execute(&self, _ctx: &ToolCtx, _args: Value) -> Result<ToolOutput> {
+            panic!("a search the provider already ran must never be dispatched")
+        }
+    }
+
+    /// What one request advertised, and the vendor budget it carried.
+    type SearchSurfaces = Arc<Mutex<Vec<(Vec<String>, Option<VendorWebSearch>)>>>;
+
+    /// Answers with a search it already ran, recording what each request
+    /// advertised and asked for.
+    struct VendorSearchProvider {
+        seen: SearchSurfaces,
+    }
+
+    #[async_trait]
+    impl ModelProvider for VendorSearchProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("fake")
+        }
+
+        async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            self.seen.lock().unwrap().push((
+                req.tools.iter().map(|tool| tool.name.clone()).collect(),
+                req.vendor_web_search,
+            ));
+            Ok(stream::iter(vec![
+                ProviderEvent::ProviderExecutedToolCall {
+                    name: crate::WEB_SEARCH_TOOL.into(),
+                    input: serde_json::json!({ "query": "openwave release notes" }),
+                    output: serde_json::json!({
+                        "provider": "anthropic",
+                        "results": [{
+                            "url": "https://www.example.com/notes",
+                            "title": "Release notes",
+                            "snippet": "what shipped",
+                        }],
+                    }),
+                    is_error: false,
+                },
+                ProviderEvent::TextDelta {
+                    text: "here is what I found".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                },
+            ])
+            .boxed())
+        }
+    }
+
+    /// A vendor turn end to end: the model is offered one web search rather
+    /// than two, the search the provider ran is kept like any other tool call,
+    /// and a later turn replays it as an ordinary pair.
+    #[tokio::test]
+    async fn a_provider_executed_search_replaces_the_host_tool_and_is_kept_like_one() {
+        let db = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                db.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            reasoning_effort: None,
+            permission_mode: None,
+            network_policy: Default::default(),
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let budget = VendorWebSearch { max_uses: 3 };
+        let agent = Agent::new(
+            Arc::new(VendorSearchProvider { seen: seen.clone() }),
+            Arc::new(
+                ToolRegistry::new()
+                    .with(Box::new(HostWebSearch))
+                    .with(Box::new(ReadFile)),
+            ),
+            store.clone(),
+            AgentConfig {
+                model: "fake".into(),
+                web_search: TurnWebSearch::Vendor(budget),
+                ..Default::default()
+            },
+        );
+
+        let (tx, rx) = unbounded();
+        agent.run_turn(&chat, "what shipped?", &tx).await.unwrap();
+        drop(tx);
+        let events: Vec<AgentEvent> = rx.collect().await;
+
+        // One capability, one name: the request carries the vendor budget and
+        // withholds the host tool, while the rest of the surface is untouched.
+        let requests = seen.lock().unwrap().clone();
+        let (advertised, vendor) = requests.first().expect("the turn made a model call");
+        assert_eq!(*vendor, Some(budget));
+        assert!(
+            !advertised.contains(&crate::WEB_SEARCH_TOOL.to_owned())
+                && advertised.contains(&"read_file".to_owned()),
+            "advertised the wrong surface: {advertised:?}"
+        );
+
+        // The reader sees the search happen and finish, exactly as they would
+        // a host search.
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentEvent::ToolCallStarted { name, .. } if name == crate::WEB_SEARCH_TOOL
+        )));
+        assert!(events
+            .iter()
+            .any(|event| matches!(event, AgentEvent::ToolCallCompleted { .. })));
+
+        let calls = store.list_tool_calls(chat.id).await.unwrap();
+        let [call] = &calls[..] else {
+            panic!("the provider's search was not recorded: {calls:?}");
+        };
+        assert_eq!(call.name, crate::WEB_SEARCH_TOOL);
+        assert_eq!(call.status, ToolCallStatus::Completed);
+        assert_eq!(call.arguments["query"], "openwave release notes");
+        assert!(call
+            .result
+            .as_deref()
+            .is_some_and(|result| result.contains("https://www.example.com/notes")));
+
+        // The record is the whole replay mechanism: a later turn rebuilds it
+        // as a tool pair with no knowledge of who ran it.
+        let messages = store.list_messages(chat.id).await.unwrap();
+        let rebuilt = rebuild_transcript(&messages, &calls, &[], DEFAULT_MAX_TOOL_RESULT_BYTES);
+        let blocks: Vec<&ContentBlock> = rebuilt
+            .iter()
+            .flat_map(|message| message.content.iter())
+            .collect();
+        let use_id = blocks
+            .iter()
+            .find_map(|block| match block {
+                ContentBlock::ToolUse { id, name, .. } if name == crate::WEB_SEARCH_TOOL => {
+                    Some(id.clone())
+                }
+                _ => None,
+            })
+            .expect("the rebuilt transcript replays the search as a tool call");
+        assert!(
+            blocks.iter().any(|block| matches!(
+                block,
+                ContentBlock::ToolResult { tool_use_id, content, .. }
+                    if *tool_use_id == use_id && content.contains("Release notes")
+            )),
+            "the replayed call kept no result: {rebuilt:?}"
+        );
     }
 
     #[test]

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -75,7 +75,7 @@ pub mod user_questions;
 
 pub use agent::{
     Agent, AgentConfig, AgentTurnOutcome, ClaimedAgentEvent, ForegroundAgentWaitRequest,
-    SandboxAgentSpawnRequest, ToolRegistry, UtilityModel,
+    SandboxAgentSpawnRequest, ToolRegistry, TurnWebSearch, UtilityModel,
 };
 pub use agent_tools::{
     sandbox_done_tool_spec, sandbox_exec_tool_spec, sandbox_read_delegated_file_tool_spec,

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -2321,7 +2321,13 @@ export type VerificationTier = "verified" | "unverified";
  * selection, credential presence, and the configured instance URL — key
  * material never crosses the secret boundary.
  */
-export type WebSearchConfigInfo = { provider?: WebSearchProviderKind, timeout_ms: number, 
+export type WebSearchConfigInfo = { provider?: WebSearchProviderKind, 
+/**
+ * Which search a turn gets. Orthogonal to the fields below, which report
+ * only the host provider's readiness: a vendor turn is unaffected by all
+ * of them.
+ */
+mode: WebSearchMode, timeout_ms: number, 
 /**
  * Whether a key is stored for the selected provider. Always false for a
  * credential-free provider, which has no key slot at all — read
@@ -2345,6 +2351,18 @@ searxng_base_url?: string, };
  * deliberately carries no secret material.
  */
 export type WebSearchCredentialReadiness = { provider: WebSearchProviderKind, has_credential: boolean, };
+
+/**
+ * Which search a turn should use, as the operator chose it.
+ *
+ * The choice is about *who runs the search*, not about which engine: a vendor
+ * search runs inside the model provider's own infrastructure and never touches
+ * this host's providers, credentials, or egress policy. `Automatic` is the
+ * default and the value every configuration written before this existed reads
+ * back as, so an installation that had web search working keeps exactly the
+ * search it had.
+ */
+export type WebSearchMode = "automatic" | "vendor" | "host" | "off";
 
 /**
  * A configured web-search backend. The stable string also selects its secret

--- a/crates/openwave-desktop/ui/src/settings/WebSearchPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/WebSearchPanel.dom.test.tsx
@@ -56,6 +56,7 @@ describe("WebSearchPanel", () => {
       has_credential: false,
       available: false,
       timeout_ms: 20_000,
+      mode: "automatic",
     });
 
     render(<WebSearchPanel client={client} />);
@@ -96,6 +97,7 @@ describe("WebSearchPanel", () => {
         has_credential: true,
         available: true,
         timeout_ms: 20_000,
+        mode: "automatic",
       },
       [
         { provider: "exa", has_credential: true },
@@ -124,6 +126,7 @@ describe("WebSearchPanel", () => {
       has_credential: false,
       available: false,
       timeout_ms: 20_000,
+      mode: "automatic",
     });
 
     render(<WebSearchPanel client={client} />);
@@ -150,6 +153,7 @@ describe("WebSearchPanel", () => {
       has_credential: true,
       available: true,
       timeout_ms: 20_000,
+      mode: "automatic",
     });
 
     render(<WebSearchPanel client={client} />);

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -492,6 +492,10 @@ pub struct ResolvedModelPolicy {
     pub input_modalities: Vec<InputModality>,
     /// Whether the provider request uses a reasoning-model shape.
     pub supports_reasoning: bool,
+    /// Whether a turn on this model may run the provider's own server-side web
+    /// search instead of the host's. Asserts that the routing adapter emits the
+    /// vendor tool, so it is never inherited by a pass-through route.
+    pub supports_vendor_web_search: bool,
     /// The reasoning-effort levels this model accepts, ascending. Empty when
     /// the model takes no effort control.
     pub reasoning_efforts: Vec<ReasoningEffort>,
@@ -510,6 +514,7 @@ impl ResolvedModelPolicy {
             max_output_tokens: spec.max_output_tokens,
             input_modalities: spec.input_modalities.to_vec(),
             supports_reasoning: spec.supports_reasoning,
+            supports_vendor_web_search: spec.supports_vendor_web_search,
             reasoning_efforts: spec.reasoning_efforts.to_vec(),
         }
     }
@@ -568,6 +573,11 @@ impl ResolvedModelPolicy {
             // Unknown endpoints get deliberately conservative request shaping.
             // Capability editing can be added later without changing the key.
             supports_reasoning: false,
+            // A pass-through endpoint cannot promise a provider-executed
+            // search, whatever upstream model it is serving — the request
+            // shape that would enable one is the vendor's own, and this route
+            // does not speak it. Deliberately not inherited by `gateway_for`.
+            supports_vendor_web_search: false,
             reasoning_efforts: Vec::new(),
         }
     }

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -153,6 +153,7 @@ pub(crate) fn freeze_foreground_turn_surface(
         None,
         false,
         &[],
+        openwave_core::TurnWebSearch::Host,
     )
 }
 
@@ -169,10 +170,21 @@ fn freeze_foreground_turn_surface_with_folders(
     office_rendering: Option<bool>,
     plan_mode: bool,
     invoked_skills: &[String],
+    web_search: openwave_core::TurnWebSearch,
 ) -> ForegroundTurnSurface {
     let mut agent_config = base_agent_config.clone();
+    // The prompt describes the capabilities the turn actually has. A vendor
+    // turn still has `web_search` — the provider runs it, but the model names
+    // and uses it the same way — so only the turn that has no search at all
+    // drops the section, and a turn that keeps it keeps the guidance that has
+    // always come with it.
+    let mut specs = tools.specs_for_surface(true, plan_mode);
+    if web_search == openwave_core::TurnWebSearch::Off {
+        specs.retain(|spec| spec.name != openwave_core::WEB_SEARCH_TOOL);
+    }
+    agent_config.web_search = web_search;
     agent_config.system_prompt = Some(crate::foreground_prompt::compose_for_surface(
-        &tools.specs_for_surface(true, plan_mode),
+        &specs,
         exec_folders,
         skills,
         plugins,
@@ -629,29 +641,6 @@ impl TurnWorker {
             Some(provider) => provider.current_timeout_ms().await,
             None => crate::code_execution::DEFAULT_TIMEOUT_MS,
         };
-        let surface = freeze_foreground_turn_surface_with_folders(
-            tools,
-            &self.agent_config,
-            &exec_folders,
-            &skills,
-            &plugins,
-            &chat.network_policy,
-            exec_timeout_ms,
-            offline_package_cache,
-            office_rendering,
-            matches!(
-                chat.permission_mode,
-                Some(openwave_core::PermissionMode::Plan)
-            ),
-            &turn.invoked_skills,
-        );
-        if let Some(prompt) = surface.agent_config.system_prompt.as_deref() {
-            eprintln!(
-                "openwave: turn {} operating_prompt={}",
-                turn.id,
-                crate::foreground_prompt::identity(prompt)
-            );
-        }
         let model_policy = if self.resolver.enforces_model_registry() {
             crate::providers::resolve_model_policy(&*self.store, &turn.model, true).await?
         } else {
@@ -668,6 +657,43 @@ impl TurnWorker {
                     "the turn's model is no longer registered for its provider",
                 )
                 .await;
+        }
+        // Resolved per turn, alongside the model: which search this turn gets
+        // depends on both host policy and the model that is about to run, and
+        // both can change between turns of one chat. A model the registry does
+        // not own claims no vendor search. It is resolved before the surface is
+        // frozen because the surface's prompt has to describe it.
+        let web_search = crate::web_search::resolve_turn_web_search(
+            &*self.store,
+            &*self.secrets,
+            model_policy
+                .as_ref()
+                .is_some_and(|policy| policy.supports_vendor_web_search),
+        )
+        .await?;
+        let surface = freeze_foreground_turn_surface_with_folders(
+            tools,
+            &self.agent_config,
+            &exec_folders,
+            &skills,
+            &plugins,
+            &chat.network_policy,
+            exec_timeout_ms,
+            offline_package_cache,
+            office_rendering,
+            matches!(
+                chat.permission_mode,
+                Some(openwave_core::PermissionMode::Plan)
+            ),
+            &turn.invoked_skills,
+            web_search,
+        );
+        if let Some(prompt) = surface.agent_config.system_prompt.as_deref() {
+            eprintln!(
+                "openwave: turn {} operating_prompt={}",
+                turn.id,
+                crate::foreground_prompt::identity(prompt)
+            );
         }
         // Resolved per turn, not at boot, so enabling a provider takes effect on
         // the next turn. `None` is not a failure: background maintenance is

--- a/crates/openwave-server/src/web_search.rs
+++ b/crates/openwave-server/src/web_search.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use openwave_core::{
     ApprovalClass, ChatId, DocumentId, DocumentUpsert, NetworkPolicy, Result, SecretProvider,
-    Store, Tool, ToolCtx, ToolOutput, ToolSpec,
+    Store, Tool, ToolCtx, ToolOutput, ToolSpec, TurnWebSearch, VendorWebSearch,
 };
 use openwave_web_search::{
     BraveProvider, ExaProvider, ExtractedPageSink, ExtractedPageSinkError, NativeExtractor,
@@ -91,12 +91,44 @@ const CREDENTIAL_PROVIDERS: [WebSearchProviderKind; 3] = [
     WebSearchProviderKind::Brave,
 ];
 
+/// Which search a turn should use, as the operator chose it.
+///
+/// The choice is about *who runs the search*, not about which engine: a vendor
+/// search runs inside the model provider's own infrastructure and never touches
+/// this host's providers, credentials, or egress policy. `Automatic` is the
+/// default and the value every configuration written before this existed reads
+/// back as, so an installation that had web search working keeps exactly the
+/// search it had.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
+#[serde(rename_all = "snake_case")]
+pub enum WebSearchMode {
+    /// Prefer a configured, usable host provider; fall back to the model's own
+    /// search when the model has one and the host has nothing to run.
+    #[default]
+    Automatic,
+    /// The model's own search, or none. Deliberately no host fallback: an
+    /// operator who chose the vendor route did so to keep queries off this
+    /// host's providers, and quietly reinstating one would defeat the choice.
+    Vendor,
+    /// The host's configured provider only, exactly as before this setting
+    /// existed.
+    Host,
+    /// No web search at all. The tool is not advertised, so the model is not
+    /// offered a capability the operator turned off.
+    Off,
+}
+
 /// Non-secret host configuration. `provider: None` is the safe default: no
 /// credential lookup and no possible outbound request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WebSearchConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider: Option<WebSearchProviderKind>,
+    /// Which search a turn gets. Independent of `provider`: the host provider
+    /// stays configured while the vendor route is selected, so switching back
+    /// does not ask for the key again.
+    #[serde(default)]
+    pub mode: WebSearchMode,
     #[serde(default = "default_timeout_ms")]
     pub timeout_ms: u64,
     /// Base URL of the operator's self-hosted SearXNG instance.
@@ -115,6 +147,7 @@ impl Default for WebSearchConfig {
     fn default() -> Self {
         Self {
             provider: None,
+            mode: WebSearchMode::Automatic,
             timeout_ms: DEFAULT_TIMEOUT_MS,
             searxng_base_url: None,
         }
@@ -164,6 +197,10 @@ pub struct WebSearchConfigInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub provider: Option<WebSearchProviderKind>,
+    /// Which search a turn gets. Orthogonal to the fields below, which report
+    /// only the host provider's readiness: a vendor turn is unaffected by all
+    /// of them.
+    pub mode: WebSearchMode,
     pub timeout_ms: u64,
     /// Whether a key is stored for the selected provider. Always false for a
     /// credential-free provider, which has no key slot at all — read
@@ -200,6 +237,9 @@ pub struct WebSearchCredentialsInfo {
 pub struct WebSearchConfigUpdate {
     #[serde(default, deserialize_with = "double_option")]
     pub provider: Option<Option<WebSearchProviderKind>>,
+    /// An omitted mode leaves the current choice unchanged.
+    #[serde(default)]
+    pub mode: Option<WebSearchMode>,
     #[serde(default)]
     pub timeout_ms: Option<u64>,
     /// An omitted value leaves the instance URL unchanged; an explicit `null`
@@ -244,27 +284,81 @@ pub async fn config_info(
     secrets: &dyn SecretProvider,
 ) -> Result<WebSearchConfigInfo> {
     let config = read_config(store).await?;
-    let has_credential = match config.provider {
-        Some(provider) => matches!(
-            WebSearchCredentials::resolve(secrets, provider).await,
-            Ok(WebSearchCredentialState::Present(_))
-        ),
-        None => false,
-    };
-    let available = match config.provider {
-        // Nothing to authenticate with; the instance URL is what it needs.
-        Some(WebSearchProviderKind::Searxng) => config.searxng_base_url().is_some(),
-        Some(_) => has_credential,
-        None => false,
-    };
+    let has_credential = host_has_credential(&config, secrets).await;
+    let available = host_is_available(&config, has_credential);
     Ok(WebSearchConfigInfo {
         provider: config.provider,
+        mode: config.mode,
         timeout_ms: config.timeout_ms,
         has_credential,
         available,
         searxng_base_url: config
             .searxng_base_url()
             .map(|base| base.as_str().to_owned()),
+    })
+}
+
+/// Whether a key is stored for the selected provider, without returning it.
+async fn host_has_credential(config: &WebSearchConfig, secrets: &dyn SecretProvider) -> bool {
+    match config.provider {
+        Some(provider) => matches!(
+            WebSearchCredentials::resolve(secrets, provider).await,
+            Ok(WebSearchCredentialState::Present(_))
+        ),
+        None => false,
+    }
+}
+
+/// Whether the selected host provider has everything it needs to be invoked.
+fn host_is_available(config: &WebSearchConfig, has_credential: bool) -> bool {
+    match config.provider {
+        // Nothing to authenticate with; the instance URL is what it needs.
+        Some(WebSearchProviderKind::Searxng) => config.searxng_base_url().is_some(),
+        Some(_) => has_credential,
+        None => false,
+    }
+}
+
+/// Decide which search one turn gets, from host policy and the model's own
+/// capabilities.
+///
+/// `supports_vendor` is the resolved model row's claim that the routing adapter
+/// emits a provider-executed search for it — not that the vendor documents one
+/// — so a model reached over a pass-through route resolves as if it had none.
+///
+/// Nothing here consults the chat's permission mode. A vendor search is
+/// provider-internal: it makes no egress from this host, reaches no new party
+/// with the conversation's data, and is already finished by the time OpenWave
+/// sees it, so there is no decision an approval card could still gate.
+pub async fn resolve_turn_web_search(
+    store: &dyn Store,
+    secrets: &dyn SecretProvider,
+    supports_vendor: bool,
+) -> Result<TurnWebSearch> {
+    let config = read_config(store).await?;
+    let vendor = || {
+        TurnWebSearch::Vendor(VendorWebSearch {
+            max_uses: VendorWebSearch::DEFAULT_MAX_USES,
+        })
+    };
+    Ok(match config.mode {
+        WebSearchMode::Off => TurnWebSearch::Off,
+        // The host tool as registered: available or not, the model is offered
+        // it and an unconfigured host answers the call with the same
+        // configuration error it always has.
+        WebSearchMode::Host => TurnWebSearch::Host,
+        WebSearchMode::Vendor if supports_vendor => vendor(),
+        WebSearchMode::Vendor => TurnWebSearch::Off,
+        WebSearchMode::Automatic => {
+            let has_credential = host_has_credential(&config, secrets).await;
+            if host_is_available(&config, has_credential) {
+                TurnWebSearch::Host
+            } else if supports_vendor {
+                vendor()
+            } else {
+                TurnWebSearch::Host
+            }
+        }
     })
 }
 
@@ -359,6 +453,9 @@ pub async fn update_config(
     let mut config = read_config(store).await?;
     if let Some(provider) = update.provider {
         config.provider = provider;
+    }
+    if let Some(mode) = update.mode {
+        config.mode = mode;
     }
     if let Some(timeout_ms) = update.timeout_ms {
         config.timeout_ms = timeout_ms;
@@ -766,6 +863,7 @@ mod tests {
             &secrets,
             WebSearchConfigUpdate {
                 provider: Some(Some(WebSearchProviderKind::Exa)),
+                mode: None,
                 timeout_ms: Some(MIN_TIMEOUT_MS),
                 searxng_base_url: None,
             },
@@ -791,6 +889,7 @@ mod tests {
         let secrets = TestSecrets::default();
         let select = |base: Option<Option<String>>| WebSearchConfigUpdate {
             provider: Some(Some(WebSearchProviderKind::Searxng)),
+            mode: None,
             timeout_ms: None,
             searxng_base_url: base,
         };
@@ -864,6 +963,78 @@ mod tests {
         assert!(!info.has_credential);
         assert!(!info.available);
         assert!(matches!(resolve_provider(&store, &secrets).await, Ok(None)));
+    }
+
+    /// The whole point of the mode: which search a turn gets, decided from
+    /// host policy and the model in front of it.
+    #[tokio::test]
+    async fn turn_resolution_prefers_a_usable_host_and_falls_back_to_the_vendor() {
+        let (store, _dir) = test_store().await;
+        let secrets = TestSecrets::default();
+        let resolve = |supports_vendor| resolve_turn_web_search(&store, &secrets, supports_vendor);
+        let vendor = TurnWebSearch::Vendor(VendorWebSearch {
+            max_uses: VendorWebSearch::DEFAULT_MAX_USES,
+        });
+
+        // Nothing configured. A capable model searches on its provider; one
+        // with no vendor search — a gateway-served row, say — is left exactly
+        // where it was, holding a host tool that will report it needs setting
+        // up when it is called.
+        assert_eq!(resolve(true).await.unwrap(), vendor);
+        assert_eq!(resolve(false).await.unwrap(), TurnWebSearch::Host);
+
+        // A selected provider is not yet a usable one: without its key there
+        // is still nothing on this host to run the search.
+        let select_exa = |mode| WebSearchConfigUpdate {
+            provider: Some(Some(WebSearchProviderKind::Exa)),
+            mode: Some(mode),
+            timeout_ms: None,
+            searxng_base_url: None,
+        };
+        update_config(&store, &secrets, select_exa(WebSearchMode::Automatic))
+            .await
+            .unwrap();
+        assert_eq!(resolve(true).await.unwrap(), vendor);
+
+        // With the key in place the host provider wins: the operator chose it,
+        // and automatic means prefer what is actually configured here.
+        write_credential(&secrets, WebSearchProviderKind::Exa, "key")
+            .await
+            .unwrap();
+        assert_eq!(resolve(true).await.unwrap(), TurnWebSearch::Host);
+
+        // The explicit modes override the preference in both directions, and
+        // the vendor choice never silently falls back to the host provider it
+        // was chosen instead of.
+        update_config(&store, &secrets, select_exa(WebSearchMode::Vendor))
+            .await
+            .unwrap();
+        assert_eq!(resolve(true).await.unwrap(), vendor);
+        assert_eq!(resolve(false).await.unwrap(), TurnWebSearch::Off);
+
+        update_config(&store, &secrets, select_exa(WebSearchMode::Off))
+            .await
+            .unwrap();
+        assert_eq!(resolve(true).await.unwrap(), TurnWebSearch::Off);
+    }
+
+    /// A configuration written before the mode existed keeps the behavior it
+    /// had, rather than reading back as whichever variant sorts first.
+    #[tokio::test]
+    async fn a_stored_configuration_without_a_mode_reads_back_as_automatic() {
+        let (store, _dir) = test_store().await;
+        store
+            .set_setting(
+                WEB_SEARCH_SETTING,
+                &serde_json::json!({ "provider": "tavily", "timeout_ms": DEFAULT_TIMEOUT_MS }),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            read_config(&store).await.unwrap().mode,
+            WebSearchMode::Automatic
+        );
     }
 
     /// Persisted policy may be hand-edited or left by an interrupted build.


### PR DESCRIPTION
Slice 3 of vendor web search: the server decides which search a turn gets,
turns the vendor one on, and keeps what it finds.

Stacked on `thet/vendor-search-2-anthropic` (#1659), which carries the
Anthropic adapter. Retarget to `main` once that lands.

## Mode

`WebSearchConfig` gains `mode`: `automatic` (the default, and what every
stored configuration reads back as), `vendor`, `host`, `off`. It is
orthogonal to `provider` — selecting the vendor route leaves the host
provider and its key in place, so switching back does not ask for the key
again. `resolve_turn_web_search` in `web_search.rs` is the whole rule:

- automatic: a configured **and usable** host provider wins; otherwise the
  model's own search if its registry row has one; otherwise nothing
  changes from today (the host tool is advertised and answers with its
  usual configuration error when called).
- vendor: the model's search, or no search. No silent host fallback —
  reinstating one would defeat the reason to pick the vendor route.
- host: today's behavior, always.
- off: no search, and no tool advertised for one.

The model's side of it comes from `ResolvedModelPolicy.supports_vendor_web_search`,
carried over from the curated row. A gateway-served model does not inherit
it even when it matches a curated id: the flag asserts that the routing
adapter emits the vendor tool, and a pass-through route cannot promise
that.

## Per-turn wiring

The mode is resolved per turn, next to the model, and before the
foreground surface is frozen — the frozen surface owns both the prompt and
the request shaping, so it needs the answer. `AgentConfig.web_search`
carries the decision into the agent loop, which:

- sets `ChatRequest.vendor_web_search` for a vendor turn (not on the
  wrap-up call, which exists to write an answer from what the turn already
  has rather than to start fresh research), and
- withholds the registered `web_search` tool from the request. The vendor
  tool and the host tool are one capability under one name; advertising
  both would send two tools called `web_search`.

The prompt's `web_search` guidance still applies to a vendor turn — the
model names and uses the tool exactly as before, it just runs on the
provider's side — so only an `off` turn drops the section along with the
tool.

Nothing here is gated on `PermissionMode`, and that is deliberate: a
vendor search makes no egress from this host, reaches no party the
conversation was not already routed through, and is already finished by
the time OpenWave sees it, so there is no decision left for an approval
card to gate. The visible asymmetry is that a chat in Ask mode searches
without the approval card a host search would raise.

## Persistence and replay

A `ProviderExecutedToolCall` block is written as an ordinary completed
`ToolCallRecord` named `web_search`, with the block's input as arguments
and its output as the result, at the point the step persists its own tool
rows and before them. It emits the same started/completed events, is
projected into the same activity card, and rebuilds through the existing
batch path as a plain `ToolUse`/`ToolResult` pair — a later turn replaying
it cannot tell who ran it, which is what makes cross-provider replay work.
A row that cannot be written does not fail the turn: the search already
happened and the model already has the results.

## Tests

- `web_search.rs`: mode resolution across the four modes and both model
  kinds, and that a stored configuration with no `mode` reads back as
  automatic rather than as whichever variant sorts first.
- `agent.rs`: one turn end to end — the request carries the budget and
  omits the host tool, the reader sees the search start and finish, the
  record lands completed, and the rebuilt transcript replays it as a tool
  pair.

## Not verified

Only the fake-provider path is exercised locally; the vendor request has
not been driven against a live Anthropic route from this branch.
