### PR TITLE
feat(server): carry turn usage and truncation counts to the renderer

### DIFF
--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -825,6 +825,7 @@ where
             _ => continue,
         };
         let invoked_skills = super::turn::invoked_skills_from_model(&turn)?;
+        let usage = super::turn::usage_from_turn_model(&turn)?;
         index_of.insert(turn.id, snapshots.len());
         snapshots.push(ChatTerminalTurnSnapshot {
             turn_id: TurnId(turn.id),
@@ -836,6 +837,7 @@ where
             failure_kind: turn.last_error_code,
             model: turn.model,
             invoked_skills,
+            usage,
             finished_at,
         });
     }

--- a/crates/openwave-core/src/db/ops/turn/resolution/cancellation.rs
+++ b/crates/openwave-core/src/db/ops/turn/resolution/cancellation.rs
@@ -537,6 +537,31 @@ async fn finish_turn_cancellation_inner(
             sea_orm::sea_query::Expr::value(Some(message_id)),
         );
     }
+    // A cancelled turn spent tokens before it stopped, and until now they
+    // reached the journal without ever reaching the row. That left the turn's
+    // durable accounting reading zero for a stopped turn, so anything rebuilt
+    // from storage — the transcript's context usage among them — understated
+    // it. `validate_terminal_usage` above has already established that this
+    // total covers the row's checkpoint, so the write stays monotonic.
+    if let Some(AgentEvent::TurnCancelled { usage }) = terminal_event {
+        cancelled = cancelled
+            .col_expr(
+                entities::turn_run::Column::InputTokens,
+                sea_orm::sea_query::Expr::value(i64::from(usage.input_tokens)),
+            )
+            .col_expr(
+                entities::turn_run::Column::OutputTokens,
+                sea_orm::sea_query::Expr::value(i64::from(usage.output_tokens)),
+            )
+            .col_expr(
+                entities::turn_run::Column::CacheReadInputTokens,
+                sea_orm::sea_query::Expr::value(i64::from(usage.cache_read_input_tokens)),
+            )
+            .col_expr(
+                entities::turn_run::Column::CacheCreationInputTokens,
+                sea_orm::sea_query::Expr::value(i64::from(usage.cache_creation_input_tokens)),
+            );
+    }
     let cancelled = cancelled
         .filter(entities::turn_run::Column::Id.eq(id.0))
         .filter(entities::turn_run::Column::Status.eq(TurnRunStatus::Cancelling.as_str()))

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -6169,6 +6169,7 @@ async fn running_turn_cancellation_holds_the_chat_until_exact_worker_acknowledge
             failure_kind: None,
             model: "gpt-5".into(),
             invoked_skills: Vec::new(),
+            usage,
             finished_at: acknowledged_at,
         }]
     );

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -120,6 +120,10 @@ pub struct ChatTerminalTurnSnapshot {
     /// Skills the user explicitly invoked when the turn was accepted, in
     /// submitted order. Empty for a turn that named none.
     pub invoked_skills: Vec<String>,
+    /// Token accounting recorded when the turn resolved. Lets a client that
+    /// opened the chat after the fact show context usage without waiting for
+    /// another turn to run.
+    pub usage: crate::provider::Usage,
     pub finished_at: chrono::DateTime<chrono::Utc>,
 }
 

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
@@ -13,6 +13,20 @@ import { TURN_CANCELLED_NOTICE } from "./MessageList";
 
 const NOW = "2026-07-23T12:00:00.000Z";
 
+/** Token counts for a fixture whose subject is not the counts themselves. */
+const NO_USAGE = {
+  input_tokens: 0,
+  output_tokens: 0,
+  cache_read_input_tokens: 0,
+  cache_creation_input_tokens: 0,
+};
+
+const TRUNCATED = {
+  type: "context_truncated",
+  original_tokens: 128_000,
+  fitted_tokens: 96_000,
+} as const;
+
 function makeDeps(): ChatSessionDeps {
   let seq = 0;
   return {
@@ -183,7 +197,7 @@ describe("text_delta", () => {
     const mid = play([TURN, { type: "text_delta", text: "Answer :cit[the" }]);
     const done = reduceChatSessionEvent(
       mid.state,
-      framed(mid.state.lastSeq + 1, { type: "turn_completed" }),
+      framed(mid.state.lastSeq + 1, { type: "turn_completed", usage: NO_USAGE }),
       makeDeps(),
     );
     const last = done.state.messages[done.state.messages.length - 1];
@@ -481,7 +495,7 @@ describe("user_steered", () => {
 
 describe("terminal events", () => {
   it("turn_completed resolves the turn and requests hydration", () => {
-    const { state, effects } = play([TURN, { type: "turn_completed" }]);
+    const { state, effects } = play([TURN, { type: "turn_completed", usage: NO_USAGE }]);
     expect(state.busy).toBe(false);
     expect(state.activeTurnId).toBeNull();
     expect(effects).toEqual([
@@ -498,6 +512,7 @@ describe("terminal events", () => {
       {
         type: "turn_refused",
         refusal: { category: "cyber", partial_output: false },
+        usage: NO_USAGE,
       },
     ]);
 
@@ -528,6 +543,7 @@ describe("terminal events", () => {
       {
         type: "turn_refused",
         refusal: { category: "general_harms", partial_output: true },
+        usage: NO_USAGE,
       },
     ]);
 
@@ -562,7 +578,7 @@ describe("terminal events", () => {
         approval: "search_may_share_query_and_excerpts",
         class: "sensitive",
       },
-      { type: "turn_cancelled" },
+      { type: "turn_cancelled", usage: NO_USAGE },
     ]);
     expect(state.busy).toBe(false);
     expect(state.messages.find((m) => m.role === "tool")).toMatchObject({
@@ -727,9 +743,9 @@ describe("context truncation notice", () => {
   it("inserts one notice above the streaming bubble and keeps the answer whole", () => {
     const { state } = play([
       TURN,
-      { type: "context_truncated" },
+      TRUNCATED,
       { type: "text_delta", text: "the answer" },
-      { type: "context_truncated" },
+      TRUNCATED,
       { type: "text_delta", text: " continues" },
     ]);
     const notices = state.messages.filter(
@@ -744,11 +760,11 @@ describe("context truncation notice", () => {
   });
 
   it("resets the once-per-turn dedup at the next turn", () => {
-    const first = play([TURN, { type: "context_truncated" }]);
+    const first = play([TURN, TRUNCATED]);
     const second = play(
       [
         { type: "turn_started", turn_id: "turn-2" },
-        { type: "context_truncated" },
+        TRUNCATED,
       ],
       first.state,
     );

--- a/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
@@ -6,6 +6,14 @@ import {
 } from "./ChatTranscriptPresentation";
 import { refusalCopy, TURN_CANCELLED_NOTICE } from "./MessageList";
 
+/** Token counts for a fixture whose subject is not the counts themselves. */
+const NO_USAGE = {
+  input_tokens: 0,
+  output_tokens: 0,
+  cache_read_input_tokens: 0,
+  cache_creation_input_tokens: 0,
+};
+
 const transcript: ChatTranscript = {
   messages: [
     {
@@ -359,6 +367,7 @@ describe("terminal transcript presentation", () => {
           partial_content: "",
           refusal: { category: "cyber", partial_output: false },
           file_changes: [],
+          usage: NO_USAGE,
           finished_at: "2026-07-19T10:00:00Z",
         },
         {
@@ -368,6 +377,7 @@ describe("terminal transcript presentation", () => {
           partial_content: "",
           refusal: { category: "general_harms", partial_output: true },
           file_changes: [],
+          usage: NO_USAGE,
           finished_at: "2026-07-19T10:01:00Z",
         },
       ],
@@ -433,6 +443,7 @@ describe("terminal transcript presentation", () => {
           partial_content: "Partial answer",
           reasoning: "Considering the first approach",
           file_changes: [],
+          usage: NO_USAGE,
           finished_at: "2026-07-19T10:01:00Z",
         },
         {
@@ -443,6 +454,7 @@ describe("terminal transcript presentation", () => {
           failure_category: "transient",
           failure_model: { id: "gpt-5.6-sol", provider: "openai" },
           file_changes: [],
+          usage: NO_USAGE,
           finished_at: "2026-07-19T10:02:00Z",
         },
       ],
@@ -507,6 +519,7 @@ describe("terminal transcript presentation", () => {
           partial_content: "",
           reasoning: "Considering the first approach",
           file_changes: [],
+          usage: NO_USAGE,
           finished_at: "2026-07-19T10:01:00Z",
         },
       ],

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -481,7 +481,12 @@ export type ChatTerminalTurnSnapshot = { turn_id: TurnId, message_id?: MessageId
  * Skills the user explicitly invoked for this turn, in submitted order.
  * Absent for the ordinary turn that invoked none.
  */
-invoked_skills?: Array<string>, finished_at: string, };
+invoked_skills?: Array<string>, 
+/**
+ * Token accounting for the turn, so a freshly opened chat can show
+ * context usage without waiting for the next turn to finish.
+ */
+usage: RendererTurnUsage, finished_at: string, };
 
 export type ChatTerminalTurnStatus = "completed" | "failed" | "cancelled";
 
@@ -1774,12 +1779,20 @@ action?: ToolActionPreview,
  * withholding it leaves the transcript asserting that something
  * happened without ever showing what.
  */
-result?: ToolResultPreview, } | { "type": "turn_completed" } | { "type": "turn_refused", refusal: RendererRefusal, } | { "type": "turn_failed", 
+result?: ToolResultPreview, } | { "type": "turn_completed", usage: RendererTurnUsage, } | { "type": "turn_refused", refusal: RendererRefusal, usage: RendererTurnUsage, } | { "type": "turn_failed", 
 /**
  * Why the turn failed, at the only resolution a client can act on.
  * The failure's `kind` and `message` stay internal.
  */
-category: TurnFailureCategory, model?: RendererModelIdentity, } | { "type": "turn_cancelled" } | { "type": "user_steered", message_id: MessageId, text: string, } | { "type": "context_truncated" } | { "type": "event_omitted" };
+category: TurnFailureCategory, model?: RendererModelIdentity, } | { "type": "turn_cancelled", usage: RendererTurnUsage, } | { "type": "user_steered", message_id: MessageId, text: string, } | { "type": "context_truncated", 
+/**
+ * Estimated transcript tokens before the reduction.
+ */
+original_tokens: number, 
+/**
+ * Estimated transcript tokens after fitting to the budget.
+ */
+fitted_tokens: number, } | { "type": "event_omitted" };
 
 /**
  * One frame on a chat's event socket.
@@ -1820,6 +1833,43 @@ export type RendererSequencedEvent = { seq: number, event: RendererAgentEvent, }
 export type RendererToolName = "search" | "list_sources" | "read_source" | "read_tool_result" | "web_search" | "web_extract" | "read_delegated_file" | "read_file" | "list_dir" | "write_file" | "request_folder_access" | "connect_folder" | "list_connected_folders" | "list_folder" | "read_connected_file" | "import_connected_file" | "write_output_to_connected_folder" | "spawn_sandbox_agent" | "wait_for_agents" | "ask_user_questions" | "exit_plan_mode" | "exec" | "create_app" | "other";
 
 export type RendererToolStatus = "completed" | "failed";
+
+/**
+ * A turn's token accounting, as the renderer needs it.
+ *
+ * The four counts are disjoint. Every adapter normalizes to the same split
+ * before the count reaches the journal: `input_tokens` is the *fresh*,
+ * uncached prompt only, and never includes `cache_read_input_tokens` or
+ * `cache_creation_input_tokens`. Anthropic reports that split natively; the
+ * OpenAI, OpenAI-compatible, and Gemini paths all subtract the cached portion
+ * out of the provider's prompt total before filling `input_tokens`. So the
+ * tokens that occupied the model's context for this turn are the plain sum of
+ * all four fields — no term is double-counted and none is missing.
+ *
+ * One caveat a reader of these numbers has to hold: they are the turn's
+ * totals, summed over every model call the agent made, not a snapshot of the
+ * final prompt. A turn that ran ten tool calls re-sent its transcript ten
+ * times, so the sum exceeds what was resident in the window at any one moment.
+ * It is a faithful measure of what the turn cost and a ceiling on what the
+ * window held.
+ */
+export type RendererTurnUsage = { 
+/**
+ * Fresh prompt tokens, excluding both cache figures below.
+ */
+input_tokens: number, 
+/**
+ * Tokens the model generated.
+ */
+output_tokens: number, 
+/**
+ * Prompt tokens served from the provider's cache.
+ */
+cache_read_input_tokens: number, 
+/**
+ * Prompt tokens written to the provider's cache.
+ */
+cache_creation_input_tokens: number, };
 
 /**
  * Non-authoritative, well-known starting location for the native picker.

--- a/crates/openwave-server/src/event_projection.rs
+++ b/crates/openwave-server/src/event_projection.rs
@@ -14,6 +14,16 @@
 //! `reasoning_content`/`reasoning`, which a gateway sets for exactly this
 //! purpose. Withholding it cost the transcript the account of how an answer was
 //! reached without protecting anything the provider was not already publishing.
+//!
+//! Token counts are the other deliberate widening. A turn's [`Usage`] is four
+//! integers with no provider diagnostics, no host state, and nothing derived
+//! from the model's output; the reader is the one paying for them, and without
+//! them the desktop cannot say how much of the context window is spoken for.
+//! They cross in full on the terminal events, and so do the two estimates on
+//! [`AgentEvent::ContextTruncated`] — a notice that earlier conversation was
+//! dropped is close to useless without the size of what was dropped.
+//!
+//! [`Usage`]: openwave_core::Usage
 
 use openwave_core::{
     AgentEvent, ApprovalClass, CallId, MessageId, RendererToolName, SequencedEvent,
@@ -77,6 +87,46 @@ impl From<&crate::bus::ChatMetadataNotice> for RendererChatMetadata {
 pub(crate) struct RendererSequencedEvent {
     pub seq: i64,
     pub event: RendererAgentEvent,
+}
+
+/// A turn's token accounting, as the renderer needs it.
+///
+/// The four counts are disjoint. Every adapter normalizes to the same split
+/// before the count reaches the journal: `input_tokens` is the *fresh*,
+/// uncached prompt only, and never includes `cache_read_input_tokens` or
+/// `cache_creation_input_tokens`. Anthropic reports that split natively; the
+/// OpenAI, OpenAI-compatible, and Gemini paths all subtract the cached portion
+/// out of the provider's prompt total before filling `input_tokens`. So the
+/// tokens that occupied the model's context for this turn are the plain sum of
+/// all four fields — no term is double-counted and none is missing.
+///
+/// One caveat a reader of these numbers has to hold: they are the turn's
+/// totals, summed over every model call the agent made, not a snapshot of the
+/// final prompt. A turn that ran ten tool calls re-sent its transcript ten
+/// times, so the sum exceeds what was resident in the window at any one moment.
+/// It is a faithful measure of what the turn cost and a ceiling on what the
+/// window held.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, TS)]
+pub(crate) struct RendererTurnUsage {
+    /// Fresh prompt tokens, excluding both cache figures below.
+    pub input_tokens: u32,
+    /// Tokens the model generated.
+    pub output_tokens: u32,
+    /// Prompt tokens served from the provider's cache.
+    pub cache_read_input_tokens: u32,
+    /// Prompt tokens written to the provider's cache.
+    pub cache_creation_input_tokens: u32,
+}
+
+impl From<openwave_core::Usage> for RendererTurnUsage {
+    fn from(value: openwave_core::Usage) -> Self {
+        Self {
+            input_tokens: value.input_tokens,
+            output_tokens: value.output_tokens,
+            cache_read_input_tokens: value.cache_read_input_tokens,
+            cache_creation_input_tokens: value.cache_creation_input_tokens,
+        }
+    }
 }
 
 /// Bounded refusal metadata safe to present in the desktop transcript.
@@ -181,9 +231,12 @@ pub(crate) enum RendererAgentEvent {
         #[ts(optional)]
         result: Option<ToolResultPreview>,
     },
-    TurnCompleted,
+    TurnCompleted {
+        usage: RendererTurnUsage,
+    },
     TurnRefused {
         refusal: RendererRefusal,
+        usage: RendererTurnUsage,
     },
     TurnFailed {
         /// Why the turn failed, at the only resolution a client can act on.
@@ -193,14 +246,21 @@ pub(crate) enum RendererAgentEvent {
         #[ts(optional)]
         model: Option<RendererModelIdentity>,
     },
-    TurnCancelled,
+    TurnCancelled {
+        usage: RendererTurnUsage,
+    },
     /// The message body is available through the transcript endpoint. Keeping
     /// only its durable id lets clients reconcile without duplicating content.
     UserSteered {
         message_id: MessageId,
         text: String,
     },
-    ContextTruncated,
+    ContextTruncated {
+        /// Estimated transcript tokens before the reduction.
+        original_tokens: u32,
+        /// Estimated transcript tokens after fitting to the budget.
+        fitted_tokens: u32,
+    },
     /// Fail-closed marker for a newer internal event until it gets an explicit
     /// renderer projection. The sequence still advances without dropping it.
     EventOmitted,
@@ -331,15 +391,20 @@ impl From<&SequencedEvent> for RendererSequencedEvent {
                 action: action.clone(),
                 result: result.clone(),
             },
-            AgentEvent::TurnCompleted { .. } => RendererAgentEvent::TurnCompleted,
-            AgentEvent::TurnRefused { refusal, .. } => RendererAgentEvent::TurnRefused {
+            AgentEvent::TurnCompleted { usage, .. } => RendererAgentEvent::TurnCompleted {
+                usage: (*usage).into(),
+            },
+            AgentEvent::TurnRefused { refusal, usage } => RendererAgentEvent::TurnRefused {
                 refusal: refusal.into(),
+                usage: (*usage).into(),
             },
             AgentEvent::TurnFailed { error } => RendererAgentEvent::TurnFailed {
                 category: TurnFailureCategory::from_kind(&error.kind),
                 model: None,
             },
-            AgentEvent::TurnCancelled { .. } => RendererAgentEvent::TurnCancelled,
+            AgentEvent::TurnCancelled { usage } => RendererAgentEvent::TurnCancelled {
+                usage: (*usage).into(),
+            },
             AgentEvent::UserSteered {
                 message_id,
                 content,
@@ -347,7 +412,13 @@ impl From<&SequencedEvent> for RendererSequencedEvent {
                 message_id: *message_id,
                 text: content.clone(),
             },
-            AgentEvent::ContextTruncated { .. } => RendererAgentEvent::ContextTruncated,
+            AgentEvent::ContextTruncated {
+                original_tokens,
+                fitted_tokens,
+            } => RendererAgentEvent::ContextTruncated {
+                original_tokens: *original_tokens,
+                fitted_tokens: *fitted_tokens,
+            },
             _ => RendererAgentEvent::EventOmitted,
         };
 
@@ -399,12 +470,57 @@ mod tests {
                         category: Some("general_harms".into()),
                         partial_output: true,
                     },
+                    usage: RendererTurnUsage {
+                        input_tokens: 42,
+                        output_tokens: 7,
+                        ..RendererTurnUsage::default()
+                    },
                 },
             }
         );
-        let json = serde_json::to_string(&projected).unwrap();
-        assert!(!json.contains("input_tokens"), "{json}");
-        assert!(!json.contains("output_tokens"), "{json}");
+    }
+
+    /// The desktop's context meter reads these four counts, so the terminal
+    /// events have to carry every one of them across the boundary intact —
+    /// and `ContextTruncated` has to carry the before/after sizes that make
+    /// its notice mean anything. Each was dropped by this projection once.
+    #[test]
+    fn terminal_events_carry_token_counts_to_the_renderer() {
+        let usage = Usage {
+            input_tokens: 1_100,
+            output_tokens: 220,
+            cache_read_input_tokens: 33_000,
+            cache_creation_input_tokens: 4_400,
+        };
+        let expected = RendererTurnUsage {
+            input_tokens: 1_100,
+            output_tokens: 220,
+            cache_read_input_tokens: 33_000,
+            cache_creation_input_tokens: 4_400,
+        };
+        let project = |event| RendererSequencedEvent::from(&SequencedEvent { seq: 1, event }).event;
+
+        assert_eq!(
+            project(AgentEvent::TurnCompleted {
+                usage,
+                stop_reason: openwave_core::StopReason::EndTurn,
+            }),
+            RendererAgentEvent::TurnCompleted { usage: expected }
+        );
+        assert_eq!(
+            project(AgentEvent::TurnCancelled { usage }),
+            RendererAgentEvent::TurnCancelled { usage: expected }
+        );
+        assert_eq!(
+            project(AgentEvent::ContextTruncated {
+                original_tokens: 128_000,
+                fitted_tokens: 96_000,
+            }),
+            RendererAgentEvent::ContextTruncated {
+                original_tokens: 128_000,
+                fitted_tokens: 96_000,
+            }
+        );
     }
 
     #[test]

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -1887,6 +1887,9 @@ pub struct ChatTerminalTurnSnapshot {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub invoked_skills: Option<Vec<String>>,
+    /// Token accounting for the turn, so a freshly opened chat can show
+    /// context usage without waiting for the next turn to finish.
+    pub usage: crate::event_projection::RendererTurnUsage,
     pub finished_at: chrono::DateTime<Utc>,
 }
 
@@ -1924,6 +1927,7 @@ impl From<openwave_core::ChatTerminalTurnSnapshot> for ChatTerminalTurnSnapshot 
             file_changes: Vec::new(),
             invoked_skills: (!snapshot.invoked_skills.is_empty())
                 .then_some(snapshot.invoked_skills),
+            usage: snapshot.usage.into(),
             finished_at: snapshot.finished_at,
         }
     }

--- a/crates/openwave-server/src/tests/websocket.rs
+++ b/crates/openwave-server/src/tests/websocket.rs
@@ -113,7 +113,7 @@ async fn read_until_turns_end(
             let event: RendererSequencedEvent = serde_json::from_str(text.as_str()).unwrap();
             if matches!(
                 event.event,
-                RendererAgentEvent::TurnCompleted | RendererAgentEvent::TurnFailed { .. }
+                RendererAgentEvent::TurnCompleted { .. } | RendererAgentEvent::TurnFailed { .. }
             ) {
                 completed += 1;
             }
@@ -177,6 +177,13 @@ where
 
 fn assert_renderer_event_frames_are_redacted(events: &[serde_json::Value]) {
     let serialized = serde_json::to_string(events).unwrap();
+    // `usage` is deliberately absent from this list: the terminal events carry
+    // the turn's four token counts so the desktop can show context usage.
+    // `stop_reason`, which sits beside it in the journal, still does not cross.
+    //
+    // Internal *keys* are written with their quotes and colon rather than bare.
+    // A bare `output` also matches the `output_tokens` count that now crosses
+    // legitimately, and a check that cannot distinguish the two is not a check.
     for forbidden in [
         "provider-secret-id",
         "provider-secret-call-id",
@@ -184,16 +191,15 @@ fn assert_renderer_event_frames_are_redacted(events: &[serde_json::Value]) {
         "/Users/private",
         "file.txt",
         "hunter2",
-        "fragment",
-        "output",
-        "content",
-        "data",
-        "summary",
-        "usage",
-        "stop_reason",
-        "diagnostic",
-        "lease",
-        "checkpoint",
+        "\"fragment\":",
+        "\"output\":",
+        "\"content\":",
+        "\"data\":",
+        "\"summary\":",
+        "\"stop_reason\":",
+        "\"diagnostic\":",
+        "\"lease\":",
+        "\"checkpoint\":",
     ] {
         assert!(
             !serialized.contains(forbidden),
@@ -355,7 +361,7 @@ async fn ws_replays_a_finished_turn_from_the_journal() {
         .any(|e| matches!(&e.event, RendererAgentEvent::TextDelta { text } if text == "hi")));
     assert!(matches!(
         events.last().unwrap().event,
-        RendererAgentEvent::TurnCompleted
+        RendererAgentEvent::TurnCompleted { .. }
     ));
     // Sequence numbers are strictly increasing.
     assert!(events.windows(2).all(|w| w[0].seq < w[1].seq));
@@ -407,7 +413,7 @@ async fn ws_replays_one_turn_then_streams_the_next_live() {
     assert_eq!(
         events
             .iter()
-            .filter(|e| matches!(e.event, RendererAgentEvent::TurnCompleted))
+            .filter(|e| matches!(e.event, RendererAgentEvent::TurnCompleted { .. }))
             .count(),
         2,
         "both turns completed over one connection"
@@ -478,7 +484,7 @@ async fn ws_subprotocol_auth_succeeds() {
                 continue;
             };
             let event: RendererSequencedEvent = serde_json::from_str(text.as_str()).unwrap();
-            if matches!(event.event, RendererAgentEvent::TurnCompleted) {
+            if matches!(event.event, RendererAgentEvent::TurnCompleted { .. }) {
                 saw_completed = true;
                 break;
             }


### PR DESCRIPTION
The journal has always recorded what a turn spent — four token counts on every terminal event — and the renderer projection dropped all of them on the floor. It did the same to the two estimates on `ContextTruncated`, so the desktop could say that earlier conversation had been trimmed but not by how much. Nothing downstream could show how full a context window was.

Terminal events now carry a `RendererTurnUsage`, and `ContextTruncated` carries its before/after sizes. Hydration goes through the transcript's terminal-turn snapshot, reading the counts already stored on the turn row, so a chat reopened after a restart shows usage without waiting for another turn.

## Cache-token semantics

The new struct's doc comment records the part that is easy to get wrong, because a consumer summing these has to know it: `input_tokens` is the **fresh** prompt only and never includes `cache_read_input_tokens` or `cache_creation_input_tokens`. Anthropic reports that split natively; the OpenAI, OpenAI-compatible, and Gemini paths each subtract the cached portion out of the provider's prompt total before filling `input_tokens`. So the tokens that occupied the context are the plain sum of all four fields — no term double-counted, none missing.

The doc comment also records the caveat: these are turn totals summed over every model call the agent made, not a snapshot of the final prompt. A turn that ran ten tool calls re-sent its transcript ten times. The sum is a faithful measure of what the turn cost and a ceiling on what the window held, not the resident size. Making it exact would mean persisting a per-call figure the turn row does not have a column for, and pre-v1 that means a baseline edit and a schema-epoch bump that discards existing databases — not worth it for a meter. Worth revisiting if the approximation reads badly in practice.

`TurnFailed` gets no usage: unlike the other three terminal events, `AgentEvent::TurnFailed` carries only the error and never had a count to forward.

## Two things this surfaced

**Cancelling a turn never persisted its usage.** The cancellation transition journaled the counts but wrote none of them to the turn row, which stayed at zero. The durable accounting for every stopped turn was wrong; hydration is just what made it visible. It now writes the four columns the way the completion path does, and the `validate_terminal_usage` call already sitting above the write proves the total covers the row's checkpoint, so it stays monotonic.

**The websocket redaction check was matching too loosely.** It listed bare `output` as a forbidden substring, which also matches the `output_tokens` that now crosses legitimately. The internal *keys* in that list are now matched as quoted JSON keys, which is what they meant — a check that cannot tell `"output":` from `output_tokens` is not a check. `usage` came off the list deliberately; `stop_reason`, which sits beside it in the journal, stays internal.

## Boundary widening

This is a deliberate opening in a closed projection, noted in the module doc beside the existing note about reasoning. A turn's usage is four integers with no provider diagnostics, no host state, and nothing derived from model output — and the reader is the one paying for them.

## Tests

One added: the projection contract, that the counts and the truncation sizes survive the boundary. Each was dropped by this projection until now, and a silent re-drop is exactly the regression worth catching.

The refusal projection test keeps its shape and now asserts the usage it previously asserted was absent. UI test fixtures gained the new required fields; no UI behavior changed in this PR.

## Verified locally

- `cargo check -p openwave-core -p openwave-server --locked --all-targets`, `cargo clippy` same scope, clean
- `cargo test -p openwave-core --lib` — 565 passed
- `cargo test -p openwave-server --lib` — 615 passed (two unrelated timing flakes under full parallel load, `heartbeats_the_lease_so_a_long_run_is_not_reaped` and `resumed_worker_preserves_checkpoint_usage_and_step_budget`, both pass in isolation)
- `wire.ts` regenerated with `UPDATE_WIRE_TYPES=1`; the staleness check passes and `Cargo.lock` is unchanged
- UI: `tsc --noEmit` clean, full `vitest run` — 769 passed

Not verified: the app was not driven. The Postgres turn-state lane covers the cancellation write on a backend I did not run locally.