### PR TITLE
feat(desktop): show context-window usage in the composer

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -56,6 +56,7 @@ import {
 import { useImageAttachments } from "./useImageAttachments";
 import { modelForSelection } from "./ModelSelection";
 import { ModelMenu } from "./ModelMenu";
+import { ContextUsageIndicator } from "./ContextUsageIndicator";
 import { PermissionModeMenu } from "./PermissionModeMenu";
 import {
   PICKER_BUSY_MESSAGE,
@@ -114,6 +115,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   const chatsLoaded = useChatListStore((state) => state.chatsLoaded);
   const deletingChatId = useChatListStore((state) => state.deletingChatId);
   const busy = useChatSessionStore((session) => session.busy);
+  const lastTurnUsage = useChatSessionStore((session) => session.lastTurnUsage);
   const [hydrated, setHydrated] = useState(false);
   const files = useComposerAttachments(chatId).files;
   const [attaching, setAttaching] = useState(false);
@@ -596,9 +598,13 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   }
 
   function renderChat(visible: boolean) {
+    // The model selected right now: the reasoning levels it accepts, and the
+    // window the context meter reads against. Switching models mid-chat
+    // re-scales the meter immediately, which is the question being asked.
+    const activeModel = modelForSelection(models, chat!.model);
     // Only the levels the selected model accepts are offerable, and a model
     // that accepts none gets no selector at all.
-    const efforts = modelForSelection(models, chat!.model)?.reasoning_efforts ?? [];
+    const efforts = activeModel?.reasoning_efforts ?? [];
     return (
       <TranscriptVisibilityProvider value={visible}>
         <ChatView
@@ -658,6 +664,13 @@ export function ChatRoute({ chatId }: { chatId: string }) {
             onRemove: images.remove,
             onRetry: images.retry,
           }}
+          composerContextMeter={
+            <ContextUsageIndicator
+              usage={lastTurnUsage}
+              contextWindow={activeModel?.context_window}
+              modelName={activeModel?.display_name}
+            />
+          }
           composerModelMenu={
             <ModelMenu
               models={models}

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
@@ -643,6 +643,7 @@ describe("applyTerminalHydration", () => {
       messages: authoritative,
       messageIds: new Set(["srv-1"]),
       lastEventSeq: 0,
+      lastTurnUsage: null,
     });
     expect(behind.lastSeq).toBe(base.lastSeq);
     expect(behind.messages).toEqual(authoritative);
@@ -652,6 +653,7 @@ describe("applyTerminalHydration", () => {
       messages: authoritative,
       messageIds: new Set(["srv-1"]),
       lastEventSeq: 99,
+      lastTurnUsage: null,
     });
     expect(ahead.lastSeq).toBe(99);
   });
@@ -748,10 +750,13 @@ describe("context truncation notice", () => {
       TRUNCATED,
       { type: "text_delta", text: " continues" },
     ]);
-    const notices = state.messages.filter(
-      (m) => m.role === "system" && m.text.includes(NOTICE),
+    const notices = state.messages.flatMap((m) =>
+      m.role === "system" && m.text.includes(NOTICE) ? [m.text] : [],
     );
     expect(notices).toHaveLength(1);
+    // The sizes are the point of the notice: without them a reader cannot
+    // tell a trivial trim from one that dropped most of the conversation.
+    expect(notices[0]).toContain("~128k → ~96k tokens");
     const last = state.messages[state.messages.length - 1];
     expect(last).toMatchObject({
       role: "assistant",
@@ -775,6 +780,76 @@ describe("context truncation notice", () => {
   });
 });
 
+describe("context usage", () => {
+  const USAGE = {
+    input_tokens: 1_000,
+    output_tokens: 500,
+    cache_read_input_tokens: 60_000,
+    cache_creation_input_tokens: 2_500,
+  };
+
+  it("has nothing to report before a turn finishes", () => {
+    const { state } = play([TURN, { type: "text_delta", text: "working" }]);
+    expect(state.lastTurnUsage).toBeNull();
+  });
+
+  it("replaces rather than accumulates across turns and terminal kinds", () => {
+    // Each turn re-sends the conversation, so the latest turn's counts are
+    // the current account of the window. Summing them would count the
+    // transcript once per turn and the meter would run away.
+    const first = play([TURN, { type: "turn_completed", usage: USAGE }]);
+    expect(first.state.lastTurnUsage).toEqual(USAGE);
+
+    const later = { ...USAGE, cache_read_input_tokens: 90_000 };
+    const second = play(
+      [
+        { type: "turn_started", turn_id: "turn-2" },
+        { type: "turn_cancelled", usage: later },
+      ],
+      first.state,
+    );
+    expect(second.state.lastTurnUsage).toEqual(later);
+
+    const refused = { ...USAGE, output_tokens: 12 };
+    const third = play(
+      [
+        { type: "turn_started", turn_id: "turn-3" },
+        {
+          type: "turn_refused",
+          refusal: { category: "cyber", partial_output: false },
+          usage: refused,
+        },
+      ],
+      second.state,
+    );
+    expect(third.state.lastTurnUsage).toEqual(refused);
+  });
+
+  it("hydrates from a snapshot so a reopened chat meters without a new turn", () => {
+    const hydrated = applyTerminalHydration(initialChatSessionState(), {
+      messages: [],
+      messageIds: new Set(),
+      lastEventSeq: 12,
+      lastTurnUsage: USAGE,
+    });
+    expect(hydrated.lastTurnUsage).toEqual(USAGE);
+
+    // A snapshot with no finished turn must not blank a reading the live
+    // stream already established.
+    const live = play(
+      [TURN, { type: "turn_completed", usage: USAGE }],
+      hydrated,
+    ).state;
+    const empty = applyTerminalHydration(live, {
+      messages: [],
+      messageIds: new Set(),
+      lastEventSeq: 20,
+      lastTurnUsage: null,
+    });
+    expect(empty.lastTurnUsage).toEqual(USAGE);
+  });
+});
+
 describe("replaying an active turn over a hydrated transcript", () => {
   it("keeps the superseded partial and steer message in journal order", () => {
     // Re-entering a chat mid-turn: hydration placed the persisted messages,
@@ -786,6 +861,7 @@ describe("replaying an active turn over a hydrated transcript", () => {
       ],
       messageIds: new Set(["u1", "steer-1"]),
       lastEventSeq: 0,
+      lastTurnUsage: null,
     });
     const { state } = play(
       [

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
@@ -1,5 +1,7 @@
 import type { SequencedEvent } from "./api";
 import { parseToolActionPreview, parseToolResultPreview } from "./api";
+import { contextTruncationNotice } from "./ContextUsage";
+import type { RendererTurnUsage } from "./generated/wire";
 import { AssistantSourceMarkerStreamScrubber } from "./AssistantSourceMarkerStream";
 import type { ChatMessage } from "./MessageList";
 import { TURN_CANCELLED_NOTICE } from "./MessageList";
@@ -37,6 +39,17 @@ export type ChatSessionState = {
   hydratedMessageIds: ReadonlySet<string>;
   /** One truncation notice per turn, however many truncation events arrive. */
   contextTruncationNoted: boolean;
+  /**
+   * Token counts from the most recent terminal turn, or null before any turn
+   * in this chat has finished.
+   *
+   * The composer's context meter reads this. It is deliberately the last
+   * turn's figures rather than a running total: each turn re-sends the
+   * conversation, so the latest turn is the best available account of what the
+   * window is holding, and summing turns would just count the transcript once
+   * per turn.
+   */
+  lastTurnUsage: RendererTurnUsage | null;
   /**
    * Whether code execution is preparing its sandbox image right now.
    *
@@ -89,6 +102,7 @@ export function initialChatSessionState(): ChatSessionState {
     provisionalToolCallIds: new Set(),
     hydratedMessageIds: new Set(),
     contextTruncationNoted: false,
+    lastTurnUsage: null,
     sandboxPreparing: false,
   };
 }
@@ -392,6 +406,7 @@ export function reduceChatSessionEvent(
           ...state,
           busy: false,
           activeTurnId: null,
+          lastTurnUsage: event.usage,
           provisionalToolCallIds: new Set(),
         },
         effects,
@@ -411,6 +426,7 @@ export function reduceChatSessionEvent(
           ...state,
           busy: false,
           activeTurnId: null,
+          lastTurnUsage: event.usage,
           provisionalToolCallIds: new Set(),
           messages: [
             ...discardToolCalls(
@@ -442,6 +458,7 @@ export function reduceChatSessionEvent(
           ...state,
           busy: false,
           activeTurnId: null,
+          lastTurnUsage: event.usage,
           provisionalToolCallIds: new Set(),
           messages: [
             ...settleActiveToolCalls(state.messages, "cancelled"),
@@ -516,7 +533,10 @@ export function reduceChatSessionEvent(
       messages.splice(insertAt, 0, {
         id: deps.nextId(),
         role: "system",
-        text: "Earlier conversation was trimmed to fit the model's context.",
+        text: contextTruncationNotice(
+          event.original_tokens,
+          event.fitted_tokens,
+        ),
       });
       return {
         state: { ...state, contextTruncationNoted: true, messages },
@@ -547,6 +567,7 @@ export function applyTerminalHydration(
     messages: ChatMessage[];
     messageIds: ReadonlySet<string>;
     lastEventSeq: number;
+    lastTurnUsage: RendererTurnUsage | null;
   },
 ): ChatSessionState {
   return {
@@ -554,6 +575,10 @@ export function applyTerminalHydration(
     lastSeq: Math.max(state.lastSeq, hydration.lastEventSeq),
     hydratedMessageIds: hydration.messageIds,
     messages: hydration.messages,
+    // The snapshot is authoritative when it has counts — it is rebuilt from
+    // the durable turn rows. A chat with no finished turn yet leaves whatever
+    // the live stream established rather than blanking the meter.
+    lastTurnUsage: hydration.lastTurnUsage ?? state.lastTurnUsage,
   };
 }
 

--- a/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.ts
+++ b/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.ts
@@ -1,4 +1,5 @@
 import type { ApiClient, ChatTranscript } from "./api";
+import type { RendererTurnUsage } from "./generated/wire";
 import type { ChatMessage } from "./MessageList";
 import { TURN_CANCELLED_NOTICE } from "./MessageList";
 import { hydrateTranscriptHistory } from "./TranscriptHistory";
@@ -15,6 +16,11 @@ export type PresentedTranscript = {
   lastEventSeq: number;
   messages: ChatMessage[];
   messageIds: Set<string>;
+  /**
+   * Token counts from the chat's most recently finished turn, for the context
+   * meter. Null for a chat that has never completed one.
+   */
+  lastTurnUsage: RendererTurnUsage | null;
 };
 
 /** Convert one durable snapshot into the renderer's closed message model. */
@@ -153,6 +159,10 @@ export function presentChatTranscript(
     lastEventSeq: transcript.last_event_seq,
     messages,
     messageIds,
+    // The server orders terminal turns oldest-first, so the meter wants the
+    // tail. Each turn re-sends the conversation, which makes the latest turn's
+    // counts the current account of the window rather than one term in a sum.
+    lastTurnUsage: transcript.terminal_turns?.at(-1)?.usage ?? null,
   };
 }
 

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -53,6 +53,7 @@ export type ChatViewProps = {
   /** The composer draft, readable synchronously — see [useTurnControls]. */
   draftRef: RefObject<string>;
   composerModelMenu: ReactNode;
+  composerContextMeter?: ReactNode;
   composerPermissionMenu: ReactNode;
   composerNetwork?: ComposerNetwork;
   composerReasoning?: ComposerReasoning;
@@ -87,6 +88,7 @@ export function ChatView({
   deletingChat,
   draftRef,
   composerModelMenu,
+  composerContextMeter,
   composerPermissionMenu,
   composerNetwork,
   composerReasoning,
@@ -416,6 +418,7 @@ export function ChatView({
           disabled={deletingChat}
           draft={draft}
           modelMenu={composerModelMenu}
+          contextMeter={composerContextMeter}
           permissionMenu={composerPermissionMenu}
           network={composerNetwork}
           reasoning={composerReasoning}

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -220,6 +220,8 @@ export type ComposerProps = {
   disabled: boolean;
   draft: string;
   modelMenu?: ReactNode;
+  /** Context-window meter, rendered beside the model menu. */
+  contextMeter?: ReactNode;
   permissionMenu?: ReactNode;
   network?: ComposerNetwork;
   reasoning?: ComposerReasoning;
@@ -249,6 +251,7 @@ export function Composer({
   disabled,
   draft,
   modelMenu,
+  contextMeter,
   permissionMenu,
   network,
   reasoning,
@@ -760,6 +763,7 @@ export function Composer({
             }
           />
           {modelMenu}
+          {contextMeter}
         </div>
         <div className="flex items-center gap-2">
           {/* The permission mode sits with the send cluster: it is what the

--- a/crates/openwave-desktop/ui/src/ContextUsage.test.ts
+++ b/crates/openwave-desktop/ui/src/ContextUsage.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  contextTokens,
+  contextTruncationNotice,
+  contextUsageLevel,
+  contextUsagePercent,
+  formatTokenCount,
+} from "./ContextUsage";
+
+const USAGE = {
+  input_tokens: 1_000,
+  output_tokens: 500,
+  cache_read_input_tokens: 60_000,
+  cache_creation_input_tokens: 2_500,
+};
+
+describe("context occupancy", () => {
+  it("counts cached prompt tokens as occupying the window", () => {
+    // The four counts are disjoint — a cache hit still fills the window, and
+    // a meter that read only `input_tokens` would report 1k against 200k for
+    // a conversation actually holding 64k.
+    expect(contextTokens(USAGE)).toBe(64_000);
+    expect(contextUsagePercent(USAGE, 200_000)).toBe(32);
+  });
+
+  it("renders nothing when the model's window is unknown", () => {
+    expect(contextUsagePercent(USAGE, undefined)).toBeNull();
+    expect(contextUsagePercent(USAGE, 0)).toBeNull();
+  });
+
+  it("clamps a turn whose totals exceed the window", () => {
+    // A long multi-step turn re-sends its transcript on every model call, so
+    // the summed totals legitimately run past the window. "Full" is the most
+    // a reader can act on.
+    expect(contextUsagePercent(USAGE, 8_000)).toBe(100);
+  });
+});
+
+describe("thresholds", () => {
+  it("escalates at 75 and 90, inclusive", () => {
+    expect(contextUsageLevel(74)).toBe("normal");
+    expect(contextUsageLevel(75)).toBe("warning");
+    expect(contextUsageLevel(89)).toBe("warning");
+    expect(contextUsageLevel(90)).toBe("critical");
+  });
+});
+
+describe("token formatting", () => {
+  it("quotes counts at the scale people use", () => {
+    expect(formatTokenCount(840)).toBe("840");
+    expect(formatTokenCount(200_000)).toBe("200k");
+    expect(formatTokenCount(1_000_000)).toBe("1M");
+    expect(formatTokenCount(1_500_000)).toBe("1.5M");
+  });
+});
+
+describe("truncation notice", () => {
+  it("carries the before and after sizes", () => {
+    expect(contextTruncationNotice(128_000, 96_000)).toContain(
+      "~128k → ~96k tokens",
+    );
+  });
+
+  it("falls back to the plain sentence when the numbers say nothing", () => {
+    // An older server sends zeros, and a "fitted" size at or above the
+    // original would be nonsense to print.
+    expect(contextTruncationNotice(0, 0)).not.toContain("~");
+    expect(contextTruncationNotice(1_000, 1_000)).not.toContain("~");
+  });
+});

--- a/crates/openwave-desktop/ui/src/ContextUsage.ts
+++ b/crates/openwave-desktop/ui/src/ContextUsage.ts
@@ -1,0 +1,80 @@
+import type { RendererTurnUsage } from "./generated/wire";
+
+/**
+ * How much of a model's context window the last turn accounted for.
+ *
+ * The four counts on [`RendererTurnUsage`] are disjoint — `input_tokens` is the
+ * fresh prompt only, and the two cache figures are the portions read from and
+ * written to the provider's prompt cache — so the tokens that occupied the
+ * window are their plain sum. See the generated type's own doc comment for why
+ * that holds on every provider, and for the caveat that these are turn totals
+ * summed across model calls rather than a snapshot of the final prompt.
+ */
+export function contextTokens(usage: RendererTurnUsage): number {
+  return (
+    usage.input_tokens +
+    usage.output_tokens +
+    usage.cache_read_input_tokens +
+    usage.cache_creation_input_tokens
+  );
+}
+
+/**
+ * Share of the window used, as a whole percent clamped to 0–100.
+ *
+ * Clamped rather than allowed to run over: a bar reading 130% tells a reader
+ * nothing they can act on beyond what "full" already tells them, and the turn
+ * totals can legitimately exceed the window on a long multi-step turn.
+ *
+ * Returns null when the denominator is unusable, which is the signal to render
+ * nothing at all — a model whose context window we do not know cannot be
+ * honestly metered.
+ */
+export function contextUsagePercent(
+  usage: RendererTurnUsage,
+  contextWindow: number | undefined,
+): number | null {
+  if (!contextWindow || contextWindow <= 0) return null;
+  const used = contextTokens(usage);
+  return Math.min(100, Math.max(0, Math.round((used / contextWindow) * 100)));
+}
+
+/** How loudly the meter should read at a given fill. */
+export type ContextUsageLevel = "normal" | "warning" | "critical";
+
+export function contextUsageLevel(percent: number): ContextUsageLevel {
+  if (percent >= 90) return "critical";
+  if (percent >= 75) return "warning";
+  return "normal";
+}
+
+/**
+ * Token counts at the scale people quote them: "200k", "1.5M", "840".
+ *
+ * Deliberately lossy. These numbers exist to convey magnitude — the exact
+ * figures belong in the tooltip, which prints them in full.
+ */
+export function formatTokenCount(tokens: number): string {
+  if (tokens >= 1_000_000) {
+    const millions = tokens / 1_000_000;
+    return `${millions >= 10 || Number.isInteger(millions) ? Math.round(millions) : millions.toFixed(1)}M`;
+  }
+  if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}k`;
+  return `${tokens}`;
+}
+
+/**
+ * The trimming notice, carrying the sizes that make it worth reading.
+ *
+ * "Earlier conversation was trimmed" on its own leaves the reader unable to
+ * tell a trivial trim from one that dropped most of the conversation.
+ */
+export function contextTruncationNotice(
+  originalTokens: number,
+  fittedTokens: number,
+): string {
+  if (originalTokens <= 0 || fittedTokens <= 0 || fittedTokens >= originalTokens) {
+    return "Earlier conversation was trimmed to fit the model's context.";
+  }
+  return `Earlier conversation was trimmed to fit the model's context (~${formatTokenCount(originalTokens)} → ~${formatTokenCount(fittedTokens)} tokens).`;
+}

--- a/crates/openwave-desktop/ui/src/ContextUsageIndicator.tsx
+++ b/crates/openwave-desktop/ui/src/ContextUsageIndicator.tsx
@@ -71,32 +71,34 @@ export function ContextUsageIndicator({
         )}
         // The visible pill is a magnitude; the accessible name is the sentence
         // a screen reader needs, since "34%" alone says nothing about of what.
+        // A graphic with a text alternative rather than a live region: this
+        // updates on every turn, and it is reference material, not an
+        // announcement worth interrupting for.
+        role="img"
         aria-label={`Context: ${percent}% of ${formatTokenCount(contextWindow)} tokens used`}
-        role="status"
       >
-        <ContextUsageRing percent={percent} level={level} />
+        <ContextUsageRing percent={percent} />
         {percent}%
       </span>
     </WithTooltip>
   );
 }
 
-/** A small filled ring, drawn as a conic sweep over a muted track. */
-function ContextUsageRing({
-  percent,
-  level,
-}: {
-  percent: number;
-  level: ReturnType<typeof contextUsageLevel>;
-}) {
+/**
+ * A small filled ring, drawn as a conic sweep over a muted track.
+ *
+ * Takes its colour from the pill via `currentColor`, so the threshold styling
+ * lives in exactly one place.
+ */
+function ContextUsageRing({ percent }: { percent: number }) {
+  const filled = `${percent * 3.6}deg`;
   return (
     <span
       aria-hidden="true"
       className="size-3 shrink-0 rounded-full"
       style={{
-        background: `conic-gradient(currentColor 0deg ${percent * 3.6}deg, color-mix(in oklch, currentColor 20%, transparent) ${percent * 3.6}deg 360deg)`,
+        background: `conic-gradient(currentColor 0deg ${filled}, color-mix(in oklch, currentColor 20%, transparent) ${filled} 360deg)`,
       }}
-      data-level={level}
     />
   );
 }

--- a/crates/openwave-desktop/ui/src/ContextUsageIndicator.tsx
+++ b/crates/openwave-desktop/ui/src/ContextUsageIndicator.tsx
@@ -1,0 +1,102 @@
+import type { RendererTurnUsage } from "./generated/wire";
+import {
+  contextTokens,
+  contextUsageLevel,
+  contextUsagePercent,
+  formatTokenCount,
+} from "./ContextUsage";
+import { WithTooltip } from "./components/ui/tooltip";
+import { cn } from "./lib/utils";
+
+/**
+ * How much of the active model's context window the last turn accounted for.
+ *
+ * Renders nothing at all when there is nothing honest to say — no turn has
+ * finished in this chat, or the selected model's window is unknown. A meter
+ * that guesses is worse than no meter.
+ *
+ * The denominator is the *currently selected* model, not the one that ran the
+ * turn. Switching models mid-chat is a question about what will fit next, so
+ * the reading moves the moment the selection does.
+ */
+export function ContextUsageIndicator({
+  usage,
+  contextWindow,
+  modelName,
+}: {
+  usage: RendererTurnUsage | null;
+  contextWindow: number | undefined;
+  modelName: string | undefined;
+}) {
+  if (!usage) return null;
+  const percent = contextUsagePercent(usage, contextWindow);
+  if (percent === null || contextWindow === undefined) return null;
+
+  const used = contextTokens(usage);
+  const level = contextUsageLevel(percent);
+  const cached =
+    usage.cache_read_input_tokens + usage.cache_creation_input_tokens > 0;
+
+  return (
+    <WithTooltip
+      label={
+        <div className="space-y-0.5 text-xs">
+          {modelName && <div className="font-medium">{modelName}</div>}
+          <div>
+            {used.toLocaleString()} of {contextWindow.toLocaleString()} tokens (
+            {percent}%)
+          </div>
+          <div className="text-muted-foreground">
+            {usage.input_tokens.toLocaleString()} in ·{" "}
+            {usage.output_tokens.toLocaleString()} out
+            {cached && (
+              <>
+                {" "}
+                · {usage.cache_read_input_tokens.toLocaleString()} cache read ·{" "}
+                {usage.cache_creation_input_tokens.toLocaleString()} cache write
+              </>
+            )}
+          </div>
+        </div>
+      }
+    >
+      <span
+        className={cn(
+          "flex h-8 shrink-0 items-center gap-1.5 rounded-md px-2 text-xs tabular-nums",
+          level === "critical"
+            ? "text-destructive"
+            : level === "warning"
+              ? "text-warning-foreground"
+              : "text-muted-foreground",
+        )}
+        // The visible pill is a magnitude; the accessible name is the sentence
+        // a screen reader needs, since "34%" alone says nothing about of what.
+        aria-label={`Context: ${percent}% of ${formatTokenCount(contextWindow)} tokens used`}
+        role="status"
+      >
+        <ContextUsageRing percent={percent} level={level} />
+        {percent}%
+      </span>
+    </WithTooltip>
+  );
+}
+
+/** A small filled ring, drawn as a conic sweep over a muted track. */
+function ContextUsageRing({
+  percent,
+  level,
+}: {
+  percent: number;
+  level: ReturnType<typeof contextUsageLevel>;
+}) {
+  return (
+    <span
+      aria-hidden="true"
+      className="size-3 shrink-0 rounded-full"
+      style={{
+        background: `conic-gradient(currentColor 0deg ${percent * 3.6}deg, color-mix(in oklch, currentColor 20%, transparent) ${percent * 3.6}deg 360deg)`,
+      }}
+      data-level={level}
+    />
+  );
+}

--- a/crates/openwave-desktop/ui/src/settings/ModelsPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ModelsPanel.dom.test.tsx
@@ -111,7 +111,7 @@ describe("ModelsPanel", () => {
     expect(putModelRole).not.toHaveBeenCalled();
     await user.click(utilityModel);
     expect(
-      screen.getByRole("option", { name: "Claude Opus 4.8 — unavailable" }),
+      screen.getByRole("option", { name: "Claude Opus 4.8 — 1M context — unavailable" }),
     ).toHaveAttribute("aria-disabled", "true");
     await user.keyboard("{Escape}");
 
@@ -119,7 +119,7 @@ describe("ModelsPanel", () => {
     await user.click(utilityProvider);
     await user.click(screen.getByRole("option", { name: "OpenAI" }));
     await user.click(utilityModel);
-    await user.click(screen.getByRole("option", { name: "GPT-4o mini" }));
+    await user.click(screen.getByRole("option", { name: "GPT-4o mini — 128k context" })) ;
     await waitFor(() =>
       expect(putModelRole).toHaveBeenCalledWith(
         "utility",
@@ -229,11 +229,11 @@ describe("ModelsPanel under managed policy", () => {
       screen.getByRole("option", { name: "Automatic — Gateway Haiku" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("option", { name: "Gateway Flagship" }),
+      screen.getByRole("option", { name: "Gateway Flagship — 1M context" }),
     ).toBeInTheDocument();
     expect(screen.queryByRole("option", { name: /Claude Opus/ })).toBeNull();
 
-    await user.click(screen.getByRole("option", { name: "Gateway Haiku" }));
+    await user.click(screen.getByRole("option", { name: /^Gateway Haiku/ }));
     await waitFor(() =>
       expect(putModelRole).toHaveBeenCalledWith(
         "utility",

--- a/crates/openwave-desktop/ui/src/settings/ModelsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ModelsPanel.tsx
@@ -12,6 +12,7 @@ import {
   modelForSelection,
   providerLabel,
 } from "../ModelSelection";
+import { formatTokenCount } from "../ContextUsage";
 import {
   Select,
   SelectContent,
@@ -331,6 +332,7 @@ function ManagedModelRoleRow({
                 disabled={!model.available}
               >
                 {model.display_name}
+                {contextWindowSuffix(model)}
               </SelectItem>
             ))}
           </SelectContent>
@@ -446,6 +448,7 @@ function ModelRoleRow({
                 disabled={!model.available}
               >
                 {model.display_name}
+                {contextWindowSuffix(model)}
                 {model.available ? "" : " — unavailable"}
               </SelectItem>
             ))}
@@ -468,6 +471,17 @@ function ModelRoleRow({
       )}
     </SettingsSection>
   );
+}
+
+/**
+ * How much conversation a model can hold, beside its name.
+ *
+ * The single number that most often decides between two otherwise similar
+ * models, and it was only visible by picking one and watching the meter.
+ */
+function contextWindowSuffix(model: ModelInfo): string {
+  if (!model.context_window) return "";
+  return ` — ${formatTokenCount(model.context_window)} context`;
 }
 
 /**


### PR DESCRIPTION
Stacked on #1667 — retarget to `main` once that lands.

The desktop had no way to answer "how much room is left?" A long conversation would keep going until the server silently trimmed it, and the only signal was a one-line notice that earlier conversation had been dropped, without saying how much.

The composer's left cluster now carries a small ring and percentage beside the model menu, reading the last finished turn's token counts against the selected model's context window. Muted by default, warning at 75%, destructive at 90%, using the existing semantic tokens. The tooltip prints the model, the exact counts, and cache reads and writes when the provider reported any.

It renders nothing at all when there is nothing honest to show — no turn has finished in this chat, or the selected model's window is unknown. A meter that guesses is worse than no meter.

## Three decisions worth naming

**The numerator sums all four token counts, cache reads included.** They are disjoint (see the type's doc comment in #1667) and a cache hit still occupies the window. Reading only `input_tokens` would report 1k against 200k for a conversation actually holding 64k.

**State keeps the last turn's counts rather than a running total.** Each turn re-sends the conversation, so accumulating across turns would count the transcript once per turn and the meter would run away. The percent is clamped at 100 for the mirror-image reason: a long multi-step turn's totals can legitimately exceed the window, because the turn re-sent its transcript on every model call. Past that point "full" is the most a reader can act on. The wire type's doc comment carries the same caveat.

**The denominator is the model selected right now, not the one that ran the turn.** Switching models mid-chat is a question about what will fit next, so the reading re-scales the moment the selection does — the numerator stays, the denominator moves.

## Also here

The truncation notice now reads "Earlier conversation was trimmed to fit the model's context (~128k → ~96k tokens)", falling back to the plain sentence when the numbers say nothing (an older server sending zeros, or a fitted size not below the original). The once-per-turn dedupe is unchanged and still covered.

The settings model picker names each model's window beside its display name — "Claude Opus 4.8 — 1M context". It is the number that most often decides between two otherwise similar models, and it was previously visible only by picking one and watching the meter.

## One fix on the way

`presentChatTranscript` now tolerates a snapshot with no `terminal_turns` instead of throwing on it, which took the whole hydration path down with it. Surfaced by an integration test the moment the presenter started reading that array.

## Tests

Two behaviors, both in the reducer where the state lives: that terminal events *replace* rather than accumulate across all three terminal kinds, and that snapshot hydration establishes a reading without a new turn (and that an empty snapshot does not blank one the live stream already established). The occupancy and threshold math gets its own small suite, including that cached tokens count and that the percent clamps.

No component-render test for the indicator: it is a formatted read of values the above already pins, and asserting it renders would be an existence test.

Existing model-picker assertions absorbed the new label suffix.

## Verified locally

- `tsc --noEmit` clean
- `vitest run` — 118 files, 779 passed
- `vite build` with a 4 GB heap, clean

Not verified: the app was not driven, so the meter's live appearance, the ring's conic fill, and the tooltip's layout are unconfirmed against real pixels. The color thresholds were picked against the existing `--warning-foreground` and `--destructive` tokens in both themes but not eyeballed in either.