### PR TITLE
fix(core): declare the scratch durability contract in the file and exec tool descriptions

### DIFF
--- a/crates/openwave-code-execution/src/tool.rs
+++ b/crates/openwave-code-execution/src/tool.rs
@@ -61,9 +61,14 @@ impl Tool for ExecTool {
                           the call on every provider. Every provider returns bounded \
                           stdout/stderr. Files you save in output/ are published to the user \
                           automatically as durable outputs; output/ and preview/ are copied back \
-                          for you and need never be listed. To update an output you already \
-                          published, save to the same filename in output/ — it becomes a new \
-                          version of the same output in place; you never track output ids. For \
+                          for you and need never be listed. Everything else the command leaves in \
+                          scratch is intermediate and ephemeral: it may not survive to a later \
+                          command or turn, and there is no undo for it. Reach for exec to run a \
+                          program, not to edit workspace text through shell redirection — \
+                          read_file and write_file do that directly and durably. To update an \
+                          output you already published, save to the same filename in output/ — it \
+                          becomes a new version of the same output in place; you never track \
+                          output ids. For \
                           visual review, save up to three PNG, JPEG, or WebP images in preview/; \
                           overview, grid, thumbnail, page, and slide filenames are prioritized; \
                           preview images are for your own review and never become outputs. When \

--- a/crates/openwave-core/src/tools/definitions.rs
+++ b/crates/openwave-core/src/tools/definitions.rs
@@ -14,26 +14,31 @@ pub(super) const WRITE_FILE: &str = "write_file";
 pub(super) fn read_file() -> ToolSpec {
     ToolSpec::for_args::<read_file_tool::Arguments>(
         READ_FILE,
-        "Read a UTF-8 text file, relative to the private scratch directory. Files under \
-         output/ are readable here, but only exec can write them.",
+        "Read a UTF-8 text file, relative to the private scratch directory. Use this, not \
+         an exec command, to read workspace text. Files under output/ are readable here, \
+         but only exec can write them.",
     )
 }
 
 pub(super) fn list_dir() -> ToolSpec {
     ToolSpec::for_args::<list_dir_tool::Arguments>(
         LIST_DIR,
-        "List the entries of a private scratch directory (defaults to the root).",
+        "List the entries of a private scratch directory (defaults to the root). Scratch \
+         holds intermediate work: apart from output/ and preview/, what is listed here \
+         may not still be there in a later command or turn.",
     )
 }
 
 pub(super) fn write_file() -> ToolSpec {
     ToolSpec::for_args::<write_file_tool::Arguments>(
         WRITE_FILE,
-        "Write a UTF-8 text file into private scratch, creating parent directories. \
-         Overwrites an existing file. Scratch files are intermediate work, not \
-         user-visible outputs: output/ is reserved and a write there is refused, \
-         because a user-visible output is published by saving it into output/ from \
-         an exec command.",
+        "Write a UTF-8 text file into private scratch, creating parent directories. Use \
+         this, not an exec command, to write workspace text. Overwrites an existing file \
+         in place: the last write wins. Scratch is an ephemeral working space — anything \
+         outside output/ and preview/ is intermediate and may not survive to a later \
+         command or turn. Only output/ is durable, and it is reserved: a write there is \
+         refused, because a user-visible output is published by saving it into output/ \
+         from an exec command, which versions it.",
     )
 }
 


### PR DESCRIPTION
Each chat's private scratch directory behaves differently depending on which execution provider is configured and which directory a file lands in, and none of it is stated where the model can see it. Local exec runs directly in scratch, so an intermediate file it writes is still there next turn; managed providers (E2B, Daytona) stage listed paths in and copy only `output/` and `preview/` back, so the same command's intermediate files silently vanish. Separately, `output/` writes become versioned outputs while plain scratch writes are last-writer-wins.

Wording only — no behavior changes. The tool descriptions now say what the contract is:

- `write_file` — scratch is an ephemeral working space, anything outside `output/` and `preview/` may not survive to a later command or turn, overwrites are last-write-wins, and `output/` is the durable directory (the reservation steering from #1534 is folded into that sentence rather than repeated).
- `read_file` / `write_file` — a short steering line that workspace text reading and writing belongs to these tools.
- `list_dir` — a listing outside `output/`/`preview/` is not a promise the entries will still be there later.
- `exec` — the counterpart steering: exec is for running programs, not for editing text through shell redirection, and everything it leaves in scratch outside `output/`/`preview/` is intermediate and ephemeral.

These strings cost tokens on every turn, so each addition is one clause, in the existing voice. Net growth is roughly 60 words across the four specs.

One deliberate omission: `write_file`'s description does not claim overwrites have no undo. Prior-byte snapshots for structured overwrites are being added separately, and a description that outlives its own accuracy by a week is worse than one that stays quiet on the point; "the last write wins" is true either way.

No golden fixtures embed these strings — the only test asserting on spec text checks for `'files'`, `preview/`, and the helper script names in the exec description, all still present.

Part of #1520