### PR TITLE
feat(desktop): web search mode setting and message source chips

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -1132,15 +1132,16 @@ fn provider_executed_entries(output: &Value) -> Vec<crate::ResultEntry> {
         .unwrap_or_default()
         .iter()
         .map(|result| {
+            let url = result
+                .get("url")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
             let entry = crate::ResultEntry::new(
                 crate::ResultEntryKind::Link,
                 result.get("title").and_then(Value::as_str).unwrap_or(""),
-            );
-            match result
-                .get("url")
-                .and_then(Value::as_str)
-                .and_then(result_host)
-            {
+            )
+            .with_web_url(url);
+            match result_host(url) {
                 Some(host) => entry.with_detail(host),
                 None => entry,
             }

--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -43,6 +43,11 @@ pub const MAX_RESULT_VIEW_URI_CHARS: usize = 2 * 1024;
 /// Longest label, detail, or meta string one listed result row carries.
 pub const MAX_RESULT_ENTRY_CHARS: usize = 200;
 
+/// Longest page address one listed result row carries. Carried whole or not at
+/// all, on the same terms as a view reference: a truncated URL opens a
+/// different page than the row names.
+pub const MAX_RESULT_ENTRY_URL_CHARS: usize = 2 * 1024;
+
 /// Most rows a result preview lists before it counts the rest instead.
 pub const MAX_RESULT_ENTRIES: usize = 50;
 
@@ -465,6 +470,21 @@ pub struct ResultEntry {
     /// [`App`]: ResultEntryKind::App
     #[serde(default, alias = "output_id")]
     pub target_id: Option<String>,
+    /// The public page this row opens, when it names one.
+    ///
+    /// The one projected field a click leaves the application with, so it is
+    /// admitted at construction rather than at the click: only `http` and
+    /// `https` survive [`Self::with_web_url`], and a row whose address is
+    /// anything else keeps its title and its domain and simply does not open.
+    /// It rides alongside the domain in `detail` rather than replacing it —
+    /// a column of rows is still told apart by host, not by query string.
+    ///
+    /// Carried because attribution for a search a chat did not run itself is
+    /// only meaningful if the reader can reach the page. `default` because
+    /// retained projections predate the field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub url: Option<String>,
 }
 
 impl ResultEntry {
@@ -478,7 +498,22 @@ impl ResultEntry {
             meta: None,
             media_type: None,
             target_id: None,
+            url: None,
         }
+    }
+
+    /// Point the row at the public page it names.
+    ///
+    /// A non-web address is dropped rather than carried: `javascript:` and
+    /// `file:` must never reach the renderer, let alone the host's opener,
+    /// and the row reads the same without one.
+    #[must_use]
+    pub fn with_web_url(mut self, url: impl Into<String>) -> Self {
+        let url = url.into();
+        if is_web_url(&url) && url.len() <= MAX_RESULT_ENTRY_URL_CHARS {
+            self.url = Some(url);
+        }
+        self
     }
 
     /// Add the secondary hint beside the name.
@@ -917,11 +952,31 @@ fn result_entry(value: &Value) -> Option<ResultEntry> {
         meta: entry_field(value.get("meta")),
         media_type: entry_field(value.get("media_type")),
         target_id: entry_field(value.get("target_id")),
+        url: entry_url(value.get("url")),
     })
 }
 
 fn entry_field(value: Option<&Value>) -> Option<String> {
     clamp(value?.as_str()?, MAX_RESULT_ENTRY_CHARS)
+}
+
+/// The row's page, admitted on the URL's own terms rather than a display
+/// field's: only a web scheme, and whole or not at all.
+fn entry_url(value: Option<&Value>) -> Option<String> {
+    let url = value?.as_str()?;
+    (is_web_url(url) && url.len() <= MAX_RESULT_ENTRY_URL_CHARS).then(|| url.to_owned())
+}
+
+/// Whether a projected address is one a reader may be sent to.
+///
+/// The gate is the scheme and nothing else: this decides what the renderer is
+/// allowed to hand the host's opener, and `javascript:` or `file:` must never
+/// get that far.
+fn is_web_url(url: &str) -> bool {
+    url.split_once("://").is_some_and(|(scheme, rest)| {
+        !rest.is_empty()
+            && (scheme.eq_ignore_ascii_case("http") || scheme.eq_ignore_ascii_case("https"))
+    })
 }
 
 /// Bound one failure row, or drop it.
@@ -1382,6 +1437,44 @@ mod tests {
         // A receipt with nothing readable left carries no output rather than
         // an empty pane.
         assert_eq!(output("  \n\u{1b}\n "), None);
+    }
+
+    /// A row's address is the one projected field that can send a reader out
+    /// of the application, so only a web scheme reaches it — at construction
+    /// and again when a stored projection is read back. A row whose address is
+    /// refused keeps everything else it had.
+    #[test]
+    fn a_result_row_carries_only_an_address_a_reader_may_be_sent_to() {
+        let admitted = |url: &str| {
+            ResultEntry::new(ResultEntryKind::Link, "Report")
+                .with_web_url(url)
+                .url
+        };
+        assert_eq!(
+            admitted("https://sec.gov/report").as_deref(),
+            Some("https://sec.gov/report")
+        );
+        assert!(admitted("HTTP://sec.gov/report").is_some());
+        for refused in [
+            "javascript:alert(1)",
+            "file:///etc/passwd",
+            "data:text/html,<script>",
+            "not a url",
+            "https://",
+        ] {
+            assert_eq!(admitted(refused), None, "{refused} must not be carried");
+        }
+
+        // Read back from a stored projection, where the value is whatever the
+        // journal holds rather than whatever the builder allowed.
+        let row = result_entry(&serde_json::json!({
+            "kind": "link",
+            "label": "Report",
+            "url": "javascript:alert(1)",
+        }))
+        .expect("a row survives an address it cannot vouch for");
+        assert_eq!(row.url, None);
+        assert_eq!(row.label, "Report");
     }
 
     /// The exec card lists the durable outputs the command published. Only

--- a/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ApprovalCard } from "./ApprovalCard";
@@ -711,8 +711,8 @@ describe("mcp app views", () => {
               tool: "entries",
               elided: 3,
               entries: [
-                { kind: "file", label: "notes.md", detail: null, meta: "1.2 KB", mediaType: null, targetId: null },
-                { kind: "folder", label: "reports", detail: null, meta: null, mediaType: null, targetId: null },
+                { kind: "file", label: "notes.md", detail: null, meta: "1.2 KB", mediaType: null, targetId: null, url: null },
+                { kind: "folder", label: "reports", detail: null, meta: null, mediaType: null, targetId: null, url: null },
               ],
               failures: [],
             },
@@ -768,7 +768,7 @@ describe("mcp app views", () => {
                   detail: "Pages 3, 7",
                   meta: "2 matches",
                   mediaType: "application/pdf",
-                  targetId: null,
+                  targetId: null, url: null,
                 },
               ],
               failures: [],
@@ -815,7 +815,7 @@ describe("mcp app views", () => {
               tool: "entries",
               elided: 0,
               entries: [
-                { kind: "file", label: "q3.md", detail: null, meta: null, mediaType: null, targetId: null },
+                { kind: "file", label: "q3.md", detail: null, meta: null, mediaType: null, targetId: null, url: null },
               ],
               failures: [
                 { label: "q4.md", error: "file is not valid UTF-8" },
@@ -881,7 +881,7 @@ describe("actionable tool results", () => {
             detail: null,
             meta: "v1 · created",
             mediaType: CHART_MEDIA_TYPE,
-            targetId: "output-2",
+            targetId: "output-2", url: null,
           },
         ],
       },
@@ -921,7 +921,7 @@ describe("actionable tool results", () => {
                   meta: "v1 · created",
                   mediaType:
                     "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-                  targetId: "output-1",
+                  targetId: "output-1", url: null,
                 },
               ],
             },
@@ -1064,7 +1064,7 @@ describe("actionable tool results", () => {
                   detail: null,
                   meta: "revision 1",
                   mediaType: null,
-                  targetId: "app-1",
+                  targetId: "app-1", url: null,
                 },
               ],
             },
@@ -1275,5 +1275,90 @@ describe("file attachment chips", () => {
 
     await user.click(screen.getByRole("button", { name: "brief.pdf" }));
     expect(openDocument).toHaveBeenCalledWith("document-1");
+  });
+});
+
+
+describe("web sources", () => {
+  it("names the pages a turn's searches found and opens one externally", async () => {
+    const user = userEvent.setup();
+    const opened: string[] = [];
+    vi.spyOn(window, "open").mockImplementation((url) => {
+      opened.push(String(url));
+      return null;
+    });
+    const found = (host: string) => ({
+      kind: "link" as const,
+      label: `${host} report`,
+      detail: host,
+      meta: null,
+      mediaType: null,
+      targetId: null,
+      url: `https://${host}/report`,
+    });
+
+    render(
+      <MessageList
+        messages={[
+          { id: "u1", role: "user", text: "What happened?" },
+          {
+            id: "t1",
+            role: "tool",
+            callId: "c1",
+            name: "web_search",
+            status: "completed",
+            result: {
+              tool: "entries",
+              elided: 0,
+              entries: [
+                found("sec.gov"),
+                found("reuters.com"),
+                found("ft.com"),
+                found("wsj.com"),
+                found("bloomberg.com"),
+                found("apnews.com"),
+                // The same page found twice is one source.
+                found("sec.gov"),
+                // A row with no address cannot be opened, so it is not listed.
+                { ...found("example.com"), url: null },
+              ],
+              failures: [],
+            },
+          },
+          {
+            id: "a1",
+            role: "assistant",
+            text: "Here is what I found.",
+            sources: [],
+          },
+        ]}
+        folderAccessRequests={[]}
+        nativeHost={false}
+        nativeBusy={false}
+        resolvingFolderCalls={new Set()}
+        folderAccessErrors={{}}
+        decidingApprovalCalls={new Set()}
+        approvalErrors={{}}
+        busy={false}
+        scrollRef={{ current: null }}
+        onScroll={noop}
+        onApproval={noop}
+        onFolderAccessDecision={noop}
+        onFolderAccessCancel={noop}
+      />,
+    );
+
+    const row = screen.getByLabelText("Web sources");
+    expect(within(row).getByText("sec.gov")).toBeInTheDocument();
+    // Six openable pages, five shown: the row says how many it is holding back
+    // rather than quietly dropping them.
+    expect(within(row).queryByText("apnews.com")).not.toBeInTheDocument();
+    expect(within(row).queryByText("example.com")).not.toBeInTheDocument();
+
+    await user.click(within(row).getByRole("button", { name: "+1 more" }));
+    expect(within(row).getByText("apnews.com")).toBeInTheDocument();
+
+    await user.click(within(row).getByRole("button", { name: "sec.gov report" }));
+    expect(opened).toEqual(["https://sec.gov/report"]);
   });
 });

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -50,6 +50,11 @@ import {
 } from "./TranscriptFileAttachments";
 import { BackgroundAgentList } from "./BackgroundAgentList";
 import { WebSearchProviderRequiredCard } from "./WebSearchProviderRequiredCard";
+import {
+  MessageWebSources,
+  collectWebSources,
+  type MessageWebSource,
+} from "./MessageWebSources";
 import { useSourceNav } from "./panel/SourceNav";
 import {
   TurnFailureNotice,
@@ -566,6 +571,10 @@ export function groupMessageItems(
   // turn, not per transcript: the next turn hitting the same wall is a live
   // prompt again, so a user message clears it.
   let standingCardKeys = new Set<string>();
+  // The pages this turn's searches found, gathered across every activity phase
+  // it passed through and listed once, under the answer they fed. Reset at the
+  // turn boundary: the previous turn's sources are not this answer's.
+  let turnWebSources: MessageWebSource[] = [];
   let index = 0;
   let groupIndex = 0;
   let streamingAssistantId: string | undefined;
@@ -593,16 +602,16 @@ export function groupMessageItems(
       if (message.role === "user") {
         lastTurnStart = items.length;
         standingCardKeys = new Set<string>();
+        turnWebSources = [];
       }
+      const closesTurn =
+        message.role === "assistant" && isTurnClosingAssistant(messages, index);
       items.push(
         <MessageBubble
           key={message.id}
           message={message}
           busy={message.id === streamingAssistantId}
-          sequenceEnd={
-            message.role !== "assistant" ||
-            isTurnClosingAssistant(messages, index)
-          }
+          sequenceEnd={message.role !== "assistant" || closesTurn}
           imageClient={imageClient}
           chatId={chatId}
           changeClient={changeClient}
@@ -611,6 +620,18 @@ export function groupMessageItems(
           }
         />,
       );
+      // A sibling of the bubble rather than part of it: the row is built from
+      // the turn's tool rows, which the bubble knows nothing about, and keeping
+      // it outside leaves the memoized bubble's props untouched.
+      if (closesTurn && turnWebSources.length > 0) {
+        items.push(
+          <MessageWebSources
+            key={`${message.id}-web-sources`}
+            sources={turnWebSources}
+          />,
+        );
+        turnWebSources = [];
+      }
       index += 1;
       continue;
     }
@@ -634,6 +655,13 @@ export function groupMessageItems(
       (entry): entry is ToolMessage =>
         entry.role === "tool" && !parked.has(entry.callId),
     );
+    // Phases accumulate: a turn that searched, answered a little, and searched
+    // again names every page it found under the answer that closes it.
+    for (const source of collectWebSources(activities)) {
+      if (!turnWebSources.some((seen) => seen.url === source.url)) {
+        turnWebSources.push(source);
+      }
+    }
     const cards = surfacedCards(
       phase,
       parked,

--- a/crates/openwave-desktop/ui/src/MessageWebSources.tsx
+++ b/crates/openwave-desktop/ui/src/MessageWebSources.tsx
@@ -1,0 +1,118 @@
+import { useState } from "react";
+
+import type { ToolResultPreview } from "./api";
+import { openExternal } from "./host";
+
+/** One page a turn's web searches surfaced, as the row shows it. */
+export type MessageWebSource = Readonly<{
+  url: string;
+  /** The page's title, or its address when the result carried no title. */
+  label: string;
+  /** The bare host, which is what the chip prints. */
+  domain: string;
+}>;
+
+/** Chips shown before the row folds the rest into a count. */
+const VISIBLE_SOURCES = 5;
+
+/**
+ * The pages behind a turn's answer, listed under it.
+ *
+ * A search the chat did not run itself — one the model provider performed
+ * inside its own infrastructure — still has to name where its answer came
+ * from, and naming it is only worth anything if the reader can reach the page.
+ * So this reads from the turn's stored `web_search` rows rather than from
+ * anything the model wrote in its prose: what is listed here is what was
+ * actually searched.
+ *
+ * Deliberately domains, not titles: a row of hosts is scannable, tells the
+ * reader whose account of something they are getting, and does not compete
+ * with the answer above it. The title rides along as the chip's tooltip and
+ * its accessible name.
+ */
+export function MessageWebSources({
+  sources,
+}: {
+  sources: readonly MessageWebSource[];
+}) {
+  const [expanded, setExpanded] = useState(false);
+  if (sources.length === 0) return null;
+
+  const shown = expanded ? sources : sources.slice(0, VISIBLE_SOURCES);
+  const hidden = sources.length - shown.length;
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-1.5 px-1 pb-2"
+      aria-label="Web sources"
+    >
+      <span className="text-xs text-muted-foreground">Sources</span>
+      {shown.map((source) => (
+        <button
+          key={source.url}
+          type="button"
+          title={source.label}
+          aria-label={source.label}
+          className="max-w-56 truncate rounded-full border bg-card px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+          onClick={() => void openSource(source.url)}
+        >
+          {source.domain}
+        </button>
+      ))}
+      {hidden > 0 && (
+        <button
+          type="button"
+          className="rounded-full px-2 py-0.5 text-xs text-muted-foreground underline-offset-2 hover:underline"
+          onClick={() => setExpanded(true)}
+        >
+          +{hidden} more
+        </button>
+      )}
+    </div>
+  );
+}
+
+/** Native opener first; `window.open` only works in a plain browser tab. */
+async function openSource(url: string): Promise<void> {
+  if (!(await openExternal(url).catch(() => false))) {
+    window.open(url, "_blank", "noreferrer,noopener");
+  }
+}
+
+/**
+ * The pages a turn's `web_search` calls found, in the order they were found.
+ *
+ * Only the search tool contributes: a page the model went on to read is part
+ * of its work, not a separate claim about where the answer came from, and
+ * listing it twice would say the turn consulted more than it did. Rows without
+ * an address are dropped rather than shown unopenable — a source chip that
+ * goes nowhere is a promise the row cannot keep. The same page found by two
+ * searches is one source.
+ */
+export function collectWebSources(
+  calls: readonly { name: string; result?: ToolResultPreview | null }[],
+): MessageWebSource[] {
+  const byUrl = new Map<string, MessageWebSource>();
+  for (const call of calls) {
+    if (call.name !== "web_search") continue;
+    if (call.result?.tool !== "entries") continue;
+    for (const entry of call.result.entries) {
+      if (entry.kind !== "link" || !entry.url || byUrl.has(entry.url)) continue;
+      byUrl.set(entry.url, {
+        url: entry.url,
+        label: entry.label || entry.url,
+        domain: entry.detail ?? hostOf(entry.url),
+      });
+    }
+  }
+  return [...byUrl.values()];
+}
+
+/** The bare host of an address the projection carried no domain for. */
+function hostOf(url: string): string {
+  try {
+    return new URL(url).host.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -1162,6 +1162,7 @@ describe("parseToolResultPreview closed results", () => {
           meta: "1.2 KB",
           mediaType: "text/markdown",
           targetId: null,
+          url: null,
         },
         {
           kind: "folder",
@@ -1170,6 +1171,7 @@ describe("parseToolResultPreview closed results", () => {
           meta: null,
           mediaType: null,
           targetId: null,
+          url: null,
         },
       ],
       failures: [{ label: "q4.md", error: "unreadable" }],
@@ -1185,6 +1187,30 @@ describe("parseToolResultPreview closed results", () => {
         elided: 0,
       }),
     ).toEqual({ tool: "entries", entries: [], failures: [], elided: 0 });
+  });
+  // A row's address is the only projected field that can send a reader out of
+  // the application, so the renderer re-checks the scheme the server admitted
+  // on. A row whose address it will not vouch for keeps its title and simply
+  // does not open.
+  it("admits only a web address a source row can be opened by", () => {
+    const entries = [
+      { kind: "link", label: "Report", url: "https://sec.gov/report" },
+      { kind: "link", label: "Injected", url: "javascript:alert(1)" },
+      { kind: "link", label: "Local", url: "file:///etc/passwd" },
+      { kind: "link", label: "Malformed", url: "not a url" },
+    ];
+    const preview = parseToolResultPreview({
+      tool: "entries",
+      entries,
+      failures: [],
+      elided: 0,
+    });
+    expect(preview?.tool).toBe("entries");
+    expect(
+      preview?.tool === "entries"
+        ? preview.entries.map((entry) => entry.url)
+        : null,
+    ).toEqual(["https://sec.gov/report", null, null, null]);
   });
 });
 

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -73,6 +73,7 @@ import {
   type StickyChatDefaults as WireStickyChatDefaults,
   type WebSearchConfigInfo as WireWebSearchConfigInfo,
   type WebSearchCredentialReadiness as WireWebSearchCredentialReadiness,
+  type WebSearchMode as WireWebSearchMode,
   type WebSearchProviderKind as WireWebSearchProviderKind,
   type PendingFolderAccessRequest as WirePendingFolderAccessRequest,
   type PendingOutputWritebackRequest as WirePendingOutputWritebackRequest,
@@ -253,6 +254,9 @@ export type Project = WireProject;
 
 /** The fixed, host-owned search providers supported by this build. */
 export type WebSearchProviderKind = WireWebSearchProviderKind;
+
+/** Which search a chat gets: the model provider's, this host's, or none. */
+export type WebSearchMode = WireWebSearchMode;
 
 /** Non-secret web-search policy and readiness for its selected provider. */
 export type WebSearchConfigInfo = WireWebSearchConfigInfo;
@@ -1007,6 +1011,7 @@ export class ApiClient {
   }
 
   putWebSearchConfig(body: {
+    mode?: WebSearchMode;
     provider?: WebSearchProviderKind | null;
     timeout_ms?: number;
     // Explicit null clears the configured instance URL; omitting the field

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -508,6 +508,12 @@ export type ResultEntry = {
    * an output row the outputs panel, an app row the apps library.
    */
   targetId: string | null;
+  /**
+   * The public page this row opens, when it names one. Re-checked here rather
+   * than trusted: it is the only projected field that can send a reader out of
+   * the application, so a non-web address never reaches the host's opener.
+   */
+  url: string | null;
 };
 
 /** One thing a listed call could not do. */
@@ -2859,7 +2865,34 @@ function parseResultEntry(value: unknown): ResultEntry | null {
   ) {
     return null;
   }
-  return { kind: kind as ResultEntryKind, label, detail, meta, mediaType, targetId };
+  // A row survives an address it cannot vouch for; it simply does not open.
+  const url = isWebUrl(value.url) ? value.url : null;
+  return {
+    kind: kind as ResultEntryKind,
+    label,
+    detail,
+    meta,
+    mediaType,
+    targetId,
+    url,
+  };
+}
+
+/**
+ * Whether a projected address may be handed to the host's external opener.
+ *
+ * The server admits only `http` and `https` into the projection, and this
+ * repeats the check on the way out: the renderer is the last thing standing
+ * between stored text and a browser window.
+ */
+function isWebUrl(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  try {
+    const { protocol } = new URL(value);
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1930,7 +1930,22 @@ media_type: string | null,
  * [`Output`]: ResultEntryKind::Output
  * [`App`]: ResultEntryKind::App
  */
-target_id: string | null, };
+target_id: string | null, 
+/**
+ * The public page this row opens, when it names one.
+ *
+ * The one projected field a click leaves the application with, so it is
+ * admitted at construction rather than at the click: only `http` and
+ * `https` survive [`Self::with_web_url`], and a row whose address is
+ * anything else keeps its title and its domain and simply does not open.
+ * It rides alongside the domain in `detail` rather than replacing it —
+ * a column of rows is still told apart by host, not by query string.
+ *
+ * Carried because attribution for a search a chat did not run itself is
+ * only meaningful if the reader can reach the page. `default` because
+ * retained projections predate the field.
+ */
+url?: string, };
 
 /**
  * What one row of a listed result is, which is what picks its icon.

--- a/crates/openwave-desktop/ui/src/settings/WebSearchPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/WebSearchPanel.dom.test.tsx
@@ -8,6 +8,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
 import type {
   ApiClient,
   WebSearchConfigInfo,
@@ -80,6 +81,7 @@ describe("WebSearchPanel", () => {
       "tavily-secret",
     );
     expect(putWebSearchConfig).toHaveBeenCalledWith({
+      mode: "automatic",
       provider: "exa",
       timeout_ms: 30_000,
       searxng_base_url: null,
@@ -138,6 +140,7 @@ describe("WebSearchPanel", () => {
 
     await waitFor(() =>
       expect(putWebSearchConfig).toHaveBeenCalledWith({
+        mode: "automatic",
         provider: "searxng",
         timeout_ms: 20_000,
         searxng_base_url: "http://localhost:8888",
@@ -145,6 +148,42 @@ describe("WebSearchPanel", () => {
     );
     expect(putWebSearchCredential).not.toHaveBeenCalled();
     expect(screen.queryByLabelText(/SearXNG API key/)).toBeNull();
+  });
+
+  // The mode decides who searches at all, so it has to survive a round trip:
+  // a panel that loaded one mode and saved another would silently retarget
+  // every chat's search.
+  it("loads the stored mode and saves the one the user picked", async () => {
+    const user = userEvent.setup();
+    const { client, putWebSearchConfig } = clientFor({
+      provider: "exa",
+      has_credential: true,
+      available: true,
+      timeout_ms: 20_000,
+      mode: "host",
+    });
+
+    render(<WebSearchPanel client={client} />);
+
+    const modeSelect = await screen.findByRole("combobox", {
+      name: "Search mode",
+    });
+    expect(modeSelect).toHaveTextContent("Configured provider");
+
+    await user.click(modeSelect);
+    await user.click(
+      screen.getByRole("option", { name: "Model provider (built-in)" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Save settings" }));
+
+    await waitFor(() =>
+      expect(putWebSearchConfig).toHaveBeenCalledWith({
+        mode: "vendor",
+        provider: "exa",
+        timeout_ms: 20_000,
+        searxng_base_url: null,
+      }),
+    );
   });
 
   it("rejects a timeout outside the bounds before touching the server", async () => {

--- a/crates/openwave-desktop/ui/src/settings/WebSearchPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/WebSearchPanel.tsx
@@ -4,6 +4,7 @@ import type {
   ApiClient,
   WebSearchConfigInfo,
   WebSearchCredentialReadiness,
+  WebSearchMode,
   WebSearchProviderKind,
 } from "../api";
 import { Button } from "@/components/ui/button";
@@ -14,6 +15,13 @@ import {
   timeoutMsFromSeconds,
 } from "./ProviderFields";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import {
   SettingsError,
   SettingsField,
@@ -31,9 +39,21 @@ const MAX_WEB_SEARCH_TIMEOUT_SECONDS = 60;
  */
 const SEARXNG_PROVIDER: WebSearchProviderKind = "searxng";
 
+/**
+ * The mode choices, in the order they narrow: the default that picks for you,
+ * then each of the two searches on its own, then none at all.
+ */
+const MODE_OPTIONS: { mode: WebSearchMode; label: string }[] = [
+  { mode: "automatic", label: "Automatic" },
+  { mode: "vendor", label: "Model provider (built-in)" },
+  { mode: "host", label: "Configured provider" },
+  { mode: "off", label: "Off" },
+];
+
 export function WebSearchPanel({ client }: { client: ApiClient }) {
   const [config, setConfig] = useState<WebSearchConfigInfo | null>(null);
   const [credentials, setCredentials] = useState<WebSearchCredentialReadiness[]>([]);
+  const [mode, setMode] = useState<WebSearchMode>("automatic");
   const [provider, setProvider] = useState<WebSearchProviderKind | "">("");
   const [timeoutSeconds, setTimeoutSeconds] = useState("");
   const [searxngBaseUrl, setSearxngBaseUrl] = useState("");
@@ -60,6 +80,7 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
         if (cancelled) return;
         setConfig(nextConfig);
         setCredentials(nextCredentials.credentials);
+        setMode(nextConfig.mode);
         setProvider(nextConfig.provider ?? "");
         setTimeoutSeconds(String(nextConfig.timeout_ms / 1000));
         setSearxngBaseUrl(nextConfig.searxng_base_url ?? "");
@@ -100,6 +121,7 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
         setApiKeys((current) => ({ ...current, [credential.provider]: "" }));
       }
       const nextConfig = await client.putWebSearchConfig({
+        mode,
         provider: provider || null,
         timeout_ms: timeout.timeoutMs,
         // An empty field clears the stored address rather than leaving a
@@ -109,6 +131,7 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
       const nextCredentials = await client.listWebSearchCredentials();
       setConfig(nextConfig);
       setCredentials(nextCredentials.credentials);
+      setMode(nextConfig.mode);
       setTimeoutSeconds(String(nextConfig.timeout_ms / 1000));
       setSearxngBaseUrl(nextConfig.searxng_base_url ?? "");
       toast.success("Saved web-search settings");
@@ -159,6 +182,33 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
             label={state.label}
             description={state.description}
           />
+
+          <SettingsSection
+            title="Search mode"
+            description="Which search a chat gets. Automatic uses your model provider's built-in search when the chat's model supports it, and the provider configured below otherwise."
+          >
+            <SettingsField
+              label="Search mode"
+              hint="Built-in search runs inside the model provider's own infrastructure and is billed through that provider's API key, not through the providers below."
+            >
+              <Select
+                value={mode}
+                disabled={working}
+                onValueChange={(next) => setMode(next as WebSearchMode)}
+              >
+                <SelectTrigger aria-label="Search mode">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {MODE_OPTIONS.map((option) => (
+                    <SelectItem key={option.mode} value={option.mode}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </SettingsField>
+          </SettingsSection>
 
           <SettingsSection
             title="Providers"
@@ -279,21 +329,49 @@ function webSearchState(config: WebSearchConfigInfo | null): {
   label: string;
   description: string;
 } {
-  if (!config?.provider) {
+  // The mode decides who searches, so it decides what the verdict is about.
+  // Only the two modes that can reach a host provider report on one.
+  if (config?.mode === "off") {
     return {
       kind: "disabled",
-      label: "Disabled",
-      description: "No web-search provider is selected.",
+      label: "Off",
+      description: "No chat can search the web.",
     };
   }
+  if (config?.mode === "vendor") {
+    return {
+      kind: "ready",
+      label: "Built-in search",
+      description:
+        "Chats search through the model provider. A model without built-in search cannot search at all.",
+    };
+  }
+  if (!config?.provider) {
+    return config?.mode === "automatic"
+      ? {
+          kind: "not-configured",
+          label: "Built-in search only",
+          description:
+            "No provider is selected here, so only models with built-in search can search.",
+        }
+      : {
+          kind: "disabled",
+          label: "Disabled",
+          description: "No web-search provider is selected.",
+        };
+  }
   if (config.available) {
+    const selected =
+      config.provider === SEARXNG_PROVIDER
+        ? `${providerLabel(config.provider)} is selected and pointed at ${config.searxng_base_url}.`
+        : `${providerLabel(config.provider)} is selected and has a saved key.`;
     return {
       kind: "ready",
       label: "Ready",
       description:
-        config.provider === SEARXNG_PROVIDER
-          ? `${providerLabel(config.provider)} is selected and pointed at ${config.searxng_base_url}.`
-          : `${providerLabel(config.provider)} is selected and has a saved key.`,
+        config.mode === "automatic"
+          ? `${selected} Models with built-in search use that instead.`
+          : selected,
     };
   }
   return {

--- a/crates/openwave-web-search/src/tool.rs
+++ b/crates/openwave-web-search/src/tool.rs
@@ -275,7 +275,7 @@ fn extraction_output(response: &WebExtractResponse, result: String) -> ToolOutpu
     } else {
         response.title.as_str()
     };
-    let mut entry = ResultEntry::new(ResultEntryKind::Link, label);
+    let mut entry = ResultEntry::new(ResultEntryKind::Link, label).with_web_url(&response.url);
     if let Some(host) = Url::parse(&response.url).ok().and_then(|url| {
         url.host_str()
             .map(|host| host.trim_start_matches("www.").to_owned())
@@ -296,7 +296,7 @@ fn extraction_output(response: &WebExtractResponse, result: String) -> ToolOutpu
 /// and forty characters of query string does that worse than "sec.gov" does.
 /// A URL the parser rejects still gets a row — its title is the result.
 fn page_entry(result: &WebSearchResult) -> ResultEntry {
-    let entry = ResultEntry::new(ResultEntryKind::Link, &result.title);
+    let entry = ResultEntry::new(ResultEntryKind::Link, &result.title).with_web_url(&result.url);
     match Url::parse(&result.url).ok().and_then(|url| {
         url.host_str()
             .map(|host| host.trim_start_matches("www.").to_owned())


### PR DESCRIPTION
The last slice of vendor web search: the two places a reader meets it.

**Settings.** The web-search panel leads with a Search mode row — Automatic, Model provider (built-in), Configured provider, Off — above the provider cards, which keep configuring the host side and still matter under Automatic and Configured provider. The readiness line reads the mode: Off and Model provider report on the mode itself, Automatic with nothing configured says built-in search only rather than the flat "Disabled" it used to, and a ready host provider under Automatic notes that a model with built-in search uses that instead. A line under the selector says built-in search bills through the model provider's API key.

**Source chips.** A turn that searched now names the pages it found in a row under the answer that closes the turn: small chips printing the bare host, titled with the page title, opening externally through the host opener with the usual `window.open` fallback. Five are shown and the rest fold into a `+N more` the reader can expand. Both search routes feed it — the host tool and the provider-executed one project the same rows — so attribution does not depend on which one ran. The row is a sibling of the assistant bubble rather than part of it: it is built from the turn's tool rows, which the memoized bubble knows nothing about.

That needed one thing the renderer did not have. A search result's row carried its title and its domain but never its address, so a chip had nowhere to send anyone. `ResultEntry` now carries an optional `url`, admitted at construction: only `http` and `https` survive `with_web_url`, an over-long address is dropped rather than truncated (a truncated URL opens a different page), and the renderer re-checks the scheme on the way out — it is the last thing standing between stored text and a browser window. A row whose address is refused keeps its title and its domain and simply does not open. Gemini's `attribution_html` is deliberately not rendered; that path is dormant and third-party markup needs its own review.

The nudge card needed no change. It is driven strictly by a `ConfigurationRequired` error from a web-capability tool, which the vendor path never raises: a capable model under Automatic or Model provider searches and never reaches it, and every state that does reach it — Configured provider with nothing configured, or Automatic with a model that has no built-in search — is one where adding a key is genuinely the fix the card names.

Tests: the panel's mode round-trip (loads the stored mode, saves the picked one — a panel that silently retargeted every chat's search would be the failure worth catching); the source row driven through `MessageList` from a fixture turn, covering dedupe, the overflow count, the dropped address, and the external open; and the scheme gate on both sides of the boundary, in `preview.rs` and in `parseResultEntry`. Existing entry fixtures gained the new field.

Stacked on #1666 (slice 3, the server route); retarget to `main` once that lands.

Verified: `pnpm test` (772 passing), `pnpm build`, `tsc`, `cargo check --workspace --locked --all-targets`, clippy and the affected suites for `openwave-core` and `openwave-web-search`, and the wire-bindings staleness check. Not driven in the running app.