### PR TITLE
fix(core): align host write_file limits with the sandbox agent

### DIFF
--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -31,6 +31,19 @@ pub const VERSION: &str = match option_env!("OPENWAVE_VERSION") {
 /// scan is behind.
 pub const OUTPUT_LOOKUP_LIMIT: u64 = 1_000;
 
+/// Largest content a single `write_file` call may write.
+///
+/// One cap for both `write_file` implementations: this crate's host tool and
+/// the sandbox-resident agent's in-container tool
+/// (`openwave_sandbox_agent::fs::MAX_WRITE_BYTES`, which aliases this). A model
+/// that learns the bound from one of them must not be surprised by the other,
+/// so the two cannot be allowed to drift. It lives here, ungated, because the
+/// sandbox agent builds without the `tools` feature the host tool is behind.
+///
+/// Above this, file production belongs in an exec command writing into
+/// `output/`: large content is a program's job, and that path publishes it.
+pub const MAX_WRITE_FILE_BYTES: usize = 1_024 * 1_024;
+
 pub mod agent;
 pub mod agent_tools;
 pub mod approval;

--- a/crates/openwave-core/src/tools/definitions.rs
+++ b/crates/openwave-core/src/tools/definitions.rs
@@ -3,8 +3,8 @@
 use crate::tool::ToolSpec;
 
 use super::{
-    create_app as create_app_tool, list_dir as list_dir_tool, read_file as read_file_tool,
-    write_file as write_file_tool,
+    create_app as create_app_tool, list_dir as list_dir_tool, private_scratch,
+    read_file as read_file_tool, write_file as write_file_tool,
 };
 
 pub(super) const READ_FILE: &str = "read_file";
@@ -14,9 +14,13 @@ pub(super) const WRITE_FILE: &str = "write_file";
 pub(super) fn read_file() -> ToolSpec {
     ToolSpec::for_args::<read_file_tool::Arguments>(
         READ_FILE,
-        "Read a UTF-8 text file, relative to the private scratch directory. Use this, not \
-         an exec command, to read workspace text. Files under output/ are readable here, \
-         but only exec can write them.",
+        format!(
+            "Read a UTF-8 text file, relative to the private scratch directory. Use this, not \
+             an exec command, to read workspace text. Reads up to {} of UTF-8 text; anything \
+             larger or non-text has to be handled by an exec command. Files under output/ are \
+             readable here, but only exec can write them.",
+            crate::preview::format_bytes(private_scratch::MAX_READ_FILE_BYTES as u64)
+        ),
     )
 }
 
@@ -32,13 +36,16 @@ pub(super) fn list_dir() -> ToolSpec {
 pub(super) fn write_file() -> ToolSpec {
     ToolSpec::for_args::<write_file_tool::Arguments>(
         WRITE_FILE,
-        "Write a UTF-8 text file into private scratch, creating parent directories. Use \
-         this, not an exec command, to write workspace text. Overwrites an existing file \
-         in place: the last write wins. Scratch is an ephemeral working space — anything \
-         outside output/ and preview/ is intermediate and may not survive to a later \
-         command or turn. Only output/ is durable, and it is reserved: a write there is \
-         refused, because a user-visible output is published by saving it into output/ \
-         from an exec command, which versions it.",
+        format!(
+            "Write a UTF-8 text file into private scratch, creating parent directories. Use \
+             this, not an exec command, to write workspace text, up to {}. Overwrites an \
+             existing file in place: the last write wins. Scratch is an ephemeral working \
+             space — anything outside output/ and preview/ is intermediate and may not survive \
+             to a later command or turn. Only output/ is durable, and it is reserved: a write \
+             there is refused, because a user-visible output is published by saving it into \
+             output/ from an exec command, which versions it.",
+            crate::preview::format_bytes(crate::MAX_WRITE_FILE_BYTES as u64)
+        ),
     )
 }
 

--- a/crates/openwave-core/src/tools/tests.rs
+++ b/crates/openwave-core/src/tools/tests.rs
@@ -393,6 +393,27 @@ async fn read_rejects_files_over_the_output_limit() {
     assert!(read.content.contains("too large"), "{read:?}");
 }
 
+/// The write cap is a contract the model is told about and routes around, so
+/// it has to refuse rather than truncate, and it has to name the exec/output
+/// path that handles content this size.
+#[tokio::test]
+async fn write_rejects_content_over_the_shared_write_cap() {
+    let dir = tempfile::tempdir().unwrap();
+    let content = "x".repeat(crate::MAX_WRITE_FILE_BYTES + 1);
+
+    let write = WriteFile
+        .execute(
+            &ctx(dir.path()),
+            json!({"path": "big.txt", "content": content}),
+        )
+        .await
+        .unwrap();
+
+    assert!(write.is_error, "{write:?}");
+    assert!(write.content.contains("output"), "{write:?}");
+    assert!(!dir.path().join("big.txt").exists());
+}
+
 #[tokio::test]
 async fn missing_file_is_a_model_facing_error_not_err() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/openwave-core/src/tools/write_file.rs
+++ b/crates/openwave-core/src/tools/write_file.rs
@@ -38,6 +38,22 @@ impl Tool for WriteFile {
             Ok(arguments) => arguments,
             Err(output) => return Ok(output),
         };
+        // Same cap the sandbox-resident write_file enforces, checked before any
+        // path work so the two variants refuse the same content for the same
+        // reason. Content this size is a program's product, not a text edit.
+        if arguments.content.len() > crate::MAX_WRITE_FILE_BYTES {
+            return Ok(ToolOutput::failed(
+                ToolErrorCategory::InvalidArguments,
+                format!(
+                    "content is {} and write_file accepts at most {}: produce a file this large \
+                     from an exec command that saves it into {}/, where it is published as a \
+                     durable, versioned output.",
+                    crate::preview::format_bytes(arguments.content.len() as u64),
+                    crate::preview::format_bytes(crate::MAX_WRITE_FILE_BYTES as u64),
+                    crate::EXEC_OUTPUT_DIRECTORY
+                ),
+            ));
+        }
         let path = match relative_path(&arguments.path) {
             Ok(path) => path,
             Err(message) => return Ok(ToolOutput::error(message)),

--- a/crates/openwave-sandbox-agent/src/fs.rs
+++ b/crates/openwave-sandbox-agent/src/fs.rs
@@ -34,7 +34,10 @@ pub const MAX_PATH_BYTES: usize = 1_024;
 /// Maximum bytes returned by one read.
 pub const MAX_READ_BYTES: usize = 256 * 1_024;
 /// Maximum bytes accepted by one write.
-pub const MAX_WRITE_BYTES: usize = 1_024 * 1_024;
+///
+/// Shared with the host `write_file` tool so the two cannot diverge; see
+/// [`openwave_core::MAX_WRITE_FILE_BYTES`].
+pub const MAX_WRITE_BYTES: usize = openwave_core::MAX_WRITE_FILE_BYTES;
 /// Maximum entries returned by one directory listing.
 pub const MAX_LIST_ENTRIES: usize = 256;
 


### PR DESCRIPTION
Stacked on #1669 — review that one first; this diff is against its branch and will be retargeted to `main` once it lands.

The two `write_file` implementations bounded content differently by accident. The sandbox-resident agent caps a write at 1 MiB (`openwave-sandbox-agent/src/fs.rs`); the host tool had no content cap at all, so the same call succeeded or failed depending on where the model happened to be running. `read_file`'s 64 KiB / UTF-8-only bound was likewise real but unstated, so an oversized read spent a turn discovering it.

- `MAX_WRITE_FILE_BYTES` now lives ungated in `openwave-core` and the sandbox agent's `MAX_WRITE_BYTES` aliases it, so the two cannot drift. It sits in `lib.rs` beside `OUTPUT_LOOKUP_LIMIT` because the sandbox agent builds without the `tools` feature the host tool is behind.
- The host `write_file` checks the cap at the top of `execute`, before any path work, and refuses with the size, the bound, and where content that large belongs: an exec command saving into `output/`, which publishes it as a versioned output.
- Both bounds are now in the spec descriptions, rendered from the constants through `format_bytes` so the text cannot go stale.

One test added, none removed: the cap refusal is a contract the model is told about and routes around, so it has to refuse rather than truncate and has to name the exec path. The sandbox agent already has the mirror-image test for its own cap.

Verified with `cargo check -p openwave-core -p openwave-code-execution -p openwave-sandbox-agent --locked` and the `tools::` and `fs::` test modules.

Part of #1520