### PR TITLE
feat(server): snapshot prior bytes when write_file overwrites a scratch file

### DIFF
--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -224,8 +224,9 @@ pub use storage::{
     MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
 };
 pub use tool::{
-    input_schema_for, strict_json_schema, ApprovalClass, OptionalProperties, Tool, ToolCtx,
-    ToolErrorCategory, ToolOutput, ToolScratch, ToolSpec, ToolUiView,
+    input_schema_for, strict_json_schema, ApprovalClass, OptionalProperties, ScratchPriorContents,
+    ScratchWriteJournal, Tool, ToolCtx, ToolErrorCategory, ToolOutput, ToolScratch, ToolSpec,
+    ToolUiView,
 };
 #[cfg(feature = "tools")]
 pub use tools::{create_app_tool_spec, CreateAppTool, ListDir, ReadFile, WriteFile};

--- a/crates/openwave-core/src/tool.rs
+++ b/crates/openwave-core/src/tool.rs
@@ -31,6 +31,45 @@ use crate::id::{CallId, ChatId, ProjectId};
 pub struct ToolScratch {
     #[cfg(feature = "tools")]
     workspace: Arc<Dir>,
+    #[cfg(feature = "tools")]
+    journal: Option<Arc<dyn ScratchWriteJournal>>,
+}
+
+/// What a private-scratch file held before a structured write replaced it.
+///
+/// A file that was not there at all has no variant here: creating a file
+/// destroys nothing, so there is nothing to retain and no row to write.
+#[derive(Debug)]
+pub enum ScratchPriorContents {
+    /// The prior bytes, small enough to retain.
+    Bytes(Vec<u8>),
+    /// The file was larger than the runtime is willing to retain. It is still
+    /// overwritten; the runtime records that this change cannot be reverted.
+    TooLarge {
+        /// The prior file's length, for the runtime's journal row.
+        byte_len: u64,
+    },
+    /// The file existed but could not be read.
+    Unreadable,
+}
+
+/// Where a private-scratch overwrite's prior bytes are retained.
+///
+/// `write_file` is a structured call that already holds the path and the new
+/// bytes, so keeping what it destroys costs one read — unlike an in-place
+/// mutation from a shell command, which the runtime cannot see. The retention
+/// itself belongs to the embedding runtime, which owns the blob store and the
+/// undo window, so this layer only reports what it replaced.
+#[async_trait]
+pub trait ScratchWriteJournal: Send + Sync {
+    /// Retain what `relative_path` held before this call overwrote it.
+    ///
+    /// `relative_path` is `/`-separated and already validated as scratch
+    /// relative. Called only after the write lands, and only when a file was
+    /// there to replace. Best effort by contract: the write has happened, so a
+    /// runtime that cannot journal it reports that rather than failing the
+    /// call.
+    async fn record_overwrite(&self, relative_path: &str, prior: ScratchPriorContents, next: &[u8]);
 }
 
 impl std::fmt::Debug for ToolScratch {
@@ -49,7 +88,20 @@ impl ToolScratch {
     pub fn from_dir(workspace: Dir) -> Self {
         Self {
             workspace: Arc::new(workspace),
+            journal: None,
         }
+    }
+
+    /// Retain the prior bytes of every overwrite this scratch handle serves.
+    ///
+    /// The journal is per turn, because that is the unit the retained bytes are
+    /// attributed to and expired with, so the runtime attaches it when it pins
+    /// the handle for a turn rather than when it opens the directory.
+    #[cfg(feature = "tools")]
+    #[must_use]
+    pub fn with_write_journal(mut self, journal: Arc<dyn ScratchWriteJournal>) -> Self {
+        self.journal = Some(journal);
+        self
     }
 }
 
@@ -567,6 +619,8 @@ pub struct ToolCtx {
     pub call_id: Option<CallId>,
     #[cfg(feature = "tools")]
     workspace: WorkspaceAccess,
+    #[cfg(feature = "tools")]
+    scratch_journal: Option<Arc<dyn ScratchWriteJournal>>,
 }
 
 #[cfg(feature = "tools")]
@@ -605,6 +659,8 @@ impl ToolCtx {
                 call_id: None,
                 #[cfg(feature = "tools")]
                 workspace: WorkspaceAccess::Unavailable(_error.to_string().into()),
+                #[cfg(feature = "tools")]
+                scratch_journal: None,
             },
         }
     }
@@ -623,6 +679,8 @@ impl ToolCtx {
             call_id: None,
             #[cfg(feature = "tools")]
             workspace: WorkspaceAccess::Open(Arc::new(workspace)),
+            #[cfg(feature = "tools")]
+            scratch_journal: None,
         })
     }
 
@@ -637,6 +695,8 @@ impl ToolCtx {
             chat_id,
             project_id,
             call_id: None,
+            #[cfg(feature = "tools")]
+            scratch_journal: scratch.journal,
             #[cfg(feature = "tools")]
             workspace: WorkspaceAccess::Open(scratch.workspace),
         }
@@ -654,6 +714,8 @@ impl ToolCtx {
             call_id: None,
             #[cfg(feature = "tools")]
             workspace: WorkspaceAccess::Unavailable("private scratch is unavailable".into()),
+            #[cfg(feature = "tools")]
+            scratch_journal: None,
         }
     }
 
@@ -673,6 +735,13 @@ impl ToolCtx {
         {
             false
         }
+    }
+
+    /// The per-turn journal that retains what a scratch overwrite destroys, or
+    /// `None` where the runtime offers no undo (legacy CLI and MCP contexts).
+    #[cfg(feature = "tools")]
+    pub(crate) fn scratch_journal(&self) -> Option<&Arc<dyn ScratchWriteJournal>> {
+        self.scratch_journal.as_ref()
     }
 
     #[cfg(feature = "tools")]

--- a/crates/openwave-core/src/tools/private_scratch.rs
+++ b/crates/openwave-core/src/tools/private_scratch.rs
@@ -8,6 +8,9 @@ use cap_fs_ext::OpenOptionsSyncExt;
 use cap_std::fs::OpenOptionsExt;
 use cap_std::fs::{Dir, OpenOptions};
 
+use crate::model::MAX_EXEC_SNAPSHOT_BYTES;
+use crate::tool::ScratchPriorContents;
+
 pub(super) const MAX_READ_FILE_BYTES: usize = 64 * 1024;
 const MAX_LIST_DIR_BYTES: usize = 64 * 1024;
 const MAX_LIST_DIR_ENTRIES: usize = 4_096;
@@ -131,6 +134,46 @@ pub(super) fn list_directory(workspace: &Dir, path: &Path) -> std::result::Resul
     }
     names.sort();
     Ok(names.join("\n"))
+}
+
+/// What `path` holds before a structured write replaces it.
+///
+/// `None` means there is nothing to retain: no such file, or an entry that the
+/// write itself will refuse. The read is bounded by
+/// [`MAX_EXEC_SNAPSHOT_BYTES`], the same ceiling folder write-back retains
+/// under, so one oversized scratch file cannot be copied into the blob store.
+pub(super) fn prior_contents(workspace: &Dir, path: &Path) -> Option<ScratchPriorContents> {
+    let metadata = workspace.symlink_metadata(path).ok()?;
+    if !metadata.is_file() {
+        return None;
+    }
+    let byte_len = metadata.len();
+    if byte_len > MAX_EXEC_SNAPSHOT_BYTES {
+        return Some(ScratchPriorContents::TooLarge { byte_len });
+    }
+    let max_bytes = usize::try_from(MAX_EXEC_SNAPSHOT_BYTES).unwrap_or(usize::MAX);
+    Some(read_regular_file_bytes(workspace, path, max_bytes).map_or(
+        ScratchPriorContents::Unreadable,
+        ScratchPriorContents::Bytes,
+    ))
+}
+
+/// The journal's `/`-separated spelling of a validated scratch-relative path.
+///
+/// Undo resolves a journaled path one component at a time, so the recorded form
+/// has to be the one that resolver accepts: no `.` segments, no platform
+/// separators. A path that cannot be spelled that way is not journaled at all
+/// rather than journaled as something undo would later refuse.
+pub(super) fn journal_path(path: &Path) -> Option<String> {
+    let mut segments = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(segment) => segments.push(segment.to_str()?),
+            Component::ParentDir | Component::Prefix(_) | Component::RootDir => return None,
+        }
+    }
+    (!segments.is_empty()).then(|| segments.join("/"))
 }
 
 pub(super) fn write_utf8_file(workspace: &Dir, path: &Path, content: &[u8]) -> std::io::Result<()> {

--- a/crates/openwave-core/src/tools/write_file.rs
+++ b/crates/openwave-core/src/tools/write_file.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::Value;
+use std::sync::Arc;
 
 use crate::error::Result;
 use crate::preview::{ResultEntry, ResultEntryKind};
@@ -9,7 +10,10 @@ use crate::tool::{ApprovalClass, Tool, ToolCtx, ToolErrorCategory, ToolOutput, T
 
 use super::arguments;
 use super::definitions;
-use super::private_scratch::{file_name, is_published_output_path, relative_path, write_utf8_file};
+use super::private_scratch::{
+    file_name, is_published_output_path, journal_path, prior_contents, relative_path,
+    write_utf8_file,
+};
 
 /// `write_file` — atomically write a UTF-8 text file into private scratch.
 pub struct WriteFile;
@@ -65,21 +69,45 @@ impl Tool for WriteFile {
             Ok(workspace) => workspace,
             Err(message) => return Ok(ToolOutput::error(message)),
         };
-        let content = arguments.content.into_bytes();
+        let content = Arc::new(arguments.content.into_bytes());
         let content_len = content.len();
-        let result =
-            tokio::task::spawn_blocking(move || write_utf8_file(&workspace, &path, &content)).await;
+        // What this call is about to destroy, kept before it stops existing.
+        // Only an overwrite has anything to retain, and only a runtime that
+        // offers undo is worth reading for.
+        let journal = ctx.scratch_journal().cloned();
+        let prior = match (&journal, journal_path(&path)) {
+            (Some(_), Some(journal_path)) => {
+                let workspace = Arc::clone(&workspace);
+                let path = path.clone();
+                tokio::task::spawn_blocking(move || prior_contents(&workspace, &path))
+                    .await
+                    .ok()
+                    .flatten()
+                    .map(|prior| (journal_path, prior))
+            }
+            _ => None,
+        };
+        let result = {
+            let content = Arc::clone(&content);
+            tokio::task::spawn_blocking(move || write_utf8_file(&workspace, &path, &content)).await
+        };
         match result {
-            Ok(Ok(())) => Ok(ToolOutput::text(format!(
-                "wrote {} bytes to {}",
-                content_len, arguments.path
-            ))
-            .with_entries(vec![ResultEntry::new(
-                ResultEntryKind::File,
-                file_name(&arguments.path),
-            )
-            .with_detail(&arguments.path)
-            .with_meta(crate::preview::format_bytes(content_len as u64))])),
+            Ok(Ok(())) => {
+                if let (Some(journal), Some((journal_path, prior))) = (journal, prior) {
+                    journal
+                        .record_overwrite(&journal_path, prior, &content)
+                        .await;
+                }
+                Ok(
+                    ToolOutput::text(format!("wrote {} bytes to {}", content_len, arguments.path))
+                        .with_entries(vec![ResultEntry::new(
+                            ResultEntryKind::File,
+                            file_name(&arguments.path),
+                        )
+                        .with_detail(&arguments.path)
+                        .with_meta(crate::preview::format_bytes(content_len as u64))]),
+                )
+            }
             Ok(Err(error)) => Ok(ToolOutput::error(format!(
                 "could not write {}: {error}",
                 arguments.path

--- a/crates/openwave-server/src/exec_write_snapshot.rs
+++ b/crates/openwave-server/src/exec_write_snapshot.rs
@@ -26,8 +26,8 @@ use openwave_code_execution::{
 };
 use openwave_core::{
     BlobStore, ChatId, DocumentSourceBlob, ExecFileChange, ExecFileRejectionReason,
-    ExecFileSnapshot, ExecFileSnapshotRecord, ExecUndoState, ImageMediaType, Store, TurnId,
-    MAX_EXEC_WORKSPACE_FILE_BYTES,
+    ExecFileSnapshot, ExecFileSnapshotRecord, ExecUndoState, ImageMediaType, ScratchPriorContents,
+    Store, TurnId, MAX_EXEC_WORKSPACE_FILE_BYTES,
 };
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
@@ -71,6 +71,87 @@ impl TurnSnapshotSink {
         self.store
             .record_exec_file_snapshots(chat_id, turn_id, &files)
             .await
+    }
+}
+
+/// Journals one turn's private-scratch overwrites through the same retained
+/// blob, digest guard, and undo window as folder write-back.
+///
+/// The chat's private scratch is an ordinary absolute directory, so its rows
+/// need nothing the journal does not already carry: the scratch directory is
+/// the folder, the tool's path is the relative path, and undo resolves and
+/// restores it exactly as it does a granted folder's file. Each overwrite
+/// commits on its own, the way a connected-app publication does, because a
+/// structured write has no later write-back step to batch behind.
+pub(crate) struct TurnScratchJournal {
+    sink: TurnSnapshotSink,
+    folder: std::path::PathBuf,
+    chat_id: ChatId,
+    turn_id: TurnId,
+}
+
+impl TurnScratchJournal {
+    pub(crate) fn new(
+        store: Arc<dyn Store>,
+        blobs: Arc<dyn BlobStore>,
+        blob_writes: Arc<BlobWriteGuard>,
+        folder: std::path::PathBuf,
+        chat_id: ChatId,
+        turn_id: TurnId,
+    ) -> Self {
+        Self {
+            sink: TurnSnapshotSink::new(store, blobs, blob_writes),
+            folder,
+            chat_id,
+            turn_id,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl openwave_core::ScratchWriteJournal for TurnScratchJournal {
+    async fn record_overwrite(
+        &self,
+        relative_path: &str,
+        prior: ScratchPriorContents,
+        next: &[u8],
+    ) {
+        let prior = match prior {
+            ScratchPriorContents::Bytes(bytes) => PriorContents::Bytes(bytes),
+            ScratchPriorContents::TooLarge { byte_len } => PriorContents::TooLarge { byte_len },
+            ScratchPriorContents::Unreadable => PriorContents::Unreadable,
+        };
+        let prepared = self
+            .sink
+            .prepare(StagedChange {
+                folder: &self.folder,
+                relative: relative_path,
+                prior,
+                next: Some(next),
+            })
+            .await;
+        match prepared {
+            // The bytes are already written; the retained copy is what is at
+            // stake here, so a failure costs the undo and nothing else.
+            Ok(prepared) => prepared.applied(),
+            Err(error) => {
+                tracing::error!(
+                    chat = %self.chat_id,
+                    turn = %self.turn_id,
+                    %error,
+                    "could not retain the bytes a scratch write replaced; undo is unavailable"
+                );
+                return;
+            }
+        }
+        if let Err(error) = self.sink.commit(self.chat_id, self.turn_id).await {
+            tracing::error!(
+                chat = %self.chat_id,
+                turn = %self.turn_id,
+                %error,
+                "could not journal a scratch write; undo is unavailable"
+            );
+        }
     }
 }
 
@@ -355,6 +436,7 @@ pub(crate) async fn list_file_change_summaries(
     store: &dyn Store,
     blobs: &dyn BlobStore,
     chat_id: ChatId,
+    scratch_folder: Option<&Path>,
 ) -> openwave_core::Result<std::collections::HashMap<TurnId, Vec<ExecFileChangeSummary>>> {
     let mut by_turn = std::collections::HashMap::<TurnId, Vec<_>>::new();
     for snapshot in store.list_exec_file_snapshots(chat_id).await? {
@@ -362,7 +444,7 @@ pub(crate) async fn list_file_change_summaries(
         by_turn
             .entry(turn_id)
             .or_default()
-            .push(summarize_applied_change(blobs, snapshot).await);
+            .push(summarize_applied_change(blobs, snapshot, scratch_folder).await);
     }
     for rejection in store.list_exec_file_rejections(chat_id).await? {
         by_turn
@@ -370,7 +452,7 @@ pub(crate) async fn list_file_change_summaries(
             .or_default()
             .push(ExecFileChangeSummary {
                 snapshot_id: format!("rejected:{}", rejection.id),
-                folder_name: display_folder_name(&rejection.file.folder_path),
+                folder_name: folder_label(&rejection.file.folder_path, scratch_folder),
                 relative_path: rejection.file.relative_path,
                 classification: ExecFileChangeClassification::Rejected,
                 change: None,
@@ -392,6 +474,7 @@ pub(crate) async fn list_file_change_summaries(
 async fn summarize_applied_change(
     blobs: &dyn BlobStore,
     snapshot: ExecFileSnapshot,
+    scratch_folder: Option<&Path>,
 ) -> ExecFileChangeSummary {
     let change = match snapshot.file.change {
         ExecFileChange::Created => ExecFileChangeKind::Created,
@@ -407,7 +490,7 @@ async fn summarize_applied_change(
     };
     ExecFileChangeSummary {
         snapshot_id: snapshot.id.to_string(),
-        folder_name: display_folder_name(&snapshot.file.folder_path),
+        folder_name: folder_label(&snapshot.file.folder_path, scratch_folder),
         relative_path: snapshot.file.relative_path,
         classification: ExecFileChangeClassification::Applied,
         change: Some(change),
@@ -772,6 +855,21 @@ async fn run_document_helper(
     Err(ExecFilePreviewError::Unavailable)
 }
 
+/// What the transcript calls the folder a change landed in.
+///
+/// The chat's private scratch is a runtime directory named after the chat id,
+/// which is neither a folder the user attached nor a name they would recognize.
+/// It is labelled by what it is instead, and the path stays server-side.
+fn folder_label(folder_path: &str, scratch_folder: Option<&Path>) -> String {
+    if scratch_folder.is_some_and(|scratch| scratch == Path::new(folder_path)) {
+        return SCRATCH_FOLDER_LABEL.to_owned();
+    }
+    display_folder_name(folder_path)
+}
+
+/// How a private-scratch change names its location in the transcript.
+const SCRATCH_FOLDER_LABEL: &str = "Scratch";
+
 fn display_folder_name(folder_path: &str) -> String {
     Path::new(folder_path)
         .file_name()
@@ -1055,9 +1153,10 @@ mod tests {
         drop(blobs);
         let restarted_store = DbStore::connect(&database_url).await.unwrap();
         let restarted_blobs = FsBlobStore::new(&blob_root);
-        let summaries = list_file_change_summaries(&restarted_store, &restarted_blobs, chat.id)
-            .await
-            .unwrap();
+        let summaries =
+            list_file_change_summaries(&restarted_store, &restarted_blobs, chat.id, None)
+                .await
+                .unwrap();
         let files = &summaries[&turn_id];
         assert_eq!(files.len(), 4);
         assert!(files.iter().any(|file| {
@@ -1110,6 +1209,103 @@ mod tests {
             .files
             .iter()
             .all(|file| file.status == ExecFileUndoStatus::AlreadyUndone));
+    }
+
+    /// The reason this journal exists: `write_file` is a structured call, so an
+    /// overwrite it performs restores through exactly the path a folder
+    /// write-back's does — and a create, which destroys nothing, journals
+    /// nothing.
+    #[tokio::test]
+    async fn a_scratch_overwrite_restores_through_the_turn_journal() {
+        use cap_std::ambient_authority;
+        use cap_std::fs::Dir;
+        use openwave_core::{Tool, ToolCtx, ToolScratch, WriteFile};
+
+        let home = tempfile::tempdir().unwrap();
+        let database_url = format!(
+            "sqlite://{}?mode=rwc",
+            home.path().join("openwave.db").display()
+        );
+        let store = Arc::new(DbStore::connect(&database_url).await.unwrap());
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            reasoning_effort: None,
+            permission_mode: None,
+            network_policy: Default::default(),
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+        let blobs = Arc::new(FsBlobStore::new(home.path().join("blobs")));
+        let scratch = home.path().join("scratch").join(chat.id.to_string());
+        std::fs::create_dir_all(&scratch).unwrap();
+
+        let turn_id = TurnId::new();
+        let journal = Arc::new(TurnScratchJournal::new(
+            store.clone(),
+            blobs.clone(),
+            Arc::new(BlobWriteGuard::new(home.path().join("blob-locks"))),
+            scratch.clone(),
+            chat.id,
+            turn_id,
+        ));
+        let ctx = ToolCtx::with_private_scratch(
+            chat.id,
+            None,
+            ToolScratch::from_dir(Dir::open_ambient_dir(&scratch, ambient_authority()).unwrap())
+                .with_write_journal(journal),
+        );
+
+        let write = |content: &'static str| {
+            WriteFile.execute(
+                &ctx,
+                serde_json::json!({ "path": "notes/plan.md", "content": content }),
+            )
+        };
+        assert!(!write("first draft").await.unwrap().is_error);
+        assert!(
+            store
+                .list_exec_file_snapshots(chat.id)
+                .await
+                .unwrap()
+                .is_empty(),
+            "creating a file destroys nothing and must not retain a copy"
+        );
+        assert!(!write("second draft").await.unwrap().is_error);
+
+        let summaries = list_file_change_summaries(&*store, &*blobs, chat.id, Some(&scratch))
+            .await
+            .unwrap();
+        let files = &summaries[&turn_id];
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].relative_path, "notes/plan.md");
+        assert_eq!(files[0].folder_name, SCRATCH_FOLDER_LABEL);
+        assert_eq!(files[0].change, Some(ExecFileChangeKind::Overwritten));
+        assert_eq!(files[0].undo, ExecFileUndoAvailability::Available);
+        assert!(files[0]
+            .diff
+            .as_deref()
+            .is_some_and(|diff| diff.contains("-first draft") && diff.contains("+second draft")));
+
+        let outcome = undo_turn_file_changes(&*store, &*blobs, chat.id, turn_id)
+            .await
+            .unwrap();
+        assert_eq!(
+            outcome
+                .files
+                .iter()
+                .map(|file| file.status)
+                .collect::<Vec<_>>(),
+            vec![ExecFileUndoStatus::Restored]
+        );
+        assert_eq!(
+            std::fs::read(scratch.join("notes").join("plan.md")).unwrap(),
+            b"first draft"
+        );
     }
 
     /// The binary-preview contract crosses the durable journal, retained blob,
@@ -1177,7 +1373,7 @@ mod tests {
             .pop()
             .unwrap();
 
-        let summary = list_file_change_summaries(&store, &blobs, chat.id)
+        let summary = list_file_change_summaries(&store, &blobs, chat.id, None)
             .await
             .unwrap();
         assert_eq!(

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -1028,6 +1028,7 @@ async fn bind_inner(
         },
     )
     .with_blobs(state.blobs.clone())
+    .with_blob_write_locks(state.blob_writes.clone())
     .with_mcp_runtime(state.mcp.clone())
     .with_exec_folder_context(code_execution.clone());
     let sandbox_worker_config = sandbox_agent_run_worker::SandboxAgentRunWorkerConfig::default()

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -2054,18 +2054,27 @@ pub async fn list_chat_messages(
             Some(snapshot)
         })
         .collect();
-    let mut file_changes_by_turn =
-        match list_file_change_summaries(&*state.store, &*state.blobs, id).await {
-            Ok(summaries) => summaries,
-            Err(error) => {
-                tracing::warn!(
-                    chat = %id,
-                    %error,
-                    "could not load connected-folder change summaries"
-                );
-                std::collections::HashMap::new()
-            }
-        };
+    let mut file_changes_by_turn = match list_file_change_summaries(
+        &*state.store,
+        &*state.blobs,
+        id,
+        Some(&crate::turn_worker::private_chat_scratch_path(
+            &state.config.data_dir.join("scratch"),
+            id,
+        )),
+    )
+    .await
+    {
+        Ok(summaries) => summaries,
+        Err(error) => {
+            tracing::warn!(
+                chat = %id,
+                %error,
+                "could not load connected-folder change summaries"
+            );
+            std::collections::HashMap::new()
+        }
+    };
     Ok(Json(ChatTranscript {
         messages,
         tool_activity: transcript.tool_activity,

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -28,10 +28,11 @@ use tokio::sync::Notify;
 use crate::approvals::ApprovalBroker;
 use crate::bus::EventBus;
 use crate::chat_titling::ChatTitler;
+use crate::exec_write_snapshot::TurnScratchJournal;
 use crate::mcp_config::McpRuntime;
 use crate::resolver::ProviderResolver;
 use crate::retry::{LaneBackoff, RetryAttempt, RetrySchedule};
-use crate::state::TurnGuard;
+use crate::state::{BlobWriteGuard, TurnGuard};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct TurnWorkerConfig {
@@ -96,6 +97,7 @@ pub(crate) struct TurnWorker {
     os_policy: Arc<dyn crate::managed_policy::OsPolicySource>,
     tools: Arc<ToolRegistry>,
     blobs: Option<Arc<dyn BlobStore>>,
+    blob_writes: Option<Arc<BlobWriteGuard>>,
     mcp: Option<Arc<McpRuntime>>,
     approvals: Arc<ApprovalBroker>,
     events: Arc<EventBus>,
@@ -365,6 +367,7 @@ impl TurnWorker {
             os_policy,
             tools,
             blobs: None,
+            blob_writes: None,
             mcp: None,
             approvals,
             events,
@@ -386,6 +389,38 @@ impl TurnWorker {
     pub(crate) fn with_blobs(mut self, blobs: Arc<dyn BlobStore>) -> Self {
         self.blobs = Some(blobs);
         self
+    }
+
+    /// Retain the bytes a structured scratch write replaces, so an overwrite in
+    /// private scratch is recoverable the way a folder write-back already is.
+    ///
+    /// Without the blob write guard there is nowhere safe to publish the
+    /// retained copy, so the journal stays off rather than racing the retirer.
+    pub(crate) fn with_blob_write_locks(mut self, blob_writes: Arc<BlobWriteGuard>) -> Self {
+        self.blob_writes = Some(blob_writes);
+        self
+    }
+
+    /// Attach this turn's scratch-overwrite journal, when the runtime has the
+    /// durable stores to keep one.
+    fn with_scratch_write_journal(
+        &self,
+        scratch: ToolScratch,
+        folder: PathBuf,
+        chat_id: openwave_core::ChatId,
+        turn_id: TurnId,
+    ) -> ToolScratch {
+        let Some((blobs, blob_writes)) = self.blobs.clone().zip(self.blob_writes.clone()) else {
+            return scratch;
+        };
+        scratch.with_write_journal(Arc::new(TurnScratchJournal::new(
+            self.store.clone(),
+            blobs,
+            blob_writes,
+            folder,
+            chat_id,
+            turn_id,
+        )))
     }
 
     /// Resolve one immutable registry when a turn begins. Runtime MCP changes
@@ -757,7 +792,12 @@ impl TurnWorker {
             config.max_steps = remaining_steps;
             config.tool_scratch = self.private_scratch_root.as_deref().and_then(|root| {
                 match private_chat_scratch(root, chat.id) {
-                    Ok(scratch) => Some(scratch),
+                    Ok(scratch) => Some(self.with_scratch_write_journal(
+                        scratch,
+                        private_chat_scratch_path(root, chat.id),
+                        chat.id,
+                        turn.id,
+                    )),
                     Err(error) => {
                         eprintln!(
                             "openwave: private scratch unavailable for chat {}: {}",
@@ -2480,6 +2520,15 @@ impl TurnWorker {
     fn publish(&self, chat_id: openwave_core::ChatId, event: SequencedEvent) {
         let _ = self.events.sender(chat_id).send(event);
     }
+}
+
+/// One chat's runtime-only scratch directory under `root`.
+///
+/// The path is derived rather than stored, so the turn worker that journals a
+/// scratch write and the transcript that labels it later agree without either
+/// one persisting a host path.
+pub(crate) fn private_chat_scratch_path(root: &Path, chat_id: openwave_core::ChatId) -> PathBuf {
+    root.join(chat_id.to_string())
 }
 
 /// Derive and create one chat's runtime-only scratch under the private server


### PR DESCRIPTION
Exec write-back to a granted folder retains the bytes it is about to destroy, journals them for the chat's last 20 turns, and offers undo. A `write_file` overwrite in private scratch had none of that: last writer wins, prior bytes gone. Since `write_file` is a structured call that already holds the path and the new bytes, keeping the prior copy costs one read — unlike an in-place mutation from a shell command, which the runtime never sees and which stays ephemeral by design.

`write_file` now reads what an existing file holds, writes, and — only once the write lands — hands the prior bytes to a per-turn journal. Creating a file journals nothing: there is nothing to restore.

The journal itself is the existing one. A chat's private scratch is an ordinary absolute directory, so its rows need nothing new: the scratch directory is the row's folder, the tool's path is the relative path, and undo resolves, digest-guards, and restores it exactly as it does a file in a granted folder. Retention, blob liveness, and the orphan/retirement rules come along unchanged. No schema change.

Wiring:

- `openwave-core` gains a `ScratchWriteJournal` trait and a `ScratchPriorContents` report, attached to the pinned `ToolScratch` handle the runtime supplies. Core stays free of the store: it says what it replaced, the runtime decides what to keep. Legacy CLI and MCP contexts pin no journal and are unchanged.
- `openwave-server` implements it over `TurnSnapshotSink`, so retained bytes pass through the same content-address write guard as every other blob publication. Each overwrite commits on its own, the way a connected-app publication does — a structured write has no later write-back step to batch behind.
- The transcript labels these rows `Scratch` rather than the chat-id-named runtime directory, which is neither a folder the user attached nor a name they would recognize. The host path stays server-side.

Two bounds worth naming. The prior read is capped at `MAX_EXEC_SNAPSHOT_BYTES`, the same ceiling folder write-back retains under; a larger file is still written and its row records that it cannot be reverted. Journaling is best effort: the write has already happened, so a runtime that cannot retain the copy logs the lost undo instead of failing the call.

One test, driven end to end through the real tool: a create journals nothing, the following overwrite shows up in the turn's change summary with a diff, and `undo_turn_file_changes` puts the first draft back on disk.

Part of #1520.
