### PR TITLE
fix(desktop): center traffic lights with the titlebar content

### DIFF
--- a/crates/openwave-desktop/tauri.macos.conf.json
+++ b/crates/openwave-desktop/tauri.macos.conf.json
@@ -14,7 +14,7 @@
         "dragDropEnabled": true,
         "trafficLightPosition": {
           "x": 16,
-          "y": 14
+          "y": 20
         }
       }
     ]


### PR DESCRIPTION
The traffic lights were pinned 14pt from the top of the window, which centers them in macOS's default ~28pt title bar. OpenWave's overlay titlebar is 40px tall (`.titlebar { flex: 0 0 40px }`), so the back/forward chevrons and the app title center at 20px while the dots sat ~6px above them.

Bumps `trafficLightPosition.y` from 14 to 20 so the dots center on the same line as the titlebar content. `x: 16` is unchanged and still matches the titlebar's `padding-left: 84px`.

Config-only change; verified the JSON parses. Not driven in the running app — worth a quick visual check on `scripts/dev.sh`.