### PR TITLE
feat(cli): interactive terminal chat via `openwave tui`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -369,7 +369,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -395,7 +395,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -948,7 +948,7 @@ dependencies = [
  "io-lifetimes 3.0.1",
  "ipnet",
  "maybe-owned",
- "rustix",
+ "rustix 1.1.4",
  "rustix-linux-procfs",
  "windows-sys 0.61.2",
  "winx",
@@ -963,7 +963,7 @@ dependencies = [
  "cap-primitives",
  "io-extras",
  "io-lifetimes 3.0.1",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -997,6 +997,21 @@ checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
 dependencies = [
  "serde",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -1141,6 +1156,20 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1316,6 +1345,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.13.0",
+ "crossterm_winapi",
+ "futures-core",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1432,6 +1487,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
+dependencies = [
+ "darling_core 0.24.0",
+ "darling_macro 0.24.0",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1459,6 +1524,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.2",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1478,6 +1556,17 @@ dependencies = [
  "darling_core 0.23.0",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
+dependencies = [
+ "darling_core 0.24.0",
+ "quote",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -1676,7 +1765,7 @@ checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
  "bit-set",
  "cssparser 0.36.0",
- "foldhash",
+ "foldhash 0.2.0",
  "html5ever 0.38.0",
  "precomputed-hash",
  "selectors 0.36.1",
@@ -1691,7 +1780,7 @@ checksum = "fac5fca71e65e94cc718a6e2af65d6e0f9c6027751c2aa562fbb5087fda639bc"
 dependencies = [
  "bit-set",
  "cssparser 0.37.0",
- "foldhash",
+ "foldhash 0.2.0",
  "html5ever 0.39.0",
  "nom 8.0.0",
  "precomputed-hash",
@@ -1707,7 +1796,7 @@ checksum = "cf8b9b294aabb8010b37c49a07d6f82175152f4927855d534979a38737721875"
 dependencies = [
  "dom_query 0.28.0",
  "flagset",
- "foldhash",
+ "foldhash 0.2.0",
  "gjson",
  "html-escape",
  "once_cell",
@@ -2021,6 +2110,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -2078,7 +2173,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes 2.0.4",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.59.0",
 ]
 
@@ -2555,13 +2650,24 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -2572,7 +2678,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -2758,7 +2864,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -3034,6 +3140,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "instability"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf84e73fa6f27f299dec58e13223cf70db80da872eb921d4f6138342a0eabc8"
+dependencies = [
+ "darling 0.24.0",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
+]
+
+[[package]]
 name = "io-extras"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3258,7 +3377,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.28.0",
  "unicode-general-category",
  "uuid-simd",
 ]
@@ -3464,6 +3583,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -3488,6 +3613,15 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru-slab"
@@ -3625,6 +3759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -4064,12 +4199,19 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 name = "openwave-cli"
 version = "0.0.0"
 dependencies = [
+ "crossterm",
+ "futures",
  "openwave-core",
  "openwave-mcp",
  "openwave-server",
+ "ratatui",
+ "reqwest 0.12.28",
+ "serde",
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-tungstenite 0.30.0",
+ "tui-textarea",
 ]
 
 [[package]]
@@ -4500,6 +4642,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "peg"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4718,7 +4866,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -5069,6 +5217,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.13.0",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum 0.26.3",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5214,7 +5383,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -5367,6 +5536,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -5374,7 +5556,7 @@ dependencies = [
  "bitflags 2.13.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -5385,7 +5567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
 dependencies = [
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -5604,7 +5786,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "sqlx-core",
- "strum",
+ "strum 0.28.0",
  "thiserror 2.0.19",
  "time",
  "tracing",
@@ -6141,6 +6323,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6325,7 +6518,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "webpki-roots",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -6517,11 +6710,33 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.28.0",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7157,7 +7372,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -7362,8 +7577,12 @@ checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite 0.30.0",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -7679,6 +7898,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tui-textarea"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5318dd619ed73c52a9417ad19046724effc1287fb75cdcc4eca1d6ac1acbae"
+dependencies = [
+ "crossterm",
+ "ratatui",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7706,6 +7936,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.10.2",
+ "rustls",
+ "rustls-pki-types",
  "sha1 0.11.0",
  "thiserror 2.0.19",
 ]
@@ -7830,6 +8062,29 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -8155,6 +8410,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -8850,7 +9114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -8953,7 +9217,7 @@ dependencies = [
  "hex",
  "libc",
  "ordered-stream",
- "rustix",
+ "rustix 1.1.4",
  "serde",
  "serde_repr",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,9 @@ sea-orm = { version = "=2.0.0", default-features = false, features = ["macros", 
 sea-orm-migration = { version = "=2.0.0", default-features = false, features = ["runtime-tokio-rustls"] }
 tokio = { version = "=1.53.1", features = ["rt", "macros", "fs"] }
 tokio-util = { version = "=0.7.19", features = ["io-util"] }
+# rustls-tls-webpki-roots (never native-tls) matches the reqwest stack; the
+# loopback chat socket itself is plain ws://.
+tokio-tungstenite = { version = "=0.30.0", default-features = false, features = ["connect", "handshake", "rustls-tls-webpki-roots"] }
 reqwest = { version = "=0.12.28", default-features = false, features = ["json", "multipart", "stream", "rustls-tls"] }
 ring = "=0.17.14"
 sha2 = "=0.11.0"

--- a/crates/openwave-cli/Cargo.toml
+++ b/crates/openwave-cli/Cargo.toml
@@ -22,8 +22,15 @@ path = "src/main.rs"
 openwave-core = { path = "../openwave-core", default-features = false, features = ["tools"] }
 openwave-mcp = { path = "../openwave-mcp" }
 openwave-server = { path = "../openwave-server" }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+crossterm = { version = "=0.28.1", features = ["event-stream"] }
+futures = { workspace = true }
+ratatui = "=0.29.0"
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "sync", "time"] }
+tokio-tungstenite = { workspace = true }
+tui-textarea = "=0.7.0"
 
 [dev-dependencies]
-serde_json = { workspace = true }
 tempfile = "=3.27.0"

--- a/crates/openwave-cli/src/main.rs
+++ b/crates/openwave-cli/src/main.rs
@@ -15,15 +15,22 @@
 //! `openwave rehome-secrets` rewrites the profile's stored credentials so their
 //! keychain items belong to the running binary's code signature, which is what
 //! stops macOS asking for credentials an earlier build created.
+//!
+//! `openwave tui [--chat <id>]` runs an interactive terminal chat: it boots the
+//! same in-process server as `serve` and drives it over the loopback HTTP+WS
+//! API, starting a fresh chat or resuming an existing one.
 
 use std::ffi::OsStr;
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use openwave_core::{AgentError, ChatId, Config, ListDir, ReadFile, Result, ToolCtx, ToolRegistry};
 
-const USAGE: &str =
-    "usage: openwave serve\n       openwave mcp <workspace>\n       openwave rehome-secrets";
+mod tui;
+
+const USAGE: &str = "usage: openwave serve\n       openwave mcp <workspace>\n       openwave \
+                     rehome-secrets\n       openwave tui [--chat <id>]";
 
 #[tokio::main]
 async fn main() {
@@ -60,6 +67,25 @@ async fn run() -> Result<()> {
                 usage_error("rehome-secrets does not accept arguments");
             }
             rehome_secrets().await
+        }
+        Some(command) if command == OsStr::new("tui") => {
+            let chat = match args.next() {
+                None => None,
+                Some(flag) if flag == OsStr::new("--chat") => {
+                    let Some(id) = args.next() else {
+                        usage_error("tui --chat requires a chat id");
+                    };
+                    match ChatId::from_str(&id.to_string_lossy()) {
+                        Ok(chat) => Some(chat),
+                        Err(_) => usage_error("tui --chat expects a chat UUID"),
+                    }
+                }
+                Some(_) => usage_error("tui accepts only an optional --chat <id>"),
+            };
+            if args.next().is_some() {
+                usage_error("tui accepts only an optional --chat <id>");
+            }
+            tui::run(chat).await
         }
         Some(other) => {
             usage_error(&format!("unknown command {other:?}"));

--- a/crates/openwave-cli/src/tui/app.rs
+++ b/crates/openwave-cli/src/tui/app.rs
@@ -1,0 +1,675 @@
+//! The interactive loop: terminal input, socket frames, and a redraw tick in
+//! one `select!`. Finished blocks (user/assistant messages, tool results,
+//! notices) are committed to real scrollback with `insert_before`; the inline
+//! viewport below them repaints the live region.
+
+use std::io::{self, Stdout};
+use std::time::Duration;
+
+use crossterm::cursor::Show;
+use crossterm::event::{
+    DisableBracketedPaste, EnableBracketedPaste, Event, EventStream, KeyCode, KeyEvent,
+    KeyEventKind, KeyModifiers, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags,
+    PushKeyboardEnhancementFlags,
+};
+use crossterm::execute;
+use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
+use futures::StreamExt;
+use openwave_core::{AgentError, CallId, ChatId, Result, TurnId};
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Paragraph, Widget};
+use ratatui::{Terminal, TerminalOptions, Viewport};
+use tokio::sync::mpsc;
+use tokio_tungstenite::tungstenite::Message;
+use tui_textarea::{Input, TextArea};
+
+use super::client::{Client, EventSocket};
+use super::render::{self, Commit};
+use super::wire::{ChatFrame, ClientEvent, SequencedFrame, ToolCallStatus};
+
+/// Fixed height of the repainting region: transient stack, composer, footer.
+/// Clamped to the terminal at startup.
+const LIVE_HEIGHT: u16 = 16;
+/// Composer rows beyond this scroll inside the textarea.
+const MAX_COMPOSER_ROWS: u16 = 4;
+const TICK: Duration = Duration::from_millis(100);
+/// One delayed reconnect after an unexpected socket close; further closes give
+/// up rather than hammering the server.
+const RECONNECT_DELAY: Duration = Duration::from_secs(2);
+const SPINNER: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+/// Outcomes of HTTP actions spawned off the UI loop, plus the one reconnect.
+enum ActionOutcome {
+    Sent { turn_id: TurnId, content: String },
+    SendFailed { content: String, error: String },
+    CancelFailed(String),
+    DecisionFailed(String),
+    Reconnected(Box<EventSocket>),
+    ReconnectFailed(String),
+}
+
+struct PendingApproval {
+    call_id: CallId,
+    action: String,
+    approval: String,
+    auto_judging: bool,
+    preview: Option<String>,
+}
+
+struct ActiveTool {
+    call_id: CallId,
+    name: String,
+}
+
+struct App {
+    client: Client,
+    chat: ChatId,
+    actions: mpsc::UnboundedSender<ActionOutcome>,
+    composer: TextArea<'static>,
+    /// Assistant text of the in-flight turn, appended by `TextDelta`.
+    streaming: String,
+    /// Reasoning tail shown dimmed while the model thinks.
+    thinking: String,
+    active_tool: Option<ActiveTool>,
+    approval: Option<PendingApproval>,
+    running_turn: Option<TurnId>,
+    /// A send whose POST hasn't resolved yet; blocks a second send in flight.
+    send_pending: bool,
+    /// Resume cursor for the reconnect: the highest journaled seq seen.
+    last_seq: i64,
+    commits: Vec<Commit>,
+    /// A transient footer message and its remaining ticks.
+    flash: Option<(String, u8)>,
+    spinner: usize,
+    should_quit: bool,
+}
+
+impl App {
+    fn new(client: Client, chat: ChatId, actions: mpsc::UnboundedSender<ActionOutcome>) -> Self {
+        Self {
+            client,
+            chat,
+            actions,
+            composer: new_composer(Vec::new()),
+            streaming: String::new(),
+            thinking: String::new(),
+            active_tool: None,
+            approval: None,
+            running_turn: None,
+            send_pending: false,
+            last_seq: 0,
+            commits: Vec::new(),
+            flash: None,
+            spinner: 0,
+            should_quit: false,
+        }
+    }
+
+    fn commit(&mut self, commit: Commit) {
+        self.commits.push(commit);
+    }
+
+    /// Flush any streamed assistant text as a finished block.
+    fn commit_streaming(&mut self) {
+        let streamed = std::mem::take(&mut self.streaming);
+        if !streamed.trim().is_empty() {
+            self.commit(Commit::AssistantText(streamed));
+        }
+        self.thinking.clear();
+    }
+
+    fn flash(&mut self, message: impl Into<String>) {
+        // ~4 seconds at the 100ms tick.
+        self.flash = Some((message.into(), 40));
+    }
+
+    fn spinner(&self) -> char {
+        SPINNER[self.spinner % SPINNER.len()]
+    }
+
+    fn on_frame(&mut self, frame: SequencedFrame) {
+        self.last_seq = frame.seq;
+        self.on_event(frame.event);
+    }
+
+    fn on_event(&mut self, event: ClientEvent) {
+        match event {
+            ClientEvent::TurnStarted { turn_id } => {
+                self.running_turn = Some(turn_id);
+                self.streaming.clear();
+                self.thinking.clear();
+            }
+            ClientEvent::TextDelta { text } => self.streaming.push_str(&text),
+            ClientEvent::ReasoningDelta { text } => {
+                self.thinking.push_str(&text);
+                // Only the tail is displayed; don't grow the buffer forever.
+                if self.thinking.len() > 8192 {
+                    self.thinking.drain(..self.thinking.len() - 4096);
+                }
+            }
+            ClientEvent::StreamInterrupted => {
+                // Partial deltas since the last stable boundary are void.
+                self.streaming.clear();
+                self.thinking.clear();
+                self.commit(Commit::Notice("stream interrupted; retrying".into()));
+            }
+            ClientEvent::ToolCallStarted { call_id, name } => {
+                self.commit_streaming();
+                self.active_tool = Some(ActiveTool { call_id, name });
+            }
+            ClientEvent::ToolCallArgsDelta => {}
+            ClientEvent::ApprovalRequired {
+                call_id,
+                action,
+                approval,
+                auto_judging,
+                preview,
+            } => {
+                self.approval = Some(PendingApproval {
+                    call_id,
+                    action,
+                    approval,
+                    auto_judging,
+                    preview: preview.as_ref().and_then(render::preview_summary),
+                });
+            }
+            ClientEvent::ApprovalDecided { call_id } => {
+                if self.approval.as_ref().is_some_and(|p| p.call_id == call_id) {
+                    self.approval = None;
+                }
+            }
+            ClientEvent::ToolCallCompleted { call_id, status } => {
+                let name = match self.active_tool.take() {
+                    Some(tool) if tool.call_id == call_id => tool.name,
+                    // A completion without a matching start (replay edge) still
+                    // earns its line; the name just isn't known.
+                    other => {
+                        self.active_tool = other;
+                        "tool".to_owned()
+                    }
+                };
+                self.commit(Commit::ToolDone {
+                    name,
+                    failed: status != ToolCallStatus::Completed,
+                });
+            }
+            ClientEvent::TurnCompleted => {
+                self.commit_streaming();
+                self.active_tool = None;
+                self.running_turn = None;
+            }
+            ClientEvent::TurnCancelled => {
+                self.commit_streaming();
+                self.active_tool = None;
+                self.approval = None;
+                self.running_turn = None;
+                self.commit(Commit::Notice("turn cancelled".into()));
+            }
+            ClientEvent::TurnFailed { category } => {
+                self.commit_streaming();
+                self.active_tool = None;
+                self.approval = None;
+                self.running_turn = None;
+                self.commit(Commit::Error(format!(
+                    "turn failed ({})",
+                    category.replace('_', " ")
+                )));
+            }
+            ClientEvent::TurnRefused { refusal } => {
+                self.commit_streaming();
+                self.active_tool = None;
+                self.running_turn = None;
+                let detail = refusal
+                    .category
+                    .map(|category| format!(" ({})", category.replace('_', " ")))
+                    .unwrap_or_default();
+                self.commit(Commit::Notice(format!("the model refused{detail}")));
+            }
+            ClientEvent::UserSteered { text } => {
+                self.commit(Commit::Notice(format!(
+                    "steered from another client: {text}"
+                )));
+            }
+            ClientEvent::ContextTruncated {
+                original_tokens,
+                fitted_tokens,
+            } => {
+                self.commit(Commit::Notice(format!(
+                    "context truncated: ~{original_tokens} → ~{fitted_tokens} tokens"
+                )));
+            }
+            ClientEvent::UserQuestionsAsked => {
+                self.commit(Commit::Notice(
+                    "the model is asking questions — answer them in the desktop app; \
+                     interactive questions aren't supported in the TUI yet"
+                        .into(),
+                ));
+            }
+            ClientEvent::PlanProposed => {
+                self.commit(Commit::Notice(
+                    "a plan is awaiting review — decide it in the desktop app; \
+                     plan mode isn't supported in the TUI yet"
+                        .into(),
+                ));
+            }
+            ClientEvent::Unknown => {}
+        }
+    }
+
+    fn on_key(&mut self, key: KeyEvent) {
+        if key.kind == KeyEventKind::Release {
+            return;
+        }
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+            if self.running_turn.is_some() {
+                self.cancel_turn();
+            } else {
+                self.should_quit = true;
+            }
+            return;
+        }
+        if self.approval.is_some() {
+            // The composer is suspended while a decision is pending.
+            match key.code {
+                KeyCode::Char('y') | KeyCode::Char('Y') => self.decide(true),
+                KeyCode::Char('n') | KeyCode::Char('N') => self.decide(false),
+                _ => {}
+            }
+            return;
+        }
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('d') {
+            if self.composer.is_empty() {
+                self.should_quit = true;
+            }
+            return;
+        }
+        match key.code {
+            KeyCode::Enter
+                if key
+                    .modifiers
+                    .intersects(KeyModifiers::ALT | KeyModifiers::SHIFT) =>
+            {
+                self.composer.insert_newline();
+            }
+            KeyCode::Enter => self.try_send(),
+            _ => {
+                self.composer.input(Input::from(key));
+            }
+        }
+    }
+
+    fn try_send(&mut self) {
+        if self.running_turn.is_some() {
+            self.flash("a turn is still running — ctrl+c cancels it");
+            return;
+        }
+        if self.send_pending {
+            return;
+        }
+        let content = self.composer.lines().join("\n");
+        if content.trim().is_empty() {
+            return;
+        }
+        self.send_pending = true;
+        self.composer = new_composer(Vec::new());
+        let turn_id = TurnId::new();
+        let (client, chat, actions) = (self.client.clone(), self.chat, self.actions.clone());
+        tokio::spawn(async move {
+            let outcome = match client.post_message(chat, turn_id, &content).await {
+                Ok(()) => ActionOutcome::Sent { turn_id, content },
+                Err(error) => ActionOutcome::SendFailed {
+                    content,
+                    error: error.to_string(),
+                },
+            };
+            let _ = actions.send(outcome);
+        });
+    }
+
+    fn cancel_turn(&mut self) {
+        let Some(turn_id) = self.running_turn else {
+            return;
+        };
+        self.flash("cancelling…");
+        let (client, chat, actions) = (self.client.clone(), self.chat, self.actions.clone());
+        tokio::spawn(async move {
+            if let Err(error) = client.cancel_turn(chat, turn_id).await {
+                let _ = actions.send(ActionOutcome::CancelFailed(error.to_string()));
+            }
+        });
+    }
+
+    fn decide(&mut self, approve: bool) {
+        let Some(pending) = self.approval.take() else {
+            return;
+        };
+        let (client, chat, actions) = (self.client.clone(), self.chat, self.actions.clone());
+        tokio::spawn(async move {
+            if let Err(error) = client.decide_approval(chat, pending.call_id, approve).await {
+                let _ = actions.send(ActionOutcome::DecisionFailed(error.to_string()));
+            }
+        });
+    }
+
+    fn on_outcome(&mut self, outcome: ActionOutcome) {
+        match outcome {
+            ActionOutcome::Sent { turn_id, content } => {
+                self.send_pending = false;
+                self.commit(Commit::UserText(content));
+                self.running_turn = Some(turn_id);
+            }
+            ActionOutcome::SendFailed { content, error } => {
+                self.send_pending = false;
+                self.composer = new_composer(content.split('\n').map(str::to_owned).collect());
+                self.commit(Commit::Error(format!("message not sent: {error}")));
+            }
+            ActionOutcome::CancelFailed(error) => {
+                self.commit(Commit::Error(format!("cancel failed: {error}")));
+            }
+            ActionOutcome::DecisionFailed(error) => {
+                self.commit(Commit::Error(format!(
+                    "approval decision failed: {error} — decide it in the desktop app"
+                )));
+            }
+            ActionOutcome::Reconnected(_) | ActionOutcome::ReconnectFailed(_) => {
+                // Handled by the loop, which owns the socket slot.
+            }
+        }
+    }
+
+    fn on_tick(&mut self) {
+        if self.running_turn.is_some() || self.active_tool.is_some() {
+            self.spinner = self.spinner.wrapping_add(1);
+        }
+        if let Some((_, remaining)) = &mut self.flash {
+            *remaining = remaining.saturating_sub(1);
+            if *remaining == 0 {
+                self.flash = None;
+            }
+        }
+    }
+
+    /// The live region's transient stack, bottom-anchored to `max` lines.
+    fn transient_lines(&self, width: usize, max: usize) -> Vec<Line<'static>> {
+        let mut lines = Vec::new();
+        if !self.thinking.is_empty() {
+            lines.extend(render::thinking_lines(&self.thinking, width));
+        }
+        if !self.streaming.is_empty() {
+            lines.extend(render::streaming_lines(&self.streaming, width));
+        }
+        if let Some(tool) = &self.active_tool {
+            lines.push(render::tool_running_line(&tool.name, self.spinner()));
+        }
+        if let Some(approval) = &self.approval {
+            lines.extend(render::approval_card(
+                &approval.action,
+                &approval.approval,
+                approval.auto_judging,
+                approval.preview.as_deref(),
+                width,
+            ));
+        }
+        if lines.len() > max {
+            lines.drain(..lines.len() - max);
+        }
+        lines
+    }
+
+    fn footer_line(&self) -> Line<'static> {
+        if let Some((message, _)) = &self.flash {
+            return Line::from(Span::styled(
+                message.clone(),
+                Style::default().fg(Color::Yellow),
+            ));
+        }
+        let hint = Style::default().fg(Color::DarkGray);
+        if self.approval.is_some() {
+            Line::from(Span::styled("y approve · n reject · ctrl+c cancel", hint))
+        } else if self.running_turn.is_some() {
+            Line::from(vec![
+                Span::styled(
+                    format!("{} ", self.spinner()),
+                    Style::default().fg(Color::Yellow),
+                ),
+                Span::styled("working… · ctrl+c cancel", hint),
+            ])
+        } else {
+            Line::from(Span::styled(
+                "enter send · alt+enter newline · ctrl+c quit",
+                hint,
+            ))
+        }
+    }
+}
+
+fn new_composer(lines: Vec<String>) -> TextArea<'static> {
+    let lines = if lines.is_empty() {
+        vec![String::new()]
+    } else {
+        lines
+    };
+    let mut composer = TextArea::new(lines);
+    composer.set_cursor_line_style(Style::default());
+    composer.set_cursor_style(Style::default().add_modifier(Modifier::REVERSED));
+    composer.set_placeholder_text("type a message");
+    composer.set_placeholder_style(Style::default().fg(Color::DarkGray));
+    composer
+}
+
+/// Restores the terminal on drop; the panic hook does the same for panics.
+struct TerminalGuard {
+    terminal: Terminal<CrosstermBackend<Stdout>>,
+    /// The inline viewport's height, clamped to the terminal's rows.
+    live_height: u16,
+}
+
+impl TerminalGuard {
+    fn new() -> Result<Self> {
+        enable_raw_mode().map_err(terminal_error)?;
+        let mut stdout = io::stdout();
+        // Bracketed paste keeps pasted newlines from firing sends; the keyboard
+        // enhancement flags are how terminals that support it deliver
+        // shift+enter distinctly. Both are no-ops where unsupported.
+        execute!(
+            stdout,
+            EnableBracketedPaste,
+            PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
+        )
+        .map_err(terminal_error)?;
+        let live_height =
+            LIVE_HEIGHT.min(crossterm::terminal::size().map_or(LIVE_HEIGHT, |(_, r)| r));
+        let terminal = Terminal::with_options(
+            CrosstermBackend::new(stdout),
+            TerminalOptions {
+                viewport: Viewport::Inline(live_height),
+            },
+        )
+        .map_err(terminal_error)?;
+        Ok(Self {
+            terminal,
+            live_height,
+        })
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        let _ = execute!(
+            self.terminal.backend_mut(),
+            DisableBracketedPaste,
+            PopKeyboardEnhancementFlags,
+            Show
+        );
+        let _ = disable_raw_mode();
+    }
+}
+
+fn install_panic_hook() {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = disable_raw_mode();
+        let _ = execute!(
+            io::stdout(),
+            DisableBracketedPaste,
+            PopKeyboardEnhancementFlags,
+            Show
+        );
+        previous(info);
+    }));
+}
+
+fn terminal_error(error: io::Error) -> AgentError {
+    AgentError::msg(format!("terminal error: {error}"))
+}
+
+/// Pending forever when the socket is gone, so the `select!` arm simply never
+/// fires between a close and a reconnect.
+async fn next_frame(
+    socket: &mut Option<EventSocket>,
+) -> Option<std::result::Result<Message, tokio_tungstenite::tungstenite::Error>> {
+    match socket {
+        Some(socket) => socket.next().await,
+        None => std::future::pending().await,
+    }
+}
+
+/// Run the chat until the user quits. Terminal state is restored on every
+/// exit path, panic included.
+pub async fn run(client: Client, chat: ChatId) -> Result<()> {
+    install_panic_hook();
+    let mut guard = TerminalGuard::new()?;
+
+    let (actions, mut outcomes) = mpsc::unbounded_channel();
+    let mut app = App::new(client, chat, actions);
+    let mut socket = match app.client.open_events(chat, 0).await {
+        Ok(socket) => Some(socket),
+        Err(error) => {
+            app.commit(Commit::Error(format!(
+                "event stream failed to open: {error}"
+            )));
+            None
+        }
+    };
+    let mut keys = EventStream::new();
+    let mut tick = tokio::time::interval(TICK);
+
+    loop {
+        tokio::select! {
+            key = keys.next() => {
+                match key {
+                    Some(Ok(Event::Key(key))) => app.on_key(key),
+                    Some(Ok(Event::Paste(text))) => {
+                        if app.approval.is_none() {
+                            app.composer.insert_str(text);
+                        }
+                    }
+                    Some(Ok(_)) => {}
+                    Some(Err(_)) | None => break,
+                }
+            }
+            frame = next_frame(&mut socket) => {
+                match frame {
+                    Some(Ok(Message::Text(text))) => match serde_json::from_str::<ChatFrame>(&text)
+                    {
+                        Ok(ChatFrame::Event(frame)) => app.on_frame(frame),
+                        Ok(ChatFrame::Metadata(_)) => {}
+                        // An undecodable frame is skipped, not fatal.
+                        Err(_) => {}
+                    },
+                    Some(Ok(Message::Ping(_) | Message::Pong(_))) => {}
+                    Some(Ok(Message::Close(_))) | Some(Err(_)) | None => {
+                        socket = None;
+                        app.commit(Commit::Notice(
+                            "event stream closed; reconnecting…".into(),
+                        ));
+                        let (client, chat, actions) =
+                            (app.client.clone(), app.chat, app.actions.clone());
+                        let after = app.last_seq;
+                        tokio::spawn(async move {
+                            tokio::time::sleep(RECONNECT_DELAY).await;
+                            let outcome = match client.open_events(chat, after).await {
+                                Ok(socket) => ActionOutcome::Reconnected(Box::new(socket)),
+                                Err(error) => {
+                                    ActionOutcome::ReconnectFailed(error.to_string())
+                                }
+                            };
+                            let _ = actions.send(outcome);
+                        });
+                    }
+                    Some(Ok(_)) => {}
+                }
+            }
+            Some(outcome) = outcomes.recv() => {
+                match outcome {
+                    ActionOutcome::Reconnected(new_socket) => {
+                        socket = Some(*new_socket);
+                        app.commit(Commit::Notice("reconnected".into()));
+                    }
+                    ActionOutcome::ReconnectFailed(error) => {
+                        app.commit(Commit::Error(format!(
+                            "event stream reconnect failed: {error} — restart the TUI to resume"
+                        )));
+                    }
+                    other => app.on_outcome(other),
+                }
+            }
+            _ = tick.tick() => app.on_tick(),
+        }
+
+        flush_commits(&mut app, &mut guard.terminal)?;
+        draw(&mut app, &mut guard.terminal, guard.live_height)?;
+        if app.should_quit {
+            return Ok(());
+        }
+    }
+
+    Ok(())
+}
+
+/// Commit finished blocks to real scrollback above the live region.
+fn flush_commits(app: &mut App, terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<()> {
+    if app.commits.is_empty() {
+        return Ok(());
+    }
+    let width = terminal.size().map_err(terminal_error)?.width.max(8) as usize;
+    let lines: Vec<Line<'static>> = app
+        .commits
+        .drain(..)
+        .flat_map(|commit| commit.lines(width))
+        .collect();
+    let height = u16::try_from(lines.len()).unwrap_or(u16::MAX);
+    terminal
+        .insert_before(height, |buf| {
+            Paragraph::new(lines).render(Rect::new(0, 0, buf.area.width, height), buf);
+        })
+        .map_err(terminal_error)
+}
+
+fn draw(
+    app: &mut App,
+    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    live_height: u16,
+) -> Result<()> {
+    let width = terminal.size().map_err(terminal_error)?.width as usize;
+    let composer_rows = (app.composer.lines().len() as u16).clamp(1, MAX_COMPOSER_ROWS);
+    let transient_rows = live_height.saturating_sub(composer_rows + 1);
+    let transient = app.transient_lines(width, transient_rows as usize);
+    terminal
+        .draw(|frame| {
+            let rows = Layout::vertical([
+                Constraint::Length(transient_rows),
+                Constraint::Length(composer_rows),
+                Constraint::Length(1),
+            ])
+            .split(frame.area());
+            frame.render_widget(Paragraph::new(transient), rows[0]);
+            frame.render_widget(&app.composer, rows[1]);
+            frame.render_widget(Paragraph::new(app.footer_line()), rows[2]);
+        })
+        .map_err(terminal_error)?;
+    Ok(())
+}

--- a/crates/openwave-cli/src/tui/app.rs
+++ b/crates/openwave-cli/src/tui/app.rs
@@ -18,7 +18,7 @@ use futures::StreamExt;
 use openwave_core::{AgentError, CallId, ChatId, Result, TurnId};
 use ratatui::backend::CrosstermBackend;
 use ratatui::layout::{Constraint, Layout, Rect};
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Widget};
 use ratatui::{Terminal, TerminalOptions, Viewport};
@@ -28,11 +28,12 @@ use tui_textarea::{Input, TextArea};
 
 use super::client::{Client, EventSocket};
 use super::render::{self, Commit};
+use super::theme;
 use super::wire::{ChatFrame, ClientEvent, SequencedFrame, ToolCallStatus};
 
 /// Fixed height of the repainting region: transient stack, composer, footer.
 /// Clamped to the terminal at startup.
-const LIVE_HEIGHT: u16 = 16;
+const LIVE_HEIGHT: u16 = 10;
 /// Composer rows beyond this scroll inside the textarea.
 const MAX_COMPOSER_ROWS: u16 = 4;
 const TICK: Duration = Duration::from_millis(100);
@@ -67,6 +68,9 @@ struct ActiveTool {
 struct App {
     client: Client,
     chat: ChatId,
+    /// First group of the chat's UUID, for the header and the footer's right
+    /// edge.
+    short_id: String,
     actions: mpsc::UnboundedSender<ActionOutcome>,
     composer: TextArea<'static>,
     /// Assistant text of the in-flight turn, appended by `TextDelta`.
@@ -91,6 +95,7 @@ impl App {
     fn new(client: Client, chat: ChatId, actions: mpsc::UnboundedSender<ActionOutcome>) -> Self {
         Self {
             client,
+            short_id: chat.to_string().chars().take(8).collect(),
             chat,
             actions,
             composer: new_composer(Vec::new()),
@@ -392,7 +397,8 @@ impl App {
         }
     }
 
-    /// The live region's transient stack, bottom-anchored to `max` lines.
+    /// The live region's transient stack, bottom-anchored within `max` lines:
+    /// blank padding goes on top, so content sits directly above the composer.
     fn transient_lines(&self, width: usize, max: usize) -> Vec<Line<'static>> {
         let mut lines = Vec::new();
         if !self.thinking.is_empty() {
@@ -416,32 +422,45 @@ impl App {
         if lines.len() > max {
             lines.drain(..lines.len() - max);
         }
-        lines
+        let pad = max.saturating_sub(lines.len());
+        let mut anchored = vec![Line::default(); pad];
+        anchored.extend(lines);
+        anchored
     }
 
+    /// The footer's left side: state segment in the accent, key hints muted,
+    /// separated by a dim "·".
     fn footer_line(&self) -> Line<'static> {
+        let sep = || Span::styled(" · ", theme::muted());
         if let Some((message, _)) = &self.flash {
-            return Line::from(Span::styled(
-                message.clone(),
-                Style::default().fg(Color::Yellow),
-            ));
+            return Line::from(Span::styled(message.clone(), theme::accent()));
         }
-        let hint = Style::default().fg(Color::DarkGray);
         if self.approval.is_some() {
-            Line::from(Span::styled("y approve · n reject · ctrl+c cancel", hint))
+            Line::from(vec![
+                Span::styled("awaiting approval", theme::accent_bold()),
+                sep(),
+                Span::styled("y approve", theme::muted()),
+                sep(),
+                Span::styled("n reject", theme::muted()),
+                sep(),
+                Span::styled("ctrl+c cancel", theme::muted()),
+            ])
         } else if self.running_turn.is_some() {
             Line::from(vec![
-                Span::styled(
-                    format!("{} ", self.spinner()),
-                    Style::default().fg(Color::Yellow),
-                ),
-                Span::styled("working… · ctrl+c cancel", hint),
+                Span::styled(format!("{} working…", self.spinner()), theme::accent()),
+                sep(),
+                Span::styled("ctrl+c cancel", theme::muted()),
             ])
         } else {
-            Line::from(Span::styled(
-                "enter send · alt+enter newline · ctrl+c quit",
-                hint,
-            ))
+            Line::from(vec![
+                Span::styled("ready", theme::muted()),
+                sep(),
+                Span::styled("enter send", theme::muted()),
+                sep(),
+                Span::styled("alt+enter newline", theme::muted()),
+                sep(),
+                Span::styled("ctrl+c quit", theme::muted()),
+            ])
         }
     }
 }
@@ -456,7 +475,7 @@ fn new_composer(lines: Vec<String>) -> TextArea<'static> {
     composer.set_cursor_line_style(Style::default());
     composer.set_cursor_style(Style::default().add_modifier(Modifier::REVERSED));
     composer.set_placeholder_text("type a message");
-    composer.set_placeholder_style(Style::default().fg(Color::DarkGray));
+    composer.set_placeholder_style(theme::muted());
     composer
 }
 
@@ -539,12 +558,15 @@ async fn next_frame(
 
 /// Run the chat until the user quits. Terminal state is restored on every
 /// exit path, panic included.
-pub async fn run(client: Client, chat: ChatId) -> Result<()> {
+pub async fn run(client: Client, chat: ChatId, resumed: bool) -> Result<()> {
     install_panic_hook();
     let mut guard = TerminalGuard::new()?;
 
     let (actions, mut outcomes) = mpsc::unbounded_channel();
     let mut app = App::new(client, chat, actions);
+    // The banner is the first thing committed to scrollback.
+    let header = render::header_lines(resumed, &app.short_id);
+    app.commit(Commit::Lines(header));
     let mut socket = match app.client.open_events(chat, 0).await {
         Ok(socket) => Some(socket),
         Err(error) => {
@@ -667,8 +689,30 @@ fn draw(
             ])
             .split(frame.area());
             frame.render_widget(Paragraph::new(transient), rows[0]);
-            frame.render_widget(&app.composer, rows[1]);
-            frame.render_widget(Paragraph::new(app.footer_line()), rows[2]);
+            // The composer gutter matches the scrollback marker for sent user
+            // messages: accent ❯ on the first row, a muted │ on wrapped rows.
+            let composer_cols =
+                Layout::horizontal([Constraint::Length(2), Constraint::Min(1)]).split(rows[1]);
+            let gutter: Vec<Line<'static>> = (0..composer_rows)
+                .map(|row| {
+                    if row == 0 {
+                        Line::from(Span::styled("❯", theme::accent_bold()))
+                    } else {
+                        Line::from(Span::styled("│", theme::muted()))
+                    }
+                })
+                .collect();
+            frame.render_widget(Paragraph::new(gutter), composer_cols[0]);
+            frame.render_widget(&app.composer, composer_cols[1]);
+            let mut footer = app.footer_line();
+            // The short chat id rides the right edge when there's room.
+            let short_id = format!("chat {}", app.short_id);
+            let pad = width.saturating_sub(footer.width() + short_id.len());
+            if pad >= 2 {
+                footer.spans.push(Span::raw(" ".repeat(pad)));
+                footer.spans.push(Span::styled(short_id, theme::muted()));
+            }
+            frame.render_widget(Paragraph::new(footer), rows[2]);
         })
         .map_err(terminal_error)?;
     Ok(())

--- a/crates/openwave-cli/src/tui/client.rs
+++ b/crates/openwave-cli/src/tui/client.rs
@@ -1,0 +1,183 @@
+//! The loopback HTTP+WebSocket client — the same contract the desktop webview
+//! consumes.
+
+use std::net::SocketAddr;
+
+use openwave_core::{AgentError, CallId, ChatId, Result, TurnId};
+use serde::Deserialize;
+use tokio::net::TcpStream;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::http::header::SEC_WEBSOCKET_PROTOCOL;
+use tokio_tungstenite::tungstenite::http::HeaderValue;
+use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+
+/// The chat event stream once the upgrade completes.
+pub type EventSocket = WebSocketStream<MaybeTlsStream<TcpStream>>;
+
+/// Bearer-authed client for one bound server. Cheap to clone: the reqwest
+/// client and the credentials are shared.
+#[derive(Clone)]
+pub struct Client {
+    http: reqwest::Client,
+    base: String,
+    token: String,
+}
+
+/// The error body every route answers with on failure.
+#[derive(Deserialize)]
+struct ErrorBody {
+    message: String,
+}
+
+/// `POST /chats` returns the whole `Chat`; only the id is read.
+#[derive(Deserialize)]
+struct ChatCreated {
+    id: ChatId,
+}
+
+impl Client {
+    pub fn new(addr: SocketAddr, token: &str) -> Result<Self> {
+        let mut headers = reqwest::header::HeaderMap::new();
+        let mut value = reqwest::header::HeaderValue::from_str(&format!("Bearer {token}"))
+            .map_err(|error| AgentError::msg(format!("invalid server token: {error}")))?;
+        value.set_sensitive(true);
+        headers.insert(reqwest::header::AUTHORIZATION, value);
+        let http = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()
+            .map_err(|error| {
+                AgentError::msg(format!("could not build the HTTP client: {error}"))
+            })?;
+        Ok(Self {
+            http,
+            base: format!("http://{addr}"),
+            token: token.to_owned(),
+        })
+    }
+
+    /// Create a fresh chat (server-side defaults seed the rest).
+    pub async fn create_chat(&self) -> Result<ChatId> {
+        let response = self
+            .http
+            .post(format!("{}/chats", self.base))
+            .json(&serde_json::json!({}))
+            .send()
+            .await
+            .map_err(request_error)?;
+        let chat = Self::expect_success(response)
+            .await?
+            .json::<ChatCreated>()
+            .await
+            .map_err(request_error)?;
+        Ok(chat.id)
+    }
+
+    /// Verify a chat exists, so `tui --chat <id>` fails fast on a typo.
+    pub async fn require_chat(&self, chat: ChatId) -> Result<()> {
+        let response = self
+            .http
+            .get(format!("{}/chats/{chat}", self.base))
+            .send()
+            .await
+            .map_err(request_error)?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(AgentError::msg(format!("chat {chat} not found")));
+        }
+        Self::expect_success(response).await?;
+        Ok(())
+    }
+
+    /// Accept a user message and queue its turn (`202`).
+    pub async fn post_message(&self, chat: ChatId, turn_id: TurnId, content: &str) -> Result<()> {
+        let response = self
+            .http
+            .post(format!("{}/chats/{chat}/messages", self.base))
+            .json(&serde_json::json!({ "turn_id": turn_id, "content": content }))
+            .send()
+            .await
+            .map_err(request_error)?;
+        Self::expect_success(response).await?;
+        Ok(())
+    }
+
+    /// Cancel one exact turn (`202`; `409` if it already finished).
+    pub async fn cancel_turn(&self, chat: ChatId, turn_id: TurnId) -> Result<()> {
+        let response = self
+            .http
+            .post(format!("{}/chats/{chat}/cancel", self.base))
+            .json(&serde_json::json!({ "turn_id": turn_id }))
+            .send()
+            .await
+            .map_err(request_error)?;
+        Self::expect_success(response).await?;
+        Ok(())
+    }
+
+    /// Decide a parked tool call (`204`). Slice 1 sends no standing grant.
+    pub async fn decide_approval(
+        &self,
+        chat: ChatId,
+        call_id: CallId,
+        approve: bool,
+    ) -> Result<()> {
+        let body = if approve {
+            serde_json::json!({ "decision": "approve" })
+        } else {
+            serde_json::json!({ "decision": "reject", "reason": "declined from terminal" })
+        };
+        let response = self
+            .http
+            .post(format!("{}/chats/{chat}/approvals/{call_id}", self.base))
+            .json(&body)
+            .send()
+            .await
+            .map_err(request_error)?;
+        Self::expect_success(response).await?;
+        Ok(())
+    }
+
+    /// Open the chat event socket: replay of everything after `after`, then
+    /// live frames. Auth rides `Sec-WebSocket-Protocol` (token prefix plus the
+    /// `openwave-v1` handshake value the server selects back).
+    pub async fn open_events(&self, chat: ChatId, after: i64) -> Result<EventSocket> {
+        let url = format!(
+            "{}/chats/{chat}/events?after={after}",
+            self.base.replacen("http", "ws", 1)
+        );
+        let mut request = url
+            .into_client_request()
+            .map_err(|error| AgentError::msg(format!("bad event socket URL: {error}")))?;
+        request.headers_mut().insert(
+            SEC_WEBSOCKET_PROTOCOL,
+            // The token is a UUID, so it is always a valid header value.
+            HeaderValue::from_str(&format!("openwave-v1, openwave-token.{}", self.token))
+                .map_err(|error| AgentError::msg(format!("invalid subprotocol header: {error}")))?,
+        );
+        let (socket, _response) = connect_async(request)
+            .await
+            .map_err(|error| AgentError::msg(format!("event socket handshake failed: {error}")))?;
+        Ok(socket)
+    }
+
+    /// Pass through a success, or lift the server's `{ kind, message }` body
+    /// into the error.
+    async fn expect_success(response: reqwest::Response) -> Result<reqwest::Response> {
+        if response.status().is_success() {
+            return Ok(response);
+        }
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        let message = serde_json::from_str::<ErrorBody>(&body)
+            .map(|body| body.message)
+            .unwrap_or(body);
+        Err(AgentError::msg(format!(
+            "request failed ({status}): {message}"
+        )))
+    }
+}
+
+/// reqwest's `Display` already strips nothing for loopback URLs, but keep the
+/// mapping in one place.
+fn request_error(error: reqwest::Error) -> AgentError {
+    AgentError::msg(format!("request failed: {error}"))
+}

--- a/crates/openwave-cli/src/tui/mod.rs
+++ b/crates/openwave-cli/src/tui/mod.rs
@@ -1,0 +1,39 @@
+//! `openwave tui` — interactive terminal chat.
+//!
+//! Boots the same in-process server `openwave serve` runs, spawns its accept
+//! loop on a background task, and drives it over the loopback HTTP+WebSocket
+//! API with the per-launch bearer token — the contract the desktop webview
+//! consumes. Logging is file-only: the TUI owns the terminal.
+
+mod app;
+mod client;
+mod render;
+mod wire;
+
+use client::Client;
+use openwave_core::{ChatId, Result};
+
+/// Boot the server, open (or resume) the chat, and run the interactive loop.
+pub async fn run(chat: Option<ChatId>) -> Result<()> {
+    let config = crate::profile_config()?;
+    openwave_server::logging::init_logging_file_only(&config.data_dir);
+    let server = openwave_server::bind_configured(config).await?;
+    let addr = server.local_addr();
+    let token = server.token().to_owned();
+    // `serve` takes ownership of the Server, whose drop aborts the background
+    // workers (turn worker etc.); keeping this JoinHandle alive for the whole
+    // session is what keeps the engine running.
+    let serve = tokio::spawn(server.serve());
+
+    let client = Client::new(addr, &token)?;
+    let chat = match chat {
+        Some(chat) => {
+            client.require_chat(chat).await?;
+            chat
+        }
+        None => client.create_chat().await?,
+    };
+    let result = app::run(client, chat).await;
+    serve.abort();
+    result
+}

--- a/crates/openwave-cli/src/tui/mod.rs
+++ b/crates/openwave-cli/src/tui/mod.rs
@@ -8,6 +8,7 @@
 mod app;
 mod client;
 mod render;
+mod theme;
 mod wire;
 
 use client::Client;
@@ -26,6 +27,7 @@ pub async fn run(chat: Option<ChatId>) -> Result<()> {
     let serve = tokio::spawn(server.serve());
 
     let client = Client::new(addr, &token)?;
+    let resumed = chat.is_some();
     let chat = match chat {
         Some(chat) => {
             client.require_chat(chat).await?;
@@ -33,7 +35,7 @@ pub async fn run(chat: Option<ChatId>) -> Result<()> {
         }
         None => client.create_chat().await?,
     };
-    let result = app::run(client, chat).await;
+    let result = app::run(client, chat, resumed).await;
     serve.abort();
     result
 }

--- a/crates/openwave-cli/src/tui/render.rs
+++ b/crates/openwave-cli/src/tui/render.rs
@@ -1,24 +1,28 @@
 //! Pure line-building for the TUI: committed scrollback blocks and the pieces
-//! of the repainting live region. No widget state lives here.
+//! of the repainting live region. No widget state lives here, and no color is
+//! named here — all styling comes from [`super::theme`].
 //!
 //! Wrapping counts characters, not display cells, so a line heavy with wide
 //! glyphs can overflow its width — acceptable for this slice's plain-text
 //! rendering.
 
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::Modifier;
 use ratatui::text::{Line, Span};
+
+use super::theme;
 
 /// A finished block ready to commit to real terminal scrollback.
 pub enum Commit {
     UserText(String),
     AssistantText(String),
-    ToolDone { name: String, failed: bool },
+    ToolDone {
+        name: String,
+        failed: bool,
+    },
     Notice(String),
     Error(String),
-}
-
-fn dim() -> Style {
-    Style::default().fg(Color::DarkGray)
+    /// Pre-rendered one-offs (the startup header).
+    Lines(Vec<Line<'static>>),
 }
 
 /// Word-wrap `text` to `width` columns, preserving hard newlines.
@@ -69,57 +73,64 @@ fn truncate(text: &str, max: usize) -> String {
 }
 
 impl Commit {
-    /// Render the block to styled lines at the current terminal width.
+    /// Render the block to styled lines at the current terminal width, with one
+    /// blank line after it so every block type breathes evenly.
     pub fn lines(self, width: usize) -> Vec<Line<'static>> {
-        match self {
-            Commit::UserText(text) => {
-                let mut lines: Vec<Line<'static>> = wrap(&text, width.saturating_sub(2))
-                    .into_iter()
-                    .enumerate()
-                    .map(|(i, line)| {
-                        let marker = if i == 0 { "❯ " } else { "  " };
-                        Line::from(vec![
-                            Span::styled(marker, Style::default().fg(Color::Cyan)),
-                            Span::styled(line, Style::default().add_modifier(Modifier::BOLD)),
-                        ])
-                    })
-                    .collect();
-                lines.push(Line::default());
-                lines
-            }
-            Commit::AssistantText(text) => {
-                let mut lines: Vec<Line<'static>> =
-                    wrap(&text, width).into_iter().map(Line::from).collect();
-                lines.push(Line::default());
-                lines
-            }
+        let mut lines = match self {
+            // The ❯/│ gutter matches the composer's, so a sent message reads
+            // as the same element it was typed into.
+            Commit::UserText(text) => wrap(&text, width.saturating_sub(2))
+                .into_iter()
+                .enumerate()
+                .map(|(i, line)| {
+                    let marker = if i == 0 {
+                        Span::styled("❯ ", theme::accent_bold())
+                    } else {
+                        Span::styled("│ ", theme::muted())
+                    };
+                    Line::from(vec![marker, Span::styled(line, theme::bold())])
+                })
+                .collect(),
+            Commit::AssistantText(text) => wrap(&text, width).into_iter().map(Line::from).collect(),
+            // Completed tool noise recedes behind the assistant text: the whole
+            // line is muted except the status mark.
             Commit::ToolDone { name, failed } => {
                 let (mark, style) = if failed {
-                    ("✗", Style::default().fg(Color::Red))
+                    ("✗", theme::destructive())
                 } else {
-                    ("✓", Style::default().fg(Color::Green))
+                    ("✓", theme::success())
                 };
                 vec![Line::from(vec![
-                    Span::styled("⚙ ", dim()),
-                    Span::raw(name),
-                    Span::styled(format!(" {mark}"), style),
+                    Span::styled(format!("⚙ {name} "), theme::muted()),
+                    Span::styled(mark, style),
                 ])]
             }
             Commit::Notice(text) => wrap(&text, width.saturating_sub(2))
                 .into_iter()
-                .map(|line| Line::from(Span::styled(format!("· {line}"), dim())))
+                .map(|line| Line::from(Span::styled(format!("· {line}"), theme::muted())))
                 .collect(),
             Commit::Error(text) => wrap(&text, width.saturating_sub(2))
                 .into_iter()
-                .map(|line| {
-                    Line::from(Span::styled(
-                        format!("✗ {line}"),
-                        Style::default().fg(Color::Red),
-                    ))
-                })
+                .map(|line| Line::from(Span::styled(format!("✗ {line}"), theme::destructive())))
                 .collect(),
-        }
+            Commit::Lines(lines) => lines,
+        };
+        lines.push(Line::default());
+        lines
     }
+}
+
+/// The compact startup banner committed to scrollback on launch.
+pub fn header_lines(resumed: bool, short_id: &str) -> Vec<Line<'static>> {
+    let kind = if resumed { "resumed chat" } else { "new chat" };
+    vec![
+        Line::from(Span::styled("OpenWave", theme::accent_bold())),
+        Line::from(Span::styled(format!("{kind} · {short_id}"), theme::muted())),
+        Line::from(Span::styled(
+            "enter send · alt+enter newline · ctrl+c quit",
+            theme::muted(),
+        )),
+    ]
 }
 
 /// The dim reasoning tail shown while the model thinks: at most the last two
@@ -134,7 +145,7 @@ pub fn thinking_lines(thinking: &str, width: usize) -> Vec<Line<'static>> {
         .map(|line| {
             Line::from(Span::styled(
                 format!("  {line}"),
-                dim().add_modifier(Modifier::ITALIC),
+                theme::muted().add_modifier(Modifier::ITALIC),
             ))
         })
         .collect()
@@ -145,13 +156,12 @@ pub fn streaming_lines(text: &str, width: usize) -> Vec<Line<'static>> {
     wrap(text, width).into_iter().map(Line::from).collect()
 }
 
-/// The running tool's spinner line.
+/// The running tool's line: spinner in the accent, name plain.
 pub fn tool_running_line(name: &str, spinner: char) -> Line<'static> {
     Line::from(vec![
-        Span::styled(format!("{spinner} "), Style::default().fg(Color::Yellow)),
-        Span::styled("⚙ ", dim()),
+        Span::styled(format!("{spinner} "), theme::accent()),
         Span::raw(name.to_owned()),
-        Span::styled(" …", dim()),
+        Span::styled(" …", theme::muted()),
     ])
 }
 
@@ -184,7 +194,9 @@ pub fn preview_summary(preview: &serde_json::Value) -> Option<String> {
     Some(truncate(&summary, 200))
 }
 
-/// The inline approval card shown while a decision is pending.
+/// The consent card shown while a decision is pending: an accent gutter on
+/// every line, bold title, the humanized kind dimmed on its own line, the
+/// preview as a dim italic block, and the two actions styled as buttons.
 pub fn approval_card(
     action: &str,
     approval: &str,
@@ -192,29 +204,37 @@ pub fn approval_card(
     preview: Option<&str>,
     width: usize,
 ) -> Vec<Line<'static>> {
-    let mut lines = Vec::new();
-    let mut heading = vec![
-        Span::styled("▲ ", Style::default().fg(Color::Yellow)),
-        Span::styled(
-            format!("approval required: {action}"),
-            Style::default().add_modifier(Modifier::BOLD),
-        ),
-        Span::styled(format!(" — {}", approval.replace('_', " ")), dim()),
+    let gutter = || Span::styled("▌ ", theme::accent());
+    let mut title = vec![
+        gutter(),
+        Span::styled("Approval required: ", theme::bold()),
+        Span::styled(action.to_owned(), theme::accent_bold()),
     ];
     if auto_judging {
-        heading.push(Span::styled(" (auto-judge deciding…)", dim()));
+        title.push(Span::styled("  (auto-judge deciding…)", theme::muted()));
     }
-    lines.push(Line::from(heading));
+    let mut lines = vec![
+        Line::from(title),
+        Line::from(vec![
+            gutter(),
+            Span::styled(approval.replace('_', " "), theme::muted()),
+        ]),
+    ];
     if let Some(preview) = preview {
         for line in wrap(preview, width.saturating_sub(2)) {
-            lines.push(Line::from(Span::styled(format!("  {line}"), dim())));
+            lines.push(Line::from(vec![
+                gutter(),
+                Span::styled(line, theme::muted().add_modifier(Modifier::ITALIC)),
+            ]));
         }
     }
     lines.push(Line::from(vec![
-        Span::styled("y", Style::default().fg(Color::Green)),
-        Span::styled(" approve · ", dim()),
-        Span::styled("n", Style::default().fg(Color::Red)),
-        Span::styled(" reject", dim()),
+        gutter(),
+        Span::styled("y", theme::accent_bold()),
+        Span::styled(" approve", theme::accent()),
+        Span::styled("  ·  ", theme::muted()),
+        Span::styled("n", theme::bold()),
+        Span::styled(" reject", theme::muted()),
     ]));
     lines
 }

--- a/crates/openwave-cli/src/tui/render.rs
+++ b/crates/openwave-cli/src/tui/render.rs
@@ -1,0 +1,220 @@
+//! Pure line-building for the TUI: committed scrollback blocks and the pieces
+//! of the repainting live region. No widget state lives here.
+//!
+//! Wrapping counts characters, not display cells, so a line heavy with wide
+//! glyphs can overflow its width — acceptable for this slice's plain-text
+//! rendering.
+
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+
+/// A finished block ready to commit to real terminal scrollback.
+pub enum Commit {
+    UserText(String),
+    AssistantText(String),
+    ToolDone { name: String, failed: bool },
+    Notice(String),
+    Error(String),
+}
+
+fn dim() -> Style {
+    Style::default().fg(Color::DarkGray)
+}
+
+/// Word-wrap `text` to `width` columns, preserving hard newlines.
+fn wrap(text: &str, width: usize) -> Vec<String> {
+    let width = width.max(8);
+    let mut out = Vec::new();
+    for source in text.split('\n') {
+        let mut line = String::new();
+        let mut col = 0usize;
+        for word in source.split(' ') {
+            let word_len = word.chars().count();
+            let gap = usize::from(!line.is_empty());
+            if col + gap + word_len > width && col > 0 {
+                out.push(std::mem::take(&mut line));
+                col = 0;
+            } else if gap == 1 {
+                line.push(' ');
+                col += 1;
+            }
+            // A word longer than the width hard-breaks.
+            let mut rest = word;
+            while rest.chars().count() > width - col && col < width {
+                let take = width - col;
+                let cut = rest.char_indices().nth(take).map_or(rest.len(), |(i, _)| i);
+                line.push_str(&rest[..cut]);
+                out.push(std::mem::take(&mut line));
+                rest = &rest[cut..];
+                col = 0;
+            }
+            line.push_str(rest);
+            col += rest.chars().count();
+        }
+        out.push(line);
+    }
+    out
+}
+
+/// Long preview fields (a command, a query) get one bounded line, not the
+/// whole payload.
+fn truncate(text: &str, max: usize) -> String {
+    let mut chars = text.chars();
+    let taken: String = chars.by_ref().take(max).collect();
+    if chars.next().is_some() {
+        format!("{taken}…")
+    } else {
+        taken
+    }
+}
+
+impl Commit {
+    /// Render the block to styled lines at the current terminal width.
+    pub fn lines(self, width: usize) -> Vec<Line<'static>> {
+        match self {
+            Commit::UserText(text) => {
+                let mut lines: Vec<Line<'static>> = wrap(&text, width.saturating_sub(2))
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, line)| {
+                        let marker = if i == 0 { "❯ " } else { "  " };
+                        Line::from(vec![
+                            Span::styled(marker, Style::default().fg(Color::Cyan)),
+                            Span::styled(line, Style::default().add_modifier(Modifier::BOLD)),
+                        ])
+                    })
+                    .collect();
+                lines.push(Line::default());
+                lines
+            }
+            Commit::AssistantText(text) => {
+                let mut lines: Vec<Line<'static>> =
+                    wrap(&text, width).into_iter().map(Line::from).collect();
+                lines.push(Line::default());
+                lines
+            }
+            Commit::ToolDone { name, failed } => {
+                let (mark, style) = if failed {
+                    ("✗", Style::default().fg(Color::Red))
+                } else {
+                    ("✓", Style::default().fg(Color::Green))
+                };
+                vec![Line::from(vec![
+                    Span::styled("⚙ ", dim()),
+                    Span::raw(name),
+                    Span::styled(format!(" {mark}"), style),
+                ])]
+            }
+            Commit::Notice(text) => wrap(&text, width.saturating_sub(2))
+                .into_iter()
+                .map(|line| Line::from(Span::styled(format!("· {line}"), dim())))
+                .collect(),
+            Commit::Error(text) => wrap(&text, width.saturating_sub(2))
+                .into_iter()
+                .map(|line| {
+                    Line::from(Span::styled(
+                        format!("✗ {line}"),
+                        Style::default().fg(Color::Red),
+                    ))
+                })
+                .collect(),
+        }
+    }
+}
+
+/// The dim reasoning tail shown while the model thinks: at most the last two
+/// wrapped lines, so a long stream doesn't crowd the live region.
+pub fn thinking_lines(thinking: &str, width: usize) -> Vec<Line<'static>> {
+    let mut lines = wrap(thinking, width.saturating_sub(2));
+    if lines.len() > 2 {
+        lines.drain(..lines.len() - 2);
+    }
+    lines
+        .into_iter()
+        .map(|line| {
+            Line::from(Span::styled(
+                format!("  {line}"),
+                dim().add_modifier(Modifier::ITALIC),
+            ))
+        })
+        .collect()
+}
+
+/// Streaming assistant text, wrapped plain.
+pub fn streaming_lines(text: &str, width: usize) -> Vec<Line<'static>> {
+    wrap(text, width).into_iter().map(Line::from).collect()
+}
+
+/// The running tool's spinner line.
+pub fn tool_running_line(name: &str, spinner: char) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(format!("{spinner} "), Style::default().fg(Color::Yellow)),
+        Span::styled("⚙ ", dim()),
+        Span::raw(name.to_owned()),
+        Span::styled(" …", dim()),
+    ])
+}
+
+/// One human-readable line for a tool's closed action preview, if it has one
+/// this build understands. Unknown preview variants fall back to nothing
+/// rather than leaking a raw JSON dump into the consent card.
+pub fn preview_summary(preview: &serde_json::Value) -> Option<String> {
+    let get = |key: &str| preview.get(key).and_then(|v| v.as_str());
+    let summary = match get("tool")? {
+        "exec" => {
+            let command = get("command").unwrap_or_default();
+            let args = preview
+                .get("args")
+                .and_then(|v| v.as_array())
+                .map(|args| {
+                    args.iter()
+                        .filter_map(|a| a.as_str())
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                })
+                .unwrap_or_default();
+            format!("$ {command} {args}").trim_end().to_owned()
+        }
+        "search" | "web_search" => format!("query: {}", get("query").unwrap_or_default()),
+        "web_extract" => format!("fetch: {}", get("url").unwrap_or_default()),
+        "write_file" => format!("write: {}", get("path").unwrap_or_default()),
+        "delegate_agent" => format!("background agent: {}", get("task").unwrap_or_default()),
+        _ => return None,
+    };
+    Some(truncate(&summary, 200))
+}
+
+/// The inline approval card shown while a decision is pending.
+pub fn approval_card(
+    action: &str,
+    approval: &str,
+    auto_judging: bool,
+    preview: Option<&str>,
+    width: usize,
+) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    let mut heading = vec![
+        Span::styled("▲ ", Style::default().fg(Color::Yellow)),
+        Span::styled(
+            format!("approval required: {action}"),
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(format!(" — {}", approval.replace('_', " ")), dim()),
+    ];
+    if auto_judging {
+        heading.push(Span::styled(" (auto-judge deciding…)", dim()));
+    }
+    lines.push(Line::from(heading));
+    if let Some(preview) = preview {
+        for line in wrap(preview, width.saturating_sub(2)) {
+            lines.push(Line::from(Span::styled(format!("  {line}"), dim())));
+        }
+    }
+    lines.push(Line::from(vec![
+        Span::styled("y", Style::default().fg(Color::Green)),
+        Span::styled(" approve · ", dim()),
+        Span::styled("n", Style::default().fg(Color::Red)),
+        Span::styled(" reject", dim()),
+    ]));
+    lines
+}

--- a/crates/openwave-cli/src/tui/theme.rs
+++ b/crates/openwave-cli/src/tui/theme.rs
@@ -1,0 +1,59 @@
+//! The TUI's single palette: every color and style in the terminal UI comes
+//! from these constants — nothing inline elsewhere.
+//!
+//! Values derive from the desktop app's dark-theme design tokens
+//! (`crates/openwave-desktop/ui/src/styles.css`, the `.dark` block), converted
+//! from oklch to sRGB. Brand and muted tones are fixed RGB — terminals are
+//! overwhelmingly truecolor and the TUI assumes the dark theme, as the desktop
+//! does — while pure semantic success/error stay on ANSI colors so they keep
+//! respecting the user's own terminal theme.
+
+use ratatui::style::{Color, Modifier, Style};
+
+/// The one brand accent: the wordmark, ❯ input markers, the working spinner,
+/// the approval card's gutter and approve action. From `--brightwave`
+/// (oklch 0.87 0.2 102).
+pub const ACCENT: Color = Color::Rgb(240, 215, 0);
+
+/// Secondary text: notices, placeholders, key hints, dim continuation
+/// markers, and the receded body of completed tool lines. From
+/// `--muted-foreground` (oklch 0.68 0.006 262).
+pub const MUTED: Color = Color::Rgb(150, 152, 156);
+
+/// Semantic success. Deliberately ANSI green rather than the `--success`
+/// token's RGB: the user's terminal theme owns what "green" looks like.
+pub const SUCCESS: Color = Color::Green;
+
+/// Semantic error. Deliberately ANSI red (the desktop reference is
+/// `--destructive`), same reasoning as [`SUCCESS`].
+pub const DESTRUCTIVE: Color = Color::Red;
+
+/// Accent text.
+pub fn accent() -> Style {
+    Style::default().fg(ACCENT)
+}
+
+/// Accent, bold — the wordmark, markers, the card title's tool name.
+pub fn accent_bold() -> Style {
+    accent().add_modifier(Modifier::BOLD)
+}
+
+/// Muted secondary text.
+pub fn muted() -> Style {
+    Style::default().fg(MUTED)
+}
+
+/// Bold default foreground — the user's own input echo, card titles.
+pub fn bold() -> Style {
+    Style::default().add_modifier(Modifier::BOLD)
+}
+
+/// Semantic success (the ✓ status mark).
+pub fn success() -> Style {
+    Style::default().fg(SUCCESS)
+}
+
+/// Semantic error (error lines, the ✗ status mark).
+pub fn destructive() -> Style {
+    Style::default().fg(DESTRUCTIVE)
+}

--- a/crates/openwave-cli/src/tui/wire.rs
+++ b/crates/openwave-cli/src/tui/wire.rs
@@ -1,0 +1,245 @@
+//! Client-side decode of the chat event socket's frames.
+//!
+//! The server sends `RendererChatFrame`s — the closed, renderer-safe projection
+//! of the internal journal (see `openwave_server::event_projection`). These
+//! types mirror that wire shape loosely on purpose: closed vocabularies the
+//! server may grow (tool names, approval kinds, preview variants) decode as
+//! plain strings or JSON here, and an unrecognized event type decodes as
+//! [`ClientEvent::Unknown`] instead of failing the whole stream.
+
+use openwave_core::{CallId, TurnId};
+use serde::Deserialize;
+
+/// One frame on the socket: a journaled event (carrying `seq`, the resume
+/// cursor) or out-of-band metadata (no sequence).
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(untagged)]
+pub enum ChatFrame {
+    Event(SequencedFrame),
+    Metadata(MetadataFrame),
+}
+
+/// A journaled event at its sequence.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct SequencedFrame {
+    pub seq: i64,
+    pub event: ClientEvent,
+}
+
+/// A metadata push; only the tag is read today (the TUI has no title surface).
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct MetadataFrame {
+    pub metadata: String,
+}
+
+/// The events the TUI renders. Only fields the TUI uses are declared; serde
+/// drops the rest, so a server-side field addition never breaks decoding.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ClientEvent {
+    TurnStarted {
+        turn_id: TurnId,
+    },
+    TextDelta {
+        text: String,
+    },
+    ReasoningDelta {
+        text: String,
+    },
+    StreamInterrupted,
+    ToolCallStarted {
+        call_id: CallId,
+        name: String,
+    },
+    ToolCallArgsDelta,
+    UserQuestionsAsked,
+    PlanProposed,
+    ApprovalRequired {
+        call_id: CallId,
+        action: String,
+        approval: String,
+        #[serde(default)]
+        auto_judging: bool,
+        #[serde(default)]
+        preview: Option<serde_json::Value>,
+    },
+    ApprovalDecided {
+        call_id: CallId,
+    },
+    ToolCallCompleted {
+        call_id: CallId,
+        status: ToolCallStatus,
+    },
+    TurnCompleted,
+    TurnRefused {
+        refusal: Refusal,
+    },
+    TurnFailed {
+        category: String,
+    },
+    TurnCancelled,
+    UserSteered {
+        text: String,
+    },
+    ContextTruncated {
+        original_tokens: u32,
+        fitted_tokens: u32,
+    },
+    /// A newer server's event this build does not know; the journal cursor
+    /// still advances past it.
+    #[serde(other)]
+    Unknown,
+}
+
+/// Whether a finished tool call succeeded. Unknown statuses decode rather than
+/// failing; they render as failures (the conservative display).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolCallStatus {
+    Completed,
+    Failed,
+    #[serde(other)]
+    Unknown,
+}
+
+/// Bounded refusal metadata, as much as a client can act on.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct Refusal {
+    #[serde(default)]
+    pub category: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn frame(json: &str) -> ChatFrame {
+        serde_json::from_str(json).expect("the frame decodes")
+    }
+
+    /// Representative frames exactly as the server serializes them (untagged
+    /// frame union, internally-tagged snake_case events). This is the contract
+    /// across the wire boundary: a rename or tag change server-side fails here.
+    #[test]
+    fn representative_frames_decode() {
+        let metadata = frame(r#"{"metadata":"titled","title":"A chat"}"#);
+        assert_eq!(
+            metadata,
+            ChatFrame::Metadata(MetadataFrame {
+                metadata: "titled".into()
+            })
+        );
+
+        let turn_started = frame(
+            r#"{"seq":1,"event":{"type":"turn_started","turn_id":"00000000-0000-0000-0000-000000000002"}}"#,
+        );
+        let ChatFrame::Event(turn_started) = turn_started else {
+            panic!("expected an event frame: {turn_started:?}");
+        };
+        assert_eq!(turn_started.seq, 1);
+        assert!(matches!(
+            turn_started.event,
+            ClientEvent::TurnStarted { .. }
+        ));
+
+        let text = frame(r#"{"seq":2,"event":{"type":"text_delta","text":"Hello"}}"#);
+        assert_eq!(
+            text,
+            ChatFrame::Event(SequencedFrame {
+                seq: 2,
+                event: ClientEvent::TextDelta {
+                    text: "Hello".into()
+                }
+            })
+        );
+
+        let tool = frame(
+            r#"{"seq":3,"event":{"type":"tool_call_started","call_id":"00000000-0000-0000-0000-000000000003","name":"exec"}}"#,
+        );
+        let ChatFrame::Event(tool) = tool else {
+            panic!("expected an event frame: {tool:?}");
+        };
+        let ClientEvent::ToolCallStarted { call_id, name } = &tool.event else {
+            panic!("expected tool_call_started: {tool:?}");
+        };
+        assert_eq!(name, "exec");
+        let started_call = *call_id;
+
+        // ApprovalRequired carries the one deliberate payload opening: the
+        // tool's closed preview of the action under review.
+        let approval = frame(&format!(
+            r#"{{"seq":4,"event":{{"type":"approval_required","call_id":"{started_call}","action":"exec","approval":"exec_may_run_networked_command","class":"sensitive","preview":{{"tool":"exec","command":"git","args":["status"],"cwd":".","files":[]}}}}}}"#
+        ));
+        let ChatFrame::Event(approval) = approval else {
+            panic!("expected an event frame: {approval:?}");
+        };
+        let ClientEvent::ApprovalRequired {
+            call_id,
+            action,
+            approval: kind,
+            auto_judging,
+            preview,
+        } = &approval.event
+        else {
+            panic!("expected approval_required: {approval:?}");
+        };
+        assert_eq!(*call_id, started_call);
+        assert_eq!(action, "exec");
+        assert_eq!(kind, "exec_may_run_networked_command");
+        assert!(!auto_judging);
+        assert_eq!(
+            preview.as_ref().and_then(|p| p.get("tool")),
+            Some(&serde_json::json!("exec"))
+        );
+
+        let completed = frame(&format!(
+            r#"{{"seq":5,"event":{{"type":"tool_call_completed","call_id":"{started_call}","status":"completed"}}}}"#
+        ));
+        assert_eq!(
+            completed,
+            ChatFrame::Event(SequencedFrame {
+                seq: 5,
+                event: ClientEvent::ToolCallCompleted {
+                    call_id: started_call,
+                    status: ToolCallStatus::Completed,
+                }
+            })
+        );
+
+        // TurnCompleted's usage is present on the wire but unread by the TUI.
+        let done = frame(
+            r#"{"seq":6,"event":{"type":"turn_completed","usage":{"input_tokens":1,"output_tokens":2,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}"#,
+        );
+        assert_eq!(
+            done,
+            ChatFrame::Event(SequencedFrame {
+                seq: 6,
+                event: ClientEvent::TurnCompleted,
+            })
+        );
+    }
+
+    /// Forward compatibility: an event type this build doesn't know decodes as
+    /// `Unknown` (the cursor advances, the stream survives), and the
+    /// projection's own fail-closed `event_omitted` marker lands there too.
+    #[test]
+    fn unrecognized_event_types_decode_as_unknown() {
+        let future = frame(r#"{"seq":9,"event":{"type":"some_future_event","payload":{}}}"#);
+        assert_eq!(
+            future,
+            ChatFrame::Event(SequencedFrame {
+                seq: 9,
+                event: ClientEvent::Unknown,
+            })
+        );
+
+        let omitted = frame(r#"{"seq":10,"event":{"type":"event_omitted"}}"#);
+        assert_eq!(
+            omitted,
+            ChatFrame::Event(SequencedFrame {
+                seq: 10,
+                event: ClientEvent::Unknown,
+            })
+        );
+    }
+}

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -91,4 +91,4 @@ openwave-sandbox-agent = { path = "../openwave-sandbox-agent" }
 sea-orm = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time", "sync"] }
 tower = { version = "=0.5.3", features = ["util"] }
-tokio-tungstenite = "=0.30.0"
+tokio-tungstenite = { workspace = true }

--- a/crates/openwave-server/src/logging.rs
+++ b/crates/openwave-server/src/logging.rs
@@ -89,6 +89,23 @@ pub fn init_logging(data_dir: &Path) {
     }
 }
 
+/// Install the file-only subscriber used by `openwave tui`.
+///
+/// The TUI owns the terminal, so unlike [`init_logging`] there is no stderr
+/// mirror — and an unusable log file degrades to no subscriber at all rather
+/// than stderr, which would corrupt the display.
+pub fn init_logging_file_only(data_dir: &Path) {
+    if let Ok(writer) = open_log_writer(data_dir) {
+        let subscriber = tracing_subscriber::registry().with(env_filter()).with(
+            tracing_subscriber::fmt::layer()
+                .compact()
+                .with_ansi(false)
+                .with_writer(writer),
+        );
+        let _ = subscriber.try_init();
+    }
+}
+
 /// The active filter: `OPENWAVE_LOG` when set and valid, the default policy
 /// otherwise.
 fn env_filter() -> EnvFilter {


### PR DESCRIPTION
## What / why

Adds `openwave tui` — an interactive, Claude-Code-style terminal chat in the CLI crate (slice 1 of #1671). `openwave tui` starts a fresh chat; `openwave tui --chat <uuid>` resumes one, replaying journal history into scrollback via the WS `after=0` handshake before going live.

## Architecture

The subcommand boots the same in-process server `openwave serve` runs (`bind_configured`), spawns its accept loop on a background task — keeping the `Server`, and the `AbortTask` workers aborted on its drop, alive for the whole session — and talks to it over the loopback HTTP+WS API with the per-launch bearer token, exactly the contract the desktop webview consumes. Rendering is ratatui's inline viewport: finished blocks (user/assistant messages, tool-result lines, notices) commit to real terminal scrollback via `insert_before`, while a fixed-height live region repaints the streaming assistant text, a dim reasoning tail, the tool spinner line, the approval card, the tui-textarea composer, and a key-hint footer.

## Details

- One tokio `select!` loop over crossterm events, WS frames, action outcomes, and a 100ms tick; finished content flows through a commit queue into scrollback.
- WS auth via `Sec-WebSocket-Protocol: openwave-v1, openwave-token.<token>`; on an unexpected close, one delayed reconnect resumes from the last seen `seq`.
- `ApprovalRequired` renders an inline card (tool, humanized approval kind, closed preview summary) answered with y/n → `POST /chats/{id}/approvals/{call_id}`; no standing grants. Composer input is suspended while a card is pending; `ApprovalDecided` clears it.
- Enter sends, Alt/Shift+Enter inserts a newline (keyboard enhancement flags pushed where supported), Ctrl+C cancels a running turn or quits, Ctrl+D on an empty composer quits. The terminal is restored on every exit path, including panic (a hook disables raw mode and shows the cursor).
- `UserQuestionsAsked` / `PlanProposed` render a "not supported in the TUI yet — use the desktop app" notice instead of crashing; `StreamInterrupted` and `ContextTruncated` get brief notice lines; unknown event types decode to a fallback rather than killing the stream.
- Logging is file-only for this subcommand (new `init_logging_file_only` in the server crate) so tracing can never corrupt the display.
- Deps: `ratatui =0.29.0`, `crossterm =0.28.1`, `tui-textarea =0.7.0` pinned exact and crate-local; `tokio-tungstenite` promoted to the workspace at `=0.30.0` with rustls (never native-tls), matching the reqwest stack; the server's dev-dep now points at the workspace entry. `cargo check --workspace --locked` is clean.

## Tests

Two wire-contract tests in `tui/wire.rs`: representative frames exactly as the server serializes them (metadata, text delta, tool start/complete, approval with exec preview, turn completed) decode into the client event type, and frames carrying a future/`event_omitted` type decode as `Unknown` — the forward-compatibility guarantee a `#[non_exhaustive]` server enum requires of this client. No widget/render tests, per repo policy.

## Not verified

The interactive TUI itself could not be driven from this environment — behavior was verified by compile, clippy, unit/integration tests, and argument-parsing smoke runs only. Streaming rendering, the approval flow, cancel, and `--chat` resume still need a manual pass on a real terminal.

Deferred to later slices (see #1671): chat picker, model picker, markdown/syntax highlighting, steering, plan-mode and user-question UI, standing grants.

Closes #1671

## Design pass (follow-up commit)

A look-and-feel pass aligns the TUI with the desktop app's dark theme (`ui/src/styles.css`): one palette module (`tui/theme.rs`) holds every color — the `--brightwave` accent and `--muted-foreground` as RGB, with success/error deliberately on ANSI green/red to respect terminal themes. Also: a compact branded startup header (wordmark, new/resumed + short chat id, key hint), a 10-row live region bottom-anchored above the composer, a composer ❯/│ gutter matching sent user messages, the approval prompt as an accent-guttered card with button-styled y/n, completed tool lines dimmed except their ✓/✗, uniform blank-line spacing after every block, and a footer split into accent state segment, muted hints, and the short chat id at the right edge. No behavior changes; styling verified by fmt/clippy/tests only, not on a live terminal.
