### PR TITLE
fix(ui): hide code execution preview images

### DIFF
--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -678,7 +678,6 @@ export function groupMessageItems(
       onApproval,
       approvalState,
       chatId,
-      imageClient,
     );
     const spawns = activities.flatMap((entry) =>
       entry.name === "spawn_sandbox_agent"
@@ -803,7 +802,6 @@ type CardContext = {
     grantScope?: GrantScopeName;
   };
   chatId?: string;
-  imageClient?: Pick<ApiClient, "getChatImageAttachment">;
 };
 
 /**
@@ -836,7 +834,6 @@ function surfacedCards(
     grantScope?: GrantScopeName;
   },
   chatId?: string,
-  imageClient?: Pick<ApiClient, "getChatImageAttachment">,
 ): ReactNode[] {
   const context: CardContext = {
     parked,
@@ -844,7 +841,6 @@ function surfacedCards(
     onApproval,
     approvalState,
     chatId,
-    imageClient,
   };
   const cards: ReactNode[] = [];
   // In the order the calls happened, so the cards read as a sequence rather
@@ -915,7 +911,6 @@ function surfacedCard(entry: ChatMessage, context: CardContext): ReactNode {
     onApproval,
     approvalState,
     chatId,
-    imageClient,
   } = context;
   if (entry.role === "approval") {
     if (entry.resolved) return null;
@@ -987,8 +982,6 @@ function surfacedCard(entry: ChatMessage, context: CardContext): ReactNode {
       status={entry.status}
       preview={entry.preview}
       result={entry.result?.tool === "exec" ? entry.result : null}
-      imageClient={imageClient}
-      chatId={chatId}
     />,
   );
 }

--- a/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
@@ -150,7 +150,7 @@ describe("ToolCommandCard", () => {
     );
   });
 
-  it("renders exec preview images inside the output surface", () => {
+  it("does not surface exec preview images in the command card", () => {
     const markup = renderToStaticMarkup(
       <ToolCommandCard
         name="exec"
@@ -172,17 +172,12 @@ describe("ToolCommandCard", () => {
             },
           ],
         }}
-        imageClient={{
-          getChatImageAttachment: async () => new Blob([], { type: "image/png" }),
-        }}
-        chatId="chat-1"
       />,
     );
 
-    expect(markup).toContain('aria-label="Command preview images"');
-    expect(markup).toContain(
-      'aria-label="Command preview 1: 800 by 600 pixels"',
-    );
+    expect(markup).not.toContain("Command preview");
+    expect(markup).not.toContain("preview-1");
+    expect(markup).toContain('aria-expanded="false"');
   });
 });
 

--- a/crates/openwave-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.tsx
@@ -12,11 +12,9 @@ import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 import type { ToolTone } from "./ToolStatusIcon";
-import type { ApiClient } from "./api";
 import { ScrollableContainer } from "./ScrollableContainer";
 import { ToolCardShell } from "./ToolCardShell";
 import { toolPreviewPresentation } from "./ToolPreview";
-import { ChatImage } from "./TranscriptImageAttachments";
 import { useChatSessionStore } from "./ChatSessionStore";
 
 /**
@@ -66,8 +64,6 @@ type ToolCommandCardProps = {
   preview: Extract<ToolActionPreview, { tool: "exec" }>;
   /** What the command produced, once it has produced anything. */
   result: ExecResultPreview | null;
-  imageClient?: Pick<ApiClient, "getChatImageAttachment">;
-  chatId?: string;
 };
 
 type ToolPresentation = {
@@ -262,8 +258,8 @@ const FALLBACK_TOOL: ToolPresentation = {
  * The command is the title, in monospace: "Ran a command" is the same sentence
  * whether the agent listed a directory or rebuilt the workspace, so the only
  * useful headline is the command itself. It opens while the command is still
- * running and when a completed command has visual previews to review; otherwise
- * it collapses back to one line once the badge carries the outcome.
+ * running; otherwise it collapses back to one line once the badge carries the
+ * outcome.
  *
  * Only tools that project a preview get a card. Everything else lives in the
  * activity rail, where a line of text is the whole story the renderer has.
@@ -273,8 +269,6 @@ export function ToolCommandCard({
   status,
   preview,
   result,
-  imageClient,
-  chatId,
 }: ToolCommandCardProps) {
   const presentation = toolCallPresentation(name, status);
   const command = toolPreviewPresentation(preview, result);
@@ -284,10 +278,9 @@ export function ToolCommandCard({
   const preparing =
     useChatSessionStore((session) => session.sandboxPreparing) && running;
   const output = commandOutput(result);
-  const images = result?.images ?? [];
   // A command that finished silently has nothing to tab between, and a
   // "Command / Output → no output" pair reads as confusing noise.
-  const tabbed = running || output !== null || images.length > 0;
+  const tabbed = running || output !== null;
 
   return (
     <div className="flex max-w-prose flex-col gap-1.5">
@@ -314,7 +307,7 @@ export function ToolCommandCard({
             />
           </>
         }
-        defaultExpanded={running || images.length > 0}
+        defaultExpanded={running}
       >
         {tabbed ? (
           <Tabs defaultValue="output">
@@ -343,26 +336,6 @@ export function ToolCommandCard({
                   <ScrollableContainer className="bg-muted text-muted-foreground rounded-md p-2 text-xs whitespace-pre-wrap">
                     {output}
                   </ScrollableContainer>
-                )}
-                {images.length > 0 && imageClient && chatId && (
-                  <div
-                    className="message-image-grid mt-2"
-                    aria-label="Command preview images"
-                  >
-                    {images.map((image, index) => (
-                      <ChatImage
-                        key={image.attachmentId}
-                        client={imageClient}
-                        chatId={chatId}
-                        attachmentId={image.attachmentId}
-                        mediaType={image.mediaType}
-                        width={image.width}
-                        height={image.height}
-                        label={`Command preview ${index + 1}: ${image.width} by ${image.height} pixels`}
-                        unavailableLabel="Command preview unavailable"
-                      />
-                    ))}
-                  </div>
                 )}
               </TabsContent>
             </div>


### PR DESCRIPTION
## Summary

- stop rendering generated image thumbnails inside code execution cards
- keep completed image-only commands collapsed
- retain exec image metadata parsing for wire and history compatibility

## Verification

- `pnpm test` (121 files, 801 tests)
- `git diff --check`

GitHub Actions is currently unavailable; this PR is being merged with the explicitly requested admin bypass.