### PR TITLE
feat(skills): guide pdf template reuse via form fill or fpdf2 reproduction

### DIFF
--- a/skills/pdf-documents/SKILL.md
+++ b/skills/pdf-documents/SKILL.md
@@ -51,6 +51,26 @@ say so plainly instead of quietly delivering a lesser format.
 - Always open source PDFs from the workspace (attachments arrive under
   `documents/`), and never assume a page count — read it.
 
+## Working from an existing PDF as a template
+
+A PDF the user supplies as a template is a read-only reference: its layout
+cannot be edited in place. There are two ways forward, and the first is much
+better whenever it applies.
+
+1. **Check for fillable form fields first.** Read the template with
+   `PdfReader.get_fields()`. If it returns usable fields, fill them as above
+   — that keeps the original design intact and is far less work than
+   rebuilding the document.
+2. **Only when there are no usable fields, reproduce the layout.** Render the
+   template to images with the helper below and study it visually — fonts,
+   sizes, margins, column positions, rules, headers and footers — alongside
+   its structure, then rebuild it as a new document with fpdf2, matching that
+   layout as closely as fpdf2 allows. Approximations are expected; say which
+   ones you made.
+
+A reproduction is a new document that resembles the template, not the
+template itself. Never present it as the original.
+
 ## Saving deliverables
 
 Save the finished PDF in `output/` — files there are published to the user


### PR DESCRIPTION
When a user supplies an existing PDF as a template, the skill gave no direction: nothing said the template's layout can't be edited in place, and nothing pointed at form filling as the cheap path before rebuilding the document from scratch.

Adds a short section to `skills/pdf-documents/SKILL.md` covering the two routes — check `get_fields()` first and fill the existing form (linking to the pypdf form guidance already in the file), and only fall back to analyzing the template visually with the bundled `render_pdf.py` helper and reproducing it in fpdf2. Also states the reproduction must never be passed off as the original.

Documentation only — frontmatter and pinned deps are unchanged. `cargo test -p openwave-code-execution skills` passes, including `bundled_skill_sources_all_parse`.