### PR TITLE
fix(desktop): camel-case presentation preview IPC fields

### DIFF
--- a/crates/openwave-desktop/src/office_pdf.rs
+++ b/crates/openwave-desktop/src/office_pdf.rs
@@ -73,8 +73,16 @@ pub(crate) struct PresentationPdfRequest {
 /// Outcome of a conversion request. A missing converter is a state the
 /// renderer designs for, not a failure: on macOS it triggers the managed
 /// download (unless one already failed this run), elsewhere the install hint.
+///
+/// `rename_all` alone renames the variants and leaves their fields in
+/// snake_case, so `rename_all_fields` is what actually makes the payload the
+/// renderer reads (`pdfBase64`, `installFailure`); the test below pins both.
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase", tag = "status")]
+#[serde(
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    tag = "status"
+)]
 pub(crate) enum PresentationPdfResult {
     Converted {
         pdf_base64: String,
@@ -744,6 +752,50 @@ mod tests {
 
         assert!(uri.starts_with("file:///"), "{uri}");
         assert!(uri.contains("OpenWave%20Preview/profile%20%231"), "{uri}");
+    }
+
+    /// The IPC wire contract for the preview. The renderer reads these keys
+    /// by name, and an enum-level `rename_all` renames only the variants —
+    /// leaving `pdf_base64` on the wire, which the renderer read as
+    /// `undefined` and handed to `atob`, failing every presentation preview.
+    #[test]
+    fn conversion_result_serializes_camel_case_variants_and_fields() {
+        let converted = serde_json::to_value(PresentationPdfResult::Converted {
+            pdf_base64: "JVBERi0=".to_owned(),
+        })
+        .unwrap();
+        assert_eq!(
+            converted,
+            serde_json::json!({ "status": "converted", "pdfBase64": "JVBERi0=" })
+        );
+
+        let missing = serde_json::to_value(PresentationPdfResult::ConverterMissing {
+            installable: true,
+            install_failure: Some("Download cancelled".to_owned()),
+        })
+        .unwrap();
+        assert_eq!(
+            missing,
+            serde_json::json!({
+                "status": "converterMissing",
+                "installable": true,
+                "installFailure": "Download cancelled",
+            })
+        );
+
+        let failed = serde_json::to_value(PresentationPdfResult::Failed {
+            message: "LibreOffice failed".to_owned(),
+            details: "Exit status: exit status: 1".to_owned(),
+        })
+        .unwrap();
+        assert_eq!(
+            failed,
+            serde_json::json!({
+                "status": "failed",
+                "message": "LibreOffice failed",
+                "details": "Exit status: exit status: 1",
+            })
+        );
     }
 
     #[test]

--- a/crates/openwave-desktop/ui/src/document/officePdf.ts
+++ b/crates/openwave-desktop/ui/src/document/officePdf.ts
@@ -83,6 +83,9 @@ export async function convertPresentationToPdf(
   if (response.status === "failed") {
     throw new PresentationConversionError(response.message, response.details);
   }
+  if (typeof response.pdfBase64 !== "string" || response.pdfBase64 === "") {
+    throw new Error("Invalid presentation preview response");
+  }
   return decodeBase64(response.pdfBase64);
 }
 
@@ -212,7 +215,14 @@ function encodeBase64(bytes: Uint8Array): string {
 }
 
 function decodeBase64(value: string): Uint8Array {
-  const binary = atob(value);
+  let binary: string;
+  try {
+    binary = atob(value);
+  } catch {
+    // `atob` rejects malformed input with "The string contains invalid
+    // characters", which says nothing about presentations to whoever reads it.
+    throw new Error("Invalid presentation preview response");
+  }
   const bytes = new Uint8Array(binary.length);
   for (let index = 0; index < binary.length; index += 1) {
     bytes[index] = binary.charCodeAt(index);


### PR DESCRIPTION
Opening any pptx/ppt/odp preview failed with "The string contains invalid characters." — every time, on every machine, whether or not LibreOffice was installed. The conversion itself was fine; the response never survived the trip to the renderer.

`PresentationPdfResult` carried `#[serde(rename_all = "camelCase", tag = "status")]`, and serde's enum-level `rename_all` renames the *variants*, not the fields inside struct variants. So the payload went out as `{"status":"converted","pdf_base64":"..."}` while `officePdf.ts` read `response.pdfBase64`, got `undefined`, and handed it to `atob` — whose complaint about its argument is the message users saw. The `converterMissing` arm had the same split on `install_failure` vs `installFailure`, which quietly disabled the managed-install retry gate.

Adding `rename_all_fields = "camelCase"` puts the fields on the wire under the names the renderer already expects. A test asserts the serialized JSON of all three variants; this contract crosses the IPC boundary with no compiler or generator holding the two sides together, and the failure mode was invisible until runtime.

On the renderer side, `convertPresentationToPdf` now rejects a converted response whose `pdfBase64` is missing or empty, and `decodeBase64` turns an `atob` throw into "Invalid presentation preview response" — so a malformed payload reads as a preview problem rather than a stray string error from the platform.

Verified locally on macOS: `cargo test -p openwave-desktop office_pdf` (7 passed, including the real-LibreOffice conversion test, which confirms only the wire naming was broken), `cargo check -p openwave-desktop --locked`, `cargo clippy -p openwave-desktop --all-targets`, and `pnpm vitest run src/document/officePdf.test.ts`. The UI test mocks already used camelCase — they encoded the correct contract and were passing against a host that did not honor it. `pnpm exec tsc --noEmit` reports four pre-existing `PluginInfo` errors in unrelated test files that also fail on `main`.
