### PR TITLE
fix(ui): update plugin test fixtures for PluginInfo fields

### DIFF
--- a/crates/openwave-desktop/ui/src/ComposerPlugins.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerPlugins.dom.test.tsx
@@ -17,6 +17,7 @@ const DOCUMENTS: PluginInfo = {
   category: "documents",
   origin: "builtin",
   capabilities: [],
+  compatibility: { status: "unchecked", issues: [] },
   enabled: false,
   skills: [],
 };

--- a/crates/openwave-desktop/ui/src/ComposerSlash.test.ts
+++ b/crates/openwave-desktop/ui/src/ComposerSlash.test.ts
@@ -16,7 +16,9 @@ const CATALOG: PluginCatalog = {
       display_name: "Documents",
       description: "Writes Word, Excel, and PowerPoint files.",
       category: "documents",
+      origin: "builtin",
       capabilities: [],
+      compatibility: { status: "unchecked", issues: [] },
       enabled: true,
       skills: [
         { name: "docx", description: "Documents.", origin: "builtin", enabled: true },
@@ -28,7 +30,9 @@ const CATALOG: PluginCatalog = {
       display_name: "Charts",
       description: "Plots data.",
       category: "visualization",
+      origin: "builtin",
       capabilities: [],
+      compatibility: { status: "unchecked", issues: [] },
       enabled: false,
       skills: [
         { name: "charts", description: "Plots.", origin: "builtin", enabled: true },

--- a/crates/openwave-desktop/ui/src/plugins/Plugins.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/plugins/Plugins.dom.test.tsx
@@ -19,6 +19,7 @@ const CATALOG: PluginCatalog = {
       category: "documents",
       origin: "builtin",
       capabilities: ["write-files", "host-install"],
+      compatibility: { status: "unchecked", issues: [] },
       enabled: false,
       skills: [
         {


### PR DESCRIPTION
`pnpm exec tsc --noEmit` fails in `crates/openwave-desktop/ui` with four errors: `PluginInfo` grew `origin` and `compatibility`, but the fixtures in `ComposerPlugins.dom.test.tsx`, `ComposerSlash.test.ts`, and `plugins/Plugins.dom.test.tsx` were never updated.

Fill in the missing fields. All the fixtures model bundles that ship with the app, so they get `origin: "builtin"` and the `unchecked` compatibility the host records for hand-authored packages (`PluginCompatibility::unchecked()` in `openwave-code-execution/src/plugins.rs`) — no issues.

Fixtures only; no behavior changes.

Verified: `pnpm exec tsc --noEmit` clean, and `pnpm vitest run` on the three files passes (15 tests).