### PR TITLE
fix(desktop): surface operation failures as toasts

### DIFF
--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Bot, ChevronDown, ChevronRight, Square } from "lucide-react";
+import { toast } from "sonner";
 
 import type { AgentActivityHistoryEntry, AgentRun } from "./api";
 import { AgentActivityTimeline, useAgentRunActivity } from "./AgentActivityTimeline";
@@ -9,6 +10,7 @@ import {
   getAgentRunDotClass,
   RUNNING_AGENT_STATUSES,
 } from "./AgentRunDisplay";
+import { friendlyErrorMessage } from "./lib/utils";
 import { SubmittedOutputPills } from "./SubmittedOutputPills";
 import type { ToolCallStatus } from "./ToolCallCard";
 import { Button } from "@/components/ui/button";
@@ -269,10 +271,11 @@ function BackgroundAgentRow({
     setStopping(true);
     try {
       await onCancel(run.id);
-    } catch {
+    } catch (caught) {
       // The durable request did not commit; return the control so the reader
       // can try again rather than leave a run stuck reading "Stopping".
       setStopping(false);
+      toast.error(friendlyErrorMessage(caught, "Could not stop that agent."));
     }
   };
 

--- a/crates/openwave-desktop/ui/src/ChangeSummaryCard.tsx
+++ b/crates/openwave-desktop/ui/src/ChangeSummaryCard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
 import {
   AlertTriangle,
   Check,
@@ -31,7 +32,6 @@ export function ChangeSummaryCard({ client, chatId, turnId, files }: Props) {
   const [rows, setRows] = useState(files);
   const [working, setWorking] = useState<Set<string>>(new Set());
   const [undoingAll, setUndoingAll] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => setRows(files), [files]);
 
@@ -80,7 +80,6 @@ export function ChangeSummaryCard({ client, chatId, turnId, files }: Props) {
   }
 
   async function undoOne(file: ExecFileChangeSummary) {
-    setError(null);
     setWorking((current) => new Set(current).add(file.snapshot_id));
     try {
       applyOutcomes([
@@ -91,7 +90,7 @@ export function ChangeSummaryCard({ client, chatId, turnId, files }: Props) {
         ),
       ]);
     } catch {
-      setError(`Could not undo ${file.relative_path}.`);
+      toast.error(`Could not undo ${file.relative_path}.`);
     } finally {
       setWorking((current) => {
         const next = new Set(current);
@@ -102,13 +101,12 @@ export function ChangeSummaryCard({ client, chatId, turnId, files }: Props) {
   }
 
   async function undoAll() {
-    setError(null);
     setUndoingAll(true);
     try {
       const outcome = await client.undoTurnFileChanges(chatId, turnId);
       applyOutcomes(outcome.files);
     } catch {
-      setError("Could not undo these changes.");
+      toast.error("Could not undo these changes.");
     } finally {
       setUndoingAll(false);
     }
@@ -157,11 +155,6 @@ export function ChangeSummaryCard({ client, chatId, turnId, files }: Props) {
           />
         ))}
       </div>
-      {error && (
-        <p className="border-t border-border px-3 py-2 text-xs text-destructive" role="alert">
-          {error}
-        </p>
-      )}
     </section>
   );
 }

--- a/crates/openwave-desktop/ui/src/apps/AppDetailView.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppDetailView.tsx
@@ -1,5 +1,6 @@
 import { ChevronLeft, ShieldCheck, Trash2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 
 import type { AppDetail, AppGrantState } from "@/api";
 import { PanelSecondaryHeader } from "@/components/PanelHeader";
@@ -92,12 +93,11 @@ export function AppDetailView({
 
   async function onRevoke() {
     setBusy(true);
-    setActionError(null);
     try {
       await apis.revoke(appId);
       setGrant(await apis.grantState(appId));
     } catch (caught) {
-      setActionError(friendlyAppsError(caught, "Could not revoke access."));
+      toast.error(friendlyAppsError(caught, "Could not revoke access."));
     } finally {
       setBusy(false);
     }
@@ -118,12 +118,11 @@ export function AppDetailView({
 
   async function onDelete() {
     setBusy(true);
-    setActionError(null);
     try {
       await apis.deleteApp(appId);
       onBack();
     } catch (caught) {
-      setActionError(friendlyAppsError(caught, "Could not delete this app."));
+      toast.error(friendlyAppsError(caught, "Could not delete this app."));
       setBusy(false);
     }
   }
@@ -168,12 +167,6 @@ export function AppDetailView({
                 error={actionError}
                 onConsent={() => void onConsent()}
               />
-            )}
-
-            {grant.granted && actionError && (
-              <p className="text-critical mx-4 text-sm" role="alert">
-                {actionError}
-              </p>
             )}
 
             <footer className="mx-4 flex flex-wrap items-center gap-x-4 gap-y-2">

--- a/crates/openwave-desktop/ui/src/apps/AppsView.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppsView.tsx
@@ -13,6 +13,7 @@ import {
   EmptyTitle,
 } from "@/components/ui/empty";
 import { WithTooltip } from "@/components/ui/tooltip";
+import { friendlyErrorMessage } from "@/lib/utils";
 import type { AppsApis } from "./appsApis";
 
 /**
@@ -163,6 +164,5 @@ export function updatedLabel(updatedAt: string): string {
 }
 
 export function friendlyAppsError(error: unknown, fallback: string): string {
-  const message = String(error).replace(/^Error:\s*/, "").trim();
-  return message && message.length <= 240 ? message : fallback;
+  return friendlyErrorMessage(error, fallback);
 }

--- a/crates/openwave-desktop/ui/src/lib/utils.ts
+++ b/crates/openwave-desktop/ui/src/lib/utils.ts
@@ -4,3 +4,15 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * A caught value as something worth showing a reader.
+ *
+ * The backend returns human-readable strings, so the caught message is usually
+ * the best copy available. Anything empty or long enough to be a stack trace or
+ * a serialized payload falls back to the caller's own wording.
+ */
+export function friendlyErrorMessage(error: unknown, fallback: string): string {
+  const message = String(error).replace(/^Error:\s*/, "").trim();
+  return message && message.length <= 240 ? message : fallback;
+}

--- a/crates/openwave-desktop/ui/src/outputs/OutputDetailRoot.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/outputs/OutputDetailRoot.dom.test.tsx
@@ -5,6 +5,7 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { DeliverablePreview, OutputRevisionInfo } from "@/deliverables";
+import { Toaster } from "@/components/ui/sonner";
 import { renderWithRouter } from "@/test/router";
 import { OutputDetailRoot, type OutputDetailApis } from "./OutputDetailRoot";
 
@@ -96,7 +97,10 @@ function detailApis(overrides: Partial<OutputDetailApis> = {}): OutputDetailApis
 
 async function openOutput(apis: OutputDetailApis, id = outputId) {
   return renderWithRouter(
-    <OutputDetailRoot chatId="chat-1" outputId={id} apis={apis} />,
+    <>
+      <OutputDetailRoot chatId="chat-1" outputId={id} apis={apis} />
+      <Toaster richColors />
+    </>,
     { initialUrl: `/c/chat-1?tabs=outputs.${id}` },
   );
 }

--- a/crates/openwave-desktop/ui/src/outputs/OutputDetailRoot.tsx
+++ b/crates/openwave-desktop/ui/src/outputs/OutputDetailRoot.tsx
@@ -1,6 +1,7 @@
 import { formatDistanceToNow } from "date-fns";
 import { ArrowLeftIcon, DownloadIcon, HistoryIcon, RotateCcwIcon } from "lucide-react";
 import { useEffect, useState } from "react";
+import { toast } from "sonner";
 
 import { PanelBreadcrumb } from "@/components/PanelHeader";
 import { Badge } from "@/components/ui/badge";
@@ -95,16 +96,11 @@ export function OutputDetailRoot({
   /** The non-current version being previewed, if any. */
   const [previewRevision, setPreviewRevision] = useState<OutputRevisionInfo | null>(null);
   const [revisionPreview, setRevisionPreview] = useState<DeliverablePreview | null>(null);
-  const [saveStatus, setSaveStatus] = useState<{
-    message: string;
-    error: boolean;
-  } | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     setPreview(null);
     setLoadError(null);
-    setSaveStatus(null);
     setRevisions(null);
     setPreviewRevision(null);
     setRevisionPreview(null);
@@ -127,24 +123,20 @@ export function OutputDetailRoot({
   async function onSave() {
     if (saving) return;
     if (!useNativePickerLatch.getState().claim(PICKER_HOLDERS.exportOutput)) {
-      setSaveStatus({ message: PICKER_BUSY_MESSAGE, error: true });
+      toast.error(PICKER_BUSY_MESSAGE);
       return;
     }
     setSaving(true);
-    setSaveStatus(null);
     try {
       const result = await apis.export(chatId, outputId);
       const filename = preview?.filename ?? "Output";
       if (result.status === "completed") {
-        setSaveStatus({ message: `${filename} was saved.`, error: false });
+        toast.success(`${filename} was saved.`);
       } else if (result.status === "failed") {
-        setSaveStatus({ message: exportFailureMessage(result.reason), error: true });
+        toast.error(exportFailureMessage(result.reason));
       }
     } catch (caught) {
-      setSaveStatus({
-        message: friendlyOutputError(caught, "Could not save that output."),
-        error: true,
-      });
+      toast.error(friendlyOutputError(caught, "Could not save that output."));
     } finally {
       useNativePickerLatch.getState().release(PICKER_HOLDERS.exportOutput);
       setSaving(false);
@@ -159,10 +151,9 @@ export function OutputDetailRoot({
       setRevisions(catalog.revisions);
     } catch (caught) {
       setHistoryOpen(false);
-      setSaveStatus({
-        message: friendlyOutputError(caught, "Could not load this output's versions."),
-        error: true,
-      });
+      toast.error(
+        friendlyOutputError(caught, "Could not load this output's versions."),
+      );
     }
   }
 
@@ -180,17 +171,13 @@ export function OutputDetailRoot({
       setRevisionPreview(content);
     } catch (caught) {
       setPreviewRevision(null);
-      setSaveStatus({
-        message: friendlyOutputError(caught, "Could not preview that version."),
-        error: true,
-      });
+      toast.error(friendlyOutputError(caught, "Could not preview that version."));
     }
   }
 
   async function onRestore() {
     if (!previewRevision || restoring) return;
     setRestoring(true);
-    setSaveStatus(null);
     try {
       await apis.restoreRevision(chatId, outputId, previewRevision.revisionId);
       const restoredOrdinal = previewRevision.ordinal;
@@ -199,15 +186,9 @@ export function OutputDetailRoot({
       setRevisions(null);
       const next = await apis.read(chatId, outputId);
       setPreview(next);
-      setSaveStatus({
-        message: `Restored version ${restoredOrdinal} as the latest version.`,
-        error: false,
-      });
+      toast.success(`Restored version ${restoredOrdinal} as the latest version.`);
     } catch (caught) {
-      setSaveStatus({
-        message: friendlyOutputError(caught, "Could not restore that version."),
-        error: true,
-      });
+      toast.error(friendlyOutputError(caught, "Could not restore that version."));
     } finally {
       setRestoring(false);
     }
@@ -349,18 +330,6 @@ export function OutputDetailRoot({
       ) : (
         <p className="p-6 text-sm text-muted-foreground" role="status">
           {previewRevision ? "Loading that version…" : "Loading this output…"}
-        </p>
-      )}
-      {saveStatus && (
-        <p
-          className={
-            saveStatus.error
-              ? "shrink-0 px-6 pb-2 text-sm text-critical"
-              : "shrink-0 px-6 pb-2 text-sm text-muted-foreground"
-          }
-          role={saveStatus.error ? "alert" : "status"}
-        >
-          {saveStatus.message}
         </p>
       )}
     </PanelFrame>

--- a/crates/openwave-desktop/ui/src/outputs/OutputsView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/outputs/OutputsView.dom.test.tsx
@@ -4,6 +4,7 @@ import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { Toaster } from "@/components/ui/sonner";
 import type { DeliverableSummary, DeliverablesCatalog } from "@/deliverables";
 import { OutputsView, type OutputsApis } from "./OutputsView";
 
@@ -80,7 +81,12 @@ describe("OutputsView", () => {
     const apis = outputApis([output()]);
     const user = userEvent.setup();
 
-    render(<OutputsView chatId="chat-1" apis={apis} />);
+    render(
+      <>
+        <OutputsView chatId="chat-1" apis={apis} />
+        <Toaster richColors />
+      </>,
+    );
     await user.click(
       await screen.findByRole("button", { name: "More options for Research brief.md" }),
     );
@@ -94,7 +100,12 @@ describe("OutputsView", () => {
     const apis = outputApis([output({ producingRunId: ids.sheet })]);
     const user = userEvent.setup();
 
-    render(<OutputsView chatId="chat-1" apis={apis} />);
+    render(
+      <>
+        <OutputsView chatId="chat-1" apis={apis} />
+        <Toaster richColors />
+      </>,
+    );
     await user.click(
       await screen.findByRole("button", { name: "More options for Research brief.md" }),
     );
@@ -122,14 +133,20 @@ describe("OutputsView", () => {
     });
     const user = userEvent.setup();
 
-    render(<OutputsView chatId="chat-1" apis={apis} />);
+    render(
+      <>
+        <OutputsView chatId="chat-1" apis={apis} />
+        <Toaster richColors />
+      </>,
+    );
     await user.click(
       await screen.findByRole("button", { name: "More options for Research brief.md" }),
     );
     await user.click(await screen.findByRole("menuitem", { name: "Save as…" }));
 
-    const alert = await screen.findByRole("alert");
-    expect(alert).toHaveTextContent("save destination is no longer available");
+    expect(
+      await screen.findByText(/save destination is no longer available/),
+    ).toBeVisible();
   });
 
   it("ignores a stale catalog response after the conversation changes", async () => {
@@ -147,7 +164,12 @@ describe("OutputsView", () => {
           }),
     );
 
-    const view = render(<OutputsView chatId="chat-1" apis={apis} />);
+    const view = render(
+      <>
+        <OutputsView chatId="chat-1" apis={apis} />
+        <Toaster richColors />
+      </>,
+    );
     await waitFor(() => expect(apis.list).toHaveBeenCalledWith("chat-1"));
 
     view.rerender(<OutputsView chatId="chat-2" apis={apis} />);

--- a/crates/openwave-desktop/ui/src/outputs/OutputsView.tsx
+++ b/crates/openwave-desktop/ui/src/outputs/OutputsView.tsx
@@ -1,5 +1,6 @@
 import { FileOutputIcon, RotateCwIcon } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 
 import { PanelSecondaryHeader } from "@/components/PanelHeader";
 import { Button } from "@/components/ui/button";
@@ -25,6 +26,7 @@ import {
   PICKER_HOLDERS,
   useNativePickerLatch,
 } from "@/NativePickerLatch";
+import { friendlyErrorMessage } from "@/lib/utils";
 import { useRefreshSignals } from "@/RefreshSignals";
 import { OutputsTable } from "./OutputsTable";
 
@@ -68,12 +70,6 @@ export function OutputsView({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [busyOutputId, setBusyOutputId] = useState<string | null>(null);
-  const [saveStatus, setSaveStatus] = useState<{
-    message: string;
-    error: boolean;
-    /** A delete offers an inline undo that restores the output. */
-    undo?: () => void;
-  } | null>(null);
   const [countSuffix, setCountSuffix] = useState("");
   const generationRef = useRef(0);
   // Bumped when the event stream reports the catalog moved — an exec call
@@ -99,7 +95,6 @@ export function OutputsView({
   useEffect(() => {
     setCatalog({ deliverables: [], truncated: false });
     setError(null);
-    setSaveStatus(null);
     setBusyOutputId(null);
     void refresh(true);
     return () => {
@@ -118,23 +113,19 @@ export function OutputsView({
     async (output: DeliverableSummary) => {
       if (busyOutputId) return;
       if (!useNativePickerLatch.getState().claim(PICKER_HOLDERS.exportOutput)) {
-        setSaveStatus({ message: PICKER_BUSY_MESSAGE, error: true });
+        toast.error(PICKER_BUSY_MESSAGE);
         return;
       }
       setBusyOutputId(output.outputId);
-      setSaveStatus(null);
       try {
         const result = await apis.export(chatId, output.outputId);
         if (result.status === "completed") {
-          setSaveStatus({ message: `${output.filename} was saved.`, error: false });
+          toast.success(`${output.filename} was saved.`);
         } else if (result.status === "failed") {
-          setSaveStatus({ message: exportFailureMessage(result.reason), error: true });
+          toast.error(exportFailureMessage(result.reason));
         }
       } catch (caught) {
-        setSaveStatus({
-          message: friendlyOutputError(caught, "Could not save that output."),
-          error: true,
-        });
+        toast.error(friendlyOutputError(caught, "Could not save that output."));
       } finally {
         useNativePickerLatch.getState().release(PICKER_HOLDERS.exportOutput);
         setBusyOutputId(null);
@@ -147,13 +138,10 @@ export function OutputsView({
     async (output: DeliverableSummary) => {
       try {
         await apis.restore(chatId, output.outputId);
-        setSaveStatus({ message: `${output.filename} was restored.`, error: false });
+        toast.success(`${output.filename} was restored.`);
         void refresh();
       } catch (caught) {
-        setSaveStatus({
-          message: friendlyOutputError(caught, "Could not restore that output."),
-          error: true,
-        });
+        toast.error(friendlyOutputError(caught, "Could not restore that output."));
       }
     },
     [apis, chatId],
@@ -163,20 +151,15 @@ export function OutputsView({
     async (output: DeliverableSummary) => {
       if (busyOutputId) return;
       setBusyOutputId(output.outputId);
-      setSaveStatus(null);
       try {
         await apis.delete(chatId, output.outputId);
-        setSaveStatus({
-          message: `${output.filename} was deleted from this conversation.`,
-          error: false,
-          undo: () => void onRestore(output),
+        toast.success(`${output.filename} was deleted from this conversation.`, {
+          // A delete stays reversible for as long as the toast is up.
+          action: { label: "Undo", onClick: () => void onRestore(output) },
         });
         void refresh();
       } catch (caught) {
-        setSaveStatus({
-          message: friendlyOutputError(caught, "Could not delete that output."),
-          error: true,
-        });
+        toast.error(friendlyOutputError(caught, "Could not delete that output."));
       } finally {
         setBusyOutputId(null);
       }
@@ -212,28 +195,6 @@ export function OutputsView({
       </PanelSecondaryHeader>
 
       <div className="flex min-h-0 flex-1 flex-col gap-2 pt-4">
-        {saveStatus && (
-          <div
-            className={
-              saveStatus.error
-                ? "mx-4 flex shrink-0 items-center justify-between gap-3 rounded-md bg-critical-background px-3 py-2 text-sm text-critical-foreground-muted"
-                : "mx-4 flex shrink-0 items-center justify-between gap-3 rounded-md bg-info-background px-3 py-2 text-sm text-info-foreground-muted"
-            }
-            role={saveStatus.error ? "alert" : "status"}
-          >
-            <span>{saveStatus.message}</span>
-            {saveStatus.undo && (
-              <Button
-                variant="outline"
-                size="xs"
-                className="shrink-0"
-                onClick={saveStatus.undo}
-              >
-                Undo
-              </Button>
-            )}
-          </div>
-        )}
         {error && (
           <div
             className="mx-4 flex shrink-0 items-center justify-between gap-3 rounded-md bg-critical-background px-3 py-2 text-sm text-critical-foreground-muted"
@@ -302,6 +263,5 @@ export function exportFailureMessage(
 }
 
 export function friendlyOutputError(error: unknown, fallback: string): string {
-  const message = String(error).replace(/^Error:\s*/, "").trim();
-  return message && message.length <= 240 ? message : fallback;
+  return friendlyErrorMessage(error, fallback);
 }


### PR DESCRIPTION
Clicking **Save as…** on an output and having it fail put the message — e.g. "Could not recover that output export" — into a paragraph pinned to the bottom of the output panel, underneath the document being read. That is far enough from the button that a reader does not connect the two, and off screen entirely for anything longer than a screenful. Delete, restore, version-history load and version-preview failures all landed in the same place. A few other actions dropped their error on the floor altogether.

The toast host (sonner) was already mounted at the app root and used by the settings panels; this routes the remaining transient operation outcomes through it.

## Now toasts

- `OutputDetailRoot` — export (including the picker-busy refusal and the `failed` receipt reasons), version-history load, version preview, and version restore. The whole bottom-of-panel `saveStatus` paragraph is gone.
- `OutputsView` — export, delete and restore from a row. The delete's inline Undo becomes the toast's action button, so it stays reversible for as long as the toast is up.
- `BackgroundAgentList` — Stop previously reset the spinner and said nothing when the cancel did not commit.
- `ChangeSummaryCard` — Undo one / Undo all reported at the foot of a potentially long file list rather than near the row that was clicked.
- `AppDetailView` — delete and revoke. Their error was gated behind `grant.granted`, so a failed **Delete app** on a not-currently-granted app was invisible.

`friendlyOutputError` and `friendlyAppsError` were byte-identical; both now delegate to one `friendlyErrorMessage` in `lib/utils` so the third caller did not add a third copy. Their names and signatures are unchanged.

## Left inline deliberately

These are in-place states for something that failed to load or render, not action failures, and they belong where they are:

- Outputs catalog load failure and app-list load failure, with their **Try again** buttons.
- Document/output preview load errors, the presentation viewer's conversion-failure card, the PDF and spreadsheet viewers' render failures, `AppFrame`'s "could not be opened", the skill dialog's instruction-body failure.
- The app consent sheet's own error — the sheet is up and the error sits under the button that produced it.
- Composer attachment, image-upload and folder-access errors, which already render next to their controls.
- `ClipboardCopyButton`'s "Copy failed" label swap and live-region announcement.

## Verification

`pnpm exec tsc --noEmit` (four pre-existing `PluginInfo.compatibility` fixture errors, identical on the base commit), `pnpm vitest run` (121 files, 801 tests), `pnpm build`.

The two outputs DOM tests now mount a real `Toaster` alongside the component, so they still assert on the text a reader would see rather than on a mocked call. One assertion moved off `getByRole("alert")` — sonner labels its toasts `role="status"`.