### PR TITLE
fix(core): carry remaining sandbox spawns across the approval park

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -896,7 +896,12 @@ pub enum AgentTurnOutcome {
 }
 
 /// One model proposal to create a durable depth-one sandbox child.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// The serialized form is the one carried across an approval park: a batch's
+/// still-ungated tail is written with the spawn checkpoint that parks the turn
+/// and handed back to the claim that resumes it, so every sibling the model
+/// named is answered under the call id it was streamed with.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct SandboxAgentSpawnRequest {
     /// Stable call identity emitted by the model stream.
     pub call_id: CallId,

--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -627,6 +627,8 @@ pub mod sandbox_spawn_checkpoint {
         #[sea_orm(column_type = "JsonBinary")]
         pub arguments: Json,
         pub result: String,
+        #[sea_orm(column_type = "JsonBinary")]
+        pub remaining_requests: Json,
         pub steer_revision: i64,
         pub event_ordinal: i32,
         pub model_steps: i32,

--- a/crates/openwave-core/src/db/migration/baseline/sandbox.rs
+++ b/crates/openwave-core/src/db/migration/baseline/sandbox.rs
@@ -459,6 +459,11 @@ pub(super) fn sandbox_spawn_checkpoint_table() -> TableCreateStatement {
                 .not_null(),
         )
         .col(
+            ColumnDef::new(SandboxSpawnCheckpoint::RemainingRequests)
+                .json_binary()
+                .not_null(),
+        )
+        .col(
             ColumnDef::new(SandboxSpawnCheckpoint::SteerRevision)
                 .big_integer()
                 .not_null(),
@@ -564,7 +569,10 @@ pub(super) fn sandbox_spawn_checkpoint_table() -> TableCreateStatement {
         )
         .check(Expr::col(SandboxSpawnCheckpoint::SteerRevision).gte(0))
         .check(Expr::col(SandboxSpawnCheckpoint::EventOrdinal).between(2, i32::MAX - 1))
-        .check(Expr::col(SandboxSpawnCheckpoint::ModelSteps).gt(0))
+        // Zero is admissible: a spawn taken from a batch that was carried
+        // across an earlier approval park is checkpointed by the claim that
+        // resumed the turn, which reached the gate without calling the model.
+        .check(Expr::col(SandboxSpawnCheckpoint::ModelSteps).gte(0))
         .check(Expr::col(SandboxSpawnCheckpoint::HistoryOrder).gt(0))
         .check(Expr::col(SandboxSpawnCheckpoint::InputTokens).between(0, i64::from(u32::MAX)))
         .check(Expr::col(SandboxSpawnCheckpoint::OutputTokens).between(0, i64::from(u32::MAX)))
@@ -587,13 +595,26 @@ pub(super) fn sandbox_spawn_checkpoint_table() -> TableCreateStatement {
 }
 
 pub(super) fn sandbox_spawn_checkpoint_indexes() -> Vec<IndexCreateStatement> {
-    vec![Index::create()
-        .name("idx_sandbox_spawn_checkpoint_event")
-        .table(SandboxSpawnCheckpoint::Table)
-        .col(SandboxSpawnCheckpoint::ChatId)
-        .col(SandboxSpawnCheckpoint::EventSeq)
-        .unique()
-        .to_owned()]
+    vec![
+        Index::create()
+            .name("idx_sandbox_spawn_checkpoint_event")
+            .table(SandboxSpawnCheckpoint::Table)
+            .col(SandboxSpawnCheckpoint::ChatId)
+            .col(SandboxSpawnCheckpoint::EventSeq)
+            .unique()
+            .to_owned(),
+        // One claim segment can park on at most one spawn checkpoint — it
+        // ends there — which is what lets the resuming claim find the batch
+        // its predecessor left behind by claim identity alone.
+        Index::create()
+            .name("idx_sandbox_spawn_checkpoint_claim_segment")
+            .table(SandboxSpawnCheckpoint::Table)
+            .col(SandboxSpawnCheckpoint::OriginTurnId)
+            .col(SandboxSpawnCheckpoint::AttemptCount)
+            .col(SandboxSpawnCheckpoint::ClaimCount)
+            .unique()
+            .to_owned(),
+    ]
 }
 
 /// One file an exec turn changed in a user folder, with the blob holding its

--- a/crates/openwave-core/src/db/migration/idens.rs
+++ b/crates/openwave-core/src/db/migration/idens.rs
@@ -233,6 +233,7 @@ pub(crate) enum SandboxSpawnCheckpoint {
     HistoryOrder,
     Arguments,
     Result,
+    RemainingRequests,
     SteerRevision,
     EventOrdinal,
     ModelSteps,

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -1072,6 +1072,15 @@ impl Store for DbStore {
         ops::turn::checkpoint_sandbox_spawn(self, request, now).await
     }
 
+    async fn resumed_sandbox_spawn_batch(
+        &self,
+        turn_id: TurnId,
+        attempt_count: i32,
+        claim_count: i32,
+    ) -> Result<Vec<crate::agent::SandboxAgentSpawnRequest>> {
+        ops::turn::resumed_sandbox_spawn_batch(self, turn_id, attempt_count, claim_count).await
+    }
+
     async fn get_sandbox_agent_admission(
         &self,
         child_run_id: AgentRunId,

--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -46,7 +46,7 @@ pub(in crate::db) use resolution::{
     record_turn_run_failure_and_append_event, recover_exact_completed_turn_event,
     request_turn_cancellation, request_turn_cancellation_and_append_event,
 };
-pub(in crate::db) use sandbox_spawn::checkpoint_sandbox_spawn;
+pub(in crate::db) use sandbox_spawn::{checkpoint_sandbox_spawn, resumed_sandbox_spawn_batch};
 pub(in crate::db) use steer::{accept_turn_steer, apply_turn_steer, list_pending_turn_steers};
 
 pub(in crate::db) async fn get_turn_run(store: &DbStore, id: TurnId) -> Result<Option<TurnRun>> {

--- a/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
+++ b/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
@@ -32,6 +32,46 @@ use super::super::{
 };
 use super::{canonical_db_timestamp, turn_run_from_model};
 
+/// The still-ungated tail of the spawn batch the previous claim segment parked
+/// on, if this claim is the one resuming that park.
+///
+/// The batch belongs to exactly one claim: the segment that parked wrote it,
+/// and the segment that resumes is the next claim of the same attempt. Any
+/// later claim — a lost lease, a retried attempt — matches nothing and starts
+/// clean, which is the fail-safe direction: a spawn nobody carried forward is
+/// simply not created.
+pub(in crate::db) async fn resumed_sandbox_spawn_batch(
+    store: &DbStore,
+    turn_id: crate::TurnId,
+    attempt_count: i32,
+    claim_count: i32,
+) -> Result<Vec<crate::agent::SandboxAgentSpawnRequest>> {
+    let Some(previous_claim) = claim_count.checked_sub(1).filter(|count| *count >= 1) else {
+        return Ok(Vec::new());
+    };
+    let Some(model) = entities::sandbox_spawn_checkpoint::Entity::find()
+        .filter(entities::sandbox_spawn_checkpoint::Column::OriginTurnId.eq(turn_id.0))
+        .filter(entities::sandbox_spawn_checkpoint::Column::AttemptCount.eq(attempt_count))
+        .filter(entities::sandbox_spawn_checkpoint::Column::ClaimCount.eq(previous_claim))
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+    else {
+        return Ok(Vec::new());
+    };
+    let remaining: Vec<crate::agent::SandboxAgentSpawnRequest> =
+        serde_json::from_value(model.remaining_requests)?;
+    if remaining
+        .iter()
+        .any(|request| !request.is_well_formed() || request.approval_gated)
+    {
+        return Err(AgentError::Store(
+            "carried sandbox spawn batch is malformed".into(),
+        ));
+    }
+    Ok(remaining)
+}
+
 pub(in crate::db) async fn checkpoint_sandbox_spawn(
     store: &DbStore,
     request: &SandboxSpawnCheckpointRequest,
@@ -306,6 +346,7 @@ where
         history_order: Set(history_order),
         arguments: Set(request.arguments.clone()),
         result: Set(request.result.clone()),
+        remaining_requests: Set(serde_json::to_value(&request.remaining_requests)?),
         steer_revision: Set(request.expected_steer_revision),
         event_ordinal: Set(request.event_ordinal),
         model_steps: Set(request.progress.model_steps),
@@ -567,12 +608,15 @@ fn validate_request(request: &SandboxSpawnCheckpointRequest) -> Result<()> {
         && !request.provider_id.contains('\0');
     let result_valid =
         !request.result.contains('\0') && request.result.len() <= ToolCallRecord::MAX_RESULT_BYTES;
+    // A zero-step checkpoint is the resumed half of a batch: the claim that
+    // picked the parked turn back up gated the next sibling and admitted it
+    // without ever calling the model, so it has no step to charge.
     if request.origin_turn_id.0.is_nil()
         || request.lease_token.is_nil()
         || request.call_id.0.is_nil()
         || request.expected_steer_revision < 0
         || !(2..i32::MAX).contains(&request.event_ordinal)
-        || request.progress.model_steps <= 0
+        || request.progress.model_steps < 0
         || request.max_active_background_agents == 0
         || request.max_active_background_agents > AgentRun::MAX_CONCURRENCY_LIMIT
         || !labels_valid
@@ -584,8 +628,33 @@ fn validate_request(request: &SandboxSpawnCheckpointRequest) -> Result<()> {
             "invalid non-blocking sandbox spawn checkpoint".into(),
         ));
     }
+    if !remaining_requests_are_valid(request) {
+        return Err(AgentError::Store(
+            "invalid carried sandbox spawn batch".into(),
+        ));
+    }
     canonical_arguments(request)?;
     Ok(())
+}
+
+/// Whether the still-ungated tail carried with this checkpoint is one this
+/// turn may replay.
+///
+/// Each entry has to be a spawn the gate can still ask about: well formed,
+/// not already gated, and a call the batch names exactly once — a duplicate
+/// or the admitted call itself would gate a decision that has already been
+/// made, and a pre-gated entry would claim a durable pending row nobody wrote.
+fn remaining_requests_are_valid(request: &SandboxSpawnCheckpointRequest) -> bool {
+    let mut seen = std::collections::HashSet::with_capacity(request.remaining_requests.len());
+    request.remaining_requests.iter().all(|remaining| {
+        remaining.is_well_formed()
+            && !remaining.approval_gated
+            && remaining.call_id != request.call_id
+            && seen.insert(remaining.call_id)
+            && !remaining.provider_id.contains('\0')
+            && serde_json::to_vec(&remaining.arguments)
+                .is_ok_and(|value| value.len() <= ToolCallRecord::MAX_ARGUMENT_BYTES)
+    })
 }
 
 fn canonical_arguments(request: &SandboxSpawnCheckpointRequest) -> Result<SpawnSandboxAgentArgs> {
@@ -658,6 +727,7 @@ fn checkpoint_matches(
         && checkpoint.steer_revision == request.expected_steer_revision
         && checkpoint.event_ordinal == request.event_ordinal
         && checkpoint.progress == request.progress
+        && checkpoint.remaining_requests == request.remaining_requests
 }
 
 fn checkpoint_from_model(
@@ -680,6 +750,7 @@ fn checkpoint_from_model(
         history_order: model.history_order,
         arguments: model.arguments,
         result: model.result,
+        remaining_requests: serde_json::from_value(model.remaining_requests)?,
         steer_revision: model.steer_revision,
         event_ordinal: model.event_ordinal,
         progress: TurnCheckpointProgress {

--- a/crates/openwave-core/src/db/tests/delegated_file_read.rs
+++ b/crates/openwave-core/src/db/tests/delegated_file_read.rs
@@ -74,6 +74,7 @@ async fn delegated_sandbox(
             model_steps: 1,
             usage: Usage::default(),
         },
+        remaining_requests: Vec::new(),
         max_active_background_agents: AgentRun::DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS,
         execution_location: crate::AgentRunExecutionLocation::InProcess,
     };

--- a/crates/openwave-core/src/db/tests/sandbox_spawn_checkpoint.rs
+++ b/crates/openwave-core/src/db/tests/sandbox_spawn_checkpoint.rs
@@ -70,6 +70,7 @@ fn request(
         .unwrap(),
         event_ordinal: ordinal,
         progress,
+        remaining_requests: Vec::new(),
         max_active_background_agents: AgentRun::DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS,
         execution_location: crate::AgentRunExecutionLocation::InProcess,
     }

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1465,6 +1465,11 @@ pub struct SandboxSpawnCheckpoint {
     pub steer_revision: i64,
     pub event_ordinal: i32,
     pub progress: TurnCheckpointProgress,
+    /// The rest of the batch this spawn came from, in model order, still
+    /// ungated. Carried durably so the claim that resumes the parked turn
+    /// gates them under their original call ids instead of asking the model
+    /// again.
+    pub remaining_requests: Vec<crate::agent::SandboxAgentSpawnRequest>,
     pub event_seq: i64,
     pub committed_at: DateTime<Utc>,
 }
@@ -1485,6 +1490,10 @@ pub struct SandboxSpawnCheckpointRequest {
     pub result: String,
     pub event_ordinal: i32,
     pub progress: TurnCheckpointProgress,
+    /// The rest of the batch the model named in this step, in model order and
+    /// not yet through the approval gate. The parked turn's next claim reads
+    /// them back and gates them without a further model call.
+    pub remaining_requests: Vec<crate::agent::SandboxAgentSpawnRequest>,
     /// Settings-resolved per-chat ceiling on nonterminal background runs.
     pub max_active_background_agents: u32,
     /// Host-resolved execution location for the child admitted by this atomic

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -2213,6 +2213,29 @@ pub trait Store: Send + Sync {
         agent_run_storage_unavailable()
     }
 
+    /// The still-ungated tail of the spawn batch the previous claim segment
+    /// parked on, for the claim that resumes it.
+    ///
+    /// A model step can name several delegations at once and each one is
+    /// approved on its own, so the turn parks once per admitted spawn. The
+    /// siblings that have not reached the gate travel with the checkpoint
+    /// rather than being re-derived from the model, which keeps every spawn on
+    /// the call id it was streamed with and spends no provider call per
+    /// approval. Returns empty for any claim that is not the immediate
+    /// successor of a spawn park.
+    ///
+    /// The default is empty rather than unimplemented: a store that never
+    /// admits sandbox children can never have parked on a spawn checkpoint
+    /// either, and this read runs on every claim.
+    async fn resumed_sandbox_spawn_batch(
+        &self,
+        _turn_id: TurnId,
+        _attempt_count: i32,
+        _claim_count: i32,
+    ) -> Result<Vec<crate::agent::SandboxAgentSpawnRequest>> {
+        Ok(Vec::new())
+    }
+
     /// Fetch immutable origin ownership for an admitted sandbox child.
     async fn get_sandbox_agent_admission(
         &self,

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -445,6 +445,7 @@ fn postgres_spawn_checkpoint_request(
         max_active_background_agents: AgentRun::DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS,
         execution_location: openwave_core::AgentRunExecutionLocation::InProcess,
         approval_gated: false,
+        remaining_requests: Vec::new(),
     }
 }
 
@@ -482,6 +483,19 @@ async fn postgres_concurrent_exact_nonblocking_spawn_checkpoint_converges_once()
     let (turn, lease) = postgres_live_turn(store.as_ref(), chat.id).await;
     append_postgres_turn_started(store.as_ref(), &turn, lease).await;
     let request = postgres_spawn_checkpoint_request(&turn, lease, CallId::new(), "race exactly");
+    // The still-ungated tail of the batch rides along in a JSONB column and
+    // has to survive the round trip on this store too — it is what the next
+    // claim gates instead of asking the model again.
+    let carried_call_id = CallId::new();
+    let mut request = request;
+    request.remaining_requests = vec![openwave_core::SandboxAgentSpawnRequest {
+        call_id: carried_call_id,
+        provider_id: format!("postgres-{carried_call_id}"),
+        child_run_id: AgentRunId::sandbox_for_spawn_call(carried_call_id),
+        task: "carried sibling".into(),
+        arguments: serde_json::json!({"task": "carried sibling"}),
+        approval_gated: false,
+    }];
     let barrier = Arc::new(tokio::sync::Barrier::new(2));
     let mut tasks = Vec::new();
     for _ in 0..2 {
@@ -507,6 +521,16 @@ async fn postgres_concurrent_exact_nonblocking_spawn_checkpoint_converges_once()
         }
     }
     assert_eq!((committed, existing), (1, 1));
+    assert_eq!(
+        store
+            .resumed_sandbox_spawn_batch(turn.id, turn.attempt_count, turn.claim_count + 1)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|request| request.call_id)
+            .collect::<Vec<_>>(),
+        vec![carried_call_id]
+    );
     assert_eq!(store.list_agent_runs(chat.id).await.unwrap().len(), 2);
     assert_eq!(store.list_tool_calls(chat.id).await.unwrap().len(), 1);
     cleanup_postgres_sandbox_chat(store.as_ref(), chat.id).await;

--- a/crates/openwave-server/src/desktop_schema.rs
+++ b/crates/openwave-server/src/desktop_schema.rs
@@ -25,7 +25,7 @@ const VECTOR_DIRECTORY: &str = "vectors";
 const MAX_MARKER_BYTES: u64 = 1_024;
 
 /// Bump this whenever the pre-v1 schema baseline changes incompatibly.
-const DESKTOP_SCHEMA_EPOCH: u32 = 10;
+const DESKTOP_SCHEMA_EPOCH: u32 = 11;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -3440,6 +3440,7 @@ mod tests {
                         model_steps: 1,
                         usage: Usage::default(),
                     },
+                    remaining_requests: Vec::new(),
                     max_active_background_agents:
                         openwave_core::AgentRun::DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS,
                     execution_location: openwave_core::AgentRunExecutionLocation::InProcess,

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -335,6 +335,75 @@ impl ModelProvider for SandboxRoundTripProvider {
     }
 }
 
+/// Names two delegations in one model step, so the batch has to survive the
+/// approval park between them. Counts foreground invocations: a resumed claim
+/// that re-invokes the model to recover the tail is the bug this exists to
+/// catch.
+#[derive(Default)]
+struct GatedSpawnBatchProvider {
+    foreground_calls: AtomicUsize,
+}
+
+#[async_trait]
+impl ModelProvider for GatedSpawnBatchProvider {
+    fn id(&self) -> ProviderId {
+        ProviderId::new("gated-spawn-batch")
+    }
+
+    async fn stream(&self, request: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+        let foreground = request
+            .tools
+            .iter()
+            .any(|tool| tool.name == openwave_core::SPAWN_SANDBOX_AGENT_TOOL);
+        if !foreground {
+            return Ok(stream::iter(vec![
+                ProviderEvent::TextDelta {
+                    text: "child result".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                },
+            ])
+            .boxed());
+        }
+        let events = if self.foreground_calls.fetch_add(1, Ordering::SeqCst) == 0 {
+            vec![
+                ProviderEvent::ToolCallStarted {
+                    index: 0,
+                    id: "delegate-1".into(),
+                    name: openwave_core::SPAWN_SANDBOX_AGENT_TOOL.into(),
+                },
+                ProviderEvent::ToolCallArgsDelta {
+                    index: 0,
+                    fragment: r#"{"task":"Research the first question."}"#.into(),
+                },
+                ProviderEvent::ToolCallStarted {
+                    index: 1,
+                    id: "delegate-2".into(),
+                    name: openwave_core::SPAWN_SANDBOX_AGENT_TOOL.into(),
+                },
+                ProviderEvent::ToolCallArgsDelta {
+                    index: 1,
+                    fragment: r#"{"task":"Research the second question."}"#.into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::ToolUse,
+                },
+            ]
+        } else {
+            vec![
+                ProviderEvent::TextDelta {
+                    text: "both delegations are running".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                },
+            ]
+        };
+        Ok(stream::iter(events).boxed())
+    }
+}
+
 /// A provider that records the model each request asked for, then answers
 /// like `FakeProvider`. Lets a test assert which model a turn ran against.
 #[derive(Clone, Default)]

--- a/crates/openwave-server/src/tests/sandbox.rs
+++ b/crates/openwave-server/src/tests/sandbox.rs
@@ -664,6 +664,7 @@ async fn delegated_file_routes_are_native_only_and_expose_only_exact_broker_auth
                     model_steps: 1,
                     usage: Usage::default(),
                 },
+                remaining_requests: Vec::new(),
                 max_active_background_agents:
                     openwave_core::AgentRun::DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS,
                 execution_location: openwave_core::AgentRunExecutionLocation::InProcess,

--- a/crates/openwave-server/src/tests/workers.rs
+++ b/crates/openwave-server/src/tests/workers.rs
@@ -367,6 +367,141 @@ async fn foreground_spawn_is_nonblocking_and_ordered_wait_resumes_with_child_res
         .any(|message| message.content.contains("premature parent answer")));
 }
 
+/// A batch of gated delegations keeps its tail across the approval park.
+///
+/// One model step can name several delegations, and a card for one of them is
+/// not consent for the rest, so the turn parks after each approval. The tail
+/// used to be dropped at that park: the resumed attempt asked the model again,
+/// which cost a round trip per approval, re-issued the same delegations under
+/// fresh call ids, and left the originals hanging in the transcript forever.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_gated_spawn_batch_is_carried_across_the_approval_park() {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let provider = Arc::new(GatedSpawnBatchProvider::default());
+    let mut tools = ToolRegistry::new();
+    tools.register_foreground_agent_orchestration();
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(provider.clone())),
+        Arc::new(MemSecrets::default()),
+        Arc::new(tools),
+        AgentConfig {
+            model: "fake".into(),
+            max_steps: 4,
+            ..AgentConfig::default()
+        },
+    );
+    let token = state.token.clone();
+    spawn_turn_worker(&state);
+    let router = app(state);
+    let bearer = format!("Bearer {token}");
+    // Left in `Ask`: every spawn in the batch has to cross the gate on its own.
+    let chat = make_chat(&router, &bearer).await;
+
+    assert_eq!(
+        send_message(&router, &bearer, chat.id, "delegate both questions").await,
+        StatusCode::ACCEPTED
+    );
+
+    async fn approval_call_ids(store: &Arc<dyn Store>, chat: ChatId) -> Vec<CallId> {
+        store
+            .list_events(chat, 0)
+            .await
+            .unwrap()
+            .iter()
+            .filter_map(|event| match &event.event {
+                AgentEvent::ApprovalRequired { call_id, .. } => Some(*call_id),
+                _ => None,
+            })
+            .collect()
+    }
+
+    async fn wait_for_approvals(store: &Arc<dyn Store>, chat: ChatId, count: usize) -> Vec<CallId> {
+        for _ in 0..500 {
+            let ids = approval_call_ids(store, chat).await;
+            if ids.len() >= count {
+                return ids;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("turn should park on {count} approval cards");
+    }
+
+    async fn approve(router: &axum::Router, bearer: &str, chat: ChatId, call_id: CallId) {
+        let decide = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/chats/{chat}/approvals/{call_id}"))
+                    .header(header::AUTHORIZATION, bearer)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"decision": "approve"}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(decide.status(), StatusCode::NO_CONTENT);
+    }
+
+    let first = wait_for_approvals(&store, chat.id, 1).await[0];
+    approve(&router, &bearer, chat.id, first).await;
+
+    let both = wait_for_approvals(&store, chat.id, 2).await;
+    assert_eq!(both[0], first);
+    assert_ne!(
+        both[1], first,
+        "each spawn is decided under its own call id"
+    );
+    // The whole point: the second card came from the batch the checkpoint
+    // carried, not from a second look at the model.
+    assert_eq!(
+        provider.foreground_calls.load(Ordering::SeqCst),
+        1,
+        "the carried batch must reach the gate without another model call"
+    );
+    approve(&router, &bearer, chat.id, both[1]).await;
+
+    for _ in 0..500 {
+        let calls = store.list_tool_calls(chat.id).await.unwrap();
+        let spawns = calls
+            .iter()
+            .filter(|call| call.name == openwave_core::SPAWN_SANDBOX_AGENT_TOOL)
+            .collect::<Vec<_>>();
+        if spawns.len() == 2
+            && spawns
+                .iter()
+                .all(|call| call.status == openwave_core::ToolCallStatus::Completed)
+        {
+            // Both delegations were answered under the call ids the model
+            // streamed, so nothing is left dangling in the transcript.
+            assert_eq!(
+                spawns
+                    .iter()
+                    .map(|call| call.id)
+                    .collect::<std::collections::HashSet<_>>(),
+                both.iter()
+                    .copied()
+                    .collect::<std::collections::HashSet<_>>()
+            );
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("both spawns in the batch should complete under their original call ids");
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn worker_drains_a_turn_queued_before_startup() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -590,8 +590,18 @@ impl TurnWorker {
         let mut checkpoint_usage = openwave_core::Usage::default();
         let mut checkpoint_steps = 0_usize;
         let mut continuation_instruction = None;
-        let mut pending_sandbox_spawns = Vec::new();
-        let mut pending_sandbox_spawn_steer_revision = None;
+        // A spawn batch the previous claim segment parked on is picked up
+        // here, before any provider call: the model already named these
+        // delegations, and re-asking it would orphan the tool calls it
+        // streamed for them. The turn's durable steer revision is the one the
+        // resumed gate has to agree with, exactly as a live generation reads
+        // it before checkpointing.
+        let mut pending_sandbox_spawns = self
+            .store
+            .resumed_sandbox_spawn_batch(turn.id, turn.attempt_count, turn.claim_count)
+            .await?;
+        let mut pending_sandbox_spawn_steer_revision =
+            (!pending_sandbox_spawns.is_empty()).then_some(turn.steer_revision);
         // A segment arriving with zero remaining steps is not refused: the
         // budget was spent by earlier segments — a checkpoint parked on the
         // last budgeted step, or a wrap-up whose provider call failed
@@ -1631,6 +1641,7 @@ impl TurnWorker {
                         })?,
                         event_ordinal: ordinal,
                         progress,
+                        remaining_requests: pending_sandbox_spawns.clone(),
                         max_active_background_agents:
                             crate::routes::read_max_active_background_agents(&*self.store).await?,
                         execution_location: self.config.sandbox_spawn_execution_location,


### PR DESCRIPTION
## The bug

When the model names several `spawn_sandbox_agent` calls in one step and the chat asks before it acts, each spawn has to cross the approval gate on its own, so the turn parks after every admitted one. The rest of the batch was held in a stack local of the worker's per-claim run function, and the park returns out of that function — the tail was dropped on the floor.

The resumed claim therefore started with an empty queue and invoked the model again. In a live journal this shows up as attempt 1 streaming four spawn calls with only the first answered, then attempts 2, 3 and 4 re-streaming the remainder as brand-new calls with new ids. It costs a provider round trip per approval, nothing stops the re-invoked model from changing its plan or duplicating a delegation, and the original sibling calls are never answered — they dangle in the transcript and in the UI.

## The fix

The still-ungated tail now travels durably with the spawn checkpoint that parks the turn (`sandbox_spawn_checkpoint.remaining_requests`, JSONB), and the claim that resumes reads it back by claim identity: the checkpoint written by the immediately preceding claim segment of the same attempt. That is exactly-once without a consuming write — a lost lease or a retried attempt matches nothing and starts clean, which is the fail-safe direction, and a stale batch can never be replayed into a later segment. The worker feeds it into the existing `with_pending_sandbox_spawns` drain with the claimed turn's durable steer revision, so every spawn is gated and answered under the call id the model streamed for it, with no further provider call.

Two smaller consequences:

- A spawn checkpoint may now carry a zero-step progress delta. The resumed sibling reaches the gate without a model call, so it has no step to charge; the request validator and the table's check constraint move from `> 0` to `>= 0`.
- The checkpoint validates the carried batch before committing it: each entry well formed, not already gated, named once, and never the call being admitted.

Steer-pending, output-superseded, cancellation, lease loss and the deliberate `AtCapacity` clear are unchanged — those all resolve inside a single claim, where the batch was already carried correctly.

The baseline schema changed, so `DESKTOP_SCHEMA_EPOCH` is bumped.

## Tests

One end-to-end test, `a_gated_spawn_batch_is_carried_across_the_approval_park`, drives the real worker and the real approval endpoint: the model names two delegations in one step, the test approves the first, and asserts the second card appears while the provider's foreground invocation count is still 1 — the tail reached the gate without another model call — and then that both spawns resolve completed under the two call ids the cards were issued for, so nothing is left dangling. Reverting the worker's carry makes it fail (the second card never appears).

The existing Postgres spawn-checkpoint race test gains a carried tail and one assertion, so the JSONB round trip and the resume lookup are exercised on that store too.

`full-ci` is on this PR for the PostgreSQL turn-state lane, since the change touches the turn-state schema and ops.