### PR TITLE
fix(server): skip the consent prompt for apps that request no tool access

### DIFF
--- a/crates/openwave-desktop/ui/src/apps/AppConsentSheet.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppConsentSheet.tsx
@@ -24,6 +24,9 @@ import { Button } from "@/components/ui/button";
  * A manifest that binds both a folder and API operations gets the explicit
  * combined-consent warning (docs/folder-bindings.md): the app can read files
  * and send data out, and the sheet says so before the user agrees.
+ *
+ * The sheet never renders for a manifest with no bindings: the server reports
+ * such an app as granted vacuously — there is nothing to consent to.
  */
 export function AppConsentSheet({
   state,
@@ -55,11 +58,7 @@ export function AppConsentSheet({
         <ShieldAlert className="text-warning size-4 shrink-0" aria-hidden="true" />
         <h2 className="text-sm font-medium">This app needs your permission</h2>
       </div>
-      {state.bindings.length === 0 ? (
-        <p className="text-muted-foreground text-sm">
-          This app requests no tool access.
-        </p>
-      ) : (
+      {state.bindings.length > 0 && (
         <ul className="flex flex-col gap-2" aria-label="Requested access">
           {state.bindings.map((binding) => (
             <li

--- a/crates/openwave-desktop/ui/src/apps/AppDetailView.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppDetailView.tsx
@@ -181,7 +181,10 @@ export function AppDetailView({
                 className="flex min-w-0 flex-1 items-center gap-3"
                 aria-label="Access"
               >
-                {grant.granted && (
+                {/* A bindingless app is granted vacuously and holds nothing
+                    revocable, so the access readout and revoke control stay
+                    hidden. */}
+                {grant.granted && grant.bindings.length > 0 && (
                   <>
                     <div className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-xs">
                       <ShieldCheck

--- a/crates/openwave-server/src/routes/app_grant.rs
+++ b/crates/openwave-server/src/routes/app_grant.rs
@@ -37,8 +37,9 @@ use crate::state::AppState;
 pub struct AppGrantState {
     /// Whether a live grant fully covers the current manifest with every
     /// bound definition unchanged since consent — the "no sheet needed"
-    /// verdict. When `false`, (re-)consent is required before every pinned
-    /// capability is invokable.
+    /// verdict. A manifest with no bindings is vacuously granted: there is
+    /// nothing to consent to, so no sheet is shown. When `false`,
+    /// (re-)consent is required before every pinned capability is invokable.
     pub granted: bool,
     /// The current manifest's bindings, one entry per bound connected app or
     /// folder.
@@ -304,14 +305,20 @@ pub(crate) fn grant_state(
             }
         })
         .collect();
-    // The invoke gate also pins targets the grant names beyond the current
-    // manifest, so the overall verdict does too.
-    let granted = grant.is_some_and(|grant| {
-        bindings.iter().all(|binding| binding.granted)
-            && grant
-                .bindings
-                .iter()
-                .all(|binding| current.grant_binding_current(binding))
-    });
+    // A manifest that binds nothing has nothing to consent to: every invoke
+    // fails the pin check before the consent gate is reached, so prompting
+    // would gate the frame on a vacuous "yes". Granted, with or without a
+    // stored grant.
+    //
+    // Otherwise the invoke gate also pins targets the grant names beyond the
+    // current manifest, so the overall verdict does too.
+    let granted = manifest.bindings.is_empty()
+        || grant.is_some_and(|grant| {
+            bindings.iter().all(|binding| binding.granted)
+                && grant
+                    .bindings
+                    .iter()
+                    .all(|binding| current.grant_binding_current(binding))
+        });
     AppGrantState { granted, bindings }
 }

--- a/crates/openwave-server/src/tests/app_grant.rs
+++ b/crates/openwave-server/src/tests/app_grant.rs
@@ -92,6 +92,42 @@ async fn unknown_apps_and_unconfigured_bindings_refuse_on_the_grant_surface() {
     assert_eq!(refused.status(), StatusCode::CONFLICT);
 }
 
+/// A manifest that binds nothing is granted vacuously — no consent sheet, no
+/// stored grant needed. There is nothing to consent to: every invoke would
+/// fail the pin check before the consent gate, so prompting would only gate
+/// the frame on an empty "yes".
+#[tokio::test]
+async fn a_manifest_with_no_bindings_reads_granted_without_consent() {
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let app_id = AppId::new();
+    store
+        .create_app(&CreateApp {
+            id: app_id,
+            revision: NewAppRevision {
+                id: AppRevisionId::new(),
+                manifest: AppManifest {
+                    name: "Calculator".into(),
+                    bindings: vec![],
+                },
+                byte_len: 1,
+                sha256: [0; 32],
+                turn_id: None,
+                producing_run_id: None,
+                chat_id: None,
+                created_at: chrono::Utc::now(),
+            },
+        })
+        .await
+        .unwrap();
+
+    let state = grant_request(&router, &bearer, "GET", app_id).await;
+    assert_eq!(state.status(), StatusCode::OK);
+    let state: serde_json::Value = serde_json::from_str(&body_string(state).await).unwrap();
+    assert_eq!(state["granted"], json!(true));
+    assert_eq!(state["bindings"], json!([]));
+}
+
 /// The projection contract: consent grants, and neither the base URL, the
 /// document hash, nor the credential reference behind the record ever reaches
 /// the renderer — the sheet gets the record's display name and the pinned


### PR DESCRIPTION
An app whose manifest binds nothing (e.g. a static calculator) still gated its frame behind the consent sheet, which could only say "This app requests no tool access" and ask for an empty affirmative.

The verdict fix is server-side: `grant_state` now reports a bindingless manifest as granted with or without a stored grant. This is safe because the invoke pin check refuses every capability an empty manifest doesn't bind before the consent gate is ever reached — consent for such an app is vacuous. The same verdict feeds the library listing badge, so a bindingless app now shows as Granted there; if that badge should instead be hidden for bindingless apps, that's a small follow-up on the listing projection.

UI cleanups that follow from the verdict:
- `AppConsentSheet` drops its now-unreachable empty-bindings branch (nothing tested it).
- `AppDetailView`'s footer hides the "Allowed to use …" readout and the revoke button when the grant holds no bindings — revoke was a no-op there. The `|| "no tools"` join fallback stays because an operations binding with zero ids is structurally valid.

Tests: one new server test pinning the vacuous-grant verdict (`a_manifest_with_no_bindings_reads_granted_without_consent`) — this is the easy-to-reverse-by-accident decision. Ran the `app_*` server suites, rustfmt, clippy on `openwave-server`, `tsc` (only pre-existing plugin-test errors, also on `main`), and the `src/apps` vitest suite (24 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)