### PR TITLE
feat(skills): edit existing workbooks via LibreOffice Calc with recalc validation

### DIFF
--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -110,10 +110,13 @@ pub const PACKAGE_MANAGER_DOMAINS: &[&str] = &[
 ];
 
 /// Files copied as one indivisible helper library into an exec workspace.
-pub const DOCUMENT_SCRIPT_FILES: [&str; 5] = [
+pub const DOCUMENT_SCRIPT_FILES: [&str; 8] = [
     "_openwave_preview.py",
+    "_openwave_calc.py",
     "render_pdf.py",
     "extract_pdf_figures.py",
     "render_office.py",
     "analyze_xlsx.py",
+    "calc_uno.py",
+    "xlsx_recalc.py",
 ];

--- a/crates/openwave-code-execution/src/skills.rs
+++ b/crates/openwave-code-execution/src/skills.rs
@@ -866,10 +866,12 @@ Instructions.\n";
                 skill.package.name
             );
         }
-        // The office skills teach a LibreOffice-backed visual QA loop; the
-        // declaration is what drives the host-side install and the honest
-        // capability line, so losing it silently regresses both.
-        for name in ["presentations", "word-documents"] {
+        // The office skills teach a LibreOffice-backed loop — visual QA for
+        // the render paths, in-place editing and recalculation for
+        // spreadsheets. The declaration is what drives the host-side install
+        // and the honest capability line, so losing it silently regresses
+        // both.
+        for name in ["presentations", "spreadsheets", "word-documents"] {
             let skill = skills
                 .iter()
                 .find(|skill| skill.package.name == name)

--- a/crates/openwave-code-execution/tests/document_scripts.rs
+++ b/crates/openwave-code-execution/tests/document_scripts.rs
@@ -8,6 +8,11 @@ const SCRIPTS: [&str; 4] = [
     "analyze_xlsx.py",
 ];
 
+/// The Calc helpers produce no preview images, so they are held to the
+/// weaker contract the sandbox image's smoke check relies on: they import
+/// and answer `--help` on a machine with no UNO bridge at all.
+const CALC_SCRIPTS: [&str; 2] = ["calc_uno.py", "xlsx_recalc.py"];
+
 fn python() -> Option<PathBuf> {
     ["python3", "python"].into_iter().find_map(|candidate| {
         Command::new(candidate)
@@ -86,6 +91,31 @@ fn document_scripts_compile_and_expose_argparse_help() {
 }
 
 #[test]
+fn calc_scripts_expose_help_without_a_uno_bridge() {
+    let Some(python) = python() else {
+        eprintln!("skipping Calc helper contracts: Python is unavailable");
+        return;
+    };
+    let directory = scripts_dir();
+    for script in CALC_SCRIPTS {
+        let help = Command::new(&python)
+            .arg(directory.join(script))
+            .arg("--help")
+            .output()
+            .expect("Python starts");
+        assert!(
+            help.status.success(),
+            "{script} --help must succeed: {}",
+            String::from_utf8_lossy(&help.stderr)
+        );
+        assert!(
+            String::from_utf8_lossy(&help.stdout).starts_with("usage:"),
+            "{script} uses argparse"
+        );
+    }
+}
+
+#[test]
 fn missing_document_tooling_fails_concisely() {
     let Some(python) = python() else {
         eprintln!("skipping document script diagnostics: Python is unavailable");
@@ -123,5 +153,13 @@ fn missing_document_tooling_fails_concisely() {
         &directory.join("analyze_xlsx.py"),
         &xlsx,
         "openpyxl",
+    );
+    // Without a UNO bridge the recalculation helper must name the sandbox
+    // rather than leave the model looking for an openpyxl workaround.
+    run_missing_tool_case(
+        &python,
+        &directory.join("xlsx_recalc.py"),
+        &xlsx,
+        "python3-uno",
     );
 }

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -120,12 +120,15 @@ fn home_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
 }
 
 fn exec_scripts_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
-    const REQUIRED_HELPERS: [&str; 5] = [
+    const REQUIRED_HELPERS: [&str; 8] = [
         "_openwave_preview.py",
+        "_openwave_calc.py",
         "render_pdf.py",
         "extract_pdf_figures.py",
         "render_office.py",
         "analyze_xlsx.py",
+        "calc_uno.py",
+        "xlsx_recalc.py",
     ];
     let directory = app
         .path()

--- a/crates/openwave-sandbox-agent/Dockerfile
+++ b/crates/openwave-sandbox-agent/Dockerfile
@@ -173,6 +173,8 @@ COPY scripts/exec-documents/ /opt/openwave/exec-scripts/
 
 RUN python3 /opt/openwave/exec-scripts/render_pdf.py --help >/dev/null \
     && python3 /opt/openwave/exec-scripts/analyze_xlsx.py --help >/dev/null \
+    && python3 /opt/openwave/exec-scripts/calc_uno.py --help >/dev/null \
+    && python3 /opt/openwave/exec-scripts/xlsx_recalc.py --help >/dev/null \
     && python3 -c "import uno" \
     && node -e "require('pptxgenjs')"
 

--- a/docs/code-execution.md
+++ b/docs/code-execution.md
@@ -208,11 +208,16 @@ Examples:
 python3 .openwave/exec-scripts/render_pdf.py documents/report.pdf --pages 1-2
 python3 .openwave/exec-scripts/extract_pdf_figures.py documents/report.pdf
 python3 .openwave/exec-scripts/analyze_xlsx.py documents/model.xlsx
+python3 .openwave/exec-scripts/calc_uno.py set-cell documents/model.xlsx Summary B7 '=SUM(B2:B6)'
+python3 .openwave/exec-scripts/xlsx_recalc.py output/model.xlsx
 ```
 
 PDF rendering uses pypdfium2 or pdf2image with Poppler, figure extraction uses
 Poppler, DOCX/PPTX rendering uses LibreOffice, and XLSX analysis uses openpyxl
-and Pillow. The sandbox image includes these tools. Local execution reports a
+and Pillow. Editing an existing spreadsheet in place and recalculating one both
+drive headless LibreOffice Calc over its `uno` Python bridge, which exists in
+the sandbox image and not on a bare host. The sandbox image includes these
+tools. Local execution reports a
 concise command error when the host lacks Python or an underlying renderer; it
 does not download tooling or use an unconfined fallback.
 

--- a/scripts/exec-documents/README.md
+++ b/scripts/exec-documents/README.md
@@ -10,6 +10,12 @@ in an exec workspace into concise stdout summaries and bounded images under
 | `extract_pdf_figures.py` | Extract embedded PDF raster figures and an overview | Python, Pillow, and Poppler `pdfimages` |
 | `render_office.py` | Convert DOCX/PPTX to PDF, then render selected pages | The PDF renderer above, plus LibreOffice in the sandbox or a host-converted PDF under `.openwave/render/` |
 | `analyze_xlsx.py` | Print sheet inventory, used ranges, and sample rows; thumbnail sheets | Python, openpyxl, and Pillow |
+| `calc_uno.py` | Inspect and edit an existing spreadsheet in place (cells, formulas, named ranges) | LibreOffice Calc plus its Python bridge (`python3-uno`) in the sandbox |
+| `xlsx_recalc.py` | Recalculate a workbook and report error cells and numbers stored as text | LibreOffice Calc plus `python3-uno` in the sandbox |
+
+`calc_uno.py` and `xlsx_recalc.py` share their soffice/UNO session plumbing in
+`_openwave_calc.py`, and both must run under the system `python3` — that is the
+interpreter LibreOffice's `uno` module is installed for.
 
 The desktop copies this directory into each exec workspace at
 `.openwave/exec-scripts`. The sandbox image exposes it at

--- a/scripts/exec-documents/_openwave_calc.py
+++ b/scripts/exec-documents/_openwave_calc.py
@@ -1,0 +1,265 @@
+"""Shared plumbing for driving a headless LibreOffice Calc over UNO.
+
+`import uno` binds to the *system* python3 that LibreOffice's `python3-uno`
+package installs into, so every helper built on this module has to run under
+`python3` rather than a virtual environment. Outside the sandbox image there
+is usually no UNO bridge at all; the loaders below say that plainly instead
+of failing with an import traceback.
+
+Each session owns a private soffice process with an isolated user profile,
+reached over a uniquely named pipe. That keeps concurrent helper runs — and
+any LibreOffice the host started for its own conversions — from sharing a
+profile lock, and it means the process can always be terminated on the way
+out rather than lingering as a document server.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+
+from _openwave_preview import HelperError
+
+# Cell strings LibreOffice renders for the spreadsheet error codes worth
+# reporting; the numeric codes differ between engines, the strings do not.
+ERROR_VALUES = (
+    "#REF!",
+    "#DIV/0!",
+    "#VALUE!",
+    "#NAME?",
+    "#N/A",
+    "#NUM!",
+    "#NULL!",
+)
+
+DEFAULT_TIMEOUT = 120
+
+
+def require_uno():
+    """Return the `uno` module, or explain that this needs the sandbox."""
+
+    try:
+        import uno
+    except ImportError as error:
+        raise HelperError(
+            "Calc automation needs LibreOffice's Python bridge (python3-uno), which "
+            "exists in the sandbox document image but not in this environment. Run "
+            "the command in a sandboxed exec workspace, or tell the user the "
+            "workbook cannot be edited here — do not rebuild it with openpyxl."
+        ) from error
+    return uno
+
+
+def require_soffice() -> str:
+    executable = shutil.which("soffice") or shutil.which("libreoffice")
+    if executable is None:
+        raise HelperError(
+            "LibreOffice is not available in this environment; Calc automation needs "
+            "the sandbox document image."
+        )
+    return executable
+
+
+def _property_values(uno_module, values: dict):
+    from com.sun.star.beans import PropertyValue
+
+    properties = []
+    for name, value in values.items():
+        prop = PropertyValue()
+        prop.Name = name
+        prop.Value = value
+        properties.append(prop)
+    return tuple(properties)
+
+
+def _connect(uno_module, pipe: str, process, deadline: float):
+    context = uno_module.getComponentContext()
+    resolver = context.ServiceManager.createInstanceWithContext(
+        "com.sun.star.bridge.UnoUrlResolver", context
+    )
+    target = f"uno:pipe,name={pipe};urp;StarOffice.ComponentContext"
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise HelperError(
+                f"LibreOffice exited before accepting connections (status {process.returncode})"
+            )
+        try:
+            return resolver.resolve(target)
+        except Exception as error:  # NoConnectException until the pipe is up.
+            last_error = error
+            time.sleep(0.25)
+    raise HelperError(
+        f"timed out after {DEFAULT_TIMEOUT}s waiting for LibreOffice to accept a "
+        f"connection ({last_error})"
+    )
+
+
+@contextmanager
+def calc_document(path: Path, *, timeout: int = DEFAULT_TIMEOUT, read_only: bool = False):
+    """Open `path` in a private headless Calc and yield the loaded document.
+
+    The document is closed and the soffice process terminated on the way out,
+    including on failure. Callers that changed something call `store()` on the
+    yielded document; storing through the original media descriptor keeps the
+    file's own format and everything the format carries.
+    """
+
+    uno_module = require_uno()
+    executable = require_soffice()
+    pipe = f"openwave-calc-{uuid.uuid4().hex}"
+    with tempfile.TemporaryDirectory(prefix="openwave-calc-") as temporary:
+        root = Path(temporary)
+        profile = root / "profile"
+        profile.mkdir()
+        environment = os.environ.copy()
+        environment["HOME"] = str(root)
+        process = subprocess.Popen(
+            [
+                executable,
+                "--headless",
+                "--invisible",
+                "--nologo",
+                "--nodefault",
+                "--norestore",
+                "--nolockcheck",
+                f"-env:UserInstallation={profile.resolve().as_uri()}",
+                f"--accept=pipe,name={pipe};urp;",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            env=environment,
+        )
+        document = None
+        try:
+            deadline = time.monotonic() + timeout
+            context = _connect(uno_module, pipe, process, deadline)
+            desktop = context.ServiceManager.createInstanceWithContext(
+                "com.sun.star.frame.Desktop", context
+            )
+            options = {"Hidden": True, "UpdateDocMode": 1}
+            if read_only:
+                options["ReadOnly"] = True
+            document = desktop.loadComponentFromURL(
+                uno_module.systemPathToFileUrl(str(path.resolve())),
+                "_blank",
+                0,
+                _property_values(uno_module, options),
+            )
+            if document is None:
+                raise HelperError(f"LibreOffice could not open {path.name}")
+            if not hasattr(document, "Sheets"):
+                raise HelperError(f"{path.name} did not open as a spreadsheet")
+            yield document
+        finally:
+            if document is not None:
+                try:
+                    document.close(False)
+                except Exception:
+                    pass
+            _terminate(process)
+
+
+def _terminate(process: subprocess.Popen) -> None:
+    if process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=20)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=10)
+
+
+def sheet_by_name(document, name: str):
+    sheets = document.Sheets
+    if not sheets.hasByName(name):
+        available = ", ".join(sheets.getElementNames())
+        raise HelperError(f"sheet {name!r} does not exist; sheets are: {available}")
+    return sheets.getByName(name)
+
+
+def cell_by_reference(sheet, reference: str):
+    try:
+        return sheet.getCellRangeByName(reference)
+    except Exception as error:
+        raise HelperError(f"invalid cell reference {reference!r}: {error}") from error
+
+
+def used_area(sheet):
+    """Return the inclusive `(columns, rows)` extent of a sheet's used area."""
+
+    cursor = sheet.createCursor()
+    cursor.gotoEndOfUsedArea(False)
+    address = cursor.RangeAddress
+    return address.EndColumn, address.EndRow
+
+
+def column_letters(index: int) -> str:
+    letters = ""
+    index += 1
+    while index:
+        index, remainder = divmod(index - 1, 26)
+        letters = chr(ord("A") + remainder) + letters
+    return letters
+
+
+def cell_reference(column: int, row: int) -> str:
+    return f"{column_letters(column)}{row + 1}"
+
+
+def apply_cell_input(cell, value: str) -> str:
+    """Set `value` on `cell`, and report how it was interpreted.
+
+    A leading `=` means a formula. Anything else is stored as a number when it
+    parses as one and as text otherwise, which is what a person typing into
+    the cell would get.
+    """
+
+    if value.startswith("="):
+        cell.setFormula(value)
+        return "formula"
+    try:
+        cell.setValue(float(value))
+    except ValueError:
+        cell.setString(value)
+        return "text"
+    return "number"
+
+
+def content_type(cell) -> str:
+    """The cell's content kind as a lowercase word: empty/number/text/formula."""
+
+    kind = cell.getType()
+    # UNO enums carry their name in `.value`; older bridges hand back an int.
+    name = getattr(kind, "value", None)
+    if name is None:
+        name = {0: "EMPTY", 1: "VALUE", 2: "TEXT", 3: "FORMULA"}.get(int(kind), "UNKNOWN")
+    return {"EMPTY": "empty", "VALUE": "number", "TEXT": "text", "FORMULA": "formula"}.get(
+        name, "unknown"
+    )
+
+
+def looks_like_number(text: str) -> bool:
+    """Whether a text cell's contents are really a number in disguise."""
+
+    candidate = text.strip().replace(",", "")
+    if not candidate or candidate in ERROR_VALUES:
+        return False
+    if candidate.endswith("%"):
+        candidate = candidate[:-1]
+    if candidate and candidate[0] in "$€£":
+        candidate = candidate[1:]
+    if candidate.startswith("(") and candidate.endswith(")"):
+        candidate = candidate[1:-1]
+    try:
+        float(candidate)
+    except ValueError:
+        return False
+    return True

--- a/scripts/exec-documents/calc_uno.py
+++ b/scripts/exec-documents/calc_uno.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Inspect and edit an existing spreadsheet through headless LibreOffice Calc.
+
+This is the edit path for workbooks that already exist. A real spreadsheet
+engine opens the file and saves it back through its own filter, so formulas
+the engine computes, named ranges, pivot tables, charts, conditional
+formatting and data validation all survive — none of which is true of a
+library that rebuilds the file from the parts it happens to model.
+
+`import uno` binds to the system python3, so run this script with `python3`.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from _openwave_calc import (
+    DEFAULT_TIMEOUT,
+    apply_cell_input,
+    calc_document,
+    cell_by_reference,
+    cell_reference,
+    content_type,
+    sheet_by_name,
+    used_area,
+)
+from _openwave_preview import HelperError, existing_file, run_cli
+
+SPREADSHEETS = [".xlsx", ".xlsm", ".ods", ".csv"]
+
+
+def parser() -> argparse.ArgumentParser:
+    cli = argparse.ArgumentParser(
+        description=(
+            "Inspect or edit an existing spreadsheet in place with headless "
+            "LibreOffice Calc."
+        ),
+    )
+    cli.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT,
+        help=f"seconds to wait for LibreOffice, from 10 through 600 (default: {DEFAULT_TIMEOUT})",
+    )
+    commands = cli.add_subparsers(dest="command", required=True)
+
+    inspect = commands.add_parser(
+        "inspect", help="list sheets, used ranges, and named ranges"
+    )
+    inspect.add_argument("workbook", help="spreadsheet inside the exec workspace")
+
+    get_cell = commands.add_parser("get-cell", help="print one cell's formula and value")
+    get_cell.add_argument("workbook", help="spreadsheet inside the exec workspace")
+    get_cell.add_argument("sheet", help="sheet name")
+    get_cell.add_argument("ref", help="cell reference such as B7")
+
+    set_cell = commands.add_parser(
+        "set-cell", help="write one cell and save the workbook in place"
+    )
+    set_cell.add_argument("workbook", help="spreadsheet inside the exec workspace")
+    set_cell.add_argument("sheet", help="sheet name")
+    set_cell.add_argument("ref", help="cell reference such as B7")
+    set_cell.add_argument(
+        "value",
+        help="cell contents; a leading '=' writes a formula, otherwise a number or text",
+    )
+
+    list_named = commands.add_parser(
+        "list-named-ranges", help="print every named range and what it refers to"
+    )
+    list_named.add_argument("workbook", help="spreadsheet inside the exec workspace")
+
+    set_named = commands.add_parser(
+        "set-named-range",
+        help="point a named range at a new reference or expression, creating it if needed",
+    )
+    set_named.add_argument("workbook", help="spreadsheet inside the exec workspace")
+    set_named.add_argument("name", help="named range")
+    set_named.add_argument("value", help="reference or expression, such as $Data.$A$1:$C$20")
+    return cli
+
+
+def _inspect(document) -> None:
+    sheets = document.Sheets
+    names = list(sheets.getElementNames())
+    print(f"Sheets: {len(names)}")
+    for name in names:
+        sheet = sheets.getByName(name)
+        end_column, end_row = used_area(sheet)
+        extent = f"A1:{cell_reference(end_column, end_row)}"
+        print(f"- {name}: used={extent}, rows={end_row + 1}, columns={end_column + 1}")
+    _print_named_ranges(document)
+
+
+def _print_named_ranges(document) -> None:
+    ranges = document.NamedRanges
+    names = list(ranges.getElementNames())
+    if not names:
+        print("Named ranges: none")
+        return
+    print(f"Named ranges: {len(names)}")
+    for name in names:
+        print(f"- {name}: {ranges.getByName(name).Content}")
+
+
+def _get_cell(document, sheet_name: str, reference: str) -> None:
+    cell = cell_by_reference(sheet_by_name(document, sheet_name), reference)
+    kind = content_type(cell)
+    print(f"{sheet_name}!{reference}: type={kind}")
+    formula = cell.getFormula()
+    if kind == "formula":
+        print(f"  formula: {formula}")
+    print(f"  displayed: {cell.getString()}")
+    if kind in {"number", "formula"}:
+        print(f"  numeric: {cell.getValue()}")
+
+
+def _set_cell(document, sheet_name: str, reference: str, value: str, path: Path) -> None:
+    cell = cell_by_reference(sheet_by_name(document, sheet_name), reference)
+    kind = apply_cell_input(cell, value)
+    document.calculateAll()
+    document.store()
+    print(f"Set {sheet_name}!{reference} as a {kind} in {path.name}.")
+    print(f"  displayed: {cell.getString()}")
+
+
+def _set_named_range(document, name: str, value: str, path: Path) -> None:
+    from com.sun.star.table import CellAddress
+
+    ranges = document.NamedRanges
+    if ranges.hasByName(name):
+        ranges.getByName(name).setContent(value)
+        action = "Updated"
+    else:
+        anchor = CellAddress()
+        anchor.Sheet = 0
+        anchor.Column = 0
+        anchor.Row = 0
+        ranges.addNewByName(name, value, anchor, 0)
+        action = "Created"
+    document.calculateAll()
+    document.store()
+    print(f"{action} named range {name} = {ranges.getByName(name).Content} in {path.name}.")
+
+
+def main() -> int:
+    args = parser().parse_args()
+    if not 10 <= args.timeout <= 600:
+        raise HelperError("timeout must be between 10 and 600 seconds")
+    source = existing_file(args.workbook, SPREADSHEETS)
+    read_only = args.command in {"inspect", "get-cell", "list-named-ranges"}
+    with calc_document(source, timeout=args.timeout, read_only=read_only) as document:
+        if args.command == "inspect":
+            _inspect(document)
+        elif args.command == "get-cell":
+            _get_cell(document, args.sheet, args.ref)
+        elif args.command == "list-named-ranges":
+            _print_named_ranges(document)
+        elif args.command == "set-cell":
+            _set_cell(document, args.sheet, args.ref, args.value, source)
+        elif args.command == "set-named-range":
+            _set_named_range(document, args.name, args.value, source)
+        else:  # argparse rejects anything else first.
+            raise HelperError(f"unknown command: {args.command}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_cli(main))

--- a/scripts/exec-documents/xlsx_recalc.py
+++ b/scripts/exec-documents/xlsx_recalc.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Recalculate a workbook with LibreOffice Calc and report broken cells.
+
+openpyxl writes formula text but never computes it, so a freshly generated
+workbook's formulas are unproven until an engine evaluates them. This script
+is that engine: it opens the file, forces a full recalculation, saves the
+computed results back, and then reads every used cell looking for the two
+defects a generated workbook actually ships with — formulas that evaluate to
+an error, and numbers that were written as text and so drop out of every
+`SUM` above them.
+
+Finding problems is not a tool failure: the report is the deliverable, and
+the exit status stays zero unless the recalculation itself could not run.
+
+`import uno` binds to the system python3, so run this script with `python3`.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from _openwave_calc import (
+    DEFAULT_TIMEOUT,
+    ERROR_VALUES,
+    calc_document,
+    cell_reference,
+    content_type,
+    looks_like_number,
+    used_area,
+)
+from _openwave_preview import HelperError, existing_file, run_cli
+
+# A used area can be enormous once a stray cell sits far from the data; stop
+# well before the scan becomes the slowest part of a turn and say so.
+CELL_SCAN_LIMIT = 200_000
+REPORTED_REFS = 5
+
+
+def parser() -> argparse.ArgumentParser:
+    cli = argparse.ArgumentParser(
+        description=(
+            "Recalculate a workbook with LibreOffice Calc, save it, and report "
+            "error cells and numbers stored as text."
+        ),
+    )
+    cli.add_argument("workbook", help="XLSX/XLSM/ODS file inside the exec workspace")
+    cli.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT,
+        help=f"seconds to wait for LibreOffice, from 10 through 600 (default: {DEFAULT_TIMEOUT})",
+    )
+    return cli
+
+
+def _scan_sheet(sheet, budget: int) -> tuple[dict[str, list[str]], list[str], int]:
+    """Return per-error cell refs, text-number refs, and cells examined."""
+
+    errors: dict[str, list[str]] = {}
+    text_numbers: list[str] = []
+    end_column, end_row = used_area(sheet)
+    examined = 0
+    for row in range(end_row + 1):
+        for column in range(end_column + 1):
+            if examined >= budget:
+                return errors, text_numbers, examined
+            cell = sheet.getCellByPosition(column, row)
+            examined += 1
+            kind = content_type(cell)
+            if kind == "empty":
+                continue
+            text = cell.getString().strip()
+            if kind == "formula" and text in ERROR_VALUES:
+                errors.setdefault(text, []).append(cell_reference(column, row))
+            elif kind == "text" and looks_like_number(text):
+                text_numbers.append(cell_reference(column, row))
+    return errors, text_numbers, examined
+
+
+def _format_refs(refs: list[str]) -> str:
+    shown = ", ".join(refs[:REPORTED_REFS])
+    if len(refs) > REPORTED_REFS:
+        shown += f", … (+{len(refs) - REPORTED_REFS} more)"
+    return shown
+
+
+def main() -> int:
+    args = parser().parse_args()
+    if not 10 <= args.timeout <= 600:
+        raise HelperError("timeout must be between 10 and 600 seconds")
+    source = existing_file(args.workbook, [".xlsx", ".xlsm", ".ods"])
+
+    total_errors = 0
+    total_text_numbers = 0
+    truncated = False
+    with calc_document(source, timeout=args.timeout) as document:
+        document.calculateAll()
+        document.store()
+        print(f"Recalculated and saved {source.name}.")
+        budget = CELL_SCAN_LIMIT
+        for name in document.Sheets.getElementNames():
+            errors, text_numbers, examined = _scan_sheet(
+                document.Sheets.getByName(name), budget
+            )
+            budget -= examined
+            if budget <= 0:
+                truncated = True
+            error_count = sum(len(refs) for refs in errors.values())
+            total_errors += error_count
+            total_text_numbers += len(text_numbers)
+            if not error_count and not text_numbers:
+                print(f"- {name}: clean ({examined} cells checked)")
+                continue
+            print(
+                f"- {name}: {error_count} error cell(s), "
+                f"{len(text_numbers)} number(s) stored as text"
+            )
+            for value, refs in sorted(errors.items()):
+                print(f"    {value}: {_format_refs(refs)}")
+            if text_numbers:
+                print(f"    text-numbers: {_format_refs(text_numbers)}")
+            if budget <= 0:
+                break
+
+    if truncated:
+        print(
+            f"Scan stopped at the {CELL_SCAN_LIMIT}-cell limit; later sheets were not "
+            "checked."
+        )
+    if total_errors or total_text_numbers:
+        print(
+            f"Found {total_errors} error cell(s) and {total_text_numbers} number(s) "
+            "stored as text — fix the source formulas or cell types and rerun."
+        )
+    else:
+        print("No error cells or text-stored numbers found.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_cli(main))

--- a/skills/spreadsheets/SKILL.md
+++ b/skills/spreadsheets/SKILL.md
@@ -1,13 +1,37 @@
 ---
 name: spreadsheets
-description: Build Excel (XLSX) workbooks with openpyxl — live formulas, number formats, layout — re-inspected with the bundled analyzer before delivery.
-deps: { python: ["openpyxl==3.1.5"] }
+description: Build Excel (XLSX) workbooks with openpyxl and edit existing ones through headless LibreOffice Calc — live formulas, number formats, layout — recalculated and re-inspected before delivery.
+deps: { python: ["openpyxl==3.1.5"], host: ["libreoffice"] }
 ---
 
 # Spreadsheets
 
-Produce XLSX deliverables with **openpyxl**. Follow every section below
-before declaring a workbook done.
+Produce XLSX deliverables with **openpyxl**, and edit workbooks that already
+exist with **LibreOffice Calc**. Follow every section below before declaring
+a workbook done.
+
+## Never round-trip an existing workbook with openpyxl
+
+**openpyxl writes new workbooks. It never touches a file that already
+exists** — not to change one number, not for a "quick value edit".
+
+`load_workbook(path)` followed by `.save(path)` does not edit the file; it
+rebuilds it from the parts openpyxl models, and everything else is gone. In
+practice that means silently losing:
+
+- **formula results** the engine computed — openpyxl drops the cached values,
+  so every formula reads as empty until someone opens the file in Excel
+- named ranges, pivot tables and their caches
+- charts, images, and shapes
+- conditional formatting and data validation
+- macros, custom styles, and sheet protection
+
+None of this raises an error. The file saves, looks plausible in an
+inspection script, and hands the user a gutted copy of their own workbook.
+
+Read-only inspection is fine and expected: `load_workbook(path,
+read_only=True)` or `data_only=True`, with no `.save()` anywhere near it. The
+bundled `analyze_xlsx.py` does exactly this.
 
 ## Installing the library
 
@@ -26,6 +50,36 @@ the library (CSV) — only with their knowledge, never as a silent
 substitution. If a dependency cannot be installed at all, say so plainly
 instead of quietly delivering a lesser format.
 
+## Creating a new workbook
+
+A workbook built from scratch is openpyxl's job, with the formula and layout
+rules below. Nothing in this section changes because of the edit path.
+
+## Editing a workbook that already exists
+
+Use the bundled Calc driver, which opens the file in a real spreadsheet
+engine and saves it back through that engine's own filter — the edit lands
+in place and everything the file already carried survives:
+
+```
+python3 .openwave/exec-scripts/calc_uno.py inspect input/model.xlsx
+python3 .openwave/exec-scripts/calc_uno.py get-cell input/model.xlsx Summary B7
+python3 .openwave/exec-scripts/calc_uno.py set-cell input/model.xlsx Summary B7 '=SUM(B2:B6)'
+python3 .openwave/exec-scripts/calc_uno.py list-named-ranges input/model.xlsx
+python3 .openwave/exec-scripts/calc_uno.py set-named-range input/model.xlsx Revenue '$Data.$B$2:$B$13'
+```
+
+`set-cell` treats a leading `=` as a formula and anything else as a number
+when it parses as one, text otherwise. Each write recalculates and saves, so
+run one `set-cell` per change rather than batching edits you cannot inspect.
+Run it with `python3`: the UNO bridge binds to the system interpreter.
+
+This needs the LibreOffice that ships in the sandbox document image. Outside
+that sandbox the script exits saying so — **that is the end of the edit
+path, not a cue to fall back to openpyxl**. Tell the user the workbook
+cannot be edited in this environment and what they would get instead (for
+example a new workbook built from scratch, which is not the same file).
+
 ## Formulas: the hard rule
 
 **Write live formulas, never precomputed values, in any cell that represents
@@ -37,12 +91,12 @@ a spreadsheet.
 openpyxl writes formulas but **does not calculate them** — the file carries
 the formula text and Excel computes it on open. Two consequences:
 
-- You cannot read a formula's result back in a later exec; do not try to
-  "verify" totals by reopening the file. Compute the expected value in
-  Python for your own checking if needed.
+- You cannot read a formula's result back by reopening the file with
+  openpyxl — there is no cached value there to read. Compute the expected
+  value in Python for your own checking, or let the recalculation step below
+  evaluate the workbook properly.
 - Any calculated value the user must see in the conversation should also be
-  stated in chat, since you cannot read it from the file and they may not
-  open the workbook immediately.
+  stated in chat, since they may not open the workbook immediately.
 
 ## Layout conventions
 
@@ -69,7 +123,25 @@ fit, tell the user and deliver a trimmed workbook plus the raw data as CSV.
 
 ## Validation before declaring done
 
-Re-inspect the saved file with the bundled analyzer:
+Two passes, in this order, after every create or edit.
+
+**1. Recalculate.** Formulas you wrote are unproven until an engine evaluates
+them:
+
+```
+python3 .openwave/exec-scripts/xlsx_recalc.py output/<file>.xlsx
+```
+
+It opens the workbook in Calc, forces a full recalculation, saves the
+computed results back, then reports per sheet any cells holding `#REF!`,
+`#DIV/0!`, `#VALUE!`, `#NAME?`, `#N/A`, `#NUM!` or `#NULL!`, plus numbers
+that were written as text and so drop out of the sums above them. Finding
+problems is a report, not a failure — fix the offending cells and rerun
+until the report is clean. Like the editor, this needs the sandbox
+LibreOffice; when it is unavailable, say the formulas could not be verified
+rather than declaring them correct.
+
+**2. Inspect visually.** Re-read the saved file with the bundled analyzer:
 
 ```
 python3 .openwave/exec-scripts/analyze_xlsx.py output/<file>.xlsx
@@ -79,4 +151,4 @@ It prints each sheet's dimensions and sample rows and writes sheet
 thumbnails into `preview/` (at most 3 images are returned per exec call).
 Check that every expected sheet exists, headers and sample rows look right,
 and the thumbnails show a readable layout. Only declare the workbook done
-after this inspection passes.
+after both passes are clean.


### PR DESCRIPTION
The spreadsheets skill could only create workbooks. Anything that already
existed had one available route — reopen it with openpyxl and save it back —
which is not an edit at all: openpyxl rebuilds the file from the parts it
models, so cached formula results, named ranges, pivot tables, charts,
conditional formatting and data validation are gone, silently, with no error
and a file that still looks plausible in an inspection script.

This adds a real edit path and a recalculation pass, both driven through the
headless LibreOffice Calc that the sandbox documents image ships.

New helpers under `scripts/exec-documents/`:

- `calc_uno.py` — `inspect`, `get-cell`, `set-cell`, `list-named-ranges` and
  `set-named-range` against an existing workbook. Calc opens the file and
  stores it back through its own filter, so the edit lands in place and the
  file keeps everything it carried. `set-cell` treats a leading `=` as a
  formula, otherwise a number when it parses as one and text if not.
- `xlsx_recalc.py` — forces `calculateAll`, saves the computed results, then
  scans every used cell for `#REF!`, `#DIV/0!`, `#VALUE!`, `#NAME?`, `#N/A`,
  `#NUM!` and `#NULL!` and for numbers stored as text (the defect that
  quietly drops rows out of a `SUM`). Finding problems is the deliverable,
  not a failure, so the exit status stays zero unless the recalculation
  itself could not run.
- `_openwave_calc.py` — the shared session plumbing. Each run owns a private
  soffice process with an isolated user profile on a uniquely named pipe,
  terminated on the way out and bounded by a timeout with a clear message
  instead of hanging. The scan is capped at 200k cells and says when it
  stopped.

Both helpers run under the system `python3`: `uno` is installed for the
interpreter LibreOffice's bridge targets. Where no bridge exists — local exec
on a bare host — they exit with a message naming the sandbox and telling the
caller not to reach for openpyxl instead.

`skills/spreadsheets/SKILL.md` gains the hard rule up front (openpyxl never
touches a file that already exists; read-only inspection is fine), the Calc
edit path, and a two-step validation section: recalculate, then the existing
visual pass. It declares `host: ["libreoffice"]`, which is what makes the
host-side install and the capability line honest for this skill — the
existing test over bundled skills' host deps is updated to expect it, and the
spreadsheets plugin now derives `HostInstall` from it like the documents
plugin does.

The helper file lists in `openwave-code-execution` and `openwave-desktop`,
the Dockerfile `--help` smoke check, the helper README and the code-execution
doc all pick up the three new files.

Verified: `cargo test -p openwave-code-execution` (95 tests), `-p
openwave-desktop`, the server's `code_execution`/`foreground_prompt` suites,
`cargo check --workspace --locked` with no lock diff, `cargo fmt --check`, and
`py_compile` plus `--help` on the new scripts. The UNO code paths themselves
were not executed — macOS here has no `python3-uno`, so what ran locally is
the syntax check and the no-bridge error path; the sandbox image lane is what
exercises them at runtime.

Based on #1694, which adds `libreoffice-calc`, `python3-uno` and the JRE to
the image these helpers need.
