### PR TITLE
feat(skills): presentations via pptxgenjs for new decks and in-place XML edits for existing ones

### DIFF
--- a/.github/workflows/publish-sandbox-image.yml
+++ b/.github/workflows/publish-sandbox-image.yml
@@ -236,7 +236,7 @@ jobs:
         run: |
           docker run --rm --entrypoint python3 \
             "$DOCUMENTS_REPOSITORY:$IMAGE_TAG-${{ matrix.arch }}" \
-            -c 'import fpdf, pypdf, pptx, docx, openpyxl, matplotlib, pypdfium2, uno'
+            -c 'import fpdf, pypdf, docx, openpyxl, matplotlib, pypdfium2, uno'
           docker run --rm --entrypoint soffice \
             "$DOCUMENTS_REPOSITORY:$IMAGE_TAG-${{ matrix.arch }}" \
             --version

--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -110,12 +110,15 @@ pub const PACKAGE_MANAGER_DOMAINS: &[&str] = &[
 ];
 
 /// Files copied as one indivisible helper library into an exec workspace.
-pub const DOCUMENT_SCRIPT_FILES: [&str; 5] = [
+pub const DOCUMENT_SCRIPT_FILES: [&str; 8] = [
     "_openwave_preview.py",
     "render_pdf.py",
     "extract_pdf_figures.py",
     "render_office.py",
     "analyze_xlsx.py",
+    "office_unpack.py",
+    "office_pack.py",
+    "pptx_clean.py",
 ];
 
 /// The baseline Python packages guaranteed on every execution backend, as

--- a/crates/openwave-code-execution/src/plugins.rs
+++ b/crates/openwave-code-execution/src/plugins.rs
@@ -1164,12 +1164,7 @@ router-preamble: Pick by the file the user needs.\n\
         let pip = skill("pip", &["python-docx==1.2.0"], &[], &[]);
         let npm = skill("npm", &[], &["mermaid@11.4.1"], &[]);
         let hosted = skill("hosted", &[], &[], &[HostDep::LibreOffice]);
-        let both = skill(
-            "both",
-            &["python-pptx==1.0.2"],
-            &[],
-            &[HostDep::LibreOffice],
-        );
+        let both = skill("both", &[], &["pptxgenjs@4.0.1"], &[HostDep::LibreOffice]);
         // Not a member of any plugin under test: a caller may pass the whole
         // catalog, and a non-member must never contribute a badge.
         let outsider = skill("outsider", &["numpy==2.3.4"], &[], &[HostDep::LibreOffice]);

--- a/crates/openwave-code-execution/src/skills.rs
+++ b/crates/openwave-code-execution/src/skills.rs
@@ -665,11 +665,11 @@ Instructions live here.\n";
     /// the manifest rather than becoming a string nothing can act on.
     #[test]
     fn host_deps_parse_from_the_closed_vocabulary_only() {
-        let combined = "---\nname: presentations\ndescription: Decks.\n\
-                        deps: { python: [\"python-pptx==1.0.2\"], host: [\"libreoffice\"] }\n\
+        let combined = "---\nname: word-documents\ndescription: Docs.\n\
+                        deps: { python: [\"python-docx==1.1.2\"], host: [\"libreoffice\"] }\n\
                         ---\nBody.\n";
         let package = parse_skill_manifest(combined, SkillOrigin::Builtin).unwrap();
-        assert_eq!(package.python_deps, ["python-pptx==1.0.2"]);
+        assert_eq!(package.python_deps, ["python-docx==1.1.2"]);
         assert_eq!(package.host_deps, [HostDep::LibreOffice]);
 
         let host_only =

--- a/crates/openwave-code-execution/src/tool.rs
+++ b/crates/openwave-code-execution/src/tool.rs
@@ -426,7 +426,7 @@ mod tests {
             .execute(
                 &ToolCtx::new_legacy_workspace(ChatId::new(), None, PathBuf::from("/tmp/unused"))
                     .with_call_id(CallId::new()),
-                json!({"command": "pip", "args": ["install", "python-pptx"]}),
+                json!({"command": "pip", "args": ["install", "python-docx"]}),
             )
             .await
             .unwrap();

--- a/crates/openwave-code-execution/tests/document_scripts.rs
+++ b/crates/openwave-code-execution/tests/document_scripts.rs
@@ -1,12 +1,18 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
-const SCRIPTS: [&str; 4] = [
+/// Helpers that turn a document into bounded images under `preview/`; every
+/// one of them takes `--preview-dir`.
+const PREVIEW_SCRIPTS: [&str; 4] = [
     "render_pdf.py",
     "extract_pdf_figures.py",
     "render_office.py",
     "analyze_xlsx.py",
 ];
+
+/// Helpers for the in-place OOXML editing pipeline. They read and write
+/// package trees and emit no previews.
+const PACKAGE_SCRIPTS: [&str; 3] = ["office_unpack.py", "office_pack.py", "pptx_clean.py"];
 
 fn python() -> Option<PathBuf> {
     ["python3", "python"].into_iter().find_map(|candidate| {
@@ -55,7 +61,7 @@ fn document_scripts_compile_and_expose_argparse_help() {
     };
     let directory = scripts_dir();
     let cache = tempfile::tempdir().unwrap();
-    for script in SCRIPTS {
+    for script in PREVIEW_SCRIPTS.iter().chain(PACKAGE_SCRIPTS.iter()) {
         let path = directory.join(script);
         let compiled = Command::new(&python)
             .args(["-m", "py_compile"])
@@ -81,7 +87,10 @@ fn document_scripts_compile_and_expose_argparse_help() {
         );
         let stdout = String::from_utf8_lossy(&help.stdout);
         assert!(stdout.starts_with("usage:"), "{script} uses argparse");
-        assert!(stdout.contains("--preview-dir"));
+        assert!(
+            !PREVIEW_SCRIPTS.contains(script) || stdout.contains("--preview-dir"),
+            "{script} must expose --preview-dir"
+        );
     }
 }
 

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -120,12 +120,15 @@ fn home_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
 }
 
 fn exec_scripts_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
-    const REQUIRED_HELPERS: [&str; 5] = [
+    const REQUIRED_HELPERS: [&str; 8] = [
         "_openwave_preview.py",
         "render_pdf.py",
         "extract_pdf_figures.py",
         "render_office.py",
         "analyze_xlsx.py",
+        "office_unpack.py",
+        "office_pack.py",
+        "pptx_clean.py",
     ];
     let directory = app
         .path()

--- a/crates/openwave-sandbox-agent/Dockerfile
+++ b/crates/openwave-sandbox-agent/Dockerfile
@@ -173,6 +173,9 @@ COPY scripts/exec-documents/ /opt/openwave/exec-scripts/
 
 RUN python3 /opt/openwave/exec-scripts/render_pdf.py --help >/dev/null \
     && python3 /opt/openwave/exec-scripts/analyze_xlsx.py --help >/dev/null \
+    && python3 /opt/openwave/exec-scripts/office_unpack.py --help >/dev/null \
+    && python3 /opt/openwave/exec-scripts/office_pack.py --help >/dev/null \
+    && python3 /opt/openwave/exec-scripts/pptx_clean.py --help >/dev/null \
     && python3 -c "import uno" \
     && node -e "require('pptxgenjs')"
 

--- a/crates/openwave-sandbox-agent/documents-requirements.txt
+++ b/crates/openwave-sandbox-agent/documents-requirements.txt
@@ -628,15 +628,9 @@ python-dateutil==2.9.0.post0 \
 python-docx==1.1.2 \
     --hash=sha256:08c20d6058916fb19853fcf080f7f42b6270d89eac9fa5f8c15f691c0017fabe \
     --hash=sha256:0cf1f22e95b9002addca7948e16f2cd7acdfd498047f1941ca5d293db7762efd
-python-pptx==1.0.2 \
-    --hash=sha256:160838e0b8565a8b1f67947675886e9fea18aa5e795db7ae531606d68e785cba \
-    --hash=sha256:479a8af0eaf0f0d76b6f00b0887732874ad2e3188230315290cd1f9dd9cc7095
 six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
 typing-extensions==4.16.0 \
     --hash=sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8 \
     --hash=sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5
-xlsxwriter==3.2.9 \
-    --hash=sha256:254b1c37a368c444eac6e2f867405cc9e461b0ed97a3233b2ac1e574efb4140c \
-    --hash=sha256:9a5db42bc5dff014806c58a20b9eae7322a134abb6fce3c92c181bfb275ec5b3

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -3540,7 +3540,7 @@ mod tests {
             "---\n\
              name: presentations\n\
              description: Decks.\n\
-             deps: { python: [\"python-pptx==1.0.2\"], host: [\"libreoffice\"] }\n\
+             deps: { npm: [\"pptxgenjs@4.0.1\"], host: [\"libreoffice\"] }\n\
              ---\n\
              Body.\n",
         )

--- a/scripts/exec-documents/README.md
+++ b/scripts/exec-documents/README.md
@@ -10,6 +10,9 @@ in an exec workspace into concise stdout summaries and bounded images under
 | `extract_pdf_figures.py` | Extract embedded PDF raster figures and an overview | Python, Pillow, and Poppler `pdfimages` |
 | `render_office.py` | Convert DOCX/PPTX to PDF, then render selected pages | The PDF renderer above, plus LibreOffice in the sandbox or a host-converted PDF under `.openwave/render/` |
 | `analyze_xlsx.py` | Print sheet inventory, used ranges, and sample rows; thumbnail sheets | Python, openpyxl, and Pillow |
+| `office_unpack.py` | Unzip an OOXML package into a directory tree for direct XML edits | Python |
+| `pptx_clean.py` | Check an unpacked PPTX tree for malformed XML and dangling relationships | Python |
+| `office_pack.py` | Zip an unpacked tree back into a valid OOXML file | Python |
 
 The desktop copies this directory into each exec workspace at
 `.openwave/exec-scripts`. The sandbox image exposes it at

--- a/scripts/exec-documents/office_pack.py
+++ b/scripts/exec-documents/office_pack.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Pack a directory unpacked by office_unpack.py back into an OOXML file.
+
+Every part is written back — nothing is added, nothing is dropped except
+editor droppings such as .DS_Store — with [Content_Types].xml first, which is
+what makes the result openable by PowerPoint, Word, and LibreOffice.
+"""
+
+from __future__ import annotations
+
+import argparse
+import zipfile
+from pathlib import Path
+
+from _openwave_preview import HelperError, run_cli
+
+CONTENT_TYPES = "[Content_Types].xml"
+DROPPINGS = {".DS_Store", "Thumbs.db", "desktop.ini"}
+DROPPING_DIRS = {"__MACOSX"}
+OOXML_SUFFIXES = [".pptx", ".docx", ".xlsx", ".xlsm"]
+
+
+def parser() -> argparse.ArgumentParser:
+    cli = argparse.ArgumentParser(
+        description="Zip an unpacked OOXML tree back into a valid PPTX/DOCX/XLSX file.",
+    )
+    cli.add_argument("directory", help="directory produced by office_unpack.py")
+    cli.add_argument("output", help="destination PPTX, DOCX, or XLSX path")
+    return cli
+
+
+def package_parts(root: Path) -> list[Path]:
+    parts = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        if path.name in DROPPINGS or path.name.endswith("~"):
+            continue
+        if DROPPING_DIRS.intersection(path.relative_to(root).parts):
+            continue
+        parts.append(path)
+    return parts
+
+
+def main() -> int:
+    args = parser().parse_args()
+    root = Path(args.directory)
+    if not root.is_dir():
+        raise HelperError(f"unpacked directory does not exist: {root}")
+    output = Path(args.output)
+    if output.suffix.lower() not in OOXML_SUFFIXES:
+        expected = ", ".join(OOXML_SUFFIXES)
+        raise HelperError(f"expected an output named with one of {expected}, got: {output.name}")
+    content_types = root / CONTENT_TYPES
+    if not content_types.is_file():
+        raise HelperError(f"{root}/{CONTENT_TYPES} is missing; this is not an OOXML tree")
+
+    parts = [content_types] + [
+        path for path in package_parts(root) if path != content_types
+    ]
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED) as archive:
+        for path in parts:
+            archive.write(path, path.relative_to(root).as_posix())
+
+    broken = zipfile.ZipFile(output).testzip()
+    if broken is not None:
+        raise HelperError(f"packed archive is corrupt at {broken}")
+    print(f"Packed {len(parts)} part(s) from {args.directory} into {output}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_cli(main))

--- a/scripts/exec-documents/office_unpack.py
+++ b/scripts/exec-documents/office_unpack.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Unpack an OOXML file (PPTX/DOCX/XLSX) into a directory tree for XML editing.
+
+Entries are written exactly as stored — no reformatting — so a later
+office_pack.py round trip changes only the parts that were edited.
+"""
+
+from __future__ import annotations
+
+import argparse
+import zipfile
+from pathlib import Path
+
+from _openwave_preview import HelperError, existing_file, run_cli
+
+OOXML_SUFFIXES = [".pptx", ".docx", ".xlsx", ".xlsm"]
+
+
+def parser() -> argparse.ArgumentParser:
+    cli = argparse.ArgumentParser(
+        description="Unzip an OOXML package into a directory tree for direct XML edits.",
+    )
+    cli.add_argument("document", help="PPTX, DOCX, or XLSX file inside the exec workspace")
+    cli.add_argument("directory", help="destination directory, created if missing")
+    return cli
+
+
+def safe_destination(root: Path, name: str) -> Path:
+    """Resolve a zip entry under `root`, refusing traversal and absolute paths."""
+
+    if name.startswith("/") or "\\" in name:
+        raise HelperError(f"package entry has an unsafe name: {name}")
+    target = (root / name).resolve()
+    if target != root and root not in target.parents:
+        raise HelperError(f"package entry escapes the destination: {name}")
+    return target
+
+
+def main() -> int:
+    args = parser().parse_args()
+    source = existing_file(args.document, OOXML_SUFFIXES)
+    root = Path(args.directory)
+    if root.exists() and any(root.iterdir()):
+        raise HelperError(f"destination directory is not empty: {root}")
+    root.mkdir(parents=True, exist_ok=True)
+    root = root.resolve()
+
+    try:
+        archive = zipfile.ZipFile(source)
+    except zipfile.BadZipFile as error:
+        raise HelperError(f"{source.name} is not a readable OOXML package: {error}") from error
+
+    written = 0
+    with archive:
+        for entry in archive.infolist():
+            destination = safe_destination(root, entry.filename)
+            if entry.is_dir():
+                destination.mkdir(parents=True, exist_ok=True)
+                continue
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes(archive.read(entry))
+            written += 1
+
+    if not (root / "[Content_Types].xml").is_file():
+        raise HelperError(
+            f"{source.name} has no [Content_Types].xml; it is not a valid OOXML package"
+        )
+    print(f"Unpacked {source.name} into {args.directory} ({written} parts).")
+    print("Edit the XML parts in place, then run pptx_clean.py and office_pack.py.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_cli(main))

--- a/scripts/exec-documents/pptx_clean.py
+++ b/scripts/exec-documents/pptx_clean.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Validate an unpacked PPTX tree before packing it back up.
+
+Checks two things that a hand edit breaks and PowerPoint reports only as
+"needs repair": every XML part still parses, and every relationship target
+still resolves to a part that exists. It reports; it never rewrites.
+"""
+
+from __future__ import annotations
+
+import argparse
+import posixpath
+import urllib.parse
+import xml.etree.ElementTree as ElementTree
+from pathlib import Path
+
+from _openwave_preview import HelperError, run_cli
+
+RELATIONSHIP_TAG = "{http://schemas.openxmlformats.org/package/2006/relationships}Relationship"
+
+
+def parser() -> argparse.ArgumentParser:
+    cli = argparse.ArgumentParser(
+        description="Check XML well-formedness and relationship targets in an unpacked PPTX tree.",
+    )
+    cli.add_argument("directory", help="directory produced by office_unpack.py")
+    return cli
+
+
+def xml_parts(root: Path) -> list[Path]:
+    return sorted(
+        path
+        for path in root.rglob("*")
+        if path.is_file() and path.suffix.lower() in {".xml", ".rels"}
+    )
+
+
+def check_well_formed(root: Path, parts: list[Path], problems: list[str]) -> None:
+    for path in parts:
+        try:
+            ElementTree.parse(path)
+        except ElementTree.ParseError as error:
+            problems.append(f"{path.relative_to(root)}: malformed XML ({error})")
+
+
+def check_relationships(root: Path, parts: list[Path], problems: list[str]) -> None:
+    for path in parts:
+        if path.suffix.lower() != ".rels" or path.parent.name != "_rels":
+            continue
+        try:
+            tree = ElementTree.parse(path)
+        except ElementTree.ParseError:
+            continue  # Already reported as malformed.
+        # A part's relationships resolve against the directory holding _rels.
+        base = path.parent.parent
+        for relationship in tree.getroot().iter(RELATIONSHIP_TAG):
+            if relationship.get("TargetMode") == "External":
+                continue
+            target = relationship.get("Target")
+            identifier = relationship.get("Id", "<no Id>")
+            if not target:
+                problems.append(f"{path.relative_to(root)}: {identifier} has no Target")
+                continue
+            cleaned = urllib.parse.unquote(target.split("#", 1)[0].split("?", 1)[0])
+            if cleaned.startswith("/"):
+                resolved = root / cleaned.lstrip("/")
+            else:
+                resolved = base / posixpath.normpath(cleaned)
+            if not resolved.is_file():
+                problems.append(
+                    f"{path.relative_to(root)}: {identifier} points at a missing part "
+                    f"({target})"
+                )
+
+
+def main() -> int:
+    args = parser().parse_args()
+    root = Path(args.directory)
+    if not root.is_dir():
+        raise HelperError(f"unpacked directory does not exist: {root}")
+    if not (root / "[Content_Types].xml").is_file():
+        raise HelperError(f"{root}/[Content_Types].xml is missing; this is not an OOXML tree")
+
+    parts = xml_parts(root)
+    if not parts:
+        raise HelperError(f"no XML parts found under {root}")
+    problems: list[str] = []
+    check_well_formed(root, parts, problems)
+    check_relationships(root, parts, problems)
+
+    if problems:
+        for problem in problems:
+            print(f"error: {problem}")
+        raise HelperError(f"{len(problems)} problem(s) found; fix them before packing")
+    print(f"Checked {len(parts)} XML part(s) under {root}: well-formed, relationships resolve.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_cli(main))

--- a/skills/presentations/SKILL.md
+++ b/skills/presentations/SKILL.md
@@ -1,62 +1,130 @@
 ---
 name: presentations
-description: Build PowerPoint (PPTX) decks with python-pptx — layouts, placeholders, in-bounds geometry, overflow-free text — with visual QA before delivery.
-deps: { python: ["python-pptx==1.0.2"], host: ["libreoffice"] }
+description: Build PowerPoint (PPTX) decks — new decks with pptxgenjs, existing decks and templates edited in place through their OOXML — with visual QA before delivery.
+deps: { npm: ["pptxgenjs@4.0.1"], host: ["libreoffice"] }
 ---
 
 # Presentations
 
-Produce PPTX deliverables with **python-pptx**. Follow every section below
-before declaring a deck done.
+Two paths produce a PPTX, and picking the wrong one destroys work. Choose
+first, then follow that path's section, and finish with the validation
+section — it applies to both.
 
-## Installing the library
+## Which path
 
-Install the pinned dependency with its own `exec` call — commands have a
-bounded wall clock, and one `pip` invocation per package stays inside it:
+- **An existing `.pptx` is in play** — a template, a deck the user uploaded,
+  a prior version of this deliverable, a downloaded starting point — **edit
+  it in place** with the XML pipeline below. Always.
+- **Nothing exists yet and there is no template** — write a Node.js script
+  with **pptxgenjs** and generate the deck.
+
+**Never rebuild an existing deck to apply a change.** Regenerating a deck
+re-authors every slide: the master, theme, fonts, colors, logos, footers, and
+every slide you did not think to re-emit are gone, silently, and the user sees
+a deck that no longer looks like theirs. A one-line text fix is a one-line XML
+edit, not a rewrite. Equally, never recreate from scratch what a template
+already provides — if the user handed you a template, its design *is* the
+requirement.
+
+## New decks: pptxgenjs
+
+`require("pptxgenjs")` resolves in the sandbox with no install — the pinned
+version is baked into the image and `NODE_PATH` points at it. On a local exec
+workspace, install it once with its own `exec` call:
 
 ```
-python3 -m pip install --user python-pptx==1.0.2
+npm install pptxgenjs@4.0.1
 ```
 
 Installs work only when this chat's network policy allows package managers,
-and they persist for the rest of the conversation. If an install is refused
-by policy, do not retry: tell the user to enable the package-manager network
-policy for this chat, and offer the closest format you can produce without
-the library (a markdown outline of the deck) — only with their knowledge,
-never as a silent substitution. If a dependency cannot be installed at all,
-say so plainly instead of quietly delivering a lesser format.
+and they persist for the rest of the conversation. If an install is refused by
+policy, do not retry: tell the user to enable the package-manager network
+policy for this chat, and offer the closest format you can produce without the
+library (a markdown outline of the deck) — only with their knowledge, never as
+a silent substitution. If a dependency cannot be installed at all, say so
+plainly instead of quietly delivering a lesser format.
 
-## Structure and layouts
+Write the deck as a script and run it:
 
-- Default structure: a title slide, then title-and-content slides — one idea
-  per slide. Use `prs.slide_layouts[0]` for the title slide and
-  `prs.slide_layouts[1]` (Title and Content) for body slides.
-- Fill the layout's placeholders (`slide.shapes.title`,
-  `slide.placeholders[1]`) instead of free-floating text boxes; placeholders
-  carry the theme's fonts and positions for free.
-- Add bullets through the content placeholder's `text_frame`: first bullet
-  on `text_frame.paragraphs[0]`, subsequent ones via `add_paragraph()`,
-  with `paragraph.level` for sub-bullets.
+```js
+const PptxGenJS = require("pptxgenjs");
 
-## Geometry and overflow
+const pres = new PptxGenJS();
+pres.defineLayout({ name: "W16x9", width: 10, height: 5.625 });
+pres.layout = "W16x9";
 
-- The default slide is 13.33 x 7.5 inches (16:9). Any shape you position
-  manually must satisfy `left + width <= slide width` and
-  `top + height <= slide height` — compute positions with `Inches(...)`
-  rather than guessing EMUs, and never let images or boxes hang off the
-  slide edge.
-- Avoid text overflow by writing less text, not by shrinking fonts:
-  at most about 6 bullets per slide and about 12 words per bullet. When
-  content does not fit, split the slide. Keep body text at 18pt or larger;
-  a slide that needs 12pt text is a document, not a slide.
+const slide = pres.addSlide();
+slide.addText("Quarterly review", {
+  x: 0.6,
+  y: 0.5,
+  w: 8.8,
+  h: 1,
+  fontSize: 36,
+  color: "1F2933",
+});
 
-## Consistency
+pres.writeFile({ fileName: "output/quarterly-review.pptx" });
+```
 
-- Keep one font family and a small, consistent color palette across the
-  deck; set them through the layout placeholders and reuse the same
-  `RGBColor` constants everywhere rather than styling each slide ad hoc.
-- Images: preserve aspect ratio by setting only width or only height, and
-  keep them inside the slide bounds.
+Style rules:
+
+- Define a 16:9 layout explicitly — `defineLayout` with 10 x 5.625 inches —
+  and lay every slide out against those bounds. Keep shapes inside them:
+  `x + w <= 10` and `y + h <= 5.625`.
+- One idea per slide. At most about 6 bullets, about 12 words each. When
+  content does not fit, split the slide rather than shrinking type.
+- Body text at 18pt or larger. A slide that needs 12pt text is a document.
+- Colors are hex **without** the `#`: `color: "1F2933"`, not `"#1F2933"`.
+- Images: set only `w` or only `h` so the aspect ratio is preserved, and keep
+  them inside the slide bounds.
+- Use the native `addTable` and `addChart` APIs — a real table and a real
+  chart, never a picture of one. Charts stay editable and tables stay
+  selectable text.
+- Avoid merged table cells (`colspan`/`rowspan`). The LibreOffice conversion
+  behind the visual check does not render them reliably, so a merged layout
+  cannot be verified before delivery.
+- Keep one font family and a small, consistent palette across the deck; define
+  the colors once as constants and reuse them.
+- Save with `pres.writeFile({ fileName: "output/<name>.pptx" })`.
+
+## Existing decks and templates: edit the XML in place
+
+A PPTX is a zip of XML parts. Editing those parts directly is the only way to
+change a deck without re-authoring it. The workflow:
+
+1. **Unpack**
+   `python3 .openwave/exec-scripts/office_unpack.py deck.pptx build/deck`
+   writes the package out as a directory tree, byte for byte.
+2. **Survey before editing.** List `build/deck/ppt/slides/` and read the
+   slides. Classify each one: a *target* you will edit, or a slide to
+   **preserve untouched**. Do not open a part you have no edit to make in.
+3. **Edit the targets.** Slide text lives in `ppt/slides/slideN.xml`, inside
+   `<a:t>` runs; images, hyperlinks, and layout links live in the matching
+   `ppt/slides/_rels/slideN.xml.rels`. Make targeted, minimal edits — replace
+   the text of a run, change one attribute — and leave the surrounding markup
+   exactly as it was. Never load the tree into a library and re-serialize the
+   whole file: a round trip through a generic XML writer reorders namespaces
+   and drops content PowerPoint needs.
+4. **To add a slide, duplicate one that already exists.** Copy
+   `ppt/slides/slide3.xml` to `slide9.xml` and its rels file alongside it,
+   then register the new part in three places: a `<p:sldId>` entry in
+   `ppt/presentation.xml`, the matching relationship in
+   `ppt/_rels/presentation.xml.rels` (with an `Id` no other relationship
+   uses), and an `<Override>` for `/ppt/slides/slide9.xml` in
+   `[Content_Types].xml`. Then edit the copy's text — a duplicated slide
+   inherits the deck's design for free. Deleting a slide is the same three
+   registrations in reverse.
+5. **Check**
+   `python3 .openwave/exec-scripts/pptx_clean.py build/deck`
+   parses every XML part and confirms every relationship target exists. Fix
+   what it names before going on; a malformed part is the "PowerPoint found a
+   problem with this content" dialog.
+6. **Pack**
+   `python3 .openwave/exec-scripts/office_pack.py build/deck output/<name>.pptx`
+   rezips the tree into a valid package.
+
+Unpack once and keep the tree for the rest of the conversation — later
+revisions are more edits to the same tree, not another round trip.
 
 ## Saving deliverables
 
@@ -67,9 +135,10 @@ only when the user asks for a distinct deck.
 
 ## Validation before declaring done
 
-1. Reopen the saved file — `pptx.Presentation("output/<file>.pptx")` — and
-   confirm the slide count and that each slide's title and body text are
-   what you intended. A file that fails to reopen is not a deliverable.
+1. Confirm the deck opens. Rendering it (step 2) is that check: LibreOffice
+   converts only a package it can parse, so a file the renderer cannot convert
+   is not a deliverable — go back and fix the generator or the XML edit rather
+   than shipping it.
 2. Render slides for a visual check with the bundled helper:
    `python3 .openwave/exec-scripts/render_office.py output/<file>.pptx`
    (images land in `preview/`; at most 3 are returned per exec call; the
@@ -80,8 +149,10 @@ only when the user asks for a distinct deck.
    `.openwave/render/`), and on a managed sandbox you must list that PDF in
    the helper call's `files` to stage it in. Inspect for clipped text,
    overlapping shapes, and anything crossing the slide edge, and fix the
-   generator rather than accepting a flawed slide. Only when the sync notes
-   say office rendering is unavailable on the host, rely on the reopen
-   check and say the visual pass was not possible.
+   generator or the edited XML rather than accepting a flawed slide. When you
+   edited an existing deck, check the slides you meant to preserve too — they
+   should look exactly as they did before. Only when the sync notes say office
+   rendering is unavailable on the host, say plainly that neither the visual
+   pass nor the open check was possible.
 
 Only declare the deck done after validation passes.


### PR DESCRIPTION
Stacked on #1695 (npm deps in skill manifests); retarget to `main` once that lands. The pptxgenjs runtime it depends on comes from #1694.

## The problem

The presentations skill built every deck with python-pptx. That gave one path for two very different jobs, and the second one it did badly: when a user hands over a template or asks for a change to a deck that already exists, the only move the skill taught was to generate a new deck. Regenerating re-authors every slide — the master, theme, fonts, logos, footers, and any slide content the model did not think to re-emit are silently gone.

## Two paths

**New deck, no template** — a Node.js script against pptxgenjs. `require("pptxgenjs")` resolves in the sandbox with no install (baked into the documents image, `NODE_PATH` set); locally it is one `npm install pptxgenjs@4.0.1`, with the same policy-refusal wording the skill already used for pip. The style rules carry over from the python-pptx section (16:9 bounds, one idea per slide, 18pt floor, aspect-ratio-preserving images) plus the pptxgenjs-specific ones: hex without `#`, native `addTable`/`addChart` instead of pictures of tables, and no merged cells because the LibreOffice conversion behind the visual check does not render them reliably.

**Existing deck or template** — edit the OOXML in place: unpack, classify slides into targets and slides to preserve, make minimal edits to `ppt/slides/slideN.xml` and its rels, validate, repack. Adding a slide is duplicating one that exists and registering the copy in `presentation.xml`, the presentation rels, and `[Content_Types].xml`, so the deck's design carries over for free. The skill says plainly never to rebuild an existing deck to apply a change, and never to recreate what a template already provides.

## Helpers

Three additions to `scripts/exec-documents/`, following the conventions there (argparse, stdlib only, `HelperError` for concise failures):

- `office_unpack.py <file> <dir>` — unzips the package byte for byte, refusing traversal entries.
- `pptx_clean.py <dir>` — validator, not a rewriter: parses every `*.xml`/`*.rels` and confirms every non-external relationship target resolves to a part that exists. Names each offending file and exits nonzero.
- `office_pack.py <dir> <file>` — rezips with `[Content_Types].xml` first, keeping every part and dropping only editor droppings (`.DS_Store`, `__MACOSX`, and friends).

They join `DOCUMENT_SCRIPT_FILES` (and the desktop's required-helpers check), so they are staged into exec workspaces with the rest of the library, and the image build's `--help` smoke check now covers them.

## Retiring python-pptx

- Manifest pin dropped; `deps` is now `{ npm: ["pptxgenjs@4.0.1"], host: ["libreoffice"] }`.
- `documents-requirements.txt` regenerated: python-pptx and its now-orphaned XlsxWriter are out, everything else (including python-docx, lxml, Pillow) unchanged.
- The publish workflow's import smoke check no longer imports `pptx`.
- The reopen check in the validation section is now LibreOffice loadability via the existing render step — a file the renderer cannot convert is not a deliverable. The visual pass is unchanged, with an added instruction to check the preserved slides when an existing deck was edited.

## Test changes

No tests added or removed. Four fixtures updated to the new truth: the two manifest fixtures that spelled the presentations skill with a python-pptx pin (`skills.rs`, `openwave-server/src/code_execution.rs`), the capability-derivation fixture in `plugins.rs`, and a `pip install` example in `tool.rs`. `document_scripts.rs` splits its script list into preview helpers and package helpers, because `--preview-dir` is asserted only of the former.

## Verified

`cargo test -p openwave-code-execution`, `cargo test -p openwave-server --lib code_execution`, `cargo test -p openwave-desktop --lib`, `node --test scripts/sandbox-image-pins.test.mjs`, `cargo check --workspace --locked` with no lock diff, `cargo fmt --check`, clippy warning count unchanged against the base.

Ran the pipeline end to end on a generated deck: unpack (38 parts) → edit a text run in `slide1.xml` → `pptx_clean.py` (35 parts checked) → pack → `unzip -t` clean, and reopening the repacked file shows the edited title with the deck otherwise intact. Also confirmed `pptx_clean.py` reports both a malformed part and a dangling relationship by name and exits 2. Not render-verified: no working LibreOffice on this machine.