### PR TITLE
feat(skills): edit existing Word documents in place via the XML pipeline

### DIFF
--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -110,9 +110,10 @@ pub const PACKAGE_MANAGER_DOMAINS: &[&str] = &[
 ];
 
 /// Files copied as one indivisible helper library into an exec workspace.
-pub const DOCUMENT_SCRIPT_FILES: [&str; 11] = [
+pub const DOCUMENT_SCRIPT_FILES: [&str; 13] = [
     "_openwave_preview.py",
     "_openwave_calc.py",
+    "_openwave_ooxml.py",
     "render_pdf.py",
     "extract_pdf_figures.py",
     "render_office.py",
@@ -122,6 +123,7 @@ pub const DOCUMENT_SCRIPT_FILES: [&str; 11] = [
     "pptx_clean.py",
     "calc_uno.py",
     "xlsx_recalc.py",
+    "docx_clean.py",
 ];
 
 /// The baseline Python packages guaranteed on every execution backend, as

--- a/crates/openwave-code-execution/tests/document_scripts.rs
+++ b/crates/openwave-code-execution/tests/document_scripts.rs
@@ -12,7 +12,12 @@ const PREVIEW_SCRIPTS: [&str; 4] = [
 
 /// Helpers for the in-place OOXML editing pipeline. They read and write
 /// package trees and emit no previews.
-const PACKAGE_SCRIPTS: [&str; 3] = ["office_unpack.py", "office_pack.py", "pptx_clean.py"];
+const PACKAGE_SCRIPTS: [&str; 4] = [
+    "office_unpack.py",
+    "office_pack.py",
+    "pptx_clean.py",
+    "docx_clean.py",
+];
 /// The Calc helpers produce no preview images, so they are held to the
 /// weaker contract the sandbox image's smoke check relies on: they import
 /// and answer `--help` on a machine with no UNO bridge at all.

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -120,9 +120,10 @@ fn home_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
 }
 
 fn exec_scripts_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
-    const REQUIRED_HELPERS: [&str; 11] = [
+    const REQUIRED_HELPERS: [&str; 13] = [
         "_openwave_preview.py",
         "_openwave_calc.py",
+        "_openwave_ooxml.py",
         "render_pdf.py",
         "extract_pdf_figures.py",
         "render_office.py",
@@ -132,6 +133,7 @@ fn exec_scripts_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
         "pptx_clean.py",
         "calc_uno.py",
         "xlsx_recalc.py",
+        "docx_clean.py",
     ];
     let directory = app
         .path()

--- a/crates/openwave-sandbox-agent/Dockerfile
+++ b/crates/openwave-sandbox-agent/Dockerfile
@@ -178,6 +178,7 @@ RUN python3 /opt/openwave/exec-scripts/render_pdf.py --help >/dev/null \
     && python3 /opt/openwave/exec-scripts/pptx_clean.py --help >/dev/null \
     && python3 /opt/openwave/exec-scripts/calc_uno.py --help >/dev/null \
     && python3 /opt/openwave/exec-scripts/xlsx_recalc.py --help >/dev/null \
+    && python3 /opt/openwave/exec-scripts/docx_clean.py --help >/dev/null \
     && python3 -c "import uno" \
     && node -e "require('pptxgenjs')"
 

--- a/scripts/exec-documents/README.md
+++ b/scripts/exec-documents/README.md
@@ -12,6 +12,7 @@ in an exec workspace into concise stdout summaries and bounded images under
 | `analyze_xlsx.py` | Print sheet inventory, used ranges, and sample rows; thumbnail sheets | Python, openpyxl, and Pillow |
 | `office_unpack.py` | Unzip an OOXML package into a directory tree for direct XML edits | Python |
 | `pptx_clean.py` | Check an unpacked PPTX tree for malformed XML and dangling relationships | Python |
+| `docx_clean.py` | Check an unpacked DOCX tree for malformed XML and dangling relationships | Python |
 | `office_pack.py` | Zip an unpacked tree back into a valid OOXML file | Python |
 | `calc_uno.py` | Inspect and edit an existing spreadsheet in place (cells, formulas, named ranges) | LibreOffice Calc plus its Python bridge (`python3-uno`) in the sandbox |
 | `xlsx_recalc.py` | Recalculate a workbook and report error cells and numbers stored as text | LibreOffice Calc plus `python3-uno` in the sandbox |

--- a/scripts/exec-documents/_openwave_ooxml.py
+++ b/scripts/exec-documents/_openwave_ooxml.py
@@ -1,0 +1,99 @@
+"""Shared validation for unpacked OOXML package trees.
+
+The two checks below are what a hand edit breaks and Word or PowerPoint
+reports only as "needs repair": every XML part still parses, and every
+relationship target still resolves to a part that exists. Neither depends on
+the package format, so `pptx_clean.py` and `docx_clean.py` are thin CLIs over
+this module. Nothing here rewrites a file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import posixpath
+import urllib.parse
+import xml.etree.ElementTree as ElementTree
+from pathlib import Path
+
+from _openwave_preview import HelperError
+
+RELATIONSHIP_TAG = "{http://schemas.openxmlformats.org/package/2006/relationships}Relationship"
+
+
+def parser(package_label: str) -> argparse.ArgumentParser:
+    cli = argparse.ArgumentParser(
+        description=(
+            f"Check XML well-formedness and relationship targets in an unpacked "
+            f"{package_label} tree."
+        ),
+    )
+    cli.add_argument("directory", help="directory produced by office_unpack.py")
+    return cli
+
+
+def xml_parts(root: Path) -> list[Path]:
+    return sorted(
+        path
+        for path in root.rglob("*")
+        if path.is_file() and path.suffix.lower() in {".xml", ".rels"}
+    )
+
+
+def check_well_formed(root: Path, parts: list[Path], problems: list[str]) -> None:
+    for path in parts:
+        try:
+            ElementTree.parse(path)
+        except ElementTree.ParseError as error:
+            problems.append(f"{path.relative_to(root)}: malformed XML ({error})")
+
+
+def check_relationships(root: Path, parts: list[Path], problems: list[str]) -> None:
+    for path in parts:
+        if path.suffix.lower() != ".rels" or path.parent.name != "_rels":
+            continue
+        try:
+            tree = ElementTree.parse(path)
+        except ElementTree.ParseError:
+            continue  # Already reported as malformed.
+        # A part's relationships resolve against the directory holding _rels.
+        base = path.parent.parent
+        for relationship in tree.getroot().iter(RELATIONSHIP_TAG):
+            if relationship.get("TargetMode") == "External":
+                continue
+            target = relationship.get("Target")
+            identifier = relationship.get("Id", "<no Id>")
+            if not target:
+                problems.append(f"{path.relative_to(root)}: {identifier} has no Target")
+                continue
+            cleaned = urllib.parse.unquote(target.split("#", 1)[0].split("?", 1)[0])
+            if cleaned.startswith("/"):
+                resolved = root / cleaned.lstrip("/")
+            else:
+                resolved = base / posixpath.normpath(cleaned)
+            if not resolved.is_file():
+                problems.append(
+                    f"{path.relative_to(root)}: {identifier} points at a missing part "
+                    f"({target})"
+                )
+
+
+def check_tree(directory: str) -> int:
+    root = Path(directory)
+    if not root.is_dir():
+        raise HelperError(f"unpacked directory does not exist: {root}")
+    if not (root / "[Content_Types].xml").is_file():
+        raise HelperError(f"{root}/[Content_Types].xml is missing; this is not an OOXML tree")
+
+    parts = xml_parts(root)
+    if not parts:
+        raise HelperError(f"no XML parts found under {root}")
+    problems: list[str] = []
+    check_well_formed(root, parts, problems)
+    check_relationships(root, parts, problems)
+
+    if problems:
+        for problem in problems:
+            print(f"error: {problem}")
+        raise HelperError(f"{len(problems)} problem(s) found; fix them before packing")
+    print(f"Checked {len(parts)} XML part(s) under {root}: well-formed, relationships resolve.")
+    return 0

--- a/scripts/exec-documents/docx_clean.py
+++ b/scripts/exec-documents/docx_clean.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""Validate an unpacked DOCX tree before packing it back up.
+
+Checks two things that a hand edit breaks and Word reports only as "needs
+repair": every XML part still parses, and every relationship target still
+resolves to a part that exists. It reports; it never rewrites.
+"""
+
+from __future__ import annotations
+
+from _openwave_ooxml import check_tree, parser
+from _openwave_preview import run_cli
+
+
+def main() -> int:
+    args = parser("DOCX").parse_args()
+    return check_tree(args.directory)
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_cli(main))

--- a/scripts/exec-documents/office_unpack.py
+++ b/scripts/exec-documents/office_unpack.py
@@ -66,7 +66,10 @@ def main() -> int:
             f"{source.name} has no [Content_Types].xml; it is not a valid OOXML package"
         )
     print(f"Unpacked {source.name} into {args.directory} ({written} parts).")
-    print("Edit the XML parts in place, then run pptx_clean.py and office_pack.py.")
+    print(
+        "Edit the XML parts in place, then run pptx_clean.py or docx_clean.py, "
+        "then office_pack.py."
+    )
     return 0
 
 

--- a/scripts/exec-documents/pptx_clean.py
+++ b/scripts/exec-documents/pptx_clean.py
@@ -8,92 +8,13 @@ still resolves to a part that exists. It reports; it never rewrites.
 
 from __future__ import annotations
 
-import argparse
-import posixpath
-import urllib.parse
-import xml.etree.ElementTree as ElementTree
-from pathlib import Path
-
-from _openwave_preview import HelperError, run_cli
-
-RELATIONSHIP_TAG = "{http://schemas.openxmlformats.org/package/2006/relationships}Relationship"
-
-
-def parser() -> argparse.ArgumentParser:
-    cli = argparse.ArgumentParser(
-        description="Check XML well-formedness and relationship targets in an unpacked PPTX tree.",
-    )
-    cli.add_argument("directory", help="directory produced by office_unpack.py")
-    return cli
-
-
-def xml_parts(root: Path) -> list[Path]:
-    return sorted(
-        path
-        for path in root.rglob("*")
-        if path.is_file() and path.suffix.lower() in {".xml", ".rels"}
-    )
-
-
-def check_well_formed(root: Path, parts: list[Path], problems: list[str]) -> None:
-    for path in parts:
-        try:
-            ElementTree.parse(path)
-        except ElementTree.ParseError as error:
-            problems.append(f"{path.relative_to(root)}: malformed XML ({error})")
-
-
-def check_relationships(root: Path, parts: list[Path], problems: list[str]) -> None:
-    for path in parts:
-        if path.suffix.lower() != ".rels" or path.parent.name != "_rels":
-            continue
-        try:
-            tree = ElementTree.parse(path)
-        except ElementTree.ParseError:
-            continue  # Already reported as malformed.
-        # A part's relationships resolve against the directory holding _rels.
-        base = path.parent.parent
-        for relationship in tree.getroot().iter(RELATIONSHIP_TAG):
-            if relationship.get("TargetMode") == "External":
-                continue
-            target = relationship.get("Target")
-            identifier = relationship.get("Id", "<no Id>")
-            if not target:
-                problems.append(f"{path.relative_to(root)}: {identifier} has no Target")
-                continue
-            cleaned = urllib.parse.unquote(target.split("#", 1)[0].split("?", 1)[0])
-            if cleaned.startswith("/"):
-                resolved = root / cleaned.lstrip("/")
-            else:
-                resolved = base / posixpath.normpath(cleaned)
-            if not resolved.is_file():
-                problems.append(
-                    f"{path.relative_to(root)}: {identifier} points at a missing part "
-                    f"({target})"
-                )
+from _openwave_ooxml import check_tree, parser
+from _openwave_preview import run_cli
 
 
 def main() -> int:
-    args = parser().parse_args()
-    root = Path(args.directory)
-    if not root.is_dir():
-        raise HelperError(f"unpacked directory does not exist: {root}")
-    if not (root / "[Content_Types].xml").is_file():
-        raise HelperError(f"{root}/[Content_Types].xml is missing; this is not an OOXML tree")
-
-    parts = xml_parts(root)
-    if not parts:
-        raise HelperError(f"no XML parts found under {root}")
-    problems: list[str] = []
-    check_well_formed(root, parts, problems)
-    check_relationships(root, parts, problems)
-
-    if problems:
-        for problem in problems:
-            print(f"error: {problem}")
-        raise HelperError(f"{len(problems)} problem(s) found; fix them before packing")
-    print(f"Checked {len(parts)} XML part(s) under {root}: well-formed, relationships resolve.")
-    return 0
+    args = parser("PPTX").parse_args()
+    return check_tree(args.directory)
 
 
 if __name__ == "__main__":

--- a/skills/word-documents/SKILL.md
+++ b/skills/word-documents/SKILL.md
@@ -1,13 +1,31 @@
 ---
 name: word-documents
-description: Create Word (DOCX) documents with python-docx — headings, styles, tables, page setup — validated by reopening before delivery.
+description: Produce Word (DOCX) documents — new documents with python-docx, existing documents and templates edited in place through their OOXML — validated before delivery.
 deps: { python: ["python-docx==1.1.2"], host: ["libreoffice"] }
 ---
 
 # Word documents
 
-Produce DOCX deliverables with **python-docx**. Follow every section below
-before declaring a document done.
+Two paths produce a DOCX, and picking the wrong one destroys work. Choose
+first, then follow that path's section, and finish with the validation
+section — it applies to both.
+
+## Which path
+
+- **An existing `.docx` is in play** — a template, a document the user
+  uploaded, a prior version of this deliverable, a downloaded starting
+  point — **edit it in place** with the XML pipeline below. Always.
+- **Nothing exists yet and there is no template** — build the document from
+  scratch with **python-docx**.
+
+**Never rebuild an existing document with python-docx to apply a change.**
+`Document()` starts from the library's default template, and it cannot
+reproduce a firm's: the style definitions, numbering, headers and footers,
+theme fonts, and page setup all come back as generic defaults, so
+regenerating silently strips the design the user is attached to. A one-line
+text fix is a one-line XML edit, not a rewrite. Equally, never recreate from
+scratch what a template already provides — if the user handed you a template,
+its design *is* the requirement.
 
 ## When DOCX is the right format
 
@@ -17,7 +35,7 @@ When the user just needs readable text they will consume in the chat or a
 plain file, a markdown output serves them better than a DOCX: say so and
 offer the simpler format instead of defaulting to Word.
 
-## Installing the library
+## New documents: python-docx
 
 Install the pinned dependency with its own `exec` call — commands have a
 bounded wall clock, and one `pip` invocation per package stays inside it:
@@ -34,8 +52,6 @@ the library (markdown or HTML) — only with their knowledge, never as a
 silent substitution. If a dependency cannot be installed at all, say so
 plainly instead of quietly delivering a lesser format.
 
-## Building documents from scratch
-
 - Start from `docx.Document()` and compose with `add_heading(...)`,
   `add_paragraph(...)`, `add_table(...)`, and `add_picture(...)`.
 - Use the built-in styles (`Heading 1`..`Heading 3`, `Title`, `List Bullet`,
@@ -51,6 +67,40 @@ plainly instead of quietly delivering a lesser format.
 - Add page breaks with `add_page_break()` between major parts rather than
   padding with empty paragraphs.
 
+## Existing documents and templates: edit the XML in place
+
+A DOCX is a zip of XML parts. Editing those parts directly is the only way to
+change a document without re-authoring it. The workflow:
+
+1. **Unpack**
+   `python3 .openwave/exec-scripts/office_unpack.py doc.docx build/doc`
+   writes the package out as a directory tree, byte for byte.
+2. **Survey before editing.** Read `build/doc/word/document.xml` and find the
+   passages you need to change. Decide what you are editing and what you are
+   leaving **untouched**. Do not open a part you have no edit to make in.
+3. **Edit the targets.** Body text lives in `word/document.xml`, inside
+   `<w:t>` runs — a single sentence is often split across several runs, so
+   search for a distinctive fragment rather than the whole phrase. Style
+   definitions live in `word/styles.xml`, headers and footers in
+   `word/headerN.xml` and `word/footerN.xml`, and every part's images,
+   hyperlinks, and part links in the matching `.rels` file under
+   `word/_rels/`. Make targeted, minimal edits — replace the text of a run,
+   change one attribute — and leave the surrounding markup exactly as it was.
+   Never load the tree into a generic XML library and re-serialize the whole
+   file: a round trip through a generic writer reorders namespaces and drops
+   content Word needs.
+4. **Check**
+   `python3 .openwave/exec-scripts/docx_clean.py build/doc`
+   parses every XML part and confirms every relationship target exists. Fix
+   what it names before going on; a malformed part is the "Word found
+   unreadable content" dialog.
+5. **Pack**
+   `python3 .openwave/exec-scripts/office_pack.py build/doc output/<name>.docx`
+   rezips the tree into a valid package.
+
+Unpack once and keep the tree for the rest of the conversation — later
+revisions are more edits to the same tree, not another round trip.
+
 ## Saving deliverables
 
 Save the finished document in `output/` — files there are published to the
@@ -60,11 +110,14 @@ change it only when the user asks for a distinct document.
 
 ## Validation before declaring done
 
-1. Reopen the saved file with the library — `docx.Document("output/<file>.docx")`
-   — and walk its paragraphs and tables to confirm the structure you meant
-   to write is actually there (headings present, table dimensions right,
-   no empty required sections). A file that fails to reopen is not a
-   deliverable.
+1. Confirm the document opens. For one you **generated** with python-docx,
+   reopen it with the library — `docx.Document("output/<file>.docx")` — and
+   walk its paragraphs and tables to confirm the structure you meant to write
+   is actually there (headings present, table dimensions right, no empty
+   required sections). For one you **edited in place**, do not reopen it with
+   python-docx: rendering it (step 2) is the check, because LibreOffice
+   converts only a package it can parse. A file that fails to open either way
+   is not a deliverable.
 2. Render pages for a visual check with the bundled helper:
    `python3 .openwave/exec-scripts/render_office.py output/<file>.docx`
    (images land in `preview/`; at most 3 are returned per exec call; the
@@ -73,8 +126,12 @@ change it only when the user asks for a distinct document.
    it renders the PDF the host converts after every successful command that
    saved the document — the workspace sync notes name it (under
    `.openwave/render/`), and on a managed sandbox you must list that PDF in
-   the helper call's `files` to stage it in. Only when the sync notes say
-   office rendering is unavailable on the host, rely on the reopen check
-   and say the visual pass was not possible.
+   the helper call's `files` to stage it in. Inspect for clipped text, broken
+   tables, and lost formatting. When you edited an existing document, check
+   the pages you meant to preserve too — they should look exactly as they did
+   before. Only when the sync notes say office rendering is unavailable on
+   the host, say plainly what could not be checked: for a generated document
+   the reopen check still stands and the visual pass does not; for an edited
+   one neither the visual pass nor the open check was possible.
 
 Only declare the document done after validation passes.


### PR DESCRIPTION
The word-documents skill knew one way to produce a DOCX: build it from scratch with python-docx. So a change to a document the user already had — their template, an upload, the previous version of the same deliverable — was answered by regenerating the whole thing. `Document()` starts from the library's default template and cannot reproduce a firm's, so the styles, numbering, headers and footers, and theme fonts came back as generic defaults and the user got a document that no longer looked like theirs.

Split the skill the same way presentations is split, with the same decision rule up top:

- Nothing existing and no template: python-docx, and those sections are unchanged.
- An existing `.docx` in play: unpack the package, make targeted edits to `word/document.xml` (and `styles.xml`, `headerN.xml`/`footerN.xml`, the `_rels/`), validate, repack. The pin stays because python-docx is still the create path.

The edit section calls out what actually bites in a DOCX body: a sentence is usually split across several `<w:t>` runs, so it says to search for a distinctive fragment rather than the whole phrase, and never to re-serialize the tree through a generic XML library.

`docx_clean.py` backs the check step. Its two checks — every XML part parses, every relationship target resolves — are the same ones `pptx_clean.py` makes and neither depends on the package format, so the shared logic moved into `_openwave_ooxml.py` and both scripts are now thin CLIs over it that differ only in the format they name and the repair dialog they mention. Like its counterpart it reports and never rewrites. `pptx_clean.py`'s CLI is unchanged.

The reopen check splits with the paths: a generated document is still walked with python-docx, an edited one is proven by LibreOffice loading it during the existing render step.

Both new files are registered everywhere the helper library is enumerated: `DOCUMENT_SCRIPT_FILES`, the desktop's `REQUIRED_HELPERS`, the Dockerfile smoke check (`docx_clean.py --help`; the private module is exercised by importing it), the package-script list in `document_scripts.rs`, and the README table.

## Verification

- `cargo test -p openwave-code-execution` (94 + 2), `cargo test -p openwave-desktop --lib` (116), `cargo check --workspace --locked` with no lock diff, `cargo fmt --check`.
- `py_compile` and `--help` on every touched script.
- Exercised the pipeline end to end: generated a DOCX with python-docx 1.1.2 (heading, paragraph, table), `office_unpack.py` → replaced the text of one `<w:t>` run → `docx_clean.py` → `office_pack.py` → `unzip -t` clean, and reopening the packed file showed the edited text with the heading and table intact. Appending junk to `document.xml` and re-running `docx_clean.py` failed with the malformed-part line and a non-zero exit.
- Not render-verified: I did not run the LibreOffice visual pass over an edited document, and the Dockerfile smoke line is checked by the image build rather than locally.