### PR TITLE
fix(desktop): restore context meter on reopen and move it to the header

### DIFF
--- a/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
@@ -153,12 +153,23 @@ vi.mock("./settings/ProvidersPanel", () => ({
   ProvidersPanel: () => <div data-testid="settings">settings</div>,
 }));
 
-vi.mock("./ChatApprovalHydration", () => ({
-  loadChatApprovalHydration: vi.fn(async () => ({
-    transcript: { messages: [], tool_activity: [], last_event_seq: 0 },
-    pendingApprovals: [],
-  })),
-}));
+vi.mock("./ChatApprovalHydration", async () => {
+  const actual = await vi.importActual<typeof import("./ChatApprovalHydration")>(
+    "./ChatApprovalHydration",
+  );
+  return {
+    ...actual,
+    loadChatApprovalHydration: vi.fn(async () => ({
+      transcript: {
+        messages: [],
+        tool_activity: [],
+        terminal_turns: [],
+        last_event_seq: 0,
+      },
+      pendingApprovals: [],
+    })),
+  };
+});
 
 // The resize library lays out from real element measurements, which jsdom does
 // not provide — left to itself it registers no panels and renders nothing. The

--- a/crates/openwave-desktop/ui/src/ChatApprovalHydration.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatApprovalHydration.test.ts
@@ -1,7 +1,18 @@
 import { describe, expect, it, vi } from "vitest";
-import { loadChatApprovalHydration } from "./ChatApprovalHydration";
+import {
+  loadChatApprovalHydration,
+  sessionFromOpenedChat,
+} from "./ChatApprovalHydration";
+import { initialChatSessionState } from "./ChatSessionReducer";
 
 const transcript = { messages: [], tool_activity: [], terminal_turns: [], last_event_seq: 7 };
+
+const USAGE = {
+  input_tokens: 12_000,
+  output_tokens: 800,
+  cache_read_input_tokens: 4_000,
+  cache_creation_input_tokens: 0,
+};
 
 describe("loadChatApprovalHydration", () => {
   it("loads pending approvals after the transcript cursor boundary", async () => {
@@ -37,5 +48,36 @@ describe("loadChatApprovalHydration", () => {
     current = false;
     release([]);
     await expect(loading).resolves.toBeNull();
+  });
+});
+
+describe("sessionFromOpenedChat", () => {
+  it("hydrates lastTurnUsage so a reopened chat meters without a new turn", () => {
+    const opened = sessionFromOpenedChat(
+      initialChatSessionState(),
+      {
+        messages: [],
+        tool_activity: [],
+        terminal_turns: [
+          {
+            turn_id: "turn-1",
+            message_id: "assistant-1",
+            status: "completed",
+            partial_content: "",
+            file_changes: [],
+            usage: USAGE,
+            voice_input_used: false,
+            finished_at: "2026-07-19T10:00:00Z",
+          },
+        ],
+        last_event_seq: 12,
+      },
+      [],
+    );
+
+    expect(opened.lastTurnUsage).toEqual(USAGE);
+    expect(opened.lastSeq).toBe(12);
+    expect(opened.busy).toBe(false);
+    expect(opened.activeTurnId).toBeNull();
   });
 });

--- a/crates/openwave-desktop/ui/src/ChatApprovalHydration.ts
+++ b/crates/openwave-desktop/ui/src/ChatApprovalHydration.ts
@@ -3,6 +3,12 @@ import type {
   ChatTranscript,
   PendingToolApproval,
 } from "./api";
+import { reconcilePendingApprovalCards } from "./ApprovalHistory";
+import {
+  applyTerminalHydration,
+  type ChatSessionState,
+} from "./ChatSessionReducer";
+import { presentChatTranscript } from "./ChatTranscriptPresentation";
 
 type ApprovalHydrationClient = Pick<
   ApiClient,
@@ -23,4 +29,29 @@ export async function loadChatApprovalHydration(
   const pendingApprovals = await client.listPendingApprovals(chatId);
   if (!isCurrent()) return null;
   return { transcript, pendingApprovals };
+}
+
+/**
+ * Fold a freshly opened chat's durable transcript into session state.
+ *
+ * Routes through {@link applyTerminalHydration} so the context meter sees the
+ * same `lastTurnUsage` path as a post-turn refresh — a reopened chat should
+ * meter without waiting for another turn to finish.
+ */
+export function sessionFromOpenedChat(
+  state: ChatSessionState,
+  transcript: ChatTranscript,
+  pendingApprovals: PendingToolApproval[],
+): ChatSessionState {
+  const presented = presentChatTranscript(transcript);
+  const pendingTurnId = pendingApprovals[0]?.turnId ?? null;
+  return {
+    ...applyTerminalHydration(state, presented),
+    messages: reconcilePendingApprovalCards(
+      presented.messages,
+      pendingApprovals,
+    ),
+    activeTurnId: pendingTurnId,
+    busy: pendingTurnId !== null,
+  };
 }

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -13,8 +13,10 @@ import { useApp } from "./AppContext";
 import { AssistantSourceMarkerStreamScrubber } from "./AssistantSourceMarkerStream";
 import { ChatHeaderTitle } from "./ChatHeaderTitle";
 import { ChatStatusChip } from "./ChatStatusChip";
-import { reconcilePendingApprovalCards } from "./ApprovalHistory";
-import { loadChatApprovalHydration } from "./ChatApprovalHydration";
+import {
+  loadChatApprovalHydration,
+  sessionFromOpenedChat,
+} from "./ChatApprovalHydration";
 import { useChatListStore } from "./ChatListStore";
 import {
   useComposerAttachments,
@@ -27,10 +29,7 @@ import {
   type ChatSessionState,
 } from "./ChatSessionReducer";
 import { useChatSessionStore } from "./ChatSessionStore";
-import {
-  loadCurrentTerminalTranscript,
-  presentChatTranscript,
-} from "./ChatTranscriptPresentation";
+import { loadCurrentTerminalTranscript } from "./ChatTranscriptPresentation";
 import { useFirstMessage } from "./FirstMessage";
 import { ChatView } from "./ChatView";
 import type { RetryableTurn } from "./MessageList";
@@ -55,8 +54,8 @@ import {
 } from "./ImageAttachments";
 import { useImageAttachments } from "./useImageAttachments";
 import { modelForSelection } from "./ModelSelection";
-import { ModelMenu } from "./ModelMenu";
 import { ContextUsageIndicator } from "./ContextUsageIndicator";
+import { ModelMenu } from "./ModelMenu";
 import { PermissionModeMenu } from "./PermissionModeMenu";
 import {
   PICKER_BUSY_MESSAGE,
@@ -205,16 +204,9 @@ export function ChatRoute({ chatId }: { chatId: string }) {
         );
         if (!hydration) return;
         const { transcript, pendingApprovals } = hydration;
-        const presented = presentChatTranscript(transcript);
-        const pendingTurnId = pendingApprovals[0]?.turnId ?? null;
-        updateSession((session) => ({
-          ...session,
-          lastSeq: transcript.last_event_seq,
-          hydratedMessageIds: presented.messageIds,
-          messages: reconcilePendingApprovalCards(presented.messages, pendingApprovals),
-          activeTurnId: pendingTurnId,
-          busy: pendingTurnId !== null,
-        }));
+        updateSession((session) =>
+          sessionFromOpenedChat(session, transcript, pendingApprovals),
+        );
         setHydrated(true);
       } catch (err) {
         if (cancelled) return;
@@ -633,9 +625,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   }
 
   function renderChat(visible: boolean) {
-    // The model selected right now: the reasoning levels it accepts, and the
-    // window the context meter reads against. Switching models mid-chat
-    // re-scales the meter immediately, which is the question being asked.
+    // The model selected right now: the reasoning levels it accepts.
     const activeModel = modelForSelection(models, chat!.model);
     // Only the levels the selected model accepts are offerable, and a model
     // that accepts none gets no selector at all.
@@ -704,13 +694,6 @@ export function ChatRoute({ chatId }: { chatId: string }) {
             onRemove: images.remove,
             onRetry: images.retry,
           }}
-          composerContextMeter={
-            <ContextUsageIndicator
-              usage={lastTurnUsage}
-              contextWindow={activeModel?.context_window}
-              modelName={activeModel?.display_name}
-            />
-          }
           composerModelMenu={
             <ModelMenu
               models={models}
@@ -818,19 +801,30 @@ export function ChatRoute({ chatId }: { chatId: string }) {
     }
   }
 
+  // Header chrome reads the active model's window so the meter stays honest
+  // when the selection changes, without living in the composer.
+  const headerModel = modelForSelection(models, chat.model);
+
   return (
     <RouteFrame sidebar={<AppSidebar chat={chat} />}>
     <div className="mr-2 flex min-h-0 min-w-0 flex-1 flex-col">
       <header className="mt-2 flex h-9 w-full shrink-0 items-center justify-between gap-2 pl-4 pr-1">
         <ChatHeaderTitle chat={chat} />
-        <ChatStatusChip
-          outputCount={deliverables.length}
-          folders={folders.items}
-          runs={chatAgentRuns}
-          onOpenOutputs={() => openPanel({ type: "outputs" })}
-          onOpenFolders={() => openPanel({ type: "folders" })}
-          onOpenAgents={() => openPanel({ type: "agents" })}
-        />
+        <div className="flex shrink-0 items-center gap-2">
+          <ContextUsageIndicator
+            usage={lastTurnUsage}
+            contextWindow={headerModel?.context_window}
+            modelName={headerModel?.display_name}
+          />
+          <ChatStatusChip
+            outputCount={deliverables.length}
+            folders={folders.items}
+            runs={chatAgentRuns}
+            onOpenOutputs={() => openPanel({ type: "outputs" })}
+            onOpenFolders={() => openPanel({ type: "folders" })}
+            onOpenAgents={() => openPanel({ type: "agents" })}
+          />
+        </div>
       </header>
       <PinnedOutputsStrip
         chatId={chatId}

--- a/crates/openwave-desktop/ui/src/ChatStatusChip.tsx
+++ b/crates/openwave-desktop/ui/src/ChatStatusChip.tsx
@@ -46,9 +46,10 @@ export type ChatStatusChipProps = {
  * work first, what it has produced otherwise.
  *
  * Behind it, the places that describe only this conversation — its outputs,
- * its folders, its background agents. The composer owns the chat's settings
- * (model, mode, effort), so none of them appear here: this chip is the
- * conversation's activity, not a second copy of its controls.
+ * its folders, its background agents. The context meter sits beside this chip
+ * in the header; the composer still owns the chat's settings (model, mode,
+ * effort). This chip is the conversation's activity, not a second copy of
+ * those controls.
  */
 export function ChatStatusChip({
   outputCount,

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -54,7 +54,6 @@ export type ChatViewProps = {
   /** The composer draft, readable synchronously — see [useTurnControls]. */
   draftRef: RefObject<string>;
   composerModelMenu: ReactNode;
-  composerContextMeter?: ReactNode;
   composerPermissionMenu: ReactNode;
   composerNetwork?: ComposerNetwork;
   composerReasoning?: ComposerReasoning;
@@ -93,7 +92,6 @@ export function ChatView({
   deletingChat,
   draftRef,
   composerModelMenu,
-  composerContextMeter,
   composerPermissionMenu,
   composerNetwork,
   composerReasoning,
@@ -448,7 +446,6 @@ export function ChatView({
           disabled={deletingChat}
           draft={draft}
           modelMenu={composerModelMenu}
-          contextMeter={composerContextMeter}
           permissionMenu={composerPermissionMenu}
           network={composerNetwork}
           reasoning={composerReasoning}

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -252,8 +252,6 @@ export type ComposerProps = {
   disabled: boolean;
   draft: string;
   modelMenu?: ReactNode;
-  /** Context-window meter, rendered beside the model menu. */
-  contextMeter?: ReactNode;
   permissionMenu?: ReactNode;
   network?: ComposerNetwork;
   reasoning?: ComposerReasoning;
@@ -283,7 +281,6 @@ export function Composer({
   disabled,
   draft,
   modelMenu,
-  contextMeter,
   permissionMenu,
   network,
   reasoning,
@@ -888,7 +885,6 @@ export function Composer({
             }
           />
           {modelMenu}
-          {contextMeter}
         </div>
         <div className="flex items-center gap-2">
           {/* The permission mode sits with the send cluster: it is what the

--- a/crates/openwave-desktop/ui/src/ContextUsageIndicator.tsx
+++ b/crates/openwave-desktop/ui/src/ContextUsageIndicator.tsx
@@ -18,6 +18,9 @@ import { cn } from "./lib/utils";
  * The denominator is the *currently selected* model, not the one that ran the
  * turn. Switching models mid-chat is a question about what will fit next, so
  * the reading moves the moment the selection does.
+ *
+ * Lives in the chat header beside the activity chip so the reading stays on
+ * screen for the whole conversation, not only while the composer is in view.
  */
 export function ContextUsageIndicator({
   usage,
@@ -62,14 +65,14 @@ export function ContextUsageIndicator({
     >
       <span
         className={cn(
-          "flex h-8 shrink-0 items-center gap-1.5 rounded-md px-2 text-xs tabular-nums",
+          "flex h-7 shrink-0 items-center gap-1.5 rounded-full border px-2.5 text-xs font-medium tabular-nums",
           level === "critical"
-            ? "text-destructive"
+            ? "border-destructive/40 bg-destructive/10 text-destructive"
             : level === "warning"
-              ? "text-warning-foreground"
-              : "text-muted-foreground",
+              ? "border-warning-border bg-warning-background text-warning-foreground"
+              : "border-border bg-muted text-foreground",
         )}
-        // The visible pill is a magnitude; the accessible name is the sentence
+        // The visible chip is a magnitude; the accessible name is the sentence
         // a screen reader needs, since "34%" alone says nothing about of what.
         // A graphic with a text alternative rather than a live region: this
         // updates on every turn, and it is reference material, not an
@@ -78,16 +81,17 @@ export function ContextUsageIndicator({
         aria-label={`Context: ${percent}% of ${formatTokenCount(contextWindow)} tokens used`}
       >
         <ContextUsageRing percent={percent} />
-        {percent}%
+        <span>{percent}%</span>
+        <span className="font-normal opacity-70">{formatTokenCount(used)}</span>
       </span>
     </WithTooltip>
   );
 }
 
 /**
- * A small filled ring, drawn as a conic sweep over a muted track.
+ * A filled ring, drawn as a conic sweep over a muted track.
  *
- * Takes its colour from the pill via `currentColor`, so the threshold styling
+ * Takes its colour from the chip via `currentColor`, so the threshold styling
  * lives in exactly one place.
  */
 function ContextUsageRing({ percent }: { percent: number }) {
@@ -95,9 +99,9 @@ function ContextUsageRing({ percent }: { percent: number }) {
   return (
     <span
       aria-hidden="true"
-      className="size-3 shrink-0 rounded-full"
+      className="size-3.5 shrink-0 rounded-full"
       style={{
-        background: `conic-gradient(currentColor 0deg ${filled}, color-mix(in oklch, currentColor 20%, transparent) ${filled} 360deg)`,
+        background: `conic-gradient(currentColor 0deg ${filled}, color-mix(in oklch, currentColor 22%, transparent) ${filled} 360deg)`,
       }}
     />
   );


### PR DESCRIPTION
## Summary
- Fix chat open hydration so `lastTurnUsage` from durable `terminal_turns` is applied via `sessionFromOpenedChat` / `applyTerminalHydration` — reopened chats show the context meter without waiting for another turn.
- Move the meter from the composer into the chat header beside the activity/outputs chip, with a clearer pill (percent + abbreviated used count, warning/critical tints).

## Test plan
- [ ] Open a chat that has finished at least one turn; confirm the header meter appears with a non-zero reading.
- [ ] Switch away and back to that chat (or reload); confirm the meter is still present without running a new turn.
- [ ] Switch models with different context windows; confirm the percent re-scales against the selected model.
- [ ] Confirm the meter is gone from the composer toolbar.
- [ ] `pnpm exec vitest run src/ChatApprovalHydration.test.ts src/AppShell.dom.test.tsx` in `crates/openwave-desktop/ui`.


Made with [Cursor](https://cursor.com)