### PR TITLE
fix(server): answer unusable sandbox tool calls instead of failing the attempt

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -37,8 +37,8 @@ use crate::model::{
     Chat, DocumentListCursor, DocumentRecord, DocumentScope, DocumentSourceBlob,
     DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message, MessageAttachment,
     MessageDocumentAttachment, NetworkPolicy, OwnerId, PermissionMode, Project, ReasoningEffort,
-    RootAttachmentChange, RootAttachmentChangeTerminal, SandboxToolCall, SandboxToolCallReceipt,
-    SandboxToolCallRequest, ToolCallRecord, ToolCallResolution, TurnCheckpointProgress,
+    RootAttachmentChange, RootAttachmentChangeTerminal, SandboxToolCall, SandboxToolCallParkEntry,
+    SandboxToolCallReceipt, ToolCallRecord, ToolCallResolution, TurnCheckpointProgress,
     TurnFailureRetry, TurnRun, MAX_ROOT_ATTACHMENTS,
 };
 #[cfg(test)]
@@ -1139,13 +1139,13 @@ impl Store for DbStore {
         &self,
         agent_run_id: AgentRunId,
         lease_token: uuid::Uuid,
-        call: &SandboxToolCallRequest,
+        entry: &SandboxToolCallParkEntry,
     ) -> Result<ParkSandboxToolCallOutcome> {
         ops::sandbox_tool::park_agent_run_for_sandbox_tool_call(
             self,
             agent_run_id,
             lease_token,
-            call,
+            entry,
         )
         .await
     }

--- a/crates/openwave-core/src/db/ops/sandbox_tool.rs
+++ b/crates/openwave-core/src/db/ops/sandbox_tool.rs
@@ -12,8 +12,9 @@ use crate::agent_tools::{
 use crate::error::{AgentError, Result};
 use crate::id::{AgentRunId, CallId, ChatId, HostRootId};
 use crate::model::{
-    AgentRunStatus, AgentRunTier, DelegatedFileReadClaim, SandboxToolCall, SandboxToolCallReceipt,
-    SandboxToolCallRequest, SandboxToolCallStatus, ToolCallRecord, ToolCallResolution,
+    AgentRunStatus, AgentRunTier, DelegatedFileReadClaim, SandboxToolCall,
+    SandboxToolCallParkEntry, SandboxToolCallReceipt, SandboxToolCallRequest,
+    SandboxToolCallStatus, ToolCallRecord, ToolCallResolution,
 };
 use crate::storage::{
     ClaimDelegatedFileReadOutcome, ClaimSandboxToolCallOutcome, ParkSandboxToolCallOutcome,
@@ -30,25 +31,39 @@ pub(in crate::db) async fn park_agent_run_for_sandbox_tool_call(
     store: &DbStore,
     agent_run_id: AgentRunId,
     lease_token: uuid::Uuid,
-    call: &SandboxToolCallRequest,
+    entry: &SandboxToolCallParkEntry,
 ) -> Result<ParkSandboxToolCallOutcome> {
+    let SandboxToolCallParkEntry { call, resolution } = entry;
+    // A synthetic entry carries the model's own arguments verbatim so the
+    // replayed transcript shows what it actually sent. Only the identity
+    // fields are checked for it; the per-tool argument rules exist to keep an
+    // executor lane from inheriting work it can only fail on, and no lane will
+    // ever see this row.
+    let dispatchable = resolution.is_none();
     if lease_token.is_nil()
         || !call.is_well_formed()
         || call.agent_run_id != agent_run_id
-        || (call.name == SANDBOX_READ_DELEGATED_FILE_TOOL
+        || (dispatchable
+            && call.name == SANDBOX_READ_DELEGATED_FILE_TOOL
             && !validate_sandbox_read_delegated_file_arguments(&call.arguments))
         // Exec arguments are checked here as well as in the executor: the
         // checkpoint is immutable once parked, so an out-of-bounds command must
         // never become a durable row the lane can only fail on.
-        || (call.name == SANDBOX_EXEC_TOOL && !validate_sandbox_exec_arguments(&call.arguments))
+        || (dispatchable
+            && call.name == SANDBOX_EXEC_TOOL
+            && !validate_sandbox_exec_arguments(&call.arguments))
     {
         return Err(AgentError::Store(
             "invalid sandbox tool checkpoint request".into(),
         ));
     }
+    if let Some(resolution) = resolution {
+        validate_resolution(resolution)?;
+    }
     let transaction = store.conn.begin().await.map_err(store_err)?;
     acquire_agent_run_claim_lock(&transaction).await?;
-    if call.name == SANDBOX_READ_DELEGATED_FILE_TOOL
+    if dispatchable
+        && call.name == SANDBOX_READ_DELEGATED_FILE_TOOL
         && !acquire_chat_write_lock(&transaction, call.chat_id).await?
     {
         transaction.commit().await.map_err(store_err)?;
@@ -61,7 +76,17 @@ pub(in crate::db) async fn park_agent_run_for_sandbox_tool_call(
         .await
         .map_err(store_err)?
     {
-        let exact = request_matches(&existing, call) && existing.park_lease_token == lease_token;
+        let receipt = entities::sandbox_tool_call_receipt::Entity::find_by_id(call.id.0)
+            .one(&transaction)
+            .await
+            .map_err(store_err)?;
+        // A synthetic park commits its row and its receipt together, so a
+        // recovered commit is only this exact park when both are present.
+        let exact = request_matches(&existing, call)
+            && existing.park_lease_token == lease_token
+            && resolution.as_ref().is_none_or(|resolution| {
+                receipt.is_some_and(|row| receipt_matches(&row, resolution))
+            });
         let run = find_by_id_on(&transaction, agent_run_id).await?;
         transaction.commit().await.map_err(store_err)?;
         return if exact {
@@ -81,7 +106,8 @@ pub(in crate::db) async fn park_agent_run_for_sandbox_tool_call(
         transaction.commit().await.map_err(store_err)?;
         return Ok(ParkSandboxToolCallOutcome::LeaseLost);
     };
-    if call.name == SANDBOX_READ_DELEGATED_FILE_TOOL
+    if dispatchable
+        && call.name == SANDBOX_READ_DELEGATED_FILE_TOOL
         && delegated_file_resource_on(&transaction, agent_run_id, call.chat_id)
             .await?
             .is_none()
@@ -118,6 +144,11 @@ pub(in crate::db) async fn park_agent_run_for_sandbox_tool_call(
         transaction.commit().await.map_err(store_err)?;
         return Ok(ParkSandboxToolCallOutcome::IdentityConflict);
     }
+    let status = resolution
+        .as_ref()
+        .map_or(SandboxToolCallStatus::Accepted, |resolution| {
+            resolution_status(resolution)
+        });
     entities::sandbox_tool_call::ActiveModel {
         id: Set(call.id.0),
         agent_run_id: Set(agent_run_id.0),
@@ -126,7 +157,7 @@ pub(in crate::db) async fn park_agent_run_for_sandbox_tool_call(
         provider_id: Set(call.provider_id.clone()),
         name: Set(call.name.clone()),
         arguments: Set(call.arguments.clone()),
-        status: Set(SandboxToolCallStatus::Accepted.as_str().into()),
+        status: Set(status.as_str().into()),
         park_lease_token: Set(lease_token),
         park_attempt_count: Set(run.attempt_count),
         park_claim_count: Set(run.claim_count),
@@ -134,16 +165,60 @@ pub(in crate::db) async fn park_agent_run_for_sandbox_tool_call(
         executor_lease_expires_at: Set(None),
         retry_at: Set(None),
         created_at: Set(now),
-        resolved_at: Set(None),
+        resolved_at: Set(resolution.as_ref().map(|_| now)),
     }
     .insert(&transaction)
     .await
     .map_err(store_err)?;
-    let updated = entities::agent_run::Entity::update_many()
-        .col_expr(
+    if let Some(resolution) = resolution {
+        let (error_code, error_detail) = resolution_error(resolution);
+        entities::sandbox_tool_call_receipt::ActiveModel {
+            call_id: Set(call.id.0),
+            // No executor ever held this call, so its own park lease stands in
+            // as the producing authority — the convention terminalization on
+            // the host side already uses.
+            executor_lease_token: Set(lease_token),
+            status: Set(status.as_str().into()),
+            result: Set(resolution.result().to_owned()),
+            error_code: Set(error_code),
+            error_detail: Set(error_detail),
+            resolved_at: Set(now),
+        }
+        .insert(&transaction)
+        .await
+        .map_err(store_err)?;
+    }
+    let mut update = entities::agent_run::Entity::update_many();
+    if resolution.is_some() {
+        // Nothing will resolve this row later, so parking it into `waiting`
+        // would strand the run there forever. It goes straight back on the
+        // schedule to consume the receipt it just committed.
+        update = update
+            .col_expr(
+                entities::agent_run::Column::Status,
+                sea_orm::sea_query::Expr::value(AgentRunStatus::RetryWait.as_str()),
+            )
+            .col_expr(
+                entities::agent_run::Column::LastErrorCode,
+                sea_orm::sea_query::Expr::value(Some("tool_checkpoint_resolved".to_owned())),
+            )
+            .col_expr(
+                entities::agent_run::Column::LastErrorDetail,
+                sea_orm::sea_query::Expr::value(Some(
+                    "sandbox tool result receipt committed".to_owned(),
+                )),
+            )
+            .col_expr(
+                entities::agent_run::Column::AvailableAt,
+                sea_orm::sea_query::Expr::value(now),
+            );
+    } else {
+        update = update.col_expr(
             entities::agent_run::Column::Status,
             sea_orm::sea_query::Expr::value(AgentRunStatus::Waiting.as_str()),
-        )
+        );
+    }
+    let updated = update
         .col_expr(
             entities::agent_run::Column::LeaseToken,
             sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -71,6 +71,14 @@ async fn temp_store() -> (tempfile::TempDir, DbStore) {
     (dir, store)
 }
 
+/// A checkpoint the host expects an executor lane to run.
+fn dispatchable(call: &crate::model::SandboxToolCallRequest) -> SandboxToolCallParkEntry {
+    SandboxToolCallParkEntry {
+        call: call.clone(),
+        resolution: None,
+    }
+}
+
 #[tokio::test]
 async fn bundled_sqlite_supports_fts5() {
     let (_dir, store) = temp_store().await;

--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -2102,14 +2102,22 @@ async fn sandbox_tool_checkpoint_is_lease_fenced_and_receipt_idempotent() {
     };
     assert!(matches!(
         store
-            .park_agent_run_for_sandbox_tool_call(sandbox.id, worker_lease, &request)
+            .park_agent_run_for_sandbox_tool_call(
+                sandbox.id,
+                worker_lease,
+                &super::dispatchable(&request)
+            )
             .await
             .unwrap(),
         ParkSandboxToolCallOutcome::Parked { .. }
     ));
     assert!(matches!(
         store
-            .park_agent_run_for_sandbox_tool_call(sandbox.id, worker_lease, &request)
+            .park_agent_run_for_sandbox_tool_call(
+                sandbox.id,
+                worker_lease,
+                &super::dispatchable(&request)
+            )
             .await
             .unwrap(),
         ParkSandboxToolCallOutcome::Existing { .. }
@@ -2220,7 +2228,11 @@ async fn a_sandbox_run_may_checkpoint_repeatedly_up_to_a_bounded_chain() {
         assert!(
             matches!(
                 store
-                    .park_agent_run_for_sandbox_tool_call(sandbox.id, worker_lease, &request)
+                    .park_agent_run_for_sandbox_tool_call(
+                        sandbox.id,
+                        worker_lease,
+                        &super::dispatchable(&request)
+                    )
                     .await
                     .unwrap(),
                 ParkSandboxToolCallOutcome::Parked { .. }
@@ -2260,7 +2272,11 @@ async fn a_sandbox_run_may_checkpoint_repeatedly_up_to_a_bounded_chain() {
     };
     assert!(matches!(
         store
-            .park_agent_run_for_sandbox_tool_call(sandbox.id, worker_lease, &over_budget)
+            .park_agent_run_for_sandbox_tool_call(
+                sandbox.id,
+                worker_lease,
+                &super::dispatchable(&over_budget)
+            )
             .await
             .unwrap(),
         ParkSandboxToolCallOutcome::IdentityConflict
@@ -2295,7 +2311,11 @@ async fn cancelling_waiting_sandbox_fences_claimed_tool_work() {
         arguments: serde_json::json!({"query": "cancel"}),
     };
     store
-        .park_agent_run_for_sandbox_tool_call(sandbox.id, worker_lease, &request)
+        .park_agent_run_for_sandbox_tool_call(
+            sandbox.id,
+            worker_lease,
+            &super::dispatchable(&request),
+        )
         .await
         .unwrap();
     let executor_lease = uuid::Uuid::new_v4();
@@ -2355,7 +2375,11 @@ async fn expired_sandbox_tool_claim_is_recoverable_and_fences_stale_executor() {
         arguments: serde_json::json!({"query": "expiry"}),
     };
     store
-        .park_agent_run_for_sandbox_tool_call(sandbox.id, worker_lease, &request)
+        .park_agent_run_for_sandbox_tool_call(
+            sandbox.id,
+            worker_lease,
+            &super::dispatchable(&request),
+        )
         .await
         .unwrap();
     let stale_executor = uuid::Uuid::new_v4();
@@ -2440,7 +2464,11 @@ async fn waiting_sandbox_deadline_fences_tool_and_delivers_parent_failure() {
         arguments: serde_json::json!({"query": "deadline"}),
     };
     store
-        .park_agent_run_for_sandbox_tool_call(sandbox.id, worker_lease, &request)
+        .park_agent_run_for_sandbox_tool_call(
+            sandbox.id,
+            worker_lease,
+            &super::dispatchable(&request),
+        )
         .await
         .unwrap();
     force_expired_agent_deadline(&store, sandbox.id).await;
@@ -2558,4 +2586,71 @@ async fn active_work_counts_gate_host_quiescence() {
     settled_run.update(&store.conn).await.unwrap();
 
     assert!(store.count_active_work().await.unwrap().is_quiescent());
+}
+
+/// A call the host answered itself never reaches an executor, so it has to
+/// land terminal with its receipt and put the run straight back on the
+/// schedule — parking it as live work would strand the run in `waiting`.
+#[tokio::test]
+async fn a_pre_resolved_sandbox_park_lands_terminal_and_reschedules_the_run() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let sandbox = accepted_sandbox_for_tool_test(&store, chat.id).await;
+    let worker_lease = uuid::Uuid::new_v4();
+    store
+        .claim_agent_run(worker_lease, Duration::minutes(5), 1, 1)
+        .await
+        .unwrap();
+    let entry = crate::SandboxToolCallParkEntry {
+        call: SandboxToolCallRequest {
+            id: CallId::new(),
+            agent_run_id: sandbox.id,
+            chat_id: chat.id,
+            provider_id: "provider-call-refused".into(),
+            // The model's own emitted name, not one this host dispatches.
+            name: "read_file".into(),
+            arguments: serde_json::json!({"path": "notes.md"}),
+        },
+        resolution: Some(ToolCallResolution::Failed {
+            result: "read_file is not available to a background task.".into(),
+            error_code: "unavailable_tool".into(),
+            error_detail: None,
+        }),
+    };
+    let call_id = entry.call.id;
+    let ParkSandboxToolCallOutcome::Parked { run, call } = store
+        .park_agent_run_for_sandbox_tool_call(sandbox.id, worker_lease, &entry)
+        .await
+        .unwrap()
+    else {
+        panic!("a pre-resolved entry must park");
+    };
+    assert_eq!(run.status, AgentRunStatus::RetryWait);
+    assert_eq!(
+        run.last_error_code.as_deref(),
+        Some("tool_checkpoint_resolved")
+    );
+    assert!(call.status.is_terminal());
+    assert!(call.resolved_at.is_some());
+    let receipt = store
+        .get_sandbox_tool_call_receipt(call_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(receipt.error_code.as_deref(), Some("unavailable_tool"));
+    // No lane may claim work the host already answered.
+    assert!(store
+        .list_sandbox_tool_call_candidates(8)
+        .await
+        .unwrap()
+        .is_empty());
+    // The same commit replayed recovers the identical checkpoint.
+    assert!(matches!(
+        store
+            .park_agent_run_for_sandbox_tool_call(sandbox.id, worker_lease, &entry)
+            .await
+            .unwrap(),
+        ParkSandboxToolCallOutcome::Existing { .. }
+    ));
 }

--- a/crates/openwave-core/src/db/tests/delegated_file_read.rs
+++ b/crates/openwave-core/src/db/tests/delegated_file_read.rs
@@ -161,7 +161,11 @@ async fn delegated_read_requires_exact_admission_and_empty_arguments() {
     let request = read_request(&run, CallId::new());
     assert_eq!(
         store
-            .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &request)
+            .park_agent_run_for_sandbox_tool_call(
+                run.id,
+                worker_lease,
+                &super::dispatchable(&request)
+            )
             .await
             .unwrap(),
         ParkSandboxToolCallOutcome::DelegatedResourceUnavailable
@@ -181,7 +185,7 @@ async fn delegated_read_requires_exact_admission_and_empty_arguments() {
     };
     assert!(matches!(
         store
-            .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &web)
+            .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &super::dispatchable(&web))
             .await
             .unwrap(),
         ParkSandboxToolCallOutcome::Parked { .. }
@@ -203,7 +207,11 @@ async fn delegated_read_requires_exact_admission_and_empty_arguments() {
         let mut malformed = read_request(&run, CallId::new());
         malformed.arguments = arguments;
         assert!(second_store
-            .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &malformed)
+            .park_agent_run_for_sandbox_tool_call(
+                run.id,
+                worker_lease,
+                &super::dispatchable(&malformed)
+            )
             .await
             .is_err());
     }
@@ -226,7 +234,7 @@ async fn delegated_read_requires_exact_admission_and_empty_arguments() {
             .park_agent_run_for_sandbox_tool_call(
                 corrupt_run.id,
                 corrupt_lease,
-                &read_request(&corrupt_run, CallId::new()),
+                &super::dispatchable(&read_request(&corrupt_run, CallId::new())),
             )
             .await
             .unwrap(),
@@ -241,14 +249,22 @@ async fn delegated_read_checkpoint_and_claim_are_exact_and_lane_isolated() {
     let request = read_request(&run, CallId::new());
     assert!(matches!(
         store
-            .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &request)
+            .park_agent_run_for_sandbox_tool_call(
+                run.id,
+                worker_lease,
+                &super::dispatchable(&request)
+            )
             .await
             .unwrap(),
         ParkSandboxToolCallOutcome::Parked { .. }
     ));
     assert!(matches!(
         store
-            .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &request)
+            .park_agent_run_for_sandbox_tool_call(
+                run.id,
+                worker_lease,
+                &super::dispatchable(&request)
+            )
             .await
             .unwrap(),
         ParkSandboxToolCallOutcome::Existing { .. }
@@ -336,7 +352,11 @@ async fn delegated_read_checkpoint_and_claim_are_exact_and_lane_isolated() {
     assert!(
         matches!(
             store
-                .park_agent_run_for_sandbox_tool_call(run.id, next_worker_lease, &second)
+                .park_agent_run_for_sandbox_tool_call(
+                    run.id,
+                    next_worker_lease,
+                    &super::dispatchable(&second)
+                )
                 .await
                 .unwrap(),
             ParkSandboxToolCallOutcome::Parked { .. }
@@ -360,7 +380,7 @@ async fn detach_before_claim_terminalizes_without_exposing_authority() {
     let (chat, run, worker_lease, resource) = delegated_sandbox(&store).await;
     let request = read_request(&run, CallId::new());
     store
-        .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &request)
+        .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &super::dispatchable(&request))
         .await
         .unwrap();
     detach_root(&store, &chat, resource.root_id).await;
@@ -403,7 +423,7 @@ async fn concurrent_detach_and_claim_require_a_final_revocation_heartbeat() {
     let (chat, run, worker_lease, resource) = delegated_sandbox(&store).await;
     let request = read_request(&run, CallId::new());
     store
-        .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &request)
+        .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &super::dispatchable(&request))
         .await
         .unwrap();
 
@@ -461,7 +481,7 @@ async fn detach_after_claim_rejects_content_at_the_atomic_resolution_fence() {
     let (chat, run, worker_lease, resource) = delegated_sandbox(&store).await;
     let request = read_request(&run, CallId::new());
     store
-        .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &request)
+        .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &super::dispatchable(&request))
         .await
         .unwrap();
     let lease = uuid::Uuid::new_v4();
@@ -513,7 +533,7 @@ async fn exact_terminal_retry_survives_a_later_attachment_revocation() {
     let (chat, run, worker_lease, resource) = delegated_sandbox(&store).await;
     let request = read_request(&run, CallId::new());
     store
-        .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &request)
+        .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &super::dispatchable(&request))
         .await
         .unwrap();
     let lease = uuid::Uuid::new_v4();
@@ -547,7 +567,7 @@ async fn wrong_and_expired_delegated_read_leases_cannot_heartbeat_or_resolve() {
     let (_chat, run, worker_lease, _resource) = delegated_sandbox(&store).await;
     let request = read_request(&run, CallId::new());
     store
-        .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &request)
+        .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &super::dispatchable(&request))
         .await
         .unwrap();
     let lease = uuid::Uuid::new_v4();
@@ -616,7 +636,7 @@ async fn cancelling_a_delegated_read_fences_native_execution_without_leaking_aut
     let (_chat, run, worker_lease, resource) = delegated_sandbox(&store).await;
     let request = read_request(&run, CallId::new());
     store
-        .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &request)
+        .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &super::dispatchable(&request))
         .await
         .unwrap();
     let lease = uuid::Uuid::new_v4();

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -177,13 +177,13 @@ pub use model::{
     Role, RootAttachmentChange, RootAttachmentChangeAction, RootAttachmentChangeFailure,
     RootAttachmentChangePhase, RootAttachmentChangeTerminal, RootAttachmentOrigin,
     RootAttachmentSubjectKind, SandboxAgentAdmission, SandboxSpawnCheckpoint,
-    SandboxSpawnCheckpointRequest, SandboxToolCall, SandboxToolCallReceipt, SandboxToolCallRequest,
-    SandboxToolCallStatus, SourceReadiness, ToolCallExecution, ToolCallRecord, ToolCallResolution,
-    ToolCallStatus, TurnAgentRunWaitSet, TurnAgentRunWaitStatus, TurnCheckpointProgress,
-    TurnClientWait, TurnClientWaitStatus, TurnFailureReceipt, TurnFailureRetry, TurnRun,
-    TurnRunStatus, TurnSteer, TurnSteerStatus, EXEC_SNAPSHOT_RETAINED_TURNS,
-    MAX_ATTACHMENT_REVISION, MAX_EXEC_SNAPSHOT_BYTES, MAX_EXEC_WORKSPACE_FILE_BYTES,
-    MAX_MESSAGE_ATTACHMENTS, MAX_ROOT_ATTACHMENTS,
+    SandboxSpawnCheckpointRequest, SandboxToolCall, SandboxToolCallParkEntry,
+    SandboxToolCallReceipt, SandboxToolCallRequest, SandboxToolCallStatus, SourceReadiness,
+    ToolCallExecution, ToolCallRecord, ToolCallResolution, ToolCallStatus, TurnAgentRunWaitSet,
+    TurnAgentRunWaitStatus, TurnCheckpointProgress, TurnClientWait, TurnClientWaitStatus,
+    TurnFailureReceipt, TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteer, TurnSteerStatus,
+    EXEC_SNAPSHOT_RETAINED_TURNS, MAX_ATTACHMENT_REVISION, MAX_EXEC_SNAPSHOT_BYTES,
+    MAX_EXEC_WORKSPACE_FILE_BYTES, MAX_MESSAGE_ATTACHMENTS, MAX_ROOT_ATTACHMENTS,
 };
 #[cfg(feature = "tools")]
 pub use output_scan::{

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1821,6 +1821,17 @@ impl SandboxToolCallRequest {
     }
 }
 
+/// One entry in a sandbox checkpoint park.
+///
+/// `resolution: Some(_)` inserts the row already terminal together with its
+/// receipt in the same transaction: the host answered the call itself and no
+/// executor lane will ever see it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SandboxToolCallParkEntry {
+    pub call: SandboxToolCallRequest,
+    pub resolution: Option<ToolCallResolution>,
+}
+
 /// Durable lifecycle of sandbox-owned tool work.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -2304,11 +2304,15 @@ pub trait Store: Send + Sync {
     /// Atomically accept canonical sandbox tool arguments, record the exact
     /// originating sandbox lease, and release that lease into `waiting`.
     /// Exact retries recover the checkpoint after the call resolves.
+    ///
+    /// An entry carrying a resolution lands terminal with its receipt in the
+    /// same transaction and releases the lease into `retry_wait` instead: the
+    /// host already answered the call and no executor lane will see it.
     async fn park_agent_run_for_sandbox_tool_call(
         &self,
         _agent_run_id: AgentRunId,
         _lease_token: uuid::Uuid,
-        _call: &crate::model::SandboxToolCallRequest,
+        _entry: &crate::model::SandboxToolCallParkEntry,
     ) -> Result<ParkSandboxToolCallOutcome> {
         agent_run_storage_unavailable()
     }

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -26,9 +26,10 @@ use openwave_core::{
     AgentError, AgentRun, AgentRunStatus, AgentRunSubmittedOutput, CallId, ChatMessage,
     ChatRequest, ContentBlock, FailAgentRunOutcome, MessageReasoning, ModelProvider,
     ParkSandboxToolCallOutcome, ProviderEvent, RequestFolderAccessArgs, Result,
-    ResumeTurnForAgentRunWaitSetOutcome, Role, SandboxToolCall, SandboxToolCallRequest,
-    SandboxToolCallStatus, SecretProvider, StopReason, Store, SubmitAgentRunResultOutcome,
-    ToolCallRecord, TurnWebSearch, MAX_SANDBOX_TOOL_CALLS, SANDBOX_EXEC_TOOL,
+    ResumeTurnForAgentRunWaitSetOutcome, Role, SandboxToolCall, SandboxToolCallParkEntry,
+    SandboxToolCallRequest, SandboxToolCallStatus, SecretProvider, StopReason, Store,
+    SubmitAgentRunResultOutcome, ToolCallRecord, ToolCallResolution, TurnWebSearch,
+    MAX_SANDBOX_TOOL_CALLS, SANDBOX_EXEC_TOOL,
 };
 use tokio::sync::Notify;
 
@@ -590,35 +591,9 @@ impl SandboxAgentRunWorker {
         let depth = previous_calls.len();
         let outcome = match completion {
             SandboxCompletion::Final(text) => self.submit_result(&run, lease_token, text).await,
-            SandboxCompletion::WebSearch {
-                provider_id,
-                arguments,
-            } => {
-                self.park_sandbox_tool_call(
-                    run,
-                    lease_token,
-                    provider_id,
-                    openwave_core::SANDBOX_WEB_SEARCH_TOOL,
-                    arguments,
-                    &narration,
-                    "sandbox web-search checkpoint identity conflict",
-                )
-                .await
-            }
-            SandboxCompletion::Exec {
-                provider_id,
-                arguments,
-            } => {
-                self.park_sandbox_tool_call(
-                    run,
-                    lease_token,
-                    provider_id,
-                    SANDBOX_EXEC_TOOL,
-                    arguments,
-                    &narration,
-                    "sandbox exec checkpoint identity conflict",
-                )
-                .await
+            SandboxCompletion::ToolCall(intent) => {
+                self.park_sandbox_tool_call(run, lease_token, intent, &narration)
+                    .await
             }
             SandboxCompletion::Done { outputs, summary } => {
                 self.submit_submission(&run, lease_token, &outputs, &summary)
@@ -627,21 +602,6 @@ impl SandboxAgentRunWorker {
             SandboxCompletion::FolderAccessProposal { request } => {
                 self.submit_folder_access_proposal(run.id, lease_token, request)
                     .await
-            }
-            SandboxCompletion::DelegatedFileRead {
-                provider_id,
-                arguments,
-            } => {
-                self.park_sandbox_tool_call(
-                    run,
-                    lease_token,
-                    provider_id,
-                    openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL,
-                    arguments,
-                    &narration,
-                    "sandbox delegated-file checkpoint identity conflict",
-                )
-                .await
             }
         };
         // Published after the step's own durable transition has committed, for
@@ -902,31 +862,48 @@ impl SandboxAgentRunWorker {
     /// Park one tool call as a durable checkpoint and release the run's lease.
     ///
     /// Every sandbox tool that needs an executor parks the same way — only the
-    /// tool name and the conflict message differ — so they share this body
-    /// rather than each carrying its own copy of the crash-recovery reasoning
-    /// below.
-    #[allow(clippy::too_many_arguments)]
+    /// tool name differs — so they share this body rather than each carrying
+    /// its own copy of the crash-recovery reasoning below. A call the host
+    /// refused parks the same way with its answer already attached, so the
+    /// next step of the run reads it as an ordinary error result.
     async fn park_sandbox_tool_call(
         &self,
         run: AgentRun,
         lease_token: uuid::Uuid,
-        provider_id: String,
-        name: &str,
-        arguments: serde_json::Value,
+        intent: SandboxToolCallIntent,
         narration: &str,
-        conflict_message: &str,
     ) -> Result<SandboxAgentRunWorkerOutcome> {
-        let call = SandboxToolCallRequest {
-            id: CallId::new(),
-            agent_run_id: run.id,
-            chat_id: run.chat_id,
+        let SandboxToolCallIntent {
             provider_id,
-            name: name.into(),
+            name,
             arguments,
+            disposition,
+        } = intent;
+        let entry = SandboxToolCallParkEntry {
+            call: SandboxToolCallRequest {
+                id: CallId::new(),
+                agent_run_id: run.id,
+                chat_id: run.chat_id,
+                provider_id,
+                name,
+                arguments,
+            },
+            resolution: match disposition {
+                SandboxToolCallDisposition::Execute => None,
+                SandboxToolCallDisposition::Rejected {
+                    error_code,
+                    message,
+                } => Some(ToolCallResolution::Failed {
+                    result: rejection_result(&message),
+                    error_code: error_code.to_owned(),
+                    error_detail: None,
+                }),
+            },
         };
+        let call = &entry.call;
         let outcome = match self
             .store
-            .park_agent_run_for_sandbox_tool_call(run.id, lease_token, &call)
+            .park_agent_run_for_sandbox_tool_call(run.id, lease_token, &entry)
             .await
         {
             Ok(outcome) => outcome,
@@ -960,12 +937,18 @@ impl SandboxAgentRunWorker {
                 self.publish_progress(run.id, call.id, narration).await;
                 // This shared wake is only a latency hint; the dedicated
                 // executor's durable candidate scan remains the recovery path.
+                // A call the host already answered has no executor and simply
+                // ignores it.
                 self.wake.notify_one();
                 Ok(SandboxAgentRunWorkerOutcome::ToolCheckpointed(call.id))
             }
             ParkSandboxToolCallOutcome::IdentityConflict => {
-                self.record_failure(&run, lease_token, AgentError::msg(conflict_message))
-                    .await
+                self.record_failure(
+                    &run,
+                    lease_token,
+                    AgentError::msg("sandbox tool checkpoint identity conflict"),
+                )
+                .await
             }
             ParkSandboxToolCallOutcome::DelegatedResourceUnavailable => {
                 self.record_failure(
@@ -1117,13 +1100,11 @@ async fn sandbox_request(
     }
     let mut messages = vec![ChatMessage::text(Role::User, task)];
     for call in calls {
-        if !matches!(
-            call.name.as_str(),
-            openwave_core::SANDBOX_WEB_SEARCH_TOOL
-                | openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL
-                | SANDBOX_EXEC_TOOL
-        ) || !call.status.is_terminal()
-        {
+        // The row's name is the model's own emitted name — dispatch data, not
+        // a replay contract. A call the host refused replays exactly like one
+        // an executor ran: what matters is that it is finished and has an
+        // answer to hand back.
+        if !call.status.is_terminal() {
             return Err(AgentError::msg("sandbox checkpoint cannot be resumed"));
         }
         let receipt = store
@@ -1265,48 +1246,140 @@ enum SandboxCompletion {
         outputs: Vec<String>,
         summary: String,
     },
-    /// One command to run in this run's own private workspace.
-    Exec {
-        provider_id: String,
-        arguments: serde_json::Value,
-    },
-    WebSearch {
-        provider_id: String,
-        arguments: serde_json::Value,
-    },
+    /// One tool call the model made, to dispatch or to answer in place.
+    ToolCall(SandboxToolCallIntent),
     FolderAccessProposal {
         request: RequestFolderAccessArgs,
     },
-    DelegatedFileRead {
-        provider_id: String,
-        arguments: serde_json::Value,
+}
+
+/// One tool call the model emitted, classified for the host.
+#[derive(Debug, Clone)]
+struct SandboxToolCallIntent {
+    provider_id: String,
+    name: String,
+    /// The model's arguments as it sent them, `Null` when its JSON never
+    /// parsed. A rejected call parks these verbatim so the replayed transcript
+    /// shows the model exactly what it asked for.
+    arguments: serde_json::Value,
+    disposition: SandboxToolCallDisposition,
+}
+
+#[derive(Debug, Clone)]
+enum SandboxToolCallDisposition {
+    /// Dispatch to the tool's executor lane.
+    Execute,
+    /// The host answers this call itself with an error result carrying this
+    /// text, so the model can correct itself on the next step.
+    Rejected {
+        error_code: &'static str,
+        message: String,
     },
+}
+
+/// The model-facing text of a refusal, shaped to what a durable receipt
+/// accepts: never empty, never carrying a NUL the model's own tool name might
+/// have contributed, and never longer than the receipt's result budget.
+fn rejection_result(message: &str) -> String {
+    let mut result: String = message.chars().filter(|byte| *byte != '\0').collect();
+    if result.len() > openwave_core::SandboxToolCall::MAX_RESULT_BYTES {
+        let mut cut = openwave_core::SandboxToolCall::MAX_RESULT_BYTES;
+        while cut > 0 && !result.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        result.truncate(cut);
+    }
+    if result.trim().is_empty() {
+        return "The call could not be dispatched.".to_owned();
+    }
+    result
+}
+
+/// Decide whether a tool call the model emitted can be dispatched.
+///
+/// A call the host cannot dispatch is not an infrastructure failure: the model
+/// asked for something that does not exist or sent arguments that do not fit,
+/// and the corrective answer belongs in the transcript. Only a call with no
+/// provider id is unanswerable — there is no id to attach a result to.
+fn classify_sandbox_tool_call(
+    provider_id: String,
+    name: String,
+    raw_arguments: &str,
+    advertised: &[String],
+) -> Result<SandboxToolCallIntent> {
+    if provider_id.is_empty() {
+        return Err(AgentError::msg(
+            "sandbox agent requested a tool without a call id",
+        ));
+    }
+    // Parsed once, up front: whatever the model sent is what the checkpoint
+    // records, so the replayed transcript shows it exactly what it asked for.
+    let parsed = serde_json::from_str::<serde_json::Value>(raw_arguments).ok();
+    let arguments = parsed.clone().unwrap_or(serde_json::Value::Null);
+    if !advertised.contains(&name) {
+        let available = advertised.join(", ");
+        let message =
+            format!("{name} is not available to a background task. Available tools: {available}.");
+        return Ok(SandboxToolCallIntent {
+            provider_id,
+            name,
+            arguments,
+            disposition: SandboxToolCallDisposition::Rejected {
+                error_code: "unavailable_tool",
+                message,
+            },
+        });
+    }
+    let invalid = |arguments: serde_json::Value| SandboxToolCallIntent {
+        provider_id: provider_id.clone(),
+        name: name.clone(),
+        arguments,
+        disposition: SandboxToolCallDisposition::Rejected {
+            error_code: "invalid_arguments",
+            message: format!(
+                "Arguments for {name} were not valid: re-send the call with arguments matching \
+                 this tool's input schema."
+            ),
+        },
+    };
+    if parsed.is_none() {
+        return Ok(invalid(serde_json::Value::Null));
+    }
+    let valid = match name.as_str() {
+        SANDBOX_EXEC_TOOL => validate_sandbox_exec_arguments(&arguments),
+        openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL => {
+            validate_sandbox_read_delegated_file_arguments(&arguments)
+        }
+        openwave_core::SANDBOX_DONE_TOOL => {
+            openwave_core::validate_sandbox_done_arguments(&arguments)
+                && serde_json::from_value::<openwave_core::SandboxDoneArgs>(arguments.clone())
+                    .is_ok()
+        }
+        openwave_core::REQUEST_FOLDER_ACCESS_TOOL => {
+            serde_json::from_value::<RequestFolderAccessArgs>(arguments.clone())
+                .is_ok_and(|request| request.is_well_formed())
+        }
+        // The web-search lane validates its own arguments when it claims the
+        // call; parsing is all this step can check.
+        _ => true,
+    };
+    if !valid {
+        return Ok(invalid(arguments));
+    }
+    Ok(SandboxToolCallIntent {
+        provider_id,
+        name,
+        arguments,
+        disposition: SandboxToolCallDisposition::Execute,
+    })
 }
 
 async fn complete_sandbox_task(
     provider: Arc<dyn ModelProvider>,
     request: ChatRequest,
 ) -> Result<SandboxStep> {
-    let web_search_advertised = request
-        .tools
-        .iter()
-        .any(|tool| tool.name == openwave_core::SANDBOX_WEB_SEARCH_TOOL);
-    let exec_advertised = request
-        .tools
-        .iter()
-        .any(|tool| tool.name == SANDBOX_EXEC_TOOL);
-    let done_advertised = request
-        .tools
-        .iter()
-        .any(|tool| tool.name == openwave_core::SANDBOX_DONE_TOOL);
-    let folder_proposal_advertised = request
-        .tools
-        .iter()
-        .any(|tool| tool.name == openwave_core::REQUEST_FOLDER_ACCESS_TOOL);
-    let delegated_file_advertised = request
-        .tools
-        .iter()
-        .any(|tool| tool.name == openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL);
+    let advertised_tools: Vec<String> =
+        request.tools.iter().map(|tool| tool.name.clone()).collect();
     let mut stream = provider.stream(request).await?;
     let mut text = String::new();
     let mut calls = std::collections::BTreeMap::<u32, (String, String, String)>::new();
@@ -1362,109 +1435,53 @@ async fn complete_sandbox_task(
                         ));
                     }
                     let (_, (provider_id, name, arguments)) = calls.into_iter().next().unwrap();
-                    if provider_id.is_empty() {
-                        return Err(AgentError::msg(
-                            "sandbox agent requested an unavailable tool",
-                        ));
-                    }
-                    if name == openwave_core::SANDBOX_WEB_SEARCH_TOOL && web_search_advertised {
-                        let arguments = serde_json::from_str(&arguments).map_err(|_| {
-                            AgentError::msg("sandbox agent emitted invalid web-search arguments")
-                        })?;
-                        return Ok(SandboxStep {
-                            narration: text,
-                            completion: SandboxCompletion::WebSearch {
-                                provider_id,
-                                arguments,
-                            },
-                            provider_executed,
-                        });
-                    }
-                    if name == SANDBOX_EXEC_TOOL && exec_advertised {
-                        let arguments = serde_json::from_str(&arguments).map_err(|_| {
-                            AgentError::msg("sandbox agent emitted invalid exec arguments")
-                        })?;
-                        if !validate_sandbox_exec_arguments(&arguments) {
-                            return Err(AgentError::msg(
-                                "sandbox agent emitted invalid exec arguments",
-                            ));
-                        }
-                        return Ok(SandboxStep {
-                            narration: text,
-                            completion: SandboxCompletion::Exec {
-                                provider_id,
-                                arguments,
-                            },
-                            provider_executed,
-                        });
-                    }
-                    if name == openwave_core::SANDBOX_DONE_TOOL && done_advertised {
-                        let arguments = serde_json::from_str::<serde_json::Value>(&arguments)
-                            .map_err(|_| {
-                                AgentError::msg("sandbox agent emitted invalid done arguments")
-                            })?;
-                        if !openwave_core::validate_sandbox_done_arguments(&arguments) {
-                            return Err(AgentError::msg(
-                                "sandbox agent emitted invalid done arguments",
-                            ));
-                        }
-                        let arguments =
-                            serde_json::from_value::<openwave_core::SandboxDoneArgs>(arguments)
+                    let intent = classify_sandbox_tool_call(
+                        provider_id,
+                        name,
+                        &arguments,
+                        &advertised_tools,
+                    )?;
+                    // These two end the run in place rather than parking work,
+                    // so they are consumed here and their narration is dropped
+                    // — the result they carry already speaks for the run.
+                    if matches!(intent.disposition, SandboxToolCallDisposition::Execute) {
+                        if intent.name == openwave_core::SANDBOX_DONE_TOOL {
+                            let arguments =
+                                serde_json::from_value::<openwave_core::SandboxDoneArgs>(
+                                    intent.arguments,
+                                )
                                 .map_err(|_| {
                                     AgentError::msg("sandbox agent emitted invalid done arguments")
                                 })?;
-                        return Ok(SandboxStep {
-                            narration: String::new(),
-                            completion: SandboxCompletion::Done {
-                                outputs: arguments.outputs,
-                                summary: arguments.summary,
-                            },
-                            provider_executed,
-                        });
-                    }
-                    if name == openwave_core::REQUEST_FOLDER_ACCESS_TOOL
-                        && folder_proposal_advertised
-                    {
-                        let request = serde_json::from_str::<RequestFolderAccessArgs>(&arguments)
-                            .map_err(|_| {
-                            AgentError::msg("sandbox agent emitted invalid folder-access proposal")
-                        })?;
-                        if !request.is_well_formed() {
-                            return Err(AgentError::msg(
-                                "sandbox agent emitted invalid folder-access proposal",
-                            ));
+                            return Ok(SandboxStep {
+                                narration: String::new(),
+                                completion: SandboxCompletion::Done {
+                                    outputs: arguments.outputs,
+                                    summary: arguments.summary,
+                                },
+                                provider_executed,
+                            });
                         }
-                        return Ok(SandboxStep {
-                            narration: String::new(),
-                            completion: SandboxCompletion::FolderAccessProposal { request },
-                            provider_executed,
-                        });
-                    }
-                    if name == openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL
-                        && delegated_file_advertised
-                    {
-                        let arguments = serde_json::from_str(&arguments).map_err(|_| {
-                            AgentError::msg(
-                                "sandbox agent emitted invalid delegated-file arguments",
-                            )
-                        })?;
-                        if !validate_sandbox_read_delegated_file_arguments(&arguments) {
-                            return Err(AgentError::msg(
-                                "sandbox agent emitted invalid delegated-file arguments",
-                            ));
+                        if intent.name == openwave_core::REQUEST_FOLDER_ACCESS_TOOL {
+                            let request =
+                                serde_json::from_value::<RequestFolderAccessArgs>(intent.arguments)
+                                    .map_err(|_| {
+                                        AgentError::msg(
+                                            "sandbox agent emitted invalid folder-access proposal",
+                                        )
+                                    })?;
+                            return Ok(SandboxStep {
+                                narration: String::new(),
+                                completion: SandboxCompletion::FolderAccessProposal { request },
+                                provider_executed,
+                            });
                         }
-                        return Ok(SandboxStep {
-                            narration: text,
-                            completion: SandboxCompletion::DelegatedFileRead {
-                                provider_id,
-                                arguments,
-                            },
-                            provider_executed,
-                        });
                     }
-                    return Err(AgentError::msg(
-                        "sandbox agent requested an unadvertised tool",
-                    ));
+                    return Ok(SandboxStep {
+                        narration: text,
+                        completion: SandboxCompletion::ToolCall(intent),
+                        provider_executed,
+                    });
                 }
                 if !calls.is_empty() {
                     return Err(AgentError::msg(
@@ -1628,6 +1645,54 @@ mod tests {
                 vec![
                     ProviderEvent::TextDelta {
                         text: "search-informed answer".into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::EndTurn,
+                    },
+                ]
+            };
+            Ok(stream::iter(events).boxed())
+        }
+    }
+
+    /// A model that reaches for a tool the run was never offered, then answers
+    /// once it has been told what it may use.
+    #[derive(Default)]
+    struct UnavailableToolThenFinalProvider {
+        requests: Mutex<Vec<ChatRequest>>,
+    }
+
+    #[async_trait]
+    impl ModelProvider for UnavailableToolThenFinalProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("sandbox-unavailable-tool")
+        }
+
+        async fn stream(&self, request: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            let call_number = {
+                let mut requests = self.requests.lock().unwrap();
+                requests.push(request);
+                requests.len()
+            };
+            let events = if call_number == 1 {
+                vec![
+                    ProviderEvent::ToolCallStarted {
+                        index: 0,
+                        id: "read_1".into(),
+                        name: "read_file".into(),
+                    },
+                    ProviderEvent::ToolCallArgsDelta {
+                        index: 0,
+                        fragment: r#"{"path":"notes.md"}"#.into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::ToolUse,
+                    },
+                ]
+            } else {
+                vec![
+                    ProviderEvent::TextDelta {
+                        text: "answer without that file".into(),
                     },
                     ProviderEvent::Stop {
                         reason: StopReason::EndTurn,
@@ -2230,6 +2295,87 @@ mod tests {
         );
     }
 
+    /// The failure this whole path exists to prevent: a background run that
+    /// reaches for a tool it was never offered used to fail its attempt, and
+    /// because every retry replays the same context it failed the same way
+    /// until the budget ran out. The call is answered instead, and the run
+    /// carries on from the same attempt.
+    #[tokio::test]
+    async fn an_unavailable_tool_call_is_answered_and_the_run_keeps_its_attempt() {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = sandbox_chat();
+        store.create_chat(&chat).await.unwrap();
+        let provider = Arc::new(UnavailableToolThenFinalProvider::default());
+        let worker = SandboxAgentRunWorker::new(
+            store.clone(),
+            test_secrets(),
+            Arc::new(FixedResolver(provider.clone())),
+            Arc::new(Notify::new()),
+            Arc::new(Notify::new()),
+            Arc::new(EventBus::default()),
+            AgentConfig {
+                model: "sandbox-model".into(),
+                max_steps: 3,
+                ..AgentConfig::default()
+            },
+            None,
+            SandboxAgentRunWorkerConfig::default(),
+        );
+        let spawn = CallId::new();
+        let id = openwave_core::AgentRunId::sandbox_for_spawn_call(spawn);
+        admit_sandbox(&store, chat.id, spawn, "Summarize the notes.").await;
+
+        let call_id = match worker.run_once().await.unwrap() {
+            SandboxAgentRunWorkerOutcome::ToolCheckpointed(call_id) => call_id,
+            outcome => panic!("unexpected outcome: {outcome:?}"),
+        };
+        let parked = store.get_agent_run(id).await.unwrap().unwrap();
+        // Not `waiting`: no executor lane will ever resolve this call, so the
+        // run has to be immediately claimable again or it would hang forever.
+        assert_eq!(parked.status, AgentRunStatus::RetryWait);
+        assert_eq!(
+            parked.last_error_code.as_deref(),
+            Some("tool_checkpoint_resolved")
+        );
+        assert_eq!(parked.attempt_count, 1);
+        let receipt = store
+            .get_sandbox_tool_call_receipt(call_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(receipt.status, SandboxToolCallStatus::Failed);
+        assert!(receipt.result.contains("Available tools:"), "{receipt:?}");
+        // The call is answered, so no executor lane may pick it up.
+        assert!(store
+            .list_sandbox_tool_call_candidates(10)
+            .await
+            .unwrap()
+            .is_empty());
+
+        assert_eq!(
+            worker.run_once().await.unwrap(),
+            SandboxAgentRunWorkerOutcome::Completed(id)
+        );
+        let after = store.get_agent_run(id).await.unwrap().unwrap();
+        assert_eq!(after.attempt_count, 1);
+        let requests = provider.requests.lock().unwrap();
+        assert_eq!(requests.len(), 2);
+        assert!(
+            matches!(&requests[1].messages[1].content[0], ContentBlock::ToolUse { id, name, input } if id == "read_1" && name == "read_file" && input == &serde_json::json!({"path":"notes.md"}))
+        );
+        assert!(
+            matches!(&requests[1].messages[2].content[0], ContentBlock::ToolResult { tool_use_id, content, is_error } if tool_use_id == "read_1" && content.contains("Available tools:") && *is_error)
+        );
+    }
+
     /// A run whose task needs more than one lookup: the checkpoint chain has to
     /// survive a second park and replay both receipts in order, because the
     /// worker rebuilds the whole transcript from the database on every claim.
@@ -2313,7 +2459,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn refuses_ambiguous_or_unavailable_sandbox_tool_events_without_checkpointing() {
+    async fn refuses_malformed_sandbox_tool_events_without_checkpointing() {
         let request = ChatRequest {
             provider: None,
             model: "m".into(),
@@ -2347,20 +2493,6 @@ mod tests {
                 ProviderEvent::ToolCallStarted {
                     index: 0,
                     id: "one".into(),
-                    name: "read_file".into(),
-                },
-                ProviderEvent::ToolCallArgsDelta {
-                    index: 0,
-                    fragment: "{}".into(),
-                },
-                ProviderEvent::Stop {
-                    reason: StopReason::ToolUse,
-                },
-            ],
-            vec![
-                ProviderEvent::ToolCallStarted {
-                    index: 0,
-                    id: "one".into(),
                     name: "web_search".into(),
                 },
                 ProviderEvent::Stop {
@@ -2381,6 +2513,16 @@ mod tests {
                     reason: StopReason::ToolUse,
                 },
             ],
+            vec![
+                ProviderEvent::ToolCallStarted {
+                    index: 0,
+                    id: String::new(),
+                    name: "web_search".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::ToolUse,
+                },
+            ],
         ] {
             assert!(
                 complete_sandbox_task(Arc::new(EventProvider(events)), request.clone())
@@ -2388,6 +2530,60 @@ mod tests {
                     .is_err()
             );
         }
+    }
+
+    /// A tool the run was never offered is the model's mistake, not the
+    /// host's: it is answered in the transcript so the next step can correct
+    /// itself, rather than spending the run's attempt budget.
+    #[tokio::test]
+    async fn unadvertised_sandbox_tool_call_is_answered_rather_than_refused() {
+        let request = ChatRequest {
+            provider: None,
+            model: "m".into(),
+            reasoning_model: false,
+            system: None,
+            messages: vec![],
+            tools: vec![sandbox_exec_tool_spec(), sandbox_done_tool_spec()],
+            max_tokens: None,
+            temperature: None,
+            reasoning_effort: None,
+            images: openwave_core::ImageAttachments::new(),
+            ..Default::default()
+        };
+        let completion = complete_sandbox_task(
+            Arc::new(EventProvider(vec![
+                ProviderEvent::ToolCallStarted {
+                    index: 0,
+                    id: "one".into(),
+                    name: "read_file".into(),
+                },
+                ProviderEvent::ToolCallArgsDelta {
+                    index: 0,
+                    fragment: "{}".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::ToolUse,
+                },
+            ])),
+            request,
+        )
+        .await
+        .unwrap()
+        .completion;
+        let SandboxCompletion::ToolCall(intent) = completion else {
+            panic!("an unadvertised tool must still produce a tool call");
+        };
+        assert_eq!(intent.name, "read_file");
+        let SandboxToolCallDisposition::Rejected {
+            error_code,
+            message,
+        } = intent.disposition
+        else {
+            panic!("an unadvertised tool must not be dispatched");
+        };
+        assert_eq!(error_code, "unavailable_tool");
+        assert!(message.contains("Available tools:"), "{message}");
+        assert!(message.contains(SANDBOX_EXEC_TOOL), "{message}");
     }
 
     #[tokio::test]
@@ -2462,11 +2658,13 @@ mod tests {
                 .park_sandbox_tool_call(
                     run,
                     lease,
-                    "search_1".into(),
-                    openwave_core::SANDBOX_WEB_SEARCH_TOOL,
-                    serde_json::json!({"query":"OpenWave"}),
+                    SandboxToolCallIntent {
+                        provider_id: "search_1".into(),
+                        name: openwave_core::SANDBOX_WEB_SEARCH_TOOL.into(),
+                        arguments: serde_json::json!({"query":"OpenWave"}),
+                        disposition: SandboxToolCallDisposition::Execute,
+                    },
                     "",
-                    "sandbox web-search checkpoint identity conflict",
                 )
                 .await
                 .unwrap(),
@@ -3251,7 +3449,23 @@ mod tests {
                 reason: StopReason::ToolUse,
             },
         ]));
-        assert!(complete_sandbox_task(provider, request).await.is_err());
+        // Calling a withdrawn tool is answered rather than failed: the step
+        // budget is spent, so the run needs the correction in its transcript,
+        // not a burned attempt.
+        let completion = complete_sandbox_task(provider, request)
+            .await
+            .unwrap()
+            .completion;
+        let SandboxCompletion::ToolCall(intent) = completion else {
+            panic!("a withdrawn tool must still produce a tool call");
+        };
+        assert!(matches!(
+            intent.disposition,
+            SandboxToolCallDisposition::Rejected {
+                error_code: "unavailable_tool",
+                ..
+            }
+        ));
     }
 
     #[tokio::test]
@@ -3304,13 +3518,18 @@ mod tests {
         ]));
         assert!(matches!(
             complete_sandbox_task(provider, request).await.unwrap().completion,
-            SandboxCompletion::DelegatedFileRead { arguments, .. }
-                if arguments == serde_json::json!({})
+            SandboxCompletion::ToolCall(SandboxToolCallIntent {
+                ref name,
+                ref arguments,
+                disposition: SandboxToolCallDisposition::Execute,
+                ..
+            }) if name == openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL
+                && *arguments == serde_json::json!({})
         ));
     }
 
     #[tokio::test]
-    async fn delegated_file_read_rejects_nonempty_arguments() {
+    async fn delegated_file_read_answers_nonempty_arguments_without_parking_work() {
         let request = ChatRequest {
             provider: None,
             model: "m".into(),
@@ -3338,7 +3557,25 @@ mod tests {
                 reason: StopReason::ToolUse,
             },
         ]));
-        assert!(complete_sandbox_task(provider, request).await.is_err());
+        let completion = complete_sandbox_task(provider, request)
+            .await
+            .unwrap()
+            .completion;
+        let SandboxCompletion::ToolCall(intent) = completion else {
+            panic!("invalid delegated-file arguments must stay a tool call");
+        };
+        assert_eq!(intent.arguments, serde_json::json!({"path":"secret"}));
+        assert!(
+            matches!(
+                intent.disposition,
+                SandboxToolCallDisposition::Rejected {
+                    error_code: "invalid_arguments",
+                    ..
+                }
+            ),
+            "{:?}",
+            intent.disposition
+        );
     }
 
     #[tokio::test]

--- a/crates/openwave-server/src/sandbox_exec_worker.rs
+++ b/crates/openwave-server/src/sandbox_exec_worker.rs
@@ -710,7 +710,11 @@ mod tests {
         };
         assert!(matches!(
             store
-                .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &request)
+                .park_agent_run_for_sandbox_tool_call(
+                    run.id,
+                    worker_lease,
+                    &crate::tests::dispatchable(&request)
+                )
                 .await
                 .unwrap(),
             ParkSandboxToolCallOutcome::Parked { .. }

--- a/crates/openwave-server/src/sandbox_web_search_worker.rs
+++ b/crates/openwave-server/src/sandbox_web_search_worker.rs
@@ -645,7 +645,11 @@ mod tests {
         };
         assert!(matches!(
             store
-                .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &request)
+                .park_agent_run_for_sandbox_tool_call(
+                    run.id,
+                    worker_lease,
+                    &crate::tests::dispatchable(&request)
+                )
                 .await
                 .unwrap(),
             ParkSandboxToolCallOutcome::Parked { .. }

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -2345,3 +2345,13 @@ async fn app_view_frames_serve_stored_revisions_under_the_same_contract() {
     let deleted = router.oneshot(mint(app_id, Some(&bearer))).await.unwrap();
     assert_eq!(deleted.status(), StatusCode::NOT_FOUND);
 }
+
+/// A checkpoint the host expects an executor lane to run.
+pub(crate) fn dispatchable(
+    call: &SandboxToolCallRequest,
+) -> openwave_core::SandboxToolCallParkEntry {
+    openwave_core::SandboxToolCallParkEntry {
+        call: call.clone(),
+        resolution: None,
+    }
+}

--- a/crates/openwave-server/src/tests/sandbox.rs
+++ b/crates/openwave-server/src/tests/sandbox.rs
@@ -138,7 +138,11 @@ async fn agent_run_snapshots_expose_only_safe_live_sandbox_activity() {
     };
     assert!(matches!(
         store
-            .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &checkpoint)
+            .park_agent_run_for_sandbox_tool_call(
+                run.id,
+                worker_lease,
+                &crate::tests::dispatchable(&checkpoint)
+            )
             .await
             .unwrap(),
         ParkSandboxToolCallOutcome::Parked { .. }
@@ -246,7 +250,11 @@ async fn agent_run_activity_history_is_ordered_typed_and_names_submitted_files()
     };
     assert!(matches!(
         store
-            .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &exec)
+            .park_agent_run_for_sandbox_tool_call(
+                run.id,
+                worker_lease,
+                &crate::tests::dispatchable(&exec)
+            )
             .await
             .unwrap(),
         ParkSandboxToolCallOutcome::Parked { .. }
@@ -300,7 +308,11 @@ async fn agent_run_activity_history_is_ordered_typed_and_names_submitted_files()
     };
     assert!(matches!(
         store
-            .park_agent_run_for_sandbox_tool_call(run.id, search_worker_lease, &search)
+            .park_agent_run_for_sandbox_tool_call(
+                run.id,
+                search_worker_lease,
+                &crate::tests::dispatchable(&search)
+            )
             .await
             .unwrap(),
         ParkSandboxToolCallOutcome::Parked { .. }
@@ -696,7 +708,11 @@ async fn delegated_file_routes_are_native_only_and_expose_only_exact_broker_auth
         arguments: serde_json::json!({}),
     };
     store
-        .park_agent_run_for_sandbox_tool_call(child.id, worker_lease, &call)
+        .park_agent_run_for_sandbox_tool_call(
+            child.id,
+            worker_lease,
+            &crate::tests::dispatchable(&call),
+        )
         .await
         .unwrap();
 
@@ -1177,7 +1193,11 @@ async fn parent_turn_cancellation_signals_its_exact_running_child_search() {
     };
     assert!(matches!(
         store
-            .park_agent_run_for_sandbox_tool_call(run.id, model_lease, &request)
+            .park_agent_run_for_sandbox_tool_call(
+                run.id,
+                model_lease,
+                &crate::tests::dispatchable(&request)
+            )
             .await
             .unwrap(),
         ParkSandboxToolCallOutcome::Parked { .. }


### PR DESCRIPTION
## The failure

A background agent that called a tool it was never offered — `read_file`, say —
or sent arguments that did not fit a tool it was, failed its run attempt. Every
retry rebuilds the transcript from the same durable checkpoints, so the model
saw the same context and made the same call again. One recoverable mistake
deterministically consumed the run's entire attempt budget.

## The fix

The host answers those calls itself. `classify_sandbox_tool_call` splits a
model's tool call into `Execute` (dispatch to the tool's lane) and `Rejected`
(the host writes the answer), and the five tool variants of `SandboxCompletion`
collapse into one `ToolCall(SandboxToolCallIntent)`.

A rejected call still becomes a durable checkpoint, because the transcript is
rebuilt from checkpoints on every claim and the answer has to survive there.
`park_agent_run_for_sandbox_tool_call` now takes a `SandboxToolCallParkEntry`;
when it carries a resolution the row is inserted already terminal together with
its receipt in the same transaction, and the run is released to `retry_wait`
with `available_at = now` rather than `waiting` — nothing will ever resolve that
row, so parking it as live work would strand the run. The per-tool argument
rules are skipped for such a row: they exist to keep an executor lane from
inheriting work it can only fail on, and no lane will see this one. Its
arguments are the model's own, verbatim, so the replay shows it what it sent.

The replay loop no longer whitelists checkpoint names. The row's name is the
name the model emitted — dispatch data, not a replay contract — so it only
requires a terminal status and a receipt.

Attempt-consuming failures are unchanged for the cases that are not the model's
to correct: stream failures, refusals, cancellation, duplicate tool-call index,
arguments over the durable limit, output over the result limit, more than one
call in a step, a stop with an incomplete call, an empty final answer, and a
call with no provider id (there is no id to attach a result to). The one call
per step limit stays; batching several is separate work.

## Tests

- `refuses_ambiguous_or_unavailable_sandbox_tool_events_without_checkpointing` →
  `refuses_malformed_sandbox_tool_events_without_checkpointing`. The unknown-tool
  case moved out (it is no longer an error); parallel calls, an incomplete call
  and oversized arguments stay, and the empty-provider-id case joins them since
  that is now the only unanswerable call.
- New `unadvertised_sandbox_tool_call_is_answered_rather_than_refused` — the
  case the old table lost: asserts the rejection carries `unavailable_tool` and
  a message listing the tools the run may use.
- New `an_unavailable_tool_call_is_answered_and_the_run_keeps_its_attempt`
  drives the whole path end to end: the run lands in `retry_wait` (not
  `waiting`, not failed) on the same attempt, no executor candidate appears, and
  the next model request replays the `read_file` ToolUse with an `is_error`
  ToolResult naming the available tools before the run completes. This is the
  regression the change exists to prevent.
- `delegated_file_read_rejects_nonempty_arguments` →
  `delegated_file_read_answers_nonempty_arguments_without_parking_work`: same
  input, but the outcome it pins is now a rejection carrying the model's
  arguments rather than an error.
- `one_model_step_never_advertises_unconsumable_web_search_work` keeps its
  advertisement assertions; its tail assertion changes from "is an error" to
  "is answered", for the same reason.
- New store-level `a_pre_resolved_sandbox_park_lands_terminal_and_reschedules_the_run`
  covers the transaction directly: terminal row plus readable receipt, run in
  `retry_wait`, nothing offered to an executor, and a replayed commit recovering
  the same checkpoint.
- Everything else is mechanical: park call sites take a `SandboxToolCallParkEntry`
  through a shared `dispatchable` test helper.

Verified locally: `cargo test -p openwave-core`, `cargo test -p openwave-server`,
`cargo check --workspace --locked` (no lockfile change), clippy clean on both
touched crates.
