### PR TITLE
feat(cli): rich TUI with desktop-parity chat surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4219,6 +4219,7 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 name = "openwave-cli"
 version = "0.0.0"
 dependencies = [
+ "chrono",
  "crossterm",
  "futures",
  "openwave-core",

--- a/crates/openwave-cli/Cargo.toml
+++ b/crates/openwave-cli/Cargo.toml
@@ -22,6 +22,8 @@ path = "src/main.rs"
 openwave-core = { path = "../openwave-core", default-features = false, features = ["tools"] }
 openwave-mcp = { path = "../openwave-mcp" }
 openwave-server = { path = "../openwave-server" }
+# Timestamps on transcript entries and inbox rows.
+chrono = { workspace = true }
 crossterm = { version = "=0.28.1", features = ["event-stream"] }
 futures = { workspace = true }
 # CommonMark parser for committed assistant text; no default features (the

--- a/crates/openwave-cli/src/api/client.rs
+++ b/crates/openwave-cli/src/api/client.rs
@@ -3,13 +3,18 @@
 
 use std::net::SocketAddr;
 
-use openwave_core::{AgentError, CallId, ChatId, Result, TurnId};
+use openwave_core::{AgentError, AgentRunId, CallId, ChatId, Result, TurnId};
 use serde::Deserialize;
 use tokio::net::TcpStream;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::http::header::SEC_WEBSOCKET_PROTOCOL;
 use tokio_tungstenite::tungstenite::http::HeaderValue;
 use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+
+use super::wire::{
+    AgentActivityItem, AgentRunSnapshot, ChatSummary, GrantRung, InboxItem, ModelCatalog,
+    PendingApprovalSnapshot, PendingPlan, PendingQuestions, Transcript,
+};
 
 /// The chat event stream once the upgrade completes.
 pub type EventSocket = WebSocketStream<MaybeTlsStream<TcpStream>>;
@@ -87,6 +92,265 @@ impl Client {
         Ok(())
     }
 
+    /// One chat's record (title, model, permission mode, …).
+    pub async fn get_chat(&self, chat: ChatId) -> Result<ChatSummary> {
+        self.get_json(format!("{}/chats/{chat}", self.base)).await
+    }
+
+    /// Every chat, most recently active first (server ordering).
+    pub async fn list_chats(&self) -> Result<Vec<ChatSummary>> {
+        self.get_json(format!("{}/chats", self.base)).await
+    }
+
+    /// Everything parked on the user across chats, oldest first.
+    pub async fn list_inbox(&self) -> Result<Vec<InboxItem>> {
+        self.get_json(format!("{}/inbox", self.base)).await
+    }
+
+    /// The visible transcript plus the journal watermark to resume events at.
+    pub async fn get_transcript(&self, chat: ChatId) -> Result<Transcript> {
+        self.get_json(format!("{}/chats/{chat}/messages", self.base))
+            .await
+    }
+
+    /// Rename a chat; `None` clears back to an untitled chat.
+    pub async fn rename_chat(&self, chat: ChatId, title: Option<&str>) -> Result<()> {
+        let response = self
+            .http
+            .patch(format!("{}/chats/{chat}", self.base))
+            .json(&serde_json::json!({ "title": title }))
+            .send()
+            .await
+            .map_err(request_error)?;
+        Self::expect_success(response).await?;
+        Ok(())
+    }
+
+    /// Patch the chat's model selection; `None` clears back to the default.
+    pub async fn set_chat_model(&self, chat: ChatId, model: Option<&str>) -> Result<()> {
+        let response = self
+            .http
+            .patch(format!("{}/chats/{chat}", self.base))
+            .json(&serde_json::json!({ "model": model }))
+            .send()
+            .await
+            .map_err(request_error)?;
+        Self::expect_success(response).await?;
+        Ok(())
+    }
+
+    /// Patch the chat's reasoning-effort override; `None` clears it.
+    pub async fn set_chat_effort(&self, chat: ChatId, effort: Option<&str>) -> Result<()> {
+        let response = self
+            .http
+            .patch(format!("{}/chats/{chat}", self.base))
+            .json(&serde_json::json!({ "reasoning_effort": effort }))
+            .send()
+            .await
+            .map_err(request_error)?;
+        Self::expect_success(response).await?;
+        Ok(())
+    }
+
+    /// Patch the chat's permission mode; `None` clears back to `ask`.
+    pub async fn set_chat_permission_mode(
+        &self,
+        chat: ChatId,
+        mode: Option<&str>,
+    ) -> Result<ChatSummary> {
+        let response = self
+            .http
+            .patch(format!("{}/chats/{chat}", self.base))
+            .json(&serde_json::json!({ "permission_mode": mode }))
+            .send()
+            .await
+            .map_err(request_error)?;
+        Self::expect_success(response)
+            .await?
+            .json::<ChatSummary>()
+            .await
+            .map_err(request_error)
+    }
+
+    /// Move a chat between projects (or out of one with `None`).
+    pub async fn set_chat_project(
+        &self,
+        chat: ChatId,
+        project: Option<openwave_core::ProjectId>,
+    ) -> Result<ChatSummary> {
+        let response = self
+            .http
+            .patch(format!("{}/chats/{chat}", self.base))
+            .json(&serde_json::json!({ "project_id": project }))
+            .send()
+            .await
+            .map_err(request_error)?;
+        Self::expect_success(response)
+            .await?
+            .json::<ChatSummary>()
+            .await
+            .map_err(request_error)
+    }
+
+    /// Every project (workspace), most recently created first.
+    pub async fn list_projects(&self) -> Result<Vec<super::wire::ProjectSummary>> {
+        self.get_json(format!("{}/projects", self.base)).await
+    }
+
+    /// Delete a chat outright.
+    pub async fn delete_chat(&self, chat: ChatId) -> Result<()> {
+        let response = self
+            .http
+            .delete(format!("{}/chats/{chat}", self.base))
+            .send()
+            .await
+            .map_err(request_error)?;
+        Self::expect_success(response).await?;
+        Ok(())
+    }
+
+    /// The selectable model catalog.
+    pub async fn list_models(&self) -> Result<ModelCatalog> {
+        self.get_json(format!("{}/models", self.base)).await
+    }
+
+    /// Background agent runs for a chat.
+    pub async fn list_agent_runs(&self, chat: ChatId) -> Result<Vec<AgentRunSnapshot>> {
+        self.get_json(format!("{}/chats/{chat}/agent-runs", self.base))
+            .await
+    }
+
+    /// A background run's ordered activity timeline.
+    pub async fn list_agent_run_activity(
+        &self,
+        chat: ChatId,
+        run: AgentRunId,
+    ) -> Result<Vec<AgentActivityItem>> {
+        self.get_json(format!(
+            "{}/chats/{chat}/agent-runs/{run}/activity",
+            self.base
+        ))
+        .await
+    }
+
+    /// Ask a background run to stop (`202`).
+    pub async fn cancel_agent_run(&self, chat: ChatId, run: AgentRunId) -> Result<()> {
+        let response = self
+            .http
+            .post(format!(
+                "{}/chats/{chat}/agent-runs/{run}/cancel",
+                self.base
+            ))
+            .json(&serde_json::json!({}))
+            .send()
+            .await
+            .map_err(request_error)?;
+        Self::expect_success(response).await?;
+        Ok(())
+    }
+
+    /// Approvals parked on this chat right now (recovery on resume).
+    pub async fn list_pending_approvals(
+        &self,
+        chat: ChatId,
+    ) -> Result<Vec<PendingApprovalSnapshot>> {
+        self.get_json(format!("{}/chats/{chat}/approvals", self.base))
+            .await
+    }
+
+    /// Plans awaiting review on this chat.
+    pub async fn list_pending_plans(&self, chat: ChatId) -> Result<Vec<PendingPlan>> {
+        self.get_json(format!("{}/chats/{chat}/plans/pending", self.base))
+            .await
+    }
+
+    /// Decide a proposed plan. `feedback` rides a reject; `mode` names the
+    /// continuation on accept (`None` leaves the server default, `auto`).
+    pub async fn decide_plan(
+        &self,
+        chat: ChatId,
+        call_id: CallId,
+        accept: bool,
+        feedback: Option<&str>,
+        mode: Option<&str>,
+    ) -> Result<()> {
+        let mut body = serde_json::json!({
+            "decision": if accept { "accept" } else { "reject" },
+        });
+        if let Some(feedback) = feedback {
+            body["feedback"] = serde_json::json!(feedback);
+        }
+        if accept {
+            if let Some(mode) = mode {
+                body["permission_mode"] = serde_json::json!(mode);
+            }
+        }
+        let response = self
+            .http
+            .post(format!(
+                "{}/chats/{chat}/plans/{call_id}/decision",
+                self.base
+            ))
+            .json(&body)
+            .send()
+            .await
+            .map_err(request_error)?;
+        Self::expect_success(response).await?;
+        Ok(())
+    }
+
+    /// Question blocks the model is waiting on.
+    pub async fn list_pending_questions(&self, chat: ChatId) -> Result<Vec<PendingQuestions>> {
+        self.get_json(format!("{}/chats/{chat}/questions/pending", self.base))
+            .await
+    }
+
+    /// Answer a parked question block. Each entry is
+    /// `{question_id, selections, custom_answer?}`.
+    pub async fn answer_questions(
+        &self,
+        chat: ChatId,
+        call_id: CallId,
+        answers: serde_json::Value,
+    ) -> Result<()> {
+        let response = self
+            .http
+            .post(format!(
+                "{}/chats/{chat}/questions/{call_id}/answer",
+                self.base
+            ))
+            .json(&answers)
+            .send()
+            .await
+            .map_err(request_error)?;
+        Self::expect_success(response).await?;
+        Ok(())
+    }
+
+    /// Steer an active turn with more user text (`202`).
+    pub async fn steer(
+        &self,
+        chat: ChatId,
+        turn_id: TurnId,
+        steer_id: TurnId,
+        content: &str,
+    ) -> Result<()> {
+        let response = self
+            .http
+            .post(format!("{}/chats/{chat}/steer", self.base))
+            .json(&serde_json::json!({
+                "steer_id": steer_id,
+                "turn_id": turn_id,
+                "content": content,
+                "interrupt": true,
+            }))
+            .send()
+            .await
+            .map_err(request_error)?;
+        Self::expect_success(response).await?;
+        Ok(())
+    }
+
     /// Accept a user message and queue its turn (`202`).
     pub async fn post_message(&self, chat: ChatId, turn_id: TurnId, content: &str) -> Result<()> {
         let response = self
@@ -113,17 +377,22 @@ impl Client {
         Ok(())
     }
 
-    /// Decide a parked tool call (`204`). Slice 1 sends no standing grant.
-    /// `reason` is recorded with a rejection and ignored on approval.
+    /// Decide a parked tool call (`204`). `grant` names a standing-grant rung
+    /// from the approval's ladder; `reason` is recorded with a rejection and
+    /// ignored on approval.
     pub async fn decide_approval(
         &self,
         chat: ChatId,
         call_id: CallId,
         approve: bool,
         reason: &str,
+        grant: Option<GrantRung>,
     ) -> Result<()> {
         let body = if approve {
-            serde_json::json!({ "decision": "approve" })
+            match grant {
+                Some(grant) => serde_json::json!({ "decision": "approve", "grant": grant }),
+                None => serde_json::json!({ "decision": "approve" }),
+            }
         } else {
             serde_json::json!({ "decision": "reject", "reason": reason })
         };
@@ -175,6 +444,16 @@ impl Client {
         Err(AgentError::msg(format!(
             "request failed ({status}): {message}"
         )))
+    }
+
+    /// GET a JSON body, lifting failures the way every other route does.
+    async fn get_json<T: serde::de::DeserializeOwned>(&self, url: String) -> Result<T> {
+        let response = self.http.get(url).send().await.map_err(request_error)?;
+        Self::expect_success(response)
+            .await?
+            .json::<T>()
+            .await
+            .map_err(request_error)
     }
 }
 

--- a/crates/openwave-cli/src/api/wire.rs
+++ b/crates/openwave-cli/src/api/wire.rs
@@ -26,10 +26,44 @@ pub struct SequencedFrame {
     pub event: ClientEvent,
 }
 
-/// A metadata push; only the tag is read today (the TUI has no title surface).
+/// A metadata push: chat state that changed outside the turn journal.
 #[derive(Debug, Clone, PartialEq, Deserialize)]
-pub struct MetadataFrame {
-    pub metadata: String,
+#[serde(tag = "metadata", rename_all = "snake_case")]
+pub enum MetadataFrame {
+    /// The chat was named — by titling, for a chat that had no name.
+    Titled { title: String },
+    /// A post-turn file-change summary is ready; the TUI has no surface for
+    /// the undo flow, but recognizing the frame keeps the tag decode closed.
+    FileChangesRecorded,
+    /// Code execution is preparing its sandbox image, or has stopped.
+    SandboxPreparing { preparing: bool },
+    /// A newer metadata kind this build does not know.
+    #[serde(other)]
+    Unknown,
+}
+
+/// A turn's token accounting, as the terminal events carry it. The four
+/// counts are disjoint; the context footprint is their plain sum.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+pub struct TurnUsage {
+    #[serde(default)]
+    pub input_tokens: u32,
+    #[serde(default)]
+    pub output_tokens: u32,
+    #[serde(default)]
+    pub cache_read_input_tokens: u32,
+    #[serde(default)]
+    pub cache_creation_input_tokens: u32,
+}
+
+impl TurnUsage {
+    /// Everything that occupied the model's context across the turn.
+    pub fn context_tokens(self) -> u64 {
+        u64::from(self.input_tokens)
+            + u64::from(self.output_tokens)
+            + u64::from(self.cache_read_input_tokens)
+            + u64::from(self.cache_creation_input_tokens)
+    }
 }
 
 /// The events the CLI renders. Only fields a CLI surface uses are declared;
@@ -52,32 +86,59 @@ pub enum ClientEvent {
         name: String,
     },
     ToolCallArgsDelta,
-    UserQuestionsAsked,
-    PlanProposed,
+    UserQuestionsAsked {
+        #[serde(default)]
+        call_id: Option<CallId>,
+    },
+    PlanProposed {
+        #[serde(default)]
+        call_id: Option<CallId>,
+    },
     ApprovalRequired {
         call_id: CallId,
         action: String,
         approval: String,
         #[serde(default)]
         auto_judging: bool,
+        /// Standing-grant ladder for this exact call, narrowest first.
+        #[serde(default)]
+        grant_rungs: Vec<GrantRung>,
         #[serde(default)]
         preview: Option<serde_json::Value>,
     },
     ApprovalDecided {
         call_id: CallId,
+        #[serde(default)]
+        approved: Option<bool>,
     },
     ToolCallCompleted {
         call_id: CallId,
         status: ToolCallStatus,
+        /// What the call did, when its tool projects it.
+        #[serde(default)]
+        action: Option<serde_json::Value>,
+        /// What the call produced, when its tool projects it.
+        #[serde(default)]
+        result: Option<serde_json::Value>,
     },
-    TurnCompleted,
+    TurnCompleted {
+        #[serde(default)]
+        usage: TurnUsage,
+    },
     TurnRefused {
         refusal: Refusal,
+        #[serde(default)]
+        usage: TurnUsage,
     },
     TurnFailed {
         category: String,
+        #[serde(default)]
+        model: Option<ModelIdentity>,
     },
-    TurnCancelled,
+    TurnCancelled {
+        #[serde(default)]
+        usage: TurnUsage,
+    },
     UserSteered {
         text: String,
     },
@@ -91,6 +152,30 @@ pub enum ClientEvent {
     Unknown,
 }
 
+/// How wide a standing grant the server offers on an approval, mirroring
+/// `ApprovalGrantRung`. Decodes from and encodes to the same wire strings so
+/// the decision can name the rung back verbatim.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GrantRung {
+    /// Exactly the action the card showed.
+    ExactAction,
+    /// A leading run of the command's argv tokens.
+    CommandPrefix { tokens: usize },
+    /// A leading run of a workspace write's path segments.
+    PathPrefix { segments: usize },
+    /// Every call to this tool.
+    WholeTool,
+}
+
+/// Exact model route involved in a provider failure.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct ModelIdentity {
+    pub id: String,
+    #[serde(default)]
+    pub provider: Option<String>,
+}
+
 /// Whether a finished tool call succeeded. Unknown statuses decode rather than
 /// failing; they render as failures (the conservative display).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
@@ -98,6 +183,7 @@ pub enum ClientEvent {
 pub enum ToolCallStatus {
     Completed,
     Failed,
+    Cancelled,
     #[serde(other)]
     Unknown,
 }
@@ -107,6 +193,334 @@ pub enum ToolCallStatus {
 pub struct Refusal {
     #[serde(default)]
     pub category: Option<String>,
+    #[serde(default)]
+    pub partial_output: bool,
+}
+
+/// One entry of the durable transcript, from `GET /chats/{id}/messages`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MessageSnapshot {
+    pub role: TranscriptRole,
+    pub content: String,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    /// Images submitted with a user message (identity and geometry only).
+    #[serde(default)]
+    pub image_attachments: Option<Vec<ImageAttachment>>,
+    /// Files submitted with a user message.
+    #[serde(default)]
+    pub file_attachments: Option<Vec<FileAttachment>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TranscriptRole {
+    User,
+    Assistant,
+    /// A durable host-authored note between turns; shown as a subtle notice.
+    System,
+    /// The transcript never emits these, but decode defensively anyway.
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ImageAttachment {
+    pub media_type: String,
+    pub width: u32,
+    pub height: u32,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct FileAttachment {
+    pub name: String,
+    /// The document's media type; decoded for forward compatibility, not yet
+    /// shown on the TUI's attachment chips.
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub media_type: String,
+}
+
+/// One finished tool call in history, projected through the renderer-safe
+/// allowlist. Only the fields the TUI renders are declared.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ToolActivitySnapshot {
+    /// The call's durable identity; the TUI doesn't key history by it yet,
+    /// but it is part of the wire contract.
+    #[allow(dead_code)]
+    pub call_id: CallId,
+    pub tool: String,
+    #[serde(default)]
+    pub action: Option<serde_json::Value>,
+    #[serde(default)]
+    pub result: Option<serde_json::Value>,
+    #[serde(default)]
+    pub status: Option<ToolCallStatus>,
+}
+
+/// One terminal turn's status and visible content.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TerminalTurnSnapshot {
+    /// The turn's identity and its partial/reasoning text are part of the
+    /// wire contract; the TUI reads the status, usage, and failure fields and
+    /// doesn't reprint settled partial text.
+    #[allow(dead_code)]
+    pub turn_id: TurnId,
+    pub status: TerminalTurnStatus,
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub partial_content: String,
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub reasoning: Option<String>,
+    #[serde(default)]
+    pub refusal: Option<Refusal>,
+    #[serde(default)]
+    pub failure_category: Option<String>,
+    #[serde(default)]
+    pub usage: TurnUsage,
+    #[allow(dead_code)]
+    pub finished_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TerminalTurnStatus {
+    Completed,
+    Failed,
+    Cancelled,
+    #[serde(other)]
+    Unknown,
+}
+
+/// The visible transcript plus the journal watermark that produced it.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Transcript {
+    #[serde(default)]
+    pub messages: Vec<MessageSnapshot>,
+    #[serde(default)]
+    pub tool_activity: Vec<ToolActivitySnapshot>,
+    #[serde(default)]
+    pub terminal_turns: Vec<TerminalTurnSnapshot>,
+    #[serde(default)]
+    pub last_event_seq: i64,
+}
+
+/// The chat record, as `GET /chats` and `GET /chats/{id}` return it.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ChatSummary {
+    pub id: openwave_core::ChatId,
+    /// The project this chat belongs to; decoded so the move picker can show
+    /// the current home, not yet rendered.
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub project_id: Option<openwave_core::ProjectId>,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub reasoning_effort: Option<String>,
+    #[serde(default)]
+    pub permission_mode: Option<String>,
+    /// When the chat was created; the TUI doesn't sort or label by it yet.
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// One project (workspace), as `GET /projects` returns it.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ProjectSummary {
+    pub id: openwave_core::ProjectId,
+    #[serde(default)]
+    pub title: Option<String>,
+    /// When the project was created; not shown in the picker.
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// One item waiting on the user, from `GET /inbox`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct InboxItem {
+    pub chat_id: openwave_core::ChatId,
+    /// The detail fields are part of the wire contract; the TUI's inbox use
+    /// is the attention marker, so only the chat identity is read today.
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub chat_title: Option<String>,
+    #[allow(dead_code)]
+    pub kind: String,
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub action: Option<String>,
+    #[allow(dead_code)]
+    pub requested_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// One background agent run, from `GET /chats/{id}/agent-runs`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AgentRunSnapshot {
+    pub id: openwave_core::AgentRunId,
+    #[serde(default)]
+    pub tier: Option<String>,
+    pub status: String,
+    #[serde(default)]
+    pub task: Option<String>,
+    #[serde(default)]
+    pub started_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(default)]
+    pub finished_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(default)]
+    pub last_error_code: Option<String>,
+    #[serde(default)]
+    pub activity: Option<AgentActivity>,
+    #[serde(default)]
+    pub terminal_text: Option<String>,
+    /// The call that spawned this run; lets a transcript attach the run to
+    /// its spawning step. The TUI doesn't join the two yet.
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub spawn_call_id: Option<CallId>,
+    #[serde(default)]
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// The live checkpoint of a background run.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AgentActivity {
+    pub kind: AgentActivityKind,
+    pub status: String,
+}
+
+/// The renderer-safe activity vocabulary, closed like the server's.
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentActivityKind {
+    Exec,
+    WebSearch,
+    ReadDelegatedFile,
+    ListConnectedFolders,
+    ListFolder,
+    ReadConnectedFile,
+    ImportConnectedFile,
+    #[serde(other)]
+    Other,
+}
+
+impl AgentActivityKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Exec => "a command",
+            Self::WebSearch => "a web search",
+            Self::ReadDelegatedFile => "a delegated file",
+            Self::ListConnectedFolders => "connected folders",
+            Self::ListFolder => "a folder",
+            Self::ReadConnectedFile => "a file",
+            Self::ImportConnectedFile => "an import",
+            Self::Other => "a step",
+        }
+    }
+}
+
+/// One history entry in a background run's activity timeline.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AgentActivityItem {
+    pub kind: AgentActivityKind,
+    pub outcome: String,
+    pub at: chrono::DateTime<chrono::Utc>,
+}
+
+/// One pending approval, from `GET /chats/{id}/approvals`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PendingApprovalSnapshot {
+    pub call_id: CallId,
+    pub action: String,
+    pub approval: String,
+    #[serde(default)]
+    pub auto_judge_status: Option<String>,
+    #[serde(default)]
+    pub preview: Option<serde_json::Value>,
+    /// Whether the kind is approvable at all; a `false` card is decline-only.
+    /// The TUI shows the same card either way today.
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub can_approve: bool,
+    #[serde(default)]
+    pub grant_rungs: Vec<GrantRung>,
+}
+
+/// One proposed plan awaiting review, from `GET /chats/{id}/plans/pending`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PendingPlan {
+    pub call_id: CallId,
+    /// The turn that proposed it; part of the wire contract, not rendered.
+    #[allow(dead_code)]
+    pub turn_id: TurnId,
+    pub title: String,
+    pub plan: String,
+}
+
+/// One block of questions the model is asking, from
+/// `GET /chats/{id}/questions/pending`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PendingQuestions {
+    pub call_id: CallId,
+    /// The turn that asked; part of the wire contract, not rendered.
+    #[allow(dead_code)]
+    pub turn_id: TurnId,
+    #[serde(default)]
+    pub questions: Vec<UserQuestion>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UserQuestion {
+    pub id: String,
+    #[serde(default)]
+    pub header: String,
+    pub question: String,
+    #[serde(default)]
+    pub options: Vec<QuestionOption>,
+    /// `"single"` or `"multi"`; anything else treats as single.
+    #[serde(default)]
+    pub question_type: String,
+    #[serde(default)]
+    pub allow_free_form: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct QuestionOption {
+    /// The option's identity, which the answer's `selected_option_ids` names.
+    pub id: String,
+    pub label: String,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+/// One selectable model, from `GET /models`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ModelInfo {
+    pub key: String,
+    pub id: String,
+    pub display_name: String,
+    /// The provider that serves the model; decoded for forward compatibility,
+    /// not yet grouped on in the picker.
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub provider: String,
+    #[serde(default)]
+    pub available: bool,
+    #[serde(default)]
+    pub context_window: u32,
+    #[serde(default)]
+    pub reasoning_efforts: Vec<String>,
+}
+
+/// The model catalog response.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ModelCatalog {
+    #[serde(default)]
+    pub models: Vec<ModelInfo>,
 }
 
 #[cfg(test)]
@@ -125,8 +539,8 @@ mod tests {
         let metadata = frame(r#"{"metadata":"titled","title":"A chat"}"#);
         assert_eq!(
             metadata,
-            ChatFrame::Metadata(MetadataFrame {
-                metadata: "titled".into()
+            ChatFrame::Metadata(MetadataFrame::Titled {
+                title: "A chat".into()
             })
         );
 
@@ -166,9 +580,10 @@ mod tests {
         let started_call = *call_id;
 
         // ApprovalRequired carries the one deliberate payload opening: the
-        // tool's closed preview of the action under review.
+        // tool's closed preview of the action under review, plus the grant
+        // ladder the decision can name back.
         let approval = frame(&format!(
-            r#"{{"seq":4,"event":{{"type":"approval_required","call_id":"{started_call}","action":"exec","approval":"exec_may_run_networked_command","class":"sensitive","preview":{{"tool":"exec","command":"git","args":["status"],"cwd":".","files":[]}}}}}}"#
+            r#"{{"seq":4,"event":{{"type":"approval_required","call_id":"{started_call}","action":"exec","approval":"exec_may_run_networked_command","class":"sensitive","grant_rungs":["exact_action",{{"command_prefix":{{"tokens":1}}}},"whole_tool"],"preview":{{"tool":"exec","command":"git","args":["status"],"cwd":".","files":[]}}}}}}"#
         ));
         let ChatFrame::Event(approval) = approval else {
             panic!("expected an event frame: {approval:?}");
@@ -178,6 +593,7 @@ mod tests {
             action,
             approval: kind,
             auto_judging,
+            grant_rungs,
             preview,
         } = &approval.event
         else {
@@ -188,25 +604,38 @@ mod tests {
         assert_eq!(kind, "exec_may_run_networked_command");
         assert!(!auto_judging);
         assert_eq!(
+            grant_rungs,
+            &vec![
+                GrantRung::ExactAction,
+                GrantRung::CommandPrefix { tokens: 1 },
+                GrantRung::WholeTool,
+            ]
+        );
+        assert_eq!(
             preview.as_ref().and_then(|p| p.get("tool")),
             Some(&serde_json::json!("exec"))
         );
 
+        // ToolCallCompleted carries the action and result projections.
         let completed = frame(&format!(
-            r#"{{"seq":5,"event":{{"type":"tool_call_completed","call_id":"{started_call}","status":"completed"}}}}"#
+            r#"{{"seq":5,"event":{{"type":"tool_call_completed","call_id":"{started_call}","status":"completed","action":{{"tool":"exec","command":"git","args":["status"],"cwd":".","files":[]}},"result":{{"tool":"exec","exit_code":0,"timed_out":false,"output_truncated":false,"stdout":"ok","stderr":""}}}}}}"#
         ));
-        assert_eq!(
-            completed,
-            ChatFrame::Event(SequencedFrame {
-                seq: 5,
-                event: ClientEvent::ToolCallCompleted {
-                    call_id: started_call,
-                    status: ToolCallStatus::Completed,
-                }
-            })
-        );
+        let ChatFrame::Event(completed) = completed else {
+            panic!("expected an event frame: {completed:?}");
+        };
+        let ClientEvent::ToolCallCompleted {
+            status,
+            action,
+            result,
+            ..
+        } = &completed.event
+        else {
+            panic!("expected tool_call_completed: {completed:?}");
+        };
+        assert_eq!(*status, ToolCallStatus::Completed);
+        assert!(action.is_some());
+        assert!(result.is_some());
 
-        // TurnCompleted's usage is present on the wire but unread by the TUI.
         let done = frame(
             r#"{"seq":6,"event":{"type":"turn_completed","usage":{"input_tokens":1,"output_tokens":2,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}"#,
         );
@@ -214,7 +643,14 @@ mod tests {
             done,
             ChatFrame::Event(SequencedFrame {
                 seq: 6,
-                event: ClientEvent::TurnCompleted,
+                event: ClientEvent::TurnCompleted {
+                    usage: TurnUsage {
+                        input_tokens: 1,
+                        output_tokens: 2,
+                        cache_read_input_tokens: 0,
+                        cache_creation_input_tokens: 0,
+                    }
+                },
             })
         );
     }

--- a/crates/openwave-cli/src/print.rs
+++ b/crates/openwave-cli/src/print.rs
@@ -136,7 +136,9 @@ async fn one_turn(
         match event {
             ClientEvent::TextDelta { text } => printer.text(&text),
             ClientEvent::ToolCallStarted { call_id, name } => printer.tool_started(call_id, name),
-            ClientEvent::ToolCallCompleted { call_id, status } => {
+            ClientEvent::ToolCallCompleted {
+                call_id, status, ..
+            } => {
                 printer.tool_completed(call_id, status);
             }
             ClientEvent::ApprovalRequired {
@@ -146,7 +148,7 @@ async fn one_turn(
                     "approval for {action} rejected: {REJECTION_REASON}"
                 ));
                 if let Err(error) = client
-                    .decide_approval(chat, call_id, false, REJECTION_REASON)
+                    .decide_approval(chat, call_id, false, REJECTION_REASON, None)
                     .await
                 {
                     // A decision that races the approval judge or a cancelled
@@ -156,7 +158,7 @@ async fn one_turn(
             }
             // Neither can be answered without a human. Cancelling is what stops
             // the parked turn from outliving this process.
-            ClientEvent::UserQuestionsAsked | ClientEvent::PlanProposed => {
+            ClientEvent::UserQuestionsAsked { .. } | ClientEvent::PlanProposed { .. } => {
                 printer.finish();
                 eprintln!(
                     "openwave: the turn needs an interactive answer, which print mode cannot \
@@ -165,19 +167,19 @@ async fn one_turn(
                 let _ = client.cancel_turn(chat, turn_id).await;
                 break EXIT_TURN_UNSUCCESSFUL;
             }
-            ClientEvent::TurnCompleted => break 0,
-            ClientEvent::TurnFailed { category } => {
+            ClientEvent::TurnCompleted { .. } => break 0,
+            ClientEvent::TurnFailed { category, .. } => {
                 printer.finish();
                 eprintln!("openwave: turn failed ({category})");
                 break EXIT_TURN_UNSUCCESSFUL;
             }
-            ClientEvent::TurnRefused { refusal } => {
+            ClientEvent::TurnRefused { refusal, .. } => {
                 printer.finish();
                 let category = refusal.category.unwrap_or_else(|| "unspecified".to_owned());
                 eprintln!("openwave: turn refused ({category})");
                 break EXIT_TURN_UNSUCCESSFUL;
             }
-            ClientEvent::TurnCancelled => {
+            ClientEvent::TurnCancelled { .. } => {
                 printer.finish();
                 eprintln!("openwave: turn cancelled");
                 break EXIT_TURN_UNSUCCESSFUL;
@@ -302,6 +304,7 @@ impl Printer {
             ToolCallStatus::Completed => "ok",
             // An unrecognized status reads as a failure: the conservative note.
             ToolCallStatus::Failed | ToolCallStatus::Unknown => "failed",
+            ToolCallStatus::Cancelled => "cancelled",
         };
         self.notice(&format!("tool: {name} {status}"));
     }

--- a/crates/openwave-cli/src/tui/app.rs
+++ b/crates/openwave-cli/src/tui/app.rs
@@ -3,6 +3,7 @@
 //! notices) are committed to real scrollback with `insert_before`; the inline
 //! viewport below them repaints the live region.
 
+use std::collections::{HashMap, HashSet};
 use std::io::{self, Stdout};
 use std::time::Duration;
 
@@ -15,27 +16,34 @@ use crossterm::event::{
 use crossterm::execute;
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 use futures::StreamExt;
-use openwave_core::{AgentError, CallId, ChatId, Result, TurnId};
+use openwave_core::{AgentError, AgentRunId, CallId, ChatId, Result, TurnId};
 use ratatui::backend::CrosstermBackend;
 use ratatui::layout::{Constraint, Layout, Rect};
-use ratatui::style::{Modifier, Style};
+use ratatui::style::Style;
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Paragraph, Widget};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Widget, Wrap};
 use ratatui::{Terminal, TerminalOptions, Viewport};
 use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::Message;
-use tui_textarea::{Input, TextArea};
+use tui_textarea::TextArea;
 
+use super::overlays::{
+    AgentsOverlay, ChatsOverlay, HelpOverlay, ModeOverlay, ModelOverlay, MoveOverlay,
+    OverlayOutcome, QuestionsOverlay,
+};
 use super::render::{self, Commit};
 use super::theme;
 use crate::api::client::{Client, EventSocket};
-use crate::api::wire::{ChatFrame, ClientEvent, SequencedFrame, ToolCallStatus};
+use crate::api::wire::{
+    AgentRunSnapshot, ChatFrame, ChatSummary, ClientEvent, MetadataFrame, PendingQuestions,
+    SequencedFrame, ToolCallStatus,
+};
 
 /// Fixed height of the repainting region: transient stack, composer, footer.
 /// Clamped to the terminal at startup.
-const LIVE_HEIGHT: u16 = 10;
+const LIVE_HEIGHT: u16 = 12;
 /// Composer rows beyond this scroll inside the textarea.
-const MAX_COMPOSER_ROWS: u16 = 4;
+const MAX_COMPOSER_ROWS: u16 = 5;
 const TICK: Duration = Duration::from_millis(100);
 /// One delayed reconnect after an unexpected socket close; further closes give
 /// up rather than hammering the server.
@@ -44,12 +52,55 @@ const SPINNER: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧
 
 /// Outcomes of HTTP actions spawned off the UI loop, plus the one reconnect.
 enum ActionOutcome {
-    Sent { turn_id: TurnId, content: String },
-    SendFailed { content: String, error: String },
+    Sent {
+        turn_id: TurnId,
+        content: String,
+    },
+    SendFailed {
+        content: String,
+        error: String,
+    },
     CancelFailed(String),
     DecisionFailed(String),
     Reconnected(Box<EventSocket>),
     ReconnectFailed(String),
+    /// The startup transcript + pending-state bundle for the current chat.
+    Hydrated(Box<Hydration>),
+    HydrationFailed(String),
+    /// A chat list refresh for the switcher, with attention markers.
+    ChatList(Vec<ChatSummary>, HashSet<ChatId>),
+    ChatListFailed(String),
+    /// Background-agent runs for the current chat.
+    AgentRuns(Vec<AgentRunSnapshot>),
+    /// One run's activity timeline, for the agents overlay's detail view.
+    AgentActivity(AgentRunId, Vec<crate::api::wire::AgentActivityItem>),
+    /// The selectable model catalog.
+    Models(Vec<crate::api::wire::ModelInfo>),
+    /// The projects list for the move picker.
+    Projects(Vec<crate::api::wire::ProjectSummary>),
+    /// A parked question block is ready to answer.
+    QuestionsReady(PendingQuestions),
+    /// A proposed plan is ready to review.
+    PlanReady(crate::api::wire::PendingPlan),
+    /// A new chat was created server-side; attach to it.
+    ChatCreated(ChatId),
+    ChatOpFailed(String),
+    Steered {
+        content: String,
+    },
+    PlanDecided,
+    QuestionsAnswered,
+    GenericOk(String),
+}
+
+/// Everything the TUI pulls to (re)hydrate a chat it just attached to.
+struct Hydration {
+    chat: ChatSummary,
+    transcript: crate::api::wire::Transcript,
+    approvals: Vec<crate::api::wire::PendingApprovalSnapshot>,
+    plans: Vec<crate::api::wire::PendingPlan>,
+    questions: Vec<PendingQuestions>,
+    runs: Vec<AgentRunSnapshot>,
 }
 
 struct PendingApproval {
@@ -57,12 +108,35 @@ struct PendingApproval {
     action: String,
     approval: String,
     auto_judging: bool,
-    preview: Option<String>,
+    preview: Option<serde_json::Value>,
+    grant_rungs: Vec<crate::api::wire::GrantRung>,
+    /// Whether the user pressed `a` to pick a standing grant.
+    picking_grant: bool,
 }
 
 struct ActiveTool {
     call_id: CallId,
     name: String,
+}
+
+/// A plan review in flight: the proposed plan plus the feedback box state.
+struct PendingPlanReview {
+    call_id: CallId,
+    title: String,
+    plan: String,
+    /// Whether the feedback textarea is open (reject-with-changes).
+    feedback: Option<TextArea<'static>>,
+}
+
+/// Which overlay, if any, owns the keyboard right now.
+enum Overlay {
+    Chats(ChatsOverlay),
+    Agents(AgentsOverlay),
+    Models(ModelOverlay),
+    Mode(ModeOverlay),
+    Move(MoveOverlay),
+    Questions(QuestionsOverlay),
+    Help(HelpOverlay),
 }
 
 struct App {
@@ -71,6 +145,10 @@ struct App {
     /// First group of the chat's UUID, for the header and the footer's right
     /// edge.
     short_id: String,
+    title: Option<String>,
+    model: Option<String>,
+    reasoning_effort: Option<String>,
+    permission_mode: String,
     actions: mpsc::UnboundedSender<ActionOutcome>,
     composer: TextArea<'static>,
     /// Assistant text of the in-flight turn, appended by `TextDelta`.
@@ -79,6 +157,8 @@ struct App {
     thinking: String,
     active_tool: Option<ActiveTool>,
     approval: Option<PendingApproval>,
+    plan: Option<PendingPlanReview>,
+    questions: Option<PendingQuestions>,
     running_turn: Option<TurnId>,
     /// A send whose POST hasn't resolved yet; blocks a second send in flight.
     send_pending: bool,
@@ -89,6 +169,24 @@ struct App {
     flash: Option<(String, u8)>,
     spinner: usize,
     should_quit: bool,
+    /// The open overlay, if any. While one is open it owns the keyboard.
+    overlay: Option<Overlay>,
+    /// Background runs for this chat, keyed by run id.
+    runs: HashMap<AgentRunId, AgentRunSnapshot>,
+    /// Chats with a parked prompt somewhere, for the switcher's markers.
+    attention: HashSet<ChatId>,
+    /// Context tokens the last completed turn reported, for the footer meter.
+    context_tokens: u64,
+    /// The context window of the current model, if the catalog has loaded.
+    context_window: Option<u32>,
+    /// The model catalog, loaded once and reused by the picker.
+    catalog: Option<Vec<crate::api::wire::ModelInfo>>,
+    /// Whether the first hydration for this chat has landed. The event socket
+    /// opens only once this is true, at the watermark hydration set.
+    hydrated: bool,
+    /// In-flight reconnect task identity, so the loop doesn't open a second
+    /// socket while one is already connecting.
+    reconnecting: Option<()>,
 }
 
 impl App {
@@ -97,12 +195,18 @@ impl App {
             client,
             short_id: chat.to_string().chars().take(8).collect(),
             chat,
+            title: None,
+            model: None,
+            reasoning_effort: None,
+            permission_mode: "ask".to_owned(),
             actions,
-            composer: new_composer(Vec::new()),
+            composer: super::composer::new(Vec::new()),
             streaming: String::new(),
             thinking: String::new(),
             active_tool: None,
             approval: None,
+            plan: None,
+            questions: None,
             running_turn: None,
             send_pending: false,
             last_seq: 0,
@@ -110,6 +214,14 @@ impl App {
             flash: None,
             spinner: 0,
             should_quit: false,
+            overlay: None,
+            runs: HashMap::new(),
+            attention: HashSet::new(),
+            context_tokens: 0,
+            context_window: None,
+            catalog: None,
+            hydrated: false,
+            reconnecting: None,
         }
     }
 
@@ -121,9 +233,15 @@ impl App {
     fn commit_streaming(&mut self) {
         let streamed = std::mem::take(&mut self.streaming);
         if !streamed.trim().is_empty() {
-            self.commit(Commit::AssistantText(streamed));
+            self.commit(Commit::AssistantText {
+                text: streamed,
+                at: Some(chrono::Utc::now()),
+            });
         }
-        self.thinking.clear();
+        let thinking = std::mem::take(&mut self.thinking);
+        if !thinking.trim().is_empty() {
+            self.commit(Commit::Reasoning { text: thinking });
+        }
     }
 
     fn flash(&mut self, message: impl Into<String>) {
@@ -138,6 +256,20 @@ impl App {
     fn on_frame(&mut self, frame: SequencedFrame) {
         self.last_seq = frame.seq;
         self.on_event(frame.event);
+    }
+
+    fn on_metadata(&mut self, metadata: MetadataFrame) {
+        match metadata {
+            MetadataFrame::Titled { title } => {
+                self.title = Some(title);
+            }
+            MetadataFrame::SandboxPreparing { preparing } => {
+                if preparing {
+                    self.flash("preparing the sandbox image — this can take a few minutes");
+                }
+            }
+            MetadataFrame::FileChangesRecorded | MetadataFrame::Unknown => {}
+        }
     }
 
     fn on_event(&mut self, event: ClientEvent) {
@@ -163,6 +295,7 @@ impl App {
             }
             ClientEvent::ToolCallStarted { call_id, name } => {
                 self.commit_streaming();
+                // A spawn shows up as an agent run too; note it live.
                 self.active_tool = Some(ActiveTool { call_id, name });
             }
             ClientEvent::ToolCallArgsDelta => {}
@@ -171,22 +304,31 @@ impl App {
                 action,
                 approval,
                 auto_judging,
+                grant_rungs,
                 preview,
             } => {
+                self.commit_streaming();
                 self.approval = Some(PendingApproval {
                     call_id,
                     action,
                     approval,
                     auto_judging,
-                    preview: preview.as_ref().and_then(render::preview_summary),
+                    preview,
+                    grant_rungs,
+                    picking_grant: false,
                 });
             }
-            ClientEvent::ApprovalDecided { call_id } => {
+            ClientEvent::ApprovalDecided { call_id, .. } => {
                 if self.approval.as_ref().is_some_and(|p| p.call_id == call_id) {
                     self.approval = None;
                 }
             }
-            ClientEvent::ToolCallCompleted { call_id, status } => {
+            ClientEvent::ToolCallCompleted {
+                call_id,
+                status,
+                action,
+                result,
+            } => {
                 let name = match self.active_tool.take() {
                     Some(tool) if tool.call_id == call_id => tool.name,
                     // A completion without a matching start (replay edge) still
@@ -196,37 +338,65 @@ impl App {
                         "tool".to_owned()
                     }
                 };
-                self.commit(Commit::ToolDone {
-                    name,
-                    failed: status != ToolCallStatus::Completed,
-                });
+                let action = action.as_ref().and_then(render::preview_summary);
+                let output = result.as_ref().and_then(render::exec_output);
+                // A spawn's completion names the delegated task as an agent
+                // run; surface it as an agent line rather than a bare tool.
+                if name == "spawn_sandbox_agent" {
+                    let task = action
+                        .as_deref()
+                        .and_then(|a| a.strip_prefix("background agent: "))
+                        .unwrap_or("background agent")
+                        .to_owned();
+                    self.commit(Commit::AgentRun {
+                        task,
+                        status: if status == ToolCallStatus::Completed {
+                            "spawned".into()
+                        } else {
+                            "declined".into()
+                        },
+                    });
+                    self.refresh_runs();
+                } else {
+                    self.commit(Commit::ToolDone {
+                        name,
+                        failed: status != ToolCallStatus::Completed,
+                        cancelled: status == ToolCallStatus::Cancelled,
+                        action,
+                        output,
+                    });
+                }
             }
-            ClientEvent::TurnCompleted => {
+            ClientEvent::TurnCompleted { usage } => {
                 self.commit_streaming();
                 self.active_tool = None;
                 self.running_turn = None;
+                self.context_tokens = usage.context_tokens();
             }
-            ClientEvent::TurnCancelled => {
+            ClientEvent::TurnCancelled { usage } => {
                 self.commit_streaming();
                 self.active_tool = None;
                 self.approval = None;
                 self.running_turn = None;
+                self.context_tokens = usage.context_tokens();
                 self.commit(Commit::Notice("turn cancelled".into()));
             }
-            ClientEvent::TurnFailed { category } => {
+            ClientEvent::TurnFailed { category, model } => {
                 self.commit_streaming();
                 self.active_tool = None;
                 self.approval = None;
                 self.running_turn = None;
-                self.commit(Commit::Error(format!(
-                    "turn failed ({})",
-                    category.replace('_', " ")
-                )));
+                let mut line = format!("turn failed ({})", category.replace('_', " "));
+                if let Some(model) = model {
+                    line.push_str(&format!(" — {}", model.id));
+                }
+                self.commit(Commit::Error(line));
             }
-            ClientEvent::TurnRefused { refusal } => {
+            ClientEvent::TurnRefused { refusal, usage } => {
                 self.commit_streaming();
                 self.active_tool = None;
                 self.running_turn = None;
+                self.context_tokens = usage.context_tokens();
                 let detail = refusal
                     .category
                     .map(|category| format!(" ({})", category.replace('_', " ")))
@@ -234,9 +404,7 @@ impl App {
                 self.commit(Commit::Notice(format!("the model refused{detail}")));
             }
             ClientEvent::UserSteered { text } => {
-                self.commit(Commit::Notice(format!(
-                    "steered from another client: {text}"
-                )));
+                self.commit(Commit::Notice(format!("steered: {text}")));
             }
             ClientEvent::ContextTruncated {
                 original_tokens,
@@ -246,26 +414,97 @@ impl App {
                     "context truncated: ~{original_tokens} → ~{fitted_tokens} tokens"
                 )));
             }
-            ClientEvent::UserQuestionsAsked => {
-                self.commit(Commit::Notice(
-                    "the model is asking questions — answer them in the desktop app; \
-                     interactive questions aren't supported in the TUI yet"
-                        .into(),
-                ));
+            ClientEvent::UserQuestionsAsked { call_id } => {
+                self.commit_streaming();
+                self.refresh_questions();
+                if let Some(call_id) = call_id {
+                    let _ = call_id;
+                }
             }
-            ClientEvent::PlanProposed => {
-                self.commit(Commit::Notice(
-                    "a plan is awaiting review — decide it in the desktop app; \
-                     plan mode isn't supported in the TUI yet"
-                        .into(),
-                ));
+            ClientEvent::PlanProposed { .. } => {
+                self.commit_streaming();
+                self.refresh_plans();
             }
             ClientEvent::Unknown => {}
         }
     }
 
+    /// Pull the parked prompts for this chat (approvals are event-driven, but
+    /// questions and plans need their recovery reads).
+    fn refresh_questions(&mut self) {
+        let (client, chat, actions) = (self.client.clone(), self.chat, self.actions.clone());
+        tokio::spawn(async move {
+            match client.list_pending_questions(chat).await {
+                Ok(mut pending) => {
+                    if let Some(block) = pending.drain(..).next() {
+                        let _ = actions.send(ActionOutcome::QuestionsReady(block));
+                    }
+                }
+                Err(error) => {
+                    let _ = actions.send(ActionOutcome::ChatOpFailed(error.to_string()));
+                }
+            }
+        });
+    }
+
+    fn refresh_plans(&mut self) {
+        let (client, chat, actions) = (self.client.clone(), self.chat, self.actions.clone());
+        tokio::spawn(async move {
+            match client.list_pending_plans(chat).await {
+                Ok(mut pending) => {
+                    if let Some(plan) = pending.drain(..).next() {
+                        let _ = actions.send(ActionOutcome::PlanReady(plan));
+                    }
+                }
+                Err(error) => {
+                    let _ = actions.send(ActionOutcome::ChatOpFailed(error.to_string()));
+                }
+            }
+        });
+    }
+
+    fn refresh_runs(&mut self) {
+        let (client, chat, actions) = (self.client.clone(), self.chat, self.actions.clone());
+        tokio::spawn(async move {
+            if let Ok(runs) = client.list_agent_runs(chat).await {
+                let _ = actions.send(ActionOutcome::AgentRuns(runs));
+            }
+        });
+    }
+
+    fn refresh_chat_list(&mut self) {
+        let (client, actions) = (self.client.clone(), self.actions.clone());
+        tokio::spawn(async move {
+            let chats = client.list_chats().await;
+            let inbox = client.list_inbox().await.unwrap_or_default();
+            let attention = inbox.into_iter().map(|item| item.chat_id).collect();
+            match chats {
+                Ok(chats) => {
+                    let _ = actions.send(ActionOutcome::ChatList(chats, attention));
+                }
+                Err(error) => {
+                    let _ = actions.send(ActionOutcome::ChatListFailed(error.to_string()));
+                }
+            }
+        });
+    }
+
+    fn refresh_models(&mut self) {
+        let (client, actions) = (self.client.clone(), self.actions.clone());
+        tokio::spawn(async move {
+            if let Ok(catalog) = client.list_models().await {
+                let _ = actions.send(ActionOutcome::Models(catalog.models));
+            }
+        });
+    }
+
     fn on_key(&mut self, key: KeyEvent) {
         if key.kind == KeyEventKind::Release {
+            return;
+        }
+        // Overlays own the keyboard while open.
+        if self.overlay.is_some() {
+            self.overlay_key(key);
             return;
         }
         if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
@@ -276,11 +515,41 @@ impl App {
             }
             return;
         }
+        // The plan review flow suspends the composer. (Questions open as a
+        // full overlay from the `QuestionsReady` outcome, not a key path.)
+        if self.plan.is_some() {
+            self.plan_key(key);
+            return;
+        }
         if self.approval.is_some() {
             // The composer is suspended while a decision is pending.
             match key.code {
-                KeyCode::Char('y') | KeyCode::Char('Y') => self.decide(true),
-                KeyCode::Char('n') | KeyCode::Char('N') => self.decide(false),
+                KeyCode::Char('y') | KeyCode::Char('Y') => self.decide(true, None),
+                KeyCode::Char('n') | KeyCode::Char('N') => self.decide(false, None),
+                KeyCode::Char('a') | KeyCode::Char('A') => {
+                    if let Some(approval) = &mut self.approval {
+                        if !approval.grant_rungs.is_empty() {
+                            approval.picking_grant = true;
+                        }
+                    }
+                }
+                KeyCode::Char(digit @ '1'..='9') => {
+                    let index = digit.to_digit(10).unwrap_or(1) as usize - 1;
+                    let rung = self
+                        .approval
+                        .as_ref()
+                        .and_then(|a| a.grant_rungs.get(index).copied());
+                    if let (Some(true), Some(rung)) =
+                        (self.approval.as_ref().map(|a| a.picking_grant), rung)
+                    {
+                        self.decide(true, Some(rung));
+                    }
+                }
+                KeyCode::Esc => {
+                    if let Some(approval) = &mut self.approval {
+                        approval.picking_grant = false;
+                    }
+                }
                 _ => {}
             }
             return;
@@ -290,6 +559,40 @@ impl App {
                 self.should_quit = true;
             }
             return;
+        }
+        // Overlay-opening shortcuts.
+        if key.modifiers.contains(KeyModifiers::CONTROL) {
+            match key.code {
+                KeyCode::Char('o') => {
+                    self.open_chats();
+                    return;
+                }
+                KeyCode::Char('g') => {
+                    self.open_agents();
+                    return;
+                }
+                KeyCode::Char('m') => {
+                    self.open_models();
+                    return;
+                }
+                KeyCode::Char('p') => {
+                    self.open_mode();
+                    return;
+                }
+                KeyCode::Char('w') => {
+                    self.open_move();
+                    return;
+                }
+                KeyCode::Char('n') => {
+                    self.new_chat();
+                    return;
+                }
+                KeyCode::Char('/') => {
+                    self.overlay = Some(Overlay::Help(HelpOverlay::new()));
+                    return;
+                }
+                _ => {}
+            }
         }
         match key.code {
             KeyCode::Enter
@@ -301,25 +604,195 @@ impl App {
             }
             KeyCode::Enter => self.try_send(),
             _ => {
-                self.composer.input(Input::from(key));
+                super::composer::edit_key(&mut self.composer, key);
             }
         }
     }
 
+    fn overlay_key(&mut self, key: KeyEvent) {
+        let Some(overlay) = self.overlay.take() else {
+            return;
+        };
+        let outcome = match overlay {
+            Overlay::Chats(mut overlay) => match overlay.key(key) {
+                OverlayOutcome::Stay => {
+                    self.overlay = Some(Overlay::Chats(overlay));
+                    None
+                }
+                outcome => Some(outcome),
+            },
+            Overlay::Agents(mut overlay) => match overlay.key(key) {
+                OverlayOutcome::Stay => {
+                    self.overlay = Some(Overlay::Agents(overlay));
+                    None
+                }
+                outcome => Some(outcome),
+            },
+            Overlay::Models(mut overlay) => match overlay.key(key) {
+                OverlayOutcome::Stay => {
+                    self.overlay = Some(Overlay::Models(overlay));
+                    None
+                }
+                outcome => Some(outcome),
+            },
+            Overlay::Mode(mut overlay) => match overlay.key(key) {
+                OverlayOutcome::Stay => {
+                    self.overlay = Some(Overlay::Mode(overlay));
+                    None
+                }
+                outcome => Some(outcome),
+            },
+            Overlay::Move(mut overlay) => match overlay.key(key) {
+                OverlayOutcome::Stay => {
+                    self.overlay = Some(Overlay::Move(overlay));
+                    None
+                }
+                outcome => Some(outcome),
+            },
+            Overlay::Questions(mut overlay) => match overlay.key(key) {
+                OverlayOutcome::Stay => {
+                    self.overlay = Some(Overlay::Questions(overlay));
+                    None
+                }
+                outcome => Some(outcome),
+            },
+            Overlay::Help(mut overlay) => match overlay.key(key) {
+                OverlayOutcome::Stay => {
+                    self.overlay = Some(Overlay::Help(overlay));
+                    None
+                }
+                outcome => Some(outcome),
+            },
+        };
+        if let Some(outcome) = outcome {
+            self.on_overlay_outcome(outcome);
+        }
+    }
+
+    fn on_overlay_outcome(&mut self, outcome: OverlayOutcome) {
+        match outcome {
+            OverlayOutcome::Open(chat) => {
+                let switching = chat != self.chat;
+                if switching {
+                    self.attach(chat);
+                }
+            }
+            OverlayOutcome::NewChat => self.new_chat(),
+            OverlayOutcome::Delete(chat) => self.delete_chat(chat),
+            OverlayOutcome::Rename(chat, title) => self.rename_chat(chat, title),
+            OverlayOutcome::MoveChat(project) => self.move_chat(project),
+            OverlayOutcome::SetModel(model) => self.set_model(model),
+            OverlayOutcome::SetEffort(effort) => self.set_effort(effort),
+            OverlayOutcome::SetMode(mode) => self.set_mode(mode),
+            OverlayOutcome::StopAgent(run) => self.stop_agent(run),
+            OverlayOutcome::SubmitQuestions(body) => self.submit_questions(body),
+            OverlayOutcome::Dismiss | OverlayOutcome::Stay => {}
+        }
+    }
+
+    fn open_chats(&mut self) {
+        self.refresh_chat_list();
+        self.overlay = Some(Overlay::Chats(ChatsOverlay::new(self.chat)));
+    }
+
+    fn open_agents(&mut self) {
+        self.refresh_runs();
+        self.overlay = Some(Overlay::Agents(AgentsOverlay::new()));
+    }
+
+    fn open_models(&mut self) {
+        self.refresh_models();
+        self.overlay = Some(Overlay::Models(ModelOverlay::new(
+            self.model.clone(),
+            self.reasoning_effort.clone(),
+        )));
+    }
+
+    fn open_mode(&mut self) {
+        self.overlay = Some(Overlay::Mode(ModeOverlay::new(&self.permission_mode)));
+    }
+
+    fn open_move(&mut self) {
+        let (client, actions) = (self.client.clone(), self.actions.clone());
+        tokio::spawn(async move {
+            match client.list_projects().await {
+                Ok(projects) => {
+                    let _ = actions.send(ActionOutcome::Projects(projects));
+                }
+                Err(error) => {
+                    let _ = actions.send(ActionOutcome::ChatOpFailed(error.to_string()));
+                }
+            }
+        });
+    }
+
+    /// The current questions overlay, if one is open.
+    fn questions_overlay(&mut self) -> Option<&mut QuestionsOverlay> {
+        match &mut self.overlay {
+            Some(Overlay::Questions(overlay)) => Some(overlay),
+            _ => None,
+        }
+    }
+
+    fn plan_key(&mut self, key: KeyEvent) {
+        let Some(plan) = &mut self.plan else {
+            return;
+        };
+        if let Some(feedback) = &mut plan.feedback {
+            match key.code {
+                KeyCode::Esc => plan.feedback = None,
+                KeyCode::Enter => {
+                    let text = feedback.lines().join("\n");
+                    let call_id = plan.call_id;
+                    self.decide_plan(call_id, false, Some(text));
+                }
+                _ => super::composer::single_line_key(feedback, key),
+            }
+            return;
+        }
+        match key.code {
+            KeyCode::Char('y') | KeyCode::Char('Y') => {
+                let call_id = plan.call_id;
+                self.decide_plan(call_id, true, None);
+            }
+            KeyCode::Char('n') | KeyCode::Char('N') => {
+                let call_id = plan.call_id;
+                self.decide_plan(call_id, false, None);
+            }
+            KeyCode::Char('f') | KeyCode::Char('F') => {
+                plan.feedback = Some(super::composer::new_single_line("", "what should change?"));
+            }
+            _ => {}
+        }
+    }
+
     fn try_send(&mut self) {
-        if self.running_turn.is_some() {
-            self.flash("a turn is still running — ctrl+c cancels it");
+        let content = self.composer.lines().join("\n");
+        if content.trim().is_empty() {
+            return;
+        }
+        // A running turn steers rather than rejects: the desktop's composer
+        // becomes "guide the active response", and so does this one.
+        if let Some(turn_id) = self.running_turn {
+            self.composer = super::composer::new(Vec::new());
+            let (client, chat, actions) = (self.client.clone(), self.chat, self.actions.clone());
+            tokio::spawn(async move {
+                let outcome = match client.steer(chat, turn_id, TurnId::new(), &content).await {
+                    Ok(()) => ActionOutcome::Steered { content },
+                    Err(error) => ActionOutcome::SendFailed {
+                        content,
+                        error: error.to_string(),
+                    },
+                };
+                let _ = actions.send(outcome);
+            });
             return;
         }
         if self.send_pending {
             return;
         }
-        let content = self.composer.lines().join("\n");
-        if content.trim().is_empty() {
-            return;
-        }
         self.send_pending = true;
-        self.composer = new_composer(Vec::new());
+        self.composer = super::composer::new(Vec::new());
         let turn_id = TurnId::new();
         let (client, chat, actions) = (self.client.clone(), self.chat, self.actions.clone());
         tokio::spawn(async move {
@@ -347,14 +820,20 @@ impl App {
         });
     }
 
-    fn decide(&mut self, approve: bool) {
+    fn decide(&mut self, approve: bool, grant: Option<crate::api::wire::GrantRung>) {
         let Some(pending) = self.approval.take() else {
             return;
         };
         let (client, chat, actions) = (self.client.clone(), self.chat, self.actions.clone());
         tokio::spawn(async move {
             if let Err(error) = client
-                .decide_approval(chat, pending.call_id, approve, "declined from terminal")
+                .decide_approval(
+                    chat,
+                    pending.call_id,
+                    approve,
+                    "declined from terminal",
+                    grant,
+                )
                 .await
             {
                 let _ = actions.send(ActionOutcome::DecisionFailed(error.to_string()));
@@ -362,16 +841,161 @@ impl App {
         });
     }
 
+    fn decide_plan(&mut self, call_id: CallId, accept: bool, feedback: Option<String>) {
+        self.plan = None;
+        let (client, chat, actions) = (self.client.clone(), self.chat, self.actions.clone());
+        tokio::spawn(async move {
+            let outcome = match client
+                .decide_plan(chat, call_id, accept, feedback.as_deref(), None)
+                .await
+            {
+                Ok(()) => ActionOutcome::PlanDecided,
+                Err(error) => ActionOutcome::DecisionFailed(error.to_string()),
+            };
+            let _ = actions.send(outcome);
+        });
+    }
+
+    fn submit_questions(&mut self, body: serde_json::Value) {
+        let call_id = self
+            .questions_overlay()
+            .map(|overlay| overlay.call_id())
+            .or_else(|| self.questions.as_ref().map(|pending| pending.call_id));
+        let Some(call_id) = call_id else {
+            return;
+        };
+        self.questions = None;
+        let (client, chat, actions) = (self.client.clone(), self.chat, self.actions.clone());
+        tokio::spawn(async move {
+            let outcome = match client.answer_questions(chat, call_id, body).await {
+                Ok(()) => ActionOutcome::QuestionsAnswered,
+                Err(error) => ActionOutcome::DecisionFailed(error.to_string()),
+            };
+            let _ = actions.send(outcome);
+        });
+    }
+
+    /// The footer shows the current chat's title when it has one.
+    fn title_label(&self) -> String {
+        self.title
+            .as_deref()
+            .map(|title| render::truncate(title, 24))
+            .unwrap_or_else(|| format!("chat {}", self.short_id))
+    }
+
+    fn new_chat(&mut self) {
+        let (client, actions) = (self.client.clone(), self.actions.clone());
+        tokio::spawn(async move {
+            let outcome = match client.create_chat().await {
+                Ok(chat) => ActionOutcome::ChatCreated(chat),
+                Err(error) => ActionOutcome::ChatOpFailed(error.to_string()),
+            };
+            let _ = actions.send(outcome);
+        });
+    }
+
+    fn delete_chat(&mut self, chat: ChatId) {
+        let (client, actions) = (self.client.clone(), self.actions.clone());
+        tokio::spawn(async move {
+            let outcome = match client.delete_chat(chat).await {
+                Ok(()) => ActionOutcome::GenericOk("chat deleted".into()),
+                Err(error) => ActionOutcome::ChatOpFailed(error.to_string()),
+            };
+            let _ = actions.send(outcome);
+        });
+    }
+
+    fn rename_chat(&mut self, chat: ChatId, title: String) {
+        let title = (!title.trim().is_empty()).then_some(title);
+        let (client, actions) = (self.client.clone(), self.actions.clone());
+        tokio::spawn(async move {
+            let outcome = match client.rename_chat(chat, title.as_deref()).await {
+                Ok(()) => ActionOutcome::GenericOk("renamed".into()),
+                Err(error) => ActionOutcome::ChatOpFailed(error.to_string()),
+            };
+            let _ = actions.send(outcome);
+        });
+    }
+
+    fn move_chat(&mut self, project: Option<openwave_core::ProjectId>) {
+        let (client, chat, actions) = (self.client.clone(), self.chat, self.actions.clone());
+        tokio::spawn(async move {
+            let outcome = match client.set_chat_project(chat, project).await {
+                Ok(_) => ActionOutcome::GenericOk("moved".into()),
+                Err(error) => ActionOutcome::ChatOpFailed(error.to_string()),
+            };
+            let _ = actions.send(outcome);
+        });
+    }
+
+    fn set_model(&mut self, model: Option<String>) {
+        let (client, chat, actions) = (self.client.clone(), self.chat, self.actions.clone());
+        tokio::spawn(async move {
+            let outcome = match client.set_chat_model(chat, model.as_deref()).await {
+                Ok(()) => ActionOutcome::GenericOk("model updated".into()),
+                Err(error) => ActionOutcome::ChatOpFailed(error.to_string()),
+            };
+            let _ = actions.send(outcome);
+        });
+    }
+
+    fn set_effort(&mut self, effort: Option<String>) {
+        let (client, chat, actions) = (self.client.clone(), self.chat, self.actions.clone());
+        tokio::spawn(async move {
+            let outcome = match client.set_chat_effort(chat, effort.as_deref()).await {
+                Ok(()) => ActionOutcome::GenericOk("effort updated".into()),
+                Err(error) => ActionOutcome::ChatOpFailed(error.to_string()),
+            };
+            let _ = actions.send(outcome);
+        });
+    }
+
+    fn set_mode(&mut self, mode: String) {
+        let (client, chat, actions) = (self.client.clone(), self.chat, self.actions.clone());
+        tokio::spawn(async move {
+            let outcome = match client.set_chat_permission_mode(chat, Some(&mode)).await {
+                Ok(_) => ActionOutcome::GenericOk("permission mode updated".into()),
+                Err(error) => ActionOutcome::ChatOpFailed(error.to_string()),
+            };
+            let _ = actions.send(outcome);
+        });
+    }
+
+    fn stop_agent(&mut self, run: AgentRunId) {
+        let (client, chat, actions) = (self.client.clone(), self.chat, self.actions.clone());
+        tokio::spawn(async move {
+            let outcome = match client.cancel_agent_run(chat, run).await {
+                Ok(()) => ActionOutcome::GenericOk("agent stopping…".into()),
+                Err(error) => ActionOutcome::ChatOpFailed(error.to_string()),
+            };
+            let _ = actions.send(outcome);
+        });
+    }
+
     fn on_outcome(&mut self, outcome: ActionOutcome) {
         match outcome {
             ActionOutcome::Sent { turn_id, content } => {
                 self.send_pending = false;
-                self.commit(Commit::UserText(content));
+                self.commit(Commit::UserText {
+                    text: content,
+                    at: Some(chrono::Utc::now()),
+                    images: Vec::new(),
+                    files: Vec::new(),
+                });
                 self.running_turn = Some(turn_id);
+            }
+            ActionOutcome::Steered { content } => {
+                self.commit(Commit::UserText {
+                    text: content,
+                    at: Some(chrono::Utc::now()),
+                    images: Vec::new(),
+                    files: Vec::new(),
+                });
             }
             ActionOutcome::SendFailed { content, error } => {
                 self.send_pending = false;
-                self.composer = new_composer(content.split('\n').map(str::to_owned).collect());
+                self.composer =
+                    super::composer::new(content.split('\n').map(str::to_owned).collect());
                 self.commit(Commit::Error(format!("message not sent: {error}")));
             }
             ActionOutcome::CancelFailed(error) => {
@@ -385,11 +1009,279 @@ impl App {
             ActionOutcome::Reconnected(_) | ActionOutcome::ReconnectFailed(_) => {
                 // Handled by the loop, which owns the socket slot.
             }
+            ActionOutcome::Hydrated(hydration) => self.apply_hydration(hydration),
+            ActionOutcome::HydrationFailed(error) => {
+                self.commit(Commit::Error(format!("could not load the chat: {error}")));
+            }
+            ActionOutcome::ChatList(chats, attention) => {
+                self.attention = attention;
+                if let Some(Overlay::Chats(overlay)) = &mut self.overlay {
+                    overlay.set_chats(chats, self.attention.clone());
+                }
+            }
+            ActionOutcome::ChatListFailed(error) => {
+                self.flash(format!("couldn't load chats: {error}"));
+            }
+            ActionOutcome::AgentRuns(runs) => {
+                self.runs = runs
+                    .into_iter()
+                    .filter(|run| run.tier.as_deref() != Some("foreground"))
+                    .map(|run| (run.id, run))
+                    .collect();
+                if let Some(Overlay::Agents(overlay)) = &mut self.overlay {
+                    overlay.set_runs(self.runs.values().cloned().collect());
+                }
+            }
+            ActionOutcome::AgentActivity(run, items) => {
+                if let Some(Overlay::Agents(overlay)) = &mut self.overlay {
+                    overlay.set_detail(run, items);
+                }
+            }
+            ActionOutcome::Models(models) => {
+                if let Some(current) = &self.model {
+                    self.context_window = models
+                        .iter()
+                        .find(|model| &model.key == current || &model.id == current)
+                        .map(|model| model.context_window);
+                } else {
+                    // No explicit selection: the default model's window.
+                    self.context_window = models
+                        .iter()
+                        .find(|model| model.available)
+                        .map(|model| model.context_window);
+                }
+                self.catalog = Some(models.clone());
+                if let Some(Overlay::Models(overlay)) = &mut self.overlay {
+                    overlay.set_models(models);
+                }
+            }
+            ActionOutcome::ChatCreated(chat) => {
+                self.attach(chat);
+            }
+            ActionOutcome::ChatOpFailed(error) => {
+                self.commit(Commit::Error(error));
+            }
+            ActionOutcome::PlanDecided => {
+                self.commit(Commit::Notice("plan decided".into()));
+            }
+            ActionOutcome::QuestionsAnswered => {
+                self.commit(Commit::Notice("answers sent".into()));
+            }
+            ActionOutcome::GenericOk(message) => {
+                self.flash(message);
+                self.refresh_chat_list();
+            }
+            ActionOutcome::Projects(projects) => {
+                self.overlay = Some(Overlay::Move(MoveOverlay::new(projects)));
+            }
+            ActionOutcome::QuestionsReady(pending) => {
+                // Questions park the turn; open the answer form immediately
+                // rather than waiting for a keypress.
+                self.overlay = Some(Overlay::Questions(QuestionsOverlay::new(pending)));
+            }
+            ActionOutcome::PlanReady(plan) => {
+                self.plan = Some(PendingPlanReview {
+                    call_id: plan.call_id,
+                    title: plan.title,
+                    plan: plan.plan,
+                    feedback: None,
+                });
+            }
+        }
+    }
+
+    /// Move the session to another chat: close the old socket, reset the live
+    /// state, and rehydrate from the transcript.
+    fn attach(&mut self, chat: ChatId) {
+        self.chat = chat;
+        self.short_id = chat.to_string().chars().take(8).collect();
+        self.title = None;
+        self.streaming.clear();
+        self.thinking.clear();
+        self.active_tool = None;
+        self.approval = None;
+        self.plan = None;
+        self.questions = None;
+        self.running_turn = None;
+        self.send_pending = false;
+        self.runs.clear();
+        self.hydrated = false;
+        self.reconnecting = None;
+        // The loop notices `hydrated == false` once the fresh hydration lands
+        // and opens the new chat's socket at its watermark.
+        // A rule separates the previous chat's history from this one's.
+        self.commit(Commit::Lines(vec![
+            Line::from(Span::styled("─".repeat(40), theme::muted())),
+            Line::default(),
+        ]));
+        self.commit(Commit::Lines(render::header_lines(true, &self.short_id)));
+        self.hydrate();
+    }
+
+    /// Pull the transcript + parked state for the current chat.
+    fn hydrate(&mut self) {
+        let (client, chat, actions) = (self.client.clone(), self.chat, self.actions.clone());
+        tokio::spawn(async move {
+            let chat_record = client.get_chat(chat).await;
+            let transcript = client.get_transcript(chat).await;
+            let approvals = client
+                .list_pending_approvals(chat)
+                .await
+                .unwrap_or_default();
+            let plans = client.list_pending_plans(chat).await.unwrap_or_default();
+            let questions = client
+                .list_pending_questions(chat)
+                .await
+                .unwrap_or_default();
+            let runs = client.list_agent_runs(chat).await.unwrap_or_default();
+            let outcome = match (chat_record, transcript) {
+                (Ok(chat), Ok(transcript)) => ActionOutcome::Hydrated(Box::new(Hydration {
+                    chat,
+                    transcript,
+                    approvals,
+                    plans,
+                    questions,
+                    runs,
+                })),
+                (Err(error), _) | (_, Err(error)) => {
+                    ActionOutcome::HydrationFailed(error.to_string())
+                }
+            };
+            let _ = actions.send(outcome);
+        });
+    }
+
+    /// Render the hydrated transcript into scrollback commits.
+    fn apply_hydration(&mut self, hydration: Box<Hydration>) {
+        let Hydration {
+            chat,
+            transcript,
+            approvals,
+            plans,
+            questions,
+            runs,
+        } = *hydration;
+        self.title = chat.title;
+        self.model = chat.model;
+        self.reasoning_effort = chat.reasoning_effort;
+        self.permission_mode = chat.permission_mode.unwrap_or_else(|| "ask".into());
+        self.last_seq = self.last_seq.max(transcript.last_event_seq);
+        self.hydrated = true;
+
+        // History replay: user and assistant messages with their timestamps,
+        // and the settled tool activity between them.
+        for message in &transcript.messages {
+            match message.role {
+                crate::api::wire::TranscriptRole::User => {
+                    self.commit(Commit::UserText {
+                        text: message.content.clone(),
+                        at: Some(message.created_at),
+                        images: message.image_attachments.clone().unwrap_or_default(),
+                        files: message.file_attachments.clone().unwrap_or_default(),
+                    });
+                }
+                crate::api::wire::TranscriptRole::Assistant => {
+                    self.commit(Commit::AssistantText {
+                        text: message.content.clone(),
+                        at: Some(message.created_at),
+                    });
+                }
+                crate::api::wire::TranscriptRole::System => {
+                    self.commit(Commit::Notice(message.content.clone()));
+                }
+                crate::api::wire::TranscriptRole::Other => {}
+            }
+        }
+        for tool in &transcript.tool_activity {
+            if tool.tool == "spawn_sandbox_agent" {
+                continue; // agent runs get their own lines below
+            }
+            let status = tool
+                .status
+                .unwrap_or(crate::api::wire::ToolCallStatus::Completed);
+            self.commit(Commit::ToolDone {
+                name: tool.tool.clone(),
+                failed: status != crate::api::wire::ToolCallStatus::Completed,
+                cancelled: status == crate::api::wire::ToolCallStatus::Cancelled,
+                action: tool.action.as_ref().and_then(render::preview_summary),
+                output: tool.result.as_ref().and_then(render::exec_output),
+            });
+        }
+        for turn in &transcript.terminal_turns {
+            self.context_tokens = turn.usage.context_tokens();
+            match turn.status {
+                crate::api::wire::TerminalTurnStatus::Failed => {
+                    self.commit(Commit::Error(format!(
+                        "turn failed ({})",
+                        turn.failure_category
+                            .clone()
+                            .unwrap_or_else(|| "unknown".into())
+                            .replace('_', " ")
+                    )));
+                }
+                crate::api::wire::TerminalTurnStatus::Cancelled => {
+                    self.commit(Commit::Notice("turn cancelled".into()));
+                }
+                _ => {}
+            }
+            if let Some(refusal) = &turn.refusal {
+                let detail = refusal
+                    .category
+                    .as_ref()
+                    .map(|category| format!(" ({})", category.replace('_', " ")))
+                    .unwrap_or_default();
+                self.commit(Commit::Notice(format!("the model refused{detail}")));
+            }
+        }
+        // Settled background runs show as their own transcript lines.
+        self.runs = runs
+            .into_iter()
+            .filter(|run| run.tier.as_deref() != Some("foreground"))
+            .map(|run| (run.id, run))
+            .collect();
+        let settled: Vec<(String, String)> = self
+            .runs
+            .values()
+            .filter(|run| run.started_at.is_some() || run.finished_at.is_some())
+            .map(|run| {
+                (
+                    run.task
+                        .clone()
+                        .unwrap_or_else(|| "background agent".into()),
+                    run.status.clone(),
+                )
+            })
+            .collect();
+        for (task, status) in settled {
+            self.commit(Commit::AgentRun { task, status });
+        }
+        // Parked state reopens its card.
+        if let Some(approval) = approvals.into_iter().next() {
+            self.approval = Some(PendingApproval {
+                call_id: approval.call_id,
+                action: approval.action,
+                approval: approval.approval,
+                auto_judging: approval.auto_judge_status.is_some(),
+                preview: approval.preview,
+                grant_rungs: approval.grant_rungs,
+                picking_grant: false,
+            });
+        }
+        if let Some(plan) = plans.into_iter().next() {
+            self.plan = Some(PendingPlanReview {
+                call_id: plan.call_id,
+                title: plan.title,
+                plan: plan.plan,
+                feedback: None,
+            });
+        }
+        if let Some(pending) = questions.into_iter().next() {
+            self.questions = Some(pending);
         }
     }
 
     fn on_tick(&mut self) {
-        if self.running_turn.is_some() || self.active_tool.is_some() {
+        if self.running_turn.is_some() || self.active_tool.is_some() || self.runs_live() {
             self.spinner = self.spinner.wrapping_add(1);
         }
         if let Some((_, remaining)) = &mut self.flash {
@@ -400,26 +1292,73 @@ impl App {
         }
     }
 
+    /// Whether any background run is live (drives the spinner and footer).
+    fn runs_live(&self) -> bool {
+        self.runs
+            .values()
+            .any(|run| render::run_is_live(&run.status))
+    }
+
     /// The live region's transient stack, bottom-anchored within `max` lines:
     /// blank padding goes on top, so content sits directly above the composer.
     fn transient_lines(&self, width: usize, max: usize) -> Vec<Line<'static>> {
         let mut lines = Vec::new();
-        if !self.thinking.is_empty() {
-            lines.extend(render::thinking_lines(&self.thinking, width));
-        }
-        if !self.streaming.is_empty() {
-            lines.extend(render::streaming_lines(&self.streaming, width));
-        }
-        if let Some(tool) = &self.active_tool {
-            lines.push(render::tool_running_line(&tool.name, self.spinner()));
-        }
-        if let Some(approval) = &self.approval {
-            lines.extend(render::approval_card(
-                &approval.action,
-                &approval.approval,
-                approval.auto_judging,
-                approval.preview.as_deref(),
+        if let Some(plan) = &self.plan {
+            lines.extend(render::plan_card(
+                &plan.title,
+                &plan.plan,
+                plan.feedback.is_some(),
                 width,
+            ));
+        } else if !self.thinking.is_empty()
+            || !self.streaming.is_empty()
+            || self.active_tool.is_some()
+            || self.approval.is_some()
+        {
+            if !self.thinking.is_empty() {
+                lines.extend(render::thinking_lines(&self.thinking, width));
+            }
+            if !self.streaming.is_empty() {
+                lines.extend(render::streaming_lines(&self.streaming, width));
+            }
+            if let Some(tool) = &self.active_tool {
+                lines.push(render::tool_running_line(&tool.name, self.spinner()));
+            }
+            if let Some(approval) = &self.approval {
+                if approval.picking_grant {
+                    lines.extend(render::grant_ladder_lines(
+                        &approval.grant_rungs,
+                        approval.preview.as_ref(),
+                    ));
+                } else {
+                    lines.extend(render::approval_card(
+                        &approval.action,
+                        &approval.approval,
+                        approval.auto_judging,
+                        approval.preview.as_ref(),
+                        &approval.grant_rungs,
+                        width,
+                    ));
+                }
+            }
+        }
+        // Live background agents ride the transient stack below the turn's
+        // own state, so long delegations stay visible.
+        let live: Vec<&AgentRunSnapshot> = self
+            .runs
+            .values()
+            .filter(|run| render::run_is_live(&run.status))
+            .collect();
+        for run in live.into_iter().take(3) {
+            let status = run
+                .activity
+                .as_ref()
+                .map(|activity| format!("{} {}", activity.status, activity.kind.label()))
+                .unwrap_or_else(|| run.status.clone());
+            lines.push(render::agent_running_line(
+                run.task.as_deref().unwrap_or("background agent"),
+                &status,
+                self.spinner(),
             ));
         }
         if lines.len() > max {
@@ -438,48 +1377,97 @@ impl App {
         if let Some((message, _)) = &self.flash {
             return Line::from(Span::styled(message.clone(), theme::accent()));
         }
-        if self.approval.is_some() {
-            Line::from(vec![
-                Span::styled("awaiting approval", theme::accent_bold()),
+        if self.plan.is_some() {
+            return Line::from(vec![
+                Span::styled("plan review", theme::accent_bold()),
                 sep(),
                 Span::styled("y approve", theme::muted()),
                 sep(),
+                Span::styled("f changes", theme::muted()),
+                sep(),
                 Span::styled("n reject", theme::muted()),
-                sep(),
-                Span::styled("ctrl+c cancel", theme::muted()),
-            ])
-        } else if self.running_turn.is_some() {
-            Line::from(vec![
-                Span::styled(format!("{} working…", self.spinner()), theme::accent()),
-                sep(),
-                Span::styled("ctrl+c cancel", theme::muted()),
-            ])
-        } else {
-            Line::from(vec![
-                Span::styled("ready", theme::muted()),
-                sep(),
-                Span::styled("enter send", theme::muted()),
-                sep(),
-                Span::styled("alt+enter newline", theme::muted()),
-                sep(),
-                Span::styled("ctrl+c quit", theme::muted()),
-            ])
+            ]);
         }
+        if self.approval.is_some() {
+            return Line::from(vec![
+                Span::styled("awaiting approval", theme::accent_bold()),
+                sep(),
+                Span::styled("y once", theme::muted()),
+                sep(),
+                Span::styled("a always…", theme::muted()),
+                sep(),
+                Span::styled("n reject", theme::muted()),
+            ]);
+        }
+        let mut spans = Vec::new();
+        if self.running_turn.is_some() {
+            spans.push(Span::styled(
+                format!("{} working…", self.spinner()),
+                theme::accent(),
+            ));
+            spans.push(sep());
+            spans.push(Span::styled("enter steer", theme::muted()));
+            spans.push(sep());
+            spans.push(Span::styled("ctrl+c cancel", theme::muted()));
+        } else {
+            spans.push(Span::styled("ready", theme::muted()));
+            spans.push(sep());
+            spans.push(Span::styled("enter send", theme::muted()));
+        }
+        spans.push(sep());
+        spans.push(Span::styled("ctrl+o chats", theme::muted()));
+        spans.push(sep());
+        spans.push(Span::styled("ctrl+g agents", theme::muted()));
+        spans.push(sep());
+        spans.push(Span::styled("ctrl+/ help", theme::muted()));
+        Line::from(spans)
     }
-}
 
-fn new_composer(lines: Vec<String>) -> TextArea<'static> {
-    let lines = if lines.is_empty() {
-        vec![String::new()]
-    } else {
-        lines
-    };
-    let mut composer = TextArea::new(lines);
-    composer.set_cursor_line_style(Style::default());
-    composer.set_cursor_style(Style::default().add_modifier(Modifier::REVERSED));
-    composer.set_placeholder_text("type a message");
-    composer.set_placeholder_style(theme::muted());
-    composer
+    /// The footer's right edge: model, effort, permission mode, context meter,
+    /// chat id.
+    fn footer_right(&self) -> Vec<Span<'static>> {
+        let mut spans = Vec::new();
+        // The permission mode pill, tinted when elevated.
+        let mode = self.permission_mode.as_str();
+        let (mode_style, mode_label) = match mode {
+            "plan" => (theme::muted(), "plan"),
+            "auto" => (theme::warning(), "auto"),
+            "allow" => (theme::warning(), "allow all"),
+            _ => (theme::muted(), "ask"),
+        };
+        spans.push(Span::styled(mode_label, mode_style));
+        spans.push(Span::styled(" · ", theme::muted()));
+        // The model, or "default" when the chat inherits.
+        let model = self.model.as_deref().unwrap_or("default");
+        spans.push(Span::styled(model.to_owned(), theme::muted()));
+        if let Some(effort) = &self.reasoning_effort {
+            spans.push(Span::styled(format!(" · {effort}"), theme::muted()));
+        }
+        // The context meter, when we know the window.
+        if let Some(window) = self.context_window.filter(|window| *window > 0) {
+            let pct = (self.context_tokens * 100 / u64::from(window)).min(100);
+            let style = if pct >= 90 {
+                theme::destructive()
+            } else if pct >= 75 {
+                theme::warning()
+            } else {
+                theme::muted()
+            };
+            spans.push(Span::styled(" · ", theme::muted()));
+            spans.push(Span::styled(
+                format!(
+                    "{}/{}",
+                    render::token_count(self.context_tokens),
+                    render::token_count(u64::from(window))
+                ),
+                theme::muted(),
+            ));
+            spans.push(Span::styled(format!(" {pct}%"), style));
+        }
+        spans.push(Span::styled(" · ", theme::muted()));
+        spans.push(Span::styled(self.title_label(), theme::muted()));
+        spans
+    }
 }
 
 /// Restores the terminal on drop; the panic hook does the same for panics.
@@ -570,17 +1558,17 @@ pub async fn run(client: Client, chat: ChatId, resumed: bool) -> Result<()> {
     // The banner is the first thing committed to scrollback.
     let header = render::header_lines(resumed, &app.short_id);
     app.commit(Commit::Lines(header));
-    let mut socket = match app.client.open_events(chat, 0).await {
-        Ok(socket) => Some(socket),
-        Err(error) => {
-            app.commit(Commit::Error(format!(
-                "event stream failed to open: {error}"
-            )));
-            None
-        }
-    };
+    app.hydrate();
+    app.refresh_models();
+    app.refresh_chat_list();
+    // The socket opens only after hydration lands, at the transcript's
+    // watermark — opening it earlier would replay history hydration already
+    // printed.
+    let mut socket: Option<EventSocket> = None;
     let mut keys = EventStream::new();
     let mut tick = tokio::time::interval(TICK);
+    // Periodic refresh for background runs while any are live.
+    let mut runs_tick = tokio::time::interval(Duration::from_secs(2));
 
     loop {
         tokio::select! {
@@ -588,8 +1576,8 @@ pub async fn run(client: Client, chat: ChatId, resumed: bool) -> Result<()> {
                 match key {
                     Some(Ok(Event::Key(key))) => app.on_key(key),
                     Some(Ok(Event::Paste(text))) => {
-                        if app.approval.is_none() {
-                            app.composer.insert_str(text);
+                        if app.approval.is_none() && app.overlay.is_none() && app.plan.is_none() {
+                            super::composer::paste(&mut app.composer, &text);
                         }
                     }
                     Some(Ok(_)) => {}
@@ -601,7 +1589,7 @@ pub async fn run(client: Client, chat: ChatId, resumed: bool) -> Result<()> {
                     Some(Ok(Message::Text(text))) => match serde_json::from_str::<ChatFrame>(&text)
                     {
                         Ok(ChatFrame::Event(frame)) => app.on_frame(frame),
-                        Ok(ChatFrame::Metadata(_)) => {}
+                        Ok(ChatFrame::Metadata(metadata)) => app.on_metadata(metadata),
                         // An undecodable frame is skipped, not fatal.
                         Err(_) => {}
                     },
@@ -614,6 +1602,7 @@ pub async fn run(client: Client, chat: ChatId, resumed: bool) -> Result<()> {
                         let (client, chat, actions) =
                             (app.client.clone(), app.chat, app.actions.clone());
                         let after = app.last_seq;
+                        app.reconnecting = Some(());
                         tokio::spawn(async move {
                             tokio::time::sleep(RECONNECT_DELAY).await;
                             let outcome = match client.open_events(chat, after).await {
@@ -631,10 +1620,12 @@ pub async fn run(client: Client, chat: ChatId, resumed: bool) -> Result<()> {
             Some(outcome) = outcomes.recv() => {
                 match outcome {
                     ActionOutcome::Reconnected(new_socket) => {
+                        app.reconnecting = None;
                         socket = Some(*new_socket);
                         app.commit(Commit::Notice("reconnected".into()));
                     }
                     ActionOutcome::ReconnectFailed(error) => {
+                        app.reconnecting = None;
                         app.commit(Commit::Error(format!(
                             "event stream reconnect failed: {error} — restart the TUI to resume"
                         )));
@@ -643,6 +1634,42 @@ pub async fn run(client: Client, chat: ChatId, resumed: bool) -> Result<()> {
                 }
             }
             _ = tick.tick() => app.on_tick(),
+            _ = runs_tick.tick() => {
+                if app.runs_live() || matches!(app.overlay, Some(Overlay::Agents(_))) {
+                    app.refresh_runs();
+                }
+                // An open agents overlay with an empty detail wants the
+                // run's timeline.
+                if let Some(Overlay::Agents(overlay)) = &app.overlay {
+                    if let Some(run) = overlay.detail_run() {
+                        let (client, chat, actions) =
+                            (app.client.clone(), app.chat, app.actions.clone());
+                        tokio::spawn(async move {
+                            if let Ok(items) = client.list_agent_run_activity(chat, run).await {
+                                let _ = actions.send(ActionOutcome::AgentActivity(run, items));
+                            }
+                        });
+                    }
+                }
+            }
+        }
+
+        // The socket opens once hydration lands (or reopens on a chat switch
+        // after the fresh hydration). The watermark is the resume cursor, so
+        // history hydration and the replay never double-print.
+        if socket.is_none() && app.hydrated && app.reconnecting.is_none() {
+            let chat = app.chat;
+            let after = app.last_seq;
+            match app.client.open_events(chat, after).await {
+                Ok(new_socket) => socket = Some(new_socket),
+                Err(error) => {
+                    app.commit(Commit::Error(format!(
+                        "event stream failed to open: {error}"
+                    )));
+                    // Back off briefly rather than spinning on a dead server.
+                    tokio::time::sleep(RECONNECT_DELAY).await;
+                }
+            }
         }
 
         flush_commits(&mut app, &mut guard.terminal)?;
@@ -707,16 +1734,72 @@ fn draw(
                 .collect();
             frame.render_widget(Paragraph::new(gutter), composer_cols[0]);
             frame.render_widget(&app.composer, composer_cols[1]);
+            // The footer is the state line on the left, the chat/model/mode
+            // cluster on the right.
             let mut footer = app.footer_line();
-            // The short chat id rides the right edge when there's room.
-            let short_id = format!("chat {}", app.short_id);
-            let pad = width.saturating_sub(footer.width() + short_id.len());
+            let right = app.footer_right();
+            let right_width: usize = right.iter().map(Span::width).sum();
+            let pad = width.saturating_sub(footer.width() + right_width);
             if pad >= 2 {
                 footer.spans.push(Span::raw(" ".repeat(pad)));
-                footer.spans.push(Span::styled(short_id, theme::muted()));
+                footer.spans.extend(right);
             }
             frame.render_widget(Paragraph::new(footer), rows[2]);
+            // An overlay floats on top of the live region.
+            if let Some(overlay) = &mut app.overlay {
+                render_overlay(overlay, frame);
+            }
+            // The plan review's feedback box, when open, replaces the composer.
+            if let Some(plan) = &mut app.plan {
+                if let Some(feedback) = &mut plan.feedback {
+                    frame.render_widget(Clear, rows[1]);
+                    let block = Block::default()
+                        .borders(Borders::ALL)
+                        .border_style(theme::border())
+                        .title(" request changes ");
+                    let inner = block.inner(rows[1]);
+                    frame.render_widget(block, rows[1]);
+                    frame.render_widget(&*feedback, inner);
+                }
+            }
         })
         .map_err(terminal_error)?;
     Ok(())
+}
+
+/// Draw the open overlay, centered and sized to its content.
+fn render_overlay(overlay: &mut Overlay, frame: &mut ratatui::Frame) {
+    let area = frame.area();
+    let (title, height_hint, width_hint): (&str, u16, u16) = match overlay {
+        Overlay::Chats(_) => ("chats", 18, 60),
+        Overlay::Agents(_) => ("agents", 16, 72),
+        Overlay::Models(_) => ("model", 16, 56),
+        Overlay::Mode(_) => ("permission mode", 10, 56),
+        Overlay::Move(_) => ("move to project", 12, 56),
+        Overlay::Questions(_) => ("the model is asking", 18, 72),
+        Overlay::Help(_) => ("shortcuts", 20, 56),
+    };
+    let height = height_hint.min(area.height.saturating_sub(2)).max(6);
+    let width = width_hint.min(area.width.saturating_sub(4)).max(30);
+    let x = (area.width.saturating_sub(width)) / 2;
+    let y = (area.height.saturating_sub(height)) / 2;
+    let rect = Rect::new(x, y, width, height);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme::border())
+        .style(Style::default().bg(theme::PANEL_BG))
+        .title(Span::styled(format!(" {title} "), theme::accent_bold()));
+    let inner = block.inner(rect);
+    let lines = match overlay {
+        Overlay::Chats(overlay) => overlay.lines(inner.width as usize),
+        Overlay::Agents(overlay) => overlay.lines(inner.width as usize),
+        Overlay::Models(overlay) => overlay.lines(inner.width as usize),
+        Overlay::Mode(overlay) => overlay.lines(inner.width as usize),
+        Overlay::Move(overlay) => overlay.lines(inner.width as usize),
+        Overlay::Questions(overlay) => overlay.lines(inner.width as usize),
+        Overlay::Help(overlay) => overlay.lines(inner.width as usize),
+    };
+    frame.render_widget(Clear, rect);
+    frame.render_widget(block, rect);
+    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
 }

--- a/crates/openwave-cli/src/tui/composer.rs
+++ b/crates/openwave-cli/src/tui/composer.rs
@@ -1,0 +1,93 @@
+//! One text-input surface for the TUI, wrapping the composer textarea with
+//! the small editing conveniences the desktop's input has: alt+backspace word
+//! delete, alt+arrow word motion, and ctrl+z/ctrl+shift+z undo/redo.
+//!
+//! Everything funnels through [`Composer::key`], which maps the raw key onto
+//! either a `tui-textarea` `Input` or a direct method call (undo/redo live on
+//! the textarea itself, not in its input vocabulary).
+
+use ratatui::style::{Modifier, Style};
+use tui_textarea::{CursorMove, Input, TextArea};
+
+use super::theme;
+
+/// Build a composer with its initial lines (empty string for one blank).
+pub fn new(lines: Vec<String>) -> TextArea<'static> {
+    let lines = if lines.is_empty() {
+        vec![String::new()]
+    } else {
+        lines
+    };
+    let mut composer = TextArea::new(lines);
+    composer.set_cursor_line_style(Style::default());
+    composer.set_cursor_style(Style::default().add_modifier(Modifier::REVERSED));
+    composer.set_placeholder_text("type a message");
+    composer.set_placeholder_style(theme::muted());
+    composer
+}
+
+/// Feed one key to the textarea, with the word-wise conveniences the raw
+/// input mapping doesn't have. Returns whether the key was consumed here
+/// (the caller's own bindings get first refusal, so this only runs for keys
+/// the app treats as text editing).
+pub fn edit_key(composer: &mut TextArea<'static>, key: crossterm::event::KeyEvent) {
+    use crossterm::event::{KeyCode, KeyModifiers};
+    let alt = key.modifiers.contains(KeyModifiers::ALT);
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+    match (key.code, alt, ctrl, shift) {
+        // Word deletion: alt+backspace deletes the word behind the cursor;
+        // ctrl+w does the same, matching every shell the user knows.
+        (KeyCode::Backspace, true, false, false) | (KeyCode::Char('w'), false, true, false) => {
+            composer.delete_word();
+        }
+        // Word motion on alt+arrows.
+        (KeyCode::Left, true, false, false) => composer.move_cursor(CursorMove::WordBack),
+        (KeyCode::Right, true, false, false) => composer.move_cursor(CursorMove::WordForward),
+        // Line motion on cmd/super-ish terminals that deliver ctrl+arrows.
+        (KeyCode::Left, false, true, false) => composer.move_cursor(CursorMove::Head),
+        (KeyCode::Right, false, true, false) => composer.move_cursor(CursorMove::End),
+        // Undo/redo, the desktop's own binding.
+        (KeyCode::Char('z'), false, true, false) => {
+            composer.undo();
+        }
+        (KeyCode::Char('z'), false, true, true) | (KeyCode::Char('y'), false, true, false) => {
+            composer.redo();
+        }
+        // Kill-to-line-end on ctrl+k, matching readline.
+        (KeyCode::Char('k'), false, true, false) => {
+            composer.delete_line_by_end();
+        }
+        // Kill-to-line-start on ctrl+u.
+        (KeyCode::Char('u'), false, true, false) => {
+            composer.delete_line_by_head();
+        }
+        _ => {
+            composer.input(Input::from(key));
+        }
+    }
+}
+
+/// A single-line input (rename boxes, feedback prompts): same surface, no
+/// newlines accepted.
+pub fn new_single_line(initial: &str, placeholder: &str) -> TextArea<'static> {
+    let mut input = new(vec![initial.to_owned()]);
+    input.set_placeholder_text(placeholder);
+    input
+}
+
+/// Enter never inserts a newline in a single-line input; the caller owns what
+/// Enter means (submit).
+pub fn single_line_key(input: &mut TextArea<'static>, key: crossterm::event::KeyEvent) {
+    use crossterm::event::KeyCode;
+    if key.code == KeyCode::Enter {
+        return;
+    }
+    edit_key(input, key);
+}
+
+/// The Input mapping the textarea crate ships already covers plain keys; this
+/// re-export keeps the one place the app constructs `Input` values (paste).
+pub fn paste(composer: &mut TextArea<'static>, text: &str) {
+    composer.insert_str(text);
+}

--- a/crates/openwave-cli/src/tui/mod.rs
+++ b/crates/openwave-cli/src/tui/mod.rs
@@ -6,7 +6,9 @@
 //! consumes. Logging is file-only: the TUI owns the terminal.
 
 mod app;
+mod composer;
 mod markdown;
+mod overlays;
 mod render;
 mod theme;
 

--- a/crates/openwave-cli/src/tui/overlays.rs
+++ b/crates/openwave-cli/src/tui/overlays.rs
@@ -1,0 +1,1077 @@
+//! The overlay surfaces: chat switcher, agents panel, model picker,
+//! permission-mode menu, move-to-project picker, user-questions form, and the
+//! help sheet. Each owns its own key handling and renders to plain styled
+//! lines; `app.rs` draws the shared panel chrome.
+//!
+//! Every overlay is a small state machine returning [`OverlayOutcome`]s; the
+//! app translates those into spawned HTTP calls, keeping the overlays free of
+//! async and of the client. Every `lines(width)` takes the panel's inner
+//! width so text clips to the panel rather than wrapping into the border.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use openwave_core::{AgentRunId, ChatId, ProjectId};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use tui_textarea::TextArea;
+
+use super::render;
+use super::theme;
+use crate::api::wire::{AgentRunSnapshot, ChatSummary, ModelInfo, PendingQuestions};
+
+/// What an overlay decided. `Stay` keeps it open; `Dismiss` closes it; the
+/// rest close it and hand the app an action.
+pub enum OverlayOutcome {
+    Stay,
+    Dismiss,
+    Open(ChatId),
+    NewChat,
+    Delete(ChatId),
+    Rename(ChatId, String),
+    MoveChat(Option<ProjectId>),
+    SetModel(Option<String>),
+    SetEffort(Option<String>),
+    SetMode(String),
+    StopAgent(AgentRunId),
+    SubmitQuestions(serde_json::Value),
+}
+
+/// Row styling helpers: the selected row gets the selection background, the
+/// rest stay plain.
+fn row(selected: bool, spans: Vec<Span<'static>>) -> Line<'static> {
+    let style = if selected {
+        theme::selected()
+    } else {
+        Style::default()
+    };
+    Line::from(
+        spans
+            .into_iter()
+            .map(|span| span.patch_style(style))
+            .collect::<Vec<_>>(),
+    )
+}
+
+fn title_or_untitled(title: Option<&str>) -> String {
+    title
+        .map(str::to_owned)
+        .unwrap_or_else(|| "new chat".to_owned())
+}
+
+// ---------------------------------------------------------------------------
+// Chats
+// ---------------------------------------------------------------------------
+
+pub struct ChatsOverlay {
+    chats: Vec<ChatSummary>,
+    attention: std::collections::HashSet<ChatId>,
+    selected: usize,
+    current: ChatId,
+    /// Inline rename state: which row and the input.
+    renaming: Option<(ChatId, TextArea<'static>)>,
+}
+
+impl ChatsOverlay {
+    pub fn new(current: ChatId) -> Self {
+        Self {
+            chats: Vec::new(),
+            attention: std::collections::HashSet::new(),
+            selected: 0,
+            current,
+            renaming: None,
+        }
+    }
+
+    pub fn set_chats(
+        &mut self,
+        chats: Vec<ChatSummary>,
+        attention: std::collections::HashSet<ChatId>,
+    ) {
+        self.chats = chats;
+        self.attention = attention;
+        if self.selected >= self.chats.len() {
+            self.selected = self.chats.len().saturating_sub(1);
+        }
+    }
+
+    pub fn key(&mut self, key: KeyEvent) -> OverlayOutcome {
+        // Inline rename captures keys until it commits or cancels.
+        if let Some((chat, input)) = &mut self.renaming {
+            match key.code {
+                KeyCode::Esc => {
+                    self.renaming = None;
+                    return OverlayOutcome::Stay;
+                }
+                KeyCode::Enter => {
+                    let title = input.lines().join("\n");
+                    let chat = *chat;
+                    self.renaming = None;
+                    return OverlayOutcome::Rename(chat, title);
+                }
+                _ => {
+                    super::composer::single_line_key(input, key);
+                    return OverlayOutcome::Stay;
+                }
+            }
+        }
+        match key.code {
+            KeyCode::Esc => OverlayOutcome::Dismiss,
+            KeyCode::Down | KeyCode::Char('j') => {
+                if !self.chats.is_empty() {
+                    self.selected = (self.selected + 1) % self.chats.len();
+                }
+                OverlayOutcome::Stay
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                if !self.chats.is_empty() {
+                    self.selected = (self.selected + self.chats.len() - 1) % self.chats.len();
+                }
+                OverlayOutcome::Stay
+            }
+            KeyCode::Enter => self
+                .chats
+                .get(self.selected)
+                .map(|chat| OverlayOutcome::Open(chat.id))
+                .unwrap_or(OverlayOutcome::Dismiss),
+            KeyCode::Char('n') if key.modifiers.is_empty() => OverlayOutcome::NewChat,
+            KeyCode::Char('r') if key.modifiers.is_empty() => {
+                if let Some(chat) = self.chats.get(self.selected) {
+                    let input = super::composer::new_single_line(
+                        chat.title.as_deref().unwrap_or(""),
+                        "chat title",
+                    );
+                    self.renaming = Some((chat.id, input));
+                }
+                OverlayOutcome::Stay
+            }
+            KeyCode::Char('d') | KeyCode::Backspace => self
+                .chats
+                .get(self.selected)
+                .map(|chat| OverlayOutcome::Delete(chat.id))
+                .unwrap_or(OverlayOutcome::Stay),
+            _ => OverlayOutcome::Stay,
+        }
+    }
+
+    pub fn lines(&self, width: usize) -> Vec<Line<'static>> {
+        let width = width.max(20);
+        let mut out = Vec::new();
+        if let Some((_, input)) = &self.renaming {
+            out.push(Line::from(Span::styled("rename:", theme::accent_bold())));
+            let mut line = String::new();
+            for (i, text) in input.lines().iter().enumerate() {
+                if i > 0 {
+                    line.push(' ');
+                }
+                line.push_str(text);
+            }
+            out.push(Line::from(Span::styled(
+                render::truncate(&line, width.saturating_sub(2)),
+                theme::bold(),
+            )));
+            out.push(Line::from(Span::styled(
+                "enter commit · esc cancel",
+                theme::muted(),
+            )));
+            return out;
+        }
+        if self.chats.is_empty() {
+            out.push(Line::from(Span::styled("loading…", theme::muted())));
+            return out;
+        }
+        for (i, chat) in self.chats.iter().enumerate() {
+            let selected = i == self.selected;
+            let marker = if chat.id == self.current {
+                Span::styled("● ", theme::accent())
+            } else if self.attention.contains(&chat.id) {
+                Span::styled("⚠ ", theme::warning())
+            } else {
+                Span::raw("  ")
+            };
+            let spans = vec![
+                Span::styled(
+                    if selected { "▸ " } else { "  " },
+                    if selected {
+                        theme::accent_bold()
+                    } else {
+                        theme::muted()
+                    },
+                ),
+                marker,
+                Span::styled(
+                    render::truncate(
+                        &title_or_untitled(chat.title.as_deref()),
+                        width.saturating_sub(6),
+                    ),
+                    if selected {
+                        theme::bold()
+                    } else {
+                        Style::default()
+                    },
+                ),
+            ];
+            out.push(row(selected, spans));
+        }
+        out.push(Line::default());
+        out.push(Line::from(Span::styled(
+            "enter open · n new · r rename · d delete · esc close",
+            theme::muted(),
+        )));
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Agents
+// ---------------------------------------------------------------------------
+
+pub struct AgentsOverlay {
+    runs: Vec<AgentRunSnapshot>,
+    selected: usize,
+    /// The expanded run's activity timeline, when one is open.
+    detail: Option<(AgentRunId, Vec<crate::api::wire::AgentActivityItem>)>,
+}
+
+impl AgentsOverlay {
+    pub fn new() -> Self {
+        Self {
+            runs: Vec::new(),
+            selected: 0,
+            detail: None,
+        }
+    }
+
+    pub fn set_runs(&mut self, mut runs: Vec<AgentRunSnapshot>) {
+        // Live runs first, then settled, most recently created first.
+        runs.sort_by_key(|run| {
+            let live = matches!(
+                run.status.as_str(),
+                "queued" | "running" | "cancelling" | "waiting" | "retry_wait"
+            );
+            (!live, std::cmp::Reverse(run.created_at))
+        });
+        self.runs = runs;
+        if self.selected >= self.runs.len() {
+            self.selected = self.runs.len().saturating_sub(1);
+        }
+    }
+
+    /// The run whose timeline the app should fetch, when the detail is open
+    /// but hasn't loaded yet.
+    pub fn detail_run(&self) -> Option<AgentRunId> {
+        match &self.detail {
+            Some((run, items)) if items.is_empty() => Some(*run),
+            _ => None,
+        }
+    }
+
+    pub fn set_detail(&mut self, run: AgentRunId, items: Vec<crate::api::wire::AgentActivityItem>) {
+        if matches!(&self.detail, Some((open, _)) if *open == run) {
+            self.detail = Some((run, items));
+        }
+    }
+
+    pub fn key(&mut self, key: KeyEvent) -> OverlayOutcome {
+        match key.code {
+            KeyCode::Esc => {
+                if self.detail.take().is_some() {
+                    OverlayOutcome::Stay
+                } else {
+                    OverlayOutcome::Dismiss
+                }
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                if !self.runs.is_empty() {
+                    self.selected = (self.selected + 1) % self.runs.len();
+                    self.detail = None;
+                }
+                OverlayOutcome::Stay
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                if !self.runs.is_empty() {
+                    self.selected = (self.selected + self.runs.len() - 1) % self.runs.len();
+                    self.detail = None;
+                }
+                OverlayOutcome::Stay
+            }
+            KeyCode::Enter => {
+                if let Some(run) = self.runs.get(self.selected) {
+                    self.detail = Some((run.id, Vec::new()));
+                }
+                OverlayOutcome::Stay
+            }
+            KeyCode::Char('s') => self
+                .runs
+                .get(self.selected)
+                .filter(|run| {
+                    matches!(
+                        run.status.as_str(),
+                        "queued" | "running" | "waiting" | "retry_wait"
+                    )
+                })
+                .map(|run| OverlayOutcome::StopAgent(run.id))
+                .unwrap_or(OverlayOutcome::Stay),
+            _ => OverlayOutcome::Stay,
+        }
+    }
+
+    pub fn lines(&self, width: usize) -> Vec<Line<'static>> {
+        let width = width.max(24);
+        let mut out = Vec::new();
+        if self.runs.is_empty() {
+            out.push(Line::from(Span::styled(
+                "no background agents yet",
+                theme::muted(),
+            )));
+            out.push(Line::from(Span::styled(
+                "the model spawns them with delegate_agent",
+                theme::muted(),
+            )));
+            return out;
+        }
+        for (i, run) in self.runs.iter().enumerate() {
+            let selected = i == self.selected;
+            let (dot, style) = match run.status.as_str() {
+                "completed" => ("✓", theme::success()),
+                "failed" => ("✗", theme::destructive()),
+                "cancelled" => ("⊘", theme::muted()),
+                "running" | "queued" | "waiting" | "retry_wait" => ("●", theme::agent()),
+                "cancelling" => ("◌", theme::warning()),
+                _ => ("·", theme::muted()),
+            };
+            let mut spans = vec![
+                Span::styled(
+                    if selected { "▸ " } else { "  " },
+                    if selected {
+                        theme::accent_bold()
+                    } else {
+                        theme::muted()
+                    },
+                ),
+                Span::styled(format!("{dot} "), style),
+                Span::styled(
+                    render::truncate(
+                        run.task.as_deref().unwrap_or("background agent"),
+                        width.saturating_sub(18),
+                    ),
+                    if selected {
+                        theme::bold()
+                    } else {
+                        Style::default()
+                    },
+                ),
+            ];
+            // The live activity detail ("running a command") when there is
+            // one; otherwise the settled status.
+            if let Some(activity) = &run.activity {
+                spans.push(Span::styled(
+                    format!("  {} {}", activity.status, activity.kind.label()),
+                    theme::muted(),
+                ));
+            } else if let Some(error) = &run.last_error_code {
+                spans.push(Span::styled(format!("  {error}"), theme::destructive()));
+            } else {
+                spans.push(Span::styled(format!("  {}", run.status), theme::muted()));
+            }
+            out.push(row(selected, spans));
+        }
+        // The expanded run's detail: activity timeline plus a result slice.
+        if let Some((open, items)) = &self.detail {
+            if let Some(run) = self.runs.iter().find(|run| run.id == *open) {
+                out.push(Line::default());
+                out.push(Line::from(Span::styled("activity", theme::accent_bold())));
+                if items.is_empty() {
+                    out.push(Line::from(Span::styled("  loading…", theme::muted())));
+                } else {
+                    for item in items {
+                        let mark = match item.outcome.as_str() {
+                            "completed" => ("✓", theme::success()),
+                            "failed" => ("✗", theme::destructive()),
+                            "cancelled" => ("⊘", theme::muted()),
+                            _ => ("·", theme::muted()),
+                        };
+                        out.push(Line::from(vec![
+                            Span::styled(format!("  {} ", mark.0), mark.1),
+                            Span::styled(item.kind.label(), Style::default()),
+                            Span::styled(
+                                format!("  {}", render::timestamp(item.at)),
+                                theme::muted(),
+                            ),
+                        ]));
+                    }
+                }
+                if let Some(terminal) = run.terminal_text.as_deref() {
+                    out.push(Line::default());
+                    out.push(Line::from(Span::styled("result", theme::accent_bold())));
+                    for line in terminal.lines().take(6) {
+                        out.push(Line::from(Span::styled(
+                            format!("  {}", render::truncate(line, width.saturating_sub(4))),
+                            theme::muted().add_modifier(Modifier::ITALIC),
+                        )));
+                    }
+                }
+            }
+        }
+        out.push(Line::default());
+        out.push(Line::from(Span::styled(
+            "enter detail · s stop selected · esc close",
+            theme::muted(),
+        )));
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Model picker (with the reasoning-effort submenu)
+// ---------------------------------------------------------------------------
+
+/// The stock reasoning-effort ladder, in the order the desktop shows it.
+const EFFORTS: &[&str] = &["none", "low", "medium", "high", "xhigh", "max"];
+
+pub struct ModelOverlay {
+    models: Vec<ModelInfo>,
+    selected: usize,
+    current: Option<String>,
+    effort: Option<String>,
+    /// Whether the effort list is showing instead of the model list.
+    picking_effort: bool,
+    /// The cursor within the effort list.
+    effort_selected: usize,
+}
+
+impl ModelOverlay {
+    pub fn new(current: Option<String>, effort: Option<String>) -> Self {
+        Self {
+            models: Vec::new(),
+            selected: 0,
+            current,
+            effort,
+            picking_effort: false,
+            effort_selected: 0,
+        }
+    }
+
+    pub fn set_models(&mut self, models: Vec<ModelInfo>) {
+        // Keep the selection on the current model the first time the catalog
+        // lands.
+        if self.models.is_empty() {
+            if let Some(current) = &self.current {
+                self.selected = models
+                    .iter()
+                    .position(|model| &model.key == current || &model.id == current)
+                    .unwrap_or(0);
+            }
+        }
+        self.models = models;
+    }
+
+    /// The effort levels the selected model accepts, or the stock list when
+    /// the catalog doesn't name one.
+    fn efforts(&self) -> Vec<String> {
+        let listed = self
+            .models
+            .get(self.selected)
+            .map(|model| model.reasoning_efforts.clone())
+            .unwrap_or_default();
+        if listed.is_empty() {
+            EFFORTS.iter().map(|effort| effort.to_string()).collect()
+        } else {
+            listed
+        }
+    }
+
+    pub fn key(&mut self, key: KeyEvent) -> OverlayOutcome {
+        if self.picking_effort {
+            let efforts = self.efforts();
+            match key.code {
+                KeyCode::Esc => {
+                    self.picking_effort = false;
+                    return OverlayOutcome::Stay;
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    if !efforts.is_empty() {
+                        self.effort_selected = (self.effort_selected + 1) % efforts.len();
+                    }
+                    return OverlayOutcome::Stay;
+                }
+                KeyCode::Up | KeyCode::Char('k') => {
+                    if !efforts.is_empty() {
+                        self.effort_selected =
+                            (self.effort_selected + efforts.len() - 1) % efforts.len();
+                    }
+                    return OverlayOutcome::Stay;
+                }
+                KeyCode::Enter => {
+                    return OverlayOutcome::SetEffort(efforts.get(self.effort_selected).cloned());
+                }
+                KeyCode::Char('d') => return OverlayOutcome::SetEffort(None),
+                _ => return OverlayOutcome::Stay,
+            }
+        }
+        match key.code {
+            KeyCode::Esc => OverlayOutcome::Dismiss,
+            KeyCode::Down | KeyCode::Char('j') => {
+                if !self.models.is_empty() {
+                    self.selected = (self.selected + 1) % self.models.len();
+                }
+                OverlayOutcome::Stay
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                if !self.models.is_empty() {
+                    self.selected = (self.selected + self.models.len() - 1) % self.models.len();
+                }
+                OverlayOutcome::Stay
+            }
+            KeyCode::Enter => self
+                .models
+                .get(self.selected)
+                .filter(|model| model.available)
+                .map(|model| OverlayOutcome::SetModel(Some(model.key.clone())))
+                .unwrap_or(OverlayOutcome::Stay),
+            KeyCode::Char('d') => OverlayOutcome::SetModel(None),
+            KeyCode::Char('e') => {
+                self.picking_effort = true;
+                self.effort_selected = 0;
+                OverlayOutcome::Stay
+            }
+            _ => OverlayOutcome::Stay,
+        }
+    }
+
+    pub fn lines(&self, width: usize) -> Vec<Line<'static>> {
+        let width = width.max(20);
+        let mut out = Vec::new();
+        if self.picking_effort {
+            out.push(Line::from(Span::styled(
+                "reasoning effort",
+                theme::accent_bold(),
+            )));
+            for (i, effort) in self.efforts().iter().enumerate() {
+                let selected = i == self.effort_selected;
+                let current = self.effort.as_deref() == Some(effort.as_str());
+                out.push(row(
+                    selected,
+                    vec![
+                        Span::styled(
+                            if selected { "▸ " } else { "  " },
+                            if selected {
+                                theme::accent_bold()
+                            } else {
+                                theme::muted()
+                            },
+                        ),
+                        Span::styled(
+                            if current { "● " } else { "  " },
+                            if current {
+                                theme::accent()
+                            } else {
+                                theme::muted()
+                            },
+                        ),
+                        Span::styled(effort.clone(), Style::default()),
+                    ],
+                ));
+            }
+            out.push(Line::default());
+            out.push(Line::from(Span::styled(
+                "enter set · d provider default · esc back",
+                theme::muted(),
+            )));
+            return out;
+        }
+        if self.models.is_empty() {
+            out.push(Line::from(Span::styled("loading…", theme::muted())));
+            return out;
+        }
+        for (i, model) in self.models.iter().enumerate() {
+            let selected = i == self.selected;
+            let current = self
+                .current
+                .as_ref()
+                .is_some_and(|current| current == &model.key || current == &model.id);
+            let mut spans = vec![
+                Span::styled(
+                    if selected { "▸ " } else { "  " },
+                    if selected {
+                        theme::accent_bold()
+                    } else {
+                        theme::muted()
+                    },
+                ),
+                Span::styled(
+                    if current { "● " } else { "  " },
+                    if current {
+                        theme::accent()
+                    } else {
+                        theme::muted()
+                    },
+                ),
+                Span::styled(
+                    render::truncate(&model.display_name, width.saturating_sub(18)),
+                    if model.available {
+                        Style::default()
+                    } else {
+                        theme::muted()
+                    },
+                ),
+            ];
+            if !model.available {
+                spans.push(Span::styled("  unavailable", theme::muted()));
+            }
+            out.push(row(selected, spans));
+        }
+        out.push(Line::default());
+        out.push(Line::from(Span::styled(
+            "enter select · d default · e effort… · esc close",
+            theme::muted(),
+        )));
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Permission mode
+// ---------------------------------------------------------------------------
+
+const MODES: &[(&str, &str, &str)] = &[
+    ("plan", "Plan", "read-only; the model proposes a plan first"),
+    ("ask", "Ask", "ask before anything consequential (default)"),
+    ("auto", "Auto", "workspace edits run without asking"),
+    ("allow", "Allow all", "no prompts in this chat"),
+];
+
+pub struct ModeOverlay {
+    selected: usize,
+}
+
+impl ModeOverlay {
+    pub fn new(current: &str) -> Self {
+        let selected = MODES
+            .iter()
+            .position(|(key, _, _)| *key == current)
+            .unwrap_or(1);
+        Self { selected }
+    }
+
+    pub fn key(&mut self, key: KeyEvent) -> OverlayOutcome {
+        match key.code {
+            KeyCode::Esc => OverlayOutcome::Dismiss,
+            KeyCode::Down | KeyCode::Char('j') => {
+                self.selected = (self.selected + 1) % MODES.len();
+                OverlayOutcome::Stay
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.selected = (self.selected + MODES.len() - 1) % MODES.len();
+                OverlayOutcome::Stay
+            }
+            KeyCode::Enter => OverlayOutcome::SetMode(MODES[self.selected].0.to_owned()),
+            _ => OverlayOutcome::Stay,
+        }
+    }
+
+    pub fn lines(&self, width: usize) -> Vec<Line<'static>> {
+        let width = width.max(24);
+        let mut out = Vec::new();
+        for (i, (_, label, blurb)) in MODES.iter().enumerate() {
+            let selected = i == self.selected;
+            out.push(row(
+                selected,
+                vec![
+                    Span::styled(
+                        if selected { "▸ " } else { "  " },
+                        if selected {
+                            theme::accent_bold()
+                        } else {
+                            theme::muted()
+                        },
+                    ),
+                    Span::styled(
+                        format!("{label:<10}"),
+                        if i >= 2 {
+                            theme::warning()
+                        } else {
+                            theme::bold()
+                        },
+                    ),
+                    Span::styled(
+                        render::truncate(blurb, width.saturating_sub(16)),
+                        theme::muted(),
+                    ),
+                ],
+            ));
+        }
+        out.push(Line::default());
+        out.push(Line::from(Span::styled(
+            "enter set · esc close",
+            theme::muted(),
+        )));
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Move to project
+// ---------------------------------------------------------------------------
+
+pub struct MoveOverlay {
+    projects: Vec<crate::api::wire::ProjectSummary>,
+    selected: usize,
+}
+
+impl MoveOverlay {
+    pub fn new(projects: Vec<crate::api::wire::ProjectSummary>) -> Self {
+        Self {
+            projects,
+            selected: 0,
+        }
+    }
+
+    pub fn key(&mut self, key: KeyEvent) -> OverlayOutcome {
+        // Row 0 is "no project"; projects follow.
+        let len = self.projects.len() + 1;
+        match key.code {
+            KeyCode::Esc => OverlayOutcome::Dismiss,
+            KeyCode::Down | KeyCode::Char('j') => {
+                self.selected = (self.selected + 1) % len;
+                OverlayOutcome::Stay
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.selected = (self.selected + len - 1) % len;
+                OverlayOutcome::Stay
+            }
+            KeyCode::Enter => {
+                if self.selected == 0 {
+                    OverlayOutcome::MoveChat(None)
+                } else {
+                    OverlayOutcome::MoveChat(Some(self.projects[self.selected - 1].id))
+                }
+            }
+            _ => OverlayOutcome::Stay,
+        }
+    }
+
+    pub fn lines(&self, width: usize) -> Vec<Line<'static>> {
+        let width = width.max(20);
+        let mut out = Vec::new();
+        out.push(row(
+            self.selected == 0,
+            vec![
+                Span::styled(
+                    if self.selected == 0 { "▸ " } else { "  " },
+                    if self.selected == 0 {
+                        theme::accent_bold()
+                    } else {
+                        theme::muted()
+                    },
+                ),
+                Span::styled("no project", Style::default()),
+            ],
+        ));
+        for (i, project) in self.projects.iter().enumerate() {
+            let selected = self.selected == i + 1;
+            out.push(row(
+                selected,
+                vec![
+                    Span::styled(
+                        if selected { "▸ " } else { "  " },
+                        if selected {
+                            theme::accent_bold()
+                        } else {
+                            theme::muted()
+                        },
+                    ),
+                    Span::styled(
+                        render::truncate(
+                            project.title.as_deref().unwrap_or("untitled project"),
+                            width.saturating_sub(4),
+                        ),
+                        Style::default(),
+                    ),
+                ],
+            ));
+        }
+        out.push(Line::default());
+        out.push(Line::from(Span::styled(
+            "enter move · esc close",
+            theme::muted(),
+        )));
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
+// User questions
+// ---------------------------------------------------------------------------
+
+pub struct QuestionsOverlay {
+    pending: PendingQuestions,
+    /// The question index being answered.
+    index: usize,
+    /// The option cursor within the current question.
+    cursor: usize,
+    /// Picked option indices per question, in question order.
+    picks: Vec<std::collections::BTreeSet<usize>>,
+    /// Free-form text per question, in question order.
+    custom: Vec<String>,
+    /// Whether the free-form box is open.
+    editing: Option<TextArea<'static>>,
+}
+
+impl QuestionsOverlay {
+    pub fn new(pending: PendingQuestions) -> Self {
+        let count = pending.questions.len();
+        Self {
+            pending,
+            index: 0,
+            cursor: 0,
+            picks: vec![std::collections::BTreeSet::new(); count],
+            custom: vec![String::new(); count],
+            editing: None,
+        }
+    }
+
+    /// The parked call these answers resolve.
+    pub fn call_id(&self) -> openwave_core::CallId {
+        self.pending.call_id
+    }
+
+    fn done(&self) -> bool {
+        self.index >= self.pending.questions.len()
+    }
+
+    fn build_answers(&self) -> serde_json::Value {
+        let answers: Vec<serde_json::Value> = self
+            .pending
+            .questions
+            .iter()
+            .enumerate()
+            .map(|(i, question)| {
+                let selections: Vec<String> = self.picks[i]
+                    .iter()
+                    .filter_map(|pick| question.options.get(*pick))
+                    .map(|option| option.id.clone())
+                    .collect();
+                let mut answer = serde_json::json!({
+                    "question_id": question.id,
+                    "selected_option_ids": selections,
+                });
+                if !self.custom[i].trim().is_empty() {
+                    answer["custom_answer"] = serde_json::json!(self.custom[i]);
+                }
+                answer
+            })
+            .collect();
+        serde_json::json!({ "answers": answers })
+    }
+
+    pub fn key(&mut self, key: KeyEvent) -> OverlayOutcome {
+        if let Some(input) = &mut self.editing {
+            match key.code {
+                KeyCode::Esc => {
+                    self.editing = None;
+                    return OverlayOutcome::Stay;
+                }
+                KeyCode::Enter => {
+                    let text = input.lines().join("\n");
+                    self.custom[self.index] = text;
+                    self.editing = None;
+                    return OverlayOutcome::Stay;
+                }
+                _ => {
+                    super::composer::single_line_key(input, key);
+                    return OverlayOutcome::Stay;
+                }
+            }
+        }
+        if self.done() {
+            return match key.code {
+                KeyCode::Esc => OverlayOutcome::Dismiss,
+                KeyCode::Enter => OverlayOutcome::SubmitQuestions(self.build_answers()),
+                _ => OverlayOutcome::Stay,
+            };
+        }
+        let question = &self.pending.questions[self.index];
+        let option_count = question.options.len();
+        let multi = question.question_type == "multi";
+        match key.code {
+            KeyCode::Esc => OverlayOutcome::Dismiss,
+            KeyCode::Down | KeyCode::Char('j') => {
+                if option_count > 0 {
+                    self.cursor = (self.cursor + 1) % option_count;
+                }
+                OverlayOutcome::Stay
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                if option_count > 0 {
+                    self.cursor = (self.cursor + option_count - 1) % option_count;
+                }
+                OverlayOutcome::Stay
+            }
+            KeyCode::Char(' ') if multi => {
+                self.picks[self.index].insert(self.cursor);
+                OverlayOutcome::Stay
+            }
+            KeyCode::Char('c') if question.allow_free_form => {
+                self.editing = Some(super::composer::new_single_line(
+                    &self.custom[self.index],
+                    "your own answer",
+                ));
+                OverlayOutcome::Stay
+            }
+            KeyCode::Enter => {
+                if !multi && option_count > 0 {
+                    self.picks[self.index].clear();
+                    self.picks[self.index].insert(self.cursor);
+                }
+                self.index += 1;
+                self.cursor = 0;
+                OverlayOutcome::Stay
+            }
+            _ => OverlayOutcome::Stay,
+        }
+    }
+
+    pub fn lines(&self, width: usize) -> Vec<Line<'static>> {
+        let width = width.max(24);
+        let mut out = Vec::new();
+        if self.done() {
+            out.push(Line::from(Span::styled(
+                "all questions answered",
+                theme::accent_bold(),
+            )));
+            out.push(Line::from(Span::styled(
+                "enter submit · esc cancel",
+                theme::muted(),
+            )));
+            return out;
+        }
+        let question = &self.pending.questions[self.index];
+        out.push(Line::from(vec![
+            Span::styled(
+                format!("{}/{} ", self.index + 1, self.pending.questions.len()),
+                theme::muted(),
+            ),
+            Span::styled(question.header.clone(), theme::accent_bold()),
+        ]));
+        for line in question.question.lines() {
+            out.push(Line::from(Span::styled(
+                render::truncate(line, width.saturating_sub(2)),
+                Style::default(),
+            )));
+        }
+        out.push(Line::default());
+        let multi = question.question_type == "multi";
+        for (i, option) in question.options.iter().enumerate() {
+            let selected = i == self.cursor;
+            let picked = self.picks[self.index].contains(&i);
+            let mark = if multi {
+                if picked {
+                    "☑"
+                } else {
+                    "☐"
+                }
+            } else if picked {
+                "●"
+            } else {
+                "○"
+            };
+            let mut spans = vec![
+                Span::styled(
+                    if selected { "▸ " } else { "  " },
+                    if selected {
+                        theme::accent_bold()
+                    } else {
+                        theme::muted()
+                    },
+                ),
+                Span::styled(format!("{mark} "), theme::accent()),
+                Span::styled(
+                    render::truncate(&option.label, width.saturating_sub(8)),
+                    Style::default(),
+                ),
+            ];
+            if let Some(description) = &option.description {
+                spans.push(Span::styled(
+                    render::truncate(description, width.saturating_sub(20)),
+                    theme::muted(),
+                ));
+            }
+            out.push(row(selected, spans));
+        }
+        if question.allow_free_form {
+            let custom = &self.custom[self.index];
+            if let Some(input) = &self.editing {
+                let text = input.lines().join(" ");
+                out.push(Line::from(vec![
+                    Span::styled("  ✎ ", theme::accent()),
+                    Span::styled(
+                        render::truncate(&text, width.saturating_sub(6)),
+                        theme::bold(),
+                    ),
+                ]));
+            } else if !custom.is_empty() {
+                out.push(Line::from(vec![
+                    Span::styled("  ✎ ", theme::accent()),
+                    Span::styled(
+                        render::truncate(custom, width.saturating_sub(6)),
+                        theme::bold(),
+                    ),
+                ]));
+            }
+        }
+        out.push(Line::default());
+        let mut hints = vec!["enter next"];
+        if multi {
+            hints.push("space toggle");
+        }
+        if question.allow_free_form {
+            hints.push("c custom");
+        }
+        hints.push("esc cancel");
+        out.push(Line::from(Span::styled(hints.join(" · "), theme::muted())));
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Help
+// ---------------------------------------------------------------------------
+
+pub struct HelpOverlay;
+
+impl HelpOverlay {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn key(&mut self, key: KeyEvent) -> OverlayOutcome {
+        match key.code {
+            KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q') => OverlayOutcome::Dismiss,
+            _ if key.modifiers.contains(KeyModifiers::CONTROL) => OverlayOutcome::Dismiss,
+            _ => OverlayOutcome::Stay,
+        }
+    }
+
+    pub fn lines(&self, _width: usize) -> Vec<Line<'static>> {
+        let rows: &[(&str, &str)] = &[
+            ("enter", "send · steer while a turn runs"),
+            ("alt+enter", "newline"),
+            ("ctrl+c", "cancel the turn · quit when idle"),
+            ("ctrl+o", "chats — open, new, rename, delete"),
+            ("ctrl+n", "new chat"),
+            ("ctrl+g", "background agents"),
+            ("ctrl+m", "model & effort"),
+            ("ctrl+p", "permission mode"),
+            ("ctrl+/", "this help"),
+            ("y / n / a", "approve once · reject · always…"),
+            ("esc", "close a panel"),
+        ];
+        rows.iter()
+            .map(|(key, what)| {
+                Line::from(vec![
+                    Span::styled(format!("{key:<10}"), theme::accent()),
+                    Span::styled(what.to_string(), theme::muted()),
+                ])
+            })
+            .collect()
+    }
+}

--- a/crates/openwave-cli/src/tui/render.rs
+++ b/crates/openwave-cli/src/tui/render.rs
@@ -6,24 +6,58 @@
 //! glyphs can overflow its width — acceptable for this slice's plain-text
 //! rendering.
 
-use ratatui::style::Modifier;
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 
 use super::markdown;
 use super::theme;
+use crate::api::wire::{FileAttachment, ImageAttachment};
 
-/// A finished block ready to commit to real terminal scrollback.
+/// A finished block ready to commit to real scrollback.
 pub enum Commit {
-    UserText(String),
-    AssistantText(String),
+    UserText {
+        text: String,
+        at: Option<chrono::DateTime<chrono::Utc>>,
+        images: Vec<ImageAttachment>,
+        files: Vec<FileAttachment>,
+    },
+    AssistantText {
+        text: String,
+        at: Option<chrono::DateTime<chrono::Utc>>,
+    },
+    /// A settled reasoning block, folded behind a one-line summary so a long
+    /// thinking stream doesn't dominate the transcript. The full text stays
+    /// in the session state for the transcript view.
+    Reasoning {
+        text: String,
+    },
     ToolDone {
         name: String,
         failed: bool,
+        cancelled: bool,
+        /// The call's closed action preview, humanized to one line.
+        action: Option<String>,
+        /// An exec result's output tail, already bounded by the server.
+        output: Option<ToolOutput>,
+    },
+    /// A background agent run changed state (spawned, settled, …).
+    AgentRun {
+        task: String,
+        status: String,
     },
     Notice(String),
     Error(String),
     /// Pre-rendered one-offs (the startup header).
     Lines(Vec<Line<'static>>),
+}
+
+/// The bounded exec output a completed call carried.
+pub struct ToolOutput {
+    pub exit_code: Option<i32>,
+    pub timed_out: bool,
+    pub truncated: bool,
+    pub stdout: String,
+    pub stderr: String,
 }
 
 /// Word-wrap `text` to `width` columns, preserving hard newlines.
@@ -63,7 +97,7 @@ fn wrap(text: &str, width: usize) -> Vec<String> {
 
 /// Long preview fields (a command, a query) get one bounded line, not the
 /// whole payload.
-fn truncate(text: &str, max: usize) -> String {
+pub fn truncate(text: &str, max: usize) -> String {
     let mut chars = text.chars();
     let taken: String = chars.by_ref().take(max).collect();
     if chars.next().is_some() {
@@ -73,39 +107,144 @@ fn truncate(text: &str, max: usize) -> String {
     }
 }
 
+/// The timestamp format used across the transcript: local wall time.
+pub fn timestamp(at: chrono::DateTime<chrono::Utc>) -> String {
+    at.with_timezone(&chrono::Local).format("%H:%M").to_string()
+}
+
+/// A dimmed right-side timestamp span, for block headers that carry one.
+fn timestamp_span(at: Option<chrono::DateTime<chrono::Utc>>) -> Option<Span<'static>> {
+    at.map(|at| Span::styled(format!("  {}", timestamp(at)), theme::muted()))
+}
+
 impl Commit {
     /// Render the block to styled lines at the current terminal width, with one
     /// blank line after it so every block type breathes evenly.
     pub fn lines(self, width: usize) -> Vec<Line<'static>> {
         let mut lines = match self {
-            // The ❯/│ gutter matches the composer's, so a sent message reads
-            // as the same element it was typed into.
-            Commit::UserText(text) => wrap(&text, width.saturating_sub(2))
-                .into_iter()
-                .enumerate()
-                .map(|(i, line)| {
-                    let marker = if i == 0 {
-                        Span::styled("❯ ", theme::accent_bold())
-                    } else {
-                        Span::styled("│ ", theme::muted())
-                    };
-                    Line::from(vec![marker, Span::styled(line, theme::bold())])
-                })
-                .collect(),
-            // Assistant text is markdown-rendered only here, at commit time —
-            // the streaming live region stays plain until the block is final.
-            Commit::AssistantText(text) => markdown::lines(&text, width),
-            // Completed tool noise recedes behind the assistant text: the whole
-            // line is muted except the status mark.
-            Commit::ToolDone { name, failed } => {
-                let (mark, style) = if failed {
+            // The user block: a bold accent "❯ you" header, then the body in
+            // the same accent gutter the composer uses, so a sent message
+            // reads as the same element it was typed into.
+            Commit::UserText {
+                text,
+                at,
+                images,
+                files,
+            } => {
+                let mut header = vec![
+                    Span::styled("❯ ", theme::accent_bold()),
+                    Span::styled("you", theme::user()),
+                ];
+                if let Some(stamp) = timestamp_span(at) {
+                    header.push(stamp);
+                }
+                let mut out = vec![Line::from(header)];
+                // Attachment chips ride above the text, as in the desktop.
+                for image in &images {
+                    out.push(Line::from(vec![
+                        Span::styled("│ ", theme::muted()),
+                        Span::styled("🖼 ", theme::muted()),
+                        Span::styled(
+                            format!(
+                                "image · {} · {}×{}",
+                                image.media_type, image.width, image.height
+                            ),
+                            theme::muted(),
+                        ),
+                    ]));
+                }
+                for file in &files {
+                    out.push(Line::from(vec![
+                        Span::styled("│ ", theme::muted()),
+                        Span::styled("📄 ", theme::muted()),
+                        Span::styled(file.name.clone(), theme::muted()),
+                    ]));
+                }
+                out.extend(
+                    wrap(&text, width.saturating_sub(2))
+                        .into_iter()
+                        .map(|line| {
+                            Line::from(vec![
+                                Span::styled("│ ", theme::muted()),
+                                Span::styled(line, theme::bold()),
+                            ])
+                        }),
+                );
+                out
+            }
+            // The assistant block: a violet "◆ openwave" header, then
+            // markdown-rendered prose with no gutter — the desktop gives the
+            // assistant a transparent, unframed column too.
+            Commit::AssistantText { text, at } => {
+                let mut header = vec![
+                    Span::styled("◆ ", theme::agent_bold()),
+                    Span::styled("openwave", theme::agent_bold()),
+                ];
+                if let Some(stamp) = timestamp_span(at) {
+                    header.push(stamp);
+                }
+                let mut out = vec![Line::from(header)];
+                out.extend(markdown::lines(&text, width));
+                out
+            }
+            // Settled reasoning folds to one dim line; the full text stays in
+            // the session for the transcript view.
+            Commit::Reasoning { text } => {
+                let words = text.split_whitespace().count();
+                vec![Line::from(vec![
+                    Span::styled("💭 ", theme::muted()),
+                    Span::styled("thought ", theme::muted().add_modifier(Modifier::ITALIC)),
+                    Span::styled(
+                        format!("({words} words)"),
+                        theme::muted().add_modifier(Modifier::ITALIC),
+                    ),
+                ])]
+            }
+            // Completed tool noise recedes behind the assistant text: the
+            // whole line is muted except the status mark.
+            Commit::ToolDone {
+                name,
+                failed,
+                cancelled,
+                action,
+                output,
+            } => {
+                let (mark, style) = if cancelled {
+                    ("⊘", theme::muted())
+                } else if failed {
                     ("✗", theme::destructive())
                 } else {
                     ("✓", theme::success())
                 };
-                vec![Line::from(vec![
+                let mut out = vec![Line::from(vec![
                     Span::styled(format!("⚙ {name} "), theme::muted()),
                     Span::styled(mark, style),
+                ])];
+                if let Some(action) = action {
+                    for line in wrap(&action, width.saturating_sub(4)) {
+                        out.push(Line::from(vec![
+                            Span::styled("  ", theme::muted()),
+                            Span::styled(line, theme::muted().add_modifier(Modifier::ITALIC)),
+                        ]));
+                    }
+                }
+                if let Some(output) = output {
+                    out.extend(output_lines(&output, width));
+                }
+                out
+            }
+            Commit::AgentRun { task, status } => {
+                let (mark, style) = match status.as_str() {
+                    "completed" => ("✓", theme::success()),
+                    "failed" => ("✗", theme::destructive()),
+                    "cancelled" => ("⊘", theme::muted()),
+                    _ => ("▸", theme::agent()),
+                };
+                vec![Line::from(vec![
+                    Span::styled("🤖 agent ", theme::agent()),
+                    Span::styled(mark, style),
+                    Span::styled(format!("  {}", truncate(&task, 120)), theme::muted()),
+                    Span::styled(format!("  · {status}"), theme::muted()),
                 ])]
             }
             Commit::Notice(text) => wrap(&text, width.saturating_sub(2))
@@ -123,6 +262,54 @@ impl Commit {
     }
 }
 
+/// The bounded exec output a completed command carried: an indented,
+/// dim block under the tool line, capped at a few lines per stream.
+fn output_lines(output: &ToolOutput, width: usize) -> Vec<Line<'static>> {
+    const MAX_STREAM_LINES: usize = 4;
+    let mut out = Vec::new();
+    let status = match (output.exit_code, output.timed_out) {
+        (Some(0), false) => None,
+        (Some(code), false) => Some(format!("exit {code}")),
+        (None, false) => Some("killed".to_owned()),
+        (_, true) => Some("timed out".to_owned()),
+    };
+    if let Some(status) = status {
+        out.push(Line::from(vec![
+            Span::styled("  ", theme::muted()),
+            Span::styled(status, theme::warning()),
+        ]));
+    }
+    for (label, text) in [("out", &output.stdout), ("err", &output.stderr)] {
+        let text = text.trim_end();
+        if text.is_empty() {
+            continue;
+        }
+        let mut lines = text.lines();
+        let mut shown = 0;
+        for line in lines.by_ref().take(MAX_STREAM_LINES) {
+            shown += 1;
+            out.push(Line::from(vec![
+                Span::styled(format!("  {label} "), theme::muted()),
+                Span::styled(truncate(line, width.saturating_sub(8)), theme::muted()),
+            ]));
+        }
+        if lines.next().is_some() {
+            out.push(Line::from(Span::styled(
+                "      …".to_owned(),
+                theme::muted(),
+            )));
+        }
+        let _ = shown;
+    }
+    if output.truncated {
+        out.push(Line::from(Span::styled(
+            "  (output truncated by the provider)".to_owned(),
+            theme::muted(),
+        )));
+    }
+    out
+}
+
 /// The compact startup banner committed to scrollback on launch.
 pub fn header_lines(resumed: bool, short_id: &str) -> Vec<Line<'static>> {
     let kind = if resumed { "resumed chat" } else { "new chat" };
@@ -130,7 +317,7 @@ pub fn header_lines(resumed: bool, short_id: &str) -> Vec<Line<'static>> {
         Line::from(Span::styled("OpenWave", theme::accent_bold())),
         Line::from(Span::styled(format!("{kind} · {short_id}"), theme::muted())),
         Line::from(Span::styled(
-            "enter send · alt+enter newline · ctrl+c quit",
+            "enter send · alt+enter newline · ctrl+o chats · ctrl+g agents · ctrl+p mode · ctrl+c quit",
             theme::muted(),
         )),
     ]
@@ -168,6 +355,17 @@ pub fn tool_running_line(name: &str, spinner: char) -> Line<'static> {
     ])
 }
 
+/// A live background-agent line for the transient stack: spinner, task, and
+/// the run's current activity.
+pub fn agent_running_line(task: &str, status: &str, spinner: char) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(format!("{spinner} "), theme::agent()),
+        Span::styled("🤖 ", theme::agent()),
+        Span::styled(truncate(task, 80), Style::default()),
+        Span::styled(format!("  {status}"), theme::muted()),
+    ])
+}
+
 /// One human-readable line for a tool's closed action preview, if it has one
 /// this build understands. Unknown preview variants fall back to nothing
 /// rather than leaking a raw JSON dump into the consent card.
@@ -188,7 +386,8 @@ pub fn preview_summary(preview: &serde_json::Value) -> Option<String> {
                 .unwrap_or_default();
             format!("$ {command} {args}").trim_end().to_owned()
         }
-        "search" | "web_search" => format!("query: {}", get("query").unwrap_or_default()),
+        "search" => format!("search: {}", get("query").unwrap_or_default()),
+        "web_search" => format!("web: {}", get("query").unwrap_or_default()),
         "web_extract" => format!("fetch: {}", get("url").unwrap_or_default()),
         "write_file" => format!("write: {}", get("path").unwrap_or_default()),
         "delegate_agent" => format!("background agent: {}", get("task").unwrap_or_default()),
@@ -197,14 +396,83 @@ pub fn preview_summary(preview: &serde_json::Value) -> Option<String> {
     Some(truncate(&summary, 200))
 }
 
+/// Pull the bounded exec output out of a tool result preview, if that's what
+/// the preview is. Anything else yields `None` — only exec output is text the
+/// TUI can usefully print.
+pub fn exec_output(result: &serde_json::Value) -> Option<ToolOutput> {
+    if result.get("tool")?.as_str()? != "exec" {
+        return None;
+    }
+    let get_str = |key: &str| result.get(key).and_then(|v| v.as_str()).unwrap_or_default();
+    Some(ToolOutput {
+        exit_code: result
+            .get("exit_code")
+            .and_then(|v| v.as_i64())
+            .map(|code| code as i32),
+        timed_out: result
+            .get("timed_out")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        truncated: result
+            .get("output_truncated")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        stdout: get_str("stdout").to_owned(),
+        stderr: get_str("stderr").to_owned(),
+    })
+}
+
+/// One human-readable line describing a standing-grant rung, for the
+/// approval card's option list.
+pub fn grant_rung_label(rung: &crate::api::wire::GrantRung, action: &serde_json::Value) -> String {
+    use crate::api::wire::GrantRung;
+    match rung {
+        GrantRung::ExactAction => "always allow exactly this".to_owned(),
+        GrantRung::CommandPrefix { tokens } => {
+            let command = action
+                .get("command")
+                .and_then(|v| v.as_str())
+                .unwrap_or("this command");
+            let args = action
+                .get("args")
+                .and_then(|v| v.as_array())
+                .map(|args| {
+                    args.iter()
+                        .filter_map(|a| a.as_str())
+                        .take(tokens.saturating_sub(1))
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                })
+                .unwrap_or_default();
+            let prefix = if args.is_empty() {
+                command.to_owned()
+            } else {
+                format!("{command} {args}")
+            };
+            format!("always allow any `{prefix}` command")
+        }
+        GrantRung::PathPrefix { segments } => {
+            let path = action.get("path").and_then(|v| v.as_str()).unwrap_or("");
+            let prefix: String = path
+                .split('/')
+                .take(*segments)
+                .collect::<Vec<_>>()
+                .join("/");
+            format!("always allow writes under {prefix}/")
+        }
+        GrantRung::WholeTool => "don't ask again for this tool in this chat".to_owned(),
+    }
+}
+
 /// The consent card shown while a decision is pending: an accent gutter on
 /// every line, bold title, the humanized kind dimmed on its own line, the
-/// preview as a dim italic block, and the two actions styled as buttons.
+/// preview as a dim italic block, and the options styled as a list.
 pub fn approval_card(
     action: &str,
     approval: &str,
     auto_judging: bool,
-    preview: Option<&str>,
+    preview: Option<&serde_json::Value>,
+    grant_rungs: &[crate::api::wire::GrantRung],
     width: usize,
 ) -> Vec<Line<'static>> {
     let gutter = || Span::styled("▌ ", theme::accent());
@@ -223,8 +491,8 @@ pub fn approval_card(
             Span::styled(approval.replace('_', " "), theme::muted()),
         ]),
     ];
-    if let Some(preview) = preview {
-        for line in wrap(preview, width.saturating_sub(2)) {
+    if let Some(preview) = preview.and_then(preview_summary) {
+        for line in wrap(&preview, width.saturating_sub(2)) {
             lines.push(Line::from(vec![
                 gutter(),
                 Span::styled(line, theme::muted().add_modifier(Modifier::ITALIC)),
@@ -234,10 +502,120 @@ pub fn approval_card(
     lines.push(Line::from(vec![
         gutter(),
         Span::styled("y", theme::accent_bold()),
-        Span::styled(" approve", theme::accent()),
+        Span::styled(" once", theme::accent()),
         Span::styled("  ·  ", theme::muted()),
         Span::styled("n", theme::bold()),
         Span::styled(" reject", theme::muted()),
+        Span::styled("  ·  ", theme::muted()),
+        Span::styled("a", theme::bold()),
+        Span::styled(" always…", theme::muted()),
+    ]));
+    let _ = grant_rungs;
+    lines
+}
+
+/// The standing-grant options list, shown when the user picks "always" on an
+/// approval. One line per rung, numbered.
+pub fn grant_ladder_lines(
+    rungs: &[crate::api::wire::GrantRung],
+    action: Option<&serde_json::Value>,
+) -> Vec<Line<'static>> {
+    let gutter = || Span::styled("▌ ", theme::accent());
+    let mut lines = vec![Line::from(vec![
+        gutter(),
+        Span::styled("remember this decision:", theme::bold()),
+    ])];
+    let empty = serde_json::Value::Null;
+    let action = action.unwrap_or(&empty);
+    for (i, rung) in rungs.iter().enumerate() {
+        lines.push(Line::from(vec![
+            gutter(),
+            Span::styled(format!("{} ", i + 1), theme::accent_bold()),
+            Span::styled(grant_rung_label(rung, action), theme::muted()),
+        ]));
+    }
+    lines.push(Line::from(vec![
+        gutter(),
+        Span::styled("esc", theme::muted()),
+        Span::styled(" back", theme::muted()),
     ]));
     lines
+}
+
+/// The plan-review card for the live region: the plan's title and a bounded
+/// slice of its body behind an accent gutter, plus the decision hints. The
+/// full plan text stays in the review state; this card shows the head.
+pub fn plan_card(title: &str, plan: &str, feedback_open: bool, width: usize) -> Vec<Line<'static>> {
+    let gutter = || Span::styled("▌ ", theme::accent());
+    let mut lines = vec![
+        Line::from(vec![
+            gutter(),
+            Span::styled("Proposed plan: ", theme::bold()),
+            Span::styled(title.to_owned(), theme::accent_bold()),
+        ]),
+        Line::from(vec![
+            gutter(),
+            Span::styled(
+                "review it below; the full text is in the chat",
+                theme::muted(),
+            ),
+        ]),
+    ];
+    // Show the plan's own text, bounded, so the decision doesn't need a
+    // second surface.
+    for line in plan.lines().take(8) {
+        for wrapped in wrap(line, width.saturating_sub(2)) {
+            lines.push(Line::from(vec![
+                gutter(),
+                Span::styled(wrapped, Style::default()),
+            ]));
+        }
+    }
+    if plan.lines().count() > 8 {
+        lines.push(Line::from(vec![
+            gutter(),
+            Span::styled("…", theme::muted()),
+        ]));
+    }
+    if feedback_open {
+        lines.push(Line::from(vec![
+            gutter(),
+            Span::styled(
+                "type the changes below · enter sends · esc back",
+                theme::muted(),
+            ),
+        ]));
+    } else {
+        lines.push(Line::from(vec![
+            gutter(),
+            Span::styled("y", theme::accent_bold()),
+            Span::styled(" approve & run", theme::accent()),
+            Span::styled("  ·  ", theme::muted()),
+            Span::styled("f", theme::bold()),
+            Span::styled(" request changes", theme::muted()),
+            Span::styled("  ·  ", theme::muted()),
+            Span::styled("n", theme::bold()),
+            Span::styled(" reject", theme::muted()),
+        ]));
+    }
+    lines
+}
+
+/// Humanize a token count for the footer meter: `12.3k`, `1.2M`.
+pub fn token_count(tokens: u64) -> String {
+    if tokens >= 1_000_000 {
+        format!("{:.1}M", tokens as f64 / 1_000_000.0)
+    } else if tokens >= 1_000 {
+        format!("{:.1}k", tokens as f64 / 1_000.0)
+    } else {
+        tokens.to_string()
+    }
+}
+
+/// Whether the status names a live run (drives the spinner and polling).
+pub fn run_is_live(status: &str) -> bool {
+    matches!(
+        status,
+        "queued" | "running" | "cancelling" | "waiting" | "retry_wait"
+    )
 }

--- a/crates/openwave-cli/src/tui/theme.rs
+++ b/crates/openwave-cli/src/tui/theme.rs
@@ -33,6 +33,25 @@ pub const DESTRUCTIVE: Color = Color::Red;
 /// terminal.
 pub const INLINE_CODE: Color = Color::Rgb(86, 182, 194);
 
+/// Agent (assistant) designation. A soft violet — clearly not the user's
+/// accent, clearly not an error. From the desktop's agent-chrome hue family.
+pub const AGENT: Color = Color::Rgb(178, 148, 214);
+
+/// Warning / attention. ANSI yellow, same reasoning as [`SUCCESS`]: the
+/// user's terminal theme owns the exact tone.
+pub const WARNING: Color = Color::Yellow;
+
+/// Selected-row highlight in overlays (chat switcher, agents, pickers). A
+/// very dark cool gray — enough contrast to read as selection without
+/// fighting the foreground.
+pub const SELECTION_BG: Color = Color::Rgb(56, 58, 64);
+
+/// Subtle panel fill behind overlays.
+pub const PANEL_BG: Color = Color::Rgb(32, 33, 36);
+
+/// Border color for cards and overlay panels.
+pub const BORDER: Color = Color::Rgb(64, 66, 72);
+
 /// Code-block token classes for syntax highlighting. Foreground-only by
 /// design: background fills read wrong against arbitrary terminal themes.
 /// Hues follow the One Dark family (the desktop dark theme's spiritual
@@ -84,4 +103,35 @@ pub fn destructive() -> Style {
 /// Inline code within assistant prose.
 pub fn inline_code() -> Style {
     Style::default().fg(INLINE_CODE)
+}
+
+/// Agent designation — the assistant's role label and agent-run markers.
+pub fn agent() -> Style {
+    Style::default().fg(AGENT)
+}
+
+/// Agent designation, bold — the assistant role label.
+pub fn agent_bold() -> Style {
+    agent().add_modifier(Modifier::BOLD)
+}
+
+/// Warning / needs-attention text.
+pub fn warning() -> Style {
+    Style::default().fg(WARNING)
+}
+
+/// The selected row in an overlay list.
+pub fn selected() -> Style {
+    Style::default().bg(SELECTION_BG)
+}
+
+/// Card and overlay borders.
+pub fn border() -> Style {
+    Style::default().fg(BORDER)
+}
+
+/// User designation — the user's role label, same accent family as the
+/// composer marker so the two read as one surface.
+pub fn user() -> Style {
+    accent_bold()
 }


### PR DESCRIPTION
The TUI was a bare composer and a stream of text. This pass makes it a client someone can actually drive a chat from, close to the desktop's own surface.

## What changed

- **History hydration** — opening or switching a chat replays the durable transcript (messages, settled tool calls with action previews and exec output tails, terminal-turn outcomes, background-agent lines) at the journal watermark, so nothing double-prints. Parked approvals, plans, and question blocks reopen their cards.
- **Differential designation** — user blocks carry a bold accent ❯ header with attachment chips; assistant blocks a violet ◆ header over unframed markdown; settled reasoning folds to a one-line summary.
- **Approvals** — the card decodes the server's standing-grant ladder and offers y-once / a-always… / n-reject, with the rungs listed narrowest-first like the desktop's ApprovalCard.
- **Background agents** — ctrl+g opens a live agents panel with status dots, per-run activity timelines, result slices, and stop; live runs also ride the transcript's transient stack.
- **Chat management** — ctrl+o chat switcher (open, new, inline rename, delete, attention markers from the inbox), ctrl+n new chat, ctrl+w move-to-project.
- **Composer controls** — ctrl+m model picker with a reasoning-effort submenu, ctrl+p permission-mode menu, and a footer carrying the mode pill, model, effort, and a context meter.
- **Steer** — typing mid-turn steers the running turn instead of being rejected.
- **Plan review & user questions** — decidable in the TUI now, with the plan card's y/f/n flow and a paged questions overlay that posts the server's exact answer shape.

The client grows the matching loopback endpoints (transcript, chats, projects, models, agent runs, approvals, plans, questions, steer) and the wire decode learns the new frame fields (usage, grant rungs, tool previews, metadata, titles).

## Verification

`cargo check --workspace --locked` (lockfile unchanged apart from the CLI's own new `chrono` dep line), `cargo clippy -p openwave-cli --all-targets` clean, `cargo fmt` clean, `cargo test -p openwave-cli` green. Not driven end-to-end against a live model — worth a smoke run before merge.