### PR TITLE
feat(plugins): install Agent Plugins manifests (plugin.json)

### DIFF
--- a/crates/openwave-code-execution/src/agent_plugins.rs
+++ b/crates/openwave-code-execution/src/agent_plugins.rs
@@ -1,0 +1,388 @@
+//! The Agent Plugins packaging format (<https://agent-plugins.org>), v1.0.0.
+//!
+//! A plugin published in that format is a directory whose root carries a
+//! `plugin.json` manifest, with components discovered at fixed locations —
+//! skills under `skills/`, one directory each. This module is the reader for
+//! that manifest: it validates the closed schema the specification defines and
+//! hands back the few facts OpenWave's own [`crate::plugins`] representation
+//! needs, so the importer can convert a standard package into the internal
+//! `PLUGIN.md` shape the loaders already understand.
+//!
+//! Two properties of the specification drive the shape of this code:
+//!
+//! * **`$schema` selects the validation rules.** It is required, and a client
+//!   that does not implement the identifier it names must reject the plugin
+//!   rather than guess. Schemas are never fetched while loading.
+//! * **Failures are graded.** Only two manifest violations are non-fatal —
+//!   unknown top-level fields, and an `extensions` value that is not an
+//!   object — and both are reported and ignored. Everything else rejects the
+//!   plugin whole, so a package never loads in a shape its author did not
+//!   describe.
+//!
+//! Client-specific data rides in `extensions` under reverse-domain
+//! namespaces. OpenWave reads [`OPENWAVE_EXTENSION_NAMESPACE`] and ignores
+//! every other namespace without inspecting it, which is what the
+//! specification requires of a client that does not implement one. Because
+//! that namespace is ours, a malformed value inside it is reported and ignored
+//! rather than fatal: the plugin still describes itself correctly to every
+//! other client.
+
+use crate::plugins::{is_valid_plugin_router_preamble, PluginCategory};
+
+/// The manifest file at the root of a plugin published in the standard format.
+pub const AGENT_PLUGIN_MANIFEST_FILE: &str = "plugin.json";
+
+/// The fixed location standard-format skills are discovered at.
+pub const AGENT_PLUGIN_SKILLS_DIR: &str = "skills";
+
+/// The specification version this client implements.
+pub const AGENT_PLUGIN_SPEC_VERSION: &str = "1.0.0";
+
+/// The only `$schema` identifier [`parse_agent_plugin_manifest`] accepts.
+pub const AGENT_PLUGIN_SCHEMA_ID: &str =
+    "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json";
+
+/// The reverse-domain namespace OpenWave's own manifest data lives under.
+pub const OPENWAVE_EXTENSION_NAMESPACE: &str = "io.brightwave.openwave";
+
+const MAX_NAME_CHARS: usize = 64;
+
+/// The manifest fields OpenWave acts on, after validation.
+///
+/// Metadata the specification type-checks but this client has no consumer for
+/// — `version`, `author`, `homepage`, `repository`, `license`, `keywords` — is
+/// validated and dropped rather than carried into a representation nothing
+/// renders.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentPluginManifest {
+    /// The package name, in the specification's grammar (which admits `.`,
+    /// unlike OpenWave's own slug).
+    pub name: String,
+    /// Free-form description, unbounded and unsanitized as the specification
+    /// leaves it. Callers rendering it must bound it themselves.
+    pub description: Option<String>,
+    /// `category` from the OpenWave extension namespace.
+    pub category: Option<PluginCategory>,
+    /// `router-preamble` from the OpenWave extension namespace, already
+    /// checked against the same one-line rule the internal parser applies.
+    pub router_preamble: Option<String>,
+}
+
+/// One manifest field that was reported and ignored instead of rejected.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IgnoredManifestField {
+    /// Pointer-ish location of the field, e.g. `extensions` or `keywords`.
+    pub field: String,
+    pub reason: String,
+}
+
+/// A manifest that validated, with the non-fatal violations found along the
+/// way. The specification recommends surfacing these, so they are returned
+/// rather than logged and dropped.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedAgentPluginManifest {
+    pub manifest: AgentPluginManifest,
+    pub ignored: Vec<IgnoredManifestField>,
+}
+
+/// Why a `plugin.json` was rejected whole.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("invalid plugin.json: {0}")]
+pub struct AgentPluginParseError(String);
+
+fn invalid(reason: impl Into<String>) -> AgentPluginParseError {
+    AgentPluginParseError(reason.into())
+}
+
+/// Whether `name` matches the specification's package-name grammar: 1–64
+/// characters of `a-z`, `0-9`, `-`, and `.`, alphanumeric at both ends, with
+/// no `--` and no `..`.
+///
+/// Written by hand rather than as a pattern because the published schema
+/// expresses the repeat prohibitions with lookahead, which the `regex` crate
+/// deliberately does not support.
+#[must_use]
+pub fn is_valid_agent_plugin_name(name: &str) -> bool {
+    let alphanumeric = |byte: u8| byte.is_ascii_lowercase() || byte.is_ascii_digit();
+    let bytes = name.as_bytes();
+    !bytes.is_empty()
+        && bytes.len() <= MAX_NAME_CHARS
+        && bytes
+            .iter()
+            .all(|byte| alphanumeric(*byte) || matches!(byte, b'-' | b'.'))
+        && bytes.first().is_some_and(|byte| alphanumeric(*byte))
+        && bytes.last().is_some_and(|byte| alphanumeric(*byte))
+        && !name.contains("--")
+        && !name.contains("..")
+}
+
+/// Parse and validate one `plugin.json` against the v1.0.0 schema.
+///
+/// The manifest is a closed object: `$schema`, `name`, `version`,
+/// `description`, `author`, `homepage`, `repository`, `license`, `keywords`,
+/// and `extensions` are the whole vocabulary. `$schema` and `name` are
+/// required. Optional metadata is checked by JSON type only — a version that
+/// is not SemVer, a license that is not an SPDX identifier, or a URL this
+/// client cannot parse are all valid manifests, and rejecting them would make
+/// this client stricter than the format it claims to read.
+pub fn parse_agent_plugin_manifest(
+    source: &str,
+) -> Result<ParsedAgentPluginManifest, AgentPluginParseError> {
+    let value: serde_json::Value = serde_json::from_str(source)
+        .map_err(|error| invalid(format!("not valid JSON: {error}")))?;
+    let serde_json::Value::Object(object) = value else {
+        return Err(invalid("manifest is not a JSON object"));
+    };
+
+    let schema = object
+        .get("$schema")
+        .ok_or_else(|| invalid("missing '$schema'"))?
+        .as_str()
+        .ok_or_else(|| invalid("'$schema' is not a string"))?;
+    if schema != AGENT_PLUGIN_SCHEMA_ID {
+        return Err(invalid(format!(
+            "'$schema' names {schema:?}, which is not the supported \
+             Agent Plugins {AGENT_PLUGIN_SPEC_VERSION} manifest schema"
+        )));
+    }
+
+    let name = object
+        .get("name")
+        .ok_or_else(|| invalid("missing 'name'"))?
+        .as_str()
+        .ok_or_else(|| invalid("'name' is not a string"))?;
+    if !is_valid_agent_plugin_name(name) {
+        return Err(invalid(format!(
+            "'name' does not match the package-name grammar: {name:?}"
+        )));
+    }
+
+    let mut ignored = Vec::new();
+    for key in object.keys() {
+        if !matches!(
+            key.as_str(),
+            "$schema"
+                | "name"
+                | "version"
+                | "description"
+                | "author"
+                | "homepage"
+                | "repository"
+                | "license"
+                | "keywords"
+                | "extensions"
+        ) {
+            ignored.push(IgnoredManifestField {
+                field: key.clone(),
+                reason: format!(
+                    "field is not part of the Agent Plugins {AGENT_PLUGIN_SPEC_VERSION} \
+                     manifest schema"
+                ),
+            });
+        }
+    }
+
+    for key in [
+        "version",
+        "description",
+        "homepage",
+        "repository",
+        "license",
+    ] {
+        if let Some(value) = object.get(key) {
+            if !value.is_string() {
+                return Err(invalid(format!("'{key}' is not a string")));
+            }
+        }
+    }
+    if let Some(keywords) = object.get("keywords") {
+        let keywords = keywords
+            .as_array()
+            .ok_or_else(|| invalid("'keywords' is not an array"))?;
+        if !keywords.iter().all(serde_json::Value::is_string) {
+            return Err(invalid("'keywords' contains a non-string entry"));
+        }
+    }
+    if let Some(author) = object.get("author") {
+        let author = author
+            .as_object()
+            .ok_or_else(|| invalid("'author' is not an object"))?;
+        for (key, value) in author {
+            if !matches!(key.as_str(), "name" | "email" | "url") {
+                return Err(invalid(format!("'author' has unknown field {key:?}")));
+            }
+            if !value.is_string() {
+                return Err(invalid(format!("'author.{key}' is not a string")));
+            }
+        }
+    }
+
+    let mut category = None;
+    let mut router_preamble = None;
+    match object.get("extensions") {
+        None => {}
+        // The one shape the specification downgrades to a warning: a client
+        // that cannot read the extension block still loads the components.
+        Some(value) if !value.is_object() => ignored.push(IgnoredManifestField {
+            field: "extensions".to_owned(),
+            reason: "value is not an object".to_owned(),
+        }),
+        Some(value) => {
+            let extensions = value.as_object().expect("checked above");
+            for (namespace, value) in extensions {
+                if !value.is_object() {
+                    return Err(invalid(format!(
+                        "'extensions.{namespace}' is not an object"
+                    )));
+                }
+            }
+            // Every other namespace is ignored without inspecting it, which
+            // is exactly what the specification asks of a client that does
+            // not implement one.
+            if let Some(ours) = extensions
+                .get(OPENWAVE_EXTENSION_NAMESPACE)
+                .and_then(serde_json::Value::as_object)
+            {
+                for (key, value) in ours {
+                    let field = format!("extensions.{OPENWAVE_EXTENSION_NAMESPACE}.{key}");
+                    match key.as_str() {
+                        "category" => match value.as_str().and_then(PluginCategory::parse) {
+                            Some(parsed) => category = Some(parsed),
+                            None => ignored.push(IgnoredManifestField {
+                                field,
+                                reason: "value is not one of the supported categories".to_owned(),
+                            }),
+                        },
+                        "router-preamble" => match value.as_str() {
+                            Some(preamble) if is_valid_plugin_router_preamble(preamble) => {
+                                router_preamble = Some(preamble.to_owned());
+                            }
+                            _ => ignored.push(IgnoredManifestField {
+                                field,
+                                reason: "value is not one bounded printable line".to_owned(),
+                            }),
+                        },
+                        _ => ignored.push(IgnoredManifestField {
+                            field,
+                            reason: "field is not read by this client".to_owned(),
+                        }),
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(ParsedAgentPluginManifest {
+        manifest: AgentPluginManifest {
+            name: name.to_owned(),
+            description: object
+                .get("description")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned),
+            category,
+            router_preamble,
+        },
+        ignored,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manifest(body: &str) -> String {
+        format!("{{\"$schema\": \"{AGENT_PLUGIN_SCHEMA_ID}\", \"name\": \"reporting\"{body}}}")
+    }
+
+    /// Contract: the two documented non-fatal violations keep the plugin
+    /// loadable, every other schema violation rejects it, and metadata the
+    /// specification only type-checks is never second-guessed.
+    #[test]
+    fn manifest_violations_are_graded_the_way_the_specification_grades_them() {
+        let parsed = parse_agent_plugin_manifest(&manifest(
+            ", \"version\": \"not.a.semver-at-all\", \"license\": \"whatever\", \
+             \"homepage\": \"not a url\", \"keywords\": [\"a\"], \
+             \"author\": {\"name\": \"A\"}, \"surprise\": 1, \"extensions\": 7",
+        ))
+        .expect("non-fatal violations keep the plugin loadable");
+        assert_eq!(
+            parsed
+                .ignored
+                .iter()
+                .map(|entry| entry.field.as_str())
+                .collect::<Vec<_>>(),
+            ["surprise", "extensions"]
+        );
+
+        for (case, source) in [
+            ("missing $schema", "{\"name\": \"reporting\"}".to_owned()),
+            (
+                "unsupported $schema",
+                "{\"$schema\": \"https://agent-plugins.org/schemas/9.9.9/plugin.schema.json\", \
+                 \"name\": \"reporting\"}"
+                    .to_owned(),
+            ),
+            (
+                "missing name",
+                format!("{{\"$schema\": \"{AGENT_PLUGIN_SCHEMA_ID}\"}}"),
+            ),
+            ("mistyped description", manifest(", \"description\": 5")),
+            ("mistyped keywords", manifest(", \"keywords\": \"a\"")),
+            (
+                "unknown author field",
+                manifest(", \"author\": {\"handle\": \"a\"}"),
+            ),
+            (
+                "non-object namespace",
+                manifest(", \"extensions\": {\"com.example\": 3}"),
+            ),
+            ("not an object", "[]".to_owned()),
+        ] {
+            assert!(
+                parse_agent_plugin_manifest(&source).is_err(),
+                "{case} should reject the plugin"
+            );
+        }
+
+        for name in ["a", "read.me", "a-b.c-9"] {
+            assert!(is_valid_agent_plugin_name(name), "{name} should be valid");
+        }
+        for name in ["", "-a", "a-", "a--b", "a..b", "A", "a_b", &"a".repeat(65)] {
+            assert!(
+                !is_valid_agent_plugin_name(name),
+                "{name} should be invalid"
+            );
+        }
+    }
+
+    /// Contract: our own namespace is read, other namespaces are passed over
+    /// untouched, and a value we cannot use inside our namespace is reported
+    /// and ignored rather than sinking a package that is valid for everyone
+    /// else.
+    #[test]
+    fn the_openwave_extension_namespace_is_read_and_others_are_left_alone() {
+        let parsed = parse_agent_plugin_manifest(&manifest(&format!(
+            ", \"extensions\": {{\
+               \"com.example.client\": {{\"anything\": [1, 2]}}, \
+               \"{OPENWAVE_EXTENSION_NAMESPACE}\": {{\
+                 \"category\": \"data\", \
+                 \"router-preamble\": \"Pick by the report the user asked for.\"}}}}"
+        )))
+        .unwrap();
+        assert!(parsed.ignored.is_empty());
+        assert_eq!(parsed.manifest.category, Some(PluginCategory::Data));
+        assert_eq!(
+            parsed.manifest.router_preamble.as_deref(),
+            Some("Pick by the report the user asked for.")
+        );
+
+        let parsed = parse_agent_plugin_manifest(&manifest(&format!(
+            ", \"extensions\": {{\"{OPENWAVE_EXTENSION_NAMESPACE}\": {{\
+               \"category\": \"wizardry\", \"router-preamble\": \"\", \"future\": 1}}}}"
+        )))
+        .expect("a value we cannot use is not fatal");
+        assert_eq!(parsed.manifest.category, None);
+        assert_eq!(parsed.manifest.router_preamble, None);
+        assert_eq!(parsed.ignored.len(), 3);
+    }
+}

--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -10,6 +10,7 @@
 //! sandbox. Managed providers run the same direct command contract in a remote
 //! sandbox and share session, idempotency, and bounded-output primitives.
 
+pub mod agent_plugins;
 mod credential;
 mod daytona;
 mod e2b;
@@ -34,6 +35,12 @@ pub mod sync;
 mod tool;
 mod types;
 
+pub use agent_plugins::{
+    is_valid_agent_plugin_name, parse_agent_plugin_manifest, AgentPluginManifest,
+    AgentPluginParseError, IgnoredManifestField, ParsedAgentPluginManifest,
+    AGENT_PLUGIN_MANIFEST_FILE, AGENT_PLUGIN_SCHEMA_ID, AGENT_PLUGIN_SKILLS_DIR,
+    AGENT_PLUGIN_SPEC_VERSION, OPENWAVE_EXTENSION_NAMESPACE,
+};
 pub use daytona::{DaytonaCredential, DaytonaExecutionProvider, DAYTONA_CREDENTIAL_KEY};
 pub use e2b::{E2BCredential, E2BExecutionProvider, E2B_CREDENTIAL_KEY};
 pub use host_paths::{
@@ -60,7 +67,8 @@ pub use plugins::{
     is_valid_plugin_router_preamble, load_plugins, merged_plugins, parse_plugin_manifest,
     LoadedPlugin, PluginCapability, PluginCategory, PluginCompatibility, PluginCompatibilityIssue,
     PluginCompatibilityStatus, PluginInstallStamp, PluginOrigin, PluginPackage, PluginParseError,
-    PLUGIN_INSTALL_STAMP_FILE, PLUGIN_INSTALL_STAMP_SCHEMA, PLUGIN_MANIFEST_FILE,
+    PluginSourceFormat, PLUGIN_INSTALL_STAMP_FILE, PLUGIN_INSTALL_STAMP_SCHEMA,
+    PLUGIN_MANIFEST_FILE,
 };
 pub use preview::{scan_preview_directory, PreviewScan};
 pub use prompts::{

--- a/crates/openwave-code-execution/src/plugins.rs
+++ b/crates/openwave-code-execution/src/plugins.rs
@@ -90,7 +90,7 @@ pub enum PluginCategory {
 }
 
 impl PluginCategory {
-    fn parse(value: &str) -> Option<Self> {
+    pub(crate) fn parse(value: &str) -> Option<Self> {
         match value {
             "documents" => Some(Self::Documents),
             "data" => Some(Self::Data),
@@ -205,6 +205,24 @@ impl PluginCompatibility {
     }
 }
 
+/// The packaging format an imported bundle was read from.
+///
+/// Recorded so a later reader can tell a bundle converted from a standard
+/// Agent Plugins package from one whose author wrote `PLUGIN.md` directly, and
+/// which version of that specification the package targeted.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum PluginSourceFormat {
+    /// An OpenWave `PLUGIN.md` bundle, or a bare Agent Skills package wrapped
+    /// as one. The default, so stamps written before this field existed keep
+    /// reading back as what they are.
+    #[default]
+    PluginManifest,
+    /// A package published in the Agent Plugins format
+    /// (<https://agent-plugins.org>), converted at import.
+    AgentPlugins { spec_version: String },
+}
+
 /// The host-owned metadata persisted beside an imported `PLUGIN.md`.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -212,6 +230,9 @@ pub struct PluginInstallStamp {
     pub schema_version: u32,
     pub source_url: String,
     pub revision: String,
+    /// Absent in stamps written before the importer read standard packages.
+    #[serde(default)]
+    pub source_format: PluginSourceFormat,
     pub compatibility: PluginCompatibility,
 }
 
@@ -587,6 +608,7 @@ fn installed_compatibility(directory: &Path, origin: PluginOrigin) -> PluginComp
         || stamp.source_url.len() > MAX_INSTALL_SOURCE_URL_BYTES
         || stamp.revision.is_empty()
         || stamp.revision.len() > 255
+        || !valid_source_format(&stamp.source_format)
         || !valid_compatibility(&stamp.compatibility)
     {
         tracing::warn!(
@@ -596,6 +618,19 @@ fn installed_compatibility(directory: &Path, origin: PluginOrigin) -> PluginComp
         return PluginCompatibility::unchecked();
     }
     stamp.compatibility
+}
+
+fn valid_source_format(format: &PluginSourceFormat) -> bool {
+    match format {
+        PluginSourceFormat::PluginManifest => true,
+        PluginSourceFormat::AgentPlugins { spec_version } => {
+            !spec_version.is_empty()
+                && spec_version.len() <= 32
+                && spec_version
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-'))
+        }
+    }
 }
 
 fn valid_compatibility(compatibility: &PluginCompatibility) -> bool {

--- a/crates/openwave-server/src/plugin_install.rs
+++ b/crates/openwave-server/src/plugin_install.rs
@@ -6,6 +6,24 @@
 //! never points at that untrusted tree: only the validated manifests and
 //! bounded one-level helper scripts are copied into the install's data
 //! directories, then the ordinary merged loaders re-read those copies.
+//!
+//! Three packaging shapes are accepted, chosen by what the archive actually
+//! contains rather than by anything the request says:
+//!
+//! * a root `plugin.json` — a package in the Agent Plugins standard format
+//!   (<https://agent-plugins.org>), whose components live at the fixed
+//!   locations that specification defines;
+//! * a `PLUGIN.md` — OpenWave's own bundle manifest;
+//! * a lone `SKILL.md` — a bare Agent Skills package, wrapped as a one-skill
+//!   bundle.
+//!
+//! The two manifest formats differ in how strictly a bad member is treated,
+//! and deliberately so. A `PLUGIN.md` *names* its members, so a member that
+//! does not parse means the manifest describes something that is not there and
+//! the whole import is refused. A standard package *discovers* its skills
+//! structurally, and the specification requires a nonconforming one to be
+//! skipped without sinking its siblings, so that is what the standard path
+//! does — with every skip reported in the install response.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::{Cursor, Read};
@@ -18,10 +36,12 @@ use async_trait::async_trait;
 use flate2::read::GzDecoder;
 use futures::StreamExt;
 use openwave_code_execution::{
-    assess_plugin_compatibility, parse_plugin_manifest, parse_skill_manifest, LoadedSkill,
-    PluginCategory, PluginCompatibility, PluginInstallStamp, PluginOrigin, PluginPackage,
-    SkillOrigin, SkillScript, PLUGIN_INSTALL_STAMP_FILE, PLUGIN_INSTALL_STAMP_SCHEMA,
-    PLUGIN_MANIFEST_FILE, SKILL_MANIFEST_FILE, SKILL_SCRIPTS_DIR,
+    assess_plugin_compatibility, is_valid_plugin_name, parse_agent_plugin_manifest,
+    parse_plugin_manifest, parse_skill_manifest, LoadedSkill, PluginCategory, PluginCompatibility,
+    PluginInstallStamp, PluginOrigin, PluginPackage, PluginSourceFormat, SkillOrigin, SkillScript,
+    AGENT_PLUGIN_MANIFEST_FILE, AGENT_PLUGIN_SKILLS_DIR, AGENT_PLUGIN_SPEC_VERSION,
+    PLUGIN_INSTALL_STAMP_FILE, PLUGIN_INSTALL_STAMP_SCHEMA, PLUGIN_MANIFEST_FILE,
+    SKILL_MANIFEST_FILE, SKILL_SCRIPTS_DIR,
 };
 use openwave_web_search::{admit_fetch_address, admit_fetch_url};
 use serde::{Deserialize, Serialize};
@@ -36,6 +56,10 @@ const MAX_ARCHIVE_BYTES: usize = 16 * 1024 * 1024;
 const MAX_UNPACKED_BYTES: u64 = 32 * 1024 * 1024;
 const MAX_ARCHIVE_ENTRIES: usize = 1_024;
 const MAX_SKIPPED_MEMBERS: usize = 32;
+/// The one-line bound the internal `PLUGIN.md` grammar holds a description to.
+/// A standard manifest's description is type-checked only, so it is normalized
+/// to this bound at conversion instead of failing the import.
+const MAX_DESCRIPTION_BYTES: usize = 200;
 const MAX_REDIRECTS: usize = 5;
 const FETCH_TIMEOUT: Duration = Duration::from_secs(30);
 const DNS_TIMEOUT: Duration = Duration::from_secs(5);
@@ -540,10 +564,27 @@ fn insert_entry(
     Ok(())
 }
 
+/// Which archive members are worth holding in memory: the manifests both
+/// formats are defined by, and one level of helper scripts.
 fn retain_archive_file(path: &[String]) -> bool {
     path.last()
         .is_some_and(|name| name == PLUGIN_MANIFEST_FILE || name == SKILL_MANIFEST_FILE)
+        || is_package_root_file(path, AGENT_PLUGIN_MANIFEST_FILE)
         || path.iter().any(|component| component == SKILL_SCRIPTS_DIR)
+}
+
+/// Whether `path` is `file` sitting where a standard package's root can be.
+///
+/// That specification puts `plugin.json` at the package root, so the only
+/// candidate positions are the top of the archive and one directory in, which
+/// is what a repository tarball adds. A file with the same basename anywhere
+/// else — a skill's `scripts/plugin.json`, say — is ordinary skill content and
+/// must not be mistaken for a package manifest, or a perfectly good
+/// `PLUGIN.md` bundle would be routed into the wrong format.
+fn is_package_root_file(path: &[String], file: &str) -> bool {
+    path.len() <= 2
+        && path.last().is_some_and(|name| name == file)
+        && !path.iter().any(|component| component == SKILL_SCRIPTS_DIR)
 }
 
 fn strip_common_root(tree: ArchiveTree) -> Result<ArchiveTree, PluginInstallError> {
@@ -587,6 +628,27 @@ fn prepare_tree(
     tree: ArchiveTree,
     source: &ResolvedPluginSource,
 ) -> Result<PreparedPlugin, PluginInstallError> {
+    // Format is decided by what the archive contains. A root `plugin.json`
+    // means the package describes itself in the standard format, and its
+    // components are discovered at that specification's fixed locations
+    // instead of being named by an OpenWave manifest. Only the positions a
+    // package root can occupy count: a skill's helper script that happens to
+    // be named `plugin.json` is skill content, not a manifest.
+    let mut standard_manifests = tree
+        .files
+        .keys()
+        .filter(|path| is_package_root_file(path, AGENT_PLUGIN_MANIFEST_FILE))
+        .cloned()
+        .collect::<Vec<_>>();
+    if standard_manifests.len() > 1 {
+        return Err(PluginInstallError::InvalidPlugin(
+            "archive contains more than one plugin.json".to_owned(),
+        ));
+    }
+    if let Some(manifest_path) = standard_manifests.pop() {
+        return prepare_standard_tree(&tree, source, &manifest_path);
+    }
+
     let mut plugin_manifests = Vec::new();
     let mut skills = Vec::new();
     for (path, bytes) in &tree.files {
@@ -672,7 +734,7 @@ fn prepare_tree(
         parse_plugin_manifest(&manifest, PluginOrigin::User)
             .map_err(|error| PluginInstallError::InvalidPlugin(error.to_string()))?;
         return Ok(PreparedPlugin {
-            stamp: install_stamp(source, compatibility),
+            stamp: install_stamp(source, PluginSourceFormat::PluginManifest, compatibility),
             manifest,
             skills: selected
                 .into_iter()
@@ -713,12 +775,188 @@ fn prepare_tree(
     // the mutable binding is used by the capped helper above.
     skipped.sort_by(|left, right| left.path.cmp(&right.path));
     Ok(PreparedPlugin {
-        stamp: install_stamp(source, compatibility),
+        stamp: install_stamp(source, PluginSourceFormat::PluginManifest, compatibility),
         manifest,
         skills: vec![skill.loaded],
         package,
         skipped,
     })
+}
+
+/// Convert one package published in the Agent Plugins standard format into the
+/// internal bundle shape.
+///
+/// Skills are discovered structurally: every immediate child directory of
+/// `skills/` that holds a regular `SKILL.md` is one skill, with no recursion
+/// below that. A child that does not conform is skipped and reported — the
+/// specification grades a nonconforming skill as a per-skill failure, so it
+/// must not take its siblings or the rest of the package down with it. A
+/// package that yields no skill at all is refused, because an OpenWave bundle
+/// with no members is not a shape the catalog can render.
+fn prepare_standard_tree(
+    tree: &ArchiveTree,
+    source: &ResolvedPluginSource,
+    manifest_path: &[String],
+) -> Result<PreparedPlugin, PluginInstallError> {
+    let root = manifest_path[..manifest_path.len() - 1].to_vec();
+    let bytes = tree
+        .files
+        .get(manifest_path)
+        .expect("the manifest path came from the retained files");
+    let manifest_source = std::str::from_utf8(bytes).map_err(|_| {
+        PluginInstallError::InvalidPlugin(format!("{} is not UTF-8", manifest_path.join("/")))
+    })?;
+    let parsed = parse_agent_plugin_manifest(manifest_source)
+        .map_err(|error| PluginInstallError::InvalidPlugin(error.to_string()))?;
+    let name = parsed.manifest.name;
+    // The standard's package-name grammar admits `.`; OpenWave addresses a
+    // plugin by a dot-free kebab-case slug everywhere from the toggle route to
+    // the installed directory name, so a dotted package is refused with a
+    // reason rather than silently renamed.
+    if !is_valid_plugin_name(&name) {
+        return Err(PluginInstallError::InvalidPlugin(format!(
+            "plugin.json names itself {name:?}; OpenWave installs plugins whose name is a \
+             kebab-case slug of lowercase letters, digits, and single dashes"
+        )));
+    }
+
+    let mut skipped = skipped_foreign_members(tree, &root);
+    // The standard's other component type. Its bytes are not installed by this
+    // importer yet, and a package that ships one should be told so rather than
+    // left to wonder why nothing connected.
+    let mcp_config = prefixed_path(&root, &["mcp.json"]);
+    if tree.paths.contains(&mcp_config) {
+        push_skipped(
+            &mut skipped,
+            mcp_config.join("/"),
+            "component type is outside the instruction-only importer",
+        );
+    }
+    for ignored in &parsed.ignored {
+        push_skipped(
+            &mut skipped,
+            format!("{AGENT_PLUGIN_MANIFEST_FILE}#{}", ignored.field),
+            &ignored.reason,
+        );
+    }
+
+    let skills_root = prefixed_path(&root, &[AGENT_PLUGIN_SKILLS_DIR]);
+    let mut selected: Vec<ParsedSkill> = Vec::new();
+    for child in standard_skill_children(tree, &skills_root) {
+        let directory = prefixed_path(&skills_root, &[child.as_str()]);
+        let manifest = prefixed_path(&directory, &[SKILL_MANIFEST_FILE]);
+        let Some(bytes) = tree.files.get(&manifest) else {
+            push_skipped(
+                &mut skipped,
+                directory.join("/"),
+                "directory has no SKILL.md and is not a skill",
+            );
+            continue;
+        };
+        match parse_archived_skill(tree, &manifest, bytes) {
+            Ok(skill) => selected.push(skill),
+            Err(error) => push_skipped(&mut skipped, directory.join("/"), &error.to_string()),
+        }
+    }
+    if selected.is_empty() {
+        return Err(PluginInstallError::InvalidPlugin(
+            "plugin has no conforming skill under skills/, and skills are the only \
+             component type this importer installs"
+                .to_owned(),
+        ));
+    }
+
+    let compatibility = assess_plugin_compatibility(
+        &selected
+            .iter()
+            .map(|skill| (&skill.loaded.package, skill.has_scripts))
+            .collect::<Vec<_>>(),
+    );
+    let mut package = PluginPackage {
+        display_name: display_name(&name),
+        description: bounded_description(parsed.manifest.description.as_deref(), &name),
+        category: parsed.manifest.category.unwrap_or(PluginCategory::Other),
+        skills: selected
+            .iter()
+            .map(|skill| skill.loaded.package.name.clone())
+            .collect(),
+        // Reusable prompts have no place in the standard format, so unlike the
+        // `PLUGIN.md` path there is nothing here to prune and disclose.
+        prompts: Vec::new(),
+        router_preamble: parsed.manifest.router_preamble,
+        origin: PluginOrigin::User,
+        compatibility: compatibility.clone(),
+        name,
+    };
+    let manifest = canonical_plugin_manifest(&package, "");
+    // The generated manifest goes through the internal parser before any byte
+    // is copied, exactly as the `PLUGIN.md` path does: nothing reaches disk in
+    // a shape the ordinary loader would later reject.
+    package = parse_plugin_manifest(&manifest, PluginOrigin::User)
+        .map_err(|error| PluginInstallError::InvalidPlugin(error.to_string()))?;
+    package.compatibility = compatibility.clone();
+    skipped.sort_by(|left, right| left.path.cmp(&right.path));
+    Ok(PreparedPlugin {
+        stamp: install_stamp(
+            source,
+            PluginSourceFormat::AgentPlugins {
+                spec_version: AGENT_PLUGIN_SPEC_VERSION.to_owned(),
+            },
+            compatibility,
+        ),
+        manifest,
+        skills: selected.into_iter().map(|skill| skill.loaded).collect(),
+        package,
+        skipped,
+    })
+}
+
+/// The immediate child directory names under `skills_root`, in name order.
+///
+/// A path one level below the root is a file, not a skill directory, so it is
+/// not a child; discovery never descends past this level.
+fn standard_skill_children(tree: &ArchiveTree, skills_root: &[String]) -> Vec<String> {
+    tree.paths
+        .iter()
+        .filter(|path| path.starts_with(skills_root) && path.len() > skills_root.len() + 1)
+        .map(|path| path[skills_root.len()].clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+/// One printable, bounded line for a description the standard only type-checks.
+///
+/// A published description may be several sentences long or carry newlines;
+/// the internal manifest grammar accepts exactly one bounded printable line, so
+/// it is normalized here rather than rejected. An absent or whitespace-only
+/// description falls back to a derived line, since the internal parser has no
+/// notion of a bundle without one.
+fn bounded_description(description: Option<&str>, name: &str) -> String {
+    let normalized = description
+        .unwrap_or_default()
+        .chars()
+        .map(|character| {
+            if character.is_control() {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    let mut end = MAX_DESCRIPTION_BYTES.min(normalized.len());
+    while end > 0 && !normalized.is_char_boundary(end) {
+        end -= 1;
+    }
+    let bounded = normalized[..end].trim_end();
+    if bounded.is_empty() {
+        format!("Skills bundled by the {name} plugin.")
+    } else {
+        bounded.to_owned()
+    }
 }
 
 fn parse_archived_skill(
@@ -829,12 +1067,14 @@ fn display_name(name: &str) -> String {
 
 fn install_stamp(
     source: &ResolvedPluginSource,
+    source_format: PluginSourceFormat,
     compatibility: PluginCompatibility,
 ) -> PluginInstallStamp {
     PluginInstallStamp {
         schema_version: PLUGIN_INSTALL_STAMP_SCHEMA,
         source_url: source.source_url.clone(),
         revision: source.revision.clone(),
+        source_format,
         compatibility,
     }
 }

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -2896,6 +2896,10 @@ async fn stamps_and_surfaces_static_plugin_compatibility() {
             "deploy-skill/scripts/deploy.py",
             b"print('requires external deployment tooling')\n",
         ),
+        // A helper script that shares the standard manifest's name is skill
+        // content, not a package manifest: this archive must still install
+        // through the internal path.
+        ("deploy-skill/scripts/plugin.json", b"{\"tool\": \"config\"}"),
     ]);
     let (router, bearer) = plugin_install_app(
         Arc::new(store),
@@ -2949,6 +2953,234 @@ async fn stamps_and_surfaces_static_plugin_compatibility() {
         .find(|plugin| plugin["name"] == "deploy-reports")
         .unwrap();
     assert_eq!(plugin["compatibility"], installed["compatibility"]);
+}
+
+/// The only manifest schema the standard-format importer accepts.
+const AGENT_PLUGIN_SCHEMA: &str = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json";
+
+/// Contract: a package published in the Agent Plugins format
+/// (<https://agent-plugins.org>) is recognized by its root `plugin.json`, its
+/// skills are discovered structurally under `skills/`, and a nonconforming
+/// skill is skipped and reported rather than sinking the package — the
+/// per-component failure grading that specification requires, and the
+/// deliberate difference from the `PLUGIN.md` path, which refuses an import
+/// whose named member does not parse.
+#[tokio::test]
+async fn installs_a_standard_format_plugin_and_skips_nonconforming_skills() {
+    let (dir, store) = temp_db_store("plugin-standard.db").await;
+    let manifest = format!(
+        "{{\"$schema\": \"{AGENT_PLUGIN_SCHEMA}\", \"name\": \"reporting\", \
+          \"version\": \"0.4.1\", \"license\": \"Apache-2.0\", \
+          \"description\": \"Weekly and monthly reporting skills.\"}}"
+    );
+    let archive = plugin_archive(&[
+        ("reporting-1.0.0/plugin.json", manifest.as_bytes()),
+        (
+            "reporting-1.0.0/skills/weekly-report/SKILL.md",
+            b"---\nname: weekly-report\ndescription: Draft the weekly report.\n---\nInstructions.\n",
+        ),
+        (
+            "reporting-1.0.0/skills/broken-report/SKILL.md",
+            b"---\nname: broken-report\ndescription: Missing its closing fence.\n",
+        ),
+        (
+            "reporting-1.0.0/skills/drafts/notes.md",
+            b"A directory that is not a skill.\n",
+        ),
+        ("reporting-1.0.0/agents/reviewer.md", b"A foreign component.\n"),
+    ]);
+    let (router, bearer) = plugin_install_app(
+        Arc::new(store),
+        dir.path(),
+        FixedPluginArchiveFetcher {
+            expected_url: "https://example.com/reporting-1.0.0.zip".to_owned(),
+            archive: Arc::new(archive),
+        },
+    );
+    let response = post_plugin_install(
+        &router,
+        &bearer,
+        serde_json::json!({
+            "source": {
+                "kind": "archive",
+                "url": "https://example.com/reporting-1.0.0.zip",
+                "revision": "1.0.0"
+            }
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let installed: serde_json::Value = json_body(response).await;
+    assert_eq!(installed["plugin"], "reporting");
+    assert_eq!(
+        installed["skipped"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|entry| entry["path"].as_str().unwrap())
+            .collect::<Vec<_>>(),
+        ["agents", "skills/broken-report", "skills/drafts"]
+    );
+
+    // The conforming skill installed; the nonconforming sibling did not.
+    assert!(dir.path().join("skills/weekly-report/SKILL.md").is_file());
+    assert!(!dir.path().join("skills/broken-report").exists());
+    let stamp: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(dir.path().join("plugins/reporting/.openwave-install.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        stamp["source_format"],
+        serde_json::json!({"kind": "agent_plugins", "spec_version": "1.0.0"})
+    );
+
+    let catalog = get_plugins(&router, &bearer).await;
+    let plugin = catalog["plugins"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|plugin| plugin["name"] == "reporting")
+        .unwrap();
+    assert_eq!(plugin["origin"], "user");
+    assert_eq!(
+        plugin["description"],
+        "Weekly and monthly reporting skills."
+    );
+    assert_eq!(plugin["category"], "other");
+    assert_eq!(plugin["skills"][0]["name"], "weekly-report");
+    assert_eq!(plugin["skills"].as_array().unwrap().len(), 1);
+}
+
+/// Contract: `$schema` is how the standard selects validation rules, so an
+/// identifier this client does not implement rejects the package whole rather
+/// than being guessed at — and a package name OpenWave cannot address is
+/// refused with a reason instead of being silently rewritten.
+#[tokio::test]
+async fn rejects_standard_packages_this_client_cannot_honour() {
+    for (case, manifest) in [
+        (
+            "unsupported schema version",
+            "{\"$schema\": \"https://agent-plugins.org/schemas/9.9.9/plugin.schema.json\", \
+              \"name\": \"reporting\"}"
+                .to_owned(),
+        ),
+        (
+            // Legal in the standard, which admits `.` in a package name;
+            // OpenWave addresses a plugin by a dot-free slug everywhere.
+            "name OpenWave cannot address",
+            format!(
+                "{{\"$schema\": \"{AGENT_PLUGIN_SCHEMA}\", \"name\": \"io.example.reporting\"}}"
+            ),
+        ),
+    ] {
+        let (dir, store) = temp_db_store("plugin-standard-reject.db").await;
+        let archive = plugin_archive(&[
+            ("pkg/plugin.json", manifest.as_bytes()),
+            (
+                "pkg/skills/weekly-report/SKILL.md",
+                b"---\nname: weekly-report\ndescription: Draft the weekly report.\n---\nBody.\n",
+            ),
+        ]);
+        let (router, bearer) = plugin_install_app(
+            Arc::new(store),
+            dir.path(),
+            FixedPluginArchiveFetcher {
+                expected_url: "https://example.com/reporting-1.0.0.zip".to_owned(),
+                archive: Arc::new(archive),
+            },
+        );
+        let response = post_plugin_install(
+            &router,
+            &bearer,
+            serde_json::json!({
+                "source": {
+                    "kind": "archive",
+                    "url": "https://example.com/reporting-1.0.0.zip",
+                    "revision": "1.0.0"
+                }
+            }),
+        )
+        .await;
+        assert_eq!(
+            response.status(),
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "{case} should refuse the package"
+        );
+        assert!(!dir.path().join("skills/weekly-report").exists());
+    }
+}
+
+/// Contract: the two violations the standard grades as non-fatal — an unknown
+/// top-level field and a non-object `extensions` — keep the package
+/// installable and are reported, and the data in OpenWave's own extension
+/// namespace reaches the installed manifest. Namespaces this client does not
+/// implement are passed over untouched.
+#[tokio::test]
+async fn standard_manifests_report_ignored_fields_and_carry_our_extension() {
+    let (dir, store) = temp_db_store("plugin-standard-extensions.db").await;
+    let manifest = format!(
+        "{{\"$schema\": \"{AGENT_PLUGIN_SCHEMA}\", \"name\": \"reporting\", \
+          \"description\": \"Reporting skills.\", \"future-field\": [1, 2], \
+          \"extensions\": {{\
+            \"com.example.other-client\": {{\"whatever\": true}}, \
+            \"io.brightwave.openwave\": {{\
+              \"category\": \"data\", \
+              \"router-preamble\": \"Pick by the reporting cadence the user asked for.\"}}}}}}"
+    );
+    let archive = plugin_archive(&[
+        ("pkg/plugin.json", manifest.as_bytes()),
+        (
+            "pkg/skills/weekly-report/SKILL.md",
+            b"---\nname: weekly-report\ndescription: Draft the weekly report.\n---\nBody.\n",
+        ),
+    ]);
+    let (router, bearer) = plugin_install_app(
+        Arc::new(store),
+        dir.path(),
+        FixedPluginArchiveFetcher {
+            expected_url: "https://example.com/reporting-1.0.0.zip".to_owned(),
+            archive: Arc::new(archive),
+        },
+    );
+    let response = post_plugin_install(
+        &router,
+        &bearer,
+        serde_json::json!({
+            "source": {
+                "kind": "archive",
+                "url": "https://example.com/reporting-1.0.0.zip",
+                "revision": "1.0.0"
+            }
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let installed: serde_json::Value = json_body(response).await;
+    assert_eq!(
+        installed["skipped"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|entry| entry["path"].as_str().unwrap())
+            .collect::<Vec<_>>(),
+        ["plugin.json#future-field"]
+    );
+
+    let written = std::fs::read_to_string(dir.path().join("plugins/reporting/PLUGIN.md")).unwrap();
+    assert!(
+        written.contains("category: data\n")
+            && written
+                .contains("router-preamble: Pick by the reporting cadence the user asked for.\n"),
+        "our extension data should reach the installed manifest, got {written:?}"
+    );
+    let catalog = get_plugins(&router, &bearer).await;
+    let plugin = catalog["plugins"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|plugin| plugin["name"] == "reporting")
+        .unwrap();
+    assert_eq!(plugin["category"], "data");
 }
 
 /// Contract: the catalog reports host-derived badges and enable state,


### PR DESCRIPTION
Teaches the plugin importer to read packages published in the [Agent Plugins](https://agent-plugins.org/) standard format (v1.0.0), so a plugin authored against the public spec installs into OpenWave without being rewritten by hand.

## What changed

Format is decided by archive content, not by the request: a root `plugin.json` takes the new standard path, otherwise the existing `PLUGIN.md` path, otherwise the existing lone-`SKILL.md` path.

`plugin.json` is validated as the closed schema [§5](https://agent-plugins.org/specification) defines. `$schema` is required and is how a client selects its validation rules — locally; the parser never fetches a schema while loading — so an identifier this client does not implement rejects the package instead of being guessed at. The two violations the spec grades as non-fatal, an unknown top-level field and a non-object `extensions`, are reported and ignored; every other schema violation refuses the import. Optional metadata is checked by JSON type only, so a non-SemVer `version`, an unparseable URL, or a non-SPDX `license` are all valid manifests here — being stricter than the format would reject packages that are perfectly conformant.

Skills are discovered structurally at the fixed location (§7.1): every immediate child directory of `skills/` holding a regular `SKILL.md`, with no recursion below that. A nonconforming skill is skipped and surfaced through the existing `skipped` disclosure rather than sinking the package or its siblings.

That last point is a deliberate difference between the two formats, documented at the module head: a `PLUGIN.md` *names* its members, so a member that does not parse means the manifest describes something that is not there and the whole import is still refused. A standard package *discovers* its skills, and the spec requires per-component failure grading.

OpenWave's own data rides in `extensions` under `io.brightwave.openwave` (`category`, `router-preamble`), converted into the canonical `PLUGIN.md` the loaders already read. Other namespaces are passed over without inspecting their contents, as §8 requires. A value we cannot use inside our own namespace is reported and ignored, not fatal — the package is still correct for every other client.

The install stamp now records the source format and the spec version it targeted. The field is defaulted, so stamps written before this change keep validating rather than degrading to `unchecked`.

## Name reconciliation

The spec's package-name grammar admits `.`; OpenWave's plugin slug does not. Since the slug is also the installed directory name, the `/plugins/enabled` toggle key, and what the UI addresses a bundle by, widening it would have to move the loader, the routes, and the UI in one change. **This PR refuses a dotted package** with an explicit error naming the limitation, rather than silently renaming it. Everything else in the two grammars already agrees (both forbid `--`, require alphanumeric ends, and cap at 64 characters), so only dotted names are affected. Widening the slug is a reasonable follow-up if real packages need it.

`mcp.json` is reported as a skipped component here; retaining it is the next PR in the stack.

## Tests

Three end-to-end installs through the real route, extending the existing fixtures: a standard package with a nonconforming skill (installs, bad skill reported skipped), the two refusals above (unsupported `$schema`, dotted name), and one asserting an unknown top-level field is reported-not-fatal while our extension round-trips into the installed manifest. Two unit tests in the parser cover the violation grading and the extension namespace rules. No tests were deleted.

`cargo fmt`, clippy `-D warnings` on both touched crates, `cargo test -p openwave-code-execution`, `cargo test -p openwave-server --lib tests::configuration`, and `cargo check --workspace --locked` (no lockfile change) all pass locally.