### PR TITLE
feat(plugins): retain bundled MCP server config from Agent Plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4262,6 +4262,7 @@ dependencies = [
  "tracing",
  "trash",
  "ts-rs",
+ "url",
  "uuid",
 ]
 

--- a/crates/openwave-code-execution/Cargo.toml
+++ b/crates/openwave-code-execution/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "net", "process", "rt", "sync", "time"] }
 tracing = "=0.1.44"
 trash = { workspace = true }
+url = "=2.5.8"
 uuid = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/openwave-code-execution/src/agent_plugins.rs
+++ b/crates/openwave-code-execution/src/agent_plugins.rs
@@ -286,6 +286,562 @@ pub fn parse_agent_plugin_manifest(
     })
 }
 
+/// The bundled MCP server configuration file, at the package root.
+pub const AGENT_PLUGIN_MCP_FILE: &str = "mcp.json";
+
+/// The only `mcp.json` `$schema` identifier this client accepts. Both schemas
+/// share the specification version, and a file whose version disagrees with the
+/// manifest's disables MCP for that plugin alone.
+pub const AGENT_PLUGIN_MCP_SCHEMA_ID: &str =
+    "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json";
+
+/// The absolute, resolved plugin root, provided to a launched server.
+pub const PLUGIN_ROOT_VARIABLE: &str = "PLUGIN_ROOT";
+/// The client-managed writable data directory, provided to a launched server.
+pub const PLUGIN_DATA_VARIABLE: &str = "PLUGIN_DATA";
+
+const MAX_MCP_SERVERS: usize = 16;
+const MAX_MCP_SERVER_NAME_BYTES: usize = 64;
+const MAX_MCP_STRING_BYTES: usize = 2_048;
+const MAX_MCP_LIST_ENTRIES: usize = 64;
+
+/// A `stdio` server: a subprocess the client launches from the plugin.
+///
+/// `${PLUGIN_ROOT}` and `${PLUGIN_DATA}` are expanded in `args`, `env` values,
+/// and `cwd` — never in `command` — in a single non-recursive textual pass, so
+/// replacement text is never rescanned and no other placeholder-like text is
+/// touched. That expansion happens when a server is actually launched; nothing
+/// here starts a process.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpStdioServer {
+    /// One executable token: a bare program name resolved by the platform, or
+    /// a `./`-relative path inside the plugin. Never expanded.
+    pub command: String,
+    pub args: Vec<String>,
+    /// Literal package data, not a secret mechanism — the specification is
+    /// explicit that these values are visible. Never log them.
+    pub env: std::collections::BTreeMap<String, String>,
+    /// Absent means the plugin root. When present it is `./`-relative or
+    /// rooted at one of the two reserved variables, and stays contained inside
+    /// that root after expansion.
+    pub cwd: Option<String>,
+}
+
+/// A `streamable-http` or legacy `sse` server: a remote endpoint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpHttpServer {
+    /// Absolute HTTP(S) URL with no userinfo and no fragment; plain HTTP only
+    /// for loopback. Never expanded.
+    pub url: String,
+    /// Literal headers, unique case-insensitively. Visible package data, like
+    /// `env`: never log the values.
+    pub headers: std::collections::BTreeMap<String, String>,
+}
+
+/// How a configured server is reached.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum McpTransport {
+    Stdio(McpStdioServer),
+    StreamableHttp(McpHttpServer),
+    /// The legacy transport the specification keeps optional.
+    Sse(McpHttpServer),
+}
+
+impl McpTransport {
+    fn type_name(&self) -> &'static str {
+        match self {
+            Self::Stdio(_) => "stdio",
+            Self::StreamableHttp(_) => "streamable-http",
+            Self::Sse(_) => "sse",
+        }
+    }
+}
+
+/// One validated server entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpServer {
+    pub name: String,
+    pub transport: McpTransport,
+}
+
+/// A plugin's validated MCP configuration.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PluginMcpConfig {
+    /// Valid entries in name order. Empty is a legitimate configuration.
+    pub servers: Vec<McpServer>,
+}
+
+/// One server entry that was dropped, with the reason it did not validate.
+///
+/// A reason never quotes a header value or an `env` value: those are visible
+/// package data the specification tells clients not to treat as secrets, which
+/// is exactly why they should not be copied into logs and API responses.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkippedMcpServer {
+    pub name: String,
+    pub reason: String,
+}
+
+/// A configuration that loaded, with the entries dropped along the way.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedPluginMcpConfig {
+    pub config: PluginMcpConfig,
+    pub skipped: Vec<SkippedMcpServer>,
+}
+
+/// Why a whole `mcp.json` was rejected. The specification grades this as
+/// disabling MCP for that plugin only: every other component still loads.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("invalid mcp.json: {0}")]
+pub struct McpConfigError(String);
+
+fn invalid_mcp(reason: impl Into<String>) -> McpConfigError {
+    McpConfigError(reason.into())
+}
+
+/// Parse and validate one `mcp.json`.
+///
+/// Failures are graded the way §7.2.2 grades them. A file that is not JSON, or
+/// whose `$schema` this client does not implement, or whose top level is not
+/// exactly `$schema` and `mcpServers`, disables MCP for the plugin — the
+/// returned `Err`. A single entry that does not validate is skipped and
+/// reported, leaving its siblings alone.
+pub fn parse_plugin_mcp_config(source: &str) -> Result<ParsedPluginMcpConfig, McpConfigError> {
+    let value: serde_json::Value = serde_json::from_str(source)
+        .map_err(|error| invalid_mcp(format!("not valid JSON: {error}")))?;
+    let serde_json::Value::Object(object) = value else {
+        return Err(invalid_mcp("configuration is not a JSON object"));
+    };
+    if let Some(unknown) = object
+        .keys()
+        .find(|key| !matches!(key.as_str(), "$schema" | "mcpServers"))
+    {
+        return Err(invalid_mcp(format!("unknown top-level field {unknown:?}")));
+    }
+    let schema = object
+        .get("$schema")
+        .ok_or_else(|| invalid_mcp("missing '$schema'"))?
+        .as_str()
+        .ok_or_else(|| invalid_mcp("'$schema' is not a string"))?;
+    if schema != AGENT_PLUGIN_MCP_SCHEMA_ID {
+        return Err(invalid_mcp(format!(
+            "'$schema' names {schema:?}, which is not the Agent Plugins \
+             {AGENT_PLUGIN_SPEC_VERSION} MCP schema this plugin targets"
+        )));
+    }
+    let servers = object
+        .get("mcpServers")
+        .ok_or_else(|| invalid_mcp("missing 'mcpServers'"))?
+        .as_object()
+        .ok_or_else(|| invalid_mcp("'mcpServers' is not an object"))?;
+    if servers.len() > MAX_MCP_SERVERS {
+        return Err(invalid_mcp("'mcpServers' declares too many servers"));
+    }
+
+    let mut parsed = Vec::new();
+    let mut skipped = Vec::new();
+    for (name, entry) in servers {
+        let reported = bounded_server_name(name);
+        if !is_valid_mcp_server_name(name) {
+            skipped.push(SkippedMcpServer {
+                name: reported,
+                reason: "server name is not one bounded printable token".to_owned(),
+            });
+            continue;
+        }
+        match parse_mcp_server(entry) {
+            Ok(transport) => parsed.push(McpServer {
+                name: name.clone(),
+                transport,
+            }),
+            Err(reason) => skipped.push(SkippedMcpServer {
+                name: reported,
+                reason,
+            }),
+        }
+    }
+    parsed.sort_by(|left, right| left.name.cmp(&right.name));
+    Ok(ParsedPluginMcpConfig {
+        config: PluginMcpConfig { servers: parsed },
+        skipped,
+    })
+}
+
+fn bounded_server_name(name: &str) -> String {
+    name.chars()
+        .filter(|character| !character.is_control())
+        .take(MAX_MCP_SERVER_NAME_BYTES)
+        .collect()
+}
+
+fn is_valid_mcp_server_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= MAX_MCP_SERVER_NAME_BYTES
+        && name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+}
+
+/// Validate one entry of `mcpServers`. The three transports are a closed union
+/// selected by `type`; an unknown field, an unknown `type`, or a field that
+/// belongs to another variant invalidates this entry and only this entry.
+fn parse_mcp_server(entry: &serde_json::Value) -> Result<McpTransport, String> {
+    let entry = entry.as_object().ok_or("entry is not an object")?;
+    let transport = entry
+        .get("type")
+        .ok_or("entry has no 'type'")?
+        .as_str()
+        .ok_or("'type' is not a string")?;
+    let allowed: &[&str] = match transport {
+        "stdio" => &["type", "command", "args", "env", "cwd"],
+        "streamable-http" | "sse" => &["type", "url", "headers"],
+        other => return Err(format!("transport {other:?} is not one this client reads")),
+    };
+    if let Some(unknown) = entry.keys().find(|key| !allowed.contains(&key.as_str())) {
+        return Err(format!(
+            "field {unknown:?} does not belong to a {transport:?} entry"
+        ));
+    }
+    if transport == "stdio" {
+        return Ok(McpTransport::Stdio(parse_stdio_server(entry)?));
+    }
+    let http = parse_http_server(entry)?;
+    Ok(if transport == "sse" {
+        McpTransport::Sse(http)
+    } else {
+        McpTransport::StreamableHttp(http)
+    })
+}
+
+fn parse_stdio_server(
+    entry: &serde_json::Map<String, serde_json::Value>,
+) -> Result<McpStdioServer, String> {
+    let command = entry
+        .get("command")
+        .ok_or("stdio entry has no 'command'")?
+        .as_str()
+        .ok_or("'command' is not a string")?;
+    if !is_valid_command_token(command) {
+        return Err("'command' is not a single executable token inside the plugin".to_owned());
+    }
+    let mut args = Vec::new();
+    if let Some(value) = entry.get("args") {
+        let listed = value.as_array().ok_or("'args' is not an array")?;
+        if listed.len() > MAX_MCP_LIST_ENTRIES {
+            return Err("'args' has too many entries".to_owned());
+        }
+        for argument in listed {
+            let argument = argument.as_str().ok_or("'args' has a non-string entry")?;
+            if argument.len() > MAX_MCP_STRING_BYTES {
+                return Err("'args' has an entry beyond the byte limit".to_owned());
+            }
+            args.push(argument.to_owned());
+        }
+    }
+    let mut env = std::collections::BTreeMap::new();
+    if let Some(value) = entry.get("env") {
+        let listed = value.as_object().ok_or("'env' is not an object")?;
+        if listed.len() > MAX_MCP_LIST_ENTRIES {
+            return Err("'env' has too many entries".to_owned());
+        }
+        for (key, value) in listed {
+            if !is_valid_env_name(key) {
+                return Err("'env' names a variable that is not a portable name".to_owned());
+            }
+            // The client sets both reserved variables last, so an entry naming
+            // one is describing an effect it cannot have.
+            if key == PLUGIN_ROOT_VARIABLE || key == PLUGIN_DATA_VARIABLE {
+                return Err(format!("'env' may not set the reserved {key} variable"));
+            }
+            let value = value.as_str().ok_or("'env' has a non-string value")?;
+            if value.len() > MAX_MCP_STRING_BYTES {
+                return Err("'env' has a value beyond the byte limit".to_owned());
+            }
+            env.insert(key.clone(), value.to_owned());
+        }
+    }
+    let cwd = match entry.get("cwd") {
+        None => None,
+        Some(value) => {
+            let cwd = value.as_str().ok_or("'cwd' is not a string")?;
+            if !is_contained_working_directory(cwd) {
+                return Err("'cwd' is not contained in the plugin root or its data \
+                            directory"
+                    .to_owned());
+            }
+            Some(cwd.to_owned())
+        }
+    };
+    Ok(McpStdioServer {
+        command: command.to_owned(),
+        args,
+        env,
+        cwd,
+    })
+}
+
+fn parse_http_server(
+    entry: &serde_json::Map<String, serde_json::Value>,
+) -> Result<McpHttpServer, String> {
+    let url = entry
+        .get("url")
+        .ok_or("entry has no 'url'")?
+        .as_str()
+        .ok_or("'url' is not a string")?;
+    let parsed = url::Url::parse(url).map_err(|_| "'url' is not an absolute URL".to_owned())?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err("'url' is not an HTTP or HTTPS endpoint".to_owned());
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err("'url' carries userinfo".to_owned());
+    }
+    if parsed.fragment().is_some() {
+        return Err("'url' carries a fragment".to_owned());
+    }
+    if parsed.scheme() == "http" && !is_loopback_host(&parsed) {
+        return Err("plain HTTP is only allowed for a loopback endpoint".to_owned());
+    }
+    if url.len() > MAX_MCP_STRING_BYTES {
+        return Err("'url' exceeds the byte limit".to_owned());
+    }
+    let mut headers = std::collections::BTreeMap::new();
+    if let Some(value) = entry.get("headers") {
+        let listed = value.as_object().ok_or("'headers' is not an object")?;
+        if listed.len() > MAX_MCP_LIST_ENTRIES {
+            return Err("'headers' has too many entries".to_owned());
+        }
+        for (name, value) in listed {
+            if !is_valid_header_name(name) {
+                return Err("'headers' has a name that is not an HTTP field name".to_owned());
+            }
+            let lowercase = name.to_ascii_lowercase();
+            let value = value.as_str().ok_or("'headers' has a non-string value")?;
+            if value.len() > MAX_MCP_STRING_BYTES || !is_valid_header_value(value) {
+                return Err("'headers' has a value that is not a valid field value".to_owned());
+            }
+            if headers.insert(lowercase, value.to_owned()).is_some() {
+                return Err("'headers' names the same field twice".to_owned());
+            }
+        }
+    }
+    Ok(McpHttpServer {
+        url: url.to_owned(),
+        headers,
+    })
+}
+
+fn is_loopback_host(url: &url::Url) -> bool {
+    match url.host() {
+        Some(url::Host::Domain(host)) => host == "localhost",
+        Some(url::Host::Ipv4(address)) => address.is_loopback(),
+        Some(url::Host::Ipv6(address)) => address.is_loopback(),
+        None => false,
+    }
+}
+
+/// Whether `command` is the single executable token the specification allows:
+/// a bare program name the platform resolves, or a `./`-relative path that
+/// stays inside the plugin. No placeholder is expanded in a command, so one
+/// appearing here would be launched literally and is refused instead.
+fn is_valid_command_token(command: &str) -> bool {
+    if command.is_empty()
+        || command.len() > MAX_MCP_STRING_BYTES
+        || command.contains("${")
+        || command.chars().any(char::is_whitespace)
+        || command.chars().any(char::is_control)
+        || command.contains('\\')
+    {
+        return false;
+    }
+    match command.strip_prefix("./") {
+        Some(relative) => is_contained_relative_path(relative),
+        None => !command.contains('/') && command != "." && command != "..",
+    }
+}
+
+/// Whether `cwd` names a directory inside one of the two roots it may be
+/// rooted at. Containment is checked on the path that remains after the
+/// placeholder, which is what expansion will produce.
+fn is_contained_working_directory(cwd: &str) -> bool {
+    if cwd.len() > MAX_MCP_STRING_BYTES || cwd.chars().any(char::is_control) {
+        return false;
+    }
+    for variable in [PLUGIN_ROOT_VARIABLE, PLUGIN_DATA_VARIABLE] {
+        if let Some(rest) = cwd.strip_prefix(&format!("${{{variable}}}")) {
+            return rest.is_empty()
+                || rest
+                    .strip_prefix('/')
+                    .is_some_and(is_contained_relative_path);
+        }
+    }
+    cwd.strip_prefix("./")
+        .is_some_and(is_contained_relative_path)
+}
+
+fn is_contained_relative_path(path: &str) -> bool {
+    !path.is_empty()
+        && !path.contains('\\')
+        && !path.contains("${")
+        && path
+            .split('/')
+            .all(|segment| !segment.is_empty() && segment != "." && segment != "..")
+}
+
+fn is_valid_env_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 255
+        && !name.as_bytes()[0].is_ascii_digit()
+        && name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+}
+
+/// An HTTP field name is a token: the `tchar` set from RFC 9110.
+fn is_valid_header_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 255
+        && name.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric()
+                || matches!(
+                    byte,
+                    b'!' | b'#'
+                        | b'$'
+                        | b'%'
+                        | b'&'
+                        | b'\''
+                        | b'*'
+                        | b'+'
+                        | b'-'
+                        | b'.'
+                        | b'^'
+                        | b'_'
+                        | b'`'
+                        | b'|'
+                        | b'~'
+                )
+        })
+}
+
+fn is_valid_header_value(value: &str) -> bool {
+    value
+        .bytes()
+        .all(|byte| byte == b'\t' || (0x20..0x7f).contains(&byte))
+}
+
+/// Render a validated configuration back as `mcp.json`.
+///
+/// The installed copy is regenerated rather than copied so that only entries
+/// that passed validation are ever written, and so the file the loader reads
+/// back is the one this client produced.
+#[must_use]
+pub fn canonical_mcp_config(config: &PluginMcpConfig) -> String {
+    let mut servers = serde_json::Map::new();
+    for server in &config.servers {
+        let mut entry = serde_json::Map::new();
+        entry.insert(
+            "type".to_owned(),
+            server.transport.type_name().to_owned().into(),
+        );
+        match &server.transport {
+            McpTransport::Stdio(stdio) => {
+                entry.insert("command".to_owned(), stdio.command.clone().into());
+                if !stdio.args.is_empty() {
+                    entry.insert("args".to_owned(), stdio.args.clone().into());
+                }
+                if !stdio.env.is_empty() {
+                    entry.insert(
+                        "env".to_owned(),
+                        serde_json::Value::Object(
+                            stdio
+                                .env
+                                .iter()
+                                .map(|(key, value)| (key.clone(), value.clone().into()))
+                                .collect(),
+                        ),
+                    );
+                }
+                if let Some(cwd) = &stdio.cwd {
+                    entry.insert("cwd".to_owned(), cwd.clone().into());
+                }
+            }
+            McpTransport::StreamableHttp(http) | McpTransport::Sse(http) => {
+                entry.insert("url".to_owned(), http.url.clone().into());
+                if !http.headers.is_empty() {
+                    entry.insert(
+                        "headers".to_owned(),
+                        serde_json::Value::Object(
+                            http.headers
+                                .iter()
+                                .map(|(name, value)| (name.clone(), value.clone().into()))
+                                .collect(),
+                        ),
+                    );
+                }
+            }
+        }
+        servers.insert(server.name.clone(), serde_json::Value::Object(entry));
+    }
+    let document = serde_json::json!({
+        "$schema": AGENT_PLUGIN_MCP_SCHEMA_ID,
+        "mcpServers": serde_json::Value::Object(servers),
+    });
+    format!(
+        "{}\n",
+        serde_json::to_string_pretty(&document).expect("a validated configuration serializes")
+    )
+}
+
+/// Read the `mcp.json` an import retained beside a plugin's manifest.
+///
+/// The retained file goes through the same parser the importer used, so a
+/// hand-edited copy cannot widen what a plugin claims. Anything unreadable or
+/// invalid is a plugin with no MCP configuration, warned about and otherwise
+/// ignored — the plugin's skills are unaffected.
+#[must_use]
+pub fn load_plugin_mcp_config(directory: &std::path::Path) -> Option<PluginMcpConfig> {
+    let path = directory.join(AGENT_PLUGIN_MCP_FILE);
+    let regular_file = path
+        .symlink_metadata()
+        .is_ok_and(|metadata| metadata.is_file() && !metadata.file_type().is_symlink());
+    if !regular_file {
+        return None;
+    }
+    let source = match std::fs::read_to_string(&path) {
+        Ok(source) if source.len() <= crate::MAX_WORKSPACE_FILE_BYTES => source,
+        Ok(_) => {
+            tracing::warn!(
+                "plugin MCP config {} exceeds the byte limit",
+                path.display()
+            );
+            return None;
+        }
+        Err(error) => {
+            tracing::warn!(
+                "plugin MCP config {} is unreadable: {error}",
+                path.display()
+            );
+            return None;
+        }
+    };
+    match parse_plugin_mcp_config(&source) {
+        Ok(parsed) => {
+            for skipped in &parsed.skipped {
+                tracing::warn!(
+                    "plugin MCP server {:?} in {} was skipped: {}",
+                    skipped.name,
+                    path.display(),
+                    skipped.reason
+                );
+            }
+            Some(parsed.config)
+        }
+        Err(error) => {
+            tracing::warn!("plugin MCP config {} is invalid: {error}", path.display());
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -384,5 +940,117 @@ mod tests {
         assert_eq!(parsed.manifest.category, None);
         assert_eq!(parsed.manifest.router_preamble, None);
         assert_eq!(parsed.ignored.len(), 3);
+    }
+
+    fn mcp(servers: &str) -> String {
+        format!("{{\"$schema\": \"{AGENT_PLUGIN_MCP_SCHEMA_ID}\", \"mcpServers\": {servers}}}")
+    }
+
+    /// Contract: an MCP configuration fails narrowly. A bad entry is dropped
+    /// and reported while its siblings connect; only a top-level problem
+    /// disables the plugin's MCP configuration entirely. Every rule asserted
+    /// here is one that would otherwise let a package launch a process or
+    /// reach an endpoint it was not supposed to.
+    #[test]
+    fn mcp_entries_fail_one_at_a_time_and_the_file_fails_as_a_whole() {
+        let parsed = parse_plugin_mcp_config(&mcp("{\
+              \"local\": {\"type\": \"stdio\", \"command\": \"./bin/serve\", \
+                \"args\": [\"--root\", \"${PLUGIN_ROOT}\"], \
+                \"env\": {\"MODE\": \"read-only\"}, \"cwd\": \"${PLUGIN_DATA}/state\"}, \
+              \"remote\": {\"type\": \"streamable-http\", \
+                \"url\": \"https://mcp.example.com/v1\", \
+                \"headers\": {\"X-Client\": \"openwave\"}}, \
+              \"loopback\": {\"type\": \"sse\", \"url\": \"http://localhost:7331/sse\"}, \
+              \"stray-field\": {\"type\": \"stdio\", \"command\": \"serve\", \"retries\": 3}, \
+              \"cross-variant\": {\"type\": \"stdio\", \"command\": \"serve\", \
+                \"url\": \"https://mcp.example.com\"}, \
+              \"unknown-transport\": {\"type\": \"websocket\", \
+                \"url\": \"wss://mcp.example.com\"}, \
+              \"expanded-command\": {\"type\": \"stdio\", \
+                \"command\": \"${PLUGIN_ROOT}/bin/serve\"}, \
+              \"escaping-cwd\": {\"type\": \"stdio\", \"command\": \"serve\", \
+                \"cwd\": \"../../etc\"}, \
+              \"reserved-env\": {\"type\": \"stdio\", \"command\": \"serve\", \
+                \"env\": {\"PLUGIN_ROOT\": \"/tmp\"}}, \
+              \"plain-http\": {\"type\": \"streamable-http\", \
+                \"url\": \"http://mcp.example.com/v1\"}, \
+              \"userinfo\": {\"type\": \"streamable-http\", \
+                \"url\": \"https://user:pass@mcp.example.com/v1\"}, \
+              \"duplicate-header\": {\"type\": \"streamable-http\", \
+                \"url\": \"https://mcp.example.com/v1\", \
+                \"headers\": {\"X-Client\": \"a\", \"x-client\": \"b\"}}}"))
+        .expect("a file whose entries are bad is still a valid file");
+        assert_eq!(
+            parsed
+                .config
+                .servers
+                .iter()
+                .map(|server| server.name.as_str())
+                .collect::<Vec<_>>(),
+            ["local", "loopback", "remote"]
+        );
+        let mut skipped = parsed
+            .skipped
+            .iter()
+            .map(|server| server.name.as_str())
+            .collect::<Vec<_>>();
+        skipped.sort_unstable();
+        assert_eq!(
+            skipped,
+            [
+                "cross-variant",
+                "duplicate-header",
+                "escaping-cwd",
+                "expanded-command",
+                "plain-http",
+                "reserved-env",
+                "stray-field",
+                "unknown-transport",
+                "userinfo",
+            ]
+        );
+        // A reason is renderable and never quotes a header or env value.
+        assert!(parsed
+            .skipped
+            .iter()
+            .all(|server| !server.reason.contains("/tmp") && !server.reason.contains('\n')));
+
+        // The retained file is regenerated from what validated, and reading it
+        // back yields the same configuration.
+        let round_tripped = parse_plugin_mcp_config(&canonical_mcp_config(&parsed.config))
+            .expect("the canonical form is valid")
+            .config;
+        assert_eq!(round_tripped, parsed.config);
+
+        for (case, source) in [
+            ("not JSON", "{".to_owned()),
+            ("missing schema", "{\"mcpServers\": {}}".to_owned()),
+            (
+                "schema version the manifest does not target",
+                "{\"$schema\": \"https://agent-plugins.org/schemas/9.9.9/mcp.schema.json\", \
+                  \"mcpServers\": {}}"
+                    .to_owned(),
+            ),
+            (
+                "unknown top-level field",
+                format!(
+                    "{{\"$schema\": \"{AGENT_PLUGIN_MCP_SCHEMA_ID}\", \"mcpServers\": {{}}, \
+                      \"timeout\": 5}}"
+                ),
+            ),
+            ("mcpServers is not an object", mcp("[]")),
+        ] {
+            assert!(
+                parse_plugin_mcp_config(&source).is_err(),
+                "{case} should disable MCP for the plugin"
+            );
+        }
+
+        // An empty server map is a valid configuration that claims nothing.
+        assert!(parse_plugin_mcp_config(&mcp("{}"))
+            .unwrap()
+            .config
+            .servers
+            .is_empty());
     }
 }

--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -36,10 +36,14 @@ mod tool;
 mod types;
 
 pub use agent_plugins::{
-    is_valid_agent_plugin_name, parse_agent_plugin_manifest, AgentPluginManifest,
-    AgentPluginParseError, IgnoredManifestField, ParsedAgentPluginManifest,
-    AGENT_PLUGIN_MANIFEST_FILE, AGENT_PLUGIN_SCHEMA_ID, AGENT_PLUGIN_SKILLS_DIR,
-    AGENT_PLUGIN_SPEC_VERSION, OPENWAVE_EXTENSION_NAMESPACE,
+    canonical_mcp_config, is_valid_agent_plugin_name, load_plugin_mcp_config,
+    parse_agent_plugin_manifest, parse_plugin_mcp_config, AgentPluginManifest,
+    AgentPluginParseError, IgnoredManifestField, McpConfigError, McpHttpServer, McpServer,
+    McpStdioServer, McpTransport, ParsedAgentPluginManifest, ParsedPluginMcpConfig,
+    PluginMcpConfig, SkippedMcpServer, AGENT_PLUGIN_MANIFEST_FILE, AGENT_PLUGIN_MCP_FILE,
+    AGENT_PLUGIN_MCP_SCHEMA_ID, AGENT_PLUGIN_SCHEMA_ID, AGENT_PLUGIN_SKILLS_DIR,
+    AGENT_PLUGIN_SPEC_VERSION, OPENWAVE_EXTENSION_NAMESPACE, PLUGIN_DATA_VARIABLE,
+    PLUGIN_ROOT_VARIABLE,
 };
 pub use daytona::{DaytonaCredential, DaytonaExecutionProvider, DAYTONA_CREDENTIAL_KEY};
 pub use e2b::{E2BCredential, E2BExecutionProvider, E2B_CREDENTIAL_KEY};

--- a/crates/openwave-code-execution/src/plugins.rs
+++ b/crates/openwave-code-execution/src/plugins.rs
@@ -144,8 +144,9 @@ pub enum PluginCapability {
     LiveControl,
     /// Bundles an MCP server, and so whatever that server exposes.
     ///
-    /// Like [`Self::LiveControl`], nothing derives this yet — plugins bundle
-    /// only skills today. It lands when MCPB-backed components do.
+    /// Derived from the validated `mcp.json` an import retained beside the
+    /// manifest — see [`PluginPackage::mcp_servers`] — never from anything the
+    /// manifest says.
     Mcp,
 }
 
@@ -335,6 +336,12 @@ pub fn derived_capabilities(
     if members.iter().any(|skill| !skill.host_deps.is_empty()) {
         capabilities.insert(PluginCapability::HostInstall);
     }
+    if plugin.mcp_servers > 0 {
+        // The bundle carries at least one server entry that validated at
+        // import. What that server exposes is not knowable from here, which is
+        // exactly what the badge is telling the user.
+        capabilities.insert(PluginCapability::Mcp);
+    }
     capabilities.into_iter().collect()
 }
 
@@ -372,6 +379,13 @@ pub struct PluginPackage {
     /// Optional line emitted above the member skills in the prompt catalog,
     /// telling the model how to choose among them.
     pub router_preamble: Option<String>,
+    /// How many MCP servers the bundle's retained configuration declares.
+    ///
+    /// Host-derived like [`Self::compatibility`]: the loader counts the
+    /// entries in the `mcp.json` an import validated and retained, and the
+    /// manifest's closed key set has nothing that could state it. Zero for
+    /// every bundle that ships no server configuration.
+    pub mcp_servers: usize,
     /// Where the package was loaded from.
     pub origin: PluginOrigin,
     /// Static sandbox-compatibility disclosure. Imported user bundles read a
@@ -557,6 +571,9 @@ pub fn parse_plugin_manifest(
         skills,
         prompts,
         router_preamble,
+        // Host-derived from the retained configuration, which the loader
+        // reads separately; a manifest cannot state it.
+        mcp_servers: 0,
         origin,
         compatibility: match origin {
             PluginOrigin::Builtin => PluginCompatibility::compatible(),
@@ -774,6 +791,8 @@ pub fn load_plugins(
             continue;
         }
         package.compatibility = installed_compatibility(&entry.path(), origin);
+        package.mcp_servers = crate::agent_plugins::load_plugin_mcp_config(&entry.path())
+            .map_or(0, |config| config.servers.len());
         if let Some(missing) = package
             .skills
             .iter()
@@ -1244,6 +1263,7 @@ router-preamble: Pick by the file the user needs.\n\
                 skills: members.iter().map(|skill| skill.name.clone()).collect(),
                 prompts: Vec::new(),
                 router_preamble: None,
+                mcp_servers: 0,
                 origin: PluginOrigin::Builtin,
                 compatibility: PluginCompatibility::compatible(),
             };
@@ -1258,9 +1278,10 @@ router-preamble: Pick by the file the user needs.\n\
             );
         }
 
-        // `live-control` and `mcp` exist in the vocabulary with no deriving
-        // source yet; nothing a plugin can contain today produces them.
-        let everything = PluginPackage {
+        // `mcp` comes from the server configuration an import validated and
+        // retained, counted by the loader — not from anything the manifest
+        // says. `live-control` still has no deriving source at all.
+        let mut everything = PluginPackage {
             name: "bundle".to_owned(),
             display_name: "Bundle".to_owned(),
             description: "A bundle.".to_owned(),
@@ -1268,12 +1289,15 @@ router-preamble: Pick by the file the user needs.\n\
             skills: vec!["both".to_owned()],
             prompts: Vec::new(),
             router_preamble: None,
+            mcp_servers: 0,
             origin: PluginOrigin::Builtin,
             compatibility: PluginCompatibility::compatible(),
         };
         let derived = derived_capabilities(&everything, &[&both]);
         assert!(!derived.contains(&PluginCapability::LiveControl));
         assert!(!derived.contains(&PluginCapability::Mcp));
+        everything.mcp_servers = 1;
+        assert!(derived_capabilities(&everything, &[&both]).contains(&PluginCapability::Mcp));
 
         // A manifest that tries to declare its own badges is rejected whole.
         assert!(parse_plugin_manifest(

--- a/crates/openwave-desktop/ui/src/plugins/pluginVocabulary.ts
+++ b/crates/openwave-desktop/ui/src/plugins/pluginVocabulary.ts
@@ -8,9 +8,9 @@ import type { PluginCapability, PluginCategory } from "@/api";
  *
  * The vocabulary is closed server-side, so this table is total: a capability
  * the host can derive always has words here rather than falling back to the
- * wire slug. `live-control` and `mcp` are not derived by anything today; they
- * are named anyway because the surface renders whatever comes back, and the
- * day a bundle earns one it should read like the others.
+ * wire slug. `live-control` is not derived by anything today; it is named
+ * anyway because the surface renders whatever comes back, and the day a bundle
+ * earns one it should read like the others.
  */
 const CAPABILITY_LABELS: Record<PluginCapability, string> = {
   "write-files": "Writes files",

--- a/crates/openwave-server/src/foreground_prompt.rs
+++ b/crates/openwave-server/src/foreground_prompt.rs
@@ -1087,6 +1087,7 @@ mod tests {
             skills: members.iter().map(|member| (*member).into()).collect(),
             prompts: Vec::new(),
             router_preamble: Some(preamble.into()),
+            mcp_servers: 0,
             origin: openwave_code_execution::PluginOrigin::Builtin,
             compatibility: openwave_code_execution::PluginCompatibility::compatible(),
         };

--- a/crates/openwave-server/src/plugin_install.rs
+++ b/crates/openwave-server/src/plugin_install.rs
@@ -36,12 +36,13 @@ use async_trait::async_trait;
 use flate2::read::GzDecoder;
 use futures::StreamExt;
 use openwave_code_execution::{
-    assess_plugin_compatibility, is_valid_plugin_name, parse_agent_plugin_manifest,
-    parse_plugin_manifest, parse_skill_manifest, LoadedSkill, PluginCategory, PluginCompatibility,
-    PluginInstallStamp, PluginOrigin, PluginPackage, PluginSourceFormat, SkillOrigin, SkillScript,
-    AGENT_PLUGIN_MANIFEST_FILE, AGENT_PLUGIN_SKILLS_DIR, AGENT_PLUGIN_SPEC_VERSION,
-    PLUGIN_INSTALL_STAMP_FILE, PLUGIN_INSTALL_STAMP_SCHEMA, PLUGIN_MANIFEST_FILE,
-    SKILL_MANIFEST_FILE, SKILL_SCRIPTS_DIR,
+    assess_plugin_compatibility, canonical_mcp_config, is_valid_plugin_name,
+    parse_agent_plugin_manifest, parse_plugin_manifest, parse_plugin_mcp_config,
+    parse_skill_manifest, LoadedSkill, PluginCategory, PluginCompatibility, PluginInstallStamp,
+    PluginMcpConfig, PluginOrigin, PluginPackage, PluginSourceFormat, SkillOrigin, SkillScript,
+    AGENT_PLUGIN_MANIFEST_FILE, AGENT_PLUGIN_MCP_FILE, AGENT_PLUGIN_SKILLS_DIR,
+    AGENT_PLUGIN_SPEC_VERSION, PLUGIN_INSTALL_STAMP_FILE, PLUGIN_INSTALL_STAMP_SCHEMA,
+    PLUGIN_MANIFEST_FILE, SKILL_MANIFEST_FILE, SKILL_SCRIPTS_DIR,
 };
 use openwave_web_search::{admit_fetch_address, admit_fetch_url};
 use serde::{Deserialize, Serialize};
@@ -362,6 +363,11 @@ fn fetch_transport_error(error: reqwest::Error) -> PluginInstallError {
 pub(crate) struct PreparedPlugin {
     pub package: PluginPackage,
     pub manifest: String,
+    /// The canonical `mcp.json` to retain beside the manifest, regenerated
+    /// from the entries that validated. `None` when the package ships no
+    /// configuration, when its configuration was rejected whole, or when
+    /// nothing in it survived validation.
+    pub mcp_config: Option<String>,
     pub skills: Vec<LoadedSkill>,
     pub stamp: PluginInstallStamp,
     pub skipped: Vec<SkippedPluginMember>,
@@ -570,6 +576,7 @@ fn retain_archive_file(path: &[String]) -> bool {
     path.last()
         .is_some_and(|name| name == PLUGIN_MANIFEST_FILE || name == SKILL_MANIFEST_FILE)
         || is_package_root_file(path, AGENT_PLUGIN_MANIFEST_FILE)
+        || is_package_root_file(path, AGENT_PLUGIN_MCP_FILE)
         || path.iter().any(|component| component == SKILL_SCRIPTS_DIR)
 }
 
@@ -676,6 +683,7 @@ fn prepare_tree(
         let root = manifest_path[..manifest_path.len() - 1].to_vec();
         let mut selected = Vec::new();
         let mut skipped = skipped_foreign_members(&tree, &root);
+        skipped_bundled_mcp_config(&tree, &root, &mut skipped);
         for prompt in &package.prompts {
             push_skipped(
                 &mut skipped,
@@ -736,6 +744,7 @@ fn prepare_tree(
         return Ok(PreparedPlugin {
             stamp: install_stamp(source, PluginSourceFormat::PluginManifest, compatibility),
             manifest,
+            mcp_config: None,
             skills: selected
                 .into_iter()
                 .map(|skill| skill.loaded.clone())
@@ -753,7 +762,14 @@ fn prepare_tree(
         }));
     }
     let skill = skills.pop().expect("one skill was checked above");
-    let mut skipped = skipped_single_skill_members(&tree, &skill.root);
+    // The specific disclosure goes in first: a bare package's generic
+    // "outside SKILL.md and one-level scripts/" reason would otherwise be the
+    // one a response shows for a file the importer has a better answer about.
+    let mut skipped = Vec::new();
+    skipped_bundled_mcp_config(&tree, &skill.root, &mut skipped);
+    for member in skipped_single_skill_members(&tree, &skill.root) {
+        push_skipped(&mut skipped, member.path, &member.reason);
+    }
     let compatibility = assess_plugin_compatibility(&[(&skill.loaded.package, skill.has_scripts)]);
     let display_name = display_name(&skill.loaded.package.name);
     let mut package = PluginPackage {
@@ -764,6 +780,7 @@ fn prepare_tree(
         skills: vec![skill.loaded.package.name.clone()],
         prompts: Vec::new(),
         router_preamble: None,
+        mcp_servers: 0,
         origin: PluginOrigin::User,
         compatibility: compatibility.clone(),
     };
@@ -777,6 +794,7 @@ fn prepare_tree(
     Ok(PreparedPlugin {
         stamp: install_stamp(source, PluginSourceFormat::PluginManifest, compatibility),
         manifest,
+        mcp_config: None,
         skills: vec![skill.loaded],
         package,
         skipped,
@@ -821,17 +839,6 @@ fn prepare_standard_tree(
     }
 
     let mut skipped = skipped_foreign_members(tree, &root);
-    // The standard's other component type. Its bytes are not installed by this
-    // importer yet, and a package that ships one should be told so rather than
-    // left to wonder why nothing connected.
-    let mcp_config = prefixed_path(&root, &["mcp.json"]);
-    if tree.paths.contains(&mcp_config) {
-        push_skipped(
-            &mut skipped,
-            mcp_config.join("/"),
-            "component type is outside the instruction-only importer",
-        );
-    }
     for ignored in &parsed.ignored {
         push_skipped(
             &mut skipped,
@@ -839,6 +846,7 @@ fn prepare_standard_tree(
             &ignored.reason,
         );
     }
+    let mcp_config = prepare_mcp_config(tree, &root, &mut skipped)?;
 
     let skills_root = prefixed_path(&root, &[AGENT_PLUGIN_SKILLS_DIR]);
     let mut selected: Vec<ParsedSkill> = Vec::new();
@@ -884,6 +892,7 @@ fn prepare_standard_tree(
         // `PLUGIN.md` path there is nothing here to prune and disclose.
         prompts: Vec::new(),
         router_preamble: parsed.manifest.router_preamble,
+        mcp_servers: mcp_config.as_ref().map_or(0, |config| config.servers.len()),
         origin: PluginOrigin::User,
         compatibility: compatibility.clone(),
         name,
@@ -892,9 +901,11 @@ fn prepare_standard_tree(
     // The generated manifest goes through the internal parser before any byte
     // is copied, exactly as the `PLUGIN.md` path does: nothing reaches disk in
     // a shape the ordinary loader would later reject.
+    let mcp_servers = package.mcp_servers;
     package = parse_plugin_manifest(&manifest, PluginOrigin::User)
         .map_err(|error| PluginInstallError::InvalidPlugin(error.to_string()))?;
     package.compatibility = compatibility.clone();
+    package.mcp_servers = mcp_servers;
     skipped.sort_by(|left, right| left.path.cmp(&right.path));
     Ok(PreparedPlugin {
         stamp: install_stamp(
@@ -905,10 +916,56 @@ fn prepare_standard_tree(
             compatibility,
         ),
         manifest,
+        mcp_config: mcp_config
+            .filter(|config| !config.servers.is_empty())
+            .as_ref()
+            .map(canonical_mcp_config),
         skills: selected.into_iter().map(|skill| skill.loaded).collect(),
         package,
         skipped,
     })
+}
+
+/// Validate the package's bundled MCP server configuration, if it ships one.
+///
+/// The specification grades MCP failures narrowly: a top-level problem —
+/// unreadable JSON, a schema identifier this client does not implement, a
+/// shape that is not `$schema` plus `mcpServers` — disables MCP for this
+/// plugin and nothing else, while a single bad entry drops only that entry.
+/// Both are reported through the ordinary skip disclosure, so an install
+/// response says what will not connect and why.
+fn prepare_mcp_config(
+    tree: &ArchiveTree,
+    root: &[String],
+    skipped: &mut Vec<SkippedPluginMember>,
+) -> Result<Option<PluginMcpConfig>, PluginInstallError> {
+    let path = prefixed_path(root, &[AGENT_PLUGIN_MCP_FILE]);
+    let Some(bytes) = tree.files.get(&path) else {
+        return Ok(None);
+    };
+    let source = std::str::from_utf8(bytes).map_err(|_| {
+        PluginInstallError::InvalidPlugin(format!("{} is not UTF-8", path.join("/")))
+    })?;
+    match parse_plugin_mcp_config(source) {
+        Ok(parsed) => {
+            for server in &parsed.skipped {
+                push_skipped(
+                    skipped,
+                    format!("{AGENT_PLUGIN_MCP_FILE}#{}", server.name),
+                    &server.reason,
+                );
+            }
+            Ok(Some(parsed.config))
+        }
+        Err(error) => {
+            push_skipped(
+                skipped,
+                AGENT_PLUGIN_MCP_FILE.to_owned(),
+                &error.to_string(),
+            );
+            Ok(None)
+        }
+    }
 }
 
 /// The immediate child directory names under `skills_root`, in name order.
@@ -1108,6 +1165,27 @@ fn skipped_foreign_members(tree: &ArchiveTree, root: &[String]) -> Vec<SkippedPl
     skipped
 }
 
+/// Report an `mcp.json` an archive ships in a format that does not define one.
+///
+/// Bundled MCP configuration is a component of the Agent Plugins standard
+/// format, read from that specification's fixed location. A `PLUGIN.md` bundle
+/// or a bare skill package carrying the same file is describing something this
+/// importer will not act on, so it is disclosed rather than dropped in silence.
+fn skipped_bundled_mcp_config(
+    tree: &ArchiveTree,
+    root: &[String],
+    skipped: &mut Vec<SkippedPluginMember>,
+) {
+    let path = prefixed_path(root, &[AGENT_PLUGIN_MCP_FILE]);
+    if tree.paths.contains(&path) {
+        push_skipped(
+            skipped,
+            path.join("/"),
+            "bundled MCP configuration is only read from Agent Plugins packages",
+        );
+    }
+}
+
 fn skipped_single_skill_members(tree: &ArchiveTree, root: &[String]) -> Vec<SkippedPluginMember> {
     let mut skipped = Vec::new();
     let scripts = prefixed_path(root, &[SKILL_SCRIPTS_DIR]);
@@ -1207,6 +1285,9 @@ pub(crate) fn install_prepared(
                 ))
             })?,
         )?;
+        if let Some(config) = &prepared.mcp_config {
+            std::fs::write(plugin_stage.join(AGENT_PLUGIN_MCP_FILE), config.as_bytes())?;
+        }
         for (skill, stage) in prepared.skills.iter().zip(&skill_stages) {
             std::fs::create_dir(stage)?;
             std::fs::write(stage.join(SKILL_MANIFEST_FILE), skill.manifest.as_bytes())?;

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -2900,6 +2900,9 @@ async fn stamps_and_surfaces_static_plugin_compatibility() {
         // content, not a package manifest: this archive must still install
         // through the internal path.
         ("deploy-skill/scripts/plugin.json", b"{\"tool\": \"config\"}"),
+        // Bundled MCP configuration is a standard-format component; a bare
+        // skill package shipping one is told it will not be read.
+        ("deploy-skill/mcp.json", b"{\"mcpServers\": {}}"),
     ]);
     let (router, bearer) = plugin_install_app(
         Arc::new(store),
@@ -2924,6 +2927,13 @@ async fn stamps_and_surfaces_static_plugin_compatibility() {
     assert_eq!(response.status(), StatusCode::CREATED);
     let installed: serde_json::Value = json_body(response).await;
     assert_eq!(installed["compatibility"]["status"], "limited");
+    assert_eq!(
+        installed["skipped"][0],
+        serde_json::json!({
+            "path": "mcp.json",
+            "reason": "bundled MCP configuration is only read from Agent Plugins packages"
+        })
+    );
     assert_eq!(
         installed["compatibility"]["issues"],
         serde_json::json!([
@@ -2957,6 +2967,9 @@ async fn stamps_and_surfaces_static_plugin_compatibility() {
 
 /// The only manifest schema the standard-format importer accepts.
 const AGENT_PLUGIN_SCHEMA: &str = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json";
+
+/// The matching schema for a package's bundled MCP server configuration.
+const AGENT_PLUGIN_MCP_SCHEMA: &str = "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json";
 
 /// Contract: a package published in the Agent Plugins format
 /// (<https://agent-plugins.org>) is recognized by its root `plugin.json`, its
@@ -3181,6 +3194,156 @@ async fn standard_manifests_report_ignored_fields_and_carry_our_extension() {
         .find(|plugin| plugin["name"] == "reporting")
         .unwrap();
     assert_eq!(plugin["category"], "data");
+}
+
+/// Contract: an `mcp.json` bundled with a standard package is validated,
+/// regenerated from what passed, and retained beside the installed manifest,
+/// which is what earns the plugin its `mcp` badge. A single bad entry is
+/// dropped and reported without touching the rest — the per-entry grading
+/// <https://agent-plugins.org/specification> §7.2.2 requires.
+#[tokio::test]
+async fn retains_validated_mcp_servers_and_derives_the_badge() {
+    let (dir, store) = temp_db_store("plugin-mcp.db").await;
+    let manifest = format!(
+        "{{\"$schema\": \"{AGENT_PLUGIN_SCHEMA}\", \"name\": \"reporting\", \
+          \"description\": \"Reporting skills.\"}}"
+    );
+    let mcp = format!(
+        "{{\"$schema\": \"{AGENT_PLUGIN_MCP_SCHEMA}\", \"mcpServers\": {{\
+           \"local\": {{\"type\": \"stdio\", \"command\": \"./bin/serve\", \
+             \"args\": [\"--root\", \"${{PLUGIN_ROOT}}\"]}}, \
+           \"remote\": {{\"type\": \"streamable-http\", \
+             \"url\": \"https://mcp.example.com/v1\"}}, \
+           \"bogus\": {{\"type\": \"stdio\", \"command\": \"serve\", \"retries\": 3}}}}}}"
+    );
+    let archive = plugin_archive(&[
+        ("pkg/plugin.json", manifest.as_bytes()),
+        ("pkg/mcp.json", mcp.as_bytes()),
+        (
+            "pkg/skills/weekly-report/SKILL.md",
+            b"---\nname: weekly-report\ndescription: Draft the weekly report.\n---\nBody.\n",
+        ),
+    ]);
+    let (router, bearer) = plugin_install_app(
+        Arc::new(store),
+        dir.path(),
+        FixedPluginArchiveFetcher {
+            expected_url: "https://example.com/reporting-1.0.0.zip".to_owned(),
+            archive: Arc::new(archive),
+        },
+    );
+    let response = post_plugin_install(
+        &router,
+        &bearer,
+        serde_json::json!({
+            "source": {
+                "kind": "archive",
+                "url": "https://example.com/reporting-1.0.0.zip",
+                "revision": "1.0.0"
+            }
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let installed: serde_json::Value = json_body(response).await;
+    assert_eq!(
+        installed["skipped"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|entry| entry["path"].as_str().unwrap())
+            .collect::<Vec<_>>(),
+        ["mcp.json#bogus"]
+    );
+
+    // Only the entries that validated are written back.
+    let retained: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(dir.path().join("plugins/reporting/mcp.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(retained["$schema"], AGENT_PLUGIN_MCP_SCHEMA);
+    assert_eq!(
+        retained["mcpServers"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .collect::<Vec<_>>(),
+        ["local", "remote"]
+    );
+
+    let catalog = get_plugins(&router, &bearer).await;
+    let plugin = catalog["plugins"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|plugin| plugin["name"] == "reporting")
+        .unwrap();
+    assert!(plugin["capabilities"]
+        .as_array()
+        .unwrap()
+        .contains(&serde_json::json!("mcp")));
+}
+
+/// Contract: a top-level problem in `mcp.json` disables that plugin's MCP
+/// configuration and nothing else — the skills still install, no server
+/// configuration is retained, and the badge is not earned.
+#[tokio::test]
+async fn an_invalid_mcp_file_disables_mcp_without_sinking_the_plugin() {
+    let (dir, store) = temp_db_store("plugin-mcp-invalid.db").await;
+    let manifest = format!(
+        "{{\"$schema\": \"{AGENT_PLUGIN_SCHEMA}\", \"name\": \"reporting\", \
+          \"description\": \"Reporting skills.\"}}"
+    );
+    let archive = plugin_archive(&[
+        ("pkg/plugin.json", manifest.as_bytes()),
+        (
+            "pkg/mcp.json",
+            b"{\"$schema\": \"https://agent-plugins.org/schemas/9.9.9/mcp.schema.json\", \
+              \"mcpServers\": {\"remote\": {\"type\": \"streamable-http\", \
+              \"url\": \"https://mcp.example.com/v1\"}}}",
+        ),
+        (
+            "pkg/skills/weekly-report/SKILL.md",
+            b"---\nname: weekly-report\ndescription: Draft the weekly report.\n---\nBody.\n",
+        ),
+    ]);
+    let (router, bearer) = plugin_install_app(
+        Arc::new(store),
+        dir.path(),
+        FixedPluginArchiveFetcher {
+            expected_url: "https://example.com/reporting-1.0.0.zip".to_owned(),
+            archive: Arc::new(archive),
+        },
+    );
+    let response = post_plugin_install(
+        &router,
+        &bearer,
+        serde_json::json!({
+            "source": {
+                "kind": "archive",
+                "url": "https://example.com/reporting-1.0.0.zip",
+                "revision": "1.0.0"
+            }
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let installed: serde_json::Value = json_body(response).await;
+    assert_eq!(installed["skipped"][0]["path"], "mcp.json");
+    assert!(!dir.path().join("plugins/reporting/mcp.json").exists());
+    assert!(dir.path().join("skills/weekly-report/SKILL.md").is_file());
+
+    let catalog = get_plugins(&router, &bearer).await;
+    let plugin = catalog["plugins"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|plugin| plugin["name"] == "reporting")
+        .unwrap();
+    assert!(!plugin["capabilities"]
+        .as_array()
+        .unwrap()
+        .contains(&serde_json::json!("mcp")));
 }
 
 /// Contract: the catalog reports host-derived badges and enable state,


### PR DESCRIPTION
Stacked on #1709. A package in the [Agent Plugins](https://agent-plugins.org/) format may ship an `mcp.json` at its root declaring the MCP servers it brings ([§7.2](https://agent-plugins.org/specification)). The importer dropped that file; it now validates it, retains a canonical copy in `plugins/<name>/`, and the loader reads it back so the catalog reflects what a plugin actually carries.

Nothing is connected or spawned here — runtime wiring is a later change. What lands is the validated, retained configuration and the badge derived from it.

## Validation

The three transports are a closed union selected by `type`:

- **stdio** — `command` is a single executable token: a bare program name the platform resolves, or a `./`-relative path inside the plugin. No placeholder is expanded in a command, so one appearing there would be launched literally and is refused instead. `cwd` must be `./`-relative or rooted at `${PLUGIN_ROOT}` / `${PLUGIN_DATA}`, and containment is checked on the path that remains after the placeholder — which is what expansion will produce. An `env` entry naming either reserved variable invalidates its server, since the client sets both last and the entry is describing an effect it cannot have.
- **streamable-http** and legacy **sse** — an absolute HTTP(S) URL with no userinfo and no fragment, HTTPS except for `localhost` and loopback literals. Headers are literal, never expanded, must be valid HTTP field names, and a case-insensitive duplicate invalidates the entry.

`env` values and header values are visible package data, not a secret mechanism — the spec is explicit about this. They are never copied into a reason string, an API response, or a log line.

The `${PLUGIN_ROOT}` / `${PLUGIN_DATA}` expansion rule (single non-recursive textual pass, only in `args`, `env` values, and `cwd`) matters when a server is launched, which is not this PR; it is documented on the types so the connect path inherits it.

## Failure grading

Per §7.2.2: an unreadable file, a `$schema` this client does not implement or whose version disagrees with the manifest's, or a top level that is not exactly `$schema` plus `mcpServers` disables MCP for that plugin alone. An unknown field, unknown `type`, or cross-variant field drops only the entry carrying it. Both go through the existing `skipped` disclosure (`mcp.json` for the whole file, `mcp.json#<server>` per entry), so an install response says what will not connect and why. `mcp/` and `mcp-servers/` — the Claude Code convention directories, not part of this standard — keep being reported as foreign members.

The retained file is regenerated from the entries that passed rather than copied through, and the loader re-parses it with the same parser, so a hand-edited copy cannot widen what a plugin claims.

## The badge

`PluginCapability::Mcp` finally has a deriving source: the loader counts the entries in the retained configuration into a host-derived `PluginPackage::mcp_servers`, and `derived_capabilities` reads that. Capabilities stay derived and unstatable by a manifest — `capabilities_derive_from_member_deps_and_never_from_the_manifest` is extended rather than replaced, and still asserts that a manifest declaring its own badges is rejected.

`url` is added to `openwave-code-execution` at the `=2.5.8` the workspace already resolves; hand-rolling URL parsing on a security boundary is not worth saving an edge in the lockfile. No version in `Cargo.lock` changes.

## Tests

Two end-to-end installs through the real route: one with a valid stdio entry, a valid streamable-http entry, and an entry with an unknown field (plugin installs, only the valid two are written back, `mcp` badge derived, bad entry reported skipped), and one whose `mcp.json` fails at the top level (plugin and its skills install, no configuration retained, no badge, disablement reported). One parser unit test covers per-entry rejection for each rule above, whole-file rejection, and the canonical round-trip. No tests were deleted.

`cargo fmt`, clippy `-D warnings` on both touched crates, `cargo test -p openwave-code-execution`, `cargo test -p openwave-server --lib tests::configuration`, and `cargo check --workspace --locked` pass locally.