### PR TITLE
feat(server): park a model step's tool calls as one batch

### DIFF
--- a/crates/openwave-core/src/agent_tools.rs
+++ b/crates/openwave-core/src/agent_tools.rs
@@ -54,6 +54,24 @@ pub const MAX_WAIT_FOR_AGENTS_CHILDREN: usize = TurnAgentRunWaitSet::MAX_CHILDRE
 /// then several commands to produce a file — so the bound is a working budget,
 /// not the one-call fence it replaced.
 pub const MAX_SANDBOX_TOOL_CALLS: usize = 16;
+/// Maximum tool calls one model step may park as a single batch.
+///
+/// A step's calls are parked together and replayed together, so this bounds how
+/// much a single completion can commit against the run's total budget above.
+pub const MAX_SANDBOX_TOOL_CALLS_PER_STEP: usize = 8;
+
+/// Whether a sandbox tool call may run alongside its batch siblings.
+///
+/// Every tool in a step is dispatched as soon as it is parked except `exec`,
+/// which mutates the run's one shared workspace: two commands running at once
+/// would race over the same files, and the model wrote them expecting the
+/// earlier one's effects. Execs therefore serialize in the order the step
+/// emitted them, while read-only tools — web search, delegated file reads —
+/// are claimed the moment they land.
+#[must_use]
+pub fn sandbox_call_is_parallel_eligible(name: &str) -> bool {
+    name != SANDBOX_EXEC_TOOL
+}
 /// Maximum web-search query length advertised to a model.
 pub const MAX_WEB_SEARCH_QUERY_CHARS: usize = 400;
 /// Maximum requested web-search result count.

--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -796,6 +796,7 @@ pub mod sandbox_tool_call {
         pub park_lease_token: Uuid,
         pub park_attempt_count: i32,
         pub park_claim_count: i32,
+        pub batch_ordinal: i16,
         pub executor_lease_token: Option<Uuid>,
         pub executor_lease_expires_at: Option<DateTimeUtc>,
         pub retry_at: Option<DateTimeUtc>,

--- a/crates/openwave-core/src/db/migration/baseline/sandbox.rs
+++ b/crates/openwave-core/src/db/migration/baseline/sandbox.rs
@@ -249,6 +249,15 @@ pub(super) fn sandbox_tool_call_table() -> TableCreateStatement {
                 .integer()
                 .not_null(),
         )
+        // Position of this call within the model step that parked it. The step
+        // emits its calls in one completion, and the transcript replays them in
+        // that order, so the order has to survive as data rather than as a
+        // property of insertion.
+        .col(
+            ColumnDef::new(SandboxToolCall::BatchOrdinal)
+                .small_integer()
+                .not_null(),
+        )
         .col(ColumnDef::new(SandboxToolCall::ExecutorLeaseToken).uuid())
         .col(ColumnDef::new(SandboxToolCall::ExecutorLeaseExpiresAt).timestamp_with_time_zone())
         .col(ColumnDef::new(SandboxToolCall::RetryAt).timestamp_with_time_zone())
@@ -288,6 +297,7 @@ pub(super) fn sandbox_tool_call_table() -> TableCreateStatement {
         )
         .check(Expr::col(SandboxToolCall::AgentRunDepth).eq(1))
         .check(Expr::col(SandboxToolCall::ParkAttemptCount).gte(1))
+        .check(Expr::col(SandboxToolCall::BatchOrdinal).gte(0))
         .check(
             Expr::col(SandboxToolCall::ParkClaimCount)
                 .gte(Expr::col(SandboxToolCall::ParkAttemptCount)),
@@ -324,6 +334,17 @@ pub(super) fn sandbox_tool_call_indexes() -> Vec<IndexCreateStatement> {
             .col(SandboxToolCall::ExecutorLeaseExpiresAt)
             .col(SandboxToolCall::CreatedAt)
             .col(SandboxToolCall::Id)
+            .to_owned(),
+        // One position per step: a recovered park that re-ran its insert cannot
+        // land a second row at an ordinal the first one already occupies.
+        Index::create()
+            .name("idx_sandbox_tool_call_batch")
+            .table(SandboxToolCall::Table)
+            .col(SandboxToolCall::AgentRunId)
+            .col(SandboxToolCall::ParkAttemptCount)
+            .col(SandboxToolCall::ParkClaimCount)
+            .col(SandboxToolCall::BatchOrdinal)
+            .unique()
             .to_owned(),
     ]
 }

--- a/crates/openwave-core/src/db/migration/idens.rs
+++ b/crates/openwave-core/src/db/migration/idens.rs
@@ -375,6 +375,7 @@ pub(crate) enum SandboxToolCall {
     ParkLeaseToken,
     ParkAttemptCount,
     ParkClaimCount,
+    BatchOrdinal,
     ExecutorLeaseToken,
     ExecutorLeaseExpiresAt,
     RetryAt,

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -1144,17 +1144,17 @@ impl Store for DbStore {
         ops::agent_run::heartbeat_agent_run(self, id, lease_token, lease_duration).await
     }
 
-    async fn park_agent_run_for_sandbox_tool_call(
+    async fn park_agent_run_for_sandbox_tool_calls(
         &self,
         agent_run_id: AgentRunId,
         lease_token: uuid::Uuid,
-        entry: &SandboxToolCallParkEntry,
+        entries: &[SandboxToolCallParkEntry],
     ) -> Result<ParkSandboxToolCallOutcome> {
-        ops::sandbox_tool::park_agent_run_for_sandbox_tool_call(
+        ops::sandbox_tool::park_agent_run_for_sandbox_tool_calls(
             self,
             agent_run_id,
             lease_token,
-            entry,
+            entries,
         )
         .await
     }

--- a/crates/openwave-core/src/db/ops/sandbox_tool.rs
+++ b/crates/openwave-core/src/db/ops/sandbox_tool.rs
@@ -1,13 +1,13 @@
 use chrono::Duration;
 use sea_orm::{
-    sea_query::ExprTrait, ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter,
-    QueryOrder, QuerySelect, Set, TransactionTrait,
+    sea_query::ExprTrait, ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait,
+    PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, Set, TransactionTrait,
 };
 
 use crate::agent_tools::{
-    validate_sandbox_exec_arguments, validate_sandbox_read_delegated_file_arguments,
-    SandboxAgentFileResource, MAX_SANDBOX_TOOL_CALLS, SANDBOX_EXEC_TOOL,
-    SANDBOX_READ_DELEGATED_FILE_TOOL,
+    sandbox_call_is_parallel_eligible, validate_sandbox_exec_arguments,
+    validate_sandbox_read_delegated_file_arguments, SandboxAgentFileResource,
+    MAX_SANDBOX_TOOL_CALLS, SANDBOX_EXEC_TOOL, SANDBOX_READ_DELEGATED_FILE_TOOL,
 };
 use crate::error::{AgentError, Result};
 use crate::id::{AgentRunId, CallId, ChatId, HostRootId};
@@ -27,66 +27,112 @@ use super::agent_run::{
     acquire_agent_run_claim_lock, agent_run_from_model, database_now, find_by_id_on,
 };
 
-pub(in crate::db) async fn park_agent_run_for_sandbox_tool_call(
+/// Park every tool call one model step emitted as a single durable batch.
+///
+/// The step is the unit: its calls are inserted together under one park lease,
+/// carry their emission order as `batch_ordinal`, and are replayed together as
+/// one assistant message and one tool-result message. The run resumes when the
+/// last of them lands terminal, not when the first does.
+pub(in crate::db) async fn park_agent_run_for_sandbox_tool_calls(
     store: &DbStore,
     agent_run_id: AgentRunId,
     lease_token: uuid::Uuid,
-    entry: &SandboxToolCallParkEntry,
+    entries: &[SandboxToolCallParkEntry],
 ) -> Result<ParkSandboxToolCallOutcome> {
-    let SandboxToolCallParkEntry { call, resolution } = entry;
-    // A synthetic entry carries the model's own arguments verbatim so the
-    // replayed transcript shows what it actually sent. Only the identity
-    // fields are checked for it; the per-tool argument rules exist to keep an
-    // executor lane from inheriting work it can only fail on, and no lane will
-    // ever see this row.
-    let dispatchable = resolution.is_none();
-    if lease_token.is_nil()
-        || !call.is_well_formed()
-        || call.agent_run_id != agent_run_id
-        || (dispatchable
-            && call.name == SANDBOX_READ_DELEGATED_FILE_TOOL
-            && !validate_sandbox_read_delegated_file_arguments(&call.arguments))
-        // Exec arguments are checked here as well as in the executor: the
-        // checkpoint is immutable once parked, so an out-of-bounds command must
-        // never become a durable row the lane can only fail on.
-        || (dispatchable
-            && call.name == SANDBOX_EXEC_TOOL
-            && !validate_sandbox_exec_arguments(&call.arguments))
-    {
+    if entries.is_empty() || lease_token.is_nil() {
         return Err(AgentError::Store(
             "invalid sandbox tool checkpoint request".into(),
         ));
     }
-    if let Some(resolution) = resolution {
-        validate_resolution(resolution)?;
+    // Both are the batch's own identity keys: the ids key the rows and their
+    // receipts, and the provider ids key the replayed tool-use blocks the model
+    // reads back. A repeat of either would make the transcript ambiguous.
+    let mut seen_ids = std::collections::HashSet::new();
+    let mut seen_provider_ids = std::collections::HashSet::new();
+    for entry in entries {
+        if !seen_ids.insert(entry.call.id) || !seen_provider_ids.insert(&entry.call.provider_id) {
+            return Err(AgentError::Store(
+                "duplicate sandbox tool checkpoint in one step".into(),
+            ));
+        }
     }
+    for entry in entries {
+        let SandboxToolCallParkEntry { call, resolution } = entry;
+        // A synthetic entry carries the model's own arguments verbatim so the
+        // replayed transcript shows what it actually sent. Only the identity
+        // fields are checked for it; the per-tool argument rules exist to keep
+        // an executor lane from inheriting work it can only fail on, and no
+        // lane will ever see this row.
+        let dispatchable = resolution.is_none();
+        if !call.is_well_formed()
+            || call.agent_run_id != agent_run_id
+            || call.chat_id != entries[0].call.chat_id
+            || (dispatchable
+                && call.name == SANDBOX_READ_DELEGATED_FILE_TOOL
+                && !validate_sandbox_read_delegated_file_arguments(&call.arguments))
+            // Exec arguments are checked here as well as in the executor: the
+            // checkpoint is immutable once parked, so an out-of-bounds command
+            // must never become a durable row the lane can only fail on.
+            || (dispatchable
+                && call.name == SANDBOX_EXEC_TOOL
+                && !validate_sandbox_exec_arguments(&call.arguments))
+        {
+            return Err(AgentError::Store(
+                "invalid sandbox tool checkpoint request".into(),
+            ));
+        }
+        if let Some(resolution) = resolution {
+            validate_resolution(resolution)?;
+        }
+    }
+    let chat_id = entries[0].call.chat_id;
+    let needs_delegated_file = entries.iter().any(|entry| {
+        entry.resolution.is_none() && entry.call.name == SANDBOX_READ_DELEGATED_FILE_TOOL
+    });
     let transaction = store.conn.begin().await.map_err(store_err)?;
     acquire_agent_run_claim_lock(&transaction).await?;
-    if dispatchable
-        && call.name == SANDBOX_READ_DELEGATED_FILE_TOOL
-        && !acquire_chat_write_lock(&transaction, call.chat_id).await?
-    {
+    if needs_delegated_file && !acquire_chat_write_lock(&transaction, chat_id).await? {
         transaction.commit().await.map_err(store_err)?;
         return Ok(ParkSandboxToolCallOutcome::DelegatedResourceUnavailable);
     }
     let now = database_now(&transaction).await?;
 
-    if let Some(existing) = entities::sandbox_tool_call::Entity::find_by_id(call.id.0)
+    if entities::sandbox_tool_call::Entity::find_by_id(entries[0].call.id.0)
         .one(&transaction)
         .await
         .map_err(store_err)?
+        .is_some()
     {
-        let receipt = entities::sandbox_tool_call_receipt::Entity::find_by_id(call.id.0)
-            .one(&transaction)
-            .await
-            .map_err(store_err)?;
-        // A synthetic park commits its row and its receipt together, so a
-        // recovered commit is only this exact park when both are present.
-        let exact = request_matches(&existing, call)
-            && existing.park_lease_token == lease_token
-            && resolution.as_ref().is_none_or(|resolution| {
-                receipt.is_some_and(|row| receipt_matches(&row, resolution))
-            });
+        // The batch commits as one transaction, so a recovered commit is this
+        // exact park only when every row — and every synthetic receipt it
+        // committed alongside — is present and matches.
+        let mut recovered = Vec::with_capacity(entries.len());
+        let mut exact = true;
+        for (ordinal, entry) in entries.iter().enumerate() {
+            let Some(existing) = entities::sandbox_tool_call::Entity::find_by_id(entry.call.id.0)
+                .one(&transaction)
+                .await
+                .map_err(store_err)?
+            else {
+                exact = false;
+                break;
+            };
+            let receipt = entities::sandbox_tool_call_receipt::Entity::find_by_id(entry.call.id.0)
+                .one(&transaction)
+                .await
+                .map_err(store_err)?;
+            if !request_matches(&existing, &entry.call)
+                || existing.park_lease_token != lease_token
+                || existing.batch_ordinal != ordinal_of(ordinal)?
+                || !entry.resolution.as_ref().is_none_or(|resolution| {
+                    receipt.is_some_and(|row| receipt_matches(&row, resolution))
+                })
+            {
+                exact = false;
+                break;
+            }
+            recovered.push(existing);
+        }
         let run = find_by_id_on(&transaction, agent_run_id).await?;
         transaction.commit().await.map_err(store_err)?;
         return if exact {
@@ -95,7 +141,10 @@ pub(in crate::db) async fn park_agent_run_for_sandbox_tool_call(
             })?;
             Ok(ParkSandboxToolCallOutcome::Existing {
                 run: agent_run_from_model(run)?,
-                call: call_from_model(existing)?,
+                calls: recovered
+                    .into_iter()
+                    .map(call_from_model)
+                    .collect::<Result<Vec<_>>>()?,
             })
         } else {
             Ok(ParkSandboxToolCallOutcome::IdentityConflict)
@@ -106,16 +155,15 @@ pub(in crate::db) async fn park_agent_run_for_sandbox_tool_call(
         transaction.commit().await.map_err(store_err)?;
         return Ok(ParkSandboxToolCallOutcome::LeaseLost);
     };
-    if dispatchable
-        && call.name == SANDBOX_READ_DELEGATED_FILE_TOOL
-        && delegated_file_resource_on(&transaction, agent_run_id, call.chat_id)
+    if needs_delegated_file
+        && delegated_file_resource_on(&transaction, agent_run_id, chat_id)
             .await?
             .is_none()
     {
         transaction.commit().await.map_err(store_err)?;
         return Ok(ParkSandboxToolCallOutcome::DelegatedResourceUnavailable);
     }
-    if run.chat_id != call.chat_id.0
+    if run.chat_id != chat_id.0
         || run.tier != AgentRunTier::Background.as_str()
         || run.status != AgentRunStatus::Running.as_str()
         || run.lease_token != Some(lease_token)
@@ -125,10 +173,12 @@ pub(in crate::db) async fn park_agent_run_for_sandbox_tool_call(
         transaction.commit().await.map_err(store_err)?;
         return Ok(ParkSandboxToolCallOutcome::LeaseLost);
     }
-    // A run parks checkpoints one at a time: parking releases the lease, and the
-    // worker only regains it once the checkpoint resolves. So an unresolved
-    // sibling means this park came from a worker running on a stale view, and the
-    // chain is bounded because the worker replays all of it on every claim.
+    // A run parks one step's calls at a time: parking releases the lease, and
+    // the worker only regains it once every call in the step resolves. So an
+    // unresolved sibling means this park came from a worker running on a stale
+    // view, and the chain is bounded because the worker replays all of it on
+    // every claim. The caller truncates an oversized step before it gets here;
+    // this keeps the durable bound regardless of what the caller computed.
     let siblings = entities::sandbox_tool_call::Entity::find()
         .filter(entities::sandbox_tool_call::Column::AgentRunId.eq(agent_run_id.0))
         .select_only()
@@ -140,59 +190,70 @@ pub(in crate::db) async fn park_agent_run_for_sandbox_tool_call(
     let all_resolved = siblings
         .iter()
         .all(|status| status_from_db(status).is_ok_and(SandboxToolCallStatus::is_terminal));
-    if !all_resolved || siblings.len() >= MAX_SANDBOX_TOOL_CALLS {
+    if !all_resolved || siblings.len().saturating_add(entries.len()) > MAX_SANDBOX_TOOL_CALLS {
         transaction.commit().await.map_err(store_err)?;
         return Ok(ParkSandboxToolCallOutcome::IdentityConflict);
     }
-    let status = resolution
-        .as_ref()
-        .map_or(SandboxToolCallStatus::Accepted, |resolution| {
-            resolution_status(resolution)
-        });
-    entities::sandbox_tool_call::ActiveModel {
-        id: Set(call.id.0),
-        agent_run_id: Set(agent_run_id.0),
-        chat_id: Set(call.chat_id.0),
-        agent_run_depth: Set(1),
-        provider_id: Set(call.provider_id.clone()),
-        name: Set(call.name.clone()),
-        arguments: Set(call.arguments.clone()),
-        status: Set(status.as_str().into()),
-        park_lease_token: Set(lease_token),
-        park_attempt_count: Set(run.attempt_count),
-        park_claim_count: Set(run.claim_count),
-        executor_lease_token: Set(None),
-        executor_lease_expires_at: Set(None),
-        retry_at: Set(None),
-        created_at: Set(now),
-        resolved_at: Set(resolution.as_ref().map(|_| now)),
-    }
-    .insert(&transaction)
-    .await
-    .map_err(store_err)?;
-    if let Some(resolution) = resolution {
-        let (error_code, error_detail) = resolution_error(resolution);
-        entities::sandbox_tool_call_receipt::ActiveModel {
-            call_id: Set(call.id.0),
-            // No executor ever held this call, so its own park lease stands in
-            // as the producing authority — the convention terminalization on
-            // the host side already uses.
-            executor_lease_token: Set(lease_token),
+    let mut any_live = false;
+    for (ordinal, entry) in entries.iter().enumerate() {
+        let SandboxToolCallParkEntry { call, resolution } = entry;
+        let status = resolution
+            .as_ref()
+            .map_or(SandboxToolCallStatus::Accepted, |resolution| {
+                resolution_status(resolution)
+            });
+        any_live |= resolution.is_none();
+        entities::sandbox_tool_call::ActiveModel {
+            id: Set(call.id.0),
+            agent_run_id: Set(agent_run_id.0),
+            chat_id: Set(call.chat_id.0),
+            agent_run_depth: Set(1),
+            provider_id: Set(call.provider_id.clone()),
+            name: Set(call.name.clone()),
+            arguments: Set(call.arguments.clone()),
             status: Set(status.as_str().into()),
-            result: Set(resolution.result().to_owned()),
-            error_code: Set(error_code),
-            error_detail: Set(error_detail),
-            resolved_at: Set(now),
+            park_lease_token: Set(lease_token),
+            park_attempt_count: Set(run.attempt_count),
+            park_claim_count: Set(run.claim_count),
+            batch_ordinal: Set(ordinal_of(ordinal)?),
+            executor_lease_token: Set(None),
+            executor_lease_expires_at: Set(None),
+            retry_at: Set(None),
+            created_at: Set(now),
+            resolved_at: Set(resolution.as_ref().map(|_| now)),
         }
         .insert(&transaction)
         .await
         .map_err(store_err)?;
+        if let Some(resolution) = resolution {
+            let (error_code, error_detail) = resolution_error(resolution);
+            entities::sandbox_tool_call_receipt::ActiveModel {
+                call_id: Set(call.id.0),
+                // No executor ever held this call, so its own park lease stands
+                // in as the producing authority — the convention terminalization
+                // on the host side already uses.
+                executor_lease_token: Set(lease_token),
+                status: Set(status.as_str().into()),
+                result: Set(resolution.result().to_owned()),
+                error_code: Set(error_code),
+                error_detail: Set(error_detail),
+                resolved_at: Set(now),
+            }
+            .insert(&transaction)
+            .await
+            .map_err(store_err)?;
+        }
     }
     let mut update = entities::agent_run::Entity::update_many();
-    if resolution.is_some() {
-        // Nothing will resolve this row later, so parking it into `waiting`
+    if any_live {
+        update = update.col_expr(
+            entities::agent_run::Column::Status,
+            sea_orm::sea_query::Expr::value(AgentRunStatus::Waiting.as_str()),
+        );
+    } else {
+        // Nothing will resolve these rows later, so parking into `waiting`
         // would strand the run there forever. It goes straight back on the
-        // schedule to consume the receipt it just committed.
+        // schedule to consume the receipts it just committed.
         update = update
             .col_expr(
                 entities::agent_run::Column::Status,
@@ -212,11 +273,6 @@ pub(in crate::db) async fn park_agent_run_for_sandbox_tool_call(
                 entities::agent_run::Column::AvailableAt,
                 sea_orm::sea_query::Expr::value(now),
             );
-    } else {
-        update = update.col_expr(
-            entities::agent_run::Column::Status,
-            sea_orm::sea_query::Expr::value(AgentRunStatus::Waiting.as_str()),
-        );
     }
     let updated = update
         .col_expr(
@@ -252,16 +308,25 @@ pub(in crate::db) async fn park_agent_run_for_sandbox_tool_call(
     let run = find_by_id_on(&transaction, agent_run_id)
         .await?
         .ok_or_else(|| AgentError::Store("parked sandbox run disappeared".into()))?;
-    let call = entities::sandbox_tool_call::Entity::find_by_id(call.id.0)
-        .one(&transaction)
-        .await
-        .map_err(store_err)?
-        .ok_or_else(|| AgentError::Store("sandbox tool checkpoint disappeared".into()))?;
+    let mut calls = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let call = entities::sandbox_tool_call::Entity::find_by_id(entry.call.id.0)
+            .one(&transaction)
+            .await
+            .map_err(store_err)?
+            .ok_or_else(|| AgentError::Store("sandbox tool checkpoint disappeared".into()))?;
+        calls.push(call_from_model(call)?);
+    }
     transaction.commit().await.map_err(store_err)?;
     Ok(ParkSandboxToolCallOutcome::Parked {
         run: agent_run_from_model(run)?,
-        call: call_from_model(call)?,
+        calls,
     })
+}
+
+fn ordinal_of(index: usize) -> Result<i16> {
+    i16::try_from(index)
+        .map_err(|_| AgentError::Store("sandbox tool checkpoint batch is too large".into()))
 }
 
 pub(in crate::db) async fn claim_sandbox_tool_call(
@@ -396,6 +461,10 @@ pub(in crate::db) async fn claim_delegated_file_read(
         transaction.commit().await.map_err(store_err)?;
         return Ok(ClaimDelegatedFileReadOutcome::Unavailable);
     };
+    if exec_predecessor_is_live_on(&transaction, &existing).await? {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(ClaimDelegatedFileReadOutcome::Unavailable);
+    }
     let expires_at = Ord::min(requested_expires_at, deadline);
     let mut active: entities::sandbox_tool_call::ActiveModel = existing.into();
     active.status = Set(SandboxToolCallStatus::Claimed.as_str().into());
@@ -481,6 +550,13 @@ async fn claim_sandbox_tool_call_matching(
         transaction.commit().await.map_err(store_err)?;
         return Ok(ClaimSandboxToolCallOutcome::Unavailable);
     };
+    // Not claimable *yet* rather than unusable: an earlier exec in the same
+    // step still owns the workspace. The lane rescans on its idle loop and
+    // picks this one up once its predecessor lands terminal.
+    if exec_predecessor_is_live_on(&transaction, &existing).await? {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(ClaimSandboxToolCallOutcome::Unavailable);
+    }
     let expires_at = Ord::min(requested_expires_at, deadline);
     let mut active: entities::sandbox_tool_call::ActiveModel = existing.into();
     active.status = Set(SandboxToolCallStatus::Claimed.as_str().into());
@@ -739,38 +815,9 @@ pub(in crate::db) async fn resolve_sandbox_tool_call(
     call_active.executor_lease_expires_at = Set(None);
     call_active.resolved_at = Set(Some(now));
     call_active.update(&transaction).await.map_err(store_err)?;
-    let resumed = entities::agent_run::Entity::update_many()
-        .col_expr(
-            entities::agent_run::Column::Status,
-            sea_orm::sea_query::Expr::value(AgentRunStatus::RetryWait.as_str()),
-        )
-        .col_expr(
-            entities::agent_run::Column::LastErrorCode,
-            sea_orm::sea_query::Expr::value(Some("tool_checkpoint_resolved".to_owned())),
-        )
-        .col_expr(
-            entities::agent_run::Column::LastErrorDetail,
-            sea_orm::sea_query::Expr::value(Some(
-                "sandbox tool result receipt committed".to_owned(),
-            )),
-        )
-        .col_expr(
-            entities::agent_run::Column::AvailableAt,
-            sea_orm::sea_query::Expr::value(now),
-        )
-        .col_expr(
-            entities::agent_run::Column::UpdatedAt,
-            sea_orm::sea_query::Expr::value(now),
-        )
-        .filter(entities::agent_run::Column::Id.eq(run.id))
-        .filter(entities::agent_run::Column::Status.eq(AgentRunStatus::Waiting.as_str()))
-        .exec(&transaction)
-        .await
-        .map_err(store_err)?;
-    if resumed.rows_affected != 1 {
-        transaction.rollback().await.map_err(store_err)?;
-        return Ok(ResolveSandboxToolCallOutcome::LeaseLost);
-    }
+    // The receipt and the call's own transition commit either way: a step whose
+    // other calls are still running simply has nothing to resume yet.
+    resume_waiting_run_if_batch_settled_on(&transaction, AgentRunId(run.id), now).await?;
     transaction.commit().await.map_err(store_err)?;
     Ok(ResolveSandboxToolCallOutcome::Resolved)
 }
@@ -1001,38 +1048,9 @@ pub(in crate::db) async fn resolve_delegated_file_read(
     call_active.executor_lease_expires_at = Set(None);
     call_active.resolved_at = Set(Some(now));
     call_active.update(&transaction).await.map_err(store_err)?;
-    let resumed = entities::agent_run::Entity::update_many()
-        .col_expr(
-            entities::agent_run::Column::Status,
-            sea_orm::sea_query::Expr::value(AgentRunStatus::RetryWait.as_str()),
-        )
-        .col_expr(
-            entities::agent_run::Column::LastErrorCode,
-            sea_orm::sea_query::Expr::value(Some("tool_checkpoint_resolved".to_owned())),
-        )
-        .col_expr(
-            entities::agent_run::Column::LastErrorDetail,
-            sea_orm::sea_query::Expr::value(Some(
-                "sandbox tool result receipt committed".to_owned(),
-            )),
-        )
-        .col_expr(
-            entities::agent_run::Column::AvailableAt,
-            sea_orm::sea_query::Expr::value(now),
-        )
-        .col_expr(
-            entities::agent_run::Column::UpdatedAt,
-            sea_orm::sea_query::Expr::value(now),
-        )
-        .filter(entities::agent_run::Column::Id.eq(run.id))
-        .filter(entities::agent_run::Column::Status.eq(AgentRunStatus::Waiting.as_str()))
-        .exec(&transaction)
-        .await
-        .map_err(store_err)?;
-    if resumed.rows_affected != 1 {
-        transaction.rollback().await.map_err(store_err)?;
-        return Ok(ResolveSandboxToolCallOutcome::LeaseLost);
-    }
+    // The receipt and the call's own transition commit either way: a step whose
+    // other calls are still running simply has nothing to resume yet.
+    resume_waiting_run_if_batch_settled_on(&transaction, AgentRunId(run.id), now).await?;
     transaction.commit().await.map_err(store_err)?;
     Ok(ResolveSandboxToolCallOutcome::Resolved)
 }
@@ -1071,6 +1089,9 @@ pub(in crate::db) async fn list_sandbox_tool_calls_for_agent_run(
         // SQLite timestamps and random IDs, so it is the replay order.
         .order_by_asc(entities::sandbox_tool_call::Column::ParkAttemptCount)
         .order_by_asc(entities::sandbox_tool_call::Column::ParkClaimCount)
+        // Within one parked step, the ordinal is the order the model emitted
+        // the calls in, and the order its transcript replays them in.
+        .order_by_asc(entities::sandbox_tool_call::Column::BatchOrdinal)
         .all(&store.conn)
         .await
         .map_err(store_err)?
@@ -1194,12 +1215,9 @@ where
         .all(conn)
         .await
         .map_err(store_err)?;
-    if calls.len() > 1 {
-        return Err(AgentError::Store(
-            "sandbox run has multiple live tool calls".into(),
-        ));
-    }
-    if let Some(call) = calls.into_iter().next() {
+    // A step parks its calls together, so a run being fenced can have several
+    // live at once; every one of them gets the same terminal answer here.
+    for call in calls {
         terminalize_on(conn, call, error_code, now).await?;
     }
     Ok(())
@@ -1262,7 +1280,41 @@ where
         .await
         .map_err(store_err)?
         .ok_or_else(|| AgentError::Store("terminal sandbox tool call disappeared".into()))?;
-    entities::agent_run::Entity::update_many()
+    resume_waiting_run_if_batch_settled_on(conn, AgentRunId(call.agent_run_id), now).await?;
+    Ok(())
+}
+
+/// Put a waiting sandbox run back on the schedule once its whole parked step
+/// has settled, and report whether it moved.
+///
+/// A step's calls resolve independently and in any order, so the first receipt
+/// to land is usually not the one that finishes the step. The run only resumes
+/// when no live call is left — the park gate keeps at most one step outstanding
+/// at a time, so counting the run's own non-terminal rows is the whole test.
+/// A caller that has just committed a receipt keeps it either way: not being
+/// ready to resume is the ordinary case, not a lost lease.
+async fn resume_waiting_run_if_batch_settled_on<C>(
+    conn: &C,
+    agent_run_id: AgentRunId,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<bool>
+where
+    C: ConnectionTrait,
+{
+    let live = entities::sandbox_tool_call::Entity::find()
+        .filter(entities::sandbox_tool_call::Column::AgentRunId.eq(agent_run_id.0))
+        .filter(entities::sandbox_tool_call::Column::Status.is_in([
+            SandboxToolCallStatus::Accepted.as_str(),
+            SandboxToolCallStatus::Claimed.as_str(),
+            SandboxToolCallStatus::RetryWait.as_str(),
+        ]))
+        .count(conn)
+        .await
+        .map_err(store_err)?;
+    if live > 0 {
+        return Ok(false);
+    }
+    let resumed = entities::agent_run::Entity::update_many()
         .col_expr(
             entities::agent_run::Column::Status,
             sea_orm::sea_query::Expr::value(AgentRunStatus::RetryWait.as_str()),
@@ -1285,12 +1337,44 @@ where
             entities::agent_run::Column::UpdatedAt,
             sea_orm::sea_query::Expr::value(now),
         )
-        .filter(entities::agent_run::Column::Id.eq(call.agent_run_id))
+        .filter(entities::agent_run::Column::Id.eq(agent_run_id.0))
         .filter(entities::agent_run::Column::Status.eq(AgentRunStatus::Waiting.as_str()))
         .exec(conn)
         .await
         .map_err(store_err)?;
-    Ok(())
+    Ok(resumed.rows_affected == 1)
+}
+
+/// Whether an earlier `exec` in this call's own parked step is still live.
+///
+/// Only execs gate each other, and only within one step: they share the run's
+/// single workspace, and the model emitted them expecting each to see the
+/// previous one's effects.
+async fn exec_predecessor_is_live_on<C>(
+    conn: &C,
+    call: &entities::sandbox_tool_call::Model,
+) -> Result<bool>
+where
+    C: ConnectionTrait,
+{
+    if sandbox_call_is_parallel_eligible(&call.name) {
+        return Ok(false);
+    }
+    let pending = entities::sandbox_tool_call::Entity::find()
+        .filter(entities::sandbox_tool_call::Column::AgentRunId.eq(call.agent_run_id))
+        .filter(entities::sandbox_tool_call::Column::ParkAttemptCount.eq(call.park_attempt_count))
+        .filter(entities::sandbox_tool_call::Column::ParkClaimCount.eq(call.park_claim_count))
+        .filter(entities::sandbox_tool_call::Column::BatchOrdinal.lt(call.batch_ordinal))
+        .filter(entities::sandbox_tool_call::Column::Name.eq(SANDBOX_EXEC_TOOL))
+        .filter(entities::sandbox_tool_call::Column::Status.is_in([
+            SandboxToolCallStatus::Accepted.as_str(),
+            SandboxToolCallStatus::Claimed.as_str(),
+            SandboxToolCallStatus::RetryWait.as_str(),
+        ]))
+        .count(conn)
+        .await
+        .map_err(store_err)?;
+    Ok(pending > 0)
 }
 
 async fn terminalize_active_delegated_read_on<C>(
@@ -1442,6 +1526,7 @@ fn call_from_model(model: entities::sandbox_tool_call::Model) -> Result<SandboxT
         park_lease_token: model.park_lease_token,
         park_attempt_count: model.park_attempt_count,
         park_claim_count: model.park_claim_count,
+        batch_ordinal: model.batch_ordinal,
         executor_lease_token: model.executor_lease_token,
         executor_lease_expires_at: model.executor_lease_expires_at,
         retry_at: model.retry_at,

--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -2102,10 +2102,10 @@ async fn sandbox_tool_checkpoint_is_lease_fenced_and_receipt_idempotent() {
     };
     assert!(matches!(
         store
-            .park_agent_run_for_sandbox_tool_call(
+            .park_agent_run_for_sandbox_tool_calls(
                 sandbox.id,
                 worker_lease,
-                &super::dispatchable(&request)
+                &[super::dispatchable(&request)]
             )
             .await
             .unwrap(),
@@ -2113,10 +2113,10 @@ async fn sandbox_tool_checkpoint_is_lease_fenced_and_receipt_idempotent() {
     ));
     assert!(matches!(
         store
-            .park_agent_run_for_sandbox_tool_call(
+            .park_agent_run_for_sandbox_tool_calls(
                 sandbox.id,
                 worker_lease,
-                &super::dispatchable(&request)
+                &[super::dispatchable(&request)]
             )
             .await
             .unwrap(),
@@ -2228,10 +2228,10 @@ async fn a_sandbox_run_may_checkpoint_repeatedly_up_to_a_bounded_chain() {
         assert!(
             matches!(
                 store
-                    .park_agent_run_for_sandbox_tool_call(
+                    .park_agent_run_for_sandbox_tool_calls(
                         sandbox.id,
                         worker_lease,
-                        &super::dispatchable(&request)
+                        &[super::dispatchable(&request)]
                     )
                     .await
                     .unwrap(),
@@ -2272,11 +2272,32 @@ async fn a_sandbox_run_may_checkpoint_repeatedly_up_to_a_bounded_chain() {
     };
     assert!(matches!(
         store
-            .park_agent_run_for_sandbox_tool_call(
+            .park_agent_run_for_sandbox_tool_calls(
                 sandbox.id,
                 worker_lease,
-                &super::dispatchable(&over_budget)
+                &[super::dispatchable(&over_budget)]
             )
+            .await
+            .unwrap(),
+        ParkSandboxToolCallOutcome::IdentityConflict
+    ));
+    // A batch is bounded by the same budget: a step whose calls would cross the
+    // total is refused whole rather than partly landed.
+    let over_budget_batch: Vec<_> = (0..2)
+        .map(|index| {
+            super::dispatchable(&SandboxToolCallRequest {
+                id: CallId::new(),
+                agent_run_id: sandbox.id,
+                chat_id: chat.id,
+                provider_id: format!("provider-batch-{index}"),
+                name: "web_search".into(),
+                arguments: serde_json::json!({"query": "batch"}),
+            })
+        })
+        .collect();
+    assert!(matches!(
+        store
+            .park_agent_run_for_sandbox_tool_calls(sandbox.id, worker_lease, &over_budget_batch)
             .await
             .unwrap(),
         ParkSandboxToolCallOutcome::IdentityConflict
@@ -2310,11 +2331,21 @@ async fn cancelling_waiting_sandbox_fences_claimed_tool_work() {
         name: "web_search".into(),
         arguments: serde_json::json!({"query": "cancel"}),
     };
+    // Both calls of one step are live when the run is cancelled: one claimed by
+    // an executor, one still waiting for a lane. Fencing has to settle both.
+    let sibling = SandboxToolCallRequest {
+        id: CallId::new(),
+        agent_run_id: sandbox.id,
+        chat_id: chat.id,
+        provider_id: "provider-call-2b".into(),
+        name: "web_search".into(),
+        arguments: serde_json::json!({"query": "cancel sibling"}),
+    };
     store
-        .park_agent_run_for_sandbox_tool_call(
+        .park_agent_run_for_sandbox_tool_calls(
             sandbox.id,
             worker_lease,
-            &super::dispatchable(&request),
+            &[super::dispatchable(&request), super::dispatchable(&sibling)],
         )
         .await
         .unwrap();
@@ -2343,16 +2374,98 @@ async fn cancelling_waiting_sandbox_fences_claimed_tool_work() {
             .unwrap(),
         ResolveSandboxToolCallOutcome::AlreadyTerminal
     );
-    assert_eq!(
+    for id in [request.id, sibling.id] {
+        assert_eq!(
+            store
+                .get_sandbox_tool_call_receipt(id)
+                .await
+                .unwrap()
+                .unwrap()
+                .status
+                .as_str(),
+            "cancelled"
+        );
+    }
+}
+
+/// Commands in one step share the run's single workspace, so they run in the
+/// order the model emitted them. Everything else in the step starts at once.
+#[tokio::test]
+async fn execs_in_one_step_serialize_while_read_only_siblings_run_immediately() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let sandbox = accepted_sandbox_for_tool_test(&store, chat.id).await;
+    let worker_lease = uuid::Uuid::new_v4();
+    store
+        .claim_agent_run(worker_lease, Duration::minutes(5), 1, 1)
+        .await
+        .unwrap();
+    let step: Vec<_> = [
+        (crate::SANDBOX_EXEC_TOOL, serde_json::json!({"command":"a"})),
+        (crate::SANDBOX_EXEC_TOOL, serde_json::json!({"command":"b"})),
+        ("web_search", serde_json::json!({"query":"c"})),
+    ]
+    .into_iter()
+    .enumerate()
+    .map(|(index, (name, arguments))| {
+        super::dispatchable(&SandboxToolCallRequest {
+            id: CallId::new(),
+            agent_run_id: sandbox.id,
+            chat_id: chat.id,
+            provider_id: format!("provider-parallel-{index}"),
+            name: name.into(),
+            arguments,
+        })
+    })
+    .collect();
+    let ids: Vec<_> = step.iter().map(|entry| entry.call.id).collect();
+    store
+        .park_agent_run_for_sandbox_tool_calls(sandbox.id, worker_lease, &step)
+        .await
+        .unwrap();
+
+    // The read-only sibling is claimable while the first command is still live.
+    assert!(matches!(
         store
-            .get_sandbox_tool_call_receipt(request.id)
+            .claim_sandbox_tool_call(ids[2], uuid::Uuid::new_v4(), Duration::minutes(2))
             .await
-            .unwrap()
-            .unwrap()
-            .status
-            .as_str(),
-        "cancelled"
-    );
+            .unwrap(),
+        ClaimSandboxToolCallOutcome::Claimed(_)
+    ));
+    // The second command is not — and is left claimable later, not terminalized.
+    assert!(matches!(
+        store
+            .claim_sandbox_tool_call(ids[1], uuid::Uuid::new_v4(), Duration::minutes(2))
+            .await
+            .unwrap(),
+        ClaimSandboxToolCallOutcome::Unavailable
+    ));
+    let head_lease = uuid::Uuid::new_v4();
+    assert!(matches!(
+        store
+            .claim_sandbox_tool_call(ids[0], head_lease, Duration::minutes(2))
+            .await
+            .unwrap(),
+        ClaimSandboxToolCallOutcome::Claimed(_)
+    ));
+    store
+        .resolve_sandbox_tool_call(
+            ids[0],
+            head_lease,
+            &ToolCallResolution::Completed {
+                result: "a done".into(),
+            },
+        )
+        .await
+        .unwrap();
+    assert!(matches!(
+        store
+            .claim_sandbox_tool_call(ids[1], uuid::Uuid::new_v4(), Duration::minutes(2))
+            .await
+            .unwrap(),
+        ClaimSandboxToolCallOutcome::Claimed(_)
+    ));
 }
 
 #[tokio::test]
@@ -2375,10 +2488,10 @@ async fn expired_sandbox_tool_claim_is_recoverable_and_fences_stale_executor() {
         arguments: serde_json::json!({"query": "expiry"}),
     };
     store
-        .park_agent_run_for_sandbox_tool_call(
+        .park_agent_run_for_sandbox_tool_calls(
             sandbox.id,
             worker_lease,
-            &super::dispatchable(&request),
+            &[super::dispatchable(&request)],
         )
         .await
         .unwrap();
@@ -2464,10 +2577,10 @@ async fn waiting_sandbox_deadline_fences_tool_and_delivers_parent_failure() {
         arguments: serde_json::json!({"query": "deadline"}),
     };
     store
-        .park_agent_run_for_sandbox_tool_call(
+        .park_agent_run_for_sandbox_tool_calls(
             sandbox.id,
             worker_lease,
-            &super::dispatchable(&request),
+            &[super::dispatchable(&request)],
         )
         .await
         .unwrap();
@@ -2602,25 +2715,29 @@ async fn a_pre_resolved_sandbox_park_lands_terminal_and_reschedules_the_run() {
         .claim_agent_run(worker_lease, Duration::minutes(5), 1, 1)
         .await
         .unwrap();
-    let entry = crate::SandboxToolCallParkEntry {
-        call: SandboxToolCallRequest {
-            id: CallId::new(),
-            agent_run_id: sandbox.id,
-            chat_id: chat.id,
-            provider_id: "provider-call-refused".into(),
-            // The model's own emitted name, not one this host dispatches.
-            name: "read_file".into(),
-            arguments: serde_json::json!({"path": "notes.md"}),
-        },
-        resolution: Some(ToolCallResolution::Failed {
-            result: "read_file is not available to a background task.".into(),
-            error_code: "unavailable_tool".into(),
-            error_detail: None,
-        }),
-    };
-    let call_id = entry.call.id;
-    let ParkSandboxToolCallOutcome::Parked { run, call } = store
-        .park_agent_run_for_sandbox_tool_call(sandbox.id, worker_lease, &entry)
+    // A whole step of calls the host answered itself, not just one: nothing in
+    // it will ever be claimed, so the run must be rescheduled rather than parked.
+    let entries: Vec<_> = ["read_file", "write_file"]
+        .into_iter()
+        .map(|name| crate::SandboxToolCallParkEntry {
+            call: SandboxToolCallRequest {
+                id: CallId::new(),
+                agent_run_id: sandbox.id,
+                chat_id: chat.id,
+                provider_id: format!("provider-call-refused-{name}"),
+                // The model's own emitted name, not one this host dispatches.
+                name: name.into(),
+                arguments: serde_json::json!({"path": "notes.md"}),
+            },
+            resolution: Some(ToolCallResolution::Failed {
+                result: format!("{name} is not available to a background task."),
+                error_code: "unavailable_tool".into(),
+                error_detail: None,
+            }),
+        })
+        .collect();
+    let ParkSandboxToolCallOutcome::Parked { run, calls } = store
+        .park_agent_run_for_sandbox_tool_calls(sandbox.id, worker_lease, &entries)
         .await
         .unwrap()
     else {
@@ -2631,14 +2748,22 @@ async fn a_pre_resolved_sandbox_park_lands_terminal_and_reschedules_the_run() {
         run.last_error_code.as_deref(),
         Some("tool_checkpoint_resolved")
     );
-    assert!(call.status.is_terminal());
-    assert!(call.resolved_at.is_some());
-    let receipt = store
-        .get_sandbox_tool_call_receipt(call_id)
-        .await
-        .unwrap()
-        .unwrap();
-    assert_eq!(receipt.error_code.as_deref(), Some("unavailable_tool"));
+    assert_eq!(
+        calls
+            .iter()
+            .map(|call| (call.batch_ordinal, call.status.is_terminal()))
+            .collect::<Vec<_>>(),
+        vec![(0, true), (1, true)]
+    );
+    assert!(calls.iter().all(|call| call.resolved_at.is_some()));
+    for call in &calls {
+        let receipt = store
+            .get_sandbox_tool_call_receipt(call.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(receipt.error_code.as_deref(), Some("unavailable_tool"));
+    }
     // No lane may claim work the host already answered.
     assert!(store
         .list_sandbox_tool_call_candidates(8)
@@ -2648,7 +2773,7 @@ async fn a_pre_resolved_sandbox_park_lands_terminal_and_reschedules_the_run() {
     // The same commit replayed recovers the identical checkpoint.
     assert!(matches!(
         store
-            .park_agent_run_for_sandbox_tool_call(sandbox.id, worker_lease, &entry)
+            .park_agent_run_for_sandbox_tool_calls(sandbox.id, worker_lease, &entries)
             .await
             .unwrap(),
         ParkSandboxToolCallOutcome::Existing { .. }

--- a/crates/openwave-core/src/db/tests/delegated_file_read.rs
+++ b/crates/openwave-core/src/db/tests/delegated_file_read.rs
@@ -162,10 +162,10 @@ async fn delegated_read_requires_exact_admission_and_empty_arguments() {
     let request = read_request(&run, CallId::new());
     assert_eq!(
         store
-            .park_agent_run_for_sandbox_tool_call(
+            .park_agent_run_for_sandbox_tool_calls(
                 run.id,
                 worker_lease,
-                &super::dispatchable(&request)
+                &[super::dispatchable(&request)]
             )
             .await
             .unwrap(),
@@ -186,7 +186,11 @@ async fn delegated_read_requires_exact_admission_and_empty_arguments() {
     };
     assert!(matches!(
         store
-            .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &super::dispatchable(&web))
+            .park_agent_run_for_sandbox_tool_calls(
+                run.id,
+                worker_lease,
+                &[super::dispatchable(&web)]
+            )
             .await
             .unwrap(),
         ParkSandboxToolCallOutcome::Parked { .. }
@@ -208,10 +212,10 @@ async fn delegated_read_requires_exact_admission_and_empty_arguments() {
         let mut malformed = read_request(&run, CallId::new());
         malformed.arguments = arguments;
         assert!(second_store
-            .park_agent_run_for_sandbox_tool_call(
+            .park_agent_run_for_sandbox_tool_calls(
                 run.id,
                 worker_lease,
-                &super::dispatchable(&malformed)
+                &[super::dispatchable(&malformed)]
             )
             .await
             .is_err());
@@ -232,10 +236,13 @@ async fn delegated_read_requires_exact_admission_and_empty_arguments() {
         .unwrap();
     assert_eq!(
         third_store
-            .park_agent_run_for_sandbox_tool_call(
+            .park_agent_run_for_sandbox_tool_calls(
                 corrupt_run.id,
                 corrupt_lease,
-                &super::dispatchable(&read_request(&corrupt_run, CallId::new())),
+                &[super::dispatchable(&read_request(
+                    &corrupt_run,
+                    CallId::new()
+                ))],
             )
             .await
             .unwrap(),
@@ -250,10 +257,10 @@ async fn delegated_read_checkpoint_and_claim_are_exact_and_lane_isolated() {
     let request = read_request(&run, CallId::new());
     assert!(matches!(
         store
-            .park_agent_run_for_sandbox_tool_call(
+            .park_agent_run_for_sandbox_tool_calls(
                 run.id,
                 worker_lease,
-                &super::dispatchable(&request)
+                &[super::dispatchable(&request)]
             )
             .await
             .unwrap(),
@@ -261,10 +268,10 @@ async fn delegated_read_checkpoint_and_claim_are_exact_and_lane_isolated() {
     ));
     assert!(matches!(
         store
-            .park_agent_run_for_sandbox_tool_call(
+            .park_agent_run_for_sandbox_tool_calls(
                 run.id,
                 worker_lease,
-                &super::dispatchable(&request)
+                &[super::dispatchable(&request)]
             )
             .await
             .unwrap(),
@@ -353,10 +360,10 @@ async fn delegated_read_checkpoint_and_claim_are_exact_and_lane_isolated() {
     assert!(
         matches!(
             store
-                .park_agent_run_for_sandbox_tool_call(
+                .park_agent_run_for_sandbox_tool_calls(
                     run.id,
                     next_worker_lease,
-                    &super::dispatchable(&second)
+                    &[super::dispatchable(&second)]
                 )
                 .await
                 .unwrap(),
@@ -381,7 +388,11 @@ async fn detach_before_claim_terminalizes_without_exposing_authority() {
     let (chat, run, worker_lease, resource) = delegated_sandbox(&store).await;
     let request = read_request(&run, CallId::new());
     store
-        .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &super::dispatchable(&request))
+        .park_agent_run_for_sandbox_tool_calls(
+            run.id,
+            worker_lease,
+            &[super::dispatchable(&request)],
+        )
         .await
         .unwrap();
     detach_root(&store, &chat, resource.root_id).await;
@@ -424,7 +435,11 @@ async fn concurrent_detach_and_claim_require_a_final_revocation_heartbeat() {
     let (chat, run, worker_lease, resource) = delegated_sandbox(&store).await;
     let request = read_request(&run, CallId::new());
     store
-        .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &super::dispatchable(&request))
+        .park_agent_run_for_sandbox_tool_calls(
+            run.id,
+            worker_lease,
+            &[super::dispatchable(&request)],
+        )
         .await
         .unwrap();
 
@@ -482,7 +497,11 @@ async fn detach_after_claim_rejects_content_at_the_atomic_resolution_fence() {
     let (chat, run, worker_lease, resource) = delegated_sandbox(&store).await;
     let request = read_request(&run, CallId::new());
     store
-        .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &super::dispatchable(&request))
+        .park_agent_run_for_sandbox_tool_calls(
+            run.id,
+            worker_lease,
+            &[super::dispatchable(&request)],
+        )
         .await
         .unwrap();
     let lease = uuid::Uuid::new_v4();
@@ -534,7 +553,11 @@ async fn exact_terminal_retry_survives_a_later_attachment_revocation() {
     let (chat, run, worker_lease, resource) = delegated_sandbox(&store).await;
     let request = read_request(&run, CallId::new());
     store
-        .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &super::dispatchable(&request))
+        .park_agent_run_for_sandbox_tool_calls(
+            run.id,
+            worker_lease,
+            &[super::dispatchable(&request)],
+        )
         .await
         .unwrap();
     let lease = uuid::Uuid::new_v4();
@@ -568,7 +591,11 @@ async fn wrong_and_expired_delegated_read_leases_cannot_heartbeat_or_resolve() {
     let (_chat, run, worker_lease, _resource) = delegated_sandbox(&store).await;
     let request = read_request(&run, CallId::new());
     store
-        .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &super::dispatchable(&request))
+        .park_agent_run_for_sandbox_tool_calls(
+            run.id,
+            worker_lease,
+            &[super::dispatchable(&request)],
+        )
         .await
         .unwrap();
     let lease = uuid::Uuid::new_v4();
@@ -637,7 +664,11 @@ async fn cancelling_a_delegated_read_fences_native_execution_without_leaking_aut
     let (_chat, run, worker_lease, resource) = delegated_sandbox(&store).await;
     let request = read_request(&run, CallId::new());
     store
-        .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &super::dispatchable(&request))
+        .park_agent_run_for_sandbox_tool_calls(
+            run.id,
+            worker_lease,
+            &[super::dispatchable(&request)],
+        )
         .await
         .unwrap();
     let lease = uuid::Uuid::new_v4();

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -91,8 +91,9 @@ pub use agent::{
     SandboxAgentSpawnRequest, ToolRegistry, TurnWebSearch, UtilityModel,
 };
 pub use agent_tools::{
-    sandbox_done_tool_spec, sandbox_exec_tool_spec, sandbox_read_delegated_file_tool_spec,
-    sandbox_web_search_tool_spec, spawn_sandbox_agent_tool_spec, validate_sandbox_done_arguments,
+    sandbox_call_is_parallel_eligible, sandbox_done_tool_spec, sandbox_exec_tool_spec,
+    sandbox_read_delegated_file_tool_spec, sandbox_web_search_tool_spec,
+    spawn_sandbox_agent_tool_spec, validate_sandbox_done_arguments,
     validate_sandbox_exec_arguments, validate_sandbox_read_delegated_file_arguments,
     validate_spawn_sandbox_agent_arguments, validate_wait_for_agents_arguments,
     wait_for_agents_tool_spec, web_extract_tool_spec, web_search_tool_spec,
@@ -101,10 +102,10 @@ pub use agent_tools::{
     WebExtractArgs, WebSearchArgs, DEFAULT_WEB_SEARCH_RESULTS, MAX_SANDBOX_AGENT_TASK_CHARS,
     MAX_SANDBOX_DONE_OUTPUTS, MAX_SANDBOX_DONE_SUMMARY_CHARS, MAX_SANDBOX_EXEC_ARGUMENTS,
     MAX_SANDBOX_EXEC_COMMAND_BYTES, MAX_SANDBOX_EXEC_CWD_BYTES, MAX_SANDBOX_TOOL_CALLS,
-    MAX_WAIT_FOR_AGENTS_CHILDREN, MAX_WEB_EXTRACT_URL_BYTES, MAX_WEB_SEARCH_DOMAINS,
-    MAX_WEB_SEARCH_QUERY_CHARS, MAX_WEB_SEARCH_RESULTS, SANDBOX_DONE_TOOL, SANDBOX_EXEC_TOOL,
-    SANDBOX_READ_DELEGATED_FILE_TOOL, SANDBOX_WEB_SEARCH_TOOL, SPAWN_SANDBOX_AGENT_TOOL,
-    WAIT_FOR_AGENTS_TOOL, WEB_EXTRACT_TOOL, WEB_SEARCH_TOOL,
+    MAX_SANDBOX_TOOL_CALLS_PER_STEP, MAX_WAIT_FOR_AGENTS_CHILDREN, MAX_WEB_EXTRACT_URL_BYTES,
+    MAX_WEB_SEARCH_DOMAINS, MAX_WEB_SEARCH_QUERY_CHARS, MAX_WEB_SEARCH_RESULTS, SANDBOX_DONE_TOOL,
+    SANDBOX_EXEC_TOOL, SANDBOX_READ_DELEGATED_FILE_TOOL, SANDBOX_WEB_SEARCH_TOOL,
+    SPAWN_SANDBOX_AGENT_TOOL, WAIT_FOR_AGENTS_TOOL, WEB_EXTRACT_TOOL, WEB_SEARCH_TOOL,
 };
 pub use approval::{
     ApprovalDecision, ApprovalFuture, ApprovalGate, ApprovalJournalIdentity, ApprovalRegistration,

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1889,6 +1889,9 @@ pub struct SandboxToolCall {
     pub park_lease_token: Uuid,
     pub park_attempt_count: i32,
     pub park_claim_count: i32,
+    /// Position of this call within the model step that parked it, from zero.
+    /// The transcript replays a step's calls in this order.
+    pub batch_ordinal: i16,
     pub executor_lease_token: Option<Uuid>,
     pub executor_lease_expires_at: Option<DateTime<Utc>>,
     /// When the call's single bounded retry becomes claimable. Set exactly

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -477,11 +477,12 @@ pub enum CheckpointSandboxSpawnOutcome {
 pub enum ParkSandboxToolCallOutcome {
     Parked {
         run: AgentRun,
-        call: crate::model::SandboxToolCall,
+        /// The step's calls, in the order the model emitted them.
+        calls: Vec<crate::model::SandboxToolCall>,
     },
     Existing {
         run: AgentRun,
-        call: crate::model::SandboxToolCall,
+        calls: Vec<crate::model::SandboxToolCall>,
     },
     IdentityConflict,
     DelegatedResourceUnavailable,
@@ -2324,18 +2325,22 @@ pub trait Store: Send + Sync {
         agent_run_storage_unavailable()
     }
 
-    /// Atomically accept canonical sandbox tool arguments, record the exact
-    /// originating sandbox lease, and release that lease into `waiting`.
-    /// Exact retries recover the checkpoint after the call resolves.
+    /// Atomically accept one model step's canonical sandbox tool arguments,
+    /// record the exact originating sandbox lease, and release that lease into
+    /// `waiting`. Exact retries recover the checkpoint after the calls resolve.
+    ///
+    /// The step's calls are one durable batch: they share a park lease, carry
+    /// their emission order as `batch_ordinal`, and the run resumes only once
+    /// every one of them is terminal.
     ///
     /// An entry carrying a resolution lands terminal with its receipt in the
-    /// same transaction and releases the lease into `retry_wait` instead: the
-    /// host already answered the call and no executor lane will see it.
-    async fn park_agent_run_for_sandbox_tool_call(
+    /// same transaction; a batch in which every entry does releases the lease
+    /// into `retry_wait` instead, since no executor lane will see any of them.
+    async fn park_agent_run_for_sandbox_tool_calls(
         &self,
         _agent_run_id: AgentRunId,
         _lease_token: uuid::Uuid,
-        _entry: &crate::model::SandboxToolCallParkEntry,
+        _entries: &[crate::model::SandboxToolCallParkEntry],
     ) -> Result<ParkSandboxToolCallOutcome> {
         agent_run_storage_unavailable()
     }

--- a/crates/openwave-server/src/desktop_schema.rs
+++ b/crates/openwave-server/src/desktop_schema.rs
@@ -25,7 +25,7 @@ const VECTOR_DIRECTORY: &str = "vectors";
 const MAX_MARKER_BYTES: u64 = 1_024;
 
 /// Bump this whenever the pre-v1 schema baseline changes incompatibly.
-const DESKTOP_SCHEMA_EPOCH: u32 = 11;
+const DESKTOP_SCHEMA_EPOCH: u32 = 12;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -2309,10 +2309,15 @@ pub struct AgentActivitySnapshot {
 }
 
 fn sandbox_activity(calls: &[SandboxToolCall]) -> Option<AgentActivitySnapshot> {
-    // A sandbox can have at most one live checkpoint. Inspecting the latest
-    // durable live checkpoint also prevents an older, completed activity from
-    // lingering in the UI after the run has advanced.
-    let call = calls.iter().rev().find(|call| !call.status.is_terminal())?;
+    // A sandbox has at most one parked step outstanding, but that step can hold
+    // several calls at once. The one being executed is what the run is actually
+    // doing, so it wins; otherwise the first still-live call in emission order
+    // stands for the step. Terminal checkpoints produce nothing, so an older
+    // completed activity cannot linger after the run has advanced.
+    let call = calls
+        .iter()
+        .find(|call| call.status == SandboxToolCallStatus::Claimed)
+        .or_else(|| calls.iter().find(|call| !call.status.is_terminal()))?;
     let kind = match call.name.as_str() {
         openwave_core::SANDBOX_EXEC_TOOL => AgentActivityKind::Exec,
         "web_search" => AgentActivityKind::WebSearch,

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -29,7 +29,7 @@ use openwave_core::{
     ResumeTurnForAgentRunWaitSetOutcome, Role, SandboxToolCall, SandboxToolCallParkEntry,
     SandboxToolCallRequest, SandboxToolCallStatus, SecretProvider, StopReason, Store,
     SubmitAgentRunResultOutcome, ToolCallRecord, ToolCallResolution, TurnWebSearch,
-    MAX_SANDBOX_TOOL_CALLS, SANDBOX_EXEC_TOOL,
+    MAX_SANDBOX_TOOL_CALLS, MAX_SANDBOX_TOOL_CALLS_PER_STEP, SANDBOX_EXEC_TOOL,
 };
 use tokio::sync::Notify;
 
@@ -588,11 +588,14 @@ impl SandboxAgentRunWorker {
             provider_executed,
         } = step;
         let run_id = run.id;
-        let depth = previous_calls.len();
+        // Progress keys are per model step, not per parked row: one step can now
+        // park several calls, and a replayed claim must land on the same key.
+        let depth = sandbox_call_steps(&previous_calls).len();
+        let previous_rows = previous_calls.len();
         let outcome = match completion {
             SandboxCompletion::Final(text) => self.submit_result(&run, lease_token, text).await,
-            SandboxCompletion::ToolCall(intent) => {
-                self.park_sandbox_tool_call(run, lease_token, intent, &narration)
+            SandboxCompletion::ToolCalls(intents) => {
+                self.park_sandbox_tool_calls(run, lease_token, intents, previous_rows, &narration)
                     .await
             }
             SandboxCompletion::Done { outputs, summary } => {
@@ -859,88 +862,169 @@ impl SandboxAgentRunWorker {
         }
     }
 
-    /// Park one tool call as a durable checkpoint and release the run's lease.
+    /// Park one model step's tool calls as a single durable batch and release
+    /// the run's lease.
     ///
     /// Every sandbox tool that needs an executor parks the same way — only the
     /// tool name differs — so they share this body rather than each carrying
     /// its own copy of the crash-recovery reasoning below. A call the host
-    /// refused parks the same way with its answer already attached, so the
+    /// refused parks alongside them with its answer already attached, so the
     /// next step of the run reads it as an ordinary error result.
-    async fn park_sandbox_tool_call(
+    ///
+    /// The step is trimmed to what the run's remaining tool budget can hold
+    /// before anything is written: rows are the durable cost, and a batch the
+    /// store would refuse is worse than one honest refusal the model can read.
+    async fn park_sandbox_tool_calls(
         &self,
         run: AgentRun,
         lease_token: uuid::Uuid,
-        intent: SandboxToolCallIntent,
+        intents: Vec<SandboxToolCallIntent>,
+        previous_rows: usize,
         narration: &str,
     ) -> Result<SandboxAgentRunWorkerOutcome> {
-        let SandboxToolCallIntent {
-            provider_id,
-            name,
-            arguments,
-            disposition,
-        } = intent;
-        let entry = SandboxToolCallParkEntry {
-            call: SandboxToolCallRequest {
-                id: CallId::new(),
-                agent_run_id: run.id,
-                chat_id: run.chat_id,
-                provider_id,
-                name,
-                arguments,
-            },
-            resolution: match disposition {
-                SandboxToolCallDisposition::Execute => None,
-                SandboxToolCallDisposition::Rejected {
-                    error_code,
-                    message,
-                } => Some(ToolCallResolution::Failed {
-                    result: rejection_result(&message),
-                    error_code: error_code.to_owned(),
-                    error_detail: None,
-                }),
-            },
-        };
-        let call = &entry.call;
+        let emitted = intents.len();
+        let remaining = MAX_SANDBOX_TOOL_CALLS.saturating_sub(previous_rows);
+        if emitted == 0 || remaining == 0 {
+            // Tool advertisement is withdrawn before the budget runs out, so a
+            // step arriving with nothing left to spend has ignored a request
+            // that offered it no dispatchable tool at all.
+            return self
+                .record_failure(
+                    &run,
+                    lease_token,
+                    AgentError::msg("sandbox tool checkpoint has no budget to park into"),
+                )
+                .await;
+        }
+        let capacity = Ord::min(MAX_SANDBOX_TOOL_CALLS_PER_STEP, remaining);
+        let mut intents = intents;
+        let mut dropped = 0;
+        if emitted > capacity {
+            // The last call the step can afford is answered rather than run, so
+            // the model learns why the rest are missing. Everything past it is
+            // dropped outright: the transcript is rebuilt from rows, so a call
+            // with no row simply never happened and leaves no dangling tool use.
+            dropped = emitted - capacity;
+            intents.truncate(capacity);
+            let last = intents
+                .last_mut()
+                .expect("capacity is at least one when a step parks");
+            let (error_code, message) = if capacity == remaining {
+                (
+                    "tool_budget_exhausted",
+                    format!(
+                        "This task's tool budget is exhausted: this call and {dropped} other \
+                         call(s) in this step were not run. Finish with done."
+                    ),
+                )
+            } else {
+                (
+                    "too_many_calls_in_step",
+                    format!(
+                        "A step may make at most {MAX_SANDBOX_TOOL_CALLS_PER_STEP} tool calls: \
+                         this call and {dropped} other call(s) in this step were not run. Re-send \
+                         them in a later step."
+                    ),
+                )
+            };
+            last.disposition = SandboxToolCallDisposition::Rejected {
+                error_code,
+                message,
+            };
+        }
+        let entries: Vec<SandboxToolCallParkEntry> = intents
+            .into_iter()
+            .map(|intent| {
+                let SandboxToolCallIntent {
+                    provider_id,
+                    name,
+                    arguments,
+                    disposition,
+                } = intent;
+                SandboxToolCallParkEntry {
+                    call: SandboxToolCallRequest {
+                        id: CallId::new(),
+                        agent_run_id: run.id,
+                        chat_id: run.chat_id,
+                        provider_id,
+                        name,
+                        arguments,
+                    },
+                    resolution: match disposition {
+                        SandboxToolCallDisposition::Execute => None,
+                        SandboxToolCallDisposition::Rejected {
+                            error_code,
+                            message,
+                        } => Some(ToolCallResolution::Failed {
+                            result: rejection_result(&message),
+                            error_code: error_code.to_owned(),
+                            error_detail: None,
+                        }),
+                    },
+                }
+            })
+            .collect();
         let outcome = match self
             .store
-            .park_agent_run_for_sandbox_tool_call(run.id, lease_token, &entry)
+            .park_agent_run_for_sandbox_tool_calls(run.id, lease_token, &entries)
             .await
         {
             Ok(outcome) => outcome,
             Err(error) => {
                 // The local transaction may have committed before its response
-                // was lost. Recover only a checkpoint whose immutable payload
-                // and producing lease match this exact model completion; never
+                // was lost. Recover only a batch whose immutable payload and
+                // producing lease match this exact model completion; never
                 // issue a second model call or tool checkpoint on ambiguity.
-                let recovered = self
+                let mut recovered = self
                     .store
                     .list_sandbox_tool_calls_for_agent_run(run.id)
                     .await?
                     .into_iter()
-                    .find(|existing| {
-                        existing.park_lease_token == lease_token
-                            && existing.provider_id == call.provider_id
-                            && existing.name == call.name
-                            && existing.arguments == call.arguments
+                    .filter(|existing| existing.park_lease_token == lease_token)
+                    .collect::<Vec<_>>();
+                recovered.sort_by_key(|call| call.batch_ordinal);
+                let matches = recovered.len() == entries.len()
+                    && recovered.iter().zip(&entries).all(|(existing, entry)| {
+                        existing.provider_id == entry.call.provider_id
+                            && existing.name == entry.call.name
+                            && existing.arguments == entry.call.arguments
                     });
-                if let Some(call) = recovered {
-                    self.publish_progress(run.id, call.id, narration).await;
+                if matches {
+                    let head = recovered[0].id;
+                    self.publish_progress(run.id, head, narration).await;
                     self.wake.notify_one();
-                    return Ok(SandboxAgentRunWorkerOutcome::ToolCheckpointed(call.id));
+                    return Ok(SandboxAgentRunWorkerOutcome::ToolCheckpointed(head));
                 }
                 return Err(error);
             }
         };
         match outcome {
-            ParkSandboxToolCallOutcome::Parked { call, .. }
-            | ParkSandboxToolCallOutcome::Existing { call, .. } => {
-                self.publish_progress(run.id, call.id, narration).await;
+            ParkSandboxToolCallOutcome::Parked { calls, .. }
+            | ParkSandboxToolCallOutcome::Existing { calls, .. } => {
+                let head = calls
+                    .first()
+                    .ok_or_else(|| AgentError::msg("sandbox tool checkpoint parked no calls"))?
+                    .id;
+                // Keyed by the batch's first call so a replayed commit
+                // republishes nothing, exactly as a single checkpoint did.
+                self.publish_progress(run.id, head, narration).await;
+                if dropped > 0 {
+                    self.publish_note(
+                        run.id,
+                        &format!("call:{head}:dropped"),
+                        &format!(
+                            "Dropped {dropped} tool call(s) from this step: no room left in this \
+                             task's tool budget."
+                        ),
+                    )
+                    .await;
+                }
                 // This shared wake is only a latency hint; the dedicated
                 // executor's durable candidate scan remains the recovery path.
                 // A call the host already answered has no executor and simply
                 // ignores it.
                 self.wake.notify_one();
-                Ok(SandboxAgentRunWorkerOutcome::ToolCheckpointed(call.id))
+                Ok(SandboxAgentRunWorkerOutcome::ToolCheckpointed(head))
             }
             ParkSandboxToolCallOutcome::IdentityConflict => {
                 self.record_failure(
@@ -979,12 +1063,18 @@ impl SandboxAgentRunWorker {
         call_id: CallId,
         narration: &str,
     ) {
+        self.publish_note(run_id, &format!("call:{call_id}"), narration)
+            .await;
+    }
+
+    /// Publish one observation under an exact idempotency key.
+    async fn publish_note(&self, run_id: openwave_core::AgentRunId, key: &str, narration: &str) {
         if narration.trim().is_empty() {
             return;
         }
         if let Err(error) = self
             .store
-            .append_agent_run_progress(run_id, &format!("call:{call_id}"), narration)
+            .append_agent_run_progress(run_id, key, narration)
             .await
         {
             eprintln!("openwave: could not publish progress for run {run_id}: {error}");
@@ -1085,6 +1175,31 @@ fn delegated_file_admission_matches(
         })
 }
 
+/// Split a run's parked calls into the model steps that produced them.
+///
+/// The list arrives ordered by park attempt, park claim, then batch ordinal, so
+/// each step is a contiguous run of rows sharing one park identity, and the
+/// ordinal is the order within it.
+fn sandbox_call_steps(calls: &[SandboxToolCall]) -> Vec<&[SandboxToolCall]> {
+    let mut steps = Vec::new();
+    let mut start = 0;
+    for index in 1..=calls.len() {
+        let boundary = index == calls.len()
+            || (
+                calls[index].park_attempt_count,
+                calls[index].park_claim_count,
+            ) != (
+                calls[start].park_attempt_count,
+                calls[start].park_claim_count,
+            );
+        if boundary {
+            steps.push(&calls[start..index]);
+            start = index;
+        }
+    }
+    steps
+}
+
 async fn sandbox_request(
     config: &AgentConfig,
     task: String,
@@ -1092,41 +1207,55 @@ async fn sandbox_request(
     store: &dyn Store,
     delegated_file_available: bool,
 ) -> Result<ChatRequest> {
-    if calls.len() > MAX_SANDBOX_TOOL_CALLS {
+    // Two different budgets ride on this list. Rows are what the run has spent
+    // of its durable tool allowance; steps are how many model completions it
+    // has already needed. One step can now hold several rows, so they diverge.
+    let rows = calls.len();
+    let steps = sandbox_call_steps(calls);
+    if rows > MAX_SANDBOX_TOOL_CALLS {
         return Err(AgentError::msg("sandbox tool budget exceeded"));
     }
-    if config.max_steps == 0 || calls.len().saturating_add(1) > config.max_steps {
+    if config.max_steps == 0 || steps.len().saturating_add(1) > config.max_steps {
         return Err(AgentError::msg("sandbox model-step budget exceeded"));
     }
     let mut messages = vec![ChatMessage::text(Role::User, task)];
-    for call in calls {
+    for step in &steps {
         // The row's name is the model's own emitted name — dispatch data, not
         // a replay contract. A call the host refused replays exactly like one
         // an executor ran: what matters is that it is finished and has an
         // answer to hand back.
-        if !call.status.is_terminal() {
-            return Err(AgentError::msg("sandbox checkpoint cannot be resumed"));
-        }
-        let receipt = store
-            .get_sandbox_tool_call_receipt(call.id)
-            .await?
-            .ok_or_else(|| AgentError::msg("sandbox checkpoint is missing its receipt"))?;
-        messages.push(ChatMessage {
-            role: Role::Assistant,
-            content: vec![ContentBlock::ToolUse {
+        let mut tool_uses = Vec::with_capacity(step.len());
+        let mut tool_results = Vec::with_capacity(step.len());
+        for call in *step {
+            if !call.status.is_terminal() {
+                return Err(AgentError::msg("sandbox checkpoint cannot be resumed"));
+            }
+            let receipt = store
+                .get_sandbox_tool_call_receipt(call.id)
+                .await?
+                .ok_or_else(|| AgentError::msg("sandbox checkpoint is missing its receipt"))?;
+            tool_uses.push(ContentBlock::ToolUse {
                 id: call.provider_id.clone(),
                 name: call.name.clone(),
                 input: call.arguments.clone(),
-            }],
+            });
+            tool_results.push(ContentBlock::ToolResult {
+                tool_use_id: call.provider_id.clone(),
+                content: receipt.result,
+                is_error: receipt.status != SandboxToolCallStatus::Completed,
+            });
+        }
+        // One step is one assistant message carrying all of its tool uses, then
+        // one message carrying all of their results — the shape the model
+        // produced, so the shape it reads back.
+        messages.push(ChatMessage {
+            role: Role::Assistant,
+            content: tool_uses,
             reasoning: MessageReasoning::default(),
         });
         messages.push(ChatMessage {
             role: Role::User,
-            content: vec![ContentBlock::ToolResult {
-                tool_use_id: call.provider_id.clone(),
-                content: receipt.result,
-                is_error: receipt.status != SandboxToolCallStatus::Completed,
-            }],
+            content: tool_results,
             reasoning: MessageReasoning::default(),
         });
     }
@@ -1144,8 +1273,7 @@ async fn sandbox_request(
         // can pay for both — never advertise work the budget cannot consume. The
         // checkpoint count is bounded separately: the whole chain is replayed on
         // every claim, so it is a working budget rather than an open loop.
-        tools: if calls.len() < MAX_SANDBOX_TOOL_CALLS
-            && calls.len().saturating_add(2) <= config.max_steps
+        tools: if rows < MAX_SANDBOX_TOOL_CALLS && steps.len().saturating_add(2) <= config.max_steps
         {
             let mut tools = vec![sandbox_exec_tool_spec()];
             // The host tool and the provider's own search are one capability
@@ -1162,7 +1290,7 @@ async fn sandbox_request(
                 tools.push(sandbox_read_delegated_file_tool_spec());
             }
             tools
-        } else if calls.len().saturating_add(1) <= config.max_steps {
+        } else if steps.len().saturating_add(1) <= config.max_steps {
             // Both of these terminate the run in place of a final answer, so
             // they need no follow-up completion and stay available to the last
             // step. Submission especially: a run that spent its budget writing
@@ -1246,8 +1374,10 @@ enum SandboxCompletion {
         outputs: Vec<String>,
         summary: String,
     },
-    /// One tool call the model made, to dispatch or to answer in place.
-    ToolCall(SandboxToolCallIntent),
+    /// Every tool call one model step made, in the order it emitted them.
+    /// Each is either dispatched or answered in place; the step parks as one
+    /// batch either way. Never empty.
+    ToolCalls(Vec<SandboxToolCallIntent>),
     FolderAccessProposal {
         request: RequestFolderAccessArgs,
     },
@@ -1429,22 +1559,32 @@ async fn complete_sandbox_task(
                     ));
                 }
                 if reason == StopReason::ToolUse {
-                    if calls.len() != 1 {
+                    if calls.is_empty() {
                         return Err(AgentError::msg(
-                            "sandbox agent emitted an ambiguous tool checkpoint",
+                            "sandbox agent stopped for tool use without a tool call",
                         ));
                     }
-                    let (_, (provider_id, name, arguments)) = calls.into_iter().next().unwrap();
-                    let intent = classify_sandbox_tool_call(
-                        provider_id,
-                        name,
-                        &arguments,
-                        &advertised_tools,
-                    )?;
+                    // The map is keyed by the provider's own call index, so
+                    // draining it in order is the order the model emitted them
+                    // — which becomes the batch's durable order.
+                    let mut intents = Vec::with_capacity(calls.len());
+                    for (_, (provider_id, name, arguments)) in calls {
+                        intents.push(classify_sandbox_tool_call(
+                            provider_id,
+                            name,
+                            &arguments,
+                            &advertised_tools,
+                        )?);
+                    }
                     // These two end the run in place rather than parking work,
                     // so they are consumed here and their narration is dropped
-                    // — the result they carry already speaks for the run.
-                    if matches!(intent.disposition, SandboxToolCallDisposition::Execute) {
+                    // — the result they carry already speaks for the run. That
+                    // only works when the step asked for nothing else: a run
+                    // cannot both finish and still have work outstanding.
+                    if intents.len() == 1
+                        && matches!(intents[0].disposition, SandboxToolCallDisposition::Execute)
+                    {
+                        let intent = intents.remove(0);
                         if intent.name == openwave_core::SANDBOX_DONE_TOOL {
                             let arguments =
                                 serde_json::from_value::<openwave_core::SandboxDoneArgs>(
@@ -1476,10 +1616,35 @@ async fn complete_sandbox_task(
                                 provider_executed,
                             });
                         }
+                        intents.push(intent);
+                    } else {
+                        // A terminal tool that arrived with company is answered
+                        // rather than obeyed. Its siblings are real work the
+                        // model asked for and still get run; only the attempt to
+                        // finish in the same breath is refused.
+                        for intent in &mut intents {
+                            if !matches!(intent.disposition, SandboxToolCallDisposition::Execute) {
+                                continue;
+                            }
+                            let terminal = intent.name == openwave_core::SANDBOX_DONE_TOOL
+                                || intent.name == openwave_core::REQUEST_FOLDER_ACCESS_TOOL;
+                            if terminal {
+                                let name = &intent.name;
+                                let message = format!(
+                                    "{name} must be the only tool call in a step. The other calls \
+                                     in this step were run; call {name} alone once you have their \
+                                     results."
+                                );
+                                intent.disposition = SandboxToolCallDisposition::Rejected {
+                                    error_code: "must_be_alone",
+                                    message,
+                                };
+                            }
+                        }
                     }
                     return Ok(SandboxStep {
                         narration: text,
-                        completion: SandboxCompletion::ToolCall(intent),
+                        completion: SandboxCompletion::ToolCalls(intents),
                         provider_executed,
                     });
                 }
@@ -1740,6 +1905,72 @@ mod tests {
                 vec![
                     ProviderEvent::TextDelta {
                         text: "answer from two searches".into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::EndTurn,
+                    },
+                ]
+            };
+            Ok(stream::iter(events).boxed())
+        }
+    }
+
+    /// One step that emits three calls at once: a command, a search, and a tool
+    /// the run was never offered. The step after it finishes the run.
+    #[derive(Default)]
+    struct ThreeCallStepThenFinalProvider {
+        requests: Mutex<Vec<ChatRequest>>,
+    }
+
+    #[async_trait]
+    impl ModelProvider for ThreeCallStepThenFinalProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("sandbox-batch")
+        }
+
+        async fn stream(&self, request: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            let call_number = {
+                let mut requests = self.requests.lock().unwrap();
+                requests.push(request);
+                requests.len()
+            };
+            let events = if call_number == 1 {
+                vec![
+                    ProviderEvent::ToolCallStarted {
+                        index: 0,
+                        id: "exec_1".into(),
+                        name: SANDBOX_EXEC_TOOL.into(),
+                    },
+                    ProviderEvent::ToolCallArgsDelta {
+                        index: 0,
+                        fragment: r#"{"command":"ls"}"#.into(),
+                    },
+                    ProviderEvent::ToolCallStarted {
+                        index: 1,
+                        id: "search_1".into(),
+                        name: openwave_core::SANDBOX_WEB_SEARCH_TOOL.into(),
+                    },
+                    ProviderEvent::ToolCallArgsDelta {
+                        index: 1,
+                        fragment: r#"{"query":"OpenWave"}"#.into(),
+                    },
+                    ProviderEvent::ToolCallStarted {
+                        index: 2,
+                        id: "read_1".into(),
+                        name: "read_file".into(),
+                    },
+                    ProviderEvent::ToolCallArgsDelta {
+                        index: 2,
+                        fragment: r#"{"path":"notes.md"}"#.into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::ToolUse,
+                    },
+                ]
+            } else {
+                vec![
+                    ProviderEvent::TextDelta {
+                        text: "answer from one parallel step".into(),
                     },
                     ProviderEvent::Stop {
                         reason: StopReason::EndTurn,
@@ -2458,6 +2689,146 @@ mod tests {
         );
     }
 
+    /// A step that asks for several things at once. The whole point of the
+    /// batch: three calls park together, the run stays parked until the last
+    /// live one is answered, and the next request replays the step as the model
+    /// produced it — one assistant message holding all three tool uses, one
+    /// message holding all three results, in emission order.
+    #[tokio::test]
+    async fn one_step_parks_its_calls_as_a_batch_and_replays_them_together() {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = sandbox_chat();
+        store.create_chat(&chat).await.unwrap();
+        let provider = Arc::new(ThreeCallStepThenFinalProvider::default());
+        let worker = SandboxAgentRunWorker::new(
+            store.clone(),
+            test_secrets(),
+            Arc::new(FixedResolver(provider.clone())),
+            Arc::new(Notify::new()),
+            Arc::new(Notify::new()),
+            Arc::new(EventBus::default()),
+            AgentConfig {
+                model: "sandbox-model".into(),
+                max_steps: 4,
+                ..AgentConfig::default()
+            },
+            None,
+            SandboxAgentRunWorkerConfig::default(),
+        );
+        let spawn = CallId::new();
+        let id = openwave_core::AgentRunId::sandbox_for_spawn_call(spawn);
+        admit_sandbox(&store, chat.id, spawn, "Do three things.").await;
+
+        assert!(matches!(
+            worker.run_once().await.unwrap(),
+            SandboxAgentRunWorkerOutcome::ToolCheckpointed(_)
+        ));
+        let parked = store
+            .list_sandbox_tool_calls_for_agent_run(id)
+            .await
+            .unwrap();
+        assert_eq!(
+            parked
+                .iter()
+                .map(|call| (call.batch_ordinal, call.name.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                (0, SANDBOX_EXEC_TOOL),
+                (1, openwave_core::SANDBOX_WEB_SEARCH_TOOL),
+                (2, "read_file"),
+            ]
+        );
+        // The unadvertised call is answered inside the same park, so it lands
+        // terminal with its receipt already attached and no lane ever sees it.
+        assert!(parked[2].status.is_terminal());
+        let refusal = store
+            .get_sandbox_tool_call_receipt(parked[2].id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(refusal.status, SandboxToolCallStatus::Failed);
+        assert_eq!(
+            store.get_agent_run(id).await.unwrap().unwrap().status,
+            AgentRunStatus::Waiting
+        );
+
+        for (index, result) in [(0, "exec output"), (1, "{\"results\":[]}")] {
+            let executor_lease = uuid::Uuid::new_v4();
+            store
+                .claim_sandbox_tool_call(
+                    parked[index].id,
+                    executor_lease,
+                    chrono::Duration::minutes(1),
+                )
+                .await
+                .unwrap();
+            store
+                .resolve_sandbox_tool_call(
+                    parked[index].id,
+                    executor_lease,
+                    &ToolCallResolution::Completed {
+                        result: result.into(),
+                    },
+                )
+                .await
+                .unwrap();
+            // The run resumes on the last receipt of the step, not the first.
+            let expected = if index == 0 {
+                AgentRunStatus::Waiting
+            } else {
+                AgentRunStatus::RetryWait
+            };
+            assert_eq!(
+                store.get_agent_run(id).await.unwrap().unwrap().status,
+                expected
+            );
+        }
+
+        assert_eq!(
+            worker.run_once().await.unwrap(),
+            SandboxAgentRunWorkerOutcome::Completed(id)
+        );
+        let after = store.get_agent_run(id).await.unwrap().unwrap();
+        assert_eq!(after.attempt_count, 1);
+        let requests = provider.requests.lock().unwrap();
+        assert_eq!(requests.len(), 2);
+        let replay = &requests[1].messages;
+        let uses: Vec<&str> = replay[1]
+            .content
+            .iter()
+            .map(|block| match block {
+                ContentBlock::ToolUse { id, .. } => id.as_str(),
+                other => panic!("unexpected assistant block: {other:?}"),
+            })
+            .collect();
+        assert_eq!(uses, vec!["exec_1", "search_1", "read_1"]);
+        let results: Vec<(&str, bool)> = replay[2]
+            .content
+            .iter()
+            .map(|block| match block {
+                ContentBlock::ToolResult {
+                    tool_use_id,
+                    is_error,
+                    ..
+                } => (tool_use_id.as_str(), *is_error),
+                other => panic!("unexpected result block: {other:?}"),
+            })
+            .collect();
+        assert_eq!(
+            results,
+            vec![("exec_1", false), ("search_1", false), ("read_1", true)]
+        );
+        assert_eq!(replay.len(), 3);
+    }
+
     #[tokio::test]
     async fn refuses_malformed_sandbox_tool_events_without_checkpointing() {
         let request = ChatRequest {
@@ -2474,21 +2845,6 @@ mod tests {
             ..Default::default()
         };
         for events in [
-            vec![
-                ProviderEvent::ToolCallStarted {
-                    index: 0,
-                    id: "one".into(),
-                    name: "web_search".into(),
-                },
-                ProviderEvent::ToolCallStarted {
-                    index: 1,
-                    id: "two".into(),
-                    name: "web_search".into(),
-                },
-                ProviderEvent::Stop {
-                    reason: StopReason::ToolUse,
-                },
-            ],
             vec![
                 ProviderEvent::ToolCallStarted {
                     index: 0,
@@ -2570,9 +2926,10 @@ mod tests {
         .await
         .unwrap()
         .completion;
-        let SandboxCompletion::ToolCall(intent) = completion else {
+        let SandboxCompletion::ToolCalls(intents) = completion else {
             panic!("an unadvertised tool must still produce a tool call");
         };
+        let [intent] = <[_; 1]>::try_from(intents).expect("one call");
         assert_eq!(intent.name, "read_file");
         let SandboxToolCallDisposition::Rejected {
             error_code,
@@ -2655,15 +3012,16 @@ mod tests {
         store.request_agent_run_cancellation(id).await.unwrap();
         assert_eq!(
             worker
-                .park_sandbox_tool_call(
+                .park_sandbox_tool_calls(
                     run,
                     lease,
-                    SandboxToolCallIntent {
+                    vec![SandboxToolCallIntent {
                         provider_id: "search_1".into(),
                         name: openwave_core::SANDBOX_WEB_SEARCH_TOOL.into(),
                         arguments: serde_json::json!({"query":"OpenWave"}),
                         disposition: SandboxToolCallDisposition::Execute,
-                    },
+                    }],
+                    0,
                     "",
                 )
                 .await
@@ -3456,9 +3814,10 @@ mod tests {
             .await
             .unwrap()
             .completion;
-        let SandboxCompletion::ToolCall(intent) = completion else {
+        let SandboxCompletion::ToolCalls(intents) = completion else {
             panic!("a withdrawn tool must still produce a tool call");
         };
+        let [intent] = <[_; 1]>::try_from(intents).expect("one call");
         assert!(matches!(
             intent.disposition,
             SandboxToolCallDisposition::Rejected {
@@ -3518,13 +3877,17 @@ mod tests {
         ]));
         assert!(matches!(
             complete_sandbox_task(provider, request).await.unwrap().completion,
-            SandboxCompletion::ToolCall(SandboxToolCallIntent {
-                ref name,
-                ref arguments,
-                disposition: SandboxToolCallDisposition::Execute,
-                ..
-            }) if name == openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL
-                && *arguments == serde_json::json!({})
+            SandboxCompletion::ToolCalls(ref intents)
+                if matches!(
+                    intents.as_slice(),
+                    [SandboxToolCallIntent {
+                        name,
+                        arguments,
+                        disposition: SandboxToolCallDisposition::Execute,
+                        ..
+                    }] if name == openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL
+                        && *arguments == serde_json::json!({})
+                )
         ));
     }
 
@@ -3561,9 +3924,10 @@ mod tests {
             .await
             .unwrap()
             .completion;
-        let SandboxCompletion::ToolCall(intent) = completion else {
+        let SandboxCompletion::ToolCalls(intents) = completion else {
             panic!("invalid delegated-file arguments must stay a tool call");
         };
+        let [intent] = <[_; 1]>::try_from(intents).expect("one call");
         assert_eq!(intent.arguments, serde_json::json!({"path":"secret"}));
         assert!(
             matches!(

--- a/crates/openwave-server/src/sandbox_exec_worker.rs
+++ b/crates/openwave-server/src/sandbox_exec_worker.rs
@@ -710,10 +710,10 @@ mod tests {
         };
         assert!(matches!(
             store
-                .park_agent_run_for_sandbox_tool_call(
+                .park_agent_run_for_sandbox_tool_calls(
                     run.id,
                     worker_lease,
-                    &crate::tests::dispatchable(&request)
+                    &[crate::tests::dispatchable(&request)]
                 )
                 .await
                 .unwrap(),

--- a/crates/openwave-server/src/sandbox_web_search_worker.rs
+++ b/crates/openwave-server/src/sandbox_web_search_worker.rs
@@ -645,10 +645,10 @@ mod tests {
         };
         assert!(matches!(
             store
-                .park_agent_run_for_sandbox_tool_call(
+                .park_agent_run_for_sandbox_tool_calls(
                     run.id,
                     worker_lease,
-                    &crate::tests::dispatchable(&request)
+                    &[crate::tests::dispatchable(&request)]
                 )
                 .await
                 .unwrap(),

--- a/crates/openwave-server/src/tests/sandbox.rs
+++ b/crates/openwave-server/src/tests/sandbox.rs
@@ -138,10 +138,10 @@ async fn agent_run_snapshots_expose_only_safe_live_sandbox_activity() {
     };
     assert!(matches!(
         store
-            .park_agent_run_for_sandbox_tool_call(
+            .park_agent_run_for_sandbox_tool_calls(
                 run.id,
                 worker_lease,
-                &crate::tests::dispatchable(&checkpoint)
+                &[crate::tests::dispatchable(&checkpoint)]
             )
             .await
             .unwrap(),
@@ -250,10 +250,10 @@ async fn agent_run_activity_history_is_ordered_typed_and_names_submitted_files()
     };
     assert!(matches!(
         store
-            .park_agent_run_for_sandbox_tool_call(
+            .park_agent_run_for_sandbox_tool_calls(
                 run.id,
                 worker_lease,
-                &crate::tests::dispatchable(&exec)
+                &[crate::tests::dispatchable(&exec)]
             )
             .await
             .unwrap(),
@@ -308,10 +308,10 @@ async fn agent_run_activity_history_is_ordered_typed_and_names_submitted_files()
     };
     assert!(matches!(
         store
-            .park_agent_run_for_sandbox_tool_call(
+            .park_agent_run_for_sandbox_tool_calls(
                 run.id,
                 search_worker_lease,
-                &crate::tests::dispatchable(&search)
+                &[crate::tests::dispatchable(&search)]
             )
             .await
             .unwrap(),
@@ -709,10 +709,10 @@ async fn delegated_file_routes_are_native_only_and_expose_only_exact_broker_auth
         arguments: serde_json::json!({}),
     };
     store
-        .park_agent_run_for_sandbox_tool_call(
+        .park_agent_run_for_sandbox_tool_calls(
             child.id,
             worker_lease,
-            &crate::tests::dispatchable(&call),
+            &[crate::tests::dispatchable(&call)],
         )
         .await
         .unwrap();
@@ -1194,10 +1194,10 @@ async fn parent_turn_cancellation_signals_its_exact_running_child_search() {
     };
     assert!(matches!(
         store
-            .park_agent_run_for_sandbox_tool_call(
+            .park_agent_run_for_sandbox_tool_calls(
                 run.id,
                 model_lease,
-                &crate::tests::dispatchable(&request)
+                &[crate::tests::dispatchable(&request)]
             )
             .await
             .unwrap(),


### PR DESCRIPTION
A model step that emitted more than one tool call used to fail the run attempt
with "ambiguous tool checkpoint". Every retry replays the same transcript, so a
model that naturally batches its calls — run a command, search, and read a file
in one breath — burned its whole attempt budget on a shape the host simply did
not support. A step's calls now park together as one durable batch, execute with
bounded concurrency, and replay as the model produced them.

## Behavior

- A step's N calls are inserted in one transaction under one park lease, each
  carrying its emission position as `batch_ordinal`.
- They replay as one assistant message holding N `tool_use` blocks and one
  message holding the N matching `tool_result` blocks, in emission order.
- `done` and `request_folder_access` still end the run in place, but only when
  they are the step's only call. Emitted alongside other work they are answered
  with a `must_be_alone` error result while their siblings still run — the model
  gets the results it asked for and can finish on the next step.
- A step that would cross the run's total tool budget parks what fits, answers
  the first call it cannot afford with `tool_budget_exhausted`, and drops the
  rest. The transcript is rebuilt from rows, so a dropped call never existed and
  leaves no dangling `tool_use`.

## Resume when the batch settles

`resolve_sandbox_tool_call` and `resolve_delegated_file_read` no longer move the
run out of `waiting` unconditionally. They commit the receipt and the call's
transition, then ask a shared helper whether any non-terminal row is left for the
run; only when none is does the run go back on the schedule. The important part
is what this replaced: the old `rows_affected != 1 -> rollback -> LeaseLost`
branch would have discarded a perfectly good receipt every time a step's first
call finished ahead of its siblings. Lease loss is now reserved for the
pre-checks that already detected it (call not claimed under this lease, run not
waiting). The park gate guarantees at most one step is outstanding, so counting
the run's own live rows is the whole test.

## Why execs serialize

Read-only calls — web search, delegated file reads — are claimable the moment
they land. `exec` is not: the run has one workspace, and the model emitted its
commands expecting each to see the previous one's effects. Before granting an
exec lease the claim path checks for an earlier still-live exec in the same
batch and, if it finds one, declines the claim without terminalizing anything.
The lane rescans on its idle loop and picks the call up once its predecessor
resolves; the candidate batch size is 16, so a blocked head cannot starve other
runs.

## Schema

`sandbox_tool_call` gains `batch_ordinal` (smallint, `>= 0`) and a unique index
on `(agent_run_id, park_attempt_count, park_claim_count, batch_ordinal)`, edited
into the baseline rather than added as a migration per the pre-v1 convention.
`DESKTOP_SCHEMA_EPOCH` goes to 12, which wipes local development databases on
next launch — expected before 1.0.

The activity read model is unchanged on the wire: `AgentRunSnapshot.activity`
stays singular, now selecting the claimed call if there is one and otherwise the
first still-live call of the step.

## Tests

- Added `one_step_parks_its_calls_as_a_batch_and_replays_them_together`: one step
  emits `exec` + `web_search` + an unadvertised `read_file`, and the test drives
  the run end to end — three rows at ordinals 0/1/2, the unadvertised row already
  terminal with an `is_error` receipt, the run still `waiting` after the first
  live call resolves and `retry_wait` only after the second, the next request
  carrying one assistant message with three tool uses and one message with three
  results in emission order, and the run completing on its original attempt.
- Added `execs_in_one_step_serialize_while_read_only_siblings_run_immediately`:
  the concurrency rule itself — the search sibling claims while the first command
  is live, the second command does not, and it becomes claimable (not terminal)
  once the first resolves.
- Removed the parallel-tool-calls row from the malformed-events table test: two
  calls in one step is now the supported path, not a malformed one. The
  incomplete-call, oversize-arguments, and empty-provider-id rows stay.
- Extended `a_pre_resolved_sandbox_park_lands_terminal_and_reschedules_the_run`
  to a two-entry all-synthetic batch, since the "no executor will ever resolve
  this, reschedule instead of parking" rule now has to hold for a whole step.
- Extended `a_sandbox_run_may_checkpoint_repeatedly_up_to_a_bounded_chain` with
  one assertion that a batch crossing `MAX_SANDBOX_TOOL_CALLS` is refused whole.
- Extended `cancelling_waiting_sandbox_fences_claimed_tool_work` to a two-call
  batch with one call claimed and one accepted at cancellation; both end with
  cancelled receipts, which the old "multiple live calls" hard error made
  impossible.
- `a_run_checkpoints_more_than_once_and_replays_every_receipt_in_order` stays as
  the one-call-per-step regression; remaining changes are mechanical park call
  sites.

## CI

Labelled `full-ci`: the resolve and claim paths have Postgres-divergent
behavior (the live-row count and the conditional run transition run inside the
same transaction as the receipt), so the PostgreSQL turn-state lane needs to
see this.

Locally: `cargo test -p openwave-core` (574 passed) and
`cargo test -p openwave-server` (625 + 5 passed), `cargo check --workspace
--locked --all-targets` with no lockfile drift, `cargo fmt --check`, and clippy
clean on both crates.
