### PR TITLE
fix(desktop): accept path_prefix grant rungs when recovering pending approvals

### DIFF
--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -362,6 +362,34 @@ describe("pending approval recovery", () => {
     });
   });
 
+  // A pending write_file approval offers path_prefix rungs. Rejecting the
+  // variant made every chat with one pending unloadable (#1712), because one
+  // invalid rung fails the whole hydration response.
+  it("accepts the path_prefix rungs a write_file approval offers", () => {
+    expect(
+      parsePendingToolApproval({
+        ...safe,
+        action: "write_file",
+        approval: "workspace_may_modify_files",
+        class: "workspace",
+        preview: { tool: "write_file", path: "data/parser.js" },
+        grant_rungs: [
+          { path_prefix: { segments: 2 } },
+          { path_prefix: { segments: 1 } },
+        ],
+      })?.grantRungs,
+    ).toEqual([
+      { path_prefix: { segments: 2 } },
+      { path_prefix: { segments: 1 } },
+    ]);
+    expect(
+      parsePendingToolApproval({
+        ...safe,
+        grant_rungs: [{ path_prefix: { segments: 0 } }],
+      }),
+    ).toBeNull();
+  });
+
   it("drops a preview it cannot fully validate rather than half-rendering it", () => {
     const exec = {
       ...safe,

--- a/crates/openwave-desktop/ui/src/api/parsers.ts
+++ b/crates/openwave-desktop/ui/src/api/parsers.ts
@@ -742,20 +742,24 @@ export function parsePendingToolApproval(
 
 function parseApprovalGrantRung(value: unknown): ApprovalGrantRung | null {
   if (value === "exact_action" || value === "whole_tool") return value;
-  if (
-    !isRecord(value) ||
-    Object.keys(value).length !== 1 ||
-    !isRecord(value.command_prefix) ||
-    Object.keys(value.command_prefix).length !== 1
-  ) {
-    return null;
+  if (!isRecord(value) || Object.keys(value).length !== 1) return null;
+  if (isRecord(value.command_prefix)) {
+    if (Object.keys(value.command_prefix).length !== 1) return null;
+    const tokens = value.command_prefix.tokens;
+    return typeof tokens === "number" && Number.isInteger(tokens) && tokens > 0
+      ? { command_prefix: { tokens } }
+      : null;
   }
-  const tokens = value.command_prefix.tokens;
-  return typeof tokens === "number" &&
-    Number.isInteger(tokens) &&
-    tokens > 0
-    ? { command_prefix: { tokens } }
-    : null;
+  if (isRecord(value.path_prefix)) {
+    if (Object.keys(value.path_prefix).length !== 1) return null;
+    const segments = value.path_prefix.segments;
+    return typeof segments === "number" &&
+      Number.isInteger(segments) &&
+      segments > 0
+      ? { path_prefix: { segments } }
+      : null;
+  }
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Entering or reloading a chat while a `write_file` approval was pending rendered only "Could not load this chat: pending approval response contains an invalid item" — no transcript, no event socket — until the approval resolved from somewhere else. In Ask mode this state is easy to sit in for most of a turn.

The server offers `{"path_prefix":{"segments":N}}` grant rungs on workspace file writes, and the generated wire type (`ApprovalGrantRung`) includes the variant, but the hand-written `parseApprovalGrantRung` only accepted `exact_action`, `whole_tool`, and `command_prefix`. `listPendingApprovals` treats one unparseable rung as a fatally invalid response, and chat hydration turns that into the error state. The approval card's grant ladder already handles `path_prefix`; only the recovery parser lagged the wire type.

Reproduced live against a dev `openwave serve` (captured payload in #1712). Closes #1712.

## Testing

- New regression test mirroring the captured server payload (two `path_prefix` rungs on a `write_file` approval), plus a rejection case for non-positive `segments`.
- `pnpm vitest run src/api.test.ts src/ChatApprovalHydration.test.ts` — 51 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)