### PR TITLE
fix(desktop): keep tool phases together across assistant bubbles that render nothing

### DIFF
--- a/crates/openwave-desktop/ui/src/MessageList.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.test.tsx
@@ -137,16 +137,18 @@ describe("MessageBubble", () => {
   });
 
   // The live reducer opens assistant bubbles that render nothing (turn-start
-  // and resume boundaries). One between two calls split a phase the hydrated
-  // transcript later merges, so the groups visibly reshuffled at turn end
-  // (#1713). A trailing empty bubble is the response about to stream and must
-  // stay outside the phase.
-  it("keeps one phase across an assistant bubble that renders nothing", () => {
+  // and resume boundaries), and approval resume cycles can stack several in a
+  // row. Any such run between two calls split a phase the hydrated transcript
+  // later merges, so the groups visibly reshuffled at turn end (#1713). A
+  // trailing empty bubble is the response about to stream and must stay
+  // outside the phase.
+  it("keeps one phase across assistant bubbles that render nothing", () => {
     const messages: ChatMessage[] = [
       { id: "tool-1", role: "tool", callId: "call-1", name: "web_search", status: "completed" },
       { id: "assistant-1", role: "assistant", text: "", sources: [] },
-      { id: "tool-2", role: "tool", callId: "call-2", name: "read_file", status: "completed" },
       { id: "assistant-2", role: "assistant", text: "", sources: [] },
+      { id: "tool-2", role: "tool", callId: "call-2", name: "read_file", status: "completed" },
+      { id: "assistant-3", role: "assistant", text: "", sources: [] },
     ];
     const markup = renderToStaticMarkup(
       <MessageList

--- a/crates/openwave-desktop/ui/src/MessageList.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.test.tsx
@@ -136,6 +136,42 @@ describe("MessageBubble", () => {
     expect(markup).not.toContain("call-1");
   });
 
+  // The live reducer opens assistant bubbles that render nothing (turn-start
+  // and resume boundaries). One between two calls split a phase the hydrated
+  // transcript later merges, so the groups visibly reshuffled at turn end
+  // (#1713). A trailing empty bubble is the response about to stream and must
+  // stay outside the phase.
+  it("keeps one phase across an assistant bubble that renders nothing", () => {
+    const messages: ChatMessage[] = [
+      { id: "tool-1", role: "tool", callId: "call-1", name: "web_search", status: "completed" },
+      { id: "assistant-1", role: "assistant", text: "", sources: [] },
+      { id: "tool-2", role: "tool", callId: "call-2", name: "read_file", status: "completed" },
+      { id: "assistant-2", role: "assistant", text: "", sources: [] },
+    ];
+    const markup = renderToStaticMarkup(
+      <MessageList
+        messages={messages}
+        folderAccessRequests={[]}
+        nativeHost={false}
+        nativeBusy={false}
+        resolvingFolderCalls={new Set()}
+        folderAccessErrors={{}}
+        decidingApprovalCalls={new Set()}
+        approvalErrors={{}}
+        busy={false}
+        scrollRef={{ current: null }}
+        onScroll={noop}
+        onApproval={noop}
+        onFolderAccessDecision={noop}
+        onFolderAccessCancel={noop}
+      />,
+    );
+
+    expect(markup).toContain('aria-controls="tool-activity-group-0"');
+    expect(markup).not.toContain('aria-controls="tool-activity-group-1"');
+    expect(markup).toContain("Read a file and 1 other task");
+  });
+
   it("splits phases at the response between them", () => {
     const messages: ChatMessage[] = [
       { id: "tool-1", role: "tool", callId: "call-1", name: "web_search", status: "completed" },

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -519,6 +519,22 @@ function isActivityMessage(message: ChatMessage | undefined): boolean {
 }
 
 /**
+ * Whether an assistant entry renders nothing at all: no prose, no sources, no
+ * reasoning. The bubble component returns `null` for these, so nothing marks
+ * their position on screen — which is exactly why they must not carry any
+ * structural weight in grouping.
+ */
+function isInvisibleAssistant(message: ChatMessage | undefined): boolean {
+  return (
+    message !== undefined &&
+    message.role === "assistant" &&
+    !message.text &&
+    message.sources.length === 0 &&
+    !message.reasoning
+  );
+}
+
+/**
  * Whether the assistant bubble at `index` closes its turn. A turn's prose is
  * split into one bubble per activity phase it passed through, and the copy
  * action and timestamp belong to the turn, not to each fragment — so only
@@ -654,9 +670,27 @@ export function groupMessageItems(
     // One phase per contiguous run of activity, however long. A phase that
     // splits at every assistant sentence is not a phase.
     const phase: ChatMessage[] = [];
-    while (index < messages.length && isActivityMessage(messages[index])) {
-      phase.push(messages[index]!);
-      index += 1;
+    while (index < messages.length) {
+      if (isActivityMessage(messages[index])) {
+        phase.push(messages[index]!);
+        index += 1;
+        continue;
+      }
+      // An assistant bubble that renders nothing must not end the phase: the
+      // live reducer opens empty bubbles at turn-start and resume boundaries,
+      // and the hydrated snapshot has no such entries — so a phase split here
+      // would merge back when the turn settles, visibly reshuffling the
+      // transcript. Only a bubble *between* activity is swallowed; a trailing
+      // one is the response now streaming in, and stays outside the phase so
+      // gaining its first characters does not move the group boundary.
+      if (
+        isInvisibleAssistant(messages[index]) &&
+        isActivityMessage(messages[index + 1])
+      ) {
+        index += 1;
+        continue;
+      }
+      break;
     }
 
     // A call parked on approval is represented by its approval card, so the

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -680,15 +680,17 @@ export function groupMessageItems(
       // live reducer opens empty bubbles at turn-start and resume boundaries,
       // and the hydrated snapshot has no such entries — so a phase split here
       // would merge back when the turn settles, visibly reshuffling the
-      // transcript. Only a bubble *between* activity is swallowed; a trailing
-      // one is the response now streaming in, and stays outside the phase so
+      // transcript. Approval resume cycles can stack several in a row, so the
+      // whole run is swallowed when activity continues past it. A trailing
+      // run is the response now streaming in, and stays outside the phase so
       // gaining its first characters does not move the group boundary.
-      if (
-        isInvisibleAssistant(messages[index]) &&
-        isActivityMessage(messages[index + 1])
-      ) {
-        index += 1;
-        continue;
+      if (isInvisibleAssistant(messages[index])) {
+        let ahead = index + 1;
+        while (isInvisibleAssistant(messages[ahead])) ahead += 1;
+        if (isActivityMessage(messages[ahead])) {
+          index = ahead;
+          continue;
+        }
       }
       break;
     }


### PR DESCRIPTION
## Summary

During streaming, consecutive tool calls could render as several adjacent activity groups with nothing visible between them, then merge into one group when the turn completed — the transcript visibly reshuffled at the boundary (observed live in the browser-UI rig: `Updated a file and 2 other tasks` / `Run a command and 2 other tasks` / `Ran a command` collapsing into `Ran a command and 6 other tasks`; DOM dumps in #1713).

Cause: `groupMessageItems` ends an activity phase at any non-activity message, including assistant bubbles that render `null` (no text, no sources, no reasoning) — which the live reducer produces at turn-start and interrupt/resume boundaries. The hydrated snapshot has no such entries, so the streamed splits merge on swap.

Phase collection now swallows an invisible assistant bubble when activity continues past it. A trailing empty bubble (the response about to stream) deliberately stays outside the phase so its first characters don't move a group boundary. Purely a renderer change; hydrated transcripts are unaffected (they contain no empty bubbles).

Closes #1713.

## Testing

- New regression test: `[tool, empty assistant, tool, empty assistant]` renders one group ("Read a file and 1 other task"), trailing bubble outside.
- `pnpm vitest run` on the four MessageList/transcript suites — 73 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)