### PR TITLE
feat(plugins): connect bundled MCP servers from installed plugins

### DIFF
--- a/crates/openwave-code-execution/src/agent_plugins.rs
+++ b/crates/openwave-code-execution/src/agent_plugins.rs
@@ -728,6 +728,41 @@ fn is_valid_header_value(value: &str) -> bool {
         .all(|byte| byte == b'\t' || (0x20..0x7f).contains(&byte))
 }
 
+/// A single non-recursive textual pass expanding `${PLUGIN_ROOT}` and
+/// `${PLUGIN_DATA}` in `text`.
+///
+/// The specification allows this expansion in `args`, `env` values, and `cwd`
+/// only — never in `command`, `url`, or `headers` — and requires exactly one
+/// pass: replacement text is never rescanned, so a root whose own path
+/// contains `${PLUGIN_DATA}` cannot expand a second time. Anything that merely
+/// looks like a placeholder (`${HOME}`, a bare `${`, a `$PLUGIN_ROOT` without
+/// braces) is left in place literally rather than being treated as an error or
+/// silently dropped, because the specification's grammar recognizes exactly
+/// two names and says nothing about the rest.
+#[must_use]
+pub fn expand_plugin_placeholders(text: &str, root: &str, data: &str) -> String {
+    let mut expanded = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(start) = rest.find("${") {
+        expanded.push_str(&rest[..start]);
+        let after = &rest[start..];
+        if let Some(tail) = after.strip_prefix(&format!("${{{PLUGIN_ROOT_VARIABLE}}}")) {
+            expanded.push_str(root);
+            rest = tail;
+        } else if let Some(tail) = after.strip_prefix(&format!("${{{PLUGIN_DATA_VARIABLE}}}")) {
+            expanded.push_str(data);
+            rest = tail;
+        } else {
+            // Not a recognized placeholder: emit the `${` literally and keep
+            // scanning after it, so the text passes through unchanged.
+            expanded.push_str("${");
+            rest = &after[2..];
+        }
+    }
+    expanded.push_str(rest);
+    expanded
+}
+
 /// Render a validated configuration back as `mcp.json`.
 ///
 /// The installed copy is regenerated rather than copied so that only entries
@@ -1052,5 +1087,40 @@ mod tests {
             .config
             .servers
             .is_empty());
+    }
+
+    /// Contract: expansion is one pass over the text. Replacement text is
+    /// never rescanned — a root that itself spells a placeholder stays as
+    /// substituted — and anything the grammar does not name survives
+    /// literally instead of vanishing.
+    #[test]
+    fn placeholders_expand_once_and_unknown_ones_stay_literal() {
+        assert_eq!(
+            expand_plugin_placeholders(
+                "${PLUGIN_ROOT}/bin --state ${PLUGIN_DATA}/db",
+                "/pkg/reporting",
+                "/data/reporting"
+            ),
+            "/pkg/reporting/bin --state /data/reporting/db"
+        );
+        // The substituted root spells the other placeholder; a second pass
+        // would expand it, and must not.
+        assert_eq!(
+            expand_plugin_placeholders("${PLUGIN_ROOT}/x", "/${PLUGIN_DATA}", "/data"),
+            "/${PLUGIN_DATA}/x"
+        );
+        for literal in [
+            "${HOME}/x",
+            "$PLUGIN_ROOT",
+            "${PLUGIN_ROOT",
+            "${plugin_root}",
+            "${}",
+        ] {
+            assert_eq!(
+                expand_plugin_placeholders(literal, "/pkg", "/data"),
+                literal,
+                "{literal} should pass through untouched"
+            );
+        }
     }
 }

--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -36,14 +36,14 @@ mod tool;
 mod types;
 
 pub use agent_plugins::{
-    canonical_mcp_config, is_valid_agent_plugin_name, load_plugin_mcp_config,
-    parse_agent_plugin_manifest, parse_plugin_mcp_config, AgentPluginManifest,
-    AgentPluginParseError, IgnoredManifestField, McpConfigError, McpHttpServer, McpServer,
-    McpStdioServer, McpTransport, ParsedAgentPluginManifest, ParsedPluginMcpConfig,
-    PluginMcpConfig, SkippedMcpServer, AGENT_PLUGIN_MANIFEST_FILE, AGENT_PLUGIN_MCP_FILE,
-    AGENT_PLUGIN_MCP_SCHEMA_ID, AGENT_PLUGIN_SCHEMA_ID, AGENT_PLUGIN_SKILLS_DIR,
-    AGENT_PLUGIN_SPEC_VERSION, OPENWAVE_EXTENSION_NAMESPACE, PLUGIN_DATA_VARIABLE,
-    PLUGIN_ROOT_VARIABLE,
+    canonical_mcp_config, expand_plugin_placeholders, is_valid_agent_plugin_name,
+    load_plugin_mcp_config, parse_agent_plugin_manifest, parse_plugin_mcp_config,
+    AgentPluginManifest, AgentPluginParseError, IgnoredManifestField, McpConfigError,
+    McpHttpServer, McpServer, McpStdioServer, McpTransport, ParsedAgentPluginManifest,
+    ParsedPluginMcpConfig, PluginMcpConfig, SkippedMcpServer, AGENT_PLUGIN_MANIFEST_FILE,
+    AGENT_PLUGIN_MCP_FILE, AGENT_PLUGIN_MCP_SCHEMA_ID, AGENT_PLUGIN_SCHEMA_ID,
+    AGENT_PLUGIN_SKILLS_DIR, AGENT_PLUGIN_SPEC_VERSION, OPENWAVE_EXTENSION_NAMESPACE,
+    PLUGIN_DATA_VARIABLE, PLUGIN_ROOT_VARIABLE,
 };
 pub use daytona::{DaytonaCredential, DaytonaExecutionProvider, DAYTONA_CREDENTIAL_KEY};
 pub use e2b::{E2BCredential, E2BExecutionProvider, E2B_CREDENTIAL_KEY};

--- a/crates/openwave-core/src/config.rs
+++ b/crates/openwave-core/src/config.rs
@@ -122,6 +122,19 @@ impl Config {
         self.data_dir.join("prompts")
     }
 
+    /// The client-managed writable data directories bundled MCP servers are
+    /// given as `PLUGIN_DATA` (`{data_dir}/plugin-data/<plugin>/`).
+    ///
+    /// A sibling of `{data_dir}/plugins` rather than a directory inside a
+    /// plugin's own tree: the Agent Plugins specification requires this
+    /// directory to survive an update of the package, and the package tree is
+    /// exactly what an update replaces. Keeping it outside also means nothing
+    /// a plugin writes at runtime can change what the package claims to be.
+    #[must_use]
+    pub fn plugin_data_dir(&self) -> PathBuf {
+        self.data_dir.join("plugin-data")
+    }
+
     /// A desktop-profile config rooted at `data_dir`.
     pub fn desktop(data_dir: impl Into<PathBuf>) -> Self {
         Self {

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1262,7 +1262,15 @@ bearer_token_env: string | null,
  * resolved from the session at every connection and never enter this
  * type.
  */
-gateway_endpoint: string | null, request_timeout_ms: number, enabled: boolean, };
+gateway_endpoint: string | null, request_timeout_ms: number, enabled: boolean, 
+/**
+ * The plugin this server was synthesized from, when it is plugin-sourced.
+ *
+ * Read-only over the API: `PUT /mcp/servers` refuses a body that sets it,
+ * and the runtime rebuilds these entries from the installed plugin tree
+ * rather than from anything a client sends or the store holds.
+ */
+plugin: string | null, };
 
 /**
  * One renderer-safe server projection. Resolved `env_from` values and child
@@ -1310,7 +1318,15 @@ bearer_token_env: string | null,
  * resolved from the session at every connection and never enter this
  * type.
  */
-gateway_endpoint: string | null, request_timeout_ms: number, enabled: boolean, };
+gateway_endpoint: string | null, request_timeout_ms: number, enabled: boolean, 
+/**
+ * The plugin this server was synthesized from, when it is plugin-sourced.
+ *
+ * Read-only over the API: `PUT /mcp/servers` refuses a body that sets it,
+ * and the runtime rebuilds these entries from the installed plugin tree
+ * rather than from anything a client sends or the store holds.
+ */
+plugin: string | null, };
 
 export type McpServersInfo = { servers: Array<McpServerInfo>, };
 

--- a/crates/openwave-desktop/ui/src/settings/ConnectedAppsPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ConnectedAppsPanel.dom.test.tsx
@@ -26,6 +26,7 @@ const docsServer: McpServerInfo = {
   gateway_endpoint: null,
   request_timeout_ms: 60_000,
   enabled: true,
+  plugin: null,
   health: "healthy",
   tool_count: 3,
   diagnostic: null,

--- a/crates/openwave-desktop/ui/src/settings/McpPanel.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/McpPanel.test.tsx
@@ -31,6 +31,7 @@ const healthy: McpServersInfo = {
       gateway_endpoint: null,
       request_timeout_ms: 60_000,
       enabled: true,
+      plugin: null,
       health: "healthy",
       tool_count: 2,
       diagnostic: null,
@@ -65,6 +66,7 @@ function gatewayMount(
     gateway_endpoint: slug,
     request_timeout_ms: 60_000,
     enabled: true,
+    plugin: null,
     health: "healthy",
     tool_count: 3,
     diagnostic: null,
@@ -699,6 +701,7 @@ describe("McpPanel", () => {
           gateway_endpoint: null,
           request_timeout_ms: 60_000,
           enabled: true,
+          plugin: null,
         },
         expect.objectContaining({
           gateway_endpoint: "example-security-tools",

--- a/crates/openwave-desktop/ui/src/settings/McpPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/McpPanel.tsx
@@ -42,6 +42,7 @@ function emptyServer(index: number): McpServerInfo {
     gateway_endpoint: null,
     request_timeout_ms: DEFAULT_TIMEOUT_MS,
     enabled: true,
+    plugin: null,
     health: "initializing",
     tool_count: 0,
     diagnostic: null,
@@ -150,6 +151,32 @@ function definition(server: McpServerInfo): McpServerDefinition {
     ...value
   } = server;
   return value;
+}
+
+/**
+ * A server a plugin brings with it. It is listed because the tools it mounts
+ * are as real as any other server's, and read-only because its definition
+ * ships inside the package: the plugin's own switch is what turns it off.
+ */
+function PluginServerSection({ server }: { server: McpServerInfo }) {
+  return (
+    <SettingsSection title={server.name}>
+      <SettingsStatus
+        tone={healthTone(server.health)}
+        label={healthLabel(server.health)}
+        description={
+          server.health === "healthy"
+            ? `${server.tool_count} tool${server.tool_count === 1 ? "" : "s"} available to new turns.`
+            : (server.diagnostic ?? "This server is not connected.")
+        }
+      />
+      <p className="text-sm leading-relaxed text-muted-foreground">
+        Provided by the <code>{server.plugin}</code> plugin. Its configuration
+        ships with the package, so it is not edited here — turn the plugin off
+        under Plugins to disconnect it and unmount its tools.
+      </p>
+    </SettingsSection>
+  );
 }
 
 export function McpPanel({
@@ -329,7 +356,9 @@ export function McpPanel({
     setSaving(true);
     setError(null);
     try {
-      const result = await client.putMcpServers(servers.map(definition));
+      const result = await client.putMcpServers(
+        servers.filter((server) => server.plugin === null).map(definition),
+      );
       // Supersede any in-flight background read; this list is fresher.
       requestRef.current += 1;
       setServers(result.servers);
@@ -352,7 +381,9 @@ export function McpPanel({
     setMounting(true);
     setError(null);
     try {
-      const current = (await client.listMcpServers()).servers.map(definition);
+      const current = (await client.listMcpServers()).servers
+        .filter((server) => server.plugin === null)
+        .map(definition);
       const without = current.filter(
         (server) => server.gateway_endpoint !== slug,
       );
@@ -604,7 +635,10 @@ export function McpPanel({
             </SettingsSection>
           )}
 
-          {servers.map((server, index) => (
+          {servers.map((server, index) =>
+            server.plugin !== null ? (
+              <PluginServerSection key={index} server={server} />
+            ) : (
             <SettingsSection
               key={index}
               title={server.name || `Server ${index + 1}`}
@@ -863,7 +897,8 @@ export function McpPanel({
                 )}
               </div>
             </SettingsSection>
-          ))}
+            ),
+          )}
 
           <div className="flex flex-wrap gap-2">
             <Button
@@ -983,6 +1018,7 @@ function mountDefinition(slug: string, name: string): McpServerDefinition {
     gateway_endpoint: slug,
     request_timeout_ms: DEFAULT_TIMEOUT_MS,
     enabled: true,
+    plugin: null,
   };
 }
 

--- a/crates/openwave-mcp/src/client.rs
+++ b/crates/openwave-mcp/src/client.rs
@@ -229,9 +229,39 @@ impl McpClient {
         initialization_timeout: Duration,
         request_timeout: Duration,
     ) -> Result<Self> {
+        Self::connect_http_with_headers(
+            server_name,
+            url,
+            bearer_token,
+            &std::collections::BTreeMap::new(),
+            initialization_timeout,
+            request_timeout,
+        )
+        .await
+    }
+
+    /// [`Self::connect_http_with_timeouts`] with static headers sent on every
+    /// request.
+    ///
+    /// This exists for configuration sources that declare their own headers —
+    /// a plugin's bundled `mcp.json` does. A header naming something the
+    /// transport generates itself (`authorization`, `accept`,
+    /// `mcp-protocol-version`, `mcp-session-id`, `host`, `content-*`) is
+    /// dropped rather than merged, and no configured header ever reaches a
+    /// second origin because this transport does not follow redirects at all.
+    /// Values are never logged.
+    pub async fn connect_http_with_headers(
+        server_name: impl Into<String>,
+        url: &str,
+        bearer_token: Option<&str>,
+        headers: &std::collections::BTreeMap<String, String>,
+        initialization_timeout: Duration,
+        request_timeout: Duration,
+    ) -> Result<Self> {
         let server_name = server_name.into();
         validate_server_name(&server_name)?;
-        let wire = HttpWire::new(url, bearer_token)?;
+        let wire =
+            HttpWire::with_headers(url, bearer_token, crate::http::static_headers(headers)?)?;
         let client =
             Self::connect_session(server_name, Session::http(wire, initialization_timeout)).await?;
         client.session.lock().await.request_timeout = request_timeout;

--- a/crates/openwave-mcp/src/http.rs
+++ b/crates/openwave-mcp/src/http.rs
@@ -25,8 +25,50 @@ pub(crate) struct HttpWire {
     /// Prebuilt `Bearer …` header value; kept whole so the raw token never
     /// travels through formatting code that could end up in an error.
     authorization: Option<String>,
+    /// Static headers the connection was configured with, already validated
+    /// and stripped of every name this transport generates itself. Sent on
+    /// every request, and — like the bearer — never logged or echoed into an
+    /// error: a configured header may carry a credential even though the
+    /// source that declared it is not treated as a secret store.
+    configured: reqwest::header::HeaderMap,
     /// Server-assigned session, echoed on every request once issued.
     session_id: Option<String>,
+}
+
+/// The header names this transport generates for itself. A configured header
+/// naming one is dropped rather than merged: the client-generated value wins
+/// on conflict, and `host`/`content-*` belong to the request the transport
+/// builds, not to configuration.
+const RESERVED_HEADERS: [&str; 7] = [
+    "accept",
+    "authorization",
+    "content-length",
+    "content-type",
+    "host",
+    PROTOCOL_VERSION_HEADER,
+    SESSION_ID_HEADER,
+];
+
+/// Turn configured `name: value` pairs into a header map, dropping the names
+/// the transport generates itself.
+///
+/// Errors name only the offending *header name* — never its value.
+pub(crate) fn static_headers(
+    headers: &std::collections::BTreeMap<String, String>,
+) -> Result<reqwest::header::HeaderMap> {
+    let mut map = reqwest::header::HeaderMap::new();
+    for (name, value) in headers {
+        let lowercase = name.to_ascii_lowercase();
+        if RESERVED_HEADERS.contains(&lowercase.as_str()) {
+            continue;
+        }
+        let name = reqwest::header::HeaderName::from_bytes(lowercase.as_bytes())
+            .map_err(|_| mcp_message("configured MCP header name is not a valid HTTP field"))?;
+        let value = reqwest::header::HeaderValue::from_str(value)
+            .map_err(|_| mcp_message("configured MCP header value is not a valid field value"))?;
+        map.insert(name, value);
+    }
+    Ok(map)
 }
 
 /// Validate a candidate MCP server URL without connecting.
@@ -51,7 +93,11 @@ pub fn validate_http_url(url: &str) -> Result<()> {
 }
 
 impl HttpWire {
-    pub(crate) fn new(url: &str, bearer_token: Option<&str>) -> Result<Self> {
+    pub(crate) fn with_headers(
+        url: &str,
+        bearer_token: Option<&str>,
+        configured: reqwest::header::HeaderMap,
+    ) -> Result<Self> {
         validate_http_url(url)?;
         let url =
             reqwest::Url::parse(url).map_err(|_| mcp_message("external server URL is invalid"))?;
@@ -66,12 +112,16 @@ impl HttpWire {
             client: reqwest::Client::builder()
                 // A credentialed client must not follow redirects: reqwest
                 // strips Authorization cross-host, but a same-host https→http
-                // downgrade would resend the bearer in cleartext.
+                // downgrade would resend the bearer in cleartext. This is also
+                // what keeps configured static headers — which reqwest knows
+                // nothing about and would carry across a hop — from ever
+                // reaching a different origin.
                 .redirect(reqwest::redirect::Policy::none())
                 .build()
                 .map_err(|error| mcp_error("could not build HTTP client", error))?,
             url,
             authorization: bearer_token.map(|token| format!("Bearer {token}")),
+            configured,
             session_id: None,
         })
     }
@@ -150,22 +200,37 @@ impl HttpWire {
             }
             None => self.authorization.clone(),
         };
-        let mut request = self
-            .client
-            .post(self.url.clone())
-            .header(
-                reqwest::header::ACCEPT,
-                "application/json, text/event-stream",
-            )
-            .header(PROTOCOL_VERSION_HEADER, PROTOCOL_VERSION)
-            .json(message);
+        // One map, built configured-first and then overwritten by every
+        // client-generated header, so a configured entry can never displace
+        // what this transport says about itself — whatever the builder's
+        // append-vs-replace semantics happen to be.
+        let mut headers = self.configured.clone();
+        headers.insert(
+            reqwest::header::ACCEPT,
+            reqwest::header::HeaderValue::from_static("application/json, text/event-stream"),
+        );
+        headers.insert(
+            reqwest::header::HeaderName::from_static(PROTOCOL_VERSION_HEADER),
+            reqwest::header::HeaderValue::from_static(PROTOCOL_VERSION),
+        );
         if let Some(authorization) = &authorization {
-            request = request.header(reqwest::header::AUTHORIZATION, authorization);
+            let mut value = reqwest::header::HeaderValue::from_str(authorization)
+                .map_err(|_| mcp_message("external server bearer token is not header-safe"))?;
+            value.set_sensitive(true);
+            headers.insert(reqwest::header::AUTHORIZATION, value);
         }
         if let Some(session_id) = &self.session_id {
-            request = request.header(SESSION_ID_HEADER, session_id);
+            let value = reqwest::header::HeaderValue::from_str(session_id)
+                .map_err(|_| mcp_message("external server session id is not header-safe"))?;
+            headers.insert(
+                reqwest::header::HeaderName::from_static(SESSION_ID_HEADER),
+                value,
+            );
         }
-        request
+        self.client
+            .post(self.url.clone())
+            .headers(headers)
+            .json(message)
             .send()
             .await
             .map_err(|error| mcp_error("could not reach external server", without_url(error)))
@@ -336,6 +401,7 @@ impl SseParser {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use reqwest::header::{HeaderMap, HeaderName};
 
     #[test]
     fn sse_parser_joins_multi_line_data_and_ignores_other_fields() {
@@ -380,13 +446,38 @@ mod tests {
 
     #[test]
     fn bearer_tokens_must_be_header_safe() {
-        assert!(HttpWire::new("http://127.0.0.1/mcp", Some("token-1")).is_ok());
-        assert!(HttpWire::new("http://127.0.0.1/mcp", None).is_ok());
+        let wire = |token| HttpWire::with_headers("http://127.0.0.1/mcp", token, HeaderMap::new());
+        assert!(wire(Some("token-1")).is_ok());
+        assert!(wire(None).is_ok());
         for token in ["", "line\nbreak", "tab\there"] {
-            assert!(
-                HttpWire::new("http://127.0.0.1/mcp", Some(token)).is_err(),
-                "{token:?} must be rejected"
-            );
+            assert!(wire(Some(token)).is_err(), "{token:?} must be rejected");
         }
+    }
+
+    /// Contract: a configured static header cannot displace one this transport
+    /// generates for itself. A plugin's `mcp.json` declares these headers, so
+    /// an entry named `authorization` would otherwise let a package override
+    /// the credential a gateway mount presents.
+    #[test]
+    fn configured_headers_never_displace_the_transports_own() {
+        let configured = static_headers(&std::collections::BTreeMap::from([
+            ("X-Client".to_owned(), "openwave".to_owned()),
+            ("Authorization".to_owned(), "Bearer smuggled".to_owned()),
+            ("MCP-Session-Id".to_owned(), "hijacked".to_owned()),
+            ("Host".to_owned(), "elsewhere.example".to_owned()),
+        ]))
+        .unwrap();
+        assert_eq!(
+            configured
+                .keys()
+                .map(HeaderName::as_str)
+                .collect::<Vec<_>>(),
+            ["x-client"]
+        );
+        assert!(static_headers(&std::collections::BTreeMap::from([(
+            "not a token".to_owned(),
+            "x".to_owned()
+        )]))
+        .is_err());
     }
 }

--- a/crates/openwave-server/src/code_execution/provider.rs
+++ b/crates/openwave-server/src/code_execution/provider.rs
@@ -58,6 +58,11 @@ pub struct ConfiguredCodeExecutionProvider {
     /// alongside the user skills and prompts they group so an added or edited
     /// bundle appears without a restart. `None` disables user plugins.
     user_plugins_dir: Option<PathBuf>,
+    /// Where the built-in plugin tree was loaded from, retained so a bundled
+    /// MCP server can be launched with its package root as `PLUGIN_ROOT`. The
+    /// packages themselves are already loaded; this is only the path they came
+    /// from.
+    plugins_dir: Option<PathBuf>,
     /// Public-HTTPS archive fetcher used only by explicit plugin installs.
     /// Injectable in route tests so the contract is driven without live
     /// internet access.
@@ -212,6 +217,7 @@ impl ConfiguredCodeExecutionProvider {
             user_prompts_dir: None,
             plugins: Arc::new(Vec::new()),
             user_plugins_dir: None,
+            plugins_dir: None,
             plugin_archive_fetcher: crate::plugin_install::default_fetcher(),
             plugin_install_lock: tokio::sync::Mutex::new(()),
             folder_grant_resolver: None,
@@ -337,6 +343,7 @@ impl ConfiguredCodeExecutionProvider {
                 })
                 .unwrap_or_default(),
         );
+        self.plugins_dir = source;
         self
     }
 
@@ -403,6 +410,37 @@ impl ConfiguredCodeExecutionProvider {
     /// directory, exactly as [`Self::installed_skills`] does.
     pub(crate) fn installed_plugins(&self) -> Vec<openwave_code_execution::PluginPackage> {
         self.merged_plugins(&self.installed_skills(), &self.installed_prompts())
+    }
+
+    /// Every installed bundle that ships a bundled MCP configuration, paired
+    /// with the absolute package root its servers are launched from.
+    ///
+    /// The root is resolved from the tree the package was loaded from and then
+    /// canonicalized, because `PLUGIN_ROOT` is specified as the *resolved*
+    /// plugin root and every containment check downstream compares against it.
+    /// A bundle whose root will not canonicalize (removed between the listing
+    /// and this call) is dropped rather than launched from a path that no
+    /// longer means what the loader read.
+    pub(crate) fn installed_plugin_mcp(
+        &self,
+    ) -> Vec<(
+        openwave_code_execution::PluginPackage,
+        PathBuf,
+        openwave_code_execution::PluginMcpConfig,
+    )> {
+        self.installed_plugins()
+            .into_iter()
+            .filter(|package| package.mcp_servers > 0)
+            .filter_map(|package| {
+                let tree = match package.origin {
+                    openwave_code_execution::PluginOrigin::Builtin => self.plugins_dir.as_deref(),
+                    openwave_code_execution::PluginOrigin::User => self.user_plugins_dir.as_deref(),
+                }?;
+                let root = std::fs::canonicalize(tree.join(&package.name)).ok()?;
+                let config = openwave_code_execution::load_plugin_mcp_config(&root)?;
+                Some((package, root, config))
+            })
+            .collect()
     }
 
     /// Fetch, validate, and publish one instruction-only plugin, then ask the

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -1542,6 +1542,8 @@ mod tests {
             gateway_endpoint: Some("tools".to_string()),
             request_timeout_ms: 60_000,
             enabled: true,
+            plugin: None,
+            launch: None,
         };
         // No environment variable anywhere: the URL and bearer come from the
         // stored session via a resource-scoped refresh (asserted inside the
@@ -1732,6 +1734,8 @@ mod tests {
                     gateway_endpoint: Some("tools".to_string()),
                     request_timeout_ms: 60_000,
                     enabled: true,
+                    plugin: None,
+                    launch: None,
                 }],
             })
             .await

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -47,6 +47,7 @@ mod model_roles;
 pub mod openapi_catalog;
 mod pairing;
 mod plugin_install;
+mod plugin_mcp;
 mod plugin_state;
 mod principal;
 mod provider;
@@ -993,7 +994,20 @@ async fn bind_inner(
         state.mcp.set_host_folders(host.clone());
     }
     state.host_folders = host_folders;
+    // Before `initialize`: a boot-file or persisted replacement derives the
+    // plugin slice in the same pass, so bundled servers come up with
+    // everything else instead of after a second reconcile.
+    state
+        .mcp
+        .set_plugin_catalog(Arc::new(plugin_mcp::InstalledPluginMcpCatalog::new(
+            code_execution.clone(),
+            state.store.clone(),
+            state.config.plugin_data_dir(),
+        )));
     state.mcp.initialize(mcp_servers).await?;
+    // A no-op when `initialize` already derived the slice; the safety net for
+    // the paths that return early (a managed profile ignoring its boot file).
+    state.mcp.reconcile_plugin_servers().await;
     let token = state.token.clone();
     let client_executor_token = state.client_executor_token.clone();
     let blob_retirement_worker = blob_retirement_worker::BlobRetirementWorker::new(

--- a/crates/openwave-server/src/mcp_config/runtime.rs
+++ b/crates/openwave-server/src/mcp_config/runtime.rs
@@ -63,6 +63,11 @@ pub(crate) struct McpRuntime {
     /// Installed after assembly on desktop embeddings (like
     /// `AppState::host_folders`); unset, the roster lists no folders.
     host_folders: std::sync::OnceLock<Arc<dyn crate::host_folders::HostFolders>>,
+    /// The installed-plugin seam bundled MCP servers are derived from.
+    /// Installed after assembly, like the host-folder seam, because the
+    /// code-execution provider that owns the plugin tree is built after this
+    /// runtime. Unset, no plugin contributes servers.
+    plugin_catalog: std::sync::OnceLock<Arc<dyn crate::plugin_mcp::PluginMcpCatalog>>,
     next_epoch: AtomicU64,
 }
 
@@ -88,6 +93,7 @@ impl McpRuntime {
             gateway,
             os_policy,
             host_folders: std::sync::OnceLock::new(),
+            plugin_catalog: std::sync::OnceLock::new(),
             next_epoch: AtomicU64::new(1),
         }
     }
@@ -96,6 +102,45 @@ impl McpRuntime {
     /// approved folders. At most once, at assembly.
     pub(crate) fn set_host_folders(&self, host: Arc<dyn crate::host_folders::HostFolders>) {
         let _ = self.host_folders.set(host);
+    }
+
+    /// Install the installed-plugin seam. At most once, at assembly; the
+    /// startup reconcile that first connects bundled servers runs after it.
+    pub(crate) fn set_plugin_catalog(&self, catalog: Arc<dyn crate::plugin_mcp::PluginMcpCatalog>) {
+        let _ = self.plugin_catalog.set(catalog);
+    }
+
+    /// The plugin-sourced definitions that belong beside `configured` right
+    /// now, read live from the installed tree and the enable flags.
+    ///
+    /// Nothing here is persisted or remembered: the answer is recomputed on
+    /// every reconcile and every replacement, so installing, uninstalling, or
+    /// toggling a plugin needs no second copy of this state to stay in sync.
+    /// Sources are sorted by plugin name so a namespace contest resolves the
+    /// same way on every host regardless of directory iteration order.
+    async fn plugin_definitions(
+        &self,
+        configured: &[McpServerDefinition],
+    ) -> Vec<McpServerDefinition> {
+        let Some(catalog) = self.plugin_catalog.get() else {
+            return Vec::new();
+        };
+        let mut sources = catalog.sources().await;
+        sources.sort_by(|left, right| left.plugin.cmp(&right.plugin));
+        let taken: HashSet<String> = configured
+            .iter()
+            .map(|definition| definition.name.clone())
+            .collect();
+        let (definitions, skipped) = crate::plugin_mcp::derive_definitions(&sources, &taken);
+        for entry in skipped {
+            tracing::warn!(
+                plugin = %entry.plugin,
+                server = %entry.server,
+                "plugin MCP server was not mounted: {}",
+                entry.reason
+            );
+        }
+        definitions
     }
 
     /// One server's literal environment as stored, by record id. A missing or
@@ -586,6 +631,8 @@ impl McpRuntime {
                 gateway_endpoint: Some(slug.clone()),
                 request_timeout_ms: DEFAULT_REQUEST_TIMEOUT_MS,
                 enabled: true,
+                plugin: None,
+                launch: None,
             });
         }
         if servers.len() == before {
@@ -717,7 +764,15 @@ impl McpRuntime {
         // one resolution path, and the file stops being a second home for
         // credentials.
         self.commit_env_values(&mut definitions, &ids).await?;
-        let definitions = definitions;
+        let configured = definitions;
+        // Plugin-sourced servers ride along the same connection pass but are
+        // never part of what is persisted or validated as a candidate: they
+        // are derived from the installed tree, so a replacement that fails
+        // cannot take them down and a replacement that succeeds cannot edit
+        // them.
+        let plugin = self.plugin_definitions(&configured).await;
+        let definitions: Vec<McpServerDefinition> =
+            configured.iter().cloned().chain(plugin).collect();
         let envs = self.resolve_envs(&definitions, &ids).await;
         let gateway = &self.gateway;
         let lockdown = self.manual_lockdown().await;
@@ -740,8 +795,13 @@ impl McpRuntime {
                 // of band (sign-out, revoked entitlement), so its failure
                 // degrades the mount instead of rejecting the candidate —
                 // otherwise a signed-out mount would block every unrelated
-                // settings save until it was deleted.
-                Err(error) if definition.gateway_endpoint.is_some() => {
+                // settings save until it was deleted. A plugin-sourced server
+                // degrades for the same reason from the other direction: it is
+                // not part of the candidate at all, so it must never be able
+                // to fail somebody's settings save.
+                Err(error)
+                    if definition.gateway_endpoint.is_some() || definition.plugin.is_some() =>
+                {
                     // The projected diagnostic is deliberately generic; keep
                     // the real cause in the log (already URL- and
                     // secret-free). The desktop installs no tracing
@@ -779,7 +839,7 @@ impl McpRuntime {
                     ManagedServer {
                         client: None,
                         health: McpHealth::Disabled,
-                        diagnostic: managed_lockdown_diagnostic(definition, lockdown),
+                        diagnostic: disabled_diagnostic(definition, lockdown),
                         reconnect_backoff: INITIAL_RECONNECT_BACKOFF,
                         epoch: self.fresh_epoch(),
                         reconnect_lock: Arc::new(Mutex::new(())),
@@ -803,9 +863,11 @@ impl McpRuntime {
         }
         if persist {
             // Before the new state publishes, while the published set is
-            // still what this replacement diffs against.
-            self.remember_endpoint_unmounts(&definitions).await;
-            self.persist_definitions(&definitions, &ids).await?;
+            // still what this replacement diffs against. Plugin-sourced
+            // definitions are excluded: they are derived, so persisting them
+            // would create a second, staler home for the same facts.
+            self.remember_endpoint_unmounts(&configured).await;
+            self.persist_definitions(&configured, &ids).await?;
         }
         self.publish(definitions, ids, servers).await;
         Ok(())
@@ -844,6 +906,8 @@ impl McpRuntime {
         definitions: Vec<McpServerDefinition>,
         ids: BTreeMap<String, ConnectedAppId>,
     ) {
+        let plugin = self.plugin_definitions(&definitions).await;
+        let definitions: Vec<McpServerDefinition> = definitions.into_iter().chain(plugin).collect();
         let envs = self.resolve_envs(&definitions, &ids).await;
         let gateway = &self.gateway;
         let lockdown = self.manual_lockdown().await;
@@ -864,7 +928,7 @@ impl McpRuntime {
                 Ok(None) => ManagedServer {
                     client: None,
                     health: McpHealth::Disabled,
-                    diagnostic: managed_lockdown_diagnostic(definition, lockdown),
+                    diagnostic: disabled_diagnostic(definition, lockdown),
                     reconnect_backoff: INITIAL_RECONNECT_BACKOFF,
                     epoch: self.fresh_epoch(),
                     reconnect_lock: Arc::new(Mutex::new(())),
@@ -901,6 +965,114 @@ impl McpRuntime {
             servers.insert(definition.name.clone(), managed);
         }
         self.publish(definitions, ids, servers).await;
+    }
+
+    /// Bring the plugin-sourced slice of the connection set in line with the
+    /// installed tree and the current enable flags.
+    ///
+    /// Run at startup, after a plugin is installed, and after the enable flags
+    /// change — the three moments the derived set can move. Only the plugin
+    /// slice is touched: a server whose definition is unchanged keeps its live
+    /// connection, one that appeared connects, and one whose plugin was
+    /// switched off or uninstalled is disconnected and its tools unmount.
+    /// User-configured servers are never reconnected by this, so toggling a
+    /// plugin does not churn somebody's stdio child.
+    ///
+    /// Returns whether the published set changed.
+    pub(crate) async fn reconcile_plugin_servers(&self) -> bool {
+        if self.plugin_catalog.get().is_none() {
+            return false;
+        }
+        let _mutation = self.mutation.lock().await;
+        let (configured, live): (Vec<McpServerDefinition>, Vec<McpServerDefinition>) = {
+            let state = self.state.lock().await;
+            state
+                .definitions
+                .iter()
+                .cloned()
+                .partition(|definition| definition.plugin.is_none())
+        };
+        let desired = self.plugin_definitions(&configured).await;
+        if desired == live {
+            return false;
+        }
+        let ids = self.state.lock().await.ids.clone();
+        let lockdown = self.manual_lockdown().await;
+        let gateway = &self.gateway;
+        // Only the entries that are new or changed are connected; the rest
+        // keep the client they already hold.
+        let fresh: Vec<&McpServerDefinition> = desired
+            .iter()
+            .filter(|definition| !live.contains(definition))
+            .collect();
+        let connections = join_all(fresh.iter().map(|definition| async move {
+            if connects(definition, lockdown) {
+                definition
+                    .connect_with_views(gateway, &BTreeMap::new())
+                    .await
+                    .map(Some)
+            } else {
+                Ok(None)
+            }
+        }))
+        .await;
+
+        let mut state = self.state.lock().await;
+        // Everything the desired set does not name goes away, taking its
+        // client — and so its mounted tools — with it.
+        let keep: HashSet<&str> = desired
+            .iter()
+            .map(|definition| definition.name.as_str())
+            .chain(configured.iter().map(|definition| definition.name.as_str()))
+            .collect();
+        state.servers.retain(|name, _| keep.contains(name.as_str()));
+        for (definition, connection) in fresh.into_iter().zip(connections) {
+            let managed = match connection {
+                Ok(Some((client, ui_views))) => ManagedServer {
+                    client: Some(client),
+                    health: McpHealth::Healthy,
+                    diagnostic: None,
+                    reconnect_backoff: INITIAL_RECONNECT_BACKOFF,
+                    epoch: self.fresh_epoch(),
+                    reconnect_lock: Arc::new(Mutex::new(())),
+                    ui_views,
+                },
+                Ok(None) => ManagedServer {
+                    client: None,
+                    health: McpHealth::Disabled,
+                    diagnostic: disabled_diagnostic(definition, lockdown),
+                    reconnect_backoff: INITIAL_RECONNECT_BACKOFF,
+                    epoch: self.fresh_epoch(),
+                    reconnect_lock: Arc::new(Mutex::new(())),
+                    ui_views: HashMap::new(),
+                },
+                Err(error) => {
+                    tracing::warn!(
+                        server = %definition.name,
+                        plugin = ?definition.plugin,
+                        "plugin MCP server connection failed: {error}"
+                    );
+                    ManagedServer {
+                        client: None,
+                        health: McpHealth::Degraded,
+                        diagnostic: Some(connection_diagnostic(definition, &error)),
+                        reconnect_backoff: INITIAL_RECONNECT_BACKOFF,
+                        epoch: self.fresh_epoch(),
+                        reconnect_lock: Arc::new(Mutex::new(())),
+                        ui_views: HashMap::new(),
+                    }
+                }
+            };
+            state.servers.insert(definition.name.clone(), managed);
+        }
+        state.definitions = configured.into_iter().chain(desired).collect();
+        state.ids = ids;
+        let registry = self.registry_for(&state).await;
+        *self
+            .tools
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(registry);
+        true
     }
 
     async fn publish(
@@ -1364,4 +1536,24 @@ fn managed_lockdown_diagnostic(
     lockdown: ManualLockdown,
 ) -> Option<String> {
     manual_lockdown_applies(definition, lockdown).then(|| MANAGED_DISABLED_DIAGNOSTIC.to_string())
+}
+
+/// Why a server that is not holding a connection is off.
+///
+/// The managed lockdown comes first: a plugin server the policy covers reads
+/// as locked, exactly like a user-typed manual server, rather than advertising
+/// the transport reason behind it. Otherwise a plugin-sourced entry explains
+/// itself — an `sse` server is listed and inert with the reason, because the
+/// specification keeps that transport optional and silently omitting the entry
+/// would leave nothing to explain the absence.
+fn disabled_diagnostic(
+    definition: &McpServerDefinition,
+    lockdown: ManualLockdown,
+) -> Option<String> {
+    managed_lockdown_diagnostic(definition, lockdown).or_else(|| {
+        definition
+            .launch
+            .as_ref()
+            .and_then(|launch| launch.disabled_reason.clone())
+    })
 }

--- a/crates/openwave-server/src/mcp_config/tests.rs
+++ b/crates/openwave-server/src/mcp_config/tests.rs
@@ -118,6 +118,8 @@ fn disabled_definition(name: &str, command: &str) -> McpServerDefinition {
         gateway_endpoint: None,
         request_timeout_ms: DEFAULT_REQUEST_TIMEOUT_MS,
         enabled: false,
+        plugin: None,
+        launch: None,
     }
 }
 
@@ -135,6 +137,8 @@ fn http_definition(name: &str, url: &str) -> McpServerDefinition {
         gateway_endpoint: None,
         request_timeout_ms: DEFAULT_REQUEST_TIMEOUT_MS,
         enabled: true,
+        plugin: None,
+        launch: None,
     }
 }
 
@@ -152,6 +156,8 @@ fn gateway_definition(name: &str, slug: &str) -> McpServerDefinition {
         gateway_endpoint: Some(slug.to_string()),
         request_timeout_ms: DEFAULT_REQUEST_TIMEOUT_MS,
         enabled: true,
+        plugin: None,
+        launch: None,
     }
 }
 
@@ -1375,4 +1381,73 @@ fn debug_projection_redacts_argument_and_literal_environment_values() {
     assert!(!debug.contains("argument-secret"));
     assert!(!debug.contains("literal-secret"));
     assert!(debug.contains("TOKEN"));
+}
+
+/// A plugin catalog with a fixed set of sources, for the runtime tests.
+struct FixedPluginCatalog(Vec<(String, std::path::PathBuf, std::path::PathBuf)>);
+
+#[async_trait::async_trait]
+impl crate::plugin_mcp::PluginMcpCatalog for FixedPluginCatalog {
+    async fn sources(&self) -> Vec<crate::plugin_mcp::PluginMcpSource> {
+        self.0
+            .iter()
+            .map(|(plugin, root, data)| crate::plugin_mcp::PluginMcpSource {
+                plugin: plugin.clone(),
+                root: root.clone(),
+                data: data.clone(),
+                config: openwave_code_execution::PluginMcpConfig {
+                    servers: vec![openwave_code_execution::McpServer {
+                        name: "local".to_owned(),
+                        transport: openwave_code_execution::McpTransport::Stdio(
+                            openwave_code_execution::McpStdioServer {
+                                command: "./serve".to_owned(),
+                                args: Vec::new(),
+                                env: BTreeMap::new(),
+                                cwd: None,
+                            },
+                        ),
+                    }],
+                },
+            })
+            .collect()
+    }
+}
+
+/// Contract: a plugin-sourced server is a manual server as far as managed
+/// policy is concerned. Derived servers bypass `PUT /mcp/servers` entirely,
+/// so if the lockdown were keyed off that route a managed profile could be
+/// handed arbitrary local subprocesses and remote endpoints by installing a
+/// plugin — the exact channel the lockdown exists to close.
+#[tokio::test]
+async fn managed_policy_locks_plugin_sourced_servers_like_manual_ones() {
+    let (runtime, store, directory) = test_runtime().await;
+    let root = directory.path().join("pkg");
+    let data = directory.path().join("data");
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::create_dir_all(&data).unwrap();
+    runtime.set_plugin_catalog(Arc::new(FixedPluginCatalog(vec![(
+        "toolbox".to_owned(),
+        root,
+        data,
+    )])));
+    crate::managed_policy::provision(&*store, "https://corp.gateway")
+        .await
+        .unwrap();
+
+    assert!(runtime.reconcile_plugin_servers().await);
+    let info = runtime.info().await;
+    assert_eq!(info.servers.len(), 1);
+    assert_eq!(
+        info.servers[0].definition.plugin.as_deref(),
+        Some("toolbox")
+    );
+    assert_eq!(info.servers[0].health, McpHealth::Disabled);
+    assert_eq!(
+        info.servers[0].diagnostic.as_deref(),
+        Some(MANAGED_DISABLED_DIAGNOSTIC),
+        "a plugin server carries the same diagnostic a user-typed one does"
+    );
+    assert_eq!(info.servers[0].tool_count, 0);
+    // Nothing about a derived server reaches durable configuration.
+    assert!(saved_records(&store).await.is_empty());
 }

--- a/crates/openwave-server/src/mcp_config/types.rs
+++ b/crates/openwave-server/src/mcp_config/types.rs
@@ -26,7 +26,7 @@ pub(super) const MAX_ENVIRONMENT_VARIABLES: usize = 128;
 pub(super) const MAX_PROCESS_STRING_BYTES: usize = 32 * 1024;
 pub(super) const MAX_ENVIRONMENT_NAME_BYTES: usize = 256;
 pub(super) const MAX_REQUEST_TIMEOUT_MS: u64 = 60 * 60 * 1000;
-pub(super) const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 60 * 1000;
+pub(crate) const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 60 * 1000;
 pub(super) const HEALTH_INTERVAL: Duration = Duration::from_secs(15);
 pub(super) const HEALTH_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 pub(super) const INITIALIZATION_TIMEOUT: Duration = Duration::from_secs(10);
@@ -182,6 +182,71 @@ pub(crate) struct McpServerDefinition {
     pub(crate) request_timeout_ms: u64,
     #[serde(default = "enabled_by_default")]
     pub(crate) enabled: bool,
+    /// The plugin this server was synthesized from, when it is plugin-sourced.
+    ///
+    /// Read-only over the API: `PUT /mcp/servers` refuses a body that sets it,
+    /// and the runtime rebuilds these entries from the installed plugin tree
+    /// rather than from anything a client sends or the store holds.
+    #[serde(default)]
+    pub(crate) plugin: Option<String>,
+    /// Connect-time material for a plugin-sourced server: the two reserved
+    /// directories, the literal environment and headers its `mcp.json`
+    /// declared, and the reason it is inert when this client cannot run it.
+    ///
+    /// Never serialized. Environment values and header values are visible
+    /// package data the specification tells clients not to treat as secrets,
+    /// which is exactly the reason not to copy them into persisted records,
+    /// API responses, or logs.
+    #[serde(skip)]
+    #[ts(skip)]
+    pub(crate) launch: Option<Box<PluginLaunch>>,
+}
+
+/// Connect-time material a plugin-sourced server carries.
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct PluginLaunch {
+    /// Absolute, resolved package root: `PLUGIN_ROOT`, and the directory a
+    /// `./`-relative command is resolved against.
+    pub(crate) root: PathBuf,
+    /// Client-managed writable directory: `PLUGIN_DATA`.
+    pub(crate) data: PathBuf,
+    /// Literal environment for a stdio server, already expanded.
+    pub(crate) env: BTreeMap<String, String>,
+    /// Static headers for a streamable-http server.
+    pub(crate) headers: BTreeMap<String, String>,
+    /// Which root the working directory is anchored to, and so which one it
+    /// has to stay inside.
+    pub(crate) cwd_anchor: CwdAnchor,
+    /// Why this entry is present but inert, for the transports this client
+    /// does not implement.
+    pub(crate) disabled_reason: Option<String>,
+}
+
+/// The root a plugin server's working directory is anchored to.
+///
+/// The specification lets `cwd` be rooted at either reserved variable, and the
+/// two are not interchangeable: the package tree is immutable once installed
+/// while the data tree is client-managed and starts empty. Which one was named
+/// is therefore carried rather than inferred from the resolved path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CwdAnchor {
+    Root,
+    Data,
+}
+
+/// Values never appear: the whole point of keeping them off the definition.
+impl std::fmt::Debug for PluginLaunch {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PluginLaunch")
+            .field("root", &self.root)
+            .field("data", &self.data)
+            .field("env_names", &self.env.keys().collect::<Vec<_>>())
+            .field("header_names", &self.headers.keys().collect::<Vec<_>>())
+            .field("cwd_anchor", &self.cwd_anchor)
+            .field("disabled_reason", &self.disabled_reason)
+            .finish()
+    }
 }
 
 impl std::fmt::Debug for McpServerDefinition {
@@ -256,17 +321,42 @@ impl McpServerDefinition {
     /// Build the child command. `env` is the definition's literal environment
     /// as resolved from the secret store — passed in rather than read off the
     /// definition, because the definition never holds values.
+    ///
+    /// A plugin-sourced server takes its environment from its own launch
+    /// material instead: package data, never secret-store entries. Its working
+    /// directory is re-checked for containment here rather than trusted from
+    /// the textual rule the importer applied, because only a check at launch
+    /// sees symlinks and edits made since.
     pub(super) fn build_command(&self, env: &BTreeMap<String, String>) -> Result<Command> {
         let Some(program) = &self.command else {
             return Err(AgentError::config(
                 "MCP server definition has no command to spawn",
             ));
         };
+        // A plugin's `./`-relative command names a file inside the package and
+        // is resolved against the package root before the child is built;
+        // everything else — including a plugin's bare command name — keeps the
+        // platform resolution every other stdio server gets, so the two paths
+        // cannot drift.
+        let program = match &self.launch {
+            Some(launch) => crate::plugin_mcp::resolve_command(program, &launch.root)
+                .map_err(AgentError::config)?,
+            None => PathBuf::from(program),
+        };
         let mut command = Command::new(program);
         command.args(&self.args);
         // Deliberately unconditional: a renderer cannot widen a child to the
         // desktop's provider credentials or other ambient environment.
         command.env_clear();
+        if let Some(launch) = &self.launch {
+            let cwd = self.cwd.as_deref().unwrap_or(&launch.root);
+            crate::plugin_mcp::working_directory(launch, cwd).map_err(AgentError::config)?;
+            for (name, value) in crate::plugin_mcp::launch_environment(launch) {
+                command.env(name, value);
+            }
+            command.current_dir(cwd);
+            return Ok(command);
+        }
         for name in &self.env_from {
             let value = std::env::var_os(name).ok_or_else(|| {
                 AgentError::config(format!(
@@ -317,10 +407,18 @@ impl McpServerDefinition {
         }
         if let Some(url) = &self.url {
             let bearer_token = self.resolve_bearer_token()?;
-            return McpClient::connect_http_with_timeouts(
+            let headers = match &self.launch {
+                Some(launch) => {
+                    admit_plugin_endpoint(url).await?;
+                    launch.headers.clone()
+                }
+                None => BTreeMap::new(),
+            };
+            return McpClient::connect_http_with_headers(
                 self.name.clone(),
                 url,
                 bearer_token.as_deref(),
+                &headers,
                 INITIALIZATION_TIMEOUT,
                 Duration::from_millis(self.request_timeout_ms),
             )
@@ -389,6 +487,67 @@ impl McpServerDefinition {
             ))
         })
     }
+}
+
+/// Admit a plugin-declared HTTP endpoint before any connection is opened.
+///
+/// A package can name any endpoint it likes, so the destination is admitted
+/// the way the native web-fetch path admits a model-chosen URL: every address
+/// the host resolves to must clear the denied-network list — loopback, RFC
+/// 1918, link-local (which includes cloud metadata services), CGNAT, and the
+/// rest — before the transport dials.
+///
+/// **Two deliberate divergences from the web-fetch rules**, both because this
+/// is a package-declared endpoint rather than a model-chosen page:
+///
+/// * A **loopback** URL is admitted. The Agent Plugins specification allows
+///   plain HTTP for loopback precisely so a plugin can ship a local server,
+///   and refusing it would make bundled local servers unrunnable. That is the
+///   one destination the fetch policy denies which this path allows, and it is
+///   permitted only when the URL's own host is a loopback literal or
+///   `localhost` — never when a DNS name merely resolves to one.
+/// * A **non-default port** is admitted. Local and self-hosted MCP endpoints
+///   routinely listen off 443; the fetch policy pins the default port because
+///   a model-chosen URL has no reason to need another.
+///
+/// Resolution here is advisory rather than a hard guarantee: the transport
+/// resolves again when it connects, so a name whose answer changes in between
+/// is not caught. That is the same TOCTOU the native fetch path lives with,
+/// and it is a weaker exposure here — the URL is fixed package data reviewed
+/// at install, not a string the model just produced. Failing admission is a
+/// per-server connection failure: the plugin's other servers still start.
+async fn admit_plugin_endpoint(url: &str) -> Result<()> {
+    use openwave_web_search::admit_fetch_address;
+
+    let parsed = url::Url::parse(url)
+        .map_err(|_| AgentError::config("plugin MCP server URL is not a valid URL"))?;
+    let refused = || AgentError::config("plugin MCP server endpoint is not an allowed destination");
+    let host = parsed.host().ok_or_else(refused)?;
+    let loopback = match host {
+        url::Host::Domain(name) => name == "localhost",
+        url::Host::Ipv4(address) => address.is_loopback(),
+        url::Host::Ipv6(address) => address.is_loopback(),
+    };
+    if loopback {
+        return Ok(());
+    }
+    let port = parsed
+        .port_or_known_default()
+        .ok_or_else(|| AgentError::config("plugin MCP server URL has no port"))?;
+    let addresses: Vec<std::net::SocketAddr> =
+        tokio::net::lookup_host((parsed.host_str().unwrap_or_default(), port))
+            .await
+            .map_err(|_| AgentError::config("plugin MCP server host could not be resolved"))?
+            .collect();
+    if addresses.is_empty() {
+        return Err(AgentError::config(
+            "plugin MCP server host resolved to no addresses",
+        ));
+    }
+    for address in addresses {
+        admit_fetch_address(address.ip()).map_err(|_| refused())?;
+    }
+    Ok(())
 }
 
 /// SHA-256 fingerprint of a server definition as configured, the value an app

--- a/crates/openwave-server/src/pairing.rs
+++ b/crates/openwave-server/src/pairing.rs
@@ -850,6 +850,8 @@ mod tests {
                 gateway_endpoint: None,
                 request_timeout_ms: 60_000,
                 enabled: true,
+                plugin: None,
+                launch: None,
             }],
         })
         .await

--- a/crates/openwave-server/src/plugin_mcp.rs
+++ b/crates/openwave-server/src/plugin_mcp.rs
@@ -1,0 +1,629 @@
+//! Bundled MCP servers, from an installed plugin to the live MCP runtime.
+//!
+//! A plugin published in the Agent Plugins format (<https://agent-plugins.org>)
+//! may ship an `mcp.json` declaring servers the client is expected to run on
+//! its behalf. The importer validates that file and retains a canonical copy
+//! beside the installed package; this module turns the retained copy into the
+//! [`McpServerDefinition`]s the runtime already knows how to connect,
+//! supervise, and project.
+//!
+//! Three properties shape the design:
+//!
+//! * **Derived, never a record.** A plugin's servers are recomputed from the
+//!   installed tree and the plugin's enable flag every time the set is
+//!   reconciled. They are not `mcp_server` connected-app records, are not
+//!   persisted, and cannot be edited or deleted through `PUT /mcp/servers` —
+//!   the plugin's own install/uninstall and enable flag are the only controls.
+//! * **The plugin never chooses its runtime name.** `mcp.json` server keys are
+//!   up to 64 bytes and may contain `.`; a runtime namespace is 32 bytes of
+//!   `[A-Za-z0-9_-]` because it has to fit inside `mcp__{server}__{tool}`. The
+//!   derivation below is deterministic, and on any collision the plugin's
+//!   server is dropped rather than displacing what is already configured.
+//! * **A bad entry costs one server.** An unsupported transport, a working
+//!   directory that escapes the root, a name already taken — each one takes
+//!   that entry out and leaves the plugin's other servers, and every other
+//!   plugin, running.
+
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use openwave_code_execution::{
+    expand_plugin_placeholders, McpTransport, PLUGIN_DATA_VARIABLE, PLUGIN_ROOT_VARIABLE,
+};
+use openwave_core::Store;
+
+use crate::mcp_config::{CwdAnchor, McpServerDefinition, PluginLaunch, DEFAULT_REQUEST_TIMEOUT_MS};
+
+/// Longest runtime server name, mirroring [`openwave_mcp::MAX_SERVER_NAME_BYTES`].
+const MAX_RUNTIME_NAME_BYTES: usize = openwave_mcp::MAX_SERVER_NAME_BYTES;
+
+/// Bytes of the derived name kept when a name has to be shortened, leaving
+/// room for the `-` and the six hex digits that make the short form stable and
+/// distinct.
+const TRUNCATED_NAME_BYTES: usize = MAX_RUNTIME_NAME_BYTES - 7;
+
+/// The diagnostic a `sse` entry carries. The specification keeps that
+/// transport optional and this client does not implement it, so the entry is
+/// surfaced disabled — with the reason — rather than silently missing.
+pub(crate) const SSE_UNSUPPORTED_DIAGNOSTIC: &str =
+    "This plugin server uses the legacy SSE transport, which OpenWave does not implement.";
+
+/// One installed, enabled plugin's bundled MCP configuration, with the two
+/// directories its servers are launched against.
+pub(crate) struct PluginMcpSource {
+    pub(crate) plugin: String,
+    /// Absolute, resolved package root — the value of `PLUGIN_ROOT`.
+    pub(crate) root: PathBuf,
+    /// Client-managed writable directory — the value of `PLUGIN_DATA`.
+    pub(crate) data: PathBuf,
+    pub(crate) config: openwave_code_execution::PluginMcpConfig,
+}
+
+/// One bundled server that did not make it into the runtime set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SkippedPluginServer {
+    pub(crate) plugin: String,
+    pub(crate) server: String,
+    pub(crate) reason: String,
+}
+
+/// The seam the MCP runtime reads plugin-sourced servers through.
+///
+/// A trait rather than a direct dependency because the runtime is assembled
+/// before the code-execution provider exists, and because embeddings without
+/// one (tests, headless servers with no plugin tree) should contribute no
+/// plugin servers rather than fail.
+#[async_trait::async_trait]
+pub(crate) trait PluginMcpCatalog: Send + Sync {
+    /// Every installed, enabled plugin's bundled configuration, read live.
+    async fn sources(&self) -> Vec<PluginMcpSource>;
+}
+
+/// The production catalog: the installed plugin tree, the stored enable flags,
+/// and the app data directory the `PLUGIN_DATA` directories live under.
+pub(crate) struct InstalledPluginMcpCatalog {
+    exec: Arc<crate::code_execution::ConfiguredCodeExecutionProvider>,
+    store: Arc<dyn Store>,
+    data_root: PathBuf,
+}
+
+impl InstalledPluginMcpCatalog {
+    pub(crate) fn new(
+        exec: Arc<crate::code_execution::ConfiguredCodeExecutionProvider>,
+        store: Arc<dyn Store>,
+        data_root: PathBuf,
+    ) -> Self {
+        Self {
+            exec,
+            store,
+            data_root,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl PluginMcpCatalog for InstalledPluginMcpCatalog {
+    async fn sources(&self) -> Vec<PluginMcpSource> {
+        let flags = crate::plugin_state::read_plugin_enable_state(&*self.store).await;
+        let installed = self.exec.installed_plugin_mcp();
+        // Uninstalling a plugin is removing its directory, so the data
+        // directory of a plugin that is no longer installed is orphaned. It is
+        // pruned against the full installed list — not the enabled one — so
+        // switching a plugin off keeps its state for when it comes back.
+        let live: BTreeSet<String> = self
+            .exec
+            .installed_plugins()
+            .into_iter()
+            .map(|package| package.name)
+            .collect();
+        prune_orphan_plugin_data(&self.data_root, &live);
+
+        let mut sources = Vec::new();
+        for (package, root, config) in installed {
+            if !flags.plugin_enabled(&package.name) {
+                continue;
+            }
+            let data = self.data_root.join(&package.name);
+            // Created before anything launches: the specification requires the
+            // directory to exist when a server starts, and a server that has
+            // to create its own state directory cannot rely on it.
+            if let Err(error) = std::fs::create_dir_all(&data) {
+                tracing::warn!(
+                    plugin = %package.name,
+                    "plugin data directory could not be created; not starting its MCP servers: \
+                     {error}"
+                );
+                continue;
+            }
+            let Ok(data) = std::fs::canonicalize(&data) else {
+                continue;
+            };
+            sources.push(PluginMcpSource {
+                plugin: package.name,
+                root,
+                data,
+                config,
+            });
+        }
+        sources
+    }
+}
+
+/// Delete every `PLUGIN_DATA` directory whose plugin is no longer installed.
+///
+/// Best effort throughout: a directory that will not read or will not delete
+/// is left alone and warned about. Nothing here can remove data for a plugin
+/// that is present, which is what makes reinstalling or updating a package
+/// preserve its state.
+fn prune_orphan_plugin_data(data_root: &Path, installed: &BTreeSet<String>) {
+    let Ok(entries) = std::fs::read_dir(data_root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let Ok(name) = entry.file_name().into_string() else {
+            continue;
+        };
+        if installed.contains(&name) {
+            continue;
+        }
+        let path = entry.path();
+        let directory = path
+            .symlink_metadata()
+            .is_ok_and(|metadata| metadata.is_dir() && !metadata.file_type().is_symlink());
+        if !directory {
+            continue;
+        }
+        if let Err(error) = std::fs::remove_dir_all(&path) {
+            tracing::warn!("could not remove orphaned plugin data {}: {error}", name);
+        }
+    }
+}
+
+/// The runtime namespace a plugin's server mounts under.
+///
+/// `{plugin}-{server}` with every character outside `[A-Za-z0-9_-]` folded to
+/// `-`, which covers the `.` both grammars admit and the runtime name does
+/// not. A name that does not fit the 32-byte namespace limit is truncated and
+/// given six hex digits of a SHA-256 over the exact `{plugin}/{server}` pair,
+/// so two long names that share a prefix stay distinct and every name is
+/// stable across restarts.
+///
+/// This is deliberately not collision-*proof*: folding `.` to `-` can make two
+/// distinct pairs agree. Collisions are resolved by dropping, not by
+/// disambiguating, so a plugin can never take a namespace by picking a name
+/// that collides with one already in use.
+#[must_use]
+pub(crate) fn runtime_server_name(plugin: &str, server: &str) -> String {
+    use sha2::Digest as _;
+
+    let folded: String = format!("{plugin}-{server}")
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '_' | '-') {
+                character
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    if folded.len() <= MAX_RUNTIME_NAME_BYTES {
+        return folded;
+    }
+    let digest = sha2::Sha256::digest(format!("{plugin}/{server}").as_bytes());
+    // Folded names are ASCII by construction, so byte slicing is safe.
+    format!(
+        "{}-{:02x}{:02x}{:02x}",
+        &folded[..TRUNCATED_NAME_BYTES],
+        digest[0],
+        digest[1],
+        digest[2]
+    )
+}
+
+/// Turn every source's bundled configuration into runtime definitions.
+///
+/// `taken` is the set of namespaces already spoken for — user-configured
+/// servers and gateway mounts — and grows as plugin servers are accepted, so
+/// the first claimant in (plugin, server) order wins and everything after it
+/// is skipped. Sources are processed in the order given; the caller sorts them
+/// by plugin name so the outcome does not depend on directory iteration order.
+pub(crate) fn derive_definitions(
+    sources: &[PluginMcpSource],
+    taken: &HashSet<String>,
+) -> (Vec<McpServerDefinition>, Vec<SkippedPluginServer>) {
+    let mut taken = taken.clone();
+    let mut definitions = Vec::new();
+    let mut skipped = Vec::new();
+    for source in sources {
+        let root = source.root.to_string_lossy();
+        let data = source.data.to_string_lossy();
+        for server in &source.config.servers {
+            let name = runtime_server_name(&source.plugin, &server.name);
+            if !taken.insert(name.clone()) {
+                skipped.push(SkippedPluginServer {
+                    plugin: source.plugin.clone(),
+                    server: server.name.clone(),
+                    reason: format!(
+                        "the MCP server namespace {name:?} it derives is already in use"
+                    ),
+                });
+                continue;
+            }
+            definitions.push(definition_for(source, server, &name, &root, &data));
+        }
+    }
+    (definitions, skipped)
+}
+
+fn definition_for(
+    source: &PluginMcpSource,
+    server: &openwave_code_execution::McpServer,
+    name: &str,
+    root: &str,
+    data: &str,
+) -> McpServerDefinition {
+    let base = McpServerDefinition {
+        name: name.to_owned(),
+        command: None,
+        args: Vec::new(),
+        // Deliberately empty: `env` names entries whose values live in the
+        // secret store, and a plugin's environment is literal package data
+        // that must never be written there. The values ride on `launch`.
+        env: BTreeSet::new(),
+        env_values: BTreeMap::new(),
+        env_from: Vec::new(),
+        cwd: None,
+        url: None,
+        bearer_token_env: None,
+        gateway_endpoint: None,
+        request_timeout_ms: DEFAULT_REQUEST_TIMEOUT_MS,
+        enabled: true,
+        plugin: Some(source.plugin.clone()),
+        launch: None,
+    };
+    let launch = PluginLaunch {
+        root: source.root.clone(),
+        data: source.data.clone(),
+        env: BTreeMap::new(),
+        headers: BTreeMap::new(),
+        cwd_anchor: CwdAnchor::Root,
+        disabled_reason: None,
+    };
+    match &server.transport {
+        McpTransport::Stdio(stdio) => {
+            let (cwd, cwd_anchor) =
+                resolve_cwd(stdio.cwd.as_deref(), &source.root, &source.data, root, data);
+            McpServerDefinition {
+                command: Some(stdio.command.clone()),
+                args: stdio
+                    .args
+                    .iter()
+                    .map(|argument| expand_plugin_placeholders(argument, root, data))
+                    .collect(),
+                cwd: Some(cwd),
+                launch: Some(Box::new(PluginLaunch {
+                    env: stdio
+                        .env
+                        .iter()
+                        .map(|(key, value)| {
+                            (key.clone(), expand_plugin_placeholders(value, root, data))
+                        })
+                        .collect(),
+                    cwd_anchor,
+                    ..launch
+                })),
+                ..base
+            }
+        }
+        McpTransport::StreamableHttp(http) => McpServerDefinition {
+            url: Some(http.url.clone()),
+            launch: Some(Box::new(PluginLaunch {
+                headers: http.headers.clone(),
+                ..launch
+            })),
+            ..base
+        },
+        McpTransport::Sse(http) => McpServerDefinition {
+            url: Some(http.url.clone()),
+            enabled: false,
+            launch: Some(Box::new(PluginLaunch {
+                disabled_reason: Some(SSE_UNSUPPORTED_DIAGNOSTIC.to_owned()),
+                ..launch
+            })),
+            ..base
+        },
+    }
+}
+
+/// The absolute working directory a stdio server starts in, and which of the
+/// two client-provided roots it is anchored to.
+///
+/// Resolved by joining onto the anchor rather than by textual expansion,
+/// because a `./`-relative `cwd` is specified as *plugin-root*-relative — and
+/// a relative path handed to the child would be resolved against whatever
+/// directory the host process happens to be in. Absent means the plugin root.
+/// Anything outside the three admitted shapes cannot reach here (import
+/// validation rejects it, and the retained file is re-parsed on load), so it
+/// falls through to plain expansion anchored on the root, which the
+/// containment check at launch then judges.
+fn resolve_cwd(
+    cwd: Option<&str>,
+    root_path: &Path,
+    data_path: &Path,
+    root: &str,
+    data: &str,
+) -> (PathBuf, CwdAnchor) {
+    let join = |base: &Path, rest: &str| base.join(rest.trim_start_matches('/'));
+    let Some(cwd) = cwd else {
+        return (root_path.to_owned(), CwdAnchor::Root);
+    };
+    if let Some(rest) = cwd.strip_prefix(&format!("${{{PLUGIN_DATA_VARIABLE}}}")) {
+        return (join(data_path, rest), CwdAnchor::Data);
+    }
+    if let Some(rest) = cwd.strip_prefix(&format!("${{{PLUGIN_ROOT_VARIABLE}}}")) {
+        return (join(root_path, rest), CwdAnchor::Root);
+    }
+    if let Some(rest) = cwd.strip_prefix("./") {
+        return (join(root_path, rest), CwdAnchor::Root);
+    }
+    (
+        PathBuf::from(expand_plugin_placeholders(cwd, root, data)),
+        CwdAnchor::Root,
+    )
+}
+
+/// The program a plugin's stdio server is launched as.
+///
+/// A `./`-relative command names a file inside the package, so it is resolved
+/// against the plugin root here rather than left for the child to resolve. On
+/// Unix the child would resolve it against its *working directory*, which is
+/// the wrong answer the moment a server configures a `cwd` — and a
+/// `${PLUGIN_DATA}`-anchored one puts it outside the package entirely. On
+/// Windows a relative program resolves against the host process's directory,
+/// which is never right. A bare name is left alone and gets exactly the
+/// platform resolution every other stdio server's command gets.
+pub(crate) fn resolve_command(command: &str, root: &Path) -> Result<PathBuf, &'static str> {
+    let Some(relative) = command.strip_prefix("./") else {
+        return Ok(PathBuf::from(command));
+    };
+    let resolved = std::fs::canonicalize(root.join(relative))
+        .map_err(|_| "plugin MCP server executable was not found inside the plugin")?;
+    // Canonicalization resolved every symlink, so this is the real file the
+    // child would execute — a link pointing out of the package is caught here
+    // rather than launched.
+    if !contained_in(&resolved, root) {
+        return Err("plugin MCP server executable is not inside the plugin root");
+    }
+    Ok(resolved)
+}
+
+/// Whether `candidate` stays inside `root` once both are resolved.
+///
+/// Checked again at connect time even though the retained `mcp.json` was
+/// validated textually at import: the textual rule cannot see a symlink, and
+/// the file on disk could have been edited since. A candidate that will not
+/// canonicalize — because it does not exist — fails the check, which is the
+/// right answer for a working directory a child is about to be started in.
+pub(crate) fn contained_in(candidate: &Path, root: &Path) -> bool {
+    let (Ok(candidate), Ok(root)) = (
+        std::fs::canonicalize(candidate),
+        std::fs::canonicalize(root),
+    ) else {
+        return false;
+    };
+    candidate.starts_with(&root)
+}
+
+/// The directory a plugin's child is started in, verified against the root it
+/// is anchored to.
+///
+/// The two anchors are treated differently on purpose. The package tree is
+/// immutable once installed, so a `${PLUGIN_ROOT}`-anchored directory that is
+/// not there is a broken package and fails. The data tree is *client-managed*
+/// — it is handed to the plugin empty — so a `${PLUGIN_DATA}`-anchored
+/// subdirectory is created here; a first launch must not fail because the
+/// server has not had a chance to create the directory it was told to start
+/// in. Containment is then checked either way, after canonicalization, so a
+/// symlink planted inside either tree cannot walk the child out of it.
+pub(crate) fn working_directory(launch: &PluginLaunch, cwd: &Path) -> Result<(), &'static str> {
+    let anchor = match launch.cwd_anchor {
+        CwdAnchor::Root => &launch.root,
+        CwdAnchor::Data => {
+            std::fs::create_dir_all(cwd)
+                .map_err(|_| "plugin MCP server working directory could not be created")?;
+            &launch.data
+        }
+    };
+    if !contained_in(cwd, anchor) {
+        return Err(
+            "plugin MCP server working directory is not inside the plugin root or its data \
+             directory",
+        );
+    }
+    Ok(())
+}
+
+/// The environment a plugin's child is launched with, in specification order:
+/// the configured overlay first, then the two reserved variables.
+///
+/// The reserved names are set last so they cannot be overridden. Configuration
+/// naming either of them is already rejected at import, so this ordering has
+/// no observable effect today — it is the property the specification states,
+/// kept where the launch happens rather than inferred from a parser two crates
+/// away.
+#[must_use]
+pub(crate) fn launch_environment(launch: &PluginLaunch) -> BTreeMap<String, String> {
+    let mut environment = launch.env.clone();
+    environment.insert(
+        PLUGIN_ROOT_VARIABLE.to_owned(),
+        launch.root.to_string_lossy().into_owned(),
+    );
+    environment.insert(
+        PLUGIN_DATA_VARIABLE.to_owned(),
+        launch.data.to_string_lossy().into_owned(),
+    );
+    environment
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openwave_code_execution::{McpHttpServer, McpServer, McpStdioServer, PluginMcpConfig};
+
+    fn source(plugin: &str, servers: Vec<McpServer>) -> PluginMcpSource {
+        PluginMcpSource {
+            plugin: plugin.to_owned(),
+            root: PathBuf::from("/pkg").join(plugin),
+            data: PathBuf::from("/data").join(plugin),
+            config: PluginMcpConfig { servers },
+        }
+    }
+
+    fn stdio(name: &str) -> McpServer {
+        McpServer {
+            name: name.to_owned(),
+            transport: McpTransport::Stdio(McpStdioServer {
+                command: "serve".to_owned(),
+                args: vec!["--root".to_owned(), "${PLUGIN_ROOT}/x".to_owned()],
+                env: BTreeMap::from([("MODE".to_owned(), "${PLUGIN_DATA}".to_owned())]),
+                cwd: None,
+            }),
+        }
+    }
+
+    /// Contract: a plugin server never displaces a namespace someone else
+    /// already holds — a user-configured server or another plugin's — and the
+    /// drop is reported rather than silent. This is the rule that keeps
+    /// installing a plugin from hijacking `mcp__github__*`.
+    #[test]
+    fn a_namespace_already_in_use_drops_the_plugin_server() {
+        let taken = HashSet::from(["notes-search".to_owned()]);
+        let sources = vec![
+            source("notes", vec![stdio("search")]),
+            source("other", vec![stdio("search")]),
+        ];
+        let (definitions, skipped) = derive_definitions(&sources, &taken);
+
+        assert_eq!(
+            definitions
+                .iter()
+                .map(|definition| definition.name.as_str())
+                .collect::<Vec<_>>(),
+            ["other-search"]
+        );
+        assert_eq!(skipped.len(), 1);
+        assert_eq!(skipped[0].plugin, "notes");
+        assert!(skipped[0].reason.contains("notes-search"));
+
+        // Two plugins claiming the same derived namespace: the first in the
+        // given order keeps it, the second is dropped.
+        let (definitions, skipped) = derive_definitions(
+            &[
+                source("a", vec![stdio("b-c")]),
+                source("a-b", vec![stdio("c")]),
+            ],
+            &HashSet::new(),
+        );
+        assert_eq!(definitions.len(), 1);
+        assert_eq!(definitions[0].name, "a-b-c");
+        assert_eq!(skipped.len(), 1);
+        assert_eq!(skipped[0].plugin, "a-b");
+    }
+
+    /// Contract: what a derived definition carries — expanded arguments and
+    /// environment, the reserved variables set last, the legacy transport
+    /// present but disabled with a reason, and a `.` in either name folded
+    /// into the runtime namespace grammar.
+    #[test]
+    fn derived_definitions_carry_the_launch_material_the_specification_requires() {
+        let sources = vec![source(
+            "read.me",
+            vec![
+                stdio("a.b"),
+                McpServer {
+                    name: "legacy".to_owned(),
+                    transport: McpTransport::Sse(McpHttpServer {
+                        url: "http://localhost:7331/sse".to_owned(),
+                        headers: BTreeMap::new(),
+                    }),
+                },
+                McpServer {
+                    name: "remote".to_owned(),
+                    transport: McpTransport::StreamableHttp(McpHttpServer {
+                        url: "https://mcp.example.com/v1".to_owned(),
+                        headers: BTreeMap::from([("x-client".to_owned(), "ow".to_owned())]),
+                    }),
+                },
+                McpServer {
+                    name: "stateful".to_owned(),
+                    transport: McpTransport::Stdio(McpStdioServer {
+                        command: "serve".to_owned(),
+                        args: Vec::new(),
+                        env: BTreeMap::new(),
+                        cwd: Some("${PLUGIN_DATA}/state".to_owned()),
+                    }),
+                },
+            ],
+        )];
+        let (definitions, skipped) = derive_definitions(&sources, &HashSet::new());
+        assert!(skipped.is_empty());
+
+        let stdio = &definitions[0];
+        assert_eq!(stdio.name, "read-me-a-b");
+        assert_eq!(stdio.command.as_deref(), Some("serve"));
+        assert_eq!(stdio.args, ["--root", "/pkg/read.me/x"]);
+        // Absent `cwd` anchors on the plugin root.
+        assert_eq!(stdio.cwd.as_deref(), Some(Path::new("/pkg/read.me")));
+        // Literal values stay off the definition, which is what the secret
+        // store and every projection read.
+        assert!(stdio.env.is_empty());
+        let launch = stdio.launch.as_ref().unwrap();
+        assert_eq!(launch.env["MODE"], "/data/read.me");
+        let environment = launch_environment(launch);
+        assert_eq!(environment[PLUGIN_ROOT_VARIABLE], "/pkg/read.me");
+        assert_eq!(environment[PLUGIN_DATA_VARIABLE], "/data/read.me");
+
+        let legacy = &definitions[1];
+        assert!(!legacy.enabled);
+        assert_eq!(
+            legacy.launch.as_ref().unwrap().disabled_reason.as_deref(),
+            Some(SSE_UNSUPPORTED_DIAGNOSTIC)
+        );
+
+        let remote = &definitions[2];
+        assert!(remote.enabled);
+        assert_eq!(remote.launch.as_ref().unwrap().headers["x-client"], "ow");
+
+        // A `${PLUGIN_DATA}`-anchored working directory resolves under the
+        // data tree and remembers that it is anchored there, so the launch
+        // check judges it against the root it actually named. Judging it
+        // against the package root — the only anchor `cwd` had before — would
+        // make every server that keeps state in its own directory unable to
+        // start.
+        let stateful = &definitions[3];
+        assert_eq!(
+            stateful.cwd.as_deref(),
+            Some(Path::new("/data/read.me/state"))
+        );
+        assert_eq!(
+            stateful.launch.as_ref().unwrap().cwd_anchor,
+            crate::mcp_config::CwdAnchor::Data
+        );
+    }
+
+    /// Contract: a name that cannot fit the namespace limit is shortened
+    /// deterministically, and two long names sharing a prefix stay distinct.
+    #[test]
+    fn long_names_shorten_to_a_stable_distinct_namespace() {
+        let long = "a".repeat(40);
+        let first = runtime_server_name(&long, "one-server-name");
+        let second = runtime_server_name(&long, "two-server-name");
+        assert_eq!(first.len(), MAX_RUNTIME_NAME_BYTES);
+        assert_ne!(first, second);
+        assert_eq!(first, runtime_server_name(&long, "one-server-name"));
+        assert!(first
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-')));
+    }
+}

--- a/crates/openwave-server/src/routes/mcp_gateway.rs
+++ b/crates/openwave-server/src/routes/mcp_gateway.rs
@@ -27,6 +27,14 @@ pub async fn get_mcp_servers(
 /// `PUT /mcp/servers` — atomically validate, connect, persist, and publish a
 /// complete replacement set. A failed candidate never changes active tools.
 ///
+/// The body describes the *user-configured* set only. Plugin-sourced servers
+/// are derived from the installed plugin tree and its enable flags, so a body
+/// naming one is refused outright rather than quietly ignored — the reader
+/// sees them in the same list and would otherwise reasonably expect an edit to
+/// land. Omitting them is not a delete: the runtime rebuilds that slice
+/// itself, and a plugin's servers go away when the plugin is switched off or
+/// uninstalled.
+///
 /// On a managed profile the manual transports are locked: a body that adds or
 /// edits a `command` or `url` server is refused with the same stable
 /// `managed_profile` kind the provider lockdown uses, before anything is
@@ -40,6 +48,16 @@ pub async fn put_mcp_servers(
     State(state): State<AppState>,
     Json(body): Json<McpServersConfig>,
 ) -> Result<Json<McpServersInfo>, ServerError> {
+    if let Some(server) = body.servers.iter().find(|server| server.plugin.is_some()) {
+        return Err(ServerError::bad_request_kind(
+            "mcp_plugin_server_read_only",
+            format!(
+                "MCP server {:?} comes from a plugin and cannot be edited here; \
+                 manage it from the plugin that provides it",
+                server.name
+            ),
+        ));
+    }
     // Resolved outside the runtime's mutation lock: a policy that flips
     // between here and the commit skips the admission check, but the commit
     // itself re-reads the lockdown under that lock, so such a definition

--- a/crates/openwave-server/src/routes/plugins.rs
+++ b/crates/openwave-server/src/routes/plugins.rs
@@ -232,6 +232,9 @@ pub async fn post_plugin_install(
                 ServerError::internal("plugin files could not be installed")
             }
         })?;
+    // A freshly installed plugin may ship bundled MCP servers; bring them up
+    // now rather than at the next restart.
+    state.mcp.reconcile_plugin_servers().await;
     Ok((StatusCode::CREATED, Json(installed)))
 }
 
@@ -382,5 +385,10 @@ pub async fn put_plugins_enabled(
         ));
     }
     write_plugin_enable_state(&*state.store, &flags).await?;
+    // Enabling a plugin connects its bundled MCP servers and mounts their
+    // tools; disabling one disconnects them. The flags are the only control a
+    // plugin-sourced server has, so this has to happen on the same write that
+    // moved them, not on the next restart.
+    state.mcp.reconcile_plugin_servers().await;
     get_plugins(State(state)).await
 }

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -3836,3 +3836,220 @@ async fn an_invoked_skill_must_be_enabled_or_the_turn_is_refused() {
     assert_eq!(mixed.status(), StatusCode::BAD_REQUEST);
     assert_eq!(store.list_turn_runs(chat.id).await.unwrap().len(), 1);
 }
+
+/// A stdio MCP server small enough to write into a plugin package: POSIX sh
+/// answering the three requests a connection makes, plus the health probe. It
+/// records the environment it was launched with on startup, which is what
+/// lets the test assert the two reserved variables actually reached the child.
+#[cfg(unix)]
+const FAKE_PLUGIN_MCP_SERVER: &str = r#"#!/bin/sh
+printf '%s|%s|%s|%s' "$PLUGIN_ROOT" "$PLUGIN_DATA" "$MODE" "$(pwd)" > "$PLUGIN_DATA/started"
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":"PROTOCOL","capabilities":{"tools":{}},"serverInfo":{"name":"toolbox","version":"1"}}}\n' "$id"
+      ;;
+    *'"method":"tools/list"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"tools":[{"name":"lookup","description":"Look something up.","inputSchema":{"type":"object"}}]}}\n' "$id"
+      ;;
+    *'"method":"ping"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{}}\n' "$id"
+      ;;
+  esac
+done
+"#;
+
+/// Contract: a plugin's bundled MCP servers are live tools exactly while the
+/// plugin is installed and enabled, and are managed only from there.
+///
+/// This is the whole lifecycle in one turn of the crank, because each half is
+/// only meaningful against the others: mounting without unmounting leaves a
+/// disabled plugin's subprocess serving tools, and a `PUT /mcp/servers` that
+/// could edit or drop a derived server would make the plugin's own switch a
+/// lie. The launch assertions cover what the Agent Plugins specification
+/// makes normative for a subprocess-launching client — `PLUGIN_ROOT` and
+/// `PLUGIN_DATA` set, the data directory created before launch, expansion in
+/// `env` values — by reading what the child itself observed.
+#[cfg(unix)]
+#[tokio::test]
+async fn a_plugins_bundled_mcp_server_mounts_only_while_the_plugin_is_enabled() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let (dir, store) = temp_db_store("plugin-mcp.db").await;
+    let store: Arc<dyn Store> = Arc::new(store);
+
+    // A bundle must claim at least one member, so it ships a skill too.
+    let skill = dir.path().join("skills/toolbox-notes");
+    std::fs::create_dir_all(&skill).unwrap();
+    std::fs::write(
+        skill.join("SKILL.md"),
+        "---\nname: toolbox-notes\ndescription: Notes.\n---\nBody.\n",
+    )
+    .unwrap();
+
+    let plugin = dir.path().join("plugins/toolbox");
+    let write_plugin = || {
+        std::fs::create_dir_all(&plugin).unwrap();
+        std::fs::write(
+            plugin.join("PLUGIN.md"),
+            "---\nname: toolbox\ndisplay-name: Toolbox\ndescription: Bundled tools.\n\
+             category: other\nskills: [\"toolbox-notes\"]\n---\n",
+        )
+        .unwrap();
+        // Exactly what the importer retains beside the manifest: the canonical
+        // form of a validated `mcp.json`.
+        std::fs::write(
+            plugin.join("mcp.json"),
+            format!(
+                "{{\"$schema\": \"{}\", \"mcpServers\": {{\"local.serve\": {{\
+                   \"type\": \"stdio\", \"command\": \"./serve\", \
+                   \"cwd\": \"${{PLUGIN_DATA}}/state\", \
+                   \"env\": {{\"MODE\": \"${{PLUGIN_DATA}}/state\"}}}}}}}}",
+                openwave_code_execution::AGENT_PLUGIN_MCP_SCHEMA_ID
+            ),
+        )
+        .unwrap();
+        let script = plugin.join("serve");
+        std::fs::write(
+            &script,
+            FAKE_PLUGIN_MCP_SERVER.replace("PROTOCOL", openwave_mcp::PROTOCOL_VERSION),
+        )
+        .unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+    };
+    write_plugin();
+
+    let build = || {
+        let secrets = Arc::new(MemSecrets::default());
+        let mut state = AppState::new(
+            Config::desktop(dir.path()),
+            store.clone(),
+            Arc::new(FixedResolver(Arc::new(FakeProvider))),
+            secrets.clone(),
+            Arc::new(ToolRegistry::new()),
+            AgentConfig {
+                model: "fake".into(),
+                ..AgentConfig::default()
+            },
+        );
+        let exec = Arc::new(
+            crate::code_execution::ConfiguredCodeExecutionProvider::new(
+                store.clone(),
+                secrets,
+                dir.path().join("scratch"),
+            )
+            .with_user_skills(Some(dir.path().join("skills")))
+            .with_user_plugins(Some(dir.path().join("plugins"))),
+        );
+        state.code_execution = Some(exec.clone());
+        state
+            .mcp
+            .set_plugin_catalog(Arc::new(crate::plugin_mcp::InstalledPluginMcpCatalog::new(
+                exec,
+                store.clone(),
+                dir.path().join("plugin-data"),
+            )));
+        let mcp = state.mcp.clone();
+        let token = state.token.clone();
+        (app(state), format!("Bearer {token}"), mcp)
+    };
+
+    let (router, bearer, mcp) = build();
+    // Startup reconcile, as `serve` runs it after `initialize`.
+    mcp.reconcile_plugin_servers().await;
+
+    // The server key is `local.serve` and the plugin is `toolbox`; the runtime
+    // namespace folds the `.` the mount grammar has no room for.
+    let mounted = "mcp__toolbox-local-serve__lookup";
+    assert!(
+        mcp.snapshot().get(mounted).is_some(),
+        "an enabled plugin's bundled server mounts its tools"
+    );
+
+    // What the child observed: both reserved variables, the configured `env`
+    // value expanded against the data directory, and the working directory it
+    // was actually started in. That last one is the whole anchored-`cwd`
+    // contract in one reading — the directory is under the data tree the
+    // configuration named, and the client created it, because a plugin is
+    // handed that tree empty and cannot be expected to have made it first.
+    // It also pins that `./serve` resolved against the *package root*: with a
+    // working directory pointing somewhere else entirely, a command left for
+    // the child to resolve would not have started at all.
+    let data = dir.path().join("plugin-data/toolbox");
+    let observed = std::fs::read_to_string(data.join("started")).unwrap();
+    let root = std::fs::canonicalize(&plugin).unwrap();
+    let data_path = std::fs::canonicalize(&data).unwrap();
+    let state = std::fs::canonicalize(data.join("state")).unwrap();
+    assert_eq!(
+        observed,
+        format!(
+            "{}|{}|{}/state|{}",
+            root.display(),
+            data_path.display(),
+            data_path.display(),
+            state.display()
+        )
+    );
+
+    // The settings surface lists it read-only, attributed to its plugin.
+    let listed = get_mcp_servers(&router, &bearer).await;
+    assert_eq!(listed["servers"].as_array().unwrap().len(), 1);
+    assert_eq!(listed["servers"][0]["name"], "toolbox-local-serve");
+    assert_eq!(listed["servers"][0]["plugin"], "toolbox");
+    assert_eq!(listed["servers"][0]["health"], "healthy");
+
+    // A body that names it is refused rather than quietly ignored, and a body
+    // that omits it does not delete it — the derived slice is rebuilt either
+    // way.
+    let refused = put_mcp_servers(
+        &router,
+        &bearer,
+        serde_json::json!({"servers": [{
+            "name": "toolbox-local-serve", "command": "/bin/false", "plugin": "toolbox"
+        }]}),
+    )
+    .await;
+    assert_eq!(refused.status(), StatusCode::BAD_REQUEST);
+    let response = put_mcp_servers(&router, &bearer, serde_json::json!({"servers": []})).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let after: serde_json::Value = json_body(response).await;
+    assert_eq!(after["servers"][0]["plugin"], "toolbox");
+    assert!(
+        mcp.snapshot().get(mounted).is_some(),
+        "omitting a derived server from a settings save must not unmount it"
+    );
+
+    // Switching the plugin off disconnects its server and unmounts its tools.
+    let response = put_plugins_enabled(
+        &router,
+        &bearer,
+        serde_json::json!({"plugins": {"toolbox": false}}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(mcp.snapshot().get(mounted).is_none());
+    assert!(get_mcp_servers(&router, &bearer).await["servers"]
+        .as_array()
+        .unwrap()
+        .is_empty());
+    // Its data survives the switch: it is off, not gone.
+    assert!(data.is_dir());
+
+    // Uninstalling — removing the package — takes the data directory with it.
+    let response = put_plugins_enabled(
+        &router,
+        &bearer,
+        serde_json::json!({"plugins": {"toolbox": true}}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    std::fs::remove_dir_all(&plugin).unwrap();
+    let (_router, _bearer, mcp) = build();
+    mcp.reconcile_plugin_servers().await;
+    assert!(mcp.snapshot().get(mounted).is_none());
+    assert!(
+        !data.exists(),
+        "uninstalling a plugin deletes the writable directory it was given"
+    );
+}


### PR DESCRIPTION
An installed [Agent Plugins](https://agent-plugins.org) package may ship an `mcp.json` declaring MCP servers the client runs on its behalf. #1710 validates that file and retains a canonical copy beside the installed package, and derives an `Mcp` capability badge from it. Nothing connected. This connects it.

## Derived, not records

Plugin-sourced servers are recomputed from the installed tree and the plugin's enable flag — at startup, after an install, and on every write to `PUT /plugins/enabled`. They are not `mcp_server` connected-app records, are never persisted, and cannot be edited through `PUT /mcp/servers`: a body naming one is refused with a clear error rather than quietly ignored (the reader sees them in the same list and would reasonably expect an edit to land), and omitting one is not a delete. Enabling a plugin connects its servers and mounts their tools; disabling or uninstalling it disconnects them and unmounts.

Reconciliation touches only the plugin slice, so toggling a plugin does not churn a user's live stdio child, and a plugin server that fails to connect degrades like a gateway mount instead of failing somebody's unrelated settings save.

Uninstalling a plugin is removing its directory — there is no uninstall route today — so the reconcile prunes the writable directory of any plugin that is no longer installed. Switching a plugin off keeps its data; only uninstalling removes it.

## Naming

A runtime namespace is 32 bytes of `[A-Za-z0-9_-]` because it has to fit inside `mcp__{server}__{tool}`, while both the package-name grammar and the `mcp.json` server key admit `.` and run to 64. The derived name is `{plugin}-{server}` with everything outside the namespace grammar folded to `-`, shortened to 25 bytes plus six hex digits of a SHA-256 over the exact `{plugin}/{server}` pair when it does not fit.

Folding can make two distinct pairs agree, so collisions are resolved by *dropping*, not disambiguating: a plugin server never displaces a namespace a user-configured server or another plugin already holds, and the drop is reported. Disambiguating would let a package take a namespace by picking a name that collides with one already in use.

## Specification conformance (v1.0.0)

- **`PLUGIN_ROOT` / `PLUGIN_DATA`** are set last, after the configured `env` overlay, and `PLUGIN_DATA` is created before the child starts. Configuration naming either is already rejected at parse, so the ordering has no observable effect today; it lives where the launch happens rather than being inferred from a parser two crates away.
- **Expansion** of `${PLUGIN_ROOT}`/`${PLUGIN_DATA}` happens in `args`, `env` values, and `cwd` only, in one non-recursive pass. Replacement text is never rescanned, and anything else that looks like a placeholder stays literal.
- **`command`** is passed through untouched and gets exactly the platform resolution every other stdio server gets, under the same `env_clear()`, so the plugin path and the user-configured path cannot drift.
- **`cwd`** defaults to the package root and is re-checked for containment at launch (canonicalize + prefix), not only textually at import — only a check at launch sees symlinks and edits made since.
- **streamable-http** connects with the configured static headers. Headers are threaded through a new `McpClient::connect_http_with_headers`; a configured header naming one the transport generates itself (`authorization`, `accept`, `mcp-protocol-version`, `mcp-session-id`, `host`, `content-*`) is dropped, so a package cannot override the credential a connection presents. Configured headers cannot reach a second origin because this transport already follows no redirects at all — that existing `Policy::none()` is now load-bearing for a second reason and says so.
- **`sse`** entries are listed disabled with the reason rather than omitted; this client does not implement the legacy transport, and silently dropping the entry would leave nothing to explain the absence.

Values — `env` and header — never enter the definition type, a persisted record, an API response, or a log.

## Policy and egress

Under managed policy a plugin-sourced server is a manual server, with the same diagnostic a user-typed one carries. Derived servers bypass `PUT /mcp/servers` entirely, so keying the lockdown off that route would let a managed profile be handed arbitrary local subprocesses and remote endpoints by installing a plugin — exactly the channel the lockdown exists to close.

Non-loopback HTTP(S) endpoints are admitted against the same denied-network list the native web-fetch path uses (`admit_fetch_address`: RFC 1918, link-local including cloud metadata, CGNAT, and the rest). **Two deliberate divergences**, documented where they are made:

- **Loopback is allowed.** The specification permits plain HTTP for loopback precisely so a plugin can ship a local server; refusing it would make bundled local servers unrunnable. Permitted only when the URL's own host is a loopback literal or `localhost`, never when a DNS name merely resolves to one.
- **A non-default port is allowed.** Local and self-hosted MCP endpoints routinely listen off 443.

Resolution is advisory rather than a hard guarantee (the transport resolves again when it connects) — the same TOCTOU the native fetch path lives with, and a weaker exposure here because the URL is fixed package data reviewed at install rather than a string the model just produced. Failing admission is a per-server connection failure, not a config error.

MCP tools remain `ApprovalClass::Sensitive`. No change.

## `PLUGIN_DATA` location

`{data_dir}/plugin-data/<plugin>/`, a sibling of `{data_dir}/plugins` rather than a directory inside the package tree — an update replaces the tree, and the specification requires this directory to survive one. Keeping it outside also means nothing a plugin writes at runtime can change what the package claims to be.

## Surfacing

`McpServerInfo` gains `plugin: Option<String>`; generated wire types regenerated. `McpPanel.tsx` renders plugin-sourced entries in the existing list as a read-only section with health and plugin attribution, and both writes send only what the user configured.

## Tests

- One end-to-end through the real routes: an installed plugin whose retained `mcp.json` launches a small POSIX-sh MCP server records the environment it was given, so the assertions on `PLUGIN_ROOT`, `PLUGIN_DATA`, directory creation, and `env` expansion read what the child actually observed. It then covers the whole lifecycle — mount, `PUT /mcp/servers` refusal and omission, disable then unmount, uninstall then data removed — in one turn of the crank, because each half is only meaningful against the others.
- One for managed-lockdown parity.
- Unit tests for the collision-drop rule, what a derived definition carries, name shortening, single-pass expansion, and the configured-header filter.

Verified: `cargo fmt --all`; clippy `-D warnings --all-targets` on the four touched crates; `cargo test -p openwave-mcp -p openwave-code-execution -p openwave-server`; `cargo check --workspace --locked --all-targets` with no lockfile drift and no new dependencies; `tsc --noEmit` and `pnpm test` (802 passing).

Not verified: driving the running desktop app. The stdio end-to-end test is `#[cfg(unix)]`.
