### PR TITLE
feat(cli): slash commands, spinner, streaming expansion, boxed selectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4235,6 +4235,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.30.0",
  "tui-textarea",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]

--- a/crates/openwave-cli/Cargo.toml
+++ b/crates/openwave-cli/Cargo.toml
@@ -41,6 +41,8 @@ serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "signal", "sync", "time"] }
 tokio-tungstenite = { workspace = true }
 tui-textarea = "=0.7.0"
+# Display-width clipping for lines rendered into fixed scrollback/panel buffers.
+unicode-width = "=0.2.0"
 
 [dev-dependencies]
 tempfile = "=3.27.0"

--- a/crates/openwave-cli/src/tui/app.rs
+++ b/crates/openwave-cli/src/tui/app.rs
@@ -48,7 +48,6 @@ const TICK: Duration = Duration::from_millis(100);
 /// One delayed reconnect after an unexpected socket close; further closes give
 /// up rather than hammering the server.
 const RECONNECT_DELAY: Duration = Duration::from_secs(2);
-const SPINNER: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
 /// Outcomes of HTTP actions spawned off the UI loop, plus the one reconnect.
 enum ActionOutcome {
@@ -187,6 +186,9 @@ struct App {
     /// In-flight reconnect task identity, so the loop doesn't open a second
     /// socket while one is already connecting.
     reconnecting: Option<()>,
+    /// The cursor in the slash-command autocomplete list, when the composer
+    /// is a `/` prefix.
+    slash_selected: usize,
 }
 
 impl App {
@@ -222,6 +224,7 @@ impl App {
             catalog: None,
             hydrated: false,
             reconnecting: None,
+            slash_selected: 0,
         }
     }
 
@@ -250,7 +253,7 @@ impl App {
     }
 
     fn spinner(&self) -> char {
-        SPINNER[self.spinner % SPINNER.len()]
+        render::spinner_at(self.spinner)
     }
 
     fn on_frame(&mut self, frame: SequencedFrame) {
@@ -602,11 +605,63 @@ impl App {
             {
                 self.composer.insert_newline();
             }
+            // Slash autocomplete: when the composer is a `/` prefix, Tab and
+            // the arrows walk the matching command list and Enter completes.
+            KeyCode::Enter if self.slash_matches().len() == 1 => {
+                self.complete_slash();
+                self.try_send();
+            }
+            KeyCode::Tab if !self.slash_matches().is_empty() => {
+                let len = self.slash_matches().len();
+                self.slash_selected = (self.slash_selected + 1) % len;
+            }
+            KeyCode::BackTab if !self.slash_matches().is_empty() => {
+                let len = self.slash_matches().len();
+                self.slash_selected = (self.slash_selected + len - 1) % len;
+            }
+            KeyCode::Down if !self.slash_matches().is_empty() => {
+                let len = self.slash_matches().len();
+                self.slash_selected = (self.slash_selected + 1) % len;
+            }
+            KeyCode::Up if !self.slash_matches().is_empty() => {
+                let len = self.slash_matches().len();
+                self.slash_selected = (self.slash_selected + len - 1) % len;
+            }
             KeyCode::Enter => self.try_send(),
             _ => {
                 super::composer::edit_key(&mut self.composer, key);
+                self.slash_selected = 0;
             }
         }
+    }
+
+    /// The composer text as a slash-command prefix: matches when the input is
+    /// a single line starting with `/` and no space yet (still naming the
+    /// command). Returns the matching canonical command names.
+    fn slash_matches(&self) -> Vec<&'static str> {
+        let line = self.composer.lines().first().cloned().unwrap_or_default();
+        if self.composer.lines().len() > 1 || !line.starts_with('/') || line.contains(' ') {
+            return Vec::new();
+        }
+        let prefix = line.trim_start_matches('/').to_lowercase();
+        super::overlays::SLASH_COMMANDS
+            .iter()
+            .map(|(name, _)| *name)
+            .filter(|name| name.starts_with(prefix.as_str()))
+            .collect()
+    }
+
+    /// Fill the composer with the selected slash command plus a trailing
+    /// space, ready for args or Enter.
+    fn complete_slash(&mut self) {
+        let matches = self.slash_matches();
+        let Some(name) = matches.get(self.slash_selected).or(matches.first()) else {
+            return;
+        };
+        self.composer = super::composer::new(vec![format!("/{name} ")]);
+        // Cursor to the end.
+        self.composer.move_cursor(tui_textarea::CursorMove::End);
+        self.slash_selected = 0;
     }
 
     fn overlay_key(&mut self, key: KeyEvent) {
@@ -766,9 +821,94 @@ impl App {
         }
     }
 
+    /// The slash-command table, Claude Code style: `/name args` in the
+    /// composer. Each entry is the canonical name plus a one-line blurb the
+    /// help overlay and the autocomplete list share.
+    /// Run a slash command. Returns true when the input was a command (so the
+    /// composer resets and nothing is sent to the model). The command table
+    /// lives in `overlays::SLASH_COMMANDS`, shared with the help overlay.
+    fn run_slash_command(&mut self, input: &str) -> bool {
+        let trimmed = input.trim();
+        let Some(body) = trimmed.strip_prefix('/') else {
+            return false;
+        };
+        let mut parts = body.splitn(2, char::is_whitespace);
+        let name = parts.next().unwrap_or("").to_lowercase();
+        let arg = parts.next().map(str::trim).unwrap_or("");
+        // The composer is consumed either way; unknown commands just flash.
+        self.composer = super::composer::new(Vec::new());
+        match name.as_str() {
+            "model" | "models" => self.open_models(),
+            "effort" => {
+                if arg.is_empty() {
+                    // No argument: open the model overlay's effort picker.
+                    self.open_models();
+                    if let Some(Overlay::Models(overlay)) = &mut self.overlay {
+                        overlay.picking_effort = true;
+                    }
+                } else {
+                    self.set_effort(Some(arg.to_owned()));
+                }
+            }
+            "mode" | "permission" | "permissions" => {
+                if arg.is_empty() {
+                    self.open_mode();
+                } else {
+                    self.set_mode(arg.to_owned());
+                }
+            }
+            "chats" | "chat" | "threads" | "switch" => self.open_chats(),
+            "new" => self.new_chat(),
+            "rename" | "title" => {
+                if arg.is_empty() {
+                    self.flash("/rename <title>");
+                } else {
+                    let chat = self.chat;
+                    self.rename_chat(chat, arg.to_owned());
+                }
+            }
+            "move" | "project" => self.open_move(),
+            "agents" | "agent" | "runs" => self.open_agents(),
+            "questions" | "question" | "ask" => {
+                let chat = self.chat;
+                self.refresh_questions_for(chat);
+            }
+            "help" | "?" => self.overlay = Some(Overlay::Help(HelpOverlay::new())),
+            "quit" | "exit" | "q" => self.should_quit = true,
+            _ => {
+                self.flash(format!("unknown command /{name} — try /help"));
+            }
+        }
+        true
+    }
+
+    /// Fetch this chat's parked questions and open the answer overlay.
+    fn refresh_questions_for(&mut self, chat: ChatId) {
+        let (client, actions) = (self.client.clone(), self.actions.clone());
+        tokio::spawn(async move {
+            match client.list_pending_questions(chat).await {
+                Ok(mut pending) => {
+                    if let Some(block) = pending.drain(..).next() {
+                        let _ = actions.send(ActionOutcome::QuestionsReady(block));
+                    } else {
+                        let _ =
+                            actions.send(ActionOutcome::GenericOk("no pending questions".into()));
+                    }
+                }
+                Err(error) => {
+                    let _ = actions.send(ActionOutcome::ChatOpFailed(error.to_string()));
+                }
+            }
+        });
+    }
+
     fn try_send(&mut self) {
         let content = self.composer.lines().join("\n");
         if content.trim().is_empty() {
+            return;
+        }
+        // Slash commands are handled locally, never sent to the model.
+        if content.trim_start().starts_with('/') && self.run_slash_command(&content) {
             return;
         }
         // A running turn steers rather than rejects: the desktop's composer
@@ -1301,7 +1441,7 @@ impl App {
 
     /// The live region's transient stack, bottom-anchored within `max` lines:
     /// blank padding goes on top, so content sits directly above the composer.
-    fn transient_lines(&self, width: usize, max: usize) -> Vec<Line<'static>> {
+    fn transient_lines(&self, width: usize) -> Vec<Line<'static>> {
         let mut lines = Vec::new();
         if let Some(plan) = &self.plan {
             lines.extend(render::plan_card(
@@ -1315,8 +1455,14 @@ impl App {
             || self.active_tool.is_some()
             || self.approval.is_some()
         {
-            if !self.thinking.is_empty() {
-                lines.extend(render::thinking_lines(&self.thinking, width));
+            // While the model works, show a spinner rather than the raw
+            // reasoning stream — the reasoning still folds into the transcript
+            // at turn end, so nothing is lost, but the live view stays calm.
+            if self.streaming.is_empty() && self.active_tool.is_none() && self.approval.is_none() {
+                lines.push(Line::from(vec![
+                    Span::styled(format!("{} ", self.spinner()), theme::accent()),
+                    Span::styled("working…", theme::muted()),
+                ]));
             }
             if !self.streaming.is_empty() {
                 lines.extend(render::streaming_lines(&self.streaming, width));
@@ -1361,13 +1507,9 @@ impl App {
                 self.spinner(),
             ));
         }
-        if lines.len() > max {
-            lines.drain(..lines.len() - max);
-        }
-        let pad = max.saturating_sub(lines.len());
-        let mut anchored = vec![Line::default(); pad];
-        anchored.extend(lines);
-        anchored
+        // The region is sized to the content (see `draw`), so nothing is
+        // drained or padded here — a growing stream grows the terminal.
+        lines
     }
 
     /// The footer's left side: state segment in the accent, key hints muted,
@@ -1414,6 +1556,8 @@ impl App {
             spans.push(sep());
             spans.push(Span::styled("enter send", theme::muted()));
         }
+        spans.push(sep());
+        spans.push(Span::styled("/ commands", theme::muted()));
         spans.push(sep());
         spans.push(Span::styled("ctrl+o chats", theme::muted()));
         spans.push(sep());
@@ -1692,6 +1836,9 @@ fn flush_commits(app: &mut App, terminal: &mut Terminal<CrosstermBackend<Stdout>
         .commits
         .drain(..)
         .flat_map(|commit| commit.lines(width))
+        // Defensive: never let a line wider than the viewport reach
+        // `insert_before`, whose fixed buffer panics on an over-wide line.
+        .map(|line| render::clip_line(line, width))
         .collect();
     let height = u16::try_from(lines.len()).unwrap_or(u16::MAX);
     terminal
@@ -1706,10 +1853,19 @@ fn draw(
     terminal: &mut Terminal<CrosstermBackend<Stdout>>,
     live_height: u16,
 ) -> Result<()> {
-    let width = terminal.size().map_err(terminal_error)?.width as usize;
+    let area = terminal.size().map_err(terminal_error)?;
+    let width = area.width as usize;
     let composer_rows = (app.composer.lines().len() as u16).clamp(1, MAX_COMPOSER_ROWS);
-    let transient_rows = live_height.saturating_sub(composer_rows + 1);
-    let transient = app.transient_lines(width, transient_rows as usize);
+    // The transient region grows with its content (so streaming text expands
+    // the terminal rather than scrolling inside a capped block), bounded by
+    // the viewport minus the composer and footer. `live_height` is the floor
+    // the loop keeps stable between turns.
+    let max_transient = area
+        .height
+        .saturating_sub(composer_rows + 1)
+        .max(live_height.saturating_sub(composer_rows + 1));
+    let transient = app.transient_lines(width);
+    let transient_rows = (transient.len() as u16).clamp(1, max_transient);
     terminal
         .draw(|frame| {
             let rows = Layout::vertical([
@@ -1745,6 +1901,42 @@ fn draw(
                 footer.spans.extend(right);
             }
             frame.render_widget(Paragraph::new(footer), rows[2]);
+            // The slash-command autocomplete floats just above the composer.
+            let slash = app.slash_matches();
+            if !slash.is_empty() {
+                let selected = app.slash_selected.min(slash.len() - 1);
+                let items: Vec<Line<'static>> = slash
+                    .iter()
+                    .enumerate()
+                    .map(|(i, name)| {
+                        let blurb = super::overlays::SLASH_COMMANDS
+                            .iter()
+                            .find(|(n, _)| n == name)
+                            .map(|(_, b)| *b)
+                            .unwrap_or("");
+                        let marker = if i == selected { "▸ " } else { "  " };
+                        let style = if i == selected {
+                            theme::selected()
+                        } else {
+                            Style::default()
+                        };
+                        Line::from(vec![
+                            Span::styled(marker, style),
+                            Span::styled(format!("/{name:<10}"), style),
+                            Span::styled(blurb, style),
+                        ])
+                    })
+                    .collect();
+                let height = items.len() as u16;
+                // Sit on top of the composer's top edge, growing upward.
+                let y = rows[1].y.saturating_sub(height);
+                let area = Rect::new(rows[1].x, y, rows[1].width.min(56), height);
+                frame.render_widget(Clear, area);
+                frame.render_widget(
+                    Paragraph::new(items).style(Style::default().bg(theme::PANEL_BG)),
+                    area,
+                );
+            }
             // An overlay floats on top of the live region.
             if let Some(overlay) = &mut app.overlay {
                 render_overlay(overlay, frame);

--- a/crates/openwave-cli/src/tui/overlays.rs
+++ b/crates/openwave-cli/src/tui/overlays.rs
@@ -18,6 +18,26 @@ use super::render;
 use super::theme;
 use crate::api::wire::{AgentRunSnapshot, ChatSummary, ModelInfo, PendingQuestions};
 
+/// The slash-command table, Claude Code style: `/name args` in the composer.
+/// Each entry is the canonical name plus a one-line blurb the help overlay and
+/// the autocomplete list share.
+pub(crate) const SLASH_COMMANDS: &[(&str, &str)] = &[
+    ("model", "pick the model (opens the selector)"),
+    (
+        "effort",
+        "set reasoning effort: none|low|medium|high|xhigh|max",
+    ),
+    ("mode", "permission mode: plan|ask|auto|allow"),
+    ("chats", "open the chat switcher"),
+    ("new", "start a new chat"),
+    ("rename", "rename this chat: /rename <title>"),
+    ("move", "move this chat to a project"),
+    ("agents", "list background agents"),
+    ("questions", "answer the model's parked questions"),
+    ("help", "shortcut and command reference"),
+    ("quit", "leave"),
+];
+
 /// What an overlay decided. `Stay` keeps it open; `Dismiss` closes it; the
 /// rest close it and hand the app an action.
 pub enum OverlayOutcome {
@@ -49,6 +69,33 @@ fn row(selected: bool, spans: Vec<Span<'static>>) -> Line<'static> {
             .map(|span| span.patch_style(style))
             .collect::<Vec<_>>(),
     )
+}
+
+/// A selectable bar row: the selected row is padded to the panel's full width
+/// so its highlight reads as a solid bar, the way a menu cursor should.
+fn bar(selected: bool, width: usize, spans: Vec<Span<'static>>) -> Line<'static> {
+    use unicode_width::UnicodeWidthStr;
+    let mut spans = spans;
+    if selected {
+        let used: usize = spans.iter().map(|span| span.content.width()).sum();
+        if used < width {
+            spans.push(Span::styled(" ".repeat(width - used), theme::selected()));
+        }
+    }
+    row(selected, spans)
+}
+
+/// Move a selection cursor. Arrows and Tab step down, Shift-Tab steps up,
+/// wrapping at the ends — the menu convention.
+fn nav_step(selected: usize, len: usize, down: bool) -> usize {
+    if len == 0 {
+        return 0;
+    }
+    if down {
+        (selected + 1) % len
+    } else {
+        (selected + len - 1) % len
+    }
 }
 
 fn title_or_untitled(title: Option<&str>) -> String {
@@ -115,15 +162,15 @@ impl ChatsOverlay {
         }
         match key.code {
             KeyCode::Esc => OverlayOutcome::Dismiss,
-            KeyCode::Down | KeyCode::Char('j') => {
+            KeyCode::Down | KeyCode::Char('j') | KeyCode::Tab => {
                 if !self.chats.is_empty() {
-                    self.selected = (self.selected + 1) % self.chats.len();
+                    self.selected = nav_step(self.selected, self.chats.len(), true);
                 }
                 OverlayOutcome::Stay
             }
-            KeyCode::Up | KeyCode::Char('k') => {
+            KeyCode::Up | KeyCode::Char('k') | KeyCode::BackTab => {
                 if !self.chats.is_empty() {
-                    self.selected = (self.selected + self.chats.len() - 1) % self.chats.len();
+                    self.selected = nav_step(self.selected, self.chats.len(), false);
                 }
                 OverlayOutcome::Stay
             }
@@ -209,11 +256,11 @@ impl ChatsOverlay {
                     },
                 ),
             ];
-            out.push(row(selected, spans));
+            out.push(bar(selected, width, spans));
         }
         out.push(Line::default());
         out.push(Line::from(Span::styled(
-            "enter open · n new · r rename · d delete · esc close",
+            "↑↓/tab move · enter open · n new · r rename · d delete · esc close",
             theme::muted(),
         )));
         out
@@ -279,16 +326,16 @@ impl AgentsOverlay {
                     OverlayOutcome::Dismiss
                 }
             }
-            KeyCode::Down | KeyCode::Char('j') => {
+            KeyCode::Down | KeyCode::Char('j') | KeyCode::Tab => {
                 if !self.runs.is_empty() {
-                    self.selected = (self.selected + 1) % self.runs.len();
+                    self.selected = nav_step(self.selected, self.runs.len(), true);
                     self.detail = None;
                 }
                 OverlayOutcome::Stay
             }
-            KeyCode::Up | KeyCode::Char('k') => {
+            KeyCode::Up | KeyCode::Char('k') | KeyCode::BackTab => {
                 if !self.runs.is_empty() {
-                    self.selected = (self.selected + self.runs.len() - 1) % self.runs.len();
+                    self.selected = nav_step(self.selected, self.runs.len(), false);
                     self.detail = None;
                 }
                 OverlayOutcome::Stay
@@ -372,7 +419,7 @@ impl AgentsOverlay {
             } else {
                 spans.push(Span::styled(format!("  {}", run.status), theme::muted()));
             }
-            out.push(row(selected, spans));
+            out.push(bar(selected, width, spans));
         }
         // The expanded run's detail: activity timeline plus a result slice.
         if let Some((open, items)) = &self.detail {
@@ -433,7 +480,7 @@ pub struct ModelOverlay {
     current: Option<String>,
     effort: Option<String>,
     /// Whether the effort list is showing instead of the model list.
-    picking_effort: bool,
+    pub(crate) picking_effort: bool,
     /// The cursor within the effort list.
     effort_selected: usize,
 }
@@ -487,16 +534,15 @@ impl ModelOverlay {
                     self.picking_effort = false;
                     return OverlayOutcome::Stay;
                 }
-                KeyCode::Down | KeyCode::Char('j') => {
+                KeyCode::Down | KeyCode::Char('j') | KeyCode::Tab => {
                     if !efforts.is_empty() {
-                        self.effort_selected = (self.effort_selected + 1) % efforts.len();
+                        self.effort_selected = nav_step(self.effort_selected, efforts.len(), true);
                     }
                     return OverlayOutcome::Stay;
                 }
-                KeyCode::Up | KeyCode::Char('k') => {
+                KeyCode::Up | KeyCode::Char('k') | KeyCode::BackTab => {
                     if !efforts.is_empty() {
-                        self.effort_selected =
-                            (self.effort_selected + efforts.len() - 1) % efforts.len();
+                        self.effort_selected = nav_step(self.effort_selected, efforts.len(), false);
                     }
                     return OverlayOutcome::Stay;
                 }
@@ -509,15 +555,15 @@ impl ModelOverlay {
         }
         match key.code {
             KeyCode::Esc => OverlayOutcome::Dismiss,
-            KeyCode::Down | KeyCode::Char('j') => {
+            KeyCode::Down | KeyCode::Char('j') | KeyCode::Tab => {
                 if !self.models.is_empty() {
-                    self.selected = (self.selected + 1) % self.models.len();
+                    self.selected = nav_step(self.selected, self.models.len(), true);
                 }
                 OverlayOutcome::Stay
             }
-            KeyCode::Up | KeyCode::Char('k') => {
+            KeyCode::Up | KeyCode::Char('k') | KeyCode::BackTab => {
                 if !self.models.is_empty() {
-                    self.selected = (self.selected + self.models.len() - 1) % self.models.len();
+                    self.selected = nav_step(self.selected, self.models.len(), false);
                 }
                 OverlayOutcome::Stay
             }
@@ -548,8 +594,9 @@ impl ModelOverlay {
             for (i, effort) in self.efforts().iter().enumerate() {
                 let selected = i == self.effort_selected;
                 let current = self.effort.as_deref() == Some(effort.as_str());
-                out.push(row(
+                out.push(bar(
                     selected,
+                    width,
                     vec![
                         Span::styled(
                             if selected { "▸ " } else { "  " },
@@ -617,11 +664,11 @@ impl ModelOverlay {
             if !model.available {
                 spans.push(Span::styled("  unavailable", theme::muted()));
             }
-            out.push(row(selected, spans));
+            out.push(bar(selected, width, spans));
         }
         out.push(Line::default());
         out.push(Line::from(Span::styled(
-            "enter select · d default · e effort… · esc close",
+            "↑↓/tab move · enter select · d default · e effort… · esc close",
             theme::muted(),
         )));
         out
@@ -655,12 +702,12 @@ impl ModeOverlay {
     pub fn key(&mut self, key: KeyEvent) -> OverlayOutcome {
         match key.code {
             KeyCode::Esc => OverlayOutcome::Dismiss,
-            KeyCode::Down | KeyCode::Char('j') => {
-                self.selected = (self.selected + 1) % MODES.len();
+            KeyCode::Down | KeyCode::Char('j') | KeyCode::Tab => {
+                self.selected = nav_step(self.selected, MODES.len(), true);
                 OverlayOutcome::Stay
             }
-            KeyCode::Up | KeyCode::Char('k') => {
-                self.selected = (self.selected + MODES.len() - 1) % MODES.len();
+            KeyCode::Up | KeyCode::Char('k') | KeyCode::BackTab => {
+                self.selected = nav_step(self.selected, MODES.len(), false);
                 OverlayOutcome::Stay
             }
             KeyCode::Enter => OverlayOutcome::SetMode(MODES[self.selected].0.to_owned()),
@@ -673,8 +720,9 @@ impl ModeOverlay {
         let mut out = Vec::new();
         for (i, (_, label, blurb)) in MODES.iter().enumerate() {
             let selected = i == self.selected;
-            out.push(row(
+            out.push(bar(
                 selected,
+                width,
                 vec![
                     Span::styled(
                         if selected { "▸ " } else { "  " },
@@ -701,7 +749,7 @@ impl ModeOverlay {
         }
         out.push(Line::default());
         out.push(Line::from(Span::styled(
-            "enter set · esc close",
+            "↑↓/tab move · enter set · esc close",
             theme::muted(),
         )));
         out
@@ -730,12 +778,12 @@ impl MoveOverlay {
         let len = self.projects.len() + 1;
         match key.code {
             KeyCode::Esc => OverlayOutcome::Dismiss,
-            KeyCode::Down | KeyCode::Char('j') => {
-                self.selected = (self.selected + 1) % len;
+            KeyCode::Down | KeyCode::Char('j') | KeyCode::Tab => {
+                self.selected = nav_step(self.selected, len, true);
                 OverlayOutcome::Stay
             }
-            KeyCode::Up | KeyCode::Char('k') => {
-                self.selected = (self.selected + len - 1) % len;
+            KeyCode::Up | KeyCode::Char('k') | KeyCode::BackTab => {
+                self.selected = nav_step(self.selected, len, false);
                 OverlayOutcome::Stay
             }
             KeyCode::Enter => {
@@ -752,8 +800,9 @@ impl MoveOverlay {
     pub fn lines(&self, width: usize) -> Vec<Line<'static>> {
         let width = width.max(20);
         let mut out = Vec::new();
-        out.push(row(
+        out.push(bar(
             self.selected == 0,
+            width,
             vec![
                 Span::styled(
                     if self.selected == 0 { "▸ " } else { "  " },
@@ -768,8 +817,9 @@ impl MoveOverlay {
         ));
         for (i, project) in self.projects.iter().enumerate() {
             let selected = self.selected == i + 1;
-            out.push(row(
+            out.push(bar(
                 selected,
+                width,
                 vec![
                     Span::styled(
                         if selected { "▸ " } else { "  " },
@@ -791,7 +841,7 @@ impl MoveOverlay {
         }
         out.push(Line::default());
         out.push(Line::from(Span::styled(
-            "enter move · esc close",
+            "↑↓/tab move · enter move · esc close",
             theme::muted(),
         )));
         out
@@ -894,15 +944,15 @@ impl QuestionsOverlay {
         let multi = question.question_type == "multi";
         match key.code {
             KeyCode::Esc => OverlayOutcome::Dismiss,
-            KeyCode::Down | KeyCode::Char('j') => {
+            KeyCode::Down | KeyCode::Char('j') | KeyCode::Tab => {
                 if option_count > 0 {
-                    self.cursor = (self.cursor + 1) % option_count;
+                    self.cursor = nav_step(self.cursor, option_count, true);
                 }
                 OverlayOutcome::Stay
             }
-            KeyCode::Up | KeyCode::Char('k') => {
+            KeyCode::Up | KeyCode::Char('k') | KeyCode::BackTab => {
                 if option_count > 0 {
-                    self.cursor = (self.cursor + option_count - 1) % option_count;
+                    self.cursor = nav_step(self.cursor, option_count, false);
                 }
                 OverlayOutcome::Stay
             }
@@ -1052,6 +1102,19 @@ impl HelpOverlay {
     }
 
     pub fn lines(&self, _width: usize) -> Vec<Line<'static>> {
+        let mut out: Vec<Line<'static>> = Vec::new();
+        out.push(Line::from(Span::styled(
+            "slash commands",
+            theme::accent_bold(),
+        )));
+        for (name, blurb) in SLASH_COMMANDS {
+            out.push(Line::from(vec![
+                Span::styled(format!("/{name:<10}"), theme::accent()),
+                Span::styled(blurb.to_string(), theme::muted()),
+            ]));
+        }
+        out.push(Line::default());
+        out.push(Line::from(Span::styled("keys", theme::accent_bold())));
         let rows: &[(&str, &str)] = &[
             ("enter", "send · steer while a turn runs"),
             ("alt+enter", "newline"),
@@ -1065,13 +1128,12 @@ impl HelpOverlay {
             ("y / n / a", "approve once · reject · always…"),
             ("esc", "close a panel"),
         ];
-        rows.iter()
-            .map(|(key, what)| {
-                Line::from(vec![
-                    Span::styled(format!("{key:<10}"), theme::accent()),
-                    Span::styled(what.to_string(), theme::muted()),
-                ])
-            })
-            .collect()
+        out.extend(rows.iter().map(|(key, what)| {
+            Line::from(vec![
+                Span::styled(format!("{key:<10}"), theme::accent()),
+                Span::styled(what.to_string(), theme::muted()),
+            ])
+        }));
+        out
     }
 }

--- a/crates/openwave-cli/src/tui/render.rs
+++ b/crates/openwave-cli/src/tui/render.rs
@@ -107,6 +107,42 @@ pub fn truncate(text: &str, max: usize) -> String {
     }
 }
 
+/// Clip a line to a display width, dropping spans (or parts of spans) that
+/// would run past it. Scrollback and panels render into fixed buffers that
+/// panic on an over-wide line, so everything that reaches one is clipped here.
+pub fn clip_line(line: Line<'static>, width: usize) -> Line<'static> {
+    use unicode_width::UnicodeWidthStr;
+    let mut out: Vec<Span<'static>> = Vec::new();
+    let mut used = 0usize;
+    for span in line.spans {
+        if used >= width {
+            break;
+        }
+        let text = span.content.as_ref();
+        let remaining = width - used;
+        if text.width() <= remaining {
+            used += text.width();
+            out.push(span);
+        } else {
+            let mut taken = String::new();
+            let mut w = 0usize;
+            for ch in text.chars() {
+                let cw = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
+                if w + cw > remaining {
+                    break;
+                }
+                w += cw;
+                taken.push(ch);
+            }
+            if !taken.is_empty() {
+                out.push(Span::styled(taken, span.style));
+            }
+            used = width;
+        }
+    }
+    Line::from(out)
+}
+
 /// The timestamp format used across the transcript: local wall time.
 pub fn timestamp(at: chrono::DateTime<chrono::Utc>) -> String {
     at.with_timezone(&chrono::Local).format("%H:%M").to_string()
@@ -325,25 +361,18 @@ pub fn header_lines(resumed: bool, short_id: &str) -> Vec<Line<'static>> {
 
 /// The dim reasoning tail shown while the model thinks: at most the last two
 /// wrapped lines, so a long stream doesn't crowd the live region.
-pub fn thinking_lines(thinking: &str, width: usize) -> Vec<Line<'static>> {
-    let mut lines = wrap(thinking, width.saturating_sub(2));
-    if lines.len() > 2 {
-        lines.drain(..lines.len() - 2);
-    }
-    lines
-        .into_iter()
-        .map(|line| {
-            Line::from(Span::styled(
-                format!("  {line}"),
-                theme::muted().add_modifier(Modifier::ITALIC),
-            ))
-        })
-        .collect()
+/// Streaming assistant text, rendered as live markdown so code fences and
+/// emphasis form as the text arrives, exactly as the settled block will.
+pub fn streaming_lines(text: &str, width: usize) -> Vec<Line<'static>> {
+    super::markdown::lines(text, width)
 }
 
-/// Streaming assistant text, wrapped plain.
-pub fn streaming_lines(text: &str, width: usize) -> Vec<Line<'static>> {
-    wrap(text, width).into_iter().map(Line::from).collect()
+/// The spinner frames, shared across the header, running tools, and live
+/// agent lines so they stay in phase.
+pub const SPINNER: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+pub fn spinner_at(tick: usize) -> char {
+    SPINNER[tick % SPINNER.len()]
 }
 
 /// The running tool's line: spinner in the accent, name plain.


### PR DESCRIPTION
Follow-up to #1705, from hands-on review of the rich TUI.

## What changed

- **Slash commands, Claude Code style** — `/model` `/effort` `/mode` `/chats` `/new` `/rename` `/move` `/agents` `/questions` `/help` `/quit`. Typing `/` opens an autocomplete list above the composer; Tab/arrows walk it and Enter completes. The ctrl-key chords stay as aliases. The table is shared with the help overlay, which now leads with the command list.
- **Loading state** — the raw reasoning stream that scrolled dim italic text while the model worked is gone from the live region; a single braille spinner (`⠋ working…`) holds it instead. The reasoning still folds into the transcript at turn end, so nothing is lost.
- **Streaming** — assistant text renders as live markdown as deltas arrive (fences and emphasis form in place), and the live region now grows with the content instead of capping the stream inside a fixed-height block that scrolled before expanding.
- **Selectors** — every menu row is a full-width highlight bar and every list takes arrows, Tab, and Shift-Tab (wrapping), matching the menu-cursor convention.
- **Crash fix** — opening the chat switcher could panic in ratatui's `insert_before` buffer when a scrollback line ran wider than the viewport. All scrollback lines are now clipped to the viewport width before they reach the fixed buffer.

The wire/client surface is unchanged; this is all rendering and input. `unicode-width` joins the CLI's deps (already in the tree via ratatui) to clip lines by display width.

## Verification

`cargo check --workspace --locked` clean (lockfile gains only the `unicode-width` edge on the CLI), `cargo clippy -p openwave-cli --all-targets` clean, `cargo fmt` clean, `cargo test -p openwave-cli` green.