### PR TITLE
feat(desktop): copy debug info button for background agent runs

### DIFF
--- a/crates/openwave-desktop/ui/src/AgentRunDebugReport.test.ts
+++ b/crates/openwave-desktop/ui/src/AgentRunDebugReport.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  copyAgentRunDebug,
+  fetchAgentRunProgress,
+  formatAgentRunDebugReport,
+} from "./AgentRunDebugReport";
+import type { AgentActivityHistoryEntry, AgentRun } from "./api";
+
+function run(overrides: Partial<AgentRun> = {}): AgentRun {
+  return {
+    id: "run-1",
+    parent_id: null,
+    tier: "background",
+    execution_location: "container",
+    status: "failed",
+    task: "Summarize the quarterly report",
+    started_at: "2026-08-01T10:00:00Z",
+    finished_at: "2026-08-01T10:04:00Z",
+    last_error_code: "SANDBOX_EXIT_1",
+    activity: null,
+    submitted_outputs: [],
+    terminal_text: null,
+    created_at: "2026-08-01T09:59:00Z",
+    updated_at: "2026-08-01T10:04:00Z",
+    spawn_call_id: "call-7",
+    ...overrides,
+  };
+}
+
+describe("formatAgentRunDebugReport", () => {
+  it("renders the run fields, activity timeline, and progress sections", () => {
+    const activity: AgentActivityHistoryEntry[] = [
+      {
+        kind: "exec",
+        outcome: "failed",
+        at: "2026-08-01T10:01:00Z",
+        detail: {
+          kind: "exec",
+          command: "python",
+          args: ["analyze.py"],
+          exit_code: 1,
+          output: "Traceback: boom",
+        },
+      },
+      {
+        kind: "web_search",
+        outcome: "completed",
+        at: "2026-08-01T10:02:00Z",
+        detail: { kind: "search", query: "quarterly revenue figures" },
+      },
+    ];
+
+    const report = formatAgentRunDebugReport({
+      run: run(),
+      activity,
+      progress: [
+        { sequence: 1, text: "Reading the spreadsheet", at: "2026-08-01T10:00:30Z" },
+        { sequence: 2, text: "Analysis script failed, retrying", at: "2026-08-01T10:01:30Z" },
+      ],
+    });
+
+    expect(report).toContain("# Background agent run debug info");
+    expect(report).toContain("- Run ID: run-1");
+    expect(report).toContain("- Status: failed");
+    expect(report).toContain("- Last error code: SANDBOX_EXIT_1");
+    expect(report).toContain("- Task: Summarize the quarterly report");
+
+    expect(report).toContain("## Activity");
+    expect(report).toContain("1. **A command failed** — failed · 2026-08-01T10:01:00Z");
+    expect(report).toContain("- Command: `python analyze.py`");
+    expect(report).toContain("- Exit code: 1");
+    expect(report).toContain("Traceback: boom");
+    expect(report).toContain("2. **Searched the web** — completed · 2026-08-01T10:02:00Z");
+    expect(report).toContain("- Query: quarterly revenue figures");
+
+    expect(report).toContain("## Progress");
+    expect(report).toContain("- 2026-08-01T10:00:30Z — Reading the spreadsheet");
+    expect(report).toContain("- 2026-08-01T10:01:30Z — Analysis script failed, retrying");
+  });
+
+  it("notes a failed fetch in place of each section that could not load", () => {
+    const report = formatAgentRunDebugReport({
+      run: run({ status: "completed", last_error_code: null }),
+      activity: null,
+      progress: null,
+    });
+
+    expect(report).toContain("_Activity history could not be fetched._");
+    expect(report).toContain("_Progress lines could not be fetched._");
+  });
+
+  it("includes the terminal result only when the run settled with one", () => {
+    const settled = formatAgentRunDebugReport({
+      run: run({ status: "completed", last_error_code: null, terminal_text: "Done." }),
+      activity: [],
+      progress: [],
+    });
+    expect(settled).toContain("## Result");
+    expect(settled).toContain("Done.");
+
+    const live = formatAgentRunDebugReport({
+      run: run({ status: "running", last_error_code: null }),
+      activity: [],
+      progress: [],
+    });
+    expect(live).not.toContain("## Result");
+    expect(live).toContain("_No recorded activity._");
+    expect(live).toContain("_No progress published._");
+  });
+});
+
+describe("fetchAgentRunProgress", () => {
+  it("pages with each page's next cursor until a page arrives empty", async () => {
+    const listPage = vi.fn(async (afterSequence: number) => {
+      if (afterSequence === 0) {
+        return {
+          entries: [
+            { sequence: 1, text: "one", at: "t1" },
+            { sequence: 2, text: "two", at: "t2" },
+          ],
+          nextSequence: 2,
+        };
+      }
+      if (afterSequence === 2) {
+        return { entries: [{ sequence: 3, text: "three", at: "t3" }], nextSequence: 3 };
+      }
+      return { entries: [], nextSequence: 3 };
+    });
+
+    const entries = await fetchAgentRunProgress(listPage);
+
+    expect(entries.map((entry) => entry.text)).toEqual(["one", "two", "three"]);
+    expect(listPage.mock.calls.map(([after]) => after)).toEqual([0, 2, 3]);
+  });
+});
+
+describe("copyAgentRunDebug", () => {
+  it("copies the report and degrades a failed section fetch instead of failing", async () => {
+    const written: string[] = [];
+    const notices: { message: string; description?: string }[] = [];
+    await copyAgentRunDebug(run(), {
+      fetchActivity: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+      fetchProgress: vi.fn(async () => [
+        { sequence: 1, text: "working", at: "t1" },
+      ]),
+      writeClipboard: async (text) => {
+        written.push(text);
+      },
+      notify: (notice) => notices.push(notice),
+    });
+
+    expect(written).toHaveLength(1);
+    expect(written[0]).toContain("_Activity history could not be fetched._");
+    expect(written[0]).toContain("working");
+    expect(notices[0]?.message).toBe("Debug info copied");
+  });
+
+  it("surfaces a clipboard failure as one error notice", async () => {
+    const notices: { message: string; description?: string }[] = [];
+    await copyAgentRunDebug(run(), {
+      fetchActivity: vi.fn(async () => []),
+      fetchProgress: vi.fn(async () => []),
+      writeClipboard: vi.fn(async () => {
+        throw new Error("clipboard unavailable");
+      }),
+      notify: (notice) => notices.push(notice),
+    });
+
+    expect(notices).toEqual([{ message: "clipboard unavailable" }]);
+  });
+});

--- a/crates/openwave-desktop/ui/src/AgentRunDebugReport.ts
+++ b/crates/openwave-desktop/ui/src/AgentRunDebugReport.ts
@@ -1,0 +1,185 @@
+import type {
+  AgentActivityHistoryEntry,
+  AgentRun,
+  AgentRunProgressEntry,
+} from "./api";
+import { agentActivityHistoryLabel } from "./AgentRunDisplay";
+import { friendlyErrorMessage } from "./lib/utils";
+
+/**
+ * "Copy debug info" for one background agent run — the per-run counterpart of
+ * the chat-level debug bundle in ChatDebugBundle.ts. There the document is
+ * built natively from the journal; a background run has no journal surface of
+ * its own, so this report is assembled client-side from the same
+ * renderer-safe endpoints the panel already reads: the run snapshot, the
+ * ordered activity history, and the run's published progress lines.
+ *
+ * The formatter is a pure function so the document is testable without the
+ * client; fetching and degrading are the orchestration below it.
+ */
+
+/** Everything the report needs, already fetched (or already failed). */
+export type AgentRunDebugReportInput = {
+  run: AgentRun;
+  /** Null when the history fetch failed; the section says so instead. */
+  activity: AgentActivityHistoryEntry[] | null;
+  /** Null when the progress fetch failed; the section says so instead. */
+  progress: AgentRunProgressEntry[] | null;
+};
+
+function valueOrDash(value: string | number | null | undefined): string {
+  if (value === null || value === undefined || value === "") return "—";
+  return String(value);
+}
+
+/** ISO, verbatim — a debug report wants the exact timestamp, not a locale's. */
+function timestamp(at: string | null | undefined): string {
+  return valueOrDash(at);
+}
+
+function formatActivityEntry(
+  entry: AgentActivityHistoryEntry,
+  index: number,
+): string[] {
+  const label = agentActivityHistoryLabel(entry);
+  const lines = [
+    `${index + 1}. **${label}** — ${entry.outcome} · ${timestamp(entry.at)}`,
+  ];
+  const detail = entry.detail;
+  if (!detail) return lines;
+  switch (detail.kind) {
+    case "exec": {
+      const command = [detail.command, ...detail.args].join(" ");
+      lines.push(`   - Command: \`${command}\``);
+      if (detail.exit_code !== undefined) {
+        lines.push(`   - Exit code: ${detail.exit_code}`);
+      }
+      if (detail.output) {
+        lines.push("   - Output:", "", "```", detail.output, "```", "");
+      }
+      return lines;
+    }
+    case "search":
+      lines.push(`   - Query: ${detail.query}`);
+      return lines;
+    case "file":
+      lines.push(`   - File: ${detail.name}`);
+      return lines;
+  }
+}
+
+/**
+ * The Markdown document for one run. Sections are stable so a report can be
+ * compared across copies: summary fields first, then the activity timeline in
+ * its recorded order, then the run's published progress, then its result.
+ */
+export function formatAgentRunDebugReport({
+  run,
+  activity,
+  progress,
+}: AgentRunDebugReportInput): string {
+  const parts: string[] = [
+    "# Background agent run debug info",
+    "",
+    "## Run",
+    "",
+    `- Run ID: ${run.id}`,
+    `- Parent run ID: ${valueOrDash(run.parent_id)}`,
+    `- Spawn call ID: ${valueOrDash(run.spawn_call_id)}`,
+    `- Tier: ${run.tier}`,
+    `- Execution location: ${run.execution_location}`,
+    `- Status: ${run.status}`,
+    `- Last error code: ${valueOrDash(run.last_error_code)}`,
+    `- Task: ${valueOrDash(run.task)}`,
+    `- Created: ${timestamp(run.created_at)}`,
+    `- Updated: ${timestamp(run.updated_at)}`,
+    `- Started: ${timestamp(run.started_at)}`,
+    `- Finished: ${timestamp(run.finished_at)}`,
+    "",
+  ];
+
+  parts.push("## Activity", "");
+  if (activity === null) {
+    parts.push("_Activity history could not be fetched._", "");
+  } else if (activity.length === 0) {
+    parts.push("_No recorded activity._", "");
+  } else {
+    activity.forEach((entry, index) => {
+      parts.push(...formatActivityEntry(entry, index));
+    });
+    parts.push("");
+  }
+
+  parts.push("## Progress", "");
+  if (progress === null) {
+    parts.push("_Progress lines could not be fetched._", "");
+  } else if (progress.length === 0) {
+    parts.push("_No progress published._", "");
+  } else {
+    for (const line of progress) {
+      parts.push(`- ${timestamp(line.at)} — ${line.text}`);
+    }
+    parts.push("");
+  }
+
+  if (run.terminal_text) {
+    parts.push("## Result", "", run.terminal_text, "");
+  }
+
+  return parts.join("\n").trimEnd() + "\n";
+}
+
+export type AgentRunDebugDeps = {
+  fetchActivity: () => Promise<AgentActivityHistoryEntry[]>;
+  fetchProgress: () => Promise<AgentRunProgressEntry[]>;
+  writeClipboard: (text: string) => Promise<void>;
+  notify: (notice: { message: string; description?: string }) => void;
+};
+
+/** Read every progress page, resuming from each page's cursor. */
+export async function fetchAgentRunProgress(
+  listPage: (
+    afterSequence: number,
+  ) => Promise<{ entries: AgentRunProgressEntry[]; nextSequence: number }>,
+): Promise<AgentRunProgressEntry[]> {
+  const entries: AgentRunProgressEntry[] = [];
+  let afterSequence = 0;
+  // Pages resume strictly forward, so once a page arrives empty there is no
+  // more to read — the cursor only matters while entries keep arriving.
+  for (;;) {
+    const page = await listPage(afterSequence);
+    entries.push(...page.entries);
+    if (page.entries.length === 0 || page.nextSequence <= afterSequence) {
+      return entries;
+    }
+    afterSequence = page.nextSequence;
+  }
+}
+
+/**
+ * Build and copy the report for one run. Activity and progress failures each
+ * degrade to a note inside their section — the snapshot alone is still worth
+ * attaching — while a total failure (the clipboard write, or the run itself
+ * being unreadable) surfaces the way errors do elsewhere: one sonner toast.
+ */
+export async function copyAgentRunDebug(
+  run: AgentRun,
+  deps: AgentRunDebugDeps,
+): Promise<void> {
+  try {
+    const [activity, progress] = await Promise.all([
+      deps.fetchActivity().catch(() => null),
+      deps.fetchProgress().catch(() => null),
+    ]);
+    await deps.writeClipboard(formatAgentRunDebugReport({ run, activity, progress }));
+    deps.notify({
+      message: "Debug info copied",
+      description:
+        "Includes the run's task, activity history, and progress. Review it before sharing.",
+    });
+  } catch (caught) {
+    deps.notify({
+      message: friendlyErrorMessage(caught, "Could not copy debug info."),
+    });
+  }
+}

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Bot, ChevronDown, ChevronRight, Square } from "lucide-react";
 import { toast } from "sonner";
 
-import type { AgentActivityHistoryEntry, AgentRun } from "./api";
+import type { AgentActivityHistoryEntry, AgentRun, ApiClient } from "./api";
 import { AgentActivityTimeline, useAgentRunActivity } from "./AgentActivityTimeline";
 import {
   AGENT_RUN_STATUS_GROUPS,
@@ -10,6 +10,7 @@ import {
   getAgentRunDotClass,
   RUNNING_AGENT_STATUSES,
 } from "./AgentRunDisplay";
+import { CopyAgentRunDebugButton } from "./BackgroundAgentPanel";
 import { friendlyErrorMessage } from "./lib/utils";
 import { SubmittedOutputPills } from "./SubmittedOutputPills";
 import type { ToolCallStatus } from "./ToolCallCard";
@@ -24,6 +25,9 @@ export type BackgroundAgentSpawn = {
 };
 
 type BackgroundAgentListProps = {
+  /** Client + chat scope for a row's "Copy debug info"; absent hides it. */
+  client?: ApiClient;
+  chatId?: string;
   spawns: readonly BackgroundAgentSpawn[];
   runs: readonly AgentRun[];
   loading: boolean;
@@ -45,6 +49,8 @@ type BackgroundAgentListProps = {
  * durable cancellation request, resolved by the same read model it polls.
  */
 export function BackgroundAgentList({
+  client,
+  chatId,
   spawns,
   runs,
   loading,
@@ -164,6 +170,8 @@ export function BackgroundAgentList({
                     {groupRuns.map((run) => (
                       <BackgroundAgentRow
                         key={run.id}
+                        client={client}
+                        chatId={chatId}
                         run={run}
                         onCancel={onCancel}
                         onLoadActivity={onLoadActivity}
@@ -226,6 +234,8 @@ export function BackgroundAgentList({
  * row under it, and a delegation of any size is a list to scan, not to read.
  */
 function BackgroundAgentRow({
+  client,
+  chatId,
   run,
   onCancel,
   onLoadActivity,
@@ -236,6 +246,8 @@ function BackgroundAgentRow({
   activityExpanded,
   onActivityExpandedChange,
 }: {
+  client?: ApiClient;
+  chatId?: string;
   run: AgentRun;
   onCancel: (runId: string) => Promise<void>;
   onLoadActivity: (runId: string) => Promise<AgentActivityHistoryEntry[]>;
@@ -318,6 +330,14 @@ function BackgroundAgentRow({
         <span className="shrink-0 text-xs text-muted-foreground">
           {showStopping ? "Stopping" : agentRunStatusDetail(run)}
         </span>
+        {client && chatId && (
+          <CopyAgentRunDebugButton
+            client={client}
+            chatId={chatId}
+            run={run}
+            className="inline-flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden"
+          />
+        )}
         {stoppable && (
           <Button
             type="button"

--- a/crates/openwave-desktop/ui/src/BackgroundAgentPanel.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Bot, Check, Clock, Square, X } from "lucide-react";
+import { toast } from "sonner";
 
 import { useApp } from "./AppContext";
 import {
@@ -7,8 +8,13 @@ import {
   summarizeAgentActivity,
   useAgentRunActivity,
 } from "./AgentActivityTimeline";
+import {
+  copyAgentRunDebug,
+  fetchAgentRunProgress,
+} from "./AgentRunDebugReport";
 import { agentRunStatusDetail, RUNNING_AGENT_STATUSES } from "./AgentRunDisplay";
-import type { AgentRun } from "./api";
+import type { AgentRun, ApiClient } from "./api";
+import { ClipboardCopyButton, copyPlainText } from "./ClipboardCopyButton";
 import { MessageMarkdown } from "./MessageMarkdown";
 import { SubmittedOutputPills } from "./SubmittedOutputPills";
 import { useAgentRuns } from "./useAgentRuns";
@@ -101,6 +107,7 @@ export function BackgroundAgentPanel({
         <BackgroundAgentDetail
           run={run}
           activity={activity}
+          chatId={chatId}
           onOpenOutput={(outputId) => openPanel({ type: "outputs", outputId })}
         />
       ) : agentRuns.error ? (
@@ -132,12 +139,15 @@ export function BackgroundAgentPanel({
 function BackgroundAgentDetail({
   run,
   activity,
+  chatId,
   onOpenOutput,
 }: {
   run: AgentRun;
   activity: ReturnType<typeof useAgentRunActivity>;
+  chatId: string;
   onOpenOutput?: (outputId: string) => void;
 }) {
+  const { client } = useApp();
   const live = RUNNING_AGENT_STATUSES.has(run.status);
   const now = useNowWhile(live);
   const elapsed = elapsedLabel(run, now);
@@ -168,7 +178,8 @@ function BackgroundAgentDetail({
               )}
             </p>
           </div>
-          <div className="mt-0.5 shrink-0">
+          <div className="mt-0.5 flex shrink-0 items-center gap-1.5">
+            <CopyAgentRunDebugButton client={client} chatId={chatId} run={run} />
             <AgentRunStatusBadge status={run.status} />
           </div>
         </div>
@@ -205,6 +216,46 @@ function BackgroundAgentDetail({
         )}
       </div>
     </div>
+  );
+}
+
+/**
+ * The "Copy debug info" affordance for one run, mirroring the chat header's.
+ * The report is assembled at click time from the run snapshot plus the two
+ * run-scoped endpoints, so a live run's copy is as fresh as the click.
+ */
+export function CopyAgentRunDebugButton({
+  client,
+  chatId,
+  run,
+  className = "inline-flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden",
+}: {
+  client: ApiClient;
+  chatId: string;
+  run: AgentRun;
+  className?: string;
+}) {
+  return (
+    <ClipboardCopyButton
+      copy={() =>
+        copyAgentRunDebug(run, {
+          fetchActivity: () => client.listAgentRunActivity(chatId, run.id),
+          fetchProgress: () =>
+            fetchAgentRunProgress((afterSequence) =>
+              client.listAgentRunProgress(chatId, run.id, afterSequence),
+            ),
+          writeClipboard: (text) => copyPlainText(text),
+          notify: ({ message, description }) =>
+            description
+              ? toast.success(message, { description })
+              : toast.error(message),
+        })
+      }
+      label="Copy debug info"
+      copiedAnnouncement="Debug info copied to clipboard."
+      failedAnnouncement="Debug info could not be copied."
+      className={className}
+    />
   );
 }
 

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -398,6 +398,7 @@ export function ChatView({
           onLoadBackgroundAgentActivity={agentRuns.loadActivity}
           onOpenBackgroundAgent={onOpenAgentPanel}
           onOpenOutput={onOpenOutput}
+          backgroundAgentClient={client}
           busy={busy}
           streamStalled={streamStalled}
           scrollRef={attachScrollRef}

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -214,6 +214,8 @@ type MessageListProps = {
   ) => Promise<AgentActivityHistoryEntry[]>;
   onOpenBackgroundAgent?: (runId: string) => void;
   onOpenOutput?: (outputId: string) => void;
+  /** The connected client, so a background agent row can fetch debug info. */
+  backgroundAgentClient?: ApiClient;
   busy: boolean;
   /** The live turn's stream has gone quiet — see [useStreamStalled]. */
   streamStalled?: boolean;
@@ -308,6 +310,7 @@ export function MessageList({
   imageClient,
   executionConfigClient,
   changeClient,
+  backgroundAgentClient,
 }: MessageListProps) {
   // Stable identity between renders so memoized rows only re-render when the
   // approval state itself changes, not on every streamed token.
@@ -338,6 +341,7 @@ export function MessageList({
       loadActivity: onLoadBackgroundAgentActivity,
       open: onOpenBackgroundAgent,
       openOutput: onOpenOutput,
+      client: backgroundAgentClient,
     },
     retry,
   );
@@ -559,6 +563,8 @@ export function groupMessageItems(
     loadActivity: (runId: string) => Promise<AgentActivityHistoryEntry[]>;
     open?: (runId: string) => void;
     openOutput?: (outputId: string) => void;
+    /** The connected client, so a row's "Copy debug info" can fetch its run. */
+    client?: ApiClient;
   } = {
     runs: [],
     loading: false,
@@ -706,6 +712,9 @@ export function groupMessageItems(
             onLoadActivity={backgroundAgents.loadActivity}
             onOpen={backgroundAgents.open}
             onOpenOutput={backgroundAgents.openOutput}
+            {...(backgroundAgents.client && chatId
+              ? { client: backgroundAgents.client, chatId }
+              : {})}
           />,
         ),
       );


### PR DESCRIPTION
A developer debugging a background agent run has to hand-copy an id, a status, or a snippet out of the panel. Add a "Copy debug info" affordance to the per-run panel (beside the status badge) and a compact icon on each transcript list row so one click puts the whole run into the clipboard as a Markdown report.

The report is built client-side from the run snapshot already in hand plus the two run-scoped endpoints the panel already reads: the ordered activity history and the live progress lines. `listAgentRunProgress` was wired to no component until now, so this change also exercises it, paging through `next_sequence`. No wire types or Rust are touched.

Implementation notes:
- New pure module `AgentRunDebugReport.ts` holds a testable `formatAgentRunDebugReport` plus the fetch/paging and copy orchestration, reusing `ClipboardCopyButton`'s async `copy()` form via a shared `CopyAgentRunDebugButton`.
- A failed activity or progress fetch degrades to a note inside that section instead of blocking the copy, and a total failure surfaces as the same sonner toast the chat debug bundle uses, via `friendlyErrorMessage`.
- There is no per-run model field, so the report deliberately omits the model rather than invent one.
- Added one focused vitest covering the formatter (a failed run with an exec error + search entry and a couple of progress lines) plus the paging loop and the failure-degradation behavior.