### PR TITLE
feat(exec): expose a managed Node runtime to the local sandbox

### DIFF
--- a/crates/openwave-code-execution/src/host_tools.rs
+++ b/crates/openwave-code-execution/src/host_tools.rs
@@ -16,6 +16,8 @@
 //! remembered failure that only an explicit retry clears), and `status`
 //! reports the current truth those rules produce.
 
+use std::path::PathBuf;
+
 use async_trait::async_trait;
 
 use crate::skills::HostDep;
@@ -44,4 +46,14 @@ pub trait HostToolBroker: Send + Sync {
 
     /// The current truth about `tool`.
     async fn status(&self, tool: HostDep) -> HostToolStatus;
+
+    /// The host directory a provisioned `tool` is rooted at, for the tools an
+    /// execution backend has to be handed a path to rather than ones the host
+    /// drives itself.
+    ///
+    /// `None` for a tool that does not resolve right now, and for a tool with
+    /// no such root — LibreOffice conversion runs on the host, so nothing
+    /// downstream ever needs its location. A returned path is a host-verified
+    /// managed install; a backend may expose it read-only and nothing more.
+    async fn managed_root(&self, tool: HostDep) -> Option<PathBuf>;
 }

--- a/crates/openwave-code-execution/src/local.rs
+++ b/crates/openwave-code-execution/src/local.rs
@@ -58,6 +58,7 @@ pub struct LocalExecutionProvider {
     timeout: Duration,
     document_scripts_dir: Option<PathBuf>,
     shared_package_cache: Option<PathBuf>,
+    managed_node_dir: Option<PathBuf>,
     network_policy: NetworkPolicy,
 }
 
@@ -93,6 +94,7 @@ impl LocalExecutionProvider {
             timeout,
             document_scripts_dir: None,
             shared_package_cache: None,
+            managed_node_dir: None,
             network_policy: NetworkPolicy::Off,
         })
     }
@@ -117,6 +119,22 @@ impl LocalExecutionProvider {
     #[must_use]
     pub fn with_shared_package_cache(mut self, directory: Option<PathBuf>) -> Self {
         self.shared_package_cache = directory;
+        self
+    }
+
+    /// Expose a host-managed Node runtime rooted at `directory`: its subtree
+    /// becomes readable and `<directory>/bin` is prepended to the sandbox's
+    /// `PATH`.
+    ///
+    /// The sandbox already allows `process-exec`, so a read allowance is the
+    /// whole gate — without one, `node` is a path the process cannot open. The
+    /// runtime is a pinned install the host verified and keeps writing itself;
+    /// like the package cache, it is never listed as writable, so a sandbox
+    /// consumes the interpreter it is given and cannot replace it for the next
+    /// conversation.
+    #[must_use]
+    pub fn with_managed_node(mut self, directory: Option<PathBuf>) -> Self {
+        self.managed_node_dir = directory;
         self
     }
 
@@ -361,6 +379,13 @@ impl CodeExecutionProvider for LocalExecutionProvider {
                 })
             })
             .transpose()?;
+        // A runtime that has been uninstalled between turns simply drops out:
+        // the profile and PATH go back to what they were rather than failing
+        // the command over an absent convenience.
+        let managed_node_dir = self
+            .managed_node_dir
+            .as_ref()
+            .and_then(|path| fs::canonicalize(path).ok());
         let result = run_native(
             &request,
             &workspace,
@@ -369,6 +394,7 @@ impl CodeExecutionProvider for LocalExecutionProvider {
             self.timeout,
             document_scripts_dir.as_deref(),
             shared_package_cache.as_deref(),
+            managed_node_dir.as_deref(),
             &folder_grants,
             &self.network_policy,
         )
@@ -772,6 +798,7 @@ async fn run_native(
     timeout: Duration,
     document_scripts_dir: Option<&Path>,
     shared_package_cache: Option<&Path>,
+    managed_node_dir: Option<&Path>,
     folder_grants: &[CanonicalExecFolderGrant],
     network_policy: &NetworkPolicy,
 ) -> Result<CodeExecutionResponse, CodeExecutionError> {
@@ -787,6 +814,7 @@ async fn run_native(
         developer_dir.as_deref(),
         document_scripts_dir,
         shared_package_cache,
+        managed_node_dir,
         folder_grants,
         broker.as_ref().map(LocalEgressBroker::port),
     )?;
@@ -814,17 +842,13 @@ async fn run_native(
             .env("NO_PROXY", "")
             .env("no_proxy", "");
     }
-    if let Some(developer_dir) = developer_dir {
-        command.env("DEVELOPER_DIR", &developer_dir).env(
-            "PATH",
-            format!(
-                "{}/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin",
-                developer_dir.display()
-            ),
-        );
-    } else {
-        command.env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin");
+    if let Some(developer_dir) = developer_dir.as_deref() {
+        command.env("DEVELOPER_DIR", developer_dir);
     }
+    command.env(
+        "PATH",
+        sandbox_path(developer_dir.as_deref(), managed_node_dir),
+    );
     if let Some(directory) = document_scripts_dir {
         command.env("OPENWAVE_EXEC_SCRIPTS", directory);
     }
@@ -906,6 +930,7 @@ async fn run_native(
     _timeout: Duration,
     _document_scripts_dir: Option<&Path>,
     _shared_package_cache: Option<&Path>,
+    _managed_node_dir: Option<&Path>,
     _folder_grants: &[()],
     _network_policy: &NetworkPolicy,
 ) -> Result<CodeExecutionResponse, CodeExecutionError> {
@@ -982,12 +1007,34 @@ async fn finish_reader(mut reader: tokio::task::JoinHandle<()>) {
 }
 
 #[cfg(target_os = "macos")]
+/// The sandbox's `PATH`, pinned to directories the host controls.
+///
+/// A managed Node runtime goes first: it is the pinned interpreter OpenWave
+/// installed and verified, and a skill's npm work should resolve it rather
+/// than whatever a system directory happens to hold. Everything after it is
+/// the fixed system set — the user's own shell `PATH` never reaches a
+/// sandboxed command.
+fn sandbox_path(developer_dir: Option<&Path>, managed_node_dir: Option<&Path>) -> String {
+    let mut entries = Vec::new();
+    if let Some(directory) = managed_node_dir {
+        entries.push(format!("{}/bin", directory.display()));
+    }
+    if let Some(directory) = developer_dir {
+        entries.push(format!("{}/usr/bin", directory.display()));
+    }
+    entries.extend(["/usr/bin", "/bin", "/usr/sbin", "/sbin"].map(str::to_owned));
+    entries.join(":")
+}
+
+#[cfg(target_os = "macos")]
+#[allow(clippy::too_many_arguments)]
 fn macos_profile(
     workspace: &Path,
     env_home: &Path,
     developer_dir: Option<&Path>,
     document_scripts_dir: Option<&Path>,
     shared_package_cache: Option<&Path>,
+    managed_node_dir: Option<&Path>,
     folder_grants: &[CanonicalExecFolderGrant],
     broker_port: Option<u16>,
 ) -> Result<String, CodeExecutionError> {
@@ -1089,6 +1136,16 @@ fn macos_profile(
         .map(sandbox_subpath)
         .transpose()?
         .unwrap_or_default();
+    // The managed Node runtime joins the same read-only allowances, and for
+    // the same reason: `(allow process-exec)` above is unconditional, so being
+    // able to *open* the interpreter is the entire gate on running it. The
+    // host installed and verified this exact runtime and keeps sole write
+    // access to it, so a sandbox can run `node` without any conversation being
+    // able to swap out what the next one runs.
+    let managed_node = managed_node_dir
+        .map(sandbox_subpath)
+        .transpose()?
+        .unwrap_or_default();
     // `folder_grants` is the canonical, host-resolved list prepared above.
     // Command, arguments, cwd, and every other model-authored field are
     // deliberately absent from these profile clauses.
@@ -1139,7 +1196,7 @@ fn macos_profile(
          (allow file-read*)\n\
          (deny file-read*\n  {denied})\n\
          (allow file-read-metadata\n  {runtime_metadata}\n  {grant_metadata})\n\
-         (allow file-read*\n  {literals}\n  {runtimes}\n  {selected_runtime}\n  {document_scripts}\n  {package_cache}\n  {granted_reads}\n  {workspace}\n  {env_home})\n\
+         (allow file-read*\n  {literals}\n  {runtimes}\n  {selected_runtime}\n  {document_scripts}\n  {package_cache}\n  {managed_node}\n  {granted_reads}\n  {workspace}\n  {env_home})\n\
          (allow file-write*\n  {granted_writes}\n  {workspace}\n  {env_home}\n  (literal \"/dev/null\"))\n"
     ))
 }
@@ -1652,6 +1709,7 @@ mod tests {
             Some(Path::new(
                 "/Users/test/.code-execution-package-cache/cp39-darwin-arm64/wheels",
             )),
+            None,
             &[],
             None,
         )
@@ -1679,6 +1737,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             &[],
             None,
         )
@@ -1690,12 +1749,88 @@ mod tests {
             None,
             None,
             None,
+            None,
             &[],
             Some(43127),
         )
         .unwrap();
         assert!(proxied.contains("(allow network-outbound (remote tcp \"localhost:43127\"))"));
         assert!(!proxied.contains("localhost:*"));
+    }
+
+    /// A managed Node runtime is a host-supplied slot like the package cache:
+    /// present only when the host hands one over, readable and never writable,
+    /// and first on `PATH` so a skill's npm work runs the pinned interpreter.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn managed_node_is_read_only_and_leads_path_only_when_supplied() {
+        let node = Path::new("/Users/test/Library/Application Support/OpenWave/node/v22.11.0");
+        let profile = |managed_node| {
+            macos_profile(
+                Path::new("/Users/test/workspace"),
+                Path::new("/Users/test/env-home"),
+                None,
+                None,
+                None,
+                managed_node,
+                &[],
+                None,
+            )
+            .unwrap()
+        };
+
+        let with_node = profile(Some(node));
+        assert!(with_node.contains(&sandbox_subpath(node).unwrap()));
+        let write_rule = with_node
+            .split("(allow file-write*")
+            .nth(1)
+            .expect("profile has a write rule");
+        assert!(!write_rule.contains("OpenWave/node"));
+        assert!(!profile(None).contains("OpenWave/node"));
+
+        let developer_dir = Path::new("/Library/Developer/CommandLineTools");
+        assert_eq!(
+            sandbox_path(Some(developer_dir), Some(node)),
+            "/Users/test/Library/Application Support/OpenWave/node/v22.11.0/bin:\
+             /Library/Developer/CommandLineTools/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+        );
+        assert_eq!(
+            sandbox_path(None, None),
+            "/usr/bin:/bin:/usr/sbin:/sbin",
+            "without a managed runtime the sandbox keeps the system PATH it always had"
+        );
+    }
+
+    /// The end of the same story, run for real: a runtime the host hands over
+    /// is executable inside Seatbelt purely because its subtree is readable,
+    /// and one the host withholds is not on `PATH` at all.
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn managed_node_runs_in_the_sandbox_and_is_absent_without_it() {
+        let scratch = tempfile::tempdir().unwrap();
+        let workspace = "chat-node";
+        fs::create_dir(scratch.path().join(workspace)).unwrap();
+        let runtime = tempfile::tempdir().unwrap();
+        let bin = runtime.path().join("bin");
+        fs::create_dir(&bin).unwrap();
+        fs::write(bin.join("node"), "#!/bin/sh\nprintf v22.11.0\n").unwrap();
+        fs::set_permissions(bin.join("node"), fs::Permissions::from_mode(0o755)).unwrap();
+        let runtime = fs::canonicalize(runtime.path()).unwrap();
+
+        let provider = LocalExecutionProvider::new(scratch.path(), Duration::from_secs(5)).unwrap();
+        let script = "node --version || printf no-node";
+        let without = provider
+            .execute(request(workspace, "call-no-node", script))
+            .await
+            .unwrap();
+        assert_eq!(without.stdout, "no-node");
+
+        let provider = provider.with_managed_node(Some(runtime));
+        let with = provider
+            .execute(request(workspace, "call-node", script))
+            .await
+            .unwrap();
+        assert_eq!(with.stdout, "v22.11.0", "stderr: {}", with.stderr);
     }
 
     #[cfg(target_os = "macos")]
@@ -1714,6 +1849,7 @@ mod tests {
         let profile = macos_profile(
             Path::new("/Users/test/workspace"),
             Path::new("/Users/test/env-home"),
+            None,
             None,
             None,
             None,

--- a/crates/openwave-code-execution/src/skills.rs
+++ b/crates/openwave-code-execution/src/skills.rs
@@ -41,16 +41,28 @@ const MAX_DEPS_PER_LIST: usize = 8;
 const MAX_DEP_BYTES: usize = 100;
 const MAX_SKILL_SCRIPTS: usize = 16;
 
-/// A host-provided tool a skill declares it wants, from a closed vocabulary.
+/// A host-provided tool a skill depends on, from a closed vocabulary.
 ///
 /// Unlike language-package deps — free-form pins the sandbox installs — a host
 /// dep names a capability only the host can provide (a managed install outside
 /// the sandbox). The vocabulary is closed on purpose: an unknown value rejects
 /// the whole manifest rather than parsing into a string nothing can act on.
+///
+/// Not every variant is declarable. [`HostDep::parse`] is the manifest surface
+/// and maps only what a skill author is expected to write; the rest are
+/// host-derived from other parts of the manifest.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HostDep {
     /// LibreOffice, for converting office documents to renderable PDFs.
     LibreOffice,
+    /// A Node.js runtime, for skills whose npm packages need an interpreter.
+    ///
+    /// Deliberately not parseable from a manifest: a skill declares the npm
+    /// packages it uses, and needing Node to run them follows from that. A
+    /// spellable `"node"` would let one manifest ask for the runtime without
+    /// the packages and another need it without saying so, and the two
+    /// statements could disagree.
+    Node,
 }
 
 impl HostDep {
@@ -662,7 +674,9 @@ Instructions live here.\n";
 
     /// The `host:` list is a closed vocabulary: `libreoffice` parses into its
     /// enum value alongside python pins or alone, and anything else rejects
-    /// the manifest rather than becoming a string nothing can act on.
+    /// the manifest rather than becoming a string nothing can act on. That
+    /// includes host deps the rest of the system derives for itself, which no
+    /// manifest gets to assert.
     #[test]
     fn host_deps_parse_from_the_closed_vocabulary_only() {
         let combined = "---\nname: word-documents\ndescription: Docs.\n\
@@ -682,6 +696,10 @@ Instructions live here.\n";
             (
                 "unknown host tool",
                 "---\nname: a\ndescription: b\ndeps: { host: [\"imagemagick\"] }\n---\nBody.\n",
+            ),
+            (
+                "a host tool no manifest may declare",
+                "---\nname: a\ndescription: b\ndeps: { host: [\"node\"] }\n---\nBody.\n",
             ),
             (
                 "duplicate host tool",

--- a/crates/openwave-desktop/src/office_install.rs
+++ b/crates/openwave-desktop/src/office_install.rs
@@ -288,6 +288,7 @@ impl openwave_code_execution::HostToolBroker for DesktopHostToolBroker {
             openwave_code_execution::HostDep::LibreOffice => {
                 warm_presentation_converter(self.app.clone());
             }
+            openwave_code_execution::HostDep::Node => {}
         }
     }
 
@@ -297,7 +298,22 @@ impl openwave_code_execution::HostToolBroker for DesktopHostToolBroker {
     ) -> openwave_code_execution::HostToolStatus {
         match tool {
             openwave_code_execution::HostDep::LibreOffice => libreoffice_status(&self.app).await,
+            openwave_code_execution::HostDep::Node => {
+                openwave_code_execution::HostToolStatus::Unavailable(
+                    "no managed Node runtime is installed".into(),
+                )
+            }
         }
+    }
+
+    async fn managed_root(
+        &self,
+        _tool: openwave_code_execution::HostDep,
+    ) -> Option<std::path::PathBuf> {
+        // Conversion runs on the host, so LibreOffice has no root anything
+        // downstream needs; the managed Node runtime the sandbox is handed is
+        // installed separately.
+        None
     }
 }
 

--- a/crates/openwave-server/src/code_execution/provider.rs
+++ b/crates/openwave-server/src/code_execution/provider.rs
@@ -27,7 +27,7 @@ use crate::state::BlobWriteGuard;
 use super::config::*;
 use super::staging::{
     implicit_staged_paths, materialize_chat_attachments, prepare_execution_directories,
-    staged_set_note, StagedFolders, StagedTurn,
+    required_host_deps, staged_set_note, StagedFolders, StagedTurn,
 };
 
 pub struct ConfiguredCodeExecutionProvider {
@@ -586,20 +586,13 @@ impl ConfiguredCodeExecutionProvider {
             return;
         }
         let skills = self.enabled_skills(installed).await;
-        // Warm the staged skills' declared host tools while the turn runs:
-        // `ensure` is fire-and-forget with the broker's own discipline
-        // (serialized installs, remembered failures), so a declaration in a
-        // staged manifest is all it takes to start the managed install long
-        // before the QA loop needs it.
+        // Warm the staged skills' host tools while the turn runs: `ensure` is
+        // fire-and-forget with the broker's own discipline (serialized
+        // installs, remembered failures), so a staged manifest is all it takes
+        // to start the managed install long before the QA loop needs it.
         if let Some(broker) = self.host_tool_broker.as_deref() {
-            let mut warmed: Vec<openwave_code_execution::HostDep> = Vec::new();
-            for skill in &skills {
-                for dep in &skill.package.host_deps {
-                    if !warmed.contains(dep) {
-                        warmed.push(*dep);
-                        broker.ensure(*dep);
-                    }
-                }
+            for dep in required_host_deps(&skills) {
+                broker.ensure(dep);
             }
         }
         let host_dir = self.scratch_root.join(chat_id.to_string());
@@ -641,6 +634,55 @@ impl ConfiguredCodeExecutionProvider {
                 .await,
             openwave_code_execution::HostToolStatus::Available
         ))
+    }
+
+    /// Whether a Node runtime is real for this turn, for the operating
+    /// prompt's capability line.
+    ///
+    /// `None` when no staged skill declares npm packages — nothing this turn
+    /// would run Node, so the line would steer nothing. Otherwise the status
+    /// is stated exactly, including [`HostToolStatus::Installing`]: a runtime
+    /// that is still downloading is worth waiting a step for, and a model told
+    /// only "unavailable" would abandon the npm path for the rest of the turn.
+    ///
+    /// Every managed backend bakes Node into its image, so only the local
+    /// backend has anything to resolve; there, a host with no broker at all
+    /// (a headless embedding) reports the honest absence rather than letting
+    /// the model discover it one failed command at a time.
+    pub(crate) async fn node_runtime_status(
+        &self,
+    ) -> Option<openwave_code_execution::HostToolStatus> {
+        let needed = self
+            .current_skills()
+            .await
+            .iter()
+            .any(|skill| !skill.package.npm_deps.is_empty());
+        if !needed {
+            return None;
+        }
+        let provider = read_config(&*self.store)
+            .await
+            .ok()
+            .and_then(|c| c.provider);
+        if !matches!(provider, None | Some(CodeExecutionProviderKind::Local)) {
+            return Some(openwave_code_execution::HostToolStatus::Available);
+        }
+        let Some(broker) = self.host_tool_broker.as_deref() else {
+            return Some(openwave_code_execution::HostToolStatus::Unavailable(
+                "this host provides no managed Node runtime".into(),
+            ));
+        };
+        Some(broker.status(openwave_code_execution::HostDep::Node).await)
+    }
+
+    /// The managed Node runtime's directory, for the local sandbox to expose
+    /// read-only. `None` whenever one does not resolve right now, which is
+    /// simply a sandbox without `node` on its `PATH`.
+    async fn managed_node_dir(&self) -> Option<std::path::PathBuf> {
+        self.host_tool_broker
+            .as_deref()?
+            .managed_root(openwave_code_execution::HostDep::Node)
+            .await
     }
 
     /// The shared package cache keyspace for the local sandbox interpreter.
@@ -1094,7 +1136,8 @@ impl ConfiguredCodeExecutionProvider {
                     )?
                     .with_network_policy(network_policy.cloned().unwrap_or_default())
                     .with_document_scripts(self.document_scripts_source.clone())
-                    .with_shared_package_cache(package_cache),
+                    .with_shared_package_cache(package_cache)
+                    .with_managed_node(self.managed_node_dir().await),
                 )
             }
             CodeExecutionProviderKind::E2b => {

--- a/crates/openwave-server/src/code_execution/staging.rs
+++ b/crates/openwave-server/src/code_execution/staging.rs
@@ -200,6 +200,30 @@ pub(super) async fn materialize_attachments(
     Ok(())
 }
 
+/// The host tools a staged set of skills needs: what the manifests declare,
+/// plus what they imply.
+///
+/// A skill declares the npm packages it uses and never the interpreter that
+/// runs them, so a non-empty npm list is the declaration of a Node dependency
+/// — the only one there is. Deriving it here keeps the two from disagreeing:
+/// there is no manifest spelling of `node` for a skill to omit or to claim
+/// without the packages behind it.
+pub(super) fn required_host_deps(
+    skills: &[openwave_code_execution::LoadedSkill],
+) -> Vec<openwave_code_execution::HostDep> {
+    let mut required: Vec<openwave_code_execution::HostDep> = Vec::new();
+    for skill in skills {
+        let implied =
+            (!skill.package.npm_deps.is_empty()).then_some(openwave_code_execution::HostDep::Node);
+        for dep in skill.package.host_deps.iter().copied().chain(implied) {
+            if !required.contains(&dep) {
+                required.push(dep);
+            }
+        }
+    }
+    required
+}
+
 pub(super) async fn prepare_execution_directories(
     host_dir: &std::path::Path,
     mirrored: bool,

--- a/crates/openwave-server/src/code_execution/tests.rs
+++ b/crates/openwave-server/src/code_execution/tests.rs
@@ -668,24 +668,22 @@ async fn disabling_drops_a_component_from_staging_and_the_catalog() {
     assert!(provider.skill_catalog().await.is_empty());
 }
 
-/// The declaration-driven host-tool contract: staging a skill that
-/// declares `host: ["libreoffice"]` warms the broker exactly once per
-/// staging, and the prompt capability flag is the broker's status — never
-/// a promise — omitted entirely when nothing declares the dependency.
+/// The host-tool contract, from a staged manifest to the prompt: a skill that
+/// declares `host: ["libreoffice"]` and npm packages warms both tools exactly
+/// once per staging — Node is derived from the npm list, which is the only
+/// place a skill can ask for it — and each capability line is the broker's
+/// status rather than a promise, omitted entirely when nothing needs the tool.
 #[tokio::test]
-async fn declared_host_deps_warm_the_broker_and_gate_the_capability_flag() {
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
+async fn staged_skills_warm_their_host_tools_and_gate_the_capability_lines() {
     struct RecordingBroker {
-        ensures: AtomicUsize,
+        ensured: Mutex<Vec<openwave_code_execution::HostDep>>,
         available: bool,
     }
 
     #[async_trait]
     impl openwave_code_execution::HostToolBroker for RecordingBroker {
         fn ensure(&self, tool: openwave_code_execution::HostDep) {
-            assert_eq!(tool, openwave_code_execution::HostDep::LibreOffice);
-            self.ensures.fetch_add(1, Ordering::SeqCst);
+            self.ensured.lock().expect("ensured tools").push(tool);
         }
 
         async fn status(
@@ -725,7 +723,7 @@ async fn declared_host_deps_warm_the_broker_and_gate_the_capability_flag() {
     .unwrap();
 
     let broker = Arc::new(RecordingBroker {
-        ensures: AtomicUsize::new(0),
+        ensured: Mutex::new(Vec::new()),
         available: true,
     });
     let provider = ConfiguredCodeExecutionProvider::new(
@@ -737,13 +735,24 @@ async fn declared_host_deps_warm_the_broker_and_gate_the_capability_flag() {
     .with_host_tool_broker(Some(broker.clone()));
 
     provider.stage_turn_workspace(ChatId::new()).await;
-    assert_eq!(broker.ensures.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        *broker.ensured.lock().expect("ensured tools"),
+        [
+            openwave_code_execution::HostDep::LibreOffice,
+            openwave_code_execution::HostDep::Node,
+        ]
+    );
     assert_eq!(provider.office_rendering_available().await, Some(true));
+    assert_eq!(
+        provider.node_runtime_status().await,
+        Some(openwave_code_execution::HostToolStatus::Available)
+    );
 
-    // An unavailable tool reports false — the prompt says so instead of
-    // teaching a QA loop the host cannot run.
+    // An unavailable tool reports itself unavailable — the prompt says so
+    // instead of teaching a QA loop the host cannot run or an npm path that
+    // has no interpreter behind it.
     let unavailable = Arc::new(RecordingBroker {
-        ensures: AtomicUsize::new(0),
+        ensured: Mutex::new(Vec::new()),
         available: false,
     });
     let provider = ConfiguredCodeExecutionProvider::new(
@@ -754,6 +763,10 @@ async fn declared_host_deps_warm_the_broker_and_gate_the_capability_flag() {
     .with_skills(Some(source.path().to_owned()))
     .with_host_tool_broker(Some(unavailable));
     assert_eq!(provider.office_rendering_available().await, Some(false));
+    assert!(matches!(
+        provider.node_runtime_status().await,
+        Some(openwave_code_execution::HostToolStatus::Unavailable(_))
+    ));
 
     // No declaration, no line; no broker, no promise.
     let no_deps = tempfile::tempdir().unwrap();
@@ -771,11 +784,16 @@ async fn declared_host_deps_warm_the_broker_and_gate_the_capability_flag() {
     )
     .with_skills(Some(no_deps.path().to_owned()));
     assert_eq!(provider.office_rendering_available().await, None);
+    assert_eq!(provider.node_runtime_status().await, None);
 
     let brokerless =
         ConfiguredCodeExecutionProvider::new(store, Arc::new(NoSecrets), scratch_root.path())
             .with_skills(Some(source.path().to_owned()));
     assert_eq!(brokerless.office_rendering_available().await, Some(false));
+    assert!(matches!(
+        brokerless.node_runtime_status().await,
+        Some(openwave_code_execution::HostToolStatus::Unavailable(_))
+    ));
 }
 
 /// Local exec is confined to the scratch directory but can create entries

--- a/crates/openwave-server/src/code_execution/tests.rs
+++ b/crates/openwave-server/src/code_execution/tests.rs
@@ -698,6 +698,13 @@ async fn declared_host_deps_warm_the_broker_and_gate_the_capability_flag() {
                 openwave_code_execution::HostToolStatus::Unavailable("not installed".into())
             }
         }
+
+        async fn managed_root(
+            &self,
+            _tool: openwave_code_execution::HostDep,
+        ) -> Option<std::path::PathBuf> {
+            None
+        }
     }
 
     let (store, _database) = test_store().await;

--- a/crates/openwave-server/src/foreground_prompt.rs
+++ b/crates/openwave-server/src/foreground_prompt.rs
@@ -66,6 +66,7 @@ pub(crate) fn compose(specs: &[ToolSpec]) -> String {
         crate::code_execution::DEFAULT_TIMEOUT_MS,
         false,
         None,
+        None,
         false,
     )
 }
@@ -181,6 +182,7 @@ pub(crate) fn compose_for_surface(
     exec_timeout_ms: u64,
     offline_package_cache: bool,
     office_rendering: Option<bool>,
+    node_runtime: Option<openwave_code_execution::HostToolStatus>,
     plan_mode: bool,
 ) -> String {
     let names = specs
@@ -569,6 +571,25 @@ pub(crate) fn compose_for_surface(
                 ),
                 None => {}
             }
+            // The same rule for the other half of a document skill's
+            // toolchain. A skill declares npm packages; whether anything can
+            // run them is host state, and a model that is told plainly does
+            // not spend a turn discovering it one failed command at a time.
+            match node_runtime {
+                Some(openwave_code_execution::HostToolStatus::Available) => lines.push(
+                    "- Node is available: run a skill's npm work with `node`, and install its pinned packages with `npm install --ignore-scripts <package>@<version>` when they are not already present. Always pass `--ignore-scripts`."
+                        .to_owned(),
+                ),
+                Some(openwave_code_execution::HostToolStatus::Installing) => lines.push(
+                    "- Node is being installed on this host right now and does not run yet. Do the parts of the task that do not need it first, then retry the Node step later in the turn; if it still does not run, say so rather than silently switching to a lesser format."
+                        .to_owned(),
+                ),
+                Some(openwave_code_execution::HostToolStatus::Unavailable(_)) => lines.push(
+                    "- Node is unavailable on this host: `node` and `npm` do not run, so a skill's npm path is not usable this turn and there is nothing to probe. Follow the skill's other path if it has one, and otherwise tell the user plainly what cannot be produced."
+                        .to_owned(),
+                ),
+                None => {}
+            }
             push_section(&mut prompt, DOCUMENT_SKILLS_HEADING, &lines);
         }
     }
@@ -764,6 +785,7 @@ mod tests {
             TIMEOUT,
             false,
             None,
+            None,
             true,
         );
         let normal = compose_for_surface(
@@ -774,6 +796,7 @@ mod tests {
             &NetworkPolicy::default(),
             TIMEOUT,
             false,
+            None,
             None,
             false,
         );
@@ -827,6 +850,7 @@ mod tests {
             TIMEOUT,
             false,
             None,
+            None,
             false,
         );
 
@@ -857,6 +881,7 @@ mod tests {
                 TIMEOUT,
                 false,
                 None,
+                None,
                 false,
             )
         };
@@ -879,6 +904,7 @@ mod tests {
             &NetworkPolicy::Off,
             TIMEOUT,
             true,
+            None,
             None,
             false,
         );
@@ -947,6 +973,7 @@ mod tests {
             1_500,
             false,
             None,
+            None,
             false,
         );
         assert!(odd.contains("killed by the host after 1500 milliseconds"));
@@ -1000,6 +1027,7 @@ mod tests {
             TIMEOUT,
             false,
             None,
+            None,
             false,
         );
         assert!(prompt.contains(DOCUMENT_SKILLS_HEADING));
@@ -1022,6 +1050,7 @@ mod tests {
             TIMEOUT,
             false,
             None,
+            None,
             false,
         );
         assert!(!without_exec.contains(DOCUMENT_SKILLS_HEADING));
@@ -1034,6 +1063,7 @@ mod tests {
             &NetworkPolicy::default(),
             TIMEOUT,
             false,
+            None,
             None,
             false,
         );
@@ -1110,6 +1140,7 @@ mod tests {
             TIMEOUT,
             false,
             None,
+            None,
             false,
         );
         let catalog = prompt
@@ -1156,6 +1187,7 @@ mod tests {
                 TIMEOUT,
                 false,
                 office_rendering,
+                None,
                 false,
             )
         };
@@ -1167,6 +1199,47 @@ mod tests {
         assert!(unavailable.contains("visual pass was not possible"));
         let undeclared = for_state(None);
         assert!(!undeclared.contains("Office rendering"));
+    }
+
+    /// The Node line carries the same host truth, with the middle state the
+    /// office line has no use for: a runtime that is still installing is
+    /// worth retrying within the turn, and one that is absent closes the npm
+    /// path instead of inviting the model to probe for it.
+    #[test]
+    fn node_runtime_line_states_availability_and_keeps_installs_scriptless() {
+        let skills = vec![SkillPackage {
+            name: "presentations".into(),
+            description: "Decks.".into(),
+            python_deps: Vec::new(),
+            npm_deps: vec!["pptxgenjs@4.0.1".into()],
+            host_deps: Vec::new(),
+            origin: SkillOrigin::Builtin,
+        }];
+        let for_state = |node_runtime| {
+            compose_for_surface(
+                &[spec("exec")],
+                &[],
+                &skills,
+                &[],
+                &NetworkPolicy::default(),
+                TIMEOUT,
+                false,
+                None,
+                node_runtime,
+                false,
+            )
+        };
+        let available = for_state(Some(openwave_code_execution::HostToolStatus::Available));
+        assert!(available.contains("Node is available"));
+        assert!(available.contains("npm install --ignore-scripts"));
+        let installing = for_state(Some(openwave_code_execution::HostToolStatus::Installing));
+        assert!(installing.contains("being installed"));
+        let unavailable = for_state(Some(openwave_code_execution::HostToolStatus::Unavailable(
+            "not installed".into(),
+        )));
+        assert!(unavailable.contains("Node is unavailable"));
+        assert!(!unavailable.contains("npm install"));
+        assert!(!for_state(None).contains("Node is"));
     }
 
     #[test]
@@ -1251,6 +1324,7 @@ mod tests {
             &NetworkPolicy::default(),
             TIMEOUT,
             false,
+            None,
             None,
             false,
         );

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -153,6 +153,7 @@ pub(crate) fn freeze_foreground_turn_surface(
         crate::code_execution::DEFAULT_TIMEOUT_MS,
         false,
         None,
+        None,
         false,
         openwave_core::TurnWebSearch::Host,
     )
@@ -169,6 +170,7 @@ fn freeze_foreground_turn_surface_with_folders(
     exec_timeout_ms: u64,
     offline_package_cache: bool,
     office_rendering: Option<bool>,
+    node_runtime: Option<openwave_code_execution::HostToolStatus>,
     plan_mode: bool,
     web_search: openwave_core::TurnWebSearch,
 ) -> ForegroundTurnSurface {
@@ -192,6 +194,7 @@ fn freeze_foreground_turn_surface_with_folders(
         exec_timeout_ms,
         offline_package_cache,
         office_rendering,
+        node_runtime,
         plan_mode,
     ));
     ForegroundTurnSurface {
@@ -679,6 +682,10 @@ impl TurnWorker {
             Some(provider) => provider.office_rendering_available().await,
             None => None,
         };
+        let node_runtime = match self.exec_folder_context.as_ref() {
+            Some(provider) => provider.node_runtime_status().await,
+            None => None,
+        };
         let exec_timeout_ms = match self.exec_folder_context.as_ref() {
             Some(provider) => provider.current_timeout_ms().await,
             None => crate::code_execution::DEFAULT_TIMEOUT_MS,
@@ -723,6 +730,7 @@ impl TurnWorker {
             exec_timeout_ms,
             offline_package_cache,
             office_rendering,
+            node_runtime,
             matches!(
                 chat.permission_mode,
                 Some(openwave_core::PermissionMode::Plan)

--- a/skills/presentations/SKILL.md
+++ b/skills/presentations/SKILL.md
@@ -33,8 +33,14 @@ version is baked into the image and `NODE_PATH` points at it. On a local exec
 workspace, install it once with its own `exec` call:
 
 ```
-npm install pptxgenjs@4.0.1
+npm install --ignore-scripts pptxgenjs@4.0.1
 ```
+
+Keep `--ignore-scripts`: a local workspace runs on the user's own machine, and
+a package's install hooks are arbitrary code nobody asked to run. The Node
+runtime itself is host-managed on that backend — the turn's operating notes say
+whether it is available, being installed, or absent, so read them before
+choosing this path.
 
 Installs work only when this chat's network policy allows package managers,
 and they persist for the rest of the conversation. If an install is refused by


### PR DESCRIPTION
Skills that declare npm packages — `presentations` and pptxgenjs — are advertised on every backend, but the local macOS sandbox pins `PATH` to system directories and most machines have no Node behind them. The agent finds that out empirically, one failed command at a time, and then falls back to a worse toolchain without telling anyone why.

This makes the runtime reachable and the prompt honest about it.

`HostDep` gains a `Node` variant that no manifest can spell. A skill declares the npm packages it uses; needing an interpreter to run them follows from that, so turn staging derives the requirement from a non-empty npm list and warms it through the same fire-and-forget broker the managed LibreOffice install already uses. The broker gains one accessor, `managed_root`, for the tools an execution backend has to be handed a path to rather than ones the host drives itself.

The local adapter accepts that path as an optional managed-node directory. `(allow process-exec)` is already unconditional in the Seatbelt profile, so being able to *open* the interpreter is the whole gate: the directory joins the read-only allowances beside the package cache — never the write ones, so no conversation can replace the interpreter the next one runs — and `<dir>/bin` leads `PATH`. Without a runtime, the profile and `PATH` are exactly what they were.

The operating prompt then states the truth for the turn: available, installing (worth retrying within the turn), or unavailable, in which case it says the npm path is closed rather than leaving the model to probe. Managed backends report available — Node is baked into the image — and a headless embedding with no broker keeps the honest absence. Local npm installs are told to pass `--ignore-scripts`, in the prompt and in the skill: a package's install hooks are arbitrary code on the user's own machine. `registry.npmjs.org` was already reachable under the package-manager policy and npm honors the broker's proxy variables, so no egress change was needed.

Tests: the profile gains the managed-node subpath and the `PATH` prepend only when a directory is supplied, and a runtime the host hands over actually executes inside a real Seatbelt sandbox while one it withholds is absent from `PATH`. The existing host-tool broker test now covers the derived Node dependency and the three prompt states.

Verification, with GitHub Actions down: `cargo check --workspace --locked` passes with no lockfile change, `cargo test -p openwave-code-execution` is green (98 + 3), and `cargo fmt`/`cargo clippy` are clean for the crates touched. `cargo test -p openwave-server` could not be run: on current `main` that crate's test target does not compile (~250 errors across `sandbox_agent_run_worker/tests.rs`, `mcp_config/tests.rs`, `code_execution/tests.rs`, and `routes/turn_control.rs`), and `cargo fmt --all` cannot parse `openwave-core/src/agent/tests/mod.rs` — both predate this branch and come from #1726. None of the remaining errors point at the code or tests added here. Cross-compiling to Linux is not possible on this machine; no `cfg(linux)` paths were added, and the non-macOS `run_native` stub was updated alongside the real one.

Closes #1722
