### PR TITLE
fix(server): restore the test build broken by the module split

### DIFF
--- a/crates/openwave-server/src/code_execution/config.rs
+++ b/crates/openwave-server/src/code_execution/config.rs
@@ -211,7 +211,7 @@ impl EgressConfig {
     /// Returns an error rather than silently opening egress when a stored
     /// pattern does not parse, so an invalid grant fails closed at the network
     /// boundary instead of degrading to unrestricted.
-    fn to_policy(&self) -> std::result::Result<Option<EgressPolicy>, EgressError> {
+    pub(super) fn to_policy(&self) -> std::result::Result<Option<EgressPolicy>, EgressError> {
         match self {
             Self::Open => Ok(None),
             Self::Allowlist { domains, cidrs } => {
@@ -285,7 +285,7 @@ impl Default for CodeExecutionConfig {
 }
 
 impl CodeExecutionConfig {
-    fn disabled() -> Self {
+    pub(super) fn disabled() -> Self {
         Self {
             provider: None,
             timeout_ms: DEFAULT_TIMEOUT_MS,
@@ -295,7 +295,7 @@ impl CodeExecutionConfig {
         }
     }
 
-    fn validate(&self) -> std::result::Result<(), ServerError> {
+    pub(super) fn validate(&self) -> std::result::Result<(), ServerError> {
         if !(MIN_TIMEOUT_MS..=MAX_TIMEOUT_MS).contains(&self.timeout_ms) {
             return Err(ServerError::bad_request(format!(
                 "code execution timeout_ms must be between {MIN_TIMEOUT_MS} and {MAX_TIMEOUT_MS}"

--- a/crates/openwave-server/src/code_execution/provider.rs
+++ b/crates/openwave-server/src/code_execution/provider.rs
@@ -31,7 +31,7 @@ use super::staging::{
 };
 
 pub struct ConfiguredCodeExecutionProvider {
-    store: Arc<dyn Store>,
+    pub(super) store: Arc<dyn Store>,
     secrets: Arc<dyn SecretProvider>,
     blobs: Option<Arc<dyn BlobStore>>,
     scratch_root: PathBuf,
@@ -814,7 +814,7 @@ impl ConfiguredCodeExecutionProvider {
     /// A folder that cannot be staged is downgraded to read-only for this turn:
     /// silently restoring direct writes would remove the overlay precisely for
     /// the largest or most unusual folders.
-    async fn open_write_overlay(
+    pub(super) async fn open_write_overlay(
         &self,
         chat: ChatId,
         turn: TurnId,
@@ -991,7 +991,7 @@ impl ConfiguredCodeExecutionProvider {
             .map(|staged| staged.overlay.inspector())
     }
 
-    async fn resolve_chat_folder_grants(
+    pub(super) async fn resolve_chat_folder_grants(
         &self,
         chat: &Chat,
     ) -> std::result::Result<Vec<ResolvedExecFolderGrant>, CodeExecutionError> {
@@ -1401,7 +1401,7 @@ impl ConfiguredCodeExecutionProvider {
     }
 }
 
-fn exec_folder_grant_for_turn(
+pub(super) fn exec_folder_grant_for_turn(
     grant: ResolvedExecFolderGrant,
     staged: &HashMap<PathBuf, PathBuf>,
 ) -> std::result::Result<ExecFolderGrant, CodeExecutionError> {

--- a/crates/openwave-server/src/code_execution/tests.rs
+++ b/crates/openwave-server/src/code_execution/tests.rs
@@ -33,12 +33,13 @@ use crate::state::BlobWriteGuard;
 
 use super::*;
 
-use chrono::Utc;
+use super::provider::exec_folder_grant_for_turn;
+use super::staging::{materialize_chat_attachments, prepare_execution_directories};
+
 use openwave_core::{
     AgentError, ChatRootAttachment, DbStore, DocumentId, DocumentSourceBlob, DocumentSourceUpsert,
-    FsBlobStore, PermissionMode, RootAttachmentOrigin, TurnId,
+    FsBlobStore, PermissionMode, RootAttachmentOrigin,
 };
-use std::sync::Mutex;
 use uuid::Uuid;
 
 struct NoSecrets;

--- a/crates/openwave-server/src/mcp_config/runtime.rs
+++ b/crates/openwave-server/src/mcp_config/runtime.rs
@@ -18,25 +18,25 @@ use crate::mcp_curated::{curation_for, McpCuration};
 use super::types::*;
 use super::validation::{connection_diagnostic, validate_servers};
 
-struct ManagedServer {
+pub(super) struct ManagedServer {
     client: Option<McpClient>,
     health: McpHealth,
     diagnostic: Option<String>,
     reconnect_backoff: Duration,
-    epoch: u64,
-    reconnect_lock: Arc<Mutex<()>>,
+    pub(super) epoch: u64,
+    pub(super) reconnect_lock: Arc<Mutex<()>>,
     /// Prefetched MCP Apps view documents, keyed by declared `ui://` URI.
     ui_views: HashMap<String, UiViewDocument>,
 }
 
-struct RuntimeState {
-    definitions: Vec<McpServerDefinition>,
+pub(super) struct RuntimeState {
+    pub(super) definitions: Vec<McpServerDefinition>,
     /// The connected-app record id behind each configured server name. App
     /// manifests and grants bind these ids; the id survives edits to the
     /// definition and dies with the record, so a name-keyed lookup here is
     /// only ever a projection detail, never the consent key.
     ids: BTreeMap<String, ConnectedAppId>,
-    servers: HashMap<String, ManagedServer>,
+    pub(super) servers: HashMap<String, ManagedServer>,
 }
 
 /// Owns the current MCP connection set and atomically published tool registry.
@@ -47,7 +47,7 @@ struct RuntimeState {
 pub(crate) struct McpRuntime {
     base_tools: ToolRegistry,
     tools: RwLock<Arc<ToolRegistry>>,
-    state: Mutex<RuntimeState>,
+    pub(super) state: Mutex<RuntimeState>,
     mutation: Mutex<()>,
     store: Arc<dyn Store>,
     /// Holds each server's literal environment values, keyed by record id.
@@ -102,7 +102,7 @@ impl McpRuntime {
     /// unreadable entry resolves empty: the child then starts without those
     /// names and fails with the server's own diagnostic, which beats taking
     /// an unrelated settings save down.
-    async fn stored_env(&self, id: ConnectedAppId) -> BTreeMap<String, String> {
+    pub(super) async fn stored_env(&self, id: ConnectedAppId) -> BTreeMap<String, String> {
         match self.secrets.get_secret(&env_secret_key(id)).await {
             Ok(Some(raw)) => serde_json::from_str(&raw).unwrap_or_default(),
             Ok(None) => BTreeMap::new(),
@@ -653,7 +653,7 @@ impl McpRuntime {
     }
 
     #[cfg(test)]
-    async fn replace_with_commit_pause(
+    pub(super) async fn replace_with_commit_pause(
         &self,
         config: McpServersConfig,
         entered: Arc<tokio::sync::Notify>,
@@ -839,7 +839,7 @@ impl McpRuntime {
             .await
     }
 
-    async fn replace_permissive(
+    pub(super) async fn replace_permissive(
         &self,
         definitions: Vec<McpServerDefinition>,
         ids: BTreeMap<String, ConnectedAppId>,
@@ -1238,7 +1238,7 @@ impl McpRuntime {
         }
     }
 
-    async fn mark_degraded(&self, name: &str, epoch: u64, backoff: Duration) {
+    pub(super) async fn mark_degraded(&self, name: &str, epoch: u64, backoff: Duration) {
         let mut state = self.state.lock().await;
         if let Some(server) = state
             .servers

--- a/crates/openwave-server/src/mcp_config/tests.rs
+++ b/crates/openwave-server/src/mcp_config/tests.rs
@@ -20,6 +20,8 @@ use crate::mcp_curated::{curation_for, McpCuration};
 
 use super::*;
 
+use super::validation::{connection_diagnostic, validate_servers};
+
 use openwave_core::DbStore;
 
 fn parse(json: &str) -> Result<ConfiguredMcpServers> {

--- a/crates/openwave-server/src/mcp_config/types.rs
+++ b/crates/openwave-server/src/mcp_config/types.rs
@@ -256,7 +256,7 @@ impl McpServerDefinition {
     /// Build the child command. `env` is the definition's literal environment
     /// as resolved from the secret store — passed in rather than read off the
     /// definition, because the definition never holds values.
-    fn build_command(&self, env: &BTreeMap<String, String>) -> Result<Command> {
+    pub(super) fn build_command(&self, env: &BTreeMap<String, String>) -> Result<Command> {
         let Some(program) = &self.command else {
             return Err(AgentError::config(
                 "MCP server definition has no command to spawn",
@@ -288,7 +288,7 @@ impl McpServerDefinition {
         Ok(command)
     }
 
-    async fn connect(
+    pub(super) async fn connect(
         &self,
         gateway: &Arc<dyn GatewayEndpoints>,
         env: &BTreeMap<String, String>,

--- a/crates/openwave-server/src/routes/turn_control.rs
+++ b/crates/openwave-server/src/routes/turn_control.rs
@@ -235,6 +235,7 @@ fn require_image_input(policy: &providers::ResolvedModelPolicy) -> Result<(), Se
 mod image_capability_tests {
     use super::*;
     use crate::model_registry::{InputModality, ModelSpec};
+    use crate::providers::ProviderKind;
 
     const TEXT_ONLY: ModelSpec = ModelSpec {
         id: "text-only-model",

--- a/crates/openwave-server/src/sandbox_agent_run_worker/tests.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker/tests.rs
@@ -26,6 +26,27 @@ use crate::state::SandboxAttemptGuard;
 
 use super::*;
 
+use std::pin::Pin;
+use std::sync::atomic::AtomicBool;
+use std::sync::Mutex;
+use std::task::{Context, Poll};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use futures::stream::{self, BoxStream};
+use openwave_core::{
+    Chat, ChatId, DbStore, ProviderId, ReasoningEffort, TurnCheckpointProgress, TurnId,
+    TurnRunStatus, Usage,
+};
+
+use super::config::{
+    sandbox_system_prompt, SandboxAgentRunWorkerOutcome, SANDBOX_PROMPT_WEB_SEARCH_CLAUSE,
+};
+use super::model_step::{
+    complete_sandbox_task, delegated_file_admission_matches, sandbox_request, SandboxCompletion,
+    SandboxToolCallDisposition, SandboxToolCallIntent,
+};
+
 #[derive(Default)]
 struct RecordingProvider {
     requests: Mutex<Vec<ChatRequest>>,

--- a/crates/openwave-server/src/sandbox_agent_run_worker/worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker/worker.rs
@@ -173,7 +173,7 @@ impl SandboxAgentRunWorker {
             .await
     }
 
-    async fn resume_parent_wait_set_with_token(
+    pub(super) async fn resume_parent_wait_set_with_token(
         &self,
         wait_id: CallId,
         resume_token: uuid::Uuid,
@@ -261,7 +261,7 @@ impl SandboxAgentRunWorker {
         Ok(outcome)
     }
 
-    async fn process(
+    pub(super) async fn process(
         &self,
         run: AgentRun,
         lease_token: uuid::Uuid,
@@ -713,7 +713,7 @@ impl SandboxAgentRunWorker {
     /// The step is trimmed to what the run's remaining tool budget can hold
     /// before anything is written: rows are the durable cost, and a batch the
     /// store would refuse is worse than one honest refusal the model can read.
-    async fn park_sandbox_tool_calls(
+    pub(super) async fn park_sandbox_tool_calls(
         &self,
         run: AgentRun,
         lease_token: uuid::Uuid,


### PR DESCRIPTION
## Summary

`cargo test -p openwave-server --locked` has not compiled on main since the module-split refactor (#1726) — 249 errors across the split-out test modules (`sandbox_agent_run_worker/tests.rs`, `code_execution/tests.rs`, `mcp_config/tests.rs`, plus one import in `routes/turn_control.rs`). It landed unseen because GitHub Actions is stuck, so no post-merge validation ran. Tracked in #1729; every Rust-side verification is blocked on it.

Mechanical restoration with no behavior change:
- Test modules regain the imports they lost when they moved out of the modules whose scope they shared (std/chrono/futures/openwave_core items, the `async_trait` attribute — whose absence also produced the E0195 lifetime mismatches — and explicit `use super::<submodule>::…` for module-internal helpers).
- Items the tests reach widen to `pub(super)`: helper fns already so marked stayed put; newly widened are one worker method (`process`, plus two wait/park methods), `ConfiguredCodeExecutionProvider::store`, `EgressConfig`-side `to_policy`/`validate`/`disabled`, and `mcp_config`'s `RuntimeState`/`ManagedServer` with the fields the reconnect tests inspect. Nothing crosses a crate boundary; `pub(super)` inside the split module is the same effective scope the inline tests had before the split.
- Duplicate-import blocks the split concatenated are merged.

Closes #1729.

## Testing

- `cargo test -p openwave-server --locked` — 633 passed, 0 failed, 3 ignored (was: 249 compile errors).
- `cargo fmt --check -p openwave-server` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)