### PR TITLE
fix(server): restore the orphaned staging doc comment and regenerate wire.ts

### DIFF
--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -260,8 +260,9 @@ export type AppGrantState = {
 /**
  * Whether a live grant fully covers the current manifest with every
  * bound definition unchanged since consent — the "no sheet needed"
- * verdict. When `false`, (re-)consent is required before every pinned
- * capability is invokable.
+ * verdict. A manifest with no bindings is vacuously granted: there is
+ * nothing to consent to, so no sheet is shown. When `false`,
+ * (re-)consent is required before every pinned capability is invokable.
  */
 granted: boolean, 
 /**

--- a/crates/openwave-server/src/code_execution/provider.rs
+++ b/crates/openwave-server/src/code_execution/provider.rs
@@ -1583,12 +1583,6 @@ impl CodeExecutionProvider for ConfiguredCodeExecutionProvider {
     // [`ConfiguredCodeExecutionProvider::workspace`] instead.
 }
 
-/// Host infrastructure staged into every managed workspace regardless of the
-/// model's listed set: the conventional-directory markers that make `output/`
-/// and `preview/` exist remotely so commands can write into them, and the
-/// bundled document helpers the tool description tells the model to invoke
-/// without listing. All of it is host-authored, bounded, and digest-skipped on
-
 /// A resolved workspace-lifecycle handle over the currently selected provider.
 pub struct ConfiguredWorkspace {
     provider: Box<dyn CodeExecutionProvider>,

--- a/crates/openwave-server/src/code_execution/staging.rs
+++ b/crates/openwave-server/src/code_execution/staging.rs
@@ -72,6 +72,12 @@ pub trait StagedFolders: Send + Sync {
     ) -> bool;
 }
 
+/// Host infrastructure staged into every managed workspace regardless of the
+/// model's listed set: the conventional-directory markers that make `output/`
+/// and `preview/` exist remotely so commands can write into them, and the
+/// bundled document helpers the tool description tells the model to invoke
+/// without listing. All of it is host-authored, bounded, and digest-skipped on
+/// a reused session.
 pub(super) fn implicit_staged_paths(
     with_document_scripts: bool,
     with_skills: bool,


### PR DESCRIPTION
Originally the companion to #1732 covering the rest of the module-split fallout; #1733 and #1736 landed the openwave-core reconstruction and the server test-import cleanup first, so this is rebased down to the two pieces main still needed:

- The doc comment for `implicit_staged_paths` was stranded in `code_execution/provider.rs` above an unrelated struct (minus its last line) by the split, tripping clippy's `empty_line_after_doc_comments`. It moves back to the function it documents in `staging.rs`, with the truncated line restored.
- `ui/src/generated/wire.ts` regenerated: it was stale against the doc comment on `AppGrantState::granted`, failing `openwave-server`'s binding-currency test.

Verified locally (Actions is down): `cargo test -p openwave-server --locked wire_types` passes, `cargo clippy -p openwave-server --locked --all-targets` has zero lint warnings, `cargo check --workspace --locked --all-targets` clean with no lockfile diff, `cargo fmt --all -- --check` clean, and the UI `tsc --noEmit` passes against the regenerated bindings.