### PR TITLE
chore(server): remove unused test-module imports left by the module-split fixes

### DIFF
--- a/crates/openwave-server/src/code_execution/tests.rs
+++ b/crates/openwave-server/src/code_execution/tests.rs
@@ -1,35 +1,21 @@
-use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
 use chrono::Utc;
 use openwave_code_execution::{
-    resolve_scratch_directory, sync, CodeExecutionError, CodeExecutionProvider,
-    CodeExecutionProviderKind, CodeExecutionRequest, CodeExecutionResponse,
-    CodeExecutionUnavailableReason, DaytonaCredential, DaytonaExecutionProvider, E2BCredential,
-    E2BExecutionProvider, ExecFolderAccess, ExecFolderGrant, ExecutionId, ExecutionWorkspaceId,
-    LocalExecutionProvider, MaterializationPrecondition, MaterializedChangeKind,
-    OutputArtifactEntry, OutputArtifactScan, OutputArtifactStatus, PreviewScan,
-    RejectedChangeReason, RemoteSessionPool, SharedPackageCache, StagedUpload, WorkspaceFilePath,
-    WorkspaceLifecycle, WorkspaceListing, WriteOverlay, WriteSnapshotSink, DAYTONA_CREDENTIAL_KEY,
-    DOCUMENT_SCRIPTS_DIR, DOCUMENT_SCRIPT_FILES, E2B_CREDENTIAL_KEY, PACKAGE_CACHE_DIR,
+    CodeExecutionProvider, CodeExecutionProviderKind, CodeExecutionUnavailableReason,
+    DaytonaCredential, DaytonaExecutionProvider, E2BCredential, E2BExecutionProvider,
+    ExecFolderAccess, ExecutionId, ExecutionWorkspaceId, LocalExecutionProvider,
+    OutputArtifactStatus, RemoteSessionPool, DOCUMENT_SCRIPTS_DIR, DOCUMENT_SCRIPT_FILES,
     PACKAGE_MANAGER_DOMAINS,
 };
 use openwave_core::{
-    exec_attachment_file_name, BlobStore, CallId, Chat, ChatId, ExecFileRejectionReason,
-    ExecFileRejectionRecord, HostRootId, MessageDocumentAttachment, NetworkPolicy, ProjectId,
-    Result, RevisionProducer, SecretProvider, Store, TurnId, MAX_EXEC_WORKSPACE_FILE_BYTES,
+    exec_attachment_file_name, BlobStore, Chat, ChatId, HostRootId, NetworkPolicy, Result,
+    SecretProvider, Store, TurnId, MAX_EXEC_WORKSPACE_FILE_BYTES,
 };
-use openwave_egress::{
-    CidrBlock, DomainPattern, EgressAllowlist, EgressEnforcement, EgressError, EgressPolicy,
-};
-use serde::{Deserialize, Serialize};
-
-use crate::error::ServerError;
-use crate::exec_write_snapshot::TurnSnapshotSink;
-use crate::state::BlobWriteGuard;
+use openwave_egress::EgressPolicy;
 
 use super::*;
 

--- a/crates/openwave-server/src/mcp_config/tests.rs
+++ b/crates/openwave-server/src/mcp_config/tests.rs
@@ -1,22 +1,11 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::fs::File;
-use std::io::Read;
-use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, RwLock};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+use std::sync::Arc;
 use std::time::Duration;
 
-use futures::future::join_all;
 use openwave_core::connected_app::{ConnectedApp, ConnectedAppKind};
 use openwave_core::id::ConnectedAppId;
-use openwave_core::local_app::CREATE_APP_TOOL;
 use openwave_core::{AgentError, Result, SecretProvider, Store, ToolRegistry};
-use openwave_mcp::{McpClient, McpProbe, MAX_SERVER_NAME_BYTES};
-use serde::{Deserialize, Serialize};
-use tokio::process::Command;
-use tokio::sync::Mutex;
-
-use crate::mcp_curated::{curation_for, McpCuration};
 
 use super::*;
 

--- a/crates/openwave-server/src/sandbox_agent_run_worker/config.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker/config.rs
@@ -2,7 +2,7 @@
 
 use std::path::PathBuf;
 #[cfg(test)]
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/crates/openwave-server/src/sandbox_agent_run_worker/model_step.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker/model_step.rs
@@ -1,7 +1,5 @@
 //! Model-step request assembly and completion for sandbox agent runs.
 
-#[cfg(test)]
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/crates/openwave-server/src/sandbox_agent_run_worker/tests.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker/tests.rs
@@ -1,27 +1,20 @@
-use std::path::PathBuf;
 #[cfg(test)]
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
 use futures::StreamExt;
 use openwave_core::{
-    sandbox_done_tool_spec, sandbox_exec_tool_spec, sandbox_folder_access_proposal_tool_spec,
-    sandbox_read_delegated_file_tool_spec, sandbox_web_search_tool_spec,
-    validate_sandbox_exec_arguments, validate_sandbox_read_delegated_file_arguments, AgentConfig,
-    AgentError, AgentRun, AgentRunStatus, AgentRunSubmittedOutput, CallId, ChatMessage,
-    ChatRequest, ContentBlock, FailAgentRunOutcome, MessageReasoning, ModelProvider,
-    ParkSandboxToolCallOutcome, ProviderEvent, RequestFolderAccessArgs, Result,
-    ResumeTurnForAgentRunWaitSetOutcome, Role, SandboxToolCall, SandboxToolCallParkEntry,
-    SandboxToolCallRequest, SandboxToolCallStatus, SecretProvider, StopReason, Store,
-    SubmitAgentRunResultOutcome, ToolCallRecord, ToolCallResolution, TurnWebSearch,
-    MAX_SANDBOX_TOOL_CALLS, MAX_SANDBOX_TOOL_CALLS_PER_STEP, SANDBOX_EXEC_TOOL,
+    sandbox_done_tool_spec, sandbox_exec_tool_spec, sandbox_read_delegated_file_tool_spec,
+    AgentConfig, AgentError, AgentRunStatus, CallId, ChatMessage, ChatRequest, ContentBlock,
+    ModelProvider, ProviderEvent, Result, Role, SandboxToolCallStatus, SecretProvider, StopReason,
+    Store, ToolCallRecord, ToolCallResolution, TurnWebSearch, SANDBOX_EXEC_TOOL,
 };
 use tokio::sync::Notify;
 
 use crate::bus::EventBus;
 use crate::resolver::ProviderResolver;
-use crate::retry::{LaneBackoff, RetryAttempt, RetrySchedule};
+use crate::retry::RetrySchedule;
 use crate::state::SandboxAttemptGuard;
 
 use super::*;


### PR DESCRIPTION
PR #1732 restored imports after a test-module split, over-broadly — `cargo check -p openwave-server --locked --all-targets` was emitting 29 unused-import warnings across `code_execution/tests.rs`, `mcp_config/tests.rs`, and `sandbox_agent_run_worker/{config,model_step,tests}.rs`. CI clippy runs `-D warnings`, so these would fail main's next push run.

This removes exactly the unused names (or narrows a `use` down to what's still referenced), without touching test bodies or visibility.

GitHub Actions is currently down, so verification was run locally:

- `cargo check -p openwave-server --locked --all-targets` — no more unused-import warnings (down from 29).
- `cargo clippy -p openwave-server --locked --all-targets` — no unused-import warnings; one pre-existing `empty_line_after_doc_comments` warning in `code_execution/provider.rs` remains, confirmed present on `main` before this change and out of scope here.
- `cargo test -p openwave-server --locked` — 631 passed, 1 failed (`wire_types::tests::the_generated_bindings_are_current`), 3 ignored; the failure is pre-existing on `main` (generated bindings drift, unrelated to imports) and reproduces identically without this change.
- `cargo fmt --all -- --check` — clean.
- `git diff --stat Cargo.lock` — empty.

Closes #1734