### PR TITLE
feat(desktop): background provisioning pass warms plugin dependencies

### DIFF
--- a/crates/openwave-desktop/ui/src/document/officePdf.ts
+++ b/crates/openwave-desktop/ui/src/document/officePdf.ts
@@ -171,6 +171,24 @@ export function warmPresentationConverter(): void {
   });
 }
 
+/**
+ * Watch the host's managed-install progress without asking for an install.
+ *
+ * The same events [`installPresentationConverter`] renders a bar from, but for
+ * a bystander: a provisioning pass the host started on its own (app launch, or
+ * a plugin being enabled) is the only thing driving them, and a surface that
+ * merely wants to say "this is being prepared" must not itself request an
+ * install. Resolves to an unsubscribe; a host with no event bridge (a browser
+ * build) simply never fires.
+ */
+export async function observeConverterInstallProgress(
+  onProgress: (progress: ConverterInstallProgress) => void,
+): Promise<() => void> {
+  return listen<ConverterInstallProgress>(INSTALL_PROGRESS_EVENT, (event) =>
+    onProgress(event.payload),
+  );
+}
+
 /** Test seam: drop the shared install/warm state between cases. */
 export function resetConverterInstallStateForTest(): void {
   installInFlight = null;

--- a/crates/openwave-desktop/ui/src/plugins/PluginsView.tsx
+++ b/crates/openwave-desktop/ui/src/plugins/PluginsView.tsx
@@ -16,6 +16,10 @@ import { Switch } from "@/components/ui/switch";
 import type { PluginsApis } from "./pluginsApis";
 import { capabilityShortLabel, categoryIcon } from "./pluginVocabulary";
 import { SkillDialog } from "./SkillDialog";
+import {
+  hostToolProvisioningLabel,
+  useHostToolProvisioning,
+} from "./useHostToolProvisioning";
 import type { PluginCatalogState } from "./usePluginCatalog";
 
 /**
@@ -42,6 +46,7 @@ export function PluginsView({
   onOpen: (pluginId: string) => void;
 }) {
   const { catalog, loading, error, reload, setEnabled } = state;
+  const provisioning = useHostToolProvisioning();
   const [openSkill, setOpenSkill] = useState<PluginSkillInfo | null>(null);
   const yourPlugins = catalog?.plugins.filter((plugin) => plugin.origin === "user") ?? [];
   const otherPlugins =
@@ -64,6 +69,12 @@ export function PluginsView({
       </PanelSecondaryHeader>
 
       <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto pt-4 pb-4">
+        {provisioning && (
+          <p className="text-muted-foreground shrink-0 px-4 text-xs" role="status">
+            {hostToolProvisioningLabel(provisioning)}
+          </p>
+        )}
+
         {error && (
           <div
             className="mx-4 flex shrink-0 items-center justify-between gap-3 rounded-md bg-critical-background px-3 py-2 text-sm text-critical-foreground-muted"

--- a/crates/openwave-desktop/ui/src/plugins/useHostToolProvisioning.ts
+++ b/crates/openwave-desktop/ui/src/plugins/useHostToolProvisioning.ts
@@ -1,0 +1,72 @@
+import { isTauri } from "@tauri-apps/api/core";
+import { useEffect, useState } from "react";
+
+import {
+  observeConverterInstallProgress,
+  type ConverterInstallProgress,
+} from "@/document/officePdf";
+
+/**
+ * How long a silent host counts as "finished" and clears the line.
+ *
+ * The host reports progress but never completion, so idleness is the only
+ * end-of-install signal available here. Generous on purpose: this is a quiet
+ * status line, and blinking it off between two slow chunks would read worse
+ * than leaving it up a few seconds past the end.
+ */
+const IDLE_MS = 5_000;
+
+/**
+ * The host tool being provisioned right now, for a panel that wants to say so
+ * quietly.
+ *
+ * Nothing here starts an install: enabling a plugin does that host-side, and
+ * this only listens to the progress that pass emits. `null` whenever no
+ * install is under way — including everywhere the host emits nothing at all,
+ * which is every platform but macOS today.
+ */
+export function useHostToolProvisioning(): ConverterInstallProgress | null {
+  const [progress, setProgress] = useState<ConverterInstallProgress | null>(null);
+
+  useEffect(() => {
+    if (!isTauri()) return;
+    let disposed = false;
+    let idle: ReturnType<typeof setTimeout> | undefined;
+    let unlisten: (() => void) | undefined;
+    void observeConverterInstallProgress((next) => {
+      if (disposed) return;
+      setProgress(next);
+      clearTimeout(idle);
+      idle = setTimeout(() => setProgress(null), IDLE_MS);
+    })
+      .then((dispose) => {
+        if (disposed) dispose();
+        else unlisten = dispose;
+      })
+      .catch(() => {
+        // Best-effort: without the host bridge there is simply nothing to show.
+      });
+    return () => {
+      disposed = true;
+      clearTimeout(idle);
+      unlisten?.();
+    };
+  }, []);
+
+  return progress;
+}
+
+/** The one muted line the panel renders for `progress`. */
+export function hostToolProvisioningLabel(
+  progress: ConverterInstallProgress,
+): string {
+  if (progress.phase === "installing") return "Preparing document tools…";
+  if (progress.totalBytes === null || progress.totalBytes <= 0) {
+    return "Preparing document tools…";
+  }
+  const percent = Math.min(
+    100,
+    Math.round((progress.downloadedBytes / progress.totalBytes) * 100),
+  );
+  return `Preparing document tools… ${percent}%`;
+}

--- a/crates/openwave-server/src/code_execution/config.rs
+++ b/crates/openwave-server/src/code_execution/config.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::ServerError;
 
-pub(super) const CODE_EXECUTION_SETTING: &str = "code_execution";
+pub(crate) const CODE_EXECUTION_SETTING: &str = "code_execution";
 /// Generous enough for a cold `pip install` that pulls compiled wheels
 /// (lxml, Pillow); 20s proved too tight and cut installs off mid-retry with
 /// empty stderr. Still host-owned: the model cannot request a longer limit.

--- a/crates/openwave-server/src/code_execution/provider.rs
+++ b/crates/openwave-server/src/code_execution/provider.rs
@@ -93,6 +93,10 @@ pub struct ConfiguredCodeExecutionProvider {
     /// Whether a host-side cache population pass is running or has succeeded;
     /// cleared again on failure so a later exec can retry.
     package_cache_population: Arc<std::sync::atomic::AtomicBool>,
+    /// Serializes cache population itself, so the exec-time pass and a
+    /// provisioning pass triggered by boot or a plugin enable cannot drive pip
+    /// against the same cache at once.
+    package_cache_lock: Arc<tokio::sync::Mutex<()>>,
     /// Where live sandbox-preparation progress is announced. Installed after
     /// the app's state is assembled, because the bus is built there; execution
     /// works exactly as before until it is.
@@ -228,6 +232,7 @@ impl ConfiguredCodeExecutionProvider {
             write_overlays: Mutex::new(HashMap::new()),
             package_cache_runtime: tokio::sync::OnceCell::new(),
             package_cache_population: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            package_cache_lock: Arc::new(tokio::sync::Mutex::new(())),
             events: OnceLock::new(),
             degradation_reported: Mutex::new(HashSet::new()),
         }
@@ -778,23 +783,7 @@ impl ConfiguredCodeExecutionProvider {
     /// ordinary networked path like any other package.
     fn spawn_package_cache_population(&self, cache: SharedPackageCache) {
         use std::sync::atomic::Ordering;
-        let mut pin_sets = Vec::new();
-        // The baseline set is preinstalled in the managed sandbox image; on
-        // this backend the cache is what makes it available offline, so it is
-        // acquired here regardless of which skills are loaded.
-        let baseline = openwave_code_execution::baseline_python_deps()
-            .iter()
-            .map(|pin| (*pin).to_owned())
-            .collect::<Vec<_>>();
-        if !baseline.is_empty() {
-            pin_sets.push(baseline);
-        }
-        pin_sets.extend(
-            self.skills
-                .iter()
-                .map(|skill| skill.package.python_deps.clone())
-                .filter(|pins| !pins.is_empty()),
-        );
+        let pin_sets = package_cache_pin_sets(self.skills.iter());
         if pin_sets.is_empty() {
             return;
         }
@@ -802,33 +791,84 @@ impl ConfiguredCodeExecutionProvider {
             return;
         }
         let latch = self.package_cache_population.clone();
+        let lock = self.package_cache_lock.clone();
         tokio::spawn(async move {
-            let mut failed = false;
-            // Per-set acquisition: each set's pins resolve as one consistent
-            // closure, and one unresolvable set cannot sink the others'
-            // artifacts.
-            for pins in pin_sets {
-                match cache
-                    .populate_with_pip(std::path::Path::new(SANDBOX_PYTHON), &pins)
-                    .await
-                {
-                    Ok(report) => tracing::info!(
-                        promoted = report.promoted,
-                        refused = report.refused,
-                        invalidated = report.invalidated,
-                        evicted = report.evicted,
-                        "shared package cache population pass finished"
-                    ),
-                    Err(error) => {
-                        failed = true;
-                        tracing::warn!(%error, "shared package cache population failed");
-                    }
-                }
-            }
-            if failed {
+            if !populate_package_cache(&lock, &cache, pin_sets).await {
                 latch.store(false, Ordering::SeqCst);
             }
         });
+    }
+
+    /// Start making the install's enabled dependencies real, in the
+    /// background.
+    ///
+    /// Enabling a plugin is the user saying they want what it does; the host
+    /// tools and pinned packages its skills need should start arriving then,
+    /// not on the first turn that reaches for them. The pass is deterministic
+    /// and host-side — no model drives it — and it returns immediately: every
+    /// piece of work behind it is already fire-and-forget or bounded by the
+    /// broker's own discipline (serialized installs, a remembered failure only
+    /// an explicit retry clears).
+    pub(crate) fn spawn_dependency_provisioning(self: &Arc<Self>) {
+        let provider = self.clone();
+        tokio::spawn(async move { provider.provision_dependencies().await });
+    }
+
+    async fn provision_dependencies(&self) {
+        let installed = self.installed_skills();
+        if installed.is_empty() {
+            return;
+        }
+        let skills = self.enabled_skills(installed).await;
+        if let Some(broker) = self.host_tool_broker.as_deref() {
+            for dep in required_host_deps(&skills) {
+                broker.ensure(dep);
+            }
+        }
+        // Unlike the exec-time pass, no conversation is involved, so there is
+        // no network policy to read: this is a host-side acquisition like the
+        // managed LibreOffice download, wanted by the same enablement that
+        // asked for the skills. Enabled user packages are included for the
+        // same reason — the pins the user switched on are the pins to warm.
+        let Ok(config) = read_config(&*self.store).await else {
+            return;
+        };
+        if config.provider != Some(CodeExecutionProviderKind::Local) {
+            return;
+        }
+        let Some(cache) = self.shared_package_cache().await else {
+            return;
+        };
+        let pin_sets = package_cache_pin_sets(skills.iter());
+        if pin_sets.is_empty() {
+            return;
+        }
+        populate_package_cache(&self.package_cache_lock, &cache, pin_sets).await;
+    }
+
+    /// The skills this install would run right now under `state`: installed,
+    /// minus anything that flag set switches off directly or through the
+    /// bundle that claims it.
+    ///
+    /// Exposed for the enable route, which compares this across the write it
+    /// just made: enabling a *bundle* moves no skill flag, so only liveness
+    /// shows what came on.
+    pub(crate) fn live_skill_names(
+        &self,
+        state: &crate::plugin_state::PluginEnableState,
+    ) -> HashSet<String> {
+        let installed = self.installed_skills();
+        let plugins = self.merged_plugins(&installed, &self.installed_prompts());
+        installed
+            .into_iter()
+            .filter(|skill| {
+                state.skill_enabled(
+                    &skill.package.name,
+                    Self::owning_plugin(&plugins, &skill.package.name),
+                )
+            })
+            .map(|skill| skill.package.name)
+            .collect()
     }
 
     /// Install the native bridge that resolves product root IDs through the
@@ -1480,6 +1520,69 @@ impl ConfiguredCodeExecutionProvider {
             notes: sync.notes,
         })
     }
+}
+
+/// The pin sets one cache-population pass acquires: the baseline set, plus
+/// each skill's own pinned requirements.
+///
+/// The baseline set is preinstalled in the managed sandbox image; on the local
+/// backend the cache is what makes it available offline, so it is acquired
+/// regardless of which skills are loaded. Each skill stays its own set because
+/// a set's pins resolve as one consistent closure, and one unresolvable set
+/// must not sink the others' artifacts.
+fn package_cache_pin_sets<'a>(
+    skills: impl Iterator<Item = &'a openwave_code_execution::LoadedSkill>,
+) -> Vec<Vec<String>> {
+    let mut pin_sets = Vec::new();
+    let baseline = openwave_code_execution::baseline_python_deps()
+        .iter()
+        .map(|pin| (*pin).to_owned())
+        .collect::<Vec<_>>();
+    if !baseline.is_empty() {
+        pin_sets.push(baseline);
+    }
+    pin_sets.extend(
+        skills
+            .map(|skill| skill.package.python_deps.clone())
+            .filter(|pins| !pins.is_empty()),
+    );
+    pin_sets
+}
+
+/// Acquire `pin_sets` into `cache`, one set at a time, and report whether
+/// every set succeeded.
+///
+/// The lock is what keeps two triggers — a boot or plugin-enable provisioning
+/// pass and the exec-time one — from running pip against the same cache
+/// concurrently. Failures are logged and not propagated: a later exec or a
+/// later enable retries, and conversations keep their networked install path
+/// meanwhile.
+async fn populate_package_cache(
+    lock: &tokio::sync::Mutex<()>,
+    cache: &SharedPackageCache,
+    pin_sets: Vec<Vec<String>>,
+) -> bool {
+    let _guard = lock.lock().await;
+    let mut succeeded = true;
+    for pins in pin_sets {
+        match cache
+            .populate_with_pip(std::path::Path::new(SANDBOX_PYTHON), &pins)
+            .await
+        {
+            Ok(report) => tracing::info!(
+                promoted = report.promoted,
+                refused = report.refused,
+                invalidated = report.invalidated,
+                evicted = report.evicted,
+                "shared package cache population pass finished"
+            ),
+            Err(error) => {
+                succeeded = false;
+                tracing::warn!(%error, "shared package cache population failed");
+            }
+        }
+    }
+    succeeded
 }
 
 pub(super) fn exec_folder_grant_for_turn(

--- a/crates/openwave-server/src/desktop_schema.rs
+++ b/crates/openwave-server/src/desktop_schema.rs
@@ -15,7 +15,7 @@ use std::path::{Path, PathBuf};
 #[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;
 
-use openwave_core::{AgentError, Config, DbStore, Result};
+use openwave_core::{AgentError, Config, DbStore, Profile, Result};
 use serde::{Deserialize, Serialize};
 
 const DATABASE_FILE: &str = "openwave.db";
@@ -48,6 +48,19 @@ pub(super) async fn connect(config: &Config) -> Result<DbStore> {
         DbStore::connect(&database_url).await
     })
     .await
+}
+
+/// Whether this profile's local database already exists, asked *before* the
+/// store is opened — after that the file is there either way.
+///
+/// A profile that keeps no local database file (the shared self-host store)
+/// answers `true`: it has no first-launch notion, and nothing should treat a
+/// server that has been running for a year as freshly installed.
+pub(super) fn store_exists(config: &Config) -> bool {
+    match config.profile {
+        Profile::Desktop => config.data_dir.join(DATABASE_FILE).exists(),
+        _ => true,
+    }
 }
 
 async fn connect_with<C, F>(config: &Config, connector: C) -> Result<DbStore>

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -873,6 +873,14 @@ async fn bind_inner(
     let instance_lock = InstanceLock::acquire(&config)?;
     let sandbox_container_admission = sandbox_admission::resolve(&config);
     let sandbox_spawn_execution_location = sandbox_container_admission.execution_location;
+    // Asked before the store is opened, because opening it creates the file:
+    // a launch that found no store is a fresh install, and the background
+    // provisioning pass below stays off for it. Built-in plugins default to
+    // enabled, so an ungated pass would start a several-hundred-megabyte
+    // managed install the first time a new install is opened. Fresh profiles
+    // warm on the first plugin enable and through the existing lazy paths
+    // instead.
+    let returning_install = desktop_schema::store_exists(&config);
     let store = connect_store(&config).await?;
     let secrets = secret_provider(&config);
     // The product boot path is where this platform's OS-managed (MDM) policy
@@ -1008,6 +1016,12 @@ async fn bind_inner(
     // A no-op when `initialize` already derived the slice; the safety net for
     // the paths that return early (a managed profile ignoring its boot file).
     state.mcp.reconcile_plugin_servers().await;
+    // Start making the enabled plugins' dependencies real while the app comes
+    // up. Nothing waits on it: the pass only spawns, and the work behind it is
+    // already fire-and-forget.
+    if returning_install {
+        code_execution.spawn_dependency_provisioning();
+    }
     let token = state.token.clone();
     let client_executor_token = state.client_executor_token.clone();
     let blob_retirement_worker = blob_retirement_worker::BlobRetirementWorker::new(

--- a/crates/openwave-server/src/routes/plugins.rs
+++ b/crates/openwave-server/src/routes/plugins.rs
@@ -363,6 +363,7 @@ pub async fn put_plugins_enabled(
     Json(body): Json<PluginEnableUpdate>,
 ) -> Result<Json<PluginCatalog>, ServerError> {
     let mut flags = read_plugin_enable_state(&*state.store).await;
+    let before = flags.clone();
     for (plugin, enabled) in &body.plugins {
         if !is_valid_plugin_name(plugin) {
             return Err(ServerError::bad_request(format!(
@@ -390,5 +391,21 @@ pub async fn put_plugins_enabled(
     // plugin-sourced server has, so this has to happen on the same write that
     // moved them, not on the next restart.
     state.mcp.reconcile_plugin_servers().await;
+    // Anything that just came live should start becoming real now rather than
+    // mid-conversation: the host tools its manifest needs and the pinned
+    // packages it installs are provisioned in the background. Liveness is
+    // compared rather than the flags themselves, because enabling a bundle
+    // brings its members back without touching a single skill flag. The pass
+    // only spawns work, so the response is not delayed by it.
+    if let Some(exec) = state.code_execution.as_ref() {
+        let live_before = exec.live_skill_names(&before);
+        if exec
+            .live_skill_names(&flags)
+            .iter()
+            .any(|skill| !live_before.contains(skill))
+        {
+            exec.spawn_dependency_provisioning();
+        }
+    }
     get_plugins(State(state)).await
 }

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -2632,6 +2632,14 @@ async fn a_superseded_gateway_session_never_reads_usable() {
 /// The catalog routes are only interesting against a real load: what they
 /// project is exactly what staging and prompt composition read.
 fn plugin_app(store: Arc<dyn Store>, data_dir: &std::path::Path) -> (Router, Arc<str>) {
+    plugin_app_with_broker(store, data_dir, None)
+}
+
+fn plugin_app_with_broker(
+    store: Arc<dyn Store>,
+    data_dir: &std::path::Path,
+    host_tool_broker: Option<Arc<dyn openwave_code_execution::HostToolBroker>>,
+) -> (Router, Arc<str>) {
     let secrets = Arc::new(MemSecrets::default());
     let mut state = AppState::new(
         Config::desktop(data_dir),
@@ -2652,7 +2660,8 @@ fn plugin_app(store: Arc<dyn Store>, data_dir: &std::path::Path) -> (Router, Arc
             data_dir.join("scratch"),
         )
         .with_skills(Some(root.join("skills")))
-        .with_plugins(Some(root.join("plugins"))),
+        .with_plugins(Some(root.join("plugins")))
+        .with_host_tool_broker(host_tool_broker),
     ));
     let token = state.token.clone();
     (app(state), token)
@@ -3447,6 +3456,97 @@ async fn the_plugin_catalog_reports_badges_and_persists_toggles() {
     )
     .await;
     assert_eq!(refused.status(), StatusCode::BAD_REQUEST);
+}
+
+/// Contract: switching a bundle back on starts making it real. The host tools
+/// its members declare are ensured through the broker on the same write that
+/// moved the flag — including the Node runtime, which only becomes required
+/// because the bundle brought a skill with npm pins back to life — so nothing
+/// waits for the first turn that reaches for them. A write that switches
+/// nothing on provisions nothing.
+#[tokio::test(flavor = "multi_thread")]
+async fn enabling_a_plugin_provisions_the_host_tools_its_skills_declare() {
+    #[derive(Default)]
+    struct RecordingBroker {
+        ensured: std::sync::Mutex<Vec<openwave_code_execution::HostDep>>,
+    }
+
+    #[async_trait]
+    impl openwave_code_execution::HostToolBroker for RecordingBroker {
+        fn ensure(&self, tool: openwave_code_execution::HostDep) {
+            self.ensured.lock().unwrap().push(tool);
+        }
+
+        async fn status(
+            &self,
+            _tool: openwave_code_execution::HostDep,
+        ) -> openwave_code_execution::HostToolStatus {
+            openwave_code_execution::HostToolStatus::Available
+        }
+
+        async fn managed_root(
+            &self,
+            _tool: openwave_code_execution::HostDep,
+        ) -> Option<std::path::PathBuf> {
+            None
+        }
+    }
+
+    let (dir, store) = temp_db_store("plugin-provisioning.db").await;
+    let store: Arc<dyn Store> = Arc::new(store);
+    // No execution provider selected, so the pass stops at the host tools
+    // instead of driving pip against a real package index from a unit test.
+    store
+        .set_setting(
+            crate::code_execution::CODE_EXECUTION_SETTING,
+            &serde_json::json!({"provider": null, "timeout_ms": 60_000}),
+        )
+        .await
+        .unwrap();
+    let mut flags = crate::plugin_state::read_plugin_enable_state(&*store).await;
+    flags.set_plugin("documents", false);
+    crate::plugin_state::write_plugin_enable_state(&*store, &flags)
+        .await
+        .unwrap();
+
+    let broker = Arc::new(RecordingBroker::default());
+    let (router, token) = plugin_app_with_broker(store.clone(), dir.path(), Some(broker.clone()));
+    let bearer = format!("Bearer {token}");
+
+    let response = put_plugins_enabled(
+        &router,
+        &bearer,
+        serde_json::json!({"plugins": {"documents": true}}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // The pass is spawned rather than awaited, so the response can land first.
+    let ensured = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            let ensured = broker.ensured.lock().unwrap().clone();
+            if ensured.contains(&openwave_code_execution::HostDep::Node) {
+                return ensured;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("the enable write should provision the bundle's host tools");
+    assert!(ensured.contains(&openwave_code_execution::HostDep::LibreOffice));
+
+    // Re-asserting the same state switches nothing on, so nothing is
+    // provisioned again.
+    broker.ensured.lock().unwrap().clear();
+    let response = put_plugins_enabled(
+        &router,
+        &bearer,
+        serde_json::json!({"plugins": {"documents": true}}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    assert!(broker.ensured.lock().unwrap().is_empty());
 }
 
 /// Contract: a bundle the user wrote in their data directory reaches the


### PR DESCRIPTION
Closes #1725. Follow-on to #1722/#1723.

Enabling a plugin whose skills need host tools or pinned packages now starts making them real immediately instead of on first use mid-conversation. The provider gains a deterministic, host-side provisioning pass: it reads the same enabled-skill view staging reads, fires the host-tool broker's `ensure()` for every dependency those skills declare or imply (Node derived from npm pins, LibreOffice where declared), and populates the shared wheel cache with the baseline pins plus each enabled skill's own. The pass only spawns; nothing waits on it, and all install discipline (serialized installs, remembered failure cleared only by explicit retry) is inherited from the existing broker machinery unchanged.

Two triggers drive it:

- `PUT /plugins/enabled`, when the write brings a skill live — compared at skill liveness rather than raw flags, because enabling a bundle moves no member flag.
- Server boot, **except on a raw first launch** (the store file didn't exist before this boot). Built-in plugins default to enabled, so an ungated boot pass would start the ~300 MB LibreOffice pull the first time a fresh install opens; a new profile warms on its first plugin enable and through the existing lazy paths instead.

The cache warm is deliberately not gated on any chat's network policy: there is no chat, and enablement is the consent it acts on — the same reasoning the ungated managed LibreOffice download already follows. It stays gated on the local provider being selected and the shared cache opening, so headless embeddings and managed backends do nothing. Population runs under a lock shared with the exec-time trigger so two passes never drive pip against one cache concurrently; the exec-time once-per-process latch is unchanged.

The Plugins panel subscribes to the existing `presentation-converter-install-progress` event while mounted and renders one muted status line ("Preparing document tools… 43%"), clearing it once the host goes quiet. It never requests an install, and no wire schema changed.

One new test pins the contract: enabling the `documents` bundle ensures LibreOffice and Node through a recording broker (Node only becomes required because the bundle brought `presentations` live), and a no-op write provisions nothing.

Deferred, per the issue: the npm analogue of the wheel-cache warm, and progress events for the managed Node install (status-only today).

Verified locally: `cargo check`/`clippy -D warnings` on the touched crates, the plugin and code-execution test modules (36 passed), `tsc --noEmit`, and the UI vitest suite (813 passed). Not verified end to end: the live warm at boot and the progress line in a running app.