### PR TITLE
feat(server): wire the Docker execution provider into selection

### DIFF
--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -926,7 +926,7 @@ export type EgressConfig = { "mode": "open" } | { "mode": "allowlist", domains: 
  * says a vendor's mechanism leaves a general-purpose destination reachable,
  * the surface must not present it as a full boundary.
  */
-export type EgressEnforcementStatus = "boundary" | "conditional_boundary" | "applied_with_gaps" | "unconfirmed";
+export type EgressEnforcementStatus = "boundary" | "conditional_boundary" | "applied_with_gaps" | "unconfirmed" | "not_enforced";
 
 /**
  * The execution backend that ran a command, as a closed vocabulary.

--- a/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
@@ -249,9 +249,12 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
             Local execution confines writes to private chat scratch and routes
             any granted network access through a loopback broker. E2B and
             Daytona run commands in managed cloud sandboxes and reuse their
-            workspace while it is alive. Every provider retains the same
-            direct-command, bounded-output, idempotency, and execution-consent
-            contract.
+            workspace while it is alive. Docker runs them in a container on
+            this machine, so staged files never leave it, with the same
+            document tooling the cloud sandboxes have — but it does not yet
+            enforce a conversation's network setting. Every provider retains
+            the same direct-command, bounded-output, idempotency, and
+            execution-consent contract.
           </p>
         </>
       )}
@@ -420,6 +423,14 @@ const EGRESS_STATUS_PRESENTATION: Record<
     badge: "warning",
     label: "Unconfirmed",
     lead: "A policy is sent at creation, but enforcement is not yet confirmed against the live API. These stay reachable regardless of policy:",
+  },
+  // Not a weaker boundary — no boundary. The conversation's network choice
+  // reaches nothing on this backend, which is worth the strongest tone the
+  // list has rather than the same amber as a partially enforced one.
+  not_enforced: {
+    badge: "critical",
+    label: "Not enforced",
+    lead: "This backend applies no network restriction, so a conversation's network setting does not reach it:",
   },
 };
 

--- a/crates/openwave-server/src/code_execution/config.rs
+++ b/crates/openwave-server/src/code_execution/config.rs
@@ -8,9 +8,9 @@ use std::time::Duration;
 use async_trait::async_trait;
 use openwave_code_execution::{
     CodeExecutionError, CodeExecutionProviderKind, CodeExecutionUnavailableReason,
-    DaytonaCredential, DaytonaExecutionProvider, E2BCredential, E2BExecutionProvider,
-    LocalExecutionProvider, RemoteSessionPool, DAYTONA_CREDENTIAL_KEY, E2B_CREDENTIAL_KEY,
-    PACKAGE_MANAGER_DOMAINS,
+    DaytonaCredential, DaytonaExecutionProvider, DockerExecutionProvider, E2BCredential,
+    E2BExecutionProvider, LocalExecutionProvider, RemoteSessionPool, DAYTONA_CREDENTIAL_KEY,
+    E2B_CREDENTIAL_KEY, PACKAGE_MANAGER_DOMAINS,
 };
 use openwave_core::{ChatId, HostRootId, NetworkPolicy, ProjectId, Result, SecretProvider, Store};
 use openwave_egress::{
@@ -169,10 +169,11 @@ pub(super) const CREDENTIAL_PROVIDERS: [CodeExecutionProviderKind; 2] = [
 /// surface reports them. Availability is computed per row, so a host with no
 /// usable provider says so with a reason for each rather than presenting a
 /// selection that cannot run.
-pub(super) const EXECUTION_PROVIDERS: [CodeExecutionProviderKind; 3] = [
+pub(super) const EXECUTION_PROVIDERS: [CodeExecutionProviderKind; 4] = [
     CodeExecutionProviderKind::Local,
     CodeExecutionProviderKind::E2b,
     CodeExecutionProviderKind::Daytona,
+    CodeExecutionProviderKind::Docker,
 ];
 
 /// Host-owned, non-secret egress policy for the managed exec sandboxes.
@@ -371,6 +372,17 @@ pub(super) fn configured_daytona(
     }
 }
 
+/// Build the container adapter. It holds no credential and compiles no
+/// egress policy — the configured policy is deliberately not passed here,
+/// because nothing in this backend would enforce it and accepting it would
+/// imply otherwise. See [`egress_enforcement_status`].
+pub(super) fn configured_docker(
+    timeout: Duration,
+    pool: RemoteSessionPool,
+) -> std::result::Result<DockerExecutionProvider, CodeExecutionError> {
+    DockerExecutionProvider::with_session_pool(timeout, pool)
+}
+
 /// Renderer-safe configuration and readiness.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
 pub struct CodeExecutionConfigInfo {
@@ -442,6 +454,11 @@ pub enum EgressEnforcementStatus {
     /// A policy is sent at creation, but the vendor's enforcement is not yet
     /// confirmed against the live API.
     Unconfirmed,
+    /// No egress restriction is applied at all: the backend creates its
+    /// sandbox with ordinary outbound access and the conversation's network
+    /// policy reaches nothing. Distinct from [`Self::Unconfirmed`], which is
+    /// a policy whose effect is unproven — here there is no policy to prove.
+    NotEnforced,
 }
 
 /// A managed provider's egress-enforcement status, as host knowledge rather
@@ -567,8 +584,24 @@ pub(super) fn egress_enforcement_status() -> Vec<CodeExecutionEgressEnforcement>
             true,
             Some(DAYTONA_TIER_REQUIREMENT),
         ),
+        // The container backend applies no network policy at all. It is not
+        // derived from an enforcement model because there is no enforcement
+        // to model: saying so plainly is the only honest row, and it is what
+        // stops a conversation set to "no network" from reading as enforced
+        // when it is running on this backend.
+        CodeExecutionEgressEnforcement {
+            provider: CodeExecutionProviderKind::Docker,
+            status: EgressEnforcementStatus::NotEnforced,
+            gaps: vec![DOCKER_OPEN_EGRESS_GAP.to_owned()],
+            requirement: None,
+        },
     ]
 }
+
+/// What the container backend leaves reachable: everything. Stated as a gap
+/// so the settings surface lists it inline beside the vendors' caveats.
+pub(super) const DOCKER_OPEN_EGRESS_GAP: &str =
+    "every destination — the container runs with ordinary internet access";
 
 /// Project one provider's enforcement declaration into the renderer-safe row.
 ///
@@ -665,6 +698,11 @@ pub(super) async fn provider_availability(
 ) -> CodeExecutionProviderAvailability {
     let reason = match provider {
         CodeExecutionProviderKind::Local => LocalExecutionProvider::availability().err(),
+        // The container backend needs no credential; what it needs is a
+        // runtime that answers. The probe distinguishes an absent runtime
+        // from an installed one whose daemon is down, and caches its answer,
+        // so rendering this surface costs at most one probe.
+        CodeExecutionProviderKind::Docker => DockerExecutionProvider::availability().await.err(),
         _ => (!has_credential(secrets, provider).await)
             .then_some(CodeExecutionUnavailableReason::MissingCredential),
     };
@@ -865,7 +903,7 @@ pub(super) async fn has_credential(
             .ok()
             .flatten()
             .is_some(),
-        CodeExecutionProviderKind::Local => false,
+        CodeExecutionProviderKind::Local | CodeExecutionProviderKind::Docker => false,
         _ => false,
     }
 }

--- a/crates/openwave-server/src/code_execution/provider.rs
+++ b/crates/openwave-server/src/code_execution/provider.rs
@@ -1209,6 +1209,16 @@ impl ConfiguredCodeExecutionProvider {
                     self.preparation_sink(),
                 )?)
             }
+            CodeExecutionProviderKind::Docker => {
+                // No credential and no egress policy: the container runs on
+                // the host's own runtime with ordinary network access, which
+                // the settings surface discloses rather than implying the
+                // conversation's policy reaches it.
+                Box::new(configured_docker(
+                    Duration::from_millis(config.timeout_ms),
+                    self.remote_sessions.clone(),
+                )?)
+            }
             _ => {
                 return Err(CodeExecutionError::Unavailable(
                     "selected provider is not supported by this build".into(),

--- a/crates/openwave-server/src/code_execution/tests.rs
+++ b/crates/openwave-server/src/code_execution/tests.rs
@@ -1005,6 +1005,16 @@ fn egress_enforcement_never_oversells_a_provider_past_its_model() {
         EgressEnforcementStatus::Boundary,
         "the tier caveat must keep Daytona off the unconditional boundary status"
     );
+
+    // The container backend sends no policy anywhere, so it must not borrow a
+    // status that implies one was sent and merely went unconfirmed. This is
+    // the assertion that catches the tempting future edit — passing the
+    // configured egress into the container adapter and calling the row
+    // enforced — without the container actually enforcing anything.
+    let docker = row(CodeExecutionProviderKind::Docker);
+    assert_eq!(docker.status, EgressEnforcementStatus::NotEnforced);
+    assert_eq!(docker.gaps, [DOCKER_OPEN_EGRESS_GAP]);
+    assert!(docker.requirement.is_none());
 }
 
 #[test]

--- a/crates/openwave-server/src/sandbox_admission.rs
+++ b/crates/openwave-server/src/sandbox_admission.rs
@@ -222,10 +222,14 @@ pub(crate) fn structural_preconditions(
 ///
 /// The token-issuer fact is deployment-wide (the gateway either can mint
 /// run-scoped tokens or it cannot); the lifetime-cap fact is per backend. The
-/// local provider reads the real Docker backend's declaration. E2B and
-/// Daytona have no sandbox backend at all today — they are exec adapters, not
-/// hosts for background agent runs — so no capability is established for them
-/// and the fail-closed evaluation names everything missing.
+/// local provider reads the real Docker backend's declaration. E2B, Daytona,
+/// and the container exec backend have no sandbox backend at all today — they
+/// are exec adapters, not hosts for background agent runs — so no capability
+/// is established for them and the fail-closed evaluation names everything
+/// missing. The container exec backend in particular is not the sandbox-agent
+/// container tier: the two are deliberately orthogonal, and running commands
+/// in a container through `docker exec` establishes none of the preconditions
+/// a detached run needs.
 pub(crate) fn settings_detached_admissions(
     config: &Config,
 ) -> Vec<(CodeExecutionProviderKind, DetachedAdmission)> {
@@ -239,6 +243,7 @@ pub(crate) fn settings_detached_admissions(
         (CodeExecutionProviderKind::Local, local_facts),
         (CodeExecutionProviderKind::E2b, (false, false)),
         (CodeExecutionProviderKind::Daytona, (false, false)),
+        (CodeExecutionProviderKind::Docker, (false, false)),
     ]
     .into_iter()
     .map(|(provider, (lifetime_cap, image_verified))| {

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -609,7 +609,7 @@ async fn code_execution_config_route_is_authenticated_and_preserves_explicit_dis
             .iter()
             .map(|row| row["provider"].as_str().unwrap().to_owned())
             .collect::<Vec<_>>(),
-        ["local", "e2b", "daytona"]
+        ["local", "e2b", "daytona", "docker"]
     );
     let local = &admission[0];
     assert_eq!(local["admitted"], false);

--- a/docs/code-execution.md
+++ b/docs/code-execution.md
@@ -1,9 +1,10 @@
 # Code execution
 
 OpenWave exposes one foreground `exec` tool through a provider-neutral command
-execution contract. The first provider is a native local sandbox. A managed
+execution contract. The first provider is a native local sandbox. Another
 provider can implement the same contract without changing the model-facing tool
-schema; E2B and Daytona are the current managed adapters.
+schema: E2B and Daytona are the managed cloud adapters, and Docker runs the same
+image in a container on the host's own runtime.
 
 This capability is separate from a sandbox *agent*. A sandbox agent is a
 depth-one model run with a constrained tool budget. A code-execution sandbox is
@@ -38,7 +39,9 @@ when execution is disabled or unsupported.
 Timeouts must be between 1 and 120 seconds; the default is 60 seconds, enough headroom for a cold package install that pulls compiled wheels. Sending `{"provider": null}`
 disables execution; sending `{"provider": "local"}` enables the local adapter.
 `e2b` and `daytona` select the managed adapters, which become available once
-their fixed credential slot is populated. No executable, endpoint, environment
+their fixed credential slot is populated. `docker` selects the container
+adapter, which needs no credential and becomes available once a
+Docker-compatible runtime is installed and its daemon answers. No executable, endpoint, environment
 value, or secret reference is accepted by the non-secret settings surface.
 
 `GET /code-execution` reports `has_credential` for the selected provider only,
@@ -84,8 +87,9 @@ The older host-level `egress` value remains readable for stored-config
 compatibility and provider disclosure, but chat execution always uses the
 per-chat policy.
 
-The `enforcement` field discloses, per managed provider, an honest `status`
-(`boundary`, `conditional_boundary`, `applied_with_gaps`, or `unconfirmed`),
+The `enforcement` field discloses, per non-native provider, an honest `status`
+(`boundary`, `conditional_boundary`, `applied_with_gaps`, `unconfirmed`, or
+`not_enforced`),
 plus the `gaps` the vendor leaves reachable regardless of policy and an optional
 `requirement` when a boundary is gated on a precondition. The status is
 **derived from the shipped enforcement model** (`EgressEnforcement`), not
@@ -114,6 +118,14 @@ destination reachable, the surface cannot present it as a full boundary.
   org default applies, so the boundary is not guaranteed — the projection
   therefore reports it as a *conditional* boundary with that requirement inline,
   never an unconditional green one.
+
+- **Docker — `not_enforced`.** The container backend applies no network
+  restriction at all: the container runs on the runtime's default network with
+  ordinary outbound access, and a conversation's network setting does not reach
+  it. This is not a weaker boundary but the absence of one, and it is disclosed
+  as its own status rather than borrowed from `unconfirmed`, which describes a
+  policy that *was* sent. Compiling the per-chat policy into container
+  networking is a later slice.
 
 The local adapter is an unconditional external boundary: direct networking
 stays denied and the only pinhole reaches the policy broker. Managed fidelity
@@ -149,7 +161,9 @@ CodeExecutionProvider::execute
     |
     +-- E2BExecutionProvider --------+
     |                                |
-    `-- DaytonaExecutionProvider ----+-- shared remote session + receipt layer
+    +-- DaytonaExecutionProvider ----+-- shared remote session + receipt layer
+    |                                |
+    `-- DockerExecutionProvider -----+
 ```
 
 A request contains:
@@ -173,6 +187,40 @@ code, stdout, stderr, timeout and truncation flags, and duration. Provider-nativ
 responses, credentials, and unbounded logs do not cross the contract. Absolute
 folder paths are a host-only input to the local adapter: they are never tool
 arguments and are stripped from managed-provider requests.
+
+## Container execution
+
+The Docker backend is opt-in and never a default. It exists because the native
+local sandbox is macOS-only: without it, a Linux or Windows host's only options
+upload the conversation's staged files to a vendor.
+
+It runs the same digest-pinned documents image the Daytona adapter registers as
+a snapshot and the E2B template is built from, so LibreOffice, the document
+skills' preinstalled Python dependencies, Node with the deck library, and the
+bundled exec helpers are present at the same versions on every backend. The pin
+lives in one module (`sandbox_image.rs`) that both backends in the crate read,
+and the image-publish workflow rewrites it there.
+
+One container serves one chat workspace, under a name derived from the
+workspace id so a restarted host adopts its containers rather than duplicating
+them. Commands cross as an argument vector through `docker exec` under an
+in-container `timeout`, so a command that exceeds its limit is stopped rather
+than left running behind an abandoned CLI. Workspace file transfers use the
+same channel. The container's only process is a bounded sleep and it is created
+with `--rm`, so an abandoned chat's container and its workspace volume remove
+themselves.
+
+Confinement is the container itself: the image's unprivileged uid forced from
+the host, every Linux capability dropped, privilege escalation refused, and
+process, memory, and CPU ceilings. No host path is bind-mounted — the workspace
+is an anonymous volume, and host files enter only through the staging the host
+performs for the paths a call listed. The root filesystem is deliberately
+writable, unlike the sandbox-agent container tier: foreground exec installs
+packages and writes scratch, and the surface a read-only root would protect is
+the container's own ephemeral layer.
+
+Network policy is **not** enforced here yet — see the `not_enforced`
+disclosure above.
 
 ## Connected folders in local exec
 

--- a/docs/sandbox-providers.md
+++ b/docs/sandbox-providers.md
@@ -18,7 +18,14 @@ connects them.
 | Tier | Today | What isolates the work |
 | --- | --- | --- |
 | Background agent run | `openwave-server` sandbox agent-run worker | Capability restriction: no history, fixed tool budget, bounded I/O. |
-| Execution provider | `openwave-code-execution` | OS or VM enforcement: Seatbelt on supported hosts, a vendor sandbox remotely. |
+| Execution provider | `openwave-code-execution` | OS, container, or VM enforcement: Seatbelt on supported hosts, a container on the host's own runtime, a vendor sandbox remotely. |
+
+Both tiers can end up running a container, which is exactly why the rule below
+matters: `openwave-server`'s `sandbox_docker` provisions containers that speak
+the sandbox-agent wire protocol for the *run* tier, while
+`openwave-code-execution`'s Docker backend runs one bounded `docker exec` per
+call for the *provider* tier. They share only the published image; neither
+depends on the other.
 
 These are orthogonal. Background agent work currently runs inside the OpenWave
 server process; an execution provider performs one bounded process invocation


### PR DESCRIPTION
Stacked on #1737 (base is that branch; retarget to `main` once it lands).

## What

Makes the container backend selectable: it joins `EXECUTION_PROVIDERS`, gets an arm in `resolve()`, and reports readiness through the same single availability decision every other provider uses. The desktop picker, the per-provider availability list, and the status headline are all driven by that list, so they pick it up without further wiring.

Readiness comes from the backend's own probe rather than a credential check — the two reasons it can be unavailable are "no runtime installed" and "runtime installed, daemon not answering", and the panel's sentences say which fix applies. It needs no credential, so it does not appear among the key slots, and it is never a default selection.

## Egress — the part to read

The configured egress policy is **not** passed to this adapter. Nothing in it would enforce one, and accepting the policy would imply otherwise. The enforcement disclosure gets a new status, `not_enforced`, rather than reusing `unconfirmed`: that one means a policy *was* sent and its effect is unproven, which is a different claim.

Concretely: a conversation whose network is set to off or package-managers-only gets no enforcement when it runs on this backend. The settings row states that in the strongest tone the list has (critical badge, "This backend applies no network restriction, so a conversation's network setting does not reach it"), and the docs carry the same statement. The chat default is `Open`, so this is not a silent downgrade of the common case, but it is a real gap for anyone who narrowed it.

The obvious next slice — `--network none` for an `Off` policy, and a proxy or allowlist beyond that — is deliberately not in this change, and the pooled session already fingerprints its egress shape, so adding it later replaces stale containers rather than reusing them.

## Detached admission

The container exec backend is not the sandbox-agent container tier; running `docker exec` establishes none of the preconditions a detached background run needs. Its admission row therefore lists every precondition as missing, exactly like E2B's and Daytona's. The two tiers sharing a runtime (and an image) is precisely why the docs now spell out that they are unrelated.

## Tests

One assertion added to the existing enforcement-honesty test: the Docker row must be `not_enforced` with its gap stated and no requirement. That is the guard against the tempting future edit — passing the configured egress into the adapter and letting the row read as enforced without the container enforcing anything. One existing wire-shape assertion updated for the fourth provider row.

Verified locally: `cargo check --workspace --locked` (no lockfile change), the full `openwave-server` lib suite, clippy on `openwave-code-execution` and `openwave-server` with `-D warnings`, and `tsc` plus `vitest` (813 tests) in the desktop UI.