### PR TITLE
feat(desktop): provision default-enabled plugins from the first launch

### DIFF
--- a/crates/openwave-server/src/desktop_schema.rs
+++ b/crates/openwave-server/src/desktop_schema.rs
@@ -15,7 +15,7 @@ use std::path::{Path, PathBuf};
 #[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;
 
-use openwave_core::{AgentError, Config, DbStore, Profile, Result};
+use openwave_core::{AgentError, Config, DbStore, Result};
 use serde::{Deserialize, Serialize};
 
 const DATABASE_FILE: &str = "openwave.db";
@@ -48,19 +48,6 @@ pub(super) async fn connect(config: &Config) -> Result<DbStore> {
         DbStore::connect(&database_url).await
     })
     .await
-}
-
-/// Whether this profile's local database already exists, asked *before* the
-/// store is opened — after that the file is there either way.
-///
-/// A profile that keeps no local database file (the shared self-host store)
-/// answers `true`: it has no first-launch notion, and nothing should treat a
-/// server that has been running for a year as freshly installed.
-pub(super) fn store_exists(config: &Config) -> bool {
-    match config.profile {
-        Profile::Desktop => config.data_dir.join(DATABASE_FILE).exists(),
-        _ => true,
-    }
 }
 
 async fn connect_with<C, F>(config: &Config, connector: C) -> Result<DbStore>

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -873,14 +873,6 @@ async fn bind_inner(
     let instance_lock = InstanceLock::acquire(&config)?;
     let sandbox_container_admission = sandbox_admission::resolve(&config);
     let sandbox_spawn_execution_location = sandbox_container_admission.execution_location;
-    // Asked before the store is opened, because opening it creates the file:
-    // a launch that found no store is a fresh install, and the background
-    // provisioning pass below stays off for it. Built-in plugins default to
-    // enabled, so an ungated pass would start a several-hundred-megabyte
-    // managed install the first time a new install is opened. Fresh profiles
-    // warm on the first plugin enable and through the existing lazy paths
-    // instead.
-    let returning_install = desktop_schema::store_exists(&config);
     let store = connect_store(&config).await?;
     let secrets = secret_provider(&config);
     // The product boot path is where this platform's OS-managed (MDM) policy
@@ -1016,12 +1008,11 @@ async fn bind_inner(
     // A no-op when `initialize` already derived the slice; the safety net for
     // the paths that return early (a managed profile ignoring its boot file).
     state.mcp.reconcile_plugin_servers().await;
-    // Start making the enabled plugins' dependencies real while the app comes
-    // up. Nothing waits on it: the pass only spawns, and the work behind it is
-    // already fire-and-forget.
-    if returning_install {
-        code_execution.spawn_dependency_provisioning();
-    }
+    // Runs on every boot, fresh installs included: built-in plugins ship
+    // enabled by default, and that default is the consent signal to start
+    // making their dependencies real from the first open. Nothing waits on
+    // it, the pass only spawns.
+    code_execution.spawn_dependency_provisioning();
     let token = state.token.clone();
     let client_executor_token = state.client_executor_token.clone();
     let blob_retirement_worker = blob_retirement_worker::BlobRetirementWorker::new(


### PR DESCRIPTION
Follow-up to #1738. The boot provisioning pass no longer skips a fresh profile's first launch: it runs on every boot. We ship several plugins enabled by default, and for those the enable trigger never fires — the default is the consent signal, so the first open is exactly when their host tools and pinned packages should start arriving. The download stays background, serialized behind the broker's existing discipline, and a no-op when the tools already exist.

The now-unused first-launch probe (`store_exists`) is deleted. The plugin-enable trigger is unchanged and still covers re-enables and user-installed plugins.

Verified locally: `cargo check`/`clippy -D warnings` on openwave-server, plugin test module (15 passed), fmt clean. Merging with admin bypass while Actions is down, same as #1738; main's lanes to be checked once Actions recovers.