### PR TITLE
feat(providers): sign in to OpenAI with a ChatGPT subscription

### DIFF
--- a/crates/openwave-connectors/src/chatgpt.rs
+++ b/crates/openwave-connectors/src/chatgpt.rs
@@ -1,0 +1,667 @@
+//! Loopback OAuth client for ChatGPT subscription sign-in.
+//!
+//! Speaks the same public Codex-compatible contract other local tools use:
+//! PKCE S256 against `auth.openai.com`, fixed loopback redirect on port
+//! 1455, and a refresh-rotating access token whose bearer is presented to
+//! the ChatGPT Codex Responses backend together with the account id.
+//!
+//! This is not a registered OpenWave client — OpenAI does not offer a
+//! public registration path for subscription inference — so the client id
+//! is the well-known Codex public client. The product surface is ours
+//! (`originator=openwave`); the OAuth identity is shared.
+
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use axum::extract::{Query, State};
+use axum::response::{Html, IntoResponse, Response};
+use axum::routing::get;
+use axum::Router;
+use base64::engine::general_purpose::{URL_SAFE_NO_PAD, STANDARD};
+use base64::Engine;
+use openwave_core::{AgentError, Result, SecretProvider};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tokio::net::TcpListener;
+use tokio::sync::{mpsc, Mutex};
+
+/// SecretProvider key for the durable ChatGPT OAuth session.
+pub const SECRET_KEY: &str = "provider.openai.chatgpt_oauth_v1";
+
+/// Codex public OAuth client id. Third-party local tools reuse this; there is
+/// no self-serve registration for a distinct OpenWave client today.
+pub const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
+
+/// Fixed redirect the public Codex client allows. Binding anything else fails
+/// at the authorize step.
+pub const REDIRECT_URI: &str = "http://localhost:1455/auth/callback";
+
+/// Loopback port carved out by [`REDIRECT_URI`].
+pub const CALLBACK_PORT: u16 = 1455;
+
+/// Product originator sent on authorize and on Codex inference.
+pub const ORIGINATOR: &str = "openwave";
+
+/// ChatGPT / Codex Responses API root (no trailing `/v1`; callers append
+/// `/responses`).
+pub const CODEX_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
+
+const DEFAULT_AUTHORIZE_URL: &str = "https://auth.openai.com/oauth/authorize";
+const DEFAULT_TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
+const DEFAULT_REVOKE_URL: &str = "https://auth.openai.com/oauth/revoke";
+const SCOPE: &str = "openid profile email offline_access";
+const EXPIRY_LEEWAY_SECONDS: u64 = 60;
+const SIGN_IN_REQUIRED_PREFIX: &str = "chatgpt sign-in required";
+
+/// True when an operation failed because there is no usable ChatGPT session.
+#[must_use]
+pub fn is_chatgpt_sign_in_required(error: &AgentError) -> bool {
+    matches!(error, AgentError::Authentication(message) if message.starts_with(SIGN_IN_REQUIRED_PREFIX))
+}
+
+fn sign_in_required(detail: &str) -> AgentError {
+    AgentError::Authentication(format!("{SIGN_IN_REQUIRED_PREFIX}: {detail}"))
+}
+
+fn chatgpt_error(context: &str, detail: impl std::fmt::Display) -> AgentError {
+    AgentError::config(format!("chatgpt oauth {context}: {detail}"))
+}
+
+/// How this client identifies itself to OpenAI's authorization server.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChatGptAuthConfig {
+    authorize_url: reqwest::Url,
+    token_url: reqwest::Url,
+    revoke_url: reqwest::Url,
+    client_id: String,
+    redirect_uri: String,
+    originator: String,
+}
+
+impl ChatGptAuthConfig {
+    /// Production endpoints and the Codex public client.
+    pub fn production() -> Self {
+        Self {
+            authorize_url: DEFAULT_AUTHORIZE_URL.parse().expect("static authorize URL"),
+            token_url: DEFAULT_TOKEN_URL.parse().expect("static token URL"),
+            revoke_url: DEFAULT_REVOKE_URL.parse().expect("static revoke URL"),
+            client_id: CLIENT_ID.to_string(),
+            redirect_uri: REDIRECT_URI.to_string(),
+            originator: ORIGINATOR.to_string(),
+        }
+    }
+
+    /// Point authorize/token/revoke at a fake origin for tests. Redirect stays
+    /// on the Codex-registered loopback URI so the callback contract matches
+    /// production.
+    pub fn for_test(auth_base: &str) -> Result<Self> {
+        let base = reqwest::Url::parse(auth_base)
+            .map_err(|_| chatgpt_error("configuration", "auth base URL is invalid"))?;
+        let join = |path: &str| -> Result<reqwest::Url> {
+            let mut root = base.to_string();
+            if !root.ends_with('/') {
+                root.push('/');
+            }
+            reqwest::Url::parse(&root)
+                .and_then(|url| url.join(path.trim_start_matches('/')))
+                .map_err(|_| chatgpt_error("configuration", "could not build auth endpoint"))
+        };
+        Ok(Self {
+            authorize_url: join("/oauth/authorize")?,
+            token_url: join("/oauth/token")?,
+            revoke_url: join("/oauth/revoke")?,
+            client_id: CLIENT_ID.to_string(),
+            redirect_uri: REDIRECT_URI.to_string(),
+            originator: ORIGINATOR.to_string(),
+        })
+    }
+
+    #[must_use]
+    pub fn redirect_uri(&self) -> &str {
+        &self.redirect_uri
+    }
+
+    #[must_use]
+    pub fn originator(&self) -> &str {
+        &self.originator
+    }
+}
+
+/// Durable ChatGPT OAuth session stored in the keychain.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChatGptCredentials {
+    access_token: String,
+    refresh_token: String,
+    /// ChatGPT account id required as `ChatGPT-Account-ID` on inference.
+    pub account_id: String,
+    expires_at_unix: u64,
+}
+
+impl ChatGptCredentials {
+    #[must_use]
+    pub fn account_id(&self) -> &str {
+        &self.account_id
+    }
+
+    fn access_is_fresh(&self) -> bool {
+        self.expires_at_unix > unix_time().saturating_add(EXPIRY_LEEWAY_SECONDS)
+    }
+}
+
+impl std::fmt::Debug for ChatGptCredentials {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ChatGptCredentials")
+            .field("account_id", &self.account_id)
+            .field("expires_at_unix", &self.expires_at_unix)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Whether a ChatGPT OAuth session is stored.
+pub async fn has_stored_chatgpt_credentials(secrets: &dyn SecretProvider) -> bool {
+    matches!(
+        secrets.get_secret(SECRET_KEY).await,
+        Ok(Some(raw)) if serde_json::from_str::<ChatGptCredentials>(&raw).is_ok()
+    )
+}
+
+/// Keychain-backed storage for [`ChatGptCredentials`].
+#[derive(Clone)]
+pub struct ChatGptCredentialVault {
+    secrets: Arc<dyn SecretProvider>,
+}
+
+impl ChatGptCredentialVault {
+    #[must_use]
+    pub fn new(secrets: Arc<dyn SecretProvider>) -> Self {
+        Self { secrets }
+    }
+
+    pub async fn load(&self) -> Result<Option<ChatGptCredentials>> {
+        let Some(raw) = self.secrets.get_secret(SECRET_KEY).await? else {
+            return Ok(None);
+        };
+        serde_json::from_str(&raw)
+            .map(Some)
+            .map_err(|_| chatgpt_error("credentials", "stored credentials are unreadable"))
+    }
+
+    pub async fn save(&self, credentials: &ChatGptCredentials) -> Result<()> {
+        let raw = serde_json::to_string(credentials)?;
+        self.secrets.set_secret(SECRET_KEY, &raw).await
+    }
+
+    pub async fn clear(&self) -> Result<()> {
+        self.secrets.delete_secret(SECRET_KEY).await
+    }
+}
+
+/// Stateless HTTP client for ChatGPT OAuth endpoints.
+#[derive(Clone)]
+pub struct ChatGptAuth {
+    config: ChatGptAuthConfig,
+    http: reqwest::Client,
+}
+
+impl ChatGptAuth {
+    pub fn new(config: ChatGptAuthConfig) -> Result<Self> {
+        let http = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(30))
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|error| chatgpt_error("client", error))?;
+        Ok(Self { config, http })
+    }
+
+    #[must_use]
+    pub fn config(&self) -> &ChatGptAuthConfig {
+        &self.config
+    }
+
+    /// Bind port 1455 and produce the URL the user's browser must visit.
+    pub async fn start_sign_in(&self) -> Result<ChatGptPendingSignIn> {
+        // Bind IPv4 loopback: the public redirect URI uses host `localhost`,
+        // which browsers resolve to 127.0.0.1 in practice; tests rewrite the
+        // fake's redirect to the literal IP for the same reason.
+        let listener = TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, CALLBACK_PORT))
+            .await
+            .map_err(|error| {
+                chatgpt_error(
+                    "sign-in",
+                    format!(
+                        "could not bind localhost:{CALLBACK_PORT} ({error}); \
+                         close any Codex login or free the port and try again"
+                    ),
+                )
+            })?;
+        let verifier = random_token();
+        let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
+        let state = random_token();
+
+        let mut authorization_url = self.config.authorize_url.clone();
+        authorization_url
+            .query_pairs_mut()
+            .append_pair("response_type", "code")
+            .append_pair("client_id", &self.config.client_id)
+            .append_pair("redirect_uri", &self.config.redirect_uri)
+            .append_pair("scope", SCOPE)
+            .append_pair("code_challenge", &challenge)
+            .append_pair("code_challenge_method", "S256")
+            .append_pair("state", &state)
+            .append_pair("id_token_add_organizations", "true")
+            .append_pair("codex_cli_simplified_flow", "true")
+            .append_pair("originator", &self.config.originator);
+
+        Ok(ChatGptPendingSignIn {
+            auth: self.clone(),
+            listener,
+            authorization_url: authorization_url.to_string(),
+            verifier,
+            state,
+        })
+    }
+
+    /// Exchange a refresh token for a new access/refresh pair.
+    pub async fn refresh(&self, refresh_token: &str) -> Result<ChatGptCredentials> {
+        let form = [
+            ("grant_type", "refresh_token"),
+            ("refresh_token", refresh_token),
+            ("client_id", self.config.client_id.as_str()),
+        ];
+        self.request_token(&form).await
+    }
+
+    /// Best-effort revoke. Failures are ignored by callers that are clearing
+    /// local state either way.
+    pub async fn revoke(&self, refresh_token: &str) -> Result<()> {
+        let response = self
+            .http
+            .post(self.config.revoke_url.clone())
+            .form(&[
+                ("token", refresh_token),
+                ("client_id", self.config.client_id.as_str()),
+            ])
+            .send()
+            .await
+            .map_err(|error| chatgpt_error("revocation request", error.without_url()))?;
+        if !response.status().is_success() {
+            return Err(chatgpt_error(
+                "revocation request",
+                format!("HTTP status {}", response.status().as_u16()),
+            ));
+        }
+        Ok(())
+    }
+
+    async fn exchange_code(&self, code: &str, verifier: &str) -> Result<ChatGptCredentials> {
+        let form = [
+            ("grant_type", "authorization_code"),
+            ("code", code),
+            ("redirect_uri", self.config.redirect_uri.as_str()),
+            ("client_id", self.config.client_id.as_str()),
+            ("code_verifier", verifier),
+        ];
+        self.request_token(&form).await
+    }
+
+    async fn request_token(&self, form: &[(&str, &str)]) -> Result<ChatGptCredentials> {
+        let response = self
+            .http
+            .post(self.config.token_url.clone())
+            .form(form)
+            .send()
+            .await
+            .map_err(|error| chatgpt_error("token request", error.without_url()))?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let error: Option<OAuthErrorResponse> = response.json().await.ok();
+            if error
+                .as_ref()
+                .is_some_and(|error| error.error == "invalid_grant")
+            {
+                return Err(sign_in_required("the ChatGPT session is no longer valid"));
+            }
+            let detail = error
+                .and_then(|error| error.error_description.or(Some(error.error)))
+                .unwrap_or_else(|| format!("HTTP status {}", status.as_u16()));
+            return Err(chatgpt_error("token request", detail));
+        }
+        let token: TokenResponse = response
+            .json()
+            .await
+            .map_err(|_| chatgpt_error("token request", "invalid token response"))?;
+        let account_id = token
+            .account_id
+            .filter(|id| !id.is_empty())
+            .or_else(|| extract_account_id(&token.access_token))
+            .or_else(|| {
+                token
+                    .id_token
+                    .as_deref()
+                    .and_then(extract_account_id)
+            })
+            .ok_or_else(|| {
+                chatgpt_error("token request", "response did not include a ChatGPT account id")
+            })?;
+        Ok(ChatGptCredentials {
+            access_token: token.access_token,
+            refresh_token: token.refresh_token,
+            account_id,
+            expires_at_unix: unix_time()
+                .saturating_add(u64::try_from(token.expires_in).unwrap_or(3600)),
+        })
+    }
+}
+
+/// A sign-in in flight. Dropping this cancels the listener.
+pub struct ChatGptPendingSignIn {
+    auth: ChatGptAuth,
+    listener: TcpListener,
+    authorization_url: String,
+    verifier: String,
+    state: String,
+}
+
+/// Completed ChatGPT sign-in ready to persist.
+#[derive(Debug, Clone)]
+pub struct ChatGptAuthorizedSession {
+    pub credentials: ChatGptCredentials,
+}
+
+impl ChatGptPendingSignIn {
+    #[must_use]
+    pub fn authorization_url(&self) -> &str {
+        &self.authorization_url
+    }
+
+    /// Wait for the browser callback, then exchange the code.
+    pub async fn finish(self, timeout: Duration) -> Result<ChatGptAuthorizedSession> {
+        let Self {
+            auth,
+            listener,
+            verifier,
+            state,
+            ..
+        } = self;
+
+        let (sender, mut receiver) = mpsc::channel::<CallbackResult>(1);
+        let callback_app = Router::new()
+            .route("/auth/callback", get(callback))
+            .with_state(CallbackState {
+                expected_state: state,
+                sender,
+            });
+        let server = tokio::spawn(async move { axum::serve(listener, callback_app).await });
+        let outcome = tokio::time::timeout(timeout, receiver.recv()).await;
+        server.abort();
+        let _ = server.await;
+
+        let callback = outcome
+            .map_err(|_| chatgpt_error("sign-in", "browser authorization timed out"))?
+            .ok_or_else(|| chatgpt_error("sign-in", "the authorization callback closed"))?;
+        if let Some(error) = callback.error {
+            return Err(chatgpt_error(
+                "sign-in",
+                format!("authorization failed: {error}"),
+            ));
+        }
+        let code = callback
+            .code
+            .ok_or_else(|| chatgpt_error("sign-in", "no authorization code was returned"))?;
+
+        let credentials = auth.exchange_code(&code, &verifier).await?;
+        Ok(ChatGptAuthorizedSession { credentials })
+    }
+}
+
+/// Vault-backed connection that refreshes access tokens under a lock.
+pub struct ChatGptConnection {
+    auth: ChatGptAuth,
+    vault: ChatGptCredentialVault,
+    token_motion: Mutex<()>,
+}
+
+impl ChatGptConnection {
+    #[must_use]
+    pub fn new(auth: ChatGptAuth, vault: ChatGptCredentialVault) -> Self {
+        Self {
+            auth,
+            vault,
+            token_motion: Mutex::new(()),
+        }
+    }
+
+    #[must_use]
+    pub fn auth(&self) -> &ChatGptAuth {
+        &self.auth
+    }
+
+    pub async fn store_session(&self, session: &ChatGptAuthorizedSession) -> Result<()> {
+        self.vault.save(&session.credentials).await
+    }
+
+    pub async fn stored_credentials(&self) -> Result<Option<ChatGptCredentials>> {
+        self.vault.load().await
+    }
+
+    /// A currently valid access token, refreshing near expiry.
+    pub async fn access_token(&self) -> Result<String> {
+        let _guard = self.token_motion.lock().await;
+        let Some(mut credentials) = self.vault.load().await? else {
+            return Err(sign_in_required("no ChatGPT session is stored"));
+        };
+        if credentials.access_is_fresh() {
+            return Ok(credentials.access_token);
+        }
+        let refreshed = self.auth.refresh(&credentials.refresh_token).await?;
+        // Preserve account id if refresh omits it (should not, but be safe).
+        if refreshed.account_id.is_empty() {
+            credentials.access_token = refreshed.access_token;
+            credentials.refresh_token = refreshed.refresh_token;
+            credentials.expires_at_unix = refreshed.expires_at_unix;
+            self.vault.save(&credentials).await?;
+            return Ok(credentials.access_token);
+        }
+        self.vault.save(&refreshed).await?;
+        Ok(refreshed.access_token)
+    }
+
+    /// Account id for the stored session, if any.
+    pub async fn account_id(&self) -> Result<Option<String>> {
+        Ok(self.vault.load().await?.map(|c| c.account_id))
+    }
+
+    /// Revoke at OpenAI (best-effort) and clear local credentials.
+    pub async fn sign_out(&self) -> Result<()> {
+        let _guard = self.token_motion.lock().await;
+        if let Some(credentials) = self.vault.load().await? {
+            let _ = self.auth.revoke(&credentials.refresh_token).await;
+        }
+        self.vault.clear().await
+    }
+}
+
+/// Pull `chatgpt_account_id` from a JWT payload without verifying the
+/// signature — the token is only used as a bearer against OpenAI, and the
+/// account id is an opaque routing hint.
+fn extract_account_id(jwt: &str) -> Option<String> {
+    let payload = jwt.split('.').nth(1)?;
+    let decoded = URL_SAFE_NO_PAD
+        .decode(payload)
+        .or_else(|_| STANDARD.decode(payload))
+        .ok()?;
+    let value: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
+    value
+        .get("https://api.openai.com/auth")
+        .and_then(|auth| auth.get("chatgpt_account_id"))
+        .and_then(|id| id.as_str())
+        .filter(|id| !id.is_empty())
+        .map(str::to_owned)
+        .or_else(|| {
+            value
+                .get("chatgpt_account_id")
+                .and_then(|id| id.as_str())
+                .filter(|id| !id.is_empty())
+                .map(str::to_owned)
+        })
+}
+
+async fn callback(
+    State(state): State<CallbackState>,
+    Query(query): Query<CallbackQuery>,
+) -> Response {
+    if query.state.as_deref() != Some(state.expected_state.as_str()) {
+        return (
+            axum::http::StatusCode::BAD_REQUEST,
+            Html(callback_page(
+                "Sign-in failed",
+                "The authorization state did not match. Return to OpenWave and try again.",
+            )),
+        )
+            .into_response();
+    }
+    let success = query.code.is_some() && query.error.is_none();
+    let _ = state.sender.try_send(CallbackResult {
+        code: query.code,
+        error: query.error,
+    });
+    let (heading, message) = if success {
+        (
+            "Signed in",
+            "You can close this window and return to OpenWave.",
+        )
+    } else {
+        ("Sign-in denied", "Return to OpenWave for details.")
+    };
+    (
+        axum::http::StatusCode::OK,
+        Html(callback_page(heading, message)),
+    )
+        .into_response()
+}
+
+fn callback_page(heading: &str, message: &str) -> String {
+    format!(
+        r#"<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{heading}</title>
+<style>
+  :root {{ color-scheme: light dark; --bg:#f4f4f5; --card:#fff; --border:#e4e4e7; --text:#18181b; --muted:#52525b; }}
+  @media (prefers-color-scheme: dark) {{
+    :root {{ --bg:#18181b; --card:#232326; --border:#3f3f46; --text:#fafafa; --muted:#a1a1aa; }}
+  }}
+  body {{ margin:0; min-height:100vh; display:grid; place-items:center; background:var(--bg); color:var(--text);
+    font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif; }}
+  main {{ background:var(--card); border:1px solid var(--border); border-radius:12px; padding:2.5rem 3rem;
+    margin:1rem; max-width:24rem; text-align:center; }}
+  .product {{ font-size:0.8125rem; font-weight:600; letter-spacing:0.08em; text-transform:uppercase;
+    color:var(--muted); margin:0 0 1rem; }}
+  h1 {{ font-size:1.375rem; font-weight:600; margin:0 0 0.5rem; }}
+  p {{ color:var(--muted); font-size:0.9375rem; line-height:1.5; margin:0; }}
+</style></head><body><main>
+<p class="product">OpenWave</p>
+<h1>{heading}</h1>
+<p>{message}</p>
+</main></body></html>"#
+    )
+}
+
+#[derive(Clone)]
+struct CallbackState {
+    expected_state: String,
+    sender: mpsc::Sender<CallbackResult>,
+}
+
+#[derive(Deserialize)]
+struct CallbackQuery {
+    code: Option<String>,
+    state: Option<String>,
+    error: Option<String>,
+}
+
+struct CallbackResult {
+    code: Option<String>,
+    error: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    expires_in: i64,
+    refresh_token: String,
+    #[serde(default)]
+    id_token: Option<String>,
+    #[serde(default)]
+    account_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct OAuthErrorResponse {
+    error: String,
+    error_description: Option<String>,
+}
+
+fn random_token() -> String {
+    format!("{}-{}", uuid::Uuid::new_v4(), uuid::Uuid::new_v4())
+}
+
+fn unix_time() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn jwt_with_account(account_id: &str) -> String {
+        let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"none"}"#);
+        let payload = URL_SAFE_NO_PAD.encode(
+            serde_json::json!({
+                "https://api.openai.com/auth": {
+                    "chatgpt_account_id": account_id
+                }
+            })
+            .to_string()
+            .as_bytes(),
+        );
+        format!("{header}.{payload}.sig")
+    }
+
+    #[test]
+    fn account_id_is_read_from_access_token_claims() {
+        let token = jwt_with_account("acct-123");
+        assert_eq!(extract_account_id(&token).as_deref(), Some("acct-123"));
+    }
+
+    #[test]
+    fn credentials_debug_redacts_tokens() {
+        let credentials = ChatGptCredentials {
+            access_token: "secret-access".into(),
+            refresh_token: "secret-refresh".into(),
+            account_id: "acct".into(),
+            expires_at_unix: 1,
+        };
+        let debug = format!("{credentials:?}");
+        assert!(!debug.contains("secret-access"));
+        assert!(!debug.contains("secret-refresh"));
+        assert!(debug.contains("acct"));
+    }
+
+    #[test]
+    fn sign_in_required_errors_are_recognizable() {
+        assert!(is_chatgpt_sign_in_required(&sign_in_required("test")));
+        assert!(!is_chatgpt_sign_in_required(&chatgpt_error("x", "y")));
+    }
+
+    #[test]
+    fn production_config_pins_codex_redirect() {
+        let config = ChatGptAuthConfig::production();
+        assert_eq!(config.redirect_uri(), REDIRECT_URI);
+        assert_eq!(config.originator(), ORIGINATOR);
+    }
+}

--- a/crates/openwave-connectors/src/chatgpt.rs
+++ b/crates/openwave-connectors/src/chatgpt.rs
@@ -10,6 +10,7 @@
 //! is the well-known Codex public client. The product surface is ours
 //! (`originator=openwave`); the OAuth identity is shared.
 
+use std::future::IntoFuture;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -17,7 +18,7 @@ use axum::extract::{Query, State};
 use axum::response::{Html, IntoResponse, Response};
 use axum::routing::get;
 use axum::Router;
-use base64::engine::general_purpose::{URL_SAFE_NO_PAD, STANDARD};
+use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
 use base64::Engine;
 use openwave_core::{AgentError, Result, SecretProvider};
 use serde::{Deserialize, Serialize};
@@ -336,14 +337,12 @@ impl ChatGptAuth {
             .account_id
             .filter(|id| !id.is_empty())
             .or_else(|| extract_account_id(&token.access_token))
-            .or_else(|| {
-                token
-                    .id_token
-                    .as_deref()
-                    .and_then(extract_account_id)
-            })
+            .or_else(|| token.id_token.as_deref().and_then(extract_account_id))
             .ok_or_else(|| {
-                chatgpt_error("token request", "response did not include a ChatGPT account id")
+                chatgpt_error(
+                    "token request",
+                    "response did not include a ChatGPT account id",
+                )
             })?;
         Ok(ChatGptCredentials {
             access_token: token.access_token,
@@ -393,10 +392,13 @@ impl ChatGptPendingSignIn {
                 expected_state: state,
                 sender,
             });
-        let server = tokio::spawn(async move { axum::serve(listener, callback_app).await });
-        let outcome = tokio::time::timeout(timeout, receiver.recv()).await;
-        server.abort();
-        let _ = server.await;
+        // The callback server runs inside this future rather than a detached
+        // task so that cancelling the waiter releases the callback port; a
+        // leaked listener would block every later sign-in.
+        let outcome = tokio::select! {
+            outcome = tokio::time::timeout(timeout, receiver.recv()) => outcome,
+            _ = axum::serve(listener, callback_app).into_future() => Ok(None),
+        };
 
         let callback = outcome
             .map_err(|_| chatgpt_error("sign-in", "browser authorization timed out"))?
@@ -513,6 +515,12 @@ async fn callback(
     Query(query): Query<CallbackQuery>,
 ) -> Response {
     if query.state.as_deref() != Some(state.expected_state.as_str()) {
+        // Report the mismatch so the waiter fails now instead of holding the
+        // callback port until the sign-in timeout expires.
+        let _ = state.sender.try_send(CallbackResult {
+            code: None,
+            error: Some("authorization state did not match".to_owned()),
+        });
         return (
             axum::http::StatusCode::BAD_REQUEST,
             Html(callback_page(

--- a/crates/openwave-connectors/src/chatgpt.rs
+++ b/crates/openwave-connectors/src/chatgpt.rs
@@ -563,12 +563,8 @@ async fn callback(
     Query(query): Query<CallbackQuery>,
 ) -> Response {
     if query.state.as_deref() != Some(state.expected_state.as_str()) {
-        // Report the mismatch so the waiter fails now instead of holding the
-        // callback port until the sign-in timeout expires.
-        let _ = state.sender.try_send(CallbackResult {
-            code: None,
-            error: Some("authorization state did not match".to_owned()),
-        });
+        // Keep waiting: a stray hit on the fixed loopback port must not
+        // retire the attempt before the real browser redirect arrives.
         return (
             axum::http::StatusCode::BAD_REQUEST,
             Html(callback_page(

--- a/crates/openwave-connectors/src/chatgpt.rs
+++ b/crates/openwave-connectors/src/chatgpt.rs
@@ -237,10 +237,29 @@ impl ChatGptAuth {
                     ),
                 )
             })?;
-        // Hosts with IPv6 disabled simply have no `::1` to serve.
-        let v6 = TcpListener::bind((std::net::Ipv6Addr::LOCALHOST, CALLBACK_PORT))
-            .await
-            .ok();
+        // Prefer dual-stack: browsers that resolve `localhost` to `::1` never
+        // reach the IPv4 listener. Skip only when the host has no IPv6; a
+        // port conflict on `::1` is the same class of failure as on IPv4.
+        let v6 = match TcpListener::bind((std::net::Ipv6Addr::LOCALHOST, CALLBACK_PORT)).await {
+            Ok(listener) => Some(listener),
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::AddrNotAvailable | std::io::ErrorKind::Unsupported
+                ) =>
+            {
+                None
+            }
+            Err(error) => {
+                return Err(chatgpt_error(
+                    "sign-in",
+                    format!(
+                        "could not bind [::1]:{CALLBACK_PORT} ({error}); \
+                         close any Codex login or free the port and try again"
+                    ),
+                ));
+            }
+        };
         let listeners = LoopbackListeners { v4, v6 };
         let verifier = random_token();
         let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));

--- a/crates/openwave-connectors/src/chatgpt.rs
+++ b/crates/openwave-connectors/src/chatgpt.rs
@@ -223,10 +223,10 @@ impl ChatGptAuth {
 
     /// Bind port 1455 and produce the URL the user's browser must visit.
     pub async fn start_sign_in(&self) -> Result<ChatGptPendingSignIn> {
-        // Bind IPv4 loopback: the public redirect URI uses host `localhost`,
-        // which browsers resolve to 127.0.0.1 in practice; tests rewrite the
-        // fake's redirect to the literal IP for the same reason.
-        let listener = TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, CALLBACK_PORT))
+        // The redirect URI the client allows names host `localhost`, so the
+        // browser may arrive over either loopback family depending on how it
+        // resolves the name. Bind both rather than betting on IPv4.
+        let v4 = TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, CALLBACK_PORT))
             .await
             .map_err(|error| {
                 chatgpt_error(
@@ -237,6 +237,11 @@ impl ChatGptAuth {
                     ),
                 )
             })?;
+        // Hosts with IPv6 disabled simply have no `::1` to serve.
+        let v6 = TcpListener::bind((std::net::Ipv6Addr::LOCALHOST, CALLBACK_PORT))
+            .await
+            .ok();
+        let listeners = LoopbackListeners { v4, v6 };
         let verifier = random_token();
         let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
         let state = random_token();
@@ -257,7 +262,7 @@ impl ChatGptAuth {
 
         Ok(ChatGptPendingSignIn {
             auth: self.clone(),
-            listener,
+            listeners,
             authorization_url: authorization_url.to_string(),
             verifier,
             state,
@@ -357,10 +362,34 @@ impl ChatGptAuth {
 /// A sign-in in flight. Dropping this cancels the listener.
 pub struct ChatGptPendingSignIn {
     auth: ChatGptAuth,
-    listener: TcpListener,
+    listeners: LoopbackListeners,
     authorization_url: String,
     verifier: String,
     state: String,
+}
+
+/// The loopback callback port, held on both families the browser might use.
+struct LoopbackListeners {
+    v4: TcpListener,
+    v6: Option<TcpListener>,
+}
+
+impl LoopbackListeners {
+    /// Accept callbacks on every bound address until the caller stops polling.
+    async fn serve(self, app: Router) {
+        match self.v6 {
+            Some(v6) => {
+                let v6_app = app.clone();
+                tokio::select! {
+                    _ = axum::serve(self.v4, app).into_future() => {}
+                    _ = axum::serve(v6, v6_app).into_future() => {}
+                }
+            }
+            None => {
+                let _ = axum::serve(self.v4, app).into_future().await;
+            }
+        }
+    }
 }
 
 /// Completed ChatGPT sign-in ready to persist.
@@ -379,7 +408,7 @@ impl ChatGptPendingSignIn {
     pub async fn finish(self, timeout: Duration) -> Result<ChatGptAuthorizedSession> {
         let Self {
             auth,
-            listener,
+            listeners,
             verifier,
             state,
             ..
@@ -397,7 +426,7 @@ impl ChatGptPendingSignIn {
         // leaked listener would block every later sign-in.
         let outcome = tokio::select! {
             outcome = tokio::time::timeout(timeout, receiver.recv()) => outcome,
-            _ = axum::serve(listener, callback_app).into_future() => Ok(None),
+            () = listeners.serve(callback_app) => Ok(None),
         };
 
         let callback = outcome

--- a/crates/openwave-connectors/src/lib.rs
+++ b/crates/openwave-connectors/src/lib.rs
@@ -1,17 +1,22 @@
-//! OpenWave connectors — loopback OAuth (RFC 8252 + PKCE) for model-gateway,
-//! plus the future source connector tools that ingest from Drive, Box, and
-//! friends.
+//! OpenWave connectors — loopback OAuth (RFC 8252 + PKCE) for model-gateway
+//! and ChatGPT subscription sign-in, plus the future source connector tools
+//! that ingest from Drive, Box, and friends.
 //!
 //! [`GatewayAuth`] speaks to a model-gateway deployment's own OAuth 2.0
 //! authorization server. The gateway's endpoints are fixed relative to its
 //! base URL, so the client pins the deployment through `/api/v1/meta`'s
 //! `installation_id` and refuses tokens minted by any other installation.
 //!
+//! [`ChatGptAuth`] speaks the Codex-compatible ChatGPT subscription OAuth
+//! surface (`auth.openai.com`, fixed localhost:1455 redirect) and stores the
+//! resulting tokens for the OpenAI provider's subscription auth mode.
+//!
 //! The flow is authorization code + PKCE S256 on a loopback redirect: the
 //! desktop opens the returned authorization URL in the system browser, the
 //! browser lands on a short-lived local listener, and the code is exchanged
-//! for a `control`-resource token. Narrower audiences (`llm`,
-//! `mcp:<endpoint>`) are minted on demand through resource-scoped refresh.
+//! for tokens. Gateway sessions mint narrower audiences (`llm`,
+//! `mcp:<endpoint>`) on demand through resource-scoped refresh; ChatGPT
+//! sessions refresh a single access token.
 //!
 //! Tokens are stored through the host's [`SecretProvider`] — the OS keychain
 //! in the desktop app — never in ordinary settings, and none of the types in
@@ -19,8 +24,15 @@
 //!
 //! [`SecretProvider`]: openwave_core::SecretProvider
 
+mod chatgpt;
 mod gateway;
 
+pub use chatgpt::{
+    has_stored_chatgpt_credentials, is_chatgpt_sign_in_required, ChatGptAuth, ChatGptAuthConfig,
+    ChatGptAuthorizedSession, ChatGptConnection, ChatGptCredentialVault, ChatGptCredentials,
+    ChatGptPendingSignIn, CALLBACK_PORT, CLIENT_ID, CODEX_BASE_URL, ORIGINATOR, REDIRECT_URI,
+    SECRET_KEY as CHATGPT_SECRET_KEY,
+};
 pub use gateway::{
     has_stored_credentials, has_stored_credentials_for, is_sign_in_required,
     validate_mcp_endpoint_slug, AuthorizedSession, CredentialVault, GatewayApp, GatewayAuth,

--- a/crates/openwave-connectors/tests/chatgpt_flow.rs
+++ b/crates/openwave-connectors/tests/chatgpt_flow.rs
@@ -1,0 +1,251 @@
+//! End-to-end ChatGPT OAuth client against an in-process fake that checks
+//! PKCE S256, the Codex public client id, and the fixed loopback redirect.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use axum::extract::{Form, Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Json, Redirect, Response};
+use axum::routing::{get, post};
+use axum::Router;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use openwave_connectors::{
+    has_stored_chatgpt_credentials, ChatGptAuth, ChatGptAuthConfig, ChatGptConnection,
+    ChatGptCredentialVault, CHATGPT_SECRET_KEY, CLIENT_ID, REDIRECT_URI,
+};
+use openwave_core::{Result as CoreResult, SecretProvider};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+const ACCOUNT: &str = "313b2c23-7977-4b2c-bf87-0ffb1c3d4217";
+
+#[derive(Default)]
+struct MockSecrets(Mutex<HashMap<String, String>>);
+
+#[async_trait::async_trait]
+impl SecretProvider for MockSecrets {
+    async fn get_secret(&self, key: &str) -> CoreResult<Option<String>> {
+        Ok(self.0.lock().unwrap().get(key).cloned())
+    }
+
+    async fn set_secret(&self, key: &str, value: &str) -> CoreResult<()> {
+        self.0.lock().unwrap().insert(key.into(), value.into());
+        Ok(())
+    }
+
+    async fn delete_secret(&self, key: &str) -> CoreResult<()> {
+        self.0.lock().unwrap().remove(key);
+        Ok(())
+    }
+}
+
+struct PendingCode {
+    challenge: String,
+    redirect_uri: String,
+}
+
+#[derive(Default)]
+struct FakeAuth {
+    codes: Mutex<HashMap<String, PendingCode>>,
+    refresh_tokens: Mutex<HashMap<String, bool>>,
+    token_requests: AtomicUsize,
+    revoked: Mutex<Vec<String>>,
+}
+
+impl FakeAuth {
+    fn mint_access_jwt(&self) -> String {
+        let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"none"}"#);
+        let payload = URL_SAFE_NO_PAD.encode(
+            json!({
+                "https://api.openai.com/auth": { "chatgpt_account_id": ACCOUNT }
+            })
+            .to_string()
+            .as_bytes(),
+        );
+        format!("{header}.{payload}.sig")
+    }
+
+    fn mint(self: &Arc<Self>) -> Value {
+        let access = self.mint_access_jwt();
+        let refresh = format!("rt_{}", next_id());
+        self.refresh_tokens
+            .lock()
+            .unwrap()
+            .insert(refresh.clone(), true);
+        json!({
+            "access_token": access,
+            "token_type": "Bearer",
+            "expires_in": 600,
+            "refresh_token": refresh,
+            "scope": "openid profile email offline_access",
+        })
+    }
+}
+
+fn next_id() -> u64 {
+    use std::sync::atomic::AtomicU64;
+    static NEXT: AtomicU64 = AtomicU64::new(1);
+    NEXT.fetch_add(1, Ordering::SeqCst)
+}
+
+async fn authorize(
+    State(auth): State<Arc<FakeAuth>>,
+    Query(query): Query<HashMap<String, String>>,
+) -> Response {
+    if query.get("client_id").map(String::as_str) != Some(CLIENT_ID)
+        || query.get("code_challenge_method").map(String::as_str) != Some("S256")
+        || query.get("response_type").map(String::as_str) != Some("code")
+        || query.get("redirect_uri").map(String::as_str) != Some(REDIRECT_URI)
+        || query.get("originator").map(String::as_str) != Some("openwave")
+        || query.get("codex_cli_simplified_flow").map(String::as_str) != Some("true")
+    {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+    let code = format!("code_{}", next_id());
+    let redirect_uri = query.get("redirect_uri").cloned().unwrap_or_default();
+    auth.codes.lock().unwrap().insert(
+        code.clone(),
+        PendingCode {
+            challenge: query.get("code_challenge").cloned().unwrap_or_default(),
+            redirect_uri: redirect_uri.clone(),
+        },
+    );
+    let state = query.get("state").cloned().unwrap_or_default();
+    // Rewrite localhost → 127.0.0.1 so the test "browser" hits the IPv4
+    // listener even when `localhost` prefers ::1 on this machine.
+    let callback = redirect_uri.replacen("://localhost:", "://127.0.0.1:", 1);
+    Redirect::to(&format!("{callback}?code={code}&state={state}")).into_response()
+}
+
+async fn token(
+    State(auth): State<Arc<FakeAuth>>,
+    Form(form): Form<HashMap<String, String>>,
+) -> Response {
+    auth.token_requests.fetch_add(1, Ordering::SeqCst);
+    match form.get("grant_type").map(String::as_str) {
+        Some("authorization_code") => {
+            let Some(code) = form.get("code") else {
+                return StatusCode::BAD_REQUEST.into_response();
+            };
+            let Some(pending) = auth.codes.lock().unwrap().remove(code) else {
+                return invalid_grant();
+            };
+            let verifier = form.get("code_verifier").cloned().unwrap_or_default();
+            let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
+            if challenge != pending.challenge
+                || form.get("redirect_uri") != Some(&pending.redirect_uri)
+                || form.get("client_id").map(String::as_str) != Some(CLIENT_ID)
+            {
+                return invalid_grant();
+            }
+            Json(auth.mint()).into_response()
+        }
+        Some("refresh_token") => {
+            let Some(refresh) = form.get("refresh_token") else {
+                return StatusCode::BAD_REQUEST.into_response();
+            };
+            if form.get("client_id").map(String::as_str) != Some(CLIENT_ID) {
+                return invalid_grant();
+            }
+            let mut refresh_tokens = auth.refresh_tokens.lock().unwrap();
+            if refresh_tokens.get(refresh) != Some(&true) {
+                drop(refresh_tokens);
+                return invalid_grant();
+            }
+            refresh_tokens.insert(refresh.clone(), false);
+            drop(refresh_tokens);
+            Json(auth.mint()).into_response()
+        }
+        _ => StatusCode::BAD_REQUEST.into_response(),
+    }
+}
+
+async fn revoke(
+    State(auth): State<Arc<FakeAuth>>,
+    Form(form): Form<HashMap<String, String>>,
+) -> StatusCode {
+    if let Some(token) = form.get("token") {
+        auth.revoked.lock().unwrap().push(token.clone());
+        auth.refresh_tokens
+            .lock()
+            .unwrap()
+            .insert(token.clone(), false);
+    }
+    StatusCode::OK
+}
+
+fn invalid_grant() -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(json!({"error": "invalid_grant", "error_description": "bad grant"})),
+    )
+        .into_response()
+}
+
+async fn spawn_fake() -> (String, Arc<FakeAuth>) {
+    let fake = Arc::new(FakeAuth::default());
+    let app = Router::new()
+        .route("/oauth/authorize", get(authorize))
+        .route("/oauth/token", post(token))
+        .route("/oauth/revoke", post(revoke))
+        .with_state(fake.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    (format!("http://{addr}"), fake)
+}
+
+fn browser() -> reqwest::Client {
+    // Follows the authorize redirect out to the loopback listener.
+    reqwest::Client::builder().build().unwrap()
+}
+
+#[tokio::test]
+async fn sign_in_refresh_and_sign_out_round_trip() {
+    let (base, fake) = spawn_fake().await;
+    let secrets: Arc<dyn SecretProvider> = Arc::new(MockSecrets::default());
+    let auth = ChatGptAuth::new(ChatGptAuthConfig::for_test(&base).unwrap()).unwrap();
+    let connection = ChatGptConnection::new(auth, ChatGptCredentialVault::new(secrets.clone()));
+
+    assert!(!has_stored_chatgpt_credentials(secrets.as_ref()).await);
+
+    let pending = connection.auth().start_sign_in().await.unwrap();
+    let url = pending.authorization_url().to_string();
+    let finish = tokio::spawn(pending.finish(Duration::from_secs(5)));
+    browser().get(&url).send().await.unwrap();
+    let session = finish.await.unwrap().unwrap();
+    assert_eq!(session.credentials.account_id(), ACCOUNT);
+    connection.store_session(&session).await.unwrap();
+    assert!(has_stored_chatgpt_credentials(secrets.as_ref()).await);
+
+    let token = connection.access_token().await.unwrap();
+    assert!(!token.is_empty());
+    assert_eq!(fake.token_requests.load(Ordering::SeqCst), 1);
+
+    // Expire the cached access token so the next read refreshes.
+    let raw = secrets
+        .get_secret(CHATGPT_SECRET_KEY)
+        .await
+        .unwrap()
+        .unwrap();
+    let mut value: Value = serde_json::from_str(&raw).unwrap();
+    value["expires_at_unix"] = json!(0);
+    secrets
+        .set_secret(CHATGPT_SECRET_KEY, &serde_json::to_string(&value).unwrap())
+        .await
+        .unwrap();
+
+    let token_after = connection.access_token().await.unwrap();
+    assert!(!token_after.is_empty());
+    assert!(fake.token_requests.load(Ordering::SeqCst) >= 2);
+
+    connection.sign_out().await.unwrap();
+    assert!(!has_stored_chatgpt_credentials(secrets.as_ref()).await);
+    assert!(!fake.revoked.lock().unwrap().is_empty());
+}

--- a/crates/openwave-desktop/ui/src/api/client.ts
+++ b/crates/openwave-desktop/ui/src/api/client.ts
@@ -47,6 +47,7 @@ import {
   type PromptBody,
   type ProviderInfo,
   type ProviderKind,
+  type ChatGptSignInStatus,
   type ReasoningEffort,
   type RestCredentialUpdate,
   type RuntimeSettings,
@@ -203,6 +204,26 @@ export class ApiClient {
   deleteCredential(kind: ProviderKind): Promise<void> {
     return this.json(`/providers/${kind}/credential`, {
       method: "DELETE",
+      headers: this.headers(),
+    });
+  }
+
+  openaiChatgptSignIn(): Promise<{ authorization_url: string }> {
+    return this.json("/providers/openai/chatgpt/sign-in", {
+      method: "POST",
+      headers: this.headers(),
+    });
+  }
+
+  openaiChatgptSignOut(): Promise<void> {
+    return this.json("/providers/openai/chatgpt/sign-out", {
+      method: "POST",
+      headers: this.headers(),
+    });
+  }
+
+  getOpenaiChatgptStatus(): Promise<ChatGptSignInStatus> {
+    return this.json("/providers/openai/chatgpt/status", {
       headers: this.headers(),
     });
   }

--- a/crates/openwave-desktop/ui/src/api/types.ts
+++ b/crates/openwave-desktop/ui/src/api/types.ts
@@ -50,7 +50,9 @@ import {
   type ModelRoleInfo as WireModelRoleInfo,
   type Project as WireProject,
   type ProviderInfo as WireProviderInfo,
+  type ProviderAuthMode as WireProviderAuthMode,
   type ProviderKind as WireProviderKind,
+  type ChatGptSignInStatus as WireChatGptSignInStatus,
   type PermissionMode as WirePermissionMode,
   type PluginCapability as WirePluginCapability,
   type PluginCatalog as WirePluginCatalog,
@@ -175,6 +177,8 @@ export type NetworkPolicy = WireNetworkPolicy;
 export type StickyChatDefaults = WireStickyChatDefaults;
 
 export type ProviderInfo = WireProviderInfo;
+export type ProviderAuthMode = WireProviderAuthMode;
+export type ChatGptSignInStatus = WireChatGptSignInStatus;
 
 export type VoiceTranscriptionModel = "local" | "gpt4o_transcribe" | "gemini_flash";
 export type LocalVoiceState =

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -435,6 +435,8 @@ root_attachments: Array<ChatRootAttachment>,
  */
 created_at: string, };
 
+export type ChatGptSignInStatus = { signed_in: boolean, pending_authorization_url?: string, error?: string, };
+
 /**
  * Identifies a persistent conversation.
  */
@@ -1750,6 +1752,11 @@ body: string, };
 export type PromptOrigin = "builtin" | "user";
 
 /**
+ * How a provider's credential was established.
+ */
+export type ProviderAuthMode = "api_key" | "chatgpt";
+
+/**
  * Public view of a provider — never includes the credential itself.
  */
 export type ProviderInfo = { 
@@ -1773,6 +1780,10 @@ vertex_location?: string,
  * Whether a credential is stored (never the credential itself).
  */
 has_credential: boolean, 
+/**
+ * How OpenAI (or similarly dual-mode providers) is authenticated.
+ */
+auth_mode?: ProviderAuthMode, 
 /**
  * Explicit custom model entries for this endpoint.
  */

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
@@ -137,10 +137,12 @@ describe("ProvidersPanel", () => {
     const openaiChatgptSignIn = vi.fn().mockResolvedValue({
       authorization_url: "https://auth.openai.com/oauth/authorize?x=1",
     });
-    const listProviders = vi.fn().mockResolvedValue({ providers: [openai] });
+    const getOpenaiChatgptStatus = vi
+      .fn()
+      .mockResolvedValue({ signed_in: false });
     const client = {
       openaiChatgptSignIn,
-      listProviders,
+      getOpenaiChatgptStatus,
       putProvider: vi.fn(),
     } as unknown as ApiClient;
     const open = vi.fn();
@@ -166,6 +168,33 @@ describe("ProvidersPanel", () => {
       "noreferrer,noopener",
     );
     vi.unstubAllGlobals();
+  });
+
+  it("resumes a ChatGPT sign-in that started before the panel mounted", async () => {
+    const getOpenaiChatgptStatus = vi
+      .fn()
+      .mockResolvedValueOnce({
+        signed_in: false,
+        pending_authorization_url: "https://auth.openai.com/oauth/authorize",
+      })
+      .mockResolvedValue({ signed_in: true });
+    const onChanged = vi.fn();
+
+    render(
+      <ProvidersPanel
+        providers={[
+          { kind: "openai", enabled: false, has_credential: false, models: [] },
+        ]}
+        client={{ getOpenaiChatgptStatus } as unknown as ApiClient}
+        onChanged={onChanged}
+      />,
+    );
+
+    // No click here: the sign-in belongs to the server, and the panel has to
+    // pick its completion up on its own.
+    await waitFor(() => expect(onChanged).toHaveBeenCalled(), {
+      timeout: 5_000,
+    });
   });
 
   it("shows ChatGPT sign-out when OpenAI is signed in via subscription", () => {

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
@@ -127,6 +127,73 @@ describe("ProvidersPanel", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("starts ChatGPT OAuth from the OpenAI provider row", async () => {
+    const openai: ProviderInfo = {
+      kind: "openai",
+      enabled: false,
+      has_credential: false,
+      models: [],
+    };
+    const openaiChatgptSignIn = vi.fn().mockResolvedValue({
+      authorization_url: "https://auth.openai.com/oauth/authorize?x=1",
+    });
+    const listProviders = vi.fn().mockResolvedValue({ providers: [openai] });
+    const client = {
+      openaiChatgptSignIn,
+      listProviders,
+      putProvider: vi.fn(),
+    } as unknown as ApiClient;
+    const open = vi.fn();
+    vi.stubGlobal("open", open);
+    const user = userEvent.setup();
+
+    render(
+      <ProvidersPanel
+        providers={[openai]}
+        client={client}
+        onChanged={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("No credential")).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: "Sign in with ChatGPT" }),
+    );
+    await waitFor(() => expect(openaiChatgptSignIn).toHaveBeenCalled());
+    expect(open).toHaveBeenCalledWith(
+      "https://auth.openai.com/oauth/authorize?x=1",
+      "_blank",
+      "noreferrer,noopener",
+    );
+    vi.unstubAllGlobals();
+  });
+
+  it("shows ChatGPT sign-out when OpenAI is signed in via subscription", () => {
+    render(
+      <ProvidersPanel
+        providers={[
+          {
+            kind: "openai",
+            enabled: true,
+            has_credential: true,
+            auth_mode: "chatgpt",
+            models: [],
+          },
+        ]}
+        client={{} as ApiClient}
+        onChanged={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Signed in with ChatGPT")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Sign out of ChatGPT" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Sign in with ChatGPT" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("configures Gemini service-account auth without projecting the secret", async () => {
     const gemini: ProviderInfo = {
       kind: "gemini",

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -485,9 +485,15 @@ function OpenAiCredentialSection({
     (authorizationUrl: string | null) => {
       stopPolling();
       setPendingUrl(authorizationUrl);
-      const settle = (signedIn: boolean, failure?: string) => {
+      // The server dropped the attempt — an API key saved, credentials
+      // cleared, or a newer sign-in started. Nothing failed, so stop without
+      // reporting anything.
+      const stopQuietly = () => {
         stopPolling();
         setPendingUrl(null);
+      };
+      const settle = (signedIn: boolean, failure?: string) => {
+        stopQuietly();
         if (signedIn) {
           onChanged();
           toast.success("Signed in with ChatGPT");
@@ -500,8 +506,9 @@ function OpenAiCredentialSection({
         void client
           .getOpenaiChatgptStatus()
           .then((status) => {
-            if (status.error) settle(false, status.error);
-            else if (status.signed_in) settle(true);
+            if (status.signed_in) settle(true);
+            else if (status.error) settle(false, status.error);
+            else if (!status.pending_authorization_url) stopQuietly();
           })
           .catch(() => {
             /* transient; keep polling until the deadline below */

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import type {
   ApiClient,
@@ -6,6 +6,7 @@ import type {
   ProviderInfo,
   ProviderKind,
 } from "../api";
+import { openSignInPage } from "../openSignInPage";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -20,6 +21,8 @@ import { Textarea } from "@/components/ui/textarea";
 import { useConfirm } from "../components/ConfirmDialog";
 import { SettingsError, SettingsPanel, SettingsSection } from "./primitives";
 import { providerLabel } from "../ModelSelection";
+
+const CHATGPT_SIGN_IN_POLL_MS = 2_000;
 
 export function ProvidersPanel({
   providers,
@@ -169,7 +172,7 @@ function ProviderRow({
         <div className="flex-1">
           <p className="text-sm font-bold">Enabled</p>
           <p className="text-xs text-muted-foreground">
-            {info.has_credential ? "Credential set" : "No credential"}
+            {credentialStatusLabel(info)}
           </p>
         </div>
         <Switch
@@ -313,6 +316,21 @@ function ProviderRow({
           </div>
         </>
       )}
+      {info.kind === "openai" ? (
+        <OpenAiCredentialSection
+          info={info}
+          client={client}
+          saving={saving}
+          setSaving={setSaving}
+          setError={setError}
+          onChanged={onChanged}
+          apiKey={key}
+          setApiKey={setKey}
+          onSaveApiKey={() => void save(true)}
+          onClear={() => void clearCredential()}
+        />
+      ) : (
+        <>
       {info.kind === "gemini" && (
         <label className="grid gap-1 text-xs text-muted-foreground">
           Credential type
@@ -400,8 +418,165 @@ function ProviderRow({
           </Button>
         )}
       </div>
+        </>
+      )}
       {error && <SettingsError>{error}</SettingsError>}
       {dialog}
     </SettingsSection>
+  );
+}
+
+function credentialStatusLabel(info: ProviderInfo): string {
+  if (!info.has_credential) return "No credential";
+  if (info.kind === "openai" && info.auth_mode === "chatgpt") {
+    return "Signed in with ChatGPT";
+  }
+  if (info.kind === "openai" && info.auth_mode === "api_key") {
+    return "API key set";
+  }
+  return "Credential set";
+}
+
+function OpenAiCredentialSection({
+  info,
+  client,
+  saving,
+  setSaving,
+  setError,
+  onChanged,
+  apiKey,
+  setApiKey,
+  onSaveApiKey,
+  onClear,
+}: {
+  info: ProviderInfo;
+  client: ApiClient;
+  saving: boolean;
+  setSaving: (value: boolean) => void;
+  setError: (value: string | null) => void;
+  onChanged: () => void;
+  apiKey: string;
+  setApiKey: (value: string) => void;
+  onSaveApiKey: () => void;
+  onClear: () => void;
+}) {
+  const signedInWithChatgpt = info.auth_mode === "chatgpt" && info.has_credential;
+  const pollRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (pollRef.current !== null) window.clearInterval(pollRef.current);
+    };
+  }, []);
+
+  async function signInWithChatgpt() {
+    setSaving(true);
+    setError(null);
+    try {
+      const { authorization_url } = await client.openaiChatgptSignIn();
+      await openSignInPage(authorization_url);
+      toast.message("Finish signing in with ChatGPT in your browser");
+      if (pollRef.current !== null) window.clearInterval(pollRef.current);
+      pollRef.current = window.setInterval(() => {
+        void client
+          .listProviders()
+          .then(({ providers }) => {
+            const openai = providers.find((provider) => provider.kind === "openai");
+            if (openai?.auth_mode === "chatgpt" && openai.has_credential) {
+              if (pollRef.current !== null) {
+                window.clearInterval(pollRef.current);
+                pollRef.current = null;
+              }
+              onChanged();
+              toast.success("Signed in with ChatGPT");
+            }
+          })
+          .catch(() => {
+            /* keep polling until timeout elsewhere */
+          });
+      }, CHATGPT_SIGN_IN_POLL_MS);
+      window.setTimeout(() => {
+        if (pollRef.current !== null) {
+          window.clearInterval(pollRef.current);
+          pollRef.current = null;
+        }
+      }, 5 * 60 * 1000);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function signOutChatgpt() {
+    setSaving(true);
+    setError(null);
+    try {
+      await client.openaiChatgptSignOut();
+      onChanged();
+      toast.success("Signed out of ChatGPT");
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (signedInWithChatgpt) {
+    return (
+      <div className="flex flex-wrap gap-2">
+        <Button
+          type="button"
+          variant="destructive"
+          disabled={saving}
+          onClick={() => void signOutChatgpt()}
+        >
+          Sign out of ChatGPT
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <p className="text-xs text-muted-foreground">
+        Use a ChatGPT subscription (Plus / Pro) or an OpenAI Platform API key.
+      </p>
+      <div className="flex flex-wrap gap-2">
+        <Button
+          type="button"
+          disabled={saving}
+          onClick={() => void signInWithChatgpt()}
+        >
+          Sign in with ChatGPT
+        </Button>
+      </div>
+      <Input
+        type="password"
+        placeholder="Or paste an API key"
+        value={apiKey}
+        onChange={(e) => setApiKey(e.target.value)}
+        autoComplete="off"
+      />
+      <div className="flex flex-wrap gap-2">
+        <Button
+          type="button"
+          disabled={saving || (!info.has_credential && !apiKey.trim())}
+          onClick={onSaveApiKey}
+        >
+          Save configuration
+        </Button>
+        {info.has_credential && (
+          <Button
+            type="button"
+            variant="destructive"
+            disabled={saving}
+            onClick={onClear}
+          >
+            Clear
+          </Button>
+        )}
+      </div>
+    </>
   );
 }

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import type {
   ApiClient,
@@ -23,6 +23,9 @@ import { SettingsError, SettingsPanel, SettingsSection } from "./primitives";
 import { providerLabel } from "../ModelSelection";
 
 const CHATGPT_SIGN_IN_POLL_MS = 2_000;
+// Matches the server's sign-in window; polling past it can only report a
+// timeout the server has already recorded.
+const CHATGPT_SIGN_IN_TIMEOUT_MS = 5 * 60 * 1000;
 
 export function ProvidersPanel({
   providers,
@@ -462,12 +465,20 @@ function OpenAiCredentialSection({
 }) {
   const signedInWithChatgpt = info.auth_mode === "chatgpt" && info.has_credential;
   const pollRef = useRef<number | null>(null);
+  const pollDeadlineRef = useRef<number | null>(null);
 
-  useEffect(() => {
-    return () => {
-      if (pollRef.current !== null) window.clearInterval(pollRef.current);
-    };
+  const stopPolling = useCallback(() => {
+    if (pollRef.current !== null) {
+      window.clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+    if (pollDeadlineRef.current !== null) {
+      window.clearTimeout(pollDeadlineRef.current);
+      pollDeadlineRef.current = null;
+    }
   }, []);
+
+  useEffect(() => stopPolling, [stopPolling]);
 
   async function signInWithChatgpt() {
     setSaving(true);
@@ -476,31 +487,31 @@ function OpenAiCredentialSection({
       const { authorization_url } = await client.openaiChatgptSignIn();
       await openSignInPage(authorization_url);
       toast.message("Finish signing in with ChatGPT in your browser");
-      if (pollRef.current !== null) window.clearInterval(pollRef.current);
+      stopPolling();
       pollRef.current = window.setInterval(() => {
         void client
-          .listProviders()
-          .then(({ providers }) => {
-            const openai = providers.find((provider) => provider.kind === "openai");
-            if (openai?.auth_mode === "chatgpt" && openai.has_credential) {
-              if (pollRef.current !== null) {
-                window.clearInterval(pollRef.current);
-                pollRef.current = null;
-              }
+          .getOpenaiChatgptStatus()
+          .then((status) => {
+            if (status.error) {
+              stopPolling();
+              setError(status.error);
+              toast.error("ChatGPT sign-in failed");
+              return;
+            }
+            if (status.signed_in) {
+              stopPolling();
               onChanged();
               toast.success("Signed in with ChatGPT");
             }
           })
           .catch(() => {
-            /* keep polling until timeout elsewhere */
+            /* transient; keep polling until the deadline below */
           });
       }, CHATGPT_SIGN_IN_POLL_MS);
-      window.setTimeout(() => {
-        if (pollRef.current !== null) {
-          window.clearInterval(pollRef.current);
-          pollRef.current = null;
-        }
-      }, 5 * 60 * 1000);
+      pollDeadlineRef.current = window.setTimeout(
+        stopPolling,
+        CHATGPT_SIGN_IN_TIMEOUT_MS,
+      );
     } catch (err) {
       setError(String(err));
     } finally {

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -464,6 +464,7 @@ function OpenAiCredentialSection({
   onClear: () => void;
 }) {
   const signedInWithChatgpt = info.auth_mode === "chatgpt" && info.has_credential;
+  const [pendingUrl, setPendingUrl] = useState<string | null>(null);
   const pollRef = useRef<number | null>(null);
   const pollDeadlineRef = useRef<number | null>(null);
 
@@ -480,33 +481,44 @@ function OpenAiCredentialSection({
 
   useEffect(() => stopPolling, [stopPolling]);
 
-  const startPolling = useCallback(() => {
-    stopPolling();
-    pollRef.current = window.setInterval(() => {
-      void client
-        .getOpenaiChatgptStatus()
-        .then((status) => {
-          if (status.error) {
-            stopPolling();
-            setError(status.error);
-            toast.error("ChatGPT sign-in failed");
-            return;
-          }
-          if (status.signed_in) {
-            stopPolling();
-            onChanged();
-            toast.success("Signed in with ChatGPT");
-          }
-        })
-        .catch(() => {
-          /* transient; keep polling until the deadline below */
-        });
-    }, CHATGPT_SIGN_IN_POLL_MS);
-    pollDeadlineRef.current = window.setTimeout(
-      stopPolling,
-      CHATGPT_SIGN_IN_TIMEOUT_MS,
-    );
-  }, [client, onChanged, setError, stopPolling]);
+  const startPolling = useCallback(
+    (authorizationUrl: string | null) => {
+      stopPolling();
+      setPendingUrl(authorizationUrl);
+      const settle = (signedIn: boolean, failure?: string) => {
+        stopPolling();
+        setPendingUrl(null);
+        if (signedIn) {
+          onChanged();
+          toast.success("Signed in with ChatGPT");
+          return;
+        }
+        setError(failure ?? "ChatGPT sign-in did not complete. Try again.");
+        toast.error("ChatGPT sign-in failed");
+      };
+      pollRef.current = window.setInterval(() => {
+        void client
+          .getOpenaiChatgptStatus()
+          .then((status) => {
+            if (status.error) settle(false, status.error);
+            else if (status.signed_in) settle(true);
+          })
+          .catch(() => {
+            /* transient; keep polling until the deadline below */
+          });
+      }, CHATGPT_SIGN_IN_POLL_MS);
+      pollDeadlineRef.current = window.setTimeout(() => {
+        stopPolling();
+        // The server's own window has closed by now, so read the outcome it
+        // recorded instead of leaving the row waiting on nothing.
+        void client
+          .getOpenaiChatgptStatus()
+          .then((status) => settle(status.signed_in, status.error))
+          .catch(() => settle(false));
+      }, CHATGPT_SIGN_IN_TIMEOUT_MS);
+    },
+    [client, onChanged, setError, stopPolling],
+  );
 
   // The sign-in runs on the server, so one started before this panel mounted —
   // or left behind when the user navigated away — is still waiting on the
@@ -524,7 +536,9 @@ function OpenAiCredentialSection({
           setError(status.error);
           return;
         }
-        if (status.pending_authorization_url) startPolling();
+        if (status.pending_authorization_url) {
+          startPolling(status.pending_authorization_url);
+        }
       })
       .catch(() => {
         /* the row still works without a resumed sign-in */
@@ -541,7 +555,7 @@ function OpenAiCredentialSection({
       const { authorization_url } = await client.openaiChatgptSignIn();
       await openSignInPage(authorization_url);
       toast.message("Finish signing in with ChatGPT in your browser");
-      startPolling();
+      startPolling(authorization_url);
     } catch (err) {
       setError(String(err));
     } finally {
@@ -592,6 +606,25 @@ function OpenAiCredentialSection({
           Sign in with ChatGPT
         </Button>
       </div>
+      {pendingUrl && (
+        <p className="text-xs text-muted-foreground">
+          Waiting for the browser to finish signing in.{" "}
+          <a
+            href={pendingUrl}
+            className="underline"
+            onClick={(event) => {
+              // No target="_blank": the shell plugin's injected click handler
+              // opens such links itself without honoring preventDefault, which
+              // doubles the tab. Route through the native opener and keep the
+              // href for hover/copy.
+              event.preventDefault();
+              void openSignInPage(pendingUrl);
+            }}
+          >
+            Open the sign-in page again
+          </a>
+        </p>
+      )}
       <Input
         type="password"
         placeholder="Or paste an API key"

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -480,6 +480,60 @@ function OpenAiCredentialSection({
 
   useEffect(() => stopPolling, [stopPolling]);
 
+  const startPolling = useCallback(() => {
+    stopPolling();
+    pollRef.current = window.setInterval(() => {
+      void client
+        .getOpenaiChatgptStatus()
+        .then((status) => {
+          if (status.error) {
+            stopPolling();
+            setError(status.error);
+            toast.error("ChatGPT sign-in failed");
+            return;
+          }
+          if (status.signed_in) {
+            stopPolling();
+            onChanged();
+            toast.success("Signed in with ChatGPT");
+          }
+        })
+        .catch(() => {
+          /* transient; keep polling until the deadline below */
+        });
+    }, CHATGPT_SIGN_IN_POLL_MS);
+    pollDeadlineRef.current = window.setTimeout(
+      stopPolling,
+      CHATGPT_SIGN_IN_TIMEOUT_MS,
+    );
+  }, [client, onChanged, setError, stopPolling]);
+
+  // The sign-in runs on the server, so one started before this panel mounted —
+  // or left behind when the user navigated away — is still waiting on the
+  // browser. Pick it back up rather than sitting on a stale "no credential".
+  const resumeChecked = useRef(false);
+  useEffect(() => {
+    if (resumeChecked.current || signedInWithChatgpt) return;
+    resumeChecked.current = true;
+    let dropped = false;
+    void client
+      .getOpenaiChatgptStatus()
+      .then((status) => {
+        if (dropped) return;
+        if (status.error) {
+          setError(status.error);
+          return;
+        }
+        if (status.pending_authorization_url) startPolling();
+      })
+      .catch(() => {
+        /* the row still works without a resumed sign-in */
+      });
+    return () => {
+      dropped = true;
+    };
+  }, [client, setError, signedInWithChatgpt, startPolling]);
+
   async function signInWithChatgpt() {
     setSaving(true);
     setError(null);
@@ -487,31 +541,7 @@ function OpenAiCredentialSection({
       const { authorization_url } = await client.openaiChatgptSignIn();
       await openSignInPage(authorization_url);
       toast.message("Finish signing in with ChatGPT in your browser");
-      stopPolling();
-      pollRef.current = window.setInterval(() => {
-        void client
-          .getOpenaiChatgptStatus()
-          .then((status) => {
-            if (status.error) {
-              stopPolling();
-              setError(status.error);
-              toast.error("ChatGPT sign-in failed");
-              return;
-            }
-            if (status.signed_in) {
-              stopPolling();
-              onChanged();
-              toast.success("Signed in with ChatGPT");
-            }
-          })
-          .catch(() => {
-            /* transient; keep polling until the deadline below */
-          });
-      }, CHATGPT_SIGN_IN_POLL_MS);
-      pollDeadlineRef.current = window.setTimeout(
-        stopPolling,
-        CHATGPT_SIGN_IN_TIMEOUT_MS,
-      );
+      startPolling();
     } catch (err) {
       setError(String(err));
     } finally {

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -506,8 +506,11 @@ function OpenAiCredentialSection({
         void client
           .getOpenaiChatgptStatus()
           .then((status) => {
-            if (status.signed_in) settle(true);
-            else if (status.error) settle(false, status.error);
+            // Prefer a recorded failure over vault-only tokens: `signed_in`
+            // requires the Oauth marker, but a half-finished persist can still
+            // leave tokens while progress is Failed.
+            if (status.error) settle(false, status.error);
+            else if (status.signed_in) settle(true);
             else if (!status.pending_authorization_url) stopQuietly();
           })
           .catch(() => {
@@ -520,7 +523,10 @@ function OpenAiCredentialSection({
         // recorded instead of leaving the row waiting on nothing.
         void client
           .getOpenaiChatgptStatus()
-          .then((status) => settle(status.signed_in, status.error))
+          .then((status) => {
+            if (status.error) settle(false, status.error);
+            else settle(status.signed_in);
+          })
           .catch(() => settle(false));
       }, CHATGPT_SIGN_IN_TIMEOUT_MS);
     },

--- a/crates/openwave-router/src/openai.rs
+++ b/crates/openwave-router/src/openai.rs
@@ -1,6 +1,7 @@
 //! Native OpenAI Responses API provider.
 
 use std::collections::{BTreeMap, HashSet};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use base64::engine::general_purpose::STANDARD as BASE64;
@@ -20,9 +21,12 @@ use crate::sse::{
     classify_in_band_error, classify_provider_error, drain_frames, frame_data,
     read_bounded_error_body,
 };
+use crate::BearerTokenSource;
 
 const DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
 const DEFAULT_MAX_TOKENS: u32 = 4096;
+const CHATGPT_BETA_HEADER: &str = "responses=v1";
+const DEFAULT_CHATGPT_ORIGINATOR: &str = "openwave";
 
 /// A [`ModelProvider`] for OpenAI's native Responses API.
 #[derive(Clone)]
@@ -30,6 +34,14 @@ pub struct OpenAiProvider {
     client: reqwest::Client,
     api_key: String,
     base_url: String,
+    /// Per-request credential supplier for ChatGPT OAuth (and similar)
+    /// short-lived tokens. Takes precedence over `api_key` when present.
+    token_source: Option<Arc<dyn BearerTokenSource>>,
+    /// When set, inference is ChatGPT-subscription shaped: send the account
+    /// id and Codex originator headers expected by the ChatGPT backend.
+    chatgpt_account_id: Option<String>,
+    /// `originator` header value when [`Self::chatgpt_account_id`] is set.
+    chatgpt_originator: String,
 }
 
 impl OpenAiProvider {
@@ -38,12 +50,39 @@ impl OpenAiProvider {
             client: crate::http::streaming_client(),
             api_key: api_key.into(),
             base_url: DEFAULT_BASE_URL.to_string(),
+            token_source: None,
+            chatgpt_account_id: None,
+            chatgpt_originator: DEFAULT_CHATGPT_ORIGINATOR.to_string(),
         }
     }
 
     #[must_use]
     pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
         self.base_url = base_url.into();
+        self
+    }
+
+    /// Fetch the credential from `source` at each request instead of using a
+    /// static key. For ChatGPT OAuth whose access tokens rotate under the
+    /// adapter.
+    #[must_use]
+    pub fn with_token_source(mut self, source: Arc<dyn BearerTokenSource>) -> Self {
+        self.token_source = Some(source);
+        self
+    }
+
+    /// Mark this provider as ChatGPT-subscription auth: attach the account id
+    /// and Codex-compatible headers on every request.
+    #[must_use]
+    pub fn with_chatgpt_account_id(mut self, account_id: impl Into<String>) -> Self {
+        self.chatgpt_account_id = Some(account_id.into());
+        self
+    }
+
+    /// Override the `originator` header sent in ChatGPT mode.
+    #[must_use]
+    pub fn with_chatgpt_originator(mut self, originator: impl Into<String>) -> Self {
+        self.chatgpt_originator = originator.into();
         self
     }
 }
@@ -57,11 +96,22 @@ impl ModelProvider for OpenAiProvider {
     async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
         let body = build_request_json(&req)?;
         let url = format!("{}/responses", self.base_url.trim_end_matches('/'));
-        let response = self
+        let api_key = match &self.token_source {
+            Some(source) => source.bearer_token_for(req.conversation).await?,
+            None => self.api_key.clone(),
+        };
+        let mut request = self
             .client
             .post(url)
-            .bearer_auth(&self.api_key)
-            .header("content-type", "application/json")
+            .bearer_auth(&api_key)
+            .header("content-type", "application/json");
+        if let Some(account_id) = &self.chatgpt_account_id {
+            request = request
+                .header("ChatGPT-Account-ID", account_id)
+                .header("OpenAI-Beta", CHATGPT_BETA_HEADER)
+                .header("originator", &self.chatgpt_originator);
+        }
+        let response = request
             .json(&body)
             .send()
             .await
@@ -1357,5 +1407,101 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn chatgpt_oauth_sends_bearer_account_and_originator_headers() {
+        use std::sync::Arc;
+
+        use axum::extract::{Request, State};
+        use axum::http::StatusCode;
+        use axum::response::IntoResponse;
+        use axum::routing::post;
+        use axum::Router;
+        use tokio::sync::oneshot;
+
+        use crate::BearerTokenSource;
+
+        struct StaticSource;
+
+        #[async_trait]
+        impl BearerTokenSource for StaticSource {
+            async fn bearer_token(&self) -> Result<String> {
+                Ok("chatgpt-access".into())
+            }
+        }
+
+        #[derive(Default)]
+        struct Captured {
+            authorization: Option<String>,
+            account: Option<String>,
+            beta: Option<String>,
+            originator: Option<String>,
+        }
+
+        async fn capture(
+            State(tx): State<Arc<std::sync::Mutex<Option<oneshot::Sender<Captured>>>>>,
+            request: Request,
+        ) -> impl IntoResponse {
+            let headers = request.headers();
+            let captured = Captured {
+                authorization: headers
+                    .get(axum::http::header::AUTHORIZATION)
+                    .and_then(|v| v.to_str().ok())
+                    .map(str::to_owned),
+                account: headers
+                    .get("chatgpt-account-id")
+                    .and_then(|v| v.to_str().ok())
+                    .map(str::to_owned),
+                beta: headers
+                    .get("openai-beta")
+                    .and_then(|v| v.to_str().ok())
+                    .map(str::to_owned),
+                originator: headers
+                    .get("originator")
+                    .and_then(|v| v.to_str().ok())
+                    .map(str::to_owned),
+            };
+            if let Some(tx) = tx.lock().unwrap().take() {
+                let _ = tx.send(captured);
+            }
+            (
+                StatusCode::OK,
+                [("content-type", "text/event-stream")],
+                concat!(
+                    "data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\n",
+                    "data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n"
+                ),
+            )
+        }
+
+        let (tx, rx) = oneshot::channel();
+        let state = Arc::new(std::sync::Mutex::new(Some(tx)));
+        let app = Router::new().fallback(post(capture)).with_state(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let provider = OpenAiProvider::new(String::new())
+            .with_base_url(format!("http://{address}/codex"))
+            .with_token_source(Arc::new(StaticSource))
+            .with_chatgpt_account_id("acct-xyz");
+        let stream = provider
+            .stream(ChatRequest {
+                model: "gpt-5.6-sol".into(),
+                messages: vec![ChatMessage::text(Role::User, "hi")],
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let _events: Vec<_> = stream.collect().await;
+        let captured = rx.await.unwrap();
+        assert_eq!(
+            captured.authorization.as_deref(),
+            Some("Bearer chatgpt-access")
+        );
+        assert_eq!(captured.account.as_deref(), Some("acct-xyz"));
+        assert_eq!(captured.beta.as_deref(), Some("responses=v1"));
+        assert_eq!(captured.originator.as_deref(), Some("openwave"));
     }
 }

--- a/crates/openwave-router/src/router.rs
+++ b/crates/openwave-router/src/router.rs
@@ -152,6 +152,9 @@ pub struct Route {
     /// Vertex resource/auth metadata. Present only for a Gemini route backed
     /// by a Google service account.
     pub vertex: Option<VertexRoute>,
+    /// ChatGPT account id for OpenAI routes authenticated via ChatGPT OAuth.
+    /// Baked into the adapter (only the bearer rotates).
+    pub chatgpt_account_id: Option<String>,
 }
 
 impl std::fmt::Debug for Route {
@@ -163,6 +166,7 @@ impl std::fmt::Debug for Route {
             .field("curated_models", &self.curated_models)
             .field("token_source", &self.token_source.is_some())
             .field("vertex", &self.vertex)
+            .field("chatgpt_account_id", &self.chatgpt_account_id)
             .finish()
     }
 }
@@ -331,7 +335,20 @@ fn build_adapter(route: &Route) -> Option<Arc<dyn ModelProvider>> {
 
         #[cfg(feature = "openai")]
         RouteKind::Openai => {
-            let mut p = OpenAiProvider::new(route.api_key.clone());
+            let mut p = if let Some(source) = route.token_source.clone() {
+                let mut provider = OpenAiProvider::new(String::new()).with_token_source(source);
+                if let Some(account_id) = &route.chatgpt_account_id {
+                    provider = provider.with_chatgpt_account_id(account_id.clone());
+                }
+                provider
+            } else {
+                // A ChatGPT account id without a live token source is not a
+                // usable Platform API-key route.
+                if route.chatgpt_account_id.is_some() {
+                    return None;
+                }
+                OpenAiProvider::new(route.api_key.clone())
+            };
             if let Some(base) = &route.base_url {
                 p = p.with_base_url(base.clone());
             }
@@ -387,7 +404,7 @@ fn fingerprint_routes(routes: &[Route]) -> String {
         .iter()
         .map(|r| {
             format!(
-                "{}|{}|{}|{}|{}",
+                "{}|{}|{}|{}|{}|{}",
                 r.kind.as_str(),
                 // A rotating token must not thrash the cached router; the
                 // fingerprint tracks *whether* a live source exists, and the
@@ -410,7 +427,8 @@ fn fingerprint_routes(routes: &[Route]) -> String {
                         .map(|byte| format!("{byte:02x}"))
                         .collect::<String>();
                     format!("{}:{credential}", vertex.location)
-                })
+                }),
+                r.chatgpt_account_id.as_deref().unwrap_or("")
             )
         })
         .collect();
@@ -442,6 +460,7 @@ mod tests {
             curated_models: models.iter().map(|m| (*m).to_string()).collect(),
             token_source: None,
             vertex: None,
+            chatgpt_account_id: None,
         }
     }
 

--- a/crates/openwave-server/src/chatgpt_runtime.rs
+++ b/crates/openwave-server/src/chatgpt_runtime.rs
@@ -140,7 +140,17 @@ impl ChatGptRuntime {
             .store_session(session)
             .await
             .map_err(ServerError::from)?;
-        // Mutual exclusivity: OAuth marker replaces any API key.
+        // Mutual exclusivity: OAuth marker replaces any API key. If either
+        // follow-up write fails, clear the vault so `status` and routing never
+        // see tokens without the Oauth marker that makes them usable.
+        if let Err(error) = self.finish_persisted_session().await {
+            let _ = self.connection.sign_out().await;
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    async fn finish_persisted_session(&self) -> Result<(), ServerError> {
         providers::write_credential(
             &*self.secrets,
             ProviderKind::Openai,
@@ -172,7 +182,15 @@ impl ChatGptRuntime {
     /// Pending / failed status for the OpenAI Providers row.
     pub async fn status(&self) -> ChatGptSignInStatus {
         let progress = self.sign_in.lock().await.progress.clone();
-        let signed_in = openwave_connectors::has_stored_chatgpt_credentials(&*self.secrets).await;
+        // Same bar as routing: vault tokens alone are not a usable session.
+        let signed_in = matches!(
+            providers::read_credential(&*self.secrets, ProviderKind::Openai)
+                .await
+                .ok()
+                .flatten(),
+            Some(ProviderCredential::Oauth {})
+        ) && openwave_connectors::has_stored_chatgpt_credentials(&*self.secrets)
+            .await;
         match progress {
             SignInProgress::Pending { authorization_url } => ChatGptSignInStatus {
                 signed_in,

--- a/crates/openwave-server/src/chatgpt_runtime.rs
+++ b/crates/openwave-server/src/chatgpt_runtime.rs
@@ -1,0 +1,191 @@
+//! ChatGPT subscription OAuth runtime for the OpenAI provider.
+//!
+//! Lighter than [`crate::gateway_runtime`]: one pending sign-in at a time,
+//! vault-backed tokens, no model sync. Completing sign-in writes the
+//! `ProviderCredential::Oauth` marker and enables the OpenAI provider.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use openwave_connectors::{
+    ChatGptAuth, ChatGptAuthConfig, ChatGptConnection, ChatGptCredentialVault,
+};
+use openwave_core::{Result, SecretProvider, Store};
+use openwave_router::BearerTokenSource;
+use tokio::sync::Mutex;
+
+use crate::error::ServerError;
+use crate::providers::{self, ProviderCredential, ProviderKind};
+
+const SIGN_IN_TIMEOUT: Duration = Duration::from_secs(300);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SignInProgress {
+    Idle,
+    Pending { authorization_url: String },
+    Failed { message: String },
+}
+
+/// Process-local ChatGPT OAuth handle shared by provider routes and routing.
+pub struct ChatGptRuntime {
+    connection: Arc<ChatGptConnection>,
+    store: Arc<dyn Store>,
+    secrets: Arc<dyn SecretProvider>,
+    sign_in: Mutex<SignInProgress>,
+    sign_in_generation: AtomicU64,
+}
+
+impl ChatGptRuntime {
+    pub fn new(store: Arc<dyn Store>, secrets: Arc<dyn SecretProvider>) -> Result<Self> {
+        let auth = ChatGptAuth::new(ChatGptAuthConfig::production())?;
+        let vault = ChatGptCredentialVault::new(secrets.clone());
+        Ok(Self {
+            connection: Arc::new(ChatGptConnection::new(auth, vault)),
+            store,
+            secrets,
+            sign_in: Mutex::new(SignInProgress::Idle),
+            sign_in_generation: AtomicU64::new(0),
+        })
+    }
+
+    /// Build route auth from the secret store. Used by the provider resolver
+    /// when assembling OpenAI ChatGPT OAuth routes.
+    pub async fn route_auth_from_secrets(
+        secrets: Arc<dyn SecretProvider>,
+    ) -> Option<(Arc<dyn BearerTokenSource>, String)> {
+        if !openwave_connectors::has_stored_chatgpt_credentials(&*secrets).await {
+            return None;
+        }
+        let auth = ChatGptAuth::new(ChatGptAuthConfig::production()).ok()?;
+        let connection = Arc::new(ChatGptConnection::new(
+            auth,
+            ChatGptCredentialVault::new(secrets),
+        ));
+        let account_id = connection.account_id().await.ok().flatten()?;
+        let source: Arc<dyn BearerTokenSource> = Arc::new(ChatGptTokenSource(connection));
+        Some((source, account_id))
+    }
+
+    /// Start browser sign-in; returns the URL to open.
+    ///
+    /// Callers must refuse managed profiles before invoking this — BYO OpenAI
+    /// credentials (key or ChatGPT OAuth) are locked out there.
+    pub async fn begin_sign_in(self: &Arc<Self>) -> Result<String, ServerError> {
+        let pending = self
+            .connection
+            .auth()
+            .start_sign_in()
+            .await
+            .map_err(ServerError::from)?;
+        let authorization_url = pending.authorization_url().to_string();
+        let generation = {
+            let mut sign_in = self.sign_in.lock().await;
+            let generation = self.sign_in_generation.fetch_add(1, Ordering::SeqCst) + 1;
+            *sign_in = SignInProgress::Pending {
+                authorization_url: authorization_url.clone(),
+            };
+            generation
+        };
+
+        let runtime = self.clone();
+        tokio::spawn(async move {
+            let finished = pending.finish(SIGN_IN_TIMEOUT).await;
+            let mut sign_in = runtime.sign_in.lock().await;
+            if runtime.sign_in_generation.load(Ordering::SeqCst) != generation {
+                return;
+            }
+            *sign_in = match finished {
+                Ok(session) => match runtime.persist_session(&session).await {
+                    Ok(()) => SignInProgress::Idle,
+                    Err(error) => SignInProgress::Failed {
+                        message: error.message().to_string(),
+                    },
+                },
+                Err(error) => SignInProgress::Failed {
+                    message: error.to_string(),
+                },
+            };
+        });
+
+        Ok(authorization_url)
+    }
+
+    async fn persist_session(
+        &self,
+        session: &openwave_connectors::ChatGptAuthorizedSession,
+    ) -> Result<(), ServerError> {
+        self.connection
+            .store_session(session)
+            .await
+            .map_err(ServerError::from)?;
+        // Mutual exclusivity: OAuth marker replaces any API key.
+        providers::write_credential(
+            &*self.secrets,
+            ProviderKind::Openai,
+            &ProviderCredential::Oauth {},
+        )
+        .await?;
+        let mut config = providers::read_config(&*self.store, ProviderKind::Openai).await?;
+        config.enabled = true;
+        providers::write_config(&*self.store, ProviderKind::Openai, &config).await?;
+        Ok(())
+    }
+
+    /// Revoke best-effort, clear vault and Oauth marker.
+    pub async fn sign_out(&self) -> Result<(), ServerError> {
+        self.sign_in_generation.fetch_add(1, Ordering::SeqCst);
+        *self.sign_in.lock().await = SignInProgress::Idle;
+        self.connection.sign_out().await.map_err(ServerError::from)?;
+        if matches!(
+            providers::read_credential(&*self.secrets, ProviderKind::Openai).await?,
+            Some(ProviderCredential::Oauth {})
+        ) {
+            providers::delete_credential(&*self.secrets, ProviderKind::Openai).await?;
+        }
+        Ok(())
+    }
+
+    /// Pending / failed status for the OpenAI Providers row.
+    pub async fn status(&self) -> ChatGptSignInStatus {
+        let progress = self.sign_in.lock().await.clone();
+        let signed_in = openwave_connectors::has_stored_chatgpt_credentials(&*self.secrets).await;
+        match progress {
+            SignInProgress::Pending { authorization_url } => ChatGptSignInStatus {
+                signed_in,
+                pending_authorization_url: Some(authorization_url),
+                error: None,
+            },
+            SignInProgress::Failed { message } => ChatGptSignInStatus {
+                signed_in,
+                pending_authorization_url: None,
+                error: Some(message),
+            },
+            SignInProgress::Idle => ChatGptSignInStatus {
+                signed_in,
+                pending_authorization_url: None,
+                error: None,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, ts_rs::TS)]
+pub struct ChatGptSignInStatus {
+    pub signed_in: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub pending_authorization_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub error: Option<String>,
+}
+
+struct ChatGptTokenSource(Arc<ChatGptConnection>);
+
+#[async_trait::async_trait]
+impl BearerTokenSource for ChatGptTokenSource {
+    async fn bearer_token(&self) -> openwave_core::Result<String> {
+        self.0.access_token().await
+    }
+}

--- a/crates/openwave-server/src/chatgpt_runtime.rs
+++ b/crates/openwave-server/src/chatgpt_runtime.rs
@@ -60,21 +60,18 @@ impl ChatGptRuntime {
         })
     }
 
-    /// Build route auth from the secret store. Used by the provider resolver
-    /// when assembling OpenAI ChatGPT OAuth routes.
-    pub async fn route_auth_from_secrets(
-        secrets: Arc<dyn SecretProvider>,
-    ) -> Option<(Arc<dyn BearerTokenSource>, String)> {
-        if !openwave_connectors::has_stored_chatgpt_credentials(&*secrets).await {
-            return None;
-        }
-        let auth = ChatGptAuth::new(ChatGptAuthConfig::production()).ok()?;
-        let connection = Arc::new(ChatGptConnection::new(
-            auth,
-            ChatGptCredentialVault::new(secrets),
-        ));
-        let account_id = connection.account_id().await.ok().flatten()?;
-        let source: Arc<dyn BearerTokenSource> = Arc::new(ChatGptTokenSource(connection));
+    /// Route auth for the OpenAI ChatGPT OAuth route, or `None` when no
+    /// session is stored.
+    ///
+    /// The token source borrows this runtime's connection rather than opening
+    /// a second one over the same vault entry: refresh rotation and sign-out
+    /// are serialized per connection, so two of them racing can push a stale
+    /// refresh token at OpenAI or resurrect a session that sign-out just
+    /// cleared.
+    pub async fn route_auth(&self) -> Option<(Arc<dyn BearerTokenSource>, String)> {
+        let account_id = self.connection.account_id().await.ok().flatten()?;
+        let source: Arc<dyn BearerTokenSource> =
+            Arc::new(ChatGptTokenSource(self.connection.clone()));
         Some((source, account_id))
     }
 

--- a/crates/openwave-server/src/chatgpt_runtime.rs
+++ b/crates/openwave-server/src/chatgpt_runtime.rs
@@ -20,11 +20,22 @@ use crate::providers::{self, ProviderCredential, ProviderKind};
 
 const SIGN_IN_TIMEOUT: Duration = Duration::from_secs(300);
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 enum SignInProgress {
+    #[default]
     Idle,
-    Pending { authorization_url: String },
-    Failed { message: String },
+    Pending {
+        authorization_url: String,
+    },
+    Failed {
+        message: String,
+    },
+}
+
+#[derive(Default)]
+struct SignInState {
+    progress: SignInProgress,
+    waiter: Option<tokio::task::JoinHandle<()>>,
 }
 
 /// Process-local ChatGPT OAuth handle shared by provider routes and routing.
@@ -32,7 +43,7 @@ pub struct ChatGptRuntime {
     connection: Arc<ChatGptConnection>,
     store: Arc<dyn Store>,
     secrets: Arc<dyn SecretProvider>,
-    sign_in: Mutex<SignInProgress>,
+    sign_in: Mutex<SignInState>,
     sign_in_generation: AtomicU64,
 }
 
@@ -44,7 +55,7 @@ impl ChatGptRuntime {
             connection: Arc::new(ChatGptConnection::new(auth, vault)),
             store,
             secrets,
-            sign_in: Mutex::new(SignInProgress::Idle),
+            sign_in: Mutex::new(SignInState::default()),
             sign_in_generation: AtomicU64::new(0),
         })
     }
@@ -72,6 +83,9 @@ impl ChatGptRuntime {
     /// Callers must refuse managed profiles before invoking this — BYO OpenAI
     /// credentials (key or ChatGPT OAuth) are locked out there.
     pub async fn begin_sign_in(self: &Arc<Self>) -> Result<String, ServerError> {
+        // A previous attempt still owns the fixed callback port, so it has to
+        // be torn down before the new listener can bind.
+        self.cancel_pending().await;
         let pending = self
             .connection
             .auth()
@@ -79,23 +93,20 @@ impl ChatGptRuntime {
             .await
             .map_err(ServerError::from)?;
         let authorization_url = pending.authorization_url().to_string();
-        let generation = {
-            let mut sign_in = self.sign_in.lock().await;
-            let generation = self.sign_in_generation.fetch_add(1, Ordering::SeqCst) + 1;
-            *sign_in = SignInProgress::Pending {
-                authorization_url: authorization_url.clone(),
-            };
-            generation
-        };
 
+        let mut sign_in = self.sign_in.lock().await;
+        let generation = self.sign_in_generation.fetch_add(1, Ordering::SeqCst) + 1;
+        sign_in.progress = SignInProgress::Pending {
+            authorization_url: authorization_url.clone(),
+        };
         let runtime = self.clone();
-        tokio::spawn(async move {
+        sign_in.waiter = Some(tokio::spawn(async move {
             let finished = pending.finish(SIGN_IN_TIMEOUT).await;
             let mut sign_in = runtime.sign_in.lock().await;
             if runtime.sign_in_generation.load(Ordering::SeqCst) != generation {
                 return;
             }
-            *sign_in = match finished {
+            sign_in.progress = match finished {
                 Ok(session) => match runtime.persist_session(&session).await {
                     Ok(()) => SignInProgress::Idle,
                     Err(error) => SignInProgress::Failed {
@@ -106,9 +117,22 @@ impl ChatGptRuntime {
                     message: error.to_string(),
                 },
             };
-        });
+        }));
 
         Ok(authorization_url)
+    }
+
+    /// Abandon any in-flight sign-in and wait for its callback listener to go
+    /// away. Aborting alone is not enough: the port is only freed once the
+    /// task has actually been dropped.
+    async fn cancel_pending(&self) {
+        self.sign_in_generation.fetch_add(1, Ordering::SeqCst);
+        let mut sign_in = self.sign_in.lock().await;
+        sign_in.progress = SignInProgress::Idle;
+        if let Some(waiter) = sign_in.waiter.take() {
+            waiter.abort();
+            let _ = waiter.await;
+        }
     }
 
     async fn persist_session(
@@ -134,9 +158,11 @@ impl ChatGptRuntime {
 
     /// Revoke best-effort, clear vault and Oauth marker.
     pub async fn sign_out(&self) -> Result<(), ServerError> {
-        self.sign_in_generation.fetch_add(1, Ordering::SeqCst);
-        *self.sign_in.lock().await = SignInProgress::Idle;
-        self.connection.sign_out().await.map_err(ServerError::from)?;
+        self.cancel_pending().await;
+        self.connection
+            .sign_out()
+            .await
+            .map_err(ServerError::from)?;
         if matches!(
             providers::read_credential(&*self.secrets, ProviderKind::Openai).await?,
             Some(ProviderCredential::Oauth {})
@@ -148,7 +174,7 @@ impl ChatGptRuntime {
 
     /// Pending / failed status for the OpenAI Providers row.
     pub async fn status(&self) -> ChatGptSignInStatus {
-        let progress = self.sign_in.lock().await.clone();
+        let progress = self.sign_in.lock().await.progress.clone();
         let signed_in = openwave_connectors::has_stored_chatgpt_credentials(&*self.secrets).await;
         match progress {
             SignInProgress::Pending { authorization_url } => ChatGptSignInStatus {

--- a/crates/openwave-server/src/chatgpt_runtime.rs
+++ b/crates/openwave-server/src/chatgpt_runtime.rs
@@ -122,7 +122,12 @@ impl ChatGptRuntime {
     /// Abandon any in-flight sign-in and wait for its callback listener to go
     /// away. Aborting alone is not enough: the port is only freed once the
     /// task has actually been dropped.
-    async fn cancel_pending(&self) {
+    ///
+    /// Callers switching the OpenAI provider to an API key must do this before
+    /// writing the key: the two credentials are mutually exclusive, and a
+    /// sign-in that lands afterwards would replace the key with the OAuth
+    /// marker.
+    pub(crate) async fn cancel_pending(&self) {
         self.sign_in_generation.fetch_add(1, Ordering::SeqCst);
         let mut sign_in = self.sign_in.lock().await;
         sign_in.progress = SignInProgress::Idle;

--- a/crates/openwave-server/src/chatgpt_runtime.rs
+++ b/crates/openwave-server/src/chatgpt_runtime.rs
@@ -122,12 +122,7 @@ impl ChatGptRuntime {
     /// Abandon any in-flight sign-in and wait for its callback listener to go
     /// away. Aborting alone is not enough: the port is only freed once the
     /// task has actually been dropped.
-    ///
-    /// Callers switching the OpenAI provider to an API key must do this before
-    /// writing the key: the two credentials are mutually exclusive, and a
-    /// sign-in that lands afterwards would replace the key with the OAuth
-    /// marker.
-    pub(crate) async fn cancel_pending(&self) {
+    async fn cancel_pending(&self) {
         self.sign_in_generation.fetch_add(1, Ordering::SeqCst);
         let mut sign_in = self.sign_in.lock().await;
         sign_in.progress = SignInProgress::Idle;

--- a/crates/openwave-server/src/chatgpt_runtime.rs
+++ b/crates/openwave-server/src/chatgpt_runtime.rs
@@ -122,7 +122,7 @@ impl ChatGptRuntime {
     /// Abandon any in-flight sign-in and wait for its callback listener to go
     /// away. Aborting alone is not enough: the port is only freed once the
     /// task has actually been dropped.
-    async fn cancel_pending(&self) {
+    pub(crate) async fn cancel_pending(&self) {
         self.sign_in_generation.fetch_add(1, Ordering::SeqCst);
         let mut sign_in = self.sign_in.lock().await;
         sign_in.progress = SignInProgress::Idle;

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -1350,6 +1350,7 @@ mod tests {
             &*store,
             &*runtime.secrets,
             runtime.route_token_source().await,
+            None,
             &policy,
         )
         .await;
@@ -1982,7 +1983,7 @@ mod tests {
         let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
             .await
             .unwrap();
-        let routes = providers::collect_routes(&*store, &*runtime.secrets, None, &policy).await;
+        let routes = providers::collect_routes(&*store, &*runtime.secrets, None, None, &policy).await;
         assert!(routes
             .iter()
             .all(|route| route.kind != openwave_router::RouteKind::ModelGateway));
@@ -2079,7 +2080,7 @@ mod tests {
         // token source in hand, the gateway route is not built.
         assert!(runtime.route_token_source().await.is_none());
         let tokens: Arc<dyn BearerTokenSource> = Arc::new(StaticTokens);
-        let routes = providers::collect_routes(&*store, &*secrets, Some(tokens), &policy).await;
+        let routes = providers::collect_routes(&*store, &*secrets, Some(tokens), None, &policy).await;
         assert!(routes
             .iter()
             .all(|route| route.kind != openwave_router::RouteKind::ModelGateway));

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -1983,7 +1983,8 @@ mod tests {
         let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
             .await
             .unwrap();
-        let routes = providers::collect_routes(&*store, &*runtime.secrets, None, None, &policy).await;
+        let routes =
+            providers::collect_routes(&*store, &*runtime.secrets, None, None, &policy).await;
         assert!(routes
             .iter()
             .all(|route| route.kind != openwave_router::RouteKind::ModelGateway));
@@ -2080,7 +2081,8 @@ mod tests {
         // token source in hand, the gateway route is not built.
         assert!(runtime.route_token_source().await.is_none());
         let tokens: Arc<dyn BearerTokenSource> = Arc::new(StaticTokens);
-        let routes = providers::collect_routes(&*store, &*secrets, Some(tokens), None, &policy).await;
+        let routes =
+            providers::collect_routes(&*store, &*secrets, Some(tokens), None, &policy).await;
         assert!(routes
             .iter()
             .all(|route| route.kind != openwave_router::RouteKind::ModelGateway));

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -1686,10 +1686,14 @@ mod tests {
         let os_policy: Arc<dyn crate::managed_policy::OsPolicySource> =
             Arc::new(crate::managed_policy::NoOsPolicy);
         let runtime = GatewayRuntime::new(store.clone(), secrets.clone(), os_policy.clone());
+        let chatgpt = Arc::new(
+            crate::chatgpt_runtime::ChatGptRuntime::new(store.clone(), secrets.clone()).unwrap(),
+        );
         let resolver = Arc::new(crate::resolver::ConfiguredResolver::new(
             store.clone(),
             secrets.clone(),
             runtime.clone(),
+            chatgpt.clone(),
             os_policy.clone(),
         ));
         let state = crate::state::AppState::with_gateway_runtime(
@@ -1701,6 +1705,7 @@ mod tests {
             openwave_core::AgentConfig::default(),
             uuid::Uuid::new_v4(),
             runtime,
+            chatgpt,
             os_policy,
         )
         .unwrap();

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -922,10 +922,15 @@ async fn bind_inner(
     }
     let gateway =
         gateway_runtime::GatewayRuntime::new(store.clone(), secrets.clone(), os_policy.clone());
+    let chatgpt = Arc::new(chatgpt_runtime::ChatGptRuntime::new(
+        store.clone(),
+        secrets.clone(),
+    )?);
     let resolver = Arc::new(KeyedResolver::new(
         store.clone(),
         secrets.clone(),
         gateway.clone(),
+        chatgpt.clone(),
         os_policy.clone(),
     ));
     let blobs: Arc<dyn BlobStore> = Arc::new(FsBlobStore::new(config.data_dir.join("blobs")));
@@ -983,6 +988,7 @@ async fn bind_inner(
         agent_config,
         client_executor_id.unwrap_or_else(Uuid::new_v4),
         gateway,
+        chatgpt,
         os_policy,
     )?;
     // Without a restart-stable native executor identity, durable

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -20,6 +20,7 @@ mod blob_orphan_auditor;
 mod blob_retirement_worker;
 mod bus;
 mod chat_titling;
+mod chatgpt_runtime;
 /// Host-owned code-execution provider selection and policy.
 pub mod code_execution;
 mod connected_apps;
@@ -433,6 +434,18 @@ pub fn app(state: AppState) -> Router {
         .route(
             "/providers/{kind}/credential",
             axum::routing::delete(routes::delete_provider_credential),
+        )
+        .route(
+            "/providers/openai/chatgpt/sign-in",
+            post(routes::post_openai_chatgpt_sign_in),
+        )
+        .route(
+            "/providers/openai/chatgpt/sign-out",
+            post(routes::post_openai_chatgpt_sign_out),
+        )
+        .route(
+            "/providers/openai/chatgpt/status",
+            get(routes::get_openai_chatgpt_status),
         )
         .merge(public_document_api)
         .merge(renderer_document_api)

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -270,9 +270,11 @@ impl ProviderKind {
 
     /// Whether this provider can use `credential` today.
     fn accepts_credential(self, credential: &ProviderCredential) -> bool {
-        matches!(credential, ProviderCredential::ApiKey { .. })
-            || (self == ProviderKind::Gemini
-                && matches!(credential, ProviderCredential::ServiceAccount { .. }))
+        match credential {
+            ProviderCredential::ApiKey { .. } => true,
+            ProviderCredential::Oauth {} => self == ProviderKind::Openai,
+            ProviderCredential::ServiceAccount { .. } => self == ProviderKind::Gemini,
+        }
     }
 }
 
@@ -739,8 +741,22 @@ pub struct ProviderInfo {
     pub vertex_location: Option<String>,
     /// Whether a credential is stored (never the credential itself).
     pub has_credential: bool,
+    /// How OpenAI (or similarly dual-mode providers) is authenticated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub auth_mode: Option<ProviderAuthMode>,
     /// Explicit custom model entries for this endpoint.
     pub models: Vec<CustomModelConfig>,
+}
+
+/// How a provider's credential was established.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderAuthMode {
+    /// Pasted / env API key.
+    ApiKey,
+    /// ChatGPT subscription OAuth.
+    Chatgpt,
 }
 
 /// Deserialize a present field (including JSON `null`) as `Some(..)`;
@@ -827,6 +843,17 @@ pub async fn write_credential(
     credential: &ProviderCredential,
 ) -> std::result::Result<(), ServerError> {
     credential.validate()?;
+    if !kind.accepts_credential(credential) {
+        return Err(ServerError::bad_request(format!(
+            "{kind} does not support this credential type"
+        )));
+    }
+    // Mutual exclusivity for OpenAI: an API key replaces ChatGPT OAuth.
+    if kind == ProviderKind::Openai && matches!(credential, ProviderCredential::ApiKey { .. }) {
+        let _ = secrets
+            .delete_secret(openwave_connectors::CHATGPT_SECRET_KEY)
+            .await;
+    }
     let raw = serde_json::to_string(credential)
         .map_err(|_| ServerError::internal("failed to serialize provider credential"))?;
     secrets
@@ -841,6 +868,11 @@ pub async fn delete_credential(secrets: &dyn SecretProvider, kind: ProviderKind)
     if kind == ProviderKind::Anthropic {
         secrets.delete_secret(LEGACY_ANTHROPIC_API_KEY).await?;
     }
+    if kind == ProviderKind::Openai {
+        let _ = secrets
+            .delete_secret(openwave_connectors::CHATGPT_SECRET_KEY)
+            .await;
+    }
     Ok(())
 }
 
@@ -849,11 +881,20 @@ pub async fn delete_credential(secrets: &dyn SecretProvider, kind: ProviderKind)
 pub async fn has_credential(secrets: &dyn SecretProvider, kind: ProviderKind) -> bool {
     match read_credential(secrets, kind).await {
         Ok(Some(credential)) => {
-            return credential.as_api_key().is_some_and(|key| !key.is_empty())
-                || (kind == ProviderKind::Gemini
-                    && credential.as_service_account().is_some_and(|json| {
-                        openwave_router::GoogleServiceAccount::from_json(json).is_ok()
-                    }));
+            if credential.as_api_key().is_some_and(|key| !key.is_empty()) {
+                return true;
+            }
+            if kind == ProviderKind::Gemini
+                && credential.as_service_account().is_some_and(|json| {
+                    openwave_router::GoogleServiceAccount::from_json(json).is_ok()
+                })
+            {
+                return true;
+            }
+            if kind == ProviderKind::Openai && matches!(credential, ProviderCredential::Oauth {}) {
+                return openwave_connectors::has_stored_chatgpt_credentials(secrets).await;
+            }
+            return false;
         }
         Err(_) => return false,
         Ok(None) => {}
@@ -863,6 +904,27 @@ pub async fn has_credential(secrets: &dyn SecretProvider, kind: ProviderKind) ->
         return openwave_connectors::has_stored_credentials(secrets).await;
     }
     env_api_key(kind).is_some()
+}
+
+async fn auth_mode_for(
+    secrets: &dyn SecretProvider,
+    kind: ProviderKind,
+) -> Option<ProviderAuthMode> {
+    if kind != ProviderKind::Openai {
+        return None;
+    }
+    match read_credential(secrets, kind).await.ok().flatten() {
+        Some(ProviderCredential::Oauth {})
+            if openwave_connectors::has_stored_chatgpt_credentials(secrets).await =>
+        {
+            Some(ProviderAuthMode::Chatgpt)
+        }
+        Some(ProviderCredential::ApiKey { key }) if !key.is_empty() => {
+            Some(ProviderAuthMode::ApiKey)
+        }
+        None if env_api_key(kind).is_some() => Some(ProviderAuthMode::ApiKey),
+        _ => None,
+    }
 }
 
 /// Build the public [`ProviderInfo`] for every known kind.
@@ -894,6 +956,7 @@ pub async fn list_providers(
                     }
                     None => false,
                 },
+                auth_mode: None,
                 models: gateway_models(store, policy).await?,
             });
             continue;
@@ -905,6 +968,7 @@ pub async fn list_providers(
             base_url: config.base_url.clone(),
             vertex_location: config.vertex_location.clone(),
             has_credential: has_credential(secrets, kind).await,
+            auth_mode: auth_mode_for(secrets, kind).await,
             models: config.models,
         });
     }
@@ -1000,11 +1064,6 @@ pub async fn update_provider(
 
     if let Some(credential) = update.credential {
         if let Some(json) = credential.as_service_account() {
-            if !kind.accepts_credential(&credential) {
-                return Err(ServerError::bad_request(format!(
-                    "{kind} does not support service_account credentials"
-                )));
-            }
             openwave_router::GoogleServiceAccount::from_json(json).map_err(|_| {
                 ServerError::bad_request("invalid Google service-account credential")
             })?;
@@ -1020,6 +1079,7 @@ pub async fn update_provider(
         base_url: config.base_url.clone(),
         vertex_location: config.vertex_location.clone(),
         has_credential: has_credential(secrets, kind).await,
+        auth_mode: auth_mode_for(secrets, kind).await,
         models: config.models,
     })
 }
@@ -1151,8 +1211,9 @@ pub fn route_kind(kind: ProviderKind) -> openwave_router::RouteKind {
 /// Collect enabled, credentialed routes for the composite router.
 ///
 /// A kind with no usable credential is skipped. Gemini service accounts become
-/// Vertex routes; API keys remain Developer API routes. Store-read failures for
-/// a single kind skip that kind (fail closed for it) rather than aborting the
+/// Vertex routes; API keys remain Developer API routes. OpenAI ChatGPT OAuth
+/// becomes a Codex-backend route via `chatgpt`. Store-read failures for a
+/// single kind skip that kind (fail closed for it) rather than aborting the
 /// whole list.
 ///
 /// On a managed profile only the gateway route is offered: BYOK kinds are
@@ -1165,6 +1226,10 @@ pub async fn collect_routes(
     store: &dyn Store,
     secrets: &dyn SecretProvider,
     gateway_tokens: Option<std::sync::Arc<dyn openwave_router::BearerTokenSource>>,
+    chatgpt: Option<(
+        std::sync::Arc<dyn openwave_router::BearerTokenSource>,
+        String,
+    )>,
     policy: &crate::managed_policy::ManagedPolicy,
 ) -> Vec<openwave_router::Route> {
     let mut routes = Vec::new();
@@ -1192,6 +1257,7 @@ pub async fn collect_routes(
                 curated_models: models.into_iter().map(|model| model.id).collect(),
                 token_source: Some(source),
                 vertex: None,
+                chatgpt_account_id: None,
             });
             continue;
         }
@@ -1210,6 +1276,25 @@ pub async fn collect_routes(
             Ok(credential) => credential,
             Err(_) => continue,
         };
+        if kind == ProviderKind::Openai
+            && matches!(stored_credential, Some(ProviderCredential::Oauth {}))
+        {
+            let Some((source, account_id)) = chatgpt.clone() else {
+                continue;
+            };
+            routes.push(openwave_router::Route {
+                kind: route_kind(kind),
+                api_key: String::new(),
+                base_url: Some(openwave_connectors::CODEX_BASE_URL.to_string()),
+                curated_models: model_registry::models_for(kind)
+                    .map(|spec| spec.id.to_string())
+                    .collect(),
+                token_source: Some(source),
+                vertex: None,
+                chatgpt_account_id: Some(account_id),
+            });
+            continue;
+        }
         if kind == ProviderKind::Gemini {
             if let Some(ProviderCredential::ServiceAccount { json }) = stored_credential.as_ref() {
                 let Ok(account) = openwave_router::GoogleServiceAccount::from_json(json) else {
@@ -1239,6 +1324,7 @@ pub async fn collect_routes(
                         location,
                         credential_fingerprint,
                     )),
+                    chatgpt_account_id: None,
                 });
                 continue;
             }
@@ -1273,6 +1359,7 @@ pub async fn collect_routes(
                 .collect(),
             token_source: None,
             vertex: None,
+            chatgpt_account_id: None,
         });
     }
     routes
@@ -1545,8 +1632,9 @@ mod tests {
                 ProviderKind::Anthropic,
                 ProviderCredential::api_key("existing-api-key"),
             ),
+            (ProviderKind::Openai, ProviderCredential::Oauth {}),
             (
-                ProviderKind::Openai,
+                ProviderKind::Gemini,
                 ProviderCredential::ServiceAccount {
                     json: r#"{"type":"service_account","client_email":"service-account@example.test","private_key":"test-private-key","project_id":"test-project"}"#.to_owned(),
                 },

--- a/crates/openwave-server/src/resolver.rs
+++ b/crates/openwave-server/src/resolver.rs
@@ -50,24 +50,30 @@ pub struct ConfiguredResolver {
     store: Arc<dyn Store>,
     secrets: Arc<dyn SecretProvider>,
     gateway: Arc<crate::gateway_runtime::GatewayRuntime>,
+    chatgpt: Arc<crate::chatgpt_runtime::ChatGptRuntime>,
     os_policy: Arc<dyn crate::managed_policy::OsPolicySource>,
     cached: Mutex<CachedProvider>,
 }
 
 impl ConfiguredResolver {
     /// A resolver that reads provider config from `store` and credentials from
-    /// `secrets`, with `gateway` supplying the model-gateway token source and
-    /// `os_policy` the OS authority for managed-mode resolution.
+    /// `secrets`, with `gateway` and `chatgpt` supplying their OAuth token
+    /// sources and `os_policy` the OS authority for managed-mode resolution.
+    ///
+    /// Both OAuth runtimes must be the same instances the rest of the process
+    /// holds — see [`crate::state::AppState::with_gateway_runtime`].
     pub fn new(
         store: Arc<dyn Store>,
         secrets: Arc<dyn SecretProvider>,
         gateway: Arc<crate::gateway_runtime::GatewayRuntime>,
+        chatgpt: Arc<crate::chatgpt_runtime::ChatGptRuntime>,
         os_policy: Arc<dyn crate::managed_policy::OsPolicySource>,
     ) -> Self {
         Self {
             store,
             secrets,
             gateway,
+            chatgpt,
             os_policy,
             cached: Mutex::new(None),
         }
@@ -87,9 +93,7 @@ impl ProviderResolver for ConfiguredResolver {
             return Arc::new(UnconfiguredProvider);
         };
         let gateway_tokens = self.gateway.route_token_source().await;
-        let chatgpt =
-            crate::chatgpt_runtime::ChatGptRuntime::route_auth_from_secrets(self.secrets.clone())
-                .await;
+        let chatgpt = self.chatgpt.route_auth().await;
         let routes = providers::collect_routes(
             &*self.store,
             &*self.secrets,

--- a/crates/openwave-server/src/resolver.rs
+++ b/crates/openwave-server/src/resolver.rs
@@ -87,8 +87,17 @@ impl ProviderResolver for ConfiguredResolver {
             return Arc::new(UnconfiguredProvider);
         };
         let gateway_tokens = self.gateway.route_token_source().await;
-        let routes =
-            providers::collect_routes(&*self.store, &*self.secrets, gateway_tokens, &policy).await;
+        let chatgpt =
+            crate::chatgpt_runtime::ChatGptRuntime::route_auth_from_secrets(self.secrets.clone())
+                .await;
+        let routes = providers::collect_routes(
+            &*self.store,
+            &*self.secrets,
+            gateway_tokens,
+            chatgpt,
+            &policy,
+        )
+        .await;
         let router = Router::build(routes);
         let fingerprint = router.fingerprint().to_string();
 

--- a/crates/openwave-server/src/routes/providers_models.rs
+++ b/crates/openwave-server/src/routes/providers_models.rs
@@ -227,6 +227,16 @@ pub async fn put_provider(
 ) -> Result<Json<ProviderInfo>, ServerError> {
     let kind = ProviderKind::parse(&kind)
         .ok_or_else(|| ServerError::not_found(format!("unknown provider kind: {kind}")))?;
+    if kind == ProviderKind::Openai
+        && matches!(
+            body.credential,
+            Some(providers::ProviderCredential::ApiKey { .. })
+        )
+    {
+        // The write below clears the ChatGPT vault, but a sign-in still in
+        // flight would repopulate it and replace the key the user just chose.
+        state.chatgpt.cancel_pending().await;
+    }
     let info = providers::update_provider(
         &*state.store,
         &*state.secrets,

--- a/crates/openwave-server/src/routes/providers_models.rs
+++ b/crates/openwave-server/src/routes/providers_models.rs
@@ -247,9 +247,10 @@ pub async fn delete_provider_credential(
         .ok_or_else(|| ServerError::not_found(format!("unknown provider kind: {kind}")))?;
     refuse_credential_writes_when_managed(&state).await?;
     if kind == ProviderKind::Openai {
-        // Prefer the ChatGPT runtime so an in-flight sign-in is cancelled too.
+        // Revoke through the runtime first so an in-flight sign-in is
+        // cancelled; the delete below still has to run because the stored
+        // credential may be an API key rather than the OAuth marker.
         state.chatgpt.sign_out().await?;
-        return Ok(StatusCode::NO_CONTENT);
     }
     providers::delete_credential(&*state.secrets, kind).await?;
     Ok(StatusCode::NO_CONTENT)
@@ -262,7 +263,9 @@ pub async fn post_openai_chatgpt_sign_in(
 ) -> Result<Json<serde_json::Value>, ServerError> {
     refuse_credential_writes_when_managed(&state).await?;
     let authorization_url = state.chatgpt.begin_sign_in().await?;
-    Ok(Json(serde_json::json!({ "authorization_url": authorization_url })))
+    Ok(Json(
+        serde_json::json!({ "authorization_url": authorization_url }),
+    ))
 }
 
 /// `POST /providers/openai/chatgpt/sign-out` — revoke and clear ChatGPT OAuth.

--- a/crates/openwave-server/src/routes/providers_models.rs
+++ b/crates/openwave-server/src/routes/providers_models.rs
@@ -239,6 +239,10 @@ pub async fn put_provider(
         // the write and replace the key) and revokes the refresh token
         // instead of dropping it locally while it stays live at OpenAI.
         state.chatgpt.sign_out().await?;
+    } else if kind == ProviderKind::Openai && body.enabled == Some(false) {
+        // Completing sign-in forces enabled=true. Drop an in-flight attempt
+        // so it cannot overwrite an explicit disable that landed first.
+        state.chatgpt.cancel_pending().await;
     }
     let info = providers::update_provider(
         &*state.store,

--- a/crates/openwave-server/src/routes/providers_models.rs
+++ b/crates/openwave-server/src/routes/providers_models.rs
@@ -233,9 +233,12 @@ pub async fn put_provider(
             Some(providers::ProviderCredential::ApiKey { .. })
         )
     {
-        // The write below clears the ChatGPT vault, but a sign-in still in
-        // flight would repopulate it and replace the key the user just chose.
-        state.chatgpt.cancel_pending().await;
+        // Switching to a key retires the subscription session. Sign out
+        // rather than letting the write clear the vault on its own: that
+        // cancels a sign-in still in flight (it would otherwise land after
+        // the write and replace the key) and revokes the refresh token
+        // instead of dropping it locally while it stays live at OpenAI.
+        state.chatgpt.sign_out().await?;
     }
     let info = providers::update_provider(
         &*state.store,

--- a/crates/openwave-server/src/routes/providers_models.rs
+++ b/crates/openwave-server/src/routes/providers_models.rs
@@ -246,8 +246,39 @@ pub async fn delete_provider_credential(
     let kind = ProviderKind::parse(&kind)
         .ok_or_else(|| ServerError::not_found(format!("unknown provider kind: {kind}")))?;
     refuse_credential_writes_when_managed(&state).await?;
+    if kind == ProviderKind::Openai {
+        // Prefer the ChatGPT runtime so an in-flight sign-in is cancelled too.
+        state.chatgpt.sign_out().await?;
+        return Ok(StatusCode::NO_CONTENT);
+    }
     providers::delete_credential(&*state.secrets, kind).await?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+/// `POST /providers/openai/chatgpt/sign-in` — start ChatGPT OAuth; returns the
+/// browser URL. Completion is asynchronous; poll `GET /providers`.
+pub async fn post_openai_chatgpt_sign_in(
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>, ServerError> {
+    refuse_credential_writes_when_managed(&state).await?;
+    let authorization_url = state.chatgpt.begin_sign_in().await?;
+    Ok(Json(serde_json::json!({ "authorization_url": authorization_url })))
+}
+
+/// `POST /providers/openai/chatgpt/sign-out` — revoke and clear ChatGPT OAuth.
+pub async fn post_openai_chatgpt_sign_out(
+    State(state): State<AppState>,
+) -> Result<StatusCode, ServerError> {
+    refuse_credential_writes_when_managed(&state).await?;
+    state.chatgpt.sign_out().await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `GET /providers/openai/chatgpt/status` — pending / signed-in / error.
+pub async fn get_openai_chatgpt_status(
+    State(state): State<AppState>,
+) -> Result<Json<crate::chatgpt_runtime::ChatGptSignInStatus>, ServerError> {
+    Ok(Json(state.chatgpt.status().await))
 }
 
 pub async fn get_voice_transcription(

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -139,6 +139,8 @@ pub struct AppState {
     /// through — see [`Self::with_gateway_runtime`] for why the process
     /// must hold exactly one.
     pub(crate) gateway: Arc<crate::gateway_runtime::GatewayRuntime>,
+    /// ChatGPT subscription OAuth for the OpenAI provider (sign-in / sign-out).
+    pub(crate) chatgpt: Arc<crate::chatgpt_runtime::ChatGptRuntime>,
     /// The OS-managed policy reader for managed-mode resolution. Directly
     /// assembled state (tests, custom hosts) gets the source that asserts
     /// nothing, so it reads nothing from the host OS; the production
@@ -324,6 +326,10 @@ impl AppState {
             os_policy.clone(),
         ));
         let rest_dispatch = crate::connected_apps::governed_rest_dispatcher(secrets.clone());
+        let chatgpt = Arc::new(crate::chatgpt_runtime::ChatGptRuntime::new(
+            store.clone(),
+            secrets.clone(),
+        )?);
         Ok(Self {
             config: Arc::new(config),
             store: store.clone(),
@@ -335,6 +341,7 @@ impl AppState {
             rest_dispatch,
             view_frames: Arc::default(),
             gateway,
+            chatgpt,
             os_policy,
             turn_job_wake: Arc::new(Notify::new()),
             agent_run_wake: Arc::new(Notify::new()),

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -139,7 +139,9 @@ pub struct AppState {
     /// through — see [`Self::with_gateway_runtime`] for why the process
     /// must hold exactly one.
     pub(crate) gateway: Arc<crate::gateway_runtime::GatewayRuntime>,
-    /// ChatGPT subscription OAuth for the OpenAI provider (sign-in / sign-out).
+    /// ChatGPT subscription OAuth for the OpenAI provider (sign-in, sign-out,
+    /// per-request tokens). Shared with the resolver for the reason given in
+    /// [`Self::with_gateway_runtime`].
     pub(crate) chatgpt: Arc<crate::chatgpt_runtime::ChatGptRuntime>,
     /// The OS-managed policy reader for managed-mode resolution. Directly
     /// assembled state (tests, custom hosts) gets the source that asserts
@@ -259,6 +261,10 @@ impl AppState {
             secrets.clone(),
             os_policy.clone(),
         );
+        let chatgpt = Arc::new(crate::chatgpt_runtime::ChatGptRuntime::new(
+            store.clone(),
+            secrets.clone(),
+        )?);
         Self::with_gateway_runtime(
             config,
             store,
@@ -268,6 +274,7 @@ impl AppState {
             agent_config,
             client_executor_id,
             gateway,
+            chatgpt,
             os_policy,
         )
     }
@@ -284,6 +291,11 @@ impl AppState {
     /// Refresh rotation is likewise serialized per instance; two instances
     /// over the same keychain entry can race a stale refresh token into the
     /// gateway's reuse detection (a spurious full sign-out).
+    ///
+    /// `chatgpt` is shared for the same reason: the resolver's per-request
+    /// token source and the `/providers/openai/chatgpt` routes refresh and
+    /// revoke the one stored subscription session, and only a shared instance
+    /// serializes them.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn with_gateway_runtime(
         config: Config,
@@ -294,6 +306,7 @@ impl AppState {
         agent_config: AgentConfig,
         client_executor_id: Uuid,
         gateway: Arc<crate::gateway_runtime::GatewayRuntime>,
+        chatgpt: Arc<crate::chatgpt_runtime::ChatGptRuntime>,
         os_policy: Arc<dyn crate::managed_policy::OsPolicySource>,
     ) -> Result<Self> {
         if client_executor_id.is_nil() {
@@ -326,10 +339,6 @@ impl AppState {
             os_policy.clone(),
         ));
         let rest_dispatch = crate::connected_apps::governed_rest_dispatcher(secrets.clone());
-        let chatgpt = Arc::new(crate::chatgpt_runtime::ChatGptRuntime::new(
-            store.clone(),
-            secrets.clone(),
-        )?);
         Ok(Self {
             config: Arc::new(config),
             store: store.clone(),

--- a/crates/openwave-server/src/tests/chat_titling.rs
+++ b/crates/openwave-server/src/tests/chat_titling.rs
@@ -128,6 +128,10 @@ async fn titling_app(
                 secrets.clone(),
                 Arc::new(crate::managed_policy::NoOsPolicy),
             ),
+            Arc::new(
+                crate::chatgpt_runtime::ChatGptRuntime::new(store.clone(), secrets.clone())
+                    .unwrap(),
+            ),
             Arc::new(crate::managed_policy::NoOsPolicy),
         )),
         secrets,

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -2003,9 +2003,11 @@ async fn malformed_gemini_service_account_never_advertises_or_builds_a_route() {
     )
     .await
     .unwrap());
-    assert!(providers::collect_routes(&*store, &*secrets, None, None, &policy)
-        .await
-        .is_empty());
+    assert!(
+        providers::collect_routes(&*store, &*secrets, None, None, &policy)
+            .await
+            .is_empty()
+    );
     assert!(providers::catalog_models(&*store, &*secrets, &policy)
         .await
         .unwrap()
@@ -2167,7 +2169,8 @@ async fn a_managed_profile_offers_only_the_gateway_route() {
     let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
         .await
         .unwrap();
-    let routes = providers::collect_routes(&*store, &*secrets, Some(tokens.clone()), None, &policy).await;
+    let routes =
+        providers::collect_routes(&*store, &*secrets, Some(tokens.clone()), None, &policy).await;
     assert_eq!(routes.len(), 1);
     assert_eq!(routes[0].kind, openwave_router::RouteKind::ModelGateway);
     assert_eq!(

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -1933,7 +1933,7 @@ async fn resolver_includes_configured_curated_api_key_providers() {
         let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
             .await
             .unwrap();
-        let routes = providers::collect_routes(&*store, &*secrets, None, &policy).await;
+        let routes = providers::collect_routes(&*store, &*secrets, None, None, &policy).await;
         assert_eq!(routes.len(), 1);
         assert_eq!(routes[0].kind, route_kind);
 
@@ -2003,7 +2003,7 @@ async fn malformed_gemini_service_account_never_advertises_or_builds_a_route() {
     )
     .await
     .unwrap());
-    assert!(providers::collect_routes(&*store, &*secrets, None, &policy)
+    assert!(providers::collect_routes(&*store, &*secrets, None, None, &policy)
         .await
         .is_empty());
     assert!(providers::catalog_models(&*store, &*secrets, &policy)
@@ -2049,7 +2049,7 @@ async fn openai_compatible_route_is_free_form_fallback() {
     let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
         .await
         .unwrap();
-    let routes = providers::collect_routes(&*store, &*secrets, None, &policy).await;
+    let routes = providers::collect_routes(&*store, &*secrets, None, None, &policy).await;
     let router = openwave_router::Router::build(routes);
     assert_eq!(
         router.select("llama-3-local"),
@@ -2150,7 +2150,7 @@ async fn a_managed_profile_offers_only_the_gateway_route() {
         .await
         .unwrap();
     let kinds: Vec<_> =
-        providers::collect_routes(&*store, &*secrets, Some(tokens.clone()), &policy)
+        providers::collect_routes(&*store, &*secrets, Some(tokens.clone()), None, &policy)
             .await
             .into_iter()
             .map(|route| route.kind)
@@ -2167,7 +2167,7 @@ async fn a_managed_profile_offers_only_the_gateway_route() {
     let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
         .await
         .unwrap();
-    let routes = providers::collect_routes(&*store, &*secrets, Some(tokens.clone()), &policy).await;
+    let routes = providers::collect_routes(&*store, &*secrets, Some(tokens.clone()), None, &policy).await;
     assert_eq!(routes.len(), 1);
     assert_eq!(routes[0].kind, openwave_router::RouteKind::ModelGateway);
     assert_eq!(
@@ -2194,7 +2194,7 @@ async fn a_managed_profile_offers_only_the_gateway_route() {
     )
     .await
     .unwrap();
-    let routes = providers::collect_routes(&*store, &*secrets, Some(tokens), &policy).await;
+    let routes = providers::collect_routes(&*store, &*secrets, Some(tokens), None, &policy).await;
     assert_eq!(routes.len(), 1);
     assert_eq!(routes[0].kind, openwave_router::RouteKind::ModelGateway);
 }

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -1323,6 +1323,10 @@ async fn configured_router_canonicalizes_typed_models_and_rejects_wrong_or_unava
                 secrets.clone(),
                 Arc::new(crate::managed_policy::NoOsPolicy),
             ),
+            Arc::new(
+                crate::chatgpt_runtime::ChatGptRuntime::new(store.clone(), secrets.clone())
+                    .unwrap(),
+            ),
             Arc::new(crate::managed_policy::NoOsPolicy),
         )),
         secrets,
@@ -1468,6 +1472,10 @@ async fn model_roles_resolve_at_read_time_and_honor_an_explicit_pin() {
                 store.clone(),
                 secrets.clone(),
                 Arc::new(crate::managed_policy::NoOsPolicy),
+            ),
+            Arc::new(
+                crate::chatgpt_runtime::ChatGptRuntime::new(store.clone(), secrets.clone())
+                    .unwrap(),
             ),
             Arc::new(crate::managed_policy::NoOsPolicy),
         )),
@@ -1848,6 +1856,9 @@ async fn resolver_builds_a_router_from_enabled_providers() {
             secrets.clone(),
             Arc::new(crate::managed_policy::NoOsPolicy),
         ),
+        Arc::new(
+            crate::chatgpt_runtime::ChatGptRuntime::new(store.clone(), secrets.clone()).unwrap(),
+        ),
         Arc::new(crate::managed_policy::NoOsPolicy),
     );
     let resolved = resolver.resolve().await;
@@ -1944,6 +1955,10 @@ async fn resolver_includes_configured_curated_api_key_providers() {
                 store.clone(),
                 secrets.clone(),
                 Arc::new(crate::managed_policy::NoOsPolicy),
+            ),
+            Arc::new(
+                crate::chatgpt_runtime::ChatGptRuntime::new(store.clone(), secrets.clone())
+                    .unwrap(),
             ),
             Arc::new(crate::managed_policy::NoOsPolicy),
         );
@@ -2243,6 +2258,9 @@ async fn an_unreadable_policy_fails_the_resolver_closed() {
             secrets.clone(),
             Arc::new(crate::managed_policy::NoOsPolicy),
         ),
+        Arc::new(
+            crate::chatgpt_runtime::ChatGptRuntime::new(store.clone(), secrets.clone()).unwrap(),
+        ),
         Arc::new(crate::managed_policy::NoOsPolicy),
     );
     assert_eq!(resolver.resolve().await.id().0, "router");
@@ -2302,6 +2320,10 @@ async fn a_misconfigured_policy_gates_the_renderer_and_refuses_a_turn() {
                 store.clone(),
                 secrets.clone(),
                 Arc::new(crate::managed_policy::NoOsPolicy),
+            ),
+            Arc::new(
+                crate::chatgpt_runtime::ChatGptRuntime::new(store.clone(), secrets.clone())
+                    .unwrap(),
             ),
             Arc::new(crate::managed_policy::NoOsPolicy),
         )),

--- a/crates/openwave-server/src/tests/image_attachment.rs
+++ b/crates/openwave-server/src/tests/image_attachment.rs
@@ -680,6 +680,10 @@ async fn a_turn_carrying_images_against_a_text_only_model_is_refused() {
                 secrets.clone(),
                 Arc::new(crate::managed_policy::NoOsPolicy),
             ),
+            Arc::new(
+                crate::chatgpt_runtime::ChatGptRuntime::new(store.clone(), secrets.clone())
+                    .unwrap(),
+            ),
             Arc::new(crate::managed_policy::NoOsPolicy),
         )),
         secrets,
@@ -787,6 +791,10 @@ async fn a_curated_openai_model_answers_after_receiving_png_and_jpeg_attachments
                 store.clone(),
                 secrets.clone(),
                 Arc::new(crate::managed_policy::NoOsPolicy),
+            ),
+            Arc::new(
+                crate::chatgpt_runtime::ChatGptRuntime::new(store.clone(), secrets.clone())
+                    .unwrap(),
             ),
             Arc::new(crate::managed_policy::NoOsPolicy),
         )),

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -353,6 +353,8 @@ mod tests {
         generate::collect_from::<crate::routes::ModelRoleInfo>(&cfg, &mut out);
         generate::collect_from::<crate::routes::ChatTranscript>(&cfg, &mut out);
         generate::collect_from::<crate::providers::ProviderInfo>(&cfg, &mut out);
+        generate::collect_from::<crate::providers::ProviderAuthMode>(&cfg, &mut out);
+        generate::collect_from::<crate::chatgpt_runtime::ChatGptSignInStatus>(&cfg, &mut out);
         generate::collect_from::<crate::web_search::WebSearchConfigInfo>(&cfg, &mut out);
         generate::collect_from::<crate::web_search::WebSearchCredentialReadiness>(&cfg, &mut out);
         generate::collect_from::<crate::code_execution::CodeExecutionConfigInfo>(&cfg, &mut out);


### PR DESCRIPTION
## Summary
- Add Codex-compatible ChatGPT OAuth (PKCE on `localhost:1455`) so unmanaged profiles can authenticate the OpenAI provider with a Plus/Pro subscription instead of only a Platform API key.
- Route ChatGPT-authed turns through the Codex Responses backend with live bearer tokens, account-id headers, and `originator: openwave`; API-key auth stays on `api.openai.com`.
- Providers UI offers Sign in with ChatGPT / Sign out alongside the API-key path, with `auth_mode` on `ProviderInfo`.

## Test plan
- [ ] `cargo test -p openwave-connectors --test chatgpt_flow`
- [ ] `cargo test -p openwave-router chatgpt_oauth`
- [ ] `cargo test -p openwave-server credentials_roundtrip_through_secret_storage`
- [ ] Providers → OpenAI → Sign in with ChatGPT completes in the browser and status shows Signed in with ChatGPT
- [ ] A turn with a curated OpenAI model succeeds on the ChatGPT path
- [ ] Saving an API key clears ChatGPT OAuth (and vice versa / Sign out)
- [ ] Managed profiles still hide BYO OpenAI credentials


Made with [Cursor](https://cursor.com)