### PR TITLE
fix(server): satisfy clippy on compaction fraction validation

### DIFF
--- a/crates/openwave-server/src/routes/settings.rs
+++ b/crates/openwave-server/src/routes/settings.rs
@@ -251,7 +251,10 @@ fn validate_compaction_settings(settings: &CompactionSettings) -> Result<(), Ser
             "compaction.target_fraction must be in (0, 1]",
         ));
     }
-    if !(settings.threshold_fraction > settings.target_fraction) {
+    // Both fractions are already known to be ordinary numbers in (0, 1], so
+    // this reads the same as rejecting `!(threshold > target)` without the
+    // negated partial-order comparison.
+    if settings.threshold_fraction <= settings.target_fraction {
         return Err(ServerError::bad_request(
             "compaction.threshold_fraction must be greater than compaction.target_fraction",
         ));


### PR DESCRIPTION
## Summary
- Main CI clippy failed on `!(settings.threshold_fraction > settings.target_fraction)` after #1752 (`clippy::neg_cmp_op_on_partial_ord`).
- Rewrite the check as `threshold_fraction <= target_fraction`; same acceptance for ordinary floats already validated into `(0, 1]`.

## Test plan
- [x] `cargo clippy -p openwave-server --locked --all-targets`
- [ ] Confirm clippy lane green on this PR / after merge on main

Made with [Cursor](https://cursor.com)