### PR TITLE
fix: clear Windows CI warnings and stabilize audit rotation test

### DIFF
--- a/crates/openwave-code-execution/src/overlay.rs
+++ b/crates/openwave-code-execution/src/overlay.rs
@@ -1039,7 +1039,7 @@ async fn observe_prior(
                 mode: Some(stamp.mode),
             })
         }
-        Some(stamp) => {
+        Some(_stamp) => {
             let bytes = match target.read_file(name).await {
                 Ok(bytes) => bytes,
                 Err(error) if error.kind() == io::ErrorKind::NotFound => {
@@ -1057,7 +1057,7 @@ async fn observe_prior(
                 prior: PriorContents::Bytes(bytes),
                 precondition: FilePrecondition::Sha256(sha256),
                 #[cfg(unix)]
-                mode: Some(stamp.mode),
+                mode: Some(_stamp.mode),
             })
         }
     }

--- a/crates/openwave-host-broker/src/audit.rs
+++ b/crates/openwave-host-broker/src/audit.rs
@@ -753,7 +753,15 @@ mod tests {
     fn interrupted_rotation_reports_the_ambiguity_then_recovers_in_place() {
         let temp = tempfile::tempdir().unwrap();
         let first = event(AuditTarget::Subject);
-        let line_bytes = serde_json::to_vec(&first).unwrap().len() as u64 + 1;
+        let second = event(AuditTarget::Subject);
+        let first_len = serde_json::to_vec(&first).unwrap().len();
+        let second_len = serde_json::to_vec(&second).unwrap().len();
+        // Rotation triggers on a strict `>` bound. Follow-up events pick up new
+        // UUID/timestamp bytes, so cap the file from the first line and require
+        // later lines to stay within it — otherwise recovery can append into a
+        // fresh active file and spuriously rotate, wiping the archive on Windows.
+        assert!(second_len <= first_len);
+        let line_bytes = first_len as u64 + 1;
         let sink = JsonlAuditSink::open(temp.path()).with_max_file_bytes(line_bytes);
         sink.record(&first).unwrap();
         sink.writer.lock().unwrap().fail_rotation_after_archive_once = true;
@@ -762,7 +770,6 @@ mod tests {
             Err(AuditError::PublicationAmbiguous)
         ));
 
-        let second = event(AuditTarget::Subject);
         sink.record(&second).unwrap();
         let archive = fs::read_to_string(temp.path().join(AUDIT_ARCHIVE_NAME)).unwrap();
         let current = fs::read_to_string(temp.path().join(AUDIT_FILE_NAME)).unwrap();

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -2617,10 +2617,14 @@ fn private_chat_scratch(
         }
         Ok(_) => {}
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            let mut builder = DirBuilder::new();
             #[cfg(unix)]
-            builder.mode(0o700);
-            root_dir.create_dir_with(&chat_name, &builder)?;
+            {
+                let mut builder = DirBuilder::new();
+                builder.mode(0o700);
+                root_dir.create_dir_with(&chat_name, &builder)?;
+            }
+            #[cfg(not(unix))]
+            root_dir.create_dir(&chat_name)?;
         }
         Err(error) => return Err(error),
     }


### PR DESCRIPTION
## Summary
- Silence Windows-only `unused variable: stamp` in `openwave-code-execution` overlay observation.
- Silence Windows-only `unused mut` on chat scratch `DirBuilder` creation in `openwave-server`.
- Fix flaky/failing `interrupted_rotation_reports_the_ambiguity_then_recovers_in_place` on Windows: follow-up audit events can serialize larger than the first line, so recovery could spuriously rotate and wipe the archive.

## Test plan
- [x] `cargo clippy -p openwave-code-execution -p openwave-server -p openwave-host-broker --locked --all-targets`
- [x] `cargo test -p openwave-host-broker --lib audit::tests --locked`
- [ ] Windows cargo check lane green on merge

Made with [Cursor](https://cursor.com)