### PR TITLE
fix(sandbox): update npm for documents image

### DIFF
--- a/crates/openwave-sandbox-agent/Dockerfile
+++ b/crates/openwave-sandbox-agent/Dockerfile
@@ -147,20 +147,23 @@ RUN apt-get update \
     && mkdir -p /opt/openwave/exec-scripts
 
 # Node.js, for the JavaScript deck path: pptxgenjs builds a PPTX from script
-# without the layout gymnastics the Python route needs for the same slide. Only
-# the interpreter and the bundled npm are taken from the pinned distribution
-# image — the `npm`/`npx` entry points are the symlinks that image ships,
-# recreated here explicitly so what lands on PATH is visible in this file.
+# without the layout gymnastics the Python route needs for the same slide. The
+# interpreter and npm bootstrap come from the pinned distribution image; npm is
+# replaced with an exact compatible pin below so its bundled dependency tree is
+# updated independently of Node releases. The `npm`/`npx` entry points are the
+# symlinks that image ships, recreated here explicitly so what lands on PATH is
+# visible in this file.
 COPY --from=nodedist /usr/local/bin/node /usr/local/bin/node
 COPY --from=nodedist /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
     && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
-# The deck library, pinned exactly like the Python closure and installed
-# globally at build time so a run needs no `npm install` and no registry
-# egress. npm verifies each package against the registry's integrity hash on
-# install, which is the equivalent of pip's `--require-hashes` here.
-RUN npm install --global --no-audit --no-fund --loglevel=error pptxgenjs@4.0.1 \
+# npm and the deck library are pinned exactly like the Python closure and
+# installed globally at build time so a run needs no package-manager egress.
+# npm verifies each package against the registry's integrity hash on install,
+# which is the equivalent of pip's `--require-hashes` here.
+RUN npm install --global --no-audit --no-fund --loglevel=error npm@10.9.9 \
+    && npm install --global --no-audit --no-fund --loglevel=error pptxgenjs@4.0.1 \
     && npm cache clean --force \
     && rm -rf /root/.npm
 


### PR DESCRIPTION
## Summary

- replace the Node base image’s bundled npm with an exact `npm@10.9.9` pin
- keep `pptxgenjs@4.0.1` pinned and installed globally for network-free document runs
- update npm’s bundled `tar` from 6.2.1 to 7.5.22, clearing CVE-2026-59873

## Why

The `v0.34.0` sandbox-image publish run built and smoke-tested both image variants, then failed the pre-push Trivy gate because the documents image inherited `tar@6.2.1` from `npm@10.8.2` in the pinned Node 20 base image.

Failed run: https://github.com/brightwave-inc/openwave/actions/runs/31136038148/job/92735522211

## Testing

- `node --test scripts/sandbox-image-pins.test.mjs scripts/workflow-security.test.mjs`
- `docker build --file crates/openwave-sandbox-agent/Dockerfile --target documents --tag openwave-sandbox-agent-documents:pr-npm-fix .`
- verified the built image contains `npm@10.9.9` and `tar@7.5.22`
- ran the workflow’s Python, LibreOffice, and PptxGenJS smoke checks
- ran Trivy 0.73.0 with `--severity CRITICAL --ignore-unfixed --exit-code 1`; zero findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time-only change to the documents image’s npm closure; no runtime agent or auth logic changes, with PR testing including image build, smoke checks, and Trivy.
> 
> **Overview**
> The **documents** sandbox image now **replaces** the Node base image’s bundled npm with a global **`npm@10.9.9`** install before the existing **`pptxgenjs@4.0.1`** pin, so npm’s dependency tree (including **`tar`**) can be updated without changing the Node digest.
> 
> Comments in the Dockerfile were updated to describe that npm is intentionally pinned separately from Node. **`pptxgenjs`** and the global install / **`NODE_PATH`** behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bd94ec38b5f2635c14351859987de20026f6f42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->