### PR TITLE
fix: preserve replayed turns and approved spawns

### DIFF
--- a/crates/openwave-core/src/agent/turn.rs
+++ b/crates/openwave-core/src/agent/turn.rs
@@ -296,21 +296,35 @@ impl Agent {
                 .await?;
         }
         if !self.pending_sandbox_spawns.is_empty() {
-            let Some(steer_revision) = self.pending_sandbox_spawn_steer_revision else {
+            let Some(mut steer_revision) = self.pending_sandbox_spawn_steer_revision else {
                 return Err(AgentError::Store(
                     "pending sandbox spawns require a durably claimed turn".into(),
                 ));
             };
-            // Every spawn from the batch passes the gate, not just the first
-            // one the step yielded: the model can name several delegations in
-            // one step, and a card for one of them is not consent for the rest.
-            // A refused spawn is answered in place and the batch moves on.
+            // A steer can land after one sibling's approval commits but before
+            // its spawn checkpoint. Apply it before replaying that admitted
+            // request, then fence the checkpoint with the resulting durable
+            // revision. If the whole carried queue is refused below, the
+            // transcript reload that follows picks these persisted steers up.
+            let mut applied_steers = Vec::new();
+            self.apply_steers(chat, turn_id, &mut applied_steers, None, events)
+                .await?;
+            if let Some(revision) = self.durable_generation_revision(turn_id).await? {
+                steer_revision = revision;
+            }
+            // An already-gated head keeps the approval the reader committed;
+            // every still-ungated sibling passes the gate independently. A
+            // card for one delegation is not consent for the rest, and a
+            // refused sibling is answered in place before the batch moves on.
             for index in 0..self.pending_sandbox_spawns.len() {
                 let request = self.pending_sandbox_spawns[index].clone();
-                match self
-                    .gate_sandbox_spawn(chat, turn_id, &request, events)
-                    .await?
-                {
+                let gate = if request.approval_gated {
+                    SandboxSpawnGate::Admit(request)
+                } else {
+                    self.gate_sandbox_spawn(chat, turn_id, &request, events)
+                        .await?
+                };
+                match gate {
                     SandboxSpawnGate::Admit(request) => {
                         return Ok(AgentTurnOutcome::SandboxAgentSpawn {
                             request,

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -761,7 +761,7 @@ pub(in crate::db) async fn get_chat_transcript(
     let message_document_attachments =
         super::message_document_attachment::list_for_chat_on(&transaction, chat_id).await?;
     let citations = super::citation::list_snapshots_on(&transaction, chat_id).await?;
-    let terminal_turns = list_terminal_turns_on(&transaction, chat_id).await?;
+    let terminal_turns = list_terminal_turns_on(&transaction, chat_id, &messages).await?;
     let tool_activity = list_terminal_tool_activity_on(&transaction, chat_id).await?;
     let last_event_seq = terminal_event_cursor_on(&transaction, chat_id).await?;
     transaction.commit().await.map_err(store_err)?;
@@ -781,11 +781,13 @@ pub(in crate::db) async fn get_chat_transcript(
 /// The journal holds every delta a chat has ever produced, tool arguments
 /// included, so this deliberately filters on the payload's variant tag in SQL
 /// rather than deserializing the chat's whole event history. Completed prose
-/// still comes from its committed message; only message-less terminal turns
-/// retain their streamed text here.
+/// still comes from its committed message. A cancellation after an intermediate
+/// step committed points at the last assistant message from that turn; only a
+/// genuinely message-less terminal turn retains its streamed text here.
 async fn list_terminal_turns_on<C>(
     conn: &C,
     chat_id: ChatId,
+    messages: &[Message],
 ) -> Result<Vec<ChatTerminalTurnSnapshot>>
 where
     C: ConnectionTrait,
@@ -806,6 +808,13 @@ where
         return Ok(Vec::new());
     }
 
+    let last_assistant_message_by_turn = messages
+        .iter()
+        .filter(|message| message.role == Role::Assistant)
+        .fold(HashMap::new(), |mut by_turn, message| {
+            by_turn.insert(message.turn_id, message.id);
+            by_turn
+        });
     let mut snapshots = Vec::with_capacity(turns.len());
     let mut index_of = HashMap::with_capacity(turns.len());
     for turn in turns {
@@ -826,10 +835,19 @@ where
         };
         let invoked_skills = super::turn::invoked_skills_from_model(&turn)?;
         let usage = super::turn::usage_from_turn_model(&turn)?;
+        let message_id = turn.output_message_id.map(MessageId).or_else(|| {
+            matches!(&status, ChatTerminalTurnStatus::Cancelled)
+                .then(|| {
+                    last_assistant_message_by_turn
+                        .get(&TurnId(turn.id))
+                        .copied()
+                })
+                .flatten()
+        });
         index_of.insert(turn.id, snapshots.len());
         snapshots.push(ChatTerminalTurnSnapshot {
             turn_id: TurnId(turn.id),
-            message_id: turn.output_message_id.map(MessageId),
+            message_id,
             status,
             partial_content: String::new(),
             reasoning: String::new(),

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -10023,6 +10023,116 @@ async fn cancellation_with_partial_output_commits_a_durable_message() {
     );
 }
 
+/// Regression for #1714: cancelling during a tool call can leave a committed
+/// assistant step even though the turn itself has no output message. Associate
+/// the cancellation with the last committed step so its journaled prose is not
+/// rendered again as a message-less terminal partial.
+#[tokio::test]
+async fn cancellation_after_committed_step_does_not_rebuild_its_prose() {
+    use crate::event::AgentEvent;
+    use crate::provider::Usage;
+
+    let (_dir, store) = temp_store().await;
+
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn_id = TurnId::new();
+    let accepted = match store
+        .accept_turn(turn_id, chat.id, "claude", "start then stop")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let lease = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(
+            lease,
+            accepted.available_at,
+            accepted.available_at + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap()
+        .turn
+        .expect("accepted turn is claimable");
+    store
+        .append_turn_event(
+            chat.id,
+            turn_id,
+            lease,
+            1,
+            accepted.available_at,
+            &AgentEvent::TextDelta {
+                text: "I will check that now.".into(),
+            },
+        )
+        .await
+        .unwrap()
+        .expect("a live attempt may journal its visible stream");
+
+    let committed = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id,
+        role: Role::Assistant,
+        reasoning: Default::default(),
+        content: "I will check that now.".into(),
+        llm_content: None,
+        created_at: accepted.available_at,
+    };
+    assert_eq!(
+        store
+            .append_claimed_assistant_message_with_citations(
+                &committed,
+                &[],
+                lease,
+                accepted.available_at,
+            )
+            .await
+            .unwrap(),
+        AppendClaimedMessageOutcome::Appended
+    );
+
+    let requested_at = accepted.available_at + chrono::Duration::seconds(1);
+    store
+        .request_turn_cancellation(turn_id, requested_at)
+        .await
+        .unwrap()
+        .expect("running cancellation is accepted");
+    store
+        .finish_turn_cancellation_and_append_event(
+            turn_id,
+            lease,
+            requested_at + chrono::Duration::seconds(1),
+            Usage::default(),
+            None,
+            &[],
+        )
+        .await
+        .unwrap()
+        .expect("worker acknowledges cancellation during the tool call");
+
+    let transcript = store.get_chat_transcript(chat.id).await.unwrap().unwrap();
+    let snapshot = transcript
+        .terminal_turns
+        .last()
+        .expect("cancelled turn remains in the transcript");
+    assert_eq!(
+        (
+            snapshot.status.clone(),
+            snapshot.message_id,
+            snapshot.partial_content.as_str(),
+        ),
+        (
+            crate::storage::ChatTerminalTurnStatus::Cancelled,
+            Some(committed.id),
+            "",
+        ),
+        "the committed step owns the cancellation instead of being duplicated from journal deltas"
+    );
+}
+
 /// The #853 scoping contract: two principals' root aggregates are disjoint
 /// under the owner-scoped surface — reads, lists, mutations, and creation
 /// against another owner's parent all behave as if the other owner's rows do

--- a/crates/openwave-core/src/db/tests/output.rs
+++ b/crates/openwave-core/src/db/tests/output.rs
@@ -695,13 +695,18 @@ mod output_scan {
         let conversation = tempfile::tempdir().unwrap();
         let store = std::sync::Arc::new(store);
         let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+        let turn_id = TurnId::new();
+        let run_id = crate::AgentRunId::new();
 
         // A foreground turn and a background run, each writing `report.md` in
         // its own workspace and publishing into the same conversation.
         let mut tasks = Vec::new();
-        for (index, bytes) in [b"# Foreground".as_slice(), b"# Background".as_slice()]
-            .into_iter()
-            .enumerate()
+        for (index, (bytes, producer)) in [
+            (b"# Foreground".as_slice(), RevisionProducer::Turn(turn_id)),
+            (b"# Background".as_slice(), RevisionProducer::Run(run_id)),
+        ]
+        .into_iter()
+        .enumerate()
         {
             let workspace = tempfile::tempdir().unwrap();
             write_output_file(workspace.path(), "report.md", bytes);
@@ -718,7 +723,7 @@ mod output_scan {
                     &publication,
                     chat.id,
                     CallId::new(),
-                    RevisionProducer::Turn(TurnId::new()),
+                    producer,
                     at(index as i64),
                 )
                 .await
@@ -753,8 +758,17 @@ mod output_scan {
             vec![OutputSyncStatus::Created, OutputSyncStatus::Updated]
         );
 
-        // Both revisions' bytes are readable where the record says they are.
-        for revision in store.list_output_revisions(output.id).await.unwrap() {
+        // Cross-producer merging preserves who wrote each version, and both
+        // revisions' bytes remain readable where the record says they are.
+        let revisions = store.list_output_revisions(output.id).await.unwrap();
+        assert_eq!(revisions.len(), 2);
+        assert!(revisions.iter().any(|revision| {
+            revision.turn_id == Some(turn_id) && revision.producing_run_id.is_none()
+        }));
+        assert!(revisions.iter().any(|revision| {
+            revision.turn_id.is_none() && revision.producing_run_id == Some(run_id)
+        }));
+        for revision in revisions {
             let relative = output_revision_relative_path(output.id, revision.id);
             assert_eq!(
                 std::fs::read(conversation.path().join(&relative))

--- a/crates/openwave-core/src/storage/store.rs
+++ b/crates/openwave-core/src/storage/store.rs
@@ -1121,17 +1121,17 @@ pub trait Store: Send + Sync {
     /// approval. Returns empty for any claim that is not the immediate
     /// successor of a spawn park.
     ///
-    /// The default is empty rather than unimplemented: a store that never
-    /// admits sandbox children can never have parked on a spawn checkpoint
-    /// either, and this read runs on every claim.
+    /// Every store states this capability explicitly. A store whose
+    /// [`checkpoint_sandbox_spawn`](Store::checkpoint_sandbox_spawn) remains
+    /// unavailable returns an empty batch; a store that can checkpoint spawns
+    /// must recover the carried tail or return an error rather than silently
+    /// dropping it.
     async fn resumed_sandbox_spawn_batch(
         &self,
-        _turn_id: TurnId,
-        _attempt_count: i32,
-        _claim_count: i32,
-    ) -> Result<Vec<crate::agent::SandboxAgentSpawnRequest>> {
-        Ok(Vec::new())
-    }
+        turn_id: TurnId,
+        attempt_count: i32,
+        claim_count: i32,
+    ) -> Result<Vec<crate::agent::SandboxAgentSpawnRequest>>;
 
     /// Fetch immutable origin ownership for an admitted sandbox child.
     async fn get_sandbox_agent_admission(

--- a/crates/openwave-core/src/storage/tests.rs
+++ b/crates/openwave-core/src/storage/tests.rs
@@ -1097,6 +1097,15 @@ impl Store for MemStore {
             .map(|(_, e)| e.clone())
             .collect())
     }
+
+    async fn resumed_sandbox_spawn_batch(
+        &self,
+        _turn_id: crate::TurnId,
+        _attempt_count: i32,
+        _claim_count: i32,
+    ) -> Result<Vec<crate::agent::SandboxAgentSpawnRequest>> {
+        Ok(Vec::new())
+    }
 }
 
 fn document_summary(document: &DocumentRecord) -> DocumentSummaryRecord {

--- a/crates/openwave-core/src/storage/types.rs
+++ b/crates/openwave-core/src/storage/types.rs
@@ -61,11 +61,12 @@ pub struct ChatCitationSnapshot {
 
 /// One terminal turn and the visible stream it produced.
 ///
-/// Completed turns point at their committed assistant message, which remains
-/// authoritative for final prose. Failed and cancelled turns have no message,
-/// so their partial prose and reasoning are rebuilt from the journal. Refusal
-/// and failure details stay outcome metadata on the same turn rather than
-/// becoming more transcript side tables.
+/// Completed turns point at their committed assistant output, which remains
+/// authoritative for final prose. A cancelled turn can instead point at its
+/// committed partial output or the last intermediate assistant step it left
+/// visible. Only a genuinely message-less failed or cancelled turn rebuilds
+/// partial prose from the journal. Refusal and failure details stay outcome
+/// metadata on the same turn rather than becoming more transcript side tables.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChatTerminalTurnSnapshot {
     pub turn_id: TurnId,

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
@@ -52,8 +52,12 @@ function play(
   return transition;
 }
 
-function framed(seq: number, event: AgentEvent): SequencedEvent {
-  return { seq, event };
+function framed(
+  seq: number,
+  event: AgentEvent,
+  replayed = false,
+): SequencedEvent {
+  return replayed ? { seq, event, replayed: true } : { seq, event };
 }
 
 const TURN: AgentEvent = { type: "turn_started", turn_id: "turn-1" };
@@ -80,6 +84,29 @@ describe("seq cursor", () => {
     expect(state.lastSeq).toBe(7);
     expect(state.messages).toEqual([]);
     expect(effects).toEqual([]);
+  });
+
+  it("suppresses animation during replay and resumes on the next live frame", () => {
+    const replayedStart = reduceChatSessionEvent(
+      initialChatSessionState(),
+      framed(1, TURN, true),
+      makeDeps(),
+    );
+    expect(replayedStart.state.animateStreaming).toBe(false);
+
+    const replayedText = reduceChatSessionEvent(
+      replayedStart.state,
+      framed(2, { type: "text_delta", text: "Already seen" }, true),
+      makeDeps(),
+    );
+    expect(replayedText.state.animateStreaming).toBe(false);
+
+    const liveText = reduceChatSessionEvent(
+      replayedText.state,
+      framed(3, { type: "text_delta", text: " and new" }),
+      makeDeps(),
+    );
+    expect(liveText.state.animateStreaming).toBe(true);
   });
 });
 

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
@@ -27,6 +27,8 @@ import { PRESENTATION_MEDIA_TYPES } from "./document/officePdf";
 export type ChatSessionState = {
   /** Highest event seq applied; events at or below it are duplicates. */
   lastSeq: number;
+  /** Whether new stream presentation should animate rather than catch up. */
+  animateStreaming: boolean;
   messages: ChatMessage[];
   busy: boolean;
   activeTurnId: string | null;
@@ -99,6 +101,7 @@ export type ChatSessionDeps = {
 export function initialChatSessionState(): ChatSessionState {
   return {
     lastSeq: 0,
+    animateStreaming: true,
     messages: [],
     busy: false,
     activeTurnId: null,
@@ -119,7 +122,14 @@ export function reduceChatSessionEvent(
   deps: ChatSessionDeps,
 ): ChatSessionTransition {
   if (framed.seq <= state.lastSeq) return { state, effects: [] };
-  state = { ...state, lastSeq: framed.seq };
+  state = {
+    ...state,
+    lastSeq: framed.seq,
+    // Replayed journal frames rebuild the active turn after navigation or a
+    // reconnect. They are current state, not new activity, so only the first
+    // genuinely live frame re-enables the presentation typewriters.
+    animateStreaming: framed.replayed !== true,
+  };
   const event = framed.event;
   const effects: ChatSessionEffect[] = [];
 

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -135,6 +135,9 @@ export function ChatView({
   );
   const messages = useChatSessionStore((session) => session.messages);
   const busy = useChatSessionStore((session) => session.busy);
+  const animateStreaming = useChatSessionStore(
+    (session) => session.animateStreaming,
+  );
   const compacting = useChatSessionStore((session) => session.compacting);
   const activeTurnId = useChatSessionStore((session) => session.activeTurnId);
   // Every applied stream event advances the seq cursor, so it doubles as the
@@ -401,6 +404,7 @@ export function ChatView({
           onOpenOutput={onOpenOutput}
           backgroundAgentClient={client}
           busy={busy}
+          animateStreaming={animateStreaming}
           compacting={compacting}
           streamStalled={streamStalled}
           scrollRef={attachScrollRef}

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -219,6 +219,8 @@ type MessageListProps = {
   /** The connected client, so a background agent row can fetch debug info. */
   backgroundAgentClient?: ApiClient;
   busy: boolean;
+  /** False while the socket is rebuilding already-seen journal history. */
+  animateStreaming?: boolean;
   /**
    * Semantic compaction is running for the open turn. Prefer a visible
    * "Compacting conversation" status over the ordinary Working indicator.
@@ -295,6 +297,7 @@ export function MessageList({
   onOpenBackgroundAgent,
   onOpenOutput,
   busy,
+  animateStreaming = true,
   compacting = false,
   streamStalled = false,
   scrollRef,
@@ -335,6 +338,7 @@ export function MessageList({
   const { items: messageItems, lastTurnStart } = groupMessageItems(
     messages,
     busy,
+    animateStreaming,
     onApproval,
     approvalState,
     imageClient,
@@ -566,6 +570,7 @@ export function isTurnClosingAssistant(
 export function groupMessageItems(
   messages: ChatMessage[],
   busy: boolean,
+  animateStreaming: boolean,
   onApproval: (
     callId: string,
     decision: "approve" | "reject",
@@ -654,6 +659,7 @@ export function groupMessageItems(
           key={message.id}
           message={message}
           busy={message.id === streamingAssistantId}
+          animateStreaming={animateStreaming}
           sequenceEnd={message.role !== "assistant" || closesTurn}
           imageClient={imageClient}
           chatId={chatId}
@@ -788,7 +794,11 @@ export function groupMessageItems(
         key={`tool-activity-group-${groupIndex}`}
         fallback={<ToolActivityUnavailable />}
       >
-        <ToolActivityGroup activities={railActivities} groupIndex={groupIndex}>
+        <ToolActivityGroup
+          activities={railActivities}
+          groupIndex={groupIndex}
+          animate={animateStreaming}
+        >
           {children.length > 0 ? children : undefined}
         </ToolActivityGroup>
       </ErrorBoundary>,
@@ -1077,6 +1087,7 @@ const EMPTY_SOURCES: readonly AssistantSource[] = [];
 function MessageBubbleImpl({
   message,
   busy,
+  animateStreaming = true,
   sequenceEnd = true,
   imageClient,
   chatId,
@@ -1085,6 +1096,7 @@ function MessageBubbleImpl({
 }: {
   message: ChatMessage;
   busy: boolean;
+  animateStreaming?: boolean;
   /** Only the turn-closing assistant bubble carries the footer. */
   sequenceEnd?: boolean;
   imageClient?: Pick<ApiClient, "getChatImageAttachment">;
@@ -1143,7 +1155,10 @@ function MessageBubbleImpl({
             />
           )}
           {message.text && (
-            <AssistantMessageBody text={message.text} streaming={busy} />
+            <AssistantMessageBody
+              text={message.text}
+              streaming={busy && animateStreaming}
+            />
           )}
           <AssistantSources
             sources={message.sources}

--- a/crates/openwave-desktop/ui/src/ToolActivityGroup.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ToolActivityGroup.dom.test.tsx
@@ -48,6 +48,19 @@ describe("ToolActivityGroup rail animation", () => {
     );
   });
 
+  it("shows a replayed active phase immediately", () => {
+    render(
+      <ToolActivityGroup
+        groupIndex={0}
+        animate={false}
+        activities={[{ id: "write", name: "write_file", status: "running" }]}
+      />,
+    );
+
+    const label = screen.getByLabelText("Updating a file");
+    expect(label.textContent).toBe("Updating a file");
+  });
+
   it("renders expanded row titles at full length without animating them", () => {
     render(
       <ToolActivityGroup

--- a/crates/openwave-desktop/ui/src/ToolActivityGroup.tsx
+++ b/crates/openwave-desktop/ui/src/ToolActivityGroup.tsx
@@ -34,6 +34,8 @@ export type ToolActivity = {
 type ToolActivityGroupProps = {
   activities: ToolActivity[];
   groupIndex: number;
+  /** Whether this active phase arrived live rather than from socket replay. */
+  animate?: boolean;
   /** Cards for the calls that have something to show, rendered below. */
   children?: ReactNode;
 };
@@ -53,6 +55,7 @@ type ToolActivityGroupProps = {
 export function ToolActivityGroup({
   activities,
   groupIndex,
+  animate = true,
   children,
 }: ToolActivityGroupProps) {
   // Total by construction: an activity that throws while being read costs its
@@ -72,6 +75,7 @@ export function ToolActivityGroup({
         <ToolActivityRail
           activities={safeActivities}
           groupIndex={groupIndex}
+          animate={animate}
         />
       </ErrorBoundary>
     );
@@ -108,9 +112,11 @@ export function ToolActivityGroup({
 function ToolActivityRail({
   activities: safeActivities,
   groupIndex,
+  animate,
 }: {
   activities: (ToolActivity | null)[];
   groupIndex: number;
+  animate: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
   const contentId = `tool-activity-group-${groupIndex}`;
@@ -124,7 +130,10 @@ function ToolActivityRail({
   // The phase line types itself out once when the phase first goes live, then
   // updates instantly as calls settle and nudge the wording — re-typing on
   // every change reads as a stutter, and a settled phase should never animate.
-  const displayedSummary = useTypewriterOnce(summary.label, summary.inProgress);
+  const displayedSummary = useTypewriterOnce(
+    summary.label,
+    summary.inProgress && animate,
+  );
 
   return (
     <>

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.ts
@@ -152,9 +152,10 @@ export function hydrateTranscriptHistory(
       resultUnreadable: activity.result_unreadable,
       createdAt: activity.started_at,
     })),
-    // Failed and stopped turns leave no assistant message behind. Their one
-    // terminal entry keeps streamed content and status adjacent in transcript
-    // order, with a stable identity across hydrations.
+    // Terminal turns that left no assistant message behind keep their streamed
+    // content and status adjacent in transcript order, with a stable identity
+    // across hydrations. A cancellation after a committed step is associated
+    // with that message above instead.
     ...terminalTurns
       .filter((turn) => !turn.message_id)
       .map((turn) => ({

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -475,8 +475,9 @@ origin: RootAttachmentOrigin, };
 /**
  * One terminal turn's renderer-safe status and visible streamed content.
  *
- * A completed turn points at its authoritative assistant message. Failed and
- * cancelled turns have no message, but remain first-class transcript entries
+ * A completed turn points at its authoritative assistant output. A cancelled
+ * turn may point at the last assistant message it committed before stopping;
+ * message-less failed and cancelled turns remain first-class transcript entries
  * carrying the partial prose and reasoning the reader already saw live.
  */
 export type ChatTerminalTurnSnapshot = { turn_id: TurnId, message_id?: MessageId, status: ChatTerminalTurnStatus, partial_content: string, reasoning?: string, refusal?: RendererRefusal, failure_category?: TurnFailureCategory, failure_model?: RendererModelIdentity, file_changes: Array<ExecFileChangeSummary>, 
@@ -1909,7 +1910,7 @@ export type RendererModelIdentity = { id: string, provider: ProviderKind, };
  */
 export type RendererRefusal = { category: string | null, partial_output: boolean, };
 
-export type RendererSequencedEvent = { seq: number, event: RendererAgentEvent, };
+export type RendererSequencedEvent = { seq: number, event: RendererAgentEvent, replayed?: boolean, };
 
 /**
  * A tool name the renderer is allowed to present.

--- a/crates/openwave-desktop/ui/src/outputs/OutputDetailRoot.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/outputs/OutputDetailRoot.dom.test.tsx
@@ -71,7 +71,7 @@ function detailApis(overrides: Partial<OutputDetailApis> = {}): OutputDetailApis
     listRevisions: vi.fn().mockResolvedValue({
       outputId,
       revisions: [
-        revisionRow(),
+        revisionRow({ producedBy: "backgroundAgent" }),
         revisionRow({
           revisionId: olderRevisionId,
           ordinal: 1,
@@ -187,6 +187,11 @@ describe("OutputDetailRoot", () => {
     );
     // The current version is labeled and offers no restore of its own.
     expect(await screen.findByText("Current version")).toBeVisible();
+    // A shared filename can carry versions from different producers; the
+    // history keeps that merge visible rather than presenting one anonymous
+    // stream of revisions.
+    expect(screen.getByText(/^Background agent ·/)).toBeVisible();
+    expect(screen.getByText(/^Agent ·/)).toBeVisible();
 
     await user.click(screen.getByRole("button", { name: /v1/ }));
     await waitFor(() =>

--- a/crates/openwave-server/src/event_projection.rs
+++ b/crates/openwave-server/src/event_projection.rs
@@ -87,6 +87,12 @@ impl From<&crate::bus::ChatMetadataNotice> for RendererChatMetadata {
 pub(crate) struct RendererSequencedEvent {
     pub seq: i64,
     pub event: RendererAgentEvent,
+    // True only when this frame came from durable catch-up rather than the live
+    // fan-out. Omitted live to preserve the established frame shape; renderers
+    // use it to avoid replaying presentation animations.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub replayed: Option<bool>,
 }
 
 /// A turn's token accounting, as the renderer needs it.
@@ -438,6 +444,7 @@ impl From<&SequencedEvent> for RendererSequencedEvent {
         Self {
             seq: value.seq,
             event,
+            replayed: None,
         }
     }
 }
@@ -447,6 +454,11 @@ impl RendererSequencedEvent {
         if let RendererAgentEvent::TurnFailed { model, .. } = &mut self.event {
             *model = selection.and_then(model_identity);
         }
+        self
+    }
+
+    pub(crate) fn mark_replayed(mut self) -> Self {
+        self.replayed = Some(true);
         self
     }
 }
@@ -489,6 +501,7 @@ mod tests {
                         ..RendererTurnUsage::default()
                     },
                 },
+                replayed: None,
             }
         );
     }
@@ -1014,6 +1027,7 @@ mod tests {
                         message_id: first_id,
                         text: "first".into(),
                     },
+                    replayed: None,
                 },
                 RendererSequencedEvent {
                     seq: 42,
@@ -1021,6 +1035,7 @@ mod tests {
                         message_id: second_id,
                         text: "second".into(),
                     },
+                    replayed: None,
                 },
             ]
         );

--- a/crates/openwave-server/src/routes/events.rs
+++ b/crates/openwave-server/src/routes/events.rs
@@ -140,7 +140,7 @@ async fn stream_events(
                         .ok()
                         .and_then(|turns| turns.into_iter().find(|turn| !turn.status.is_terminal()))
                         .map(|turn| turn.model);
-                    if send_event(&mut socket, &event, model.as_deref()).await.is_err() {
+                    if send_event(&mut socket, &event, model.as_deref(), false).await.is_err() {
                         break;
                     }
                 }
@@ -185,7 +185,7 @@ async fn replay_after(
             active_turn_id = Some(*turn_id);
         }
         let model = active_turn_id.and_then(|turn_id| turn_models.get(&turn_id));
-        send_event(socket, &event, model.map(String::as_str))
+        send_event(socket, &event, model.map(String::as_str), true)
             .await
             .map_err(|_| ())?;
     }
@@ -197,14 +197,15 @@ async fn send_event(
     socket: &mut WebSocket,
     event: &SequencedEvent,
     model: Option<&str>,
+    replayed: bool,
 ) -> Result<(), axum::Error> {
-    send_frame(
-        socket,
-        &RendererChatFrame::Event(Box::new(
-            RendererSequencedEvent::from(event).with_turn_model(model),
-        )),
-    )
-    .await
+    let projected = RendererSequencedEvent::from(event).with_turn_model(model);
+    let projected = if replayed {
+        projected.mark_replayed()
+    } else {
+        projected
+    };
+    send_frame(socket, &RendererChatFrame::Event(Box::new(projected))).await
 }
 
 /// Send one frame as JSON text. A frame that fails to serialize is skipped

--- a/crates/openwave-server/src/routes/projects_chats.rs
+++ b/crates/openwave-server/src/routes/projects_chats.rs
@@ -438,8 +438,9 @@ impl From<openwave_core::MessageDocumentAttachment> for TranscriptFileAttachment
 
 /// One terminal turn's renderer-safe status and visible streamed content.
 ///
-/// A completed turn points at its authoritative assistant message. Failed and
-/// cancelled turns have no message, but remain first-class transcript entries
+/// A completed turn points at its authoritative assistant output. A cancelled
+/// turn may point at the last assistant message it committed before stopping;
+/// message-less failed and cancelled turns remain first-class transcript entries
 /// carrying the partial prose and reasoning the reader already saw live.
 #[derive(Debug, Serialize, ts_rs::TS)]
 pub struct ChatTerminalTurnSnapshot {

--- a/crates/openwave-server/src/sandbox_agent_run_worker/tests.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker/tests.rs
@@ -1723,35 +1723,39 @@ async fn immediate_failures_release_capacity_then_deliver_a_terminal_parent_rece
         }
     };
     let first = child("first".into()).await;
-    let worker = SandboxAgentRunWorker::new(
-        store.clone(),
-        test_secrets(),
-        Arc::new(FixedResolver(Arc::new(FailingProvider))),
-        Arc::new(Notify::new()),
-        Arc::new(Notify::new()),
-        Arc::new(EventBus::default()),
-        AgentConfig {
-            model: "m".into(),
-            ..AgentConfig::default()
-        },
-        None,
-        SandboxAgentRunWorkerConfig {
-            failure_delay: Duration::from_secs(1),
-            // Shrink the production backoff so the test observes each
-            // retry becoming claimable without waiting seconds for it.
-            retry: RetrySchedule::new(
-                Duration::from_millis(100),
-                Duration::from_millis(200),
-                Duration::from_secs(60),
-            ),
-            max_concurrency: 1,
-            max_running_global: 1,
-            max_running_per_chat: 1,
-            ..SandboxAgentRunWorkerConfig::default()
-        },
-    );
+    let worker = |retry| {
+        SandboxAgentRunWorker::new(
+            store.clone(),
+            test_secrets(),
+            Arc::new(FixedResolver(Arc::new(FailingProvider))),
+            Arc::new(Notify::new()),
+            Arc::new(Notify::new()),
+            Arc::new(EventBus::default()),
+            AgentConfig {
+                model: "m".into(),
+                ..AgentConfig::default()
+            },
+            None,
+            SandboxAgentRunWorkerConfig {
+                failure_delay: Duration::from_secs(1),
+                retry,
+                max_concurrency: 1,
+                max_running_global: 1,
+                max_running_per_chat: 1,
+                ..SandboxAgentRunWorkerConfig::default()
+            },
+        )
+    };
+    // Keep the capacity probe's retry outside the test's runtime. The claim
+    // below scans every eligible run, so a short retry would let this first
+    // run legitimately win again before the assertion on the second run.
+    let capacity_worker = worker(RetrySchedule::new(
+        Duration::from_secs(60 * 60),
+        Duration::from_secs(60 * 60),
+        Duration::from_secs(2 * 60 * 60),
+    ));
     assert_eq!(
-        worker.run_once().await.unwrap(),
+        capacity_worker.run_once().await.unwrap(),
         SandboxAgentRunWorkerOutcome::RetryScheduled(first)
     );
     let first_state = store.get_agent_run(first).await.unwrap().unwrap();
@@ -1771,21 +1775,32 @@ async fn immediate_failures_release_capacity_then_deliver_a_terminal_parent_rece
         .finish_agent_run_cancellation(second, claimed.lease_token.unwrap())
         .await
         .unwrap();
+
+    let terminal = child("terminal".into()).await;
+    let terminal_worker = worker(RetrySchedule::new(
+        Duration::from_millis(100),
+        Duration::from_millis(200),
+        Duration::from_secs(60),
+    ));
+    assert_eq!(
+        terminal_worker.run_once().await.unwrap(),
+        SandboxAgentRunWorkerOutcome::RetryScheduled(terminal)
+    );
     // Each remaining attempt parks in retry-wait until the durable
     // budget is spent and the run fails terminally.
-    let mut outcome = SandboxAgentRunWorkerOutcome::RetryScheduled(first);
+    let mut outcome = SandboxAgentRunWorkerOutcome::RetryScheduled(terminal);
     for _ in 1..openwave_core::AgentRun::DEFAULT_MAX_ATTEMPTS {
         tokio::time::sleep(Duration::from_millis(300)).await;
-        outcome = worker.run_once().await.unwrap();
+        outcome = terminal_worker.run_once().await.unwrap();
     }
-    assert_eq!(outcome, SandboxAgentRunWorkerOutcome::Failed(first));
-    let terminal = store.get_agent_run(first).await.unwrap().unwrap();
-    assert_eq!(terminal.status, AgentRunStatus::Failed);
+    assert_eq!(outcome, SandboxAgentRunWorkerOutcome::Failed(terminal));
+    let terminal_state = store.get_agent_run(terminal).await.unwrap().unwrap();
+    assert_eq!(terminal_state.status, AgentRunStatus::Failed);
     let inbox = store
         .list_agent_run_inbox(openwave_core::AgentRunId::foreground_for_chat(chat.id))
         .await
         .unwrap();
-    assert!(inbox.iter().any(|entry| entry.child_run_id == first
+    assert!(inbox.iter().any(|entry| entry.child_run_id == terminal
         && entry.result.text.contains("sandbox_execution_failed")));
 }
 

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -676,6 +676,7 @@ struct PauseTerminalStore {
     fail_after_assistant_commit: std::sync::atomic::AtomicBool,
     assistant_append_calls: AtomicUsize,
     fail_after_park_commit: std::sync::atomic::AtomicBool,
+    pause_before_spawn_checkpoint: std::sync::atomic::AtomicBool,
     fail_after_apply_steer_commit: std::sync::atomic::AtomicBool,
     cancel_after_apply_steer_commit: std::sync::atomic::AtomicBool,
     apply_steer_cancellation_committed: Arc<Notify>,
@@ -706,6 +707,7 @@ impl PauseTerminalStore {
             fail_after_assistant_commit: std::sync::atomic::AtomicBool::new(false),
             assistant_append_calls: AtomicUsize::new(0),
             fail_after_park_commit: std::sync::atomic::AtomicBool::new(false),
+            pause_before_spawn_checkpoint: std::sync::atomic::AtomicBool::new(false),
             fail_after_apply_steer_commit: std::sync::atomic::AtomicBool::new(false),
             cancel_after_apply_steer_commit: std::sync::atomic::AtomicBool::new(false),
             apply_steer_cancellation_committed: Arc::new(Notify::new()),
@@ -755,6 +757,11 @@ impl PauseTerminalStore {
 
     fn fail_after_next_park_commit(&self) {
         self.fail_after_park_commit.store(true, Ordering::SeqCst);
+    }
+
+    fn pause_before_next_spawn_checkpoint(&self) {
+        self.pause_before_spawn_checkpoint
+            .store(true, Ordering::SeqCst);
     }
 
     fn fail_after_next_apply_steer_commit(&self) {
@@ -1223,6 +1230,30 @@ impl Store for PauseTerminalStore {
         }
         Ok(outcome)
     }
+    async fn checkpoint_sandbox_spawn(
+        &self,
+        request: &openwave_core::SandboxSpawnCheckpointRequest,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Option<openwave_core::CheckpointSandboxSpawnOutcome>> {
+        if self
+            .pause_before_spawn_checkpoint
+            .swap(false, Ordering::SeqCst)
+        {
+            self.entered.notify_one();
+            self.release.notified().await;
+        }
+        self.inner.checkpoint_sandbox_spawn(request, now).await
+    }
+    async fn resumed_sandbox_spawn_batch(
+        &self,
+        turn_id: TurnId,
+        attempt_count: i32,
+        claim_count: i32,
+    ) -> Result<Vec<openwave_core::SandboxAgentSpawnRequest>> {
+        self.inner
+            .resumed_sandbox_spawn_batch(turn_id, attempt_count, claim_count)
+            .await
+    }
     async fn record_turn_run_failure_and_append_event(
         &self,
         id: TurnId,
@@ -1413,6 +1444,60 @@ impl Store for PauseTerminalStore {
         self.inner
             .accept_claimed_tool_call(call, lease_token, now)
             .await
+    }
+    async fn request_tool_call_approval(
+        &self,
+        request: &openwave_core::ApprovalRequest,
+        requested_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<openwave_core::RequestToolApprovalOutcome> {
+        self.inner
+            .request_tool_call_approval(request, requested_at)
+            .await
+    }
+    async fn request_tool_call_approval_and_append_event(
+        &self,
+        request: &openwave_core::ApprovalRequest,
+        lease_token: uuid::Uuid,
+        event_ordinal: i32,
+        requested_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<openwave_core::JournaledToolApprovalOutcome> {
+        self.inner
+            .request_tool_call_approval_and_append_event(
+                request,
+                lease_token,
+                event_ordinal,
+                requested_at,
+            )
+            .await
+    }
+    async fn decide_tool_call_approval(
+        &self,
+        chat_id: ChatId,
+        call_id: CallId,
+        decision: &openwave_core::ApprovalDecision,
+        decided_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<openwave_core::DecideToolApprovalOutcome> {
+        self.inner
+            .decide_tool_call_approval(chat_id, call_id, decision, decided_at)
+            .await
+    }
+    async fn decide_tool_call_approval_with_grant(
+        &self,
+        chat_id: ChatId,
+        call_id: CallId,
+        decision: &openwave_core::ApprovalDecision,
+        grant: &openwave_core::StandingGrant,
+        decided_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<openwave_core::DecideToolApprovalOutcome> {
+        self.inner
+            .decide_tool_call_approval_with_grant(chat_id, call_id, decision, grant, decided_at)
+            .await
+    }
+    async fn get_tool_call_approval(
+        &self,
+        call_id: CallId,
+    ) -> Result<Option<openwave_core::ToolApproval>> {
+        self.inner.get_tool_call_approval(call_id).await
     }
     async fn claim_client_tool_call(
         &self,

--- a/crates/openwave-server/src/tests/lifecycle.rs
+++ b/crates/openwave-server/src/tests/lifecycle.rs
@@ -2427,6 +2427,13 @@ async fn resumed_worker_preserves_checkpoint_usage_and_step_budget() {
     let completed_progress = test_client_checkpoint_progress(1);
     let (_, completed_call) =
         park_client_wait_for_route_test(&*store, completed_chat.id, completed_progress).await;
+    // This helper claims from the whole turn queue. Park both cases before the
+    // worker starts so it cannot race the helper for the exhausted turn.
+    let exhausted_chat = make_chat(&router, &bearer).await;
+    let exhausted_progress = test_client_checkpoint_progress(2);
+    let (_, exhausted_call) =
+        park_client_wait_for_route_test(&*store, exhausted_chat.id, exhausted_progress).await;
+
     resolve_parked_client_call(&*store, completed_chat.id, &completed_call).await;
     spawn_turn_worker(&state);
     state.turn_job_wake.notify_one();
@@ -2443,10 +2450,6 @@ async fn resumed_worker_preserves_checkpoint_usage_and_step_budget() {
     ));
     assert_eq!(calls.load(Ordering::SeqCst), 1);
 
-    let exhausted_chat = make_chat(&router, &bearer).await;
-    let exhausted_progress = test_client_checkpoint_progress(2);
-    let (_, exhausted_call) =
-        park_client_wait_for_route_test(&*store, exhausted_chat.id, exhausted_progress).await;
     resolve_parked_client_call(&*store, exhausted_chat.id, &exhausted_call).await;
     state.turn_job_wake.notify_one();
     let exhausted_events = wait_for_turn(&store, exhausted_chat.id).await;

--- a/crates/openwave-server/src/tests/websocket.rs
+++ b/crates/openwave-server/src/tests/websocket.rs
@@ -232,6 +232,10 @@ async fn ws_live_and_replay_frames_use_the_renderer_safe_projection() {
     send_message_http(&client, addr, &token, chat.id).await;
     let live = read_raw_until_terminal(&mut live_socket).await;
     assert_renderer_event_frames_are_redacted(&live);
+    assert!(
+        live.iter().all(|event| event.get("replayed").is_none()),
+        "live frames retain their established wire shape"
+    );
 
     wait_for_turn(&store, chat.id).await;
     let mut replay_request = format!("ws://{addr}/chats/{}/events?after=0", chat.id)
@@ -243,6 +247,12 @@ async fn ws_live_and_replay_frames_use_the_renderer_safe_projection() {
     let (mut replay_socket, _) = connect_async(replay_request).await.unwrap();
     let replay = read_raw_until_terminal(&mut replay_socket).await;
     assert_renderer_event_frames_are_redacted(&replay);
+    assert!(
+        replay
+            .iter()
+            .all(|event| event.get("replayed") == Some(&serde_json::Value::Bool(true))),
+        "durable catch-up frames identify themselves to the renderer"
+    );
 
     let live_sequences = live
         .iter()

--- a/crates/openwave-server/src/tests/workers.rs
+++ b/crates/openwave-server/src/tests/workers.rs
@@ -15,6 +15,72 @@ async fn allow_delegation(store: &dyn Store, chat: ChatId) {
         .unwrap();
 }
 
+async fn approval_call_ids(store: &Arc<dyn Store>, chat: ChatId) -> Vec<CallId> {
+    store
+        .list_events(chat, 0)
+        .await
+        .unwrap()
+        .iter()
+        .filter_map(|event| match &event.event {
+            AgentEvent::ApprovalRequired { call_id, .. } => Some(*call_id),
+            _ => None,
+        })
+        .collect()
+}
+
+async fn wait_for_approvals(store: &Arc<dyn Store>, chat: ChatId, count: usize) -> Vec<CallId> {
+    for _ in 0..500 {
+        let ids = approval_call_ids(store, chat).await;
+        if ids.len() >= count {
+            return ids;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("turn should park on {count} approval cards");
+}
+
+async fn approve_delegation(router: &axum::Router, bearer: &str, chat: ChatId, call_id: CallId) {
+    let decide = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/chats/{chat}/approvals/{call_id}"))
+                .header(header::AUTHORIZATION, bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({"decision": "approve"}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(decide.status(), StatusCode::NO_CONTENT);
+}
+
+async fn wait_for_completed_spawn_call_ids(
+    store: &Arc<dyn Store>,
+    chat: ChatId,
+    count: usize,
+) -> Vec<CallId> {
+    for _ in 0..500 {
+        let calls = store.list_tool_calls(chat).await.unwrap();
+        let spawns = calls
+            .iter()
+            .filter(|call| call.name == openwave_core::SPAWN_SANDBOX_AGENT_TOOL)
+            .collect::<Vec<_>>();
+        if spawns.len() == count
+            && spawns
+                .iter()
+                .all(|call| call.status == openwave_core::ToolCallStatus::Completed)
+        {
+            return spawns.iter().map(|call| call.id).collect();
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("{count} spawn calls should complete under their original call ids");
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn configured_model_is_used_for_the_turn() {
     let recorder = RecordingProvider::default();
@@ -412,51 +478,8 @@ async fn a_gated_spawn_batch_is_carried_across_the_approval_park() {
         StatusCode::ACCEPTED
     );
 
-    async fn approval_call_ids(store: &Arc<dyn Store>, chat: ChatId) -> Vec<CallId> {
-        store
-            .list_events(chat, 0)
-            .await
-            .unwrap()
-            .iter()
-            .filter_map(|event| match &event.event {
-                AgentEvent::ApprovalRequired { call_id, .. } => Some(*call_id),
-                _ => None,
-            })
-            .collect()
-    }
-
-    async fn wait_for_approvals(store: &Arc<dyn Store>, chat: ChatId, count: usize) -> Vec<CallId> {
-        for _ in 0..500 {
-            let ids = approval_call_ids(store, chat).await;
-            if ids.len() >= count {
-                return ids;
-            }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-        panic!("turn should park on {count} approval cards");
-    }
-
-    async fn approve(router: &axum::Router, bearer: &str, chat: ChatId, call_id: CallId) {
-        let decide = router
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri(format!("/chats/{chat}/approvals/{call_id}"))
-                    .header(header::AUTHORIZATION, bearer)
-                    .header(header::CONTENT_TYPE, "application/json")
-                    .body(Body::from(
-                        serde_json::json!({"decision": "approve"}).to_string(),
-                    ))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(decide.status(), StatusCode::NO_CONTENT);
-    }
-
     let first = wait_for_approvals(&store, chat.id, 1).await[0];
-    approve(&router, &bearer, chat.id, first).await;
+    approve_delegation(&router, &bearer, chat.id, first).await;
 
     let both = wait_for_approvals(&store, chat.id, 2).await;
     assert_eq!(both[0], first);
@@ -471,35 +494,138 @@ async fn a_gated_spawn_batch_is_carried_across_the_approval_park() {
         1,
         "the carried batch must reach the gate without another model call"
     );
-    approve(&router, &bearer, chat.id, both[1]).await;
+    approve_delegation(&router, &bearer, chat.id, both[1]).await;
 
-    for _ in 0..500 {
-        let calls = store.list_tool_calls(chat.id).await.unwrap();
-        let spawns = calls
-            .iter()
-            .filter(|call| call.name == openwave_core::SPAWN_SANDBOX_AGENT_TOOL)
-            .collect::<Vec<_>>();
-        if spawns.len() == 2
-            && spawns
-                .iter()
-                .all(|call| call.status == openwave_core::ToolCallStatus::Completed)
-        {
-            // Both delegations were answered under the call ids the model
-            // streamed, so nothing is left dangling in the transcript.
-            assert_eq!(
-                spawns
-                    .iter()
-                    .map(|call| call.id)
-                    .collect::<std::collections::HashSet<_>>(),
-                both.iter()
-                    .copied()
-                    .collect::<std::collections::HashSet<_>>()
-            );
-            return;
-        }
-        tokio::time::sleep(Duration::from_millis(10)).await;
-    }
-    panic!("both spawns in the batch should complete under their original call ids");
+    // Both delegations were answered under the call ids the model streamed,
+    // so nothing is left dangling in the transcript.
+    assert_eq!(
+        wait_for_completed_spawn_call_ids(&store, chat.id, 2)
+            .await
+            .into_iter()
+            .collect::<std::collections::HashSet<_>>(),
+        both.iter()
+            .copied()
+            .collect::<std::collections::HashSet<_>>()
+    );
+}
+
+/// An approval that commits before a spawn checkpoint is superseded remains
+/// admitted. The worker applies the steer, replays that exact call without a
+/// second card, then resumes gating the still-ungated siblings in model order.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_approved_spawn_is_replayed_after_checkpoint_steer() {
+    let dir = tempfile::tempdir().unwrap();
+    let inner: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let checkpoint_entered = Arc::new(Notify::new());
+    let release_checkpoint = Arc::new(Notify::new());
+    let injected = Arc::new(PauseTerminalStore::new(
+        inner,
+        checkpoint_entered.clone(),
+        release_checkpoint.clone(),
+    ));
+    injected.do_not_pause_terminal();
+    injected.pause_before_next_spawn_checkpoint();
+    let store: Arc<dyn Store> = injected;
+    let provider = Arc::new(GatedSpawnBatchProvider::default());
+    let mut tools = ToolRegistry::new();
+    tools.register_foreground_agent_orchestration();
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(provider.clone())),
+        Arc::new(MemSecrets::default()),
+        Arc::new(tools),
+        AgentConfig {
+            model: "fake".into(),
+            max_steps: 4,
+            ..AgentConfig::default()
+        },
+    );
+    let token = state.token.clone();
+    spawn_turn_worker(&state);
+    let router = app(state);
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let turn_id = TurnId::new();
+
+    assert_eq!(
+        send_message_with_id(
+            &router,
+            &bearer,
+            chat.id,
+            turn_id,
+            "delegate both questions",
+        )
+        .await,
+        StatusCode::ACCEPTED
+    );
+
+    let first = wait_for_approvals(&store, chat.id, 1).await[0];
+    approve_delegation(&router, &bearer, chat.id, first).await;
+    tokio::time::timeout(Duration::from_secs(2), checkpoint_entered.notified())
+        .await
+        .expect("approved spawn reached its checkpoint");
+
+    assert_eq!(
+        steer_turn(
+            &router,
+            &bearer,
+            chat.id,
+            turn_id,
+            "incorporate this new constraint",
+            false,
+        )
+        .await,
+        StatusCode::ACCEPTED
+    );
+    release_checkpoint.notify_one();
+
+    let both = wait_for_approvals(&store, chat.id, 2).await;
+    assert_eq!(both.len(), 2, "the admitted head must not ask twice");
+    assert_eq!(both[0], first);
+    assert_ne!(both[1], first, "the tail keeps its own approval card");
+    assert_eq!(
+        provider.foreground_calls.load(Ordering::SeqCst),
+        1,
+        "the admitted request and tail must replay without another model call"
+    );
+    let first_call = store
+        .list_tool_calls(chat.id)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|call| call.id == first)
+        .expect("the approved spawn keeps its original call id");
+    assert_eq!(first_call.status, openwave_core::ToolCallStatus::Completed);
+    assert!(store
+        .list_events(chat.id, 0)
+        .await
+        .unwrap()
+        .iter()
+        .any(|event| matches!(
+            &event.event,
+            AgentEvent::UserSteered { content, .. }
+                if content == "incorporate this new constraint"
+        )));
+
+    approve_delegation(&router, &bearer, chat.id, both[1]).await;
+    assert_eq!(
+        wait_for_completed_spawn_call_ids(&store, chat.id, 2)
+            .await
+            .into_iter()
+            .collect::<std::collections::HashSet<_>>(),
+        both.iter()
+            .copied()
+            .collect::<std::collections::HashSet<_>>()
+    );
+    assert_eq!(approval_call_ids(&store, chat.id).await, both);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -1703,6 +1703,13 @@ impl TurnWorker {
                             }
                             Ok(Some(CheckpointSandboxSpawnOutcome::SteerPending(_)))
                             | Ok(Some(CheckpointSandboxSpawnOutcome::OutputSuperseded(_))) => {
+                                // The approval gate may already have committed
+                                // a decision for this exact call. Keep that
+                                // admitted head with its original siblings;
+                                // the next loop applies the steer, replays the
+                                // head without a second approval, and gates the
+                                // still-ungated tail normally.
+                                pending_sandbox_spawns.insert(0, request);
                                 break;
                             }
                             Ok(Some(CheckpointSandboxSpawnOutcome::AtCapacity)) => {

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -247,9 +247,12 @@ delegated siblings never share scratch. It carries no folder authority and
 stages no host paths: delegation already runs outside the conversation's
 approval gate, and the sandbox filesystem is the whole of what a delegated run
 can reach. Files the run leaves under `output/` are published to the parent
-conversation as outputs named by their own filenames — writing the same filename
-again produces the next version of that output rather than a second one. The run
-never names an output identity, and neither does the host.
+conversation as outputs named by their own filenames. A filename is scoped to
+the conversation, not to its producer: a foreground turn or any background run
+that publishes an already-live name appends the next version to that one output
+rather than creating a producer-namespaced copy. Version history identifies
+whether each revision came from the foreground agent, a background agent, or the
+user. The run never names an output identity, and neither does the host.
 
 The delegated read is available only when the foreground
 spawn named one exact `{root_id, relative_path}` that was attached to the chat


### PR DESCRIPTION
## Summary

- Preserve an already-approved sandbox spawn when a pending steer supersedes its first checkpoint. The original call ID is replayed without a second approval, while ungated siblings continue through the normal gate.
- Make `Store::resumed_sandbox_spawn_batch` an explicit capability contract so checkpoint-capable stores cannot silently discard carried work.
- Reconcile durable transcript hydration with what the reader already saw: cancelled tool-bearing turns reuse their committed assistant step instead of duplicating it, and WebSocket catch-up frames carry an optional `replayed: true` marker so the desktop skips replay-only typewriter animations.
- Remove two high-concurrency test ordering races without changing scheduler behavior.
- Clarify and pin the existing output contract: a filename is conversation-scoped, and revisions retain foreground/background producer attribution.

The replay marker is additive and omitted from live frames, preserving the existing live event shape. #1715 remains open and blocked because durable reasoning interleaving needs a separate protocol/presentation decision.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p openwave-core -p openwave-server --locked --all-targets -- -D warnings`
- `cargo test -p openwave-server --locked --lib` — 640 passed, 3 ignored
- Focused `openwave-core` cancellation, output-concurrency, and store-contract regressions
- `pnpm exec tsc --noEmit`
- Focused desktop tests — 54 passed
- Full desktop test run during implementation — 821 passed
- `pnpm build`
- `git diff --check`

The two tests from #1596 were also stress-run after the fixes without recurrence. No tests were removed.

Closes #1707
Closes #1708
Closes #1714
Closes #1716
Closes #1596
