### PR TITLE
feat(desktop): render the agent's task plan on the activity surface

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -286,6 +286,9 @@ export function ChatRoute({ chatId }: { chatId: string }) {
       case "refresh_plan_approvals":
         signalRefresh("planApprovals");
         return;
+      case "refresh_task_plan":
+        signalRefresh("taskPlan");
+        return;
       case "warm_presentation_converter":
         warmPresentationConverter();
         return;

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
@@ -271,6 +271,19 @@ describe("tool call lifecycle", () => {
     expect(state.messages).toEqual([]);
   });
 
+  it("refreshes the task plan from the bounded plan-updated hint", () => {
+    const { state, effects } = play([
+      {
+        type: "task_plan_updated",
+        call_id: "plan-call",
+        turn_id: "turn-1",
+      },
+    ]);
+    expect(effects).toContainEqual({ type: "refresh_task_plan" });
+    // The hint carries no steps, so it leaves the transcript alone.
+    expect(state.messages).toEqual([]);
+  });
+
   it("keeps args streaming from downgrading an approval wait", () => {
     const { state } = play([
       TURN,

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
@@ -72,6 +72,11 @@ export type ChatSessionEffect =
   | { type: "refresh_output_writebacks" }
   | { type: "refresh_user_questions" }
   | { type: "refresh_plan_approvals" }
+  /**
+   * The agent replaced its task plan. The event carries no steps — it is a
+   * hint that the chat's durable plan moved on, and the panel re-reads it.
+   */
+  | { type: "refresh_task_plan" }
   /** A turn began; the host resets cancel state (and steer state when asked). */
   | { type: "turn_began"; turnId: string; startsDifferentTurn: boolean }
   /** A turn reached a terminal event; the host clears cancel/steer state. */
@@ -281,6 +286,11 @@ export function reduceChatSessionEvent(
 
     case "plan_proposed": {
       effects.push({ type: "refresh_plan_approvals" });
+      return { state, effects };
+    }
+
+    case "task_plan_updated": {
+      effects.push({ type: "refresh_task_plan" });
       return { state, effects };
     }
 

--- a/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
@@ -25,6 +25,7 @@ const client = {
   listPendingFolderAccessRequests: vi.fn().mockResolvedValue([]),
   listPendingUserQuestions: vi.fn().mockResolvedValue([]),
   listAgentRuns: vi.fn().mockResolvedValue([]),
+  getTaskPlan: vi.fn().mockResolvedValue(null),
   decideApproval: vi.fn().mockResolvedValue(undefined),
   cancel: vi.fn().mockResolvedValue(undefined),
   steer: vi.fn().mockResolvedValue(undefined),

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -34,6 +34,8 @@ import { useToolApprovals } from "./useToolApprovals";
 import { useStreamStalled } from "./useStreamStalled";
 import { useTurnControls } from "./useTurnControls";
 import { usePlanApprovals } from "./usePlanApprovals";
+import { useTaskPlan } from "./useTaskPlan";
+import { TaskPlanCard } from "./TaskPlanCard";
 import { useUserQuestions } from "./useUserQuestions";
 import { useComposerPlugins } from "./plugins/useComposerPlugins";
 import { recentChatFiles } from "./ComposerMentions";
@@ -149,6 +151,12 @@ export function ChatView({
     [messages],
   );
   const agentRuns = useAgentRuns(client, chat.id, backgroundAgentSpawnKeys);
+  const taskPlan = useTaskPlan(client, chat.id);
+  // The plan belongs to the turn that wrote it, so liveness comes from the
+  // session the transcript already tracks rather than from another read: a
+  // plan whose turn is not the running one describes work that has stopped.
+  const taskPlanLive =
+    taskPlan !== null && busy && activeTurnId === taskPlan.turn_id;
   // The files already on this conversation, so `@` can name one instead of
   // sending the reader back to the picker for a document we are already
   // holding. Read from the transcript rather than fetched: these are the
@@ -442,6 +450,11 @@ export function ChatView({
       </div>
 
       <div className="px-[clamp(0.5rem,4%,5rem)] pb-2">
+        {taskPlan !== null && (
+          <div className="pb-2">
+            <TaskPlanCard plan={taskPlan} live={taskPlanLive} />
+          </div>
+        )}
         <Composer
           activeTurnId={activeTurnId}
           busy={busy}

--- a/crates/openwave-desktop/ui/src/RefreshSignals.ts
+++ b/crates/openwave-desktop/ui/src/RefreshSignals.ts
@@ -7,7 +7,8 @@ export type RefreshTarget =
   | "folderAccess"
   | "outputWritebacks"
   | "userQuestions"
-  | "planApprovals";
+  | "planApprovals"
+  | "taskPlan";
 
 /**
  * A revision counter per pollable target.
@@ -24,6 +25,7 @@ export type RefreshSignalStore = {
   outputWritebacks: number;
   userQuestions: number;
   planApprovals: number;
+  taskPlan: number;
   signal: (target: RefreshTarget) => void;
 };
 
@@ -33,6 +35,7 @@ export function createRefreshSignalStore() {
     outputWritebacks: 0,
     userQuestions: 0,
     planApprovals: 0,
+    taskPlan: 0,
     signal: (target) =>
       set((state) => ({ [target]: state[target] + 1 }) as Partial<RefreshSignalStore>),
   }));

--- a/crates/openwave-desktop/ui/src/TaskPlanCard.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/TaskPlanCard.dom.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { TaskPlan } from "./api";
+import { TaskPlanCard } from "./TaskPlanCard";
+
+afterEach(cleanup);
+
+const PLAN: TaskPlan = {
+  turn_id: "turn-1",
+  updated_at: "2026-01-01T00:00:00Z",
+  steps: [
+    { content: "Read the spec", status: "completed" },
+    { content: "Draft the change", status: "in_progress" },
+    { content: "Run the tests", status: "pending" },
+  ],
+};
+
+describe("TaskPlanCard", () => {
+  it("stops claiming work is under way once the plan's turn has ended", () => {
+    const { container, rerender } = render(
+      <TaskPlanCard plan={PLAN} live={true} />,
+    );
+
+    // While the turn runs the plan is open and the current step spins.
+    expect(screen.getByRole("button", { name: /task plan/i })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+    expect(screen.getByText("Draft the change")).toBeInTheDocument();
+    expect(container.querySelector(".animate-spin")).not.toBeNull();
+
+    rerender(<TaskPlanCard plan={PLAN} live={false} />);
+
+    // The plan stays as history, but nothing in it still animates.
+    expect(screen.getByRole("button", { name: /task plan/i })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+    expect(screen.getByText("1/3")).toBeInTheDocument();
+    expect(container.querySelector(".animate-spin")).toBeNull();
+  });
+});

--- a/crates/openwave-desktop/ui/src/TaskPlanCard.tsx
+++ b/crates/openwave-desktop/ui/src/TaskPlanCard.tsx
@@ -1,0 +1,167 @@
+import { useId, useRef, useState } from "react";
+import { Circle, CircleCheck, CircleDashed, ChevronDown } from "lucide-react";
+
+import type { TaskPlan, TaskPlanStepStatus } from "./api";
+import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/utils";
+
+export type TaskPlanCardProps = {
+  /** The chat's current plan, or `null` when it has none. */
+  plan: TaskPlan | null;
+  /**
+   * Whether the turn that wrote this plan is still running.
+   *
+   * A plan outlives its turn — it stays on screen as the record of what the
+   * agent set out to do — so nothing about a settled plan may keep claiming
+   * that work is under way.
+   */
+  live: boolean;
+};
+
+/**
+ * The checklist the agent keeps for a long turn.
+ *
+ * It sits between the transcript and the composer rather than in the
+ * transcript, because the whole point of it is to still be readable an hour
+ * into a turn that has scrolled several screens of activity past it. Open
+ * while its turn runs, folded to one line once the turn ends: a finished plan
+ * is history worth keeping, not something to keep looking at.
+ */
+export function TaskPlanCard({ plan, live }: TaskPlanCardProps) {
+  const [expanded, setExpanded] = useState(live);
+  const bodyId = useId();
+
+  // Liveness drives the fold, and a toggle in between is the reader's to keep
+  // until liveness itself changes. Adjusted during render rather than in an
+  // effect so a turn ending does not paint the open card once before folding
+  // it.
+  const lastLiveRef = useRef(live);
+  if (lastLiveRef.current !== live) {
+    lastLiveRef.current = live;
+    setExpanded(live);
+  }
+
+  // A chat with no plan says nothing at all: an empty checklist above the
+  // composer is chrome that describes nothing.
+  if (!plan) return null;
+
+  const total = plan.steps.length;
+  const completed = plan.steps.filter(
+    (step) => step.status === "completed",
+  ).length;
+
+  return (
+    <section
+      className={cn(
+        "bg-background w-full max-w-prose overflow-hidden rounded-lg border",
+        !live && "opacity-80",
+      )}
+      aria-label="Task plan"
+    >
+      <button
+        type="button"
+        className="hover:bg-muted/50 focus-visible:ring-ring flex w-full items-center justify-between gap-2 px-2.5 py-1.5 text-left transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden"
+        aria-expanded={expanded}
+        aria-controls={bodyId}
+        onClick={() => setExpanded((current) => !current)}
+      >
+        <span className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-xs font-medium">
+          <ChevronDown
+            className={cn(
+              "size-3.5 shrink-0 transition-transform",
+              !expanded && "-rotate-90",
+            )}
+            aria-hidden="true"
+          />
+          <span className="truncate">Task plan</span>
+        </span>
+        <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
+          {completed}/{total}
+        </span>
+      </button>
+      {expanded && (
+        <ol id={bodyId} className="grid gap-1.5 border-t px-2.5 py-2 text-sm">
+          {plan.steps.map((step, index) => (
+            <TaskPlanRow
+              // Steps have no identity of their own — the plan is replaced
+              // whole — so position is what they are keyed on.
+              key={index}
+              content={step.content}
+              status={step.status}
+              live={live}
+            />
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}
+
+/**
+ * One step: a status glyph and the line the agent wrote.
+ *
+ * Status is carried by the glyph alone. Striking a finished step through
+ * trades legibility for decoration, and a plan is read to find out what is
+ * left rather than to admire what is done.
+ */
+function TaskPlanRow({
+  content,
+  status,
+  live,
+}: {
+  content: string;
+  status: TaskPlanStepStatus;
+  live: boolean;
+}) {
+  const working = status === "in_progress" && live;
+  return (
+    <li className="flex items-start gap-2">
+      <span className="mt-0.5 shrink-0" aria-hidden="true">
+        <StepGlyph status={status} live={live} />
+      </span>
+      <span
+        className={cn(
+          "min-w-0",
+          working ? "text-foreground" : "text-muted-foreground",
+        )}
+      >
+        {content}
+      </span>
+      <span className="sr-only">{statusLabel(status, live)}</span>
+    </li>
+  );
+}
+
+function StepGlyph({
+  status,
+  live,
+}: {
+  status: TaskPlanStepStatus;
+  live: boolean;
+}) {
+  if (status === "completed") {
+    return <CircleCheck className="text-success size-4" />;
+  }
+  if (status === "in_progress") {
+    // A spinner on a turn that is over would animate a claim that nothing is
+    // making true. The step still reads as started rather than untouched, but
+    // it reads as stopped.
+    return live ? (
+      <Spinner className="text-foreground size-4" />
+    ) : (
+      <CircleDashed className="text-muted-foreground size-4" />
+    );
+  }
+  return <Circle className="text-muted-foreground/60 size-4" />;
+}
+
+function statusLabel(status: TaskPlanStepStatus, live: boolean): string {
+  switch (status) {
+    case "completed":
+      return "Done";
+    case "in_progress":
+      return live ? "In progress" : "Unfinished";
+    case "pending":
+      return live ? "To do" : "Not started";
+  }
+}

--- a/crates/openwave-desktop/ui/src/TaskPlanCard.tsx
+++ b/crates/openwave-desktop/ui/src/TaskPlanCard.tsx
@@ -6,8 +6,11 @@ import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
 
 export type TaskPlanCardProps = {
-  /** The chat's current plan, or `null` when it has none. */
-  plan: TaskPlan | null;
+  /**
+   * The chat's plan. A chat without one renders no card at all, which the
+   * caller decides — there is no such thing as an empty plan to draw.
+   */
+  plan: TaskPlan;
   /**
    * Whether the turn that wrote this plan is still running.
    *
@@ -41,10 +44,6 @@ export function TaskPlanCard({ plan, live }: TaskPlanCardProps) {
     setExpanded(live);
   }
 
-  // A chat with no plan says nothing at all: an empty checklist above the
-  // composer is chrome that describes nothing.
-  if (!plan) return null;
-
   const total = plan.steps.length;
   const completed = plan.steps.filter(
     (step) => step.status === "completed",
@@ -53,7 +52,7 @@ export function TaskPlanCard({ plan, live }: TaskPlanCardProps) {
   return (
     <section
       className={cn(
-        "bg-background w-full max-w-prose overflow-hidden rounded-lg border",
+        "bg-background mx-auto w-full max-w-3xl overflow-hidden rounded-lg border",
         !live && "opacity-80",
       )}
       aria-label="Task plan"
@@ -80,7 +79,14 @@ export function TaskPlanCard({ plan, live }: TaskPlanCardProps) {
         </span>
       </button>
       {expanded && (
-        <ol id={bodyId} className="grid gap-1.5 border-t px-2.5 py-2 text-sm">
+        // Capped and scrolled rather than allowed to grow: the card opens
+        // itself when a turn goes live, so a twenty-step plan would otherwise
+        // push the composer out of a pane that cannot scroll. The cap shows
+        // most of a plan at a glance and leaves the rest a scroll away.
+        <ol
+          id={bodyId}
+          className="grid max-h-64 gap-1.5 overflow-y-auto border-t px-2.5 py-2 text-sm"
+        >
           {plan.steps.map((step, index) => (
             <TaskPlanRow
               // Steps have no identity of their own — the plan is replaced
@@ -121,7 +127,10 @@ function TaskPlanRow({
       </span>
       <span
         className={cn(
-          "min-w-0",
+          // The line is the agent's own text, up to 500 characters of it and
+          // not necessarily with a space in them. It wraps rather than being
+          // clipped away by the card's own overflow.
+          "min-w-0 break-words",
           working ? "text-foreground" : "text-muted-foreground",
         )}
       >

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -9,6 +9,7 @@ import {
   parsePendingUserQuestions,
   parsePendingToolApproval,
   parseSandboxAgentCancellation,
+  parseTaskPlan,
   parseToolActionPreview,
   parseToolResultPreview,
 } from "./api";
@@ -222,6 +223,43 @@ describe("parseOutputWritebackRequest", () => {
         path: "private/file.txt",
       }),
     ).toBeNull();
+  });
+});
+
+describe("parseTaskPlan", () => {
+  const safe = {
+    turn_id: "turn-1",
+    updated_at: "2026-08-06T12:00:00Z",
+    steps: [
+      { content: "Read the spec", status: "completed" },
+      { content: "Draft the change", status: "in_progress" },
+    ],
+  };
+
+  it("accepts a well-formed plan in the order the agent wrote it", () => {
+    expect(parseTaskPlan(safe)).toEqual(safe);
+  });
+
+  // All or nothing: a plan is written as one replacement, so dropping the step
+  // that failed validation would leave a checklist that silently disagrees
+  // with the work the agent thinks it is doing.
+  it.each([
+    ["an unknown key", { ...safe, note: "extra" }],
+    [
+      "a status outside the closed vocabulary",
+      { ...safe, steps: [{ content: "Read the spec", status: "skipped" }] },
+    ],
+    [
+      "a step past the server's own length limit",
+      { ...safe, steps: [{ content: "x".repeat(501), status: "pending" }] },
+    ],
+    [
+      "a step carrying a line break",
+      { ...safe, steps: [{ content: "one\ntwo", status: "pending" }] },
+    ],
+    ["no steps at all", { ...safe, steps: [] }],
+  ])("rejects the whole plan over %s", (_case, payload) => {
+    expect(parseTaskPlan(payload)).toBeNull();
   });
 });
 

--- a/crates/openwave-desktop/ui/src/api/client.ts
+++ b/crates/openwave-desktop/ui/src/api/client.ts
@@ -68,6 +68,7 @@ import {
   type LocalVoiceInfo,
   type InboxItem,
   type PendingChatPrompt,
+  type TaskPlan,
 } from "./types";
 import {
   parseAgentActivityHistory,
@@ -80,6 +81,7 @@ import {
   parsePendingToolApproval,
   parsePendingUserQuestions,
   parseSandboxAgentCancellation,
+  parseTaskPlan,
 } from "./parsers";
 
 const WS_HANDSHAKE = "openwave-v1";
@@ -1012,6 +1014,21 @@ export class ApiClient {
       headers: this.headers(true),
       body: JSON.stringify({ network_policy: networkPolicy }),
     });
+  }
+
+  /**
+   * The conversation's current task plan, or `null` when it has none.
+   *
+   * The journal only carries a hint that the plan moved on, so this is where
+   * the steps come from — on the hint, and again on reload. The payload is
+   * model-authored text, so it is validated here rather than trusted.
+   */
+  async getTaskPlan(chatId: string): Promise<TaskPlan | null> {
+    const body = await this.json<unknown>(
+      `/chats/${encodeURIComponent(chatId)}/task-plan`,
+      { headers: this.headers() },
+    );
+    return parseTaskPlan(body);
   }
 
   listAgentRuns(chatId: string): Promise<AgentRun[]> {

--- a/crates/openwave-desktop/ui/src/api/parsers.ts
+++ b/crates/openwave-desktop/ui/src/api/parsers.ts
@@ -9,6 +9,9 @@ import {
   type PendingOutputWritebackRequest as WirePendingOutputWritebackRequest,
   type PendingPlanApproval as WirePendingPlanApproval,
   type PendingUserQuestions as WirePendingUserQuestions,
+  type TaskPlan as WireTaskPlan,
+  type TaskPlanStep as WireTaskPlanStep,
+  type TaskPlanStepStatus,
   type UserQuestion as WireUserQuestion,
   type UserQuestionOption as WireUserQuestionOption,
 } from "../generated/wire";
@@ -36,6 +39,8 @@ import {
   type ResultEntryKind,
   type ResultFailure,
   type SandboxAgentCancellation,
+  type TaskPlan,
+  type TaskPlanStep,
   type ToolActionPreview,
   type ToolResultPreview,
   type UserQuestion,
@@ -273,8 +278,62 @@ export function parsePendingPlanApproval(
   };
 }
 
-export function parsePendingUserQuestions(
-  value: unknown,
+/** The plan's step statuses, as a closed set the renderer can switch on. */
+const TASK_PLAN_STEP_STATUSES = new Set<TaskPlanStepStatus>([
+  "pending",
+  "in_progress",
+  "completed",
+]);
+
+/** Mirrors the server's own limits on a plan it will accept. */
+const MAX_TASK_PLAN_STEPS = 20;
+const MAX_TASK_PLAN_STEP_CHARS = 500;
+
+/**
+ * The chat's current plan, or `null` when it has none or the payload is not
+ * one the renderer will draw.
+ *
+ * All or nothing, because a plan is written as one replacement and read as one
+ * checklist: dropping a step that failed validation would leave a list that
+ * silently disagrees with the work the agent thinks it is doing, which is a
+ * worse answer than showing no plan at all.
+ */
+export function parseTaskPlan(value: unknown): TaskPlan | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireTaskPlan>(value, ["turn_id", "steps", "updated_at"]) ||
+    !nonEmptyBounded(value.turn_id, 128) ||
+    !nonEmptyBounded(value.updated_at, 64) ||
+    !Array.isArray(value.steps) ||
+    value.steps.length === 0 ||
+    value.steps.length > MAX_TASK_PLAN_STEPS
+  ) {
+    return null;
+  }
+  const steps: TaskPlanStep[] = [];
+  for (const step of value.steps) {
+    if (
+      !isRecord(step) ||
+      !onlyKeys<WireTaskPlanStep>(step, ["content", "status"]) ||
+      !nonEmptyBounded(step.content, MAX_TASK_PLAN_STEP_CHARS) ||
+      typeof step.status !== "string" ||
+      !TASK_PLAN_STEP_STATUSES.has(step.status as TaskPlanStepStatus)
+    ) {
+      return null;
+    }
+    steps.push({
+      content: step.content,
+      status: step.status as TaskPlanStepStatus,
+    });
+  }
+  return {
+    turn_id: value.turn_id,
+    steps,
+    updated_at: value.updated_at,
+  };
+}
+
+export function parsePendingUserQuestions(  value: unknown,
 ): PendingUserQuestions | null {
   if (
     !isRecord(value) ||

--- a/crates/openwave-desktop/ui/src/api/parsers.ts
+++ b/crates/openwave-desktop/ui/src/api/parsers.ts
@@ -333,7 +333,8 @@ export function parseTaskPlan(value: unknown): TaskPlan | null {
   };
 }
 
-export function parsePendingUserQuestions(  value: unknown,
+export function parsePendingUserQuestions(
+  value: unknown,
 ): PendingUserQuestions | null {
   if (
     !isRecord(value) ||

--- a/crates/openwave-desktop/ui/src/api/types.ts
+++ b/crates/openwave-desktop/ui/src/api/types.ts
@@ -86,6 +86,9 @@ import {
   type RendererSequencedEvent,
   type RendererToolName,
   type ResultEntryKind,
+  type TaskPlan as WireTaskPlan,
+  type TaskPlanStep as WireTaskPlanStep,
+  type TaskPlanStepStatus as WireTaskPlanStepStatus,
   type ToolActionPreview,
   type TranscriptImageAttachment as WireTranscriptImageAttachment,
   type TranscriptRole,
@@ -383,6 +386,15 @@ export type ChatTranscript = WireChatTranscript;
 /** A durable foreground coordinator or sandboxed background run. */
 /** A durable foreground coordinator or sandboxed background run. */
 export type AgentRun = AgentRunSnapshot;
+
+/**
+ * The checklist the agent keeps for a long turn: replaced whole on every
+ * update, and the only place the steps themselves are carried — the event
+ * stream only says the plan moved on.
+ */
+export type TaskPlan = WireTaskPlan;
+export type TaskPlanStep = WireTaskPlanStep;
+export type TaskPlanStepStatus = WireTaskPlanStepStatus;
 
 /** The complete renderer projection returned by one sandbox stop request. */
 /** The complete renderer projection returned by one sandbox stop request. */

--- a/crates/openwave-desktop/ui/src/useTaskPlan.ts
+++ b/crates/openwave-desktop/ui/src/useTaskPlan.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef, useState } from "react";
+
+import type { ApiClient, TaskPlan } from "./api";
+import { useRefreshSignals } from "./RefreshSignals";
+
+/**
+ * The conversation's task plan, kept current from the durable route.
+ *
+ * The event stream says only that the plan moved on, never what it now says,
+ * so every read comes from `GET /chats/{id}/task-plan`: once when the chat
+ * opens, which is also how a reload recovers the plan, and again on each hint.
+ * There is nothing to poll for — a plan only changes when the agent replaces
+ * it, and replacing it always raises the hint.
+ *
+ * A failed read keeps the last plan on screen rather than blanking it: a
+ * transient error is not evidence that the agent abandoned its checklist.
+ */
+export function useTaskPlan(
+  client: ApiClient | null,
+  chatId: string | null,
+): TaskPlan | null {
+  const [plan, setPlan] = useState<TaskPlan | null>(null);
+  const refreshRef = useRef<(() => void) | null>(null);
+  const signal = useRefreshSignals((state) => state.taskPlan);
+
+  useEffect(() => {
+    if (!client || !chatId) {
+      setPlan(null);
+      refreshRef.current = null;
+      return;
+    }
+
+    let cancelled = false;
+    let requestSeq = 0;
+    const refresh = async () => {
+      const seq = ++requestSeq;
+      try {
+        const current = await client.getTaskPlan(chatId);
+        if (cancelled || seq !== requestSeq) return;
+        setPlan(current);
+      } catch (error) {
+        if (!cancelled && seq === requestSeq) {
+          console.error("failed to read the task plan", error);
+        }
+      }
+    };
+
+    setPlan(null);
+    refreshRef.current = () => void refresh();
+    void refresh();
+    return () => {
+      cancelled = true;
+      requestSeq += 1;
+      refreshRef.current = null;
+    };
+  }, [client, chatId]);
+
+  // The counter is app-wide and may already be well past zero on arrival, so
+  // only a signal raised after this mounted means anything.
+  const lastSignalRef = useRef(signal);
+  useEffect(() => {
+    if (lastSignalRef.current === signal) return;
+    lastSignalRef.current = signal;
+    refreshRef.current?.();
+  }, [signal]);
+
+  return plan;
+}


### PR DESCRIPTION
The visible half of the task-plan feature. The backend on the base branch
writes a durable checklist and puts a bounded `task_plan_updated` hint on the
chat socket; this renders it.

## Behavior

- **Reading the plan.** The hint carries no steps, so every read comes from
  `GET /chats/{id}/task-plan` — once when a chat opens, which is also how a
  reload recovers the plan, and again on each hint. The hint travels the
  existing refresh-signal channel that `plan_proposed` and
  `user_questions_asked` already use: a new `refresh_task_plan` effect in
  `ChatSessionReducer`, signalled as `taskPlan` from `ChatRoute`, consumed by
  `useTaskPlan`. No polling — a plan changes only when the agent replaces it,
  and replacing it always raises the hint. A failed read keeps the last plan on
  screen rather than blanking it.
- **The card.** One row per step: status glyph plus the line the agent wrote.
  Pending is a muted outline circle, the current step is the existing spinner
  primitive, a finished step is a success-toned check. No strikethrough
  anywhere — a plan is read to find what is left, and struck-out text trades
  legibility for decoration. The header is "Task plan" with a completed/total
  counter and folds the list away (hand-rolled `useState` + `aria-expanded`,
  matching the other rails). It is open while its turn runs and folded once
  that turn ends; a reader's own toggle sticks until liveness changes again.
- **Terminal coercion.** Liveness is `busy && activeTurnId === plan.turn_id`,
  read from the session the transcript already tracks — no extra call. Once the
  owning turn is over nothing in the card animates or claims to be running: an
  unfinished step renders as a muted dashed circle rather than a spinner, and
  the whole card dims. A finished plan stays as history, quietly.
- **Empty state.** No plan renders nothing at all.
- **Validation.** Step text is model-authored, so it is parsed at the API
  boundary against the server's own limits (20 steps, 500 chars, closed status
  vocabulary) rather than trusted. All-or-nothing: a checklist quietly missing a
  step would disagree with the work the agent thinks it is doing, which is worse
  than showing no plan.

## Placement

The card sits between the transcript and the composer, above it and outside the
scroller. A plan earns its place precisely on turns long enough that the call
which wrote it has scrolled several screens away, so anchoring it to its spot in
the activity rail would hide it exactly when it is most useful. Keeping it in
the chat pane rather than the side panel means it travels with the conversation
it describes.

## Transcript noise

No change was needed. `update_task_plan` has no entry in
`ToolActionPreview::build` and returns plain text, so `surfacedCard` in
`MessageList` already declines it on both the preview and result paths: the call
appears only as an ordinary compact row inside the collapsed activity rail,
which is what we want now that the panel says the same thing better.

## Tests

Two, per the repo's test policy:

- a reducer test that `task_plan_updated` produces `refresh_task_plan` and
  leaves the transcript alone, mirroring the `user_questions_asked` test beside
  it;
- a component test pinning terminal coercion — a live plan spins and is open,
  the same plan on a dead turn folds and has nothing animating.

The `ChatView` DOM test's stub client gained a `getTaskPlan` mock so the new
hook does not log a failed read through the existing cases.

## Verification

`tsc --noEmit`, `pnpm test` (821 passing), and `pnpm build` all clean locally.
Screenshots are not possible from this environment, and the running app was not
driven — the visual result of the card in place is unverified.

Part of #411