### PR TITLE
feat(server): let sandbox agents keep a task plan across their run

### DIFF
--- a/crates/openwave-core/src/agent_tools.rs
+++ b/crates/openwave-core/src/agent_tools.rs
@@ -46,14 +46,29 @@ pub const SANDBOX_DONE_TOOL: &str = "done";
 pub const MAX_SANDBOX_AGENT_TASK_CHARS: usize = 16_000;
 /// Maximum number of depth-one children in one foreground wait request.
 pub const MAX_WAIT_FOR_AGENTS_CHILDREN: usize = TurnAgentRunWaitSet::MAX_CHILDREN;
-/// Maximum host-executed tool checkpoints one sandbox run may accumulate.
+/// Maximum host-executed *work* checkpoints one sandbox run may accumulate.
 ///
 /// A sandbox run's checkpoints form a chain the worker replays in full on every
 /// claim, so the count is bounded rather than open-ended: the whole chain rides
 /// each model request. Real delegated work needs a sequence — search, read,
 /// then several commands to produce a file — so the bound is a working budget,
 /// not the one-call fence it replaced.
+///
+/// `update_task_plan` rows are counted against
+/// [`MAX_SANDBOX_TASK_PLAN_CALLS`] instead, so the run's bookkeeping cannot
+/// spend the allowance its actual work needs.
 pub const MAX_SANDBOX_TOOL_CALLS: usize = 16;
+/// Maximum `update_task_plan` checkpoints one sandbox run may accumulate.
+///
+/// Plan rows are budgeted separately from the work budget above, and the reason
+/// is the prompt: a run is told to keep its plan current as steps finish, which
+/// is a call after most real steps. Charged to the same 16 rows, bookkeeping
+/// would starve the exec and search calls the task is actually for — the run
+/// would run out of budget describing work it never got to do. Their own cap
+/// keeps that from happening while still bounding a model that does nothing but
+/// rewrite its checklist. It is smaller than the work budget because a plan is
+/// replaced whole: eight revisions is a generous account of one delegated task.
+pub const MAX_SANDBOX_TASK_PLAN_CALLS: usize = 8;
 /// Maximum tool calls one model step may park as a single batch.
 ///
 /// A step's calls are parked together and replayed together, so this bounds how

--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -1067,6 +1067,26 @@ pub mod task_plan {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+pub mod agent_run_task_plan {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "agent_run_task_plan")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub agent_run_id: Uuid,
+        pub call_id: Uuid,
+        pub steps: String,
+        pub created_at: DateTimeUtc,
+        pub updated_at: DateTimeUtc,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub mod user_question_request {
     use sea_orm::entity::prelude::*;
 

--- a/crates/openwave-core/src/db/migration/baseline/mod.rs
+++ b/crates/openwave-core/src/db/migration/baseline/mod.rs
@@ -176,6 +176,10 @@ pub(super) fn tables() -> Vec<BaselineTable> {
             sandbox::sandbox_spawn_checkpoint_indexes(),
         ),
         entry(
+            sandbox::agent_run_task_plan_table(),
+            sandbox::agent_run_task_plan_indexes(),
+        ),
+        entry(
             sandbox::exec_file_snapshot_table(),
             sandbox::exec_file_snapshot_indexes(),
         ),

--- a/crates/openwave-core/src/db/migration/baseline/sandbox.rs
+++ b/crates/openwave-core/src/db/migration/baseline/sandbox.rs
@@ -788,3 +788,62 @@ pub(super) fn exec_file_rejection_indexes() -> Vec<IndexCreateStatement> {
         .col(ExecFileRejection::TurnId)
         .to_owned()]
 }
+
+/// A background agent's durable task plan: one row per run, replaced whole by
+/// each `update_task_plan` checkpoint that run resolves.
+///
+/// Keyed by the run rather than the chat, unlike the foreground `task_plan`.
+/// One conversation can have several sandbox children working at once, and
+/// each is doing a different delegated task; a chat-keyed row would make four
+/// siblings overwrite each other's checklists and the conversation's own.
+///
+/// The steps ride as a JSON array for the same reasons the foreground table
+/// does: they are bounded and validated at the tool boundary before anything
+/// is written, nothing queries an individual step, and a whole-list
+/// replacement is one row write rather than an ordered delete-and-reinsert.
+///
+/// `call_id` names the checkpoint whose resolution last wrote the row, which
+/// is what lets a replayed resolution recognize its own write instead of
+/// committing a second one.
+pub(super) fn agent_run_task_plan_table() -> TableCreateStatement {
+    Table::create()
+        .table(AgentRunTaskPlan::Table)
+        .col(
+            ColumnDef::new(AgentRunTaskPlan::AgentRunId)
+                .uuid()
+                .not_null()
+                .primary_key(),
+        )
+        .col(ColumnDef::new(AgentRunTaskPlan::CallId).uuid().not_null())
+        .col(ColumnDef::new(AgentRunTaskPlan::Steps).text().not_null())
+        .col(
+            ColumnDef::new(AgentRunTaskPlan::CreatedAt)
+                .timestamp_with_time_zone()
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(AgentRunTaskPlan::UpdatedAt)
+                .timestamp_with_time_zone()
+                .not_null(),
+        )
+        .foreign_key(
+            ForeignKey::create()
+                .name("fk_agent_run_task_plan_run")
+                .from(AgentRunTaskPlan::Table, AgentRunTaskPlan::AgentRunId)
+                .to(AgentRun::Table, AgentRun::Id)
+                .on_delete(ForeignKeyAction::Restrict),
+        )
+        .foreign_key(
+            ForeignKey::create()
+                .name("fk_agent_run_task_plan_call")
+                .from(AgentRunTaskPlan::Table, AgentRunTaskPlan::CallId)
+                .to(SandboxToolCall::Table, SandboxToolCall::Id)
+                .on_delete(ForeignKeyAction::Restrict),
+        )
+        .check(Expr::col(AgentRunTaskPlan::UpdatedAt).gte(Expr::col(AgentRunTaskPlan::CreatedAt)))
+        .to_owned()
+}
+
+pub(super) fn agent_run_task_plan_indexes() -> Vec<IndexCreateStatement> {
+    Vec::new()
+}

--- a/crates/openwave-core/src/db/migration/idens.rs
+++ b/crates/openwave-core/src/db/migration/idens.rs
@@ -724,6 +724,16 @@ pub(crate) enum TaskPlan {
 }
 
 #[derive(DeriveIden)]
+pub(crate) enum AgentRunTaskPlan {
+    Table,
+    AgentRunId,
+    CallId,
+    Steps,
+    CreatedAt,
+    UpdatedAt,
+}
+
+#[derive(DeriveIden)]
 pub(crate) enum UserQuestion {
     Table,
     CallId,

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -1240,6 +1240,24 @@ impl Store for DbStore {
         ops::sandbox_tool::resolve_sandbox_tool_call(self, id, lease_token, resolution).await
     }
 
+    async fn resolve_sandbox_task_plan_call(
+        &self,
+        id: CallId,
+        lease_token: uuid::Uuid,
+        steps: &[crate::TaskPlanStep],
+        resolution: &ToolCallResolution,
+    ) -> Result<ResolveSandboxToolCallOutcome> {
+        ops::sandbox_tool::resolve_sandbox_task_plan_call(self, id, lease_token, steps, resolution)
+            .await
+    }
+
+    async fn get_agent_run_task_plan(
+        &self,
+        agent_run_id: AgentRunId,
+    ) -> Result<Option<crate::AgentRunTaskPlan>> {
+        ops::task_plan::get_for_agent_run(self, agent_run_id).await
+    }
+
     async fn get_sandbox_tool_call(&self, id: CallId) -> Result<Option<SandboxToolCall>> {
         ops::sandbox_tool::get_sandbox_tool_call(self, id).await
     }

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -614,6 +614,21 @@ pub(in crate::db) async fn delete_chat(
         .exec(&transaction)
         .await
         .map_err(store_err)?;
+    // A background run's plan restricts against both the run and the checkpoint
+    // that wrote it, so it goes before the sandbox call rows and the runs.
+    entities::agent_run_task_plan::Entity::delete_many()
+        .filter(
+            entities::agent_run_task_plan::Column::AgentRunId.in_subquery(
+                entities::agent_run::Entity::find()
+                    .select_only()
+                    .column(entities::agent_run::Column::Id)
+                    .filter(entities::agent_run::Column::ChatId.eq(chat_id.0))
+                    .into_query(),
+            ),
+        )
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
     entities::sandbox_tool_call_receipt::Entity::delete_many()
         .filter(
             entities::sandbox_tool_call_receipt::Column::CallId.in_subquery(

--- a/crates/openwave-core/src/db/ops/sandbox_tool.rs
+++ b/crates/openwave-core/src/db/ops/sandbox_tool.rs
@@ -7,7 +7,8 @@ use sea_orm::{
 use crate::agent_tools::{
     sandbox_call_is_parallel_eligible, validate_sandbox_exec_arguments,
     validate_sandbox_read_delegated_file_arguments, SandboxAgentFileResource,
-    MAX_SANDBOX_TOOL_CALLS, SANDBOX_EXEC_TOOL, SANDBOX_READ_DELEGATED_FILE_TOOL,
+    MAX_SANDBOX_TASK_PLAN_CALLS, MAX_SANDBOX_TOOL_CALLS, SANDBOX_EXEC_TOOL,
+    SANDBOX_READ_DELEGATED_FILE_TOOL,
 };
 use crate::error::{AgentError, Result};
 use crate::id::{AgentRunId, CallId, ChatId, HostRootId};
@@ -183,14 +184,31 @@ pub(in crate::db) async fn park_agent_run_for_sandbox_tool_calls(
         .filter(entities::sandbox_tool_call::Column::AgentRunId.eq(agent_run_id.0))
         .select_only()
         .column(entities::sandbox_tool_call::Column::Status)
-        .into_tuple::<String>()
+        .column(entities::sandbox_tool_call::Column::Name)
+        .into_tuple::<(String, String)>()
         .all(&transaction)
         .await
         .map_err(store_err)?;
     let all_resolved = siblings
         .iter()
-        .all(|status| status_from_db(status).is_ok_and(SandboxToolCallStatus::is_terminal));
-    if !all_resolved || siblings.len().saturating_add(entries.len()) > MAX_SANDBOX_TOOL_CALLS {
+        .all(|(status, _)| status_from_db(status).is_ok_and(SandboxToolCallStatus::is_terminal));
+    // Two budgets, counted by tool name. Plan bookkeeping is deliberately not
+    // charged to the work budget — a run told to keep its checklist current
+    // would otherwise spend the allowance for the exec and search calls the
+    // task is for — so the durable bound has to know which row is which. The
+    // caller trims an oversized step before it gets here; this keeps both
+    // bounds regardless of what the caller computed.
+    let plan_row = |name: &str| name == crate::UPDATE_TASK_PLAN_TOOL;
+    let existing_plan_rows = siblings.iter().filter(|(_, name)| plan_row(name)).count();
+    let added_plan_rows = entries
+        .iter()
+        .filter(|entry| plan_row(&entry.call.name))
+        .count();
+    let over_budget = existing_plan_rows.saturating_add(added_plan_rows)
+        > MAX_SANDBOX_TASK_PLAN_CALLS
+        || (siblings.len() - existing_plan_rows).saturating_add(entries.len() - added_plan_rows)
+            > MAX_SANDBOX_TOOL_CALLS;
+    if !all_resolved || over_budget {
         transaction.commit().await.map_err(store_err)?;
         return Ok(ParkSandboxToolCallOutcome::IdentityConflict);
     }

--- a/crates/openwave-core/src/db/ops/sandbox_tool.rs
+++ b/crates/openwave-core/src/db/ops/sandbox_tool.rs
@@ -747,6 +747,34 @@ pub(in crate::db) async fn resolve_sandbox_tool_call(
     lease_token: uuid::Uuid,
     resolution: &ToolCallResolution,
 ) -> Result<ResolveSandboxToolCallOutcome> {
+    resolve_sandbox_tool_call_with_plan(store, id, lease_token, resolution, None).await
+}
+
+/// Resolve one `update_task_plan` checkpoint and commit the plan it recorded in
+/// the same transaction.
+///
+/// The plan write and the receipt the model reads back must land together. If
+/// they were two transactions, an interrupted executor could hand the run
+/// "Task plan updated" for a plan nobody stored, or store a plan whose
+/// checkpoint never settled — and the run replays its whole chain on every
+/// claim, so it would keep reading the lie.
+pub(in crate::db) async fn resolve_sandbox_task_plan_call(
+    store: &DbStore,
+    id: CallId,
+    lease_token: uuid::Uuid,
+    steps: &[crate::TaskPlanStep],
+    resolution: &ToolCallResolution,
+) -> Result<ResolveSandboxToolCallOutcome> {
+    resolve_sandbox_tool_call_with_plan(store, id, lease_token, resolution, Some(steps)).await
+}
+
+async fn resolve_sandbox_tool_call_with_plan(
+    store: &DbStore,
+    id: CallId,
+    lease_token: uuid::Uuid,
+    resolution: &ToolCallResolution,
+    plan_steps: Option<&[crate::TaskPlanStep]>,
+) -> Result<ResolveSandboxToolCallOutcome> {
     validate_resolution(resolution)?;
     if id.0.is_nil() || lease_token.is_nil() {
         return Err(AgentError::Store(
@@ -794,6 +822,23 @@ pub(in crate::db) async fn resolve_sandbox_tool_call(
     if run.chat_id != call.chat_id || run.status != AgentRunStatus::Waiting.as_str() {
         transaction.commit().await.map_err(store_err)?;
         return Ok(ResolveSandboxToolCallOutcome::LeaseLost);
+    }
+    if let Some(steps) = plan_steps {
+        // The name is proven from the durable row, not from what the executor
+        // lane believed it claimed: only an `update_task_plan` checkpoint may
+        // move a run's plan.
+        if call.name != crate::UPDATE_TASK_PLAN_TOOL {
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(ResolveSandboxToolCallOutcome::LeaseLost);
+        }
+        super::task_plan::upsert_for_agent_run_on(
+            &transaction,
+            AgentRunId(call.agent_run_id),
+            id,
+            steps,
+            now,
+        )
+        .await?;
     }
     let status = resolution_status(resolution);
     let (error_code, error_detail) = resolution_error(resolution);

--- a/crates/openwave-core/src/db/ops/task_plan.rs
+++ b/crates/openwave-core/src/db/ops/task_plan.rs
@@ -4,7 +4,10 @@ use sea_orm::{ActiveModelTrait, EntityTrait, Set, TransactionTrait};
 use crate::error::{AgentError, Result};
 use crate::event::AgentEvent;
 use crate::storage::TurnLeaseFence;
-use crate::{CallId, ChatId, TaskPlan, TaskPlanStep, TurnId, UPDATE_TASK_PLAN_TOOL};
+use crate::{
+    AgentRunId, AgentRunTaskPlan, CallId, ChatId, TaskPlan, TaskPlanStep, TurnId,
+    UPDATE_TASK_PLAN_TOOL,
+};
 
 use super::super::{entities, store_err, DbStore};
 use super::turn::{canonical_db_timestamp, turn_lease_is_current_on};
@@ -168,4 +171,90 @@ fn projection(row: &entities::task_plan::Model) -> Result<TaskPlan> {
         steps: serde_json::from_str(&row.steps)?,
         updated_at: row.updated_at,
     })
+}
+
+/// Replace one background run's task plan inside its resolving transaction.
+///
+/// The caller is the sandbox checkpoint resolution, which already holds the
+/// executor lease and the claim lock, so this takes no fence of its own: a
+/// write that reaches here has already proven it owns the call. Committing the
+/// plan and the checkpoint's receipt together is the point — a run must never
+/// read "plan updated" back from a receipt whose plan write did not land.
+///
+/// A replayed resolution recognizes its own row by `call_id` and leaves it
+/// alone, the same way the chat-scoped plan does.
+pub(in crate::db) async fn upsert_for_agent_run_on<C>(
+    connection: &C,
+    agent_run_id: AgentRunId,
+    call_id: CallId,
+    steps: &[TaskPlanStep],
+    now: DateTime<Utc>,
+) -> Result<()>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    let encoded = serde_json::to_string(steps)?;
+    let existing = entities::agent_run_task_plan::Entity::find_by_id(agent_run_id.0)
+        .one(connection)
+        .await
+        .map_err(store_err)?;
+    match existing {
+        Some(existing) if existing.call_id == call_id.0 => Ok(()),
+        Some(existing) => {
+            // A retried write must never move `updated_at` behind the row's
+            // own creation, which the table's check constraint forbids.
+            let updated_at = now.max(existing.created_at);
+            let mut row: entities::agent_run_task_plan::ActiveModel = existing.into();
+            row.call_id = Set(call_id.0);
+            row.steps = Set(encoded);
+            row.updated_at = Set(updated_at);
+            row.update(connection).await.map_err(store_err)?;
+            Ok(())
+        }
+        None => {
+            entities::agent_run_task_plan::ActiveModel {
+                agent_run_id: Set(agent_run_id.0),
+                call_id: Set(call_id.0),
+                steps: Set(encoded),
+                created_at: Set(now),
+                updated_at: Set(now),
+            }
+            .insert(connection)
+            .await
+            .map_err(store_err)?;
+            Ok(())
+        }
+    }
+}
+
+/// One background run's current plan, or `None` when it never made one.
+pub(in crate::db) async fn get_for_agent_run(
+    store: &DbStore,
+    agent_run_id: AgentRunId,
+) -> Result<Option<AgentRunTaskPlan>> {
+    let Some(row) = entities::agent_run_task_plan::Entity::find_by_id(agent_run_id.0)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+    else {
+        return Ok(None);
+    };
+    // An unreadable plan is one unreadable checklist, not a run the reader can
+    // no longer open. Reporting "no plan" keeps every other surface working and
+    // lets the run's next call replace it.
+    match serde_json::from_str(&row.steps) {
+        Ok(steps) => Ok(Some(AgentRunTaskPlan {
+            run_id: agent_run_id,
+            steps,
+            updated_at: row.updated_at,
+        })),
+        Err(error) => {
+            tracing::warn!(
+                agent_run_id = %agent_run_id,
+                %error,
+                "stored sandbox task plan could not be read; reporting no plan"
+            );
+            Ok(None)
+        }
+    }
 }

--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -2779,3 +2779,175 @@ async fn a_pre_resolved_sandbox_park_lands_terminal_and_reschedules_the_run() {
         ParkSandboxToolCallOutcome::Existing { .. }
     ));
 }
+
+/// A background run's plan is its own, replaced whole, and erased with the
+/// conversation.
+///
+/// The three properties that matter are all durable ones. The plan is keyed by
+/// the run, so a sibling working a different task cannot overwrite it. The plan
+/// row and the checkpoint's receipt commit in one transaction, so a run never
+/// reads "plan updated" back from a receipt whose write did not land. And the
+/// row restricts against both the run and the checkpoint that wrote it, which
+/// is exactly the shape that made a chat undeletable the last time a plan table
+/// was added without teaching `delete_chat` about it.
+#[tokio::test]
+async fn a_background_run_keeps_its_own_plan_and_the_chat_can_still_be_deleted() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (turn, _turn_lease) = live_turn_for_sandbox_test(&store, chat.id).await;
+    let sandbox = accepted_sandbox_for_tool_test(&store, chat.id).await;
+    let sibling = admit_sandbox_for_test(&store, chat.id, "a different delegated task").await;
+
+    let plan = |content: &str, status| {
+        vec![crate::TaskPlanStep {
+            content: content.into(),
+            status,
+        }]
+    };
+    let record = |run: &AgentRun, provider_id: &str, steps: Vec<crate::TaskPlanStep>| {
+        let run_id = run.id;
+        let provider_id = provider_id.to_owned();
+        let store = &store;
+        async move {
+            let worker_lease = uuid::Uuid::new_v4();
+            let claimed = store
+                .claim_agent_run(worker_lease, Duration::minutes(5), 8, 8)
+                .await
+                .unwrap()
+                .expect("a queued sandbox run claims");
+            assert_eq!(claimed.id, run_id);
+            let request = SandboxToolCallRequest {
+                id: CallId::new(),
+                agent_run_id: run_id,
+                chat_id: chat.id,
+                provider_id,
+                name: crate::UPDATE_TASK_PLAN_TOOL.into(),
+                arguments: serde_json::json!({"steps": []}),
+            };
+            store
+                .park_agent_run_for_sandbox_tool_calls(
+                    run_id,
+                    worker_lease,
+                    &[super::dispatchable(&request)],
+                )
+                .await
+                .unwrap();
+            let executor_lease = uuid::Uuid::new_v4();
+            store
+                .claim_sandbox_tool_call(request.id, executor_lease, Duration::minutes(2))
+                .await
+                .unwrap();
+            assert_eq!(
+                store
+                    .resolve_sandbox_task_plan_call(
+                        request.id,
+                        executor_lease,
+                        &steps,
+                        &ToolCallResolution::Completed {
+                            result: crate::task_plan_summary(&steps),
+                        },
+                    )
+                    .await
+                    .unwrap(),
+                ResolveSandboxToolCallOutcome::Resolved
+            );
+            // The receipt the model reads back and the plan it names commit
+            // together, so the summary is never a claim about a row that is
+            // not there.
+            let receipt = store
+                .get_sandbox_tool_call_receipt(request.id)
+                .await
+                .unwrap()
+                .unwrap();
+            assert!(receipt.result.contains("Task plan updated"));
+            request.id
+        }
+    };
+
+    record(
+        &sandbox,
+        "call-1",
+        plan("draft the outline", crate::TaskPlanStepStatus::InProgress),
+    )
+    .await;
+    assert_eq!(
+        store
+            .get_agent_run_task_plan(sandbox.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .steps,
+        plan("draft the outline", crate::TaskPlanStepStatus::InProgress)
+    );
+    // A sibling delegated a different task writes its own row and leaves the
+    // first alone. One chat-keyed row would have made these two overwrite each
+    // other, which is the whole reason this table is keyed by the run.
+    record(
+        &sibling,
+        "call-2",
+        plan("read the source", crate::TaskPlanStepStatus::Completed),
+    )
+    .await;
+    // The second call replaces the whole list rather than merging into it.
+    record(
+        &sandbox,
+        "call-3",
+        plan("draft the outline", crate::TaskPlanStepStatus::Completed),
+    )
+    .await;
+    let current = store
+        .get_agent_run_task_plan(sandbox.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(current.run_id, sandbox.id);
+    assert_eq!(
+        current.steps,
+        plan("draft the outline", crate::TaskPlanStepStatus::Completed)
+    );
+    assert_eq!(
+        store
+            .get_agent_run_task_plan(sibling.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .steps,
+        plan("read the source", crate::TaskPlanStepStatus::Completed)
+    );
+
+    for run in [sandbox.id, sibling.id] {
+        assert!(matches!(
+            store.request_agent_run_cancellation(run).await.unwrap(),
+            Some(RequestAgentRunCancellationOutcome::Cancelled(_))
+        ));
+    }
+    let turn = store.get_turn_run(turn.id).await.unwrap().unwrap();
+    store
+        .request_turn_cancellation_and_append_event(turn.id, turn.updated_at + Duration::seconds(1))
+        .await
+        .unwrap();
+    // The spawning turn is quiesced the same way a worker acknowledgement
+    // would leave it; deletion is what this half of the test is about, not the
+    // turn state machine.
+    let mut settled: crate::db::entities::turn_run::ActiveModel =
+        crate::db::entities::turn_run::Entity::find_by_id(turn.id.0)
+            .one(&store.conn)
+            .await
+            .unwrap()
+            .unwrap()
+            .into();
+    settled.status = Set(TurnRunStatus::Cancelled.as_str().into());
+    settled.lease_token = Set(None);
+    settled.lease_expires_at = Set(None);
+    settled.finished_at = Set(Some(Utc::now()));
+    settled.update(&store.conn).await.unwrap();
+    assert_eq!(
+        store.delete_chat(chat.id).await.unwrap(),
+        crate::DeleteChatOutcome::Deleted
+    );
+    assert_eq!(
+        store.get_agent_run_task_plan(sandbox.id).await.unwrap(),
+        None
+    );
+}

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -103,11 +103,12 @@ pub use agent_tools::{
     SpawnSandboxAgentResult, WaitForAgentResult, WaitForAgentsArgs, WaitForAgentsResult,
     WebExtractArgs, WebSearchArgs, DEFAULT_WEB_SEARCH_RESULTS, MAX_SANDBOX_AGENT_TASK_CHARS,
     MAX_SANDBOX_DONE_OUTPUTS, MAX_SANDBOX_DONE_SUMMARY_CHARS, MAX_SANDBOX_EXEC_ARGUMENTS,
-    MAX_SANDBOX_EXEC_COMMAND_BYTES, MAX_SANDBOX_EXEC_CWD_BYTES, MAX_SANDBOX_TOOL_CALLS,
-    MAX_SANDBOX_TOOL_CALLS_PER_STEP, MAX_WAIT_FOR_AGENTS_CHILDREN, MAX_WEB_EXTRACT_URL_BYTES,
-    MAX_WEB_SEARCH_DOMAINS, MAX_WEB_SEARCH_QUERY_CHARS, MAX_WEB_SEARCH_RESULTS, SANDBOX_DONE_TOOL,
-    SANDBOX_EXEC_TOOL, SANDBOX_READ_DELEGATED_FILE_TOOL, SANDBOX_WEB_SEARCH_TOOL,
-    SPAWN_SANDBOX_AGENT_TOOL, WAIT_FOR_AGENTS_TOOL, WEB_EXTRACT_TOOL, WEB_SEARCH_TOOL,
+    MAX_SANDBOX_EXEC_COMMAND_BYTES, MAX_SANDBOX_EXEC_CWD_BYTES, MAX_SANDBOX_TASK_PLAN_CALLS,
+    MAX_SANDBOX_TOOL_CALLS, MAX_SANDBOX_TOOL_CALLS_PER_STEP, MAX_WAIT_FOR_AGENTS_CHILDREN,
+    MAX_WEB_EXTRACT_URL_BYTES, MAX_WEB_SEARCH_DOMAINS, MAX_WEB_SEARCH_QUERY_CHARS,
+    MAX_WEB_SEARCH_RESULTS, SANDBOX_DONE_TOOL, SANDBOX_EXEC_TOOL, SANDBOX_READ_DELEGATED_FILE_TOOL,
+    SANDBOX_WEB_SEARCH_TOOL, SPAWN_SANDBOX_AGENT_TOOL, WAIT_FOR_AGENTS_TOOL, WEB_EXTRACT_TOOL,
+    WEB_SEARCH_TOOL,
 };
 pub use approval::{
     ApprovalDecision, ApprovalFuture, ApprovalGate, ApprovalJournalIdentity, ApprovalRegistration,
@@ -245,9 +246,10 @@ pub use storage::{
     MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
 };
 pub use task_plan::{
-    open_task_plan_steps, parse_update_task_plan_arguments, task_plan_summary,
-    update_task_plan_tool_spec, AgentRunTaskPlan, TaskPlan, TaskPlanStep, TaskPlanStepStatus,
-    UpdateTaskPlanArgs, MAX_TASK_PLAN_STEPS, MAX_TASK_PLAN_STEP_CHARS, UPDATE_TASK_PLAN_TOOL,
+    open_task_plan_steps, parse_update_task_plan_arguments, sandbox_update_task_plan_tool_spec,
+    task_plan_summary, update_task_plan_tool_spec, AgentRunTaskPlan, TaskPlan, TaskPlanStep,
+    TaskPlanStepStatus, UpdateTaskPlanArgs, MAX_TASK_PLAN_STEPS, MAX_TASK_PLAN_STEP_CHARS,
+    UPDATE_TASK_PLAN_TOOL,
 };
 pub use tool::{
     input_schema_for, strict_json_schema, ApprovalClass, OptionalProperties, ScratchPriorContents,

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -245,9 +245,9 @@ pub use storage::{
     MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
 };
 pub use task_plan::{
-    parse_update_task_plan_arguments, task_plan_summary, update_task_plan_tool_spec, TaskPlan,
-    TaskPlanStep, TaskPlanStepStatus, UpdateTaskPlanArgs, MAX_TASK_PLAN_STEPS,
-    MAX_TASK_PLAN_STEP_CHARS, UPDATE_TASK_PLAN_TOOL,
+    open_task_plan_steps, parse_update_task_plan_arguments, task_plan_summary,
+    update_task_plan_tool_spec, AgentRunTaskPlan, TaskPlan, TaskPlanStep, TaskPlanStepStatus,
+    UpdateTaskPlanArgs, MAX_TASK_PLAN_STEPS, MAX_TASK_PLAN_STEP_CHARS, UPDATE_TASK_PLAN_TOOL,
 };
 pub use tool::{
     input_schema_for, strict_json_schema, ApprovalClass, OptionalProperties, ScratchPriorContents,

--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -1100,7 +1100,12 @@ fn survives_clamp(value: &str) -> bool {
 ///
 /// This clamp is shared by foreground approval previews and background
 /// activity details, so extending it hardens both renderer surfaces together.
-fn preview_formatting_character(character: char) -> bool {
+///
+/// It is also the admission rule for text a tool boundary stores and a renderer
+/// later shows verbatim — see [`crate::task_plan`]. A surface that clamps on
+/// read and a surface that rejects on write must agree on the character set, or
+/// the writer produces payloads the reader silently drops.
+pub(crate) fn preview_formatting_character(character: char) -> bool {
     character.is_control()
         || matches!(
             character,

--- a/crates/openwave-core/src/storage/store.rs
+++ b/crates/openwave-core/src/storage/store.rs
@@ -1342,6 +1342,30 @@ pub trait Store: Send + Sync {
         agent_run_storage_unavailable()
     }
 
+    /// Resolve one `update_task_plan` checkpoint and commit the plan it
+    /// recorded in the same transaction.
+    ///
+    /// Steps must already be validated at the tool boundary; storage records
+    /// what it is given. The plan is keyed by the checkpoint's own run, so
+    /// sandbox siblings never overwrite each other or the chat's plan.
+    async fn resolve_sandbox_task_plan_call(
+        &self,
+        _id: CallId,
+        _lease_token: uuid::Uuid,
+        _steps: &[crate::TaskPlanStep],
+        _resolution: &ToolCallResolution,
+    ) -> Result<ResolveSandboxToolCallOutcome> {
+        agent_run_storage_unavailable()
+    }
+
+    /// One background run's current task plan, or `None` when it made none.
+    async fn get_agent_run_task_plan(
+        &self,
+        _agent_run_id: AgentRunId,
+    ) -> Result<Option<crate::AgentRunTaskPlan>> {
+        agent_run_storage_unavailable()
+    }
+
     /// Fetch a sandbox tool checkpoint by its stable model-visible identity.
     async fn get_sandbox_tool_call(
         &self,

--- a/crates/openwave-core/src/task_plan.rs
+++ b/crates/openwave-core/src/task_plan.rs
@@ -1,4 +1,4 @@
-//! The foreground agent's durable task plan.
+//! An agent's durable task plan.
 //!
 //! A plan is a short ordered checklist the agent keeps for itself while it
 //! works through a request with several dependent steps. It is not a
@@ -10,13 +10,21 @@
 //! makes the durable row a projection of one call rather than a fold over a
 //! history of edits: nothing has to reconcile a partial update against what an
 //! interrupted earlier call did or did not commit.
+//!
+//! Two agents keep plans and they are scoped differently. A foreground plan is
+//! the conversation's, so it is keyed by chat and outlives the turn that wrote
+//! it ([`TaskPlan`]). A background agent's plan belongs to the one delegated
+//! task it was created for, and a chat may have many of those running at once,
+//! so it is keyed by the run ([`AgentRunTaskPlan`]). Sharing one chat-keyed row
+//! between them would let four sandbox siblings overwrite each other and the
+//! conversation's own plan.
 
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::{ToolSpec, TurnId};
+use crate::{AgentRunId, ToolSpec, TurnId};
 
 /// Stable foreground-only tool name.
 pub const UPDATE_TASK_PLAN_TOOL: &str = "update_task_plan";
@@ -68,6 +76,33 @@ pub struct TaskPlan {
     pub steps: Vec<TaskPlanStep>,
     /// When the last replacement committed.
     pub updated_at: DateTime<Utc>,
+}
+
+/// Renderer-safe durable projection of one background run's current plan.
+///
+/// The run-scoped twin of [`TaskPlan`]. It carries no turn: a background run
+/// is one delegated task from start to finish, so the run is the only scope
+/// its plan ever had.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
+pub struct AgentRunTaskPlan {
+    pub run_id: AgentRunId,
+    /// The steps, in order.
+    pub steps: Vec<TaskPlanStep>,
+    /// When the last replacement committed.
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Steps a plan has not finished, in order, for a reminder the model reads.
+///
+/// Empty when every step is `completed`, which is the only state in which a
+/// run has nothing left to close out.
+#[must_use]
+pub fn open_task_plan_steps(steps: &[TaskPlanStep]) -> Vec<&str> {
+    steps
+        .iter()
+        .filter(|step| step.status != TaskPlanStepStatus::Completed)
+        .map(|step| step.content.as_str())
+        .collect()
 }
 
 /// Parse and check one call's arguments, or say exactly what to fix.

--- a/crates/openwave-core/src/task_plan.rs
+++ b/crates/openwave-core/src/task_plan.rs
@@ -26,7 +26,11 @@ use serde_json::Value;
 
 use crate::{AgentRunId, ToolSpec, TurnId};
 
-/// Stable foreground-only tool name.
+/// Stable tool name, shared by the foreground turn and the sandbox surface.
+///
+/// One name, two spec descriptions: the foreground call commits and returns,
+/// while the sandbox call is a durable checkpoint that parks the run. See
+/// [`update_task_plan_tool_spec`] and [`sandbox_update_task_plan_tool_spec`].
 pub const UPDATE_TASK_PLAN_TOOL: &str = "update_task_plan";
 
 pub const MAX_TASK_PLAN_STEPS: usize = 20;
@@ -150,9 +154,21 @@ fn check_steps(steps: &[TaskPlanStep]) -> std::result::Result<(), String> {
                 index + 1
             ));
         }
-        if step.content.chars().any(char::is_control) {
+        // The same predicate the renderer clamps with. Step content is one of
+        // the few model-authored strings a surface shows verbatim rather than
+        // through the clamp, so the write side has to reject exactly what the
+        // read side would strip: control characters, the line/paragraph
+        // separators, and the bidi overrides and isolates that let one line
+        // rewrite the visual order of what is around it. Rejecting here rather
+        // than sanitizing keeps the stored plan the plan the model sent, and
+        // keeps a step that would clamp away to nothing from ever existing.
+        if step
+            .content
+            .chars()
+            .any(crate::preview::preview_formatting_character)
+        {
             return Err(format!(
-                "step {} contains control characters; send plain single-line text",
+                "step {} contains control or text-direction characters; send plain single-line text",
                 index + 1
             ));
         }
@@ -190,6 +206,28 @@ pub fn task_plan_summary(steps: &[TaskPlanStep]) -> String {
         }
         None => format!("Task plan updated: {completed}/{total} steps completed."),
     }
+}
+
+/// The same tool on the sandbox surface, described as it actually behaves.
+///
+/// The arguments and their bounds are the foreground spec's — one shared
+/// schema, so the two surfaces cannot drift into accepting different plans.
+/// The description cannot be shared: a background run's plan row lives in the
+/// host's database, so the call is a durable checkpoint that parks the run and
+/// resumes it with the result, and telling the model it "returns immediately
+/// and does not pause the turn" would be false on exactly the surface where the
+/// pause is real and paid for out of a budget.
+#[must_use]
+pub fn sandbox_update_task_plan_tool_spec() -> ToolSpec {
+    ToolSpec::for_args::<UpdateTaskPlanArgs>(
+        UPDATE_TASK_PLAN_TOOL,
+        "Record the ordered steps you intend to work through on this background task, so the \
+         reader can follow long work as it progresses. Send the complete list every time — each \
+         call replaces the previous plan. Keep exactly one step in_progress while you work on it, \
+         mark it completed as soon as it is done, and update the plan as you go rather than in a \
+         batch at the end. Like your other tools this call is a step: it pauses the task, records \
+         the plan, and hands the result back before you continue.",
+    )
 }
 
 #[must_use]
@@ -244,6 +282,25 @@ mod tests {
         let mut blank = sample();
         blank["steps"][0]["content"] = Value::String("   ".into());
         assert!(parse_update_task_plan_arguments(&blank).is_err());
+
+        // Step content is shown verbatim on surfaces that clamp everything
+        // else, so the write side rejects exactly what the renderer clamp
+        // strips — not just C0 controls, but the separators and bidi overrides
+        // that let one step rewrite the visual order of the rows around it. A
+        // plan the clamp would gut must never be storable in the first place.
+        for spoof in [
+            "line\u{2028}break",
+            "para\u{2029}break",
+            "\u{202e}drowkcab",
+            "\u{2066}isolated\u{2069}",
+        ] {
+            let mut formatted = sample();
+            formatted["steps"][0]["content"] = Value::String(spoof.into());
+            assert!(
+                parse_update_task_plan_arguments(&formatted).is_err(),
+                "{spoof:?} must not be storable"
+            );
+        }
     }
 
     #[test]
@@ -271,6 +328,16 @@ mod tests {
         assert!(
             crate::tool::strict_json_schema(&schema, crate::tool::OptionalProperties::Reject)
                 .is_some()
+        );
+        // The sandbox surface differs only in what it tells the model about
+        // pausing; both surfaces must accept exactly the same plan.
+        let sandbox = sandbox_update_task_plan_tool_spec();
+        assert_eq!(sandbox.name, UPDATE_TASK_PLAN_TOOL);
+        assert_eq!(sandbox.input_schema, schema);
+        assert_ne!(
+            sandbox.description,
+            update_task_plan_tool_spec().description,
+            "a checkpointed call must not claim it returns without pausing"
         );
     }
 }

--- a/crates/openwave-desktop/ui/src/AgentRunDisplay.ts
+++ b/crates/openwave-desktop/ui/src/AgentRunDisplay.ts
@@ -58,6 +58,7 @@ export function agentRunStatusDetail(run: AgentRun): string {
     const activity = {
       exec: { running: "Running a command", waiting: "Waiting to run a command" },
       web_search: { running: "Searching the web", waiting: "Waiting to search" },
+      update_task_plan: { running: "Updating its plan", waiting: "Waiting to update its plan" },
       read_delegated_file: {
         running: "Reading a delegated file",
         waiting: "Waiting to read a delegated file",
@@ -118,6 +119,13 @@ const ACTIVITY_HISTORY_LABELS: Record<
     completed: "Searched the web",
     failed: "Web search failed",
     cancelled: "Web search stopped",
+  },
+  update_task_plan: {
+    waiting: "Waiting to update its plan",
+    running: "Updating its plan",
+    completed: "Updated its plan",
+    failed: "Could not update its plan",
+    cancelled: "Plan update stopped",
   },
   read_delegated_file: {
     waiting: "Waiting to read a delegated file",

--- a/crates/openwave-desktop/ui/src/api/parsers.ts
+++ b/crates/openwave-desktop/ui/src/api/parsers.ts
@@ -436,6 +436,7 @@ function forbiddenPreviewCharacter(character: string): boolean {
 const AGENT_ACTIVITY_KINDS = new Set<AgentActivityKind>([
   "exec",
   "web_search",
+  "update_task_plan",
   "read_delegated_file",
   "list_connected_folders",
   "list_folder",

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -201,10 +201,14 @@ updated_at: string, };
  * A run's plan as a status row needs it: the count, and the current step.
  *
  * Step text is model-authored, like the command and query headlines the
- * activity history carries. It is bounded and single-line before it is ever
- * stored — the tool boundary rejects a step longer than
- * [`openwave_core::MAX_TASK_PLAN_STEP_CHARS`] or carrying control characters —
- * so the projection copies it as stored rather than re-clamping it here.
+ * activity history carries. The difference is that those go through the
+ * renderer clamp on the way out and this does not, so the tool boundary
+ * rejects on the way in against the very same predicate: a step longer than
+ * [`openwave_core::MAX_TASK_PLAN_STEP_CHARS`], or carrying any character the
+ * preview clamp would strip — control characters, the line and paragraph
+ * separators, the bidi overrides and isolates — never becomes a stored step.
+ * Copying it as stored is therefore not a gap in the clamp; it is the same
+ * rule enforced one surface earlier.
  */
 export type AgentRunTaskPlanProgress = { completed: number, total: number, 
 /**

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -53,7 +53,7 @@ export type AgentActivityHistoryItem = { kind: AgentActivityKind, outcome: Agent
  * Adding a durable tool does not automatically expose it to a renderer: it
  * must be deliberately admitted here with a safe label.
  */
-export type AgentActivityKind = "exec" | "web_search" | "read_delegated_file" | "list_connected_folders" | "list_folder" | "read_connected_file" | "import_connected_file";
+export type AgentActivityKind = "exec" | "web_search" | "update_task_plan" | "read_delegated_file" | "list_connected_folders" | "list_folder" | "read_connected_file" | "import_connected_file";
 
 /**
  * Coarse, renderer-safe lifecycle for one historical activity entry.
@@ -160,6 +160,17 @@ activity: AgentActivitySnapshot | null,
  */
 submitted_outputs: Array<SubmittedOutputSnapshot>, 
 /**
+ * How far this run's own task plan has got, when it keeps one.
+ *
+ * The full list is its own route; the snapshot carries only what a status
+ * row needs — how many steps are done, and the one step being worked on.
+ *
+ * Omitted rather than null when there is no plan, which keeps the wire
+ * additive: every run before this field existed, and every foreground
+ * coordinator, reads back in the shape it always had.
+ */
+task_plan?: AgentRunTaskPlanProgress, 
+/**
  * Bounded terminal display text returned to the parent, if settled.
  */
 terminal_text: string | null, created_at: string, updated_at: string, spawn_call_id: CallId | null, };
@@ -168,6 +179,38 @@ terminal_text: string | null, created_at: string, updated_at: string, spawn_call
  * Durable lifecycle of an [`AgentRun`].
  */
 export type AgentRunStatus = "active" | "queued" | "running" | "cancelling" | "waiting" | "retry_wait" | "completed" | "failed" | "cancelled";
+
+/**
+ * Renderer-safe durable projection of one background run's current plan.
+ *
+ * The run-scoped twin of [`TaskPlan`]. It carries no turn: a background run
+ * is one delegated task from start to finish, so the run is the only scope
+ * its plan ever had.
+ */
+export type AgentRunTaskPlan = { run_id: AgentRunId, 
+/**
+ * The steps, in order.
+ */
+steps: Array<TaskPlanStep>, 
+/**
+ * When the last replacement committed.
+ */
+updated_at: string, };
+
+/**
+ * A run's plan as a status row needs it: the count, and the current step.
+ *
+ * Step text is model-authored, like the command and query headlines the
+ * activity history carries. It is bounded and single-line before it is ever
+ * stored — the tool boundary rejects a step longer than
+ * [`openwave_core::MAX_TASK_PLAN_STEP_CHARS`] or carrying control characters —
+ * so the projection copies it as stored rather than re-clamping it here.
+ */
+export type AgentRunTaskPlanProgress = { completed: number, total: number, 
+/**
+ * The one step marked `in_progress`, when there is one.
+ */
+current: string | null, updated_at: string, };
 
 /**
  * Run tier of an [`AgentRun`]: who advances the run.

--- a/crates/openwave-sandbox-agent/src/tools.rs
+++ b/crates/openwave-sandbox-agent/src/tools.rs
@@ -27,6 +27,17 @@
 //!   [`list_dir`](crate::fs)** — path-validated filesystem access within the
 //!   agent's workspace directory.
 //!
+//! # Host-side tools are not registry entries
+//!
+//! This registry names the tools the loop runs *locally*. A background agent's
+//! host-side surface — submission, public web search, the task plan — is not
+//! here and must not be added here: those calls write to the host's database or
+//! leave the host's network, and executing them in the container would either
+//! be impossible or would hand container-resident model output the authority
+//! the container exists to withhold. They reach the host over durable
+//! checkpoints instead. Routing one into the container would need a new reverse
+//! capability, which is the separate design this module's gate is about.
+//!
 //! # NOT YET FOR CREDENTIAL-BEARING WORK
 //!
 //! `exec` can make network calls. Egress is meant to be routed through the

--- a/crates/openwave-server/src/desktop_schema.rs
+++ b/crates/openwave-server/src/desktop_schema.rs
@@ -25,7 +25,7 @@ const VECTOR_DIRECTORY: &str = "vectors";
 const MAX_MARKER_BYTES: u64 = 1_024;
 
 /// Bump this whenever the pre-v1 schema baseline changes incompatibly.
-const DESKTOP_SCHEMA_EPOCH: u32 = 14;
+const DESKTOP_SCHEMA_EPOCH: u32 = 15;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -69,6 +69,7 @@ mod sandbox_container_run_worker;
 /// correlation-tag orphan sweep.
 pub mod sandbox_docker;
 mod sandbox_exec_worker;
+mod sandbox_task_plan_worker;
 mod sandbox_web_search_worker;
 mod scoped_model_token;
 mod scoped_store;
@@ -476,6 +477,10 @@ pub fn app(state: AppState) -> Router {
             get(routes::list_agent_run_activity),
         )
         .route(
+            "/chats/{chat_id}/agent-runs/{run_id}/task-plan",
+            get(routes::get_agent_run_task_plan),
+        )
+        .route(
             "/chats/{chat_id}/agent-runs/{run_id}/progress",
             get(routes::list_agent_run_progress),
         )
@@ -635,6 +640,7 @@ pub struct Server {
     _sandbox_agent_run_worker: AbortTask,
     _sandbox_container_run_worker: Option<AbortTask>,
     _sandbox_web_search_worker: AbortTask,
+    _sandbox_task_plan_worker: AbortTask,
     _sandbox_exec_worker: AbortTask,
     _agent_run_scratch_reaper: AbortTask,
     _blob_retirement_worker: AbortTask,
@@ -1101,6 +1107,11 @@ async fn bind_inner(
             state.sandbox_attempts.clone(),
             sandbox_web_search_worker::SandboxWebSearchWorkerConfig::default(),
         );
+    let sandbox_task_plan_worker = sandbox_task_plan_worker::SandboxTaskPlanWorker::new(
+        state.store.clone(),
+        state.agent_run_wake.clone(),
+        sandbox_task_plan_worker::SandboxTaskPlanWorkerConfig::default(),
+    );
     let sandbox_exec_worker = sandbox_exec_worker::SandboxExecWorker::with_attempts(
         state.store.clone(),
         code_execution.clone(),
@@ -1144,6 +1155,7 @@ async fn bind_inner(
     let sandbox_container_run_worker =
         sandbox_container_run_worker.map(|worker| tokio::spawn(worker.run()));
     let sandbox_web_search_worker = tokio::spawn(sandbox_web_search_worker.run());
+    let sandbox_task_plan_worker = tokio::spawn(sandbox_task_plan_worker.run());
     let sandbox_exec_worker = tokio::spawn(sandbox_exec_worker.run());
     let agent_run_scratch_reaper = tokio::spawn(agent_run_scratch_reaper.run());
     let blob_retirement_worker = tokio::spawn(blob_retirement_worker.run());
@@ -1170,6 +1182,7 @@ async fn bind_inner(
         _sandbox_agent_run_worker: AbortTask(sandbox_agent_run_worker),
         _sandbox_container_run_worker: sandbox_container_run_worker.map(AbortTask),
         _sandbox_web_search_worker: AbortTask(sandbox_web_search_worker),
+        _sandbox_task_plan_worker: AbortTask(sandbox_task_plan_worker),
         _sandbox_exec_worker: AbortTask(sandbox_exec_worker),
         _agent_run_scratch_reaper: AbortTask(agent_run_scratch_reaper),
         _blob_retirement_worker: AbortTask(blob_retirement_worker),

--- a/crates/openwave-server/src/routes/agent_runs.rs
+++ b/crates/openwave-server/src/routes/agent_runs.rs
@@ -106,10 +106,14 @@ pub struct SubmittedOutputSnapshot {
 /// A run's plan as a status row needs it: the count, and the current step.
 ///
 /// Step text is model-authored, like the command and query headlines the
-/// activity history carries. It is bounded and single-line before it is ever
-/// stored — the tool boundary rejects a step longer than
-/// [`openwave_core::MAX_TASK_PLAN_STEP_CHARS`] or carrying control characters —
-/// so the projection copies it as stored rather than re-clamping it here.
+/// activity history carries. The difference is that those go through the
+/// renderer clamp on the way out and this does not, so the tool boundary
+/// rejects on the way in against the very same predicate: a step longer than
+/// [`openwave_core::MAX_TASK_PLAN_STEP_CHARS`], or carrying any character the
+/// preview clamp would strip — control characters, the line and paragraph
+/// separators, the bidi overrides and isolates — never becomes a stored step.
+/// Copying it as stored is therefore not a gap in the clamp; it is the same
+/// rule enforced one surface earlier.
 #[derive(Debug, Clone, Serialize, ts_rs::TS)]
 pub struct AgentRunTaskPlanProgress {
     pub completed: u32,

--- a/crates/openwave-server/src/routes/agent_runs.rs
+++ b/crates/openwave-server/src/routes/agent_runs.rs
@@ -45,6 +45,17 @@ pub struct AgentRunSnapshot {
     /// by name; nothing here is host-authored, and a run that submitted nothing
     /// carries an empty list.
     pub submitted_outputs: Vec<SubmittedOutputSnapshot>,
+    /// How far this run's own task plan has got, when it keeps one.
+    ///
+    /// The full list is its own route; the snapshot carries only what a status
+    /// row needs — how many steps are done, and the one step being worked on.
+    ///
+    /// Omitted rather than null when there is no plan, which keeps the wire
+    /// additive: every run before this field existed, and every foreground
+    /// coordinator, reads back in the shape it always had.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub task_plan: Option<AgentRunTaskPlanProgress>,
     /// Bounded terminal display text returned to the parent, if settled.
     pub terminal_text: Option<String>,
     pub created_at: chrono::DateTime<Utc>,
@@ -61,6 +72,7 @@ impl AgentRunSnapshot {
         activity: Option<AgentActivitySnapshot>,
         terminal_text: Option<String>,
         submitted_outputs: Vec<SubmittedOutputSnapshot>,
+        task_plan: Option<AgentRunTaskPlanProgress>,
     ) -> Self {
         Self {
             id: run.id,
@@ -75,6 +87,7 @@ impl AgentRunSnapshot {
             last_error_code: run.last_error_code,
             activity,
             submitted_outputs,
+            task_plan,
             terminal_text,
             created_at: run.created_at,
             updated_at: run.updated_at,
@@ -90,6 +103,43 @@ pub struct SubmittedOutputSnapshot {
     pub filename: String,
 }
 
+/// A run's plan as a status row needs it: the count, and the current step.
+///
+/// Step text is model-authored, like the command and query headlines the
+/// activity history carries. It is bounded and single-line before it is ever
+/// stored — the tool boundary rejects a step longer than
+/// [`openwave_core::MAX_TASK_PLAN_STEP_CHARS`] or carrying control characters —
+/// so the projection copies it as stored rather than re-clamping it here.
+#[derive(Debug, Clone, Serialize, ts_rs::TS)]
+pub struct AgentRunTaskPlanProgress {
+    pub completed: u32,
+    pub total: u32,
+    /// The one step marked `in_progress`, when there is one.
+    pub current: Option<String>,
+    pub updated_at: chrono::DateTime<Utc>,
+}
+
+impl AgentRunTaskPlanProgress {
+    fn from_plan(plan: &openwave_core::AgentRunTaskPlan) -> Self {
+        Self {
+            completed: u32::try_from(
+                plan.steps
+                    .iter()
+                    .filter(|step| step.status == openwave_core::TaskPlanStepStatus::Completed)
+                    .count(),
+            )
+            .unwrap_or(u32::MAX),
+            total: u32::try_from(plan.steps.len()).unwrap_or(u32::MAX),
+            current: plan
+                .steps
+                .iter()
+                .find(|step| step.status == openwave_core::TaskPlanStepStatus::InProgress)
+                .map(|step| step.content.clone()),
+            updated_at: plan.updated_at,
+        }
+    }
+}
+
 /// Fixed, renderer-safe names for supported live work.
 ///
 /// Adding a durable tool does not automatically expose it to a renderer: it
@@ -99,6 +149,7 @@ pub struct SubmittedOutputSnapshot {
 pub enum AgentActivityKind {
     Exec,
     WebSearch,
+    UpdateTaskPlan,
     ReadDelegatedFile,
     ListConnectedFolders,
     ListFolder,
@@ -137,6 +188,7 @@ fn sandbox_activity(calls: &[SandboxToolCall]) -> Option<AgentActivitySnapshot> 
     let kind = match call.name.as_str() {
         openwave_core::SANDBOX_EXEC_TOOL => AgentActivityKind::Exec,
         "web_search" => AgentActivityKind::WebSearch,
+        openwave_core::UPDATE_TASK_PLAN_TOOL => AgentActivityKind::UpdateTaskPlan,
         openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL => AgentActivityKind::ReadDelegatedFile,
         // Unknown tool names are executor data, not a renderer API contract.
         _ => return None,
@@ -227,6 +279,7 @@ fn sandbox_activity_history_item(
     let kind = match call.name.as_str() {
         openwave_core::SANDBOX_EXEC_TOOL => AgentActivityKind::Exec,
         "web_search" => AgentActivityKind::WebSearch,
+        openwave_core::UPDATE_TASK_PLAN_TOOL => AgentActivityKind::UpdateTaskPlan,
         openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL => AgentActivityKind::ReadDelegatedFile,
         // Unknown tool names are executor data, not a renderer API contract.
         _ => return None,
@@ -349,8 +402,16 @@ pub async fn list_agent_runs(
                 .map(|code| format!("Sandbox task failed ({code})")),
             _ => None,
         };
+        let mut task_plan = None;
         let activity = if run.tier == AgentRunTier::Background {
             let calls = store.list_sandbox_tool_calls_for_agent_run(run.id).await?;
+            // Only a background run keeps a run-scoped plan. The foreground
+            // coordinator's plan belongs to the chat and has its own route.
+            task_plan = store
+                .get_agent_run_task_plan(run.id)
+                .await?
+                .as_ref()
+                .map(AgentRunTaskPlanProgress::from_plan);
             sandbox_activity(&calls)
         } else if run.tier == AgentRunTier::Foreground {
             foreground_activity(&client_calls, now)
@@ -362,6 +423,7 @@ pub async fn list_agent_runs(
             activity,
             terminal_text,
             submitted_outputs,
+            task_plan,
         ));
     }
     Ok(Json(snapshots))
@@ -429,6 +491,35 @@ pub async fn list_agent_run_activity(
         delegated_file.as_deref(),
         &receipts,
     )))
+}
+
+/// `GET /chats/{chat_id}/agent-runs/{run_id}/task-plan` — the full ordered
+/// checklist one background run keeps, or `null`.
+///
+/// The snapshot carries the count and the current step because that is all a
+/// status row needs; a reader opening the run wants the whole list. The steps
+/// are the run's own model-authored text, bounded and single-line before
+/// storage accepts them. Nothing else about the run crosses here — no
+/// checkpoint arguments, receipts, leases, or diagnostics.
+///
+/// Read-only and bound to the exact chat: a missing, wrong-chat, or foreground
+/// run returns `404`, exactly as the activity history does. A run that never
+/// made a plan is not an error; it answers `null`.
+pub async fn get_agent_run_task_plan(
+    store: ScopedStore,
+    Path((chat_id, run_id)): Path<(ChatId, openwave_core::AgentRunId)>,
+) -> Result<Json<Option<openwave_core::AgentRunTaskPlan>>, ServerError> {
+    store.require_chat(chat_id).await?;
+    let run = store
+        .get_agent_run(run_id)
+        .await?
+        .filter(|run| run.chat_id == chat_id && run.tier == AgentRunTier::Background);
+    if run.is_none() {
+        return Err(ServerError::not_found(format!(
+            "agent run {run_id} not found"
+        )));
+    }
+    Ok(Json(store.get_agent_run_task_plan(run_id).await?))
 }
 
 /// One line of live progress a background run published, as the renderer sees

--- a/crates/openwave-server/src/sandbox_agent_run_worker/config.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker/config.rs
@@ -27,6 +27,7 @@ pub(super) const SANDBOX_PROMPT_DELEGATED_FILE_CLAUSE: &str =
 pub(super) const SANDBOX_PROMPT_WEB_SEARCH_CLAUSE: &str =
     "web_search when current public-web information is necessary";
 pub(super) const SANDBOX_PROMPT_FOLDER_ACCESS_CLAUSE: &str = "request_folder_access only to propose that your foreground parent decide whether to ask the user — the proposal grants no access and cannot open a picker";
+pub(super) const SANDBOX_PROMPT_TASK_PLAN_CLAUSE: &str = "update_task_plan to keep an ordered checklist when the task takes several steps — send the whole list every time, keep exactly one step in_progress, and update it as steps finish rather than all at the end";
 pub(super) const SANDBOX_PROMPT_CLOSING: &str = "Take as many tool steps as the task genuinely needs, then finish by calling done with the filenames you wrote under output/ and a short summary of what you produced.";
 
 /// Compose the run's instructions for the surface it actually has.
@@ -38,13 +39,14 @@ pub(super) fn sandbox_system_prompt(
     delegated_file_available: bool,
     web_search: TurnWebSearch,
 ) -> String {
-    let mut clauses = Vec::with_capacity(3);
+    let mut clauses = Vec::with_capacity(4);
     if delegated_file_available {
         clauses.push(SANDBOX_PROMPT_DELEGATED_FILE_CLAUSE);
     }
     if web_search != TurnWebSearch::Off {
         clauses.push(SANDBOX_PROMPT_WEB_SEARCH_CLAUSE);
     }
+    clauses.push(SANDBOX_PROMPT_TASK_PLAN_CLAUSE);
     clauses.push(SANDBOX_PROMPT_FOLDER_ACCESS_CLAUSE);
     let last = clauses
         .pop()

--- a/crates/openwave-server/src/sandbox_agent_run_worker/model_step.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker/model_step.rs
@@ -7,12 +7,12 @@ use futures::StreamExt;
 use openwave_core::{
     parse_update_task_plan_arguments, sandbox_done_tool_spec, sandbox_exec_tool_spec,
     sandbox_folder_access_proposal_tool_spec, sandbox_read_delegated_file_tool_spec,
-    sandbox_web_search_tool_spec, update_task_plan_tool_spec, validate_sandbox_exec_arguments,
-    validate_sandbox_read_delegated_file_arguments, AgentConfig, AgentError, AgentRun, ChatMessage,
-    ChatRequest, ContentBlock, MessageReasoning, ModelProvider, ProviderEvent,
-    RequestFolderAccessArgs, Result, Role, SandboxToolCall, SandboxToolCallStatus, StopReason,
-    Store, ToolCallRecord, TurnWebSearch, MAX_SANDBOX_TOOL_CALLS, SANDBOX_EXEC_TOOL,
-    UPDATE_TASK_PLAN_TOOL,
+    sandbox_update_task_plan_tool_spec, sandbox_web_search_tool_spec,
+    validate_sandbox_exec_arguments, validate_sandbox_read_delegated_file_arguments, AgentConfig,
+    AgentError, AgentRun, ChatMessage, ChatRequest, ContentBlock, MessageReasoning, ModelProvider,
+    ProviderEvent, RequestFolderAccessArgs, Result, Role, SandboxToolCall, SandboxToolCallStatus,
+    StopReason, Store, ToolCallRecord, TurnWebSearch, MAX_SANDBOX_TASK_PLAN_CALLS,
+    MAX_SANDBOX_TOOL_CALLS, SANDBOX_EXEC_TOOL, UPDATE_TASK_PLAN_TOOL,
 };
 
 use super::config::*;
@@ -66,12 +66,13 @@ pub(super) async fn sandbox_request(
     store: &dyn Store,
     delegated_file_available: bool,
 ) -> Result<ChatRequest> {
-    // Two different budgets ride on this list. Rows are what the run has spent
-    // of its durable tool allowance; steps are how many model completions it
-    // has already needed. One step can now hold several rows, so they diverge.
-    let rows = calls.len();
+    // Three different budgets ride on this list. Work rows are what the run has
+    // spent of its durable tool allowance; plan rows are the separate, smaller
+    // allowance its own bookkeeping gets; steps are how many model completions
+    // it has already needed. One step can hold several rows, so they diverge.
+    let SandboxRowBudget { work, plan } = sandbox_row_budget(calls);
     let steps = sandbox_call_steps(calls);
-    if rows > MAX_SANDBOX_TOOL_CALLS {
+    if work > MAX_SANDBOX_TOOL_CALLS || plan > MAX_SANDBOX_TASK_PLAN_CALLS {
         return Err(AgentError::msg("sandbox tool budget exceeded"));
     }
     if config.max_steps == 0 || steps.len().saturating_add(1) > config.max_steps {
@@ -127,44 +128,14 @@ pub(super) async fn sandbox_request(
             config.web_search,
         )),
         messages,
-        // A checkpoint costs one model completion now and one more to consume its
-        // receipt, so tools are only advertised while the remaining step budget
-        // can pay for both — never advertise work the budget cannot consume. The
-        // checkpoint count is bounded separately: the whole chain is replayed on
-        // every claim, so it is a working budget rather than an open loop.
-        tools: if rows < MAX_SANDBOX_TOOL_CALLS && steps.len().saturating_add(2) <= config.max_steps
-        {
-            let mut tools = vec![sandbox_exec_tool_spec()];
-            // The host tool and the provider's own search are one capability
-            // with one name, so the host one is advertised for exactly the runs
-            // the host routed here. A vendor run's searches arrive already
-            // finished and never become checkpoints; an off run is offered no
-            // search at all.
-            if config.web_search == TurnWebSearch::Host {
-                tools.push(sandbox_web_search_tool_spec());
-            }
-            // The plan is a checkpoint like any other: the row it writes lives
-            // in the host's database, so the call round-trips and costs the
-            // same budget its siblings do.
-            tools.push(update_task_plan_tool_spec());
-            tools.push(sandbox_done_tool_spec());
-            tools.push(sandbox_folder_access_proposal_tool_spec());
-            if delegated_file_available {
-                tools.push(sandbox_read_delegated_file_tool_spec());
-            }
-            tools
-        } else if steps.len().saturating_add(1) <= config.max_steps {
-            // Both of these terminate the run in place of a final answer, so
-            // they need no follow-up completion and stay available to the last
-            // step. Submission especially: a run that spent its budget writing
-            // files must still be able to hand them over.
-            vec![
-                sandbox_done_tool_spec(),
-                sandbox_folder_access_proposal_tool_spec(),
-            ]
-        } else {
-            vec![]
-        },
+        // A checkpoint costs one model completion now and one more to consume
+        // its receipt, so anything that parks is advertised only while the
+        // remaining step budget can pay for both — never advertise work the
+        // budget cannot consume. Each row budget then withdraws its own tools
+        // independently: a run that has spent its work allowance can still
+        // record what it managed to do, and a run that has spent its plan
+        // allowance keeps every tool the task is actually for.
+        tools: sandbox_tools(config, steps.len(), work, plan, delegated_file_available),
         max_tokens: config.max_tokens,
         temperature: config.temperature,
         reasoning_effort: config.reasoning_effort,
@@ -180,6 +151,70 @@ pub(super) async fn sandbox_request(
         images: openwave_core::ImageAttachments::new(),
         ..Default::default()
     })
+}
+
+/// What a run has spent of each durable row allowance.
+///
+/// `update_task_plan` rows are counted apart from the rest deliberately. The
+/// run is told to keep its plan current as steps finish, so charging that to
+/// the work budget would let bookkeeping starve the exec and search calls the
+/// delegated task is actually for. The separate cap still bounds a model that
+/// does nothing but rewrite its checklist. The durable store enforces the same
+/// split, so the two cannot disagree about what a run has left.
+pub(super) struct SandboxRowBudget {
+    pub(super) work: usize,
+    pub(super) plan: usize,
+}
+
+pub(super) fn sandbox_row_budget(calls: &[SandboxToolCall]) -> SandboxRowBudget {
+    let plan = calls
+        .iter()
+        .filter(|call| call.name == UPDATE_TASK_PLAN_TOOL)
+        .count();
+    SandboxRowBudget {
+        work: calls.len() - plan,
+        plan,
+    }
+}
+
+/// The tools one model step is offered, given what it can still afford.
+fn sandbox_tools(
+    config: &AgentConfig,
+    steps: usize,
+    work_rows: usize,
+    plan_rows: usize,
+    delegated_file_available: bool,
+) -> Vec<openwave_core::ToolSpec> {
+    if steps.saturating_add(1) > config.max_steps {
+        return Vec::new();
+    }
+    let can_checkpoint = steps.saturating_add(2) <= config.max_steps;
+    let work_available = can_checkpoint && work_rows < MAX_SANDBOX_TOOL_CALLS;
+    let plan_available = can_checkpoint && plan_rows < MAX_SANDBOX_TASK_PLAN_CALLS;
+    let mut tools = Vec::new();
+    if work_available {
+        tools.push(sandbox_exec_tool_spec());
+        // The host tool and the provider's own search are one capability with
+        // one name, so the host one is advertised for exactly the runs the host
+        // routed here. A vendor run's searches arrive already finished and
+        // never become checkpoints; an off run is offered no search at all.
+        if config.web_search == TurnWebSearch::Host {
+            tools.push(sandbox_web_search_tool_spec());
+        }
+    }
+    if plan_available {
+        tools.push(sandbox_update_task_plan_tool_spec());
+    }
+    // Both of these terminate the run in place of a final answer, so they need
+    // no follow-up completion and stay available to the last step. Submission
+    // especially: a run that spent its budget writing files must still be able
+    // to hand them over.
+    tools.push(sandbox_done_tool_spec());
+    tools.push(sandbox_folder_access_proposal_tool_spec());
+    if work_available && delegated_file_available {
+        tools.push(sandbox_read_delegated_file_tool_spec());
+    }
+    tools
 }
 
 /// One completed model step: the tool checkpoint or terminal outcome it

--- a/crates/openwave-server/src/sandbox_agent_run_worker/model_step.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker/model_step.rs
@@ -5,12 +5,14 @@ use std::time::Duration;
 
 use futures::StreamExt;
 use openwave_core::{
-    sandbox_done_tool_spec, sandbox_exec_tool_spec, sandbox_folder_access_proposal_tool_spec,
-    sandbox_read_delegated_file_tool_spec, sandbox_web_search_tool_spec,
-    validate_sandbox_exec_arguments, validate_sandbox_read_delegated_file_arguments, AgentConfig,
-    AgentError, AgentRun, ChatMessage, ChatRequest, ContentBlock, MessageReasoning, ModelProvider,
-    ProviderEvent, RequestFolderAccessArgs, Result, Role, SandboxToolCall, SandboxToolCallStatus,
-    StopReason, Store, ToolCallRecord, TurnWebSearch, MAX_SANDBOX_TOOL_CALLS, SANDBOX_EXEC_TOOL,
+    parse_update_task_plan_arguments, sandbox_done_tool_spec, sandbox_exec_tool_spec,
+    sandbox_folder_access_proposal_tool_spec, sandbox_read_delegated_file_tool_spec,
+    sandbox_web_search_tool_spec, update_task_plan_tool_spec, validate_sandbox_exec_arguments,
+    validate_sandbox_read_delegated_file_arguments, AgentConfig, AgentError, AgentRun, ChatMessage,
+    ChatRequest, ContentBlock, MessageReasoning, ModelProvider, ProviderEvent,
+    RequestFolderAccessArgs, Result, Role, SandboxToolCall, SandboxToolCallStatus, StopReason,
+    Store, ToolCallRecord, TurnWebSearch, MAX_SANDBOX_TOOL_CALLS, SANDBOX_EXEC_TOOL,
+    UPDATE_TASK_PLAN_TOOL,
 };
 
 use super::config::*;
@@ -141,6 +143,10 @@ pub(super) async fn sandbox_request(
             if config.web_search == TurnWebSearch::Host {
                 tools.push(sandbox_web_search_tool_spec());
             }
+            // The plan is a checkpoint like any other: the row it writes lives
+            // in the host's database, so the call round-trips and costs the
+            // same budget its siblings do.
+            tools.push(update_task_plan_tool_spec());
             tools.push(sandbox_done_tool_spec());
             tools.push(sandbox_folder_access_proposal_tool_spec());
             if delegated_file_available {
@@ -228,6 +234,11 @@ pub(super) enum SandboxCompletion {
     Final(String),
     /// The run's own files, offered as the deliverables for the task.
     Done {
+        /// The call the model made, kept so the host can hand this step back
+        /// unfinished instead of accepting it — see the plan reminder in
+        /// [`super::worker`].
+        provider_id: String,
+        arguments: serde_json::Value,
         outputs: Vec<String>,
         summary: String,
     },
@@ -331,6 +342,29 @@ pub(super) fn classify_sandbox_tool_call(
     };
     if parsed.is_none() {
         return Ok(invalid(serde_json::Value::Null));
+    }
+    // The plan validator's message is the correction — the rule it enforces
+    // (one `in_progress` step, whole list every time) is not expressible in the
+    // advertised schema, so a generic "arguments were not valid" would tell the
+    // model nothing it could act on.
+    if name == UPDATE_TASK_PLAN_TOOL {
+        if let Err(correction) = parse_update_task_plan_arguments(&arguments) {
+            return Ok(SandboxToolCallIntent {
+                provider_id,
+                name,
+                arguments,
+                disposition: SandboxToolCallDisposition::Rejected {
+                    error_code: "invalid_arguments",
+                    message: correction,
+                },
+            });
+        }
+        return Ok(SandboxToolCallIntent {
+            provider_id,
+            name,
+            arguments,
+            disposition: SandboxToolCallDisposition::Execute,
+        });
     }
     let valid = match name.as_str() {
         SANDBOX_EXEC_TOOL => validate_sandbox_exec_arguments(&arguments),
@@ -445,7 +479,7 @@ pub(super) async fn complete_sandbox_task(
                         if intent.name == openwave_core::SANDBOX_DONE_TOOL {
                             let arguments =
                                 serde_json::from_value::<openwave_core::SandboxDoneArgs>(
-                                    intent.arguments,
+                                    intent.arguments.clone(),
                                 )
                                 .map_err(|_| {
                                     AgentError::msg("sandbox agent emitted invalid done arguments")
@@ -453,6 +487,8 @@ pub(super) async fn complete_sandbox_task(
                             return Ok(SandboxStep {
                                 narration: String::new(),
                                 completion: SandboxCompletion::Done {
+                                    provider_id: intent.provider_id,
+                                    arguments: intent.arguments,
                                     outputs: arguments.outputs,
                                     summary: arguments.summary,
                                 },

--- a/crates/openwave-server/src/sandbox_agent_run_worker/tests.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker/tests.rs
@@ -652,6 +652,7 @@ async fn completes_a_claimed_run_with_a_no_tools_private_request() {
         vec![
             SANDBOX_EXEC_TOOL,
             openwave_core::SANDBOX_WEB_SEARCH_TOOL,
+            openwave_core::UPDATE_TASK_PLAN_TOOL,
             openwave_core::SANDBOX_DONE_TOOL,
             openwave_core::REQUEST_FOLDER_ACCESS_TOOL,
         ]
@@ -2070,6 +2071,7 @@ async fn sandbox_request_does_not_inherit_foreground_system_or_tools() {
         vec![
             SANDBOX_EXEC_TOOL,
             openwave_core::SANDBOX_WEB_SEARCH_TOOL,
+            openwave_core::UPDATE_TASK_PLAN_TOOL,
             openwave_core::SANDBOX_DONE_TOOL,
             openwave_core::REQUEST_FOLDER_ACCESS_TOOL,
         ]
@@ -2612,4 +2614,195 @@ fn sandbox_chat() -> Chat {
         root_attachments: Vec::new(),
         created_at: chrono::Utc::now(),
     }
+}
+
+#[derive(Default)]
+struct TaskPlanThenDoneProvider {
+    requests: Mutex<Vec<ChatRequest>>,
+}
+
+impl TaskPlanThenDoneProvider {
+    fn plan_call(id: &str, arguments: &str) -> Vec<ProviderEvent> {
+        vec![
+            ProviderEvent::TextDelta {
+                text: "Writing the plan down first.".into(),
+            },
+            ProviderEvent::ToolCallStarted {
+                index: 0,
+                id: id.into(),
+                name: openwave_core::UPDATE_TASK_PLAN_TOOL.into(),
+            },
+            ProviderEvent::ToolCallArgsDelta {
+                index: 0,
+                fragment: arguments.into(),
+            },
+            ProviderEvent::Stop {
+                reason: StopReason::ToolUse,
+            },
+        ]
+    }
+
+    fn done_call(id: &str) -> Vec<ProviderEvent> {
+        vec![
+            ProviderEvent::ToolCallStarted {
+                index: 0,
+                id: id.into(),
+                name: openwave_core::SANDBOX_DONE_TOOL.into(),
+            },
+            ProviderEvent::ToolCallArgsDelta {
+                index: 0,
+                fragment: r#"{"outputs":[],"summary":"finished the research"}"#.into(),
+            },
+            ProviderEvent::Stop {
+                reason: StopReason::ToolUse,
+            },
+        ]
+    }
+}
+
+#[async_trait]
+impl ModelProvider for TaskPlanThenDoneProvider {
+    fn id(&self) -> ProviderId {
+        ProviderId::new("sandbox-task-plan")
+    }
+
+    async fn stream(&self, request: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+        let call_number = {
+            let mut requests = self.requests.lock().unwrap();
+            requests.push(request);
+            requests.len()
+        };
+        let events = match call_number {
+            1 => Self::plan_call(
+                "plan_1",
+                r#"{"steps":[{"content":"read the brief","status":"in_progress"},{"content":"write the summary","status":"pending"}]}"#,
+            ),
+            2 => Self::plan_call(
+                "plan_2",
+                r#"{"steps":[{"content":"read the brief","status":"completed"},{"content":"write the summary","status":"in_progress"}]}"#,
+            ),
+            // Two attempts to finish: the first still has an open step and is
+            // handed back, the second is accepted whether or not the model
+            // closed the plan.
+            _ => Self::done_call(&format!("done_{call_number}")),
+        };
+        Ok(stream::iter(events).boxed())
+    }
+}
+
+/// A background run keeps a plan across its own checkpoints, and abandoning it
+/// mid-list is pointed out once rather than accepted silently or refused.
+///
+/// This drives the whole path the way the run does: the tool is advertised to
+/// the sandbox surface, each call parks a durable checkpoint that the host —
+/// not the sandbox — resolves, and the plan that comes back is keyed by the
+/// run. The `done` push-back is the part worth pinning: it must be one
+/// rejected call the model can read and answer, and it must never be able to
+/// stop the run from finishing.
+#[tokio::test]
+async fn a_sandbox_run_keeps_a_plan_and_is_reminded_once_before_it_finishes() {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let chat = sandbox_chat();
+    store.create_chat(&chat).await.unwrap();
+    let provider = Arc::new(TaskPlanThenDoneProvider::default());
+    let worker = SandboxAgentRunWorker::new(
+        store.clone(),
+        test_secrets(),
+        Arc::new(FixedResolver(provider.clone())),
+        Arc::new(Notify::new()),
+        Arc::new(Notify::new()),
+        Arc::new(EventBus::default()),
+        AgentConfig {
+            model: "sandbox-model".into(),
+            max_steps: 8,
+            ..AgentConfig::default()
+        },
+        None,
+        SandboxAgentRunWorkerConfig::default(),
+    );
+    let plans = crate::sandbox_task_plan_worker::SandboxTaskPlanWorker::new(
+        store.clone(),
+        Arc::new(Notify::new()),
+        crate::sandbox_task_plan_worker::SandboxTaskPlanWorkerConfig::default(),
+    );
+    let spawn = CallId::new();
+    let id = openwave_core::AgentRunId::sandbox_for_spawn_call(spawn);
+    admit_sandbox(&store, chat.id, spawn, "Research this.").await;
+
+    // The plan tool is offered to the sandbox surface alongside the rest.
+    assert!(matches!(
+        worker.run_once().await.unwrap(),
+        SandboxAgentRunWorkerOutcome::ToolCheckpointed(_)
+    ));
+    assert!(provider.requests.lock().unwrap()[0]
+        .tools
+        .iter()
+        .any(|tool| tool.name == openwave_core::UPDATE_TASK_PLAN_TOOL));
+    // Nothing is recorded until the host lane resolves the checkpoint: the row
+    // lives in this database, not where the agent runs.
+    assert!(store.get_agent_run_task_plan(id).await.unwrap().is_none());
+    assert!(matches!(
+        plans.run_once().await.unwrap(),
+        crate::sandbox_task_plan_worker::SandboxTaskPlanWorkerOutcome::Resolved(_)
+    ));
+    let first = store.get_agent_run_task_plan(id).await.unwrap().unwrap();
+    assert_eq!(first.run_id, id);
+    assert_eq!(
+        first.steps[0].status,
+        openwave_core::TaskPlanStepStatus::InProgress
+    );
+
+    // The second call replaces the list rather than appending to it.
+    assert!(matches!(
+        worker.run_once().await.unwrap(),
+        SandboxAgentRunWorkerOutcome::ToolCheckpointed(_)
+    ));
+    assert!(matches!(
+        plans.run_once().await.unwrap(),
+        crate::sandbox_task_plan_worker::SandboxTaskPlanWorkerOutcome::Resolved(_)
+    ));
+    let second = store.get_agent_run_task_plan(id).await.unwrap().unwrap();
+    assert_eq!(second.steps.len(), 2);
+    assert_eq!(
+        second.steps[0].status,
+        openwave_core::TaskPlanStepStatus::Completed
+    );
+    assert_eq!(
+        second.steps[1].status,
+        openwave_core::TaskPlanStepStatus::InProgress
+    );
+
+    // `done` with an unfinished plan is handed back as an ordinary error
+    // result, keeping the run's attempt, rather than completing it.
+    let reminder = match worker.run_once().await.unwrap() {
+        SandboxAgentRunWorkerOutcome::ToolCheckpointed(call_id) => call_id,
+        outcome => panic!("unexpected outcome: {outcome:?}"),
+    };
+    let receipt = store
+        .get_sandbox_tool_call_receipt(reminder)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(receipt.status, SandboxToolCallStatus::Failed);
+    assert_eq!(receipt.error_code.as_deref(), Some("task_plan_incomplete"));
+    assert!(receipt.result.contains("write the summary"));
+    assert_eq!(
+        store.get_agent_run(id).await.unwrap().unwrap().status,
+        AgentRunStatus::RetryWait
+    );
+
+    // The reminder is spent. A run that calls `done` again finishes, so a
+    // model that will not close its list is never trapped.
+    assert_eq!(
+        worker.run_once().await.unwrap(),
+        SandboxAgentRunWorkerOutcome::Completed(id)
+    );
 }

--- a/crates/openwave-server/src/sandbox_agent_run_worker/tests.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker/tests.rs
@@ -36,8 +36,8 @@ use super::config::{
     sandbox_system_prompt, SandboxAgentRunWorkerOutcome, SANDBOX_PROMPT_WEB_SEARCH_CLAUSE,
 };
 use super::model_step::{
-    complete_sandbox_task, delegated_file_admission_matches, sandbox_request, SandboxCompletion,
-    SandboxToolCallDisposition, SandboxToolCallIntent,
+    complete_sandbox_task, delegated_file_admission_matches, sandbox_request, sandbox_row_budget,
+    SandboxCompletion, SandboxToolCallDisposition, SandboxToolCallIntent,
 };
 
 #[derive(Default)]
@@ -1325,7 +1325,7 @@ async fn cancellation_fence_prevents_a_stale_worker_from_parking_web_search() {
                     arguments: serde_json::json!({"query":"OpenWave"}),
                     disposition: SandboxToolCallDisposition::Execute,
                 }],
-                0,
+                &sandbox_row_budget(&[]),
                 "",
             )
             .await
@@ -2616,12 +2616,30 @@ fn sandbox_chat() -> Chat {
     }
 }
 
-#[derive(Default)]
+/// Emits `plan_calls` successive `update_task_plan` calls, then `done` for
+/// every step after that.
 struct TaskPlanThenDoneProvider {
     requests: Mutex<Vec<ChatRequest>>,
+    plan_calls: usize,
+}
+
+impl Default for TaskPlanThenDoneProvider {
+    fn default() -> Self {
+        Self {
+            requests: Mutex::new(Vec::new()),
+            plan_calls: 2,
+        }
+    }
 }
 
 impl TaskPlanThenDoneProvider {
+    fn with_plan_calls(plan_calls: usize) -> Self {
+        Self {
+            plan_calls,
+            ..Self::default()
+        }
+    }
+
     fn plan_call(id: &str, arguments: &str) -> Vec<ProviderEvent> {
         vec![
             ProviderEvent::TextDelta {
@@ -2672,19 +2690,21 @@ impl ModelProvider for TaskPlanThenDoneProvider {
             requests.push(request);
             requests.len()
         };
-        let events = match call_number {
-            1 => Self::plan_call(
+        let events = if call_number == 1 {
+            Self::plan_call(
                 "plan_1",
                 r#"{"steps":[{"content":"read the brief","status":"in_progress"},{"content":"write the summary","status":"pending"}]}"#,
-            ),
-            2 => Self::plan_call(
-                "plan_2",
+            )
+        } else if call_number <= self.plan_calls {
+            Self::plan_call(
+                &format!("plan_{call_number}"),
                 r#"{"steps":[{"content":"read the brief","status":"completed"},{"content":"write the summary","status":"in_progress"}]}"#,
-            ),
-            // Two attempts to finish: the first still has an open step and is
-            // handed back, the second is accepted whether or not the model
-            // closed the plan.
-            _ => Self::done_call(&format!("done_{call_number}")),
+            )
+        } else {
+            // Every later step tries to finish. The first attempt may still
+            // have an open step and be handed back; a later one is accepted
+            // whether or not the model closed the plan.
+            Self::done_call(&format!("done_{call_number}"))
         };
         Ok(stream::iter(events).boxed())
     }
@@ -2801,6 +2821,170 @@ async fn a_sandbox_run_keeps_a_plan_and_is_reminded_once_before_it_finishes() {
 
     // The reminder is spent. A run that calls `done` again finishes, so a
     // model that will not close its list is never trapped.
+    assert_eq!(
+        worker.run_once().await.unwrap(),
+        SandboxAgentRunWorkerOutcome::Completed(id)
+    );
+}
+
+/// Plan bookkeeping has its own allowance and cannot starve the work the task
+/// is for.
+///
+/// The failure this pins is the one the shared budget would cause: a run told
+/// to keep its checklist current spends rows on it, and if those rows came out
+/// of the same 16 the commands and searches use, the run would run out of
+/// budget describing work it never got to do. At the plan cap only the plan
+/// tool goes away — everything else is still offered — and the durable store
+/// has to agree, or one of these parks would come back a conflict.
+#[tokio::test]
+async fn plan_rows_have_their_own_cap_and_leave_the_work_budget_alone() {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let chat = sandbox_chat();
+    store.create_chat(&chat).await.unwrap();
+    let provider = Arc::new(TaskPlanThenDoneProvider::with_plan_calls(
+        openwave_core::MAX_SANDBOX_TASK_PLAN_CALLS,
+    ));
+    let worker = SandboxAgentRunWorker::new(
+        store.clone(),
+        test_secrets(),
+        Arc::new(FixedResolver(provider.clone())),
+        Arc::new(Notify::new()),
+        Arc::new(Notify::new()),
+        Arc::new(EventBus::default()),
+        AgentConfig {
+            model: "sandbox-model".into(),
+            // Generous, so the step budget is never what withdraws a tool here.
+            max_steps: 64,
+            ..AgentConfig::default()
+        },
+        None,
+        SandboxAgentRunWorkerConfig::default(),
+    );
+    let plans = crate::sandbox_task_plan_worker::SandboxTaskPlanWorker::new(
+        store.clone(),
+        Arc::new(Notify::new()),
+        crate::sandbox_task_plan_worker::SandboxTaskPlanWorkerConfig::default(),
+    );
+    let spawn = CallId::new();
+    let id = openwave_core::AgentRunId::sandbox_for_spawn_call(spawn);
+    admit_sandbox(&store, chat.id, spawn, "Research this.").await;
+
+    for _ in 0..openwave_core::MAX_SANDBOX_TASK_PLAN_CALLS {
+        assert!(matches!(
+            worker.run_once().await.unwrap(),
+            SandboxAgentRunWorkerOutcome::ToolCheckpointed(_)
+        ));
+        assert!(matches!(
+            plans.run_once().await.unwrap(),
+            crate::sandbox_task_plan_worker::SandboxTaskPlanWorkerOutcome::Resolved(_)
+        ));
+    }
+    let calls = store
+        .list_sandbox_tool_calls_for_agent_run(id)
+        .await
+        .unwrap();
+    assert_eq!(calls.len(), openwave_core::MAX_SANDBOX_TASK_PLAN_CALLS);
+
+    // The plan is spent; the task's own tools are untouched.
+    let spent = sandbox_request(
+        &AgentConfig {
+            model: "m".into(),
+            max_steps: 64,
+            ..AgentConfig::default()
+        },
+        "task".into(),
+        &calls,
+        &*store,
+        false,
+    )
+    .await
+    .unwrap();
+    let offered: Vec<&str> = spent.tools.iter().map(|tool| tool.name.as_str()).collect();
+    assert_eq!(
+        offered,
+        vec![
+            SANDBOX_EXEC_TOOL,
+            openwave_core::SANDBOX_WEB_SEARCH_TOOL,
+            openwave_core::SANDBOX_DONE_TOOL,
+            openwave_core::REQUEST_FOLDER_ACCESS_TOOL,
+        ]
+    );
+}
+
+/// A run one model step from its ceiling submits instead of being reminded.
+///
+/// The reminder parks a row the next completion has to read, so it can only be
+/// offered while the run can still pay for that completion. Getting this wrong
+/// turns the nudge into a failure on exactly the runs that were about to
+/// finish: the step budget would be exceeded assembling the request that was
+/// supposed to carry the correction.
+#[tokio::test]
+async fn a_run_at_its_last_step_submits_rather_than_being_reminded() {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let chat = sandbox_chat();
+    store.create_chat(&chat).await.unwrap();
+    let provider = Arc::new(TaskPlanThenDoneProvider::with_plan_calls(1));
+    let worker = SandboxAgentRunWorker::new(
+        store.clone(),
+        test_secrets(),
+        Arc::new(FixedResolver(provider.clone())),
+        Arc::new(Notify::new()),
+        Arc::new(Notify::new()),
+        Arc::new(EventBus::default()),
+        AgentConfig {
+            model: "sandbox-model".into(),
+            // One checkpoint, then one completion to read it. `done` on that
+            // second step leaves no room for a third.
+            max_steps: 2,
+            ..AgentConfig::default()
+        },
+        None,
+        SandboxAgentRunWorkerConfig::default(),
+    );
+    let plans = crate::sandbox_task_plan_worker::SandboxTaskPlanWorker::new(
+        store.clone(),
+        Arc::new(Notify::new()),
+        crate::sandbox_task_plan_worker::SandboxTaskPlanWorkerConfig::default(),
+    );
+    let spawn = CallId::new();
+    let id = openwave_core::AgentRunId::sandbox_for_spawn_call(spawn);
+    admit_sandbox(&store, chat.id, spawn, "Research this.").await;
+
+    assert!(matches!(
+        worker.run_once().await.unwrap(),
+        SandboxAgentRunWorkerOutcome::ToolCheckpointed(_)
+    ));
+    assert!(matches!(
+        plans.run_once().await.unwrap(),
+        crate::sandbox_task_plan_worker::SandboxTaskPlanWorkerOutcome::Resolved(_)
+    ));
+    // The plan is left with an open step, which is exactly what would earn a
+    // reminder if the run could afford one.
+    assert!(!openwave_core::open_task_plan_steps(
+        &store
+            .get_agent_run_task_plan(id)
+            .await
+            .unwrap()
+            .unwrap()
+            .steps
+    )
+    .is_empty());
     assert_eq!(
         worker.run_once().await.unwrap(),
         SandboxAgentRunWorkerOutcome::Completed(id)

--- a/crates/openwave-server/src/sandbox_agent_run_worker/worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker/worker.rs
@@ -10,8 +10,8 @@ use openwave_core::{
     AgentConfig, AgentError, AgentRun, AgentRunStatus, AgentRunSubmittedOutput, CallId,
     FailAgentRunOutcome, ModelProvider, ParkSandboxToolCallOutcome, RequestFolderAccessArgs,
     Result, ResumeTurnForAgentRunWaitSetOutcome, SandboxToolCallParkEntry, SandboxToolCallRequest,
-    SecretProvider, Store, SubmitAgentRunResultOutcome, ToolCallResolution, MAX_SANDBOX_TOOL_CALLS,
-    MAX_SANDBOX_TOOL_CALLS_PER_STEP,
+    SecretProvider, Store, SubmitAgentRunResultOutcome, ToolCallResolution,
+    MAX_SANDBOX_TASK_PLAN_CALLS, MAX_SANDBOX_TOOL_CALLS, MAX_SANDBOX_TOOL_CALLS_PER_STEP,
 };
 use tokio::sync::Notify;
 
@@ -22,6 +22,10 @@ use crate::state::SandboxAttemptGuard;
 
 use super::config::*;
 use super::model_step::*;
+
+/// The receipt code the plan reminder writes, and the exact marker that says a
+/// run has already had its one push-back.
+const TASK_PLAN_INCOMPLETE: &str = "task_plan_incomplete";
 
 impl SandboxAgentRunWorker {
     #[cfg(test)]
@@ -430,12 +434,18 @@ impl SandboxAgentRunWorker {
         // Progress keys are per model step, not per parked row: one step can now
         // park several calls, and a replayed claim must land on the same key.
         let depth = sandbox_call_steps(&previous_calls).len();
-        let previous_rows = previous_calls.len();
+        let previous_budget = sandbox_row_budget(&previous_calls);
         let outcome = match completion {
             SandboxCompletion::Final(text) => self.submit_result(&run, lease_token, text).await,
             SandboxCompletion::ToolCalls(intents) => {
-                self.park_sandbox_tool_calls(run, lease_token, intents, previous_rows, &narration)
-                    .await
+                self.park_sandbox_tool_calls(
+                    run,
+                    lease_token,
+                    intents,
+                    &previous_budget,
+                    &narration,
+                )
+                .await
             }
             SandboxCompletion::Done {
                 provider_id,
@@ -443,7 +453,13 @@ impl SandboxAgentRunWorker {
                 outputs,
                 summary,
             } => match self
-                .done_plan_reminder(&run, &previous_calls, depth, agent_config.max_steps)
+                .done_plan_reminder(
+                    &run,
+                    &previous_calls,
+                    &previous_budget,
+                    depth,
+                    agent_config.max_steps,
+                )
                 .await?
             {
                 Some(message) => {
@@ -452,12 +468,18 @@ impl SandboxAgentRunWorker {
                         name: openwave_core::SANDBOX_DONE_TOOL.to_owned(),
                         arguments,
                         disposition: SandboxToolCallDisposition::Rejected {
-                            error_code: "task_plan_incomplete",
+                            error_code: TASK_PLAN_INCOMPLETE,
                             message,
                         },
                     };
-                    self.park_sandbox_tool_calls(run, lease_token, vec![intent], previous_rows, "")
-                        .await
+                    self.park_sandbox_tool_calls(
+                        run,
+                        lease_token,
+                        vec![intent],
+                        &previous_budget,
+                        "",
+                    )
+                    .await
                 }
                 None => {
                     self.submit_submission(&run, lease_token, &outputs, &summary)
@@ -712,30 +734,47 @@ impl SandboxAgentRunWorker {
     /// - it is a rejected tool call, the same feedback shape a call that
     ///   arrived with company already gets, so the run reads it as an ordinary
     ///   error result and keeps its attempt;
-    /// - it happens at most once per run. `done` is terminal, so the only way a
-    ///   `done` row exists at all is that the host already handed one back, and
-    ///   a second refusal would trap a run whose model will not close its list;
+    /// - it happens at most once per run, and the once is keyed on the reminder
+    ///   itself rather than on the presence of a `done` row. A `done` row can
+    ///   exist for reasons that have nothing to do with the plan — a `done`
+    ///   emitted alongside a sibling is answered with `must_be_alone`, and
+    ///   malformed arguments are answered too — and a model that calls tools in
+    ///   parallel is exactly the population this reminder is for. Only a prior
+    ///   receipt carrying [`TASK_PLAN_INCOMPLETE`] spends it;
     /// - it is withheld unless the run can afford the row it parks into and the
     ///   model step that consumes it, so the reminder never converts a run that
-    ///   was about to finish into a budget failure.
+    ///   was about to finish into a budget failure. The row it parks is a
+    ///   rejected `done`, which belongs to the work budget like any other
+    ///   non-plan row.
     ///
     /// A run with no plan, or one whose steps are all `completed`, is never
-    /// interrupted.
+    /// interrupted. Neither is a run that ends by simply producing final text
+    /// instead of calling `done`: that path has no tool call to hand back, and
+    /// inventing a synthetic one to reject would be a worse trade than missing
+    /// the reminder on a run that never asked to submit anything.
     async fn done_plan_reminder(
         &self,
         run: &AgentRun,
         previous_calls: &[openwave_core::SandboxToolCall],
+        previous_budget: &SandboxRowBudget,
         depth: usize,
         max_steps: usize,
     ) -> Result<Option<String>> {
-        if previous_calls
-            .iter()
-            .any(|call| call.name == openwave_core::SANDBOX_DONE_TOOL)
-        {
+        if previous_budget.work >= MAX_SANDBOX_TOOL_CALLS || depth.saturating_add(2) > max_steps {
             return Ok(None);
         }
-        if previous_calls.len() >= MAX_SANDBOX_TOOL_CALLS || depth.saturating_add(2) > max_steps {
-            return Ok(None);
+        for call in previous_calls
+            .iter()
+            .filter(|call| call.name == openwave_core::SANDBOX_DONE_TOOL)
+        {
+            let already_reminded = self
+                .store
+                .get_sandbox_tool_call_receipt(call.id)
+                .await?
+                .is_some_and(|receipt| receipt.error_code.as_deref() == Some(TASK_PLAN_INCOMPLETE));
+            if already_reminded {
+                return Ok(None);
+            }
         }
         let Some(plan) = self.store.get_agent_run_task_plan(run.id).await? else {
             return Ok(None);
@@ -792,15 +831,36 @@ impl SandboxAgentRunWorker {
         run: AgentRun,
         lease_token: uuid::Uuid,
         intents: Vec<SandboxToolCallIntent>,
-        previous_rows: usize,
+        previous_budget: &SandboxRowBudget,
         narration: &str,
     ) -> Result<SandboxAgentRunWorkerOutcome> {
         let emitted = intents.len();
-        let remaining = MAX_SANDBOX_TOOL_CALLS.saturating_sub(previous_rows);
-        if emitted == 0 || remaining == 0 {
-            // Tool advertisement is withdrawn before the budget runs out, so a
-            // step arriving with nothing left to spend has ignored a request
-            // that offered it no dispatchable tool at all.
+        // Each budget is spent by the rows that belong to it, so a batch is
+        // admitted call by call rather than by one count: a step that mixes a
+        // plan update with real work can exhaust one allowance while the other
+        // still has room. The prefix that fits is what parks.
+        let mut work_left = MAX_SANDBOX_TOOL_CALLS.saturating_sub(previous_budget.work);
+        let mut plan_left = MAX_SANDBOX_TASK_PLAN_CALLS.saturating_sub(previous_budget.plan);
+        let mut admitted = 0;
+        for intent in &intents {
+            if admitted == MAX_SANDBOX_TOOL_CALLS_PER_STEP {
+                break;
+            }
+            let left = if intent.name == openwave_core::UPDATE_TASK_PLAN_TOOL {
+                &mut plan_left
+            } else {
+                &mut work_left
+            };
+            if *left == 0 {
+                break;
+            }
+            *left -= 1;
+            admitted += 1;
+        }
+        if emitted == 0 || admitted == 0 {
+            // Tool advertisement is withdrawn before a budget runs out, so a
+            // step whose very first call has nothing left to spend has ignored
+            // a request that offered it no such tool at all.
             return self
                 .record_failure(
                     &run,
@@ -809,34 +869,32 @@ impl SandboxAgentRunWorker {
                 )
                 .await;
         }
-        let capacity = Ord::min(MAX_SANDBOX_TOOL_CALLS_PER_STEP, remaining);
         let mut intents = intents;
-        let mut dropped = 0;
-        if emitted > capacity {
+        let dropped = emitted - admitted;
+        if dropped > 0 {
             // The last call the step can afford is answered rather than run, so
             // the model learns why the rest are missing. Everything past it is
             // dropped outright: the transcript is rebuilt from rows, so a call
             // with no row simply never happened and leaves no dangling tool use.
-            dropped = emitted - capacity;
-            intents.truncate(capacity);
+            intents.truncate(admitted);
             let last = intents
                 .last_mut()
-                .expect("capacity is at least one when a step parks");
-            let (error_code, message) = if capacity == remaining {
-                (
-                    "tool_budget_exhausted",
-                    format!(
-                        "This task's tool budget is exhausted: this call and {dropped} other \
-                         call(s) in this step were not run. Finish with done."
-                    ),
-                )
-            } else {
+                .expect("at least one call is admitted when a step parks");
+            let (error_code, message) = if admitted == MAX_SANDBOX_TOOL_CALLS_PER_STEP {
                 (
                     "too_many_calls_in_step",
                     format!(
                         "A step may make at most {MAX_SANDBOX_TOOL_CALLS_PER_STEP} tool calls: \
                          this call and {dropped} other call(s) in this step were not run. Re-send \
                          them in a later step."
+                    ),
+                )
+            } else {
+                (
+                    "tool_budget_exhausted",
+                    format!(
+                        "This task's tool budget is exhausted: this call and {dropped} other \
+                         call(s) in this step were not run. Finish with done."
                     ),
                 )
             };

--- a/crates/openwave-server/src/sandbox_agent_run_worker/worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker/worker.rs
@@ -437,10 +437,33 @@ impl SandboxAgentRunWorker {
                 self.park_sandbox_tool_calls(run, lease_token, intents, previous_rows, &narration)
                     .await
             }
-            SandboxCompletion::Done { outputs, summary } => {
-                self.submit_submission(&run, lease_token, &outputs, &summary)
-                    .await
-            }
+            SandboxCompletion::Done {
+                provider_id,
+                arguments,
+                outputs,
+                summary,
+            } => match self
+                .done_plan_reminder(&run, &previous_calls, depth, agent_config.max_steps)
+                .await?
+            {
+                Some(message) => {
+                    let intent = SandboxToolCallIntent {
+                        provider_id,
+                        name: openwave_core::SANDBOX_DONE_TOOL.to_owned(),
+                        arguments,
+                        disposition: SandboxToolCallDisposition::Rejected {
+                            error_code: "task_plan_incomplete",
+                            message,
+                        },
+                    };
+                    self.park_sandbox_tool_calls(run, lease_token, vec![intent], previous_rows, "")
+                        .await
+                }
+                None => {
+                    self.submit_submission(&run, lease_token, &outputs, &summary)
+                        .await
+                }
+            },
             SandboxCompletion::FolderAccessProposal { request } => {
                 self.submit_folder_access_proposal(run.id, lease_token, request)
                     .await
@@ -677,6 +700,57 @@ impl SandboxAgentRunWorker {
             .await?
             .iter()
             .any(|revision| revision.producing_run_id == Some(run_id)))
+    }
+
+    /// Whether a run calling `done` should be handed its unfinished plan back
+    /// once before the submission is accepted.
+    ///
+    /// A plan the run itself wrote and then abandoned mid-list is the clearest
+    /// signal available that it stopped early, and the cheapest correction is
+    /// to say so and let it decide. It is deliberately soft on every axis:
+    ///
+    /// - it is a rejected tool call, the same feedback shape a call that
+    ///   arrived with company already gets, so the run reads it as an ordinary
+    ///   error result and keeps its attempt;
+    /// - it happens at most once per run. `done` is terminal, so the only way a
+    ///   `done` row exists at all is that the host already handed one back, and
+    ///   a second refusal would trap a run whose model will not close its list;
+    /// - it is withheld unless the run can afford the row it parks into and the
+    ///   model step that consumes it, so the reminder never converts a run that
+    ///   was about to finish into a budget failure.
+    ///
+    /// A run with no plan, or one whose steps are all `completed`, is never
+    /// interrupted.
+    async fn done_plan_reminder(
+        &self,
+        run: &AgentRun,
+        previous_calls: &[openwave_core::SandboxToolCall],
+        depth: usize,
+        max_steps: usize,
+    ) -> Result<Option<String>> {
+        if previous_calls
+            .iter()
+            .any(|call| call.name == openwave_core::SANDBOX_DONE_TOOL)
+        {
+            return Ok(None);
+        }
+        if previous_calls.len() >= MAX_SANDBOX_TOOL_CALLS || depth.saturating_add(2) > max_steps {
+            return Ok(None);
+        }
+        let Some(plan) = self.store.get_agent_run_task_plan(run.id).await? else {
+            return Ok(None);
+        };
+        let open = openwave_core::open_task_plan_steps(&plan.steps);
+        if open.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(format!(
+            "Your task plan still has {count} step(s) that are not completed: {steps}. Finish \
+             them, or update the plan to say what you actually did, then call done again. Calling \
+             done again without changing anything will submit what you have.",
+            count = open.len(),
+            steps = open.join("; "),
+        )))
     }
 
     async fn submit_folder_access_proposal(

--- a/crates/openwave-server/src/sandbox_task_plan_worker.rs
+++ b/crates/openwave-server/src/sandbox_task_plan_worker.rs
@@ -33,6 +33,7 @@ pub(crate) struct SandboxTaskPlanWorkerConfig {
     idle_cap: Duration,
     failure_delay: Duration,
     failure_delay_cap: Duration,
+    max_concurrency: usize,
 }
 
 impl Default for SandboxTaskPlanWorkerConfig {
@@ -43,6 +44,7 @@ impl Default for SandboxTaskPlanWorkerConfig {
             idle_cap: Duration::from_secs(5),
             failure_delay: Duration::from_secs(1),
             failure_delay_cap: Duration::from_secs(30),
+            max_concurrency: 2,
         }
     }
 }
@@ -68,6 +70,7 @@ impl SandboxTaskPlanWorker {
         config: SandboxTaskPlanWorkerConfig,
     ) -> Self {
         assert!(!config.lease.is_zero());
+        assert!(config.max_concurrency > 0);
         Self {
             store,
             wake,
@@ -76,6 +79,22 @@ impl SandboxTaskPlanWorker {
     }
 
     pub(crate) async fn run(self) {
+        let mut lanes = tokio::task::JoinSet::new();
+        for _ in 0..self.config.max_concurrency {
+            lanes.spawn(self.clone().run_lane());
+        }
+        let mut restart_backoff =
+            LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap);
+        while let Some(result) = lanes.join_next().await {
+            if let Err(error) = result {
+                eprintln!("openwave: sandbox task-plan worker lane stopped: {error}");
+                tokio::time::sleep(restart_backoff.next_delay()).await;
+            }
+            lanes.spawn(self.clone().run_lane());
+        }
+    }
+
+    async fn run_lane(self) {
         let mut idle_delay = self.config.idle_min;
         let mut failure_backoff =
             LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap);

--- a/crates/openwave-server/src/sandbox_task_plan_worker.rs
+++ b/crates/openwave-server/src/sandbox_task_plan_worker.rs
@@ -1,0 +1,190 @@
+//! Durable execution of a background run's `update_task_plan` checkpoint.
+//!
+//! A sandbox agent's plan row lives in the host's database, so the call cannot
+//! be answered where the agent runs. It takes the same shape every other
+//! sandbox tool takes: the run parks a checkpoint and releases its lease, this
+//! lane claims that checkpoint under its own exact executor lease, and the
+//! run resumes from the immutable receipt.
+//!
+//! Unlike the search and exec lanes there is nothing here to time out, retry,
+//! or cancel mid-flight: the work is one local transaction that both records
+//! the plan and writes the receipt, so a claim either commits both or neither.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use openwave_core::{
+    parse_update_task_plan_arguments, task_plan_summary, AgentError, ClaimSandboxToolCallOutcome,
+    ResolveSandboxToolCallOutcome, Result, SandboxToolCall, Store, ToolCallResolution,
+    UPDATE_TASK_PLAN_TOOL,
+};
+use tokio::sync::Notify;
+
+use crate::retry::LaneBackoff;
+
+const CANDIDATE_BATCH_SIZE: u64 = 16;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SandboxTaskPlanWorkerConfig {
+    /// Short by design: the whole operation is one local transaction, so a
+    /// lease long enough to survive scheduling is already generous.
+    lease: Duration,
+    idle_min: Duration,
+    idle_cap: Duration,
+    failure_delay: Duration,
+    failure_delay_cap: Duration,
+}
+
+impl Default for SandboxTaskPlanWorkerConfig {
+    fn default() -> Self {
+        Self {
+            lease: Duration::from_secs(30),
+            idle_min: Duration::from_millis(250),
+            idle_cap: Duration::from_secs(5),
+            failure_delay: Duration::from_secs(1),
+            failure_delay_cap: Duration::from_secs(30),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SandboxTaskPlanWorkerOutcome {
+    Idle,
+    Resolved(openwave_core::CallId),
+    LeaseLost(openwave_core::CallId),
+}
+
+#[derive(Clone)]
+pub(crate) struct SandboxTaskPlanWorker {
+    store: Arc<dyn Store>,
+    wake: Arc<Notify>,
+    config: SandboxTaskPlanWorkerConfig,
+}
+
+impl SandboxTaskPlanWorker {
+    pub(crate) fn new(
+        store: Arc<dyn Store>,
+        wake: Arc<Notify>,
+        config: SandboxTaskPlanWorkerConfig,
+    ) -> Self {
+        assert!(!config.lease.is_zero());
+        Self {
+            store,
+            wake,
+            config,
+        }
+    }
+
+    pub(crate) async fn run(self) {
+        let mut idle_delay = self.config.idle_min;
+        let mut failure_backoff =
+            LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap);
+        loop {
+            match self.run_once().await {
+                Ok(SandboxTaskPlanWorkerOutcome::Idle) => {
+                    failure_backoff.reset();
+                    tokio::select! {
+                        _ = tokio::time::sleep(idle_delay) => {}
+                        _ = self.wake.notified() => {}
+                    }
+                    idle_delay = idle_delay.saturating_mul(2).min(self.config.idle_cap);
+                }
+                Ok(_) => {
+                    failure_backoff.reset();
+                    idle_delay = self.config.idle_min;
+                }
+                Err(error) => {
+                    eprintln!("openwave: sandbox task-plan worker iteration failed: {error}");
+                    let delay = failure_backoff.next_delay();
+                    tokio::select! {
+                        _ = tokio::time::sleep(delay) => {}
+                        _ = self.wake.notified() => {}
+                    }
+                }
+            }
+        }
+    }
+
+    /// Claim and resolve one exact persisted plan checkpoint.
+    pub(crate) async fn run_once(&self) -> Result<SandboxTaskPlanWorkerOutcome> {
+        for candidate in self
+            .store
+            .list_sandbox_tool_call_candidates_named(UPDATE_TASK_PLAN_TOOL, CANDIDATE_BATCH_SIZE)
+            .await?
+        {
+            let lease_token = uuid::Uuid::new_v4();
+            let call = match self
+                .store
+                .claim_sandbox_tool_call_named(
+                    candidate.id,
+                    UPDATE_TASK_PLAN_TOOL,
+                    lease_token,
+                    chrono_duration(self.config.lease)?,
+                )
+                .await?
+            {
+                ClaimSandboxToolCallOutcome::Claimed(call)
+                | ClaimSandboxToolCallOutcome::Existing(call) => call,
+                ClaimSandboxToolCallOutcome::Unavailable => continue,
+            };
+            self.wake.notify_one();
+            return self.process(call, lease_token).await;
+        }
+        Ok(SandboxTaskPlanWorkerOutcome::Idle)
+    }
+
+    async fn process(
+        &self,
+        call: SandboxToolCall,
+        lease_token: uuid::Uuid,
+    ) -> Result<SandboxTaskPlanWorkerOutcome> {
+        // The model step already validated these arguments before parking the
+        // checkpoint, so a failure here is a row nothing should have written.
+        // It still answers rather than wedges: the run reads the correction and
+        // carries on from the same attempt.
+        let outcome = match parse_update_task_plan_arguments(&call.arguments) {
+            Ok(arguments) => {
+                let resolution = ToolCallResolution::Completed {
+                    result: task_plan_summary(&arguments.steps),
+                };
+                self.store
+                    .resolve_sandbox_task_plan_call(
+                        call.id,
+                        lease_token,
+                        &arguments.steps,
+                        &resolution,
+                    )
+                    .await?
+            }
+            Err(correction) => {
+                self.store
+                    .resolve_sandbox_tool_call(
+                        call.id,
+                        lease_token,
+                        &ToolCallResolution::Failed {
+                            result: correction,
+                            error_code: "invalid_arguments".into(),
+                            error_detail: None,
+                        },
+                    )
+                    .await?
+            }
+        };
+        match outcome {
+            ResolveSandboxToolCallOutcome::Resolved | ResolveSandboxToolCallOutcome::Existing => {
+                self.wake.notify_one();
+                Ok(SandboxTaskPlanWorkerOutcome::Resolved(call.id))
+            }
+            ResolveSandboxToolCallOutcome::NotFound
+            | ResolveSandboxToolCallOutcome::AlreadyTerminal
+            | ResolveSandboxToolCallOutcome::LeaseLost => {
+                Ok(SandboxTaskPlanWorkerOutcome::LeaseLost(call.id))
+            }
+        }
+    }
+}
+
+fn chrono_duration(duration: Duration) -> Result<chrono::Duration> {
+    chrono::Duration::from_std(duration)
+        .map_err(|error| AgentError::msg(format!("invalid sandbox task-plan duration: {error}")))
+}

--- a/crates/openwave-server/src/scoped_store.rs
+++ b/crates/openwave-server/src/scoped_store.rs
@@ -278,6 +278,14 @@ impl ScopedStore {
         self.store.get_agent_run(id).await
     }
 
+    /// [`Store::get_agent_run_task_plan`].
+    pub async fn get_agent_run_task_plan(
+        &self,
+        id: AgentRunId,
+    ) -> Result<Option<openwave_core::AgentRunTaskPlan>> {
+        self.store.get_agent_run_task_plan(id).await
+    }
+
     /// [`Store::get_agent_run_result`].
     pub async fn get_agent_run_result(&self, id: AgentRunId) -> Result<Option<AgentRunResult>> {
         self.store.get_agent_run_result(id).await

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -396,6 +396,9 @@ mod tests {
         // A separate endpoint root: the ordered activity history is returned by
         // its own route, so the snapshot walk never reaches it.
         generate::collect_from::<crate::routes::AgentActivityHistoryItem>(&cfg, &mut out);
+        // Its own endpoint root too: the snapshot carries a run's plan progress,
+        // while the full ordered list is fetched per run.
+        generate::collect_from::<openwave_core::AgentRunTaskPlan>(&cfg, &mut out);
         // Likewise its own endpoint root: the live progress stream is paged by
         // its own route rather than embedded in a snapshot.
         generate::collect_from::<crate::routes::AgentRunProgressPage>(&cfg, &mut out);

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -202,12 +202,29 @@ database, so the call parks, the host resolves it, and the run reads the result
 back on its next step. Each call replaces the whole list, and the plan is keyed
 by the run rather than by the chat — four siblings delegated in one message are
 working four different tasks, and a chat-keyed row would have them overwriting
-each other and the conversation's own plan. When a run calls `done` with steps
-still open, the host hands that call back once with the open steps named, the
-same way it answers a terminal tool that arrived with company. It is a
-reminder, not a gate: the second `done` submits, the push-back is withheld
-when the run cannot afford the row and step it costs, and a run that never made
-a plan is never interrupted.
+each other and the conversation's own plan.
+
+Plan rows are budgeted apart from the rest. A run is told to keep its checklist
+current as steps finish, which is a call after most real steps; charged to the
+same tool allowance, bookkeeping would starve the commands and searches the task
+is actually for, and the run would exhaust itself describing work it never got
+to do. So the allowance above bounds work rows, and plan rows get their own
+smaller cap — enough revisions to narrate one delegated task, few enough to
+bound a model that does nothing else. Each budget withdraws its own tools when
+it runs out, and the durable store enforces the same split, so the advertised
+surface and the bound the transaction applies cannot disagree. Model steps are
+unaffected: every checkpoint still costs the completion that makes it and the
+completion that reads its result.
+
+When a run calls `done` with steps still open, the host hands that call back
+once with the open steps named, the same way it answers a terminal tool that
+arrived with company. It is a reminder, not a gate: the second `done` submits,
+the push-back is spent by its own receipt code rather than by the presence of
+any earlier `done`, it is withheld when the run cannot afford the work row and
+the step it costs, and a run that never made a plan is never interrupted. A run
+that ends by producing final text rather than by submitting is not interrupted
+either — there is no call to hand back, and a synthetic one would be worse than
+the miss.
 
 The sandbox boundary should remain useful outside the desktop product. A local
 process sandbox is the first execution adapter; self-hosted and managed profiles

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -196,6 +196,19 @@ read before claim, at the final pre-dispatch heartbeat, or at resolution; if
 content arrived after authority was lost, it is discarded rather than returned
 to the model.
 
+A background run also keeps an ordered checklist of its own. `update_task_plan`
+is a checkpoint like the others, not a local note: the row lives in the host's
+database, so the call parks, the host resolves it, and the run reads the result
+back on its next step. Each call replaces the whole list, and the plan is keyed
+by the run rather than by the chat — four siblings delegated in one message are
+working four different tasks, and a chat-keyed row would have them overwriting
+each other and the conversation's own plan. When a run calls `done` with steps
+still open, the host hands that call back once with the open steps named, the
+same way it answers a terminal tool that arrived with company. It is a
+reminder, not a gate: the second `done` submits, the push-back is withheld
+when the run cannot afford the row and step it costs, and a run that never made
+a plan is never interrupted.
+
 The sandbox boundary should remain useful outside the desktop product. A local
 process sandbox is the first execution adapter; self-hosted and managed profiles
 may later supply stronger isolation behind the same contract.
@@ -323,6 +336,15 @@ results, folder/root identities, relative paths, filenames, host paths, grants,
 provider identifiers, executor leases, and raw failures remain server-side.
 New tools are invisible to the renderer until they receive their own safe
 activity projection.
+
+A snapshot of a background run may also carry how far its own task plan has
+got: how many steps are completed, out of how many, and the one step marked
+`in_progress`. That last field is the exception to the fixed-vocabulary rule
+above, and it is the same exception the activity headlines already make — the
+text is the run's own, bounded and single-line before storage accepts it. The
+whole ordered list is a separate read,
+`GET /chats/{chat_id}/agent-runs/{run_id}/task-plan`, bound to the exact chat
+and run like the two below it; a run that made no plan answers `null`.
 
 `GET /chats/{chat_id}/agent-runs/{run_id}/activity` rebuilds the background
 run's ordered history from those durable checkpoints. Each item keeps the fixed


### PR DESCRIPTION
A background agent works alone for minutes at a time and the only thing an
observer can see is which tool step it is on. `update_task_plan` already gives
the foreground agent an ordered checklist; this puts the same tool on the
sandbox surface. Written on top of #1762 and rebased onto `main` after it
merged.

## Behavior

The plan row lives in the host's database, so the call cannot be answered where
the agent runs. It takes the shape every other host-side sandbox tool takes: the
run parks a checkpoint and releases its lease, a small executor lane claims it,
and the run resumes from the immutable receipt. The plan write and that receipt
commit in one transaction — a run must never read "plan updated" back from a
receipt whose write did not land, because it replays its whole chain on every
claim and would keep reading the lie.

The tool is advertised and argument-checked like its siblings, except that a
call breaking the one-`in_progress` rule gets that rule back as the correction
instead of a generic schema error. It carries its own spec description rather
than the foreground one, whose "returns immediately and does not pause the turn"
is false where the call is a checkpoint; the argument schema is shared, so the
two surfaces cannot drift into accepting different plans. The system prompt
gains one clause in the existing comma-joined capability sentence.

Plan rows are budgeted apart from the work budget. The prompt asks a run to keep
its checklist current as steps finish, which is a call after most real steps;
charged to the same sixteen rows, bookkeeping would starve the commands and
searches the delegated task is for. Plan rows get their own cap of eight, each
budget withdraws its own tools independently, and the durable park transaction
enforces the same split so the advertised surface and the bound the store
applies cannot disagree. Model steps are unaffected — every checkpoint still
costs the completion that makes it and the one that reads its result.

Calling `done` with steps still open hands that call back once, with the open
steps named. That reuses the rejected-call feedback a terminal tool arriving
with company already gets, so the model reads it as an ordinary error result and
keeps its attempt. It is a reminder rather than a gate on every axis: it is
spent by its own receipt code rather than by the presence of any earlier `done`
row (a `done` emitted alongside a sibling parks a row too, and a model that
calls tools in parallel is the population this is most for), it is withheld
unless the run can afford the work row and the model step it costs, and a run
with no plan or a finished one is never interrupted. A run that ends by
producing final text rather than submitting is not interrupted either: there is
no call to hand back, and a synthetic one would be a worse trade than the miss.

## Schema decision

New `agent_run_task_plan` table, keyed by the run rather than the chat. Four
children delegated in one message are working four different tasks; overloading
the chat-scoped `task_plan` row would have them overwriting each other and the
conversation's own plan. Columns mirror the foreground table — `call_id` for
replay idempotency, JSON steps, `created_at`/`updated_at` with the same check —
with RESTRICT foreign keys to `agent_run` and `sandbox_tool_call`. `delete_chat`
erases it ahead of the sandbox call rows, which is the same hand-enumeration
that made a chat with a foreground plan undeletable. Baseline edited in place;
`DESKTOP_SCHEMA_EPOCH` moves 14 to 15.

## Renderer surface

A background run's snapshot gains `task_plan: {completed, total, current,
updated_at}` — optional on the wire, so a foreground coordinator and a run with
no plan read back in the shape they always had. The full ordered list is its own
read, `GET /chats/{chat_id}/agent-runs/{run_id}/task-plan`, bound to the exact
chat and run and returning `404` for a missing, wrong-chat, or foreground run
like the activity and progress reads. Step text is the same class of
model-authored text the activity headlines carry, but those go through the
renderer clamp on the way out and this does not — so the tool boundary rejects
on the way in against the very same predicate. `preview_formatting_character` is
now shared rather than duplicated: a step longer than 500 characters, or
carrying a control character, line/paragraph separator, or bidi override or
isolate, never becomes a stored step, on either surface. `update_task_plan` also gets its own fixed `AgentActivityKind` so a plan
step reads as itself in a run's history instead of being dropped as an unknown
tool.

## Deviation: the container-resident registry is unchanged

The plan for this slice called for adding the tool to
`SANDBOX_REGISTRY_TOOL_NAMES`. Reading that registry, it names the tools the
in-container loop runs *locally* — `exec` and the three filesystem tools. The
host-side surface is not in it: neither `done` nor `web_search` appears there,
and the container's only host round-trip is `ReverseRequest::ModelInference`.
Adding the plan tool there would mean executing it in the container, where the
database it writes to does not exist. Routing it to the host instead would need
a new reverse capability plus its conformance fixtures and grant plumbing —
the separate design that module's gate is explicitly about. The pinned set and
its test are untouched; the reasoning is recorded in the module header.

## Tests

- `a_sandbox_run_keeps_a_plan_and_is_reminded_once_before_it_finishes` — drives
  the in-process worker and the real executor lane through two plan updates and
  both `done` attempts, asserting advertisement, the host round-trip, the
  per-run projection, and that the push-back is one readable rejection that
  cannot trap the run.
- `a_background_run_keeps_its_own_plan_and_the_chat_can_still_be_deleted` —
  the durable half: a sibling run's plan does not disturb this one's, the
  receipt and the row commit together, and the chat still deletes.
- `plan_rows_have_their_own_cap_and_leave_the_work_budget_alone` — drives a run
  to its plan cap and asserts only the plan tool is withdrawn; the durable store
  agrees, or one of those parks comes back a conflict.
- `a_run_at_its_last_step_submits_rather_than_being_reminded` — the reminder
  parks a row the next completion must read, so offering it one step from the
  ceiling would turn a nudge into a budget failure on a run that was finishing.
- The existing plan-validation test gains the separator and bidi reject cases.
- Two existing assertions on the advertised sandbox tool vector updated for the
  new entry. Nothing removed.

## Deferred

The desktop panel that renders a background run's plan. It reuses the foreground
plan component and is its own slice; nothing here touches the UI beyond the
regenerated wire types, the new activity kind's labels, and its entry in the
parser's admitted set.

## Verification

`cargo check --workspace --locked` (no lockfile diff), `cargo fmt --check`,
clippy `-D warnings` on `openwave-core`, `openwave-server`, and
`openwave-sandbox-agent`, those three crates' full suites, and the desktop UI's
`tsc` and `vitest`. Labelled `full-ci`: the change adds a table, and the
PostgreSQL turn-state lane only runs there.

Part of #411

