### PR TITLE
feat(desktop): show a background run's task plan on its card

### DIFF
--- a/crates/openwave-desktop/ui/src/AgentRunTaskPlan.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/AgentRunTaskPlan.dom.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { AgentRun, AgentRunTaskPlan } from "./api";
+import {
+  AgentRunTaskPlanChecklist,
+  AgentRunTaskPlanProgress,
+  type AgentRunTaskPlanState,
+} from "./AgentRunTaskPlan";
+
+afterEach(cleanup);
+
+const PLAN: AgentRunTaskPlan = {
+  run_id: "run-1",
+  updated_at: "2026-08-07T12:00:00Z",
+  steps: [
+    { content: "Gather the figures", status: "completed" },
+    { content: "Write the summary", status: "in_progress" },
+  ],
+};
+
+const LOADED: AgentRunTaskPlanState = {
+  loading: false,
+  error: false,
+  loaded: true,
+  plan: PLAN,
+};
+
+function run(status: AgentRun["status"]): AgentRun {
+  return {
+    id: "run-1",
+    parent_id: "foreground",
+    spawn_call_id: "spawn-call",
+    tier: "background",
+    execution_location: "in_process",
+    status,
+    task: "Prepare the report",
+    started_at: "2026-08-07T11:00:00Z",
+    finished_at: null,
+    last_error_code: null,
+    activity: null,
+    submitted_outputs: [],
+    task_plan: {
+      completed: 1,
+      total: 2,
+      current: "Write the summary",
+      updated_at: "2026-08-07T12:00:00Z",
+    },
+    terminal_text: null,
+    created_at: "2026-08-07T11:00:00Z",
+    updated_at: "2026-08-07T12:00:00Z",
+  };
+}
+
+describe("a background run's task plan", () => {
+  it("drops every claim of work in flight once the run has stopped", () => {
+    const live = render(
+      <>
+        <AgentRunTaskPlanProgress run={run("running")} live={true} />
+        <AgentRunTaskPlanChecklist state={LOADED} live={true} />
+      </>,
+    );
+    // Named twice while live: once as the step in flight, once on the row.
+    expect(screen.getAllByText("Write the summary")).toHaveLength(2);
+    expect(live.container.querySelector(".animate-spin")).not.toBeNull();
+    expect(live.container.querySelector("[data-slot='progress']")).not.toBeNull();
+
+    cleanup();
+
+    const settled = render(
+      <>
+        <AgentRunTaskPlanProgress run={run("failed")} live={false} />
+        <AgentRunTaskPlanChecklist state={LOADED} live={false} />
+      </>,
+    );
+    // The record of what the run set out to do survives...
+    expect(screen.getByText("1/2 steps")).toBeInTheDocument();
+    // ...but the row stops naming a current step, because there isn't one.
+    expect(screen.getAllByText("Write the summary")).toHaveLength(1);
+    // ...without a spinner or a bar still tracking work that has stopped.
+    expect(settled.container.querySelector(".animate-spin")).toBeNull();
+    expect(settled.container.querySelector("[data-slot='progress']")).toBeNull();
+  });
+});

--- a/crates/openwave-desktop/ui/src/AgentRunTaskPlan.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/AgentRunTaskPlan.dom.test.tsx
@@ -1,11 +1,12 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, renderHook, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 
 import type { AgentRun, AgentRunTaskPlan } from "./api";
 import {
   AgentRunTaskPlanChecklist,
   AgentRunTaskPlanProgress,
+  useAgentRunTaskPlan,
   type AgentRunTaskPlanState,
 } from "./AgentRunTaskPlan";
 
@@ -25,6 +26,7 @@ const LOADED: AgentRunTaskPlanState = {
   error: false,
   loaded: true,
   plan: PLAN,
+  retry: () => undefined,
 };
 
 function run(status: AgentRun["status"]): AgentRun {
@@ -81,5 +83,66 @@ describe("a background run's task plan", () => {
     // ...without a spinner or a bar still tracking work that has stopped.
     expect(settled.container.querySelector(".animate-spin")).toBeNull();
     expect(settled.container.querySelector("[data-slot='progress']")).toBeNull();
+  });
+});
+
+describe("useAgentRunTaskPlan", () => {
+  it("never answers about the run it was previously asked about", async () => {
+    const plans: Record<string, AgentRunTaskPlan> = {
+      "run-1": PLAN,
+      "run-2": { ...PLAN, run_id: "run-2", steps: [PLAN.steps[0]!] },
+    };
+    // Held on an object so the assignment inside the promise is visible to
+    // the checker rather than narrowed away.
+    const gate: { release: () => void } = { release: () => undefined };
+    const loadTaskPlan = async (id: string) => {
+      if (id === "run-2") {
+        await new Promise<void>((resolve) => {
+          gate.release = resolve;
+        });
+      }
+      return plans[id] ?? null;
+    };
+
+    const { result, rerender } = renderHook(
+      ({ runId }: { runId: string }) =>
+        useAgentRunTaskPlan(runId, "2026-08-07T12:00:00Z", true, loadTaskPlan),
+      { initialProps: { runId: "run-1" } },
+    );
+    await waitFor(() => expect(result.current.plan?.run_id).toBe("run-1"));
+
+    // Switching runs while the next read is still in flight must not leave the
+    // previous run's steps standing under the new run's heading.
+    rerender({ runId: "run-2" });
+    expect(result.current.plan).toBeNull();
+
+    gate.release();
+    await waitFor(() => expect(result.current.plan?.run_id).toBe("run-2"));
+  });
+
+  it("keeps the last good plan when a refresh fails, and can be retried", async () => {
+    let attempts = 0;
+    const loadTaskPlan = async () => {
+      attempts += 1;
+      if (attempts === 2) throw new Error("network");
+      return PLAN;
+    };
+
+    const { result, rerender } = renderHook(
+      ({ updatedAt }: { updatedAt: string }) =>
+        useAgentRunTaskPlan("run-1", updatedAt, true, loadTaskPlan),
+      { initialProps: { updatedAt: "2026-08-07T12:00:00Z" } },
+    );
+    await waitFor(() => expect(result.current.plan).toEqual(PLAN));
+
+    rerender({ updatedAt: "2026-08-07T12:05:00Z" });
+    await waitFor(() => expect(result.current.error).toBe(true));
+    // A failed refresh is not evidence the plan is gone.
+    expect(result.current.plan).toEqual(PLAN);
+
+    // A settled run's timestamp never moves again, so the retry is the only
+    // thing that can clear this.
+    result.current.retry();
+    await waitFor(() => expect(result.current.error).toBe(false));
   });
 });

--- a/crates/openwave-desktop/ui/src/AgentRunTaskPlan.tsx
+++ b/crates/openwave-desktop/ui/src/AgentRunTaskPlan.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import type { AgentRun, AgentRunTaskPlan } from "./api";
 import { TaskPlanStepList } from "./TaskPlanSteps";
@@ -10,6 +10,25 @@ export type AgentRunTaskPlanState = {
   error: boolean;
   loaded: boolean;
   plan: AgentRunTaskPlan | null;
+  /** Read the list again after a failure; the effect alone never retries. */
+  retry: () => void;
+};
+
+/** The held read, plus the run it is an answer about. */
+type HeldTaskPlan = {
+  runId: string | null;
+  loading: boolean;
+  error: boolean;
+  loaded: boolean;
+  plan: AgentRunTaskPlan | null;
+};
+
+const NO_PLAN_HELD: HeldTaskPlan = {
+  runId: null,
+  loading: false,
+  error: false,
+  loaded: false,
+  plan: null,
 };
 
 /**
@@ -20,6 +39,15 @@ export type AgentRunTaskPlanState = {
  * the list exactly when it has actually changed, and never while the reader
  * has it closed. Mirrors `useAgentRunActivity`, which observes the run's
  * activity history the same way.
+ *
+ * The held answer remembers which run it is about. A panel that switches runs
+ * without remounting would otherwise show the previous run's steps under the
+ * new run's heading until the next read lands — a wrong answer rather than a
+ * late one.
+ *
+ * A settled run's `updated_at` never changes again, so nothing would re-run
+ * the effect after a failed read. The retry is therefore explicit rather than
+ * a matter of waiting.
  */
 export function useAgentRunTaskPlan(
   runId: string | null,
@@ -27,38 +55,49 @@ export function useAgentRunTaskPlan(
   enabled: boolean,
   loadTaskPlan: (runId: string) => Promise<AgentRunTaskPlan | null>,
 ): AgentRunTaskPlanState {
-  const [state, setState] = useState<AgentRunTaskPlanState>({
-    loading: false,
-    error: false,
-    loaded: false,
-    plan: null,
-  });
+  const [held, setHeld] = useState<HeldTaskPlan>(NO_PLAN_HELD);
+  const [attempt, setAttempt] = useState(0);
 
   useEffect(() => {
     if (!enabled || runId === null) return;
     let cancelled = false;
-    setState((current) => ({
-      ...current,
-      loading: !current.loaded,
-      error: false,
-    }));
+    setHeld((current) =>
+      current.runId === runId
+        ? { ...current, loading: !current.loaded, error: false }
+        : { ...NO_PLAN_HELD, runId, loading: true },
+    );
     loadTaskPlan(runId)
       .then((plan) => {
         if (!cancelled) {
-          setState({ loading: false, error: false, loaded: true, plan });
+          setHeld({ runId, loading: false, error: false, loaded: true, plan });
         }
       })
       .catch(() => {
         if (!cancelled) {
-          setState((current) => ({ ...current, loading: false, error: true }));
+          setHeld((current) =>
+            current.runId === runId
+              ? { ...current, loading: false, error: true }
+              : current,
+          );
         }
       });
     return () => {
       cancelled = true;
     };
-  }, [enabled, runId, updatedAt, loadTaskPlan]);
+  }, [enabled, runId, updatedAt, loadTaskPlan, attempt]);
 
-  return state;
+  const retry = useCallback(() => setAttempt((current) => current + 1), []);
+
+  // Answers about another run are not this run's to show, not even for the
+  // one commit before the effect resets them.
+  const current = held.runId === runId ? held : NO_PLAN_HELD;
+  return {
+    loading: current.loading,
+    error: current.error,
+    loaded: current.loaded,
+    plan: current.plan,
+    retry,
+  };
 }
 
 /**
@@ -95,14 +134,7 @@ export function AgentRunTaskPlanProgress({
             aria-label="Task plan progress"
           />
         )}
-        <span
-          className={cn(
-            "shrink-0 text-xs tabular-nums text-muted-foreground",
-            // With no bar beside it the count would otherwise float in the
-            // middle of the row.
-            !live && "order-first",
-          )}
-        >
+        <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
           {completed}/{progress.total} steps
         </span>
       </div>
@@ -131,26 +163,41 @@ export function AgentRunTaskPlanChecklist({
 }: {
   state: AgentRunTaskPlanState;
   live: boolean;
+  /**
+   * The frame around the list, including its height cap. The caller owns it:
+   * these lists are nested inside scrollers of their own, and a cap chosen
+   * here would stack a second scrollbar inside the first.
+   */
   className?: string;
 }) {
-  if (state.error) {
+  // A failed refresh is not evidence the plan is gone. While a good read is
+  // still held it keeps rendering, and the failure costs nothing visible —
+  // the next successful read replaces it.
+  if (state.error && state.plan === null) {
     return (
-      <p className={cn("text-xs text-muted-foreground", className)} role="status">
-        The task plan could not be loaded.
-      </p>
+      <div
+        className="flex items-center justify-between gap-3 text-xs text-muted-foreground"
+        role="status"
+      >
+        <span>The task plan could not be loaded.</span>
+        <button
+          type="button"
+          className="shrink-0 font-medium text-primary hover:underline"
+          onClick={state.retry}
+        >
+          Retry
+        </button>
+      </div>
     );
   }
   // Nothing while the first read is in flight: the progress line above already
   // says a plan exists and how far it has got, so a skeleton here would only
   // make the row jump.
-  if (!state.loaded || state.plan === null) return null;
+  if (state.plan === null) return null;
 
   return (
     <TaskPlanStepList
-      className={cn(
-        "grid max-h-48 gap-1.5 overflow-y-auto text-xs",
-        className,
-      )}
+      className={cn("grid gap-1.5 overflow-y-auto text-xs", className)}
       steps={state.plan.steps}
       live={live}
     />

--- a/crates/openwave-desktop/ui/src/AgentRunTaskPlan.tsx
+++ b/crates/openwave-desktop/ui/src/AgentRunTaskPlan.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useState } from "react";
+
+import type { AgentRun, AgentRunTaskPlan } from "./api";
+import { TaskPlanStepList } from "./TaskPlanSteps";
+import { Progress } from "@/components/ui/progress";
+import { cn } from "@/lib/utils";
+
+export type AgentRunTaskPlanState = {
+  loading: boolean;
+  error: boolean;
+  loaded: boolean;
+  plan: AgentRunTaskPlan | null;
+};
+
+/**
+ * The full checklist behind a run's progress line, read on demand.
+ *
+ * Deliberately not its own polling loop: the snapshot poll `useAgentRuns`
+ * already runs carries the plan's `updated_at`, so passing that in re-reads
+ * the list exactly when it has actually changed, and never while the reader
+ * has it closed. Mirrors `useAgentRunActivity`, which observes the run's
+ * activity history the same way.
+ */
+export function useAgentRunTaskPlan(
+  runId: string | null,
+  updatedAt: string | undefined,
+  enabled: boolean,
+  loadTaskPlan: (runId: string) => Promise<AgentRunTaskPlan | null>,
+): AgentRunTaskPlanState {
+  const [state, setState] = useState<AgentRunTaskPlanState>({
+    loading: false,
+    error: false,
+    loaded: false,
+    plan: null,
+  });
+
+  useEffect(() => {
+    if (!enabled || runId === null) return;
+    let cancelled = false;
+    setState((current) => ({
+      ...current,
+      loading: !current.loaded,
+      error: false,
+    }));
+    loadTaskPlan(runId)
+      .then((plan) => {
+        if (!cancelled) {
+          setState({ loading: false, error: false, loaded: true, plan });
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setState((current) => ({ ...current, loading: false, error: true }));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, runId, updatedAt, loadTaskPlan]);
+
+  return state;
+}
+
+/**
+ * How far a background run has got, as a status row shows it.
+ *
+ * Secondary information on a card whose subject is the run: a hairline bar,
+ * the count, and the step being worked on — no heading, and nothing that
+ * competes with the task and status above it. The bar is the part that only
+ * makes sense while the work is moving, so a settled run keeps the count and
+ * drops it.
+ */
+export function AgentRunTaskPlanProgress({
+  run,
+  live,
+  className,
+}: {
+  run: AgentRun;
+  live: boolean;
+  className?: string;
+}) {
+  const progress = run.task_plan;
+  if (!progress || progress.total === 0) return null;
+
+  const completed = Math.min(progress.completed, progress.total);
+  const percentage = Math.round((completed / progress.total) * 100);
+
+  return (
+    <div className={cn("flex min-w-0 flex-col gap-1", className)}>
+      <div className="flex min-w-0 items-center gap-2">
+        {live && (
+          <Progress
+            value={percentage}
+            className="h-1 max-w-40 flex-1 bg-muted"
+            aria-label="Task plan progress"
+          />
+        )}
+        <span
+          className={cn(
+            "shrink-0 text-xs tabular-nums text-muted-foreground",
+            // With no bar beside it the count would otherwise float in the
+            // middle of the row.
+            !live && "order-first",
+          )}
+        >
+          {completed}/{progress.total} steps
+        </span>
+      </div>
+      {/* The current step is what the run is doing right now, so it goes when
+          the run does: on a settled run it would name a step that stopped. */}
+      {live && progress.current !== null && (
+        <p className="min-w-0 truncate text-xs text-muted-foreground">
+          {progress.current}
+        </p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The run's checklist in full, in the same step vocabulary the conversation's
+ * own plan uses.
+ *
+ * A run that has stopped never shows a spinner on the step it was working —
+ * liveness here is the run's own status, not any turn's.
+ */
+export function AgentRunTaskPlanChecklist({
+  state,
+  live,
+  className,
+}: {
+  state: AgentRunTaskPlanState;
+  live: boolean;
+  className?: string;
+}) {
+  if (state.error) {
+    return (
+      <p className={cn("text-xs text-muted-foreground", className)} role="status">
+        The task plan could not be loaded.
+      </p>
+    );
+  }
+  // Nothing while the first read is in flight: the progress line above already
+  // says a plan exists and how far it has got, so a skeleton here would only
+  // make the row jump.
+  if (!state.loaded || state.plan === null) return null;
+
+  return (
+    <TaskPlanStepList
+      className={cn(
+        "grid max-h-48 gap-1.5 overflow-y-auto text-xs",
+        className,
+      )}
+      steps={state.plan.steps}
+      live={live}
+    />
+  );
+}

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.dom.test.tsx
@@ -50,6 +50,7 @@ describe("BackgroundAgentList activity disclosure", () => {
         onRetry={() => undefined}
         onCancel={async () => undefined}
         onLoadActivity={loadActivity}
+        onLoadTaskPlan={async () => null}
       />
     );
 

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.test.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.test.tsx
@@ -30,6 +30,7 @@ function run(
 
 const noop = async () => undefined;
 const noActivity = async () => [];
+const noTaskPlan = async () => null;
 
 describe("BackgroundAgentList", () => {
   it("groups only the durable children of its own spawn step", () => {
@@ -49,6 +50,7 @@ describe("BackgroundAgentList", () => {
         onRetry={() => undefined}
         onCancel={noop}
         onLoadActivity={noActivity}
+        onLoadTaskPlan={noTaskPlan}
       />,
     );
 
@@ -75,6 +77,7 @@ describe("BackgroundAgentList", () => {
         onRetry={() => undefined}
         onCancel={noop}
         onLoadActivity={noActivity}
+        onLoadTaskPlan={noTaskPlan}
       />,
     );
 
@@ -98,6 +101,7 @@ describe("BackgroundAgentList", () => {
         onRetry={() => undefined}
         onCancel={noop}
         onLoadActivity={noActivity}
+        onLoadTaskPlan={noTaskPlan}
       />,
     );
 
@@ -115,6 +119,7 @@ describe("BackgroundAgentList", () => {
         onRetry={() => undefined}
         onCancel={noop}
         onLoadActivity={noActivity}
+        onLoadTaskPlan={noTaskPlan}
       />,
     );
 
@@ -131,6 +136,7 @@ describe("BackgroundAgentList", () => {
         onRetry={() => undefined}
         onCancel={noop}
         onLoadActivity={noActivity}
+        onLoadTaskPlan={noTaskPlan}
       />,
     );
 
@@ -147,6 +153,7 @@ describe("BackgroundAgentList", () => {
         onRetry={() => undefined}
         onCancel={noop}
         onLoadActivity={noActivity}
+        onLoadTaskPlan={noTaskPlan}
       />,
     );
 
@@ -170,6 +177,7 @@ describe("BackgroundAgentList", () => {
         onRetry={() => undefined}
         onCancel={noop}
         onLoadActivity={noActivity}
+        onLoadTaskPlan={noTaskPlan}
       />,
     );
 
@@ -186,6 +194,7 @@ describe("BackgroundAgentList", () => {
         onRetry={() => undefined}
         onCancel={noop}
         onLoadActivity={noActivity}
+        onLoadTaskPlan={noTaskPlan}
       />,
     );
 

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
@@ -2,7 +2,17 @@ import { useEffect, useState } from "react";
 import { Bot, ChevronDown, ChevronRight, Square } from "lucide-react";
 import { toast } from "sonner";
 
-import type { AgentActivityHistoryEntry, AgentRun, ApiClient } from "./api";
+import type {
+  AgentActivityHistoryEntry,
+  AgentRun,
+  AgentRunTaskPlan,
+  ApiClient,
+} from "./api";
+import {
+  AgentRunTaskPlanChecklist,
+  AgentRunTaskPlanProgress,
+  useAgentRunTaskPlan,
+} from "./AgentRunTaskPlan";
 import { AgentActivityTimeline, useAgentRunActivity } from "./AgentActivityTimeline";
 import {
   AGENT_RUN_STATUS_GROUPS,
@@ -37,6 +47,8 @@ type BackgroundAgentListProps = {
   onCancel: (runId: string) => Promise<void>;
   /** Fetch a run's ordered, renderer-safe activity history. */
   onLoadActivity: (runId: string) => Promise<AgentActivityHistoryEntry[]>;
+  /** Fetch a run's full task plan, read only when a row is opened. */
+  onLoadTaskPlan: (runId: string) => Promise<AgentRunTaskPlan | null>;
   /** Open one run's dedicated panel beside the conversation. */
   onOpen?: (runId: string) => void;
   /** Open one file a run submitted, from its pill on the row. */
@@ -58,6 +70,7 @@ export function BackgroundAgentList({
   onRetry,
   onCancel,
   onLoadActivity,
+  onLoadTaskPlan,
   onOpen,
   onOpenOutput,
 }: BackgroundAgentListProps) {
@@ -175,6 +188,7 @@ export function BackgroundAgentList({
                         run={run}
                         onCancel={onCancel}
                         onLoadActivity={onLoadActivity}
+                        onLoadTaskPlan={onLoadTaskPlan}
                         onOpen={onOpen}
                         onOpenOutput={onOpenOutput}
                         expanded={expandedRunIds.has(run.id)}
@@ -239,6 +253,7 @@ function BackgroundAgentRow({
   run,
   onCancel,
   onLoadActivity,
+  onLoadTaskPlan,
   onOpen,
   onOpenOutput,
   expanded,
@@ -251,6 +266,7 @@ function BackgroundAgentRow({
   run: AgentRun;
   onCancel: (runId: string) => Promise<void>;
   onLoadActivity: (runId: string) => Promise<AgentActivityHistoryEntry[]>;
+  onLoadTaskPlan: (runId: string) => Promise<AgentRunTaskPlan | null>;
   onOpen?: (runId: string) => void;
   onOpenOutput?: (outputId: string) => void;
   expanded: boolean;
@@ -264,6 +280,15 @@ function BackgroundAgentRow({
     run.updated_at,
     expanded,
     onLoadActivity,
+  );
+  const live = RUNNING_AGENT_STATUSES.has(run.status);
+  // Keyed on the plan's own timestamp rather than the run's: the row re-reads
+  // the list when the plan moves on, not on every poll that touches the run.
+  const taskPlan = useAgentRunTaskPlan(
+    run.id,
+    run.task_plan?.updated_at,
+    expanded && run.task_plan !== undefined,
+    onLoadTaskPlan,
   );
 
   // The Stop control is offered only while a fresh cancel would still change
@@ -352,6 +377,11 @@ function BackgroundAgentRow({
           </Button>
         )}
       </div>
+      {run.task_plan && (
+        <div className="mt-1.5 pl-5">
+          <AgentRunTaskPlanProgress run={run} live={live} />
+        </div>
+      )}
       {run.submitted_outputs.length > 0 && (
         <div className="mt-2 pl-5">
           <SubmittedOutputPills
@@ -361,14 +391,15 @@ function BackgroundAgentRow({
         </div>
       )}
       {expanded && (
-        <div id={contentId} className="mt-2 pl-5">
+        <div id={contentId} className="mt-2 flex flex-col gap-2 pl-5">
+          {run.task_plan && (
+            <AgentRunTaskPlanChecklist state={taskPlan} live={live} />
+          )}
           <AgentActivityTimeline
             state={activity}
-            active={RUNNING_AGENT_STATUSES.has(run.status)}
+            active={live}
             activeLabel={agentRunStatusDetail(run)}
-            expanded={
-              activityExpanded ?? RUNNING_AGENT_STATUSES.has(run.status)
-            }
+            expanded={activityExpanded ?? live}
             onExpandedChange={onActivityExpandedChange}
           />
         </div>

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
@@ -393,7 +393,14 @@ function BackgroundAgentRow({
       {expanded && (
         <div id={contentId} className="mt-2 flex flex-col gap-2 pl-5">
           {run.task_plan && (
-            <AgentRunTaskPlanChecklist state={taskPlan} live={live} />
+            <AgentRunTaskPlanChecklist
+              state={taskPlan}
+              live={live}
+              // Shallow on purpose: this row already sits inside the list's
+              // own 12rem viewport, so a tall checklist here would nest a
+              // second scrollbar and push its siblings out of reach.
+              className="max-h-24"
+            />
           )}
           <AgentActivityTimeline
             state={activity}

--- a/crates/openwave-desktop/ui/src/BackgroundAgentPanel.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentPanel.tsx
@@ -13,6 +13,11 @@ import {
   fetchAgentRunProgress,
 } from "./AgentRunDebugReport";
 import { agentRunStatusDetail, RUNNING_AGENT_STATUSES } from "./AgentRunDisplay";
+import {
+  AgentRunTaskPlanChecklist,
+  AgentRunTaskPlanProgress,
+  useAgentRunTaskPlan,
+} from "./AgentRunTaskPlan";
 import type { AgentRun, ApiClient } from "./api";
 import { ClipboardCopyButton, copyPlainText } from "./ClipboardCopyButton";
 import { MessageMarkdown } from "./MessageMarkdown";
@@ -66,6 +71,14 @@ export function BackgroundAgentPanel({
     run !== null,
     agentRuns.loadActivity,
   );
+  // Opening the panel is the intent the row's chevron stands for, so the full
+  // checklist is read here rather than waiting on a second disclosure.
+  const taskPlan = useAgentRunTaskPlan(
+    runId,
+    run?.task_plan?.updated_at,
+    run?.task_plan !== undefined,
+    agentRuns.loadTaskPlan,
+  );
 
   const stopButton = stoppable ? (
     <Button
@@ -107,6 +120,7 @@ export function BackgroundAgentPanel({
         <BackgroundAgentDetail
           run={run}
           activity={activity}
+          taskPlan={taskPlan}
           chatId={chatId}
           onOpenOutput={(outputId) => openPanel({ type: "outputs", outputId })}
         />
@@ -139,11 +153,13 @@ export function BackgroundAgentPanel({
 function BackgroundAgentDetail({
   run,
   activity,
+  taskPlan,
   chatId,
   onOpenOutput,
 }: {
   run: AgentRun;
   activity: ReturnType<typeof useAgentRunActivity>;
+  taskPlan: ReturnType<typeof useAgentRunTaskPlan>;
   chatId: string;
   onOpenOutput?: (outputId: string) => void;
 }) {
@@ -190,6 +206,12 @@ function BackgroundAgentDetail({
         )}
       </div>
       <div className="mt-3 flex shrink-0 flex-col gap-2 border-b px-4 pb-3 empty:hidden">
+        {run.task_plan && (
+          <div className="flex flex-col gap-1.5">
+            <AgentRunTaskPlanProgress run={run} live={live} />
+            <AgentRunTaskPlanChecklist state={taskPlan} live={live} />
+          </div>
+        )}
         {run.submitted_outputs.length > 0 && (
           <SubmittedOutputPills
             outputs={run.submitted_outputs}

--- a/crates/openwave-desktop/ui/src/BackgroundAgentPanel.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentPanel.tsx
@@ -209,7 +209,13 @@ function BackgroundAgentDetail({
         {run.task_plan && (
           <div className="flex flex-col gap-1.5">
             <AgentRunTaskPlanProgress run={run} live={live} />
-            <AgentRunTaskPlanChecklist state={taskPlan} live={live} />
+            <AgentRunTaskPlanChecklist
+              state={taskPlan}
+              live={live}
+              // The strip above the timeline does not scroll, so the plan is
+              // capped to leave the activity pane below it its own room.
+              className="max-h-40"
+            />
           </div>
         )}
         {run.submitted_outputs.length > 0 && (

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -408,6 +408,7 @@ export function ChatView({
           onRetryBackgroundAgentRuns={agentRuns.refresh}
           onCancelBackgroundAgentRun={agentRuns.cancel}
           onLoadBackgroundAgentActivity={agentRuns.loadActivity}
+          onLoadBackgroundAgentTaskPlan={agentRuns.loadTaskPlan}
           onOpenBackgroundAgent={onOpenAgentPanel}
           onOpenOutput={onOpenOutput}
           backgroundAgentClient={client}

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -5,6 +5,7 @@ import type {
   ApiClient,
   AgentRun,
   AgentActivityHistoryEntry,
+  AgentRunTaskPlan,
   PendingFolderAccessRequest,
   PendingOutputWritebackRequest,
   PendingPlanApproval,
@@ -214,6 +215,9 @@ type MessageListProps = {
   onLoadBackgroundAgentActivity?: (
     runId: string,
   ) => Promise<AgentActivityHistoryEntry[]>;
+  onLoadBackgroundAgentTaskPlan?: (
+    runId: string,
+  ) => Promise<AgentRunTaskPlan | null>;
   onOpenBackgroundAgent?: (runId: string) => void;
   onOpenOutput?: (outputId: string) => void;
   /** The connected client, so a background agent row can fetch debug info. */
@@ -294,6 +298,7 @@ export function MessageList({
   onRetryBackgroundAgentRuns = () => undefined,
   onCancelBackgroundAgentRun = async () => undefined,
   onLoadBackgroundAgentActivity = async () => [],
+  onLoadBackgroundAgentTaskPlan = async () => null,
   onOpenBackgroundAgent,
   onOpenOutput,
   busy,
@@ -351,6 +356,7 @@ export function MessageList({
       retry: onRetryBackgroundAgentRuns,
       cancel: onCancelBackgroundAgentRun,
       loadActivity: onLoadBackgroundAgentActivity,
+      loadTaskPlan: onLoadBackgroundAgentTaskPlan,
       open: onOpenBackgroundAgent,
       openOutput: onOpenOutput,
       client: backgroundAgentClient,
@@ -594,6 +600,7 @@ export function groupMessageItems(
     retry: () => void;
     cancel: (runId: string) => Promise<void>;
     loadActivity: (runId: string) => Promise<AgentActivityHistoryEntry[]>;
+    loadTaskPlan: (runId: string) => Promise<AgentRunTaskPlan | null>;
     open?: (runId: string) => void;
     openOutput?: (outputId: string) => void;
     /** The connected client, so a row's "Copy debug info" can fetch its run. */
@@ -605,6 +612,7 @@ export function groupMessageItems(
     retry: () => undefined,
     cancel: async () => undefined,
     loadActivity: async () => [],
+    loadTaskPlan: async () => null,
   },
   retry?: { failureId: string; onRetry: () => void },
 ) {
@@ -764,6 +772,7 @@ export function groupMessageItems(
             onRetry={backgroundAgents.retry}
             onCancel={backgroundAgents.cancel}
             onLoadActivity={backgroundAgents.loadActivity}
+            onLoadTaskPlan={backgroundAgents.loadTaskPlan}
             onOpen={backgroundAgents.open}
             onOpenOutput={backgroundAgents.openOutput}
             {...(backgroundAgents.client && chatId

--- a/crates/openwave-desktop/ui/src/TaskPlanCard.tsx
+++ b/crates/openwave-desktop/ui/src/TaskPlanCard.tsx
@@ -1,8 +1,8 @@
 import { useId, useRef, useState } from "react";
-import { Circle, CircleCheck, CircleDashed, ChevronDown } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 
-import type { TaskPlan, TaskPlanStepStatus } from "./api";
-import { Spinner } from "@/components/ui/spinner";
+import type { TaskPlan } from "./api";
+import { TaskPlanStepList } from "./TaskPlanSteps";
 import { cn } from "@/lib/utils";
 
 export type TaskPlanCardProps = {
@@ -83,94 +83,13 @@ export function TaskPlanCard({ plan, live }: TaskPlanCardProps) {
         // itself when a turn goes live, so a twenty-step plan would otherwise
         // push the composer out of a pane that cannot scroll. The cap shows
         // most of a plan at a glance and leaves the rest a scroll away.
-        <ol
+        <TaskPlanStepList
           id={bodyId}
           className="grid max-h-64 gap-1.5 overflow-y-auto border-t px-2.5 py-2 text-sm"
-        >
-          {plan.steps.map((step, index) => (
-            <TaskPlanRow
-              // Steps have no identity of their own — the plan is replaced
-              // whole — so position is what they are keyed on.
-              key={index}
-              content={step.content}
-              status={step.status}
-              live={live}
-            />
-          ))}
-        </ol>
+          steps={plan.steps}
+          live={live}
+        />
       )}
     </section>
   );
-}
-
-/**
- * One step: a status glyph and the line the agent wrote.
- *
- * Status is carried by the glyph alone. Striking a finished step through
- * trades legibility for decoration, and a plan is read to find out what is
- * left rather than to admire what is done.
- */
-function TaskPlanRow({
-  content,
-  status,
-  live,
-}: {
-  content: string;
-  status: TaskPlanStepStatus;
-  live: boolean;
-}) {
-  const working = status === "in_progress" && live;
-  return (
-    <li className="flex items-start gap-2">
-      <span className="mt-0.5 shrink-0" aria-hidden="true">
-        <StepGlyph status={status} live={live} />
-      </span>
-      <span
-        className={cn(
-          // The line is the agent's own text, up to 500 characters of it and
-          // not necessarily with a space in them. It wraps rather than being
-          // clipped away by the card's own overflow.
-          "min-w-0 break-words",
-          working ? "text-foreground" : "text-muted-foreground",
-        )}
-      >
-        {content}
-      </span>
-      <span className="sr-only">{statusLabel(status, live)}</span>
-    </li>
-  );
-}
-
-function StepGlyph({
-  status,
-  live,
-}: {
-  status: TaskPlanStepStatus;
-  live: boolean;
-}) {
-  if (status === "completed") {
-    return <CircleCheck className="text-success size-4" />;
-  }
-  if (status === "in_progress") {
-    // A spinner on a turn that is over would animate a claim that nothing is
-    // making true. The step still reads as started rather than untouched, but
-    // it reads as stopped.
-    return live ? (
-      <Spinner className="text-foreground size-4" />
-    ) : (
-      <CircleDashed className="text-muted-foreground size-4" />
-    );
-  }
-  return <Circle className="text-muted-foreground/60 size-4" />;
-}
-
-function statusLabel(status: TaskPlanStepStatus, live: boolean): string {
-  switch (status) {
-    case "completed":
-      return "Done";
-    case "in_progress":
-      return live ? "In progress" : "Unfinished";
-    case "pending":
-      return live ? "To do" : "Not started";
-  }
 }

--- a/crates/openwave-desktop/ui/src/TaskPlanSteps.tsx
+++ b/crates/openwave-desktop/ui/src/TaskPlanSteps.tsx
@@ -1,0 +1,124 @@
+import { Circle, CircleCheck, CircleDashed } from "lucide-react";
+
+import type { TaskPlanStep, TaskPlanStepStatus } from "./api";
+import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/utils";
+
+/**
+ * How a checklist's steps are drawn, in one place.
+ *
+ * Two surfaces render a task plan — the conversation's own, above the
+ * composer, and a background run's, on its card — and they agree on more than
+ * they differ on: the glyph vocabulary, the wrapping, the muting, and what a
+ * step says to a screen reader. Only the frame around the list differs, so
+ * that is all each caller supplies.
+ */
+
+/**
+ * One step: a status glyph and the line the agent wrote.
+ *
+ * Status is carried by the glyph alone. Striking a finished step through
+ * trades legibility for decoration, and a plan is read to find out what is
+ * left rather than to admire what is done.
+ */
+export function TaskPlanStepRow({
+  content,
+  status,
+  live,
+}: {
+  content: string;
+  status: TaskPlanStepStatus;
+  /**
+   * Whether the work this plan describes is still under way — a running turn,
+   * or a running background run. A settled plan stays readable as the record
+   * of what was attempted, but nothing in it may still claim to be moving.
+   */
+  live: boolean;
+}) {
+  const working = status === "in_progress" && live;
+  return (
+    <li className="flex items-start gap-2">
+      <span className="mt-0.5 shrink-0" aria-hidden="true">
+        <StepGlyph status={status} live={live} />
+      </span>
+      <span
+        className={cn(
+          // The line is the agent's own text, up to 500 characters of it and
+          // not necessarily with a space in them. It wraps rather than being
+          // clipped away by the card's own overflow.
+          "min-w-0 break-words",
+          working ? "text-foreground" : "text-muted-foreground",
+        )}
+      >
+        {content}
+      </span>
+      <span className="sr-only">{statusLabel(status, live)}</span>
+    </li>
+  );
+}
+
+/**
+ * The ordered list of steps. The caller owns the frame — its padding, its
+ * height cap, and whatever it is nested in — because that is the only part
+ * the two surfaces disagree about.
+ */
+export function TaskPlanStepList({
+  steps,
+  live,
+  id,
+  className,
+}: {
+  steps: readonly TaskPlanStep[];
+  live: boolean;
+  id?: string;
+  className?: string;
+}) {
+  return (
+    <ol id={id} className={className}>
+      {steps.map((step, index) => (
+        <TaskPlanStepRow
+          // Steps have no identity of their own — the plan is replaced
+          // whole — so position is what they are keyed on.
+          key={index}
+          content={step.content}
+          status={step.status}
+          live={live}
+        />
+      ))}
+    </ol>
+  );
+}
+
+function StepGlyph({
+  status,
+  live,
+}: {
+  status: TaskPlanStepStatus;
+  live: boolean;
+}) {
+  if (status === "completed") {
+    return <CircleCheck className="text-success size-4" />;
+  }
+  if (status === "in_progress") {
+    // A spinner on work that has stopped would animate a claim that nothing is
+    // making true. The step still reads as started rather than untouched, but
+    // it reads as stopped.
+    return live ? (
+      <Spinner className="text-foreground size-4" />
+    ) : (
+      <CircleDashed className="text-muted-foreground size-4" />
+    );
+  }
+  return <Circle className="text-muted-foreground/60 size-4" />;
+}
+
+function statusLabel(status: TaskPlanStepStatus, live: boolean): string {
+  switch (status) {
+    case "completed":
+      return "Done";
+    case "in_progress":
+      return live ? "In progress" : "Unfinished";
+    case "pending":
+      return live ? "To do" : "Not started";
+  }
+}

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   ApiClient,
   parseAgentActivityHistory,
+  parseAgentRunTaskPlan,
   parseFolderAccessRequest,
   parseInboxItem,
   parsePendingChatPrompt,
@@ -260,6 +261,35 @@ describe("parseTaskPlan", () => {
     ["no steps at all", { ...safe, steps: [] }],
   ])("rejects the whole plan over %s", (_case, payload) => {
     expect(parseTaskPlan(payload)).toBeNull();
+  });
+});
+
+describe("parseAgentRunTaskPlan", () => {
+  const safe = {
+    run_id: "run-1",
+    updated_at: "2026-08-07T12:00:00Z",
+    steps: [
+      { content: "Gather the figures", status: "completed" },
+      { content: "Write the summary", status: "in_progress" },
+    ],
+  };
+
+  it("accepts a well-formed run plan", () => {
+    expect(parseAgentRunTaskPlan(safe)).toEqual(safe);
+  });
+
+  // The steps go through the same validation the chat plan's do, so this
+  // covers the run-shaped envelope and one representative step failure rather
+  // than restating the step table already pinned above.
+  it.each([
+    ["a plan keyed by turn rather than run", { ...safe, turn_id: "turn-1" }],
+    [
+      "a step outside the closed status vocabulary",
+      { ...safe, steps: [{ content: "Write it", status: "skipped" }] },
+    ],
+    ["no steps at all", { ...safe, steps: [] }],
+  ])("rejects the whole plan over %s", (_case, payload) => {
+    expect(parseAgentRunTaskPlan(payload)).toBeNull();
   });
 });
 

--- a/crates/openwave-desktop/ui/src/api/client.ts
+++ b/crates/openwave-desktop/ui/src/api/client.ts
@@ -67,6 +67,7 @@ import {
   type AgentRunProgress,
   type LocalVoiceInfo,
   type InboxItem,
+  type AgentRunTaskPlan,
   type PendingChatPrompt,
   type TaskPlan,
 } from "./types";
@@ -80,6 +81,7 @@ import {
   parsePendingPlanApproval,
   parsePendingToolApproval,
   parsePendingUserQuestions,
+  parseAgentRunTaskPlan,
   parseSandboxAgentCancellation,
   parseTaskPlan,
 } from "./parsers";
@@ -1053,6 +1055,25 @@ export class ApiClient {
       { headers: this.headers() },
     );
     return parseAgentActivityHistory(body);
+  }
+
+  /**
+   * The full ordered checklist one background run keeps, or `null`.
+   *
+   * The run snapshot already carries the count and the current step, which is
+   * all a status row needs; this is the list behind it, read when a reader
+   * opens the run. A wrong-chat, foreground, or missing run answers `404`,
+   * which surfaces as a thrown error.
+   */
+  async getAgentRunTaskPlan(
+    chatId: string,
+    runId: string,
+  ): Promise<AgentRunTaskPlan | null> {
+    const body = await this.json<unknown>(
+      `/chats/${encodeURIComponent(chatId)}/agent-runs/${encodeURIComponent(runId)}/task-plan`,
+      { headers: this.headers() },
+    );
+    return parseAgentRunTaskPlan(body);
   }
 
   /**

--- a/crates/openwave-desktop/ui/src/api/parsers.ts
+++ b/crates/openwave-desktop/ui/src/api/parsers.ts
@@ -9,6 +9,7 @@ import {
   type PendingOutputWritebackRequest as WirePendingOutputWritebackRequest,
   type PendingPlanApproval as WirePendingPlanApproval,
   type PendingUserQuestions as WirePendingUserQuestions,
+  type AgentRunTaskPlan as WireAgentRunTaskPlan,
   type TaskPlan as WireTaskPlan,
   type TaskPlanStep as WireTaskPlanStep,
   type TaskPlanStepStatus,
@@ -39,6 +40,7 @@ import {
   type ResultEntryKind,
   type ResultFailure,
   type SandboxAgentCancellation,
+  type AgentRunTaskPlan,
   type TaskPlan,
   type TaskPlanStep,
   type ToolActionPreview,
@@ -292,26 +294,69 @@ const MAX_TASK_PLAN_STEP_CHARS = 500;
 /**
  * The chat's current plan, or `null` when it has none or the payload is not
  * one the renderer will draw.
- *
- * All or nothing, because a plan is written as one replacement and read as one
- * checklist: dropping a step that failed validation would leave a list that
- * silently disagrees with the work the agent thinks it is doing, which is a
- * worse answer than showing no plan at all.
  */
 export function parseTaskPlan(value: unknown): TaskPlan | null {
   if (
     !isRecord(value) ||
     !onlyKeys<WireTaskPlan>(value, ["turn_id", "steps", "updated_at"]) ||
     !nonEmptyBounded(value.turn_id, 128) ||
-    !nonEmptyBounded(value.updated_at, 64) ||
-    !Array.isArray(value.steps) ||
-    value.steps.length === 0 ||
-    value.steps.length > MAX_TASK_PLAN_STEPS
+    !nonEmptyBounded(value.updated_at, 64)
+  ) {
+    return null;
+  }
+  const steps = parseTaskPlanSteps(value.steps);
+  if (steps === null) return null;
+  return {
+    turn_id: value.turn_id,
+    steps,
+    updated_at: value.updated_at,
+  };
+}
+
+/**
+ * One background run's plan, or `null` when it has none or the payload is not
+ * one the renderer will draw.
+ *
+ * The run-scoped twin of {@link parseTaskPlan}, holding the steps to the same
+ * rules — they are the same model-authored text written through the same tool,
+ * and the only difference is what owns the list.
+ */
+export function parseAgentRunTaskPlan(value: unknown): AgentRunTaskPlan | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireAgentRunTaskPlan>(value, ["run_id", "steps", "updated_at"]) ||
+    !nonEmptyBounded(value.run_id, 128) ||
+    !nonEmptyBounded(value.updated_at, 64)
+  ) {
+    return null;
+  }
+  const steps = parseTaskPlanSteps(value.steps);
+  if (steps === null) return null;
+  return {
+    run_id: value.run_id,
+    steps,
+    updated_at: value.updated_at,
+  };
+}
+
+/**
+ * The steps of a plan, or `null` when any one of them fails.
+ *
+ * All or nothing, because a plan is written as one replacement and read as one
+ * checklist: dropping a step that failed validation would leave a list that
+ * silently disagrees with the work the agent thinks it is doing, which is a
+ * worse answer than showing no plan at all.
+ */
+function parseTaskPlanSteps(value: unknown): TaskPlanStep[] | null {
+  if (
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    value.length > MAX_TASK_PLAN_STEPS
   ) {
     return null;
   }
   const steps: TaskPlanStep[] = [];
-  for (const step of value.steps) {
+  for (const step of value) {
     if (
       !isRecord(step) ||
       !onlyKeys<WireTaskPlanStep>(step, ["content", "status"]) ||
@@ -326,11 +371,7 @@ export function parseTaskPlan(value: unknown): TaskPlan | null {
       status: step.status as TaskPlanStepStatus,
     });
   }
-  return {
-    turn_id: value.turn_id,
-    steps,
-    updated_at: value.updated_at,
-  };
+  return steps;
 }
 
 export function parsePendingUserQuestions(

--- a/crates/openwave-desktop/ui/src/api/types.ts
+++ b/crates/openwave-desktop/ui/src/api/types.ts
@@ -15,6 +15,8 @@ import {
   type AgentRunProgressLine,
   type AgentRunCancellationSnapshot,
   type AgentRunSnapshot,
+  type AgentRunTaskPlan as WireAgentRunTaskPlan,
+  type AgentRunTaskPlanProgress as WireAgentRunTaskPlanProgress,
   type Chat as WireChat,
   type ChatTranscript as WireChatTranscript,
   type CodeExecutionConfigInfo as WireCodeExecutionConfigInfo,
@@ -393,6 +395,15 @@ export type AgentRun = AgentRunSnapshot;
  * stream only says the plan moved on.
  */
 export type TaskPlan = WireTaskPlan;
+
+/**
+ * The run-scoped twin of {@link TaskPlan}: one background run's checklist,
+ * carrying no turn because a run is one delegated task start to finish.
+ */
+export type AgentRunTaskPlan = WireAgentRunTaskPlan;
+
+/** A run's plan as a status row needs it: the count and the current step. */
+export type AgentRunTaskPlanProgress = WireAgentRunTaskPlanProgress;
 export type TaskPlanStep = WireTaskPlanStep;
 export type TaskPlanStepStatus = WireTaskPlanStepStatus;
 

--- a/crates/openwave-desktop/ui/src/api/types.ts
+++ b/crates/openwave-desktop/ui/src/api/types.ts
@@ -16,7 +16,6 @@ import {
   type AgentRunCancellationSnapshot,
   type AgentRunSnapshot,
   type AgentRunTaskPlan as WireAgentRunTaskPlan,
-  type AgentRunTaskPlanProgress as WireAgentRunTaskPlanProgress,
   type Chat as WireChat,
   type ChatTranscript as WireChatTranscript,
   type CodeExecutionConfigInfo as WireCodeExecutionConfigInfo,
@@ -401,9 +400,6 @@ export type TaskPlan = WireTaskPlan;
  * carrying no turn because a run is one delegated task start to finish.
  */
 export type AgentRunTaskPlan = WireAgentRunTaskPlan;
-
-/** A run's plan as a status row needs it: the count and the current step. */
-export type AgentRunTaskPlanProgress = WireAgentRunTaskPlanProgress;
 export type TaskPlanStep = WireTaskPlanStep;
 export type TaskPlanStepStatus = WireTaskPlanStepStatus;
 

--- a/crates/openwave-desktop/ui/src/useAgentRuns.ts
+++ b/crates/openwave-desktop/ui/src/useAgentRuns.ts
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import type { AgentActivityHistoryEntry, AgentRun, ApiClient } from "./api";
+import type {
+  AgentActivityHistoryEntry,
+  AgentRun,
+  AgentRunTaskPlan,
+  ApiClient,
+} from "./api";
 import { RUNNING_AGENT_STATUSES } from "./AgentRunDisplay";
 import type { ChatMessage } from "./MessageList";
 
@@ -38,6 +43,14 @@ export type AgentRuns = {
   cancel: (runId: string) => Promise<void>;
   /** Fetch the ordered, renderer-safe activity history for one background run. */
   loadActivity: (runId: string) => Promise<AgentActivityHistoryEntry[]>;
+  /**
+   * Fetch the full checklist one background run keeps.
+   *
+   * The snapshot poll already carries the count and the current step, so this
+   * is read only when a reader opens the run — and again when the snapshot
+   * says the plan has moved on.
+   */
+  loadTaskPlan: (runId: string) => Promise<AgentRunTaskPlan | null>;
 };
 
 /**
@@ -137,6 +150,13 @@ export function useAgentRuns(
     },
     [client, chatId],
   );
+  const loadTaskPlan = useCallback(
+    async (runId: string) => {
+      if (!client || !chatId) return null;
+      return client.getAgentRunTaskPlan(chatId, runId);
+    },
+    [client, chatId],
+  );
 
   return {
     runs,
@@ -145,5 +165,6 @@ export function useAgentRuns(
     refresh: () => refreshRef.current?.(),
     cancel,
     loadActivity,
+    loadTaskPlan,
   };
 }


### PR DESCRIPTION
The last slice of #411. Background runs keep their own checklist; until now the
only way to see how far one had got was to open its activity timeline and infer
it from the tool calls.

## Behavior

**On the run row.** The run snapshot already carries `task_plan`
(`{completed, total, current}`), so the compact progress costs no new request
and rides the poll `useAgentRuns` already runs: a hairline bar, a
`{completed}/{total} steps` counter, and the current step on a truncated muted
line, tucked under the task the run was given. It is secondary information on a
card whose subject is the run, so there is no heading and nothing that competes
with the task and status above it.

**Expanded.** Opening a row — the same chevron that already reveals the
activity timeline — reads the full list from
`GET /chats/{chat_id}/agent-runs/{run_id}/task-plan` and draws it above the
timeline. The dedicated run panel shows the list without a second disclosure:
opening the panel *is* the intent the row's chevron stands for.

**Terminal coercion**, keyed on the run's own status (`RUNNING_AGENT_STATUSES`)
rather than any chat turn. A run that has stopped keeps its count and its steps
— the record of what it set out to do — but loses the bar, the current-step
line, and the spinner on whatever step it was working. An unfinished step
renders as a dashed circle: started, but stopped.

**Refresh.** No new polling loop. The snapshot poll carries the plan's
`updated_at`, so passing that to `useAgentRunTaskPlan` re-reads the list exactly
when the plan has moved on and never while the reader has the row closed —
the same arrangement `useAgentRunActivity` uses for the activity history.

## What was factored

`TaskPlanSteps.tsx` now owns the step rendering both surfaces share: the glyph
vocabulary (`StepGlyph`), the sr-only status wording (`statusLabel`), the
wrapping and muting, and the ordered list. Only the frame around the list
differs, so that is all each caller supplies — `TaskPlanCard` passes its
`<ol>` id and className verbatim and renders exactly what it did before (its
existing DOM test passes unchanged; the diff is a pure move).

On the parsing side, `parseTaskPlan`'s step validation moved to a shared
`parseTaskPlanSteps`, and `parseAgentRunTaskPlan` reuses it for the run-shaped
envelope. Same rules, one copy: the steps are the same model-authored text
written through the same tool. Snapshot parsing is untouched — `task_plan`
rides the existing `AgentRunSnapshot` cast rather than gaining a lone
validator for one field.

## Tests

Two, per the repo's test policy:

- a component test pinning dead-run coercion across both new pieces — a live
  run spins, shows the bar, and names the current step twice (row and list); a
  failed run keeps the count and the steps and has no spinner, no bar, and no
  current-step line;
- an accept/reject pair for `parseAgentRunTaskPlan`, covering the run-shaped
  envelope and one representative step failure rather than restating the step
  table `parseTaskPlan`'s suite already pins.

Ten existing `BackgroundAgentList` test call sites gained the new required
`onLoadTaskPlan` prop; no assertions changed.

## Verification

`pnpm exec tsc --noEmit` clean, `pnpm test` 834 passing across 125 files,
`pnpm build` clean. The app was not driven: the rendered appearance of the bar
and the checklist in place, and the live refetch against a real running agent,
are unverified. Screenshots are not possible from this environment.

Closes #411