### PR TITLE
feat(desktop): rework the parked question and plan cards

### DIFF
--- a/crates/openwave-core/src/db/ops/plan.rs
+++ b/crates/openwave-core/src/db/ops/plan.rs
@@ -319,6 +319,8 @@ pub(in crate::db) async fn decide(
         active_chat.update(&transaction).await.map_err(store_err)?;
     }
 
+    let plan_title = plan_request.title.clone();
+    let plan = plan_request.plan.clone();
     let mut active_request: entities::plan_request::ActiveModel = plan_request.into();
     active_request.status = Set(decided_status.as_str().into());
     active_request.feedback = Set(request.decision.feedback.clone());
@@ -331,10 +333,52 @@ pub(in crate::db) async fn decide(
     let mut active_call: entities::tool_call::ActiveModel = call.into();
     active_call.status = Set(ToolCallStatus::Completed.as_str().into());
     active_call.result = Set(Some(result));
+    // Read back on history rehydration, so reopening the chat shows the same
+    // recap the live transcript settled to.
+    let preview = crate::ToolResultPreview::PlanDecision {
+        title: plan_title,
+        plan,
+        accepted: matches!(request.decision.decision, PlanDecisionChoice::Accept),
+        feedback: request.decision.feedback.clone(),
+    };
+    active_call.result_preview = Set(Some(serde_json::to_value(&preview)?));
     active_call.error_code = Set(None);
     active_call.error_detail = Set(None);
     active_call.resolved_at = Set(Some(decided_at));
     let resolved = active_call.update(&transaction).await.map_err(store_err)?;
+    // The plan call resolves outside the agent loop, so nothing else ever
+    // announces that it finished: the resumed worker reads the committed
+    // result straight into the model transcript and never revisits the call.
+    // Without this event the renderer showed the card waiting from
+    // `PlanProposed` until the turn's terminal hydration finally settled it —
+    // the decision looked lost exactly when it had committed.
+    //
+    // Journaled here, in the transaction that makes the row terminal, so the
+    // event cannot disagree with the row it describes. An exact retry returns
+    // above as `Existing` without reaching this, so the call announces itself
+    // once. Chat-scoped like its `PlanProposed`: the turn is parked with no
+    // lease, so no attempt owns this event.
+    let completion_event = AgentEvent::ToolCallCompleted {
+        call_id: request.call_id,
+        output: crate::ToolOutput::text(resolved.result.clone().ok_or_else(|| {
+            AgentError::Store(format!(
+                "decided plan {} committed no result",
+                request.call_id
+            ))
+        })?),
+        action: crate::ToolActionPreview::build(&resolved.name, &resolved.arguments),
+        result: Some(preview),
+    };
+    let seq = super::conversation::append_event_on(
+        &transaction,
+        ChatId(resolved.chat_id),
+        None,
+        None,
+        None,
+        None,
+        &completion_event,
+    )
+    .await?;
     let transition =
         super::turn::advance_turn_after_client_resolution_on(&transaction, &resolved, decided_at)
             .await?
@@ -345,7 +389,13 @@ pub(in crate::db) async fn decide(
                 ))
             })?;
     transaction.commit().await.map_err(store_err)?;
-    Ok(DecidePlanOutcome::Decided(transition.turn))
+    Ok(DecidePlanOutcome::Decided {
+        turn: transition.turn,
+        completion_event: Box::new(SequencedEvent {
+            seq,
+            event: completion_event,
+        }),
+    })
 }
 
 /// Close presentation state when cancellation terminalizes the unclaimed

--- a/crates/openwave-core/src/db/ops/user_question.rs
+++ b/crates/openwave-core/src/db/ops/user_question.rs
@@ -365,6 +365,11 @@ pub(in crate::db) async fn answer(
     let mut active_call: entities::tool_call::ActiveModel = call.into();
     active_call.status = Set(ToolCallStatus::Completed.as_str().into());
     active_call.result = Set(Some(result));
+    // The recap card reads this column on history rehydration, the same way
+    // every other settled card does. Without it, reopening the chat showed the
+    // answered question as a bare rail line.
+    let preview = answers_preview(&questions, &canonical)?;
+    active_call.result_preview = Set(Some(serde_json::to_value(&preview)?));
     active_call.error_code = Set(None);
     active_call.error_detail = Set(None);
     active_call.resolved_at = Set(Some(answered_at));
@@ -390,7 +395,7 @@ pub(in crate::db) async fn answer(
             ))
         })?),
         action: crate::ToolActionPreview::build(&resolved.name, &resolved.arguments),
-        result: None,
+        result: Some(preview),
     };
     let seq = super::conversation::append_event_on(
         &transaction,
@@ -586,6 +591,45 @@ fn canonical_answers(
         answers,
         additional_user_context: supplied.additional_user_context.clone(),
     }))
+}
+
+/// Project the settled recap card from the questions and the exact answers.
+///
+/// Option *labels*, not ids: the recap is read by a person, and the ids are an
+/// internal handle they never saw. Every question is listed, answered or not,
+/// so the card can say which ones were skipped rather than quietly omitting
+/// them.
+fn answers_preview(
+    questions: &[entities::user_question::Model],
+    canonical: &crate::AnswerUserQuestions,
+) -> Result<crate::ToolResultPreview> {
+    let by_id: HashMap<_, _> = canonical
+        .answers
+        .iter()
+        .map(|answer| (answer.question_id.as_str(), answer))
+        .collect();
+    let mut answers = Vec::with_capacity(questions.len());
+    for question in questions {
+        let answer = by_id.get(question.question_id.as_str());
+        let options: Vec<crate::UserQuestionOption> =
+            serde_json::from_value(question.options.clone())?;
+        let selected = options
+            .into_iter()
+            .filter(|option| {
+                answer.is_some_and(|answer| answer.selected_option_ids.contains(&option.id))
+            })
+            .map(|option| option.label)
+            .collect();
+        answers.push(crate::AnsweredUserQuestion {
+            question: question.prompt.clone(),
+            selected,
+            custom_answer: answer.and_then(|answer| answer.custom_answer.clone()),
+        });
+    }
+    Ok(crate::ToolResultPreview::UserQuestions {
+        answers,
+        additional_context: canonical.additional_user_context.clone(),
+    })
 }
 
 fn stored_answers_match(

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -4102,7 +4102,10 @@ async fn user_questions_survive_reconnect_and_answer_exactly_once() {
     // The answer announces the call's completion itself: the renderer settles
     // the card from this event rather than waiting for the turn to end.
     let crate::AgentEvent::ToolCallCompleted {
-        call_id, output, ..
+        call_id,
+        output,
+        result: Some(preview),
+        ..
     } = &completion_event.event
     else {
         panic!("unexpected completion event: {completion_event:?}");
@@ -4113,6 +4116,45 @@ async fn user_questions_survive_reconnect_and_answer_exactly_once() {
         serde_json::from_str::<crate::AnswerUserQuestions>(&output.content).unwrap(),
         sample_user_answers()
     );
+    // The recap the transcript shows once the card is gone: option *labels*
+    // rather than ids, and a row for the question nobody answered so the card
+    // can say it was skipped instead of quietly dropping it.
+    let crate::ToolResultPreview::UserQuestions {
+        answers,
+        additional_context,
+    } = preview
+    else {
+        panic!("unexpected question recap: {preview:?}");
+    };
+    assert_eq!(
+        answers,
+        &vec![
+            crate::AnsweredUserQuestion {
+                question: "Where should I deploy?".into(),
+                selected: vec!["Staging".into(), "Production".into()],
+                custom_answer: Some("Start with a canary.".into()),
+            },
+            crate::AnsweredUserQuestion {
+                question: "Anything else I should know?".into(),
+                selected: Vec::new(),
+                custom_answer: None,
+            },
+        ]
+    );
+    assert_eq!(
+        additional_context.as_deref(),
+        Some("Keep the rollout reversible.")
+    );
+    let answered_call = restarted
+        .list_tool_calls(chat.id)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|call| call.id == request.id)
+        .unwrap();
+    // Rehydration reads the stored column, not the event, so a reload has to
+    // find the same recap there.
+    assert_eq!(answered_call.result_preview.as_ref(), Some(preview));
     let journaled_completions = restarted
         .list_events(chat.id, 0)
         .await
@@ -4603,10 +4645,39 @@ async fn accepted_plan_resumes_the_turn_and_leaves_plan_mode() {
         },
     };
     let decided_at = parked_at + chrono::Duration::seconds(1);
+    let outcome = restarted
+        .decide_plan(&decide_request, decided_at)
+        .await
+        .unwrap();
+    let crate::storage::DecidePlanOutcome::Decided {
+        turn,
+        completion_event,
+    } = outcome
+    else {
+        panic!("unexpected plan decision: {outcome:?}");
+    };
+    assert_eq!(turn.id, turn_id);
+    assert_eq!(turn.status, TurnRunStatus::Resuming);
+    // The call resolves outside the agent loop, so this event is the only
+    // thing that tells a connected renderer the card settled — and it carries
+    // the recap the transcript shows in the pending card's place.
+    let crate::AgentEvent::ToolCallCompleted {
+        call_id,
+        result: Some(preview),
+        ..
+    } = &completion_event.event
+    else {
+        panic!("unexpected completion: {:?}", completion_event.event);
+    };
+    assert_eq!(*call_id, request.id);
     assert!(matches!(
-        restarted.decide_plan(&decide_request, decided_at).await.unwrap(),
-        crate::storage::DecidePlanOutcome::Decided(turn)
-            if turn.id == turn_id && turn.status == TurnRunStatus::Resuming
+        preview,
+        crate::ToolResultPreview::PlanDecision {
+            title,
+            plan,
+            accepted: true,
+            feedback: None,
+        } if title == "Add health checks" && plan.contains("/healthz")
     ));
     assert_eq!(
         restarted
@@ -4628,6 +4699,9 @@ async fn accepted_plan_resumes_the_turn_and_leaves_plan_mode() {
     let result: serde_json::Value = serde_json::from_str(call.result.as_deref().unwrap()).unwrap();
     assert_eq!(result["decision"], "accepted");
     assert!(result["note"].as_str().unwrap().contains("left plan mode"));
+    // Rehydration reads the stored column, not the event, so a reload has to
+    // find the same recap there.
+    assert_eq!(call.result_preview.as_ref(), Some(preview));
 
     // An exact retry recovers; a different decision conflicts.
     assert!(matches!(
@@ -4684,7 +4758,7 @@ async fn rejected_plan_keeps_plan_mode_and_carries_feedback() {
             )
             .await
             .unwrap(),
-        crate::storage::DecidePlanOutcome::Decided(turn)
+        crate::storage::DecidePlanOutcome::Decided { turn, .. }
             if turn.id == turn_id && turn.status == TurnRunStatus::Resuming
     ));
     assert_eq!(
@@ -4702,6 +4776,14 @@ async fn rejected_plan_keeps_plan_mode_and_carries_feedback() {
     let result: serde_json::Value = serde_json::from_str(call.result.as_deref().unwrap()).unwrap();
     assert_eq!(result["decision"], "rejected");
     assert_eq!(result["feedback"], "Split step 2 into its own slice.");
+    assert!(matches!(
+        call.result_preview.as_ref(),
+        Some(crate::ToolResultPreview::PlanDecision {
+            accepted: false,
+            feedback: Some(feedback),
+            ..
+        }) if feedback == "Split step 2 into its own slice."
+    ));
 }
 
 #[tokio::test]
@@ -7625,7 +7707,7 @@ async fn delete_chat_erases_quiesced_history_and_fails_closed_for_live_work_or_r
             )
             .await
             .unwrap(),
-        crate::storage::DecidePlanOutcome::Decided(_)
+        crate::storage::DecidePlanOutcome::Decided { .. }
     ));
     let planned_turn = store.get_turn_run(planned_turn_id).await.unwrap().unwrap();
     store

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -206,8 +206,8 @@ pub use plan_mode::{
     MAX_PLAN_FEEDBACK_CHARS, MAX_PLAN_TITLE_CHARS, MIN_PLAN_CONTENT_CHARS,
 };
 pub use preview::{
-    format_bytes, AgentActivityDetail, ExecDegradation, ResultEntry, ResultEntryKind,
-    ResultFailure, ToolActionPreview, ToolResultPreview, MAX_RESULT_ENTRIES,
+    format_bytes, AgentActivityDetail, AnsweredUserQuestion, ExecDegradation, ResultEntry,
+    ResultEntryKind, ResultFailure, ToolActionPreview, ToolResultPreview, MAX_RESULT_ENTRIES,
     MAX_RESULT_ENTRY_CHARS,
 };
 pub use provider::{

--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -657,6 +657,25 @@ pub enum ExecBackend {
     Docker,
 }
 
+/// One question as it was asked, with what the reader chose.
+///
+/// Labels rather than option ids: the recap is read by a person, and the ids
+/// are an internal handle they never saw. A question the reader skipped
+/// carries neither a selection nor an answer, which is how the card knows to
+/// say so.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+pub struct AnsweredUserQuestion {
+    /// The prompt the reader answered.
+    pub question: String,
+    /// Labels of the options chosen, in the order the question listed them.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub selected: Vec<String>,
+    /// The reader's own words, when the question allowed them.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub custom_answer: Option<String>,
+}
+
 /// What a call produced, in a form a human can read.
 ///
 /// A command's output is the whole reason to run it. Withholding it leaves the
@@ -727,6 +746,34 @@ pub enum ToolResultPreview {
         /// that silently lists the first fifty of two hundred results is
         /// telling the reader something false.
         elided: u32,
+    },
+    /// The answers a parked `ask_user_questions` call was resolved with.
+    ///
+    /// Built where the answer commits rather than by [`ToolResultPreview::build`]:
+    /// this call resolves outside the agent loop, so there is no `ToolOutput`
+    /// to read it out of. Carries only the presentation fields the pending
+    /// card already showed, plus what the reader chose.
+    UserQuestions {
+        answers: Vec<AnsweredUserQuestion>,
+        /// Whatever the reader added on their own, when they added any.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        additional_context: Option<String>,
+    },
+    /// The decision a parked `exit_plan_mode` call was resolved with.
+    ///
+    /// Built at the deciding transaction, on the same terms as
+    /// [`ToolResultPreview::UserQuestions`]. The plan text is the same
+    /// model-authored markdown the approval card already rendered.
+    PlanDecision {
+        title: String,
+        plan: String,
+        /// Whether the reader approved the plan as proposed.
+        accepted: bool,
+        /// What the reader asked to change, when they sent it back.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        feedback: Option<String>,
     },
 }
 
@@ -893,6 +940,9 @@ impl ToolResultPreview {
             // An empty list is still something to show, and saying so is the
             // point: the card reports that the call found nothing.
             Self::Entries { .. } => true,
+            // A recap of what the reader chose, which is the whole reason the
+            // turn parked. Skipping everything is itself the answer.
+            Self::UserQuestions { .. } | Self::PlanDecision { .. } => true,
         }
     }
 }

--- a/crates/openwave-core/src/storage/types.rs
+++ b/crates/openwave-core/src/storage/types.rs
@@ -744,7 +744,13 @@ pub enum HeartbeatClientToolCallOutcome {
 pub enum DecidePlanOutcome {
     /// The decision completed the tool call and made the turn resumable. An
     /// accepted decision also moved the chat out of plan mode.
-    Decided(TurnRun),
+    Decided {
+        /// The resumable turn.
+        turn: TurnRun,
+        /// The call's journaled completion, committed with the decision so a
+        /// live renderer settles the card now rather than at the turn's end.
+        completion_event: Box<SequencedEvent>,
+    },
     /// An ambiguous retry recovered the same committed decision.
     Existing(TurnRun),
     /// The request already committed a different decision.

--- a/crates/openwave-desktop/ui/package.json
+++ b/crates/openwave-desktop/ui/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-dropdown-menu": "2.1.21",
     "@radix-ui/react-popover": "1.1.23",
     "@radix-ui/react-progress": "1.1.16",
+    "@radix-ui/react-radio-group": "1.4.7",
     "@radix-ui/react-select": "2.3.7",
     "@radix-ui/react-separator": "1.1.15",
     "@radix-ui/react-slot": "1.3.0",

--- a/crates/openwave-desktop/ui/pnpm-lock.yaml
+++ b/crates/openwave-desktop/ui/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@radix-ui/react-progress':
         specifier: 1.1.16
         version: 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-radio-group':
+        specifier: 1.4.7
+        version: 1.4.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-select':
         specifier: 2.3.7
         version: 2.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -991,6 +994,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-radio-group@1.4.7':
+    resolution: {integrity: sha512-cgYFEkntCxppHZgtSZ+7vh0wbZQ+IC7PPMw8DSnRG27B6kDd32/Zw0OJt7dGDigCoprMuWHjg2PvUn3PYvPFoQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-roving-focus@1.1.16':
     resolution: {integrity: sha512-w7lLsTSd3940vFYEshKkHw+NGf7H0QDJPHYsy8NRjDCVbO6ZdKW1X/xoJSYHZtttnrdZiYqbN2O/2uHGB0zasw==}
     peerDependencies:
@@ -1304,79 +1320,66 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
@@ -1446,28 +1449,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
     resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
     resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.3':
     resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.3':
     resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
@@ -2694,28 +2693,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -4355,6 +4350,23 @@ snapshots:
     dependencies:
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-radio-group@1.4.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-size': 1.1.4(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:

--- a/crates/openwave-desktop/ui/src/ApprovalCard.tsx
+++ b/crates/openwave-desktop/ui/src/ApprovalCard.tsx
@@ -255,12 +255,12 @@ export function approvalAsk(
 }
 
 /** How many grants show before the rest move behind "More options". */
-const INLINE_GRANTS = 1;
+const INLINE_GRANTS = 2;
 
 /**
  * Narrowest grant first, decline last.
  *
- * The broader rungs start hidden. Every option on screen is one keystroke
+ * The widest rungs start hidden. Every option on screen is one keystroke
  * away, so a list that shows "don't ask again" beside "just this once" makes
  * the widest grant as cheap as the narrowest — and scope is easy to widen by
  * accident and hard to notice afterwards.
@@ -295,9 +295,12 @@ export function approvalOptions(
   ];
 
   const grants = canRemember ? grantLadder(preview, scope, grantRungs) : [];
-  const visible = expanded ? grants : grants.slice(0, INLINE_GRANTS);
+  // Folding a single rung costs a row to save a row: the list is no shorter for
+  // hiding it, and the reader pays a keystroke to see what was already there.
+  const fold = !expanded && grants.length > INLINE_GRANTS + 1;
+  const visible = fold ? grants.slice(0, INLINE_GRANTS) : grants;
   options.push(...visible);
-  if (grants.length > visible.length) {
+  if (fold) {
     options.push({ kind: "more", key: "more", label: "More options" });
   }
   options.push(declineOption());

--- a/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
@@ -163,6 +163,48 @@ describe("ChatView", () => {
     expect(await screen.findByText("Which quarter?")).toBeInTheDocument();
   });
 
+  it("stands the question in the composer's place until it is answered", async () => {
+    // A parked question is the one thing the turn wants back, so it takes the
+    // slot the composer would otherwise fill: nothing to scroll off, and no
+    // field inviting a reply the turn will not read.
+    const user = userEvent.setup();
+    usePendingPrompts.setState({
+      chatId: "chat-1",
+      userQuestions: [
+        {
+          callId: "call-q",
+          turnId: "turn-1",
+          askedAt: "2026-07-24T00:00:00.000Z",
+          questions: [
+            {
+              id: "q1",
+              header: "Scope",
+              question: "Which quarter?",
+              options: [],
+              questionType: "single_select",
+              allowFreeForm: true,
+            },
+          ],
+        },
+      ] as never,
+    });
+
+    await renderChatView();
+
+    expect(await screen.findByText("Which quarter?")).toBeInTheDocument();
+    expect(screen.queryByRole("textbox", { name: "Message" })).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Skip questions" }));
+    act(() => {
+      usePendingPrompts.setState({ chatId: "chat-1", userQuestions: [] });
+    });
+
+    // Answered, the slot is the composer's again.
+    expect(
+      await screen.findByRole("textbox", { name: "Message" }),
+    ).toBeInTheDocument();
+  });
+
   it("reveals the card a deep link named, then drops it from the URL", async () => {
     // What the inbox promises: opening an item lands on the exact card that
     // parked, not at the bottom of a transcript the reader has to search.

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -8,23 +8,26 @@ import {
   type RefObject,
 } from "react";
 import type { ApiClient, Chat } from "./api";
-import { followScrollBehavior, isNearBottom, scrollToLatest } from "./ChatScroll";
+import {
+  followScrollBehavior,
+  isNearBottom,
+  scrollToLatest,
+} from "./ChatScroll";
 import { useChatSessionStore } from "./ChatSessionStore";
 import {
   useComposerAttachments,
   useComposerDraft,
   useComposerDrafts,
-} from "./ComposerDrafts";import {
+} from "./ComposerDrafts";
+import {
   Composer,
   type ComposerFiles,
   type ComposerFolders,
   type ComposerImages,
   type ComposerVoice,
 } from "./Composer";
-import type {
-  ComposerNetwork,
-  ComposerReasoning,
-} from "./ComposerToolsMenu";
+import { ComposerPrompt } from "./ComposerPrompt";
+import type { ComposerNetwork, ComposerReasoning } from "./ComposerToolsMenu";
 import { MessageList, type RetryableTurn } from "./MessageList";
 import { revealPendingCall } from "./TranscriptFocus";
 import { useTranscriptVisible } from "./TranscriptVisibility";
@@ -125,6 +128,10 @@ export function ChatView({
   const userQuestions = useUserQuestions(client, chat.id);
   const planApprovals = usePlanApprovals(client, chat.id);
   const approvals = useToolApprovals(client, chat.id);
+  // A question or a proposed plan is the one thing the turn wants back, so its
+  // card stands in the composer's slot until it is answered.
+  const pendingPromptCount =
+    userQuestions.requests.length + planApprovals.requests.length;
   const turnControls = useTurnControls(
     client,
     chat.id,
@@ -175,9 +182,12 @@ export function ChatView({
   );
 
   const navigate = useNavigate();
-  const focusCallId = (useSearch({ strict: false }) as { focus?: string }).focus;
+  const focusCallId = (useSearch({ strict: false }) as { focus?: string })
+    .focus;
 
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  /** The composer's slot, which a pending question or plan card takes over. */
+  const promptSlotRef = useRef<HTMLDivElement | null>(null);
   const followsLatestRef = useRef(true);
   const isProgrammaticRef = useRef(false);
   const visibleContinuationCallIdsRef = useRef<Set<string>>(new Set());
@@ -346,13 +356,19 @@ export function ChatView({
     };
     const attempt = () => {
       if (settled) return;
-      if (!revealPendingCall(scrollRef.current, focusCallId)) return;
-      // Arriving at a specific card means the reader is no longer following
-      // the end of the transcript; letting follow stay armed would scroll them
-      // straight back off it.
-      followsLatestRef.current = false;
-      setScrolledAway(true);
-      clear();
+      if (revealPendingCall(scrollRef.current, focusCallId)) {
+        // Arriving at a specific card means the reader is no longer following
+        // the end of the transcript; letting follow stay armed would scroll them
+        // straight back off it.
+        followsLatestRef.current = false;
+        setScrolledAway(true);
+        clear();
+        return;
+      }
+      // A question or a proposed plan stands in the composer's slot rather than
+      // the transcript, so it is on screen already: pointing it out is the whole
+      // reveal, and the transcript is left following its end.
+      if (revealPendingCall(promptSlotRef.current, focusCallId)) clear();
     };
     const timer = window.setInterval(attempt, 120);
     const deadline = window.setTimeout(clear, 5_000);
@@ -385,20 +401,13 @@ export function ChatView({
           chatId={chat.id}
           folderAccessRequests={folderAccess.requests}
           outputWritebackRequests={outputWritebacks.requests}
-          userQuestionRequests={userQuestions.requests}
-          planApprovalRequests={planApprovals.requests}
+          pendingPromptCount={pendingPromptCount}
           nativeHost={nativeHost}
           nativeBusy={folderAccess.resolving.size > 0}
           resolvingFolderCalls={folderAccess.resolving}
           folderAccessErrors={folderAccess.errors}
           resolvingOutputWritebackCalls={outputWritebacks.resolving}
           outputWritebackErrors={outputWritebacks.errors}
-          answeringQuestionCalls={userQuestions.answering}
-          userQuestionErrors={userQuestions.errors}
-          decidingPlanCalls={planApprovals.deciding}
-          planApprovalErrors={planApprovals.errors}
-          onPlanDecision={planApprovals.decide}
-          onPlanCancel={planApprovals.cancel}
           decidingApprovalCalls={approvals.deciding}
           approvalErrors={approvals.errors}
           grantScope={chat.project_id ? "project" : "chat"}
@@ -427,7 +436,6 @@ export function ChatView({
           onOutputWritebackCancel={(callId, turnId) =>
             outputWritebacks.cancel(callId, turnId)
           }
-          onAnswerUserQuestions={userQuestions.answer}
           onSelectPrompt={onSelectPrompt}
           onRetryTurn={onRetryTurn}
           hydrated={hydrated}
@@ -450,67 +458,79 @@ export function ChatView({
         </button>
       </div>
 
-      <div className="px-[clamp(0.5rem,4%,5rem)] pb-2">
+      <div className="px-[clamp(0.5rem,4%,5rem)] pb-2" ref={promptSlotRef}>
         {taskPlan !== null && (
           <div className="pb-2">
             <TaskPlanCard plan={taskPlan} live={taskPlanLive} />
           </div>
         )}
-        <Composer
-          activeTurnId={activeTurnId}
-          busy={busy}
-          cancelError={turnControls.cancelError}
-          cancelPending={
-            activeTurnId !== null &&
-            turnControls.cancelPendingTurnId === activeTurnId
-          }
-          disabled={deletingChat}
-          draft={draft}
-          modelMenu={composerModelMenu}
-          permissionMenu={composerPermissionMenu}
-          network={composerNetwork}
-          reasoning={composerReasoning}
-          plugins={composerPlugins.plugins}
-          slash={{
-            options: composerPlugins.slashOptions,
-            invoked: invokedSkills,
-            onInvoke: (names) =>
-              useComposerDrafts
-                .getState()
-                .setSkills(chat.id, [...invokedSkills, ...names]),
-            onRemove: (name) =>
-              useComposerDrafts
-                .getState()
-                .setSkills(
+        {pendingPromptCount > 0 ? (
+          <ComposerPrompt
+            userQuestionRequests={userQuestions.requests}
+            answeringQuestionCalls={userQuestions.answering}
+            userQuestionErrors={userQuestions.errors}
+            onAnswerUserQuestions={userQuestions.answer}
+            planApprovalRequests={planApprovals.requests}
+            decidingPlanCalls={planApprovals.deciding}
+            planApprovalErrors={planApprovals.errors}
+            onPlanDecision={planApprovals.decide}
+            onPlanCancel={planApprovals.cancel}
+          />
+        ) : (
+          <Composer
+            activeTurnId={activeTurnId}
+            busy={busy}
+            cancelError={turnControls.cancelError}
+            cancelPending={
+              activeTurnId !== null &&
+              turnControls.cancelPendingTurnId === activeTurnId
+            }
+            disabled={deletingChat}
+            draft={draft}
+            modelMenu={composerModelMenu}
+            permissionMenu={composerPermissionMenu}
+            network={composerNetwork}
+            reasoning={composerReasoning}
+            plugins={composerPlugins.plugins}
+            slash={{
+              options: composerPlugins.slashOptions,
+              invoked: invokedSkills,
+              onInvoke: (names) =>
+                useComposerDrafts
+                  .getState()
+                  .setSkills(chat.id, [...invokedSkills, ...names]),
+              onRemove: (name) =>
+                useComposerDrafts.getState().setSkills(
                   chat.id,
                   invokedSkills.filter((skill) => skill !== name),
                 ),
-            loadPromptBody: composerPlugins.loadPromptBody,
-          }}
-          images={composerImages}
-          files={composerFiles}
-          folders={folders}
-          voice={voice}
-          nativeDropTarget={nativeDropTarget}
-          attachError={attachError}
-          // Typing retires the verdict on the last piece of guidance. Accepted
-          // guidance clears the draft through the raw callback instead, so
-          // "Guidance sent" survives the clearing it caused.
-          onDraftChange={(value) => {
-            turnControls.clearSteerFeedback();
-            onDraftChange(value);
-          }}
-          onSend={handleSend}
-          onSteer={turnControls.steer}
-          onStop={turnControls.cancel}
-          resetKey={chat.id}
-          steerError={turnControls.steerError}
-          steerPending={
-            activeTurnId !== null &&
-            turnControls.steerPendingTurnId === activeTurnId
-          }
-          steerStatus={turnControls.steerStatus}
-        />
+              loadPromptBody: composerPlugins.loadPromptBody,
+            }}
+            images={composerImages}
+            files={composerFiles}
+            folders={folders}
+            voice={voice}
+            nativeDropTarget={nativeDropTarget}
+            attachError={attachError}
+            // Typing retires the verdict on the last piece of guidance. Accepted
+            // guidance clears the draft through the raw callback instead, so
+            // "Guidance sent" survives the clearing it caused.
+            onDraftChange={(value) => {
+              turnControls.clearSteerFeedback();
+              onDraftChange(value);
+            }}
+            onSend={handleSend}
+            onSteer={turnControls.steer}
+            onStop={turnControls.cancel}
+            resetKey={chat.id}
+            steerError={turnControls.steerError}
+            steerPending={
+              activeTurnId !== null &&
+              turnControls.steerPendingTurnId === activeTurnId
+            }
+            steerStatus={turnControls.steerStatus}
+          />
+        )}
       </div>
     </section>
   );

--- a/crates/openwave-desktop/ui/src/ComposerPrompt.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerPrompt.tsx
@@ -1,0 +1,108 @@
+import { useState } from "react";
+import type {
+  PendingPlanApproval,
+  PendingUserQuestions,
+  PlanDecision,
+  UserQuestionAnswer,
+} from "./api";
+import { cn } from "@/lib/utils";
+import { isolatedCard } from "./PendingCard";
+import { PlanApprovalCard } from "./PlanApprovalCard";
+import { UserQuestionsCard } from "./UserQuestionsCard";
+
+/**
+ * The prompts a turn parks on the reader, standing where the composer stands.
+ *
+ * A question or a proposed plan is not a message in the transcript; it is the
+ * turn asking for one thing back, and until it gets it there is nothing else to
+ * send. Rendered inline the card scrolls away under a composer that keeps
+ * inviting a reply the turn will not read. Taking the composer's slot puts the
+ * decision where the hands already are and makes what is being asked for the
+ * only thing on offer.
+ *
+ * Cancelling is still reachable throughout: every card carries its own way out
+ * (skip the questions, cancel the turn), which is what returns the composer.
+ */
+export function ComposerPrompt({
+  userQuestionRequests,
+  answeringQuestionCalls,
+  userQuestionErrors,
+  onAnswerUserQuestions,
+  planApprovalRequests,
+  decidingPlanCalls,
+  planApprovalErrors,
+  onPlanDecision,
+  onPlanCancel,
+}: {
+  userQuestionRequests: PendingUserQuestions[];
+  answeringQuestionCalls: Set<string>;
+  userQuestionErrors: Record<string, string>;
+  onAnswerUserQuestions: (
+    callId: string,
+    answers: UserQuestionAnswer[],
+    additionalUserContext?: string,
+  ) => void;
+  planApprovalRequests: PendingPlanApproval[];
+  decidingPlanCalls: Set<string>;
+  planApprovalErrors: Record<string, string>;
+  onPlanDecision: (callId: string, decision: PlanDecision) => void;
+  onPlanCancel: (turnId: string) => void;
+}) {
+  // A plan card can take the whole pane; the flag lives here because the
+  // wrapper that has to grow is the one this component owns.
+  const [fullscreen, setFullscreen] = useState(false);
+  return (
+    // Wider than the composer it replaces: a plan is a document, and the extra
+    // measure is what keeps it from becoming a scroller inside a scroller.
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-2">
+      {userQuestionRequests.map((request) =>
+        isolatedCard(
+          `user-questions-${request.callId}`,
+          `${answeringQuestionCalls.has(request.callId)} ${userQuestionErrors[request.callId] ?? ""}`,
+          <div className="border-border bg-background relative rounded-xl shadow-lg">
+            <UserQuestionsCard
+              request={request}
+              working={answeringQuestionCalls.has(request.callId)}
+              error={userQuestionErrors[request.callId]}
+              onAnswer={(answers, additionalUserContext) =>
+                onAnswerUserQuestions(
+                  request.callId,
+                  answers,
+                  additionalUserContext,
+                )
+              }
+            />
+          </div>,
+          request.callId,
+        ),
+      )}
+      {planApprovalRequests.map((request) =>
+        isolatedCard(
+          `plan-approval-${request.callId}`,
+          `${decidingPlanCalls.has(request.callId)} ${planApprovalErrors[request.callId] ?? ""}`,
+          <div
+            className={cn(
+              "border-border bg-background relative rounded-xl shadow-lg",
+              fullscreen &&
+                "absolute inset-4 top-22 mx-auto max-w-4xl border shadow-none",
+            )}
+          >
+            <div className={cn(fullscreen && "h-full")}>
+              <PlanApprovalCard
+                request={request}
+                working={decidingPlanCalls.has(request.callId)}
+                error={planApprovalErrors[request.callId]}
+                onDecide={(decision) =>
+                  onPlanDecision(request.callId, decision)
+                }
+                onCancel={() => onPlanCancel(request.turnId)}
+                onFullscreenChange={setFullscreen}
+              />
+            </div>
+          </div>,
+          request.callId,
+        ),
+      )}
+    </div>
+  );
+}

--- a/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
@@ -214,15 +214,16 @@ describe("approval card interactions", () => {
       }),
     );
 
-    // Every option on screen is one keystroke away, so the narrowest grant is
-    // inline and the wider ones are not.
+    // Every option on screen is one keystroke away, so the narrowest grants are
+    // inline and the widest ones are not.
     expect(
       screen.getAllByRole("option").map((option) => option.textContent),
     ).toEqual([
       "1.Yes, run it once",
       "2.Yes, and always allow exactly \u201ccargo test\u201d",
-      `3.${MORE}`,
-      "4.No, don't allow this",
+      "3.Yes, and always allow any \u201ccargo test\u201d command",
+      `4.${MORE}`,
+      "5.No, don't allow this",
     ]);
 
     await user.click(screen.getByText(MORE));
@@ -231,13 +232,47 @@ describe("approval card interactions", () => {
     ).toEqual([
       "1.Yes, run it once",
       "2.Yes, and always allow exactly \u201ccargo test\u201d",
-      // The rung this ladder previously could not offer.
       "3.Yes, and always allow any \u201ccargo test\u201d command",
+      // The rungs this ladder previously could not offer.
       "4.Yes, and always allow any \u201ccargo\u201d command",
       "5.Yes, and don't ask again about commands in this chat",
       "6.No, don't allow this",
     ]);
     expect(onDecide).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Folding one rung behind "More options" spends a row to save a row, so the
+   * list is exactly as long either way and the keystroke buys nothing.
+   */
+  it("shows a short ladder whole rather than folding a single rung", () => {
+    render(
+      card({
+        preview: {
+          tool: "exec",
+          command: "cargo",
+          args: ["test"],
+          cwd: ".",
+          files: [],
+        },
+        grantRungs: [
+          "exact_action",
+          { command_prefix: { tokens: 2 } },
+          "whole_tool",
+        ],
+      }),
+    );
+
+    expect(
+      screen.getAllByRole("option").map((option) => option.textContent),
+    ).toEqual([
+      "1.Yes, run it once",
+      "2.Yes, and always allow exactly \u201ccargo test\u201d",
+      "3.Yes, and always allow any \u201ccargo test\u201d command",
+      "4.Yes, and don't ask again about commands in this chat",
+      "5.No, don't allow this",
+    ]);
+    expect(screen.queryByText(MORE)).toBeNull();
   });
 
   it("names the project when a remembered answer will reach past this chat", async () => {
@@ -258,12 +293,18 @@ describe("approval card interactions", () => {
       card({
         onDecide,
         preview: { tool: "exec", command: "cargo", args: ["test"], cwd: ".", files: [] },
+        grantRungs: [
+          "exact_action",
+          { command_prefix: { tokens: 2 } },
+          { command_prefix: { tokens: 1 } },
+          "whole_tool",
+        ],
       }),
     );
 
-    // "More options" sat at row 3; expanding puts a broader grant there. A
+    // "More options" sat at row 4; expanding puts a broader grant there. A
     // stray Enter must not commit whatever moved under the cursor.
-    await user.keyboard("3{Enter}");
+    await user.keyboard("4{Enter}");
     expect(screen.getAllByRole("option")[0]).toHaveAttribute(
       "aria-selected",
       "true",
@@ -297,7 +338,7 @@ describe("approval card interactions", () => {
     ).toEqual([
       ONCE,
       "2.Yes, and always allow exactly “quarterly filings”",
-      `3.${MORE}`,
+      "3.Yes, and don't ask again in this chat",
       "4.No, don't allow this",
     ]);
     // The filters are part of what is being consented to, so the card shows

--- a/crates/openwave-desktop/ui/src/MessageList.isolation.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.isolation.dom.test.tsx
@@ -100,45 +100,47 @@ describe("a tool result that cannot render", () => {
 });
 
 describe("a continuation card that cannot render", () => {
-  it("leaves the question the turn is waiting on standing", () => {
+  it("leaves the decision the turn is waiting on standing", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
-    list([], {
-      folderAccessRequests: [
+    list(
+      [
         {
-          callId: "f1",
-          turnId: "turn-1",
-          reason: "read the project folder",
-          folderHint: null,
-          claimedByDesktop: true,
+          id: "a1",
+          role: "approval",
+          callId: "c1",
+          summary: "Allow OpenWave to run a command?",
+          preview: {
+            tool: "exec",
+            command: "cargo",
+            args: ["build"],
+            cwd: ".",
+            files: [],
+          },
+          canApprove: true,
+          canRemember: true,
         },
       ],
-      userQuestionRequests: [
-        {
-          callId: "q1",
-          turnId: "turn-1",
-          questions: [
-            {
-              id: "q",
-              header: "Environment",
-              question: "Which environment?",
-              options: [
-                { id: "o1", label: "Staging", description: "the shared one" },
-              ],
-              questionType: "single_select",
-              allowFreeForm: false,
-            },
-          ],
-          askedAt: "2026-07-30T00:00:00Z",
-        },
-      ],
-    });
+      {
+        folderAccessRequests: [
+          {
+            callId: "f1",
+            turnId: "turn-1",
+            reason: "read the project folder",
+            folderHint: null,
+            claimedByDesktop: true,
+          },
+        ],
+      },
+    );
 
-    // Both cards are prompts the turn cannot get past. Sharing one boundary
-    // with the transcript meant either one taking the whole surface down.
+    // Both are prompts the turn cannot get past. Sharing one boundary with the
+    // transcript meant either one taking the whole surface down.
     expect(screen.getAllByText("This step could not be displayed.").length).toBe(
       1,
     );
-    expect(screen.getByText("Which environment?")).toBeTruthy();
+    expect(
+      screen.getByRole("option", { name: /Yes, run it once/ }),
+    ).toBeTruthy();
   });
 });
 

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -8,12 +8,8 @@ import type {
   AgentRunTaskPlan,
   PendingFolderAccessRequest,
   PendingOutputWritebackRequest,
-  PendingPlanApproval,
-  PendingUserQuestions,
-  PlanDecision,
   ToolActionPreview,
   ToolResultPreview,
-  UserQuestionAnswer,
   ExecFileChangeSummary,
   ModelInfo,
 } from "./api";
@@ -33,6 +29,8 @@ import { ThinkingAccordion } from "./ThinkingAccordion";
 import { stripCitationDirectives } from "./citationDirectives";
 import { MessageCitationsProvider } from "./InlineCitation";
 import { McpAppCard } from "./McpAppCard";
+import { PlanDecisionResultCard } from "./PlanDecisionResultCard";
+import { UserQuestionsResultCard } from "./UserQuestionsResultCard";
 import { OutputCardList } from "./OutputCard";
 import { ToolCommandCard, type ToolCallStatus } from "./ToolCallCard";
 import { ErrorBoundary } from "./ErrorBoundary";
@@ -41,8 +39,7 @@ import {
   ToolActivityUnavailable,
 } from "./ToolActivityGroup";
 import { WelcomeState } from "./WelcomeState";
-import { PlanApprovalCard } from "./PlanApprovalCard";
-import { UserQuestionsCard } from "./UserQuestionsCard";
+import { isolatedCard } from "./PendingCard";
 import type { TranscriptImageAttachment } from "./ImageAttachments";
 import { TranscriptImageAttachments } from "./TranscriptImageAttachments";
 import {
@@ -193,16 +190,19 @@ type MessageListProps = {
   chatId?: string;
   folderAccessRequests: PendingFolderAccessRequest[];
   outputWritebackRequests?: PendingOutputWritebackRequest[];
-  userQuestionRequests?: PendingUserQuestions[];
-  planApprovalRequests?: PendingPlanApproval[];
+  /**
+   * How many questions and plan approvals are parked on the reader. Their cards
+   * stand in the composer's slot rather than the transcript, so the list never
+   * renders them — it only needs to know a turn is waiting on someone, so that
+   * an otherwise-empty chat isn't greeted and the Working indicator stays down.
+   */
+  pendingPromptCount?: number;
   nativeHost: boolean;
   nativeBusy: boolean;
   resolvingFolderCalls: Set<string>;
   folderAccessErrors: Record<string, string>;
   resolvingOutputWritebackCalls?: Set<string>;
   outputWritebackErrors?: Record<string, string>;
-  answeringQuestionCalls?: Set<string>;
-  userQuestionErrors?: Record<string, string>;
   decidingApprovalCalls: Set<string>;
   approvalErrors: Record<string, string>;
   /** How far a remembered approval reaches, for the card's labels. */
@@ -254,15 +254,6 @@ type MessageListProps = {
     decision: OutputWritebackDecision,
   ) => void;
   onOutputWritebackCancel?: (callId: string, turnId: string) => void;
-  onAnswerUserQuestions?: (
-    callId: string,
-    answers: UserQuestionAnswer[],
-    additionalUserContext?: string,
-  ) => void;
-  decidingPlanCalls?: Set<string>;
-  planApprovalErrors?: Record<string, string>;
-  onPlanDecision?: (callId: string, decision: PlanDecision) => void;
-  onPlanCancel?: (turnId: string) => void;
   onSelectPrompt?: (prompt: string) => void;
   /** Resend the failed turn. Offered only on the transcript's newest failure. */
   onRetryTurn?: (turn: RetryableTurn) => void;
@@ -280,15 +271,13 @@ export function MessageList({
   chatId,
   folderAccessRequests,
   outputWritebackRequests = [],
-  userQuestionRequests = [],
+  pendingPromptCount = 0,
   nativeHost,
   nativeBusy,
   resolvingFolderCalls,
   folderAccessErrors,
   resolvingOutputWritebackCalls = new Set(),
   outputWritebackErrors = {},
-  answeringQuestionCalls = new Set(),
-  userQuestionErrors = {},
   decidingApprovalCalls,
   approvalErrors,
   grantScope,
@@ -314,12 +303,6 @@ export function MessageList({
   onFolderAccessCancel,
   onOutputWritebackDecision = () => undefined,
   onOutputWritebackCancel = () => undefined,
-  onAnswerUserQuestions = () => undefined,
-  planApprovalRequests = [],
-  decidingPlanCalls = new Set<string>(),
-  planApprovalErrors = {},
-  onPlanDecision = () => undefined,
-  onPlanCancel = () => undefined,
   onSelectPrompt,
   onRetryTurn,
   hydrated = true,
@@ -371,7 +354,7 @@ export function MessageList({
     messages.length === 0 &&
     folderAccessRequests.length === 0 &&
     outputWritebackRequests.length === 0 &&
-    userQuestionRequests.length === 0 &&
+    pendingPromptCount === 0 &&
     !busy;
 
   if (isEmpty) {
@@ -439,39 +422,6 @@ export function MessageList({
           request.callId,
         ),
       )}
-      {userQuestionRequests.map((request) =>
-        isolatedCard(
-          `user-questions-${request.callId}`,
-          `${answeringQuestionCalls.has(request.callId)} ${userQuestionErrors[request.callId] ?? ""}`,
-          <UserQuestionsCard
-            request={request}
-            working={answeringQuestionCalls.has(request.callId)}
-            error={userQuestionErrors[request.callId]}
-            onAnswer={(answers, additionalUserContext) =>
-              onAnswerUserQuestions(
-                request.callId,
-                answers,
-                additionalUserContext,
-              )
-            }
-          />,
-          request.callId,
-        ),
-      )}
-      {planApprovalRequests.map((request) =>
-        isolatedCard(
-          `plan-approval-${request.callId}`,
-          `${decidingPlanCalls.has(request.callId)} ${planApprovalErrors[request.callId] ?? ""}`,
-          <PlanApprovalCard
-            request={request}
-            working={decidingPlanCalls.has(request.callId)}
-            error={planApprovalErrors[request.callId]}
-            onDecide={(decision) => onPlanDecision(request.callId, decision)}
-            onCancel={() => onPlanCancel(request.turnId)}
-          />,
-          request.callId,
-        ),
-      )}
       {compacting ? (
         <AssistantWorkingIndicator compacting />
       ) : (
@@ -480,8 +430,7 @@ export function MessageList({
           busy,
           folderAccessRequests.length +
             outputWritebackRequests.length +
-            userQuestionRequests.length +
-            planApprovalRequests.length,
+            pendingPromptCount,
           streamStalled,
         ) && <AssistantWorkingIndicator />
       )}
@@ -818,46 +767,6 @@ export function groupMessageItems(
   return { items, lastTurnStart };
 }
 
-/**
- * One card, contained.
- *
- * Cards render model-influenced data through several defensive parsers, and one
- * of them being wrong must not cost the card next to it. The siblings that make
- * this matter are the cards the turn is waiting on — an approval prompt, a
- * folder-access request, a question put to the user. A pending decision that
- * renders as nothing leaves the reader with no way to answer, no explanation,
- * and a turn that cannot proceed.
- *
- * `signature` is the data the card draws on, reduced to what decides whether it
- * can render, so a card that threw mid-stream is retried when its call moves on
- * rather than staying broken for the life of the transcript.
- */
-function isolatedCard(
-  key: string,
-  signature: string,
-  card: ReactNode,
-  /**
-   * The parked call this card decides, when it decides one. It is written to
-   * the DOM so a deep link from the inbox can find the card it named — the
-   * transcript is otherwise addressable only by scroll position.
-   */
-  pendingCallId?: string,
-): ReactNode {
-  return (
-    <ErrorBoundary
-      key={key}
-      resetKey={signature}
-      fallback={<ToolActivityUnavailable />}
-    >
-      {pendingCallId ? (
-        <div data-pending-call-id={pendingCallId}>{card}</div>
-      ) : (
-        card
-      )}
-    </ErrorBoundary>
-  );
-}
-
 /** What deciding a card needs beyond the entry it is deciding about. */
 type CardContext = {
   parked: Set<string>;
@@ -1037,6 +946,31 @@ function surfacedCard(entry: ChatMessage, context: CardContext): ReactNode {
         resourceUri={entry.result.resourceUri}
         chatId={chatId}
         callId={entry.callId}
+      />,
+    );
+  }
+  // A settled question round or plan decision is keyed on the *result*: the
+  // card exists to say what the reader chose, which the arguments never held.
+  // Still parked, the pinned card above the composer is asking the same thing.
+  if (entry.result?.tool === "user_questions" && !parked.has(entry.callId)) {
+    return isolatedCard(
+      entry.id,
+      "",
+      <UserQuestionsResultCard
+        answers={entry.result.answers}
+        additionalContext={entry.result.additionalContext}
+      />,
+    );
+  }
+  if (entry.result?.tool === "plan_decision" && !parked.has(entry.callId)) {
+    return isolatedCard(
+      entry.id,
+      "",
+      <PlanDecisionResultCard
+        title={entry.result.title}
+        plan={entry.result.plan}
+        accepted={entry.result.accepted}
+        feedback={entry.result.feedback}
       />,
     );
   }

--- a/crates/openwave-desktop/ui/src/MessageMarkdown.tsx
+++ b/crates/openwave-desktop/ui/src/MessageMarkdown.tsx
@@ -3,6 +3,7 @@ import {
   memo,
   useMemo,
   useRef,
+  type ReactElement,
   type ReactNode,
 } from "react";
 import ReactMarkdown, {
@@ -363,23 +364,31 @@ const MarkdownBlock = memo(function MarkdownBlock({
   headingIds,
   highlightStart,
   highlightEnd,
+  wrapBlock,
 }: {
   block: string;
   headingIds: boolean;
   /** Range to mark, in this block's own source. Primitives, so memo compares. */
   highlightStart?: number;
   highlightEnd?: number;
+  /** Stable across renders, or every block re-parses on every tick. */
+  wrapBlock?: WrapMarkdownBlock;
 }) {
   const processed = useMemo(() => processMarkdownContent(block), [block]);
   const plugins = useMemo(
     () => blockRehypePlugins(block, highlightStart, highlightEnd),
     [block, highlightStart, highlightEnd],
   );
+  const blockComponents = useMemo(() => {
+    const base = headingIds ? componentsWithHeadingIds : components;
+    const wrapping = wrappingComponents(wrapBlock, processed);
+    return wrapping ? { ...base, ...wrapping } : base;
+  }, [headingIds, wrapBlock, processed]);
   return (
     <ReactMarkdown
       remarkPlugins={remarkPlugins}
       rehypePlugins={plugins}
-      components={headingIds ? componentsWithHeadingIds : components}
+      components={blockComponents}
       skipHtml
       urlTransform={(url) => safeMarkdownUrl(url) ?? ""}
     >
@@ -426,6 +435,78 @@ function blockRehypePlugins(
   ];
 }
 
+/**
+ * Wrap each addressable block of a rendered message in caller-supplied chrome.
+ *
+ * The caller gets the block's own Markdown source alongside the element, which
+ * is what lets a comment be filed against the text a reader pointed at rather
+ * than against a rendered node nobody can name. Blocks are the units a person
+ * would quote: paragraphs, leaf list items, quotes, and code fences. A list
+ * item holding a nested list is left alone — wrapping it would put the chrome
+ * around its whole subtree, and its leaves are wrapped individually anyway.
+ */
+export type WrapMarkdownBlock = (
+  source: string,
+  element: ReactElement,
+) => ReactNode;
+
+/**
+ * The block-wrapping overrides for one parsed block, or nothing when the
+ * caller wants none.
+ *
+ * `processed` is what the parser was handed, so the offsets it recorded index
+ * into it and not into the caller's original text.
+ */
+function wrappingComponents(
+  wrapBlock: WrapMarkdownBlock | undefined,
+  processed: string,
+): Components | undefined {
+  if (!wrapBlock) return undefined;
+  const wrap = (
+    node: { position?: { start: { offset?: number }; end: { offset?: number } } } | undefined,
+    element: ReactElement,
+  ): ReactNode => {
+    const start = node?.position?.start.offset;
+    const end = node?.position?.end.offset;
+    const source =
+      start != null && end != null ? processed.slice(start, end) : "";
+    return wrapBlock(source, element);
+  };
+  return {
+    p: ({ node, children }) => wrap(node, <p>{children}</p>),
+    li: ({ node, children }) => {
+      const nested = node?.children?.some(
+        (child) =>
+          child.type === "element" &&
+          (child.tagName === "ul" || child.tagName === "ol"),
+      );
+      return nested ? <li>{children}</li> : wrap(node, <li>{children}</li>);
+    },
+    blockquote: ({ node, children }) =>
+      wrap(node, <blockquote>{children}</blockquote>),
+    // The fence keeps its copy button; the chrome goes around the whole block
+    // so it does not land on top of it.
+    pre: ({ node, children }) => {
+      const source = node ? rawCodeText(node) : "";
+      return wrap(
+        node,
+        <div className="code-block">
+          {source && (
+            <ClipboardCopyButton
+              value={source}
+              label="Copy code"
+              copiedAnnouncement="Code copied"
+              failedAnnouncement="Copy failed"
+              className="code-block-copy"
+            />
+          )}
+          <pre>{children}</pre>
+        </div>,
+      );
+    },
+  };
+}
+
 interface MessageMarkdownProps {
   children: string;
   /**
@@ -441,12 +522,19 @@ interface MessageMarkdownProps {
    * placed against the offsets the parser recorded for each of them.
    */
   highlightRange?: HighlightRange;
+  /**
+   * Wrap every addressable block in caller-supplied chrome — the plan card's
+   * per-block comment affordance. Must be stable (`useCallback`), or each
+   * render re-parses every block.
+   */
+  wrapBlock?: WrapMarkdownBlock;
 }
 
 export const MessageMarkdown = memo(function MessageMarkdown({
   children,
   headingIds = false,
   highlightRange,
+  wrapBlock,
 }: MessageMarkdownProps) {
   const blocks = useMemo(() => splitMarkdownBlocks(children), [children]);
   const blockStarts = useMemo(() => pieceStartOffsets(blocks), [blocks]);
@@ -467,6 +555,7 @@ export const MessageMarkdown = memo(function MessageMarkdown({
             headingIds={headingIds}
             highlightStart={inBlock?.start}
             highlightEnd={inBlock?.end}
+            wrapBlock={wrapBlock}
           />
         );
       })}

--- a/crates/openwave-desktop/ui/src/ParkedResultCards.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ParkedResultCards.dom.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, expect, it } from "vitest";
+import { PlanDecisionResultCard } from "./PlanDecisionResultCard";
+import { UserQuestionsResultCard } from "./UserQuestionsResultCard";
+
+afterEach(cleanup);
+
+/**
+ * The turn stopped to ask, so the settled transcript has to say what it was
+ * told — including the questions that were passed over, which read as an answer
+ * of their own.
+ */
+it("recaps chosen labels and names what was skipped", () => {
+  render(
+    <UserQuestionsResultCard
+      answers={[
+        {
+          question: "Where should I deploy?",
+          selected: ["Staging", "Production"],
+          customAnswer: "Start with a canary.",
+        },
+        { question: "Anything else?", selected: [], customAnswer: null },
+      ]}
+      additionalContext="Keep the rollout reversible."
+    />,
+  );
+  expect(screen.getByText("1. Where should I deploy?")).toBeInTheDocument();
+  expect(
+    screen.getByText("Staging, Production, Start with a canary."),
+  ).toBeInTheDocument();
+  expect(screen.getByText("Skipped")).toBeInTheDocument();
+  expect(screen.getByText("Keep the rollout reversible.")).toBeInTheDocument();
+});
+
+it("says so when every question was passed over", () => {
+  render(
+    <UserQuestionsResultCard
+      answers={[
+        { question: "Anything else?", selected: [], customAnswer: null },
+      ]}
+      additionalContext={null}
+    />,
+  );
+  expect(screen.getByText("All questions were skipped.")).toBeInTheDocument();
+});
+
+/** A revised plan carries the feedback that sent it back; an accepted one has none. */
+it("shows the revision feedback only on a rejected plan", () => {
+  const { rerender } = render(
+    <PlanDecisionResultCard
+      title="Add health checks"
+      plan="1. Add a `/healthz` route."
+      accepted={false}
+      feedback="Split step 2 into its own slice."
+    />,
+  );
+  expect(screen.getByText("Revised")).toBeInTheDocument();
+  expect(
+    screen.getByText("Split step 2 into its own slice."),
+  ).toBeInTheDocument();
+
+  rerender(
+    <PlanDecisionResultCard
+      title="Add health checks"
+      plan="1. Add a `/healthz` route."
+      accepted
+      feedback={null}
+    />,
+  );
+  expect(screen.getByText("Accepted")).toBeInTheDocument();
+  expect(screen.queryByText("Revision feedback")).not.toBeInTheDocument();
+});

--- a/crates/openwave-desktop/ui/src/PendingCard.tsx
+++ b/crates/openwave-desktop/ui/src/PendingCard.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from "react";
+import { ErrorBoundary } from "./ErrorBoundary";
+import { ToolActivityUnavailable } from "./ToolActivityGroup";
+
+/**
+ * One card, contained.
+ *
+ * Cards render model-influenced data through several defensive parsers, and one
+ * of them being wrong must not cost the card next to it. The siblings that make
+ * this matter are the cards the turn is waiting on — an approval prompt, a
+ * folder-access request, a question put to the user. A pending decision that
+ * renders as nothing leaves the reader with no way to answer, no explanation,
+ * and a turn that cannot proceed.
+ *
+ * `signature` is the data the card draws on, reduced to what decides whether it
+ * can render, so a card that threw mid-stream is retried when its call moves on
+ * rather than staying broken for the life of the transcript.
+ */
+export function isolatedCard(
+  key: string,
+  signature: string,
+  card: ReactNode,
+  /**
+   * The parked call this card decides, when it decides one. It is written to
+   * the DOM so a deep link from the inbox can find the card it named — the
+   * transcript is otherwise addressable only by scroll position.
+   */
+  pendingCallId?: string,
+): ReactNode {
+  return (
+    <ErrorBoundary
+      key={key}
+      resetKey={signature}
+      fallback={<ToolActivityUnavailable />}
+    >
+      {pendingCallId ? (
+        <div data-pending-call-id={pendingCallId}>{card}</div>
+      ) : (
+        card
+      )}
+    </ErrorBoundary>
+  );
+}

--- a/crates/openwave-desktop/ui/src/PlanApprovalCard.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/PlanApprovalCard.dom.test.tsx
@@ -1,16 +1,21 @@
 // @vitest-environment jsdom
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PlanApprovalCard } from "./PlanApprovalCard";
+import { usePlanComments } from "./PlanComments";
 
 afterEach(cleanup);
+beforeEach(() => {
+  window.localStorage.clear();
+  usePlanComments.setState({ byCall: {} });
+});
 
 const request = {
   callId: "call-1",
   turnId: "turn-1",
   title: "Add health checks",
-  plan: "## Steps\n1. Add a `/healthz` route.\n2. Cover it with one lifecycle test.",
+  plan: "## Steps\n\n1. Add a `/healthz` route.\n\n2. Cover it with one lifecycle test.",
   proposedAt: "2026-07-30T12:00:00Z",
 };
 
@@ -29,11 +34,16 @@ describe("PlanApprovalCard", () => {
     );
     expect(screen.getByText("Add health checks")).toBeInTheDocument();
     expect(screen.getByText(/lifecycle test/)).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: /Approve and run/ }));
+    await user.click(screen.getByRole("button", { name: /Execute plan/ }));
     expect(onDecide).toHaveBeenCalledWith({ decision: "accept" });
   });
 
-  it("sends the plan back with the exact typed feedback", async () => {
+  /**
+   * The revision path is per-block comments now, and the server still takes one
+   * feedback string — this pins the join, which is the only place the two
+   * shapes meet.
+   */
+  it("sends block comments back as quoted feedback", async () => {
     const user = userEvent.setup();
     const onDecide = vi.fn();
     render(
@@ -45,17 +55,41 @@ describe("PlanApprovalCard", () => {
         onCancel={vi.fn()}
       />,
     );
-    await user.click(screen.getByRole("button", { name: "Request changes" }));
+    const [firstStep] = screen.getAllByRole("button", { name: "Add comment" });
+    await user.click(firstStep!);
     await user.type(
       screen.getByLabelText("What should change"),
-      "Split step 2 into its own slice.",
+      "Split this into its own slice.",
     );
-    await user.click(
-      screen.getByRole("button", { name: "Send back for changes" }),
-    );
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(screen.getByText("1 edit added")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Update plan/ }));
     expect(onDecide).toHaveBeenCalledWith({
       decision: "reject",
-      feedback: "Split step 2 into its own slice.",
+      feedback: "> Add a `/healthz` route.\n\nSplit this into its own slice.",
     });
+  });
+
+  it("drops pending edits when they are cancelled", async () => {
+    const user = userEvent.setup();
+    render(
+      <PlanApprovalCard
+        request={request}
+        working={false}
+        error={undefined}
+        onDecide={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const [firstStep] = screen.getAllByRole("button", { name: "Add comment" });
+    await user.click(firstStep!);
+    await user.type(
+      screen.getByLabelText("What should change"),
+      "Reword this.",
+    );
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    await user.click(screen.getByRole("button", { name: "Cancel edits" }));
+    expect(screen.getByText("Hover over plan to edit")).toBeInTheDocument();
   });
 });

--- a/crates/openwave-desktop/ui/src/PlanApprovalCard.tsx
+++ b/crates/openwave-desktop/ui/src/PlanApprovalCard.tsx
@@ -1,17 +1,192 @@
-import { useState } from "react";
-import { CornerDownLeft, NotebookPen, X } from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import {
+  Compass,
+  CornerDownLeft,
+  Maximize2,
+  MessageSquare,
+  MessageSquarePlus,
+  Minimize2,
+  Trash2,
+  X,
+} from "lucide-react";
 import type { PendingPlanApproval, PlanDecision } from "./api";
 import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
 import { MessageMarkdown } from "./MessageMarkdown";
+import { serializePlanComments, usePlanComments } from "./PlanComments";
+
+/**
+ * One block of the plan, with the affordance for commenting on it.
+ *
+ * The comment is addressed to the block's own source text, so it survives the
+ * plan being re-rendered and reads back as a quote of exactly what the reader
+ * was looking at when they wrote it.
+ */
+function CommentBlock({
+  callId,
+  blockText,
+  disabled,
+  children,
+}: {
+  callId: string;
+  blockText: string;
+  disabled: boolean;
+  children: ReactElement;
+}) {
+  const [open, setOpen] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  const [draft, setDraft] = useState("");
+  const setComment = usePlanComments((state) => state.setComment);
+  const removeComment = usePlanComments((state) => state.removeComment);
+  const existing = usePlanComments(
+    (state) =>
+      (state.byCall[callId] ?? []).find(
+        (entry) => entry.blockText === blockText,
+      )?.comment ?? null,
+  );
+  const hasComment = existing !== null;
+
+  useEffect(() => {
+    if (!open) setHovered(false);
+  }, [open]);
+
+  const save = () => {
+    const trimmed = draft.trim();
+    if (!trimmed) return;
+    setComment(callId, blockText, trimmed);
+    setOpen(false);
+  };
+
+  return (
+    <div
+      className="flex items-start gap-1"
+      onMouseOver={(event) => {
+        event.stopPropagation();
+        setHovered(true);
+      }}
+      onMouseOut={() => setHovered(false)}
+    >
+      <div
+        className={cn(
+          "min-w-0 flex-1 rounded px-1 transition-colors",
+          hasComment && "bg-accent",
+          !hasComment && (open || hovered) && "bg-accent/50",
+        )}
+      >
+        {children}
+      </div>
+      <div className="mt-0.5 shrink-0">
+        <Popover
+          open={open}
+          onOpenChange={(next) => {
+            if (next) setDraft(existing ?? "");
+            setOpen(next);
+          }}
+        >
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              disabled={disabled}
+              className={cn(
+                "hover:text-foreground hover:bg-muted rounded p-2 transition-opacity",
+                hasComment
+                  ? "text-primary opacity-100"
+                  : cn(
+                      "text-muted-foreground",
+                      hovered ? "opacity-100" : "opacity-0",
+                    ),
+              )}
+              aria-label={hasComment ? "Edit comment" : "Add comment"}
+              title={hasComment ? "Edit comment" : "Add comment for this block"}
+            >
+              {hasComment ? (
+                <MessageSquare aria-hidden="true" className="size-4" />
+              ) : (
+                <MessageSquarePlus aria-hidden="true" className="size-4" />
+              )}
+            </button>
+          </PopoverTrigger>
+          <PopoverContent side="right" align="start" className="w-72">
+            <div className="space-y-3">
+              <Textarea
+                maxLength={2000}
+                placeholder="What should change?"
+                aria-label="What should change"
+                value={draft}
+                onChange={(event) => setDraft(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" && (event.metaKey || event.ctrlKey))
+                    save();
+                }}
+                className="min-h-20"
+                autoFocus
+              />
+              <div className="flex items-center justify-between gap-2">
+                {hasComment ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    aria-label="Delete comment"
+                    onClick={() => {
+                      removeComment(callId, blockText);
+                      setDraft("");
+                      setOpen(false);
+                    }}
+                  >
+                    <Trash2 aria-hidden="true" />
+                  </Button>
+                ) : (
+                  <div />
+                )}
+                <div className="flex gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setOpen(false)}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    onClick={save}
+                    disabled={!draft.trim()}
+                  >
+                    Save
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </PopoverContent>
+        </Popover>
+      </div>
+    </div>
+  );
+}
 
 /**
  * The decision card for a plan the agent proposed from plan mode.
  *
  * Approving is the mode hand-off: the server moves the chat out of plan mode
  * and the resumed turn executes with its full tool surface, so the primary
- * action says exactly that. "Request changes" keeps the chat in plan mode and
- * sends the feedback back to be revised.
+ * action says exactly that. Revising is done in the plan itself — a comment on
+ * any block collects into the feedback the rejected call carries back, which
+ * keeps the chat in plan mode for another pass.
  */
 export function PlanApprovalCard({
   request,
@@ -19,123 +194,206 @@ export function PlanApprovalCard({
   error,
   onDecide,
   onCancel,
+  onFullscreenChange,
 }: {
   request: PendingPlanApproval;
   working: boolean;
   error: string | undefined;
   onDecide: (decision: PlanDecision) => void;
   onCancel: () => void;
+  onFullscreenChange?: (fullscreen: boolean) => void;
 }) {
-  const [revising, setRevising] = useState(false);
-  const [feedback, setFeedback] = useState("");
+  const callId = request.callId;
+  const [fullscreen, setFullscreen] = useState(false);
+  const [showTopFade, setShowTopFade] = useState(false);
+  const [showBottomFade, setShowBottomFade] = useState(false);
+  const scroller = useRef<HTMLDivElement>(null);
+
+  const hydrate = usePlanComments((state) => state.hydrate);
+  const clear = usePlanComments((state) => state.clear);
+  const comments = usePlanComments((state) => state.byCall[callId]);
+  const commentCount = comments?.length ?? 0;
+
+  useEffect(() => hydrate(callId), [callId, hydrate]);
+
+  const checkScroll = useCallback(() => {
+    const node = scroller.current;
+    if (!node) return;
+    const scrollable = node.scrollHeight > node.clientHeight;
+    setShowTopFade(scrollable && node.scrollTop > 0);
+    setShowBottomFade(
+      scrollable && node.scrollTop + node.clientHeight < node.scrollHeight - 1,
+    );
+  }, []);
+
+  useEffect(() => checkScroll(), [checkScroll, request.plan]);
+
+  const wrapBlock = useCallback(
+    (source: string, element: ReactElement): ReactNode => (
+      <CommentBlock callId={callId} blockText={source} disabled={working}>
+        {element}
+      </CommentBlock>
+    ),
+    [callId, working],
+  );
+
+  const accept = () => {
+    clear(callId);
+    onDecide({ decision: "accept" });
+  };
+
+  const requestChanges = () => {
+    const feedback = serializePlanComments(comments ?? []);
+    clear(callId);
+    onDecide(
+      feedback ? { decision: "reject", feedback } : { decision: "reject" },
+    );
+  };
+
+  const toggleFullscreen = () => {
+    setFullscreen((previous) => {
+      const next = !previous;
+      onFullscreenChange?.(next);
+      return next;
+    });
+  };
+
+  const header = (
+    <>
+      <div className="py-1">
+        <Compass
+          aria-hidden="true"
+          className="text-muted-foreground size-4 shrink-0"
+        />
+      </div>
+      <h3
+        id={`plan-${callId}`}
+        className={cn(
+          "min-w-0 font-medium break-words",
+          fullscreen && "text-sm",
+        )}
+      >
+        {request.title}
+      </h3>
+      <div className="flex-1" />
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        className="text-muted-foreground shrink-0"
+        disabled={working}
+        onClick={toggleFullscreen}
+        aria-label={fullscreen ? "Exit full screen" : "Full screen"}
+        title={fullscreen ? "Exit full screen" : "Full screen"}
+      >
+        {fullscreen ? (
+          <Minimize2 aria-hidden="true" />
+        ) : (
+          <Maximize2 aria-hidden="true" />
+        )}
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        className="text-muted-foreground shrink-0"
+        disabled={working}
+        onClick={onCancel}
+        aria-label="Cancel turn"
+        title="Cancel turn"
+      >
+        <X aria-hidden="true" />
+      </Button>
+    </>
+  );
+
+  const footer =
+    commentCount > 0 ? (
+      <>
+        <span className="text-muted-foreground grow text-sm">
+          {commentCount} edit{commentCount > 1 ? "s" : ""} added
+        </span>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={working}
+          onClick={() => clear(callId)}
+        >
+          Cancel edits
+        </Button>
+        <Button type="button" disabled={working} onClick={requestChanges}>
+          {working ? "Sending…" : "Update plan"}
+          {!working && <CornerDownLeft aria-hidden="true" />}
+        </Button>
+      </>
+    ) : (
+      <>
+        <span className="text-muted-foreground grow text-sm">
+          Hover over plan to edit
+        </span>
+        <Button type="button" disabled={working} onClick={accept}>
+          {working ? "Sending…" : "Execute plan"}
+          {!working && <CornerDownLeft aria-hidden="true" />}
+        </Button>
+      </>
+    );
+
+  const errorNotice = error ? (
+    <p className="text-destructive text-xs break-words" role="alert">
+      {error}
+    </p>
+  ) : null;
+
+  const plan = (
+    <MessageMarkdown wrapBlock={wrapBlock}>{request.plan}</MessageMarkdown>
+  );
+
+  if (fullscreen) {
+    return (
+      <section
+        className="flex h-full flex-col"
+        aria-labelledby={`plan-${callId}`}
+        aria-busy={working}
+      >
+        <div className="flex items-start gap-2 border-b px-4 py-3">
+          {header}
+        </div>
+        <div className="flex-1 overflow-y-auto p-4 text-sm">{plan}</div>
+        <div className="border-t px-4 py-3">
+          {errorNotice}
+          <div className="flex items-center justify-end gap-3">{footer}</div>
+        </div>
+      </section>
+    );
+  }
 
   return (
     <section
-      className="bg-background flex w-full max-w-prose flex-col gap-3 rounded-[20px] border p-3.5 shadow-sm"
-      aria-labelledby={`plan-${request.callId}`}
+      className="bg-background rounded-lg border p-4"
+      aria-labelledby={`plan-${callId}`}
       aria-busy={working}
     >
-      <div className="flex items-start gap-2.5">
-        <div className="min-w-0 flex-1">
-          <p className="text-muted-foreground flex items-center gap-1.5 text-xs font-semibold tracking-wide uppercase">
-            <NotebookPen aria-hidden="true" className="size-3.5" />
-            Proposed plan
-          </p>
-          <h3
-            id={`plan-${request.callId}`}
-            className="mt-1 text-[15px] leading-5 font-semibold break-words"
-          >
-            {request.title}
-          </h3>
-        </div>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-xs"
-          disabled={working}
-          onClick={onCancel}
-          aria-label="Cancel turn"
-          title="Cancel turn"
-          className="text-muted-foreground shrink-0"
+      <div className="mb-2 flex items-start gap-2">{header}</div>
+
+      <div className="relative">
+        {showTopFade && (
+          <div className="from-background pointer-events-none absolute top-0 right-0 left-0 z-10 h-16 bg-gradient-to-b to-transparent" />
+        )}
+        <div
+          ref={scroller}
+          onScroll={checkScroll}
+          className="max-h-[400px] max-w-none overflow-y-auto text-sm"
         >
-          <X aria-hidden="true" />
-        </Button>
-      </div>
-
-      <div className="max-h-80 overflow-y-auto rounded-[10px] border px-3 py-2 text-sm">
-        <MessageMarkdown>{request.plan}</MessageMarkdown>
-      </div>
-
-      {revising && (
-        <Textarea
-          maxLength={4000}
-          rows={3}
-          value={feedback}
-          onChange={(event) => setFeedback(event.target.value)}
-          disabled={working}
-          aria-label="What should change"
-          placeholder="What should change?"
-          autoFocus
-          className="min-h-16 resize-y rounded-[10px] py-2.5 text-sm focus-visible:border-foreground focus-visible:ring-0 focus-visible:ring-offset-0"
-        />
-      )}
-
-      {error && (
-        <p className="text-destructive text-xs break-words" role="alert">
-          {error}
-        </p>
-      )}
-
-      <div className="flex items-center justify-end gap-2 pt-0.5">
-        {revising ? (
-          <>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              disabled={working}
-              onClick={() => setRevising(false)}
-            >
-              Back
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              disabled={working}
-              onClick={() =>
-                onDecide(
-                  feedback.trim()
-                    ? { decision: "reject", feedback: feedback.trim() }
-                    : { decision: "reject" },
-                )
-              }
-            >
-              {working ? "Sending…" : "Send back for changes"}
-            </Button>
-          </>
-        ) : (
-          <>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              disabled={working}
-              onClick={() => setRevising(true)}
-            >
-              Request changes
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              disabled={working}
-              onClick={() => onDecide({ decision: "accept" })}
-            >
-              {working ? "Sending…" : "Approve and run"}
-              {!working && <CornerDownLeft aria-hidden="true" />}
-            </Button>
-          </>
+          {plan}
+        </div>
+        {showBottomFade && (
+          <div className="from-background pointer-events-none absolute right-0 bottom-0 left-0 z-10 h-16 bg-gradient-to-t to-transparent" />
         )}
       </div>
+
+      {errorNotice}
+
+      <div className="mt-6 flex items-center justify-end gap-3">{footer}</div>
     </section>
   );
 }

--- a/crates/openwave-desktop/ui/src/PlanComments.ts
+++ b/crates/openwave-desktop/ui/src/PlanComments.ts
@@ -1,0 +1,118 @@
+import { create } from "zustand";
+
+const KEY_PREFIX = "plan_comments_";
+
+/** A note the reader attached to one block of a proposed plan. */
+export type PlanComment = {
+  /** The block's raw markdown source, which is both its identity and its quote. */
+  blockText: string;
+  comment: string;
+};
+
+type PlanCommentsState = {
+  byCall: Record<string, PlanComment[]>;
+  hydrate: (callId: string) => void;
+  setComment: (callId: string, blockText: string, comment: string) => void;
+  removeComment: (callId: string, blockText: string) => void;
+  clear: (callId: string) => void;
+};
+
+function persist(callId: string, comments: PlanComment[]): void {
+  try {
+    if (comments.length === 0) {
+      window.localStorage.removeItem(`${KEY_PREFIX}${callId}`);
+      return;
+    }
+    window.localStorage.setItem(
+      `${KEY_PREFIX}${callId}`,
+      JSON.stringify(comments),
+    );
+  } catch {
+    // Comments that outlive a reload are a convenience; an unwritable store is
+    // not a reason to refuse the edit.
+  }
+}
+
+function readStored(callId: string): PlanComment[] | undefined {
+  try {
+    const raw = window.localStorage.getItem(`${KEY_PREFIX}${callId}`);
+    if (!raw) return undefined;
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return undefined;
+    return parsed.filter(
+      (entry): entry is PlanComment =>
+        typeof entry === "object" &&
+        entry !== null &&
+        typeof (entry as PlanComment).blockText === "string" &&
+        typeof (entry as PlanComment).comment === "string",
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Block-level comments on a proposed plan, keyed by the parked call.
+ *
+ * They live on the client until the reader sends them: a plan the agent has
+ * not been asked to revise yet is a private draft. Persisting to localStorage
+ * is what keeps a half-written round of edits from evaporating on a reload.
+ * One comment per block — a second note on the same block replaces the first.
+ */
+export const usePlanComments = create<PlanCommentsState>((set, get) => ({
+  byCall: {},
+
+  hydrate: (callId) => {
+    if (get().byCall[callId]) return;
+    const stored = readStored(callId);
+    if (!stored?.length) return;
+    set((state) => ({ byCall: { ...state.byCall, [callId]: stored } }));
+  },
+
+  setComment: (callId, blockText, comment) =>
+    set((state) => {
+      const existing = state.byCall[callId] ?? [];
+      const next = existing.some((entry) => entry.blockText === blockText)
+        ? existing.map((entry) =>
+            entry.blockText === blockText ? { ...entry, comment } : entry,
+          )
+        : [...existing, { blockText, comment }];
+      persist(callId, next);
+      return { byCall: { ...state.byCall, [callId]: next } };
+    }),
+
+  removeComment: (callId, blockText) =>
+    set((state) => {
+      const next = (state.byCall[callId] ?? []).filter(
+        (entry) => entry.blockText !== blockText,
+      );
+      persist(callId, next);
+      return { byCall: { ...state.byCall, [callId]: next } };
+    }),
+
+  clear: (callId) =>
+    set((state) => {
+      persist(callId, []);
+      const { [callId]: _dropped, ...rest } = state.byCall;
+      return { byCall: rest };
+    }),
+}));
+
+/**
+ * Render the collected comments as the one feedback string the server takes.
+ *
+ * The revision request is a single message, so each note becomes a markdown
+ * blockquote of the block it addresses followed by what the reader asked for —
+ * the same pairing they saw on screen, in a form the agent reads as prose.
+ */
+export function serializePlanComments(comments: PlanComment[]): string {
+  return comments
+    .map(
+      (entry) =>
+        `${entry.blockText
+          .split("\n")
+          .map((line) => `> ${line}`)
+          .join("\n")}\n\n${entry.comment}`,
+    )
+    .join("\n\n---\n\n");
+}

--- a/crates/openwave-desktop/ui/src/PlanDecisionResultCard.tsx
+++ b/crates/openwave-desktop/ui/src/PlanDecisionResultCard.tsx
@@ -1,0 +1,56 @@
+import { Compass } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { MessageMarkdown } from "./MessageMarkdown";
+
+/**
+ * The plan as it was proposed, with what the reader decided about it.
+ *
+ * Accepting a plan is the moment the chat left plan mode, and revising it is
+ * why the next pass looks different — both are worth keeping in the transcript
+ * rather than collapsing to a settled line on the rail.
+ */
+export function PlanDecisionResultCard({
+  title,
+  plan,
+  accepted,
+  feedback,
+}: {
+  title: string;
+  plan: string;
+  accepted: boolean;
+  feedback: string | null;
+}) {
+  return (
+    <section className="bg-background rounded-lg border p-4">
+      <div className="mb-2 flex items-start gap-2">
+        <div className="py-1">
+          <Compass
+            aria-hidden="true"
+            className="text-muted-foreground size-4 shrink-0"
+          />
+        </div>
+        <h3 className="min-w-0 font-medium break-words">{title}</h3>
+        <Badge variant={accepted ? "success" : "warning"}>
+          {accepted ? "Accepted" : "Revised"}
+        </Badge>
+      </div>
+
+      <div className="max-h-[300px] max-w-none overflow-y-auto text-sm">
+        <MessageMarkdown>{plan}</MessageMarkdown>
+      </div>
+
+      {!accepted && feedback && (
+        <>
+          <Separator className="my-4" />
+          <div>
+            <h4 className="mb-2 text-sm font-medium">Revision feedback</h4>
+            <div className="text-muted-foreground text-sm">
+              <MessageMarkdown>{feedback}</MessageMarkdown>
+            </div>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}

--- a/crates/openwave-desktop/ui/src/UserQuestionsCard.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/UserQuestionsCard.dom.test.tsx
@@ -63,13 +63,16 @@ describe("UserQuestionsCard", () => {
       "Start with a canary.",
     );
     await user.click(screen.getByRole("button", { name: "Next" }));
-    const submit = screen.getByRole("button", { name: "Continue" });
-    expect(submit).toBeEnabled();
+    // The second page is where the last question lives; context is a page of
+    // its own behind "Continue and add context".
+    await user.click(
+      screen.getByRole("button", { name: "Continue and add context" }),
+    );
     await user.type(
       screen.getByRole("textbox", { name: "Additional context" }),
       "Keep it reversible.",
     );
-    await user.click(submit);
+    await user.click(screen.getByRole("button", { name: "Continue" }));
     expect(onAnswer).toHaveBeenCalledWith(
       [
         {
@@ -80,6 +83,52 @@ describe("UserQuestionsCard", () => {
       ],
       "Keep it reversible.",
     );
+  });
+
+  /**
+   * Paging back has to keep what was already chosen: the answers are collected
+   * across pages and only sent once, so a lost draft is a silently wrong answer.
+   */
+  it("keeps answers when paging back and forward", async () => {
+    const user = userEvent.setup();
+    const onAnswer = vi.fn();
+    render(
+      <UserQuestionsCard
+        request={request}
+        working={false}
+        error={undefined}
+        onAnswer={onAnswer}
+      />,
+    );
+    await user.click(screen.getByLabelText(/Staging/));
+    await user.click(screen.getByRole("button", { name: "Next" }));
+    await user.click(screen.getByRole("button", { name: "Back" }));
+    expect(screen.getByLabelText(/Staging/)).toBeChecked();
+    await user.click(screen.getByRole("button", { name: "Go to question 2" }));
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+    expect(onAnswer).toHaveBeenCalledWith(
+      [{ questionId: "target", selectedOptionIds: ["staging"] }],
+      undefined,
+    );
+  });
+
+  it("skips all questions from the footer menu without cancelling the turn", async () => {
+    const user = userEvent.setup();
+    const onAnswer = vi.fn();
+    render(
+      <UserQuestionsCard
+        request={request}
+        working={false}
+        error={undefined}
+        onAnswer={onAnswer}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Skip all/ }));
+    await user.click(
+      await screen.findByRole("menuitem", { name: "Skip these questions" }),
+    );
+    expect(onAnswer).toHaveBeenCalledWith([]);
   });
 
   it("skips all questions without cancelling the turn", async () => {

--- a/crates/openwave-desktop/ui/src/UserQuestionsCard.tsx
+++ b/crates/openwave-desktop/ui/src/UserQuestionsCard.tsx
@@ -1,15 +1,71 @@
-import { useMemo, useState } from "react";
-import { CornerDownLeft, X } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
+import { ChevronDown, CornerDownLeft, X } from "lucide-react";
 import type { PendingUserQuestions, UserQuestionAnswer } from "./api";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
 
 type DraftAnswer = {
   selectedOptionIds: string[];
+  /** Undefined means "Other" is not chosen; "" means chosen but still empty. */
   customAnswer?: string;
 };
+
+function QuestionOption({
+  label,
+  description,
+  selected,
+  disabled,
+  onSelect,
+  children,
+}: {
+  label: string;
+  description: string | null;
+  selected: boolean;
+  disabled: boolean;
+  onSelect: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "hover:bg-accent/50 flex cursor-pointer items-start space-x-3 rounded-md p-2 transition-colors",
+        selected && "bg-accent",
+        disabled && "pointer-events-none opacity-60",
+      )}
+      role="button"
+      tabIndex={0}
+      onClick={onSelect}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onSelect();
+        }
+      }}
+    >
+      {children}
+      <div className="grid min-w-0 flex-1 gap-1.5 leading-none">
+        <div className="cursor-pointer text-sm leading-none font-medium break-words">
+          {label}
+        </div>
+        {description && (
+          <p className="text-muted-foreground cursor-pointer text-sm break-words">
+            {description}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
 
 export function UserQuestionsCard({
   request,
@@ -27,7 +83,9 @@ export function UserQuestionsCard({
 }) {
   const [drafts, setDrafts] = useState<Record<string, DraftAnswer>>({});
   const [currentPage, setCurrentPage] = useState(0);
+  const [showContextForm, setShowContextForm] = useState(false);
   const [additionalContext, setAdditionalContext] = useState("");
+
   const answers = useMemo(
     () =>
       request.questions.flatMap<UserQuestionAnswer>((question) => {
@@ -45,265 +103,343 @@ export function UserQuestionsCard({
       }),
     [drafts, request.questions],
   );
+
+  const submit = useCallback(
+    (context?: string) => {
+      const trimmed = context?.trim();
+      onAnswer(answers, trimmed || undefined);
+    },
+    [answers, onAnswer],
+  );
+  const skipAll = useCallback(() => onAnswer([]), [onAnswer]);
+
+  const questions = request.questions;
   const currentQuestion =
-    request.questions[Math.min(currentPage, request.questions.length - 1)];
+    questions[Math.min(currentPage, questions.length - 1)];
   if (!currentQuestion) return null;
-  const currentDraft = drafts[currentQuestion.id] ?? {
-    selectedOptionIds: [],
+
+  const question = currentQuestion;
+  const draft = drafts[question.id] ?? { selectedOptionIds: [] };
+  const isMultiSelect = question.questionType === "multi_select";
+  const isLastPage = currentPage === questions.length - 1;
+  const otherChosen = draft.customAnswer !== undefined;
+
+  const update = (next: DraftAnswer) =>
+    setDrafts((current) => ({ ...current, [question.id]: next }));
+
+  const chooseOption = (optionId: string) => {
+    if (working) return;
+    if (isMultiSelect) {
+      update({
+        ...draft,
+        selectedOptionIds: draft.selectedOptionIds.includes(optionId)
+          ? draft.selectedOptionIds.filter((id) => id !== optionId)
+          : [...draft.selectedOptionIds, optionId],
+      });
+      return;
+    }
+    // Picking a listed option in a single-select drops any "Other" text, so the
+    // two can never both count as the answer.
+    update({ selectedOptionIds: [optionId] });
   };
-  const isMultiSelect = currentQuestion.questionType === "multi_select";
-  const isLastPage = currentPage === request.questions.length - 1;
 
-  const chooseSingleOption = (questionId: string, optionId: string) =>
-    setDrafts((current) => ({
-      ...current,
-      [questionId]: { selectedOptionIds: [optionId] },
-    }));
+  const chooseOther = () => {
+    if (working) return;
+    update({
+      selectedOptionIds: isMultiSelect ? draft.selectedOptionIds : [],
+      customAnswer: draft.customAnswer ?? "",
+    });
+  };
 
-  const toggleOption = (questionId: string, optionId: string) =>
-    setDrafts((current) => {
-      const draft = current[questionId] ?? { selectedOptionIds: [] };
-      return {
-        ...current,
-        [questionId]: {
-          ...draft,
-          selectedOptionIds: draft.selectedOptionIds.includes(optionId)
-            ? draft.selectedOptionIds.filter((id) => id !== optionId)
-            : [...draft.selectedOptionIds, optionId],
-        },
-      };
+  const setCustomAnswer = (value: string) =>
+    update({
+      selectedOptionIds: isMultiSelect ? draft.selectedOptionIds : [],
+      customAnswer: value,
     });
 
-  const updateCustomAnswer = (
-    questionId: string,
-    value: string | undefined,
-  ) =>
-    setDrafts((current) => {
-      const draft = current[questionId] ?? { selectedOptionIds: [] };
-      return {
-        ...current,
-        [questionId]: {
-          selectedOptionIds: isMultiSelect ? draft.selectedOptionIds : [],
-          ...(value === undefined ? {} : { customAnswer: value }),
-        },
-      };
+  const toggleOther = (checked: boolean) =>
+    update({
+      selectedOptionIds: draft.selectedOptionIds,
+      ...(checked ? { customAnswer: draft.customAnswer ?? "" } : {}),
     });
 
-  const submitAnswers = () => {
-    const context = additionalContext.trim();
-    onAnswer(answers, context || undefined);
-  };
+  const errorNotice = error ? (
+    <p className="text-destructive text-xs break-words" role="alert">
+      {error}
+    </p>
+  ) : null;
+
+  if (showContextForm) {
+    return (
+      <section
+        className="bg-background rounded-lg border p-4"
+        aria-labelledby={`questions-${request.callId}`}
+        aria-busy={working}
+      >
+        <div className="mb-6 flex items-start justify-between gap-3">
+          <h3
+            id={`questions-${request.callId}`}
+            className="min-w-0 font-medium"
+          >
+            What would you like to add or clarify?
+          </h3>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            className="text-muted-foreground shrink-0"
+            disabled={working}
+            onClick={skipAll}
+            aria-label="Skip questions"
+            title="Skip questions"
+          >
+            <X aria-hidden="true" />
+          </Button>
+        </div>
+
+        <div className="space-y-6">
+          <Input
+            maxLength={2000}
+            placeholder="Add additional context"
+            aria-label="Additional context"
+            value={additionalContext}
+            disabled={working}
+            onChange={(event) => setAdditionalContext(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && !working) {
+                submit(additionalContext);
+              }
+            }}
+            autoFocus
+          />
+
+          {errorNotice}
+
+          <Separator />
+
+          <div className="flex items-center justify-between">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={working}
+              onClick={() => setShowContextForm(false)}
+            >
+              Back
+            </Button>
+            <Button
+              type="button"
+              disabled={working}
+              onClick={() => submit(additionalContext)}
+            >
+              {working ? "Sending…" : "Continue"}
+              {!working && <CornerDownLeft aria-hidden="true" />}
+            </Button>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  const otherRow = question.allowFreeForm ? (
+    <div className="flex items-center space-x-3 p-2">
+      {isMultiSelect ? (
+        <Checkbox
+          checked={otherChosen}
+          disabled={working}
+          onCheckedChange={(checked) => toggleOther(checked === true)}
+          aria-label="Other"
+        />
+      ) : (
+        <RadioGroupItem value="other" aria-label="Other" disabled={working} />
+      )}
+      <Input
+        maxLength={2000}
+        placeholder="Other"
+        aria-label="Other answer"
+        value={draft.customAnswer ?? ""}
+        disabled={working}
+        onChange={(event) => setCustomAnswer(event.target.value)}
+        onClick={() => {
+          if (!isMultiSelect && !otherChosen) chooseOther();
+        }}
+        className="flex-1"
+      />
+    </div>
+  ) : null;
 
   return (
     <section
-      className="bg-background flex w-full max-w-prose flex-col gap-3 rounded-[20px] border p-3.5 shadow-sm"
+      className="bg-background rounded-lg border p-4"
       aria-labelledby={`questions-${request.callId}`}
       aria-busy={working}
     >
-      <div className="flex items-start gap-2.5">
-        <div className="min-w-0 flex-1">
-          <p className="text-muted-foreground text-xs font-semibold tracking-wide uppercase">
-            {currentQuestion.header}
-          </p>
-          <h3
-            id={`questions-${request.callId}`}
-            className="mt-1 text-[15px] leading-5 font-semibold break-words"
-          >
-            {currentQuestion.question}
-            {isMultiSelect && " Select all that apply."}
-          </h3>
-        </div>
+      <div className="mb-2 flex items-start justify-between gap-3">
+        <h3 id={`questions-${request.callId}`} className="min-w-0 font-medium">
+          {question.question}
+          {isMultiSelect ? " Select all that apply." : ""}
+        </h3>
         <Button
           type="button"
           variant="ghost"
           size="icon-xs"
+          className="text-muted-foreground shrink-0"
           disabled={working}
-          onClick={() => onAnswer([])}
+          onClick={skipAll}
           aria-label="Skip questions"
           title="Skip questions"
-          className="text-muted-foreground shrink-0"
         >
           <X aria-hidden="true" />
         </Button>
       </div>
 
-      {currentQuestion.options.length > 0 && (
-        <div
-          role={isMultiSelect ? "group" : "radiogroup"}
-          aria-label={currentQuestion.header}
-          className="grid gap-1"
-        >
-          {currentQuestion.options.map((option) => {
-            const selected = currentDraft.selectedOptionIds.includes(option.id);
-            return (
-              <label
-                key={option.id}
-                className={cn(
-                  "hover:bg-muted/40 flex min-w-0 cursor-pointer items-start gap-2.5 rounded-[10px] border px-2.5 py-2.5 transition-colors",
-                  selected && "border-foreground bg-muted",
-                  working && "pointer-events-none opacity-60",
-                )}
-              >
-                <input
-                  type={isMultiSelect ? "checkbox" : "radio"}
-                  name={`${request.callId}-${currentQuestion.id}`}
-                  checked={selected}
-                  disabled={working}
-                  onChange={() =>
-                    isMultiSelect
-                      ? toggleOption(currentQuestion.id, option.id)
-                      : chooseSingleOption(currentQuestion.id, option.id)
-                  }
-                  className="accent-foreground mt-0.5 size-[18px] shrink-0"
-                />
-                <span className="min-w-0">
-                  <span className="block text-sm font-medium break-words">
-                    {option.label}
-                  </span>
-                  {option.description && (
-                    <span className="text-muted-foreground mt-0.5 block text-xs leading-4 break-words">
-                      {option.description}
-                    </span>
-                  )}
-                </span>
-              </label>
-            );
-          })}
-          {currentQuestion.allowFreeForm && (
-            <label
-              className={cn(
-                "flex min-w-0 items-center gap-2.5 px-1 py-1.5",
-                working && "pointer-events-none opacity-60",
-              )}
+      <div className="space-y-4">
+        <div>
+          {isMultiSelect ? (
+            <div
+              role="group"
+              aria-label={question.header}
+              className="flex flex-col gap-1"
             >
-              <input
-                type={isMultiSelect ? "checkbox" : "radio"}
-                name={`${request.callId}-${currentQuestion.id}`}
-                checked={currentDraft.customAnswer !== undefined}
-                disabled={working}
-                onChange={(event) =>
-                  updateCustomAnswer(
-                    currentQuestion.id,
-                    event.target.checked
-                      ? (currentDraft.customAnswer ?? "")
-                      : undefined,
-                  )
-                }
-                className="accent-foreground size-[18px] shrink-0"
-              />
-              <Input
-                type="text"
-                maxLength={2000}
-                value={currentDraft.customAnswer ?? ""}
-                onFocus={() => {
-                  if (currentDraft.customAnswer === undefined) {
-                    updateCustomAnswer(currentQuestion.id, "");
-                  }
-                }}
-                onChange={(event) =>
-                  updateCustomAnswer(currentQuestion.id, event.target.value)
-                }
-                disabled={working}
-                aria-label="Other answer"
-                placeholder="Other"
-                className="h-auto min-w-0 flex-1 rounded-lg px-2.5 py-2 text-sm focus-visible:border-foreground focus-visible:ring-0 focus-visible:ring-offset-0"
-              />
-            </label>
+              {question.options.map((option) => {
+                const selected = draft.selectedOptionIds.includes(option.id);
+                return (
+                  <QuestionOption
+                    key={option.id}
+                    label={option.label}
+                    description={option.description}
+                    selected={selected}
+                    disabled={working}
+                    onSelect={() => chooseOption(option.id)}
+                  >
+                    <Checkbox
+                      checked={selected}
+                      disabled={working}
+                      onCheckedChange={() => chooseOption(option.id)}
+                      aria-label={option.label}
+                    />
+                  </QuestionOption>
+                );
+              })}
+              {otherRow}
+            </div>
+          ) : (
+            <RadioGroup
+              className="gap-1"
+              aria-label={question.header}
+              value={draft.selectedOptionIds[0] ?? (otherChosen ? "other" : "")}
+              onValueChange={(value) =>
+                value === "other" ? chooseOther() : chooseOption(value)
+              }
+            >
+              {question.options.map((option) => (
+                <QuestionOption
+                  key={option.id}
+                  label={option.label}
+                  description={option.description}
+                  selected={draft.selectedOptionIds[0] === option.id}
+                  disabled={working}
+                  onSelect={() => chooseOption(option.id)}
+                >
+                  <RadioGroupItem
+                    value={option.id}
+                    disabled={working}
+                    aria-label={option.label}
+                  />
+                </QuestionOption>
+              ))}
+              {otherRow}
+            </RadioGroup>
           )}
         </div>
-      )}
 
-      {currentQuestion.allowFreeForm &&
-        currentQuestion.options.length === 0 && (
-          <Textarea
-            maxLength={2000}
-            rows={3}
-            value={currentDraft.customAnswer ?? ""}
-            onChange={(event) =>
-              updateCustomAnswer(currentQuestion.id, event.target.value)
-            }
-            disabled={working}
-            aria-label={currentQuestion.header}
-            placeholder="Your answer"
-            className="min-h-16 resize-y rounded-[10px] py-2.5 text-sm focus-visible:border-foreground focus-visible:ring-0 focus-visible:ring-offset-0"
-          />
-        )}
+        {errorNotice}
 
-      <Textarea
-        maxLength={2000}
-        rows={2}
-        value={additionalContext}
-        onChange={(event) => setAdditionalContext(event.target.value)}
-        disabled={working}
-        aria-label="Additional context"
-        placeholder="Additional context (optional)"
-        className="min-h-14 resize-y rounded-[10px] py-2.5 text-sm focus-visible:border-foreground focus-visible:ring-0 focus-visible:ring-offset-0"
-      />
+        <Separator />
 
-      {request.questions.length > 1 && (
-        <div
-          className="flex items-center justify-center gap-1.5 pt-0.5"
-          aria-label="Questions"
-        >
-          {request.questions.map((question, index) => (
-            <button
-              key={question.id}
-              type="button"
-              disabled={working}
-              onClick={() => setCurrentPage(index)}
-              aria-label={`Go to question ${index + 1}`}
-              aria-current={index === currentPage ? "step" : undefined}
-              className={cn(
-                "size-1.5 rounded-full transition-opacity",
-                index === currentPage
-                  ? "bg-foreground"
-                  : "bg-muted-foreground opacity-40 hover:opacity-70",
-              )}
-            />
-          ))}
-        </div>
-      )}
-
-      {error && (
-        <p className="text-destructive text-xs break-words" role="alert">
-          {error}
-        </p>
-      )}
-
-      <div className="flex items-center justify-between gap-2 pt-0.5">
-        <div>
-          {currentPage > 0 && (
+        <div className="flex items-center justify-between gap-2">
+          {currentPage === 0 ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button type="button" variant="outline" disabled={working}>
+                  {questions.length === 1 ? "Skip" : "Skip all"}
+                  <ChevronDown aria-hidden="true" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start">
+                <DropdownMenuItem onClick={() => setShowContextForm(true)}>
+                  Add your own context
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={skipAll}>
+                  {questions.length === 1
+                    ? "Skip question"
+                    : "Skip these questions"}
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : (
             <Button
               type="button"
               variant="outline"
-              size="sm"
               disabled={working}
               onClick={() => setCurrentPage((page) => page - 1)}
             >
               Back
             </Button>
           )}
+
+          {questions.length > 1 && (
+            <div className="flex items-center gap-2">
+              {questions.map((entry, index) => (
+                <button
+                  key={entry.id}
+                  type="button"
+                  disabled={working}
+                  onClick={() => setCurrentPage(index)}
+                  className={cn(
+                    "h-2 w-2 rounded-full transition-colors",
+                    index === currentPage
+                      ? "bg-primary"
+                      : "bg-muted-foreground/30",
+                  )}
+                  aria-label={`Go to question ${index + 1}`}
+                  aria-current={index === currentPage ? "step" : undefined}
+                />
+              ))}
+            </div>
+          )}
+
+          <div className="flex gap-2">
+            {isLastPage ? (
+              <>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={working}
+                  onClick={() => setShowContextForm(true)}
+                >
+                  Continue and add context
+                </Button>
+                <Button
+                  type="button"
+                  disabled={working}
+                  onClick={() => submit()}
+                >
+                  {working ? "Sending…" : "Continue"}
+                  {!working && <CornerDownLeft aria-hidden="true" />}
+                </Button>
+              </>
+            ) : (
+              <Button
+                type="button"
+                variant="outline"
+                disabled={working}
+                onClick={() => setCurrentPage((page) => page + 1)}
+              >
+                Next
+              </Button>
+            )}
+          </div>
         </div>
-        {isLastPage ? (
-          <Button
-            type="button"
-            size="sm"
-            disabled={working}
-            onClick={submitAnswers}
-          >
-            {working ? "Sending…" : "Continue"}
-            {!working && <CornerDownLeft aria-hidden="true" />}
-          </Button>
-        ) : (
-          <Button
-            type="button"
-            size="sm"
-            disabled={working}
-            onClick={() => setCurrentPage((page) => page + 1)}
-          >
-            Next
-          </Button>
-        )}
       </div>
     </section>
   );

--- a/crates/openwave-desktop/ui/src/UserQuestionsResultCard.tsx
+++ b/crates/openwave-desktop/ui/src/UserQuestionsResultCard.tsx
@@ -1,0 +1,65 @@
+import type { AnsweredUserQuestion } from "./api";
+import { Separator } from "@/components/ui/separator";
+
+/**
+ * What a parked question round was answered with, once it has settled.
+ *
+ * The turn stopped to ask, so the transcript has to say what it was told —
+ * otherwise reopening a chat shows a gap where a decision was made. Labels
+ * rather than option ids: this is read by the person who chose them.
+ */
+export function UserQuestionsResultCard({
+  answers,
+  additionalContext,
+}: {
+  answers: AnsweredUserQuestion[];
+  additionalContext: string | null;
+}) {
+  const allSkipped = answers.every(
+    (answer) => answer.selected.length === 0 && !answer.customAnswer,
+  );
+
+  return (
+    <section className="bg-background rounded-lg border p-6">
+      {allSkipped ? (
+        <p className="text-muted-foreground text-sm">
+          All questions were skipped.
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {answers.map((answer, index) => {
+            const chosen = [
+              ...answer.selected,
+              ...(answer.customAnswer ? [answer.customAnswer] : []),
+            ];
+            return (
+              <div key={index} className="space-y-1">
+                <h4 className="text-sm font-medium break-words">
+                  {index + 1}. {answer.question}
+                </h4>
+                {chosen.length === 0 ? (
+                  <p className="text-muted-foreground text-sm">Skipped</p>
+                ) : (
+                  <p className="text-muted-foreground text-sm break-words italic">
+                    {chosen.join(", ")}
+                  </p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+      {additionalContext && (
+        <>
+          <Separator className="my-3" />
+          <div className="space-y-1">
+            <h4 className="text-sm font-medium">Additional context</h4>
+            <p className="text-muted-foreground text-sm break-words italic">
+              {additionalContext}
+            </p>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}

--- a/crates/openwave-desktop/ui/src/api/parsers.ts
+++ b/crates/openwave-desktop/ui/src/api/parsers.ts
@@ -3,6 +3,7 @@ import {
   type AgentActivityDetail,
   type AgentActivityKind,
   type AgentActivityOutcome,
+  type AnsweredUserQuestion as WireAnsweredUserQuestion,
   type PendingApprovalSnapshot,
   type ToolResultPreview as WireToolResultPreview,
   type PendingFolderAccessRequest as WirePendingFolderAccessRequest,
@@ -39,6 +40,7 @@ import {
   type ResultEntry,
   type ResultEntryKind,
   type ResultFailure,
+  type AnsweredUserQuestion,
   type SandboxAgentCancellation,
   type AgentRunTaskPlan,
   type TaskPlan,
@@ -945,6 +947,18 @@ type UncheckedEntriesResult = Partial<
   Record<keyof Extract<WireToolResultPreview, { tool: "entries" }>, unknown>
 >;
 
+type UncheckedUserQuestionsResult = Partial<
+  Record<keyof Extract<WireToolResultPreview, { tool: "user_questions" }>, unknown>
+>;
+
+type UncheckedPlanDecisionResult = Partial<
+  Record<keyof Extract<WireToolResultPreview, { tool: "plan_decision" }>, unknown>
+>;
+
+type UncheckedAnsweredUserQuestion = Partial<
+  Record<keyof WireAnsweredUserQuestion, unknown>
+>;
+
 const RESULT_ENTRY_KINDS: readonly ResultEntryKind[] = [
   "file",
   "folder",
@@ -1031,6 +1045,33 @@ function parseResultFailure(value: unknown): ResultFailure | null {
 }
 
 /**
+ * Validate one recap row.
+ *
+ * `selected` and `customAnswer` are both genuinely absent for a question the
+ * reader skipped, which is a row the card still shows — so their absence is
+ * normalized rather than rejected, and only a present value of the wrong type
+ * fails the row.
+ */
+function parseAnsweredUserQuestion(
+  value: unknown,
+): AnsweredUserQuestion | null {
+  if (!isRecord(value)) return null;
+  const { question, selected, custom_answer }: UncheckedAnsweredUserQuestion = value;
+  const labels = selected ?? [];
+  const custom = custom_answer ?? null;
+  if (
+    typeof question !== "string" ||
+    question.length === 0 ||
+    !Array.isArray(labels) ||
+    !labels.every((label) => typeof label === "string") ||
+    !isOptionalString(custom)
+  ) {
+    return null;
+  }
+  return { question, selected: labels as string[], customAnswer: custom };
+}
+
+/**
  * Validate a result field by field, on the same terms as an action: anything
  * that cannot be fully verified is dropped rather than half-rendered.
  */
@@ -1081,6 +1122,41 @@ export function parseToolResultPreview(
         Number(elided) +
         (entries.length - parsedEntries.length) +
         (failures.length - parsedFailures.length),
+    };
+  }
+  if (value.tool === "user_questions") {
+    const { answers, additional_context }: UncheckedUserQuestionsResult = value;
+    if (!Array.isArray(answers) || !isOptionalString(additional_context ?? null)) {
+      return null;
+    }
+    const parsed = answers
+      .map(parseAnsweredUserQuestion)
+      .filter((answer): answer is AnsweredUserQuestion => answer !== null);
+    // A recap that lost a row would misreport what the reader chose, so a
+    // malformed row takes the whole card down rather than being elided.
+    if (parsed.length !== answers.length) return null;
+    return {
+      tool: "user_questions",
+      answers: parsed,
+      additionalContext: (additional_context as string | undefined) ?? null,
+    };
+  }
+  if (value.tool === "plan_decision") {
+    const { title, plan, accepted, feedback }: UncheckedPlanDecisionResult = value;
+    if (
+      typeof title !== "string" ||
+      typeof plan !== "string" ||
+      typeof accepted !== "boolean" ||
+      !isOptionalString(feedback ?? null)
+    ) {
+      return null;
+    }
+    return {
+      tool: "plan_decision",
+      title,
+      plan,
+      accepted,
+      feedback: (feedback as string | undefined) ?? null,
     };
   }
   if (value.tool !== "exec") return null;

--- a/crates/openwave-desktop/ui/src/api/types.ts
+++ b/crates/openwave-desktop/ui/src/api/types.ts
@@ -504,7 +504,36 @@ export type ToolResultPreview =
       failures: ResultFailure[];
       /** Rows the server bounded away, counted rather than shown. */
       elided: number;
+    }
+  | {
+      /** The answers a parked question call was resolved with. */
+      tool: "user_questions";
+      answers: AnsweredUserQuestion[];
+      /** Whatever the reader added on their own, when they added any. */
+      additionalContext: string | null;
+    }
+  | {
+      /** The decision a parked plan proposal was resolved with. */
+      tool: "plan_decision";
+      title: string;
+      plan: string;
+      accepted: boolean;
+      /** What the reader asked to change, when they sent it back. */
+      feedback: string | null;
     };
+
+/**
+ * One question as it was asked, with what the reader chose.
+ *
+ * A question with neither a selection nor an answer was skipped, which the
+ * recap says out loud rather than omitting the row.
+ */
+export type AnsweredUserQuestion = {
+  question: string;
+  /** Option labels, in the order the question listed them. */
+  selected: string[];
+  customAnswer: string | null;
+};
 
 /** One row of a listed result. */
 export type ResultEntry = {

--- a/crates/openwave-desktop/ui/src/components/ui/radio-group.tsx
+++ b/crates/openwave-desktop/ui/src/components/ui/radio-group.tsx
@@ -1,0 +1,38 @@
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
+import { CircleIcon } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const RadioGroup = React.forwardRef<
+  React.ComponentRef<typeof RadioGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <RadioGroupPrimitive.Root
+    ref={ref}
+    className={cn("grid gap-2", className)}
+    {...props}
+  />
+));
+RadioGroup.displayName = RadioGroupPrimitive.Root.displayName;
+
+const RadioGroupItem = React.forwardRef<
+  React.ComponentRef<typeof RadioGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <RadioGroupPrimitive.Item
+    ref={ref}
+    className={cn(
+      "aspect-square size-4 shrink-0 cursor-pointer rounded-full border border-primary text-primary ring-offset-background focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+      <CircleIcon className="size-2.5 fill-current text-current" />
+    </RadioGroupPrimitive.Indicator>
+  </RadioGroupPrimitive.Item>
+));
+RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName;
+
+export { RadioGroup, RadioGroupItem };

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -227,6 +227,28 @@ current: string | null, updated_at: string, };
 export type AgentRunTier = "foreground" | "background";
 
 /**
+ * One question as it was asked, with what the reader chose.
+ *
+ * Labels rather than option ids: the recap is read by a person, and the ids
+ * are an internal handle they never saw. A question the reader skipped
+ * carries neither a selection nor an answer, which is how the card knows to
+ * say so.
+ */
+export type AnsweredUserQuestion = { 
+/**
+ * The prompt the reader answered.
+ */
+question: string, 
+/**
+ * Labels of the options chosen, in the order the question listed them.
+ */
+selected?: Array<string>, 
+/**
+ * The reader's own words, when the question allowed them.
+ */
+custom_answer?: string, };
+
+/**
  * One app's detail: the summary fields plus its revision history.
  */
 export type AppDetail = { id: AppId, name: string, 
@@ -2425,7 +2447,19 @@ failures: Array<ResultFailure>,
  * that silently lists the first fifty of two hundred results is
  * telling the reader something false.
  */
-elided: number, };
+elided: number, } | { "tool": "user_questions", answers: Array<AnsweredUserQuestion>, 
+/**
+ * Whatever the reader added on their own, when they added any.
+ */
+additional_context?: string, } | { "tool": "plan_decision", title: string, plan: string, 
+/**
+ * Whether the reader approved the plan as proposed.
+ */
+accepted: boolean, 
+/**
+ * What the reader asked to change, when they sent it back.
+ */
+feedback?: string, };
 
 /**
  * One renderer-safe source document attached to a historical user message.

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -372,6 +372,9 @@ body {
   min-height: 0;
   min-width: 0;
   overflow: clip;
+  /* A plan card taken full screen fills the pane, not the window: the pane is
+     the positioning context it expands into. */
+  position: relative;
 }
 
 /* ---------- Agent activity ---------- */

--- a/crates/openwave-server/src/routes/plans.rs
+++ b/crates/openwave-server/src/routes/plans.rs
@@ -54,7 +54,15 @@ pub async fn decide_plan(
         )
         .await?;
     let (disposition, turn) = match outcome {
-        DecidePlanOutcome::Decided(turn) => (PlanDecisionDisposition::Decided, turn),
+        DecidePlanOutcome::Decided {
+            turn,
+            completion_event,
+        } => {
+            // Live delivery of the journaled completion; replay covers anyone
+            // not connected, so a missed send is not a correctness gap.
+            let _ = state.events.sender(chat_id).send(*completion_event);
+            (PlanDecisionDisposition::Decided, turn)
+        }
         DecidePlanOutcome::Existing(turn) => (PlanDecisionDisposition::Existing, turn),
         DecidePlanOutcome::DecisionConflict => {
             return Err(ServerError::conflict(format!(


### PR DESCRIPTION
## What changed

**Placement.** A parked question or proposed plan now stands in the composer's slot instead of rendering inline. It is not a message in the transcript — it is the turn asking for one thing back, and until it gets it there is nothing else to send. Inline, the card scrolls away under a composer that keeps inviting a reply the turn will not read. Tool approval cards stay inline, where the command they describe is.

**Question card.** Rebuilt around the interactions it was missing:

- A labelled skip menu on the footer ("Add your own context" / "Skip these questions") in place of an unlabelled ✕ as the only way out. The ✕ is still there in the header.
- Additional context moves to a page of its own, reached from the skip menu or "Continue and add context" on the last question, replacing the always-visible textarea that asked for something most rounds don't want.
- Back on the footer's left, and the dot pager centred between it and the primary action.
- Options are shadcn `Checkbox` / `RadioGroupItem` rows with the whole row as the hit target. This adds `@radix-ui/react-radio-group` (exact pin, matching the lockfile) and vendors `components/ui/radio-group.tsx`.

**Plan card.** The "Request changes" textarea is gone. Revision is done in the plan itself: hover any block, leave a note, and a footer that reads "N edits added" sends them back. The collected notes serialise into markdown — each a blockquote of the block it addresses, followed by the note — and go out as the single `feedback` string `decidePlan`'s reject path already takes, so the server contract is unchanged. Comments live in a small zustand store keyed by call id and persisted to `localStorage`, which is what keeps a half-written round of edits from evaporating on a reload. The card also gains a fullscreen toggle (it expands into the chat pane, which needed `position: relative`) and top/bottom scroll fades.

This is backed by a new optional `wrapBlock` prop on `MessageMarkdown`: when supplied it wraps `p`, `li`, `blockquote`, and `pre` in caller chrome, addressed by the raw source slice the parser recorded for each block. Absent, it costs nothing.

**Settled results.** Neither tool left anything behind once it resolved. An answered question journalled its `ToolCallCompleted` with `result: None`, a decided plan journalled no completion event at all, and neither wrote the `tool_call.result_preview` column history rehydration reads — so reopening a chat showed a bare rail line where a decision had been made.

Both now build a closed `ToolResultPreview` at the commit that makes the call terminal and store it alongside the result. `UserQuestions` carries each question with the option *labels* chosen (the ids are an internal handle the reader never saw) and any custom answer; a question with neither is how the card knows to say "Skipped". `PlanDecision` carries the title, the plan, the decision, and the feedback. The plan path additionally journals a completion event, mirroring the questions path, and `routes/plans.rs` broadcasts it so the live transcript settles without waiting for terminal hydration. `DecidePlanOutcome::Decided` became a struct variant to carry it.

**Approval ladder.** `INLINE_GRANTS` 1 → 2, and a lone remaining row is no longer folded. Before, four grants rendered as three rows plus "show all" — a click to reveal exactly what it had hidden.

## Tests

- Extended three existing Rust tests rather than adding new ones: the questions round-trip test now asserts the stored preview and the broadcast event carry the two-row recap and the additional context; the accept and reject plan tests assert the decision, feedback, and stored column.
- UI: the question card's context flow, Back/forward paging keeping answers, and skip-through-the-menu; the plan card's accept, comment → "1 edit added" → serialised feedback, and cancel-edits; one test file for the two recap cards.
- Deleted the assertions pinned to the removed additional-context and "Request changes" textareas rather than adapting them — they described controls that no longer exist.

## Verification

`cargo fmt --check`, `cargo check -p openwave-core -p openwave-server --all-targets --locked`, `cargo test -p openwave-core -- user_question plan` (18), the wire-generation test, `tsc`, `pnpm test` (827 across 124 files), and `pnpm build` all pass locally. Labelled `full-ci` because this crosses the Rust/UI boundary and regenerates the wire types.

I have not driven a live turn to a parked question or a proposed plan.