### PR TITLE
fix(core): delete plan_request rows when deleting a chat

### DIFF
--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -595,6 +595,14 @@ pub(in crate::db) async fn delete_chat(
         .exec(&transaction)
         .await
         .map_err(store_err)?;
+    // A plan request restricts against the chat, its turn, the call that
+    // proposed it, and the journal row carrying its renderer hint, so it goes
+    // before all four.
+    entities::plan_request::Entity::delete_many()
+        .filter(entities::plan_request::Column::ChatId.eq(chat_id.0))
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
     // The task plan restricts against the chat, its last-writing turn, and the
     // call that wrote it, so it goes before all three.
     entities::task_plan::Entity::delete_many()

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -7599,6 +7599,52 @@ async fn delete_chat_erases_quiesced_history_and_fails_closed_for_live_work_or_r
     );
     assert_eq!(store.get_task_plan(active.id).await.unwrap(), None);
 
+    // A plan request restricts against the chat, its turn, the proposing call,
+    // and the journal row holding its renderer hint. Before deletion erased it,
+    // any chat that ever left plan mode was undeletable.
+    let planned = Chat {
+        permission_mode: Some(crate::PermissionMode::Plan),
+        ..sample_chat()
+    };
+    store.create_chat(&planned).await.unwrap();
+    let (planned_turn_id, plan_call, parked_at) = park_test_plan(&store, planned.id).await;
+    let decided_at = parked_at + chrono::Duration::seconds(1);
+    assert!(matches!(
+        store
+            .decide_plan(
+                &crate::DecidePlanRequest {
+                    chat_id: planned.id,
+                    call_id: plan_call.id,
+                    decision: crate::PlanDecision {
+                        decision: crate::PlanDecisionChoice::Accept,
+                        feedback: None,
+                        permission_mode: None,
+                    },
+                },
+                decided_at,
+            )
+            .await
+            .unwrap(),
+        crate::storage::DecidePlanOutcome::Decided(_)
+    ));
+    let planned_turn = store.get_turn_run(planned_turn_id).await.unwrap().unwrap();
+    store
+        .request_turn_cancellation_and_append_event(
+            planned_turn_id,
+            planned_turn.updated_at + chrono::Duration::seconds(1),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        store.delete_chat(planned.id).await.unwrap(),
+        DeleteChatOutcome::Deleted
+    );
+    assert!(store
+        .list_pending_plan_approvals(planned.id)
+        .await
+        .unwrap()
+        .is_empty());
+
     let root = HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap();
     let mut rooted = sample_chat();
     rooted.attachment_revision = 1;


### PR DESCRIPTION
## Bug

`delete_chat` hand-enumerates every dependent table with `ON DELETE RESTRICT` foreign keys before it deletes `turn_run` and `chat`, and `plan_request` was never added to that list. `plan_request` restricts against `tool_call`, `turn_run`, `chat`, and the `event` row that carries its renderer hint, so any chat where `exit_plan_mode` ever checkpointed a plan failed deletion with a foreign-key violation (SQLite code 1811; Postgres enforces the same). `DELETE /chats/{id}` returned 500 for that chat forever.

## Fix

Delete the chat's `plan_request` rows ahead of the `tool_call`, `event`, `turn_run`, and `chat` deletes — the same slot the `task_plan` delete occupies, which shares three of the four references.

I also swept the baseline for every table with a `Restrict` foreign key and diffed the sources against what `delete_chat` erases. `plan_request` was the only gap: `exec_file_snapshot` and `message_attachment` look absent from the function body but are erased through their own `delete_for_chat_on` helpers, and everything else is enumerated inline.

## Test

`delete_chat_erases_quiesced_history_and_fails_closed_for_live_work_or_roots` grows one case: a plan-mode chat that parks a real `exit_plan_mode` call through `park_test_plan`, accepts the plan, terminalizes the turn, and then deletes. With the new delete removed the case fails on the exact reported error — `(code: 1811) FOREIGN KEY constraint failed` — so it pins the regression rather than the code path's existence.

Closes #1763