### PR TITLE
fix(server): scope plan and question routes to the requesting principal

### DIFF
--- a/crates/openwave-server/src/routes/client_execution.rs
+++ b/crates/openwave-server/src/routes/client_execution.rs
@@ -22,6 +22,7 @@ use openwave_core::{
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
 use crate::principal::ClientExecutor;
+use crate::scoped_store::ScopedStore;
 use crate::state::AppState;
 
 const CLIENT_EXECUTION_LEASE: Duration = Duration::seconds(60);
@@ -175,12 +176,11 @@ pub struct PendingOutputWritebackRequest {
 /// Unknown, malformed, or non-folder-access client calls are omitted rather
 /// than exposing their canonical records across the renderer boundary.
 pub async fn list_pending_folder_access_requests(
-    State(state): State<AppState>,
+    store: ScopedStore,
     Path(id): Path<ChatId>,
 ) -> Result<Json<Vec<PendingFolderAccessRequest>>, ServerError> {
-    ensure_chat(&state, id).await?;
-    let requests = state
-        .store
+    store.require_chat(id).await?;
+    let requests = store
         .list_pending_client_tool_calls(id)
         .await?
         .into_iter()
@@ -194,12 +194,11 @@ pub async fn list_pending_folder_access_requests(
 /// Create/no-clobber calls are handled automatically by the native executor and
 /// are intentionally omitted from the renderer.
 pub async fn list_pending_output_writebacks(
-    State(state): State<AppState>,
+    store: ScopedStore,
     Path(id): Path<ChatId>,
 ) -> Result<Json<Vec<PendingOutputWritebackRequest>>, ServerError> {
-    ensure_chat(&state, id).await?;
-    let requests = state
-        .store
+    store.require_chat(id).await?;
+    let requests = store
         .list_pending_client_tool_calls(id)
         .await?
         .into_iter()
@@ -210,14 +209,13 @@ pub async fn list_pending_output_writebacks(
 
 /// Native-only authoritative pending work used by the trusted executor.
 pub async fn list_pending_client_executions_raw(
-    State(state): State<AppState>,
+    store: ScopedStore,
     _executor: ClientExecutor,
     Path(id): Path<ChatId>,
 ) -> Result<Json<Vec<ToolCallRecord>>, ServerError> {
-    ensure_chat(&state, id).await?;
+    store.require_chat(id).await?;
     Ok(Json(
-        state
-            .store
+        store
             .list_pending_client_tool_calls(id)
             .await?
             .into_iter()
@@ -269,17 +267,16 @@ fn renderer_output_writeback_request(
 
 /// `POST .../{call_id}/claim` — atomically acquire or recover one exact claim.
 pub async fn claim_client_execution(
-    State(state): State<AppState>,
+    store: ScopedStore,
     _executor: ClientExecutor,
     Path((id, call_id)): Path<(ChatId, CallId)>,
     Json(body): Json<ClaimClientExecution>,
 ) -> Result<Json<ClaimedClientExecution>, ServerError> {
-    ensure_chat(&state, id).await?;
+    store.require_chat(id).await?;
     ensure_non_nil(body.executor_id, "executor_id")?;
     ensure_non_nil(body.lease_token, "lease_token")?;
     let now = Utc::now();
-    let outcome = state
-        .store
+    let outcome = store
         .claim_client_tool_call(
             call_id,
             id,
@@ -309,16 +306,15 @@ pub async fn claim_client_execution(
 /// Heartbeats are monotonic liveness updates rather than exact commands: a
 /// repeated request can extend the lease again from its new server receive time.
 pub async fn heartbeat_client_execution(
-    State(state): State<AppState>,
+    store: ScopedStore,
     _executor: ClientExecutor,
     Path((id, call_id)): Path<(ChatId, CallId)>,
     Json(body): Json<HeartbeatClientExecution>,
 ) -> Result<Json<ClientExecutionHeartbeat>, ServerError> {
-    ensure_chat(&state, id).await?;
+    store.require_chat(id).await?;
     ensure_non_nil(body.lease_token, "lease_token")?;
     let now = Utc::now();
-    let disposition = match state
-        .store
+    let disposition = match store
         .heartbeat_client_tool_call(
             call_id,
             id,
@@ -346,18 +342,18 @@ pub async fn heartbeat_client_execution(
 /// with the first committed result.
 pub async fn resolve_client_execution(
     State(state): State<AppState>,
+    store: ScopedStore,
     _executor: ClientExecutor,
     Path((id, call_id)): Path<(ChatId, CallId)>,
     Json(body): Json<ResolveClientExecution>,
 ) -> Result<Json<ResolvedClientExecution>, ServerError> {
-    ensure_chat(&state, id).await?;
+    store.require_chat(id).await?;
     ensure_non_nil(body.lease_token, "lease_token")?;
     let rows = body.resolution.rows().cloned();
     let resolution = body.resolution.into_core();
     validate_resolution(&resolution)?;
     let now = Utc::now();
-    let mut resolution_receipt = state
-        .store
+    let mut resolution_receipt = store
         .resolve_client_tool_call_and_append_event_with_rows(
             call_id,
             id,
@@ -369,8 +365,7 @@ pub async fn resolve_client_execution(
         )
         .await?;
     if resolution_receipt.outcome == ResolveToolCallOutcome::LeaseLost {
-        resolution_receipt = state
-            .store
+        resolution_receipt = store
             .resolve_expired_client_tool_call_and_append_event_with_rows(
                 call_id,
                 id,
@@ -413,13 +408,6 @@ pub async fn resolve_client_execution(
         state.turn_job_wake.notify_one();
     }
     Ok(Json(ResolvedClientExecution { disposition }))
-}
-
-async fn ensure_chat(state: &AppState, id: ChatId) -> Result<(), ServerError> {
-    if state.store.get_chat(id).await?.is_none() {
-        return Err(ServerError::not_found(format!("chat {id} not found")));
-    }
-    Ok(())
 }
 
 fn ensure_non_nil(value: uuid::Uuid, field: &str) -> Result<(), ServerError> {

--- a/crates/openwave-server/src/routes/image_attachment.rs
+++ b/crates/openwave-server/src/routes/image_attachment.rs
@@ -35,6 +35,7 @@ use openwave_core::{
 use crate::error::ServerError;
 use crate::extract::{Path, RawBytes};
 use crate::routes::SERVED_BYTES_CONTENT_POLICY;
+use crate::scoped_store::ScopedStore;
 use crate::state::AppState;
 
 /// Body limit for the publish endpoint, matching the durable per-image ceiling
@@ -81,13 +82,12 @@ impl From<ImageRef> for PublishedImageAttachment {
 /// identical bytes twice yields the same id and one stored copy.
 pub async fn publish_chat_image_attachment(
     State(state): State<AppState>,
+    store: ScopedStore,
     Path(chat_id): Path<ChatId>,
     headers: HeaderMap,
     RawBytes(bytes): RawBytes,
 ) -> Result<impl IntoResponse, ServerError> {
-    if state.store.get_chat(chat_id).await?.is_none() {
-        return Err(ServerError::not_found(format!("chat {chat_id} not found")));
-    }
+    store.require_chat(chat_id).await?;
     let bytes = bytes.to_vec();
     let image = inspect_image_bytes(&bytes)?;
     require_declared_type_matches(&headers, image.media_type)?;
@@ -112,21 +112,18 @@ pub async fn publish_chat_image_attachment(
 /// chat before bytes can cross this endpoint.
 pub async fn get_chat_image_attachment(
     State(state): State<AppState>,
+    store: ScopedStore,
     Path((chat_id, attachment_id)): Path<(ChatId, Uuid)>,
 ) -> Result<Response, ServerError> {
-    if state.store.get_chat(chat_id).await?.is_none() {
-        return Err(ServerError::not_found(format!("chat {chat_id} not found")));
-    }
-    let message_image = state
-        .store
+    store.require_chat(chat_id).await?;
+    let message_image = store
         .list_message_attachments(chat_id)
         .await?
         .into_iter()
         .find(|attachment| attachment.image.blob_id == attachment_id)
         .map(|attachment| attachment.image);
     let tool_image = if message_image.is_none() {
-        state
-            .store
+        store
             .list_tool_calls(chat_id)
             .await?
             .into_iter()

--- a/crates/openwave-server/src/routes/plans.rs
+++ b/crates/openwave-server/src/routes/plans.rs
@@ -10,19 +10,18 @@ use serde::Serialize;
 
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
+use crate::scoped_store::ScopedStore;
 use crate::state::AppState;
 
 /// A conservative body cap above the validated semantic limits.
 pub const MAX_PLAN_DECISION_BODY_BYTES: usize = 16 * 1024;
 
 pub async fn list_pending_plan_approvals(
-    State(state): State<AppState>,
+    store: ScopedStore,
     Path(chat_id): Path<ChatId>,
 ) -> Result<Json<Vec<PendingPlanApproval>>, ServerError> {
-    ensure_chat(&state, chat_id).await?;
-    Ok(Json(
-        state.store.list_pending_plan_approvals(chat_id).await?,
-    ))
+    store.require_chat(chat_id).await?;
+    Ok(Json(store.list_pending_plan_approvals(chat_id).await?))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -39,12 +38,12 @@ pub struct DecidedPlan {
 
 pub async fn decide_plan(
     State(state): State<AppState>,
+    store: ScopedStore,
     Path((chat_id, call_id)): Path<(ChatId, CallId)>,
     Json(decision): Json<PlanDecision>,
 ) -> Result<Json<DecidedPlan>, ServerError> {
-    ensure_chat(&state, chat_id).await?;
-    let outcome = state
-        .store
+    store.require_chat(chat_id).await?;
+    let outcome = store
         .decide_plan(
             &DecidePlanRequest {
                 chat_id,
@@ -77,11 +76,4 @@ pub async fn decide_plan(
         state.turn_job_wake.notify_one();
     }
     Ok(Json(DecidedPlan { disposition }))
-}
-
-async fn ensure_chat(state: &AppState, chat_id: ChatId) -> Result<(), ServerError> {
-    if state.store.get_chat(chat_id).await?.is_none() {
-        return Err(ServerError::not_found(format!("chat {chat_id} not found")));
-    }
-    Ok(())
 }

--- a/crates/openwave-server/src/routes/user_questions.rs
+++ b/crates/openwave-server/src/routes/user_questions.rs
@@ -10,19 +10,18 @@ use serde::Serialize;
 
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
+use crate::scoped_store::ScopedStore;
 use crate::state::AppState;
 
 /// A conservative body cap above the validated semantic limits.
 pub const MAX_USER_QUESTION_ANSWER_BODY_BYTES: usize = 8 * 1024;
 
 pub async fn list_pending_user_questions(
-    State(state): State<AppState>,
+    store: ScopedStore,
     Path(chat_id): Path<ChatId>,
 ) -> Result<Json<Vec<PendingUserQuestions>>, ServerError> {
-    ensure_chat(&state, chat_id).await?;
-    Ok(Json(
-        state.store.list_pending_user_questions(chat_id).await?,
-    ))
+    store.require_chat(chat_id).await?;
+    Ok(Json(store.list_pending_user_questions(chat_id).await?))
 }
 
 /// `GET /chats/pending-prompts` — opaque cross-conversation attention state.
@@ -50,12 +49,12 @@ pub struct AnsweredUserQuestions {
 
 pub async fn answer_user_questions(
     State(state): State<AppState>,
+    store: ScopedStore,
     Path((chat_id, call_id)): Path<(ChatId, CallId)>,
     Json(answers): Json<AnswerUserQuestions>,
 ) -> Result<Json<AnsweredUserQuestions>, ServerError> {
-    ensure_chat(&state, chat_id).await?;
-    let outcome = state
-        .store
+    store.require_chat(chat_id).await?;
+    let outcome = store
         .answer_user_questions(
             &AnswerUserQuestionsRequest {
                 chat_id,
@@ -96,11 +95,4 @@ pub async fn answer_user_questions(
         state.turn_job_wake.notify_one();
     }
     Ok(Json(AnsweredUserQuestions { disposition }))
-}
-
-async fn ensure_chat(state: &AppState, chat_id: ChatId) -> Result<(), ServerError> {
-    if state.store.get_chat(chat_id).await?.is_none() {
-        return Err(ServerError::not_found(format!("chat {chat_id} not found")));
-    }
-    Ok(())
 }

--- a/crates/openwave-server/src/scoped_store.rs
+++ b/crates/openwave-server/src/scoped_store.rs
@@ -25,14 +25,18 @@ use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
 use axum::http::StatusCode;
 
+use openwave_core::storage::DecidePlanOutcome;
 use openwave_core::{
-    AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentRun, AgentRunId, AgentRunResult, CallId, Chat,
-    ChatId, ChatTranscriptSnapshot, DeleteChatOutcome, DeleteProjectOutcome, DocumentId,
-    DocumentListCursor, DocumentRecord, DocumentScope, DocumentSourceUpsert, DocumentSummaryRecord,
-    ImageRef, JournaledTurnOutcome, NetworkPolicy, OwnerId, PermissionMode, Project, ProjectId,
+    AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentRun, AgentRunId, AgentRunResult,
+    AnswerUserQuestionsOutcome, AnswerUserQuestionsRequest, CallId, Chat, ChatId,
+    ChatTranscriptSnapshot, ClaimClientToolCallOutcome, DecidePlanRequest, DeleteChatOutcome,
+    DeleteProjectOutcome, DocumentId, DocumentListCursor, DocumentRecord, DocumentScope,
+    DocumentSourceUpsert, DocumentSummaryRecord, HeartbeatClientToolCallOutcome, ImageRef,
+    JournaledClientToolCallOutcome, JournaledTurnOutcome, MessageAttachment, NetworkPolicy,
+    OwnerId, PendingPlanApproval, PendingUserQuestions, PermissionMode, Project, ProjectId,
     ReasoningEffort, RequestAgentRunCancellationOutcome, RequestTurnCancellationOutcome, Result,
     SandboxAgentAdmission, SandboxToolCall, SandboxToolCallReceipt, SequencedEvent, Store,
-    TaskPlan, ToolApproval, ToolCallRecord, TurnId, TurnRun, TurnSteerId,
+    TaskPlan, ToolApproval, ToolCallRecord, ToolCallResolution, TurnId, TurnRun, TurnSteerId,
 };
 
 use crate::error::ServerError;
@@ -388,6 +392,132 @@ impl ScopedStore {
     /// [`Store::get_task_plan`].
     pub async fn get_task_plan(&self, chat_id: ChatId) -> Result<Option<TaskPlan>> {
         self.store.get_task_plan(chat_id).await
+    }
+
+    /// [`Store::list_pending_plan_approvals`].
+    pub async fn list_pending_plan_approvals(
+        &self,
+        chat_id: ChatId,
+    ) -> Result<Vec<PendingPlanApproval>> {
+        self.store.list_pending_plan_approvals(chat_id).await
+    }
+
+    /// [`Store::decide_plan`].
+    pub async fn decide_plan(
+        &self,
+        request: &DecidePlanRequest,
+        decided_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<DecidePlanOutcome> {
+        self.store.decide_plan(request, decided_at).await
+    }
+
+    /// [`Store::list_pending_user_questions`].
+    pub async fn list_pending_user_questions(
+        &self,
+        chat_id: ChatId,
+    ) -> Result<Vec<PendingUserQuestions>> {
+        self.store.list_pending_user_questions(chat_id).await
+    }
+
+    /// [`Store::answer_user_questions`].
+    pub async fn answer_user_questions(
+        &self,
+        request: &AnswerUserQuestionsRequest,
+        answered_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<AnswerUserQuestionsOutcome> {
+        self.store.answer_user_questions(request, answered_at).await
+    }
+
+    /// [`Store::list_message_attachments`].
+    pub async fn list_message_attachments(
+        &self,
+        chat_id: ChatId,
+    ) -> Result<Vec<MessageAttachment>> {
+        self.store.list_message_attachments(chat_id).await
+    }
+
+    /// [`Store::list_tool_calls`].
+    pub async fn list_tool_calls(&self, chat_id: ChatId) -> Result<Vec<ToolCallRecord>> {
+        self.store.list_tool_calls(chat_id).await
+    }
+
+    /// [`Store::claim_client_tool_call`].
+    pub async fn claim_client_tool_call(
+        &self,
+        id: CallId,
+        chat_id: ChatId,
+        executor_id: uuid::Uuid,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+        lease_expires_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<ClaimClientToolCallOutcome> {
+        self.store
+            .claim_client_tool_call(id, chat_id, executor_id, lease_token, now, lease_expires_at)
+            .await
+    }
+
+    /// [`Store::heartbeat_client_tool_call`].
+    pub async fn heartbeat_client_tool_call(
+        &self,
+        id: CallId,
+        chat_id: ChatId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+        lease_expires_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<HeartbeatClientToolCallOutcome> {
+        self.store
+            .heartbeat_client_tool_call(id, chat_id, lease_token, now, lease_expires_at)
+            .await
+    }
+
+    /// [`Store::resolve_client_tool_call_and_append_event_with_rows`].
+    #[allow(clippy::too_many_arguments)]
+    pub async fn resolve_client_tool_call_and_append_event_with_rows(
+        &self,
+        id: CallId,
+        chat_id: ChatId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+        resolution: &ToolCallResolution,
+        resolved_at: chrono::DateTime<chrono::Utc>,
+        rows: Option<&serde_json::Value>,
+    ) -> Result<JournaledClientToolCallOutcome> {
+        self.store
+            .resolve_client_tool_call_and_append_event_with_rows(
+                id,
+                chat_id,
+                lease_token,
+                now,
+                resolution,
+                resolved_at,
+                rows,
+            )
+            .await
+    }
+
+    /// [`Store::resolve_expired_client_tool_call_and_append_event_with_rows`].
+    #[allow(clippy::too_many_arguments)]
+    pub async fn resolve_expired_client_tool_call_and_append_event_with_rows(
+        &self,
+        id: CallId,
+        chat_id: ChatId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+        resolution: &ToolCallResolution,
+        resolved_at: chrono::DateTime<chrono::Utc>,
+        rows: Option<&serde_json::Value>,
+    ) -> Result<JournaledClientToolCallOutcome> {
+        self.store
+            .resolve_expired_client_tool_call_and_append_event_with_rows(
+                id,
+                chat_id,
+                lease_token,
+                now,
+                resolution,
+                resolved_at,
+                rows,
+            )
+            .await
     }
 }
 

--- a/crates/openwave-server/src/tests/lifecycle.rs
+++ b/crates/openwave-server/src/tests/lifecycle.rs
@@ -3162,6 +3162,24 @@ async fn routes_scope_root_aggregates_to_the_requesting_principal() {
         "a listing never carries another owner's rows"
     );
 
+    // The parked-work recovery routes hang off the same gate: a pending plan
+    // approval or question set is only reachable through the chat that owns it.
+    for path in ["plans/pending", "questions/pending", "task-plan"] {
+        assert_eq!(
+            get(alice, format!("/chats/{}/{path}", chat.id))
+                .await
+                .status(),
+            StatusCode::OK
+        );
+        assert_eq!(
+            get(bob, format!("/chats/{}/{path}", chat.id))
+                .await
+                .status(),
+            StatusCode::NOT_FOUND,
+            "{path} must not answer for another owner's chat"
+        );
+    }
+
     // Mutations answer the same way: nothing to patch, nothing to delete.
     let patch = router
         .clone()


### PR DESCRIPTION
## The rule

`crates/openwave-server/src/scoped_store.rs` states it: route handlers do not
touch `Store` directly. They extract a `ScopedStore` — the store bound to the
requesting principal's `OwnerId` — so route code cannot express a query that
crosses owners. Root aggregates go through the owner-scoped trait variants;
non-root reads hang off a root the handler has already authorized through the
view. `routes/events.rs` and `routes/task_plan.rs` are the canonical shape.

## The violations

`routes/plans.rs` and `routes/user_questions.rs` took `State<AppState>` and did
both halves on the unscoped handle: an inline `state.store.get_chat(id)` gate
followed by `list_pending_plan_approvals` / `list_pending_user_questions` and
the decide/answer command. On a multi-principal deployment the gate passes for
any chat that exists, so principal B could read and act on principal A's parked
plan approval or question set by naming their chat id.

Both handlers now extract `ScopedStore` and gate on `require_chat`. The payload
reads and the two commands are added as pass-throughs beside the existing
non-root operations, following how `get_task_plan` was added.

## Sweep

Every other handler in `routes/` that reaches `state.store`:

Converted — same chat-scoped gate, same inline `get_chat` check:

- `routes/image_attachment.rs` — publish and fetch. The fetch path returns
  image bytes, so the gate was the only thing standing between a principal and
  another's attachment pixels.
- `routes/client_execution.rs` — all six handlers (the two renderer pending
  lists, the raw executor list, claim, heartbeat, resolve). The
  `ClientExecutor` extractor is a capability bit on an existing context, not an
  identity, so scoping these to the presenting principal is what the principal
  module already says should happen.

Left alone, deliberately:

- `routes/settings.rs`, `routes/providers_models.rs`, `routes/plugins.rs`,
  `routes/mcp_gateway.rs`, `routes/connected_apps.rs`, `routes/app_library.rs`,
  `routes/app_grant.rs`, `routes/app_invoke.rs` — deployment-scoped config,
  provider credentials, model catalog, and the app registry. Not chat-scoped;
  scoping them is a separate design question, not a bug.
- `routes/settings.rs` file-change undo/preview and `routes/agent_runs.rs`
  already take `ScopedStore` and gate on it; their remaining `state.store`
  uses are post-commit signalling helpers, which are not request paths.
- `routes/events.rs` uses `&*state.store` for WebSocket replay, but only after
  `store.require_chat`. That is the documented shape, not a lapse.
- `routes/projects_chats.rs` and `routes/turn_control.rs` use `state.store`
  only for sticky defaults and model-policy resolution.

Ambiguous, left as-is:

- `routes/user_questions.rs::list_pending_chat_prompts` (`GET
  /chats/pending-prompts`) is a cross-chat summary with no owner scoping and no
  scoped variant on the trait. It is the same shape as `list_inbox_items`,
  which does have a `_scoped` variant, so the fix is presumably a
  `list_pending_chat_prompts_scoped` in core with SQLite and Postgres
  implementations — out of scope for a route-layer change.
- `routes/root_attachment.rs` scopes by `client_executor_id` rather than by
  chat, and `begin_root_attachment_change` never checks chat ownership at all
  (it relies on the store's own `ChatNotFound` outcome). Whether that surface
  should be principal-scoped or stay executor-scoped is a design call.

## Behavior

The 404 is unchanged. Each removed inline check produced exactly the message
`require_chat` produces (`chat {id} not found`) with the same status, so no
response shape moved and no existing test expectation needed editing.

On the desktop profile `ScopedStore` resolves the principal to the fixed
`OwnerId::local` key for every request, so the narrowing is transparent: the
scoped store queries are the same queries against the one owner that owns
every row.

## Tests

No new test. The existing
`routes_scope_root_aggregates_to_the_requesting_principal` in
`src/tests/lifecycle.rs` already stands up a two-user self-host router and
walks the cross-owner assertions, so the three recovery routes were added to
its loop rather than duplicated into a new test. Full `openwave-server` suite
passes (644 tests), plus `cargo check --workspace --locked` with no lock diff,
fmt, and clippy `--all-targets -D warnings` on `openwave-server`.
