### PR TITLE
fix(release): reject malformed PR title scopes

### DIFF
--- a/scripts/check-pr-title.mjs
+++ b/scripts/check-pr-title.mjs
@@ -19,7 +19,7 @@ export const ALLOWED_TYPES = [
 const RELEASING_TYPES = new Set(["feat", "fix", "perf", "deps", "revert"]);
 
 const TITLE_PATTERN = new RegExp(
-  `^(${ALLOWED_TYPES.join("|")})(?:\\(([a-z0-9][a-z0-9._/-]*)\\))?(!)?: (\\S.*)$`,
+  `^(${ALLOWED_TYPES.join("|")})(?:\\(([a-z0-9]+(?:[._/-][a-z0-9]+)*)\\))?(!)?: (\\S.*)$`,
 );
 
 export function parsePrTitle(title) {

--- a/scripts/check-pr-title.test.mjs
+++ b/scripts/check-pr-title.test.mjs
@@ -10,6 +10,7 @@ for (const title of [
   "deps(cargo): update database dependencies",
   "revert: restore the previous storage behavior",
   "ci(deps): update the checkout action",
+  "fix(desktop/ui): preserve release formatting",
   "chore(main): release 0.1.0",
 ]) {
   test(`accepts ${title}`, () => {
@@ -50,6 +51,8 @@ for (const title of [
   "Add document search",
   "feature: add document search",
   "feat(Core): add document search",
+  "fix(ui/): keep release automation running",
+  "fix(ui//tests): keep release automation running",
   "feat: ",
   "feat(core) add document search",
   "refactor(core)!: replace the public API",

--- a/scripts/format-release-notes.test.mjs
+++ b/scripts/format-release-notes.test.mjs
@@ -68,3 +68,11 @@ test("uses readable acronyms in singleton scope prefixes", () => {
 `,
   );
 });
+
+test("keeps historical titles with malformed scopes without crashing", () => {
+  const notes = `### Bug Fixes
+- fix(ui/): keep release automation running ([#20](https://example.com/20)) by @octo
+`;
+
+  assert.equal(formatReleaseNotes(notes), notes);
+});


### PR DESCRIPTION
## What changed

The semantic title policy now requires every scope segment to be non-empty while preserving the supported `.`, `_`, `/`, and `-` separators. Titles such as `fix(ui/): ...` and `fix(ui//tests): ...` are rejected before merge, while existing scopes such as `host-broker` and `desktop/ui` remain valid.

This closes the gap where CI accepted a title that made the post-merge release-note formatter call `toUpperCase()` on an empty scope segment and crash the release-draft workflow. Historical malformed entries are treated as unparsed release-note lines, so formatting remains fail-safe.

## Tests

- `node --test scripts/*.test.mjs` (89 passed)
- `node --test scripts/check-pr-title.test.mjs scripts/format-release-notes.test.mjs` after rebasing onto current `main` (24 passed)
- `git diff --check origin/main...HEAD`

Closes #1780