### PR TITLE
fix(desktop): surface network policy save failures

### DIFF
--- a/crates/openwave-desktop/ui/src/NetworkPolicyDialog.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/NetworkPolicyDialog.dom.test.tsx
@@ -71,11 +71,16 @@ describe("NetworkPolicyDialog", () => {
     const internetAccess = screen
       .getByText(/Reach public internet destinations/i)
       .closest("button")!;
+    expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
+
     fireEvent.click(internetAccess);
     fireEvent.click(internetAccess);
 
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(internetAccess).toBeDisabled();
+    expect(
+      screen.queryByRole("button", { name: "Close" }),
+    ).not.toBeInTheDocument();
     expect(screen.getByRole("status")).toHaveTextContent("Saving network policy");
 
     await act(async () => {
@@ -86,6 +91,7 @@ describe("NetworkPolicyDialog", () => {
       "The network policy could not be saved.",
     );
     expect(internetAccess).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
     expect(onOpenChange).not.toHaveBeenCalledWith(false);
   });
 });

--- a/crates/openwave-desktop/ui/src/NetworkPolicyDialog.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/NetworkPolicyDialog.dom.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { NetworkPolicyDialog } from "./NetworkPolicyDialog";
@@ -50,5 +50,42 @@ describe("NetworkPolicyDialog", () => {
       allowed_hosts: ["api.example.com", "files.example.com"],
       package_managers: true,
     });
+  });
+
+  it("keeps the dialog open with an actionable error when saving fails", async () => {
+    let rejectUpdate!: (reason?: unknown) => void;
+    const update = new Promise<void>((_resolve, reject) => {
+      rejectUpdate = reject;
+    });
+    const onChange = vi.fn(() => update);
+    const onOpenChange = vi.fn();
+    render(
+      <NetworkPolicyDialog
+        open
+        onOpenChange={onOpenChange}
+        value={{ mode: "off" }}
+        onChange={onChange}
+      />,
+    );
+
+    const internetAccess = screen
+      .getByText(/Reach public internet destinations/i)
+      .closest("button")!;
+    fireEvent.click(internetAccess);
+    fireEvent.click(internetAccess);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(internetAccess).toBeDisabled();
+    expect(screen.getByRole("status")).toHaveTextContent("Saving network policy");
+
+    await act(async () => {
+      rejectUpdate(new Error("The network policy could not be saved."));
+    });
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "The network policy could not be saved.",
+    );
+    expect(internetAccess).not.toBeDisabled();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
   });
 });

--- a/crates/openwave-desktop/ui/src/NetworkPolicyDialog.tsx
+++ b/crates/openwave-desktop/ui/src/NetworkPolicyDialog.tsx
@@ -82,8 +82,13 @@ export function NetworkPolicyDialog({
   // edit does not survive into the next visit.
   const [hosts, setHosts] = useState("");
   const [includePackages, setIncludePackages] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const controlsDisabled = disabled || saving;
 
   function openAndHydrate(next: boolean) {
+    if (!next && saving) return;
+    if (!next) setSaveError(null);
     if (next && value.mode === "allowed_hosts") {
       setHosts(value.allowed_hosts.join("\n"));
       setIncludePackages(value.package_managers);
@@ -91,9 +96,19 @@ export function NetworkPolicyDialog({
     onOpenChange(next);
   }
 
-  function select(policy: NetworkPolicy) {
-    void onChange(policy);
-    onOpenChange(false);
+  async function select(policy: NetworkPolicy) {
+    if (controlsDisabled) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await onChange(policy);
+      onOpenChange(false);
+    } catch (caught) {
+      const message = String(caught).replace(/^Error:\s*/, "").trim();
+      setSaveError(message || "Could not update the network policy.");
+    } finally {
+      setSaving(false);
+    }
   }
 
   function saveCustom() {
@@ -105,7 +120,7 @@ export function NetworkPolicyDialog({
           .filter(Boolean),
       ),
     ];
-    select({
+    void select({
       mode: "allowed_hosts",
       allowed_hosts: allowedHosts,
       package_managers: includePackages,
@@ -114,7 +129,7 @@ export function NetworkPolicyDialog({
 
   return (
     <Dialog open={open} onOpenChange={openAndHydrate}>
-      <DialogContent className="max-w-md space-y-3">
+      <DialogContent className="max-w-md space-y-3" aria-busy={saving}>
         <DialogHeader>
           <DialogTitle>Code execution network</DialogTitle>
           <DialogDescription>
@@ -132,8 +147,8 @@ export function NetworkPolicyDialog({
                   key={option.mode}
                   type="button"
                   className="flex w-full items-start gap-2 rounded-md p-2 text-left hover:bg-muted"
-                  disabled={disabled}
-                  onClick={() => select({ mode: option.mode })}
+                  disabled={controlsDisabled}
+                  onClick={() => void select({ mode: option.mode })}
                 >
                   <Icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
                   <span className="min-w-0 flex-1">
@@ -160,7 +175,7 @@ export function NetworkPolicyDialog({
           <Textarea
             aria-label="Allowed network hosts"
             value={hosts}
-            disabled={disabled}
+            disabled={controlsDisabled}
             onChange={(event) => setHosts(event.target.value)}
             placeholder={"api.example.com\nfiles.example.com"}
             className="min-h-20 font-mono text-xs"
@@ -168,7 +183,7 @@ export function NetworkPolicyDialog({
           <label className="flex items-center gap-2 text-xs">
             <Checkbox
               checked={includePackages}
-              disabled={disabled}
+              disabled={controlsDisabled}
               onCheckedChange={(checked) => setIncludePackages(checked === true)}
             />
             Also allow package registries
@@ -177,12 +192,22 @@ export function NetworkPolicyDialog({
             type="button"
             size="sm"
             className="w-full"
-            disabled={disabled || (!hosts.trim() && !includePackages)}
+            disabled={controlsDisabled || (!hosts.trim() && !includePackages)}
             onClick={saveCustom}
           >
             Use custom policy
           </Button>
         </div>
+        {saving && (
+          <p className="text-muted-foreground text-sm" role="status">
+            Saving network policy…
+          </p>
+        )}
+        {saveError && (
+          <p className="text-destructive text-sm" role="alert">
+            {saveError}
+          </p>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/crates/openwave-desktop/ui/src/NetworkPolicyDialog.tsx
+++ b/crates/openwave-desktop/ui/src/NetworkPolicyDialog.tsx
@@ -129,7 +129,11 @@ export function NetworkPolicyDialog({
 
   return (
     <Dialog open={open} onOpenChange={openAndHydrate}>
-      <DialogContent className="max-w-md space-y-3" aria-busy={saving}>
+      <DialogContent
+        className="max-w-md space-y-3"
+        aria-busy={saving}
+        withCloseButton={!saving}
+      >
         <DialogHeader>
           <DialogTitle>Code execution network</DialogTitle>
           <DialogDescription>


### PR DESCRIPTION
## Summary

- wait for an existing chat's network-policy update before closing the dialog
- disable policy controls and dismissal while the request is pending
- keep the dialog open with an inline error when persistence fails
- cover the rejected-save and duplicate-submit behavior

## Verification

- `pnpm --dir crates/openwave-desktop/ui test -- NetworkPolicyDialog.dom.test.tsx` (the project script runs the full Vitest suite: 125 files, 837 tests)
- `pnpm --dir crates/openwave-desktop/ui build`
- `git diff --check`

Closes #1775