### PR TITLE
fix(server): validate chat creation before sticky writes

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -629,7 +629,7 @@ impl Store for DbStore {
     }
 
     async fn create_chat_with_project_defaults(&self, chat: &Chat) -> Result<Chat> {
-        ops::conversation::create_chat_with_project_defaults(self, chat, None).await
+        ops::conversation::create_chat_with_project_defaults(self, chat, None, &[]).await
     }
 
     async fn create_chat_with_project_defaults_scoped(
@@ -637,7 +637,17 @@ impl Store for DbStore {
         owner: &OwnerId,
         chat: &Chat,
     ) -> Result<Chat> {
-        ops::conversation::create_chat_with_project_defaults(self, chat, Some(owner)).await
+        ops::conversation::create_chat_with_project_defaults(self, chat, Some(owner), &[]).await
+    }
+
+    async fn create_chat_with_project_defaults_and_settings_scoped(
+        &self,
+        owner: &OwnerId,
+        chat: &Chat,
+        settings: &[(String, Value)],
+    ) -> Result<Chat> {
+        ops::conversation::create_chat_with_project_defaults(self, chat, Some(owner), settings)
+            .await
     }
 
     async fn set_chat_model(&self, id: ChatId, model: Option<String>) -> Result<()> {

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -6,6 +6,7 @@ use sea_orm::{
     ActiveModelTrait, ColumnTrait, ConnectionTrait, DatabaseBackend, EntityTrait, QueryFilter,
     QueryOrder, QuerySelect, QueryTrait, Set, TransactionTrait, TryInsertResult,
 };
+use serde_json::Value;
 
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
@@ -122,6 +123,7 @@ pub(in crate::db) async fn create_chat_with_project_defaults(
     store: &DbStore,
     base: &Chat,
     owner: Option<&OwnerId>,
+    settings: &[(String, Value)],
 ) -> Result<Chat> {
     if base.attachment_revision != 0 || !base.root_attachments.is_empty() {
         return Err(AgentError::Store(
@@ -144,6 +146,20 @@ pub(in crate::db) async fn create_chat_with_project_defaults(
     validate_chat_root_projection(&chat).map_err(|message| AgentError::Store(message.into()))?;
     insert_chat_on(&transaction, &chat, owner).await?;
     insert_foreground_agent_run_on(&transaction, chat.id, chat.created_at).await?;
+    for (key, value) in settings {
+        entities::setting::Entity::insert(entities::setting::ActiveModel {
+            key: Set(key.clone()),
+            value_json: Set(value.clone()),
+        })
+        .on_conflict(
+            OnConflict::column(entities::setting::Column::Key)
+                .update_column(entities::setting::Column::ValueJson)
+                .to_owned(),
+        )
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
+    }
     transaction.commit().await.map_err(store_err)?;
     Ok(chat)
 }

--- a/crates/openwave-core/src/storage/store.rs
+++ b/crates/openwave-core/src/storage/store.rs
@@ -412,7 +412,16 @@ pub trait Store: Send + Sync {
         owner: &OwnerId,
         chat: &Chat,
         settings: &[(String, Value)],
-    ) -> Result<Chat>;
+    ) -> Result<Chat> {
+        if settings.is_empty() {
+            return self
+                .create_chat_with_project_defaults_scoped(owner, chat)
+                .await;
+        }
+        Err(AgentError::Store(
+            "atomic chat creation with setting updates is not implemented by this Store".into(),
+        ))
+    }
 
     /// Fetch `owner`'s chat by id; `None` when it does not exist **or**
     /// belongs to someone else.

--- a/crates/openwave-core/src/storage/store.rs
+++ b/crates/openwave-core/src/storage/store.rs
@@ -404,6 +404,16 @@ pub trait Store: Send + Sync {
         self.create_chat_with_project_defaults(chat).await
     }
 
+    /// Create `owner`'s chat and apply the supplied settings in one atomic
+    /// operation. Setting updates must not become visible when chat creation
+    /// fails.
+    async fn create_chat_with_project_defaults_and_settings_scoped(
+        &self,
+        owner: &OwnerId,
+        chat: &Chat,
+        settings: &[(String, Value)],
+    ) -> Result<Chat>;
+
     /// Fetch `owner`'s chat by id; `None` when it does not exist **or**
     /// belongs to someone else.
     async fn get_chat_scoped(&self, owner: &OwnerId, id: ChatId) -> Result<Option<Chat>> {

--- a/crates/openwave-core/src/storage/tests.rs
+++ b/crates/openwave-core/src/storage/tests.rs
@@ -458,6 +458,49 @@ impl Store for MemStore {
         chats.insert(chat.id, chat.clone());
         Ok(chat)
     }
+    async fn create_chat_with_project_defaults_and_settings_scoped(
+        &self,
+        _owner: &crate::model::OwnerId,
+        base: &Chat,
+        setting_updates: &[(String, Value)],
+    ) -> Result<Chat> {
+        if base.attachment_revision != 0 || !base.root_attachments.is_empty() {
+            return Err(AgentError::Store(
+                "chat project defaults must start from an empty revision-zero projection".into(),
+            ));
+        }
+        let mut settings = self.settings.lock().unwrap();
+        let projects = self.projects.lock().unwrap();
+        let mut chat = base.clone();
+        if let Some(project_id) = chat.project_id {
+            let project = projects
+                .get(&project_id)
+                .ok_or_else(|| AgentError::Store("chat project does not exist".into()))?;
+            chat.root_attachments = project
+                .root_attachments
+                .iter()
+                .copied()
+                .map(|root_id| ChatRootAttachment {
+                    root_id,
+                    origin: RootAttachmentOrigin::ProjectDefault,
+                })
+                .collect();
+            if !chat.root_attachments.is_empty() {
+                chat.attachment_revision = 1;
+            }
+        }
+        validate_chat_root_projection(&chat)
+            .map_err(|message| AgentError::Store(message.into()))?;
+        let mut chats = self.chats.lock().unwrap();
+        if chats.contains_key(&chat.id) {
+            return Err(AgentError::Store("chat already exists".into()));
+        }
+        chats.insert(chat.id, chat.clone());
+        for (key, value) in setting_updates {
+            settings.insert(key.clone(), value.clone());
+        }
+        Ok(chat)
+    }
     async fn get_chat(&self, id: ChatId) -> Result<Option<Chat>> {
         Ok(self.chats.lock().unwrap().get(&id).cloned())
     }

--- a/crates/openwave-core/src/storage/tests.rs
+++ b/crates/openwave-core/src/storage/tests.rs
@@ -458,49 +458,6 @@ impl Store for MemStore {
         chats.insert(chat.id, chat.clone());
         Ok(chat)
     }
-    async fn create_chat_with_project_defaults_and_settings_scoped(
-        &self,
-        _owner: &crate::model::OwnerId,
-        base: &Chat,
-        setting_updates: &[(String, Value)],
-    ) -> Result<Chat> {
-        if base.attachment_revision != 0 || !base.root_attachments.is_empty() {
-            return Err(AgentError::Store(
-                "chat project defaults must start from an empty revision-zero projection".into(),
-            ));
-        }
-        let mut settings = self.settings.lock().unwrap();
-        let projects = self.projects.lock().unwrap();
-        let mut chat = base.clone();
-        if let Some(project_id) = chat.project_id {
-            let project = projects
-                .get(&project_id)
-                .ok_or_else(|| AgentError::Store("chat project does not exist".into()))?;
-            chat.root_attachments = project
-                .root_attachments
-                .iter()
-                .copied()
-                .map(|root_id| ChatRootAttachment {
-                    root_id,
-                    origin: RootAttachmentOrigin::ProjectDefault,
-                })
-                .collect();
-            if !chat.root_attachments.is_empty() {
-                chat.attachment_revision = 1;
-            }
-        }
-        validate_chat_root_projection(&chat)
-            .map_err(|message| AgentError::Store(message.into()))?;
-        let mut chats = self.chats.lock().unwrap();
-        if chats.contains_key(&chat.id) {
-            return Err(AgentError::Store("chat already exists".into()));
-        }
-        chats.insert(chat.id, chat.clone());
-        for (key, value) in setting_updates {
-            settings.insert(key.clone(), value.clone());
-        }
-        Ok(chat)
-    }
     async fn get_chat(&self, id: ChatId) -> Result<Option<Chat>> {
         Ok(self.chats.lock().unwrap().get(&id).cloned())
     }
@@ -1231,6 +1188,51 @@ fn store_is_object_safe_and_roundtrips() {
     block_on(store.delete_document(source.id)).unwrap();
     block_on(store.delete_document(source.id)).unwrap();
     assert_eq!(block_on(store.get_document(source.id)).unwrap(), None);
+}
+
+#[test]
+fn custom_store_atomic_chat_default_fails_closed() {
+    let store: Arc<dyn Store> = Arc::new(MemStore::default());
+    let chat = Chat {
+        id: ChatId::new(),
+        project_id: None,
+        title: None,
+        model: None,
+        reasoning_effort: None,
+        permission_mode: None,
+        network_policy: Default::default(),
+        attachment_revision: 0,
+        root_attachments: Vec::new(),
+        created_at: chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0).unwrap(),
+    };
+    let owner = crate::model::OwnerId::local();
+
+    let created =
+        block_on(store.create_chat_with_project_defaults_and_settings_scoped(&owner, &chat, &[]))
+            .unwrap();
+    assert_eq!(created, chat);
+
+    let rejected = Chat {
+        id: ChatId::new(),
+        ..chat
+    };
+    block_on(store.set_setting("model", &serde_json::json!("before"))).unwrap();
+    let error = block_on(store.create_chat_with_project_defaults_and_settings_scoped(
+        &owner,
+        &rejected,
+        &[("model".into(), serde_json::json!("after"))],
+    ))
+    .unwrap_err();
+    assert!(matches!(
+        error,
+        AgentError::Store(message)
+            if message == "atomic chat creation with setting updates is not implemented by this Store"
+    ));
+    assert_eq!(block_on(store.get_chat(rejected.id)).unwrap(), None);
+    assert_eq!(
+        block_on(store.get_setting("model")).unwrap(),
+        Some(serde_json::json!("before"))
+    );
 }
 
 #[test]

--- a/crates/openwave-server/src/routes/projects_chats.rs
+++ b/crates/openwave-server/src/routes/projects_chats.rs
@@ -207,6 +207,7 @@ pub async fn create_chat(
     if let Some(policy) = body.network_policy.as_mut() {
         crate::code_execution::normalize_network_policy(policy)?;
     }
+    let title = normalize_chat_title(body.title)?;
     // An explicit choice at creation is as much "the last-chosen mode" as one
     // made mid-chat — the home composer's pickers land here, never at PATCH —
     // so record it the same way. Absent fields never clear a sticky default;
@@ -267,7 +268,7 @@ pub async fn create_chat(
     let chat = Chat {
         id: ChatId::new(),
         project_id: body.project_id,
-        title: normalize_chat_title(body.title)?,
+        title,
         model,
         reasoning_effort,
         permission_mode,

--- a/crates/openwave-server/src/routes/projects_chats.rs
+++ b/crates/openwave-server/src/routes/projects_chats.rs
@@ -23,8 +23,9 @@ use crate::state::AppState;
 
 use super::providers_models::{refuse_permission_mode_over_ceiling, validate_model_selection};
 use super::settings::{
-    double_option, read_sticky_default, write_sticky_default, STICKY_MODEL_KEY,
-    STICKY_NETWORK_POLICY_KEY, STICKY_PERMISSION_MODE_KEY, STICKY_REASONING_EFFORT_KEY,
+    double_option, read_sticky_default, sticky_default_value, write_sticky_default,
+    STICKY_MODEL_KEY, STICKY_NETWORK_POLICY_KEY, STICKY_PERMISSION_MODE_KEY,
+    STICKY_REASONING_EFFORT_KEY,
 };
 
 /// Product-facing project names stay compact across desktop and API clients.
@@ -208,24 +209,8 @@ pub async fn create_chat(
         crate::code_execution::normalize_network_policy(policy)?;
     }
     let title = normalize_chat_title(body.title)?;
-    // An explicit choice at creation is as much "the last-chosen mode" as one
-    // made mid-chat — the home composer's pickers land here, never at PATCH —
-    // so record it the same way. Absent fields never clear a sticky default;
-    // only an explicit PATCH `null` does.
-    if let Some(model) = &body.model {
-        write_sticky_default(&*state.store, STICKY_MODEL_KEY, Some(model)).await?;
-    }
-    if let Some(effort) = &body.reasoning_effort {
-        write_sticky_default(&*state.store, STICKY_REASONING_EFFORT_KEY, Some(effort)).await?;
-    }
-    if let Some(mode) = &body.permission_mode {
-        write_sticky_default(&*state.store, STICKY_PERMISSION_MODE_KEY, Some(mode)).await?;
-    }
-    if let Some(policy) = &body.network_policy {
-        write_sticky_default(&*state.store, STICKY_NETWORK_POLICY_KEY, Some(policy)).await?;
-    }
-    let model = match body.model {
-        Some(model) => Some(model),
+    let model = match body.model.as_ref() {
+        Some(model) => Some(model.clone()),
         // A sticky selection that no longer validates — deregistered model,
         // disabled or uncredentialed provider — falls back to the configured
         // default instead of failing the create or pinning a dead model.
@@ -234,12 +219,12 @@ pub async fn create_chat(
             None => None,
         },
     };
-    let reasoning_effort = match body.reasoning_effort {
-        Some(effort) => Some(effort),
+    let reasoning_effort = match body.reasoning_effort.as_ref() {
+        Some(effort) => Some(*effort),
         None => read_sticky_default(&*state.store, STICKY_REASONING_EFFORT_KEY).await?,
     };
-    let permission_mode = match body.permission_mode {
-        Some(mode) => Some(mode),
+    let permission_mode = match body.permission_mode.as_ref() {
+        Some(mode) => Some(*mode),
         // The managed ceiling clamps a sticky mode recorded before the policy
         // arrived: a remembered `allow` under an `ask` ceiling seeds `ask`,
         // mirroring how the turn gate treats stored over-ceiling modes.
@@ -250,8 +235,8 @@ pub async fn create_chat(
             None => None,
         },
     };
-    let network_policy = match body.network_policy {
-        Some(policy) => policy,
+    let network_policy = match body.network_policy.as_ref() {
+        Some(policy) => policy.clone(),
         None => {
             let mut sticky = read_sticky_default(&*state.store, STICKY_NETWORK_POLICY_KEY)
                 .await?
@@ -265,6 +250,36 @@ pub async fn create_chat(
             sticky
         }
     };
+    // An explicit choice at creation is as much "the last-chosen mode" as one
+    // made mid-chat — the home composer's pickers land here, never at PATCH.
+    // Apply only supplied values, and only in the transaction that successfully
+    // inserts the chat, so a project deletion race cannot partially advance
+    // the defaults before the create reports its failure.
+    let mut sticky_default_updates = Vec::with_capacity(4);
+    if let Some(model) = &body.model {
+        sticky_default_updates.push((
+            STICKY_MODEL_KEY.to_owned(),
+            sticky_default_value(Some(model))?,
+        ));
+    }
+    if let Some(effort) = &body.reasoning_effort {
+        sticky_default_updates.push((
+            STICKY_REASONING_EFFORT_KEY.to_owned(),
+            sticky_default_value(Some(effort))?,
+        ));
+    }
+    if let Some(mode) = &body.permission_mode {
+        sticky_default_updates.push((
+            STICKY_PERMISSION_MODE_KEY.to_owned(),
+            sticky_default_value(Some(mode))?,
+        ));
+    }
+    if let Some(policy) = &body.network_policy {
+        sticky_default_updates.push((
+            STICKY_NETWORK_POLICY_KEY.to_owned(),
+            sticky_default_value(Some(policy))?,
+        ));
+    }
     let chat = Chat {
         id: ChatId::new(),
         project_id: body.project_id,
@@ -277,7 +292,9 @@ pub async fn create_chat(
         root_attachments: Vec::new(),
         created_at: Utc::now(),
     };
-    let chat = store.create_chat_with_project_defaults(&chat).await?;
+    let chat = store
+        .create_chat_with_project_defaults_and_settings(&chat, &sticky_default_updates)
+        .await?;
     Ok((StatusCode::CREATED, Json(chat)))
 }
 

--- a/crates/openwave-server/src/routes/settings.rs
+++ b/crates/openwave-server/src/routes/settings.rs
@@ -663,17 +663,24 @@ pub(super) async fn read_sticky_default<T: serde::de::DeserializeOwned>(
         .and_then(|value| serde_json::from_value(value).ok()))
 }
 
+/// Encode one sticky new-chat default for a direct or transactional write.
+pub(super) fn sticky_default_value<T: Serialize>(
+    value: Option<&T>,
+) -> Result<serde_json::Value, ServerError> {
+    match value {
+        Some(value) => serde_json::to_value(value)
+            .map_err(|_| ServerError::internal("could not encode a sticky chat default")),
+        None => Ok(serde_json::Value::Null),
+    }
+}
+
 /// Record (or clear, with `None`) one sticky new-chat default.
 pub(super) async fn write_sticky_default<T: Serialize>(
     store: &dyn Store,
     key: &str,
     value: Option<&T>,
 ) -> Result<(), ServerError> {
-    let value = match value {
-        Some(value) => serde_json::to_value(value)
-            .map_err(|_| ServerError::internal("could not encode a sticky chat default"))?,
-        None => serde_json::Value::Null,
-    };
+    let value = sticky_default_value(value)?;
     Ok(store.set_setting(key, &value).await?)
 }
 

--- a/crates/openwave-server/src/scoped_store.rs
+++ b/crates/openwave-server/src/scoped_store.rs
@@ -24,6 +24,7 @@ use std::sync::Arc;
 use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
 use axum::http::StatusCode;
+use serde_json::Value;
 
 use openwave_core::{
     AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentRun, AgentRunId, AgentRunResult, CallId, Chat,
@@ -82,11 +83,15 @@ impl ScopedStore {
         self.store.list_chats_scoped(&self.owner).await
     }
 
-    /// Create a chat owned by the principal, resolving project defaults only
-    /// from the principal's own projects.
-    pub async fn create_chat_with_project_defaults(&self, chat: &Chat) -> Result<Chat> {
+    /// Create a chat and apply related settings only if the chat insert
+    /// succeeds.
+    pub async fn create_chat_with_project_defaults_and_settings(
+        &self,
+        chat: &Chat,
+        settings: &[(String, Value)],
+    ) -> Result<Chat> {
         self.store
-            .create_chat_with_project_defaults_scoped(&self.owner, chat)
+            .create_chat_with_project_defaults_and_settings_scoped(&self.owner, chat, settings)
             .await
     }
 

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -922,6 +922,16 @@ impl Store for PauseTerminalStore {
     async fn create_chat_with_project_defaults(&self, chat: &Chat) -> Result<Chat> {
         self.inner.create_chat_with_project_defaults(chat).await
     }
+    async fn create_chat_with_project_defaults_and_settings_scoped(
+        &self,
+        owner: &openwave_core::OwnerId,
+        chat: &Chat,
+        settings: &[(String, serde_json::Value)],
+    ) -> Result<Chat> {
+        self.inner
+            .create_chat_with_project_defaults_and_settings_scoped(owner, chat, settings)
+            .await
+    }
     async fn get_chat(&self, id: ChatId) -> Result<Option<Chat>> {
         self.inner.get_chat(id).await
     }

--- a/crates/openwave-server/src/tests/conversations.rs
+++ b/crates/openwave-server/src/tests/conversations.rs
@@ -630,6 +630,42 @@ async fn chat_settings_stick_to_the_next_chat() {
 }
 
 #[tokio::test]
+async fn rejected_chat_creation_does_not_change_sticky_defaults() {
+    let (router, token, _store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+
+    let rejected = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/chats")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "title": "t".repeat(routes::MAX_CHAT_TITLE_CHARS + 1),
+                        "model": "m-rejected",
+                        "reasoning_effort": "high",
+                        "permission_mode": "allow",
+                        "network_policy": {"mode": "off"},
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(rejected.status(), StatusCode::BAD_REQUEST);
+
+    let next = make_chat(&router, &bearer).await;
+    assert_eq!(next.model, None);
+    assert_eq!(next.reasoning_effort, None);
+    assert_eq!(next.permission_mode, None);
+    assert_eq!(next.network_policy, openwave_core::NetworkPolicy::Open);
+}
+
+#[tokio::test]
 async fn chat_network_policy_defaults_open_and_persists_normalized_exact_hosts() {
     let (router, token, _store, _dir) = test_app().await;
     let bearer = format!("Bearer {token}");

--- a/crates/openwave-server/src/tests/conversations.rs
+++ b/crates/openwave-server/src/tests/conversations.rs
@@ -308,7 +308,7 @@ async fn chat_referencing_an_unknown_project_is_rejected() {
 }
 
 #[tokio::test]
-async fn chat_creation_reports_not_found_when_project_deletion_wins_after_preflight() {
+async fn project_deletion_during_chat_creation_leaves_sticky_defaults_unchanged() {
     let dir = tempfile::tempdir().unwrap();
     let database = Arc::new(
         DbStore::connect(&format!(
@@ -332,18 +332,52 @@ async fn chat_creation_reports_not_found_when_project_deletion_wins_after_prefli
         Arc::new(Notify::new()),
     ));
     injected.do_not_pause_terminal();
-    injected.delete_project_after_next_get();
-    let (router, token, _store, _dir) = test_app_from_parts(Arc::new(FakeProvider), injected, dir);
+    let (router, token, _store, _dir) =
+        test_app_from_parts(Arc::new(FakeProvider), injected.clone(), dir);
 
-    let response = router
+    let bearer = format!("Bearer {token}");
+    let baseline = router
+        .clone()
         .oneshot(
             Request::builder()
                 .method("POST")
                 .uri("/chats")
-                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .header(header::AUTHORIZATION, &bearer)
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from(
-                    serde_json::json!({"project_id": project.id}).to_string(),
+                    serde_json::json!({
+                        "model": "m-before",
+                        "reasoning_effort": "low",
+                        "permission_mode": "ask",
+                        "network_policy": {"mode": "off"},
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(baseline.status(), StatusCode::CREATED);
+    let baseline: Chat = json_body(baseline).await;
+
+    injected.delete_project_after_next_get();
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/chats")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "project_id": project.id,
+                        "model": "m-race",
+                        "reasoning_effort": "high",
+                        "permission_mode": "allow",
+                        "network_policy": {"mode": "package_managers"},
+                    })
+                    .to_string(),
                 ))
                 .unwrap(),
         )
@@ -353,7 +387,39 @@ async fn chat_creation_reports_not_found_when_project_deletion_wins_after_prefli
     let info: AgentErrorInfo = json_body(response).await;
     assert_eq!(info.kind, "not_found");
     assert!(database.get_project(project.id).await.unwrap().is_none());
-    assert!(database.list_chats().await.unwrap().is_empty());
+    assert_eq!(
+        database
+            .list_chats()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|chat| chat.id)
+            .collect::<Vec<_>>(),
+        vec![baseline.id]
+    );
+
+    let settings: serde_json::Value = json_body(
+        router
+            .oneshot(
+                Request::builder()
+                    .uri("/settings")
+                    .header(header::AUTHORIZATION, &bearer)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(
+        settings["chat_defaults"],
+        serde_json::json!({
+            "model": "m-before",
+            "reasoning_effort": "low",
+            "permission_mode": "ask",
+            "network_policy": {"mode": "off"},
+        })
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What changed

- normalize and validate a requested chat title before persisting any explicit sticky chat defaults
- add an API regression test proving a rejected create leaves model, reasoning effort, permission mode, and network policy defaults unchanged

## Verification

- `cargo test -p openwave-server rejected_chat_creation_does_not_change_sticky_defaults --locked`
- `cargo test -p openwave-server chat_settings_stick_to_the_next_chat --locked`
- `cargo fmt --all --check`
- `cargo check -p openwave-server --locked`
- `git diff --check`

Closes #1778