### PR TITLE
fix(auth): preserve ChatGPT OAuth refresh state

### DIFF
--- a/crates/openwave-connectors/src/chatgpt.rs
+++ b/crates/openwave-connectors/src/chatgpt.rs
@@ -288,14 +288,25 @@ impl ChatGptAuth {
         })
     }
 
-    /// Exchange a refresh token for a new access/refresh pair.
+    /// Exchange a refresh token for a complete replacement credential set.
+    ///
+    /// Vault-backed callers should use [`ChatGptConnection`], which can retain
+    /// stable fields when a refresh response omits them.
     pub async fn refresh(&self, refresh_token: &str) -> Result<ChatGptCredentials> {
+        self.refresh_with_fallback(refresh_token, None).await
+    }
+
+    async fn refresh_with_fallback(
+        &self,
+        refresh_token: &str,
+        fallback: Option<&ChatGptCredentials>,
+    ) -> Result<ChatGptCredentials> {
         let form = [
             ("grant_type", "refresh_token"),
             ("refresh_token", refresh_token),
             ("client_id", self.config.client_id.as_str()),
         ];
-        self.request_token(&form).await
+        credentials_from_token(self.request_token(&form).await?, fallback)
     }
 
     /// Best-effort revoke. Failures are ignored by callers that are clearing
@@ -328,10 +339,10 @@ impl ChatGptAuth {
             ("client_id", self.config.client_id.as_str()),
             ("code_verifier", verifier),
         ];
-        self.request_token(&form).await
+        credentials_from_token(self.request_token(&form).await?, None)
     }
 
-    async fn request_token(&self, form: &[(&str, &str)]) -> Result<ChatGptCredentials> {
+    async fn request_token(&self, form: &[(&str, &str)]) -> Result<TokenResponse> {
         let response = self
             .http
             .post(self.config.token_url.clone())
@@ -353,29 +364,55 @@ impl ChatGptAuth {
                 .unwrap_or_else(|| format!("HTTP status {}", status.as_u16()));
             return Err(chatgpt_error("token request", detail));
         }
-        let token: TokenResponse = response
+        response
             .json()
             .await
-            .map_err(|_| chatgpt_error("token request", "invalid token response"))?;
-        let account_id = token
-            .account_id
-            .filter(|id| !id.is_empty())
-            .or_else(|| extract_account_id(&token.access_token))
-            .or_else(|| token.id_token.as_deref().and_then(extract_account_id))
-            .ok_or_else(|| {
-                chatgpt_error(
-                    "token request",
-                    "response did not include a ChatGPT account id",
-                )
-            })?;
-        Ok(ChatGptCredentials {
-            access_token: token.access_token,
-            refresh_token: token.refresh_token,
-            account_id,
-            expires_at_unix: unix_time()
-                .saturating_add(u64::try_from(token.expires_in).unwrap_or(3600)),
-        })
+            .map_err(|_| chatgpt_error("token request", "invalid token response"))
     }
+}
+
+fn credentials_from_token(
+    token: TokenResponse,
+    fallback: Option<&ChatGptCredentials>,
+) -> Result<ChatGptCredentials> {
+    let TokenResponse {
+        access_token,
+        expires_in,
+        refresh_token,
+        id_token,
+        account_id,
+    } = token;
+    if access_token.is_empty() {
+        return Err(chatgpt_error(
+            "token request",
+            "response did not include an access token",
+        ));
+    }
+    let account_id = account_id
+        .filter(|id| !id.is_empty())
+        .or_else(|| extract_account_id(&access_token))
+        .or_else(|| id_token.as_deref().and_then(extract_account_id))
+        .or_else(|| fallback.map(|credentials| credentials.account_id.clone()))
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| {
+            chatgpt_error(
+                "token request",
+                "response did not include a ChatGPT account id",
+            )
+        })?;
+    let refresh_token = refresh_token
+        .filter(|token| !token.is_empty())
+        .or_else(|| fallback.map(|credentials| credentials.refresh_token.clone()))
+        .filter(|token| !token.is_empty())
+        .ok_or_else(|| {
+            chatgpt_error("token request", "response did not include a refresh token")
+        })?;
+    Ok(ChatGptCredentials {
+        access_token,
+        refresh_token,
+        account_id,
+        expires_at_unix: unix_time().saturating_add(u64::try_from(expires_in).unwrap_or(3600)),
+    })
 }
 
 /// A sign-in in flight. Dropping this cancels the listener.
@@ -499,21 +536,16 @@ impl ChatGptConnection {
     /// A currently valid access token, refreshing near expiry.
     pub async fn access_token(&self) -> Result<String> {
         let _guard = self.token_motion.lock().await;
-        let Some(mut credentials) = self.vault.load().await? else {
+        let Some(credentials) = self.vault.load().await? else {
             return Err(sign_in_required("no ChatGPT session is stored"));
         };
         if credentials.access_is_fresh() {
             return Ok(credentials.access_token);
         }
-        let refreshed = self.auth.refresh(&credentials.refresh_token).await?;
-        // Preserve account id if refresh omits it (should not, but be safe).
-        if refreshed.account_id.is_empty() {
-            credentials.access_token = refreshed.access_token;
-            credentials.refresh_token = refreshed.refresh_token;
-            credentials.expires_at_unix = refreshed.expires_at_unix;
-            self.vault.save(&credentials).await?;
-            return Ok(credentials.access_token);
-        }
+        let refreshed = self
+            .auth
+            .refresh_with_fallback(&credentials.refresh_token, Some(&credentials))
+            .await?;
         self.vault.save(&refreshed).await?;
         Ok(refreshed.access_token)
     }
@@ -642,7 +674,8 @@ struct CallbackResult {
 struct TokenResponse {
     access_token: String,
     expires_in: i64,
-    refresh_token: String,
+    #[serde(default)]
+    refresh_token: Option<String>,
     #[serde(default)]
     id_token: Option<String>,
     #[serde(default)]

--- a/crates/openwave-connectors/tests/chatgpt_flow.rs
+++ b/crates/openwave-connectors/tests/chatgpt_flow.rs
@@ -84,6 +84,15 @@ impl FakeAuth {
             "scope": "openid profile email offline_access",
         })
     }
+
+    fn sparse_refresh(&self) -> Value {
+        json!({
+            "access_token": format!("opaque-access-{}", next_id()),
+            "token_type": "Bearer",
+            "expires_in": 600,
+            "scope": "openid profile email offline_access",
+        })
+    }
 }
 
 fn next_id() -> u64 {
@@ -151,14 +160,12 @@ async fn token(
             if form.get("client_id").map(String::as_str) != Some(CLIENT_ID) {
                 return invalid_grant();
             }
-            let mut refresh_tokens = auth.refresh_tokens.lock().unwrap();
-            if refresh_tokens.get(refresh) != Some(&true) {
-                drop(refresh_tokens);
+            if auth.refresh_tokens.lock().unwrap().get(refresh) != Some(&true) {
                 return invalid_grant();
             }
-            refresh_tokens.insert(refresh.clone(), false);
-            drop(refresh_tokens);
-            Json(auth.mint()).into_response()
+            // OAuth refresh responses may keep the existing refresh token and
+            // omit identity fields that were already established at sign-in.
+            Json(auth.sparse_refresh()).into_response()
         }
         _ => StatusCode::BAD_REQUEST.into_response(),
     }
@@ -206,6 +213,21 @@ fn browser() -> reqwest::Client {
     reqwest::Client::builder().build().unwrap()
 }
 
+async fn expire_stored_access_token(secrets: &dyn SecretProvider) -> Value {
+    let raw = secrets
+        .get_secret(CHATGPT_SECRET_KEY)
+        .await
+        .unwrap()
+        .unwrap();
+    let mut value: Value = serde_json::from_str(&raw).unwrap();
+    value["expires_at_unix"] = json!(0);
+    secrets
+        .set_secret(CHATGPT_SECRET_KEY, &serde_json::to_string(&value).unwrap())
+        .await
+        .unwrap();
+    value
+}
+
 #[tokio::test]
 async fn sign_in_refresh_and_sign_out_round_trip() {
     let (base, fake) = spawn_fake().await;
@@ -228,24 +250,40 @@ async fn sign_in_refresh_and_sign_out_round_trip() {
     assert!(!token.is_empty());
     assert_eq!(fake.token_requests.load(Ordering::SeqCst), 1);
 
-    // Expire the cached access token so the next read refreshes.
-    let raw = secrets
-        .get_secret(CHATGPT_SECRET_KEY)
-        .await
+    // Expire the cached access token so the next read refreshes. The fake's
+    // refresh response deliberately omits account_id, id_token, and
+    // refresh_token; the connection must retain those durable fields.
+    let before_refresh = expire_stored_access_token(secrets.as_ref()).await;
+    let original_refresh = before_refresh["refresh_token"]
+        .as_str()
         .unwrap()
-        .unwrap();
-    let mut value: Value = serde_json::from_str(&raw).unwrap();
-    value["expires_at_unix"] = json!(0);
-    secrets
-        .set_secret(CHATGPT_SECRET_KEY, &serde_json::to_string(&value).unwrap())
-        .await
-        .unwrap();
+        .to_string();
 
     let token_after = connection.access_token().await.unwrap();
-    assert!(!token_after.is_empty());
-    assert!(fake.token_requests.load(Ordering::SeqCst) >= 2);
+    assert!(token_after.starts_with("opaque-access-"));
+    assert_eq!(fake.token_requests.load(Ordering::SeqCst), 2);
+
+    let persisted: Value = serde_json::from_str(
+        &secrets
+            .get_secret(CHATGPT_SECRET_KEY)
+            .await
+            .unwrap()
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(persisted["account_id"], ACCOUNT);
+    assert_eq!(persisted["refresh_token"], original_refresh);
+
+    // The retained token must remain usable for another refresh, not merely
+    // survive serialization once.
+    expire_stored_access_token(secrets.as_ref()).await;
+    let token_again = connection.access_token().await.unwrap();
+    assert!(token_again.starts_with("opaque-access-"));
+    assert_eq!(fake.token_requests.load(Ordering::SeqCst), 3);
 
     connection.sign_out().await.unwrap();
     assert!(!has_stored_chatgpt_credentials(secrets.as_ref()).await);
-    assert!(!fake.revoked.lock().unwrap().is_empty());
+    let revoked = fake.revoked.lock().unwrap();
+    assert_eq!(revoked.len(), 1);
+    assert_eq!(revoked[0], original_refresh);
 }


### PR DESCRIPTION
## Summary

- merge sparse ChatGPT OAuth refresh responses with the durable session so omitted account and refresh-token fields remain available
- keep the initial authorization exchange strict about receiving a complete credential set
- exercise two consecutive sparse refreshes and verify sign-out revokes the retained refresh token

## Verification

- `cargo fmt --all --check`
- `cargo test -p openwave-connectors --test chatgpt_flow --locked`
- `cargo test -p openwave-connectors --locked`

The flow is covered against the in-process OAuth server; a live OpenAI sign-in was not exercised locally.

Closes #1781