### PR TITLE
feat(gateway): route models by synced protocol

### DIFF
--- a/crates/openwave-connectors/src/gateway.rs
+++ b/crates/openwave-connectors/src/gateway.rs
@@ -149,6 +149,14 @@ pub struct GatewayIdentity {
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct GatewayModel {
     pub id: String,
+    /// The gateway inference protocol this model is served through.
+    ///
+    /// Older gateways exposed only Anthropic Messages and omitted the field,
+    /// so absence preserves that route. Newer deployments report their exact
+    /// protocol (`anthropic_messages` or `openai_chat_completions`) so clients
+    /// can select the matching compatibility surface.
+    #[serde(default = "default_gateway_model_protocol")]
+    pub protocol: String,
     /// The provider-side id this deployment routes to, when it differs from
     /// `id` — a deployment alias such as `us.anthropic.claude-opus-5` behind
     /// the gateway id `anthropic-us-claude-opus-5`. Optional because gateways
@@ -160,6 +168,10 @@ pub struct GatewayModel {
     pub max_output_tokens: Option<i64>,
     pub supports_tools: bool,
     pub supports_vision: bool,
+}
+
+fn default_gateway_model_protocol() -> String {
+    "anthropic_messages".to_string()
 }
 
 /// One entitled connected app from `/api/v1/cli/apps`: the apps the user
@@ -454,7 +466,8 @@ impl GatewayAuth {
     }
 
     /// The models the authenticated user may invoke, optionally filtered to
-    /// one inference protocol (`anthropic` / `openai`).
+    /// one inference protocol (`anthropic_messages` /
+    /// `openai_chat_completions`).
     pub async fn models(
         &self,
         access_token: &str,

--- a/crates/openwave-connectors/tests/gateway_flow.rs
+++ b/crates/openwave-connectors/tests/gateway_flow.rs
@@ -268,14 +268,25 @@ async fn models(State(gateway): State<Arc<FakeGateway>>, headers: HeaderMap) -> 
         return StatusCode::UNAUTHORIZED.into_response();
     }
     Json(json!({
-        "models": [{
-            "id": "anthropic/claude-fable-5",
-            "name": "Claude Fable 5",
-            "context_window": 500000,
-            "max_output_tokens": 64000,
-            "supports_tools": true,
-            "supports_vision": true,
-        }]
+        "models": [
+            {
+                "id": "anthropic/claude-fable-5",
+                "name": "Claude Fable 5",
+                "context_window": 500000,
+                "max_output_tokens": 64000,
+                "supports_tools": true,
+                "supports_vision": true,
+            },
+            {
+                "id": "openai/gpt-fable-5",
+                "protocol": "openai_chat_completions",
+                "name": "GPT Fable 5",
+                "context_window": 256000,
+                "max_output_tokens": 32000,
+                "supports_tools": true,
+                "supports_vision": true,
+            }
+        ]
     }))
     .into_response()
 }
@@ -389,7 +400,9 @@ async fn access_tokens_cache_per_resource_and_rotate_on_refresh() {
 
     let models = connection.models(None).await.unwrap();
     assert_eq!(models[0].id, "anthropic/claude-fable-5");
+    assert_eq!(models[0].protocol, "anthropic_messages");
     assert!(models[0].supports_tools);
+    assert_eq!(models[1].protocol, "openai_chat_completions");
     let identity = connection.identity().await.unwrap();
     assert_eq!(identity.user_id, USER);
 }

--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -30,11 +30,6 @@ const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
 const ANTHROPIC_VERSION: &str = "2023-06-01";
 const DEFAULT_MAX_TOKENS: u32 = 4096;
 
-/// Header a model-gateway deployment reads to group inference into one
-/// conversation. The gateway digests the value per user and harness; it is
-/// never forwarded upstream.
-const GATEWAY_CONVERSATION_HEADER: &str = "x-model-gateway-conversation-id";
-
 /// Description for the synthetic tool that carries a constrained response.
 ///
 /// The model is told what the call is for, because a forced tool with an opaque
@@ -258,7 +253,10 @@ impl AnthropicProvider {
         // The id is a UUID, so it satisfies the gateway's bound on the value
         // (1-256 ASCII graphic bytes) by construction.
         if let (true, Some(conversation)) = (self.conversation_attribution, conversation) {
-            request = request.header(GATEWAY_CONVERSATION_HEADER, conversation.to_string());
+            request = request.header(
+                crate::router::GATEWAY_CONVERSATION_HEADER,
+                conversation.to_string(),
+            );
         }
         let response = request
             .json(body)
@@ -2815,10 +2813,14 @@ mod tests {
         let requests = capture_state.0.lock().unwrap();
         assert_eq!(requests.len(), 2);
         assert_eq!(
-            requests[0].get(GATEWAY_CONVERSATION_HEADER).unwrap(),
+            requests[0]
+                .get(crate::router::GATEWAY_CONVERSATION_HEADER)
+                .unwrap(),
             conversation.to_string().as_str()
         );
-        assert!(requests[1].get(GATEWAY_CONVERSATION_HEADER).is_none());
+        assert!(requests[1]
+            .get(crate::router::GATEWAY_CONVERSATION_HEADER)
+            .is_none());
         server.abort();
     }
 

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -43,6 +43,9 @@ pub struct OpenAiCompatProvider {
     /// Off for ordinary compatible endpoints, which are not parties to the
     /// host's chat organization.
     conversation_attribution: bool,
+    /// Whether to ask the endpoint to include usage in its streaming response.
+    /// Off for arbitrary compatible endpoints, which may reject this option.
+    streaming_usage: bool,
     /// Stable id reported by [`ModelProvider::id`] — `"openai"` or
     /// `"openai_compatible"` depending on how the caller configured it.
     provider_id: String,
@@ -60,6 +63,7 @@ impl OpenAiCompatProvider {
             base_url: DEFAULT_BASE_URL.to_string(),
             token_source: None,
             conversation_attribution: false,
+            streaming_usage: true,
             provider_id: "openai".to_string(),
         }
     }
@@ -72,6 +76,7 @@ impl OpenAiCompatProvider {
             base_url: base_url.into(),
             token_source: None,
             conversation_attribution: false,
+            streaming_usage: false,
             provider_id: "openai_compatible".to_string(),
         }
     }
@@ -108,6 +113,13 @@ impl OpenAiCompatProvider {
         self.conversation_attribution = true;
         self
     }
+
+    /// Ask the endpoint to include usage in its streaming response.
+    #[must_use]
+    pub(crate) fn with_streaming_usage(mut self) -> Self {
+        self.streaming_usage = true;
+        self
+    }
 }
 
 #[async_trait]
@@ -118,10 +130,10 @@ impl ModelProvider for OpenAiCompatProvider {
 
     async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
         let mut body = build_request_json(&req)?;
-        // Native OpenAI omits usage on streaming chunks unless asked. Local
-        // openai_compatible servers often reject unknown fields, so only set
-        // this for the openai provider id.
-        if self.provider_id == "openai" {
+        // Chat Completions omits usage on streaming chunks unless asked. Local
+        // openai_compatible servers often reject unknown fields, so callers
+        // opt in only for endpoints known to implement this option.
+        if self.streaming_usage {
             body["stream_options"] = json!({ "include_usage": true });
         }
         let url = format!("{}/chat/completions", self.base_url.trim_end_matches('/'));
@@ -1311,23 +1323,35 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_gateway_request_uses_the_rotating_conversation_token_and_attribution_header() {
-        use axum::extract::{Request, State};
+    async fn a_gateway_request_uses_conversation_credentials_and_requests_streaming_usage() {
+        use axum::body::Bytes;
+        use axum::extract::State;
         use axum::http::{header, HeaderMap, StatusCode};
         use axum::response::IntoResponse;
         use axum::routing::post;
         use axum::Router;
         use std::sync::{Arc, Mutex};
 
-        #[derive(Clone, Default)]
-        struct Capture(Arc<Mutex<Vec<(String, HeaderMap)>>>);
+        struct CapturedRequest {
+            path: String,
+            headers: HeaderMap,
+            body: Value,
+        }
 
-        async fn capture(State(capture): State<Capture>, request: Request) -> impl IntoResponse {
-            capture
-                .0
-                .lock()
-                .unwrap()
-                .push((request.uri().path().to_owned(), request.headers().clone()));
+        #[derive(Clone, Default)]
+        struct Capture(Arc<Mutex<Vec<CapturedRequest>>>);
+
+        async fn capture(
+            State(capture): State<Capture>,
+            headers: HeaderMap,
+            uri: axum::http::Uri,
+            body: Bytes,
+        ) -> impl IntoResponse {
+            capture.0.lock().unwrap().push(CapturedRequest {
+                path: uri.path().to_owned(),
+                headers,
+                body: serde_json::from_slice(&body).expect("request body is JSON"),
+            });
             (
                 StatusCode::OK,
                 [(header::CONTENT_TYPE, "text/event-stream")],
@@ -1361,15 +1385,19 @@ mod tests {
         let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
 
         let source = Arc::new(RecordingTokenSource(Mutex::new(Vec::new())));
-        let provider = OpenAiCompatProvider::compatible(
-            "unused",
-            format!("http://{address}/compat/openai/v1"),
-        )
-        .with_token_source(source.clone())
-        .with_conversation_attribution();
+        let provider = crate::Router::build(vec![crate::Route {
+            kind: crate::RouteKind::ModelGatewayOpenai,
+            api_key: String::new(),
+            base_url: Some(format!("http://{address}/compat/openai/v1")),
+            curated_models: vec!["gpt-fable-5".to_string()],
+            token_source: Some(source.clone()),
+            vertex: None,
+            chatgpt_account_id: None,
+        }]);
         let conversation = openwave_core::id::ChatId::new();
         let stream = provider
             .stream(ChatRequest {
+                provider: Some(ProviderId::new("model_gateway")),
                 model: "gpt-fable-5".into(),
                 conversation: Some(conversation),
                 messages: vec![ChatMessage::text(Role::User, "hi")],
@@ -1400,26 +1428,31 @@ mod tests {
         assert_eq!(source.0.lock().unwrap().as_slice(), &[Some(conversation)]);
         let requests = capture_state.0.lock().unwrap();
         assert_eq!(requests.len(), 2);
-        assert_eq!(requests[0].0, "/compat/openai/v1/chat/completions");
+        assert_eq!(requests[0].path, "/compat/openai/v1/chat/completions");
         assert_eq!(
-            requests[0].1.get(header::AUTHORIZATION).unwrap(),
+            requests[0].headers.get(header::AUTHORIZATION).unwrap(),
             "Bearer mg_at_rotating"
         );
         assert_eq!(
             requests[0]
-                .1
+                .headers
                 .get(crate::router::GATEWAY_CONVERSATION_HEADER)
                 .unwrap(),
             conversation.to_string().as_str()
         );
         assert_eq!(
-            requests[1].1.get(header::AUTHORIZATION).unwrap(),
+            requests[0].body["stream_options"],
+            json!({ "include_usage": true })
+        );
+        assert_eq!(
+            requests[1].headers.get(header::AUTHORIZATION).unwrap(),
             "Bearer direct-key"
         );
         assert!(requests[1]
-            .1
+            .headers
             .get(crate::router::GATEWAY_CONVERSATION_HEADER)
             .is_none());
+        assert!(requests[1].body.get("stream_options").is_none());
         server.abort();
     }
 }

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -36,6 +36,13 @@ pub struct OpenAiCompatProvider {
     client: reqwest::Client,
     api_key: String,
     base_url: String,
+    /// Per-request credential supplier for gateways that mint short-lived
+    /// tokens. Takes precedence over `api_key` when present.
+    token_source: Option<std::sync::Arc<dyn crate::BearerTokenSource>>,
+    /// Whether to declare the request's conversation to a model gateway.
+    /// Off for ordinary compatible endpoints, which are not parties to the
+    /// host's chat organization.
+    conversation_attribution: bool,
     /// Stable id reported by [`ModelProvider::id`] — `"openai"` or
     /// `"openai_compatible"` depending on how the caller configured it.
     provider_id: String,
@@ -51,6 +58,8 @@ impl OpenAiCompatProvider {
             client: crate::http::streaming_client(),
             api_key: api_key.into(),
             base_url: DEFAULT_BASE_URL.to_string(),
+            token_source: None,
+            conversation_attribution: false,
             provider_id: "openai".to_string(),
         }
     }
@@ -61,6 +70,8 @@ impl OpenAiCompatProvider {
             client: crate::http::streaming_client(),
             api_key: api_key.into(),
             base_url: base_url.into(),
+            token_source: None,
+            conversation_attribution: false,
             provider_id: "openai_compatible".to_string(),
         }
     }
@@ -76,6 +87,25 @@ impl OpenAiCompatProvider {
     #[must_use]
     pub fn with_id(mut self, id: impl Into<String>) -> Self {
         self.provider_id = id.into();
+        self
+    }
+
+    /// Fetch the credential from `source` at each request instead of using a
+    /// static key. Gateway token sources refresh behind their own lock.
+    #[must_use]
+    pub fn with_token_source(
+        mut self,
+        source: std::sync::Arc<dyn crate::BearerTokenSource>,
+    ) -> Self {
+        self.token_source = Some(source);
+        self
+    }
+
+    /// Declare each request's conversation to the gateway this provider points
+    /// at, so usage and attested tool calls are attributed to the same chat.
+    #[must_use]
+    pub fn with_conversation_attribution(mut self) -> Self {
+        self.conversation_attribution = true;
         self
     }
 }
@@ -95,12 +125,23 @@ impl ModelProvider for OpenAiCompatProvider {
             body["stream_options"] = json!({ "include_usage": true });
         }
         let url = format!("{}/chat/completions", self.base_url.trim_end_matches('/'));
+        let api_key = match &self.token_source {
+            Some(source) => source.bearer_token_for(req.conversation).await?,
+            None => self.api_key.clone(),
+        };
 
-        let response = self
+        let mut request = self
             .client
             .post(url)
-            .bearer_auth(&self.api_key)
-            .header("content-type", "application/json")
+            .bearer_auth(api_key)
+            .header("content-type", "application/json");
+        if let (true, Some(conversation)) = (self.conversation_attribution, req.conversation) {
+            request = request.header(
+                crate::router::GATEWAY_CONVERSATION_HEADER,
+                conversation.to_string(),
+            );
+        }
+        let response = request
             .json(&body)
             .send()
             .await
@@ -1267,5 +1308,118 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn a_gateway_request_uses_the_rotating_conversation_token_and_attribution_header() {
+        use axum::extract::{Request, State};
+        use axum::http::{header, HeaderMap, StatusCode};
+        use axum::response::IntoResponse;
+        use axum::routing::post;
+        use axum::Router;
+        use std::sync::{Arc, Mutex};
+
+        #[derive(Clone, Default)]
+        struct Capture(Arc<Mutex<Vec<(String, HeaderMap)>>>);
+
+        async fn capture(State(capture): State<Capture>, request: Request) -> impl IntoResponse {
+            capture
+                .0
+                .lock()
+                .unwrap()
+                .push((request.uri().path().to_owned(), request.headers().clone()));
+            (
+                StatusCode::OK,
+                [(header::CONTENT_TYPE, "text/event-stream")],
+                "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+            )
+        }
+
+        struct RecordingTokenSource(Mutex<Vec<Option<openwave_core::id::ChatId>>>);
+
+        #[async_trait::async_trait]
+        impl crate::BearerTokenSource for RecordingTokenSource {
+            async fn bearer_token(&self) -> openwave_core::Result<String> {
+                unreachable!("the gateway adapter must ask for a conversation token");
+            }
+
+            async fn bearer_token_for(
+                &self,
+                conversation: Option<openwave_core::id::ChatId>,
+            ) -> openwave_core::Result<String> {
+                self.0.lock().unwrap().push(conversation);
+                Ok("mg_at_rotating".to_string())
+            }
+        }
+
+        let capture_state = Capture::default();
+        let app = Router::new()
+            .fallback(post(capture))
+            .with_state(capture_state.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let source = Arc::new(RecordingTokenSource(Mutex::new(Vec::new())));
+        let provider = OpenAiCompatProvider::compatible(
+            "unused",
+            format!("http://{address}/compat/openai/v1"),
+        )
+        .with_token_source(source.clone())
+        .with_conversation_attribution();
+        let conversation = openwave_core::id::ChatId::new();
+        let stream = provider
+            .stream(ChatRequest {
+                model: "gpt-fable-5".into(),
+                conversation: Some(conversation),
+                messages: vec![ChatMessage::text(Role::User, "hi")],
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let _: Vec<_> = stream.collect().await;
+
+        // A normal compatible endpoint uses its static key and must not learn
+        // how the host groups conversations merely because the request has an
+        // id available.
+        let direct = OpenAiCompatProvider::compatible(
+            "direct-key",
+            format!("http://{address}/compat/openai/v1"),
+        );
+        let stream = direct
+            .stream(ChatRequest {
+                model: "gpt-fable-5".into(),
+                conversation: Some(conversation),
+                messages: vec![ChatMessage::text(Role::User, "hi")],
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let _: Vec<_> = stream.collect().await;
+
+        assert_eq!(source.0.lock().unwrap().as_slice(), &[Some(conversation)]);
+        let requests = capture_state.0.lock().unwrap();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].0, "/compat/openai/v1/chat/completions");
+        assert_eq!(
+            requests[0].1.get(header::AUTHORIZATION).unwrap(),
+            "Bearer mg_at_rotating"
+        );
+        assert_eq!(
+            requests[0]
+                .1
+                .get(crate::router::GATEWAY_CONVERSATION_HEADER)
+                .unwrap(),
+            conversation.to_string().as_str()
+        );
+        assert_eq!(
+            requests[1].1.get(header::AUTHORIZATION).unwrap(),
+            "Bearer direct-key"
+        );
+        assert!(requests[1]
+            .1
+            .get(crate::router::GATEWAY_CONVERSATION_HEADER)
+            .is_none());
+        server.abort();
     }
 }

--- a/crates/openwave-router/src/router.rs
+++ b/crates/openwave-router/src/router.rs
@@ -373,7 +373,8 @@ fn build_adapter(route: &Route) -> Option<Arc<dyn ModelProvider>> {
             Some(Arc::new(
                 OpenAiCompatProvider::compatible(String::new(), base.to_string())
                     .with_token_source(source)
-                    .with_conversation_attribution(),
+                    .with_conversation_attribution()
+                    .with_streaming_usage(),
             ))
         }
         #[cfg(not(feature = "openai-compat"))]

--- a/crates/openwave-router/src/router.rs
+++ b/crates/openwave-router/src/router.rs
@@ -26,6 +26,11 @@ use crate::OpenAiCompatProvider;
 #[cfg(feature = "openai")]
 use crate::OpenAiProvider;
 
+/// Header a model-gateway deployment reads to group inference into one
+/// conversation. Gateway adapters opt in explicitly; direct providers never
+/// send it.
+pub(crate) const GATEWAY_CONVERSATION_HEADER: &str = "x-model-gateway-conversation-id";
+
 /// A per-request credential supplier for routes whose token is short-lived.
 ///
 /// A static key is snapshotted into the adapter for the lifetime of a cached
@@ -108,10 +113,16 @@ pub enum RouteKind {
     /// A model-gateway deployment's Anthropic-compatible surface, authenticated
     /// with short-lived resource-scoped tokens instead of a static key.
     ModelGateway,
+    /// The same model-gateway deployment's OpenAI-compatible Chat Completions
+    /// surface. It shares the public `model_gateway` provider namespace with
+    /// [`ModelGateway`](Self::ModelGateway); the synced model protocol chooses
+    /// which concrete route serves a request.
+    ModelGatewayOpenai,
 }
 
 impl RouteKind {
-    /// Stable id string matching the server's provider kind wire form.
+    /// Stable concrete-route id. Use [`provider_id`](Self::provider_id) for
+    /// the host-facing provider namespace.
     pub fn as_str(self) -> &'static str {
         match self {
             RouteKind::Anthropic => "anthropic",
@@ -119,6 +130,16 @@ impl RouteKind {
             RouteKind::OpenaiCompatible => "openai_compatible",
             RouteKind::Gemini => "gemini",
             RouteKind::ModelGateway => "model_gateway",
+            RouteKind::ModelGatewayOpenai => "model_gateway_openai",
+        }
+    }
+
+    /// Provider id used in host model selections. The two concrete gateway
+    /// adapters deliberately share one public provider namespace.
+    fn provider_id(self) -> &'static str {
+        match self {
+            Self::ModelGatewayOpenai => "model_gateway",
+            _ => self.as_str(),
         }
     }
 
@@ -202,7 +223,7 @@ impl Router {
                 has_openai_compat = true;
             }
             for model in &route.curated_models {
-                curated.insert(format!("{}::{model}", route.kind.as_str()), route.kind);
+                curated.insert(format!("{}::{model}", route.kind.provider_id()), route.kind);
             }
             if let Some(adapter) = build_adapter(&route) {
                 adapters.insert(route.kind, adapter);
@@ -230,11 +251,13 @@ impl Router {
             RouteKind::Openai,
             RouteKind::Gemini,
             RouteKind::ModelGateway,
+            RouteKind::ModelGatewayOpenai,
             RouteKind::OpenaiCompatible,
         ] {
             if self
                 .curated
-                .contains_key(&format!("{}::{model}", kind.as_str()))
+                .get(&format!("{}::{model}", kind.provider_id()))
+                == Some(&kind)
                 && self.adapters.contains_key(&kind)
             {
                 return Some(kind);
@@ -256,6 +279,10 @@ impl Router {
         let Some(provider) = provider else {
             return self.select(model);
         };
+        if provider.0 == "model_gateway" {
+            let kind = *self.curated.get(&format!("model_gateway::{model}"))?;
+            return self.adapters.contains_key(&kind).then_some(kind);
+        }
         let kind = RouteKind::parse(&provider.0)?;
         if !self.adapters.contains_key(&kind) {
             return None;
@@ -332,6 +359,25 @@ fn build_adapter(route: &Route) -> Option<Arc<dyn ModelProvider>> {
         }
         #[cfg(not(feature = "anthropic"))]
         RouteKind::ModelGateway => None,
+
+        #[cfg(feature = "openai-compat")]
+        RouteKind::ModelGatewayOpenai => {
+            // Like the Anthropic gateway route, this surface is unusable
+            // without a live token source: static credentials cannot follow
+            // the gateway's rotation or conversation attestation context.
+            let base = route.base_url.as_deref()?;
+            if !(base.starts_with("https://") || base.starts_with("http://")) {
+                return None;
+            }
+            let source = route.token_source.clone()?;
+            Some(Arc::new(
+                OpenAiCompatProvider::compatible(String::new(), base.to_string())
+                    .with_token_source(source)
+                    .with_conversation_attribution(),
+            ))
+        }
+        #[cfg(not(feature = "openai-compat"))]
+        RouteKind::ModelGatewayOpenai => None,
 
         #[cfg(feature = "openai")]
         RouteKind::Openai => {
@@ -569,6 +615,36 @@ mod tests {
             with.select_for(Some(&ProviderId::new("model_gateway")), "unknown"),
             None
         );
+    }
+
+    #[test]
+    fn a_gateway_provider_selects_each_models_synced_protocol() {
+        let mut anthropic = route(
+            RouteKind::ModelGateway,
+            "",
+            &["claude-fable-5"],
+            Some("http://127.0.0.1:28081/compat/anthropic"),
+        );
+        anthropic.token_source = Some(Arc::new(StaticSource("mg_at_x")));
+        let mut openai = route(
+            RouteKind::ModelGatewayOpenai,
+            "",
+            &["gpt-fable-5"],
+            Some("http://127.0.0.1:28081/compat/openai/v1"),
+        );
+        openai.token_source = Some(Arc::new(StaticSource("mg_at_x")));
+
+        let router = Router::build(vec![anthropic, openai]);
+        let gateway = ProviderId::new("model_gateway");
+        assert_eq!(
+            router.select_for(Some(&gateway), "claude-fable-5"),
+            Some(RouteKind::ModelGateway)
+        );
+        assert_eq!(
+            router.select_for(Some(&gateway), "gpt-fable-5"),
+            Some(RouteKind::ModelGatewayOpenai)
+        );
+        assert_eq!(router.select_for(Some(&gateway), "unknown"), None);
     }
 
     #[test]

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -453,6 +453,7 @@ impl GatewayRuntime {
                     &providers::GatewayModelSnapshot {
                         gateway_url: base_url,
                         models: Vec::new(),
+                        model_protocols: Default::default(),
                     },
                 )
                 .await?;
@@ -535,22 +536,33 @@ impl GatewayRuntime {
         let policy = crate::managed_policy::resolve(&*self.store, &*self.os_policy).await?;
         let base_url = require_managed(&policy)?;
         let connection = self.connection_at(base_url.clone()).await?;
-        // The gateway routes these models over its Anthropic-compatible
-        // surface, so sync exactly the set that protocol can serve. Fetched
-        // before the row lock is taken: the entitlement round-trip must not
-        // stall the other row writers.
+        // Fetch the full entitled set: each row names the compatibility
+        // protocol the gateway serves it through, and route collection splits
+        // the snapshot across matching adapters. Fetched before the row lock
+        // is taken: the entitlement round-trip must not stall other writers.
+        let mut model_protocols = std::collections::BTreeMap::new();
         let models: Vec<CustomModelConfig> = connection
-            .models(Some("anthropic_messages"))
+            .models(None)
             .await?
             .into_iter()
-            .map(|model| CustomModelConfig {
-                id: model.id,
-                display_name: Some(model.name),
-                // Carried so a deployment-aliased id can still be matched to
-                // its curated row; gateways older than the field send none.
-                upstream_id: model.upstream_id,
-                context_window: clamp_u32(model.context_window, 32_768),
-                max_output_tokens: clamp_u32(model.max_output_tokens, 4_096),
+            .filter_map(|model| {
+                let Some(protocol) = providers::GatewayModelProtocol::parse(&model.protocol) else {
+                    tracing::debug!(
+                        "gateway model sync skipped a model with an unsupported inference protocol"
+                    );
+                    return None;
+                };
+                let id = model.id;
+                model_protocols.insert(id.clone(), protocol);
+                Some(CustomModelConfig {
+                    id,
+                    display_name: Some(model.name),
+                    // Carried so a deployment-aliased id can still be matched to
+                    // its curated row; gateways older than the field send none.
+                    upstream_id: model.upstream_id,
+                    context_window: clamp_u32(model.context_window, 32_768),
+                    max_output_tokens: clamp_u32(model.max_output_tokens, 4_096),
+                })
             })
             .collect();
         // The gateway is trusted for entitlements, not for shapes: the synced
@@ -579,6 +591,7 @@ impl GatewayRuntime {
             &providers::GatewayModelSnapshot {
                 gateway_url: base_url,
                 models,
+                model_protocols,
             },
         )
         .await?;
@@ -929,10 +942,7 @@ mod tests {
         axum::extract::Query(query): axum::extract::Query<HashMap<String, String>>,
         headers: HeaderMap,
     ) -> Response {
-        assert_eq!(
-            query.get("protocol").map(String::as_str),
-            Some("anthropic_messages")
-        );
+        assert!(!query.contains_key("protocol"));
         let bearer = headers
             .get("authorization")
             .and_then(|value| value.to_str().ok())
@@ -942,6 +952,7 @@ mod tests {
             "models": [
                 {
                     "id": "sample-claude",
+                    "protocol": "anthropic_messages",
                     "name": "Sample Claude",
                     "context_window": 200000,
                     "max_output_tokens": 8192,
@@ -950,6 +961,7 @@ mod tests {
                 },
                 {
                     "id": "sample-coder",
+                    "protocol": "openai_chat_completions",
                     "name": "Sample Coder",
                     "context_window": null,
                     "max_output_tokens": null,
@@ -1129,6 +1141,18 @@ mod tests {
         // Absent limits fall back to the conservative custom-model defaults.
         assert_eq!(models[1].context_window, 32_768);
         assert_eq!(models[1].max_output_tokens, 4_096);
+        let snapshot = providers::read_gateway_snapshot(&*store)
+            .await
+            .unwrap()
+            .expect("the sync persisted its protocol map");
+        assert_eq!(
+            snapshot.model_protocols.get("sample-claude"),
+            Some(&providers::GatewayModelProtocol::AnthropicMessages)
+        );
+        assert_eq!(
+            snapshot.model_protocols.get("sample-coder"),
+            Some(&providers::GatewayModelProtocol::OpenaiChatCompletions)
+        );
 
         // The synced snapshot resolves as a model policy under the gateway key.
         let policy =
@@ -1183,6 +1207,7 @@ mod tests {
                         max_output_tokens: 32_000,
                     },
                 ],
+                model_protocols: Default::default(),
             },
         )
         .await
@@ -1354,18 +1379,31 @@ mod tests {
             &policy,
         )
         .await;
-        let gateway_route = routes
+        let anthropic_route = routes
             .iter()
             .find(|route| route.kind == openwave_router::RouteKind::ModelGateway)
-            .expect("gateway route present");
+            .expect("Anthropic gateway route present");
         assert_eq!(
-            gateway_route.base_url.as_deref(),
+            anthropic_route.base_url.as_deref(),
             Some(format!("{base}/compat/anthropic").as_str())
         );
-        assert!(gateway_route.api_key.is_empty());
-        assert!(gateway_route
+        assert!(anthropic_route.api_key.is_empty());
+        assert!(anthropic_route
             .curated_models
             .contains(&"sample-claude".to_string()));
+        assert!(!anthropic_route
+            .curated_models
+            .contains(&"sample-coder".to_string()));
+        let openai_route = routes
+            .iter()
+            .find(|route| route.kind == openwave_router::RouteKind::ModelGatewayOpenai)
+            .expect("OpenAI gateway route present");
+        assert_eq!(
+            openai_route.base_url.as_deref(),
+            Some(format!("{base}/compat/openai/v1").as_str())
+        );
+        assert!(openai_route.api_key.is_empty());
+        assert_eq!(openai_route.curated_models, ["sample-coder"]);
         assert!(providers::provider_is_usable(
             &*store,
             &*runtime.secrets,

--- a/crates/openwave-server/src/model_roles.rs
+++ b/crates/openwave-server/src/model_roles.rs
@@ -460,6 +460,7 @@ mod tests {
                         max_output_tokens: 8_192,
                     },
                 ],
+                model_protocols: Default::default(),
             },
         )
         .await

--- a/crates/openwave-server/src/pairing.rs
+++ b/crates/openwave-server/src/pairing.rs
@@ -618,6 +618,7 @@ mod tests {
                     context_window: 32_768,
                     max_output_tokens: 4_096,
                 }],
+                model_protocols: Default::default(),
             },
         )
         .await

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -12,6 +12,7 @@
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
 
 use openwave_core::{AgentConfig, ProviderId, ReasoningEffort, Result, SecretProvider, Store};
 
@@ -59,6 +60,36 @@ pub(crate) struct GatewayModelSnapshot {
     /// The normalized gateway base URL the models were fetched from.
     pub(crate) gateway_url: String,
     pub(crate) models: Vec<CustomModelConfig>,
+    /// Per-model inference protocol. An absent map is a snapshot written by a
+    /// gateway generation that served only Anthropic Messages, so lookup
+    /// defaults to that protocol for backward compatibility.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub(crate) model_protocols: BTreeMap<String, GatewayModelProtocol>,
+}
+
+/// The compatibility protocol a managed gateway uses for one entitled model.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum GatewayModelProtocol {
+    /// Anthropic Messages at `/compat/anthropic/v1/messages`.
+    #[default]
+    AnthropicMessages,
+    /// OpenAI Chat Completions at `/compat/openai/v1/chat/completions`.
+    OpenaiChatCompletions,
+}
+
+impl GatewayModelProtocol {
+    /// Accept the canonical gateway values plus the short names older
+    /// deployments used for the model-list filter.
+    pub(crate) fn parse(value: &str) -> Option<Self> {
+        match value {
+            "anthropic" | "anthropic_messages" => Some(Self::AnthropicMessages),
+            "openai" | "openai_compatible" | "openai_chat_completions" => {
+                Some(Self::OpenaiChatCompletions)
+            }
+            _ => None,
+        }
+    }
 }
 
 /// Read the stored snapshot regardless of provenance. Callers that offer
@@ -92,14 +123,22 @@ pub(crate) async fn gateway_models(
     store: &dyn Store,
     policy: &crate::managed_policy::ManagedPolicy,
 ) -> Result<Vec<CustomModelConfig>> {
+    Ok(gateway_snapshot_for_policy(store, policy)
+        .await?
+        .map(|snapshot| snapshot.models)
+        .unwrap_or_default())
+}
+
+async fn gateway_snapshot_for_policy(
+    store: &dyn Store,
+    policy: &crate::managed_policy::ManagedPolicy,
+) -> Result<Option<GatewayModelSnapshot>> {
     let Some(gateway_url) = policy.gateway_url.as_deref().filter(|_| policy.managed) else {
-        return Ok(Vec::new());
+        return Ok(None);
     };
     Ok(read_gateway_snapshot(store)
         .await?
-        .filter(|snapshot| snapshot.gateway_url == gateway_url)
-        .map(|snapshot| snapshot.models)
-        .unwrap_or_default())
+        .filter(|snapshot| snapshot.gateway_url == gateway_url))
 }
 
 /// One-shot boot cutover for the retired additive gateway configuration.
@@ -184,6 +223,7 @@ pub(crate) async fn retire_legacy_gateway_row(
         &GatewayModelSnapshot {
             gateway_url,
             models: row.models,
+            model_protocols: BTreeMap::new(),
         },
     )
     .await?;
@@ -217,8 +257,8 @@ pub enum ProviderKind {
     /// Any OpenAI-compatible Chat Completions gateway (OpenRouter, vLLM, …).
     OpenaiCompatible,
     /// A signed-in model-gateway deployment: entitled models synced from the
-    /// gateway, inference through its Anthropic-compatible surface with
-    /// short-lived OAuth tokens.
+    /// gateway, inference through each model's Anthropic- or OpenAI-compatible
+    /// surface with short-lived OAuth tokens.
     ModelGateway,
 }
 
@@ -1249,16 +1289,64 @@ pub async fn collect_routes(
             if !(base.starts_with("https://") || base.starts_with("http://")) {
                 continue;
             }
-            let models = gateway_models(store, policy).await.unwrap_or_default();
-            routes.push(openwave_router::Route {
-                kind: route_kind(kind),
-                api_key: String::new(),
-                base_url: Some(format!("{}/compat/anthropic", base.trim_end_matches('/'))),
-                curated_models: models.into_iter().map(|model| model.id).collect(),
-                token_source: Some(source),
-                vertex: None,
-                chatgpt_account_id: None,
-            });
+            let (models, model_protocols) = match gateway_snapshot_for_policy(store, policy)
+                .await
+                .unwrap_or_default()
+            {
+                Some(GatewayModelSnapshot {
+                    models,
+                    model_protocols,
+                    ..
+                }) => (models, model_protocols),
+                None => (Vec::new(), BTreeMap::new()),
+            };
+            let mut anthropic_models = Vec::new();
+            let mut openai_models = Vec::new();
+            for model in models {
+                match model_protocols.get(&model.id).copied().unwrap_or_default() {
+                    GatewayModelProtocol::AnthropicMessages => anthropic_models.push(model.id),
+                    GatewayModelProtocol::OpenaiChatCompletions => openai_models.push(model.id),
+                }
+            }
+            let base = base.trim_end_matches('/');
+            // Preserve the pre-protocol route shape before the first sync (or
+            // for an empty entitlement set): it still selects no model, but a
+            // signed-in managed profile has one inert gateway adapter rather
+            // than looking indistinguishable from missing credentials.
+            if anthropic_models.is_empty() && openai_models.is_empty() {
+                routes.push(openwave_router::Route {
+                    kind: route_kind(kind),
+                    api_key: String::new(),
+                    base_url: Some(format!("{base}/compat/anthropic")),
+                    curated_models: Vec::new(),
+                    token_source: Some(source),
+                    vertex: None,
+                    chatgpt_account_id: None,
+                });
+            } else {
+                if !anthropic_models.is_empty() {
+                    routes.push(openwave_router::Route {
+                        kind: route_kind(kind),
+                        api_key: String::new(),
+                        base_url: Some(format!("{base}/compat/anthropic")),
+                        curated_models: anthropic_models,
+                        token_source: Some(source.clone()),
+                        vertex: None,
+                        chatgpt_account_id: None,
+                    });
+                }
+                if !openai_models.is_empty() {
+                    routes.push(openwave_router::Route {
+                        kind: openwave_router::RouteKind::ModelGatewayOpenai,
+                        api_key: String::new(),
+                        base_url: Some(format!("{base}/compat/openai/v1")),
+                        curated_models: openai_models,
+                        token_source: Some(source),
+                        vertex: None,
+                        chatgpt_account_id: None,
+                    });
+                }
+            }
             continue;
         }
         if policy.managed {
@@ -1684,6 +1772,29 @@ mod tests {
             "provider.anthropic.credential"
         );
         assert_eq!(ProviderKind::Openai.setting_key(), "provider.openai");
+    }
+
+    #[test]
+    fn a_pre_protocol_gateway_snapshot_keeps_its_anthropic_route() {
+        let snapshot: GatewayModelSnapshot = serde_json::from_value(serde_json::json!({
+            "gateway_url": "https://gateway.example/",
+            "models": [{
+                "id": "legacy-claude",
+                "context_window": 32768,
+                "max_output_tokens": 4096
+            }]
+        }))
+        .expect("the persisted shape from before per-model protocols still loads");
+
+        assert!(snapshot.model_protocols.is_empty());
+        assert_eq!(
+            snapshot
+                .model_protocols
+                .get("legacy-claude")
+                .copied()
+                .unwrap_or_default(),
+            GatewayModelProtocol::AnthropicMessages
+        );
     }
 
     /// An unset display name is represented by the key being absent, in both

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -1721,6 +1721,7 @@ async fn model_roles_resolve_at_read_time_and_honor_an_explicit_pin() {
                     max_output_tokens: 8_192,
                 },
             ],
+            model_protocols: Default::default(),
         },
     )
     .await

--- a/docs/gateway-boundary.md
+++ b/docs/gateway-boundary.md
@@ -125,12 +125,14 @@ The connector speaks a small, versioned HTTP surface on the gateway:
 - `/api/v1/meta` — unauthenticated deployment identity, shown before and
   during sign-in.
 - `/api/v1/cli/me` — the authenticated user, for the account hint.
-- `/api/v1/cli/models` — the models this user may invoke, optionally
-  filtered by `?protocol=` (`anthropic` / `openai`). Synced into a local
-  snapshot stamped with the gateway URL after sign-in and on the explicit
-  "Refresh models" affordance; the snapshot is what the model picker
-  offers, and sign-out empties it. A stamp that no longer matches policy
-  invalidates the snapshot rather than serving another gateway's models.
+- `/api/v1/cli/models` — the models this user may invoke. OpenWave syncs the
+  full list and retains each row's `protocol` (`anthropic_messages` or
+  `openai_chat_completions`) in a local snapshot stamped with the gateway URL
+  after sign-in and on the explicit "Refresh models" affordance; gateways
+  predating the field are treated as Anthropic-only. The snapshot is what the
+  model picker offers, and sign-out empties it. A stamp that no longer matches
+  policy invalidates the snapshot rather than serving another gateway's
+  models.
 - `/api/v1/cli/apps` — entitled connected apps
   (`id`, `name`, `app_kind`, `enabled`, `mcp_endpoint_slugs`), listed in
   the gateway settings panel. A `404` means an older gateway; the section
@@ -142,14 +144,16 @@ The connector speaks a small, versioned HTTP surface on the gateway:
   chat's inference tokens with its MCP tokens so gateway-attested endpoints
   can match tool calls against model-emitted observations; it carries no
   chat content and is meaningless outside the session it is pinned to.
-- Inference itself — invoked with `llm`-audience bearers on the gateway's
-  protocol-compatible routes, through the same provider machinery as any
-  direct provider. A turn's request also declares which conversation it
+- Inference itself — invoked with `llm`-audience bearers through the matching
+  gateway surface: Anthropic Messages at `/compat/anthropic/v1/messages`, or
+  OpenAI Chat Completions at `/compat/openai/v1/chat/completions`. Both use
+  the same provider machinery as their direct counterparts and fetch the
+  rotating bearer per request. A turn also declares which conversation it
   belongs to, as an `x-model-gateway-conversation-id` header carrying the
   chat's id, so the gateway's usage views group inference the way the app
-  does. The header is a per-route opt-in: only the gateway adapter sends it,
-  a direct provider never does, and it is a header rather than wire data, so
-  no model receives it. The chat id is the only thing declared — no title, no
+  does. The header is a per-route opt-in: only gateway adapters send it, a
+  direct provider never does, and it is a header rather than wire data, so no
+  model receives it. The chat id is the only thing declared — no title, no
   content, no participant.
 - MCP — `{base}/mcp/{slug}` per mounted endpoint. The connection minting
   its `mcp:<slug>` bearer at connect time rides the shared connect


### PR DESCRIPTION
## Summary

- sync the complete gateway entitlement list and persist each model’s inference protocol
- keep the public `model_gateway::<id>` namespace while selecting an Anthropic Messages or OpenAI Chat Completions adapter per model
- route OpenAI-protocol models through `/compat/openai/v1/chat/completions` with the same rotating `llm` bearer and conversation attribution used by the Anthropic gateway route
- preserve pre-protocol snapshots as Anthropic-only and keep unsupported future protocols out of the routable snapshot

## Why

Gateway model sync previously requested only the `anthropic_messages` subset, so models available exclusively through the gateway’s OpenAI-compatible surface never reached the picker. A single concrete gateway adapter also could not safely serve models with different wire protocols.

## Verification

- `cargo fmt --all --check`
- `cargo check --workspace --locked`
- `cargo clippy -p openwave-router -p openwave-connectors -p openwave-server --all-targets --locked -- -D warnings`
- `cargo test -p openwave-router --locked` (119 unit tests + 4 replay contracts)
- `cargo test -p openwave-connectors --locked` (20 tests)
- `cargo test -p openwave-server gateway_runtime::tests --locked` (21 tests)
- `cargo test -p openwave-server a_managed_profile_offers_only_the_gateway_route --locked`
- `cargo test -p openwave-server a_pre_protocol_gateway_snapshot_keeps_its_anthropic_route --locked`

No tests were removed. The running desktop app was not driven against a live gateway; request routing, credentials, headers, sync, and compatibility behavior are covered by in-process boundary tests.

Closes #1651