### PR TITLE
feat(desktop): ask before writing outputs into connected folders in Ask mode

### DIFF
--- a/crates/openwave-core/src/agent/dispatch.rs
+++ b/crates/openwave-core/src/agent/dispatch.rs
@@ -446,9 +446,12 @@ impl Agent {
             return Err("not run: that user continuation is available only from a durably claimed foreground turn. Continue without it.");
         }
         // Plan turns advertise only read-only client tools, and a call that
-        // slipped past advertisement is refused here for the same reason
-        // server-side mutations are: client execution is ungated by design,
-        // so the only write gate a plan turn has is never issuing the request.
+        // slipped past advertisement is refused here. The class/mode gate is
+        // server-side, and a client call does not re-enter it: the trusted
+        // desktop carries its own consent, and the one client write that leaves
+        // the sandbox consults the mode where it executes
+        // (`OutputWriteMode::requires_user_decision`). Never issuing the
+        // request is what keeps a plan turn from changing anything.
         if matches!(chat.permission_mode, Some(PermissionMode::Plan))
             && self.tools.registered_class(&call.name) != Some(ApprovalClass::ReadOnly)
         {

--- a/crates/openwave-core/src/client_tools.rs
+++ b/crates/openwave-core/src/client_tools.rs
@@ -252,7 +252,7 @@ pub struct ImportConnectedFileArgs {
 }
 
 /// Whether connected-folder publication may replace an existing regular file.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 #[schemars(description = "", transform = preserve_enum_wire_shape)]
 pub enum OutputWriteMode {
@@ -262,6 +262,32 @@ pub enum OutputWriteMode {
     /// Replace one existing regular file after a fresh native approval.
     #[schemars(description = "")]
     Replace,
+}
+
+impl OutputWriteMode {
+    /// Whether publishing an output this way needs a fresh user decision in a
+    /// chat running under `mode`.
+    ///
+    /// This is the one client-executed write that leaves the sandbox and lands
+    /// in a real folder the reader owns, so it is the one client call the
+    /// chat's permission mode governs. `Ask` promises that workspace mutations
+    /// ask, and a create is a workspace mutation; `Auto` and `Allow` are
+    /// standing answers to exactly that question and let it through. `Plan`
+    /// never checkpoints the call at all, but a mode flipped while one is
+    /// parked resolves the conservative way.
+    ///
+    /// Replacement always asks, in every mode: it destroys bytes the agent did
+    /// not write, and no mode advertises consent for that.
+    #[must_use]
+    pub fn requires_user_decision(self, mode: Option<crate::PermissionMode>) -> bool {
+        match self {
+            Self::Replace => true,
+            Self::Create => matches!(
+                mode.unwrap_or(crate::PermissionMode::Ask),
+                crate::PermissionMode::Ask | crate::PermissionMode::Plan
+            ),
+        }
+    }
 }
 
 /// Model proposal for writing one published output to an attached root.
@@ -465,7 +491,7 @@ pub fn import_connected_file_tool_spec() -> ToolSpec {
 pub fn write_output_to_connected_folder_tool_spec() -> ToolSpec {
     ToolSpec::for_args::<WriteOutputToConnectedFolderProposal>(
         WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL,
-        "Copy an output already published in this conversation into a folder already connected to this conversation. Provide only the output's filename exactly as reported when it was published, the opaque root_id, a bounded root-relative destination, and explicit create or replace intent. Create refuses an existing entry. Replace requires fresh user approval; never provide output bytes or an absolute path.",
+        "Copy an output already published in this conversation into a folder already connected to this conversation. Provide only the output's filename exactly as reported when it was published, the opaque root_id, a bounded root-relative destination, and explicit create or replace intent. Create refuses an existing entry, and may still need user approval depending on the conversation's permission mode. Replace always requires fresh user approval; never provide output bytes or an absolute path.",
     )
 }
 
@@ -758,6 +784,31 @@ mod tests {
         assert!(!spec.description.contains("output_id"));
         assert!(spec.description.contains("never provide output bytes"));
         assert!(!spec.description.contains("scratch"));
+    }
+
+    /// The one client-executed write that leaves the sandbox is the one place
+    /// the chat's permission mode reaches client execution. `Ask` advertises
+    /// that workspace mutations ask, and a create into a real folder is one;
+    /// replacement asks everywhere, because no mode consents to destroying
+    /// bytes the agent did not write.
+    #[test]
+    fn a_connected_folder_write_asks_exactly_where_the_mode_promises() {
+        use crate::PermissionMode;
+
+        for mode in [
+            None,
+            Some(PermissionMode::Plan),
+            Some(PermissionMode::Ask),
+            Some(PermissionMode::Auto),
+            Some(PermissionMode::Allow),
+        ] {
+            assert!(OutputWriteMode::Replace.requires_user_decision(mode));
+        }
+        assert!(OutputWriteMode::Create.requires_user_decision(None));
+        assert!(OutputWriteMode::Create.requires_user_decision(Some(PermissionMode::Ask)));
+        assert!(OutputWriteMode::Create.requires_user_decision(Some(PermissionMode::Plan)));
+        assert!(!OutputWriteMode::Create.requires_user_decision(Some(PermissionMode::Auto)));
+        assert!(!OutputWriteMode::Create.requires_user_decision(Some(PermissionMode::Allow)));
     }
 
     #[test]

--- a/crates/openwave-core/src/model/chat_settings.rs
+++ b/crates/openwave-core/src/model/chat_settings.rs
@@ -127,6 +127,14 @@ impl ReasoningEffort {
 /// on it: `Plan < Ask < Auto < Allow`, matching [`Self::ALL`]. Managed-policy
 /// ceilings compare modes with it, so a new variant must slot into this
 /// scale, not just onto the end of the list.
+///
+/// The mode governs the server-side approval gate, which is where all but one
+/// mutating call lives. Client-executed tools run in the trusted desktop under
+/// their own consent — a folder grant the reader picked, a card the native side
+/// raises — and do not re-enter that gate. The one client call that mutates
+/// something the reader owns, publishing an output into a connected folder,
+/// consults the mode itself: see
+/// [`crate::OutputWriteMode::requires_user_decision`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 pub enum PermissionMode {
@@ -135,15 +143,19 @@ pub enum PermissionMode {
     /// card — so a plan turn cannot change anything no matter what the
     /// reader approves.
     Plan,
-    /// Every uncovered mutating call parks on the approval card. The default,
-    /// and the only mode where `Workspace`-class tools ask.
+    /// Every uncovered mutating call parks on the approval card, including the
+    /// one client-executed write that leaves the sandbox. The default, and the
+    /// only mode where `Workspace`-class tools ask.
     Ask,
     /// The agent proceeds through `Workspace` writes on its own; uncovered
     /// `Sensitive` calls still ask. This is a standing "yes" to workspace
-    /// edits stated as a mode instead of a per-tool grant.
+    /// edits stated as a mode instead of a per-tool grant. Replacing an
+    /// existing file in a connected folder still asks: no mode advertises
+    /// consent for destroying bytes the agent did not write.
     Auto,
-    /// Nothing asks. An explicit per-chat opt-in to full autonomy; the
-    /// approval gate is bypassed for every class.
+    /// Nothing asks, with the same replacement exception `Auto` carries. An
+    /// explicit per-chat opt-in to full autonomy; the approval gate is
+    /// bypassed for every class.
     Allow,
 }
 

--- a/crates/openwave-desktop/src/client_execution/output_writeback.rs
+++ b/crates/openwave-desktop/src/client_execution/output_writeback.rs
@@ -67,8 +67,8 @@ pub(crate) async fn resolve_output_writeback_request(
         .find(|call| call.id == call_id)
         .ok_or_else(|| "output write-back request is no longer pending".to_owned())?;
     let arguments = canonical_arguments(&call, chat_id, call_id)?;
-    if arguments.mode != OutputWriteMode::Replace {
-        return Err("only replacement write-backs require a decision".to_owned());
+    if !requires_user_decision(&state, chat_id, arguments.mode).await? {
+        return Err("this write-back does not require a decision".to_owned());
     }
 
     let claim = client
@@ -91,7 +91,12 @@ pub(crate) async fn resolve_output_writeback_request(
                 call_id,
                 claim.lease_token,
                 &StoredResolution::Cancelled {
-                    result: "Output replacement was declined.".to_owned(),
+                    result: match arguments.mode {
+                        OutputWriteMode::Create => {
+                            "Writing that output to the connected folder was declined.".to_owned()
+                        }
+                        OutputWriteMode::Replace => "Output replacement was declined.".to_owned(),
+                    },
                 },
             )
             .await
@@ -167,8 +172,16 @@ async fn recover_once(app: &AppHandle) -> bool {
             let Ok(arguments) = canonical_arguments(call, summary.chat_id, call_id) else {
                 continue;
             };
-            if arguments.mode != OutputWriteMode::Create {
-                continue;
+            // A write-back the reader still has to decide belongs to the
+            // approval card, not to this executor. The mode is read live, so a
+            // chat moved to `Auto` while one was parked simply proceeds here.
+            match requires_user_decision(&state, summary.chat_id, arguments.mode).await {
+                Ok(false) => {}
+                Ok(true) => continue,
+                Err(_) => {
+                    failed = true;
+                    continue;
+                }
             }
             let lease_token = Uuid::new_v4();
             let claim = match client
@@ -212,6 +225,24 @@ async fn recover_once(app: &AppHandle) -> bool {
         }
     }
     failed
+}
+
+/// Whether this write-back parks on the approval card instead of running
+/// unattended, under the chat's current permission mode.
+async fn requires_user_decision(
+    state: &HostAccess,
+    chat_id: ChatId,
+    mode: OutputWriteMode,
+) -> Result<bool, String> {
+    let store = state
+        .store()
+        .ok_or_else(|| "OpenWave is still starting".to_owned())?;
+    let chat = store
+        .get_chat(chat_id)
+        .await
+        .map_err(|_| "could not read the conversation's permission mode".to_owned())?
+        .ok_or_else(|| "conversation is no longer available".to_owned())?;
+    Ok(mode.requires_user_decision(chat.permission_mode))
 }
 
 async fn prepare_receipt(

--- a/crates/openwave-desktop/src/client_execution/receipt_store.rs
+++ b/crates/openwave-desktop/src/client_execution/receipt_store.rs
@@ -692,9 +692,11 @@ impl OutputWritebackReceipt {
             })
             || self.byte_len == 0
             || self.byte_len > MAX_BINARY_DELIVERABLE_BYTES as u64
-            || matches!(self.mode, OutputWriteMode::Create) && self.approval_id.is_some()
-            || matches!(self.mode, OutputWriteMode::Replace)
-                && self.approval_id.is_none_or(|id| id.is_nil())
+            // A create carries an approval id when the chat's permission mode
+            // made the reader decide it, and none when it ran unattended.
+            // Replacement always asks, so it always carries one.
+            || self.approval_id.is_some_and(|id| id.is_nil())
+            || matches!(self.mode, OutputWriteMode::Replace) && self.approval_id.is_none()
             || self.resolution.is_some() && self.phase != FolderOperationPhase::DispatchStarted
         {
             return Err(invalid_data("invalid output-writeback receipt"));

--- a/crates/openwave-desktop/ui/src/OutputWritebackCard.test.tsx
+++ b/crates/openwave-desktop/ui/src/OutputWritebackCard.test.tsx
@@ -2,18 +2,19 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
 import { OutputWritebackCard } from "./OutputWritebackCard";
+import type { PendingOutputWritebackRequest } from "./api";
 
-const request = {
-  callId: "call-1",
-  turnId: "turn-1",
-  claimedByDesktop: false,
-};
+function request(
+  mode: PendingOutputWritebackRequest["mode"],
+): PendingOutputWritebackRequest {
+  return { callId: "call-1", turnId: "turn-1", mode, claimedByDesktop: false };
+}
 
 describe("OutputWritebackCard", () => {
   it("names the replacement without rendering destination data", () => {
     const html = renderToStaticMarkup(
       <OutputWritebackCard
-        request={request}
+        request={request("replace")}
         nativeHost
         working={false}
         error={undefined}
@@ -29,10 +30,27 @@ describe("OutputWritebackCard", () => {
     expect(html).not.toContain("Documents/");
   });
 
+  it("asks about a create as a write rather than a replacement", () => {
+    const html = renderToStaticMarkup(
+      <OutputWritebackCard
+        request={request("create")}
+        nativeHost
+        working={false}
+        error={undefined}
+        onDecision={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain("Write a file to a connected folder?");
+    expect(html).toContain("Allow write");
+    expect(html).not.toContain("Replace an existing file?");
+  });
+
   it("fails closed in browser-only mode", () => {
     const html = renderToStaticMarkup(
       <OutputWritebackCard
-        request={request}
+        request={request("replace")}
         nativeHost={false}
         working={false}
         error={undefined}

--- a/crates/openwave-desktop/ui/src/OutputWritebackCard.tsx
+++ b/crates/openwave-desktop/ui/src/OutputWritebackCard.tsx
@@ -19,12 +19,23 @@ export function OutputWritebackCard({
   onCancel: () => void;
 }) {
   const actionable = nativeHost && !request.claimedByDesktop && !working;
+  const replacing = request.mode === "replace";
+  const title = replacing
+    ? "Replace an existing file?"
+    : "Write a file to a connected folder?";
+  const subtitle = replacing
+    ? "The agent wants to replace a file in a folder connected to this chat. The native desktop will verify the connected folder, destination, and current output revision before writing."
+    : "The agent wants to write one of this chat's outputs into a folder connected to this chat. The native desktop will verify the connected folder, destination, and current output revision before writing.";
+  const allowLabel = replacing ? "Allow replacement" : "Allow write";
+  const unavailable = replacing
+    ? "File replacement is unavailable in browser-only mode."
+    : "Writing to connected folders is unavailable in browser-only mode.";
 
   return (
     <AttentionCard
-      title="Replace an existing file?"
+      title={title}
       titleId={`output-writeback-${request.callId}`}
-      subtitle="The agent wants to replace a file in a folder connected to this chat. The native desktop will verify the connected folder, destination, and current output revision before writing."
+      subtitle={subtitle}
       busy={working}
       error={error}
     >
@@ -34,7 +45,9 @@ export function OutputWritebackCard({
           role="status"
           aria-live="polite"
         >
-          Resolving the replacement request…
+          {replacing
+            ? "Resolving the replacement request…"
+            : "Resolving the write request…"}
         </p>
       ) : request.claimedByDesktop ? (
         <p
@@ -46,9 +59,7 @@ export function OutputWritebackCard({
         </p>
       ) : !nativeHost ? (
         <>
-          <p className="text-muted-foreground text-sm">
-            File replacement is unavailable in browser-only mode.
-          </p>
+          <p className="text-muted-foreground text-sm">{unavailable}</p>
           <div className="flex flex-wrap gap-2">
             <Button variant="outline" size="sm" onClick={onCancel}>
               Cancel turn
@@ -57,8 +68,12 @@ export function OutputWritebackCard({
         </>
       ) : (
         <div className="flex flex-wrap gap-2">
-          <Button size="sm" disabled={!actionable} onClick={() => onDecision("allow")}>
-            Allow replacement
+          <Button
+            size="sm"
+            disabled={!actionable}
+            onClick={() => onDecision("allow")}
+          >
+            {allowLabel}
           </Button>
           <Button
             variant="outline"

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -204,22 +204,33 @@ describe("pending chat prompt summaries", () => {
 });
 
 describe("parseOutputWritebackRequest", () => {
-  it("accepts only opaque identities and claimed state", () => {
+  it("accepts only opaque identities, mode, and claimed state", () => {
     expect(
       parseOutputWritebackRequest({
         call_id: "call-1",
         turn_id: "turn-1",
+        mode: "create",
         claimed: false,
       }),
     ).toEqual({
       callId: "call-1",
       turnId: "turn-1",
+      mode: "create",
       claimedByDesktop: false,
     });
     expect(
       parseOutputWritebackRequest({
         call_id: "call-1",
         turn_id: "turn-1",
+        mode: "append",
+        claimed: false,
+      }),
+    ).toBeNull();
+    expect(
+      parseOutputWritebackRequest({
+        call_id: "call-1",
+        turn_id: "turn-1",
+        mode: "replace",
         claimed: false,
         path: "private/file.txt",
       }),

--- a/crates/openwave-desktop/ui/src/api/parsers.ts
+++ b/crates/openwave-desktop/ui/src/api/parsers.ts
@@ -97,10 +97,12 @@ export function parseOutputWritebackRequest(
     !onlyKeys<WirePendingOutputWritebackRequest>(value, [
       "call_id",
       "turn_id",
+      "mode",
       "claimed",
     ]) ||
     !nonEmptyBounded(value.call_id, 128) ||
     !nonEmptyBounded(value.turn_id, 128) ||
+    (value.mode !== "create" && value.mode !== "replace") ||
     typeof value.claimed !== "boolean"
   ) {
     return null;
@@ -108,6 +110,7 @@ export function parseOutputWritebackRequest(
   return {
     callId: value.call_id,
     turnId: value.turn_id,
+    mode: value.mode,
     claimedByDesktop: value.claimed,
   };
 }

--- a/crates/openwave-desktop/ui/src/api/types.ts
+++ b/crates/openwave-desktop/ui/src/api/types.ts
@@ -723,10 +723,14 @@ export type PendingFolderAccessRequest = {
   claimedByDesktop: boolean;
 };
 
-/** Renderer-safe replacement prompt. Canonical output, root, and path stay native. */
+/** How a write-back means to land in the connected folder. */
+export type OutputWriteMode = "create" | "replace";
+
+/** Renderer-safe write-back prompt. Canonical output, root, and path stay native. */
 export type PendingOutputWritebackRequest = {
   callId: string;
   turnId: string;
+  mode: OutputWriteMode;
   claimedByDesktop: boolean;
 };
 

--- a/crates/openwave-desktop/ui/src/generated/fixtures.ts
+++ b/crates/openwave-desktop/ui/src/generated/fixtures.ts
@@ -60,5 +60,6 @@ export const PENDING_FOLDER_ACCESS_REQUEST = {
 export const PENDING_OUTPUT_WRITEBACK_REQUEST = {
   "call_id": "00000000-0000-0000-0000-000000000006",
   "claimed": false,
+  "mode": "replace",
   "turn_id": "00000000-0000-0000-0000-000000000007"
 } as const;

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1529,6 +1529,11 @@ export type NetworkPolicy = { "mode": "off" } | { "mode": "package_managers" } |
 export type OutputId = string;
 
 /**
+ * Whether connected-folder publication may replace an existing regular file.
+ */
+export type OutputWriteMode = "create" | "replace";
+
+/**
  * Closed renderer-safe pending approval projection. Canonical arguments,
  * model-authored summaries, and unknown tool names never cross this boundary;
  * only a tool's own closed preview of the action under review does.
@@ -1561,10 +1566,12 @@ auto_judge_status?: AutoJudgeStatus, };
 export type PendingFolderAccessRequest = { call_id: CallId, turn_id: TurnId, reason: string, folder_hint: RequestedFolderHint | null, claimed: boolean, };
 
 /**
- * Renderer-safe replacement approval. Canonical output, root, and destination
- * identities remain native-only; the card can approve or decline this exact call.
+ * Renderer-safe write-back approval. Canonical output, root, and destination
+ * identities remain native-only; the card can approve or decline this exact
+ * call. The mode is carried so the card can name what is being decided —
+ * creating a new file reads very differently from destroying an existing one.
  */
-export type PendingOutputWritebackRequest = { call_id: CallId, turn_id: TurnId, claimed: boolean, };
+export type PendingOutputWritebackRequest = { call_id: CallId, turn_id: TurnId, mode: OutputWriteMode, claimed: boolean, };
 
 /**
  * Renderer-safe, durable card projection of a proposed plan.
@@ -1596,6 +1603,14 @@ export type PendingUserQuestions = { call_id: CallId, turn_id: TurnId, questions
  * on it: `Plan < Ask < Auto < Allow`, matching [`Self::ALL`]. Managed-policy
  * ceilings compare modes with it, so a new variant must slot into this
  * scale, not just onto the end of the list.
+ *
+ * The mode governs the server-side approval gate, which is where all but one
+ * mutating call lives. Client-executed tools run in the trusted desktop under
+ * their own consent — a folder grant the reader picked, a card the native side
+ * raises — and do not re-enter that gate. The one client call that mutates
+ * something the reader owns, publishing an output into a connected folder,
+ * consults the mode itself: see
+ * [`crate::OutputWriteMode::requires_user_decision`].
  */
 export type PermissionMode = "plan" | "ask" | "auto" | "allow";
 

--- a/crates/openwave-desktop/ui/src/useOutputWritebackRequests.ts
+++ b/crates/openwave-desktop/ui/src/useOutputWritebackRequests.ts
@@ -17,7 +17,11 @@ export type OutputWritebackRequests = {
   cancel: (callId: string, turnId: string) => void;
 };
 
-/** Resolves explicit replacement consent; create/no-clobber writes run natively. */
+/**
+ * Resolves write-back consent. Replacement always asks; a create asks only
+ * where the chat's permission mode says workspace mutations ask, and otherwise
+ * runs natively without reaching this hook.
+ */
 export function useOutputWritebackRequests(
   client: ApiClient | null,
   chatId: string | null,

--- a/crates/openwave-server/src/routes/client_execution.rs
+++ b/crates/openwave-server/src/routes/client_execution.rs
@@ -13,8 +13,8 @@ use serde::{Deserialize, Serialize};
 use chrono::{Duration, Utc};
 use openwave_core::{
     CallId, ChatId, ClaimClientToolCallOutcome, HeartbeatClientToolCallOutcome, OutputWriteMode,
-    RequestFolderAccessArgs, RequestedFolderHint, ResolveToolCallOutcome, ToolCallExecution,
-    ToolCallRecord, ToolCallResolution, ToolCallStatus, TurnId, TurnRunStatus,
+    PermissionMode, RequestFolderAccessArgs, RequestedFolderHint, ResolveToolCallOutcome,
+    ToolCallExecution, ToolCallRecord, ToolCallResolution, ToolCallStatus, TurnId, TurnRunStatus,
     WriteOutputToConnectedFolderArgs, REQUEST_FOLDER_ACCESS_TOOL,
     WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL,
 };
@@ -162,12 +162,15 @@ pub struct PendingFolderAccessRequest {
     pub claimed: bool,
 }
 
-/// Renderer-safe replacement approval. Canonical output, root, and destination
-/// identities remain native-only; the card can approve or decline this exact call.
+/// Renderer-safe write-back approval. Canonical output, root, and destination
+/// identities remain native-only; the card can approve or decline this exact
+/// call. The mode is carried so the card can name what is being decided —
+/// creating a new file reads very differently from destroying an existing one.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
 pub struct PendingOutputWritebackRequest {
     pub call_id: CallId,
     pub turn_id: TurnId,
+    pub mode: OutputWriteMode,
     pub claimed: bool,
 }
 
@@ -189,20 +192,21 @@ pub async fn list_pending_folder_access_requests(
     Ok(Json(requests))
 }
 
-/// `GET /chats/{id}/output-writebacks/pending` — replacement approvals only.
+/// `GET /chats/{id}/output-writebacks/pending` — write-backs awaiting a decision.
 ///
-/// Create/no-clobber calls are handled automatically by the native executor and
-/// are intentionally omitted from the renderer.
+/// Replacement always asks. A create asks only where the chat's permission mode
+/// says workspace mutations ask; under `Auto` and `Allow` the native executor
+/// takes it automatically and it is intentionally omitted from the renderer.
 pub async fn list_pending_output_writebacks(
     store: ScopedStore,
     Path(id): Path<ChatId>,
 ) -> Result<Json<Vec<PendingOutputWritebackRequest>>, ServerError> {
-    store.require_chat(id).await?;
+    let chat = store.require_chat(id).await?;
     let requests = store
         .list_pending_client_tool_calls(id)
         .await?
         .into_iter()
-        .filter_map(renderer_output_writeback_request)
+        .filter_map(|call| renderer_output_writeback_request(call, chat.permission_mode))
         .collect();
     Ok(Json(requests))
 }
@@ -246,6 +250,7 @@ fn renderer_folder_access_request(call: ToolCallRecord) -> Option<PendingFolderA
 
 fn renderer_output_writeback_request(
     call: ToolCallRecord,
+    permission_mode: Option<PermissionMode>,
 ) -> Option<PendingOutputWritebackRequest> {
     if call.name != WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL
         || call.execution != ToolCallExecution::Client
@@ -255,12 +260,13 @@ fn renderer_output_writeback_request(
     }
     let arguments: WriteOutputToConnectedFolderArgs =
         serde_json::from_value(call.arguments).ok()?;
-    if !arguments.is_well_formed() || arguments.mode != OutputWriteMode::Replace {
+    if !arguments.is_well_formed() || !arguments.mode.requires_user_decision(permission_mode) {
         return None;
     }
     Some(PendingOutputWritebackRequest {
         call_id: call.id,
         turn_id: call.turn_id,
+        mode: arguments.mode,
         claimed: call.client_executor_id.is_some(),
     })
 }

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -631,6 +631,7 @@ mod tests {
         let output_writeback = crate::routes::client_execution::PendingOutputWritebackRequest {
             call_id: openwave_core::CallId(id(6)),
             turn_id: openwave_core::TurnId(id(7)),
+            mode: openwave_core::OutputWriteMode::Replace,
             claimed: false,
         };
 


### PR DESCRIPTION
Closes #1459.

The issue asked for a decision. This takes **option 2** — card `Create` write-backs into connected folders where the chat's permission mode says workspace mutations ask — and folds in option 3's documentation work so `Ask`'s promise is stated accurately.

Option 1 (route every client `Workspace` call through the class/mode gate) is not the small diff the issue assumed. Client calls checkpoint and are executed by the trusted desktop; putting them through the server-side broker means journal identity for a call the server never dispatched, `ApprovalBroker::register`, and decision-vs-cancel racing against the client control plane. The asymmetry the issue is really about is one call: publishing an output into a connected folder is the only client-executed write that leaves the sandbox and lands somewhere the reader owns.

## What changed

- `OutputWriteMode::requires_user_decision(permission_mode)` in `openwave-core` is the single predicate. `Replace` asks in every mode — it destroys bytes the agent did not write, and no mode advertises consent for that. `Create` asks under `Ask` (the default) and under `Plan`, and proceeds under `Auto`/`Allow`, which are standing answers to exactly that question.
- The server's renderer projection (`list_pending_output_writebacks`) reads the chat's mode and no longer drops every create, and the pending request now carries its `mode` so the card can word itself.
- The native executor consults the same predicate in both directions: `resolve_output_writeback_request` accepts a decision for anything that needs one, and the recovery loop skips anything still awaiting the reader instead of skipping by mode alone.
- Receipt validation accepts a create with or without an approval id — it carries one when the reader decided it, none when it ran unattended. Replacement still must carry one.
- The card titles/labels branch on the mode ("Write a file to a connected folder?" / "Allow write" vs the replacement wording).
- `PermissionMode`'s docs said `Ask` was "the only mode where `Workspace`-class tools ask" without mentioning that client-executed tools never reached the gate. The enum doc now points at the predicate, and `Auto`/`Allow` state that replacement still asks.

The mode is read live rather than stamped on the checkpointed call. A chat moved to `Auto` while a create is parked lets it proceed, which is what "Auto is a standing yes to workspace edits" should mean. Both desktop paths serialize on the write-back lock, so a card approval racing the recovery loop resolves as "no longer pending" rather than a double write.

## Tests

Added one Rust test asserting the predicate's whole table (every mode × both write modes) and one UI test that a create is worded as a write, not a replacement; the parser test now covers the new `mode` key. No new scaffolding-heavy cases.

Verified locally: `cargo fmt --check`, `clippy --all-targets` over the three touched crates, and the `openwave-core` / `openwave-server` / `openwave-desktop` lib suites, plus `tsc --noEmit` and `pnpm test` in the UI.

## Not verified

I did not drive the running app; the card's appearance in an `Ask` chat after a real `write_output_to_connected_folder` is unexercised outside the unit tests.