### PR TITLE
feat(router): add first-class Google Vertex AI support

### DIFF
--- a/crates/openwave-core/src/agent/tests/mod.rs
+++ b/crates/openwave-core/src/agent/tests/mod.rs
@@ -170,8 +170,8 @@ impl ModelProvider for ToolSurfaceRecordingProvider {
     }
 }
 
-/// Streams a reasoning block beside its tool call, then answers,
-/// recording the reasoning each request carried.
+/// Streams a provider replay block beside a tool-only step, then answers,
+/// recording the native state each request carried.
 struct ReasoningRecordingProvider {
     calls: AtomicUsize,
     seen: Arc<Mutex<Vec<Vec<Value>>>>,
@@ -198,9 +198,6 @@ impl ModelProvider for ReasoningRecordingProvider {
                         "thinking": "plan: read the note first",
                         "signature": "sig-1",
                     }),
-                },
-                ProviderEvent::TextDelta {
-                    text: "checking the note".into(),
                 },
                 ProviderEvent::ToolCallStarted {
                     index: 0,
@@ -2662,13 +2659,12 @@ async fn a_changed_argument_resets_the_repeat_streak() {
     );
 }
 
-/// A reasoning block streamed on one step must ride the step's assistant
-/// message — verbatim and whole — into the next step's request, and must
-/// survive the turn: it is persisted with that message, so a later turn
-/// rebuilt from the store still carries it. Whether it goes on the wire is
-/// then the adapter's call — see the router's replay gate.
+/// A provider replay block streamed on a tool-only step must gain a durable
+/// empty assistant carrier, ride verbatim into the next request, and survive
+/// the turn. Whether it goes on the wire is then the adapter's call — see the
+/// router's replay gate.
 #[tokio::test]
-async fn reasoning_blocks_survive_the_turn_that_produced_them() {
+async fn tool_only_provider_replay_survives_the_turn_that_produced_it() {
     let workspace = tempfile::tempdir().unwrap();
     std::fs::write(workspace.path().join("note.txt"), "secret").unwrap();
     let db = tempfile::tempdir().unwrap();

--- a/crates/openwave-core/src/agent/transcript.rs
+++ b/crates/openwave-core/src/agent/transcript.rs
@@ -89,7 +89,7 @@ pub(crate) fn rebuild_transcript_with_boundary(
                 push_tool_batch(
                     &mut out,
                     &batches[batch_i],
-                    text.is_some().then_some(*message),
+                    (text.is_some() || !message.reasoning.is_empty()).then_some(*message),
                     max_result_bytes,
                     image_input,
                 );
@@ -355,11 +355,11 @@ pub(crate) fn push_tool_batch(
         out.push(ChatMessage {
             role: Role::Assistant,
             content: blocks,
-            // The step's reasoning was persisted with its prose preamble, so
-            // it comes back here. A step that wrote no preamble has no message
-            // row to have carried any, and replaying nothing is the valid
-            // degradation. Whether these blocks actually go on the wire is the
-            // adapter's call: they replay only to the route that minted them.
+            // The step's provider-native replay state was persisted with its
+            // assistant message. Tool-only steps may use an empty message as
+            // that durable carrier. Whether these blocks actually go on the
+            // wire is the adapter's call: they replay only to the route that
+            // minted them.
             reasoning: assistant
                 .map(|message| message.reasoning.clone())
                 .unwrap_or_default(),

--- a/crates/openwave-core/src/agent/turn.rs
+++ b/crates/openwave-core/src/agent/turn.rs
@@ -750,12 +750,14 @@ impl Agent {
             let mut blocks: Vec<ContentBlock> = Vec::new();
             if !text.is_empty() {
                 blocks.push(ContentBlock::Text { text: text.clone() });
-                if !calls.is_empty() {
-                    // A checkpoint returns from the loop and the resumed
-                    // attempt rebuilds its transcript from the store, so an
-                    // unpersisted preamble would be lost.
-                    self.persist_assistant(chat.id, turn_id, &candidate).await?;
-                }
+            }
+            if !calls.is_empty() && (!text.is_empty() || !candidate.reasoning.is_empty()) {
+                // A checkpoint returns from the loop and the resumed attempt
+                // rebuilds its transcript from the store, so an unpersisted
+                // prose preamble or provider-native tool replay block would be
+                // lost. A tool-only Gemini step therefore writes an empty
+                // assistant message solely as the durable replay carrier.
+                self.persist_assistant(chat.id, turn_id, &candidate).await?;
             }
             // Searches the provider ran on its own infrastructure during this
             // step. They sit between the prose and the calls the loop is about

--- a/crates/openwave-core/src/model/messages.rs
+++ b/crates/openwave-core/src/model/messages.rs
@@ -34,13 +34,12 @@ pub struct Message {
     /// prompt. `None` means the model sees `content` byte-for-byte.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub llm_content: Option<String>,
-    /// Reasoning blocks this message's step produced, with the route that
-    /// minted them.
+    /// Provider-native replay blocks this message's step produced, with the
+    /// route that minted them.
     ///
-    /// Persisted so an assistant message keeps its reasoning across a reload
-    /// and can be replayed to the same model on a later turn. Empty for every
-    /// user message, and for an assistant step whose reasoning had no message
-    /// row to ride (a tool step with no prose preamble writes no message).
+    /// Persisted so an assistant message keeps reasoning or signed tool state
+    /// across a reload and can replay it to the same model on a later turn.
+    /// Empty for every user message.
     #[serde(default, skip_serializing_if = "MessageReasoning::is_empty")]
     pub reasoning: MessageReasoning,
     /// When it was created.

--- a/crates/openwave-core/src/provider.rs
+++ b/crates/openwave-core/src/provider.rs
@@ -48,14 +48,15 @@ pub struct ReasoningOrigin {
     pub model: String,
 }
 
-/// A message's opaque reasoning blocks, bound to the route that minted them.
+/// A message's opaque provider replay blocks, bound to the route that minted
+/// them.
 ///
-/// The blocks are provider values kept in emission order and kept whole — a
-/// message replays either all of them or none, because a provider that
-/// validates replay (Anthropic) rejects rearranged, edited, or partially
-/// dropped reasoning. They stay a `Vec`: a provider may emit several in one
-/// step, and flattening them into one block would lose both the count and the
-/// per-block signatures.
+/// Most blocks are reasoning artifacts (Anthropic thinking or xAI encrypted
+/// reasoning). Gemini also uses this channel for compact signed-function-call
+/// records: the opaque `thoughtSignature` belongs to the assistant step and
+/// must return only to the exact route that minted it. Values stay in emission
+/// order and whole — a message replays either all of them or none, because a
+/// validating provider rejects rearranged, edited, or partially dropped state.
 ///
 /// The origin travels with the blocks so a consumer can tell whether they are
 /// valid input for the request it is about to send. Blocks and origin are set
@@ -655,17 +656,17 @@ pub enum ProviderEvent {
         /// The reasoning fragment.
         text: String,
     },
-    /// One reasoning block, complete and opaque, as the provider emitted it.
+    /// One replay block, complete and opaque, as the provider emitted it.
     ///
-    /// Where `ReasoningDelta` is display text, this is the replayable
-    /// artifact (an Anthropic `thinking` / `redacted_thinking` block or an xAI
-    /// encrypted `reasoning` item). `data` is the block exactly as the provider
-    /// accepts it back; consumers must not parse, filter, or reorder it,
-    /// because replay validity depends on the blocks matching what the model
-    /// generated. Carried in-memory for one turn at most — it is never
-    /// journaled or persisted.
+    /// Where `ReasoningDelta` is display text, this is replayable native state:
+    /// an Anthropic `thinking` / `redacted_thinking` block, an xAI encrypted
+    /// `reasoning` item, or a compact Gemini call-id/`thoughtSignature` record.
+    /// Consumers must not filter or reorder it because replay validity depends
+    /// on matching what the model generated. Carried in-memory for one turn at
+    /// most — it is never journaled directly, though the agent may persist it
+    /// with the assistant message for later same-route replay.
     ReasoningBlock {
-        /// The provider-native block, replayed verbatim.
+        /// The provider-native replay state.
         data: Value,
     },
     /// A tool call has begun; name and id are known.

--- a/crates/openwave-desktop/ui/src/ModelMenu.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.tsx
@@ -34,6 +34,7 @@ const PROVIDER_ORDER: readonly ProviderKind[] = [
   "openai",
   "xai",
   "gemini",
+  "vertex",
 ];
 
 const UNVERIFIED_TOOLTIP =

--- a/crates/openwave-desktop/ui/src/ModelSelection.test.ts
+++ b/crates/openwave-desktop/ui/src/ModelSelection.test.ts
@@ -44,6 +44,15 @@ const models: ModelInfo[] = [
     vendor: null,
     input_modalities: ["text"],
   },
+  {
+    ...base,
+    key: "vertex::unique",
+    id: "unique",
+    provider: "vertex",
+    vendor: "anthropic",
+    verification: "unverified",
+    input_modalities: ["text"],
+  },
 ];
 
 describe("typed model selection", () => {
@@ -63,6 +72,7 @@ describe("typed model selection", () => {
     expect(providerLabel("openai")).toBe("OpenAI");
     expect(providerLabel("xai")).toBe("xAI");
     expect(providerLabel("gemini")).toBe("Google Gemini");
+    expect(providerLabel("vertex")).toBe("Google Vertex AI");
     expect(providerLabel("openai_compatible")).toBe("OpenAI-compatible");
   });
 });

--- a/crates/openwave-desktop/ui/src/ModelSelection.ts
+++ b/crates/openwave-desktop/ui/src/ModelSelection.ts
@@ -10,8 +10,9 @@ import type {
  * Resolve a stored selection against the typed catalog.
  *
  * New values match only their provider-qualified key. Old bare ids are
- * accepted only when the catalog has exactly one owner, so migration can never
- * silently change providers.
+ * accepted only when exactly one direct-vendor row owns it. Hosted mirrors
+ * (for example Vertex) carry `vendor` and never steal a legacy selection from
+ * the original direct route.
  */
 export function modelForSelection(
   models: ModelInfo[],
@@ -21,7 +22,9 @@ export function modelForSelection(
   const exact = models.find((model) => model.key === value);
   if (exact) return exact;
   if (value.includes("::")) return null;
-  const legacy = models.filter((model) => model.id === value);
+  const legacy = models.filter(
+    (model) => model.id === value && model.vendor === null,
+  );
   return legacy.length === 1 ? legacy[0] : null;
 }
 
@@ -44,6 +47,8 @@ export function providerLabel(provider: ProviderKind): string {
       return "xAI";
     case "gemini":
       return "Google Gemini";
+    case "vertex":
+      return "Google Vertex AI";
     case "openai_compatible":
       return "OpenAI-compatible";
     case "model_gateway":

--- a/crates/openwave-desktop/ui/src/ProviderIcons.tsx
+++ b/crates/openwave-desktop/ui/src/ProviderIcons.tsx
@@ -135,6 +135,8 @@ export function ProviderIcon({
       return <XaiIcon {...rest} />;
     case "gemini":
       return <GeminiIcon {...rest} />;
+    case "vertex":
+      return <GeminiIcon {...rest} />;
     case "openai_compatible":
     case "model_gateway":
       return <OpenModelIcon {...rest} />;

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1480,7 +1480,8 @@ vendor: ProviderKind | null,
  */
 verification: VerificationTier, 
 /**
- * Whether the provider is enabled, configured, and credentialed.
+ * Whether the provider is enabled, configured, credentialed, and able to
+ * serve this model at its configured endpoint/location.
  */
 available: boolean, 
 /**

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1875,7 +1875,7 @@ export type PromptOrigin = "builtin" | "user";
 /**
  * How a provider's credential was established.
  */
-export type ProviderAuthMode = "api_key" | "chatgpt";
+export type ProviderAuthMode = "api_key" | "chatgpt" | "service_account";
 
 /**
  * Public view of a provider — never includes the credential itself.
@@ -1914,7 +1914,7 @@ models: Array<CustomModelConfig>, };
  * The known provider kinds. `#[non_exhaustive]` so new kinds can land without
  * breaking wire clients that match on the string form.
  */
-export type ProviderKind = "anthropic" | "openai" | "xai" | "gemini" | "openai_compatible" | "model_gateway";
+export type ProviderKind = "anthropic" | "openai" | "xai" | "gemini" | "vertex" | "openai_compatible" | "model_gateway";
 
 /**
  * How hard a reasoning-capable model should think before answering.

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1895,7 +1895,9 @@ enabled: boolean,
  */
 base_url?: string, 
 /**
- * Vertex AI location. Never includes the project id from the credential.
+ * Vertex AI location. The first-class Vertex provider is global-only;
+ * legacy Gemini service-account configurations may retain a region. Never
+ * includes the project id from the credential.
  */
 vertex_location?: string, 
 /**

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
@@ -300,6 +300,14 @@ describe("ProvidersPanel", () => {
       />,
     );
 
+    expect(
+      screen.getByText(
+        (_, element) =>
+          element?.tagName === "P" &&
+          element.textContent?.includes("Claude models require global") === true,
+      ),
+    ).toBeInTheDocument();
+
     fireEvent.change(screen.getByLabelText("Vertex AI location"), {
       target: { value: "us-central1" },
     });

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
@@ -282,31 +282,24 @@ describe("ProvidersPanel", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("configures Gemini service-account auth without projecting the secret", async () => {
-    const gemini: ProviderInfo = {
-      kind: "gemini",
+  it("configures Vertex service-account auth without projecting the secret", async () => {
+    const vertex: ProviderInfo = {
+      kind: "vertex",
       enabled: false,
       has_credential: false,
       models: [],
     };
-    const putProvider = vi.fn().mockResolvedValue(gemini);
+    const putProvider = vi.fn().mockResolvedValue(vertex);
     const client = { putProvider } as unknown as ApiClient;
 
     render(
       <ProvidersPanel
-        providers={[gemini]}
+        providers={[vertex]}
         client={client}
         onChanged={vi.fn()}
       />,
     );
 
-    const user = userEvent.setup();
-    await user.click(screen.getByLabelText("Gemini credential type"));
-    await user.click(
-      await screen.findByRole("option", {
-        name: "Google Cloud service account",
-      }),
-    );
     fireEvent.change(screen.getByLabelText("Vertex AI location"), {
       target: { value: "us-central1" },
     });
@@ -318,7 +311,7 @@ describe("ProvidersPanel", () => {
     );
 
     await waitFor(() =>
-      expect(putProvider).toHaveBeenCalledWith("gemini", {
+      expect(putProvider).toHaveBeenCalledWith("vertex", {
         enabled: true,
         vertex_location: "us-central1",
         credential: {

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
@@ -286,6 +286,7 @@ describe("ProvidersPanel", () => {
     const vertex: ProviderInfo = {
       kind: "vertex",
       enabled: false,
+      vertex_location: "us-central1",
       has_credential: false,
       models: [],
     };
@@ -300,17 +301,19 @@ describe("ProvidersPanel", () => {
       />,
     );
 
+    const locationNotice = screen.getByText(
+      (_, element) =>
+        element?.tagName === "P" &&
+        element.textContent?.includes(
+          "This provider uses the global Vertex location",
+        ) === true,
+    );
+    expect(locationNotice).toHaveTextContent(
+      /saving updates its location to global/i,
+    );
     expect(
-      screen.getByText(
-        (_, element) =>
-          element?.tagName === "P" &&
-          element.textContent?.includes("Claude models require global") === true,
-      ),
-    ).toBeInTheDocument();
-
-    fireEvent.change(screen.getByLabelText("Vertex AI location"), {
-      target: { value: "us-central1" },
-    });
+      screen.queryByLabelText("Vertex AI location"),
+    ).not.toBeInTheDocument();
     fireEvent.change(screen.getByLabelText("Google service account JSON"), {
       target: { value: '  {"type":"service_account","private_key":"secret"}  ' },
     });
@@ -321,11 +324,49 @@ describe("ProvidersPanel", () => {
     await waitFor(() =>
       expect(putProvider).toHaveBeenCalledWith("vertex", {
         enabled: true,
-        vertex_location: "us-central1",
+        vertex_location: "global",
         credential: {
           type: "service_account",
           json: '{"type":"service_account","private_key":"secret"}',
         },
+      }),
+    );
+  });
+
+  it("retains regional location editing for a legacy Gemini service account", async () => {
+    const gemini: ProviderInfo = {
+      kind: "gemini",
+      enabled: true,
+      vertex_location: "us-central1",
+      has_credential: true,
+      auth_mode: "service_account",
+      models: [],
+    };
+    const putProvider = vi.fn().mockResolvedValue(gemini);
+    const client = { putProvider } as unknown as ApiClient;
+
+    render(
+      <ProvidersPanel
+        providers={[gemini]}
+        client={client}
+        onChanged={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/Gemini 3 requests always use/i)).toHaveTextContent(
+      /global endpoint/i,
+    );
+    fireEvent.change(screen.getByLabelText("Vertex AI location"), {
+      target: { value: "us-east5" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Save configuration" }),
+    );
+
+    await waitFor(() =>
+      expect(putProvider).toHaveBeenCalledWith("gemini", {
+        enabled: true,
+        vertex_location: "us-east5",
       }),
     );
   });

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -475,6 +475,8 @@ function ProviderRow({
               />
               <p className="text-xs text-muted-foreground">
                 Use <code>global</code> or a region such as <code>us-east5</code>.
+                Claude models require <code>global</code>; regional locations
+                expose only the Vertex models OpenWave can route there.
                 Multi-region aliases and ambient application-default credentials
                 are not configured by this surface.
               </p>

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -11,13 +11,6 @@ import { openSignInPage } from "../openSignInPage";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { useConfirm } from "../components/ConfirmDialog";
@@ -104,10 +97,11 @@ function ProviderRow({
   client: ApiClient;
   onChanged: () => void;
 }) {
+  const usesServiceAccount =
+    info.kind === "vertex" ||
+    (info.kind === "gemini" && info.auth_mode === "service_account");
   const [key, setKey] = useState("");
-  const [credentialType, setCredentialType] = useState<
-    "api_key" | "service_account"
-  >("api_key");
+  const credentialType = usesServiceAccount ? "service_account" : "api_key";
   const [serviceAccountJson, setServiceAccountJson] = useState("");
   const [vertexLocation, setVertexLocation] = useState(
     info.vertex_location ?? "global",
@@ -152,7 +146,7 @@ function ProviderRow({
       if (key.trim()) {
         body.credential = { type: "api_key", key: key.trim() };
       }
-      if (info.kind === "gemini" && credentialType === "service_account") {
+      if (usesServiceAccount && credentialType === "service_account") {
         body.vertex_location = vertexLocation.trim() || "global";
         if (serviceAccountJson.trim()) {
           body.credential = {
@@ -455,95 +449,80 @@ function ProviderRow({
         />
       ) : (
         <>
-      {info.kind === "gemini" && (
-        <label className="grid gap-1 text-xs text-muted-foreground">
-          Credential type
-          <Select
-            value={credentialType}
-            disabled={saving}
-            onValueChange={(value) =>
-              setCredentialType(value as "api_key" | "service_account")
-            }
-          >
-            <SelectTrigger aria-label="Gemini credential type" className="h-9">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="api_key">Gemini API key</SelectItem>
-              <SelectItem value="service_account">
-                Google Cloud service account
-              </SelectItem>
-            </SelectContent>
-          </Select>
-        </label>
-      )}
-      {credentialType === "api_key" && (
-        <Input
-          type="password"
-          placeholder="API key"
-          value={key}
-          onChange={(e) => setKey(e.target.value)}
-          autoComplete="off"
-        />
-      )}
-      {info.kind === "gemini" && credentialType === "service_account" && (
-        <>
-          <Input
-            type="text"
-            aria-label="Vertex AI location"
-            placeholder="Vertex AI location"
-            value={vertexLocation}
-            onChange={(event) => setVertexLocation(event.target.value)}
-            autoComplete="off"
-          />
-          <p className="text-xs text-muted-foreground">
-            Gemini 3 models always use Google&apos;s global endpoint. This
-            location applies to models that support regional Vertex endpoints.
-          </p>
-          <Textarea
-            aria-label="Google service account JSON"
-            className="min-h-28 font-mono text-sm text-foreground"
-            placeholder="Paste the Google service-account JSON key file"
-            value={serviceAccountJson}
-            onChange={(event) => setServiceAccountJson(event.target.value)}
-            autoComplete="off"
-            spellCheck={false}
-          />
-        </>
-      )}
-      <div className="flex flex-wrap gap-2">
-        <Button
-          type="button"
-          disabled={
-            saving ||
-            (!info.has_credential &&
-              credentialType === "api_key" &&
-              info.kind !== "openai_compatible" &&
-              !key.trim()) ||
-            (!info.has_credential &&
-              info.kind === "gemini" &&
-              credentialType === "service_account" &&
-              !serviceAccountJson.trim()) ||
-            (info.kind === "openai_compatible" &&
-              models.some((model) => !model.id.trim())) ||
-            (info.kind === "xai" &&
-              (models.length === 0 || models.some((model) => !model.id.trim())))
-          }
-          onClick={() => void save(true)}
-        >
-          Save configuration
-        </Button>
-        {info.has_credential && (
-          <Button
-            type="button"
-            variant="destructive"
-            disabled={saving}
-            onClick={() => void clearCredential()}
-          >
-            Clear
-          </Button>
-        )}
-      </div>
+          {credentialType === "api_key" && (
+            <Input
+              type="password"
+              placeholder="API key"
+              value={key}
+              onChange={(e) => setKey(e.target.value)}
+              autoComplete="off"
+            />
+          )}
+          {usesServiceAccount && credentialType === "service_account" && (
+            <>
+              <p className="text-xs text-muted-foreground">
+                {info.kind === "vertex"
+                  ? "Vertex AI uses this service account for native Gemini and Claude requests. OpenWave derives Google hosts itself and does not accept a custom Vertex endpoint."
+                  : "This existing Gemini service-account configuration is retained for compatibility. New Vertex AI configurations belong in the Google Vertex AI provider row."}
+              </p>
+              <Input
+                type="text"
+                aria-label="Vertex AI location"
+                placeholder="Vertex AI location"
+                value={vertexLocation}
+                onChange={(event) => setVertexLocation(event.target.value)}
+                autoComplete="off"
+              />
+              <p className="text-xs text-muted-foreground">
+                Use <code>global</code> or a region such as <code>us-east5</code>.
+                Multi-region aliases and ambient application-default credentials
+                are not configured by this surface.
+              </p>
+              <Textarea
+                aria-label="Google service account JSON"
+                className="min-h-28 font-mono text-sm text-foreground"
+                placeholder="Paste the Google service-account JSON key file"
+                value={serviceAccountJson}
+                onChange={(event) => setServiceAccountJson(event.target.value)}
+                autoComplete="off"
+                spellCheck={false}
+              />
+            </>
+          )}
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              disabled={
+                saving ||
+                (!info.has_credential &&
+                  credentialType === "api_key" &&
+                  info.kind !== "openai_compatible" &&
+                  !key.trim()) ||
+                (!info.has_credential &&
+                  usesServiceAccount &&
+                  credentialType === "service_account" &&
+                  !serviceAccountJson.trim()) ||
+                (info.kind === "openai_compatible" &&
+                  models.some((model) => !model.id.trim())) ||
+                (info.kind === "xai" &&
+                  (models.length === 0 ||
+                    models.some((model) => !model.id.trim())))
+              }
+              onClick={() => void save(true)}
+            >
+              Save configuration
+            </Button>
+            {info.has_credential && (
+              <Button
+                type="button"
+                variant="destructive"
+                disabled={saving}
+                onClick={() => void clearCredential()}
+              >
+                Clear
+              </Button>
+            )}
+          </div>
         </>
       )}
       {error && <SettingsError>{error}</SettingsError>}
@@ -559,6 +538,9 @@ function credentialStatusLabel(info: ProviderInfo): string {
   }
   if (info.kind === "openai" && info.auth_mode === "api_key") {
     return "API key set";
+  }
+  if (info.auth_mode === "service_account") {
+    return "Google service account set";
   }
   return "Credential set";
 }

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -97,8 +97,9 @@ function ProviderRow({
   client: ApiClient;
   onChanged: () => void;
 }) {
+  const isFirstClassVertex = info.kind === "vertex";
   const usesServiceAccount =
-    info.kind === "vertex" ||
+    isFirstClassVertex ||
     (info.kind === "gemini" && info.auth_mode === "service_account");
   const [key, setKey] = useState("");
   const credentialType = usesServiceAccount ? "service_account" : "api_key";
@@ -147,7 +148,9 @@ function ProviderRow({
         body.credential = { type: "api_key", key: key.trim() };
       }
       if (usesServiceAccount && credentialType === "service_account") {
-        body.vertex_location = vertexLocation.trim() || "global";
+        body.vertex_location = isFirstClassVertex
+          ? "global"
+          : vertexLocation.trim() || "global";
         if (serviceAccountJson.trim()) {
           body.credential = {
             type: "service_account",
@@ -461,25 +464,43 @@ function ProviderRow({
           {usesServiceAccount && credentialType === "service_account" && (
             <>
               <p className="text-xs text-muted-foreground">
-                {info.kind === "vertex"
+                {isFirstClassVertex
                   ? "Vertex AI uses this service account for native Gemini and Claude requests. OpenWave derives Google hosts itself and does not accept a custom Vertex endpoint."
                   : "This existing Gemini service-account configuration is retained for compatibility. New Vertex AI configurations belong in the Google Vertex AI provider row."}
               </p>
-              <Input
-                type="text"
-                aria-label="Vertex AI location"
-                placeholder="Vertex AI location"
-                value={vertexLocation}
-                onChange={(event) => setVertexLocation(event.target.value)}
-                autoComplete="off"
-              />
-              <p className="text-xs text-muted-foreground">
-                Use <code>global</code> or a region such as <code>us-east5</code>.
-                Claude models require <code>global</code>; regional locations
-                expose only the Vertex models OpenWave can route there.
-                Multi-region aliases and ambient application-default credentials
-                are not configured by this surface.
-              </p>
+              {isFirstClassVertex ? (
+                <p className="text-xs text-muted-foreground">
+                  This provider uses the <code>global</code> Vertex location for
+                  every curated model. Regional locations, multi-region aliases,
+                  and ambient application-default credentials are not configured
+                  by this surface.
+                  {info.vertex_location != null &&
+                    info.vertex_location !== "global" && (
+                      <>
+                        {" "}This older configuration is unavailable until it is
+                        saved; saving updates its location to <code>global</code>.
+                      </>
+                    )}
+                </p>
+              ) : (
+                <>
+                  <Input
+                    type="text"
+                    aria-label="Vertex AI location"
+                    placeholder="Vertex AI location"
+                    value={vertexLocation}
+                    onChange={(event) => setVertexLocation(event.target.value)}
+                    autoComplete="off"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    This legacy setting is retained for compatibility with older
+                    regional Gemini models. Curated Gemini 3 requests always use
+                    the <code>global</code> endpoint. Multi-region aliases and
+                    ambient application-default credentials are not configured by
+                    this surface.
+                  </p>
+                </>
+              )}
               <Textarea
                 aria-label="Google service account JSON"
                 className="min-h-28 font-mono text-sm text-foreground"

--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -23,8 +23,8 @@ use openwave_core::{ImageAttachments, ReasoningEffort, Role};
 
 use crate::google::{valid_resource_segment, valid_vertex_location};
 use crate::sse::{
-    classify_in_band_error, classify_provider_error, classify_provider_error_redacting,
-    drain_frames, frame_data, read_bounded_error_body,
+    classify_in_band_error, classify_in_band_error_redacting, classify_provider_error,
+    classify_provider_error_redacting, drain_frames, frame_data, read_bounded_error_body,
 };
 
 const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
@@ -194,6 +194,7 @@ impl ModelProvider for AnthropicProvider {
         let conversation = req.conversation;
         let model = req.model.clone();
         let provider_name = self.provider_name();
+        let vertex_project_id = self.vertex.as_ref().map(|vertex| vertex.project_id.clone());
         let ceiling = crate::http::timeouts().total_stream;
         let stream = async_stream::stream! {
             let mut response = response;
@@ -201,6 +202,7 @@ impl ModelProvider for AnthropicProvider {
                 output_tool,
                 raw_blocks: continuations_allowed.then(RawAssistantBlocks::default),
                 replay_origin: Some(replay_origin),
+                vertex_project_id,
                 ..StreamState::default()
             };
             let mut continuations = 0u32;
@@ -997,6 +999,9 @@ struct StreamState {
     /// Route that minted this stream's provider-executed calls, so their
     /// native blocks can be origin-gated on a later request.
     replay_origin: Option<ReasoningOrigin>,
+    /// Sensitive route identity retained only so accepted Vertex streams can
+    /// redact Google resource paths and attribute in-band failures correctly.
+    vertex_project_id: Option<String>,
 }
 
 impl StreamState {
@@ -1134,11 +1139,15 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
         // the truncated step would read as a clean end and commit.
         Some("error") => {
             state.terminal = true;
+            let error = data.get("error").unwrap_or(data);
+            let error = match state.vertex_project_id.as_deref() {
+                Some(project_id) => {
+                    classify_in_band_error_redacting("vertex", error, &[project_id])
+                }
+                None => classify_in_band_error("anthropic", error),
+            };
             vec![ProviderEvent::Failed {
-                error: ProviderErrorInfo::from_error(&classify_in_band_error(
-                    "anthropic",
-                    data.get("error").unwrap_or(data),
-                )),
+                error: ProviderErrorInfo::from_error(&error),
             }]
         }
         Some("message_start") => {
@@ -3093,5 +3102,74 @@ mod tests {
         assert!(visible.contains("vertex returned 403"), "{visible}");
         assert!(visible.contains("permission_denied"), "{visible}");
         assert!(!visible.contains(PROJECT_ID), "{visible}");
+    }
+
+    #[tokio::test]
+    async fn vertex_in_band_error_redacts_project_and_uses_vertex_attribution() {
+        use axum::http::header;
+        use axum::response::IntoResponse;
+        use axum::routing::post;
+        use axum::Router;
+
+        const PROJECT_ID: &str = "customer-project-123";
+
+        struct StaticToken;
+
+        #[async_trait::async_trait]
+        impl crate::BearerTokenSource for StaticToken {
+            async fn bearer_token(&self) -> openwave_core::Result<String> {
+                Ok("vertex-bearer".into())
+            }
+        }
+
+        async fn deny_after_accepting() -> impl IntoResponse {
+            let frame = json!({
+                "type": "error",
+                "error": {
+                    "code": 403,
+                    "type": "permission_denied",
+                    "message": format!(
+                        "Permission denied on projects/{PROJECT_ID}/locations/global"
+                    ),
+                }
+            });
+            (
+                [(header::CONTENT_TYPE, "text/event-stream")],
+                format!("data: {frame}\n\n"),
+            )
+        }
+
+        let app = Router::new().fallback(post(deny_after_accepting));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let provider =
+            AnthropicProvider::vertex(PROJECT_ID, "global", std::sync::Arc::new(StaticToken))
+                .unwrap()
+                .with_base_url(format!("http://{address}"));
+        let events: Vec<_> = provider
+            .stream(ChatRequest {
+                provider: Some(ProviderId::new("vertex")),
+                model: "claude-opus-4-8".into(),
+                messages: vec![ChatMessage::text(Role::User, "hi")],
+                ..Default::default()
+            })
+            .await
+            .unwrap()
+            .collect()
+            .await;
+        server.abort();
+
+        assert_eq!(
+            events,
+            vec![ProviderEvent::Failed {
+                error: ProviderErrorInfo {
+                    kind: "authentication".into(),
+                    message: "vertex returned 403 (permission_denied)".into(),
+                },
+            }]
+        );
+        assert!(!format!("{events:?}").contains(PROJECT_ID));
     }
 }

--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -19,7 +19,7 @@ use openwave_core::provider::{
     ToolChoice, Usage,
 };
 use openwave_core::tool::{strict_json_schema, OptionalProperties};
-use openwave_core::{ImageAttachments, Role};
+use openwave_core::{ImageAttachments, ReasoningEffort, Role};
 
 use crate::google::{valid_resource_segment, valid_vertex_location};
 use crate::sse::{
@@ -559,7 +559,8 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
         // `type == "thinking"`.
         body["thinking"] = json!({ "type": "adaptive", "display": "summarized" });
         if let Some(effort) = req.reasoning_effort {
-            body["output_config"] = json!({ "effort": effort.as_str() });
+            body["output_config"] =
+                json!({ "effort": wire_reasoning_effort(&req.model, effort).as_str() });
         }
         attach_reasoning_blocks(&mut body, req);
     }
@@ -738,6 +739,23 @@ fn takes_adaptive_thinking(model: &str) -> bool {
     /// First Claude generation that reasons on `thinking: {"type": "adaptive"}`.
     const FIRST_ADAPTIVE: (u32, u32) = (4, 6);
     claude_generation(model).is_some_and(|generation| generation >= FIRST_ADAPTIVE)
+}
+
+/// The final effort value safe to put on an Anthropic request.
+///
+/// Host model policy normally clamps a stored selection against the curated
+/// catalog before building a [`ChatRequest`]. Keep the same guard at this last
+/// request boundary for embedders and stale in-memory configurations that can
+/// construct a request directly: Opus and Sonnet 4.6 accept `max`, but reject
+/// the newer `xhigh` token.
+fn wire_reasoning_effort(model: &str, effort: ReasoningEffort) -> ReasoningEffort {
+    let claude_4_6 = claude_generation(model) == Some((4, 6))
+        && (model.starts_with("claude-opus-") || model.starts_with("claude-sonnet-"));
+    if claude_4_6 && effort == ReasoningEffort::XHigh {
+        ReasoningEffort::High
+    } else {
+        effort
+    }
 }
 
 /// The name Anthropic gives its server-side web search tool, and the name the
@@ -1763,6 +1781,31 @@ mod tests {
     }
 
     #[test]
+    fn claude_4_6_xhigh_is_clamped_before_the_request_wire() {
+        for id in [
+            "claude-opus-4-6",
+            "claude-sonnet-4-6",
+            "claude-sonnet-4-6-20260101",
+        ] {
+            let body =
+                build_request_json(&reasoning_request(id, Some(ReasoningEffort::XHigh))).unwrap();
+            assert_eq!(body["output_config"]["effort"], "high", "{id}");
+
+            let body =
+                build_request_json(&reasoning_request(id, Some(ReasoningEffort::Max))).unwrap();
+            assert_eq!(body["output_config"]["effort"], "max", "{id}");
+        }
+
+        // The newer rows that do accept xhigh keep it unchanged.
+        let body = build_request_json(&reasoning_request(
+            "claude-opus-4-7",
+            Some(ReasoningEffort::XHigh),
+        ))
+        .unwrap();
+        assert_eq!(body["output_config"]["effort"], "xhigh");
+    }
+
+    #[test]
     fn a_non_reasoning_request_asks_for_no_thinking() {
         let req = request_with(
             vec![ContentBlock::Text { text: "hi".into() }],
@@ -1775,16 +1818,17 @@ mod tests {
     }
 
     #[test]
-    fn a_pre_adaptive_model_keeps_the_request_it_understands() {
-        // Claude Haiku 4.5 rejects both an adaptive thinking block and
-        // `output_config.effort`; sending either would fail the whole turn.
-        let body = build_request_json(&reasoning_request(
-            "claude-haiku-4-5-20251001",
-            Some(ReasoningEffort::High),
-        ))
-        .unwrap();
-        assert!(body.get("thinking").is_none());
-        assert!(body.get("output_config").is_none());
+    fn haiku_4_5_never_gets_an_unsupported_adaptive_request() {
+        // Both curated routes mark Haiku 4.5 non-reasoning until classic
+        // `budget_tokens` thinking is implemented. A stale direct request that
+        // still calls it reasoning-capable must remain safe too: this adapter
+        // cannot silently substitute the adaptive 4.6+ shape.
+        for id in ["claude-haiku-4-5-20251001", "claude-haiku-4-5"] {
+            let body =
+                build_request_json(&reasoning_request(id, Some(ReasoningEffort::High))).unwrap();
+            assert!(body.get("thinking").is_none(), "{id}");
+            assert!(body.get("output_config").is_none(), "{id}");
+        }
     }
 
     #[test]

--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -23,8 +23,8 @@ use openwave_core::{ImageAttachments, ReasoningEffort, Role};
 
 use crate::google::{valid_resource_segment, valid_vertex_location};
 use crate::sse::{
-    classify_in_band_error, classify_provider_error, drain_frames, frame_data,
-    read_bounded_error_body,
+    classify_in_band_error, classify_provider_error, classify_provider_error_redacting,
+    drain_frames, frame_data, read_bounded_error_body,
 };
 
 const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
@@ -352,12 +352,21 @@ impl AnthropicProvider {
         if !status.is_success() {
             let retry_after = crate::sse::retry_after_hint(response.headers());
             let body = read_bounded_error_body(response.bytes_stream()).await;
-            return Err(classify_provider_error(
-                self.provider_name(),
-                status.as_u16(),
-                &body,
-                retry_after,
-            ));
+            return Err(match &self.vertex {
+                Some(vertex) => classify_provider_error_redacting(
+                    self.provider_name(),
+                    status.as_u16(),
+                    &body,
+                    retry_after,
+                    &[vertex.project_id.as_str()],
+                ),
+                None => classify_provider_error(
+                    self.provider_name(),
+                    status.as_u16(),
+                    &body,
+                    retry_after,
+                ),
+            });
         }
         Ok(response)
     }
@@ -3022,5 +3031,67 @@ mod tests {
             })
             .await;
         assert_eq!(source.0.lock().unwrap().as_slice(), &[Some(conversation)]);
+    }
+
+    #[tokio::test]
+    async fn vertex_error_does_not_expose_the_service_account_project() {
+        use axum::http::StatusCode;
+        use axum::response::IntoResponse;
+        use axum::routing::post;
+        use axum::{Json, Router};
+
+        const PROJECT_ID: &str = "customer-project-123";
+
+        struct StaticToken;
+
+        #[async_trait::async_trait]
+        impl crate::BearerTokenSource for StaticToken {
+            async fn bearer_token(&self) -> openwave_core::Result<String> {
+                Ok("vertex-bearer".into())
+            }
+        }
+
+        async fn deny() -> impl IntoResponse {
+            (
+                StatusCode::FORBIDDEN,
+                Json(json!({
+                    "error": {
+                        "code": "permission_denied",
+                        "message": format!(
+                            "Permission denied on projects/{PROJECT_ID}/locations/global"
+                        ),
+                    }
+                })),
+            )
+        }
+
+        let app = Router::new().fallback(post(deny));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let provider =
+            AnthropicProvider::vertex(PROJECT_ID, "global", std::sync::Arc::new(StaticToken))
+                .unwrap()
+                .with_base_url(format!("http://{address}"));
+        let error = match provider
+            .stream(ChatRequest {
+                provider: Some(ProviderId::new("vertex")),
+                model: "claude-opus-4-8".into(),
+                messages: vec![ChatMessage::text(Role::User, "hi")],
+                ..Default::default()
+            })
+            .await
+        {
+            Err(error) => error,
+            Ok(_) => panic!("Vertex Claude unexpectedly accepted the denied request"),
+        };
+        server.abort();
+
+        assert!(matches!(error, AgentError::Authentication(_)));
+        let visible = error.to_string();
+        assert!(visible.contains("vertex returned 403"), "{visible}");
+        assert!(visible.contains("permission_denied"), "{visible}");
+        assert!(!visible.contains(PROJECT_ID), "{visible}");
     }
 }

--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -21,6 +21,7 @@ use openwave_core::provider::{
 use openwave_core::tool::{strict_json_schema, OptionalProperties};
 use openwave_core::{ImageAttachments, Role};
 
+use crate::google::{valid_resource_segment, valid_vertex_location};
 use crate::sse::{
     classify_in_band_error, classify_provider_error, drain_frames, frame_data,
     read_bounded_error_body,
@@ -28,8 +29,14 @@ use crate::sse::{
 
 const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
 const ANTHROPIC_VERSION: &str = "2023-06-01";
+const VERTEX_ANTHROPIC_VERSION: &str = "vertex-2023-10-16";
 const DEFAULT_MAX_TOKENS: u32 = 4096;
 
+#[derive(Clone)]
+struct VertexEndpoint {
+    project_id: String,
+    location: String,
+}
 /// Description for the synthetic tool that carries a constrained response.
 ///
 /// The model is told what the call is for, because a forced tool with an opaque
@@ -45,6 +52,7 @@ pub struct AnthropicProvider {
     client: reqwest::Client,
     api_key: String,
     base_url: String,
+    vertex: Option<VertexEndpoint>,
     /// Per-request credential supplier for gateways that mint short-lived
     /// tokens. Takes precedence over `api_key` when present.
     token_source: Option<std::sync::Arc<dyn crate::BearerTokenSource>>,
@@ -61,9 +69,46 @@ impl AnthropicProvider {
             client: crate::http::streaming_client(),
             api_key: api_key.into(),
             base_url: DEFAULT_BASE_URL.to_string(),
+            vertex: None,
             token_source: None,
             conversation_attribution: false,
         }
+    }
+
+    /// Build the native Anthropic Messages protocol on Vertex AI.
+    ///
+    /// The host is derived from a validated Google Cloud location and cannot
+    /// be supplied by credential material. The bearer source is shared with
+    /// the native Gemini-on-Vertex adapter and refreshes behind its own lock.
+    pub fn vertex(
+        project_id: impl Into<String>,
+        location: impl Into<String>,
+        token_source: std::sync::Arc<dyn crate::BearerTokenSource>,
+    ) -> Result<Self> {
+        let project_id = project_id.into();
+        let location = location.into();
+        if !valid_resource_segment(&project_id) {
+            return Err(AgentError::config("invalid Vertex AI project"));
+        }
+        if !valid_vertex_location(&location) {
+            return Err(AgentError::config("invalid Vertex AI location"));
+        }
+        let base_url = if location == "global" {
+            "https://aiplatform.googleapis.com".to_string()
+        } else {
+            format!("https://{location}-aiplatform.googleapis.com")
+        };
+        Ok(Self {
+            client: crate::http::streaming_client(),
+            api_key: String::new(),
+            base_url,
+            vertex: Some(VertexEndpoint {
+                project_id,
+                location,
+            }),
+            token_source: Some(token_source),
+            conversation_attribution: false,
+        })
     }
 
     /// Override the base URL — e.g. to route through a gateway that speaks the
@@ -101,11 +146,26 @@ impl AnthropicProvider {
 #[async_trait]
 impl ModelProvider for AnthropicProvider {
     fn id(&self) -> ProviderId {
-        ProviderId::new("anthropic")
+        ProviderId::new(if self.vertex.is_some() {
+            "vertex"
+        } else {
+            "anthropic"
+        })
     }
 
     async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+        if self.vertex.is_some() && req.vendor_web_search.is_some() {
+            return Err(AgentError::config(
+                "Vertex AI Claude does not support Anthropic server-side web search",
+            ));
+        }
         let mut body = build_request_json(&req)?;
+        if self.vertex.is_some() {
+            body.as_object_mut()
+                .expect("the Anthropic request body is an object")
+                .remove("model");
+            body["anthropic_version"] = json!(VERTEX_ANTHROPIC_VERSION);
+        }
         // `build_request_json` has already rejected a format it cannot enforce.
         let output_tool = match &req.response_format {
             Some(ResponseFormat::JsonSchema { name, .. }) => Some(name.clone()),
@@ -119,7 +179,9 @@ impl ModelProvider for AnthropicProvider {
         // Setup failures (connection, auth, 4xx/5xx) surface here as `Err` so the
         // router can classify and fail over; the returned stream only yields
         // normalized events.
-        let response = self.send(&body, &api_key, req.conversation).await?;
+        let response = self
+            .send(&body, &api_key, req.conversation, &req.model)
+            .await?;
 
         // Only a request that can pause needs its raw blocks kept, and only
         // Anthropic's own server tools pause a turn.
@@ -130,6 +192,8 @@ impl ModelProvider for AnthropicProvider {
         };
         let provider = self.clone();
         let conversation = req.conversation;
+        let model = req.model.clone();
+        let provider_name = self.provider_name();
         let ceiling = crate::http::timeouts().total_stream;
         let stream = async_stream::stream! {
             let mut response = response;
@@ -155,7 +219,7 @@ impl ModelProvider for AnthropicProvider {
                         Err(error) => {
                             yield ProviderEvent::Failed {
                                 error: ProviderErrorInfo::provider(
-                                    error.client_message("anthropic"),
+                                    error.client_message(provider_name),
                                 ),
                             };
                             return;
@@ -202,7 +266,7 @@ impl ModelProvider for AnthropicProvider {
                         .unwrap_or_default();
                     replace_paused_assistant_message(&mut body, blocks, continuations == 1);
                     state.begin_continuation();
-                    match provider.send(&body, &api_key, conversation).await {
+                    match provider.send(&body, &api_key, conversation, &model).await {
                         Ok(next) => {
                             response = next;
                             continue 'legs;
@@ -241,14 +305,26 @@ impl AnthropicProvider {
         body: &Value,
         api_key: &str,
         conversation: Option<openwave_core::id::ChatId>,
+        model: &str,
     ) -> Result<reqwest::Response> {
-        let url = format!("{}/v1/messages", self.base_url);
-        let mut request = self
-            .client
-            .post(url)
-            .header("x-api-key", api_key)
-            .header("anthropic-version", ANTHROPIC_VERSION)
-            .header("content-type", "application/json");
+        let mut request = if let Some(vertex) = &self.vertex {
+            if !valid_anthropic_model_id(model) {
+                return Err(AgentError::config("invalid Vertex AI Claude model id"));
+            }
+            self.client
+                .post(format!(
+                    "{}/v1/projects/{}/locations/{}/publishers/anthropic/models/{}:streamRawPredict",
+                    self.base_url, vertex.project_id, vertex.location, model
+                ))
+                .bearer_auth(api_key)
+                .header("content-type", "application/json")
+        } else {
+            self.client
+                .post(format!("{}/v1/messages", self.base_url))
+                .header("x-api-key", api_key)
+                .header("anthropic-version", ANTHROPIC_VERSION)
+                .header("content-type", "application/json")
+        };
         // A conversation is declared only where one is configured to be read.
         // The id is a UUID, so it satisfies the gateway's bound on the value
         // (1-256 ASCII graphic bytes) by construction.
@@ -265,7 +341,9 @@ impl AnthropicProvider {
             // reqwest's display includes the URL, and a gateway URL can carry
             // tenant-identifying parts; `AgentError` strings reach the client
             // via TurnFailed. Only the fact of a failed request surfaces.
-            .map_err(|_| AgentError::Provider("anthropic request failed".into()))?;
+            .map_err(|_| {
+                AgentError::Provider(format!("{} request failed", self.provider_name()))
+            })?;
 
         // Surface non-2xx without the raw body — it can echo key material, and
         // `AgentError` strings reach the client via TurnFailed. Status (+ a
@@ -275,7 +353,7 @@ impl AnthropicProvider {
             let retry_after = crate::sse::retry_after_hint(response.headers());
             let body = read_bounded_error_body(response.bytes_stream()).await;
             return Err(classify_provider_error(
-                "anthropic",
+                self.provider_name(),
                 status.as_u16(),
                 &body,
                 retry_after,
@@ -283,6 +361,22 @@ impl AnthropicProvider {
         }
         Ok(response)
     }
+
+    fn provider_name(&self) -> &'static str {
+        if self.vertex.is_some() {
+            "vertex"
+        } else {
+            "anthropic"
+        }
+    }
+}
+
+fn valid_anthropic_model_id(model: &str) -> bool {
+    !model.is_empty()
+        && model.len() <= 128
+        && model
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'@'))
 }
 
 /// How many times one turn may be resumed after the provider pauses it.
@@ -1999,6 +2093,25 @@ mod tests {
             body["messages"][2]["content"][0]["cache_control"],
             ephemeral_cache_control()
         );
+
+        // The same native protocol hosted by Vertex has a distinct route
+        // identity. Its blocks replay on Vertex, but never on direct Anthropic.
+        req.provider = Some(ProviderId::new("vertex"));
+        req.messages[1].reasoning = MessageReasoning::captured(
+            ReasoningOrigin {
+                provider: Some(ProviderId::new("vertex")),
+                model: "claude-opus-5".into(),
+            },
+            reasoning.clone(),
+        );
+        let body = build_request_json(&req).unwrap();
+        assert_eq!(
+            body["messages"][1]["content"].as_array().unwrap()[..2],
+            reasoning[..]
+        );
+        req.provider = Some(ProviderId::new("anthropic"));
+        let body = build_request_json(&req).unwrap();
+        assert_eq!(body["messages"][1]["content"].as_array().unwrap().len(), 2);
     }
 
     #[test]
@@ -2028,6 +2141,8 @@ mod tests {
             step(Some("anthropic"), "claude-sonnet-5"),
             // Another provider entirely.
             step(Some("openai"), "claude-opus-5"),
+            // The same protocol through a different serving provider.
+            step(Some("vertex"), "claude-opus-5"),
         ] {
             let mut req = reasoning_request("claude-opus-5", None);
             req.messages = vec![ChatMessage::text(Role::User, "hi"), origin];

--- a/crates/openwave-router/src/gemini.rs
+++ b/crates/openwave-router/src/gemini.rs
@@ -2,10 +2,11 @@
 //!
 //! Gemini's GenerateContent protocol differs materially from OpenAI-compatible
 //! chat completions: output limits live under `generationConfig`, streamed SSE
-//! frames are complete (but partial) responses, and tool results carry no call
-//! id at all — they are correlated to their calls by function name and order. Keeping that conversion here makes the
-//! catalog's Gemini rows honest rather than depending on a compatibility layer
-//! silently accepting or dropping fields it does not understand.
+//! frames are complete (but partial) responses, and current tool calls carry
+//! ids plus opaque thought signatures that must survive a same-route replay.
+//! Keeping that conversion here makes the catalog's Gemini rows honest rather
+//! than depending on a compatibility layer silently accepting or dropping
+//! fields it does not understand.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, LazyLock};
@@ -27,8 +28,9 @@ use openwave_core::{ImageAttachments, ReasoningEffort, Role};
 
 use crate::google::{valid_resource_segment, valid_vertex_location};
 use crate::sse::{
-    classify_in_band_error, classify_provider_error, drain_frames, frame_data_raw,
-    read_bounded_error_body,
+    classify_in_band_error, classify_provider_error, classify_provider_error_redacting,
+    drain_frames, frame_data_raw, read_bounded_error_body, safe_http_error,
+    safe_http_error_redacting,
 };
 use crate::BearerTokenSource;
 
@@ -255,7 +257,16 @@ impl ModelProvider for GeminiProvider {
         if !status.is_success() {
             let retry_after = crate::sse::retry_after_hint(response.headers());
             let body = read_bounded_error_body(response.bytes_stream()).await;
-            return Err(classify_gemini_error(status.as_u16(), &body, retry_after));
+            let project_id = match &self.endpoint_family {
+                EndpointFamily::VertexAi { project_id, .. } => Some(project_id.as_str()),
+                EndpointFamily::DeveloperApi => None,
+            };
+            return Err(classify_gemini_error(
+                status.as_u16(),
+                &body,
+                retry_after,
+                project_id,
+            ));
         }
 
         let ceiling = crate::http::timeouts().total_stream;
@@ -376,7 +387,13 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
 
     let grounding = declares_search_grounding(req);
     let mut body = json!({
-        "contents": gemini_contents(&req.messages, &req.images, grounding)?,
+        "contents": gemini_contents(
+            &req.messages,
+            &req.images,
+            grounding,
+            req.provider.as_ref(),
+            &req.model,
+        )?,
         "generationConfig": generation_config,
     });
     if let Some(system) = &req.system {
@@ -416,10 +433,11 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
 /// `toolConfig.includeServerSideToolInvocations` set: that flag turns on tool
 /// context circulation, which drops `AUTO` function-calling mode and requires
 /// every later turn to replay the model's own parts verbatim, including part
-/// ids and opaque `thoughtSignature` values. OpenWave stores provider-neutral
-/// history precisely so a chat can switch models mid-conversation, so it sends
-/// the documented signature bypass and mints its own call ids — replaying what
-/// circulation demands is not something this adapter can do today.
+/// ids and opaque `thoughtSignature` values. OpenWave captures those parts as
+/// route-originated replay state for ordinary host tool calls, but it still
+/// stores provider-neutral history so a chat can switch models. On a foreign
+/// route the native state flattens away and the documented signature bypass
+/// keeps that older history portable.
 ///
 /// Dropping the host's tools to make room for grounding would be worse than
 /// ignoring grounding: the turn would lose the agent's whole tool loop. So the
@@ -834,14 +852,17 @@ fn gemini_thinking_level(effort: ReasoningEffort) -> &'static str {
 /// Gemini requires all responses to the parallel calls in one model turn to
 /// form one following user message. The stored transcript keeps tool results as
 /// independent messages, so consecutive pure result messages are coalesced.
-/// Neither side of the protocol carries a call id, so that ordering is the only
-/// correlation the model has and the coalescing pass is load-bearing.
+/// Current Gemini calls and responses both carry the durable call id. The
+/// coalescing pass remains load-bearing because Gemini requires every response
+/// to parallel calls in one model turn to share the following user message.
 /// `rename_client_web_search` rewrites the name of historical client-style
 /// `web_search` calls — see [`PRIOR_WEB_SEARCH_TOOL`].
 fn gemini_contents(
     messages: &[openwave_core::provider::ChatMessage],
     images: &ImageAttachments,
     rename_client_web_search: bool,
+    provider: Option<&ProviderId>,
+    model: &str,
 ) -> Result<Vec<Value>> {
     let rename = rename_client_web_search;
     let tool_names: HashMap<&str, &str> = messages
@@ -866,20 +887,23 @@ fn gemini_contents(
         for block in &message.content {
             match block {
                 ContentBlock::Text { text } => parts.push(json!({ "text": text })),
-                ContentBlock::ToolUse { name, input, .. } => {
-                    // `FunctionCall` has no id field, and ids minted by other
-                    // providers must never reach Gemini: a call is correlated
-                    // to its response by function name and part order.
+                ContentBlock::ToolUse { id, name, input } => {
                     let mut part = json!({
                         "functionCall": {
+                            "id": id,
                             "name": replayed_tool_name(name, rename),
                             "args": input,
                         },
                     });
-                    // Gemini validates the first call part of each model turn.
-                    // We deliberately use its portable bypass rather than
-                    // persisting opaque provider state in a cross-model chat.
-                    if !attached_signature {
+                    // Same-route history restores the provider's opaque bytes
+                    // exactly. Foreign or legacy history has no valid native
+                    // signature, so only that fallback takes the documented
+                    // validator bypass.
+                    if let Some(signature) = gemini_thought_signature(message, provider, model, id)
+                    {
+                        part["thoughtSignature"] = signature;
+                        attached_signature = true;
+                    } else if !attached_signature {
                         part["thoughtSignature"] = json!(thought_signature_bypass());
                         attached_signature = true;
                     }
@@ -895,8 +919,8 @@ fn gemini_contents(
                             "gemini tool result has no matching function call".to_string(),
                         )
                     })?;
-                    // `FunctionResponse` likewise carries no id, and its
-                    // `response` struct expresses failure with an `error` key.
+                    // Its `response` struct expresses failure with an `error`
+                    // key; the id and name together match the original call.
                     let response = if *is_error {
                         json!({ "error": content })
                     } else {
@@ -904,6 +928,7 @@ fn gemini_contents(
                     };
                     parts.push(json!({
                         "functionResponse": {
+                            "id": tool_use_id,
                             "name": name,
                             "response": response,
                         },
@@ -980,6 +1005,24 @@ fn gemini_contents(
         }
     }
     Ok(merged)
+}
+
+/// The exact thought signature captured for `tool_use_id`, but only when the
+/// message state came from this provider+model route.
+fn gemini_thought_signature(
+    message: &openwave_core::provider::ChatMessage,
+    provider: Option<&ProviderId>,
+    model: &str,
+    tool_use_id: &str,
+) -> Option<Value> {
+    message
+        .reasoning
+        .replayable_for(provider, model)
+        .iter()
+        .find(|part| part.pointer("/functionCall/id").and_then(Value::as_str) == Some(tool_use_id))
+        .and_then(|part| part.get("thoughtSignature"))
+        .filter(|signature| signature.is_string())
+        .cloned()
 }
 
 #[derive(Default)]
@@ -1093,6 +1136,14 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
                 let index = state.next_tool_index;
                 state.next_tool_index = state.next_tool_index.saturating_add(1);
                 state.saw_tool_call = true;
+                if part.get("thoughtSignature").is_some_and(Value::is_string) {
+                    events.push(ProviderEvent::ReasoningBlock {
+                        data: json!({
+                            "functionCall": {"id": id.clone()},
+                            "thoughtSignature": part["thoughtSignature"].clone(),
+                        }),
+                    });
+                }
                 events.push(ProviderEvent::ToolCallStarted {
                     index,
                     id,
@@ -1325,6 +1376,7 @@ fn classify_gemini_error(
     status: u16,
     body: &str,
     retry_after: Option<std::time::Duration>,
+    vertex_project_id: Option<&str>,
 ) -> AgentError {
     let prompt_too_long = serde_json::from_str::<Value>(body)
         .ok()
@@ -1342,15 +1394,24 @@ fn classify_gemini_error(
                 || message.contains("maximum number of tokens")
         });
     if prompt_too_long {
-        return AgentError::PromptTooLong(crate::sse::safe_http_error("gemini", status, body));
+        let message = match vertex_project_id {
+            Some(project_id) => safe_http_error_redacting("gemini", status, body, &[project_id]),
+            None => safe_http_error("gemini", status, body),
+        };
+        return AgentError::PromptTooLong(message);
     }
-    classify_provider_error("gemini", status, body, retry_after)
+    match vertex_project_id {
+        Some(project_id) => {
+            classify_provider_error_redacting("gemini", status, body, retry_after, &[project_id])
+        }
+        None => classify_provider_error("gemini", status, body, retry_after),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openwave_core::provider::{ChatMessage, MessageReasoning};
+    use openwave_core::provider::{ChatMessage, MessageReasoning, ReasoningOrigin};
     use openwave_core::tool::{Tool, ToolSpec};
     use openwave_core::{
         ask_user_questions_tool_spec, create_app_tool_spec, exit_plan_mode_tool_spec,
@@ -1607,7 +1668,7 @@ mod tests {
     }
 
     #[test]
-    fn tool_results_correlate_by_name_and_order_without_ids() {
+    fn tool_calls_and_results_preserve_ids_and_same_route_signatures() {
         let messages = vec![
             ChatMessage {
                 role: Role::Assistant,
@@ -1623,7 +1684,22 @@ mod tests {
                         input: json!({"path": "two"}),
                     },
                 ],
-                reasoning: MessageReasoning::default(),
+                reasoning: MessageReasoning::captured(
+                    ReasoningOrigin {
+                        provider: Some(ProviderId::new("gemini")),
+                        model: "gemini-3.6-flash".into(),
+                    },
+                    vec![
+                        json!({
+                            "functionCall": {"id": "call_one"},
+                            "thoughtSignature": "b3BhcXVlLXNpZ25hdHVyZS0x",
+                        }),
+                        json!({
+                            "functionCall": {"id": "call_two"},
+                            "thoughtSignature": "b3BhcXVlLXNpZ25hdHVyZS0y",
+                        }),
+                    ],
+                ),
             },
             ChatMessage {
                 role: Role::User,
@@ -1649,33 +1725,21 @@ mod tests {
         assert_eq!(contents.len(), 2);
         assert_eq!(contents[0]["role"], "model");
 
-        // The proto has no id on either side; correlation is by function name
-        // and the order of the parts, so no provider-minted id may leak out.
         let calls = contents[0]["parts"].as_array().unwrap();
-        for call in calls {
-            assert!(call["functionCall"].get("id").is_none());
-            assert!(call["functionCall"].get("call_id").is_none());
-        }
+        assert_eq!(calls[0]["functionCall"]["id"], "call_one");
+        assert_eq!(calls[1]["functionCall"]["id"], "call_two");
         assert_eq!(calls[0]["functionCall"]["args"]["path"], "one");
         assert_eq!(calls[1]["functionCall"]["args"]["path"], "two");
-
-        // `thoughtSignature` is proto `bytes`, so the JSON value must be the
-        // base64 encoding of the bypass token, not the token itself, and it
-        // rides only the first call part of the turn.
-        let signature = calls[0]["thoughtSignature"].as_str().unwrap();
-        assert_eq!(
-            String::from_utf8(BASE64.decode(signature).unwrap()).unwrap(),
-            THOUGHT_SIGNATURE_BYPASS
-        );
-        assert!(calls[1].get("thoughtSignature").is_none());
+        assert_eq!(calls[0]["thoughtSignature"], "b3BhcXVlLXNpZ25hdHVyZS0x");
+        assert_eq!(calls[1]["thoughtSignature"], "b3BhcXVlLXNpZ25hdHVyZS0y");
 
         let responses = contents[1]["parts"].as_array().unwrap();
         assert_eq!(responses.len(), 2);
-        for response in responses {
-            assert_eq!(response["functionResponse"]["name"], "read_file");
-            assert!(response["functionResponse"].get("id").is_none());
-            assert!(response["functionResponse"].get("call_id").is_none());
-        }
+        assert_eq!(responses[0]["functionResponse"]["id"], "call_one");
+        assert_eq!(responses[1]["functionResponse"]["id"], "call_two");
+        assert!(responses
+            .iter()
+            .all(|response| response["functionResponse"]["name"] == "read_file"));
         assert_eq!(
             responses[0]["functionResponse"]["response"]["output"],
             "one"
@@ -1687,6 +1751,71 @@ mod tests {
         assert!(responses[1]["functionResponse"]["response"]
             .get("is_error")
             .is_none());
+    }
+
+    #[test]
+    fn vertex_replays_its_signature_and_route_switches_use_the_legacy_bypass() {
+        let tool_message = |origin_provider: &str| ChatMessage {
+            role: Role::Assistant,
+            content: vec![ContentBlock::ToolUse {
+                id: "call_one".into(),
+                name: "read_file".into(),
+                input: json!({"path": "one"}),
+            }],
+            reasoning: MessageReasoning::captured(
+                ReasoningOrigin {
+                    provider: Some(ProviderId::new(origin_provider)),
+                    model: "gemini-3.6-flash".into(),
+                },
+                vec![json!({
+                    "functionCall": {"id": "call_one"},
+                    "thoughtSignature": "dmVydGV4LW9wYXF1ZS1zaWduYXR1cmU=",
+                })],
+            ),
+        };
+
+        let mut vertex = request(vec![tool_message("vertex")]);
+        vertex.provider = Some(ProviderId::new("vertex"));
+        let body = build_request_json(&vertex).unwrap();
+        assert_eq!(
+            body["contents"][0]["parts"][0]["thoughtSignature"],
+            "dmVydGV4LW9wYXF1ZS1zaWduYXR1cmU="
+        );
+
+        let mut switched = request(vec![tool_message("gemini")]);
+        switched.provider = Some(ProviderId::new("vertex"));
+        let body = build_request_json(&switched).unwrap();
+        let signature = body["contents"][0]["parts"][0]["thoughtSignature"]
+            .as_str()
+            .unwrap();
+        assert_eq!(
+            String::from_utf8(BASE64.decode(signature).unwrap()).unwrap(),
+            THOUGHT_SIGNATURE_BYPASS
+        );
+
+        let legacy = request(vec![ChatMessage {
+            role: Role::Assistant,
+            content: vec![ContentBlock::ToolUse {
+                id: "call_one".into(),
+                name: "read_file".into(),
+                input: json!({"path": "one"}),
+            }],
+            reasoning: MessageReasoning::default(),
+        }]);
+        let body = build_request_json(&legacy).unwrap();
+        assert_eq!(
+            String::from_utf8(
+                BASE64
+                    .decode(
+                        body["contents"][0]["parts"][0]["thoughtSignature"]
+                            .as_str()
+                            .unwrap(),
+                    )
+                    .unwrap(),
+            )
+            .unwrap(),
+            THOUGHT_SIGNATURE_BYPASS
+        );
     }
 
     // ── Image blocks ───────────────────────────────────────────────
@@ -1755,8 +1884,8 @@ mod tests {
             json!({"candidates":[{"content":{"parts":[
                 {"thought": true, "text":"considering"},
                 {"text":"I'll inspect it."},
-                {"functionCall":{"id":"call_1", "name":"read_file", "args":{"path":"a"}}},
-                {"functionCall":{"id":"call_2", "name":"read_file", "args":{"path":"b"}}}
+                {"functionCall":{"id":"call_1", "name":"read_file", "args":{"path":"a"}}, "thoughtSignature":"c2lnbmF0dXJlLW9uZQ=="},
+                {"functionCall":{"id":"call_2", "name":"read_file", "args":{"path":"b"}}, "thoughtSignature":"c2lnbmF0dXJlLXR3bw=="}
             ]}}]}),
             json!({"candidates":[{"finishReason":"STOP"}], "usageMetadata": {
                 "promptTokenCount": 10,
@@ -1774,6 +1903,12 @@ mod tests {
                 ProviderEvent::TextDelta {
                     text: "I'll inspect it.".into()
                 },
+                ProviderEvent::ReasoningBlock {
+                    data: json!({
+                        "functionCall": {"id": "call_1"},
+                        "thoughtSignature": "c2lnbmF0dXJlLW9uZQ==",
+                    })
+                },
                 ProviderEvent::ToolCallStarted {
                     index: 0,
                     id: "call_1".into(),
@@ -1782,6 +1917,12 @@ mod tests {
                 ProviderEvent::ToolCallArgsDelta {
                     index: 0,
                     fragment: r#"{"path":"a"}"#.into()
+                },
+                ProviderEvent::ReasoningBlock {
+                    data: json!({
+                        "functionCall": {"id": "call_2"},
+                        "thoughtSignature": "c2lnbmF0dXJlLXR3bw==",
+                    })
                 },
                 ProviderEvent::ToolCallStarted {
                     index: 1,
@@ -2117,5 +2258,52 @@ mod tests {
             "read_file"
         );
         server.abort();
+    }
+
+    #[tokio::test]
+    async fn vertex_error_does_not_expose_the_service_account_project() {
+        use axum::http::StatusCode;
+        use axum::response::IntoResponse;
+        use axum::routing::post;
+        use axum::{Json, Router};
+
+        const PROJECT_ID: &str = "customer-project-123";
+
+        async fn deny() -> impl IntoResponse {
+            (
+                StatusCode::FORBIDDEN,
+                Json(json!({
+                    "error": {
+                        "code": "permission_denied",
+                        "message": format!(
+                            "Permission denied on projects/{PROJECT_ID}/locations/global"
+                        ),
+                    }
+                })),
+            )
+        }
+
+        let app = Router::new().fallback(post(deny));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let provider = GeminiProvider::vertex(PROJECT_ID, "global", Arc::new(StaticToken))
+            .unwrap()
+            .with_base_url(format!("http://{address}"));
+        let error = match provider
+            .stream(request(vec![ChatMessage::text(Role::User, "hi")]))
+            .await
+        {
+            Err(error) => error,
+            Ok(_) => panic!("Vertex Gemini unexpectedly accepted the denied request"),
+        };
+        server.abort();
+
+        assert!(matches!(error, AgentError::Authentication(_)));
+        let visible = error.to_string();
+        assert!(visible.contains("gemini returned 403"), "{visible}");
+        assert!(visible.contains("permission_denied"), "{visible}");
+        assert!(!visible.contains(PROJECT_ID), "{visible}");
     }
 }

--- a/crates/openwave-router/src/gemini.rs
+++ b/crates/openwave-router/src/gemini.rs
@@ -147,9 +147,11 @@ impl GeminiProvider {
                 project_id,
                 location,
             } => {
-                // Gemini 3 is global-only. Keep a regional setting useful for
-                // older/future regional models without sending a curated 3.x
-                // row to an endpoint Google cannot serve.
+                // Gemini 3 is global-only. Legacy Gemini service-account
+                // configurations retain a regional setting for older/future
+                // regional models without sending a curated 3.x row to an
+                // endpoint Google cannot serve. First-class Vertex is
+                // global-only at the server configuration boundary.
                 let location = if requires_global_vertex(model) {
                     "global"
                 } else {
@@ -2008,7 +2010,7 @@ mod tests {
     }
 
     #[test]
-    fn vertex_endpoints_distinguish_global_and_regional_hosts() {
+    fn legacy_vertex_endpoints_distinguish_global_and_regional_hosts() {
         let global =
             GeminiProvider::vertex("test-project", "global", Arc::new(StaticToken)).unwrap();
         assert_eq!(

--- a/crates/openwave-router/src/gemini.rs
+++ b/crates/openwave-router/src/gemini.rs
@@ -25,7 +25,7 @@ use openwave_core::provider::{
 use openwave_core::tool::{strict_json_schema, OptionalProperties};
 use openwave_core::{ImageAttachments, ReasoningEffort, Role};
 
-use crate::google_auth::{valid_resource_segment, valid_vertex_location};
+use crate::google::{valid_resource_segment, valid_vertex_location};
 use crate::sse::{
     classify_in_band_error, classify_provider_error, drain_frames, frame_data_raw,
     read_bounded_error_body,

--- a/crates/openwave-router/src/gemini.rs
+++ b/crates/openwave-router/src/gemini.rs
@@ -28,9 +28,9 @@ use openwave_core::{ImageAttachments, ReasoningEffort, Role};
 
 use crate::google::{valid_resource_segment, valid_vertex_location};
 use crate::sse::{
-    classify_in_band_error, classify_provider_error, classify_provider_error_redacting,
-    drain_frames, frame_data_raw, read_bounded_error_body, safe_http_error,
-    safe_http_error_redacting,
+    classify_in_band_error, classify_in_band_error_redacting, classify_provider_error,
+    classify_provider_error_redacting, drain_frames, frame_data_raw, read_bounded_error_body,
+    safe_http_error, safe_http_error_redacting,
 };
 use crate::BearerTokenSource;
 
@@ -270,11 +270,18 @@ impl ModelProvider for GeminiProvider {
         }
 
         let ceiling = crate::http::timeouts().total_stream;
+        let vertex_project_id = match &self.endpoint_family {
+            EndpointFamily::VertexAi { project_id, .. } => Some(project_id.clone()),
+            EndpointFamily::DeveloperApi => None,
+        };
         let stream = async_stream::stream! {
             let bytes = crate::http::with_stream_deadline(response.bytes_stream(), ceiling);
             futures::pin_mut!(bytes);
             let mut buffer = Vec::new();
-            let mut state = StreamState::default();
+            let mut state = StreamState {
+                vertex_project_id,
+                ..StreamState::default()
+            };
             while let Some(chunk) = bytes.next().await {
                 let chunk = match chunk {
                     Ok(chunk) => chunk,
@@ -1033,6 +1040,9 @@ struct StreamState {
     saw_tool_call: bool,
     terminal: bool,
     reported_grounding: bool,
+    /// Sensitive route identity retained only so accepted Vertex streams can
+    /// redact Google resource paths and attribute in-band failures correctly.
+    vertex_project_id: Option<String>,
 }
 
 /// Convert one complete Gemini response frame into provider-neutral events.
@@ -1042,8 +1052,12 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
     }
     if let Some(error) = data.get("error") {
         state.terminal = true;
+        let error = match state.vertex_project_id.as_deref() {
+            Some(project_id) => classify_in_band_error_redacting("vertex", error, &[project_id]),
+            None => classify_in_band_error("gemini", error),
+        };
         return vec![ProviderEvent::Failed {
-            error: ProviderErrorInfo::from_error(&classify_in_band_error("gemini", error)),
+            error: ProviderErrorInfo::from_error(&error),
         }];
     }
     if let Some(block_reason) = data
@@ -2305,5 +2319,58 @@ mod tests {
         assert!(visible.contains("gemini returned 403"), "{visible}");
         assert!(visible.contains("permission_denied"), "{visible}");
         assert!(!visible.contains(PROJECT_ID), "{visible}");
+    }
+
+    #[tokio::test]
+    async fn vertex_in_band_error_redacts_project_and_uses_vertex_attribution() {
+        use axum::http::header;
+        use axum::response::IntoResponse;
+        use axum::routing::post;
+        use axum::Router;
+
+        const PROJECT_ID: &str = "customer-project-123";
+
+        async fn deny_after_accepting() -> impl IntoResponse {
+            let frame = json!({
+                "error": {
+                    "code": 403,
+                    "type": "permission_denied",
+                    "message": format!(
+                        "Permission denied on projects/{PROJECT_ID}/locations/global"
+                    ),
+                }
+            });
+            (
+                [(header::CONTENT_TYPE, "text/event-stream")],
+                format!("data: {frame}\n\n"),
+            )
+        }
+
+        let app = Router::new().fallback(post(deny_after_accepting));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let provider = GeminiProvider::vertex(PROJECT_ID, "global", Arc::new(StaticToken))
+            .unwrap()
+            .with_base_url(format!("http://{address}"));
+        let events: Vec<_> = provider
+            .stream(request(vec![ChatMessage::text(Role::User, "hi")]))
+            .await
+            .unwrap()
+            .collect()
+            .await;
+        server.abort();
+
+        assert_eq!(
+            events,
+            vec![ProviderEvent::Failed {
+                error: ProviderErrorInfo {
+                    kind: "authentication".into(),
+                    message: "vertex returned 403 (permission_denied)".into(),
+                },
+            }]
+        );
+        assert!(!format!("{events:?}").contains(PROJECT_ID));
     }
 }

--- a/crates/openwave-router/src/gemini.rs
+++ b/crates/openwave-router/src/gemini.rs
@@ -66,6 +66,22 @@ enum EndpointFamily {
     },
 }
 
+impl EndpointFamily {
+    fn provider_name(&self) -> &'static str {
+        match self {
+            Self::DeveloperApi => "gemini",
+            Self::VertexAi { .. } => "vertex",
+        }
+    }
+
+    fn vertex_project_id(&self) -> Option<&str> {
+        match self {
+            Self::DeveloperApi => None,
+            Self::VertexAi { project_id, .. } => Some(project_id),
+        }
+    }
+}
+
 /// A [`ModelProvider`] for native Gemini GenerateContent over either the
 /// Developer API or Vertex AI.
 #[derive(Clone)]
@@ -136,7 +152,10 @@ impl GeminiProvider {
                 .bytes()
                 .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
         {
-            return Err(AgentError::config("invalid Gemini model id"));
+            return Err(AgentError::config(format!(
+                "{} received an invalid model id",
+                self.endpoint_family.provider_name()
+            )));
         }
         match &self.endpoint_family {
             EndpointFamily::DeveloperApi => {
@@ -181,6 +200,7 @@ impl GeminiProvider {
         content_type: &str,
         audio_base64: &str,
     ) -> Result<String> {
+        let provider = self.endpoint_family.provider_name();
         let endpoint = self
             .endpoint(model)?
             .replace(":streamGenerateContent?alt=sse", ":generateContent");
@@ -201,24 +221,41 @@ impl GeminiProvider {
             .json(&body);
         let request = match &self.auth {
             GeminiAuth::ApiKey(api_key) => request.header("x-goog-api-key", api_key),
-            GeminiAuth::Bearer(source) => request.bearer_auth(source.bearer_token().await?),
+            GeminiAuth::Bearer(source) => request.bearer_auth(
+                source
+                    .bearer_token()
+                    .await
+                    .map_err(|error| credential_setup_error(provider, error))?,
+            ),
         };
         let response = request.send().await.map_err(|_| {
-            AgentError::Provider("gemini audio transcription request failed".into())
+            AgentError::Provider(format!("{provider} audio transcription request failed"))
         })?;
         if !response.status().is_success() {
             return Err(AgentError::Provider(format!(
-                "gemini audio transcription returned {}",
+                "{provider} audio transcription returned {}",
                 response.status().as_u16()
             )));
         }
         let body: Value = response.json().await.map_err(|_| {
-            AgentError::Provider("gemini returned an invalid audio transcription response".into())
+            AgentError::Provider(format!(
+                "{provider} returned an invalid audio transcription response"
+            ))
         })?;
         body.pointer("/candidates/0/content/parts/0/text")
             .and_then(Value::as_str)
             .map(str::to_owned)
-            .ok_or_else(|| AgentError::Provider("gemini returned no audio transcript".into()))
+            .ok_or_else(|| AgentError::Provider(format!("{provider} returned no audio transcript")))
+    }
+}
+
+fn credential_setup_error(provider: &str, error: AgentError) -> AgentError {
+    let message = format!("{provider} credential setup failed");
+    match error {
+        AgentError::Config(_) => AgentError::Config(message),
+        AgentError::MissingCredential(_) => AgentError::MissingCredential(provider.to_string()),
+        AgentError::Authentication(_) => AgentError::Authentication(message),
+        _ => AgentError::Provider(message),
     }
 }
 
@@ -236,6 +273,7 @@ impl ModelProvider for GeminiProvider {
     }
 
     async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+        let provider = self.endpoint_family.provider_name();
         let body = build_request_json(&req)?;
         let request = self
             .client
@@ -244,28 +282,30 @@ impl ModelProvider for GeminiProvider {
             .json(&body);
         let request = match &self.auth {
             GeminiAuth::ApiKey(api_key) => request.header("x-goog-api-key", api_key),
-            GeminiAuth::Bearer(source) => request.bearer_auth(source.bearer_token().await?),
+            GeminiAuth::Bearer(source) => request.bearer_auth(
+                source
+                    .bearer_token()
+                    .await
+                    .map_err(|error| credential_setup_error(provider, error))?,
+            ),
         };
         let response = request
             .send()
             .await
             // reqwest's display includes the URL; a Vertex URL contains the
             // project id extracted from the secret key file.
-            .map_err(|_| AgentError::Provider("gemini request failed".into()))?;
+            .map_err(|_| AgentError::Provider(format!("{provider} request failed")))?;
 
         let status = response.status();
         if !status.is_success() {
             let retry_after = crate::sse::retry_after_hint(response.headers());
             let body = read_bounded_error_body(response.bytes_stream()).await;
-            let project_id = match &self.endpoint_family {
-                EndpointFamily::VertexAi { project_id, .. } => Some(project_id.as_str()),
-                EndpointFamily::DeveloperApi => None,
-            };
             return Err(classify_gemini_error(
+                provider,
                 status.as_u16(),
                 &body,
                 retry_after,
-                project_id,
+                self.endpoint_family.vertex_project_id(),
             ));
         }
 
@@ -291,7 +331,7 @@ impl ModelProvider for GeminiProvider {
                     // carries no such thing and is worth surfacing.
                     Err(error) => {
                         yield ProviderEvent::Failed {
-                            error: ProviderErrorInfo::provider(error.client_message("gemini")),
+                            error: ProviderErrorInfo::provider(error.client_message(provider)),
                         };
                         return;
                     }
@@ -306,7 +346,7 @@ impl ModelProvider for GeminiProvider {
                         Err(_) => {
                             yield ProviderEvent::Failed {
                                 error: ProviderErrorInfo::provider(
-                                    "gemini returned an invalid stream frame",
+                                    format!("{provider} returned an invalid stream frame"),
                                 ),
                             };
                             return;
@@ -328,7 +368,7 @@ impl ModelProvider for GeminiProvider {
                         Err(_) => {
                             yield ProviderEvent::Failed {
                                 error: ProviderErrorInfo::provider(
-                                    "gemini returned an invalid stream frame",
+                                    format!("{provider} returned an invalid stream frame"),
                                 ),
                             };
                             return;
@@ -1045,6 +1085,16 @@ struct StreamState {
     vertex_project_id: Option<String>,
 }
 
+impl StreamState {
+    fn provider_name(&self) -> &'static str {
+        if self.vertex_project_id.is_some() {
+            "vertex"
+        } else {
+            "gemini"
+        }
+    }
+}
+
 /// Convert one complete Gemini response frame into provider-neutral events.
 fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
     if state.terminal {
@@ -1053,8 +1103,10 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
     if let Some(error) = data.get("error") {
         state.terminal = true;
         let error = match state.vertex_project_id.as_deref() {
-            Some(project_id) => classify_in_band_error_redacting("vertex", error, &[project_id]),
-            None => classify_in_band_error("gemini", error),
+            Some(project_id) => {
+                classify_in_band_error_redacting(state.provider_name(), error, &[project_id])
+            }
+            None => classify_in_band_error(state.provider_name(), error),
         };
         return vec![ProviderEvent::Failed {
             error: ProviderErrorInfo::from_error(&error),
@@ -1119,9 +1171,10 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
                 else {
                     state.terminal = true;
                     events.push(ProviderEvent::Failed {
-                        error: ProviderErrorInfo::provider(
-                            "gemini returned a malformed function call",
-                        ),
+                        error: ProviderErrorInfo::provider(format!(
+                            "{} returned a malformed function call",
+                            state.provider_name()
+                        )),
                     });
                     return events;
                 };
@@ -1141,9 +1194,10 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
                 if !args.is_object() {
                     state.terminal = true;
                     events.push(ProviderEvent::Failed {
-                        error: ProviderErrorInfo::provider(
-                            "gemini returned non-object function arguments",
-                        ),
+                        error: ProviderErrorInfo::provider(format!(
+                            "{} returned non-object function arguments",
+                            state.provider_name()
+                        )),
                     });
                     return events;
                 }
@@ -1328,7 +1382,10 @@ fn finish_candidate(reason: &str, state: &mut StreamState, events: &mut Vec<Prov
         }
         "MALFORMED_FUNCTION_CALL" | "UNEXPECTED_TOOL_CALL" => {
             events.push(ProviderEvent::Failed {
-                error: ProviderErrorInfo::provider("gemini rejected a function call"),
+                error: ProviderErrorInfo::provider(format!(
+                    "{} rejected a function call",
+                    state.provider_name()
+                )),
             });
         }
         "MAX_TOKENS" => events.push(ProviderEvent::Stop {
@@ -1387,6 +1444,7 @@ fn refusal_details(reason: &str) -> RefusalDetails {
 }
 
 fn classify_gemini_error(
+    provider: &str,
     status: u16,
     body: &str,
     retry_after: Option<std::time::Duration>,
@@ -1409,16 +1467,16 @@ fn classify_gemini_error(
         });
     if prompt_too_long {
         let message = match vertex_project_id {
-            Some(project_id) => safe_http_error_redacting("gemini", status, body, &[project_id]),
-            None => safe_http_error("gemini", status, body),
+            Some(project_id) => safe_http_error_redacting(provider, status, body, &[project_id]),
+            None => safe_http_error(provider, status, body),
         };
         return AgentError::PromptTooLong(message);
     }
     match vertex_project_id {
         Some(project_id) => {
-            classify_provider_error_redacting("gemini", status, body, retry_after, &[project_id])
+            classify_provider_error_redacting(provider, status, body, retry_after, &[project_id])
         }
-        None => classify_provider_error("gemini", status, body, retry_after),
+        None => classify_provider_error(provider, status, body, retry_after),
     }
 }
 
@@ -2181,6 +2239,94 @@ mod tests {
         }
     }
 
+    struct FailingToken;
+
+    #[async_trait]
+    impl BearerTokenSource for FailingToken {
+        async fn bearer_token(&self) -> Result<String> {
+            Err(AgentError::Authentication(
+                "token exchange mentioned customer-project-123".into(),
+            ))
+        }
+    }
+
+    #[tokio::test]
+    async fn endpoint_family_labels_setup_and_connection_failures() {
+        let providers = [
+            (
+                GeminiProvider::new("developer-key").with_base_url("http://127.0.0.1:1"),
+                "gemini",
+            ),
+            (
+                GeminiProvider::vertex("customer-project-123", "global", Arc::new(StaticToken))
+                    .unwrap()
+                    .with_base_url("http://127.0.0.1:1"),
+                "vertex",
+            ),
+        ];
+        for (provider, expected) in providers {
+            let mut invalid = request(vec![ChatMessage::text(Role::User, "hi")]);
+            invalid.model = "../not-a-model".into();
+            let error = match provider.stream(invalid).await {
+                Err(error) => error,
+                Ok(_) => panic!("{expected} unexpectedly accepted an invalid model id"),
+            };
+            assert!(
+                error
+                    .to_string()
+                    .contains(&format!("{expected} received an invalid model id")),
+                "{error}"
+            );
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        drop(listener);
+        let base_url = format!("http://{address}");
+        let providers = [
+            (
+                GeminiProvider::new("developer-key").with_base_url(&base_url),
+                "gemini",
+            ),
+            (
+                GeminiProvider::vertex("customer-project-123", "global", Arc::new(StaticToken))
+                    .unwrap()
+                    .with_base_url(&base_url),
+                "vertex",
+            ),
+        ];
+        for (provider, expected) in providers {
+            let error = match provider
+                .stream(request(vec![ChatMessage::text(Role::User, "hi")]))
+                .await
+            {
+                Err(error) => error,
+                Ok(_) => panic!("{expected} unexpectedly connected to a closed fixture port"),
+            };
+            assert_eq!(
+                error.to_string(),
+                format!("provider error: {expected} request failed")
+            );
+        }
+
+        let provider =
+            GeminiProvider::vertex("customer-project-123", "global", Arc::new(FailingToken))
+                .unwrap();
+        let error = match provider
+            .stream(request(vec![ChatMessage::text(Role::User, "hi")]))
+            .await
+        {
+            Err(error) => error,
+            Ok(_) => panic!("Vertex unexpectedly accepted a failed credential setup"),
+        };
+        assert!(matches!(error, AgentError::Authentication(_)));
+        assert_eq!(
+            error.to_string(),
+            "provider authentication failed: vertex credential setup failed"
+        );
+        assert!(!error.to_string().contains("customer-project-123"));
+    }
+
     #[test]
     fn legacy_vertex_endpoints_distinguish_global_and_regional_hosts() {
         let global =
@@ -2275,7 +2421,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn vertex_error_does_not_expose_the_service_account_project() {
+    async fn http_errors_use_endpoint_family_and_redact_the_vertex_project() {
         use axum::http::StatusCode;
         use axum::response::IntoResponse;
         use axum::routing::post;
@@ -2302,9 +2448,23 @@ mod tests {
         let address = listener.local_addr().unwrap();
         let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
 
+        let base_url = format!("http://{address}");
+        let developer = GeminiProvider::new("developer-key").with_base_url(&base_url);
+        let error = match developer
+            .stream(request(vec![ChatMessage::text(Role::User, "hi")]))
+            .await
+        {
+            Err(error) => error,
+            Ok(_) => panic!("Gemini unexpectedly accepted the denied request"),
+        };
+        assert!(matches!(error, AgentError::Authentication(_)));
+        let visible = error.to_string();
+        assert!(visible.contains("gemini returned 403"), "{visible}");
+        assert!(visible.contains("permission_denied"), "{visible}");
+
         let provider = GeminiProvider::vertex(PROJECT_ID, "global", Arc::new(StaticToken))
             .unwrap()
-            .with_base_url(format!("http://{address}"));
+            .with_base_url(&base_url);
         let error = match provider
             .stream(request(vec![ChatMessage::text(Role::User, "hi")]))
             .await
@@ -2316,9 +2476,132 @@ mod tests {
 
         assert!(matches!(error, AgentError::Authentication(_)));
         let visible = error.to_string();
-        assert!(visible.contains("gemini returned 403"), "{visible}");
+        assert!(visible.contains("vertex returned 403"), "{visible}");
         assert!(visible.contains("permission_denied"), "{visible}");
         assert!(!visible.contains(PROJECT_ID), "{visible}");
+    }
+
+    #[test]
+    fn prompt_too_long_uses_endpoint_family_and_redacts_the_vertex_project() {
+        const PROJECT_ID: &str = "customer-project-123";
+        let body = json!({
+            "error": {
+                "code": "invalid_argument",
+                "message": format!(
+                    "Input token count for projects/{PROJECT_ID} exceeds the maximum number of tokens"
+                ),
+            }
+        })
+        .to_string();
+
+        let direct = classify_gemini_error("gemini", 400, &body, None, None);
+        assert!(matches!(direct, AgentError::PromptTooLong(_)));
+        assert!(direct.to_string().contains("gemini returned 400"));
+
+        let vertex = classify_gemini_error("vertex", 400, &body, None, Some(PROJECT_ID));
+        assert!(matches!(vertex, AgentError::PromptTooLong(_)));
+        let visible = vertex.to_string();
+        assert!(visible.contains("vertex returned 400"), "{visible}");
+        assert!(!visible.contains(PROJECT_ID), "{visible}");
+    }
+
+    #[tokio::test]
+    async fn malformed_frames_use_endpoint_family_attribution() {
+        use axum::http::header;
+        use axum::response::IntoResponse;
+        use axum::routing::post;
+        use axum::Router;
+
+        async fn malformed() -> impl IntoResponse {
+            (
+                [(header::CONTENT_TYPE, "text/event-stream")],
+                "data: not-json\n\n",
+            )
+        }
+
+        let app = Router::new().fallback(post(malformed));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let base_url = format!("http://{address}");
+        let providers = [
+            (
+                GeminiProvider::new("developer-key").with_base_url(&base_url),
+                "gemini",
+            ),
+            (
+                GeminiProvider::vertex("customer-project-123", "global", Arc::new(StaticToken))
+                    .unwrap()
+                    .with_base_url(&base_url),
+                "vertex",
+            ),
+        ];
+        for (provider, expected) in providers {
+            let events: Vec<_> = provider
+                .stream(request(vec![ChatMessage::text(Role::User, "hi")]))
+                .await
+                .unwrap()
+                .collect()
+                .await;
+            assert_eq!(
+                events,
+                vec![ProviderEvent::Failed {
+                    error: ProviderErrorInfo::provider(format!(
+                        "{expected} returned an invalid stream frame"
+                    )),
+                }]
+            );
+        }
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn transport_failures_use_endpoint_family_attribution() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            for _ in 0..2 {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let mut request = [0; 4096];
+                let _ = socket.read(&mut request).await.unwrap();
+                socket
+                    .write_all(
+                        b"HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: 128\r\nconnection: close\r\n\r\n: accepted\n\n",
+                    )
+                    .await
+                    .unwrap();
+            }
+        });
+        let base_url = format!("http://{address}");
+        let providers = [
+            (
+                GeminiProvider::new("developer-key").with_base_url(&base_url),
+                "gemini",
+            ),
+            (
+                GeminiProvider::vertex("customer-project-123", "global", Arc::new(StaticToken))
+                    .unwrap()
+                    .with_base_url(&base_url),
+                "vertex",
+            ),
+        ];
+        for (provider, expected) in providers {
+            let events: Vec<_> = provider
+                .stream(request(vec![ChatMessage::text(Role::User, "hi")]))
+                .await
+                .unwrap()
+                .collect()
+                .await;
+            assert_eq!(
+                events,
+                vec![ProviderEvent::Failed {
+                    error: ProviderErrorInfo::provider(format!("{expected} stream ended early")),
+                }]
+            );
+        }
+        server.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/openwave-router/src/gemini.rs
+++ b/crates/openwave-router/src/gemini.rs
@@ -1407,6 +1407,23 @@ mod tests {
     }
 
     #[test]
+    fn low_reasoning_request_uses_low_not_minimal() {
+        // Direct Gemini and Vertex Gemini share this request builder. The host
+        // policy raises a stored `none` to `low` for Gemini 3.1 Pro Preview;
+        // keep that reconciled level intact on the native wire.
+        let mut req = request(vec![ChatMessage::text(Role::User, "hi")]);
+        req.model = "gemini-3.1-pro-preview".into();
+        req.reasoning_effort = Some(ReasoningEffort::Low);
+
+        let body = build_request_json(&req).unwrap();
+        assert_eq!(
+            body["generationConfig"]["thinkingConfig"]["thinkingLevel"],
+            "low"
+        );
+        assert!(!body.to_string().contains("minimal"));
+    }
+
+    #[test]
     fn all_tool_schemas_translate_to_geminis_supported_subset() {
         let mut req = request(vec![ChatMessage::text(Role::User, "hi")]);
         req.tools = vec![

--- a/crates/openwave-router/src/google.rs
+++ b/crates/openwave-router/src/google.rs
@@ -1,0 +1,30 @@
+//! Shared validation for Google Cloud resource paths.
+//!
+//! These checks sit below both Vertex protocol families. Keeping them apart
+//! from OAuth parsing means the Anthropic adapter does not need to depend on
+//! service-account key machinery merely to build a safe resource URL.
+
+/// Validate a Google project/location path segment before interpolating it
+/// into a Vertex URL.
+pub fn valid_resource_segment(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 63
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+        && !value.starts_with('-')
+        && !value.ends_with('-')
+}
+
+/// Validate a Vertex location without pinning a list that goes stale whenever
+/// Google adds a region.
+///
+/// Multi-region aliases such as `us` and `eu` are intentionally not accepted:
+/// the adapters currently derive only the documented global or regional host
+/// shapes, and must not imply broader endpoint support.
+pub fn valid_vertex_location(value: &str) -> bool {
+    value == "global"
+        || (valid_resource_segment(value)
+            && value.contains('-')
+            && value.ends_with(|character: char| character.is_ascii_digit()))
+}

--- a/crates/openwave-router/src/google_auth.rs
+++ b/crates/openwave-router/src/google_auth.rs
@@ -19,6 +19,7 @@ use serde_json::json;
 
 use openwave_core::error::{AgentError, Result};
 
+use crate::google::valid_resource_segment;
 use crate::BearerTokenSource;
 
 const GOOGLE_TOKEN_URI: &str = "https://oauth2.googleapis.com/token";
@@ -136,27 +137,6 @@ fn decode_pkcs8_pem(pem: &str) -> Result<Vec<u8>> {
     STANDARD.decode(encoded).map_err(|_| {
         AgentError::config("Google service-account credential has an invalid private_key")
     })
-}
-
-/// Validate a Google project/location path segment before interpolating it
-/// into a Vertex URL.
-pub fn valid_resource_segment(value: &str) -> bool {
-    !value.is_empty()
-        && value.len() <= 63
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
-        && !value.starts_with('-')
-        && !value.ends_with('-')
-}
-
-/// Validate a Vertex location without pinning a list that goes stale whenever
-/// Google adds a region.
-pub fn valid_vertex_location(value: &str) -> bool {
-    value == "global"
-        || (valid_resource_segment(value)
-            && value.contains('-')
-            && value.ends_with(|character: char| character.is_ascii_digit()))
 }
 
 #[derive(Clone)]

--- a/crates/openwave-router/src/lib.rs
+++ b/crates/openwave-router/src/lib.rs
@@ -12,6 +12,9 @@ pub mod router;
 mod sse;
 
 #[cfg(feature = "_http")]
+mod google;
+
+#[cfg(feature = "_http")]
 pub mod http;
 
 #[cfg(feature = "anthropic")]
@@ -32,19 +35,23 @@ pub mod gemini;
 #[cfg(feature = "gemini")]
 pub mod google_auth;
 
+#[cfg(all(feature = "anthropic", feature = "gemini"))]
+pub mod vertex;
+
 #[cfg(feature = "anthropic")]
 pub use anthropic::AnthropicProvider;
 #[cfg(feature = "gemini")]
 pub use gemini::GeminiProvider;
+#[cfg(feature = "_http")]
+pub use google::{valid_resource_segment as valid_google_resource_segment, valid_vertex_location};
 #[cfg(feature = "gemini")]
-pub use google_auth::{
-    valid_resource_segment as valid_google_resource_segment, valid_vertex_location,
-    GoogleServiceAccount, GoogleServiceAccountTokenSource,
-};
+pub use google_auth::{GoogleServiceAccount, GoogleServiceAccountTokenSource};
 #[cfg(feature = "openai")]
 pub use openai::OpenAiProvider;
 #[cfg(feature = "openai-compat")]
 pub use openai_compat::OpenAiCompatProvider;
-pub use router::{BearerTokenSource, Route, RouteKind, Router, VertexRoute};
+pub use router::{BearerTokenSource, Route, RouteKind, Router, VertexModelFamily, VertexRoute};
 #[cfg(feature = "xai")]
 pub use xai::XaiProvider;
+#[cfg(all(feature = "anthropic", feature = "gemini"))]
+pub use vertex::VertexProvider;

--- a/crates/openwave-router/src/lib.rs
+++ b/crates/openwave-router/src/lib.rs
@@ -51,7 +51,7 @@ pub use openai::OpenAiProvider;
 #[cfg(feature = "openai-compat")]
 pub use openai_compat::OpenAiCompatProvider;
 pub use router::{BearerTokenSource, Route, RouteKind, Router, VertexModelFamily, VertexRoute};
-#[cfg(feature = "xai")]
-pub use xai::XaiProvider;
 #[cfg(all(feature = "anthropic", feature = "gemini"))]
 pub use vertex::VertexProvider;
+#[cfg(feature = "xai")]
+pub use xai::XaiProvider;

--- a/crates/openwave-router/src/router.rs
+++ b/crates/openwave-router/src/router.rs
@@ -25,10 +25,10 @@ use crate::GeminiProvider;
 use crate::OpenAiCompatProvider;
 #[cfg(feature = "openai")]
 use crate::OpenAiProvider;
-#[cfg(feature = "xai")]
-use crate::XaiProvider;
 #[cfg(all(feature = "anthropic", feature = "gemini"))]
 use crate::VertexProvider;
+#[cfg(feature = "xai")]
+use crate::XaiProvider;
 
 /// Native request protocol used by one curated Vertex model.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/openwave-router/src/router.rs
+++ b/crates/openwave-router/src/router.rs
@@ -827,6 +827,32 @@ mod tests {
     }
 
     #[test]
+    fn first_class_vertex_rejects_regional_route_claims() {
+        let mut route = route(
+            RouteKind::Vertex,
+            "",
+            &["gemini-3.6-flash", "claude-opus-5"],
+            None,
+        );
+        route.token_source = Some(Arc::new(StaticSource("vertex-token")));
+        route.vertex = Some(
+            VertexRoute::new("test-project", "us-east5", [1; 32]).with_model_families([
+                ("gemini-3.6-flash".to_string(), VertexModelFamily::Gemini),
+                ("claude-opus-5".to_string(), VertexModelFamily::Anthropic),
+            ]),
+        );
+        let router = Router::build(vec![route]);
+        assert_eq!(
+            router.select_for(Some(&ProviderId::new("vertex")), "gemini-3.6-flash"),
+            None
+        );
+        assert_eq!(
+            router.select_for(Some(&ProviderId::new("vertex")), "claude-opus-5"),
+            None
+        );
+    }
+
+    #[test]
     fn fingerprint_does_not_contain_raw_key() {
         let router = Router::build(vec![route(
             RouteKind::Anthropic,

--- a/crates/openwave-router/src/router.rs
+++ b/crates/openwave-router/src/router.rs
@@ -27,6 +27,17 @@ use crate::OpenAiCompatProvider;
 use crate::OpenAiProvider;
 #[cfg(feature = "xai")]
 use crate::XaiProvider;
+#[cfg(all(feature = "anthropic", feature = "gemini"))]
+use crate::VertexProvider;
+
+/// Native request protocol used by one curated Vertex model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum VertexModelFamily {
+    /// Google Gemini GenerateContent.
+    Gemini,
+    /// Anthropic Claude Messages over `streamRawPredict`.
+    Anthropic,
+}
 
 /// Header a model-gateway deployment reads to group inference into one
 /// conversation. Gateway adapters opt in explicitly; direct providers never
@@ -66,6 +77,7 @@ pub struct VertexRoute {
     project_id: String,
     location: String,
     credential_fingerprint: [u8; 32],
+    model_families: Vec<(String, VertexModelFamily)>,
 }
 
 impl VertexRoute {
@@ -79,7 +91,19 @@ impl VertexRoute {
             project_id: project_id.into(),
             location: location.into(),
             credential_fingerprint,
+            model_families: Vec::new(),
         }
+    }
+
+    /// Attach the explicit protocol family for every model curated under the
+    /// first-class Vertex provider. Legacy Gemini service-account routes leave
+    /// this empty because their route kind already determines the protocol.
+    pub fn with_model_families(
+        mut self,
+        model_families: impl IntoIterator<Item = (String, VertexModelFamily)>,
+    ) -> Self {
+        self.model_families = model_families.into_iter().collect();
+        self
     }
 
     pub fn project_id(&self) -> &str {
@@ -96,6 +120,7 @@ impl std::fmt::Debug for VertexRoute {
             .field("project_id", &"***")
             .field("location", &self.location)
             .field("credential_fingerprint", &"***")
+            .field("model_families", &self.model_families)
             .finish()
     }
 }
@@ -114,6 +139,8 @@ pub enum RouteKind {
     OpenaiCompatible,
     /// Google Gemini Developer API (native GenerateContent protocol).
     Gemini,
+    /// Google Vertex AI with native Gemini and Anthropic Claude protocols.
+    Vertex,
     /// A model-gateway deployment's Anthropic-compatible surface, authenticated
     /// with short-lived resource-scoped tokens instead of a static key.
     ModelGateway,
@@ -134,6 +161,7 @@ impl RouteKind {
             RouteKind::Xai => "xai",
             RouteKind::OpenaiCompatible => "openai_compatible",
             RouteKind::Gemini => "gemini",
+            RouteKind::Vertex => "vertex",
             RouteKind::ModelGateway => "model_gateway",
             RouteKind::ModelGatewayOpenai => "model_gateway_openai",
         }
@@ -155,6 +183,7 @@ impl RouteKind {
             "xai" => Some(Self::Xai),
             "openai_compatible" => Some(Self::OpenaiCompatible),
             "gemini" => Some(Self::Gemini),
+            "vertex" => Some(Self::Vertex),
             "model_gateway" => Some(Self::ModelGateway),
             _ => None,
         }
@@ -176,8 +205,8 @@ pub struct Route {
     /// Per-request credential supplier for short-lived tokens. Takes
     /// precedence over `api_key` when present.
     pub token_source: Option<Arc<dyn BearerTokenSource>>,
-    /// Vertex resource/auth metadata. Present only for a Gemini route backed
-    /// by a Google service account.
+    /// Vertex resource/auth metadata. Present for the first-class Vertex route
+    /// and for a legacy Gemini route backed by a Google service account.
     pub vertex: Option<VertexRoute>,
     /// ChatGPT account id for OpenAI routes authenticated via ChatGPT OAuth.
     /// Baked into the adapter (only the bearer rotates).
@@ -257,6 +286,7 @@ impl Router {
             RouteKind::Openai,
             RouteKind::Xai,
             RouteKind::Gemini,
+            RouteKind::Vertex,
             RouteKind::ModelGateway,
             RouteKind::ModelGatewayOpenai,
             RouteKind::OpenaiCompatible,
@@ -325,9 +355,9 @@ impl ModelProvider for Router {
                 req.model
             )));
         };
-        // The route hint is host policy, not provider wire data, but adapters
-        // retain it for origin-gating provider-native replay. Their encoders
-        // must never serialize it into the provider request body.
+        // The route hint is host policy, not provider wire data. Adapters keep
+        // it only to gate provider-native reasoning/tool replay; their request
+        // builders enumerate wire fields explicitly and never serialize it.
         adapter.stream(req).await
     }
 }
@@ -448,6 +478,24 @@ fn build_adapter(route: &Route) -> Option<Arc<dyn ModelProvider>> {
             }
             Some(Arc::new(p))
         }
+        #[cfg(all(feature = "anthropic", feature = "gemini"))]
+        RouteKind::Vertex => {
+            let vertex = route.vertex.as_ref()?;
+            let source = route.token_source.clone()?;
+            let mut provider = VertexProvider::new(
+                vertex.project_id.clone(),
+                vertex.location.clone(),
+                source,
+                vertex.model_families.clone(),
+            )
+            .ok()?;
+            if let Some(base) = &route.base_url {
+                provider = provider.with_base_url(base.clone());
+            }
+            Some(Arc::new(provider))
+        }
+        #[cfg(not(all(feature = "anthropic", feature = "gemini")))]
+        RouteKind::Vertex => None,
         #[cfg(not(feature = "gemini"))]
         RouteKind::Gemini => None,
         #[cfg(not(feature = "openai"))]
@@ -488,7 +536,14 @@ fn fingerprint_routes(routes: &[Route]) -> String {
                         .iter()
                         .map(|byte| format!("{byte:02x}"))
                         .collect::<String>();
-                    format!("{}:{credential}", vertex.location)
+                    let mut families = vertex.model_families.clone();
+                    families.sort_by(|left, right| left.0.cmp(&right.0));
+                    let families = families
+                        .into_iter()
+                        .map(|(model, family)| format!("{model}:{family:?}"))
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    format!("{}:{credential}:{families}", vertex.location)
                 }),
                 r.chatgpt_account_id.as_deref().unwrap_or("")
             )
@@ -734,6 +789,40 @@ mod tests {
         assert_ne!(
             build("global", 1).fingerprint(),
             build("global", 2).fingerprint()
+        );
+    }
+
+    #[test]
+    fn first_class_vertex_routes_both_curated_protocol_families() {
+        let mut route = route(
+            RouteKind::Vertex,
+            "",
+            &["gemini-3.6-flash", "claude-opus-5"],
+            None,
+        );
+        route.token_source = Some(Arc::new(StaticSource("vertex-token")));
+        route.vertex = Some(
+            VertexRoute::new("test-project", "global", [1; 32]).with_model_families([
+                ("gemini-3.6-flash".to_string(), VertexModelFamily::Gemini),
+                ("claude-opus-5".to_string(), VertexModelFamily::Anthropic),
+            ]),
+        );
+        let router = Router::build(vec![route]);
+        assert_eq!(
+            router.select_for(Some(&ProviderId::new("vertex")), "gemini-3.6-flash"),
+            Some(RouteKind::Vertex)
+        );
+        assert_eq!(
+            router.select_for(Some(&ProviderId::new("vertex")), "claude-opus-5"),
+            Some(RouteKind::Vertex)
+        );
+        assert_eq!(
+            router.select_for(Some(&ProviderId::new("vertex")), "unknown"),
+            None
+        );
+        assert_eq!(
+            router.select_for(Some(&ProviderId::new("anthropic")), "claude-opus-5"),
+            None
         );
     }
 

--- a/crates/openwave-router/src/sse.rs
+++ b/crates/openwave-router/src/sse.rs
@@ -171,13 +171,28 @@ pub fn classify_in_band_error(
     provider: &str,
     error: &serde_json::Value,
 ) -> openwave_core::error::AgentError {
+    classify_in_band_error_redacting(provider, error, &[])
+}
+
+/// Classify an error delivered inside a 200 stream while preventing known
+/// values from entering the client-visible message.
+///
+/// This is the streaming counterpart of
+/// [`classify_provider_error_redacting`]. Vertex adapters pass the
+/// service-account project id because Google can include the full resource
+/// path in an otherwise ordinary permission error frame.
+pub fn classify_in_band_error_redacting(
+    provider: &str,
+    error: &serde_json::Value,
+    sensitive_values: &[&str],
+) -> openwave_core::error::AgentError {
     let status = error
         .get("code")
         .and_then(serde_json::Value::as_u64)
         .and_then(|code| u16::try_from(code).ok())
         .filter(|code| (100..=599).contains(code))
         .unwrap_or(500);
-    classify_provider_error(provider, status, &error.to_string(), None)
+    classify_provider_error_redacting(provider, status, &error.to_string(), None, sensitive_values)
 }
 
 /// Accept only a compact enum-style token. Error fields come from an

--- a/crates/openwave-router/src/sse.rs
+++ b/crates/openwave-router/src/sse.rs
@@ -108,6 +108,23 @@ pub fn frame_data(frame: &str) -> Option<serde_json::Value> {
 /// credentials or request fragments, so only a short single-line excerpt that
 /// passes conservative secret redaction reaches `TurnFailed`.
 pub fn safe_http_error(provider: &str, status: u16, body: &str) -> String {
+    safe_http_error_redacting(provider, status, body, &[])
+}
+
+/// Build a client-safe provider error while treating exact caller-supplied
+/// values as secrets.
+///
+/// Vertex adapters use this for the service-account project id: Google may put
+/// the full `projects/{project_id}/...` resource in an otherwise ordinary
+/// permission or not-found message. The status and an unrelated enum-style
+/// code remain useful, but any code or message containing a known value is
+/// omitted whole rather than partially rewritten.
+pub fn safe_http_error_redacting(
+    provider: &str,
+    status: u16,
+    body: &str,
+    sensitive_values: &[&str],
+) -> String {
     let parsed = serde_json::from_str::<serde_json::Value>(body).ok();
     let error = parsed
         .as_ref()
@@ -115,14 +132,15 @@ pub fn safe_http_error(provider: &str, status: u16, body: &str) -> String {
     let raw_code = error
         .and_then(|error| error.get("type").or_else(|| error.get("code")))
         .and_then(serde_json::Value::as_str);
-    let code = raw_code.filter(|code| safe_error_code(code));
+    let code = raw_code
+        .filter(|code| safe_error_code(code) && !contains_sensitive_value(code, sensitive_values));
     let message = raw_code
         .is_none_or(safe_error_code)
         .then(|| {
             error
                 .and_then(|error| error.get("message"))
                 .and_then(serde_json::Value::as_str)
-                .and_then(safe_error_message)
+                .and_then(|message| safe_error_message(message, sensitive_values))
         })
         .flatten();
 
@@ -175,10 +193,13 @@ fn safe_error_code(code: &str) -> bool {
             .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || *byte == b'_')
 }
 
-fn safe_error_message(message: &str) -> Option<String> {
+fn safe_error_message(message: &str, sensitive_values: &[&str]) -> Option<String> {
     const MAX_ERROR_MESSAGE_CHARS: usize = 240;
     let collapsed = message.split_whitespace().collect::<Vec<_>>().join(" ");
-    if collapsed.is_empty() || contains_secret_marker(&collapsed) {
+    if collapsed.is_empty()
+        || contains_secret_marker(&collapsed)
+        || contains_sensitive_value(&collapsed, sensitive_values)
+    {
         return None;
     }
     let mut excerpt: String = collapsed.chars().take(MAX_ERROR_MESSAGE_CHARS).collect();
@@ -186,6 +207,13 @@ fn safe_error_message(message: &str) -> Option<String> {
         excerpt.push('…');
     }
     Some(excerpt)
+}
+
+fn contains_sensitive_value(text: &str, sensitive_values: &[&str]) -> bool {
+    let lower = text.to_ascii_lowercase();
+    sensitive_values
+        .iter()
+        .any(|value| !value.is_empty() && lower.contains(value.to_ascii_lowercase().as_str()))
 }
 
 fn contains_secret_marker(message: &str) -> bool {
@@ -258,6 +286,18 @@ pub fn classify_provider_error(
     body: &str,
     retry_after: Option<Duration>,
 ) -> openwave_core::error::AgentError {
+    classify_provider_error_redacting(provider, status, body, retry_after, &[])
+}
+
+/// Classify a provider HTTP error while preventing known values from entering
+/// the client-visible message.
+pub fn classify_provider_error_redacting(
+    provider: &str,
+    status: u16,
+    body: &str,
+    retry_after: Option<Duration>,
+    sensitive_values: &[&str],
+) -> openwave_core::error::AgentError {
     use openwave_core::error::{AgentError, ProviderFailure};
 
     let parsed = serde_json::from_str::<serde_json::Value>(body).ok();
@@ -272,7 +312,7 @@ pub fn classify_provider_error(
         .and_then(|error| error.get("message"))
         .and_then(serde_json::Value::as_str)
         .unwrap_or("");
-    let safe = || safe_http_error(provider, status, body);
+    let safe = || safe_http_error_redacting(provider, status, body, sensitive_values);
 
     if status == 400
         && (code == "context_length_exceeded" || message.contains("prompt is too long"))
@@ -486,5 +526,22 @@ mod tests {
             safe_http_error("gemini", 400, secret),
             "gemini returned 400"
         );
+    }
+
+    #[test]
+    fn known_vertex_project_is_removed_while_status_and_code_remain() {
+        let project_id = "customer-project-123";
+        let body = serde_json::json!({
+            "error": {
+                "code": "permission_denied",
+                "message": format!(
+                    "Permission denied on projects/{project_id}/locations/global"
+                ),
+            }
+        })
+        .to_string();
+        let error = safe_http_error_redacting("vertex", 403, &body, &[project_id]);
+        assert_eq!(error, "vertex returned 403 (permission_denied)");
+        assert!(!error.contains(project_id));
     }
 }

--- a/crates/openwave-router/src/vertex.rs
+++ b/crates/openwave-router/src/vertex.rs
@@ -26,9 +26,9 @@ pub struct VertexProvider {
 }
 
 impl VertexProvider {
-    /// Build a Vertex provider from validated resource identity and an explicit
-    /// model-family map. The bearer source is shared so both protocols use the
-    /// same serialized, expiry-aware Google token cache.
+    /// Build a global Vertex provider from validated resource identity and an
+    /// explicit model-family map. The bearer source is shared so both
+    /// protocols use the same serialized, expiry-aware Google token cache.
     pub fn new(
         project_id: impl Into<String>,
         location: impl Into<String>,
@@ -37,6 +37,11 @@ impl VertexProvider {
     ) -> Result<Self> {
         let project_id = project_id.into();
         let location = location.into();
+        if location != "global" {
+            return Err(AgentError::config(
+                "first-class Vertex AI routes require the global location",
+            ));
+        }
         let mut mapped = HashMap::new();
         for (model, family) in models {
             if mapped.insert(model, family).is_some() {

--- a/crates/openwave-router/src/vertex.rs
+++ b/crates/openwave-router/src/vertex.rs
@@ -1,0 +1,86 @@
+//! First-class Google Vertex AI provider.
+//!
+//! Vertex serves two native protocol families from one Google Cloud identity:
+//! Gemini uses GenerateContent under the `google` publisher, while Claude uses
+//! Anthropic Messages through `streamRawPredict`. This adapter keeps that
+//! distinction explicit and refuses every model that the host did not curate.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+
+use openwave_core::error::{AgentError, Result};
+use openwave_core::provider::{ChatRequest, ModelProvider, ProviderEvent, ProviderId};
+
+use crate::{AnthropicProvider, BearerTokenSource, GeminiProvider, VertexModelFamily};
+
+/// A provider that dispatches only its curated model ids to the matching
+/// native Vertex protocol adapter.
+#[derive(Clone)]
+pub struct VertexProvider {
+    models: HashMap<String, VertexModelFamily>,
+    gemini: GeminiProvider,
+    anthropic: AnthropicProvider,
+}
+
+impl VertexProvider {
+    /// Build a Vertex provider from validated resource identity and an explicit
+    /// model-family map. The bearer source is shared so both protocols use the
+    /// same serialized, expiry-aware Google token cache.
+    pub fn new(
+        project_id: impl Into<String>,
+        location: impl Into<String>,
+        token_source: Arc<dyn BearerTokenSource>,
+        models: impl IntoIterator<Item = (String, VertexModelFamily)>,
+    ) -> Result<Self> {
+        let project_id = project_id.into();
+        let location = location.into();
+        let mut mapped = HashMap::new();
+        for (model, family) in models {
+            if mapped.insert(model, family).is_some() {
+                return Err(AgentError::config("duplicate model id in Vertex AI route"));
+            }
+        }
+        if mapped.is_empty() {
+            return Err(AgentError::config("Vertex AI route has no curated models"));
+        }
+        Ok(Self {
+            models: mapped,
+            gemini: GeminiProvider::vertex(
+                project_id.clone(),
+                location.clone(),
+                token_source.clone(),
+            )?,
+            anthropic: AnthropicProvider::vertex(project_id, location, token_source)?,
+        })
+    }
+
+    /// Override both derived hosts for a controlled local fixture server.
+    #[must_use]
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        let base_url = base_url.into();
+        self.gemini = self.gemini.with_base_url(base_url.clone());
+        self.anthropic = self.anthropic.with_base_url(base_url);
+        self
+    }
+}
+
+#[async_trait]
+impl ModelProvider for VertexProvider {
+    fn id(&self) -> ProviderId {
+        ProviderId::new("vertex")
+    }
+
+    async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+        match self.models.get(&req.model) {
+            Some(VertexModelFamily::Gemini) => self.gemini.stream(req).await,
+            Some(VertexModelFamily::Anthropic) => self.anthropic.stream(req).await,
+            None => Err(AgentError::config(format!(
+                "Vertex AI cannot serve uncurated model `{}`",
+                req.model
+            ))),
+        }
+    }
+}

--- a/crates/openwave-router/tests/fixtures/gemini/tool_loop_closure.request.json
+++ b/crates/openwave-router/tests/fixtures/gemini/tool_loop_closure.request.json
@@ -19,17 +19,20 @@
               "args": {
                 "path": "a.toml"
               },
+              "id": "call_1",
               "name": "read_file"
             },
-            "thoughtSignature": "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="
+            "thoughtSignature": "c2lnbmF0dXJlLW9uZQ=="
           },
           {
             "functionCall": {
               "args": {
                 "path": "b.toml"
               },
+              "id": "call_2",
               "name": "read_file"
-            }
+            },
+            "thoughtSignature": "c2lnbmF0dXJlLXR3bw=="
           }
         ],
         "role": "model"
@@ -38,6 +41,7 @@
         "parts": [
           {
             "functionResponse": {
+              "id": "call_1",
               "name": "read_file",
               "response": {
                 "output": "retries = 3"
@@ -46,6 +50,7 @@
           },
           {
             "functionResponse": {
+              "id": "call_2",
               "name": "read_file",
               "response": {
                 "error": "no such file"

--- a/crates/openwave-router/tests/fixtures/vertex_anthropic/tool_loop_closure.request.json
+++ b/crates/openwave-router/tests/fixtures/vertex_anthropic/tool_loop_closure.request.json
@@ -1,0 +1,107 @@
+{
+  "body": {
+    "anthropic_version": "vertex-2023-10-16",
+    "max_tokens": 4096,
+    "messages": [
+      {
+        "content": [
+          {
+            "text": "Read both configs.",
+            "type": "text"
+          }
+        ],
+        "role": "user"
+      },
+      {
+        "content": [
+          {
+            "text": "Reading both.",
+            "type": "text"
+          },
+          {
+            "id": "call_1",
+            "input": {
+              "path": "a.toml"
+            },
+            "name": "read_file",
+            "type": "tool_use"
+          },
+          {
+            "id": "call_2",
+            "input": {
+              "path": "b.toml"
+            },
+            "name": "read_file",
+            "type": "tool_use"
+          }
+        ],
+        "role": "assistant"
+      },
+      {
+        "content": [
+          {
+            "content": "retries = 3",
+            "is_error": false,
+            "tool_use_id": "call_1",
+            "type": "tool_result"
+          },
+          {
+            "cache_control": {
+              "type": "ephemeral"
+            },
+            "content": "no such file",
+            "is_error": true,
+            "tool_use_id": "call_2",
+            "type": "tool_result"
+          }
+        ],
+        "role": "user"
+      }
+    ],
+    "output_config": {
+      "effort": "high"
+    },
+    "stream": true,
+    "system": [
+      {
+        "cache_control": {
+          "type": "ephemeral"
+        },
+        "text": "Use the tools.",
+        "type": "text"
+      }
+    ],
+    "thinking": {
+      "display": "summarized",
+      "type": "adaptive"
+    },
+    "tools": [
+      {
+        "cache_control": {
+          "type": "ephemeral"
+        },
+        "description": "Read a file from the workspace.",
+        "input_schema": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "path"
+          ],
+          "type": "object"
+        },
+        "name": "read_file"
+      }
+    ]
+  },
+  "headers": {
+    "authorization": "<redacted>",
+    "content-type": "application/json"
+  },
+  "method": "POST",
+  "path": "/v1/projects/test-project/locations/global/publishers/anthropic/models/claude-opus-5:streamRawPredict",
+  "query": null
+}

--- a/crates/openwave-router/tests/fixtures/vertex_gemini/tool_loop_closure.request.json
+++ b/crates/openwave-router/tests/fixtures/vertex_gemini/tool_loop_closure.request.json
@@ -1,0 +1,106 @@
+{
+  "body": {
+    "contents": [
+      {
+        "parts": [
+          {
+            "text": "Read both configs."
+          }
+        ],
+        "role": "user"
+      },
+      {
+        "parts": [
+          {
+            "text": "Reading both."
+          },
+          {
+            "functionCall": {
+              "args": {
+                "path": "a.toml"
+              },
+              "name": "read_file"
+            },
+            "thoughtSignature": "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="
+          },
+          {
+            "functionCall": {
+              "args": {
+                "path": "b.toml"
+              },
+              "name": "read_file"
+            }
+          }
+        ],
+        "role": "model"
+      },
+      {
+        "parts": [
+          {
+            "functionResponse": {
+              "name": "read_file",
+              "response": {
+                "output": "retries = 3"
+              }
+            }
+          },
+          {
+            "functionResponse": {
+              "name": "read_file",
+              "response": {
+                "error": "no such file"
+              }
+            }
+          }
+        ],
+        "role": "user"
+      }
+    ],
+    "generationConfig": {
+      "maxOutputTokens": 4096,
+      "thinkingConfig": {
+        "thinkingLevel": "high"
+      }
+    },
+    "systemInstruction": {
+      "parts": [
+        {
+          "text": "Use the tools."
+        }
+      ]
+    },
+    "toolConfig": {
+      "functionCallingConfig": {
+        "mode": "AUTO"
+      }
+    },
+    "tools": [
+      {
+        "functionDeclarations": [
+          {
+            "description": "Read a file from the workspace.",
+            "name": "read_file",
+            "parameters": {
+              "properties": {
+                "path": {
+                  "type": "STRING"
+                }
+              },
+              "required": [
+                "path"
+              ],
+              "type": "OBJECT"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "headers": {
+    "authorization": "<redacted>",
+    "content-type": "application/json"
+  },
+  "method": "POST",
+  "path": "/v1/projects/test-project/locations/global/publishers/google/models/gemini-3.6-flash:streamGenerateContent",
+  "query": "alt=sse"
+}

--- a/crates/openwave-router/tests/fixtures/vertex_gemini/tool_loop_closure.request.json
+++ b/crates/openwave-router/tests/fixtures/vertex_gemini/tool_loop_closure.request.json
@@ -19,17 +19,20 @@
               "args": {
                 "path": "a.toml"
               },
+              "id": "call_1",
               "name": "read_file"
             },
-            "thoughtSignature": "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="
+            "thoughtSignature": "c2lnbmF0dXJlLW9uZQ=="
           },
           {
             "functionCall": {
               "args": {
                 "path": "b.toml"
               },
+              "id": "call_2",
               "name": "read_file"
-            }
+            },
+            "thoughtSignature": "c2lnbmF0dXJlLXR3bw=="
           }
         ],
         "role": "model"
@@ -38,6 +41,7 @@
         "parts": [
           {
             "functionResponse": {
+              "id": "call_1",
               "name": "read_file",
               "response": {
                 "output": "retries = 3"
@@ -46,6 +50,7 @@
           },
           {
             "functionResponse": {
+              "id": "call_2",
               "name": "read_file",
               "response": {
                 "error": "no such file"

--- a/crates/openwave-router/tests/replay_contracts.rs
+++ b/crates/openwave-router/tests/replay_contracts.rs
@@ -44,7 +44,7 @@ use futures::StreamExt;
 use openwave_core::model::ReasoningEffort;
 use openwave_core::{
     ChatMessage, ChatRequest, ContentBlock, MessageReasoning, ModelProvider, ProviderEvent,
-    ResponseFormat, Role, ToolChoice, ToolSpec,
+    ProviderId, ReasoningOrigin, ResponseFormat, Role, ToolChoice, ToolSpec,
 };
 use openwave_router::{AnthropicProvider, GeminiProvider, OpenAiCompatProvider, OpenAiProvider};
 use openwave_router::{BearerTokenSource, VertexModelFamily, VertexProvider};
@@ -179,6 +179,28 @@ fn tool_loop_closure(model: &str) -> ChatRequest {
     }
 }
 
+fn gemini_tool_loop_closure(model: &str, provider: &str) -> ChatRequest {
+    let mut request = tool_loop_closure(model);
+    request.provider = Some(ProviderId::new(provider));
+    request.messages[1].reasoning = MessageReasoning::captured(
+        ReasoningOrigin {
+            provider: Some(ProviderId::new(provider)),
+            model: model.to_string(),
+        },
+        vec![
+            json!({
+                "functionCall": {"id": "call_1"},
+                "thoughtSignature": "c2lnbmF0dXJlLW9uZQ==",
+            }),
+            json!({
+                "functionCall": {"id": "call_2"},
+                "thoughtSignature": "c2lnbmF0dXJlLXR3bw==",
+            }),
+        ],
+    );
+    request
+}
+
 /// A schema-constrained answer from a reasoning model.
 ///
 /// The constraint is the interesting part: three adapters express it three ways,
@@ -304,7 +326,7 @@ async fn vertex_gemini_replay_request_contract() {
     check_scenario(
         "vertex_gemini",
         "tool_loop_closure",
-        tool_loop_closure("gemini-3.6-flash"),
+        gemini_tool_loop_closure("gemini-3.6-flash", "vertex"),
         |base_url| {
             Arc::new(
                 VertexProvider::new(
@@ -351,6 +373,11 @@ async fn check_adapter(
     build: impl Fn(&str) -> Arc<dyn ModelProvider>,
 ) {
     for (scenario, request) in scenarios(model) {
+        let request = if provider == "gemini" && scenario == "tool_loop_closure" {
+            gemini_tool_loop_closure(model, "gemini")
+        } else {
+            request
+        };
         let recording = recorded_response(provider, scenario);
         let response_body = recording
             .clone()

--- a/crates/openwave-router/tests/replay_contracts.rs
+++ b/crates/openwave-router/tests/replay_contracts.rs
@@ -47,6 +47,7 @@ use openwave_core::{
     ResponseFormat, Role, ToolChoice, ToolSpec,
 };
 use openwave_router::{AnthropicProvider, GeminiProvider, OpenAiCompatProvider, OpenAiProvider};
+use openwave_router::{BearerTokenSource, VertexModelFamily, VertexProvider};
 use serde_json::{json, Value};
 
 /// The credential every adapter is handed. It must never reach a fixture: the
@@ -289,6 +290,59 @@ async fn gemini_request_contracts() {
     .await;
 }
 
+struct StaticVertexToken;
+
+#[async_trait::async_trait]
+impl BearerTokenSource for StaticVertexToken {
+    async fn bearer_token(&self) -> openwave_core::Result<String> {
+        Ok("test-vertex-access-token".into())
+    }
+}
+
+#[tokio::test]
+async fn vertex_gemini_replay_request_contract() {
+    check_scenario(
+        "vertex_gemini",
+        "tool_loop_closure",
+        tool_loop_closure("gemini-3.6-flash"),
+        |base_url| {
+            Arc::new(
+                VertexProvider::new(
+                    "test-project",
+                    "global",
+                    Arc::new(StaticVertexToken),
+                    [("gemini-3.6-flash".to_string(), VertexModelFamily::Gemini)],
+                )
+                .unwrap()
+                .with_base_url(base_url),
+            )
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn vertex_anthropic_replay_request_contract() {
+    check_scenario(
+        "vertex_anthropic",
+        "tool_loop_closure",
+        tool_loop_closure("claude-opus-5"),
+        |base_url| {
+            Arc::new(
+                VertexProvider::new(
+                    "test-project",
+                    "global",
+                    Arc::new(StaticVertexToken),
+                    [("claude-opus-5".to_string(), VertexModelFamily::Anthropic)],
+                )
+                .unwrap()
+                .with_base_url(base_url),
+            )
+        },
+    )
+    .await;
+}
+
 /// Run every scenario through one adapter and compare both directions against
 /// the committed fixtures.
 async fn check_adapter(
@@ -312,6 +366,21 @@ async fn check_adapter(
             assert_matches_fixture(&format!("{provider}/{scenario}.events.json"), &events);
         }
     }
+}
+
+/// Run one high-value replay scenario through a hosted protocol route. The
+/// direct adapters already pin every ordinary request shape; this fixture is
+/// deliberately narrower and proves the provider-specific endpoint/auth/body
+/// delta without duplicating all four contracts.
+async fn check_scenario(
+    provider: &str,
+    scenario: &str,
+    request: ChatRequest,
+    build: impl Fn(&str) -> Arc<dyn ModelProvider>,
+) {
+    let response_body = terminal_frame(provider).to_string();
+    let (captured, _) = round_trip(build, request, response_body).await;
+    assert_matches_fixture(&format!("{provider}/{scenario}.request.json"), &captured);
 }
 
 // ---------------------------------------------------------------------------
@@ -401,12 +470,12 @@ async fn intercept(State(endpoint): State<Endpoint>, request: Request) -> Respon
 /// subject is the request rather than the decode path.
 fn terminal_frame(provider: &str) -> &'static str {
     match provider {
-        "anthropic" => {
+        "anthropic" | "vertex_anthropic" => {
             "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"}}\n\n"
         }
         "openai" => "data: {\"type\":\"response.completed\",\"response\":{}}\n\n",
         "openai_compat" => "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
-        "gemini" => "data: {\"candidates\":[{\"finishReason\":\"STOP\"}]}\n\n",
+        "gemini" | "vertex_gemini" => "data: {\"candidates\":[{\"finishReason\":\"STOP\"}]}\n\n",
         other => panic!("no terminal frame for {other}"),
     }
 }

--- a/crates/openwave-server/src/model_registry.rs
+++ b/crates/openwave-server/src/model_registry.rs
@@ -69,10 +69,16 @@ const EFFORT_NONE_TO_XHIGH: &[ReasoningEffort] = &[
     ReasoningEffort::High,
     ReasoningEffort::XHigh,
 ];
-/// Gemini 3 maps OpenWave's `none` to its `minimal` thinking level and has no
-/// separate levels above `high`.
+/// Gemini 3 Flash maps OpenWave's `none` to its `minimal` thinking level and
+/// has no separate levels above `high`.
 const EFFORT_NONE_TO_HIGH: &[ReasoningEffort] = &[
     ReasoningEffort::None,
+    ReasoningEffort::Low,
+    ReasoningEffort::Medium,
+    ReasoningEffort::High,
+];
+/// Gemini 3.1 Pro Preview starts at `low`; it does not accept `minimal`.
+const EFFORT_LOW_TO_HIGH: &[ReasoningEffort] = &[
     ReasoningEffort::Low,
     ReasoningEffort::Medium,
     ReasoningEffort::High,
@@ -350,8 +356,9 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
     },
     // Gemini rows are intentionally limited to ids currently published by
     // Google. All four accept images, expose thinking levels through `high`,
-    // and have 1,048,576 input / 65,536 output token limits; the native
-    // adapter owns the corresponding GenerateContent wire shape.
+    // and have 1,048,576 input / 65,536 output token limits; the Flash rows
+    // start at `minimal`, while Pro Preview starts at `low`. The native adapter
+    // owns the corresponding GenerateContent wire shape.
     ModelSpec {
         id: "gemini-3.6-flash",
         display_name: "Gemini 3.6 Flash",
@@ -398,7 +405,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
         supports_vendor_web_search: false,
-        reasoning_efforts: EFFORT_NONE_TO_HIGH,
+        reasoning_efforts: EFFORT_LOW_TO_HIGH,
     },
     // Vertex is one explicit serving provider with two native protocol
     // families. These rows intentionally mirror only models in the current
@@ -452,7 +459,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
         supports_vendor_web_search: false,
-        reasoning_efforts: EFFORT_NONE_TO_HIGH,
+        reasoning_efforts: EFFORT_LOW_TO_HIGH,
     },
     ModelSpec {
         id: "claude-opus-5",
@@ -853,8 +860,20 @@ mod tests {
             assert_eq!(spec.context_window, 1_048_576, "{}", spec.id);
             assert_eq!(spec.max_output_tokens, 65_536, "{}", spec.id);
             assert!(spec.supports_reasoning, "{}", spec.id);
-            assert_eq!(spec.reasoning_efforts, EFFORT_NONE_TO_HIGH, "{}", spec.id);
+            if spec.id != "gemini-3.1-pro-preview" {
+                assert_eq!(spec.reasoning_efforts, EFFORT_NONE_TO_HIGH, "{}", spec.id);
+            }
         }
+    }
+
+    #[test]
+    fn gemini_3_1_pro_excludes_minimal_on_direct_and_vertex() {
+        let direct = find_for(ProviderKind::Gemini, "gemini-3.1-pro-preview").unwrap();
+        let vertex = find_for(ProviderKind::Vertex, "gemini-3.1-pro-preview").unwrap();
+
+        assert_eq!(direct.reasoning_efforts, EFFORT_LOW_TO_HIGH);
+        assert_eq!(vertex.reasoning_efforts, direct.reasoning_efforts);
+        assert!(!direct.reasoning_efforts.contains(&ReasoningEffort::None));
     }
 
     #[test]

--- a/crates/openwave-server/src/model_registry.rs
+++ b/crates/openwave-server/src/model_registry.rs
@@ -129,6 +129,21 @@ pub struct ModelSpec {
 }
 
 impl ModelSpec {
+    /// Upstream vendor for a model hosted through a provider that serves more
+    /// than one native protocol family.
+    pub fn vendor(&self) -> Option<ProviderKind> {
+        if self.provider != ProviderKind::Vertex {
+            return None;
+        }
+        if self.id.starts_with("gemini-") {
+            Some(ProviderKind::Gemini)
+        } else if self.id.starts_with("claude-") {
+            Some(ProviderKind::Anthropic)
+        } else {
+            None
+        }
+    }
+
     /// Whether this model accepts `modality`.
     #[cfg(test)]
     pub fn accepts(&self, modality: InputModality) -> bool {
@@ -385,6 +400,156 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         supports_vendor_web_search: false,
         reasoning_efforts: EFFORT_NONE_TO_HIGH,
     },
+    // Vertex is one explicit serving provider with two native protocol
+    // families. These rows intentionally mirror only models in the current
+    // direct catalogs above: provider-qualified keys keep routing unambiguous,
+    // while the vendor projection keeps icons and legacy bare-id migration on
+    // the original direct provider. Request-shape fixtures cover both Vertex
+    // protocols, but the live provider/model combinations remain unverified.
+    ModelSpec {
+        id: "gemini-3.6-flash",
+        display_name: "Gemini 3.6 Flash",
+        provider: ProviderKind::Vertex,
+        verification: VerificationTier::Unverified,
+        context_window: 1_048_576,
+        max_output_tokens: 65_536,
+        input_modalities: TEXT_AND_IMAGE,
+        supports_reasoning: true,
+        supports_vendor_web_search: false,
+        reasoning_efforts: EFFORT_NONE_TO_HIGH,
+    },
+    ModelSpec {
+        id: "gemini-3.5-flash",
+        display_name: "Gemini 3.5 Flash",
+        provider: ProviderKind::Vertex,
+        verification: VerificationTier::Unverified,
+        context_window: 1_048_576,
+        max_output_tokens: 65_536,
+        input_modalities: TEXT_AND_IMAGE,
+        supports_reasoning: true,
+        supports_vendor_web_search: false,
+        reasoning_efforts: EFFORT_NONE_TO_HIGH,
+    },
+    ModelSpec {
+        id: "gemini-3.5-flash-lite",
+        display_name: "Gemini 3.5 Flash-Lite",
+        provider: ProviderKind::Vertex,
+        verification: VerificationTier::Unverified,
+        context_window: 1_048_576,
+        max_output_tokens: 65_536,
+        input_modalities: TEXT_AND_IMAGE,
+        supports_reasoning: true,
+        supports_vendor_web_search: false,
+        reasoning_efforts: EFFORT_NONE_TO_HIGH,
+    },
+    ModelSpec {
+        id: "gemini-3.1-pro-preview",
+        display_name: "Gemini 3.1 Pro Preview",
+        provider: ProviderKind::Vertex,
+        verification: VerificationTier::Unverified,
+        context_window: 1_048_576,
+        max_output_tokens: 65_536,
+        input_modalities: TEXT_AND_IMAGE,
+        supports_reasoning: true,
+        supports_vendor_web_search: false,
+        reasoning_efforts: EFFORT_NONE_TO_HIGH,
+    },
+    ModelSpec {
+        id: "claude-opus-5",
+        display_name: "Claude Opus 5",
+        provider: ProviderKind::Vertex,
+        verification: VerificationTier::Unverified,
+        context_window: 1_000_000,
+        max_output_tokens: 128_000,
+        input_modalities: TEXT_AND_IMAGE,
+        supports_reasoning: true,
+        supports_vendor_web_search: false,
+        reasoning_efforts: EFFORT_LOW_TO_MAX,
+    },
+    ModelSpec {
+        id: "claude-fable-5",
+        display_name: "Claude Fable 5",
+        provider: ProviderKind::Vertex,
+        verification: VerificationTier::Unverified,
+        context_window: 1_000_000,
+        max_output_tokens: 128_000,
+        input_modalities: TEXT_AND_IMAGE,
+        supports_reasoning: true,
+        supports_vendor_web_search: false,
+        reasoning_efforts: EFFORT_LOW_TO_MAX,
+    },
+    ModelSpec {
+        id: "claude-sonnet-5",
+        display_name: "Claude Sonnet 5",
+        provider: ProviderKind::Vertex,
+        verification: VerificationTier::Unverified,
+        context_window: 1_000_000,
+        max_output_tokens: 128_000,
+        input_modalities: TEXT_AND_IMAGE,
+        supports_reasoning: true,
+        supports_vendor_web_search: false,
+        reasoning_efforts: EFFORT_LOW_TO_MAX,
+    },
+    ModelSpec {
+        id: "claude-opus-4-8",
+        display_name: "Claude Opus 4.8",
+        provider: ProviderKind::Vertex,
+        verification: VerificationTier::Unverified,
+        context_window: 1_000_000,
+        max_output_tokens: 128_000,
+        input_modalities: TEXT_AND_IMAGE,
+        supports_reasoning: true,
+        supports_vendor_web_search: false,
+        reasoning_efforts: EFFORT_LOW_TO_MAX,
+    },
+    ModelSpec {
+        id: "claude-opus-4-7",
+        display_name: "Claude Opus 4.7",
+        provider: ProviderKind::Vertex,
+        verification: VerificationTier::Unverified,
+        context_window: 1_000_000,
+        max_output_tokens: 128_000,
+        input_modalities: TEXT_AND_IMAGE,
+        supports_reasoning: true,
+        supports_vendor_web_search: false,
+        reasoning_efforts: EFFORT_LOW_TO_MAX,
+    },
+    ModelSpec {
+        id: "claude-opus-4-6",
+        display_name: "Claude Opus 4.6",
+        provider: ProviderKind::Vertex,
+        verification: VerificationTier::Unverified,
+        context_window: 1_000_000,
+        max_output_tokens: 128_000,
+        input_modalities: TEXT_AND_IMAGE,
+        supports_reasoning: true,
+        supports_vendor_web_search: false,
+        reasoning_efforts: EFFORT_LOW_TO_MAX,
+    },
+    ModelSpec {
+        id: "claude-sonnet-4-6",
+        display_name: "Claude Sonnet 4.6",
+        provider: ProviderKind::Vertex,
+        verification: VerificationTier::Unverified,
+        context_window: 1_000_000,
+        max_output_tokens: 128_000,
+        input_modalities: TEXT_AND_IMAGE,
+        supports_reasoning: true,
+        supports_vendor_web_search: false,
+        reasoning_efforts: EFFORT_LOW_TO_MAX,
+    },
+    ModelSpec {
+        id: "claude-haiku-4-5",
+        display_name: "Claude Haiku 4.5",
+        provider: ProviderKind::Vertex,
+        verification: VerificationTier::Unverified,
+        context_window: 200_000,
+        max_output_tokens: 64_000,
+        input_modalities: TEXT_AND_IMAGE,
+        supports_reasoning: true,
+        supports_vendor_web_search: false,
+        reasoning_efforts: EFFORT_UNSUPPORTED,
+    },
 ];
 
 /// Curated entries belonging to `provider`, preserving registry display order.
@@ -394,9 +559,13 @@ pub fn models_for(provider: ProviderKind) -> impl Iterator<Item = &'static Model
         .filter(move |spec| spec.provider == provider)
 }
 
-/// Find a bare curated model id only when exactly one provider owns it.
+/// Find the canonical direct-vendor owner of a bare curated model id.
+///
+/// First-class hosted providers may mirror an upstream id under their own
+/// provider-qualified key. They do not make an old bare selection change
+/// providers or become unresolvable: only the direct row participates here.
 pub fn find(id: &str) -> Option<&'static ModelSpec> {
-    let mut matches = models_named(id);
+    let mut matches = models_named(id).filter(|spec| spec.vendor().is_none());
     let first = matches.next()?;
     matches.next().is_none().then_some(first)
 }
@@ -515,6 +684,7 @@ mod tests {
             ProviderKind::Openai => true,
             ProviderKind::Xai => true,
             ProviderKind::Gemini => true,
+            ProviderKind::Vertex => true,
             ProviderKind::OpenaiCompatible => false,
             ProviderKind::ModelGateway => true,
         }
@@ -685,6 +855,40 @@ mod tests {
             assert!(spec.supports_reasoning, "{}", spec.id);
             assert_eq!(spec.reasoning_efforts, EFFORT_NONE_TO_HIGH, "{}", spec.id);
         }
+    }
+
+    #[test]
+    fn vertex_rows_are_curated_as_two_native_unverified_families() {
+        let vertex: Vec<_> = models_for(ProviderKind::Vertex).collect();
+        assert_eq!(vertex.len(), 12);
+        assert_eq!(
+            vertex
+                .iter()
+                .filter(|spec| spec.vendor() == Some(ProviderKind::Gemini))
+                .count(),
+            4
+        );
+        assert_eq!(
+            vertex
+                .iter()
+                .filter(|spec| spec.vendor() == Some(ProviderKind::Anthropic))
+                .count(),
+            8
+        );
+        for spec in vertex {
+            assert_eq!(spec.verification, VerificationTier::Unverified);
+            assert!(!spec.supports_vendor_web_search);
+            assert!(spec.vendor().is_some(), "{} has no Vertex family", spec.id);
+        }
+        assert_eq!(
+            find("claude-opus-5").map(|spec| spec.provider),
+            Some(ProviderKind::Anthropic),
+            "legacy bare ids stay on their direct provider"
+        );
+        assert_eq!(
+            find("gemini-3.6-flash").map(|spec| spec.provider),
+            Some(ProviderKind::Gemini)
+        );
     }
 
     #[test]

--- a/crates/openwave-server/src/model_registry.rs
+++ b/crates/openwave-server/src/model_registry.rs
@@ -90,6 +90,13 @@ const EFFORT_LOW_TO_MAX: &[ReasoningEffort] = &[
     ReasoningEffort::XHigh,
     ReasoningEffort::Max,
 ];
+/// Claude Opus and Sonnet 4.6 accept `max`, but not the newer `xhigh` level.
+const EFFORT_LOW_TO_HIGH_AND_MAX: &[ReasoningEffort] = &[
+    ReasoningEffort::Low,
+    ReasoningEffort::Medium,
+    ReasoningEffort::High,
+    ReasoningEffort::Max,
+];
 /// For a model that takes no effort parameter at all. Not the same as a model
 /// that ignores one: Claude Haiku 4.5 rejects the request.
 const EFFORT_UNSUPPORTED: &[ReasoningEffort] = &[];
@@ -181,9 +188,10 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         supports_reasoning: true,
         supports_vendor_web_search: true,
         // Claude 4.6 and later reason on an adaptive thinking block, and the
-        // Anthropic adapter sends one along with the chat's chosen effort. That
-        // generation onward takes `low` through `max`; there is no `none`,
-        // because a model on the adaptive block always reasons.
+        // Anthropic adapter sends one along with the chat's chosen effort. The
+        // newest generation takes this full scale; 4.6 has the narrower scale
+        // declared on its own rows below. There is no `none`, because a model
+        // on the adaptive block always reasons.
         reasoning_efforts: EFFORT_LOW_TO_MAX,
     },
     // Second, not first: the built-in default is this provider's first curated
@@ -221,10 +229,11 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         context_window: 200_000,
         max_output_tokens: 64_000,
         input_modalities: TEXT_AND_IMAGE,
-        supports_reasoning: true,
+        // Haiku 4.5 uses classic extended thinking with a token budget. Until
+        // the adapter can send that request shape, keep the runtime honest and
+        // do not advertise reasoning that every request would silently omit.
+        supports_reasoning: false,
         supports_vendor_web_search: true,
-        // Haiku 4.5 predates the adaptive switch: it rejects the effort
-        // control, so the adapter leaves both off and the picker hides it.
         reasoning_efforts: EFFORT_UNSUPPORTED,
     },
     ModelSpec {
@@ -261,7 +270,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
         supports_vendor_web_search: true,
-        reasoning_efforts: EFFORT_LOW_TO_MAX,
+        reasoning_efforts: EFFORT_LOW_TO_HIGH_AND_MAX,
     },
     ModelSpec {
         id: "claude-sonnet-4-6",
@@ -273,7 +282,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
         supports_vendor_web_search: true,
-        reasoning_efforts: EFFORT_LOW_TO_MAX,
+        reasoning_efforts: EFFORT_LOW_TO_HIGH_AND_MAX,
     },
     ModelSpec {
         id: "gpt-5.6-sol",
@@ -531,7 +540,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
         supports_vendor_web_search: false,
-        reasoning_efforts: EFFORT_LOW_TO_MAX,
+        reasoning_efforts: EFFORT_LOW_TO_HIGH_AND_MAX,
     },
     ModelSpec {
         id: "claude-sonnet-4-6",
@@ -543,7 +552,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
         supports_vendor_web_search: false,
-        reasoning_efforts: EFFORT_LOW_TO_MAX,
+        reasoning_efforts: EFFORT_LOW_TO_HIGH_AND_MAX,
     },
     ModelSpec {
         id: "claude-haiku-4-5",
@@ -553,7 +562,9 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         context_window: 200_000,
         max_output_tokens: 64_000,
         input_modalities: TEXT_AND_IMAGE,
-        supports_reasoning: true,
+        // The Vertex route speaks the same adapter request shape as direct
+        // Anthropic, so it cannot claim classic extended thinking either.
+        supports_reasoning: false,
         supports_vendor_web_search: false,
         reasoning_efforts: EFFORT_UNSUPPORTED,
     },
@@ -767,30 +778,72 @@ mod tests {
         assert!(sonnet.supports_reasoning);
         assert_eq!(sonnet.reasoning_efforts, EFFORT_LOW_TO_MAX);
 
-        // Haiku 4.5 predates the adaptive thinking switch and rejects the
-        // effort control, so it is the one Anthropic row without it.
+        // Haiku 4.5 needs the classic token-budget thinking request that the
+        // adapter does not implement yet, so the catalog must not promise a
+        // reasoning stream or an effort control.
         let haiku = find("claude-haiku-4-5-20251001").unwrap();
         assert_eq!(haiku.context_window, 200_000);
         assert_eq!(haiku.max_output_tokens, 64_000);
-        assert!(haiku.supports_reasoning);
+        assert!(!haiku.supports_reasoning);
         assert!(!haiku.supports_reasoning_effort());
         assert!(haiku.reasoning_efforts.is_empty());
     }
 
     #[test]
-    fn every_anthropic_entry_that_takes_an_effort_takes_xhigh_and_refuses_none() {
+    fn anthropic_effort_catalogs_refuse_none() {
         for spec in
             models_for(ProviderKind::Anthropic).filter(|spec| spec.supports_reasoning_effort())
         {
             assert!(
-                spec.reasoning_efforts.contains(&ReasoningEffort::XHigh),
-                "{} omits the level recommended for coding and agentic work",
-                spec.id
-            );
-            assert!(
                 !spec.reasoning_efforts.contains(&ReasoningEffort::None),
                 "{} offers an OpenAI-only level the Anthropic route rejects",
                 spec.id
+            );
+        }
+    }
+
+    #[test]
+    fn claude_4_6_effort_catalogs_match_on_direct_and_vertex() {
+        for id in ["claude-opus-4-6", "claude-sonnet-4-6"] {
+            let direct = find_for(ProviderKind::Anthropic, id).unwrap();
+            let vertex = find_for(ProviderKind::Vertex, id).unwrap();
+
+            assert_eq!(direct.reasoning_efforts, EFFORT_LOW_TO_HIGH_AND_MAX);
+            assert_eq!(vertex.reasoning_efforts, direct.reasoning_efforts);
+            assert!(!direct.reasoning_efforts.contains(&ReasoningEffort::XHigh));
+            assert!(direct.reasoning_efforts.contains(&ReasoningEffort::Max));
+        }
+
+        // The generations that do accept `xhigh` keep advertising it.
+        for id in [
+            "claude-opus-5",
+            "claude-fable-5",
+            "claude-sonnet-5",
+            "claude-opus-4-8",
+            "claude-opus-4-7",
+        ] {
+            assert!(
+                find_for(ProviderKind::Anthropic, id)
+                    .unwrap()
+                    .reasoning_efforts
+                    .contains(&ReasoningEffort::XHigh),
+                "{id} lost xhigh while narrowing only Claude 4.6"
+            );
+        }
+    }
+
+    #[test]
+    fn haiku_4_5_is_non_reasoning_on_direct_and_vertex() {
+        for (provider, id) in [
+            (ProviderKind::Anthropic, "claude-haiku-4-5-20251001"),
+            (ProviderKind::Vertex, "claude-haiku-4-5"),
+        ] {
+            let spec = find_for(provider, id).unwrap();
+            assert!(!spec.supports_reasoning, "{}::{id}", provider.as_str());
+            assert!(
+                spec.reasoning_efforts.is_empty(),
+                "{}::{id}",
+                provider.as_str()
             );
         }
     }

--- a/crates/openwave-server/src/model_roles.rs
+++ b/crates/openwave-server/src/model_roles.rs
@@ -54,6 +54,7 @@ const UTILITY_DEFAULTS: &[&str] = &[
     "anthropic::claude-haiku-4-5-20251001",
     "openai::gpt-5.4-nano",
     "gemini::gemini-3.5-flash-lite",
+    "vertex::gemini-3.5-flash-lite",
 ];
 
 impl ModelRole {
@@ -266,11 +267,9 @@ async fn usable_policy(
     let Some(policy) = providers::resolve_model_policy(store, selection, false).await? else {
         return Ok(None);
     };
-    Ok(
-        providers::provider_is_usable(store, secrets, policy.provider, managed)
-            .await?
-            .then_some(policy),
-    )
+    Ok(providers::model_is_usable(store, secrets, &policy, managed)
+        .await?
+        .then_some(policy))
 }
 
 /// Resolve the `utility` role into the shape the agent carries for one turn.

--- a/crates/openwave-server/src/model_roles.rs
+++ b/crates/openwave-server/src/model_roles.rs
@@ -329,6 +329,34 @@ mod tests {
         }
     }
 
+    struct RegionalVertexUtilitySecrets;
+
+    #[async_trait::async_trait]
+    impl SecretProvider for RegionalVertexUtilitySecrets {
+        async fn get_secret(&self, key: &str) -> Result<Option<String>> {
+            if key == ProviderKind::Vertex.credential_key() {
+                panic!("regional Vertex must be rejected before its credential is read");
+            }
+            if key == ProviderKind::Openai.credential_key() {
+                return Ok(Some(
+                    serde_json::to_string(&crate::providers::ProviderCredential::api_key(
+                        "sk-openai",
+                    ))
+                    .unwrap(),
+                ));
+            }
+            Ok(None)
+        }
+
+        async fn set_secret(&self, key: &str, _value: &str) -> Result<()> {
+            panic!("test must not write secret `{key}`")
+        }
+
+        async fn delete_secret(&self, key: &str) -> Result<()> {
+            panic!("test must not delete secret `{key}`")
+        }
+    }
+
     #[test]
     fn every_role_default_names_a_curated_model() {
         for &role in ModelRole::ALL {
@@ -363,6 +391,60 @@ mod tests {
                 "a user credentialed only on {provider} has no default utility model",
             );
         }
+    }
+
+    #[tokio::test]
+    async fn utility_selection_skips_a_stored_regional_vertex_configuration() {
+        let directory = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                directory
+                    .path()
+                    .join("regional-vertex-utility.db")
+                    .display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let secrets: Arc<dyn SecretProvider> = Arc::new(RegionalVertexUtilitySecrets);
+        let os_policy = crate::managed_policy::NoOsPolicy;
+
+        providers::write_config(
+            &*store,
+            ProviderKind::Vertex,
+            &ProviderConfig {
+                enabled: true,
+                vertex_location: Some("us-east5".into()),
+                ..ProviderConfig::disabled()
+            },
+        )
+        .await
+        .unwrap();
+        providers::write_config(
+            &*store,
+            ProviderKind::Openai,
+            &ProviderConfig {
+                enabled: true,
+                ..ProviderConfig::disabled()
+            },
+        )
+        .await
+        .unwrap();
+        write_selection(
+            &*store,
+            ModelRole::Utility,
+            Some("vertex::gemini-3.5-flash-lite"),
+        )
+        .await
+        .unwrap();
+
+        let utility = resolve_utility_model(&*store, &*secrets, &os_policy)
+            .await
+            .unwrap()
+            .expect("utility falls through to another usable provider");
+        assert_eq!(utility.provider, Some(ProviderId::new("openai")));
+        assert_eq!(utility.model, "gpt-5.4-nano");
     }
 
     /// Utility work on a managed profile: the curated defaults all name BYOK

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -325,6 +325,7 @@ impl ProviderKind {
                 self,
                 ProviderKind::Anthropic
                     | ProviderKind::Openai
+                    | ProviderKind::Xai
                     | ProviderKind::Gemini
                     | ProviderKind::OpenaiCompatible
             ),
@@ -1638,8 +1639,8 @@ pub async fn collect_routes(
                 kind,
                 ProviderKind::Gemini | ProviderKind::Xai | ProviderKind::Vertex
             ))
-                .then_some(config.base_url)
-                .flatten(),
+            .then_some(config.base_url)
+            .flatten(),
             curated_models: model_registry::models_for(kind)
                 .map(|spec| spec.id.to_string())
                 .chain(config.models.into_iter().map(|model| model.id))

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -2318,6 +2318,21 @@ mod tests {
         }
     }
 
+    #[test]
+    fn gemini_3_1_pro_none_clamps_to_low_for_direct_and_vertex() {
+        for provider in [ProviderKind::Gemini, ProviderKind::Vertex] {
+            let mut config = AgentConfig::default();
+            let policy = ResolvedModelPolicy::curated(
+                model_registry::find_for(provider, "gemini-3.1-pro-preview").unwrap(),
+            );
+
+            apply_model_policy(&mut config, &policy, Some(ReasoningEffort::None)).unwrap();
+
+            assert_eq!(config.provider, Some(ProviderId::new(provider.as_str())));
+            assert_eq!(config.reasoning_effort, Some(ReasoningEffort::Low));
+        }
+    }
+
     /// Repro: a chat pinned to `openai::gpt-5.6-sol` reached the
     /// OpenAI-compatible `/v1/chat/completions` route with `reasoning_effort`
     /// attached and the vendor refused the request. The free-form turn path

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -256,6 +256,8 @@ pub enum ProviderKind {
     Xai,
     /// Google Gemini Developer API (generativelanguage.googleapis.com).
     Gemini,
+    /// Google Vertex AI with native Gemini and Anthropic Claude protocols.
+    Vertex,
     /// Any OpenAI-compatible Chat Completions gateway (OpenRouter, vLLM, …).
     OpenaiCompatible,
     /// A signed-in model-gateway deployment: entitled models synced from the
@@ -271,6 +273,7 @@ impl ProviderKind {
         ProviderKind::Openai,
         ProviderKind::Xai,
         ProviderKind::Gemini,
+        ProviderKind::Vertex,
         ProviderKind::OpenaiCompatible,
         ProviderKind::ModelGateway,
     ];
@@ -282,6 +285,7 @@ impl ProviderKind {
             ProviderKind::Openai => "openai",
             ProviderKind::Xai => "xai",
             ProviderKind::Gemini => "gemini",
+            ProviderKind::Vertex => "vertex",
             ProviderKind::OpenaiCompatible => "openai_compatible",
             ProviderKind::ModelGateway => "model_gateway",
         }
@@ -294,6 +298,7 @@ impl ProviderKind {
             "openai" => Some(Self::Openai),
             "xai" => Some(Self::Xai),
             "gemini" => Some(Self::Gemini),
+            "vertex" => Some(Self::Vertex),
             "openai_compatible" => Some(Self::OpenaiCompatible),
             "model_gateway" => Some(Self::ModelGateway),
             _ => None,
@@ -316,9 +321,17 @@ impl ProviderKind {
     /// Whether this provider can use `credential` today.
     fn accepts_credential(self, credential: &ProviderCredential) -> bool {
         match credential {
-            ProviderCredential::ApiKey { .. } => true,
+            ProviderCredential::ApiKey { .. } => matches!(
+                self,
+                ProviderKind::Anthropic
+                    | ProviderKind::Openai
+                    | ProviderKind::Gemini
+                    | ProviderKind::OpenaiCompatible
+            ),
             ProviderCredential::Oauth {} => self == ProviderKind::Openai,
-            ProviderCredential::ServiceAccount { .. } => self == ProviderKind::Gemini,
+            ProviderCredential::ServiceAccount { .. } => {
+                matches!(self, ProviderKind::Gemini | ProviderKind::Vertex)
+            }
         }
     }
 }
@@ -454,8 +467,9 @@ pub struct ProviderConfig {
     /// Optional base URL override (required for `openai_compatible`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_url: Option<String>,
-    /// Vertex AI location used only when Gemini has a service-account
-    /// credential. An absent value defaults to `global`.
+    /// Vertex AI location used by the first-class Vertex provider and retained
+    /// for legacy Gemini service-account configurations. An absent value
+    /// defaults to `global`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub vertex_location: Option<String>,
     /// Explicit model rows served by a configurable endpoint.
@@ -587,7 +601,7 @@ impl ResolvedModelPolicy {
             id: spec.id.to_owned(),
             display_name: spec.display_name.to_owned(),
             provider: spec.provider,
-            vendor: None,
+            vendor: spec.vendor(),
             verification: spec.verification,
             context_window: spec.context_window,
             max_output_tokens: spec.max_output_tokens,
@@ -773,12 +787,7 @@ pub fn curated_model_policy(value: &str) -> Option<ResolvedModelPolicy> {
     if let Some((provider, id)) = model_registry::parse_selection_key(value) {
         return model_registry::find_for(provider, id).map(ResolvedModelPolicy::curated);
     }
-    let mut owners = model_registry::models_named(value);
-    let spec = owners.next()?;
-    owners
-        .next()
-        .is_none()
-        .then(|| ResolvedModelPolicy::curated(spec))
+    model_registry::find(value).map(ResolvedModelPolicy::curated)
 }
 
 /// Configure a turn whose selection did not resolve through the host registry.
@@ -844,6 +853,8 @@ pub enum ProviderAuthMode {
     ApiKey,
     /// ChatGPT subscription OAuth.
     Chatgpt,
+    /// Uploaded Google Cloud service-account key file.
+    ServiceAccount,
 }
 
 /// Deserialize a present field (including JSON `null`) as `Some(..)`;
@@ -972,7 +983,7 @@ pub async fn has_credential(secrets: &dyn SecretProvider, kind: ProviderKind) ->
             if credential.as_api_key().is_some_and(|key| !key.is_empty()) {
                 return true;
             }
-            if kind == ProviderKind::Gemini
+            if matches!(kind, ProviderKind::Gemini | ProviderKind::Vertex)
                 && credential.as_service_account().is_some_and(|json| {
                     openwave_router::GoogleServiceAccount::from_json(json).is_ok()
                 })
@@ -998,19 +1009,26 @@ async fn auth_mode_for(
     secrets: &dyn SecretProvider,
     kind: ProviderKind,
 ) -> Option<ProviderAuthMode> {
-    if kind != ProviderKind::Openai {
-        return None;
-    }
     match read_credential(secrets, kind).await.ok().flatten() {
         Some(ProviderCredential::Oauth {})
             if openwave_connectors::has_stored_chatgpt_credentials(secrets).await =>
         {
             Some(ProviderAuthMode::Chatgpt)
         }
-        Some(ProviderCredential::ApiKey { key }) if !key.is_empty() => {
+        Some(ProviderCredential::ApiKey { key })
+            if kind == ProviderKind::Openai && !key.is_empty() =>
+        {
             Some(ProviderAuthMode::ApiKey)
         }
-        None if env_api_key(kind).is_some() => Some(ProviderAuthMode::ApiKey),
+        Some(ProviderCredential::ServiceAccount { json })
+            if matches!(kind, ProviderKind::Gemini | ProviderKind::Vertex)
+                && openwave_router::GoogleServiceAccount::from_json(&json).is_ok() =>
+        {
+            Some(ProviderAuthMode::ServiceAccount)
+        }
+        None if kind == ProviderKind::Openai && env_api_key(kind).is_some() => {
+            Some(ProviderAuthMode::ApiKey)
+        }
         _ => None,
     }
 }
@@ -1113,6 +1131,11 @@ pub async fn update_provider(
                 "xai uses its fixed first-party API endpoint",
             ));
         }
+        Some(_) if kind == ProviderKind::Vertex => {
+            return Err(ServerError::bad_request(
+                "Vertex AI uses fixed Google endpoints and does not support base_url",
+            ));
+        }
         Some(None) => config.base_url = None,
         Some(Some(url)) => {
             if url.is_empty() {
@@ -1123,9 +1146,9 @@ pub async fn update_provider(
     }
     match update.vertex_location {
         None => {}
-        Some(_) if kind != ProviderKind::Gemini => {
+        Some(_) if !matches!(kind, ProviderKind::Gemini | ProviderKind::Vertex) => {
             return Err(ServerError::bad_request(
-                "vertex_location is only supported by gemini",
+                "vertex_location is only supported by vertex and legacy gemini service accounts",
             ));
         }
         Some(None) => config.vertex_location = None,
@@ -1343,6 +1366,9 @@ fn env_api_key(kind: ProviderKind) -> Option<String> {
         ProviderKind::Gemini => std::env::var("GEMINI_API_KEY")
             .ok()
             .filter(|k| !k.is_empty()),
+        // Vertex credentials are explicit service-account material in the
+        // keychain. Ambient ADC and API-key modes are not implied.
+        ProviderKind::Vertex => None,
         ProviderKind::OpenaiCompatible => None,
         // Gateway tokens rotate; they are supplied per request by the route's
         // token source, never resolved into a static key.
@@ -1363,6 +1389,7 @@ pub fn route_kind(kind: ProviderKind) -> openwave_router::RouteKind {
         ProviderKind::Openai => openwave_router::RouteKind::Openai,
         ProviderKind::Xai => openwave_router::RouteKind::Xai,
         ProviderKind::Gemini => openwave_router::RouteKind::Gemini,
+        ProviderKind::Vertex => openwave_router::RouteKind::Vertex,
         ProviderKind::OpenaiCompatible => openwave_router::RouteKind::OpenaiCompatible,
         ProviderKind::ModelGateway => openwave_router::RouteKind::ModelGateway,
     }
@@ -1503,7 +1530,7 @@ pub async fn collect_routes(
             });
             continue;
         }
-        if kind == ProviderKind::Gemini {
+        if matches!(kind, ProviderKind::Gemini | ProviderKind::Vertex) {
             if let Some(ProviderCredential::ServiceAccount { json }) = stored_credential.as_ref() {
                 let Ok(account) = openwave_router::GoogleServiceAccount::from_json(json) else {
                     continue;
@@ -1517,6 +1544,24 @@ pub async fn collect_routes(
                 let source = std::sync::Arc::new(
                     openwave_router::GoogleServiceAccountTokenSource::new(account),
                 );
+                let vertex =
+                    openwave_router::VertexRoute::new(project_id, location, credential_fingerprint);
+                let vertex = if kind == ProviderKind::Vertex {
+                    vertex.with_model_families(model_registry::models_for(kind).filter_map(
+                        |spec| {
+                            let family = match spec.vendor()? {
+                                ProviderKind::Gemini => openwave_router::VertexModelFamily::Gemini,
+                                ProviderKind::Anthropic => {
+                                    openwave_router::VertexModelFamily::Anthropic
+                                }
+                                _ => return None,
+                            };
+                            Some((spec.id.to_string(), family))
+                        },
+                    ))
+                } else {
+                    vertex
+                };
                 routes.push(openwave_router::Route {
                     kind: route_kind(kind),
                     api_key: String::new(),
@@ -1527,11 +1572,7 @@ pub async fn collect_routes(
                         .map(|spec| spec.id.to_string())
                         .collect(),
                     token_source: Some(source),
-                    vertex: Some(openwave_router::VertexRoute::new(
-                        project_id,
-                        location,
-                        credential_fingerprint,
-                    )),
+                    vertex: Some(vertex),
                     chatgpt_account_id: None,
                 });
                 continue;
@@ -1560,9 +1601,12 @@ pub async fn collect_routes(
         routes.push(openwave_router::Route {
             kind: route_kind(kind),
             api_key,
-            // Gemini and xAI use fixed first-party endpoints in production.
+            // Gemini, xAI, and Vertex use fixed first-party endpoints in production.
             // Never let a stale/directly written setting redirect their keys.
-            base_url: (!matches!(kind, ProviderKind::Gemini | ProviderKind::Xai))
+            base_url: (!matches!(
+                kind,
+                ProviderKind::Gemini | ProviderKind::Xai | ProviderKind::Vertex
+            ))
                 .then_some(config.base_url)
                 .flatten(),
             curated_models: model_registry::models_for(kind)
@@ -1647,8 +1691,9 @@ pub async fn resolve_model_policy(
             }));
     }
 
-    let mut owners = model_registry::models_named(value)
+    let mut owners = model_registry::find(value)
         .map(ResolvedModelPolicy::curated)
+        .into_iter()
         .collect::<Vec<_>>();
     for provider in [ProviderKind::Xai, ProviderKind::OpenaiCompatible] {
         let config = read_config(store, provider).await?;
@@ -1699,7 +1744,7 @@ pub async fn provider_is_usable(
     if !config.enabled || !has_credential(secrets, kind).await {
         return Ok(false);
     }
-    if kind == ProviderKind::Gemini
+    if matches!(kind, ProviderKind::Gemini | ProviderKind::Vertex)
         && config
             .vertex_location
             .as_deref()
@@ -1864,6 +1909,12 @@ mod tests {
                     json: r#"{"type":"service_account","client_email":"service-account@example.test","private_key":"test-private-key","project_id":"test-project"}"#.to_owned(),
                 },
             ),
+            (
+                ProviderKind::Vertex,
+                ProviderCredential::ServiceAccount {
+                    json: r#"{"type":"service_account","client_email":"service-account@example.test","private_key":"test-private-key","project_id":"test-project"}"#.to_owned(),
+                },
+            ),
         ];
 
         for (kind, credential) in credentials {
@@ -1909,6 +1960,7 @@ mod tests {
             ProviderKind::parse("openai_compatible"),
             Some(ProviderKind::OpenaiCompatible)
         );
+        assert_eq!(ProviderKind::parse("vertex"), Some(ProviderKind::Vertex));
         assert_eq!(
             ProviderKind::Anthropic.credential_key(),
             "provider.anthropic.credential"
@@ -2097,6 +2149,14 @@ mod tests {
         assert_eq!(config.reasoning_effort, Some(ReasoningEffort::XHigh));
         assert_eq!(config.temperature, None);
         assert!(config.image_input);
+
+        let vertex = ResolvedModelPolicy::curated(
+            model_registry::find_for(ProviderKind::Vertex, "claude-opus-5").unwrap(),
+        );
+        assert_eq!(vertex.provider, ProviderKind::Vertex);
+        assert_eq!(vertex.vendor, Some(ProviderKind::Anthropic));
+        assert_eq!(vertex.verification, VerificationTier::Unverified);
+        assert!(!vertex.supports_vendor_web_search);
 
         // Haiku 4.5 reasons but rejects the effort control, so the request is
         // shaped without it rather than with something the model would refuse.

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -467,9 +467,9 @@ pub struct ProviderConfig {
     /// Optional base URL override (required for `openai_compatible`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_url: Option<String>,
-    /// Vertex AI location used by the first-class Vertex provider and retained
-    /// for legacy Gemini service-account configurations. An absent value
-    /// defaults to `global`.
+    /// Vertex AI location. The first-class Vertex provider accepts only
+    /// `global`; regional values are retained only for legacy Gemini
+    /// service-account configurations. An absent value defaults to `global`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub vertex_location: Option<String>,
     /// Explicit model rows served by a configurable endpoint.
@@ -831,7 +831,9 @@ pub struct ProviderInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub base_url: Option<String>,
-    /// Vertex AI location. Never includes the project id from the credential.
+    /// Vertex AI location. The first-class Vertex provider is global-only;
+    /// legacy Gemini service-account configurations may retain a region. Never
+    /// includes the project id from the credential.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub vertex_location: Option<String>,
@@ -1153,6 +1155,11 @@ pub async fn update_provider(
         }
         Some(None) => config.vertex_location = None,
         Some(Some(location)) => {
+            if kind == ProviderKind::Vertex && location != "global" {
+                return Err(ServerError::bad_request(
+                    "the first-class Vertex provider supports only vertex_location `global`",
+                ));
+            }
             if location.trim() != location || !openwave_router::valid_vertex_location(&location) {
                 return Err(ServerError::bad_request(
                     "vertex_location must be a valid Google Cloud location",
@@ -1160,6 +1167,14 @@ pub async fn update_provider(
             }
             config.vertex_location = Some(location);
         }
+    }
+    if kind == ProviderKind::Vertex
+        && config.enabled
+        && !configured_vertex_location_is_usable(kind, config.vertex_location.as_deref())
+    {
+        return Err(ServerError::bad_request(
+            "the first-class Vertex provider supports only vertex_location `global`; update the stored location before enabling it",
+        ));
     }
     if let Some(models) = update.models {
         if !matches!(kind, ProviderKind::OpenaiCompatible | ProviderKind::Xai) {
@@ -1395,22 +1410,20 @@ pub fn route_kind(kind: ProviderKind) -> openwave_router::RouteKind {
     }
 }
 
-/// Whether one curated row can be served under this provider configuration.
+/// Whether the configured Vertex location belongs to the provider surface.
 ///
-/// The first-class Vertex surface accepts only `global` and single-region
-/// locations. Google's current Claude catalog is not available in those
-/// single regions (only global plus multi-regions this surface deliberately
-/// does not accept), so keep Claude global-only until the registry carries an
-/// explicit per-model location matrix. Gemini keeps its existing endpoint
-/// rules, including the adapter's global override for Gemini 3.
-fn curated_model_is_routable(
-    kind: ProviderKind,
-    vendor: Option<ProviderKind>,
-    vertex_location: Option<&str>,
-) -> bool {
-    kind != ProviderKind::Vertex
-        || vendor != Some(ProviderKind::Anthropic)
-        || vertex_location.unwrap_or("global") == "global"
+/// First-class Vertex is global-only because every curated row on that surface
+/// is global-only today. Legacy Gemini service-account configurations keep
+/// accepting validated regions; their adapter continues to move Gemini 3
+/// requests to the global endpoint while preserving older regional behavior.
+fn configured_vertex_location_is_usable(kind: ProviderKind, vertex_location: Option<&str>) -> bool {
+    match kind {
+        ProviderKind::Vertex => vertex_location.unwrap_or("global") == "global",
+        ProviderKind::Gemini => vertex_location
+            .map(openwave_router::valid_vertex_location)
+            .unwrap_or(true),
+        _ => true,
+    }
 }
 
 /// Collect enabled, credentialed routes for the composite router.
@@ -1524,6 +1537,9 @@ pub async fn collect_routes(
         if !config.enabled {
             continue;
         }
+        if !configured_vertex_location_is_usable(kind, config.vertex_location.as_deref()) {
+            continue;
+        }
 
         let stored_credential = match read_credential(secrets, kind).await {
             Ok(credential) => credential,
@@ -1554,17 +1570,12 @@ pub async fn collect_routes(
                     continue;
                 };
                 let location = config.vertex_location.as_deref().unwrap_or("global");
-                if !openwave_router::valid_vertex_location(location) {
-                    continue;
-                }
                 let project_id = account.project_id().to_owned();
                 let credential_fingerprint: [u8; 32] = Sha256::digest(json.as_bytes()).into();
                 let source = std::sync::Arc::new(
                     openwave_router::GoogleServiceAccountTokenSource::new(account),
                 );
-                let curated_models = model_registry::models_for(kind)
-                    .filter(|spec| curated_model_is_routable(kind, spec.vendor(), Some(location)))
-                    .collect::<Vec<_>>();
+                let curated_models = model_registry::models_for(kind).collect::<Vec<_>>();
                 let vertex =
                     openwave_router::VertexRoute::new(project_id, location, credential_fingerprint);
                 let vertex = if kind == ProviderKind::Vertex {
@@ -1761,15 +1772,12 @@ pub async fn provider_is_usable(
         return Ok(false);
     }
     let config = read_config(store, kind).await?;
-    if !config.enabled || !has_credential(secrets, kind).await {
+    if !config.enabled
+        || !configured_vertex_location_is_usable(kind, config.vertex_location.as_deref())
+    {
         return Ok(false);
     }
-    if matches!(kind, ProviderKind::Gemini | ProviderKind::Vertex)
-        && config
-            .vertex_location
-            .as_deref()
-            .is_some_and(|location| !openwave_router::valid_vertex_location(location))
-    {
+    if !has_credential(secrets, kind).await {
         return Ok(false);
     }
     if kind == ProviderKind::OpenaiCompatible {
@@ -1794,18 +1802,7 @@ pub async fn model_is_usable(
     model: &ResolvedModelPolicy,
     policy: &crate::managed_policy::ManagedPolicy,
 ) -> Result<bool> {
-    if !provider_is_usable(store, secrets, model.provider, policy).await? {
-        return Ok(false);
-    }
-    if model.provider != ProviderKind::Vertex {
-        return Ok(true);
-    }
-    let config = read_config(store, ProviderKind::Vertex).await?;
-    Ok(curated_model_is_routable(
-        model.provider,
-        model.vendor,
-        config.vertex_location.as_deref(),
-    ))
+    provider_is_usable(store, secrets, model.provider, policy).await
 }
 
 /// Full typed catalog. Unavailable rows remain visible for provider-scoped
@@ -1818,15 +1815,9 @@ pub async fn catalog_models(
     let mut models = Vec::new();
     for &kind in ProviderKind::ALL {
         let available = provider_is_usable(store, secrets, kind, policy).await?;
-        let vertex_location = if kind == ProviderKind::Vertex {
-            read_config(store, kind).await?.vertex_location
-        } else {
-            None
-        };
         models.extend(model_registry::models_for(kind).map(|spec| CatalogModel {
             policy: ResolvedModelPolicy::curated(spec),
-            available: available
-                && curated_model_is_routable(kind, spec.vendor(), vertex_location.as_deref()),
+            available,
         }));
         // Configured model sets: the compatible endpoint's custom entries,
         // and the managed gateway's entitled snapshot — which is empty on an
@@ -1853,7 +1844,6 @@ pub async fn catalog_models(
 mod tests {
     use super::*;
     use std::collections::HashMap;
-    use std::sync::Arc;
     use std::sync::Mutex;
 
     #[derive(Default)]
@@ -1876,15 +1866,6 @@ mod tests {
         async fn delete_secret(&self, key: &str) -> Result<()> {
             self.0.lock().unwrap().remove(key);
             Ok(())
-        }
-    }
-
-    struct StaticToken;
-
-    #[async_trait::async_trait]
-    impl openwave_router::BearerTokenSource for StaticToken {
-        async fn bearer_token(&self) -> Result<String> {
-            Ok("vertex-test-token".to_owned())
         }
     }
 
@@ -2264,62 +2245,27 @@ mod tests {
     }
 
     #[test]
-    fn regional_vertex_keeps_claude_unavailable_and_out_of_the_route() {
-        let location = "us-east5";
-        let routed = model_registry::models_for(ProviderKind::Vertex)
-            .filter(|spec| {
-                curated_model_is_routable(ProviderKind::Vertex, spec.vendor(), Some(location))
-            })
-            .collect::<Vec<_>>();
-
-        assert!(routed
-            .iter()
-            .all(|spec| spec.vendor() == Some(ProviderKind::Gemini)));
-        assert!(model_registry::models_for(ProviderKind::Vertex)
-            .filter(|spec| spec.vendor() == Some(ProviderKind::Anthropic))
-            .all(|spec| !curated_model_is_routable(
-                ProviderKind::Vertex,
-                spec.vendor(),
-                Some(location),
-            )));
-        assert!(
-            model_registry::models_for(ProviderKind::Vertex).all(|spec| {
-                curated_model_is_routable(ProviderKind::Vertex, spec.vendor(), Some("global"))
-            })
-        );
-
-        let route = openwave_router::Route {
-            kind: openwave_router::RouteKind::Vertex,
-            api_key: String::new(),
-            base_url: None,
-            curated_models: routed.iter().map(|spec| spec.id.to_owned()).collect(),
-            token_source: Some(Arc::new(StaticToken)),
-            vertex: Some(
-                openwave_router::VertexRoute::new("test-project", location, [1; 32])
-                    .with_model_families(routed.iter().map(|spec| {
-                        (
-                            spec.id.to_owned(),
-                            openwave_router::VertexModelFamily::Gemini,
-                        )
-                    })),
-            ),
-            chatgpt_account_id: None,
-        };
-        let router = openwave_router::Router::build(vec![route]);
-        assert_eq!(
-            router.select_for(
-                Some(&openwave_core::ProviderId::new("vertex")),
-                "gemini-3.5-flash-lite",
-            ),
-            Some(openwave_router::RouteKind::Vertex)
-        );
-        assert_eq!(
-            router.select_for(
-                Some(&openwave_core::ProviderId::new("vertex")),
-                "claude-opus-5",
-            ),
+    fn first_class_vertex_is_global_only_while_legacy_gemini_keeps_regions() {
+        assert!(configured_vertex_location_is_usable(
+            ProviderKind::Vertex,
             None
-        );
+        ));
+        assert!(configured_vertex_location_is_usable(
+            ProviderKind::Vertex,
+            Some("global")
+        ));
+        assert!(!configured_vertex_location_is_usable(
+            ProviderKind::Vertex,
+            Some("us-east5")
+        ));
+        assert!(configured_vertex_location_is_usable(
+            ProviderKind::Gemini,
+            Some("us-east5")
+        ));
+        assert!(!configured_vertex_location_is_usable(
+            ProviderKind::Gemini,
+            Some("../global")
+        ));
     }
 
     #[test]

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -2197,15 +2197,20 @@ mod tests {
         assert_eq!(vertex.verification, VerificationTier::Unverified);
         assert!(!vertex.supports_vendor_web_search);
 
-        // Haiku 4.5 reasons but rejects the effort control, so the request is
-        // shaped without it rather than with something the model would refuse.
-        let mut config = AgentConfig::default();
+        // Haiku 4.5 needs a classic token-budget thinking request that the
+        // adapter cannot send yet, so policy keeps both reasoning and effort
+        // off rather than promising reasoning that disappears on the wire.
+        let mut config = AgentConfig {
+            temperature: Some(0.7),
+            ..AgentConfig::default()
+        };
         let haiku = ResolvedModelPolicy::curated(
             model_registry::find_for(ProviderKind::Anthropic, "claude-haiku-4-5-20251001").unwrap(),
         );
         apply_model_policy(&mut config, &haiku, Some(ReasoningEffort::High)).unwrap();
-        assert!(config.reasoning_model);
+        assert!(!config.reasoning_model);
         assert_eq!(config.reasoning_effort, None);
+        assert_eq!(config.temperature, Some(0.7));
 
         let mut config = AgentConfig::default();
         let gpt = ResolvedModelPolicy::curated(
@@ -2305,16 +2310,52 @@ mod tests {
             ),
             Some(ReasoningEffort::XHigh)
         );
-        // Haiku 4.5 errors on the parameter, so it is dropped outright.
-        for effort in ReasoningEffort::ALL {
-            assert_eq!(
-                apply(
-                    "claude-haiku-4-5-20251001",
-                    ProviderKind::Anthropic,
-                    *effort
-                ),
-                None
-            );
+    }
+
+    #[test]
+    fn claude_policy_clamps_4_6_xhigh_and_disables_haiku_4_5_before_requests() {
+        for provider in [ProviderKind::Anthropic, ProviderKind::Vertex] {
+            for id in ["claude-opus-4-6", "claude-sonnet-4-6"] {
+                let policy =
+                    ResolvedModelPolicy::curated(model_registry::find_for(provider, id).unwrap());
+
+                let mut config = AgentConfig::default();
+                apply_model_policy(&mut config, &policy, Some(ReasoningEffort::XHigh)).unwrap();
+                assert!(config.reasoning_model, "{}::{id}", provider.as_str());
+                assert_eq!(
+                    config.reasoning_effort,
+                    Some(ReasoningEffort::High),
+                    "{}::{id} let xhigh survive policy",
+                    provider.as_str()
+                );
+
+                let mut config = AgentConfig::default();
+                apply_model_policy(&mut config, &policy, Some(ReasoningEffort::Max)).unwrap();
+                assert_eq!(
+                    config.reasoning_effort,
+                    Some(ReasoningEffort::Max),
+                    "{}::{id} lost its supported max level",
+                    provider.as_str()
+                );
+            }
+        }
+
+        for (provider, id) in [
+            (ProviderKind::Anthropic, "claude-haiku-4-5-20251001"),
+            (ProviderKind::Vertex, "claude-haiku-4-5"),
+        ] {
+            let policy =
+                ResolvedModelPolicy::curated(model_registry::find_for(provider, id).unwrap());
+            for effort in ReasoningEffort::ALL {
+                let mut config = AgentConfig {
+                    temperature: Some(0.7),
+                    ..AgentConfig::default()
+                };
+                apply_model_policy(&mut config, &policy, Some(*effort)).unwrap();
+                assert!(!config.reasoning_model, "{}::{id}", provider.as_str());
+                assert_eq!(config.reasoning_effort, None, "{}::{id}", provider.as_str());
+                assert_eq!(config.temperature, Some(0.7), "{}::{id}", provider.as_str());
+            }
         }
     }
 

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -1395,6 +1395,24 @@ pub fn route_kind(kind: ProviderKind) -> openwave_router::RouteKind {
     }
 }
 
+/// Whether one curated row can be served under this provider configuration.
+///
+/// The first-class Vertex surface accepts only `global` and single-region
+/// locations. Google's current Claude catalog is not available in those
+/// single regions (only global plus multi-regions this surface deliberately
+/// does not accept), so keep Claude global-only until the registry carries an
+/// explicit per-model location matrix. Gemini keeps its existing endpoint
+/// rules, including the adapter's global override for Gemini 3.
+fn curated_model_is_routable(
+    kind: ProviderKind,
+    vendor: Option<ProviderKind>,
+    vertex_location: Option<&str>,
+) -> bool {
+    kind != ProviderKind::Vertex
+        || vendor != Some(ProviderKind::Anthropic)
+        || vertex_location.unwrap_or("global") == "global"
+}
+
 /// Collect enabled, credentialed routes for the composite router.
 ///
 /// A kind with no usable credential is skipped. Gemini service accounts become
@@ -1544,21 +1562,22 @@ pub async fn collect_routes(
                 let source = std::sync::Arc::new(
                     openwave_router::GoogleServiceAccountTokenSource::new(account),
                 );
+                let curated_models = model_registry::models_for(kind)
+                    .filter(|spec| curated_model_is_routable(kind, spec.vendor(), Some(location)))
+                    .collect::<Vec<_>>();
                 let vertex =
                     openwave_router::VertexRoute::new(project_id, location, credential_fingerprint);
                 let vertex = if kind == ProviderKind::Vertex {
-                    vertex.with_model_families(model_registry::models_for(kind).filter_map(
-                        |spec| {
-                            let family = match spec.vendor()? {
-                                ProviderKind::Gemini => openwave_router::VertexModelFamily::Gemini,
-                                ProviderKind::Anthropic => {
-                                    openwave_router::VertexModelFamily::Anthropic
-                                }
-                                _ => return None,
-                            };
-                            Some((spec.id.to_string(), family))
-                        },
-                    ))
+                    vertex.with_model_families(curated_models.iter().filter_map(|spec| {
+                        let family = match spec.vendor()? {
+                            ProviderKind::Gemini => openwave_router::VertexModelFamily::Gemini,
+                            ProviderKind::Anthropic => {
+                                openwave_router::VertexModelFamily::Anthropic
+                            }
+                            _ => return None,
+                        };
+                        Some((spec.id.to_string(), family))
+                    }))
                 } else {
                     vertex
                 };
@@ -1568,7 +1587,8 @@ pub async fn collect_routes(
                     // Production Vertex hosts are derived by the adapter.
                     // Never let stored config redirect a bearer token.
                     base_url: None,
-                    curated_models: model_registry::models_for(kind)
+                    curated_models: curated_models
+                        .into_iter()
                         .map(|spec| spec.id.to_string())
                         .collect(),
                     token_source: Some(source),
@@ -1766,6 +1786,28 @@ pub async fn provider_is_usable(
     Ok(true)
 }
 
+/// Whether this exact resolved model can run under the provider's current
+/// credential and non-secret configuration.
+pub async fn model_is_usable(
+    store: &dyn Store,
+    secrets: &dyn SecretProvider,
+    model: &ResolvedModelPolicy,
+    policy: &crate::managed_policy::ManagedPolicy,
+) -> Result<bool> {
+    if !provider_is_usable(store, secrets, model.provider, policy).await? {
+        return Ok(false);
+    }
+    if model.provider != ProviderKind::Vertex {
+        return Ok(true);
+    }
+    let config = read_config(store, ProviderKind::Vertex).await?;
+    Ok(curated_model_is_routable(
+        model.provider,
+        model.vendor,
+        config.vertex_location.as_deref(),
+    ))
+}
+
 /// Full typed catalog. Unavailable rows remain visible for provider-scoped
 /// settings, but clients must not offer them as usable selections.
 pub async fn catalog_models(
@@ -1776,9 +1818,15 @@ pub async fn catalog_models(
     let mut models = Vec::new();
     for &kind in ProviderKind::ALL {
         let available = provider_is_usable(store, secrets, kind, policy).await?;
+        let vertex_location = if kind == ProviderKind::Vertex {
+            read_config(store, kind).await?.vertex_location
+        } else {
+            None
+        };
         models.extend(model_registry::models_for(kind).map(|spec| CatalogModel {
             policy: ResolvedModelPolicy::curated(spec),
-            available,
+            available: available
+                && curated_model_is_routable(kind, spec.vendor(), vertex_location.as_deref()),
         }));
         // Configured model sets: the compatible endpoint's custom entries,
         // and the managed gateway's entitled snapshot — which is empty on an
@@ -1805,6 +1853,7 @@ pub async fn catalog_models(
 mod tests {
     use super::*;
     use std::collections::HashMap;
+    use std::sync::Arc;
     use std::sync::Mutex;
 
     #[derive(Default)]
@@ -1827,6 +1876,15 @@ mod tests {
         async fn delete_secret(&self, key: &str) -> Result<()> {
             self.0.lock().unwrap().remove(key);
             Ok(())
+        }
+    }
+
+    struct StaticToken;
+
+    #[async_trait::async_trait]
+    impl openwave_router::BearerTokenSource for StaticToken {
+        async fn bearer_token(&self) -> Result<String> {
+            Ok("vertex-test-token".to_owned())
         }
     }
 
@@ -2203,6 +2261,65 @@ mod tests {
         assert_eq!(config.max_tokens, Some(4_096));
         assert!(!config.reasoning_model);
         assert_eq!(config.reasoning_effort, None);
+    }
+
+    #[test]
+    fn regional_vertex_keeps_claude_unavailable_and_out_of_the_route() {
+        let location = "us-east5";
+        let routed = model_registry::models_for(ProviderKind::Vertex)
+            .filter(|spec| {
+                curated_model_is_routable(ProviderKind::Vertex, spec.vendor(), Some(location))
+            })
+            .collect::<Vec<_>>();
+
+        assert!(routed
+            .iter()
+            .all(|spec| spec.vendor() == Some(ProviderKind::Gemini)));
+        assert!(model_registry::models_for(ProviderKind::Vertex)
+            .filter(|spec| spec.vendor() == Some(ProviderKind::Anthropic))
+            .all(|spec| !curated_model_is_routable(
+                ProviderKind::Vertex,
+                spec.vendor(),
+                Some(location),
+            )));
+        assert!(
+            model_registry::models_for(ProviderKind::Vertex).all(|spec| {
+                curated_model_is_routable(ProviderKind::Vertex, spec.vendor(), Some("global"))
+            })
+        );
+
+        let route = openwave_router::Route {
+            kind: openwave_router::RouteKind::Vertex,
+            api_key: String::new(),
+            base_url: None,
+            curated_models: routed.iter().map(|spec| spec.id.to_owned()).collect(),
+            token_source: Some(Arc::new(StaticToken)),
+            vertex: Some(
+                openwave_router::VertexRoute::new("test-project", location, [1; 32])
+                    .with_model_families(routed.iter().map(|spec| {
+                        (
+                            spec.id.to_owned(),
+                            openwave_router::VertexModelFamily::Gemini,
+                        )
+                    })),
+            ),
+            chatgpt_account_id: None,
+        };
+        let router = openwave_router::Router::build(vec![route]);
+        assert_eq!(
+            router.select_for(
+                Some(&openwave_core::ProviderId::new("vertex")),
+                "gemini-3.5-flash-lite",
+            ),
+            Some(openwave_router::RouteKind::Vertex)
+        );
+        assert_eq!(
+            router.select_for(
+                Some(&openwave_core::ProviderId::new("vertex")),
+                "claude-opus-5",
+            ),
+            None
+        );
     }
 
     #[test]

--- a/crates/openwave-server/src/routes/providers_models.rs
+++ b/crates/openwave-server/src/routes/providers_models.rs
@@ -76,13 +76,11 @@ pub(super) async fn validate_model_selection(
         ));
     };
     let managed = crate::managed_policy::resolve(&*state.store, &*state.os_policy).await?;
-    if !providers::provider_is_usable(&*state.store, &*state.secrets, policy.provider, &managed)
-        .await?
-    {
+    if !providers::model_is_usable(&*state.store, &*state.secrets, &policy, &managed).await? {
         return Err(ServerError::conflict_kind(
             "model_provider_unavailable",
             format!(
-                "provider `{}` for model `{}` is disabled, unconfigured, or missing a credential",
+                "provider `{}` cannot serve model `{}` with its current configuration or credential",
                 policy.provider, policy.id
             ),
         ));
@@ -366,7 +364,8 @@ pub struct ModelInfo {
     pub vendor: Option<ProviderKind>,
     /// How thoroughly OpenWave has exercised this provider/model combination.
     pub verification: crate::model_registry::VerificationTier,
-    /// Whether the provider is enabled, configured, and credentialed.
+    /// Whether the provider is enabled, configured, credentialed, and able to
+    /// serve this model at its configured endpoint/location.
     pub available: bool,
     /// Approximate context window in tokens.
     pub context_window: u32,

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -1218,6 +1218,61 @@ async fn gemini_vertex_location_is_validated_and_public_info_never_grows_a_proje
 }
 
 #[tokio::test]
+async fn vertex_provider_accepts_only_derived_google_endpoints_and_service_account_auth() {
+    let (router, token, _store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+
+    let configured = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/providers/vertex")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "enabled": false,
+                        "vertex_location": "us-east5"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(configured.status(), StatusCode::OK);
+    let body: serde_json::Value = json_body(configured).await;
+    assert_eq!(body["kind"], "vertex");
+    assert_eq!(body["vertex_location"], "us-east5");
+    assert_eq!(body["has_credential"], false);
+    assert!(body.get("project_id").is_none());
+
+    for update in [
+        serde_json::json!({"base_url": "https://example.test"}),
+        serde_json::json!({"credential": {"type": "api_key", "key": "not-supported"}}),
+        serde_json::json!({"vertex_location": "us"}),
+    ] {
+        let rejected = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/providers/vertex")
+                    .header(header::AUTHORIZATION, &bearer)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(update.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(rejected.status(), StatusCode::BAD_REQUEST);
+        let body: serde_json::Value = json_body(rejected).await;
+        assert!(!body.to_string().contains("not-supported"));
+    }
+}
+
+#[tokio::test]
 async fn openai_compatible_requires_base_url_when_enabled() {
     let (router, token, _store, _dir) = test_app().await;
     let response = router

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -1547,6 +1547,17 @@ async fn xai_config_builds_a_provider_qualified_native_route() {
     assert_eq!(routes[0].base_url, None);
     assert_eq!(routes[0].curated_models, ["grok-account-model"]);
 
+    let configured = providers::resolve_model_policy(&*store, "grok-account-model", false)
+        .await
+        .unwrap()
+        .expect("a bare configured xAI id resolves to its sole owner");
+    assert_eq!(configured.provider, providers::ProviderKind::Xai);
+    let curated = providers::resolve_model_policy(&*store, "gpt-5.6-sol", false)
+        .await
+        .unwrap()
+        .expect("a bare curated id keeps the registry's direct owner");
+    assert_eq!(curated.provider, providers::ProviderKind::Openai);
+
     let router = openwave_router::Router::build(routes);
     assert_eq!(
         router.select_for(

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -1219,7 +1219,7 @@ async fn gemini_vertex_location_is_validated_and_public_info_never_grows_a_proje
 
 #[tokio::test]
 async fn vertex_provider_accepts_only_derived_google_endpoints_and_service_account_auth() {
-    let (router, token, _store, _dir) = test_app().await;
+    let (router, token, store, _dir) = test_app().await;
     let bearer = format!("Bearer {token}");
 
     let configured = router
@@ -1233,7 +1233,7 @@ async fn vertex_provider_accepts_only_derived_google_endpoints_and_service_accou
                 .body(Body::from(
                     serde_json::json!({
                         "enabled": false,
-                        "vertex_location": "us-east5"
+                        "vertex_location": "global"
                     })
                     .to_string(),
                 ))
@@ -1244,13 +1244,14 @@ async fn vertex_provider_accepts_only_derived_google_endpoints_and_service_accou
     assert_eq!(configured.status(), StatusCode::OK);
     let body: serde_json::Value = json_body(configured).await;
     assert_eq!(body["kind"], "vertex");
-    assert_eq!(body["vertex_location"], "us-east5");
+    assert_eq!(body["vertex_location"], "global");
     assert_eq!(body["has_credential"], false);
     assert!(body.get("project_id").is_none());
 
     for update in [
         serde_json::json!({"base_url": "https://example.test"}),
         serde_json::json!({"credential": {"type": "api_key", "key": "not-supported"}}),
+        serde_json::json!({"vertex_location": "us-east5"}),
         serde_json::json!({"vertex_location": "us"}),
     ] {
         let rejected = router
@@ -1270,6 +1271,34 @@ async fn vertex_provider_accepts_only_derived_google_endpoints_and_service_accou
         let body: serde_json::Value = json_body(rejected).await;
         assert!(!body.to_string().contains("not-supported"));
     }
+
+    // A regional row written by an older build remains inert. The API refuses
+    // to re-enable it until the caller explicitly moves it to global.
+    providers::write_config(
+        &*store,
+        providers::ProviderKind::Vertex,
+        &providers::ProviderConfig {
+            enabled: false,
+            base_url: None,
+            vertex_location: Some("us-east5".into()),
+            models: Vec::new(),
+        },
+    )
+    .await
+    .unwrap();
+    let rejected = router
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/providers/vertex")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(serde_json::json!({"enabled": true}).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(rejected.status(), StatusCode::BAD_REQUEST);
 }
 
 #[tokio::test]
@@ -2228,6 +2257,87 @@ async fn resolver_includes_configured_curated_api_key_providers() {
         assert_eq!(router.select(model), Some(route_kind));
         assert_eq!(router.select("claude-opus-4-8"), None);
     }
+}
+
+struct NoSecretReads;
+
+#[async_trait]
+impl SecretProvider for NoSecretReads {
+    async fn get_secret(&self, key: &str) -> Result<Option<String>> {
+        panic!("regional Vertex configuration must be rejected before reading secret `{key}`")
+    }
+
+    async fn set_secret(&self, key: &str, _value: &str) -> Result<()> {
+        panic!("test must not write secret `{key}`")
+    }
+
+    async fn delete_secret(&self, key: &str) -> Result<()> {
+        panic!("test must not delete secret `{key}`")
+    }
+}
+
+#[tokio::test]
+async fn stored_regional_vertex_is_unavailable_and_claims_no_models_or_route() {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}/test.db?mode=rwc",
+            dir.path().display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let secrets: Arc<dyn SecretProvider> = Arc::new(NoSecretReads);
+    providers::write_config(
+        &*store,
+        providers::ProviderKind::Vertex,
+        &providers::ProviderConfig {
+            enabled: true,
+            base_url: None,
+            vertex_location: Some("us-east5".into()),
+            models: Vec::new(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
+        .await
+        .unwrap();
+    assert!(!providers::provider_is_usable(
+        &*store,
+        &*secrets,
+        providers::ProviderKind::Vertex,
+        &policy
+    )
+    .await
+    .unwrap());
+
+    let routes = providers::collect_routes(&*store, &*secrets, None, None, &policy).await;
+    let router = openwave_router::Router::build(routes);
+    assert_eq!(
+        router.select_for(
+            Some(&openwave_core::ProviderId::new("vertex")),
+            "gemini-3.5-flash-lite",
+        ),
+        None
+    );
+    assert_eq!(
+        router.select_for(
+            Some(&openwave_core::ProviderId::new("vertex")),
+            "claude-opus-5",
+        ),
+        None
+    );
+
+    let vertex_models = providers::catalog_models(&*store, &*secrets, &policy)
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|model| model.policy.provider == providers::ProviderKind::Vertex)
+        .collect::<Vec<_>>();
+    assert!(!vertex_models.is_empty());
+    assert!(vertex_models.iter().all(|model| !model.available));
 }
 
 #[tokio::test]

--- a/crates/openwave-server/src/tests/conversations.rs
+++ b/crates/openwave-server/src/tests/conversations.rs
@@ -462,14 +462,40 @@ async fn models_catalog_is_served() {
         opus["reasoning_efforts"],
         serde_json::json!(["low", "medium", "high", "xhigh", "max"])
     );
-    // A model that reasons but rejects the effort parameter advertises no
-    // levels at all, which is what tells a client to hide the control.
-    let haiku = models
-        .iter()
-        .find(|m| m["id"] == "claude-haiku-4-5-20251001")
-        .expect("curated Anthropic model is present");
-    assert!(haiku["supports_reasoning"].as_bool().unwrap());
-    assert_eq!(haiku["reasoning_efforts"], serde_json::json!([]));
+    // Claude 4.6 accepts `max` but not `xhigh`, on both the direct and Vertex
+    // routes. The public catalog must expose the same narrowed mirror so the UI
+    // cannot offer a request token either route would reject.
+    for key in [
+        "anthropic::claude-opus-4-6",
+        "anthropic::claude-sonnet-4-6",
+        "vertex::claude-opus-4-6",
+        "vertex::claude-sonnet-4-6",
+    ] {
+        let model = models
+            .iter()
+            .find(|model| model["key"] == key)
+            .unwrap_or_else(|| panic!("catalog omitted {key}"));
+        assert!(model["supports_reasoning"].as_bool().unwrap(), "{key}");
+        assert_eq!(
+            model["reasoning_efforts"],
+            serde_json::json!(["low", "medium", "high", "max"]),
+            "{key}"
+        );
+    }
+    // Haiku 4.5 needs classic extended-thinking budget requests, which the
+    // shared Anthropic adapter cannot emit yet. Both catalog rows therefore
+    // stay non-reasoning and hide the effort control.
+    for key in [
+        "anthropic::claude-haiku-4-5-20251001",
+        "vertex::claude-haiku-4-5",
+    ] {
+        let haiku = models
+            .iter()
+            .find(|model| model["key"] == key)
+            .unwrap_or_else(|| panic!("catalog omitted {key}"));
+        assert!(!haiku["supports_reasoning"].as_bool().unwrap(), "{key}");
+        assert_eq!(haiku["reasoning_efforts"], serde_json::json!([]), "{key}");
+    }
     // The GPT-5 line adds an off level, and only the 5.6 generation reaches
     // `max`.
     let gpt = models

--- a/docs-site/content/docs/models-and-providers.mdx
+++ b/docs-site/content/docs/models-and-providers.mdx
@@ -16,9 +16,24 @@ Open **Settings → Providers**. Each provider is its own section: turn on
 | --- | --- |
 | Anthropic | API key |
 | OpenAI | A ChatGPT subscription (**Sign in with ChatGPT**) or a platform API key |
-| Google Gemini | A Gemini API key, or a Google Cloud service-account JSON plus a Vertex AI location |
+| Google Gemini | Gemini Developer API key |
+| Google Vertex AI | Google Cloud service-account JSON containing its project ID; curated routes use the `global` location |
 | xAI | API key, plus the model IDs you want to use |
 | OpenAI-compatible | Base URL, optional key, plus the model IDs you want to use |
+
+For new Google Cloud service-account setups, use the **Google Vertex AI**
+provider row. Paste the JSON key file; OpenWave reads the project ID from that
+credential and uses the `global` Vertex location for its curated native Gemini
+and Claude models. It derives the Google hosts itself: this setup does not
+accept a custom endpoint, a regional or multi-region location, or ambient
+Application Default Credentials.
+
+**Google Gemini** is the direct Gemini Developer API path and accepts a Gemini
+API key. If an older OpenWave installation already stored a service account
+under Gemini, the panel keeps that credential and its validated location
+available for compatibility with older regional models. New service-account
+configurations belong under Google Vertex AI, and curated Gemini 3 requests use
+the global endpoint in either case.
 
 The panel never shows a saved key back to you. It shows a status —
 **API key set**, **Signed in with ChatGPT**, **Credential set**, or
@@ -36,10 +51,11 @@ from the environment as a fallback when no credential is saved.
 
 ## Curated models
 
-Anthropic, OpenAI, and Gemini ship with a curated list of models. Nothing to
-configure — once the provider has a credential, its models appear in the
-picker. The list is versioned with the app and refreshed as providers ship new
-models.
+Anthropic, OpenAI, Gemini, and Google Vertex AI ship with a curated list of
+models. Vertex includes provider-qualified native Gemini and Claude rows.
+Nothing to configure — once the provider has a credential, its models appear
+in the picker. The list is versioned with the app and refreshed as providers
+ship new models.
 
 Each entry carries what the app actually knows about it: context window,
 maximum output, whether it accepts images, whether it produces a reasoning

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -56,9 +56,11 @@ Major surfaces present today:
 
 ## `openwave-router` — model providers & routing 🟢
 
-Owns the concrete Anthropic, OpenAI Responses, xAI Responses, Gemini, and
-OpenAI-compatible provider adapters (including Fireworks, OpenRouter, vLLM,
-and LM Studio endpoints) plus a composite `Router`.
+Owns the concrete Anthropic, OpenAI Responses, xAI Responses, Gemini, Google
+Vertex AI, and OpenAI-compatible provider adapters (including Fireworks,
+OpenRouter, vLLM, and LM Studio endpoints) plus a composite `Router`. Vertex
+keeps native Gemini GenerateContent and Claude Messages-over-`streamRawPredict`
+as separate protocol families under one explicit provider identity.
 
 The `Router` is itself a `ModelProvider`, so the agent loop holds one provider
 contract and does not depend on a concrete backend. Two things define it:

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -303,9 +303,11 @@ independently reauthorizes its live grant. Resolve checks attachment authority
 again, which discards content if a detach won while the read was in flight. A
 crash after possible broker dispatch becomes a safe unavailable result instead
 of another read.
-The model router supports Anthropic, OpenAI, xAI, Gemini, and OpenAI-compatible
-endpoints. It fails closed: if no enabled provider with a usable credential can
-serve the selected model, no model request is sent.
+The model router supports Anthropic, OpenAI, xAI, Gemini, Google Vertex AI, and
+OpenAI-compatible endpoints. Vertex routes curated Gemini and Claude models
+through their native Google publisher surfaces using a fixed-endpoint,
+short-lived Google bearer. It fails closed: if no enabled provider with a
+usable credential can serve the selected model, no model request is sent.
 
 ### Tool calls are small state machines too
 

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -96,11 +96,14 @@ families:
 - Claude models use Anthropic Messages through Vertex `streamRawPredict`.
 
 The provider derives its host from a validated `global` or regional location;
-credentials cannot supply an endpoint. Uploaded service-account JSON is
-exchanged only through Google's fixed OAuth token endpoint and never appears in
-the provider API response. Custom Vertex hosts, multi-region aliases, ambient
-Application Default Credentials, and arbitrary Model Garden entries are not
-promised by this surface.
+credentials cannot supply an endpoint. Curated Claude rows are first-class only
+at `global`: Google's other documented Claude locations are multi-regions this
+surface deliberately does not accept, so a single-region setting leaves those
+rows unavailable and routes only the supported Gemini family. Uploaded
+service-account JSON is exchanged only through Google's fixed OAuth token
+endpoint and never appears in the provider API response. Custom Vertex hosts,
+multi-region aliases, ambient Application Default Credentials, and arbitrary
+Model Garden entries are not promised by this surface.
 
 Vertex rows remain provider-qualified (`vertex::<model>`), even when the raw
 model id matches a direct Anthropic or Gemini row. That identity is also the

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -86,6 +86,28 @@ Existing machinery that already follows this:
 - Registry flags such as `supports_vendor_web_search` — honest absence beats
   a half-working path.
 
+## Google Vertex AI
+
+Vertex is a first-class serving provider, not a Gemini credential mode. One
+validated Google Cloud service account can route two curated native protocol
+families:
+
+- Gemini models use Vertex GenerateContent under the `google` publisher.
+- Claude models use Anthropic Messages through Vertex `streamRawPredict`.
+
+The provider derives its host from a validated `global` or regional location;
+credentials cannot supply an endpoint. Uploaded service-account JSON is
+exchanged only through Google's fixed OAuth token endpoint and never appears in
+the provider API response. Custom Vertex hosts, multi-region aliases, ambient
+Application Default Credentials, and arbitrary Model Garden entries are not
+promised by this surface.
+
+Vertex rows remain provider-qualified (`vertex::<model>`), even when the raw
+model id matches a direct Anthropic or Gemini row. That identity is also the
+native-replay boundary: a Claude reasoning block produced through Vertex may
+replay only to the same Vertex model. Switching to direct Anthropic (or the
+reverse) drops the opaque block and keeps the portable transcript.
+
 ## Checklist for a new provider-coupled feature
 
 Before merging something that adds provider-native state to a turn:

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -78,7 +78,9 @@ Consequences:
 Existing machinery that already follows this:
 
 - [`MessageReasoning::replayable_for`](../crates/openwave-core/src/provider.rs)
-  — thinking blocks only for the minting route.
+  — thinking blocks and signed Gemini function-call state only for the minting
+  route. Foreign or legacy Gemini history uses Google's documented validator
+  bypass instead of replaying another route's opaque signature.
 - [`ProviderToolReplay::replayable_for`](../crates/openwave-core/src/provider.rs)
   — provider-executed native blocks only for the minting route.
 - Host-shaped cleartext on `ProviderExecutedToolCall.output` — what foreign
@@ -113,7 +115,10 @@ Vertex rows remain provider-qualified (`vertex::<model>`), even when the raw
 model id matches a direct Anthropic or Gemini row. That identity is also the
 native-replay boundary: a Claude reasoning block produced through Vertex may
 replay only to the same Vertex model. Switching to direct Anthropic (or the
-reverse) drops the opaque block and keeps the portable transcript.
+reverse) drops the opaque block and keeps the portable transcript. Gemini
+`thoughtSignature` values follow the same rule between direct Gemini and
+Vertex Gemini, while durable function-call ids remain paired with their
+responses on either route.
 
 ## Checklist for a new provider-coupled feature
 

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -95,15 +95,19 @@ families:
 - Gemini models use Vertex GenerateContent under the `google` publisher.
 - Claude models use Anthropic Messages through Vertex `streamRawPredict`.
 
-The provider derives its host from a validated `global` or regional location;
-credentials cannot supply an endpoint. Curated Claude rows are first-class only
-at `global`: Google's other documented Claude locations are multi-regions this
-surface deliberately does not accept, so a single-region setting leaves those
-rows unavailable and routes only the supported Gemini family. Uploaded
-service-account JSON is exchanged only through Google's fixed OAuth token
-endpoint and never appears in the provider API response. Custom Vertex hosts,
-multi-region aliases, ambient Application Default Credentials, and arbitrary
-Model Garden entries are not promised by this surface.
+The provider uses the `global` Vertex location for every curated row;
+credentials cannot supply an endpoint. A regional value written by an older
+build remains unavailable until it is changed to `global`, and new regional
+values are rejected. Uploaded service-account JSON is exchanged only through
+Google's fixed OAuth token endpoint and never appears in the provider API
+response. Custom Vertex hosts, regional and multi-region locations, ambient
+Application Default Credentials, and arbitrary Model Garden entries are not
+promised by this surface.
+
+Legacy Gemini service-account configurations keep their existing validated
+location setting for compatibility with older regional models. Curated Gemini 3
+requests still use the global endpoint. New service-account configurations
+belong under the global-only Vertex provider.
 
 Vertex rows remain provider-qualified (`vertex::<model>`), even when the raw
 model id matches a direct Anthropic or Gemini row. That identity is also the


### PR DESCRIPTION
## Summary

- add Google Vertex AI as an explicit provider with provider-qualified routing
- route curated Gemini models through native Vertex GenerateContent and curated Claude models through Anthropic Messages on streamRawPredict
- reuse the fixed-endpoint, redacted Google service-account token boundary and preserve legacy Gemini service-account configurations
- add conservative Vertex model metadata, settings/API/UI support, provider-specific replay gating, and protocol request fixtures

## Auth and supported surface

- accepts uploaded Google Cloud service-account JSON and exchanges it only through the fixed Google OAuth token endpoint
- derives global or validated regional Vertex hosts; credential material cannot choose an endpoint
- intentionally does not add ambient Application Default Credentials, custom Vertex hosts, multi-region aliases, arbitrary Model Garden entries, or Anthropic server-side web search on Vertex
- keeps all new Vertex provider/model rows unverified until live tool and streaming contracts are exercised

## Verification

- cargo test -p openwave-router --locked
- cargo test -p openwave-server --locked model_registry::tests
- cargo test -p openwave-server --locked vertex_provider_accepts_only_derived_google_endpoints_and_service_account_auth
- cargo test -p openwave-server --locked wire_types::tests::the_generated_bindings_are_current
- cargo clippy -p openwave-server --all-targets --locked -- -D warnings
- pnpm --dir crates/openwave-desktop/ui exec vitest run src/ModelSelection.test.ts src/ModelMenu.test.tsx src/settings/ProvidersPanel.dom.test.tsx
- pnpm --dir crates/openwave-desktop/ui build

Closes #1770