### PR TITLE
feat(router): add native xAI Responses provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ foreground/background execution model is described in
 | Crate | What it is |
 | --- | --- |
 | [`openwave-core`](crates/openwave-core) | agent loop, tools, event stream, storage traits |
-| [`openwave-router`](crates/openwave-router) | Anthropic and OpenAI-compatible providers + model routing |
+| [`openwave-router`](crates/openwave-router) | Anthropic, OpenAI, xAI, Gemini, and compatible providers + model routing |
 | [`openwave-code-execution`](crates/openwave-code-execution) | provider-neutral command execution + native local sandbox |
 | [`openwave-server`](crates/openwave-server) | authenticated local HTTP/WebSocket API + durable workers |
 | [`openwave-connectors`](crates/openwave-connectors) | OAuth + source connectors |

--- a/crates/openwave-core/src/image.rs
+++ b/crates/openwave-core/src/image.rs
@@ -46,12 +46,12 @@ pub const MAX_IMAGE_BYTES: u64 = 16 * 1024 * 1024;
 
 /// Image formats OpenWave will send to a provider.
 ///
-/// Deliberately closed. Every variant here is accepted by both the Anthropic
-/// and OpenAI image APIs, so a value of this type can always be shaped for the
-/// selected provider — adapters never have to reject a media type at send time.
-/// Vector and exotic raster formats are excluded rather than passed through:
-/// an unsupported type must fail at the trusted ingest boundary, where the user
-/// can still act on it, not deep inside a turn.
+/// Deliberately closed. Every variant here is accepted by the baseline
+/// Anthropic and OpenAI image APIs. A provider with a narrower documented set
+/// must refuse its unsupported variants before egress (xAI, for example,
+/// accepts only PNG and JPEG) rather than passing them through to a provider
+/// 400. Vector and exotic raster formats are excluded at the trusted ingest
+/// boundary instead of being passed through at all.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, TS)]
 #[serde(rename_all = "snake_case")]
 pub enum ImageMediaType {

--- a/crates/openwave-core/src/provider.rs
+++ b/crates/openwave-core/src/provider.rs
@@ -658,8 +658,8 @@ pub enum ProviderEvent {
     /// One reasoning block, complete and opaque, as the provider emitted it.
     ///
     /// Where `ReasoningDelta` is display text, this is the replayable
-    /// artifact (an Anthropic `thinking` or `redacted_thinking` block,
-    /// signature included). `data` is the block exactly as the provider
+    /// artifact (an Anthropic `thinking` / `redacted_thinking` block or an xAI
+    /// encrypted `reasoning` item). `data` is the block exactly as the provider
     /// accepts it back; consumers must not parse, filter, or reorder it,
     /// because replay validity depends on the blocks matching what the model
     /// generated. Carried in-memory for one turn at most — it is never

--- a/crates/openwave-desktop/ui/src/ModelMenu.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.tsx
@@ -29,7 +29,12 @@ import { cn } from "@/lib/utils";
  * not reshuffle when a provider is configured or a custom endpoint gains a
  * model — muscle memory is worth more here than catalog order.
  */
-const PROVIDER_ORDER: readonly ProviderKind[] = ["anthropic", "openai", "gemini"];
+const PROVIDER_ORDER: readonly ProviderKind[] = [
+  "anthropic",
+  "openai",
+  "xai",
+  "gemini",
+];
 
 const UNVERIFIED_TOOLTIP =
   "OpenWave hasn't verified tool-calling and streaming for this model; issues are likely the model or provider, not the app";

--- a/crates/openwave-desktop/ui/src/ModelSelection.test.ts
+++ b/crates/openwave-desktop/ui/src/ModelSelection.test.ts
@@ -61,6 +61,7 @@ describe("typed model selection", () => {
 
   it("uses product-facing provider labels", () => {
     expect(providerLabel("openai")).toBe("OpenAI");
+    expect(providerLabel("xai")).toBe("xAI");
     expect(providerLabel("gemini")).toBe("Google Gemini");
     expect(providerLabel("openai_compatible")).toBe("OpenAI-compatible");
   });

--- a/crates/openwave-desktop/ui/src/ModelSelection.ts
+++ b/crates/openwave-desktop/ui/src/ModelSelection.ts
@@ -40,6 +40,8 @@ export function providerLabel(provider: ProviderKind): string {
       return "Anthropic";
     case "openai":
       return "OpenAI";
+    case "xai":
+      return "xAI";
     case "gemini":
       return "Google Gemini";
     case "openai_compatible":

--- a/crates/openwave-desktop/ui/src/ProviderIcons.tsx
+++ b/crates/openwave-desktop/ui/src/ProviderIcons.tsx
@@ -52,6 +52,24 @@ export function GeminiIcon(props: IconProps) {
   );
 }
 
+export function XaiIcon(props: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.4"
+      strokeLinecap="round"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M5 4l14 16" />
+      <path d="M19 4L5 20" />
+    </svg>
+  );
+}
+
 export function KimiIcon(props: IconProps) {
   return (
     <svg
@@ -113,6 +131,8 @@ export function ProviderIcon({
       return <ClaudeIcon {...rest} />;
     case "openai":
       return <OpenAIIcon {...rest} />;
+    case "xai":
+      return <XaiIcon {...rest} />;
     case "gemini":
       return <GeminiIcon {...rest} />;
     case "openai_compatible":

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1183,12 +1183,12 @@ export type HostRootId = string;
 /**
  * Image formats OpenWave will send to a provider.
  *
- * Deliberately closed. Every variant here is accepted by both the Anthropic
- * and OpenAI image APIs, so a value of this type can always be shaped for the
- * selected provider — adapters never have to reject a media type at send time.
- * Vector and exotic raster formats are excluded rather than passed through:
- * an unsupported type must fail at the trusted ingest boundary, where the user
- * can still act on it, not deep inside a turn.
+ * Deliberately closed. Every variant here is accepted by the baseline
+ * Anthropic and OpenAI image APIs. A provider with a narrower documented set
+ * must refuse its unsupported variants before egress (xAI, for example,
+ * accepts only PNG and JPEG) rather than passing them through to a provider
+ * 400. Vector and exotic raster formats are excluded at the trusted ingest
+ * boundary instead of being passed through at all.
  */
 export type ImageMediaType = "png" | "jpeg" | "webp" | "gif";
 

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -929,8 +929,11 @@ export type ConsentVerb = { "kind": "tool", action: RendererToolName, approval: 
 export type CredentialPlacement = "bearer" | { "header": string };
 
 /**
- * Conservative, user-inspectable capabilities for one model served by an
- * OpenAI-compatible endpoint.
+ * User-inspectable routing limits and capabilities for one configured model.
+ *
+ * OpenAI-compatible rows are validated to the conservative text-only shape.
+ * xAI rows may opt into the capabilities its first-party Responses adapter
+ * actually carries end to end.
  */
 export type CustomModelConfig = { 
 /**
@@ -957,7 +960,19 @@ context_window: number,
 /**
  * Maximum output sent to the endpoint.
  */
-max_output_tokens: number, };
+max_output_tokens: number, 
+/**
+ * Inputs OpenWave may place on this model's request.
+ */
+input_modalities: Array<InputModality>, 
+/**
+ * Whether the model uses xAI's reasoning request shape.
+ */
+supports_reasoning: boolean, 
+/**
+ * Reasoning-effort levels accepted by the model, ascending.
+ */
+reasoning_efforts: Array<ReasoningEffort>, };
 
 /**
  * Wire mirror of the admission gate's typed denial reasons
@@ -1891,7 +1906,7 @@ has_credential: boolean,
  */
 auth_mode?: ProviderAuthMode, 
 /**
- * Explicit custom model entries for this endpoint.
+ * Explicit configured model entries for this endpoint.
  */
 models: Array<CustomModelConfig>, };
 
@@ -1899,7 +1914,7 @@ models: Array<CustomModelConfig>, };
  * The known provider kinds. `#[non_exhaustive]` so new kinds can land without
  * breaking wire clients that match on the string form.
  */
-export type ProviderKind = "anthropic" | "openai" | "gemini" | "openai_compatible" | "model_gateway";
+export type ProviderKind = "anthropic" | "openai" | "xai" | "gemini" | "openai_compatible" | "model_gateway";
 
 /**
  * How hard a reasoning-capable model should think before answering.

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
@@ -137,6 +137,7 @@ describe("ProvidersPanel", () => {
     fireEvent.click(screen.getByRole("checkbox", { name: "low" }));
     fireEvent.click(screen.getByRole("checkbox", { name: "medium" }));
     fireEvent.click(screen.getByRole("checkbox", { name: "high" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "xhigh" }));
     fireEvent.click(
       screen.getByRole("button", { name: "Save configuration" }),
     );
@@ -153,7 +154,7 @@ describe("ProvidersPanel", () => {
             max_output_tokens: 4_096,
             input_modalities: ["text", "image"],
             supports_reasoning: true,
-            reasoning_efforts: ["low", "medium", "high"],
+            reasoning_efforts: ["low", "medium", "high", "xhigh"],
           },
         ],
       }),

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
@@ -62,6 +62,9 @@ describe("ProvidersPanel", () => {
             display_name: "Vendor Model",
             context_window: 65_536,
             max_output_tokens: 8_192,
+            input_modalities: ["text"],
+            supports_reasoning: false,
+            reasoning_efforts: [],
           },
         ],
       }),
@@ -101,8 +104,62 @@ describe("ProvidersPanel", () => {
       id: "vendor/model",
       context_window: 32_768,
       max_output_tokens: 4_096,
+      input_modalities: ["text"],
+      supports_reasoning: false,
+      reasoning_efforts: [],
     });
     expect("display_name" in sent.models[0]).toBe(false);
+  });
+
+  it("configures xAI model capabilities without an endpoint override", async () => {
+    const xai: ProviderInfo = {
+      kind: "xai",
+      enabled: false,
+      has_credential: false,
+      models: [],
+    };
+    const putProvider = vi.fn().mockResolvedValue(xai);
+    const client = { putProvider } as unknown as ApiClient;
+
+    render(
+      <ProvidersPanel providers={[xai]} client={client} onChanged={vi.fn()} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Add model" }));
+    fireEvent.change(screen.getByLabelText("Custom model 1 ID"), {
+      target: { value: "grok-account-model" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("API key"), {
+      target: { value: "xai-key" },
+    });
+    fireEvent.click(screen.getByRole("checkbox", { name: "Image input" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Reasoning model" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "low" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "medium" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "high" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Save configuration" }),
+    );
+
+    await waitFor(() =>
+      expect(putProvider).toHaveBeenCalledWith("xai", {
+        enabled: true,
+        credential: { type: "api_key", key: "xai-key" },
+        models: [
+          {
+            id: "grok-account-model",
+            display_name: undefined,
+            context_window: 32_768,
+            max_output_tokens: 4_096,
+            input_modalities: ["text", "image"],
+            supports_reasoning: true,
+            reasoning_efforts: ["low", "medium", "high"],
+          },
+        ],
+      }),
+    );
+    expect(screen.queryByPlaceholderText(/base URL/i)).not.toBeInTheDocument();
+    expect(screen.getByText("Requests go directly to api.x.ai/v1.")).toBeInTheDocument();
   });
 
   it("does not expose custom model registration for curated providers", () => {

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
@@ -134,6 +134,7 @@ describe("ProvidersPanel", () => {
     });
     fireEvent.click(screen.getByRole("checkbox", { name: "Image input" }));
     fireEvent.click(screen.getByRole("checkbox", { name: "Reasoning model" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "none" }));
     fireEvent.click(screen.getByRole("checkbox", { name: "low" }));
     fireEvent.click(screen.getByRole("checkbox", { name: "medium" }));
     fireEvent.click(screen.getByRole("checkbox", { name: "high" }));
@@ -154,7 +155,7 @@ describe("ProvidersPanel", () => {
             max_output_tokens: 4_096,
             input_modalities: ["text", "image"],
             supports_reasoning: true,
-            reasoning_efforts: ["low", "medium", "high", "xhigh"],
+            reasoning_efforts: ["none", "low", "medium", "high", "xhigh"],
           },
         ],
       }),

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -5,9 +5,11 @@ import type {
   CustomModelConfig,
   ProviderInfo,
   ProviderKind,
+  ReasoningEffort,
 } from "../api";
 import { openSignInPage } from "../openSignInPage";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -26,6 +28,22 @@ const CHATGPT_SIGN_IN_POLL_MS = 2_000;
 // Matches the server's sign-in window; polling past it can only report a
 // timeout the server has already recorded.
 const CHATGPT_SIGN_IN_TIMEOUT_MS = 5 * 60 * 1000;
+const XAI_REASONING_EFFORTS: readonly ReasoningEffort[] = [
+  "low",
+  "medium",
+  "high",
+];
+
+function newConfiguredModel(): CustomModelConfig {
+  return {
+    id: "",
+    context_window: 32_768,
+    max_output_tokens: 4_096,
+    input_modalities: ["text"],
+    supports_reasoning: false,
+    reasoning_efforts: [],
+  };
+}
 
 export function ProvidersPanel({
   providers,
@@ -97,6 +115,8 @@ function ProviderRow({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const { confirm, dialog } = useConfirm();
+  const hasConfigurableModels =
+    info.kind === "openai_compatible" || info.kind === "xai";
 
   async function save(enabled: boolean) {
     setSaving(true);
@@ -111,8 +131,10 @@ function ProviderRow({
           | { type: "service_account"; json: string };
         models?: CustomModelConfig[];
       } = { enabled };
-      if (info.kind === "openai_compatible") {
-        body.base_url = baseUrl.trim() || null;
+      if (hasConfigurableModels) {
+        if (info.kind === "openai_compatible") {
+          body.base_url = baseUrl.trim() || null;
+        }
         body.models = models.map((model) => ({
           ...model,
           id: model.id.trim(),
@@ -120,6 +142,9 @@ function ProviderRow({
           // unset display name and what it sends back. `models` is a full
           // replacement list, so an absent key clears it just as null did.
           display_name: model.display_name?.trim() || undefined,
+          input_modalities: model.input_modalities ?? ["text"],
+          supports_reasoning: model.supports_reasoning ?? false,
+          reasoning_efforts: model.reasoning_efforts ?? [],
         }));
       }
       if (key.trim()) {
@@ -185,14 +210,21 @@ function ProviderRow({
           onCheckedChange={(checked) => void save(checked)}
         />
       </div>
-      {info.kind === "openai_compatible" && (
+      {hasConfigurableModels && (
         <>
-          <Input
-            type="text"
-            placeholder="base URL (e.g. http://127.0.0.1:1234/v1)"
-            value={baseUrl}
-            onChange={(e) => setBaseUrl(e.target.value)}
-          />
+          {info.kind === "openai_compatible" && (
+            <Input
+              type="text"
+              placeholder="base URL (e.g. http://127.0.0.1:1234/v1)"
+              value={baseUrl}
+              onChange={(e) => setBaseUrl(e.target.value)}
+            />
+          )}
+          {info.kind === "xai" && (
+            <p className="text-xs text-muted-foreground">
+              Requests go directly to api.x.ai/v1.
+            </p>
+          )}
           <div className="space-y-2">
             <div className="flex items-center justify-between gap-3">
               <span className="text-sm font-medium">Models</span>
@@ -201,14 +233,7 @@ function ProviderRow({
                 variant="outline"
                 disabled={saving}
                 onClick={() =>
-                  setModels((current) => [
-                    ...current,
-                    {
-                      id: "",
-                      context_window: 32_768,
-                      max_output_tokens: 4_096,
-                    },
-                  ])
+                  setModels((current) => [...current, newConfiguredModel()])
                 }
               >
                 Add model
@@ -216,8 +241,9 @@ function ProviderRow({
             </div>
             {models.length === 0 && (
               <p className="text-xs text-muted-foreground">
-                Add each model this endpoint serves. Custom models start with
-                conservative text-only, non-reasoning capabilities.
+                {info.kind === "xai"
+                  ? "Add each xAI model available to this API key, including its limits and supported capabilities."
+                  : "Add each model this endpoint serves. Custom models start with conservative text-only, non-reasoning capabilities."}
               </p>
             )}
             {models.map((model, index) => (
@@ -302,6 +328,99 @@ function ProviderRow({
                     />
                   </label>
                 </div>
+                {info.kind === "xai" && (
+                  <div className="grid gap-2 rounded-md bg-muted/40 p-2 text-xs">
+                    <label className="flex items-center gap-2">
+                      <Checkbox
+                        checked={
+                          model.input_modalities?.includes("image") ?? false
+                        }
+                        disabled={saving}
+                        onCheckedChange={(checked) =>
+                          setModels((current) =>
+                            current.map((item, itemIndex) =>
+                              itemIndex === index
+                                ? {
+                                    ...item,
+                                    input_modalities:
+                                      checked === true
+                                        ? ["text", "image"]
+                                        : ["text"],
+                                  }
+                                : item,
+                            ),
+                          )
+                        }
+                      />
+                      Image input
+                    </label>
+                    <label className="flex items-center gap-2">
+                      <Checkbox
+                        checked={model.supports_reasoning ?? false}
+                        disabled={saving}
+                        onCheckedChange={(checked) =>
+                          setModels((current) =>
+                            current.map((item, itemIndex) =>
+                              itemIndex === index
+                                ? {
+                                    ...item,
+                                    supports_reasoning: checked === true,
+                                    reasoning_efforts:
+                                      checked === true
+                                        ? item.reasoning_efforts ?? []
+                                        : [],
+                                  }
+                                : item,
+                            ),
+                          )
+                        }
+                      />
+                      Reasoning model
+                    </label>
+                    {model.supports_reasoning && (
+                      <div className="grid gap-1">
+                        <span className="text-muted-foreground">
+                          Supported reasoning efforts
+                        </span>
+                        <div className="flex flex-wrap gap-3">
+                          {XAI_REASONING_EFFORTS.map((effort) => (
+                            <label
+                              className="flex items-center gap-1.5"
+                              key={effort}
+                            >
+                              <Checkbox
+                                checked={
+                                  model.reasoning_efforts?.includes(effort) ??
+                                  false
+                                }
+                                disabled={saving}
+                                onCheckedChange={(checked) =>
+                                  setModels((current) =>
+                                    current.map((item, itemIndex) => {
+                                      if (itemIndex !== index) return item;
+                                      const selected = new Set(
+                                        item.reasoning_efforts ?? [],
+                                      );
+                                      if (checked === true) selected.add(effort);
+                                      else selected.delete(effort);
+                                      return {
+                                        ...item,
+                                        reasoning_efforts: XAI_REASONING_EFFORTS.filter(
+                                          (candidate) => selected.has(candidate),
+                                        ),
+                                      };
+                                    }),
+                                  )
+                                }
+                              />
+                              {effort}
+                            </label>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
                 <Button
                   type="button"
                   variant="outline"
@@ -404,7 +523,9 @@ function ProviderRow({
               credentialType === "service_account" &&
               !serviceAccountJson.trim()) ||
             (info.kind === "openai_compatible" &&
-              models.some((model) => !model.id.trim()))
+              models.some((model) => !model.id.trim())) ||
+            (info.kind === "xai" &&
+              (models.length === 0 || models.some((model) => !model.id.trim())))
           }
           onClick={() => void save(true)}
         >

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -29,6 +29,7 @@ const CHATGPT_SIGN_IN_POLL_MS = 2_000;
 // timeout the server has already recorded.
 const CHATGPT_SIGN_IN_TIMEOUT_MS = 5 * 60 * 1000;
 const XAI_REASONING_EFFORTS: readonly ReasoningEffort[] = [
+  "none",
   "low",
   "medium",
   "high",

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -32,6 +32,7 @@ const XAI_REASONING_EFFORTS: readonly ReasoningEffort[] = [
   "low",
   "medium",
   "high",
+  "xhigh",
 ];
 
 function newConfiguredModel(): CustomModelConfig {

--- a/crates/openwave-router/Cargo.toml
+++ b/crates/openwave-router/Cargo.toml
@@ -11,11 +11,14 @@ authors.workspace = true
 workspace = true
 
 [features]
-default = ["anthropic", "openai", "openai-compat", "gemini"]
+default = ["anthropic", "openai", "xai", "openai-compat", "gemini"]
 # The Anthropic (Messages API) provider adapter.
 anthropic = ["_http"]
 # Native OpenAI Responses API adapter.
 openai = ["_http"]
+# First-party xAI Responses API adapter. It reuses the shared Responses
+# transport while retaining a distinct provider identity and error profile.
+xai = ["openai"]
 # OpenAI-compatible Chat Completions adapter (OpenRouter, vLLM, …).
 openai-compat = ["_http"]
 # Google Gemini Developer API adapter (native GenerateContent protocol).

--- a/crates/openwave-router/src/lib.rs
+++ b/crates/openwave-router/src/lib.rs
@@ -23,6 +23,9 @@ pub mod openai_compat;
 #[cfg(feature = "openai")]
 pub mod openai;
 
+#[cfg(feature = "xai")]
+pub mod xai;
+
 #[cfg(feature = "gemini")]
 pub mod gemini;
 
@@ -43,3 +46,5 @@ pub use openai::OpenAiProvider;
 #[cfg(feature = "openai-compat")]
 pub use openai_compat::OpenAiCompatProvider;
 pub use router::{BearerTokenSource, Route, RouteKind, Router, VertexRoute};
+#[cfg(feature = "xai")]
+pub use xai::XaiProvider;

--- a/crates/openwave-router/src/openai.rs
+++ b/crates/openwave-router/src/openai.rs
@@ -15,7 +15,7 @@ use openwave_core::provider::{
     ProviderId, RefusalDetails, ResponseFormat, StopReason, ToolChoice, Usage,
 };
 use openwave_core::tool::{strict_json_schema, OptionalProperties};
-use openwave_core::{ImageAttachments, Role};
+use openwave_core::Role;
 
 use crate::sse::{
     classify_in_band_error, classify_provider_error, drain_frames, frame_data,
@@ -134,6 +134,11 @@ impl OpenAiProvider {
     pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
         self.base_url = base_url.into();
         self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn base_url_for_test(&self) -> &str {
+        &self.base_url
     }
 
     /// Fetch the credential from `source` at each request instead of using a
@@ -255,7 +260,7 @@ pub(crate) fn build_request_json_for(
     req: &ChatRequest,
     profile: ResponsesProfile,
 ) -> Result<Value> {
-    let input = build_input(req)?;
+    let input = build_input_for(req, profile)?;
     let mut body = json!({
         "model": req.model,
         "input": input,
@@ -271,6 +276,12 @@ pub(crate) fn build_request_json_for(
             } else {
                 json!({ "effort": effort.as_str() })
             };
+        }
+        if profile == ResponsesProfile::Xai {
+            // xAI is stateless here (`store: false`). Its encrypted reasoning
+            // output is the only provider-native state that preserves full
+            // context across later turns and tool continuations.
+            body["include"] = json!(["reasoning.encrypted_content"]);
         }
     } else if profile == ResponsesProfile::OpenAi {
         if let Some(temperature) = req.temperature {
@@ -324,7 +335,7 @@ pub(crate) fn build_request_json_for(
     Ok(body)
 }
 
-fn build_input(req: &ChatRequest) -> Result<Vec<Value>> {
+fn build_input_for(req: &ChatRequest, profile: ResponsesProfile) -> Result<Vec<Value>> {
     let mut out = Vec::new();
     if let Some(system) = &req.system {
         out.push(json!({
@@ -338,19 +349,25 @@ fn build_input(req: &ChatRequest) -> Result<Vec<Value>> {
     // carries two different tools called the same thing.
     let rename_client_web_search = req.vendor_web_search.is_some();
     for message in &req.messages {
-        extend_input(&mut out, message, &req.images, rename_client_web_search)?;
+        extend_input(&mut out, message, req, rename_client_web_search, profile)?;
     }
     Ok(sanitize_tool_pairs(out))
+}
+
+#[cfg(test)]
+fn build_input(req: &ChatRequest) -> Result<Vec<Value>> {
+    build_input_for(req, ResponsesProfile::OpenAi)
 }
 
 fn extend_input(
     out: &mut Vec<Value>,
     message: &openwave_core::ChatMessage,
-    images: &ImageAttachments,
+    req: &ChatRequest,
     rename_client_web_search: bool,
+    profile: ResponsesProfile,
 ) -> Result<()> {
     if message.role == Role::Assistant {
-        return extend_assistant_input(out, message, rename_client_web_search);
+        return extend_assistant_input(out, message, req, rename_client_web_search, profile);
     }
     let mut message_parts = Vec::new();
     for block in &message.content {
@@ -359,12 +376,23 @@ fn extend_input(
                 message_parts.push(json!({ "type": "input_text", "text": text }));
             }
             ContentBlock::Image { image } => {
-                let data = images.get(image.blob_id).ok_or_else(|| {
+                let data = req.images.get(image.blob_id).ok_or_else(|| {
                     AgentError::Provider(format!(
                         "image attachment {} has no hydrated bytes",
                         image.blob_id
                     ))
                 })?;
+                if profile == ResponsesProfile::Xai
+                    && matches!(
+                        data.media_type(),
+                        openwave_core::ImageMediaType::Webp | openwave_core::ImageMediaType::Gif
+                    )
+                {
+                    return Err(AgentError::Provider(format!(
+                        "xai image input supports only PNG and JPEG, not {}",
+                        data.media_type()
+                    )));
+                }
                 message_parts.push(json!({
                     "type": "input_image",
                     "image_url": format!(
@@ -435,8 +463,19 @@ fn extend_input(
 fn extend_assistant_input(
     out: &mut Vec<Value>,
     message: &openwave_core::ChatMessage,
+    req: &ChatRequest,
     rename_client_web_search: bool,
+    profile: ResponsesProfile,
 ) -> Result<()> {
+    if profile == ResponsesProfile::Xai && req.reasoning_model {
+        out.extend(
+            message
+                .reasoning
+                .replayable_for(req.provider.as_ref(), &req.model)
+                .iter()
+                .cloned(),
+        );
+    }
     let mut texts = Vec::new();
     let mut calls = Vec::new();
     for block in &message.content {
@@ -674,6 +713,16 @@ fn normalize_for(
         "response.output_item.done" => {
             if data["item"]["type"] == "web_search_call" {
                 return finish_search(&data["item"], state, provider);
+            }
+            if provider == "xai"
+                && data["item"]["type"] == "reasoning"
+                && data["item"]["encrypted_content"]
+                    .as_str()
+                    .is_some_and(|content| !content.is_empty())
+            {
+                return vec![ProviderEvent::ReasoningBlock {
+                    data: data["item"].clone(),
+                }];
             }
             start_call(data, state, true)
         }
@@ -913,7 +962,7 @@ mod tests {
     use super::*;
     use openwave_core::provider::{ChatMessage, MessageReasoning, VendorWebSearch};
     use openwave_core::tool::ToolSpec;
-    use openwave_core::{ImageData, ImageMediaType, ImageRef, ReasoningEffort};
+    use openwave_core::{ImageAttachments, ImageData, ImageMediaType, ImageRef, ReasoningEffort};
 
     fn tool() -> ToolSpec {
         ToolSpec {

--- a/crates/openwave-router/src/openai.rs
+++ b/crates/openwave-router/src/openai.rs
@@ -1,4 +1,4 @@
-//! Native OpenAI Responses API provider.
+//! Shared native Responses API transport for OpenAI and xAI.
 
 use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
@@ -19,7 +19,7 @@ use openwave_core::{ImageAttachments, Role};
 
 use crate::sse::{
     classify_in_band_error, classify_provider_error, drain_frames, frame_data,
-    read_bounded_error_body,
+    read_bounded_error_body, safe_http_error,
 };
 use crate::BearerTokenSource;
 
@@ -27,6 +27,62 @@ const DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
 const DEFAULT_MAX_TOKENS: u32 = 4096;
 const CHATGPT_BETA_HEADER: &str = "responses=v1";
 const DEFAULT_CHATGPT_ORIGINATOR: &str = "openwave";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ResponsesProfile {
+    OpenAi,
+    Xai,
+}
+
+impl ResponsesProfile {
+    const fn provider(self) -> &'static str {
+        match self {
+            Self::OpenAi => "openai",
+            Self::Xai => "xai",
+        }
+    }
+
+    fn classify_http_error(
+        self,
+        status: u16,
+        body: &str,
+        retry_after: Option<std::time::Duration>,
+    ) -> AgentError {
+        // xAI currently reports a bad API key as a 400 with a human message,
+        // rather than the 401 / `invalid_api_key` shape the shared classifier
+        // already recognizes. Inspect only for classification; the client-safe
+        // message still comes from the same bounded/redacted formatter.
+        if self == Self::Xai && status == 400 && xai_bad_api_key(body) {
+            return AgentError::Authentication(safe_http_error("xai", status, body));
+        }
+        classify_provider_error(self.provider(), status, body, retry_after)
+    }
+}
+
+fn xai_bad_api_key(body: &str) -> bool {
+    let parsed = serde_json::from_str::<Value>(body).ok();
+    let top_level_error = parsed
+        .as_ref()
+        .and_then(|value| value.get("error"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let error = parsed
+        .as_ref()
+        .map(|value| value.get("error").unwrap_or(value));
+    let code = error
+        .and_then(|value| value.get("code").or_else(|| value.get("type")))
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let message = error
+        .and_then(|value| value.get("message"))
+        .and_then(Value::as_str)
+        .unwrap_or(top_level_error)
+        .to_ascii_lowercase();
+    matches!(code.as_str(), "invalid_api_key" | "authentication_error")
+        || message.contains("incorrect api key")
+        || message.contains("invalid api key")
+}
 
 /// A [`ModelProvider`] for OpenAI's native Responses API.
 #[derive(Clone)]
@@ -42,6 +98,7 @@ pub struct OpenAiProvider {
     chatgpt_account_id: Option<String>,
     /// `originator` header value when [`Self::chatgpt_account_id`] is set.
     chatgpt_originator: String,
+    profile: ResponsesProfile,
 }
 
 impl OpenAiProvider {
@@ -53,6 +110,23 @@ impl OpenAiProvider {
             token_source: None,
             chatgpt_account_id: None,
             chatgpt_originator: DEFAULT_CHATGPT_ORIGINATOR.to_string(),
+            profile: ResponsesProfile::OpenAi,
+        }
+    }
+
+    pub(crate) fn for_profile(
+        api_key: impl Into<String>,
+        base_url: impl Into<String>,
+        profile: ResponsesProfile,
+    ) -> Self {
+        Self {
+            client: crate::http::streaming_client(),
+            api_key: api_key.into(),
+            base_url: base_url.into(),
+            token_source: None,
+            chatgpt_account_id: None,
+            chatgpt_originator: DEFAULT_CHATGPT_ORIGINATOR.to_string(),
+            profile,
         }
     }
 
@@ -90,11 +164,12 @@ impl OpenAiProvider {
 #[async_trait]
 impl ModelProvider for OpenAiProvider {
     fn id(&self) -> ProviderId {
-        ProviderId::new("openai")
+        ProviderId::new(self.profile.provider())
     }
 
     async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
-        let body = build_request_json(&req)?;
+        let body = build_request_json_for(&req, self.profile)?;
+        let provider = self.profile.provider();
         let url = format!("{}/responses", self.base_url.trim_end_matches('/'));
         let api_key = match &self.token_source {
             Some(source) => source.bearer_token_for(req.conversation).await?,
@@ -115,18 +190,15 @@ impl ModelProvider for OpenAiProvider {
             .json(&body)
             .send()
             .await
-            .map_err(|_| AgentError::Provider("openai request failed".into()))?;
+            .map_err(|_| AgentError::Provider(format!("{provider} request failed")))?;
 
         let status = response.status();
         if !status.is_success() {
             let retry_after = crate::sse::retry_after_hint(response.headers());
             let body = read_bounded_error_body(response.bytes_stream()).await;
-            return Err(classify_provider_error(
-                "openai",
-                status.as_u16(),
-                &body,
-                retry_after,
-            ));
+            return Err(self
+                .profile
+                .classify_http_error(status.as_u16(), &body, retry_after));
         }
 
         let ceiling = crate::http::timeouts().total_stream;
@@ -140,7 +212,7 @@ impl ModelProvider for OpenAiProvider {
                     Ok(chunk) => chunk,
                     Err(error) => {
                         yield ProviderEvent::Failed {
-                            error: ProviderErrorInfo::provider(error.client_message("openai")),
+                            error: ProviderErrorInfo::provider(error.client_message(provider)),
                         };
                         return;
                     }
@@ -148,7 +220,7 @@ impl ModelProvider for OpenAiProvider {
                 buffer.extend_from_slice(&chunk);
                 for frame in drain_frames(&mut buffer) {
                     if let Some(data) = frame_data(&frame) {
-                        for event in normalize(&data, &mut state) {
+                        for event in normalize_for(&data, &mut state, provider) {
                             yield event;
                         }
                     }
@@ -157,14 +229,16 @@ impl ModelProvider for OpenAiProvider {
             if !buffer.is_empty() {
                 let frame = String::from_utf8_lossy(&buffer).into_owned();
                 if let Some(data) = frame_data(&frame) {
-                    for event in normalize(&data, &mut state) {
+                    for event in normalize_for(&data, &mut state, provider) {
                         yield event;
                     }
                 }
             }
             if !state.terminal {
                 yield ProviderEvent::Failed {
-                    error: ProviderErrorInfo::provider("openai stream ended before completion"),
+                    error: ProviderErrorInfo::provider(format!(
+                        "{provider} stream ended before completion"
+                    )),
                 };
             }
         };
@@ -172,7 +246,15 @@ impl ModelProvider for OpenAiProvider {
     }
 }
 
+#[cfg(test)]
 fn build_request_json(req: &ChatRequest) -> Result<Value> {
+    build_request_json_for(req, ResponsesProfile::OpenAi)
+}
+
+pub(crate) fn build_request_json_for(
+    req: &ChatRequest,
+    profile: ResponsesProfile,
+) -> Result<Value> {
     let input = build_input(req)?;
     let mut body = json!({
         "model": req.model,
@@ -184,10 +266,16 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
 
     if req.reasoning_model {
         if let Some(effort) = req.reasoning_effort {
-            body["reasoning"] = json!({ "effort": effort.as_str(), "summary": "auto" });
+            body["reasoning"] = if profile == ResponsesProfile::OpenAi {
+                json!({ "effort": effort.as_str(), "summary": "auto" })
+            } else {
+                json!({ "effort": effort.as_str() })
+            };
         }
-    } else if let Some(temperature) = req.temperature {
-        body["temperature"] = json!(temperature);
+    } else if profile == ResponsesProfile::OpenAi {
+        if let Some(temperature) = req.temperature {
+            body["temperature"] = json!(temperature);
+        }
     }
 
     if !req.tools.is_empty() {
@@ -229,7 +317,7 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
         None => {}
         Some(other) => {
             return Err(AgentError::Provider(format!(
-                "openai cannot enforce response format {other:?}"
+                "Responses API cannot enforce response format {other:?}"
             )))
         }
     }
@@ -328,7 +416,7 @@ fn extend_input(
             }
             other => {
                 return Err(AgentError::Provider(format!(
-                    "openai cannot express content block {other:?}"
+                    "Responses API cannot express content block {other:?}"
                 )))
             }
         }
@@ -356,7 +444,7 @@ fn extend_assistant_input(
             ContentBlock::Text { text } => texts.push(text.clone()),
             ContentBlock::Image { .. } => {
                 return Err(AgentError::Provider(
-                    "openai cannot express an image in assistant history".into(),
+                    "Responses API cannot express an image in assistant history".into(),
                 ))
             }
             ContentBlock::ToolUse { id, name, input } => {
@@ -396,7 +484,7 @@ fn extend_assistant_input(
             )),
             other => {
                 return Err(AgentError::Provider(format!(
-                    "openai cannot express content block {other:?}"
+                    "Responses API cannot express content block {other:?}"
                 )))
             }
         }
@@ -472,7 +560,7 @@ fn openai_tool_choice(choice: &ToolChoice) -> Result<Value> {
         ToolChoice::Tool { name } => json!({ "type": "function", "name": name }),
         other => {
             return Err(AgentError::Provider(format!(
-                "openai cannot express tool choice {other:?}"
+                "Responses API cannot express tool choice {other:?}"
             )))
         }
     })
@@ -519,7 +607,16 @@ struct CallState {
     saw_argument_delta: bool,
 }
 
+#[cfg(test)]
 fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
+    normalize_for(data, state, "openai")
+}
+
+fn normalize_for(
+    data: &Value,
+    state: &mut StreamState,
+    provider: &'static str,
+) -> Vec<ProviderEvent> {
     if state.terminal {
         return Vec::new();
     }
@@ -527,10 +624,10 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
     match event_type {
         "error" => {
             state.terminal = true;
-            let mut events = flush_search(state);
+            let mut events = flush_search(state, provider);
             events.push(ProviderEvent::Failed {
                 error: ProviderErrorInfo::from_error(&classify_in_band_error(
-                    "openai",
+                    provider,
                     data.get("error").unwrap_or(data),
                 )),
             });
@@ -576,14 +673,14 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
         }
         "response.output_item.done" => {
             if data["item"]["type"] == "web_search_call" {
-                return finish_search(&data["item"], state);
+                return finish_search(&data["item"], state, provider);
             }
             start_call(data, state, true)
         }
         "response.completed" => {
             state.terminal = true;
             let response = &data["response"];
-            let mut events = flush_search(state);
+            let mut events = flush_search(state, provider);
             events.extend(usage_event(response));
             if state.refused {
                 events.push(ProviderEvent::Refusal {
@@ -604,7 +701,7 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
         "response.incomplete" => {
             state.terminal = true;
             let response = &data["response"];
-            let mut events = flush_search(state);
+            let mut events = flush_search(state, provider);
             events.extend(usage_event(response));
             match response["incomplete_details"]["reason"].as_str() {
                 Some("max_output_tokens") => events.push(ProviderEvent::Stop {
@@ -614,9 +711,9 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
                     details: RefusalDetails::from_category(Some("content_filter")),
                 }),
                 _ => events.push(ProviderEvent::Failed {
-                    error: ProviderErrorInfo::provider(
-                        "openai response ended incomplete without a supported reason",
-                    ),
+                    error: ProviderErrorInfo::provider(format!(
+                        "{provider} response ended incomplete without a supported reason"
+                    )),
                 }),
             }
             events
@@ -624,9 +721,9 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
         "response.failed" => {
             state.terminal = true;
             let error = data["response"].get("error").unwrap_or(&data["response"]);
-            let mut events = flush_search(state);
+            let mut events = flush_search(state, provider);
             events.push(ProviderEvent::Failed {
-                error: ProviderErrorInfo::from_error(&classify_in_band_error("openai", error)),
+                error: ProviderErrorInfo::from_error(&classify_in_band_error(provider, error)),
             });
             events
         }
@@ -640,10 +737,14 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
 /// search was pending before it. A search that ended any other way produced
 /// nothing to cite, so it goes out immediately as a failure — dropping it
 /// would hide from the host that the model tried to search at all.
-fn finish_search(item: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
+fn finish_search(
+    item: &Value,
+    state: &mut StreamState,
+    provider: &'static str,
+) -> Vec<ProviderEvent> {
     let input = search_input(item.get("action"));
     let status = item["status"].as_str().unwrap_or_default();
-    let mut events = flush_search(state);
+    let mut events = flush_search(state, provider);
     if status == "completed" {
         state.pending_search = Some(PendingSearch {
             input,
@@ -716,7 +817,7 @@ fn collect_citation(annotation: &Value, state: &mut StreamState) {
 
 /// Emit the pending search, if there is one, as a finished provider-executed
 /// call.
-fn flush_search(state: &mut StreamState) -> Vec<ProviderEvent> {
+fn flush_search(state: &mut StreamState, provider: &'static str) -> Vec<ProviderEvent> {
     let Some(search) = state.pending_search.take() else {
         return Vec::new();
     };
@@ -725,7 +826,7 @@ fn flush_search(state: &mut StreamState) -> Vec<ProviderEvent> {
         input: search.input,
         // A search that cited nothing still ran, and is reported as a search
         // that found nothing rather than as a failure.
-        output: json!({ "provider": "openai", "results": search.results }),
+        output: json!({ "provider": provider, "results": search.results }),
         is_error: false,
         replay: None,
     }]

--- a/crates/openwave-router/src/openai.rs
+++ b/crates/openwave-router/src/openai.rs
@@ -283,7 +283,7 @@ pub(crate) fn build_request_json_for(
             // context across later turns and tool continuations.
             body["include"] = json!(["reasoning.encrypted_content"]);
         }
-    } else if profile == ResponsesProfile::OpenAi {
+    } else {
         if let Some(temperature) = req.temperature {
             body["temperature"] = json!(temperature);
         }

--- a/crates/openwave-router/src/router.rs
+++ b/crates/openwave-router/src/router.rs
@@ -409,13 +409,10 @@ fn build_adapter(route: &Route) -> Option<Arc<dyn ModelProvider>> {
             Some(Arc::new(p))
         }
         #[cfg(feature = "xai")]
-        RouteKind::Xai => {
-            let mut p = XaiProvider::new(route.api_key.clone());
-            if let Some(base) = &route.base_url {
-                p = p.with_base_url(base.clone());
-            }
-            Some(Arc::new(p))
-        }
+        // xAI credentials are valid only for the fixed first-party endpoint.
+        // Ignore even a directly constructed route override so stale config
+        // cannot redirect the bearer token around the server's collector.
+        RouteKind::Xai => Some(Arc::new(XaiProvider::new(route.api_key.clone()))),
         #[cfg(feature = "openai-compat")]
         RouteKind::OpenaiCompatible => {
             let base = route.base_url.as_deref()?;

--- a/crates/openwave-router/src/router.rs
+++ b/crates/openwave-router/src/router.rs
@@ -25,6 +25,8 @@ use crate::GeminiProvider;
 use crate::OpenAiCompatProvider;
 #[cfg(feature = "openai")]
 use crate::OpenAiProvider;
+#[cfg(feature = "xai")]
+use crate::XaiProvider;
 
 /// Header a model-gateway deployment reads to group inference into one
 /// conversation. Gateway adapters opt in explicitly; direct providers never
@@ -106,6 +108,8 @@ pub enum RouteKind {
     Anthropic,
     /// Native OpenAI Responses API (api.openai.com).
     Openai,
+    /// Native xAI Responses API (api.x.ai).
+    Xai,
     /// Any OpenAI-compatible Chat Completions gateway.
     OpenaiCompatible,
     /// Google Gemini Developer API (native GenerateContent protocol).
@@ -127,6 +131,7 @@ impl RouteKind {
         match self {
             RouteKind::Anthropic => "anthropic",
             RouteKind::Openai => "openai",
+            RouteKind::Xai => "xai",
             RouteKind::OpenaiCompatible => "openai_compatible",
             RouteKind::Gemini => "gemini",
             RouteKind::ModelGateway => "model_gateway",
@@ -147,6 +152,7 @@ impl RouteKind {
         match value {
             "anthropic" => Some(Self::Anthropic),
             "openai" => Some(Self::Openai),
+            "xai" => Some(Self::Xai),
             "openai_compatible" => Some(Self::OpenaiCompatible),
             "gemini" => Some(Self::Gemini),
             "model_gateway" => Some(Self::ModelGateway),
@@ -249,6 +255,7 @@ impl Router {
         for kind in [
             RouteKind::Anthropic,
             RouteKind::Openai,
+            RouteKind::Xai,
             RouteKind::Gemini,
             RouteKind::ModelGateway,
             RouteKind::ModelGatewayOpenai,
@@ -401,6 +408,14 @@ fn build_adapter(route: &Route) -> Option<Arc<dyn ModelProvider>> {
             }
             Some(Arc::new(p))
         }
+        #[cfg(feature = "xai")]
+        RouteKind::Xai => {
+            let mut p = XaiProvider::new(route.api_key.clone());
+            if let Some(base) = &route.base_url {
+                p = p.with_base_url(base.clone());
+            }
+            Some(Arc::new(p))
+        }
         #[cfg(feature = "openai-compat")]
         RouteKind::OpenaiCompatible => {
             let base = route.base_url.as_deref()?;
@@ -439,6 +454,8 @@ fn build_adapter(route: &Route) -> Option<Arc<dyn ModelProvider>> {
         RouteKind::Gemini => None,
         #[cfg(not(feature = "openai"))]
         RouteKind::Openai => None,
+        #[cfg(not(feature = "xai"))]
+        RouteKind::Xai => None,
         #[cfg(not(feature = "openai-compat"))]
         RouteKind::OpenaiCompatible => None,
     }
@@ -532,6 +549,28 @@ mod tests {
         let router = Router::build(vec![route(RouteKind::Openai, "sk-o", &["gpt-4o"], None)]);
         assert_eq!(router.select("gpt-4o"), Some(RouteKind::Openai));
         assert_eq!(router.select("unknown"), None);
+    }
+
+    #[test]
+    fn explicit_xai_model_selects_xai_without_compat_fallback() {
+        let router = Router::build(vec![
+            route(RouteKind::Xai, "xai-key", &["grok-custom"], None),
+            route(
+                RouteKind::OpenaiCompatible,
+                "compat-key",
+                &[],
+                Some("http://127.0.0.1:1234/v1"),
+            ),
+        ]);
+        assert_eq!(router.select("grok-custom"), Some(RouteKind::Xai));
+        assert_eq!(
+            router.select_for(Some(&ProviderId::new("xai")), "grok-custom"),
+            Some(RouteKind::Xai)
+        );
+        assert_eq!(
+            router.select_for(Some(&ProviderId::new("openai")), "grok-custom"),
+            None
+        );
     }
 
     #[test]

--- a/crates/openwave-router/src/router.rs
+++ b/crates/openwave-router/src/router.rs
@@ -309,7 +309,7 @@ impl ModelProvider for Router {
         ProviderId::new("router")
     }
 
-    async fn stream(&self, mut req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+    async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
         let Some(kind) = self.select_for(req.provider.as_ref(), &req.model) else {
             return Err(AgentError::config(format!(
                 "provider `{}` is unavailable or cannot serve model `{}`",
@@ -325,8 +325,9 @@ impl ModelProvider for Router {
                 req.model
             )));
         };
-        // The route hint is host policy, not provider wire data.
-        req.provider = None;
+        // The route hint is host policy, not provider wire data, but adapters
+        // retain it for origin-gating provider-native replay. Their encoders
+        // must never serialize it into the provider request body.
         adapter.stream(req).await
     }
 }
@@ -511,7 +512,13 @@ fn fnv1a64(s: &str) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "xai")]
+    use openwave_core::provider::{ContentBlock, MessageReasoning, ReasoningOrigin};
     use openwave_core::ImageAttachments;
+    #[cfg(feature = "xai")]
+    use openwave_core::{ChatMessage, Role};
+    #[cfg(feature = "xai")]
+    use serde_json::json;
 
     fn route(kind: RouteKind, key: &str, models: &[&str], base: Option<&str>) -> Route {
         Route {
@@ -769,5 +776,80 @@ mod tests {
             Err(err) => assert!(err.to_string().contains("unavailable")),
             Ok(_) => panic!("expected fail-closed error"),
         }
+    }
+
+    #[cfg(feature = "xai")]
+    struct XaiShapingProbe {
+        body: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<serde_json::Value>>>,
+    }
+
+    #[cfg(feature = "xai")]
+    #[async_trait]
+    impl ModelProvider for XaiShapingProbe {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("xai")
+        }
+
+        async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            let body =
+                crate::openai::build_request_json_for(&req, crate::openai::ResponsesProfile::Xai)?;
+            if let Some(tx) = self.body.lock().unwrap().take() {
+                let _ = tx.send(body);
+            }
+            Ok(Box::pin(futures::stream::empty::<ProviderEvent>()))
+        }
+    }
+
+    #[cfg(feature = "xai")]
+    #[tokio::test]
+    async fn router_preserves_xai_identity_for_reasoning_replay_without_serializing_it() {
+        let reasoning = json!({
+            "id": "rs_previous",
+            "summary": [],
+            "type": "reasoning",
+            "status": "completed",
+            "encrypted_content": "opaque-previous",
+        });
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let mut adapters: HashMap<RouteKind, Arc<dyn ModelProvider>> = HashMap::new();
+        adapters.insert(
+            RouteKind::Xai,
+            Arc::new(XaiShapingProbe {
+                body: std::sync::Mutex::new(Some(tx)),
+            }),
+        );
+        let router = Router {
+            adapters,
+            curated: HashMap::from([("xai::grok-test".into(), RouteKind::Xai)]),
+            has_openai_compat: false,
+            fingerprint: String::new(),
+        };
+
+        let _stream = router
+            .stream(ChatRequest {
+                provider: Some(ProviderId::new("xai")),
+                model: "grok-test".into(),
+                reasoning_model: true,
+                messages: vec![ChatMessage {
+                    role: Role::Assistant,
+                    content: vec![ContentBlock::Text {
+                        text: "first answer".into(),
+                    }],
+                    reasoning: MessageReasoning::captured(
+                        ReasoningOrigin {
+                            provider: Some(ProviderId::new("xai")),
+                            model: "grok-test".into(),
+                        },
+                        vec![reasoning.clone()],
+                    ),
+                }],
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let body = rx.await.unwrap();
+        assert_eq!(body["input"][0], reasoning);
+        assert!(body.get("provider").is_none());
     }
 }

--- a/crates/openwave-router/src/sse.rs
+++ b/crates/openwave-router/src/sse.rs
@@ -196,6 +196,7 @@ fn contains_secret_marker(message: &str) -> bool {
         "bearer ",
         "api_key",
         "api-key",
+        "api key",
         "apikey",
         "authorization:",
         "x-goog-api-key",

--- a/crates/openwave-router/src/xai.rs
+++ b/crates/openwave-router/src/xai.rs
@@ -24,10 +24,15 @@ impl XaiProvider {
         }
     }
 
-    #[must_use]
-    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+    #[cfg(test)]
+    fn with_base_url_for_test(mut self, base_url: impl Into<String>) -> Self {
         self.inner = self.inner.with_base_url(base_url);
         self
+    }
+
+    #[cfg(test)]
+    fn base_url_for_test(&self) -> &str {
+        self.inner.base_url_for_test()
     }
 }
 
@@ -44,17 +49,32 @@ impl ModelProvider for XaiProvider {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::{Arc, Mutex};
+
     use super::*;
+    use axum::body::Body;
+    use axum::extract::{Request, State};
+    use axum::response::{IntoResponse, Response};
+    use axum::routing::any;
     use futures::StreamExt;
     use openwave_core::error::AgentError;
     use openwave_core::provider::{
         ContentBlock, MessageReasoning, ProviderToolReplay, ReasoningOrigin,
     };
-    use openwave_core::{ChatMessage, Role};
+    use openwave_core::tool::ToolSpec;
+    use openwave_core::{
+        ChatMessage, ImageAttachments, ImageData, ImageMediaType, ImageRef, ReasoningEffort, Role,
+    };
+    use serde_json::{json, Value};
+
+    const TEST_API_KEY: &str = "test-provider-key-not-a-secret";
 
     #[test]
     fn uses_a_distinct_provider_identity() {
-        assert_eq!(XaiProvider::new("key").id(), ProviderId::new("xai"));
+        let provider = XaiProvider::new("key");
+        assert_eq!(provider.id(), ProviderId::new("xai"));
+        assert_eq!(provider.base_url_for_test(), DEFAULT_BASE_URL);
     }
 
     #[test]
@@ -92,6 +112,124 @@ mod tests {
         assert!(!body.to_string().contains("opaque"));
     }
 
+    #[test]
+    fn same_route_reasoning_replays_for_a_stateless_continuation() {
+        let reasoning = reasoning_item("rs_previous", "opaque-previous");
+        let request = ChatRequest {
+            provider: Some(ProviderId::new("xai")),
+            model: "grok-test".into(),
+            reasoning_model: true,
+            messages: vec![
+                ChatMessage::text(Role::User, "first question"),
+                ChatMessage {
+                    role: Role::Assistant,
+                    content: vec![ContentBlock::Text {
+                        text: "first answer".into(),
+                    }],
+                    reasoning: MessageReasoning::captured(
+                        xai_origin("grok-test"),
+                        vec![reasoning.clone()],
+                    ),
+                },
+                ChatMessage::text(Role::User, "follow up"),
+            ],
+            ..Default::default()
+        };
+        let body = crate::openai::build_request_json_for(&request, ResponsesProfile::Xai)
+            .expect("same-route reasoning is a valid xAI input item");
+        let input = body["input"].as_array().unwrap();
+        assert_eq!(input[1], reasoning);
+        assert_eq!(input[2]["role"], "assistant");
+        assert_eq!(body["include"], json!(["reasoning.encrypted_content"]));
+    }
+
+    #[test]
+    fn provider_or_model_switch_omits_xai_reasoning() {
+        let step = |origin: ReasoningOrigin| ChatMessage {
+            role: Role::Assistant,
+            content: vec![ContentBlock::Text {
+                text: "first answer".into(),
+            }],
+            reasoning: MessageReasoning::captured(
+                origin,
+                vec![reasoning_item("rs_previous", "opaque-previous")],
+            ),
+        };
+        for message in [
+            step(ReasoningOrigin {
+                provider: Some(ProviderId::new("openai")),
+                model: "grok-test".into(),
+            }),
+            step(xai_origin("grok-other")),
+        ] {
+            let request = ChatRequest {
+                provider: Some(ProviderId::new("xai")),
+                model: "grok-test".into(),
+                reasoning_model: true,
+                messages: vec![message],
+                ..Default::default()
+            };
+            let body = crate::openai::build_request_json_for(&request, ResponsesProfile::Xai)
+                .expect("foreign reasoning flattens to ordinary assistant text");
+            assert!(
+                !body.to_string().contains("opaque-previous"),
+                "foreign provider-native state must not cross routes: {body}"
+            );
+        }
+    }
+
+    #[test]
+    fn xai_image_gate_allows_png_and_jpeg_but_refuses_webp_and_gif() {
+        for media_type in [ImageMediaType::Webp, ImageMediaType::Gif] {
+            let error = crate::openai::build_request_json_for(
+                &image_request(media_type),
+                ResponsesProfile::Xai,
+            )
+            .expect_err("xAI documents only PNG and JPEG image input");
+            assert!(error.to_string().contains(media_type.as_str()), "{error}");
+        }
+        for media_type in [ImageMediaType::Png, ImageMediaType::Jpeg] {
+            crate::openai::build_request_json_for(
+                &image_request(media_type),
+                ResponsesProfile::Xai,
+            )
+            .expect("xAI documents PNG and JPEG image input");
+        }
+    }
+
+    #[tokio::test]
+    async fn request_and_encrypted_reasoning_fixtures_match_the_xai_contract() {
+        let (minimal, _) = round_trip(
+            minimal_turn(),
+            "data: {\"type\":\"response.completed\",\"response\":{}}\n\n",
+        )
+        .await;
+        assert_eq!(
+            minimal,
+            fixture(include_str!(
+                "../tests/fixtures/xai/minimal_turn.request.json"
+            ))
+        );
+
+        let (tool_request, events) = round_trip(
+            tool_loop_closure(),
+            include_str!("../tests/fixtures/xai/tool_loop_closure.response.sse"),
+        )
+        .await;
+        assert_eq!(
+            tool_request,
+            fixture(include_str!(
+                "../tests/fixtures/xai/tool_loop_closure.request.json"
+            ))
+        );
+        assert_eq!(
+            serde_json::to_value(events).unwrap(),
+            fixture(include_str!(
+                "../tests/fixtures/xai/tool_loop_closure.events.json"
+            ))
+        );
+    }
+
     #[tokio::test]
     async fn classifies_xai_incorrect_key_400_as_authentication() {
         let body: serde_json::Value = serde_json::from_str(include_str!(
@@ -105,7 +243,7 @@ mod tests {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
-        let provider = XaiProvider::new("bad").with_base_url(format!("http://{address}"));
+        let provider = XaiProvider::new("bad").with_base_url_for_test(format!("http://{address}"));
         let result = provider
             .stream(ChatRequest {
                 model: "grok-test".into(),
@@ -133,7 +271,7 @@ mod tests {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
-        let provider = XaiProvider::new("key").with_base_url(format!("http://{address}"));
+        let provider = XaiProvider::new("key").with_base_url_for_test(format!("http://{address}"));
         let events = provider
             .stream(ChatRequest {
                 model: "grok-test".into(),
@@ -150,5 +288,209 @@ mod tests {
             panic!("expected failed event, got {:?}", events[0]);
         };
         assert!(error.message.contains("xai returned 500"));
+    }
+
+    fn xai_origin(model: &str) -> ReasoningOrigin {
+        ReasoningOrigin {
+            provider: Some(ProviderId::new("xai")),
+            model: model.into(),
+        }
+    }
+
+    fn reasoning_item(id: &str, encrypted_content: &str) -> Value {
+        json!({
+            "id": id,
+            "summary": [],
+            "type": "reasoning",
+            "status": "completed",
+            "encrypted_content": encrypted_content,
+        })
+    }
+
+    fn read_file_tool() -> ToolSpec {
+        ToolSpec {
+            name: "read_file".into(),
+            description: "Read a file from the workspace.".into(),
+            input_schema: json!({
+                "type": "object",
+                "properties": { "path": { "type": "string" } },
+                "required": ["path"],
+                "additionalProperties": false,
+            }),
+        }
+    }
+
+    fn image_request(media_type: ImageMediaType) -> ChatRequest {
+        let blob_id = uuid::Uuid::from_u128(match media_type {
+            ImageMediaType::Png => 1,
+            ImageMediaType::Jpeg => 2,
+            ImageMediaType::Webp => 3,
+            ImageMediaType::Gif => 4,
+        });
+        let image = ImageRef {
+            blob_id,
+            media_type,
+            width: 1,
+            height: 1,
+            byte_len: 3,
+        };
+        let mut images = ImageAttachments::new();
+        images.insert(blob_id, ImageData::new(media_type, vec![1, 2, 3]));
+        ChatRequest {
+            provider: Some(ProviderId::new("xai")),
+            model: "grok-vision".into(),
+            messages: vec![ChatMessage {
+                role: Role::User,
+                content: vec![ContentBlock::Image { image }],
+                reasoning: MessageReasoning::default(),
+            }],
+            images,
+            ..Default::default()
+        }
+    }
+
+    fn minimal_turn() -> ChatRequest {
+        ChatRequest {
+            provider: Some(ProviderId::new("xai")),
+            model: "grok-test".into(),
+            system: Some("You are a careful assistant.".into()),
+            messages: vec![ChatMessage::text(Role::User, "What changed in this file?")],
+            max_tokens: Some(1024),
+            temperature: Some(0.2),
+            ..Default::default()
+        }
+    }
+
+    fn tool_loop_closure() -> ChatRequest {
+        ChatRequest {
+            provider: Some(ProviderId::new("xai")),
+            model: "grok-test".into(),
+            system: Some("Use the tools.".into()),
+            messages: vec![
+                ChatMessage::text(Role::User, "Read both configs."),
+                ChatMessage {
+                    role: Role::Assistant,
+                    content: vec![
+                        ContentBlock::Text {
+                            text: "Reading both.".into(),
+                        },
+                        ContentBlock::ToolUse {
+                            id: "call_1".into(),
+                            name: "read_file".into(),
+                            input: json!({ "path": "a.toml" }),
+                        },
+                        ContentBlock::ToolUse {
+                            id: "call_2".into(),
+                            name: "read_file".into(),
+                            input: json!({ "path": "b.toml" }),
+                        },
+                    ],
+                    reasoning: MessageReasoning::captured(
+                        xai_origin("grok-test"),
+                        vec![reasoning_item("rs_previous", "opaque-previous")],
+                    ),
+                },
+                ChatMessage {
+                    role: Role::User,
+                    content: vec![
+                        ContentBlock::ToolResult {
+                            tool_use_id: "call_1".into(),
+                            content: "retries = 3".into(),
+                            is_error: false,
+                        },
+                        ContentBlock::ToolResult {
+                            tool_use_id: "call_2".into(),
+                            content: "no such file".into(),
+                            is_error: true,
+                        },
+                    ],
+                    reasoning: MessageReasoning::default(),
+                },
+            ],
+            tools: vec![read_file_tool()],
+            reasoning_model: true,
+            reasoning_effort: Some(ReasoningEffort::XHigh),
+            max_tokens: Some(4096),
+            ..Default::default()
+        }
+    }
+
+    #[derive(Clone)]
+    struct Endpoint {
+        captured: Arc<Mutex<Option<Value>>>,
+        response: Arc<String>,
+    }
+
+    async fn round_trip(request: ChatRequest, response: &str) -> (Value, Vec<ProviderEvent>) {
+        let endpoint = Endpoint {
+            captured: Arc::new(Mutex::new(None)),
+            response: Arc::new(response.to_owned()),
+        };
+        let app = axum::Router::new()
+            .fallback(any(intercept))
+            .with_state(endpoint.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let provider =
+            XaiProvider::new(TEST_API_KEY).with_base_url_for_test(format!("http://{address}"));
+        let events = provider
+            .stream(request)
+            .await
+            .unwrap()
+            .collect::<Vec<_>>()
+            .await;
+        server.abort();
+        let captured = endpoint
+            .captured
+            .lock()
+            .unwrap()
+            .take()
+            .expect("the adapter sent exactly one request");
+        (captured, events)
+    }
+
+    async fn intercept(State(endpoint): State<Endpoint>, request: Request) -> Response {
+        let (parts, body) = request.into_parts();
+        let mut headers = BTreeMap::new();
+        for (name, value) in &parts.headers {
+            let name = name.as_str().to_ascii_lowercase();
+            if [
+                "host",
+                "content-length",
+                "accept",
+                "accept-encoding",
+                "connection",
+                "user-agent",
+            ]
+            .contains(&name.as_str())
+            {
+                continue;
+            }
+            let value = if name == "authorization" {
+                "<redacted>".to_owned()
+            } else {
+                String::from_utf8_lossy(value.as_bytes()).into_owned()
+            };
+            headers.insert(name, Value::String(value));
+        }
+        let bytes = axum::body::to_bytes(body, usize::MAX).await.unwrap();
+        let body: Value = serde_json::from_slice(&bytes).unwrap();
+        *endpoint.captured.lock().unwrap() = Some(json!({
+            "method": parts.method.as_str(),
+            "path": parts.uri.path(),
+            "query": parts.uri.query(),
+            "headers": Value::Object(headers.into_iter().collect()),
+            "body": body,
+        }));
+        (
+            [(axum::http::header::CONTENT_TYPE, "text/event-stream")],
+            Body::from(endpoint.response.as_str().to_owned()),
+        )
+            .into_response()
+    }
+
+    fn fixture(source: &str) -> Value {
+        serde_json::from_str(source).unwrap()
     }
 }

--- a/crates/openwave-router/src/xai.rs
+++ b/crates/openwave-router/src/xai.rs
@@ -1,0 +1,154 @@
+//! First-class xAI provider on its native Responses API surface.
+
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+
+use openwave_core::error::Result;
+use openwave_core::provider::{ChatRequest, ModelProvider, ProviderEvent, ProviderId};
+
+use crate::openai::{OpenAiProvider, ResponsesProfile};
+
+/// xAI's public API root. The shared Responses transport appends `/responses`.
+pub const DEFAULT_BASE_URL: &str = "https://api.x.ai/v1";
+
+/// A [`ModelProvider`] for xAI's first-party Responses API.
+#[derive(Clone)]
+pub struct XaiProvider {
+    inner: OpenAiProvider,
+}
+
+impl XaiProvider {
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self {
+            inner: OpenAiProvider::for_profile(api_key, DEFAULT_BASE_URL, ResponsesProfile::Xai),
+        }
+    }
+
+    #[must_use]
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.inner = self.inner.with_base_url(base_url);
+        self
+    }
+}
+
+#[async_trait]
+impl ModelProvider for XaiProvider {
+    fn id(&self) -> ProviderId {
+        ProviderId::new("xai")
+    }
+
+    async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+        self.inner.stream(req).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+    use openwave_core::error::AgentError;
+    use openwave_core::provider::{
+        ContentBlock, MessageReasoning, ProviderToolReplay, ReasoningOrigin,
+    };
+    use openwave_core::{ChatMessage, Role};
+
+    #[test]
+    fn uses_a_distinct_provider_identity() {
+        assert_eq!(XaiProvider::new("key").id(), ProviderId::new("xai"));
+    }
+
+    #[test]
+    fn foreign_provider_tools_flatten_to_cleartext_on_xai() {
+        let request = ChatRequest {
+            provider: Some(ProviderId::new("xai")),
+            model: "grok-test".into(),
+            messages: vec![ChatMessage {
+                role: Role::Assistant,
+                content: vec![ContentBlock::ProviderExecutedToolCall {
+                    name: "web_search".into(),
+                    input: serde_json::json!({"query": "release notes"}),
+                    output: serde_json::json!({"results": [{"title": "Notes"}]}),
+                    is_error: false,
+                    replay: Some(ProviderToolReplay::captured(
+                        ReasoningOrigin {
+                            provider: Some(ProviderId::new("anthropic")),
+                            model: "claude-test".into(),
+                        },
+                        vec![serde_json::json!({"encrypted_content": "opaque"})],
+                    )),
+                }],
+                reasoning: MessageReasoning::default(),
+            }],
+            ..Default::default()
+        };
+        let body = crate::openai::build_request_json_for(&request, ResponsesProfile::Xai)
+            .expect("foreign provider output flattens to a normal Responses input");
+        let input = body["input"].as_array().unwrap();
+        assert_eq!(input.len(), 1);
+        assert_eq!(input[0]["role"], "assistant");
+        let cleartext = input[0]["content"].as_str().unwrap();
+        assert!(cleartext.contains("web_search"));
+        assert!(!body.to_string().contains("encrypted_content"));
+        assert!(!body.to_string().contains("opaque"));
+    }
+
+    #[tokio::test]
+    async fn classifies_xai_incorrect_key_400_as_authentication() {
+        let body: serde_json::Value = serde_json::from_str(include_str!(
+            "../tests/fixtures/xai/authentication_error.response.json"
+        ))
+        .unwrap();
+        let app = axum::Router::new().fallback(move || {
+            let body = body.clone();
+            async move { (axum::http::StatusCode::BAD_REQUEST, axum::Json(body)) }
+        });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let provider = XaiProvider::new("bad").with_base_url(format!("http://{address}"));
+        let result = provider
+            .stream(ChatRequest {
+                model: "grok-test".into(),
+                messages: vec![ChatMessage::text(Role::User, "hello")],
+                ..Default::default()
+            })
+            .await;
+        server.abort();
+        let error = match result {
+            Ok(_) => panic!("the provider must reject the bad key"),
+            Err(error) => error,
+        };
+        assert!(matches!(error, AgentError::Authentication(_)), "{error:?}");
+        assert!(error.to_string().contains("xai returned 400"));
+    }
+
+    #[tokio::test]
+    async fn stream_errors_keep_the_xai_identity() {
+        let app = axum::Router::new().fallback(|| async {
+            (
+                [(axum::http::header::CONTENT_TYPE, "text/event-stream")],
+                "data: {\"type\":\"response.failed\",\"response\":{\"error\":{\"type\":\"server_error\"}}}\n\n",
+            )
+        });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let provider = XaiProvider::new("key").with_base_url(format!("http://{address}"));
+        let events = provider
+            .stream(ChatRequest {
+                model: "grok-test".into(),
+                messages: vec![ChatMessage::text(Role::User, "hello")],
+                ..Default::default()
+            })
+            .await
+            .unwrap()
+            .collect::<Vec<_>>()
+            .await;
+        server.abort();
+        assert_eq!(events.len(), 1);
+        let ProviderEvent::Failed { error } = &events[0] else {
+            panic!("expected failed event, got {:?}", events[0]);
+        };
+        assert!(error.message.contains("xai returned 500"));
+    }
+}

--- a/crates/openwave-router/tests/fixtures/xai/authentication_error.response.json
+++ b/crates/openwave-router/tests/fixtures/xai/authentication_error.response.json
@@ -1,0 +1,4 @@
+{
+  "code": "Client specified an invalid argument",
+  "error": "Incorrect API key provided"
+}

--- a/crates/openwave-router/tests/fixtures/xai/minimal_turn.request.json
+++ b/crates/openwave-router/tests/fixtures/xai/minimal_turn.request.json
@@ -23,7 +23,8 @@
     "max_output_tokens": 1024,
     "model": "grok-test",
     "store": false,
-    "stream": true
+    "stream": true,
+    "temperature": 0.20000000298023224
   },
   "headers": {
     "authorization": "<redacted>",

--- a/crates/openwave-router/tests/fixtures/xai/minimal_turn.request.json
+++ b/crates/openwave-router/tests/fixtures/xai/minimal_turn.request.json
@@ -1,0 +1,35 @@
+{
+  "body": {
+    "input": [
+      {
+        "content": [
+          {
+            "text": "You are a careful assistant.",
+            "type": "input_text"
+          }
+        ],
+        "role": "system"
+      },
+      {
+        "content": [
+          {
+            "text": "What changed in this file?",
+            "type": "input_text"
+          }
+        ],
+        "role": "user"
+      }
+    ],
+    "max_output_tokens": 1024,
+    "model": "grok-test",
+    "store": false,
+    "stream": true
+  },
+  "headers": {
+    "authorization": "<redacted>",
+    "content-type": "application/json"
+  },
+  "method": "POST",
+  "path": "/responses",
+  "query": null
+}

--- a/crates/openwave-router/tests/fixtures/xai/tool_loop_closure.events.json
+++ b/crates/openwave-router/tests/fixtures/xai/tool_loop_closure.events.json
@@ -4,6 +4,16 @@
     "type": "reasoning_delta"
   },
   {
+    "data": {
+      "encrypted_content": "opaque-current",
+      "id": "rs_current",
+      "status": "completed",
+      "summary": [],
+      "type": "reasoning"
+    },
+    "type": "reasoning_block"
+  },
+  {
     "text": "a.toml is read. ",
     "type": "text_delta"
   },

--- a/crates/openwave-router/tests/fixtures/xai/tool_loop_closure.events.json
+++ b/crates/openwave-router/tests/fixtures/xai/tool_loop_closure.events.json
@@ -1,0 +1,41 @@
+[
+  {
+    "text": "Checking the files. ",
+    "type": "reasoning_delta"
+  },
+  {
+    "text": "a.toml is read. ",
+    "type": "text_delta"
+  },
+  {
+    "text": "Retrying b.toml.",
+    "type": "text_delta"
+  },
+  {
+    "id": "call_3",
+    "index": 0,
+    "name": "read_file",
+    "type": "tool_call_started"
+  },
+  {
+    "fragment": "{\"path\":",
+    "index": 0,
+    "type": "tool_call_args_delta"
+  },
+  {
+    "fragment": "\"b.toml\"}",
+    "index": 0,
+    "type": "tool_call_args_delta"
+  },
+  {
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 128,
+    "input_tokens": 284,
+    "output_tokens": 37,
+    "type": "usage"
+  },
+  {
+    "reason": "tool_use",
+    "type": "stop"
+  }
+]

--- a/crates/openwave-router/tests/fixtures/xai/tool_loop_closure.request.json
+++ b/crates/openwave-router/tests/fixtures/xai/tool_loop_closure.request.json
@@ -1,0 +1,84 @@
+{
+  "body": {
+    "input": [
+      {
+        "content": [
+          {
+            "text": "Use the tools.",
+            "type": "input_text"
+          }
+        ],
+        "role": "system"
+      },
+      {
+        "content": [
+          {
+            "text": "Read both configs.",
+            "type": "input_text"
+          }
+        ],
+        "role": "user"
+      },
+      {
+        "content": "Reading both.",
+        "role": "assistant"
+      },
+      {
+        "arguments": "{\"path\":\"a.toml\"}",
+        "call_id": "call_1",
+        "name": "read_file",
+        "type": "function_call"
+      },
+      {
+        "arguments": "{\"path\":\"b.toml\"}",
+        "call_id": "call_2",
+        "name": "read_file",
+        "type": "function_call"
+      },
+      {
+        "call_id": "call_1",
+        "output": "retries = 3",
+        "type": "function_call_output"
+      },
+      {
+        "call_id": "call_2",
+        "output": "Error: the tool call failed.\nno such file",
+        "type": "function_call_output"
+      }
+    ],
+    "max_output_tokens": 4096,
+    "model": "grok-test",
+    "reasoning": {
+      "effort": "high"
+    },
+    "store": false,
+    "stream": true,
+    "tools": [
+      {
+        "description": "Read a file from the workspace.",
+        "name": "read_file",
+        "parameters": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "path"
+          ],
+          "type": "object"
+        },
+        "strict": true,
+        "type": "function"
+      }
+    ]
+  },
+  "headers": {
+    "authorization": "<redacted>",
+    "content-type": "application/json"
+  },
+  "method": "POST",
+  "path": "/responses",
+  "query": null
+}

--- a/crates/openwave-router/tests/fixtures/xai/tool_loop_closure.request.json
+++ b/crates/openwave-router/tests/fixtures/xai/tool_loop_closure.request.json
@@ -1,5 +1,8 @@
 {
   "body": {
+    "include": [
+      "reasoning.encrypted_content"
+    ],
     "input": [
       {
         "content": [
@@ -18,6 +21,13 @@
           }
         ],
         "role": "user"
+      },
+      {
+        "encrypted_content": "opaque-previous",
+        "id": "rs_previous",
+        "status": "completed",
+        "summary": [],
+        "type": "reasoning"
       },
       {
         "content": "Reading both.",
@@ -49,7 +59,7 @@
     "max_output_tokens": 4096,
     "model": "grok-test",
     "reasoning": {
-      "effort": "high"
+      "effort": "xhigh"
     },
     "store": false,
     "stream": true,

--- a/crates/openwave-router/tests/fixtures/xai/tool_loop_closure.response.sse
+++ b/crates/openwave-router/tests/fixtures/xai/tool_loop_closure.response.sse
@@ -1,0 +1,15 @@
+data: {"type":"response.reasoning_summary_text.delta","delta":"Checking the files. "}
+
+data: {"type":"response.output_text.delta","delta":"a.toml is read. "}
+
+data: {"type":"response.output_text.delta","delta":"Retrying b.toml."}
+
+data: {"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_3","name":"read_file"}}
+
+data: {"type":"response.function_call_arguments.delta","call_id":"call_3","delta":"{\"path\":"}
+
+data: {"type":"response.function_call_arguments.delta","call_id":"call_3","delta":"\"b.toml\"}"}
+
+data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_3","name":"read_file","arguments":"{\"path\":\"b.toml\"}"}}
+
+data: {"type":"response.completed","response":{"usage":{"input_tokens":412,"input_tokens_details":{"cached_tokens":128},"output_tokens":37}}}

--- a/crates/openwave-router/tests/fixtures/xai/tool_loop_closure.response.sse
+++ b/crates/openwave-router/tests/fixtures/xai/tool_loop_closure.response.sse
@@ -1,5 +1,7 @@
 data: {"type":"response.reasoning_summary_text.delta","delta":"Checking the files. "}
 
+data: {"type":"response.output_item.done","item":{"id":"rs_current","summary":[],"type":"reasoning","status":"completed","encrypted_content":"opaque-current"}}
+
 data: {"type":"response.output_text.delta","delta":"a.toml is read. "}
 
 data: {"type":"response.output_text.delta","delta":"Retrying b.toml."}

--- a/crates/openwave-router/tests/replay_contracts.rs
+++ b/crates/openwave-router/tests/replay_contracts.rs
@@ -1,6 +1,6 @@
 //! Replay contracts: what each provider adapter actually puts on the wire.
 //!
-//! Adapters translate one normalized [`ChatRequest`] into four very different
+//! Adapters translate one normalized [`ChatRequest`] into several provider
 //! request shapes, and the translation is where provider drift bites: a new
 //! model generation starts rejecting a parameter an older one accepted, and the
 //! first thing anyone sees is a 400 in a user's turn. The unit tests in each
@@ -46,7 +46,9 @@ use openwave_core::{
     ChatMessage, ChatRequest, ContentBlock, MessageReasoning, ModelProvider, ProviderEvent,
     ResponseFormat, Role, ToolChoice, ToolSpec,
 };
-use openwave_router::{AnthropicProvider, GeminiProvider, OpenAiCompatProvider, OpenAiProvider};
+use openwave_router::{
+    AnthropicProvider, GeminiProvider, OpenAiCompatProvider, OpenAiProvider, XaiProvider,
+};
 use serde_json::{json, Value};
 
 /// The credential every adapter is handed. It must never reach a fixture: the
@@ -79,7 +81,7 @@ const REDACTED: &str = "<redacted>";
 
 /// The canonical requests every adapter is measured against.
 ///
-/// One list, shared by all four providers, so a fixture diff reads as "this is
+/// One list, shared by all adapters, so a fixture diff reads as "this is
 /// how provider X shapes the same turn" and the scenarios cannot drift apart
 /// per adapter.
 fn scenarios(model: &str) -> Vec<(&'static str, ChatRequest)> {
@@ -274,6 +276,17 @@ async fn openai_responses_request_contracts() {
 }
 
 #[tokio::test]
+async fn xai_responses_request_contracts() {
+    check_selected_adapter(
+        "xai",
+        "grok-test",
+        &["minimal_turn", "tool_loop_closure"],
+        |base_url| Arc::new(XaiProvider::new(TEST_API_KEY).with_base_url(base_url)),
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn openai_compat_request_contracts() {
     check_adapter("openai_compat", "gpt-5.6-sol", |base_url| {
         Arc::new(OpenAiCompatProvider::compatible(TEST_API_KEY, base_url))
@@ -296,7 +309,22 @@ async fn check_adapter(
     model: &str,
     build: impl Fn(&str) -> Arc<dyn ModelProvider>,
 ) {
-    for (scenario, request) in scenarios(model) {
+    check_selected_adapter(provider, model, &[], build).await;
+}
+
+/// Run only the named scenarios. An empty selection means every canonical
+/// scenario; direct xAI pins the two boundaries this provider claim depends on
+/// without duplicating all of OpenAI's shared encoder fixtures.
+async fn check_selected_adapter(
+    provider: &str,
+    model: &str,
+    selected: &[&str],
+    build: impl Fn(&str) -> Arc<dyn ModelProvider>,
+) {
+    for (scenario, request) in scenarios(model)
+        .into_iter()
+        .filter(|(scenario, _)| selected.is_empty() || selected.contains(scenario))
+    {
         let recording = recorded_response(provider, scenario);
         let response_body = recording
             .clone()
@@ -405,6 +433,7 @@ fn terminal_frame(provider: &str) -> &'static str {
             "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"}}\n\n"
         }
         "openai" => "data: {\"type\":\"response.completed\",\"response\":{}}\n\n",
+        "xai" => "data: {\"type\":\"response.completed\",\"response\":{}}\n\n",
         "openai_compat" => "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
         "gemini" => "data: {\"candidates\":[{\"finishReason\":\"STOP\"}]}\n\n",
         other => panic!("no terminal frame for {other}"),

--- a/crates/openwave-router/tests/replay_contracts.rs
+++ b/crates/openwave-router/tests/replay_contracts.rs
@@ -46,9 +46,7 @@ use openwave_core::{
     ChatMessage, ChatRequest, ContentBlock, MessageReasoning, ModelProvider, ProviderEvent,
     ResponseFormat, Role, ToolChoice, ToolSpec,
 };
-use openwave_router::{
-    AnthropicProvider, GeminiProvider, OpenAiCompatProvider, OpenAiProvider, XaiProvider,
-};
+use openwave_router::{AnthropicProvider, GeminiProvider, OpenAiCompatProvider, OpenAiProvider};
 use serde_json::{json, Value};
 
 /// The credential every adapter is handed. It must never reach a fixture: the
@@ -276,17 +274,6 @@ async fn openai_responses_request_contracts() {
 }
 
 #[tokio::test]
-async fn xai_responses_request_contracts() {
-    check_selected_adapter(
-        "xai",
-        "grok-test",
-        &["minimal_turn", "tool_loop_closure"],
-        |base_url| Arc::new(XaiProvider::new(TEST_API_KEY).with_base_url(base_url)),
-    )
-    .await;
-}
-
-#[tokio::test]
 async fn openai_compat_request_contracts() {
     check_adapter("openai_compat", "gpt-5.6-sol", |base_url| {
         Arc::new(OpenAiCompatProvider::compatible(TEST_API_KEY, base_url))
@@ -309,22 +296,7 @@ async fn check_adapter(
     model: &str,
     build: impl Fn(&str) -> Arc<dyn ModelProvider>,
 ) {
-    check_selected_adapter(provider, model, &[], build).await;
-}
-
-/// Run only the named scenarios. An empty selection means every canonical
-/// scenario; direct xAI pins the two boundaries this provider claim depends on
-/// without duplicating all of OpenAI's shared encoder fixtures.
-async fn check_selected_adapter(
-    provider: &str,
-    model: &str,
-    selected: &[&str],
-    build: impl Fn(&str) -> Arc<dyn ModelProvider>,
-) {
-    for (scenario, request) in scenarios(model)
-        .into_iter()
-        .filter(|(scenario, _)| selected.is_empty() || selected.contains(scenario))
-    {
+    for (scenario, request) in scenarios(model) {
         let recording = recorded_response(provider, scenario);
         let response_body = recording
             .clone()
@@ -433,7 +405,6 @@ fn terminal_frame(provider: &str) -> &'static str {
             "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"}}\n\n"
         }
         "openai" => "data: {\"type\":\"response.completed\",\"response\":{}}\n\n",
-        "xai" => "data: {\"type\":\"response.completed\",\"response\":{}}\n\n",
         "openai_compat" => "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
         "gemini" => "data: {\"candidates\":[{\"finishReason\":\"STOP\"}]}\n\n",
         other => panic!("no terminal frame for {other}"),

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -562,6 +562,9 @@ impl GatewayRuntime {
                     upstream_id: model.upstream_id,
                     context_window: clamp_u32(model.context_window, 32_768),
                     max_output_tokens: clamp_u32(model.max_output_tokens, 4_096),
+                    input_modalities: vec![crate::model_registry::InputModality::Text],
+                    supports_reasoning: false,
+                    reasoning_efforts: Vec::new(),
                 })
             })
             .collect();
@@ -1191,6 +1194,7 @@ mod tests {
                         display_name: Some("Opus (gateway)".to_string()),
                         context_window: 200_000,
                         max_output_tokens: 32_000,
+                        ..Default::default()
                     },
                     CustomModelConfig {
                         id: "anthropic-us-claude-opus-5".to_string(),
@@ -1198,6 +1202,7 @@ mod tests {
                         display_name: None,
                         context_window: 200_000,
                         max_output_tokens: 32_000,
+                        ..Default::default()
                     },
                     CustomModelConfig {
                         id: "acme-inhouse-llm".to_string(),
@@ -1205,6 +1210,7 @@ mod tests {
                         display_name: None,
                         context_window: 200_000,
                         max_output_tokens: 32_000,
+                        ..Default::default()
                     },
                 ],
                 model_protocols: Default::default(),
@@ -2086,6 +2092,7 @@ mod tests {
                     display_name: None,
                     context_window: 32_768,
                     max_output_tokens: 4_096,
+                    ..Default::default()
                 }],
             },
         )
@@ -2201,6 +2208,7 @@ mod tests {
                 display_name: None,
                 context_window: 32_768,
                 max_output_tokens: 4_096,
+                ..Default::default()
             }],
         };
         providers::write_config(
@@ -2278,6 +2286,7 @@ mod tests {
                     display_name: None,
                     context_window: 32_768,
                     max_output_tokens: 4_096,
+                    ..Default::default()
                 }],
             },
         )
@@ -2330,6 +2339,7 @@ mod tests {
                     display_name: None,
                     context_window: 32_768,
                     max_output_tokens: 4_096,
+                    ..Default::default()
                 }],
             },
         )

--- a/crates/openwave-server/src/model_registry.rs
+++ b/crates/openwave-server/src/model_registry.rs
@@ -12,7 +12,7 @@ use crate::providers::ProviderKind;
 ///
 /// `snake_case` matches the strings `as_str` has always produced, so the enum
 /// serializes exactly as the hand-built list of strings it replaces on the wire.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, ts_rs::TS)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 pub enum InputModality {
     /// Plain text and structured text content.
@@ -513,6 +513,7 @@ mod tests {
         match provider {
             ProviderKind::Anthropic => true,
             ProviderKind::Openai => true,
+            ProviderKind::Xai => true,
             ProviderKind::Gemini => true,
             ProviderKind::OpenaiCompatible => false,
             ProviderKind::ModelGateway => true,

--- a/crates/openwave-server/src/model_roles.rs
+++ b/crates/openwave-server/src/model_roles.rs
@@ -451,6 +451,7 @@ mod tests {
                         display_name: Some("Gateway Flagship".to_string()),
                         context_window: 1_000_000,
                         max_output_tokens: 64_000,
+                        ..Default::default()
                     },
                     CustomModelConfig {
                         id: "gateway-haiku".to_string(),
@@ -458,6 +459,7 @@ mod tests {
                         display_name: Some("Gateway Haiku".to_string()),
                         context_window: 200_000,
                         max_output_tokens: 8_192,
+                        ..Default::default()
                     },
                 ],
                 model_protocols: Default::default(),

--- a/crates/openwave-server/src/pairing.rs
+++ b/crates/openwave-server/src/pairing.rs
@@ -617,6 +617,7 @@ mod tests {
                     display_name: None,
                     context_window: 32_768,
                     max_output_tokens: 4_096,
+                    ..Default::default()
                 }],
                 model_protocols: Default::default(),
             },

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -252,6 +252,8 @@ pub enum ProviderKind {
     Anthropic,
     /// Native OpenAI Responses API (api.openai.com).
     Openai,
+    /// Native xAI Responses API (api.x.ai).
+    Xai,
     /// Google Gemini Developer API (generativelanguage.googleapis.com).
     Gemini,
     /// Any OpenAI-compatible Chat Completions gateway (OpenRouter, vLLM, …).
@@ -267,6 +269,7 @@ impl ProviderKind {
     pub const ALL: &'static [ProviderKind] = &[
         ProviderKind::Anthropic,
         ProviderKind::Openai,
+        ProviderKind::Xai,
         ProviderKind::Gemini,
         ProviderKind::OpenaiCompatible,
         ProviderKind::ModelGateway,
@@ -277,6 +280,7 @@ impl ProviderKind {
         match self {
             ProviderKind::Anthropic => "anthropic",
             ProviderKind::Openai => "openai",
+            ProviderKind::Xai => "xai",
             ProviderKind::Gemini => "gemini",
             ProviderKind::OpenaiCompatible => "openai_compatible",
             ProviderKind::ModelGateway => "model_gateway",
@@ -288,6 +292,7 @@ impl ProviderKind {
         match s {
             "anthropic" => Some(Self::Anthropic),
             "openai" => Some(Self::Openai),
+            "xai" => Some(Self::Xai),
             "gemini" => Some(Self::Gemini),
             "openai_compatible" => Some(Self::OpenaiCompatible),
             "model_gateway" => Some(Self::ModelGateway),
@@ -453,11 +458,12 @@ pub struct ProviderConfig {
     /// credential. An absent value defaults to `global`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub vertex_location: Option<String>,
-    /// Explicit model ids served by a custom OpenAI-compatible endpoint.
+    /// Explicit model rows served by a configurable endpoint.
     ///
-    /// Curated providers ignore this field and obtain their models from the
-    /// host registry. Keeping custom entries beside the endpoint removes the
-    /// old ambiguous global free-form model setting.
+    /// OpenAI-compatible and xAI catalogs can change independently of an
+    /// OpenWave release, so their configured rows live beside the endpoint.
+    /// Other curated providers ignore this field and obtain their models from
+    /// the host registry.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub models: Vec<CustomModelConfig>,
 }
@@ -482,8 +488,15 @@ fn default_custom_max_output_tokens() -> u32 {
     4_096
 }
 
-/// Conservative, user-inspectable capabilities for one model served by an
-/// OpenAI-compatible endpoint.
+fn default_custom_input_modalities() -> Vec<InputModality> {
+    vec![InputModality::Text]
+}
+
+/// User-inspectable routing limits and capabilities for one configured model.
+///
+/// OpenAI-compatible rows are validated to the conservative text-only shape.
+/// xAI rows may opt into the capabilities its first-party Responses adapter
+/// actually carries end to end.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 #[serde(deny_unknown_fields)]
 pub struct CustomModelConfig {
@@ -506,6 +519,30 @@ pub struct CustomModelConfig {
     /// Maximum output sent to the endpoint.
     #[serde(default = "default_custom_max_output_tokens")]
     pub max_output_tokens: u32,
+    /// Inputs OpenWave may place on this model's request.
+    #[serde(default = "default_custom_input_modalities")]
+    pub input_modalities: Vec<InputModality>,
+    /// Whether the model uses xAI's reasoning request shape.
+    #[serde(default)]
+    pub supports_reasoning: bool,
+    /// Reasoning-effort levels accepted by the model, ascending.
+    #[serde(default)]
+    pub reasoning_efforts: Vec<ReasoningEffort>,
+}
+
+impl Default for CustomModelConfig {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            display_name: None,
+            upstream_id: None,
+            context_window: default_custom_context_window(),
+            max_output_tokens: default_custom_max_output_tokens(),
+            input_modalities: default_custom_input_modalities(),
+            supports_reasoning: false,
+            reasoning_efforts: Vec::new(),
+        }
+    }
 }
 
 /// Owned runtime policy resolved from a provider-qualified selection.
@@ -599,6 +636,7 @@ impl ResolvedModelPolicy {
     }
 
     fn custom_for(provider: ProviderKind, model: &CustomModelConfig) -> Self {
+        let first_party_xai = provider == ProviderKind::Xai;
         Self {
             key: model_registry::selection_key(provider, &model.id),
             id: model.id.clone(),
@@ -611,16 +649,22 @@ impl ResolvedModelPolicy {
             verification: VerificationTier::Unverified,
             context_window: model.context_window,
             max_output_tokens: model.max_output_tokens,
-            input_modalities: vec![InputModality::Text],
-            // Unknown endpoints get deliberately conservative request shaping.
-            // Capability editing can be added later without changing the key.
-            supports_reasoning: false,
+            input_modalities: if first_party_xai {
+                model.input_modalities.clone()
+            } else {
+                vec![InputModality::Text]
+            },
+            supports_reasoning: first_party_xai && model.supports_reasoning,
             // A pass-through endpoint cannot promise a provider-executed
             // search, whatever upstream model it is serving — the request
             // shape that would enable one is the vendor's own, and this route
             // does not speak it. Deliberately not inherited by `gateway_for`.
             supports_vendor_web_search: false,
-            reasoning_efforts: Vec::new(),
+            reasoning_efforts: if first_party_xai {
+                model.reasoning_efforts.clone()
+            } else {
+                Vec::new()
+            },
         }
     }
 
@@ -633,6 +677,9 @@ impl ResolvedModelPolicy {
                 upstream_id: None,
                 context_window: default_custom_context_window(),
                 max_output_tokens: default_custom_max_output_tokens(),
+                input_modalities: default_custom_input_modalities(),
+                supports_reasoning: false,
+                reasoning_efforts: Vec::new(),
             },
         )
     }
@@ -785,7 +832,7 @@ pub struct ProviderInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub auth_mode: Option<ProviderAuthMode>,
-    /// Explicit custom model entries for this endpoint.
+    /// Explicit configured model entries for this endpoint.
     pub models: Vec<CustomModelConfig>,
 }
 
@@ -822,7 +869,8 @@ pub struct ProviderUpdate {
     pub vertex_location: Option<Option<String>>,
     #[serde(default)]
     pub credential: Option<ProviderCredential>,
-    /// Replacement custom-model list. Only valid for `openai_compatible`.
+    /// Replacement configured-model list. Valid for `openai_compatible` and
+    /// first-party xAI.
     #[serde(default)]
     pub models: Option<Vec<CustomModelConfig>>,
 }
@@ -1060,6 +1108,11 @@ pub async fn update_provider(
     }
     match update.base_url {
         None => {}
+        Some(_) if kind == ProviderKind::Xai => {
+            return Err(ServerError::bad_request(
+                "xai uses its fixed first-party API endpoint",
+            ));
+        }
         Some(None) => config.base_url = None,
         Some(Some(url)) => {
             if url.is_empty() {
@@ -1086,12 +1139,12 @@ pub async fn update_provider(
         }
     }
     if let Some(models) = update.models {
-        if kind != ProviderKind::OpenaiCompatible {
+        if !matches!(kind, ProviderKind::OpenaiCompatible | ProviderKind::Xai) {
             return Err(ServerError::bad_request(
-                "custom models are only supported by openai_compatible",
+                "configured models are only supported by openai_compatible and xai",
             ));
         }
-        validate_custom_models(&models)?;
+        validate_configured_models(kind, &models)?;
         config.models = models;
     }
 
@@ -1099,6 +1152,11 @@ pub async fn update_provider(
     if kind == ProviderKind::OpenaiCompatible && config.enabled && config.base_url.is_none() {
         return Err(ServerError::bad_request(
             "openai_compatible requires a base_url when enabled",
+        ));
+    }
+    if kind == ProviderKind::Xai && config.enabled && config.models.is_empty() {
+        return Err(ServerError::bad_request(
+            "xai requires at least one configured model when enabled",
         ));
     }
 
@@ -1127,12 +1185,20 @@ pub async fn update_provider(
 pub(crate) fn validate_custom_models(
     models: &[CustomModelConfig],
 ) -> std::result::Result<(), ServerError> {
-    validate_custom_models_against(models, |id| {
-        model_registry::find_for(ProviderKind::OpenaiCompatible, id).is_some()
+    validate_configured_models(ProviderKind::OpenaiCompatible, models)
+}
+
+fn validate_configured_models(
+    kind: ProviderKind,
+    models: &[CustomModelConfig],
+) -> std::result::Result<(), ServerError> {
+    validate_configured_models_against(kind, models, |id| {
+        model_registry::find_for(kind, id).is_some()
     })
 }
 
-fn validate_custom_models_against(
+fn validate_configured_models_against(
+    kind: ProviderKind,
     models: &[CustomModelConfig],
     is_curated: impl Fn(&str) -> bool,
 ) -> std::result::Result<(), ServerError> {
@@ -1143,7 +1209,7 @@ fn validate_custom_models_against(
 
     if models.len() > MAX_CUSTOM_MODELS {
         return Err(ServerError::bad_request(format!(
-            "openai_compatible supports at most {MAX_CUSTOM_MODELS} custom models"
+            "{kind} supports at most {MAX_CUSTOM_MODELS} configured models"
         )));
     }
     let mut ids = std::collections::HashSet::new();
@@ -1155,22 +1221,22 @@ fn validate_custom_models_against(
             || id.chars().any(char::is_control)
         {
             return Err(ServerError::bad_request(
-                "custom model id must be non-empty, bounded, and contain no whitespace or control characters",
+                "configured model id must be non-empty, bounded, and contain no whitespace or control characters",
             ));
         }
         if id != model.id {
             return Err(ServerError::bad_request(
-                "custom model id must not have leading or trailing whitespace",
+                "configured model id must not have leading or trailing whitespace",
             ));
         }
         if !ids.insert(id) {
             return Err(ServerError::bad_request(format!(
-                "duplicate custom model id `{id}`"
+                "duplicate configured model id `{id}`"
             )));
         }
         if is_curated(id) {
             return Err(ServerError::bad_request(format!(
-                "custom model id `{id}` conflicts with a curated openai_compatible model"
+                "configured model id `{id}` conflicts with a curated {kind} model"
             )));
         }
         if model.display_name.as_ref().is_some_and(|name| {
@@ -1180,17 +1246,65 @@ fn validate_custom_models_against(
                 || name.chars().any(char::is_control)
         }) {
             return Err(ServerError::bad_request(
-                "custom model display_name must be non-empty, bounded, and contain no control characters",
+                "configured model display_name must be non-empty, bounded, and contain no control characters",
             ));
         }
         if !(1_024..=MAX_CONTEXT_WINDOW).contains(&model.context_window) {
             return Err(ServerError::bad_request(format!(
-                "custom model `{id}` context_window must be between 1024 and {MAX_CONTEXT_WINDOW}"
+                "configured model `{id}` context_window must be between 1024 and {MAX_CONTEXT_WINDOW}"
             )));
         }
         if model.max_output_tokens == 0 || model.max_output_tokens > model.context_window {
             return Err(ServerError::bad_request(format!(
-                "custom model `{id}` max_output_tokens must be positive and not exceed context_window"
+                "configured model `{id}` max_output_tokens must be positive and not exceed context_window"
+            )));
+        }
+        if model.input_modalities.is_empty()
+            || !model.input_modalities.contains(&InputModality::Text)
+            || model
+                .input_modalities
+                .iter()
+                .enumerate()
+                .any(|(index, modality)| model.input_modalities[..index].contains(modality))
+        {
+            return Err(ServerError::bad_request(format!(
+                "configured model `{id}` input_modalities must contain text exactly once and no duplicates"
+            )));
+        }
+        if kind != ProviderKind::Xai && model.input_modalities != [InputModality::Text] {
+            return Err(ServerError::bad_request(
+                "only xai configured models may enable image input",
+            ));
+        }
+        if !model.supports_reasoning && !model.reasoning_efforts.is_empty() {
+            return Err(ServerError::bad_request(format!(
+                "configured model `{id}` cannot list reasoning_efforts when supports_reasoning is false"
+            )));
+        }
+        if kind != ProviderKind::Xai
+            && (model.supports_reasoning || !model.reasoning_efforts.is_empty())
+        {
+            return Err(ServerError::bad_request(
+                "only xai configured models may enable reasoning",
+            ));
+        }
+        if model
+            .reasoning_efforts
+            .windows(2)
+            .any(|pair| pair[0] >= pair[1])
+        {
+            return Err(ServerError::bad_request(format!(
+                "configured model `{id}` reasoning_efforts must be unique and ascending"
+            )));
+        }
+        if model.reasoning_efforts.iter().any(|effort| {
+            !matches!(
+                effort,
+                ReasoningEffort::Low | ReasoningEffort::Medium | ReasoningEffort::High
+            )
+        }) {
+            return Err(ServerError::bad_request(format!(
+                "configured model `{id}` uses a reasoning effort xai does not support"
             )));
         }
     }
@@ -1221,6 +1335,7 @@ fn env_api_key(kind: ProviderKind) -> Option<String> {
         ProviderKind::Openai => std::env::var("OPENAI_API_KEY")
             .ok()
             .filter(|k| !k.is_empty()),
+        ProviderKind::Xai => std::env::var("XAI_API_KEY").ok().filter(|k| !k.is_empty()),
         ProviderKind::Gemini => std::env::var("GEMINI_API_KEY")
             .ok()
             .filter(|k| !k.is_empty()),
@@ -1242,6 +1357,7 @@ pub fn route_kind(kind: ProviderKind) -> openwave_router::RouteKind {
     match kind {
         ProviderKind::Anthropic => openwave_router::RouteKind::Anthropic,
         ProviderKind::Openai => openwave_router::RouteKind::Openai,
+        ProviderKind::Xai => openwave_router::RouteKind::Xai,
         ProviderKind::Gemini => openwave_router::RouteKind::Gemini,
         ProviderKind::OpenaiCompatible => openwave_router::RouteKind::OpenaiCompatible,
         ProviderKind::ModelGateway => openwave_router::RouteKind::ModelGateway,
@@ -1428,6 +1544,9 @@ pub async fn collect_routes(
         if kind == ProviderKind::OpenaiCompatible && config.base_url.is_none() {
             continue;
         }
+        if kind == ProviderKind::Xai && config.models.is_empty() {
+            continue;
+        }
         if kind == ProviderKind::OpenaiCompatible {
             let base = config.base_url.as_deref().unwrap_or("");
             if !(base.starts_with("https://") || base.starts_with("http://")) {
@@ -1502,7 +1621,9 @@ pub async fn resolve_model_policy(
             return Ok(Some(ResolvedModelPolicy::curated(spec)));
         }
         let models = match provider {
-            ProviderKind::OpenaiCompatible => read_config(store, provider).await?.models,
+            ProviderKind::OpenaiCompatible | ProviderKind::Xai => {
+                read_config(store, provider).await?.models
+            }
             // Resolution is not an offer: usability and routing gate the
             // gateway on policy separately, so the raw snapshot read here
             // only keeps stored selections legible.
@@ -1521,17 +1642,19 @@ pub async fn resolve_model_policy(
             }));
     }
 
-    let config = read_config(store, ProviderKind::OpenaiCompatible).await?;
     let mut owners = model_registry::models_named(value)
         .map(ResolvedModelPolicy::curated)
         .collect::<Vec<_>>();
-    owners.extend(
-        config
-            .models
-            .iter()
-            .filter(|model| model.id == value)
-            .map(|model| ResolvedModelPolicy::custom_for(ProviderKind::OpenaiCompatible, model)),
-    );
+    for provider in [ProviderKind::Xai, ProviderKind::OpenaiCompatible] {
+        let config = read_config(store, provider).await?;
+        owners.extend(
+            config
+                .models
+                .iter()
+                .filter(|model| model.id == value)
+                .map(|model| ResolvedModelPolicy::custom_for(provider, model)),
+        );
+    }
     match owners.len() {
         1 => return Ok(owners.pop()),
         count if count > 1 => return Ok(None),
@@ -1587,6 +1710,9 @@ pub async fn provider_is_usable(
             return Ok(false);
         }
     }
+    if kind == ProviderKind::Xai && config.models.is_empty() {
+        return Ok(false);
+    }
     Ok(true)
 }
 
@@ -1608,7 +1734,9 @@ pub async fn catalog_models(
         // and the managed gateway's entitled snapshot — which is empty on an
         // unmanaged profile, so no gateway row ever reaches the catalog there.
         let configured = match kind {
-            ProviderKind::OpenaiCompatible => read_config(store, kind).await?.models,
+            ProviderKind::OpenaiCompatible | ProviderKind::Xai => {
+                read_config(store, kind).await?.models
+            }
             ProviderKind::ModelGateway => gateway_models(store, policy).await?,
             _ => Vec::new(),
         };
@@ -1720,6 +1848,10 @@ mod tests {
                 ProviderKind::Anthropic,
                 ProviderCredential::api_key("existing-api-key"),
             ),
+            (
+                ProviderKind::Xai,
+                ProviderCredential::api_key("existing-xai-api-key"),
+            ),
             (ProviderKind::Openai, ProviderCredential::Oauth {}),
             (
                 ProviderKind::Gemini,
@@ -1738,6 +1870,11 @@ mod tests {
                 Some(credential)
             );
         }
+        assert!(
+            write_credential(&secrets, ProviderKind::Xai, &ProviderCredential::Oauth {})
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]
@@ -1772,6 +1909,11 @@ mod tests {
             "provider.anthropic.credential"
         );
         assert_eq!(ProviderKind::Openai.setting_key(), "provider.openai");
+        assert_eq!(ProviderKind::parse("xai"), Some(ProviderKind::Xai));
+        assert_eq!(
+            ProviderKind::Xai.credential_key(),
+            "provider.xai.credential"
+        );
     }
 
     #[test]
@@ -1811,6 +1953,7 @@ mod tests {
             display_name: None,
             context_window: 32_768,
             max_output_tokens: 4_096,
+            ..Default::default()
         };
         let json = serde_json::to_value(&unset).expect("a model config serializes");
         assert!(
@@ -1866,12 +2009,17 @@ mod tests {
             display_name: Some("Local Model".into()),
             context_window: 32_768,
             max_output_tokens: 4_096,
+            ..Default::default()
         };
         assert!(validate_custom_models(std::slice::from_ref(&valid)).is_ok());
         assert!(validate_custom_models(&[valid.clone(), valid.clone()]).is_err());
         assert!(
-            validate_custom_models_against(std::slice::from_ref(&valid), |id| id == "local/model")
-                .is_err(),
+            validate_configured_models_against(
+                ProviderKind::OpenaiCompatible,
+                std::slice::from_ref(&valid),
+                |id| id == "local/model"
+            )
+            .is_err(),
             "custom ids must not shadow a curated id under the same provider"
         );
         assert!(validate_custom_models(&[CustomModelConfig {
@@ -1880,6 +2028,7 @@ mod tests {
             display_name: None,
             context_window: 32_768,
             max_output_tokens: 4_096,
+            ..Default::default()
         }])
         .is_err());
         assert!(validate_custom_models(&[CustomModelConfig {
@@ -1888,8 +2037,39 @@ mod tests {
             display_name: None,
             context_window: 1_000,
             max_output_tokens: 4_096,
+            ..Default::default()
         }])
         .is_err());
+    }
+
+    #[test]
+    fn xai_configured_models_carry_only_supported_capabilities() {
+        let model = CustomModelConfig {
+            id: "grok-account-model".into(),
+            display_name: Some("Grok account model".into()),
+            context_window: 500_000,
+            max_output_tokens: 32_768,
+            input_modalities: vec![InputModality::Text, InputModality::Image],
+            supports_reasoning: true,
+            reasoning_efforts: vec![
+                ReasoningEffort::Low,
+                ReasoningEffort::Medium,
+                ReasoningEffort::High,
+            ],
+            ..Default::default()
+        };
+        validate_configured_models(ProviderKind::Xai, std::slice::from_ref(&model)).unwrap();
+
+        let policy = ResolvedModelPolicy::custom_for(ProviderKind::Xai, &model);
+        assert_eq!(policy.provider, ProviderKind::Xai);
+        assert_eq!(policy.input_modalities, model.input_modalities);
+        assert!(policy.supports_reasoning);
+        assert_eq!(policy.reasoning_efforts, model.reasoning_efforts);
+
+        let mut unsupported = model.clone();
+        unsupported.reasoning_efforts.push(ReasoningEffort::XHigh);
+        assert!(validate_configured_models(ProviderKind::Xai, &[unsupported]).is_err());
+        assert!(validate_configured_models(ProviderKind::OpenaiCompatible, &[model]).is_err());
     }
 
     #[test]
@@ -1945,6 +2125,7 @@ mod tests {
                 display_name: None,
                 context_window: 32_768,
                 max_output_tokens: 4_096,
+                ..Default::default()
             },
         );
         assert_eq!(custom.verification, VerificationTier::Unverified);

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -1300,7 +1300,10 @@ fn validate_configured_models_against(
         if model.reasoning_efforts.iter().any(|effort| {
             !matches!(
                 effort,
-                ReasoningEffort::Low | ReasoningEffort::Medium | ReasoningEffort::High
+                ReasoningEffort::Low
+                    | ReasoningEffort::Medium
+                    | ReasoningEffort::High
+                    | ReasoningEffort::XHigh
             )
         }) {
             return Err(ServerError::bad_request(format!(
@@ -1556,8 +1559,9 @@ pub async fn collect_routes(
         routes.push(openwave_router::Route {
             kind: route_kind(kind),
             api_key,
-            // Gemini's curated Developer API endpoint is fixed in production.
-            base_url: (kind != ProviderKind::Gemini)
+            // Gemini and xAI use fixed first-party endpoints in production.
+            // Never let a stale/directly written setting redirect their keys.
+            base_url: (!matches!(kind, ProviderKind::Gemini | ProviderKind::Xai))
                 .then_some(config.base_url)
                 .flatten(),
             curated_models: model_registry::models_for(kind)
@@ -2055,6 +2059,7 @@ mod tests {
                 ReasoningEffort::Low,
                 ReasoningEffort::Medium,
                 ReasoningEffort::High,
+                ReasoningEffort::XHigh,
             ],
             ..Default::default()
         };
@@ -2067,7 +2072,7 @@ mod tests {
         assert_eq!(policy.reasoning_efforts, model.reasoning_efforts);
 
         let mut unsupported = model.clone();
-        unsupported.reasoning_efforts.push(ReasoningEffort::XHigh);
+        unsupported.reasoning_efforts.push(ReasoningEffort::Max);
         assert!(validate_configured_models(ProviderKind::Xai, &[unsupported]).is_err());
         assert!(validate_configured_models(ProviderKind::OpenaiCompatible, &[model]).is_err());
     }

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -1300,7 +1300,8 @@ fn validate_configured_models_against(
         if model.reasoning_efforts.iter().any(|effort| {
             !matches!(
                 effort,
-                ReasoningEffort::Low
+                ReasoningEffort::None
+                    | ReasoningEffort::Low
                     | ReasoningEffort::Medium
                     | ReasoningEffort::High
                     | ReasoningEffort::XHigh
@@ -2056,6 +2057,7 @@ mod tests {
             input_modalities: vec![InputModality::Text, InputModality::Image],
             supports_reasoning: true,
             reasoning_efforts: vec![
+                ReasoningEffort::None,
                 ReasoningEffort::Low,
                 ReasoningEffort::Medium,
                 ReasoningEffort::High,

--- a/crates/openwave-server/src/routes/providers_models.rs
+++ b/crates/openwave-server/src/routes/providers_models.rs
@@ -71,7 +71,7 @@ pub(super) async fn validate_model_selection(
         return Err(ServerError::bad_request_kind(
             "unknown_model",
             format!(
-                "model `{value}` is not registered for that provider; configure it under OpenAI-compatible models first"
+                "model `{value}` is not registered for that provider; configure it in that provider's model list first"
             ),
         ));
     };

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -1360,7 +1360,7 @@ async fn xai_settings_publish_explicit_model_capabilities() {
                             "max_output_tokens": 32768,
                             "input_modalities": ["text", "image"],
                             "supports_reasoning": true,
-                            "reasoning_efforts": ["low", "medium", "high"]
+                            "reasoning_efforts": ["low", "medium", "high", "xhigh"]
                         }]
                     })
                     .to_string(),
@@ -1396,7 +1396,7 @@ async fn xai_settings_publish_explicit_model_capabilities() {
     );
     assert_eq!(
         model["reasoning_efforts"],
-        serde_json::json!(["low", "medium", "high"])
+        serde_json::json!(["low", "medium", "high", "xhigh"])
     );
     assert!(model["supports_reasoning"].as_bool().unwrap());
     assert!(model["available"].as_bool().unwrap());
@@ -1426,7 +1426,10 @@ async fn xai_config_builds_a_provider_qualified_native_route() {
         providers::ProviderKind::Xai,
         &providers::ProviderConfig {
             enabled: true,
-            base_url: None,
+            // Seed a value that the public update path refuses, as a stale DB
+            // row or direct write could still contain it. Route collection
+            // must not let it redirect the credential.
+            base_url: Some("https://attacker.invalid/v1".into()),
             vertex_location: None,
             models: vec![providers::CustomModelConfig {
                 id: "grok-account-model".into(),
@@ -1441,6 +1444,7 @@ async fn xai_config_builds_a_provider_qualified_native_route() {
                     openwave_core::ReasoningEffort::Low,
                     openwave_core::ReasoningEffort::Medium,
                     openwave_core::ReasoningEffort::High,
+                    openwave_core::ReasoningEffort::XHigh,
                 ],
                 ..Default::default()
             }],

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -1298,6 +1298,184 @@ async fn models_catalog_includes_enabled_credentialed_providers() {
 }
 
 #[tokio::test]
+async fn xai_settings_publish_explicit_model_capabilities() {
+    let (router, token, _store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+
+    let endpoint_override = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/providers/xai")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({"base_url": "https://example.test/v1"}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(endpoint_override.status(), StatusCode::BAD_REQUEST);
+
+    let missing_models = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/providers/xai")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "enabled": true,
+                        "credential": {"type": "api_key", "key": "xai-key"},
+                        "models": []
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(missing_models.status(), StatusCode::BAD_REQUEST);
+
+    let put = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/providers/xai")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "enabled": true,
+                        "credential": {"type": "api_key", "key": "xai-key"},
+                        "models": [{
+                            "id": "grok-account-model",
+                            "display_name": "Grok account model",
+                            "context_window": 500000,
+                            "max_output_tokens": 32768,
+                            "input_modalities": ["text", "image"],
+                            "supports_reasoning": true,
+                            "reasoning_efforts": ["low", "medium", "high"]
+                        }]
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(put.status(), StatusCode::OK);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/models")
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let catalog: serde_json::Value = json_body(response).await;
+    let model = catalog["models"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|model| model["key"] == "xai::grok-account-model")
+        .unwrap();
+    assert_eq!(model["provider"], "xai");
+    assert_eq!(
+        model["input_modalities"],
+        serde_json::json!(["text", "image"])
+    );
+    assert_eq!(
+        model["reasoning_efforts"],
+        serde_json::json!(["low", "medium", "high"])
+    );
+    assert!(model["supports_reasoning"].as_bool().unwrap());
+    assert!(model["available"].as_bool().unwrap());
+}
+
+#[tokio::test]
+async fn xai_config_builds_a_provider_qualified_native_route() {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}/test.db?mode=rwc",
+            dir.path().display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let secrets: Arc<dyn SecretProvider> = Arc::new(MemSecrets::default());
+    providers::write_credential(
+        &*secrets,
+        providers::ProviderKind::Xai,
+        &providers::ProviderCredential::api_key("xai-key"),
+    )
+    .await
+    .unwrap();
+    providers::write_config(
+        &*store,
+        providers::ProviderKind::Xai,
+        &providers::ProviderConfig {
+            enabled: true,
+            base_url: None,
+            vertex_location: None,
+            models: vec![providers::CustomModelConfig {
+                id: "grok-account-model".into(),
+                context_window: 500_000,
+                max_output_tokens: 32_768,
+                input_modalities: vec![
+                    crate::model_registry::InputModality::Text,
+                    crate::model_registry::InputModality::Image,
+                ],
+                supports_reasoning: true,
+                reasoning_efforts: vec![
+                    openwave_core::ReasoningEffort::Low,
+                    openwave_core::ReasoningEffort::Medium,
+                    openwave_core::ReasoningEffort::High,
+                ],
+                ..Default::default()
+            }],
+        },
+    )
+    .await
+    .unwrap();
+
+    let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
+        .await
+        .unwrap();
+    let routes = providers::collect_routes(&*store, &*secrets, None, None, &policy).await;
+    assert_eq!(routes.len(), 1);
+    assert_eq!(routes[0].kind, openwave_router::RouteKind::Xai);
+    assert_eq!(routes[0].base_url, None);
+    assert_eq!(routes[0].curated_models, ["grok-account-model"]);
+
+    let router = openwave_router::Router::build(routes);
+    assert_eq!(
+        router.select_for(
+            Some(&openwave_core::ProviderId::new("xai")),
+            "grok-account-model"
+        ),
+        Some(openwave_router::RouteKind::Xai)
+    );
+    assert_eq!(
+        router.select_for(
+            Some(&openwave_core::ProviderId::new("openai")),
+            "grok-account-model"
+        ),
+        None
+    );
+}
+
+#[tokio::test]
 async fn configured_router_canonicalizes_typed_models_and_rejects_wrong_or_unavailable_providers() {
     let dir = tempfile::tempdir().unwrap();
     let store: Arc<dyn Store> = Arc::new(
@@ -1712,6 +1890,7 @@ async fn model_roles_resolve_at_read_time_and_honor_an_explicit_pin() {
                     display_name: Some("Gateway Flagship".to_string()),
                     context_window: 1_000_000,
                     max_output_tokens: 64_000,
+                    ..Default::default()
                 },
                 providers::CustomModelConfig {
                     id: "gateway-haiku".to_string(),
@@ -1719,6 +1898,7 @@ async fn model_roles_resolve_at_read_time_and_honor_an_explicit_pin() {
                     display_name: Some("Gateway Haiku".to_string()),
                     context_window: 200_000,
                     max_output_tokens: 8_192,
+                    ..Default::default()
                 },
             ],
             model_protocols: Default::default(),

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -1360,7 +1360,7 @@ async fn xai_settings_publish_explicit_model_capabilities() {
                             "max_output_tokens": 32768,
                             "input_modalities": ["text", "image"],
                             "supports_reasoning": true,
-                            "reasoning_efforts": ["low", "medium", "high", "xhigh"]
+                            "reasoning_efforts": ["none", "low", "medium", "high", "xhigh"]
                         }]
                     })
                     .to_string(),
@@ -1396,7 +1396,7 @@ async fn xai_settings_publish_explicit_model_capabilities() {
     );
     assert_eq!(
         model["reasoning_efforts"],
-        serde_json::json!(["low", "medium", "high", "xhigh"])
+        serde_json::json!(["none", "low", "medium", "high", "xhigh"])
     );
     assert!(model["supports_reasoning"].as_bool().unwrap());
     assert!(model["available"].as_bool().unwrap());
@@ -1441,6 +1441,7 @@ async fn xai_config_builds_a_provider_qualified_native_route() {
                 ],
                 supports_reasoning: true,
                 reasoning_efforts: vec![
+                    openwave_core::ReasoningEffort::None,
                     openwave_core::ReasoningEffort::Low,
                     openwave_core::ReasoningEffort::Medium,
                     openwave_core::ReasoningEffort::High,

--- a/crates/openwave-server/src/tests/image_attachment.rs
+++ b/crates/openwave-server/src/tests/image_attachment.rs
@@ -657,6 +657,7 @@ async fn a_turn_carrying_images_against_a_text_only_model_is_refused() {
                 display_name: Some("Vendor Model".into()),
                 context_window: 65_536,
                 max_output_tokens: 8_192,
+                ..Default::default()
             }],
         },
     )

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -56,9 +56,9 @@ Major surfaces present today:
 
 ## `openwave-router` — model providers & routing 🟢
 
-Owns the concrete Anthropic and OpenAI-compatible provider adapters (including
-OpenAI, Fireworks, OpenRouter, vLLM, and LM Studio endpoints) plus a composite
-`Router`.
+Owns the concrete Anthropic, OpenAI Responses, xAI Responses, Gemini, and
+OpenAI-compatible provider adapters (including Fireworks, OpenRouter, vLLM,
+and LM Studio endpoints) plus a composite `Router`.
 
 The `Router` is itself a `ModelProvider`, so the agent loop holds one provider
 contract and does not depend on a concrete backend. Two things define it:

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -154,10 +154,13 @@ reports what each role resolves to so a client can label the automatic choice.
 
 OpenAI-compatible endpoints can register custom model IDs and their context and
 output limits in provider settings. Those models enter the same catalog with
-conservative text-only, non-reasoning capabilities. Existing unqualified model
-settings are migrated at the API boundary when exactly one configured provider
-owns the ID. Ambiguous IDs fail closed and must be reselected with their
-provider, so routing never depends on registry order.
+conservative text-only, non-reasoning capabilities. xAI also uses explicit
+configured model rows because the models available to an API key can change
+independently of an OpenWave release; each row records its own limits, image
+input support, reasoning support, and accepted effort levels. Existing
+unqualified model settings are migrated at the API boundary when exactly one
+configured provider owns the ID. Ambiguous IDs fail closed and must be
+reselected with their provider, so routing never depends on registry order.
 
 ## What happens during a chat turn
 
@@ -300,9 +303,9 @@ independently reauthorizes its live grant. Resolve checks attachment authority
 again, which discards content if a detach won while the read was in flight. A
 crash after possible broker dispatch becomes a safe unavailable result instead
 of another read.
-The model router supports Anthropic, OpenAI, and OpenAI-compatible endpoints. It
-fails closed: if no enabled provider with a usable credential can serve the
-selected model, no model request is sent.
+The model router supports Anthropic, OpenAI, xAI, Gemini, and OpenAI-compatible
+endpoints. It fails closed: if no enabled provider with a usable credential can
+serve the selected model, no model request is sent.
 
 ### Tool calls are small state machines too
 


### PR DESCRIPTION
## Summary

- add a first-class `xai` provider and route on the native Responses API at `https://api.x.ai/v1`
- support stored or `XAI_API_KEY` credentials, fixed-endpoint routing, provider-qualified selection, xAI-specific auth/error classification, and flatten-on-switch replay
- add explicit configurable xAI model rows with context/output limits, image input, reasoning, and supported effort metadata across the REST API and desktop settings UI
- pin basic, reasoning/tool, streaming, and bad-key failure contracts with focused fixtures

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p openwave-server --locked`
- `cargo test -p openwave-router --locked`
- `cargo test -p openwave-server xai --lib --locked`
- `cargo test -p openwave-server wire_types::tests::the_generated_bindings_are_current --locked -- --exact`
- `pnpm test` (846 tests)
- `pnpm build`

## Deliberate scope

- xAI uses API keys only; no consumer-subscription OAuth is added.
- The first-party endpoint is fixed so an xAI key cannot be redirected to an arbitrary host.
- xAI hosted search is not advertised until its provider-specific tool contract is implemented and exercised end to end.

Closes #1771