### PR TITLE
fix(desktop): snap the streaming typewriter when catch-up puts it far behind

### DIFF
--- a/crates/openwave-desktop/ui/src/useStreamingTypewriter.test.ts
+++ b/crates/openwave-desktop/ui/src/useStreamingTypewriter.test.ts
@@ -52,4 +52,21 @@ describe("useStreamingTypewriter", () => {
 
     expect(result.current).toBe("Searched the web and 1 other task");
   });
+
+  // A reconnect replays the active turn's whole journal in a burst (#1716);
+  // the animation must not re-type prose the reader already watched stream.
+  it("snaps instead of animating when catch-up puts it far behind", async () => {
+    vi.useFakeTimers();
+    const { result, rerender } = renderHook(
+      ({ text, live }) => useStreamingTypewriter(text, live),
+      { initialProps: { text: "", live: true } },
+    );
+
+    const replayed = "already-streamed prose ".repeat(50).trim();
+    rerender({ text: replayed, live: true });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20);
+    });
+    expect(result.current).toBe(replayed);
+  });
 });

--- a/crates/openwave-desktop/ui/src/useStreamingTypewriter.ts
+++ b/crates/openwave-desktop/ui/src/useStreamingTypewriter.ts
@@ -4,6 +4,15 @@ const TICK_INTERVAL_MS = 20;
 const SMOOTHING_FACTOR = 18;
 
 /**
+ * How far the animation may trail its target before it stops animating and
+ * snaps. Live streaming never opens a gap this size: deltas arrive in small
+ * chunks and each tick closes most of what remains. A gap this large means
+ * catch-up — a reconnect replaying the active turn's journal (#1716) — and
+ * animating it re-types prose the reader already watched stream.
+ */
+const CATCH_UP_SNAP_CHARS = 600;
+
+/**
  * Types subsequent live changes without reanimating content that was already
  * present when the component mounted. Transcript history therefore appears
  * immediately, while an active step gains motion only as it receives new
@@ -50,6 +59,11 @@ export function useStreamingTypewriter(text: string, live: boolean): string {
     const remaining = target.length - current.length;
     if (remaining <= 0) {
       timerRef.current = null;
+      return;
+    }
+    if (remaining > CATCH_UP_SNAP_CHARS) {
+      timerRef.current = null;
+      showImmediately(target);
       return;
     }
 


### PR DESCRIPTION
## Summary

Re-entering a chat mid-turn replays the active turn's journal from the terminal cursor (by design — see #1716), and the typewriter animated the replay burst as if it were live: the whole turn re-typed itself in front of the reader.

The renderer has no marker separating replayed events from live ones, but it doesn't need one to stop the re-typing: live streaming never puts the animation hundreds of characters behind its target (deltas arrive in small chunks and each tick closes most of the remaining gap), while a replay burst instantly does. When the gap exceeds 600 characters the animation snaps to target instead of re-typing.

This removes the symptom without deciding #1716's protocol question (catch-up watermark), which stays open — the issue is left open deliberately and only the re-typing behavior is addressed.

## Testing

- Unit: new regression case — a live hook pushed a ~1.2k-char burst renders it fully on the next tick; existing behavior (history immediate, live updates animate, settle snaps) covered by the prior cases. Full UI suite: 846 passed.
- Browser (same repro as the bug): streamed a ~700-char paragraph, navigated away and back during the turn's `sleep 15`. Sampled assistant text length every 100ms from re-entry: hydration at ~240ms, then the replayed content lands in a single 100ms step and stays flat. Pre-fix reference capture (issue #1716) showed the same content re-growing over 1.5+ seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)