### PR TITLE
feat(router): add native Amazon Bedrock support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,6 +333,10 @@ jobs:
           save-if: false
       - name: clippy
         run: cargo clippy --workspace --all-targets --locked -- -D warnings
+      - name: Check router feature boundaries
+        run: |
+          cargo check -p openwave-router --no-default-features --locked
+          cargo check -p openwave-router --no-default-features --features anthropic --locked
 
   desktop:
     name: desktop test

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ foreground/background execution model is described in
 | Crate | What it is |
 | --- | --- |
 | [`openwave-core`](crates/openwave-core) | agent loop, tools, event stream, storage traits |
-| [`openwave-router`](crates/openwave-router) | Anthropic, OpenAI, xAI, Gemini, and compatible providers + model routing |
+| [`openwave-router`](crates/openwave-router) | Anthropic, OpenAI, xAI, Gemini, Amazon Bedrock Mantle, and compatible providers + model routing |
 | [`openwave-code-execution`](crates/openwave-code-execution) | provider-neutral command execution + native local sandbox |
 | [`openwave-server`](crates/openwave-server) | authenticated local HTTP/WebSocket API + durable workers |
 | [`openwave-connectors`](crates/openwave-connectors) | OAuth + source connectors |

--- a/crates/openwave-desktop/ui/src/ModelMenu.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.tsx
@@ -35,6 +35,7 @@ const PROVIDER_ORDER: readonly ProviderKind[] = [
   "xai",
   "gemini",
   "vertex",
+  "bedrock",
   "fireworks",
   "together",
 ];

--- a/crates/openwave-desktop/ui/src/ModelSelection.test.ts
+++ b/crates/openwave-desktop/ui/src/ModelSelection.test.ts
@@ -75,6 +75,7 @@ describe("typed model selection", () => {
     expect(providerLabel("xai")).toBe("xAI");
     expect(providerLabel("gemini")).toBe("Google Gemini");
     expect(providerLabel("vertex")).toBe("Google Vertex AI");
+    expect(providerLabel("bedrock")).toBe("Amazon Bedrock");
     expect(providerLabel("fireworks")).toBe("Fireworks AI");
     expect(providerLabel("together")).toBe("Together AI");
     expect(providerLabel("openai_compatible")).toBe("OpenAI-compatible");

--- a/crates/openwave-desktop/ui/src/ModelSelection.ts
+++ b/crates/openwave-desktop/ui/src/ModelSelection.ts
@@ -49,6 +49,8 @@ export function providerLabel(provider: ProviderKind): string {
       return "Google Gemini";
     case "vertex":
       return "Google Vertex AI";
+    case "bedrock":
+      return "Amazon Bedrock";
     case "fireworks":
       return "Fireworks AI";
     case "together":

--- a/crates/openwave-desktop/ui/src/ProviderIcons.tsx
+++ b/crates/openwave-desktop/ui/src/ProviderIcons.tsx
@@ -137,6 +137,7 @@ export function ProviderIcon({
       return <GeminiIcon {...rest} />;
     case "vertex":
       return <GeminiIcon {...rest} />;
+    case "bedrock":
     case "fireworks":
     case "together":
     case "openai_compatible":

--- a/crates/openwave-desktop/ui/src/api/client.ts
+++ b/crates/openwave-desktop/ui/src/api/client.ts
@@ -192,9 +192,16 @@ export class ApiClient {
       enabled?: boolean;
       base_url?: string | null;
       vertex_location?: string | null;
+      aws_region?: string | null;
       credential?:
         | { type: "api_key"; key: string }
-        | { type: "service_account"; json: string };
+        | { type: "service_account"; json: string }
+        | {
+            type: "aws_credentials";
+            access_key_id: string;
+            secret_access_key: string;
+            session_token?: string;
+          };
       models?: CustomModelConfig[];
     },
   ): Promise<ProviderInfo> {

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1885,7 +1885,7 @@ export type PromptOrigin = "builtin" | "user";
 /**
  * How a provider's credential was established.
  */
-export type ProviderAuthMode = "api_key" | "chatgpt" | "service_account";
+export type ProviderAuthMode = "api_key" | "chatgpt" | "service_account" | "aws_credentials";
 
 /**
  * Public view of a provider — never includes the credential itself.
@@ -1926,7 +1926,7 @@ models: Array<CustomModelConfig>, aws_region?: string, };
  * The known provider kinds. `#[non_exhaustive]` so new kinds can land without
  * breaking wire clients that match on the string form.
  */
-export type ProviderKind = "anthropic" | "openai" | "xai" | "gemini" | "vertex" | "fireworks" | "together" | "openai_compatible" | "model_gateway";
+export type ProviderKind = "anthropic" | "openai" | "xai" | "gemini" | "vertex" | "bedrock" | "fireworks" | "together" | "openai_compatible" | "model_gateway";
 
 /**
  * How hard a reasoning-capable model should think before answering.

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1920,7 +1920,7 @@ auth_mode?: ProviderAuthMode,
 /**
  * Explicit configured model entries for this endpoint.
  */
-models: Array<CustomModelConfig>, };
+models: Array<CustomModelConfig>, aws_region?: string, };
 
 /**
  * The known provider kinds. `#[non_exhaustive]` so new kinds can land without

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
@@ -406,6 +406,75 @@ describe("ProvidersPanel", () => {
     );
   });
 
+  it("configures Bedrock SigV4 credentials, region, and explicit models", async () => {
+    const bedrock: ProviderInfo = {
+      kind: "bedrock",
+      enabled: false,
+      has_credential: false,
+      models: [],
+    };
+    const putProvider = vi.fn().mockResolvedValue(bedrock);
+    const client = { putProvider } as unknown as ApiClient;
+
+    render(
+      <ProvidersPanel
+        providers={[bedrock]}
+        client={client}
+        onChanged={vi.fn()}
+      />,
+    );
+
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByLabelText("Amazon Bedrock credential type"),
+    );
+    await user.click(
+      await screen.findByRole("option", { name: "AWS access keys (SigV4)" }),
+    );
+    fireEvent.change(screen.getByLabelText("AWS region"), {
+      target: { value: "us-west-2" },
+    });
+    fireEvent.change(screen.getByLabelText("AWS access key ID"), {
+      target: { value: " AKIAEXAMPLE " },
+    });
+    fireEvent.change(screen.getByLabelText("AWS secret access key"), {
+      target: { value: " secret-access-key " },
+    });
+    fireEvent.change(screen.getByLabelText("AWS session token"), {
+      target: { value: " session-token " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add model" }));
+    fireEvent.change(screen.getByLabelText("Custom model 1 ID"), {
+      target: { value: " openai.gpt-oss-120b " },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Save configuration" }),
+    );
+
+    await waitFor(() =>
+      expect(putProvider).toHaveBeenCalledWith("bedrock", {
+        enabled: true,
+        aws_region: "us-west-2",
+        credential: {
+          type: "aws_credentials",
+          access_key_id: "AKIAEXAMPLE",
+          secret_access_key: "secret-access-key",
+          session_token: "session-token",
+        },
+        models: [
+          {
+            id: "openai.gpt-oss-120b",
+            context_window: 32_768,
+            max_output_tokens: 4_096,
+            input_modalities: ["text"],
+            supports_reasoning: false,
+            reasoning_efforts: [],
+          },
+        ],
+      }),
+    );
+  });
+
   it("offers no credential editing on a managed profile", () => {
     const putProvider = vi.fn();
     const client = { putProvider } as unknown as ApiClient;

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
@@ -475,6 +475,39 @@ describe("ProvidersPanel", () => {
     );
   });
 
+  it("does not persist an untouched environment-resolved Bedrock region", async () => {
+    const bedrock: ProviderInfo = {
+      kind: "bedrock",
+      enabled: false,
+      has_credential: true,
+      aws_region: "eu-west-1",
+      models: [],
+    };
+    const putProvider = vi.fn().mockResolvedValue({
+      ...bedrock,
+      enabled: true,
+    });
+    const client = { putProvider } as unknown as ApiClient;
+
+    render(
+      <ProvidersPanel
+        providers={[bedrock]}
+        client={client}
+        onChanged={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText("AWS region")).toHaveValue("eu-west-1");
+    fireEvent.click(screen.getByRole("switch", { name: "Enabled" }));
+
+    await waitFor(() =>
+      expect(putProvider).toHaveBeenCalledWith("bedrock", {
+        enabled: true,
+        models: [],
+      }),
+    );
+  });
+
   it("offers no credential editing on a managed profile", () => {
     const putProvider = vi.fn();
     const client = { putProvider } as unknown as ApiClient;

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -104,7 +104,13 @@ function ProviderRow({
     isFirstClassVertex ||
     (info.kind === "gemini" && info.auth_mode === "service_account");
   const [key, setKey] = useState("");
-  const credentialType = usesServiceAccount ? "service_account" : "api_key";
+  const [credentialType, setCredentialType] = useState<CredentialType>(
+    info.kind === "bedrock" && info.auth_mode === "aws_credentials"
+      ? "aws_credentials"
+      : usesServiceAccount
+        ? "service_account"
+        : "api_key",
+  );
   const [serviceAccountJson, setServiceAccountJson] = useState("");
   const [vertexLocation, setVertexLocation] = useState(
     info.vertex_location ?? "global",
@@ -499,10 +505,54 @@ function ProviderRow({
         />
       ) : (
         <>
+          {info.kind === "bedrock" && (
+            <>
+              <label className="grid gap-1 text-xs text-muted-foreground">
+                Credential type
+                <Select
+                  value={credentialType}
+                  disabled={saving}
+                  onValueChange={(value) =>
+                    setCredentialType(value as CredentialType)
+                  }
+                >
+                  <SelectTrigger
+                    aria-label="Amazon Bedrock credential type"
+                    className="h-9"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="api_key">Bedrock API key</SelectItem>
+                    <SelectItem value="aws_credentials">
+                      AWS access keys (SigV4)
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </label>
+              <Input
+                type="text"
+                aria-label="AWS region"
+                placeholder="AWS region"
+                value={awsRegion}
+                onChange={(event) => {
+                  setAwsRegion(event.target.value);
+                  setAwsRegionTouched(true);
+                }}
+                autoComplete="off"
+              />
+              <p className="text-xs text-muted-foreground">
+                OpenWave derives the Bedrock Mantle endpoint from this region;
+                credentials cannot redirect requests to another host.
+              </p>
+            </>
+          )}
           {credentialType === "api_key" && (
             <Input
               type="password"
-              placeholder="API key"
+              placeholder={
+                info.kind === "bedrock" ? "Bedrock API key" : "API key"
+              }
               value={key}
               onChange={(e) => setKey(e.target.value)}
               autoComplete="off"
@@ -559,6 +609,37 @@ function ProviderRow({
               />
             </>
           )}
+          {info.kind === "bedrock" &&
+            credentialType === "aws_credentials" && (
+              <div className="grid gap-2">
+                <Input
+                  type="password"
+                  aria-label="AWS access key ID"
+                  placeholder="AWS access key ID"
+                  value={awsAccessKeyId}
+                  onChange={(event) => setAwsAccessKeyId(event.target.value)}
+                  autoComplete="off"
+                />
+                <Input
+                  type="password"
+                  aria-label="AWS secret access key"
+                  placeholder="AWS secret access key"
+                  value={awsSecretAccessKey}
+                  onChange={(event) =>
+                    setAwsSecretAccessKey(event.target.value)
+                  }
+                  autoComplete="off"
+                />
+                <Input
+                  type="password"
+                  aria-label="AWS session token"
+                  placeholder="AWS session token (optional)"
+                  value={awsSessionToken}
+                  onChange={(event) => setAwsSessionToken(event.target.value)}
+                  autoComplete="off"
+                />
+              </div>
+            )}
           <div className="flex flex-wrap gap-2">
             <Button
               type="button"
@@ -572,11 +653,14 @@ function ProviderRow({
                   usesServiceAccount &&
                   credentialType === "service_account" &&
                   !serviceAccountJson.trim()) ||
-                (info.kind === "openai_compatible" &&
+                (!info.has_credential &&
+                  info.kind === "bedrock" &&
+                  credentialType === "aws_credentials" &&
+                  (!awsAccessKeyId.trim() || !awsSecretAccessKey.trim())) ||
+                (hasConfigurableModels &&
                   models.some((model) => !model.id.trim())) ||
-                (info.kind === "xai" &&
-                  (models.length === 0 ||
-                    models.some((model) => !model.id.trim())))
+                (info.kind === "xai" && models.length === 0) ||
+                (info.kind === "bedrock" && !awsRegion.trim())
               }
               onClick={() => void save(true)}
             >
@@ -611,6 +695,12 @@ function credentialStatusLabel(info: ProviderInfo): string {
   }
   if (info.auth_mode === "service_account") {
     return "Google service account set";
+  }
+  if (info.kind === "bedrock" && info.auth_mode === "aws_credentials") {
+    return "AWS access keys set";
+  }
+  if (info.kind === "bedrock" && info.auth_mode === "api_key") {
+    return "Bedrock API key set";
   }
   return "Credential set";
 }

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -110,7 +110,8 @@ function ProviderRow({
     info.vertex_location ?? "global",
   );
   const [baseUrl, setBaseUrl] = useState(info.base_url ?? "");
-  const [awsRegion, setAwsRegion] = useState(info.aws_region ?? "us-east-1");
+  const [awsRegion, setAwsRegion] = useState(info.aws_region ?? "");
+  const [awsRegionTouched, setAwsRegionTouched] = useState(false);
   const [awsAccessKeyId, setAwsAccessKeyId] = useState("");
   const [awsSecretAccessKey, setAwsSecretAccessKey] = useState("");
   const [awsSessionToken, setAwsSessionToken] = useState("");
@@ -174,7 +175,9 @@ function ProviderRow({
         }
       }
       if (info.kind === "bedrock") {
-        body.aws_region = awsRegion.trim() || null;
+        if (awsRegionTouched) {
+          body.aws_region = awsRegion.trim() || null;
+        }
         if (
           credentialType === "aws_credentials" &&
           awsAccessKeyId.trim() &&
@@ -196,6 +199,7 @@ function ProviderRow({
       setAwsAccessKeyId("");
       setAwsSecretAccessKey("");
       setAwsSessionToken("");
+      setAwsRegionTouched(false);
       onChanged();
       toast.success(`Saved ${providerLabel(info.kind)} settings`);
     } catch (err) {

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -40,6 +40,8 @@ function newConfiguredModel(): CustomModelConfig {
   };
 }
 
+type CredentialType = "api_key" | "service_account" | "aws_credentials";
+
 export function ProvidersPanel({
   providers,
   client,
@@ -108,12 +110,18 @@ function ProviderRow({
     info.vertex_location ?? "global",
   );
   const [baseUrl, setBaseUrl] = useState(info.base_url ?? "");
+  const [awsRegion, setAwsRegion] = useState(info.aws_region ?? "us-east-1");
+  const [awsAccessKeyId, setAwsAccessKeyId] = useState("");
+  const [awsSecretAccessKey, setAwsSecretAccessKey] = useState("");
+  const [awsSessionToken, setAwsSessionToken] = useState("");
   const [models, setModels] = useState<CustomModelConfig[]>(info.models);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const { confirm, dialog } = useConfirm();
   const hasConfigurableModels =
-    info.kind === "openai_compatible" || info.kind === "xai";
+    info.kind === "openai_compatible" ||
+    info.kind === "xai" ||
+    info.kind === "bedrock";
 
   async function save(enabled: boolean) {
     setSaving(true);
@@ -123,9 +131,16 @@ function ProviderRow({
         enabled: boolean;
         base_url?: string | null;
         vertex_location?: string | null;
+        aws_region?: string | null;
         credential?:
           | { type: "api_key"; key: string }
-          | { type: "service_account"; json: string };
+          | { type: "service_account"; json: string }
+          | {
+              type: "aws_credentials";
+              access_key_id: string;
+              secret_access_key: string;
+              session_token?: string;
+            };
         models?: CustomModelConfig[];
       } = { enabled };
       if (hasConfigurableModels) {
@@ -158,9 +173,29 @@ function ProviderRow({
           };
         }
       }
+      if (info.kind === "bedrock") {
+        body.aws_region = awsRegion.trim() || null;
+        if (
+          credentialType === "aws_credentials" &&
+          awsAccessKeyId.trim() &&
+          awsSecretAccessKey.trim()
+        ) {
+          body.credential = {
+            type: "aws_credentials",
+            access_key_id: awsAccessKeyId.trim(),
+            secret_access_key: awsSecretAccessKey.trim(),
+            ...(awsSessionToken.trim()
+              ? { session_token: awsSessionToken.trim() }
+              : {}),
+          };
+        }
+      }
       await client.putProvider(info.kind as ProviderKind, body);
       setKey("");
       setServiceAccountJson("");
+      setAwsAccessKeyId("");
+      setAwsSecretAccessKey("");
+      setAwsSessionToken("");
       onChanged();
       toast.success(`Saved ${providerLabel(info.kind)} settings`);
     } catch (err) {
@@ -242,6 +277,8 @@ function ProviderRow({
               <p className="text-xs text-muted-foreground">
                 {info.kind === "xai"
                   ? "Add each xAI model available to this API key, including its limits and supported capabilities."
+                  : info.kind === "bedrock"
+                  ? "Add exact Bedrock Mantle model IDs. Anthropic IDs use Claude Messages; other IDs use OpenAI Responses. Custom rows start with conservative text-only, non-reasoning capabilities."
                   : "Add each model this endpoint serves. Custom models start with conservative text-only, non-reasoning capabilities."}
               </p>
             )}

--- a/crates/openwave-router/Cargo.toml
+++ b/crates/openwave-router/Cargo.toml
@@ -11,7 +11,7 @@ authors.workspace = true
 workspace = true
 
 [features]
-default = ["anthropic", "openai", "xai", "openai-compat", "gemini"]
+default = ["anthropic", "openai", "xai", "openai-compat", "gemini", "bedrock"]
 # The Anthropic (Messages API) provider adapter.
 anthropic = ["_http"]
 # Native OpenAI Responses API adapter.
@@ -23,6 +23,8 @@ xai = ["openai"]
 openai-compat = ["_http"]
 # Google Gemini Developer API adapter (native GenerateContent protocol).
 gemini = ["_http", "dep:ring", "dep:uuid"]
+# Amazon Bedrock Mantle Messages + Responses, with API-key or SigV4 auth.
+bedrock = ["anthropic", "openai", "dep:ring"]
 # Internal: the shared HTTP transport every adapter is built on. Not meant to
 # be enabled directly.
 _http = ["dep:reqwest", "dep:async-stream", "dep:tokio"]

--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -119,6 +119,18 @@ impl AnthropicProvider {
         self
     }
 
+    /// Authenticate the exact serialized request through a shared transport.
+    #[must_use]
+    pub(crate) fn with_request_auth(
+        mut self,
+        auth: std::sync::Arc<dyn crate::http::RequestAuthenticator>,
+        provider_label: &'static str,
+    ) -> Self {
+        self.request_auth = Some(auth);
+        self.provider_label = provider_label;
+        self
+    }
+
     /// Fetch the credential from `source` at each request instead of using a
     /// static key. For gateways whose tokens rotate under the adapter.
     #[must_use]
@@ -171,9 +183,10 @@ impl ModelProvider for AnthropicProvider {
             Some(ResponseFormat::JsonSchema { name, .. }) => Some(name.clone()),
             _ => None,
         };
-        let api_key = match &self.token_source {
-            Some(source) => source.bearer_token_for(req.conversation).await?,
-            None => self.api_key.clone(),
+        let api_key = match (&self.request_auth, &self.token_source) {
+            (Some(_), _) => String::new(),
+            (None, Some(source)) => source.bearer_token_for(req.conversation).await?,
+            (None, None) => self.api_key.clone(),
         };
 
         // Setup failures (connection, auth, 4xx/5xx) surface here as `Err` so the
@@ -199,6 +212,7 @@ impl ModelProvider for AnthropicProvider {
         let stream = async_stream::stream! {
             let mut response = response;
             let mut state = StreamState {
+                provider_label: provider.provider_label,
                 output_tool,
                 raw_blocks: continuations_allowed.then(RawAssistantBlocks::default),
                 replay_origin: Some(replay_origin),
@@ -337,7 +351,7 @@ impl AnthropicProvider {
             );
         }
         let response = request
-            .json(body)
+            .body(body)
             .send()
             .await
             // reqwest's display includes the URL, and a gateway URL can carry
@@ -810,6 +824,12 @@ fn web_search_tool_type(model: &str) -> &'static str {
 /// anything longer than two digits does not count as one.
 fn claude_generation(model: &str) -> Option<(u32, u32)> {
     let starts_with_digit = |token: &&str| token.starts_with(|c: char| c.is_ascii_digit());
+    let leaf = model.rsplit('/').next().unwrap_or(model);
+    let model = ["us.", "eu.", "apac.", "jp.", "au.", "global."]
+        .iter()
+        .find_map(|prefix| leaf.strip_prefix(prefix))
+        .unwrap_or(leaf);
+    let model = model.strip_prefix("anthropic.").unwrap_or(model);
     let mut tokens = model
         .strip_prefix("claude-")?
         .split('-')
@@ -951,6 +971,7 @@ fn anthropic_role(role: Role) -> &'static str {
 /// Prompt-cache-aware token counts accumulated across a stream.
 #[derive(Default)]
 struct StreamState {
+    provider_label: &'static str,
     input_tokens: u32,
     cache_read_input_tokens: u32,
     cache_creation_input_tokens: u32,
@@ -1119,7 +1140,10 @@ fn end_of_stream(state: &StreamState) -> Option<ProviderEvent> {
         return None;
     }
     Some(ProviderEvent::Failed {
-        error: ProviderErrorInfo::provider("anthropic stream ended mid-tool-call"),
+        error: ProviderErrorInfo::provider(format!(
+            "{} stream ended mid-tool-call",
+            stream_provider_label(state)
+        )),
     })
 }
 
@@ -1410,6 +1434,14 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
             events
         }
         _ => Vec::new(),
+    }
+}
+
+fn stream_provider_label(state: &StreamState) -> &'static str {
+    if state.provider_label.is_empty() {
+        "anthropic"
+    } else {
+        state.provider_label
     }
 }
 

--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -53,6 +53,8 @@ pub struct AnthropicProvider {
     api_key: String,
     base_url: String,
     vertex: Option<VertexEndpoint>,
+    request_auth: Option<std::sync::Arc<dyn crate::http::RequestAuthenticator>>,
+    provider_label: &'static str,
     /// Per-request credential supplier for gateways that mint short-lived
     /// tokens. Takes precedence over `api_key` when present.
     token_source: Option<std::sync::Arc<dyn crate::BearerTokenSource>>,
@@ -70,6 +72,8 @@ impl AnthropicProvider {
             api_key: api_key.into(),
             base_url: DEFAULT_BASE_URL.to_string(),
             vertex: None,
+            request_auth: None,
+            provider_label: "anthropic",
             token_source: None,
             conversation_attribution: false,
         }
@@ -106,6 +110,8 @@ impl AnthropicProvider {
                 project_id,
                 location,
             }),
+            request_auth: None,
+            provider_label: "vertex",
             token_source: Some(token_source),
             conversation_attribution: false,
         })
@@ -158,11 +164,7 @@ impl AnthropicProvider {
 #[async_trait]
 impl ModelProvider for AnthropicProvider {
     fn id(&self) -> ProviderId {
-        ProviderId::new(if self.vertex.is_some() {
-            "vertex"
-        } else {
-            "anthropic"
-        })
+        ProviderId::new(self.provider_label)
     }
 
     async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
@@ -323,6 +325,7 @@ impl AnthropicProvider {
         conversation: Option<openwave_core::id::ChatId>,
         model: &str,
     ) -> Result<reqwest::Response> {
+        let body = serde_json::to_vec(body)?;
         let mut request = if let Some(vertex) = &self.vertex {
             if !valid_anthropic_model_id(model) {
                 return Err(AgentError::config("invalid Vertex AI Claude model id"));
@@ -335,11 +338,18 @@ impl AnthropicProvider {
                 .bearer_auth(api_key)
                 .header("content-type", "application/json")
         } else {
-            self.client
-                .post(format!("{}/v1/messages", self.base_url))
-                .header("x-api-key", api_key)
+            let url = format!("{}/v1/messages", self.base_url.trim_end_matches('/'));
+            let url = reqwest::Url::parse(&url)
+                .map_err(|_| AgentError::config("invalid Messages API endpoint"))?;
+            let request = self
+                .client
+                .post(url.clone())
                 .header("anthropic-version", ANTHROPIC_VERSION)
-                .header("content-type", "application/json")
+                .header("content-type", "application/json");
+            match &self.request_auth {
+                Some(auth) => auth.authenticate(request, &url, &body)?,
+                None => request.header("x-api-key", api_key),
+            }
         };
         // A conversation is declared only where one is configured to be read.
         // The id is a UUID, so it satisfies the gateway's bound on the value
@@ -357,9 +367,7 @@ impl AnthropicProvider {
             // reqwest's display includes the URL, and a gateway URL can carry
             // tenant-identifying parts; `AgentError` strings reach the client
             // via TurnFailed. Only the fact of a failed request surfaces.
-            .map_err(|_| {
-                AgentError::Provider(format!("{} request failed", self.provider_name()))
-            })?;
+            .map_err(|_| AgentError::Provider(format!("{} request failed", self.provider_label)))?;
 
         // Surface non-2xx without the raw body — it can echo key material, and
         // `AgentError` strings reach the client via TurnFailed. Status (+ a
@@ -370,14 +378,14 @@ impl AnthropicProvider {
             let body = read_bounded_error_body(response.bytes_stream()).await;
             return Err(match &self.vertex {
                 Some(vertex) => classify_provider_error_redacting(
-                    self.provider_name(),
+                    self.provider_label,
                     status.as_u16(),
                     &body,
                     retry_after,
                     &[vertex.project_id.as_str()],
                 ),
                 None => classify_provider_error(
-                    self.provider_name(),
+                    self.provider_label,
                     status.as_u16(),
                     &body,
                     retry_after,
@@ -388,11 +396,7 @@ impl AnthropicProvider {
     }
 
     fn provider_name(&self) -> &'static str {
-        if self.vertex.is_some() {
-            "vertex"
-        } else {
-            "anthropic"
-        }
+        self.provider_label
     }
 }
 
@@ -1168,7 +1172,7 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
                 Some(project_id) => {
                     classify_in_band_error_redacting("vertex", error, &[project_id])
                 }
-                None => classify_in_band_error("anthropic", error),
+                None => classify_in_band_error(stream_provider_label(state), error),
             };
             vec![ProviderEvent::Failed {
                 error: ProviderErrorInfo::from_error(&error),

--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -1397,7 +1397,7 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
                         return events;
                     }
                 }
-                let mut reason = match map_stop_reason(reason) {
+                let mut reason = match map_stop_reason(stream_provider_label(state), reason) {
                     StopOutcome::Reason(reason) => reason,
                     // Whatever streamed before this stop is a fragment, so no
                     // clean stop may follow it. Failing the stream is what the
@@ -1529,7 +1529,7 @@ enum StopOutcome {
     Interrupted(ProviderErrorInfo),
 }
 
-fn map_stop_reason(reason: &str) -> StopOutcome {
+fn map_stop_reason(provider_label: &str, reason: &str) -> StopOutcome {
     match reason {
         "max_tokens" => StopOutcome::Reason(StopReason::MaxTokens),
         "tool_use" => StopOutcome::Reason(StopReason::ToolUse),
@@ -1544,16 +1544,16 @@ fn map_stop_reason(reason: &str) -> StopOutcome {
         // same oversized request.
         "model_context_window_exceeded" => {
             StopOutcome::Interrupted(ProviderErrorInfo::from_error(&AgentError::PromptTooLong(
-                "anthropic: the model's context window was exceeded mid-response".into(),
+                format!("{provider_label}: the model's context window was exceeded mid-response"),
             )))
         }
         // The provider suspended the turn for a long-running server-side tool
         // and expects the paused response replayed back to resume it. Nothing
         // here drives that continuation, so the paused fragment is incomplete
         // by construction and must not read as a finished answer.
-        "pause_turn" => StopOutcome::Interrupted(ProviderErrorInfo::provider(
-            "anthropic: the provider paused the turn",
-        )),
+        "pause_turn" => StopOutcome::Interrupted(ProviderErrorInfo::provider(format!(
+            "{provider_label}: the provider paused the turn"
+        ))),
         // "end_turn" and anything we don't yet model fall back to a clean end.
         _ => StopOutcome::Reason(StopReason::EndTurn),
     }
@@ -2287,17 +2287,32 @@ mod tests {
     #[test]
     fn maps_stop_reasons() {
         use StopOutcome::{Interrupted, Reason};
-        assert_eq!(map_stop_reason("tool_use"), Reason(StopReason::ToolUse));
-        assert_eq!(map_stop_reason("max_tokens"), Reason(StopReason::MaxTokens));
-        assert_eq!(map_stop_reason("refusal"), Reason(StopReason::Refusal));
         assert_eq!(
-            map_stop_reason("future_reason"),
+            map_stop_reason("anthropic", "tool_use"),
+            Reason(StopReason::ToolUse)
+        );
+        assert_eq!(
+            map_stop_reason("anthropic", "max_tokens"),
+            Reason(StopReason::MaxTokens)
+        );
+        assert_eq!(
+            map_stop_reason("anthropic", "refusal"),
+            Reason(StopReason::Refusal)
+        );
+        assert_eq!(
+            map_stop_reason("anthropic", "future_reason"),
             Reason(StopReason::EndTurn)
         );
-        assert!(matches!(map_stop_reason("pause_turn"), Interrupted(_)));
         assert!(matches!(
-            map_stop_reason("model_context_window_exceeded"),
-            Interrupted(_)
+            map_stop_reason("bedrock", "pause_turn"),
+            Interrupted(error) if error.message == "bedrock: the provider paused the turn"
+        ));
+        assert!(matches!(
+            map_stop_reason("bedrock", "model_context_window_exceeded"),
+            Interrupted(error)
+                if error.kind == "prompt_too_long"
+                    && error.message
+                        == "bedrock: the model's context window was exceeded mid-response"
         ));
     }
 

--- a/crates/openwave-router/src/bedrock.rs
+++ b/crates/openwave-router/src/bedrock.rs
@@ -23,57 +23,9 @@ use openwave_core::error::{AgentError, Result};
 use openwave_core::provider::{ChatRequest, ModelProvider, ProviderEvent, ProviderId};
 
 use crate::http::RequestAuthenticator;
-use crate::{AnthropicProvider, OpenAiProvider};
+use crate::{AnthropicProvider, AwsCredentials, OpenAiProvider};
 
 const BEDROCK_MANTLE_SERVICE: &str = "bedrock-mantle";
-
-/// Long-lived AWS credentials used to sign Bedrock requests.
-///
-/// Every field is secret material. The type's `Debug` implementation never
-/// renders values, and the server keeps the serialized credential in the
-/// profile secret store rather than the operational database.
-#[derive(Clone, PartialEq, Eq)]
-pub struct AwsCredentials {
-    access_key_id: String,
-    secret_access_key: String,
-    session_token: Option<String>,
-}
-
-impl AwsCredentials {
-    pub fn new(
-        access_key_id: impl Into<String>,
-        secret_access_key: impl Into<String>,
-        session_token: Option<String>,
-    ) -> Self {
-        Self {
-            access_key_id: access_key_id.into(),
-            secret_access_key: secret_access_key.into(),
-            session_token,
-        }
-    }
-
-    pub fn access_key_id(&self) -> &str {
-        &self.access_key_id
-    }
-
-    pub fn secret_access_key(&self) -> &str {
-        &self.secret_access_key
-    }
-
-    pub fn session_token(&self) -> Option<&str> {
-        self.session_token.as_deref()
-    }
-}
-
-impl std::fmt::Debug for AwsCredentials {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("AwsCredentials")
-            .field("access_key_id", &"***")
-            .field("secret_access_key", &"***")
-            .field("session_token", &self.session_token.as_ref().map(|_| "***"))
-            .finish()
-    }
-}
 
 /// Authentication accepted by direct Bedrock Mantle endpoints.
 #[derive(Clone)]
@@ -330,6 +282,11 @@ fn hex(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::http::header;
+    use axum::response::IntoResponse;
+    use axum::routing::post;
+    use axum::Router as AxumRouter;
+    use futures::StreamExt as _;
     use openwave_core::provider::ChatMessage;
     use openwave_core::Role;
 
@@ -422,6 +379,44 @@ mod tests {
         assert!(matches!(
             error,
             AgentError::Provider(message) if message == "bedrock request failed"
+        ));
+    }
+
+    #[tokio::test]
+    async fn messages_context_window_stops_are_attributed_to_bedrock() {
+        async fn context_overflow() -> impl IntoResponse {
+            (
+                [(header::CONTENT_TYPE, "text/event-stream")],
+                "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"model_context_window_exceeded\"}}\n\n",
+            )
+        }
+
+        let app = AxumRouter::new().fallback(post(context_overflow));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let provider = BedrockProvider::new("us-east-1", BedrockAuth::ApiKey("secret".into()))
+            .unwrap()
+            .with_base_url(format!("http://{address}"));
+        let events: Vec<ProviderEvent> = provider
+            .stream(ChatRequest {
+                model: "anthropic.claude-sonnet-5".into(),
+                messages: vec![ChatMessage::text(Role::User, "hi")],
+                ..Default::default()
+            })
+            .await
+            .unwrap()
+            .collect()
+            .await;
+        server.abort();
+
+        assert!(matches!(
+            events.as_slice(),
+            [ProviderEvent::Failed { error }]
+                if error.kind == "prompt_too_long"
+                    && error.message
+                        == "bedrock: the model's context window was exceeded mid-response"
         ));
     }
 }

--- a/crates/openwave-router/src/bedrock.rs
+++ b/crates/openwave-router/src/bedrock.rs
@@ -330,6 +330,8 @@ fn hex(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openwave_core::provider::ChatMessage;
+    use openwave_core::Role;
 
     #[test]
     fn protocol_selection_keeps_claude_on_messages_and_text_models_on_responses() {
@@ -392,5 +394,34 @@ mod tests {
         assert!(!valid_aws_region("../us-east-1"));
         assert!(!valid_aws_region("US-EAST-1"));
         assert!(!valid_aws_region("us-east-1.example.com"));
+    }
+
+    #[tokio::test]
+    async fn messages_transport_failures_are_attributed_to_bedrock() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (socket, _) = listener.accept().await.unwrap();
+            drop(socket);
+        });
+
+        let provider = BedrockProvider::new("us-east-1", BedrockAuth::ApiKey("secret".into()))
+            .unwrap()
+            .with_base_url(format!("http://{address}"));
+        let error = provider
+            .stream(ChatRequest {
+                model: "anthropic.claude-sonnet-5".into(),
+                messages: vec![ChatMessage::text(Role::User, "hi")],
+                ..Default::default()
+            })
+            .await
+            .err()
+            .expect("the dropped connection must fail before a response");
+        server.await.unwrap();
+
+        assert!(matches!(
+            error,
+            AgentError::Provider(message) if message == "bedrock request failed"
+        ));
     }
 }

--- a/crates/openwave-router/src/bedrock.rs
+++ b/crates/openwave-router/src/bedrock.rs
@@ -1,0 +1,396 @@
+//! Amazon Bedrock Mantle, normalized through the native protocol adapters.
+//!
+//! Bedrock Mantle deliberately exposes established inference contracts rather
+//! than another Bedrock-specific body:
+//!
+//! - Anthropic model ids use the Messages API at `/anthropic/v1/messages`.
+//! - Other explicitly configured text model ids use the OpenAI Responses API
+//!   at `/v1/responses`.
+//!
+//! Those streams are ordinary SSE, so the mature Anthropic and OpenAI adapters
+//! continue to own request shaping, replay, and normalization. This module owns
+//! the Bedrock endpoint boundary and its two authentication modes: Bedrock API
+//! keys and AWS Signature Version 4 credentials.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use futures::stream::BoxStream;
+use ring::{digest, hmac};
+
+use openwave_core::error::{AgentError, Result};
+use openwave_core::provider::{ChatRequest, ModelProvider, ProviderEvent, ProviderId};
+
+use crate::http::RequestAuthenticator;
+use crate::{AnthropicProvider, OpenAiProvider};
+
+const BEDROCK_MANTLE_SERVICE: &str = "bedrock-mantle";
+
+/// Long-lived AWS credentials used to sign Bedrock requests.
+///
+/// Every field is secret material. The type's `Debug` implementation never
+/// renders values, and the server keeps the serialized credential in the
+/// profile secret store rather than the operational database.
+#[derive(Clone, PartialEq, Eq)]
+pub struct AwsCredentials {
+    access_key_id: String,
+    secret_access_key: String,
+    session_token: Option<String>,
+}
+
+impl AwsCredentials {
+    pub fn new(
+        access_key_id: impl Into<String>,
+        secret_access_key: impl Into<String>,
+        session_token: Option<String>,
+    ) -> Self {
+        Self {
+            access_key_id: access_key_id.into(),
+            secret_access_key: secret_access_key.into(),
+            session_token,
+        }
+    }
+
+    pub fn access_key_id(&self) -> &str {
+        &self.access_key_id
+    }
+
+    pub fn secret_access_key(&self) -> &str {
+        &self.secret_access_key
+    }
+
+    pub fn session_token(&self) -> Option<&str> {
+        self.session_token.as_deref()
+    }
+}
+
+impl std::fmt::Debug for AwsCredentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AwsCredentials")
+            .field("access_key_id", &"***")
+            .field("secret_access_key", &"***")
+            .field("session_token", &self.session_token.as_ref().map(|_| "***"))
+            .finish()
+    }
+}
+
+/// Authentication accepted by direct Bedrock Mantle endpoints.
+#[derive(Clone)]
+pub enum BedrockAuth {
+    /// A Bedrock API key. Messages sends it as `x-api-key`; Responses uses the
+    /// OpenAI-compatible bearer header.
+    ApiKey(String),
+    /// AWS credentials signed with Signature Version 4.
+    AwsCredentials(AwsCredentials),
+}
+
+impl std::fmt::Debug for BedrockAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ApiKey(_) => f.debug_tuple("ApiKey").field(&"***").finish(),
+            Self::AwsCredentials(credentials) => {
+                f.debug_tuple("AwsCredentials").field(credentials).finish()
+            }
+        }
+    }
+}
+
+/// A direct Amazon Bedrock Mantle model provider.
+#[derive(Clone)]
+pub struct BedrockProvider {
+    auth: BedrockAuth,
+    region: String,
+    base_url: String,
+}
+
+impl BedrockProvider {
+    /// Build a provider for the standard Bedrock Mantle endpoint in `region`.
+    pub fn new(region: impl Into<String>, auth: BedrockAuth) -> Result<Self> {
+        let region = region.into();
+        if !valid_aws_region(&region) {
+            return Err(AgentError::config("invalid AWS region for Bedrock"));
+        }
+        Ok(Self {
+            auth,
+            base_url: format!("https://bedrock-mantle.{region}.api.aws"),
+            region,
+        })
+    }
+
+    /// Override the endpoint root for a local contract test.
+    ///
+    /// Production routing never reads a stored endpoint for Bedrock: API keys
+    /// and SigV4 credentials may only go to the host derived from the configured
+    /// AWS region.
+    #[must_use]
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = base_url.into();
+        self
+    }
+
+    fn request_auth(&self, protocol: BedrockProtocol) -> Arc<dyn RequestAuthenticator> {
+        Arc::new(BedrockRequestAuth {
+            auth: self.auth.clone(),
+            region: self.region.clone(),
+            protocol,
+        })
+    }
+}
+
+/// A conservative AWS region validator suitable for endpoint construction.
+pub fn valid_aws_region(region: &str) -> bool {
+    let bytes = region.as_bytes();
+    !bytes.is_empty()
+        && bytes.len() <= 64
+        && bytes[0].is_ascii_alphanumeric()
+        && bytes[bytes.len() - 1].is_ascii_alphanumeric()
+        && bytes
+            .iter()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || *byte == b'-')
+}
+
+#[async_trait]
+impl ModelProvider for BedrockProvider {
+    fn id(&self) -> ProviderId {
+        ProviderId::new("bedrock")
+    }
+
+    async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+        match protocol_for_model(&req.model) {
+            BedrockProtocol::Messages => {
+                AnthropicProvider::new("")
+                    .with_base_url(format!("{}/anthropic", self.base_url.trim_end_matches('/')))
+                    .with_request_auth(self.request_auth(BedrockProtocol::Messages), "bedrock")
+                    .stream(req)
+                    .await
+            }
+            BedrockProtocol::Responses => {
+                OpenAiProvider::new("")
+                    .with_base_url(format!("{}/v1", self.base_url.trim_end_matches('/')))
+                    .with_request_auth(self.request_auth(BedrockProtocol::Responses), "bedrock")
+                    .stream(req)
+                    .await
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BedrockProtocol {
+    Messages,
+    Responses,
+}
+
+fn protocol_for_model(model: &str) -> BedrockProtocol {
+    let leaf = model.rsplit('/').next().unwrap_or(model);
+    let without_region = ["us.", "eu.", "apac.", "jp.", "au.", "global."]
+        .iter()
+        .find_map(|prefix| leaf.strip_prefix(prefix))
+        .unwrap_or(leaf);
+    if without_region.starts_with("anthropic.") {
+        BedrockProtocol::Messages
+    } else {
+        BedrockProtocol::Responses
+    }
+}
+
+#[derive(Clone)]
+struct BedrockRequestAuth {
+    auth: BedrockAuth,
+    region: String,
+    protocol: BedrockProtocol,
+}
+
+impl RequestAuthenticator for BedrockRequestAuth {
+    fn authenticate(
+        &self,
+        request: reqwest::RequestBuilder,
+        url: &reqwest::Url,
+        body: &[u8],
+    ) -> Result<reqwest::RequestBuilder> {
+        match &self.auth {
+            BedrockAuth::ApiKey(key) => Ok(match self.protocol {
+                BedrockProtocol::Messages => request.header("x-api-key", key),
+                BedrockProtocol::Responses => request.bearer_auth(key),
+            }),
+            BedrockAuth::AwsCredentials(credentials) => {
+                let signed = sign_request(url, body, &self.region, credentials, Utc::now())?;
+                let mut request = request
+                    .header("x-amz-date", signed.amz_date)
+                    .header("x-amz-content-sha256", signed.payload_hash)
+                    .header(reqwest::header::AUTHORIZATION, signed.authorization);
+                if let Some(token) = credentials.session_token() {
+                    request = request.header("x-amz-security-token", token);
+                }
+                Ok(request)
+            }
+        }
+    }
+}
+
+struct SignedRequest {
+    amz_date: String,
+    payload_hash: String,
+    authorization: String,
+}
+
+fn sign_request(
+    url: &reqwest::Url,
+    body: &[u8],
+    region: &str,
+    credentials: &AwsCredentials,
+    now: DateTime<Utc>,
+) -> Result<SignedRequest> {
+    let host = canonical_host(url)?;
+    let amz_date = now.format("%Y%m%dT%H%M%SZ").to_string();
+    let date = now.format("%Y%m%d").to_string();
+    let payload_hash = sha256_hex(body);
+    let mut headers = vec![
+        ("content-type", "application/json".to_owned()),
+        ("host", host),
+        ("x-amz-content-sha256", payload_hash.clone()),
+        ("x-amz-date", amz_date.clone()),
+    ];
+    if let Some(token) = credentials.session_token() {
+        headers.push(("x-amz-security-token", token.to_owned()));
+    }
+    headers.sort_by_key(|(name, _)| *name);
+    let signed_headers = headers
+        .iter()
+        .map(|(name, _)| *name)
+        .collect::<Vec<_>>()
+        .join(";");
+    let canonical_headers = headers
+        .iter()
+        .map(|(name, value)| format!("{name}:{}\n", collapse_spaces(value)))
+        .collect::<String>();
+    let canonical_request = format!(
+        "POST\n{}\n\n{canonical_headers}\n{signed_headers}\n{payload_hash}",
+        url.path()
+    );
+    let scope = format!("{date}/{region}/{BEDROCK_MANTLE_SERVICE}/aws4_request");
+    let string_to_sign = format!(
+        "AWS4-HMAC-SHA256\n{amz_date}\n{scope}\n{}",
+        sha256_hex(canonical_request.as_bytes())
+    );
+    let date_key = hmac_sha256(
+        format!("AWS4{}", credentials.secret_access_key()).as_bytes(),
+        date.as_bytes(),
+    );
+    let region_key = hmac_sha256(&date_key, region.as_bytes());
+    let service_key = hmac_sha256(&region_key, BEDROCK_MANTLE_SERVICE.as_bytes());
+    let signing_key = hmac_sha256(&service_key, b"aws4_request");
+    let signature = hex(&hmac_sha256(&signing_key, string_to_sign.as_bytes()));
+    let authorization = format!(
+        "AWS4-HMAC-SHA256 Credential={}/{scope}, SignedHeaders={signed_headers}, Signature={signature}",
+        credentials.access_key_id()
+    );
+    Ok(SignedRequest {
+        amz_date,
+        payload_hash,
+        authorization,
+    })
+}
+
+fn canonical_host(url: &reqwest::Url) -> Result<String> {
+    let host = url
+        .host_str()
+        .ok_or_else(|| AgentError::config("Bedrock endpoint has no host"))?;
+    Ok(match url.port() {
+        Some(port) => format!("{host}:{port}"),
+        None => host.to_owned(),
+    })
+}
+
+fn collapse_spaces(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    hex(digest::digest(&digest::SHA256, bytes).as_ref())
+}
+
+fn hmac_sha256(key: &[u8], message: &[u8]) -> Vec<u8> {
+    hmac::sign(&hmac::Key::new(hmac::HMAC_SHA256, key), message)
+        .as_ref()
+        .to_vec()
+}
+
+fn hex(bytes: &[u8]) -> String {
+    const DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(DIGITS[(byte >> 4) as usize] as char);
+        out.push(DIGITS[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn protocol_selection_keeps_claude_on_messages_and_text_models_on_responses() {
+        assert_eq!(
+            protocol_for_model("anthropic.claude-sonnet-5"),
+            BedrockProtocol::Messages
+        );
+        assert_eq!(
+            protocol_for_model("us.anthropic.claude-sonnet-5"),
+            BedrockProtocol::Messages
+        );
+        assert_eq!(
+            protocol_for_model("openai.gpt-oss-120b"),
+            BedrockProtocol::Responses
+        );
+    }
+
+    #[test]
+    fn sigv4_signature_is_deterministic_and_redacts_debug() {
+        let credentials = AwsCredentials::new(
+            "AKIDEXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+            Some("session-token".into()),
+        );
+        let url =
+            reqwest::Url::parse("https://bedrock-mantle.us-east-1.api.aws/anthropic/v1/messages")
+                .unwrap();
+        let now = DateTime::parse_from_rfc3339("2026-08-07T12:34:56Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let signed =
+            sign_request(&url, br#"{"messages":[]}"#, "us-east-1", &credentials, now).unwrap();
+        assert_eq!(signed.amz_date, "20260807T123456Z");
+        assert_eq!(
+            signed.payload_hash,
+            "5e4ce7b36ba37b78a5d5f9fd08e6b7b54ba6879d651aa46ec9e1d6fa24ebe30a"
+        );
+        let (authorization, signature) = signed.authorization.rsplit_once("Signature=").unwrap();
+        assert_eq!(
+            authorization,
+            "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20260807/us-east-1/bedrock-mantle/aws4_request, SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token, "
+        );
+        assert_eq!(
+            signature,
+            hex(&[
+                0x34, 0xca, 0x24, 0xb8, 0x07, 0x2c, 0xd0, 0x9c, 0x22, 0x91, 0xb2, 0x0f, 0x7f, 0x83,
+                0xf9, 0x65, 0xd8, 0x49, 0xab, 0x2b, 0x7c, 0xc9, 0xdd, 0x7c, 0xfa, 0x65, 0xe9, 0x5a,
+                0xc8, 0x38, 0x20, 0x4b,
+            ])
+        );
+        let debug = format!("{credentials:?}");
+        assert!(!debug.contains("AKIDEXAMPLE"));
+        assert!(!debug.contains("session-token"));
+    }
+
+    #[test]
+    fn region_validation_rejects_host_escape_characters() {
+        assert!(valid_aws_region("us-east-1"));
+        assert!(valid_aws_region("us-gov-west-1"));
+        assert!(!valid_aws_region("../us-east-1"));
+        assert!(!valid_aws_region("US-EAST-1"));
+        assert!(!valid_aws_region("us-east-1.example.com"));
+    }
+}

--- a/crates/openwave-router/src/http.rs
+++ b/crates/openwave-router/src/http.rs
@@ -37,6 +37,24 @@ use std::time::Duration;
 
 use futures::{Stream, StreamExt};
 
+use openwave_core::error::Result;
+
+/// Provider-specific authentication applied to an already-shaped HTTP request.
+///
+/// Most adapters own a fixed header scheme, but Bedrock Mantle exposes existing
+/// Messages and Responses wire contracts behind either a bearer key or AWS
+/// Signature Version 4. Keeping authentication at this boundary lets those
+/// adapters retain their mature request/stream normalization while signing the
+/// exact bytes they send.
+pub(crate) trait RequestAuthenticator: Send + Sync {
+    fn authenticate(
+        &self,
+        request: reqwest::RequestBuilder,
+        url: &reqwest::Url,
+        body: &[u8],
+    ) -> Result<reqwest::RequestBuilder>;
+}
+
 /// Connect-phase budget. Loopback is instant and a reachable hosted provider
 /// completes TCP + TLS well inside this; anything slower is unreachable, not
 /// slow.

--- a/crates/openwave-router/src/lib.rs
+++ b/crates/openwave-router/src/lib.rs
@@ -41,7 +41,7 @@ pub mod vertex;
 #[cfg(feature = "anthropic")]
 pub use anthropic::AnthropicProvider;
 #[cfg(feature = "bedrock")]
-pub use bedrock::{valid_aws_region, AwsCredentials, BedrockAuth, BedrockProvider};
+pub use bedrock::{valid_aws_region, BedrockAuth, BedrockProvider};
 #[cfg(feature = "gemini")]
 pub use gemini::GeminiProvider;
 #[cfg(feature = "_http")]

--- a/crates/openwave-router/src/lib.rs
+++ b/crates/openwave-router/src/lib.rs
@@ -38,6 +38,9 @@ pub mod google_auth;
 #[cfg(all(feature = "anthropic", feature = "gemini"))]
 pub mod vertex;
 
+#[cfg(feature = "bedrock")]
+pub mod bedrock;
+
 #[cfg(feature = "anthropic")]
 pub use anthropic::AnthropicProvider;
 #[cfg(feature = "bedrock")]
@@ -52,7 +55,10 @@ pub use google_auth::{GoogleServiceAccount, GoogleServiceAccountTokenSource};
 pub use openai::OpenAiProvider;
 #[cfg(feature = "openai-compat")]
 pub use openai_compat::OpenAiCompatProvider;
-pub use router::{BearerTokenSource, Route, RouteKind, Router, VertexModelFamily, VertexRoute};
+pub use router::{
+    AwsCredentials, BearerTokenSource, BedrockRoute, Route, RouteKind, Router, VertexModelFamily,
+    VertexRoute,
+};
 #[cfg(all(feature = "anthropic", feature = "gemini"))]
 pub use vertex::VertexProvider;
 #[cfg(feature = "xai")]

--- a/crates/openwave-router/src/lib.rs
+++ b/crates/openwave-router/src/lib.rs
@@ -40,6 +40,8 @@ pub mod vertex;
 
 #[cfg(feature = "anthropic")]
 pub use anthropic::AnthropicProvider;
+#[cfg(feature = "bedrock")]
+pub use bedrock::{valid_aws_region, AwsCredentials, BedrockAuth, BedrockProvider};
 #[cfg(feature = "gemini")]
 pub use gemini::GeminiProvider;
 #[cfg(feature = "_http")]

--- a/crates/openwave-router/src/openai.rs
+++ b/crates/openwave-router/src/openai.rs
@@ -90,6 +90,8 @@ pub struct OpenAiProvider {
     client: reqwest::Client,
     api_key: String,
     base_url: String,
+    request_auth: Option<Arc<dyn crate::http::RequestAuthenticator>>,
+    provider_label: &'static str,
     /// Per-request credential supplier for ChatGPT OAuth (and similar)
     /// short-lived tokens. Takes precedence over `api_key` when present.
     token_source: Option<Arc<dyn BearerTokenSource>>,
@@ -107,6 +109,8 @@ impl OpenAiProvider {
             client: crate::http::streaming_client(),
             api_key: api_key.into(),
             base_url: DEFAULT_BASE_URL.to_string(),
+            request_auth: None,
+            provider_label: "openai",
             token_source: None,
             chatgpt_account_id: None,
             chatgpt_originator: DEFAULT_CHATGPT_ORIGINATOR.to_string(),
@@ -123,6 +127,8 @@ impl OpenAiProvider {
             client: crate::http::streaming_client(),
             api_key: api_key.into(),
             base_url: base_url.into(),
+            request_auth: None,
+            provider_label: profile.provider(),
             token_source: None,
             chatgpt_account_id: None,
             chatgpt_originator: DEFAULT_CHATGPT_ORIGINATOR.to_string(),
@@ -139,6 +145,18 @@ impl OpenAiProvider {
     #[cfg(test)]
     pub(crate) fn base_url_for_test(&self) -> &str {
         &self.base_url
+    }
+
+    /// Authenticate the exact serialized request through a shared transport.
+    #[must_use]
+    pub(crate) fn with_request_auth(
+        mut self,
+        auth: Arc<dyn crate::http::RequestAuthenticator>,
+        provider_label: &'static str,
+    ) -> Self {
+        self.request_auth = Some(auth);
+        self.provider_label = provider_label;
+        self
     }
 
     /// Fetch the credential from `source` at each request instead of using a
@@ -169,22 +187,30 @@ impl OpenAiProvider {
 #[async_trait]
 impl ModelProvider for OpenAiProvider {
     fn id(&self) -> ProviderId {
-        ProviderId::new(self.profile.provider())
+        ProviderId::new(self.provider_label)
     }
 
     async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
         let body = build_request_json_for(&req, self.profile)?;
-        let provider = self.profile.provider();
+        let wire_provider = self.profile.provider();
+        let provider_label = self.provider_label;
         let url = format!("{}/responses", self.base_url.trim_end_matches('/'));
-        let api_key = match &self.token_source {
-            Some(source) => source.bearer_token_for(req.conversation).await?,
-            None => self.api_key.clone(),
+        let url = reqwest::Url::parse(&url)
+            .map_err(|_| AgentError::config("invalid Responses API endpoint"))?;
+        let body = serde_json::to_vec(&body)?;
+        let api_key = match (&self.request_auth, &self.token_source) {
+            (Some(_), _) => String::new(),
+            (None, Some(source)) => source.bearer_token_for(req.conversation).await?,
+            (None, None) => self.api_key.clone(),
         };
         let mut request = self
             .client
-            .post(url)
-            .bearer_auth(&api_key)
+            .post(url.clone())
             .header("content-type", "application/json");
+        request = match &self.request_auth {
+            Some(auth) => auth.authenticate(request, &url, &body)?,
+            None => request.bearer_auth(&api_key),
+        };
         if let Some(account_id) = &self.chatgpt_account_id {
             request = request
                 .header("ChatGPT-Account-ID", account_id)
@@ -192,18 +218,21 @@ impl ModelProvider for OpenAiProvider {
                 .header("originator", &self.chatgpt_originator);
         }
         let response = request
-            .json(&body)
+            .body(body)
             .send()
             .await
-            .map_err(|_| AgentError::Provider(format!("{provider} request failed")))?;
+            .map_err(|_| AgentError::Provider(format!("{provider_label} request failed")))?;
 
         let status = response.status();
         if !status.is_success() {
             let retry_after = crate::sse::retry_after_hint(response.headers());
             let body = read_bounded_error_body(response.bytes_stream()).await;
-            return Err(self
-                .profile
-                .classify_http_error(status.as_u16(), &body, retry_after));
+            return Err(if provider_label == wire_provider {
+                self.profile
+                    .classify_http_error(status.as_u16(), &body, retry_after)
+            } else {
+                classify_provider_error(provider_label, status.as_u16(), &body, retry_after)
+            });
         }
 
         let ceiling = crate::http::timeouts().total_stream;
@@ -211,13 +240,16 @@ impl ModelProvider for OpenAiProvider {
             let bytes = crate::http::with_stream_deadline(response.bytes_stream(), ceiling);
             futures::pin_mut!(bytes);
             let mut buffer = Vec::new();
-            let mut state = StreamState::default();
+            let mut state = StreamState {
+                provider_label,
+                ..StreamState::default()
+            };
             while let Some(chunk) = bytes.next().await {
                 let chunk = match chunk {
                     Ok(chunk) => chunk,
                     Err(error) => {
                         yield ProviderEvent::Failed {
-                            error: ProviderErrorInfo::provider(error.client_message(provider)),
+                            error: ProviderErrorInfo::provider(error.client_message(provider_label)),
                         };
                         return;
                     }
@@ -225,7 +257,7 @@ impl ModelProvider for OpenAiProvider {
                 buffer.extend_from_slice(&chunk);
                 for frame in drain_frames(&mut buffer) {
                     if let Some(data) = frame_data(&frame) {
-                        for event in normalize_for(&data, &mut state, provider) {
+                        for event in normalize_for(&data, &mut state, wire_provider) {
                             yield event;
                         }
                     }
@@ -234,7 +266,7 @@ impl ModelProvider for OpenAiProvider {
             if !buffer.is_empty() {
                 let frame = String::from_utf8_lossy(&buffer).into_owned();
                 if let Some(data) = frame_data(&frame) {
-                    for event in normalize_for(&data, &mut state, provider) {
+                    for event in normalize_for(&data, &mut state, wire_provider) {
                         yield event;
                     }
                 }
@@ -242,7 +274,7 @@ impl ModelProvider for OpenAiProvider {
             if !state.terminal {
                 yield ProviderEvent::Failed {
                     error: ProviderErrorInfo::provider(format!(
-                        "{provider} stream ended before completion"
+                        "{provider_label} stream ended before completion"
                     )),
                 };
             }
@@ -607,6 +639,7 @@ fn openai_tool_choice(choice: &ToolChoice) -> Result<Value> {
 
 #[derive(Default)]
 struct StreamState {
+    provider_label: &'static str,
     calls: BTreeMap<String, CallState>,
     next_index: u32,
     terminal: bool,
@@ -666,7 +699,7 @@ fn normalize_for(
             let mut events = flush_search(state, provider);
             events.push(ProviderEvent::Failed {
                 error: ProviderErrorInfo::from_error(&classify_in_band_error(
-                    provider,
+                    stream_provider_label(state),
                     data.get("error").unwrap_or(data),
                 )),
             });
@@ -761,7 +794,8 @@ fn normalize_for(
                 }),
                 _ => events.push(ProviderEvent::Failed {
                     error: ProviderErrorInfo::provider(format!(
-                        "{provider} response ended incomplete without a supported reason"
+                        "{} response ended incomplete without a supported reason",
+                        stream_provider_label(state)
                     )),
                 }),
             }
@@ -772,11 +806,22 @@ fn normalize_for(
             let error = data["response"].get("error").unwrap_or(&data["response"]);
             let mut events = flush_search(state, provider);
             events.push(ProviderEvent::Failed {
-                error: ProviderErrorInfo::from_error(&classify_in_band_error(provider, error)),
+                error: ProviderErrorInfo::from_error(&classify_in_band_error(
+                    stream_provider_label(state),
+                    error,
+                )),
             });
             events
         }
         _ => Vec::new(),
+    }
+}
+
+fn stream_provider_label(state: &StreamState) -> &'static str {
+    if state.provider_label.is_empty() {
+        "openai"
+    } else {
+        state.provider_label
     }
 }
 

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -1734,6 +1734,7 @@ mod tests {
             curated_models: vec!["gpt-fable-5".to_string()],
             token_source: Some(source.clone()),
             vertex: None,
+            bedrock: None,
             chatgpt_account_id: None,
         }]);
         let conversation = openwave_core::id::ChatId::new();

--- a/crates/openwave-router/src/router.rs
+++ b/crates/openwave-router/src/router.rs
@@ -29,6 +29,8 @@ use crate::OpenAiProvider;
 use crate::VertexProvider;
 #[cfg(feature = "xai")]
 use crate::XaiProvider;
+#[cfg(feature = "bedrock")]
+use crate::{BedrockAuth, BedrockProvider};
 
 /// Native request protocol used by one curated Vertex model.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -78,6 +80,39 @@ pub struct VertexRoute {
     location: String,
     credential_fingerprint: [u8; 32],
     model_families: Vec<(String, VertexModelFamily)>,
+}
+
+/// Bedrock-specific endpoint and SigV4 metadata.
+///
+/// The region is non-secret. AWS credentials stay redacted through their own
+/// `Debug` implementation and are hashed, never copied, into router cache
+/// fingerprints.
+#[derive(Clone)]
+pub struct BedrockRoute {
+    region: String,
+    credentials: Option<crate::AwsCredentials>,
+}
+
+impl BedrockRoute {
+    pub fn new(region: impl Into<String>, credentials: Option<crate::AwsCredentials>) -> Self {
+        Self {
+            region: region.into(),
+            credentials,
+        }
+    }
+
+    pub fn region(&self) -> &str {
+        &self.region
+    }
+}
+
+impl std::fmt::Debug for BedrockRoute {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BedrockRoute")
+            .field("region", &self.region)
+            .field("credentials", &self.credentials)
+            .finish()
+    }
 }
 
 impl VertexRoute {
@@ -216,6 +251,9 @@ pub struct Route {
     /// Vertex resource/auth metadata. Present for the first-class Vertex route
     /// and for a legacy Gemini route backed by a Google service account.
     pub vertex: Option<VertexRoute>,
+    /// Bedrock region and optional SigV4 credentials. An absent credential
+    /// means `api_key` supplies a Bedrock API key.
+    pub bedrock: Option<BedrockRoute>,
     /// ChatGPT account id for OpenAI routes authenticated via ChatGPT OAuth.
     /// Baked into the adapter (only the bearer rotates).
     pub chatgpt_account_id: Option<String>,
@@ -230,6 +268,7 @@ impl std::fmt::Debug for Route {
             .field("curated_models", &self.curated_models)
             .field("token_source", &self.token_source.is_some())
             .field("vertex", &self.vertex)
+            .field("bedrock", &self.bedrock)
             .field("chatgpt_account_id", &self.chatgpt_account_id)
             .finish()
     }
@@ -373,7 +412,14 @@ impl ModelProvider for Router {
 }
 
 fn build_adapter(route: &Route) -> Option<Arc<dyn ModelProvider>> {
-    if route.api_key.is_empty() && route.token_source.is_none() {
+    if route.api_key.is_empty()
+        && route.token_source.is_none()
+        && route
+            .bedrock
+            .as_ref()
+            .and_then(|bedrock| bedrock.credentials.as_ref())
+            .is_none()
+    {
         return None;
     }
     match route.kind {
@@ -509,6 +555,20 @@ fn build_adapter(route: &Route) -> Option<Arc<dyn ModelProvider>> {
         RouteKind::Vertex => None,
         #[cfg(not(feature = "gemini"))]
         RouteKind::Gemini => None,
+        #[cfg(feature = "bedrock")]
+        RouteKind::Bedrock => {
+            let bedrock = route.bedrock.as_ref()?;
+            let auth = match &bedrock.credentials {
+                Some(credentials) => BedrockAuth::AwsCredentials(credentials.clone()),
+                None if !route.api_key.is_empty() => BedrockAuth::ApiKey(route.api_key.clone()),
+                None => return None,
+            };
+            Some(Arc::new(
+                BedrockProvider::new(bedrock.region.clone(), auth).ok()?,
+            ))
+        }
+        #[cfg(not(feature = "bedrock"))]
+        RouteKind::Bedrock => None,
         #[cfg(not(feature = "openai"))]
         RouteKind::Openai => None,
         #[cfg(not(feature = "xai"))]
@@ -525,7 +585,7 @@ fn fingerprint_routes(routes: &[Route]) -> String {
         .iter()
         .map(|r| {
             format!(
-                "{}|{}|{}|{}|{}|{}",
+                "{}|{}|{}|{}|{}|{}|{}",
                 r.kind.as_str(),
                 // A rotating token must not thrash the cached router; the
                 // fingerprint tracks *whether* a live source exists, and the
@@ -556,6 +616,21 @@ fn fingerprint_routes(routes: &[Route]) -> String {
                         .join(",");
                     format!("{}:{credential}:{families}", vertex.location)
                 }),
+                r.bedrock.as_ref().map_or_else(String::new, |bedrock| {
+                    let credential =
+                        bedrock
+                            .credentials
+                            .as_ref()
+                            .map_or_else(String::new, |credentials| {
+                                format!(
+                                    "{:x}:{:x}:{:x}",
+                                    fnv1a64(credentials.access_key_id()),
+                                    fnv1a64(credentials.secret_access_key()),
+                                    credentials.session_token().map_or(0, fnv1a64),
+                                )
+                            });
+                    format!("{}:{credential}", bedrock.region)
+                }),
                 r.chatgpt_account_id.as_deref().unwrap_or("")
             )
         })
@@ -578,11 +653,9 @@ fn fnv1a64(s: &str) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(feature = "xai")]
-    use openwave_core::provider::{ContentBlock, MessageReasoning, ReasoningOrigin};
-    use openwave_core::ImageAttachments;
-    #[cfg(feature = "xai")]
-    use openwave_core::{ChatMessage, Role};
+    use futures::StreamExt as _;
+    use openwave_core::provider::{ChatMessage, ContentBlock, MessageReasoning, ReasoningOrigin};
+    use openwave_core::{ImageAttachments, Role};
     #[cfg(feature = "xai")]
     use serde_json::json;
 
@@ -594,6 +667,7 @@ mod tests {
             curated_models: models.iter().map(|m| (*m).to_string()).collect(),
             token_source: None,
             vertex: None,
+            bedrock: None,
             chatgpt_account_id: None,
         }
     }
@@ -997,5 +1071,78 @@ mod tests {
         let body = rx.await.unwrap();
         assert_eq!(body["input"][0], reasoning);
         assert!(body.get("provider").is_none());
+    }
+
+    #[tokio::test]
+    async fn router_preserves_the_route_hint_needed_for_native_reasoning_replay() {
+        use axum::body::Body;
+        use axum::extract::{Request, State};
+        use axum::response::IntoResponse;
+        use axum::routing::post;
+        use tokio::sync::oneshot;
+
+        async fn capture(
+            State(tx): State<Arc<std::sync::Mutex<Option<oneshot::Sender<serde_json::Value>>>>>,
+            request: Request,
+        ) -> impl IntoResponse {
+            let body = axum::body::to_bytes(request.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            if let Some(tx) = tx.lock().unwrap().take() {
+                let _ = tx.send(serde_json::from_slice(&body).unwrap());
+            }
+            (
+                [("content-type", "text/event-stream")],
+                Body::from(
+                    "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"}}\n\n",
+                ),
+            )
+        }
+
+        let (tx, rx) = oneshot::channel();
+        let app = axum::Router::new()
+            .fallback(post(capture))
+            .with_state(Arc::new(std::sync::Mutex::new(Some(tx))));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let model = "claude-sonnet-5";
+        let router = Router::build(vec![route(
+            RouteKind::Anthropic,
+            "key",
+            &[model],
+            Some(&format!("http://{address}")),
+        )]);
+        let mut stream = router
+            .stream(ChatRequest {
+                provider: Some(ProviderId::new("anthropic")),
+                model: model.into(),
+                reasoning_model: true,
+                messages: vec![ChatMessage {
+                    role: Role::Assistant,
+                    content: vec![ContentBlock::Text {
+                        text: "answer".into(),
+                    }],
+                    reasoning: MessageReasoning::captured(
+                        ReasoningOrigin {
+                            provider: Some(ProviderId::new("anthropic")),
+                            model: model.into(),
+                        },
+                        vec![serde_json::json!({
+                            "type": "thinking",
+                            "thinking": "plan",
+                            "signature": "signed",
+                        })],
+                    ),
+                }],
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        while stream.next().await.is_some() {}
+
+        let body = rx.await.unwrap();
+        assert_eq!(body["messages"][0]["content"][0]["type"], "thinking");
     }
 }

--- a/crates/openwave-router/src/router.rs
+++ b/crates/openwave-router/src/router.rs
@@ -228,6 +228,8 @@ pub enum RouteKind {
     Gemini,
     /// Google Vertex AI with native Gemini and Anthropic Claude protocols.
     Vertex,
+    /// Amazon Bedrock Mantle (Claude Messages or OpenAI Responses).
+    Bedrock,
     /// A model-gateway deployment's Anthropic-compatible surface, authenticated
     /// with short-lived resource-scoped tokens instead of a static key.
     ModelGateway,
@@ -251,6 +253,7 @@ impl RouteKind {
             RouteKind::OpenaiCompatible => "openai_compatible",
             RouteKind::Gemini => "gemini",
             RouteKind::Vertex => "vertex",
+            RouteKind::Bedrock => "bedrock",
             RouteKind::ModelGateway => "model_gateway",
             RouteKind::ModelGatewayOpenai => "model_gateway_openai",
         }
@@ -275,6 +278,7 @@ impl RouteKind {
             "openai_compatible" => Some(Self::OpenaiCompatible),
             "gemini" => Some(Self::Gemini),
             "vertex" => Some(Self::Vertex),
+            "bedrock" => Some(Self::Bedrock),
             "model_gateway" => Some(Self::ModelGateway),
             _ => None,
         }
@@ -382,6 +386,7 @@ impl Router {
             RouteKind::Xai,
             RouteKind::Gemini,
             RouteKind::Vertex,
+            RouteKind::Bedrock,
             RouteKind::Fireworks,
             RouteKind::Together,
             RouteKind::ModelGateway,

--- a/crates/openwave-router/src/router.rs
+++ b/crates/openwave-router/src/router.rs
@@ -82,6 +82,54 @@ pub struct VertexRoute {
     model_families: Vec<(String, VertexModelFamily)>,
 }
 
+/// Long-lived AWS credentials used to sign Bedrock requests.
+///
+/// This carrier remains available without the `bedrock` transport feature so
+/// the public route configuration types keep compiling in narrower feature
+/// builds. Every field is secret material, and `Debug` never renders values.
+#[derive(Clone, PartialEq, Eq)]
+pub struct AwsCredentials {
+    access_key_id: String,
+    secret_access_key: String,
+    session_token: Option<String>,
+}
+
+impl AwsCredentials {
+    pub fn new(
+        access_key_id: impl Into<String>,
+        secret_access_key: impl Into<String>,
+        session_token: Option<String>,
+    ) -> Self {
+        Self {
+            access_key_id: access_key_id.into(),
+            secret_access_key: secret_access_key.into(),
+            session_token,
+        }
+    }
+
+    pub fn access_key_id(&self) -> &str {
+        &self.access_key_id
+    }
+
+    pub fn secret_access_key(&self) -> &str {
+        &self.secret_access_key
+    }
+
+    pub fn session_token(&self) -> Option<&str> {
+        self.session_token.as_deref()
+    }
+}
+
+impl std::fmt::Debug for AwsCredentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AwsCredentials")
+            .field("access_key_id", &"***")
+            .field("secret_access_key", &"***")
+            .field("session_token", &self.session_token.as_ref().map(|_| "***"))
+            .finish()
+    }
+}
+
 /// Bedrock-specific endpoint and SigV4 metadata.
 ///
 /// The region is non-secret. AWS credentials stay redacted through their own
@@ -90,11 +138,11 @@ pub struct VertexRoute {
 #[derive(Clone)]
 pub struct BedrockRoute {
     region: String,
-    credentials: Option<crate::AwsCredentials>,
+    credentials: Option<AwsCredentials>,
 }
 
 impl BedrockRoute {
-    pub fn new(region: impl Into<String>, credentials: Option<crate::AwsCredentials>) -> Self {
+    pub fn new(region: impl Into<String>, credentials: Option<AwsCredentials>) -> Self {
         Self {
             region: region.into(),
             credentials,

--- a/crates/openwave-router/src/sse.rs
+++ b/crates/openwave-router/src/sse.rs
@@ -236,6 +236,7 @@ fn contains_secret_marker(message: &str) -> bool {
     [
         "sk-",
         "aiza",
+        "absk",
         "bearer ",
         "api_key",
         "api-key",
@@ -245,6 +246,13 @@ fn contains_secret_marker(message: &str) -> bool {
         "x-goog-api-key",
         "private_key",
         "private key",
+        "access_key_id",
+        "access key id",
+        "secret_access_key",
+        "secret access key",
+        "session_token",
+        "session token",
+        "x-amz-security-token",
     ]
     .iter()
     .any(|marker| lower.contains(marker))

--- a/crates/openwave-router/src/sse.rs
+++ b/crates/openwave-router/src/sse.rs
@@ -233,7 +233,7 @@ fn contains_sensitive_value(text: &str, sensitive_values: &[&str]) -> bool {
 
 fn contains_secret_marker(message: &str) -> bool {
     let lower = message.to_ascii_lowercase();
-    [
+    if [
         "sk-",
         "aiza",
         "absk",
@@ -256,6 +256,55 @@ fn contains_secret_marker(message: &str) -> bool {
     ]
     .iter()
     .any(|marker| lower.contains(marker))
+    {
+        return true;
+    }
+
+    // AWS credential fields are emitted in several naming styles: process
+    // credentials use PascalCase, SDKs commonly use camelCase, and environment
+    // variables and shared config use separators. Compare a compact form so
+    // every spelling fails closed, including harmless punctuation or spacing
+    // inserted around a field name.
+    let compact = lower
+        .bytes()
+        .filter(u8::is_ascii_alphanumeric)
+        .map(char::from)
+        .collect::<String>();
+    if [
+        "accesskeyid",
+        "secretaccesskey",
+        "sessiontoken",
+        "xamzsecuritytoken",
+        "aws4hmacsha256credential",
+        "xamzcredential",
+    ]
+    .iter()
+    .any(|marker| compact.contains(marker))
+    {
+        return true;
+    }
+
+    contains_aws_access_key_id(message)
+}
+
+/// Recognize a bare 20-character AWS access key ID without treating ordinary
+/// words containing `asia` as credentials. Long-term keys use `AKIA`; temporary
+/// STS credentials use `ASIA`.
+fn contains_aws_access_key_id(message: &str) -> bool {
+    const ACCESS_KEY_ID_LEN: usize = 20;
+    let bytes = message.as_bytes();
+    bytes
+        .windows(ACCESS_KEY_ID_LEN)
+        .enumerate()
+        .any(|(start, candidate)| {
+            let has_prefix = candidate[..4].eq_ignore_ascii_case(b"AKIA")
+                || candidate[..4].eq_ignore_ascii_case(b"ASIA");
+            let has_valid_body = candidate[4..].iter().all(u8::is_ascii_alphanumeric);
+            let starts_at_boundary = start == 0 || !bytes[start - 1].is_ascii_alphanumeric();
+            let end = start + ACCESS_KEY_ID_LEN;
+            let ends_at_boundary = end == bytes.len() || !bytes[end].is_ascii_alphanumeric();
+            has_prefix && has_valid_body && starts_at_boundary && ends_at_boundary
+        })
 }
 
 /// Longest provider-requested wait taken at face value.

--- a/crates/openwave-router/src/sse.rs
+++ b/crates/openwave-router/src/sse.rs
@@ -601,6 +601,54 @@ mod tests {
     }
 
     #[test]
+    fn bedrock_http_and_in_band_errors_redact_credential_material() {
+        let markers = [
+            "ABSKDISTINCTIVEBEDROCKKEY",
+            "access_key_id=AKIAEXAMPLE",
+            "secret_access_key=distinctive-secret",
+            "session_token=distinctive-session",
+            "x-amz-security-token: distinctive-token",
+            "AccessKeyId=AKIAEXAMPLE",
+            "SecretAccessKey=distinctive-compact-secret",
+            "secretAccessKey: distinctive-camel-secret",
+            "SessionToken=distinctive-compact-session",
+            "sessionToken: distinctive-camel-session",
+            "AKIAIOSFODNN7EXAMPLE",
+            "ASIAIOSFODNN7EXAMPLE",
+            concat!(
+                "AWS4-HMAC-SHA256 Credential=EXAMPLEKEY/20260807/us-east-1/",
+                "bedrock-mantle/aws4_request, SignedHeaders=host;x-amz-date, ",
+                "Signature=distinctive-signature"
+            ),
+            concat!(
+                "X-Amz-Credential=EXAMPLEKEY%2F20260807%2Fus-east-1%2F",
+                "bedrock-mantle%2Faws4_request"
+            ),
+        ];
+
+        for marker in markers {
+            let body = serde_json::json!({
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": format!("provider echoed {marker}")
+                }
+            })
+            .to_string();
+            let http = safe_http_error("bedrock", 400, &body);
+            assert_eq!(http, "bedrock returned 400 (invalid_request_error)");
+            assert!(!http.contains(marker));
+
+            let frame = serde_json::json!({
+                "code": 400,
+                "message": format!("provider echoed {marker}")
+            });
+            let in_band = classify_in_band_error("bedrock", &frame).to_string();
+            assert!(!in_band.contains(marker));
+            assert!(!in_band.contains("provider echoed"));
+        }
+    }
+
+    #[test]
     fn known_vertex_project_is_removed_while_status_and_code_remain() {
         let project_id = "customer-project-123";
         let body = serde_json::json!({

--- a/crates/openwave-router/tests/fixtures/bedrock/messages/tool_loop_closure.events.json
+++ b/crates/openwave-router/tests/fixtures/bedrock/messages/tool_loop_closure.events.json
@@ -1,0 +1,37 @@
+[
+  {
+    "text": "a.toml is read. ",
+    "type": "text_delta"
+  },
+  {
+    "text": "Retrying b.toml.",
+    "type": "text_delta"
+  },
+  {
+    "id": "toolu_3",
+    "index": 1,
+    "name": "read_file",
+    "type": "tool_call_started"
+  },
+  {
+    "fragment": "{\"path\":",
+    "index": 1,
+    "type": "tool_call_args_delta"
+  },
+  {
+    "fragment": "\"b.toml\"}",
+    "index": 1,
+    "type": "tool_call_args_delta"
+  },
+  {
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 128,
+    "input_tokens": 412,
+    "output_tokens": 37,
+    "type": "usage"
+  },
+  {
+    "reason": "tool_use",
+    "type": "stop"
+  }
+]

--- a/crates/openwave-router/tests/fixtures/bedrock/messages/tool_loop_closure.request.json
+++ b/crates/openwave-router/tests/fixtures/bedrock/messages/tool_loop_closure.request.json
@@ -1,0 +1,108 @@
+{
+  "body": {
+    "max_tokens": 4096,
+    "messages": [
+      {
+        "content": [
+          {
+            "text": "Read both configs.",
+            "type": "text"
+          }
+        ],
+        "role": "user"
+      },
+      {
+        "content": [
+          {
+            "text": "Reading both.",
+            "type": "text"
+          },
+          {
+            "id": "call_1",
+            "input": {
+              "path": "a.toml"
+            },
+            "name": "read_file",
+            "type": "tool_use"
+          },
+          {
+            "id": "call_2",
+            "input": {
+              "path": "b.toml"
+            },
+            "name": "read_file",
+            "type": "tool_use"
+          }
+        ],
+        "role": "assistant"
+      },
+      {
+        "content": [
+          {
+            "content": "retries = 3",
+            "is_error": false,
+            "tool_use_id": "call_1",
+            "type": "tool_result"
+          },
+          {
+            "cache_control": {
+              "type": "ephemeral"
+            },
+            "content": "no such file",
+            "is_error": true,
+            "tool_use_id": "call_2",
+            "type": "tool_result"
+          }
+        ],
+        "role": "user"
+      }
+    ],
+    "model": "anthropic.claude-sonnet-5",
+    "output_config": {
+      "effort": "high"
+    },
+    "stream": true,
+    "system": [
+      {
+        "cache_control": {
+          "type": "ephemeral"
+        },
+        "text": "Use the tools.",
+        "type": "text"
+      }
+    ],
+    "thinking": {
+      "display": "summarized",
+      "type": "adaptive"
+    },
+    "tools": [
+      {
+        "cache_control": {
+          "type": "ephemeral"
+        },
+        "description": "Read a file from the workspace.",
+        "input_schema": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "path"
+          ],
+          "type": "object"
+        },
+        "name": "read_file"
+      }
+    ]
+  },
+  "headers": {
+    "anthropic-version": "2023-06-01",
+    "content-type": "application/json",
+    "x-api-key": "<redacted>"
+  },
+  "method": "POST",
+  "path": "/anthropic/v1/messages",
+  "query": null
+}

--- a/crates/openwave-router/tests/fixtures/bedrock/messages/tool_loop_closure.response.sse
+++ b/crates/openwave-router/tests/fixtures/bedrock/messages/tool_loop_closure.response.sse
@@ -1,0 +1,29 @@
+event: message_start
+data: {"type":"message_start","message":{"usage":{"input_tokens":412,"cache_read_input_tokens":128}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"a.toml is read. "}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Retrying b.toml."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_3","name":"read_file"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"path\":"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\"b.toml\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":37}}

--- a/crates/openwave-router/tests/fixtures/bedrock/responses/tool_loop_closure.events.json
+++ b/crates/openwave-router/tests/fixtures/bedrock/responses/tool_loop_closure.events.json
@@ -1,0 +1,37 @@
+[
+  {
+    "text": "a.toml is read. ",
+    "type": "text_delta"
+  },
+  {
+    "text": "Retrying b.toml.",
+    "type": "text_delta"
+  },
+  {
+    "id": "call_3",
+    "index": 0,
+    "name": "read_file",
+    "type": "tool_call_started"
+  },
+  {
+    "fragment": "{\"path\":",
+    "index": 0,
+    "type": "tool_call_args_delta"
+  },
+  {
+    "fragment": "\"b.toml\"}",
+    "index": 0,
+    "type": "tool_call_args_delta"
+  },
+  {
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 128,
+    "input_tokens": 284,
+    "output_tokens": 37,
+    "type": "usage"
+  },
+  {
+    "reason": "tool_use",
+    "type": "stop"
+  }
+]

--- a/crates/openwave-router/tests/fixtures/bedrock/responses/tool_loop_closure.request.json
+++ b/crates/openwave-router/tests/fixtures/bedrock/responses/tool_loop_closure.request.json
@@ -1,0 +1,81 @@
+{
+  "body": {
+    "input": [
+      {
+        "content": [
+          {
+            "text": "Use the tools.",
+            "type": "input_text"
+          }
+        ],
+        "role": "system"
+      },
+      {
+        "content": [
+          {
+            "text": "Read both configs.",
+            "type": "input_text"
+          }
+        ],
+        "role": "user"
+      },
+      {
+        "content": "Reading both.",
+        "role": "assistant"
+      },
+      {
+        "arguments": "{\"path\":\"a.toml\"}",
+        "call_id": "call_1",
+        "name": "read_file",
+        "type": "function_call"
+      },
+      {
+        "arguments": "{\"path\":\"b.toml\"}",
+        "call_id": "call_2",
+        "name": "read_file",
+        "type": "function_call"
+      },
+      {
+        "call_id": "call_1",
+        "output": "retries = 3",
+        "type": "function_call_output"
+      },
+      {
+        "call_id": "call_2",
+        "output": "Error: the tool call failed.\nno such file",
+        "type": "function_call_output"
+      }
+    ],
+    "max_output_tokens": 4096,
+    "model": "openai.gpt-oss-120b",
+    "store": false,
+    "stream": true,
+    "tools": [
+      {
+        "description": "Read a file from the workspace.",
+        "name": "read_file",
+        "parameters": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "path"
+          ],
+          "type": "object"
+        },
+        "strict": true,
+        "type": "function"
+      }
+    ]
+  },
+  "headers": {
+    "authorization": "<redacted>",
+    "content-type": "application/json"
+  },
+  "method": "POST",
+  "path": "/v1/responses",
+  "query": null
+}

--- a/crates/openwave-router/tests/fixtures/bedrock/responses/tool_loop_closure.response.sse
+++ b/crates/openwave-router/tests/fixtures/bedrock/responses/tool_loop_closure.response.sse
@@ -1,0 +1,13 @@
+data: {"type":"response.output_text.delta","delta":"a.toml is read. "}
+
+data: {"type":"response.output_text.delta","delta":"Retrying b.toml."}
+
+data: {"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_3","name":"read_file"}}
+
+data: {"type":"response.function_call_arguments.delta","call_id":"call_3","delta":"{\"path\":"}
+
+data: {"type":"response.function_call_arguments.delta","call_id":"call_3","delta":"\"b.toml\"}"}
+
+data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_3","name":"read_file","arguments":"{\"path\":\"b.toml\"}"}}
+
+data: {"type":"response.completed","response":{"usage":{"input_tokens":412,"input_tokens_details":{"cached_tokens":128},"output_tokens":37}}}

--- a/crates/openwave-router/tests/replay_contracts.rs
+++ b/crates/openwave-router/tests/replay_contracts.rs
@@ -46,7 +46,10 @@ use openwave_core::{
     ChatMessage, ChatRequest, ContentBlock, MessageReasoning, ModelProvider, ProviderEvent,
     ProviderId, ReasoningOrigin, ResponseFormat, Role, ToolChoice, ToolSpec,
 };
-use openwave_router::{AnthropicProvider, GeminiProvider, OpenAiCompatProvider, OpenAiProvider};
+use openwave_router::{
+    AnthropicProvider, BedrockAuth, BedrockProvider, GeminiProvider, OpenAiCompatProvider,
+    OpenAiProvider,
+};
 use openwave_router::{BearerTokenSource, VertexModelFamily, VertexProvider};
 use serde_json::{json, Value};
 
@@ -433,6 +436,43 @@ async fn gemini_request_contracts() {
     .await;
 }
 
+#[tokio::test]
+async fn bedrock_messages_request_and_stream_contract() {
+    check_one_contract(
+        "bedrock/messages",
+        "tool_loop_closure",
+        tool_loop_closure("anthropic.claude-sonnet-5"),
+        |base_url| {
+            Arc::new(
+                BedrockProvider::new("us-east-1", BedrockAuth::ApiKey(TEST_API_KEY.into()))
+                    .unwrap()
+                    .with_base_url(base_url),
+            )
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn bedrock_responses_request_and_stream_contract() {
+    let mut request = tool_loop_closure("openai.gpt-oss-120b");
+    request.reasoning_model = false;
+    request.reasoning_effort = None;
+    check_one_contract(
+        "bedrock/responses",
+        "tool_loop_closure",
+        request,
+        |base_url| {
+            Arc::new(
+                BedrockProvider::new("us-east-1", BedrockAuth::ApiKey(TEST_API_KEY.into()))
+                    .unwrap()
+                    .with_base_url(base_url),
+            )
+        },
+    )
+    .await;
+}
+
 struct StaticVertexToken;
 
 #[async_trait::async_trait]
@@ -529,6 +569,22 @@ async fn check_scenario(
     let response_body = terminal_frame(provider).to_string();
     let (captured, _) = round_trip(build, request, response_body).await;
     assert_matches_fixture(&format!("{provider}/{scenario}.request.json"), &captured);
+}
+
+async fn check_one_contract(
+    provider: &str,
+    scenario: &str,
+    request: ChatRequest,
+    build: impl Fn(&str) -> Arc<dyn ModelProvider>,
+) {
+    let response_body = recorded_response(provider, scenario)
+        .unwrap_or_else(|| panic!("{provider}/{scenario} has no recorded response fixture"));
+    let (captured, events) = round_trip(build, request, response_body).await;
+    assert_matches_fixture(&format!("{provider}/{scenario}.request.json"), &captured);
+    assert_matches_fixture(
+        &format!("{provider}/{scenario}.events.json"),
+        &serde_json::to_value(&events).expect("provider events serialize"),
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -1372,6 +1372,7 @@ mod tests {
                 enabled: true,
                 base_url: Some("http://127.0.0.1:9".to_string()),
                 vertex_location: None,
+                aws_region: None,
                 models: Vec::new(),
             },
         )
@@ -2089,6 +2090,7 @@ mod tests {
                 enabled: true,
                 base_url: Some(format!("{base}/")),
                 vertex_location: None,
+                aws_region: None,
                 models: vec![CustomModelConfig {
                     id: "legacy-model".to_string(),
                     upstream_id: None,
@@ -2205,6 +2207,7 @@ mod tests {
             enabled: true,
             base_url: Some("https://corp.gateway".to_string()),
             vertex_location: None,
+            aws_region: None,
             models: vec![CustomModelConfig {
                 id: id.to_string(),
                 upstream_id: None,
@@ -2283,6 +2286,7 @@ mod tests {
                 enabled: true,
                 base_url: Some("https://other.gateway".to_string()),
                 vertex_location: None,
+                aws_region: None,
                 models: vec![CustomModelConfig {
                     id: "foreign-model".to_string(),
                     upstream_id: None,
@@ -2336,6 +2340,7 @@ mod tests {
                 enabled: true,
                 base_url: Some("https://corp.gateway".to_string()),
                 vertex_location: None,
+                aws_region: None,
                 models: vec![CustomModelConfig {
                     id: "legacy-model".to_string(),
                     upstream_id: None,

--- a/crates/openwave-server/src/model_registry.rs
+++ b/crates/openwave-server/src/model_registry.rs
@@ -365,7 +365,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
         supports_vendor_web_search: false,
-        reasoning_efforts: EFFORT_LOW_TO_MAX,
+        reasoning_efforts: EFFORT_LOW_TO_HIGH,
     },
     ModelSpec {
         id: "anthropic.claude-sonnet-5",
@@ -377,7 +377,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
         supports_vendor_web_search: false,
-        reasoning_efforts: EFFORT_LOW_TO_MAX,
+        reasoning_efforts: EFFORT_LOW_TO_HIGH,
     },
     ModelSpec {
         id: "gpt-5.6-sol",

--- a/crates/openwave-server/src/model_registry.rs
+++ b/crates/openwave-server/src/model_registry.rs
@@ -350,6 +350,35 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         supports_vendor_web_search: true,
         reasoning_efforts: EFFORT_LOW_TO_HIGH_AND_MAX,
     },
+    // Bedrock model ids are provider-owned route ids rather than Anthropic API
+    // ids. These rows use the native Claude Messages body over Bedrock Mantle;
+    // the adapter carries images, tools, adaptive reasoning, and signed
+    // reasoning replay, but deliberately does not advertise Anthropic's
+    // provider-executed web search through this route.
+    ModelSpec {
+        id: "anthropic.claude-fable-5",
+        display_name: "Claude Fable 5",
+        provider: ProviderKind::Bedrock,
+        verification: VerificationTier::Unverified,
+        context_window: 1_000_000,
+        max_output_tokens: 128_000,
+        input_modalities: TEXT_AND_IMAGE,
+        supports_reasoning: true,
+        supports_vendor_web_search: false,
+        reasoning_efforts: EFFORT_LOW_TO_MAX,
+    },
+    ModelSpec {
+        id: "anthropic.claude-sonnet-5",
+        display_name: "Claude Sonnet 5",
+        provider: ProviderKind::Bedrock,
+        verification: VerificationTier::Unverified,
+        context_window: 1_000_000,
+        max_output_tokens: 128_000,
+        input_modalities: TEXT_AND_IMAGE,
+        supports_reasoning: true,
+        supports_vendor_web_search: false,
+        reasoning_efforts: EFFORT_LOW_TO_MAX,
+    },
     ModelSpec {
         id: "gpt-5.6-sol",
         display_name: "GPT-5.6 Sol",

--- a/crates/openwave-server/src/model_registry.rs
+++ b/crates/openwave-server/src/model_registry.rs
@@ -215,6 +215,7 @@ impl ModelSpec {
             | ProviderKind::Openai
             | ProviderKind::Gemini
             | ProviderKind::Vertex
+            | ProviderKind::Bedrock
             | ProviderKind::Fireworks => true,
             ProviderKind::Together => matches!(
                 self.id,
@@ -1096,6 +1097,7 @@ mod tests {
             ProviderKind::Xai => true,
             ProviderKind::Gemini => true,
             ProviderKind::Vertex => true,
+            ProviderKind::Bedrock => true,
             ProviderKind::Fireworks => true,
             ProviderKind::Together => true,
             ProviderKind::OpenaiCompatible => false,

--- a/crates/openwave-server/src/model_roles.rs
+++ b/crates/openwave-server/src/model_roles.rs
@@ -55,6 +55,7 @@ const UTILITY_DEFAULTS: &[&str] = &[
     "openai::gpt-5.4-nano",
     "gemini::gemini-3.5-flash-lite",
     "vertex::gemini-3.5-flash-lite",
+    "bedrock::anthropic.claude-sonnet-5",
     "fireworks::accounts/fireworks/models/deepseek-v4-flash",
     "together::deepseek-ai/DeepSeek-V4-Flash-0731",
 ];

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -394,6 +394,13 @@ pub enum ProviderCredential {
         /// The raw JSON key-file contents.
         json: String,
     },
+    /// AWS access credentials for Signature Version 4 requests.
+    AwsCredentials {
+        access_key_id: String,
+        secret_access_key: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        session_token: Option<String>,
+    },
 }
 
 impl ProviderCredential {
@@ -407,7 +414,7 @@ impl ProviderCredential {
         match self {
             Self::ApiKey { key } => Some(key.as_str()),
             Self::Oauth {} => None,
-            Self::ServiceAccount { .. } => None,
+            Self::ServiceAccount { .. } | Self::AwsCredentials { .. } => None,
         }
     }
 
@@ -415,7 +422,22 @@ impl ProviderCredential {
     pub(crate) fn as_service_account(&self) -> Option<&str> {
         match self {
             Self::ServiceAccount { json } => Some(json),
-            Self::ApiKey { .. } | Self::Oauth {} => None,
+            Self::ApiKey { .. } | Self::Oauth {} | Self::AwsCredentials { .. } => None,
+        }
+    }
+
+    pub(crate) fn as_aws_credentials(&self) -> Option<openwave_router::AwsCredentials> {
+        match self {
+            Self::AwsCredentials {
+                access_key_id,
+                secret_access_key,
+                session_token,
+            } => Some(openwave_router::AwsCredentials::new(
+                access_key_id.clone(),
+                secret_access_key.clone(),
+                session_token.clone(),
+            )),
+            _ => None,
         }
     }
 
@@ -430,6 +452,36 @@ impl ProviderCredential {
             }
             Self::ApiKey { .. } | Self::Oauth {} => Ok(()),
             Self::ServiceAccount { json } => validate_service_account(json),
+            Self::AwsCredentials {
+                access_key_id,
+                secret_access_key,
+                session_token,
+            } => {
+                if access_key_id.trim().is_empty() || secret_access_key.trim().is_empty() {
+                    return Err(ServerError::bad_request(
+                        "AWS access key id and secret access key must not be empty",
+                    ));
+                }
+                if access_key_id.trim() != access_key_id
+                    || secret_access_key.trim() != secret_access_key
+                    || session_token
+                        .as_ref()
+                        .is_some_and(|token| token.trim() != token)
+                {
+                    return Err(ServerError::bad_request(
+                        "AWS credentials must not have surrounding whitespace",
+                    ));
+                }
+                if session_token
+                    .as_ref()
+                    .is_some_and(|token| token.trim().is_empty())
+                {
+                    return Err(ServerError::bad_request(
+                        "AWS session token must not be empty when provided",
+                    ));
+                }
+                Ok(())
+            }
         }
     }
 }
@@ -443,6 +495,12 @@ impl std::fmt::Debug for ProviderCredential {
             Self::ServiceAccount { .. } => f
                 .debug_struct("ServiceAccount")
                 .field("json", &"***")
+                .finish(),
+            Self::AwsCredentials { session_token, .. } => f
+                .debug_struct("AwsCredentials")
+                .field("access_key_id", &"***")
+                .field("secret_access_key", &"***")
+                .field("session_token", &session_token.as_ref().map(|_| "***"))
                 .finish(),
         }
     }
@@ -500,12 +558,15 @@ pub struct ProviderConfig {
     /// service-account configurations. An absent value defaults to `global`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub vertex_location: Option<String>,
+    /// AWS region used to derive the direct Bedrock Mantle endpoint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aws_region: Option<String>,
     /// Explicit model rows served by a configurable endpoint.
     ///
-    /// OpenAI-compatible and xAI catalogs can change independently of an
-    /// OpenWave release, so their configured rows live beside the endpoint.
-    /// Other curated providers ignore this field and obtain their models from
-    /// the host registry.
+    /// OpenAI-compatible, xAI, and Bedrock catalogs can change independently
+    /// of an OpenWave release, so their configured rows live beside the
+    /// endpoint. Other curated providers ignore this field and obtain their
+    /// models from the host registry.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub models: Vec<CustomModelConfig>,
 }
@@ -517,6 +578,7 @@ impl ProviderConfig {
             enabled: false,
             base_url: None,
             vertex_location: None,
+            aws_region: None,
             models: Vec::new(),
         }
     }
@@ -890,6 +952,12 @@ pub struct ProviderInfo {
     pub auth_mode: Option<ProviderAuthMode>,
     /// Explicit configured model entries for this endpoint.
     pub models: Vec<CustomModelConfig>,
+    // Public non-secret routing metadata. Kept after the documented fields so
+    // ts-rs emits it on the declaration's closing line without adding generated
+    // trailing whitespace.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub aws_region: Option<String>,
 }
 
 /// How a provider's credential was established.
@@ -925,10 +993,12 @@ pub struct ProviderUpdate {
     pub base_url: Option<Option<String>>,
     #[serde(default, deserialize_with = "double_option")]
     pub vertex_location: Option<Option<String>>,
+    #[serde(default, deserialize_with = "double_option")]
+    pub aws_region: Option<Option<String>>,
     #[serde(default)]
     pub credential: Option<ProviderCredential>,
-    /// Replacement configured-model list. Valid for `openai_compatible` and
-    /// first-party xAI.
+    /// Replacement configured-model list. Valid for `openai_compatible`,
+    /// first-party xAI, and `bedrock`.
     #[serde(default)]
     pub models: Option<Vec<CustomModelConfig>>,
 }
@@ -1040,6 +1110,12 @@ pub async fn has_credential(secrets: &dyn SecretProvider, kind: ProviderKind) ->
             if kind == ProviderKind::Openai && matches!(credential, ProviderCredential::Oauth {}) {
                 return openwave_connectors::has_stored_chatgpt_credentials(secrets).await;
             }
+            if kind == ProviderKind::Bedrock
+                && matches!(credential, ProviderCredential::AwsCredentials { .. })
+                && credential.validate().is_ok()
+            {
+                return true;
+            }
             return false;
         }
         Err(_) => return false,
@@ -1050,6 +1126,7 @@ pub async fn has_credential(secrets: &dyn SecretProvider, kind: ProviderKind) ->
         return openwave_connectors::has_stored_credentials(secrets).await;
     }
     env_api_key(kind).is_some()
+        || (kind == ProviderKind::Bedrock && env_aws_credentials().is_some())
 }
 
 async fn auth_mode_for(
@@ -1058,7 +1135,8 @@ async fn auth_mode_for(
 ) -> Option<ProviderAuthMode> {
     match read_credential(secrets, kind).await.ok().flatten() {
         Some(ProviderCredential::Oauth {})
-            if openwave_connectors::has_stored_chatgpt_credentials(secrets).await =>
+            if kind == ProviderKind::Openai
+                && openwave_connectors::has_stored_chatgpt_credentials(secrets).await =>
         {
             Some(ProviderAuthMode::Chatgpt)
         }
@@ -1101,6 +1179,7 @@ pub async fn list_providers(
                 enabled: policy.gateway_url.is_some(),
                 base_url: policy.gateway_url.clone(),
                 vertex_location: None,
+                aws_region: None,
                 // Deployment-matched: a session a re-point superseded must
                 // not read as this deployment's credential.
                 has_credential: match policy.gateway_url.as_deref() {
@@ -1123,6 +1202,7 @@ pub async fn list_providers(
                 .map(str::to_owned)
                 .or_else(|| config.base_url.clone()),
             vertex_location: config.vertex_location.clone(),
+            aws_region: config.aws_region.clone(),
             has_credential: has_credential(secrets, kind).await,
             auth_mode: auth_mode_for(secrets, kind).await,
             models: config.models,
@@ -1163,7 +1243,12 @@ pub async fn update_provider(
         ));
     }
     let policy = crate::managed_policy::resolve(store, os_policy).await?;
-    if policy.managed && (update.credential.is_some() || update.base_url.is_some()) {
+    if policy.managed
+        && (update.credential.is_some()
+            || update.base_url.is_some()
+            || update.vertex_location.is_some()
+            || update.aws_region.is_some())
+    {
         return Err(managed_profile_refusal(format!(
             "this profile is managed by a model gateway; {kind} credentials and endpoints are locked"
         )));
@@ -1227,7 +1312,26 @@ pub async fn update_provider(
     if let Some(models) = update.models {
         if !matches!(kind, ProviderKind::OpenaiCompatible | ProviderKind::Xai) {
             return Err(ServerError::bad_request(
-                "configured models are only supported by openai_compatible and xai",
+                "aws_region is only supported by bedrock",
+            ));
+        }
+        Some(None) => config.aws_region = None,
+        Some(Some(region)) => {
+            if region.trim() != region || !openwave_router::valid_aws_region(&region) {
+                return Err(ServerError::bad_request(
+                    "aws_region must be a valid AWS region",
+                ));
+            }
+            config.aws_region = Some(region);
+        }
+    }
+    if let Some(models) = update.models {
+        if !matches!(
+            kind,
+            ProviderKind::OpenaiCompatible | ProviderKind::Xai | ProviderKind::Bedrock
+        ) {
+            return Err(ServerError::bad_request(
+                "configured models are only supported by openai_compatible, xai, and bedrock",
             ));
         }
         validate_configured_models(kind, &models)?;
@@ -1243,6 +1347,11 @@ pub async fn update_provider(
     if kind == ProviderKind::Xai && config.enabled && config.models.is_empty() {
         return Err(ServerError::bad_request(
             "xai requires at least one configured model when enabled",
+        ));
+    }
+    if kind == ProviderKind::Bedrock && config.enabled && resolved_aws_region(&config).is_none() {
+        return Err(ServerError::bad_request(
+            "bedrock requires an aws_region when enabled",
         ));
     }
 
@@ -1265,6 +1374,7 @@ pub async fn update_provider(
             .map(str::to_owned)
             .or_else(|| config.base_url.clone()),
         vertex_location: config.vertex_location.clone(),
+        aws_region: config.aws_region.clone(),
         has_credential: has_credential(secrets, kind).await,
         auth_mode: auth_mode_for(secrets, kind).await,
         models: config.models,
@@ -1448,6 +1558,36 @@ fn env_api_key(kind: ProviderKind) -> Option<String> {
     }
 }
 
+fn env_aws_credentials() -> Option<openwave_router::AwsCredentials> {
+    let access_key_id = std::env::var("AWS_ACCESS_KEY_ID")
+        .ok()
+        .filter(|value| !value.is_empty() && value.trim() == value)?;
+    let secret_access_key = std::env::var("AWS_SECRET_ACCESS_KEY")
+        .ok()
+        .filter(|value| !value.is_empty() && value.trim() == value)?;
+    let session_token = std::env::var("AWS_SESSION_TOKEN")
+        .ok()
+        .filter(|value| !value.is_empty() && value.trim() == value);
+    Some(openwave_router::AwsCredentials::new(
+        access_key_id,
+        secret_access_key,
+        session_token,
+    ))
+}
+
+fn resolved_aws_region(config: &ProviderConfig) -> Option<String> {
+    config.aws_region.clone().or_else(|| {
+        std::env::var("AWS_REGION")
+            .ok()
+            .filter(|region| openwave_router::valid_aws_region(region))
+            .or_else(|| {
+                std::env::var("AWS_DEFAULT_REGION")
+                    .ok()
+                    .filter(|region| openwave_router::valid_aws_region(region))
+            })
+    })
+}
+
 /// Resolve the Anthropic API key (stored / legacy / env). Thin wrapper kept for
 /// call sites that are Anthropic-specific.
 pub async fn resolve_anthropic_api_key(secrets: &dyn SecretProvider) -> Option<String> {
@@ -1558,6 +1698,7 @@ pub async fn collect_routes(
                     curated_models: Vec::new(),
                     token_source: Some(source),
                     vertex: None,
+                    bedrock: None,
                     chatgpt_account_id: None,
                 });
             } else {
@@ -1569,6 +1710,7 @@ pub async fn collect_routes(
                         curated_models: anthropic_models,
                         token_source: Some(source.clone()),
                         vertex: None,
+                        bedrock: None,
                         chatgpt_account_id: None,
                     });
                 }
@@ -1580,6 +1722,7 @@ pub async fn collect_routes(
                         curated_models: openai_models,
                         token_source: Some(source),
                         vertex: None,
+                        bedrock: None,
                         chatgpt_account_id: None,
                     });
                 }
@@ -1619,6 +1762,7 @@ pub async fn collect_routes(
                     .collect(),
                 token_source: Some(source),
                 vertex: None,
+                bedrock: None,
                 chatgpt_account_id: Some(account_id),
             });
             continue;
@@ -1709,6 +1853,7 @@ pub async fn collect_routes(
                 .collect(),
             token_source: None,
             vertex: None,
+            bedrock: None,
             chatgpt_account_id: None,
         });
     }
@@ -1740,6 +1885,7 @@ pub async fn migrate_legacy_anthropic(
                 enabled: true,
                 base_url: None,
                 vertex_location: None,
+                aws_region: None,
                 models: Vec::new(),
             },
         )
@@ -1764,7 +1910,7 @@ pub async fn resolve_model_policy(
             return Ok(Some(ResolvedModelPolicy::curated(spec)));
         }
         let models = match provider {
-            ProviderKind::OpenaiCompatible | ProviderKind::Xai => {
+            ProviderKind::OpenaiCompatible | ProviderKind::Xai | ProviderKind::Bedrock => {
                 read_config(store, provider).await?.models
             }
             // Resolution is not an offer: usability and routing gate the
@@ -1789,7 +1935,11 @@ pub async fn resolve_model_policy(
         .map(ResolvedModelPolicy::curated)
         .into_iter()
         .collect::<Vec<_>>();
-    for provider in [ProviderKind::Xai, ProviderKind::OpenaiCompatible] {
+    for provider in [
+        ProviderKind::Xai,
+        ProviderKind::Bedrock,
+        ProviderKind::OpenaiCompatible,
+    ] {
         let config = read_config(store, provider).await?;
         owners.extend(
             config
@@ -1855,6 +2005,9 @@ pub async fn provider_is_usable(
     if kind == ProviderKind::Xai && config.models.is_empty() {
         return Ok(false);
     }
+    if kind == ProviderKind::Bedrock && resolved_aws_region(&config).is_none() {
+        return Ok(false);
+    }
     Ok(true)
 }
 
@@ -1887,7 +2040,7 @@ pub async fn catalog_models(
         // and the managed gateway's entitled snapshot — which is empty on an
         // unmanaged profile, so no gateway row ever reaches the catalog there.
         let configured = match kind {
-            ProviderKind::OpenaiCompatible | ProviderKind::Xai => {
+            ProviderKind::OpenaiCompatible | ProviderKind::Xai | ProviderKind::Bedrock => {
                 read_config(store, kind).await?.models
             }
             ProviderKind::ModelGateway => gateway_models(store, policy).await?,
@@ -1993,6 +2146,37 @@ mod tests {
         assert!(!format!("{error:?}").contains("service-account@example.test"));
     }
 
+    #[test]
+    fn aws_credentials_validate_roundtrip_and_redact_debug() {
+        let credential = ProviderCredential::AwsCredentials {
+            access_key_id: "AKIAEXAMPLE".into(),
+            secret_access_key: "secret-access-key".into(),
+            session_token: Some("session-token".into()),
+        };
+        credential.validate().unwrap();
+        let stored = serde_json::to_string(&credential).unwrap();
+        let roundtrip: ProviderCredential = serde_json::from_str(&stored).unwrap();
+        assert_eq!(roundtrip, credential);
+        let debug = format!("{credential:?}");
+        assert!(!debug.contains("AKIAEXAMPLE"));
+        assert!(!debug.contains("secret-access-key"));
+        assert!(!debug.contains("session-token"));
+
+        let empty = ProviderCredential::AwsCredentials {
+            access_key_id: String::new(),
+            secret_access_key: "secret".into(),
+            session_token: None,
+        };
+        assert!(empty.validate().is_err());
+
+        let padded = ProviderCredential::AwsCredentials {
+            access_key_id: " AKIAEXAMPLE".into(),
+            secret_access_key: "secret".into(),
+            session_token: None,
+        };
+        assert!(padded.validate().is_err());
+    }
+
     #[tokio::test]
     async fn credentials_roundtrip_through_secret_storage() {
         let secrets = TestSecrets::default();
@@ -2085,6 +2269,10 @@ mod tests {
         assert_eq!(
             ProviderKind::Together.default_base_url(),
             Some("https://api.together.ai/v1")
+        );
+        assert_eq!(
+            ProviderKind::Bedrock.credential_key(),
+            "provider.bedrock.credential"
         );
     }
 

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -952,9 +952,9 @@ pub struct ProviderInfo {
     pub auth_mode: Option<ProviderAuthMode>,
     /// Explicit configured model entries for this endpoint.
     pub models: Vec<CustomModelConfig>,
-    // Public non-secret routing metadata. Kept after the documented fields so
-    // ts-rs emits it on the declaration's closing line without adding generated
-    // trailing whitespace.
+    // Effective AWS region from stored config or the AWS environment fallback.
+    // Kept after the documented fields so ts-rs emits it on the declaration's
+    // closing line without adding generated trailing whitespace.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub aws_region: Option<String>,
@@ -1194,6 +1194,11 @@ pub async fn list_providers(
             continue;
         }
         let config = read_config(store, kind).await?;
+        let aws_region = if kind == ProviderKind::Bedrock {
+            resolved_aws_region(&config)
+        } else {
+            None
+        };
         out.push(ProviderInfo {
             kind,
             enabled: config.enabled,
@@ -1202,7 +1207,7 @@ pub async fn list_providers(
                 .map(str::to_owned)
                 .or_else(|| config.base_url.clone()),
             vertex_location: config.vertex_location.clone(),
-            aws_region: config.aws_region.clone(),
+            aws_region,
             has_credential: has_credential(secrets, kind).await,
             auth_mode: auth_mode_for(secrets, kind).await,
             models: config.models,
@@ -1366,6 +1371,11 @@ pub async fn update_provider(
 
     write_config(store, kind, &config).await?;
 
+    let aws_region = if kind == ProviderKind::Bedrock {
+        resolved_aws_region(&config)
+    } else {
+        None
+    };
     Ok(ProviderInfo {
         kind,
         enabled: config.enabled,
@@ -1374,7 +1384,7 @@ pub async fn update_provider(
             .map(str::to_owned)
             .or_else(|| config.base_url.clone()),
         vertex_location: config.vertex_location.clone(),
-        aws_region: config.aws_region.clone(),
+        aws_region,
         has_credential: has_credential(secrets, kind).await,
         auth_mode: auth_mode_for(secrets, kind).await,
         models: config.models,
@@ -1393,7 +1403,29 @@ fn validate_configured_models(
 ) -> std::result::Result<(), ServerError> {
     validate_configured_models_against(kind, models, |id| {
         model_registry::find_for(kind, id).is_some()
-    })
+    })?;
+    if kind == ProviderKind::Bedrock
+        && models
+            .iter()
+            .any(|model| is_application_inference_profile_arn(&model.id))
+    {
+        return Err(ServerError::bad_request(
+            "Bedrock application-inference-profile ARNs are not supported until their target model can be resolved",
+        ));
+    }
+    Ok(())
+}
+
+fn is_application_inference_profile_arn(id: &str) -> bool {
+    let mut fields = id.splitn(6, ':');
+    fields.next() == Some("arn")
+        && fields.next().is_some()
+        && fields.next() == Some("bedrock")
+        && fields.next().is_some()
+        && fields.next().is_some()
+        && fields
+            .next()
+            .is_some_and(|resource| resource.starts_with("application-inference-profile/"))
 }
 
 fn validate_configured_models_against(

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -258,6 +258,8 @@ pub enum ProviderKind {
     Gemini,
     /// Google Vertex AI with native Gemini and Anthropic Claude protocols.
     Vertex,
+    /// Direct Amazon Bedrock Mantle.
+    Bedrock,
     /// Fireworks AI's hosted OpenAI-compatible Chat Completions API.
     Fireworks,
     /// Together AI's hosted OpenAI-compatible Chat Completions API.
@@ -278,6 +280,7 @@ impl ProviderKind {
         ProviderKind::Xai,
         ProviderKind::Gemini,
         ProviderKind::Vertex,
+        ProviderKind::Bedrock,
         ProviderKind::Fireworks,
         ProviderKind::Together,
         ProviderKind::OpenaiCompatible,
@@ -292,6 +295,7 @@ impl ProviderKind {
             ProviderKind::Xai => "xai",
             ProviderKind::Gemini => "gemini",
             ProviderKind::Vertex => "vertex",
+            ProviderKind::Bedrock => "bedrock",
             ProviderKind::Fireworks => "fireworks",
             ProviderKind::Together => "together",
             ProviderKind::OpenaiCompatible => "openai_compatible",
@@ -307,6 +311,7 @@ impl ProviderKind {
             "xai" => Some(Self::Xai),
             "gemini" => Some(Self::Gemini),
             "vertex" => Some(Self::Vertex),
+            "bedrock" => Some(Self::Bedrock),
             "fireworks" => Some(Self::Fireworks),
             "together" => Some(Self::Together),
             "openai_compatible" => Some(Self::OpenaiCompatible),
@@ -354,12 +359,14 @@ impl ProviderKind {
                     | ProviderKind::Openai
                     | ProviderKind::Xai
                     | ProviderKind::Gemini
+                    | ProviderKind::Bedrock
                     | ProviderKind::OpenaiCompatible
             ),
             ProviderCredential::Oauth {} => self == ProviderKind::Openai,
             ProviderCredential::ServiceAccount { .. } => {
                 matches!(self, ProviderKind::Gemini | ProviderKind::Vertex)
             }
+            ProviderCredential::AwsCredentials { .. } => self == ProviderKind::Bedrock,
         }
     }
 }
@@ -970,6 +977,8 @@ pub enum ProviderAuthMode {
     Chatgpt,
     /// Uploaded Google Cloud service-account key file.
     ServiceAccount,
+    /// AWS access credentials signed with Signature Version 4.
+    AwsCredentials,
 }
 
 /// Deserialize a present field (including JSON `null`) as `Some(..)`;
@@ -1155,7 +1164,7 @@ async fn auth_mode_for(
             Some(ProviderAuthMode::Chatgpt)
         }
         Some(ProviderCredential::ApiKey { key })
-            if kind == ProviderKind::Openai && !key.is_empty() =>
+            if matches!(kind, ProviderKind::Openai | ProviderKind::Bedrock) && !key.is_empty() =>
         {
             Some(ProviderAuthMode::ApiKey)
         }
@@ -1165,8 +1174,18 @@ async fn auth_mode_for(
         {
             Some(ProviderAuthMode::ServiceAccount)
         }
-        None if kind == ProviderKind::Openai && env_api_key(kind).is_some() => {
+        Some(credential @ ProviderCredential::AwsCredentials { .. })
+            if kind == ProviderKind::Bedrock && credential.validate().is_ok() =>
+        {
+            Some(ProviderAuthMode::AwsCredentials)
+        }
+        None if matches!(kind, ProviderKind::Openai | ProviderKind::Bedrock)
+            && env_api_key(kind).is_some() =>
+        {
             Some(ProviderAuthMode::ApiKey)
+        }
+        None if kind == ProviderKind::Bedrock && env_aws_credentials().is_some() => {
+            Some(ProviderAuthMode::AwsCredentials)
         }
         _ => None,
     }
@@ -1328,8 +1347,9 @@ pub async fn update_provider(
             "the first-class Vertex provider supports only vertex_location `global`; update the stored location before enabling it",
         ));
     }
-    if let Some(models) = update.models {
-        if !matches!(kind, ProviderKind::OpenaiCompatible | ProviderKind::Xai) {
+    match update.aws_region {
+        None => {}
+        Some(_) if kind != ProviderKind::Bedrock => {
             return Err(ServerError::bad_request(
                 "aws_region is only supported by bedrock",
             ));
@@ -1591,6 +1611,9 @@ fn env_api_key(kind: ProviderKind) -> Option<String> {
         // Vertex credentials are explicit service-account material in the
         // keychain. Ambient ADC and API-key modes are not implied.
         ProviderKind::Vertex => None,
+        ProviderKind::Bedrock => std::env::var("AWS_BEARER_TOKEN_BEDROCK")
+            .ok()
+            .filter(|key| !key.is_empty()),
         ProviderKind::Fireworks => std::env::var("FIREWORKS_API_KEY")
             .ok()
             .filter(|k| !k.is_empty()),
@@ -1648,6 +1671,7 @@ pub fn route_kind(kind: ProviderKind) -> openwave_router::RouteKind {
         ProviderKind::Xai => openwave_router::RouteKind::Xai,
         ProviderKind::Gemini => openwave_router::RouteKind::Gemini,
         ProviderKind::Vertex => openwave_router::RouteKind::Vertex,
+        ProviderKind::Bedrock => openwave_router::RouteKind::Bedrock,
         ProviderKind::Fireworks => openwave_router::RouteKind::Fireworks,
         ProviderKind::Together => openwave_router::RouteKind::Together,
         ProviderKind::OpenaiCompatible => openwave_router::RouteKind::OpenaiCompatible,
@@ -1813,6 +1837,46 @@ pub async fn collect_routes(
             });
             continue;
         }
+        if kind == ProviderKind::Bedrock {
+            let Some(region) = resolved_aws_region(&config) else {
+                continue;
+            };
+            let (api_key, credentials) = match stored_credential {
+                Some(ProviderCredential::ApiKey { key }) if !key.is_empty() => (key, None),
+                Some(credential @ ProviderCredential::AwsCredentials { .. })
+                    if credential.validate().is_ok() =>
+                {
+                    let Some(credentials) = credential.as_aws_credentials() else {
+                        continue;
+                    };
+                    (String::new(), Some(credentials))
+                }
+                Some(_) => continue,
+                None => match env_api_key(kind) {
+                    Some(key) => (key, None),
+                    None => {
+                        let Some(credentials) = env_aws_credentials() else {
+                            continue;
+                        };
+                        (String::new(), Some(credentials))
+                    }
+                },
+            };
+            routes.push(openwave_router::Route {
+                kind: route_kind(kind),
+                api_key,
+                base_url: None,
+                curated_models: model_registry::models_for(kind)
+                    .map(|spec| spec.id.to_string())
+                    .chain(config.models.into_iter().map(|model| model.id))
+                    .collect(),
+                token_source: None,
+                vertex: None,
+                bedrock: Some(openwave_router::BedrockRoute::new(region, credentials)),
+                chatgpt_account_id: None,
+            });
+            continue;
+        }
         if matches!(kind, ProviderKind::Gemini | ProviderKind::Vertex) {
             if let Some(ProviderCredential::ServiceAccount { json }) = stored_credential.as_ref() {
                 let Ok(account) = openwave_router::GoogleServiceAccount::from_json(json) else {
@@ -1853,6 +1917,7 @@ pub async fn collect_routes(
                         .collect(),
                     token_source: Some(source),
                     vertex: Some(vertex),
+                    bedrock: None,
                     chatgpt_account_id: None,
                 });
                 continue;

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -1035,10 +1035,16 @@ pub async fn read_credential(
         if raw.is_empty() {
             return Ok(None);
         }
-        // Prefer the typed blob; a bare string is treated as an api_key for
-        // resilience against hand-edited keychain entries.
+        // Prefer the typed blob. Legacy bare API-key values remain readable,
+        // but an object/array/JSON value belongs to the typed format and must
+        // never be transmitted verbatim when this version cannot decode it.
         if let Ok(cred) = serde_json::from_str::<ProviderCredential>(&raw) {
             return Ok(Some(cred));
+        }
+        if looks_like_structured_credential(&raw) {
+            return Err(openwave_core::AgentError::config(format!(
+                "stored {kind} credential is unreadable"
+            )));
         }
         return Ok(Some(ProviderCredential::api_key(raw)));
     }
@@ -1050,6 +1056,14 @@ pub async fn read_credential(
         }
     }
     Ok(None)
+}
+
+fn looks_like_structured_credential(raw: &str) -> bool {
+    let trimmed = raw.trim_start();
+    matches!(
+        trimmed.as_bytes().first(),
+        Some(b'{') | Some(b'[') | Some(b'"')
+    )
 }
 
 /// Store a validated typed credential for `kind`.
@@ -2271,6 +2285,50 @@ mod tests {
                 .as_api_key(),
             Some("existing-api-key")
         );
+    }
+
+    #[tokio::test]
+    async fn legacy_bare_api_key_remains_readable() {
+        let secrets = TestSecrets::default();
+        secrets
+            .set_secret(
+                &ProviderKind::Bedrock.credential_key(),
+                "ABSKLEGACYBEDROCKKEY",
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            read_credential(&secrets, ProviderKind::Bedrock)
+                .await
+                .unwrap()
+                .and_then(|credential| credential.as_api_key().map(str::to_owned)),
+            Some("ABSKLEGACYBEDROCKKEY".to_owned())
+        );
+    }
+
+    #[tokio::test]
+    async fn unreadable_structured_credentials_fail_closed_without_echoing_secrets() {
+        let secrets = TestSecrets::default();
+        let secret = "distinctive-bedrock-secret";
+        let blobs = [
+            format!(r#"{{"type":"future_aws_credentials","secret_access_key":"{secret}"}}"#),
+            format!(r#"{{"type":"aws_credentials","secret_access_key":"{secret}""#),
+        ];
+
+        for raw in blobs {
+            secrets
+                .set_secret(&ProviderKind::Bedrock.credential_key(), &raw)
+                .await
+                .unwrap();
+
+            let error = read_credential(&secrets, ProviderKind::Bedrock)
+                .await
+                .expect_err("structured credential material must not become an API key");
+            assert!(!error.to_string().contains(secret));
+            assert!(!has_credential(&secrets, ProviderKind::Bedrock).await);
+            assert_eq!(resolve_api_key(&secrets, ProviderKind::Bedrock).await, None);
+        }
     }
 
     #[test]

--- a/crates/openwave-server/src/tests/chat_titling.rs
+++ b/crates/openwave-server/src/tests/chat_titling.rs
@@ -105,6 +105,7 @@ async fn titling_app(
             enabled: true,
             base_url: Some(format!("http://{address}/v1")),
             vertex_location: None,
+            aws_region: None,
             models: Vec::new(),
         },
     )

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -2715,6 +2715,71 @@ async fn bedrock_aws_credentials_build_an_explicit_non_fallback_route() {
 }
 
 #[tokio::test]
+async fn unreadable_bedrock_credential_never_advertises_or_builds_a_route() {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}/test.db?mode=rwc",
+            dir.path().display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let secrets: Arc<dyn SecretProvider> = Arc::new(MemSecrets::default());
+    providers::write_config(
+        &*store,
+        providers::ProviderKind::Bedrock,
+        &providers::ProviderConfig {
+            enabled: true,
+            base_url: None,
+            vertex_location: None,
+            aws_region: Some("us-east-1".into()),
+            models: Vec::new(),
+        },
+    )
+    .await
+    .unwrap();
+    let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
+        .await
+        .unwrap();
+    let secret = "distinctive-bedrock-secret";
+
+    for raw in [
+        format!(r#"{{"type":"future_aws_credentials","secret_access_key":"{secret}"}}"#),
+        format!(r#"{{"type":"aws_credentials","secret_access_key":"{secret}""#),
+    ] {
+        secrets
+            .set_secret(&providers::ProviderKind::Bedrock.credential_key(), &raw)
+            .await
+            .unwrap();
+
+        let error = providers::read_credential(&*secrets, providers::ProviderKind::Bedrock)
+            .await
+            .expect_err("unreadable structured credentials must fail closed");
+        assert!(!error.to_string().contains(secret));
+        assert!(!providers::provider_is_usable(
+            &*store,
+            &*secrets,
+            providers::ProviderKind::Bedrock,
+            &policy
+        )
+        .await
+        .unwrap());
+        assert!(
+            providers::collect_routes(&*store, &*secrets, None, None, &policy)
+                .await
+                .is_empty()
+        );
+        assert!(providers::catalog_models(&*store, &*secrets, &policy)
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|model| model.policy.provider == providers::ProviderKind::Bedrock)
+            .all(|model| !model.available));
+    }
+}
+
+#[tokio::test]
 async fn openai_compatible_route_is_free_form_fallback() {
     let dir = tempfile::tempdir().unwrap();
     let store: Arc<dyn Store> = Arc::new(

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -1308,6 +1308,92 @@ async fn vertex_provider_accepts_only_derived_google_endpoints_and_service_accou
 }
 
 #[tokio::test]
+async fn bedrock_enable_preserves_an_environment_resolved_region() {
+    let _env = ENV_LOCK.lock().await;
+    let _aws_region = ScopedEnv::set("AWS_REGION", "eu-west-1");
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/providers")
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: serde_json::Value = json_body(response).await;
+    let bedrock = body["providers"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|provider| provider["kind"] == "bedrock")
+        .unwrap();
+    assert_eq!(bedrock["aws_region"], "eu-west-1");
+
+    let enabled = router
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/providers/bedrock")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(serde_json::json!({"enabled": true}).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(enabled.status(), StatusCode::OK);
+    let info: serde_json::Value = json_body(enabled).await;
+    assert_eq!(info["aws_region"], "eu-west-1");
+
+    let stored = providers::read_config(&*store, providers::ProviderKind::Bedrock)
+        .await
+        .unwrap();
+    assert!(stored.enabled);
+    assert_eq!(stored.aws_region, None);
+}
+
+#[tokio::test]
+async fn bedrock_rejects_application_inference_profile_custom_models() {
+    let (router, token, store, _dir) = test_app().await;
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/providers/bedrock")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "models": [{
+                            "id": "arn:aws:bedrock:us-west-2:123456789012:application-inference-profile/my-claude-profile",
+                            "context_window": 200000,
+                            "max_output_tokens": 64000
+                        }]
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let error: AgentErrorInfo = json_body(response).await;
+    assert_eq!(error.kind, "bad_request");
+    assert!(error.message.contains("application-inference-profile"));
+
+    let stored = providers::read_config(&*store, providers::ProviderKind::Bedrock)
+        .await
+        .unwrap();
+    assert!(stored.models.is_empty());
+}
+
+#[tokio::test]
 async fn openai_compatible_requires_base_url_when_enabled() {
     let (router, token, _store, _dir) = test_app().await;
     let response = router

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -1287,6 +1287,7 @@ async fn vertex_provider_accepts_only_derived_google_endpoints_and_service_accou
             enabled: false,
             base_url: None,
             vertex_location: Some("us-east5".into()),
+            aws_region: None,
             models: Vec::new(),
         },
     )
@@ -1300,6 +1301,101 @@ async fn vertex_provider_accepts_only_derived_google_endpoints_and_service_accou
                 .header(header::AUTHORIZATION, &bearer)
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from(serde_json::json!({"enabled": true}).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(rejected.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn bedrock_settings_keep_aws_secrets_out_of_api_and_publish_configured_models() {
+    let (router, token, _store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/providers/bedrock")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "enabled": true,
+                        "aws_region": "us-east-1",
+                        "credential": {
+                            "type": "aws_credentials",
+                            "access_key_id": "AKIAEXAMPLE",
+                            "secret_access_key": "bedrock-secret",
+                            "session_token": "bedrock-session"
+                        },
+                        "models": [{
+                            "id": "openai.gpt-oss-120b",
+                            "display_name": "GPT OSS 120B",
+                            "context_window": 131072,
+                            "max_output_tokens": 32768
+                        }]
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let info: serde_json::Value = json_body(response).await;
+    assert_eq!(info["kind"], "bedrock");
+    assert_eq!(info["aws_region"], "us-east-1");
+    assert_eq!(info["auth_mode"], "aws_credentials");
+    assert_eq!(info["has_credential"], true);
+    assert!(info.get("credential").is_none());
+    assert!(!info.to_string().contains("AKIAEXAMPLE"));
+    assert!(!info.to_string().contains("bedrock-secret"));
+    assert!(!info.to_string().contains("bedrock-session"));
+
+    let models = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/models")
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let catalog: serde_json::Value = json_body(models).await;
+    let rows = catalog["models"].as_array().unwrap();
+    let custom = rows
+        .iter()
+        .find(|model| model["key"] == "bedrock::openai.gpt-oss-120b")
+        .unwrap();
+    assert_eq!(custom["input_modalities"], serde_json::json!(["text"]));
+    assert_eq!(custom["verification"], "unverified");
+    assert_eq!(custom["available"], true);
+    let claude = rows
+        .iter()
+        .find(|model| model["key"] == "bedrock::anthropic.claude-fable-5")
+        .unwrap();
+    assert_eq!(
+        claude["input_modalities"],
+        serde_json::json!(["text", "image"])
+    );
+    assert_eq!(claude["supports_reasoning"], true);
+    assert_eq!(claude["verification"], "unverified");
+    assert_eq!(claude["available"], true);
+
+    let rejected = router
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/providers/bedrock")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({"aws_region": "../us-east-1"}).to_string(),
+                ))
                 .unwrap(),
         )
         .await
@@ -2527,6 +2623,7 @@ async fn stored_regional_vertex_is_unavailable_and_claims_no_models_or_route() {
             enabled: true,
             base_url: None,
             vertex_location: Some("us-east5".into()),
+            aws_region: None,
             models: Vec::new(),
         },
     )
@@ -2854,6 +2951,7 @@ async fn direct_compatible_presets_use_fixed_endpoints_and_distinct_routes() {
                 enabled: true,
                 base_url: None,
                 vertex_location: None,
+                aws_region: None,
                 models: Vec::new(),
             },
         )

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -1541,6 +1541,7 @@ async fn xai_config_builds_a_provider_qualified_native_route() {
             // must not let it redirect the credential.
             base_url: Some("https://attacker.invalid/v1".into()),
             vertex_location: None,
+            aws_region: None,
             models: vec![providers::CustomModelConfig {
                 id: "grok-account-model".into(),
                 context_window: 500_000,
@@ -1620,6 +1621,7 @@ async fn configured_router_canonicalizes_typed_models_and_rejects_wrong_or_unava
             enabled: true,
             base_url: None,
             vertex_location: None,
+            aws_region: None,
             models: Vec::new(),
         },
     )
@@ -2269,6 +2271,7 @@ async fn resolver_builds_a_router_from_enabled_providers() {
             enabled: true,
             base_url: None,
             vertex_location: None,
+            aws_region: None,
             models: Vec::new(),
         },
     )
@@ -2316,6 +2319,7 @@ async fn resolver_builds_a_router_from_enabled_providers() {
             enabled: false,
             base_url: None,
             vertex_location: None,
+            aws_region: None,
             models: Vec::new(),
         },
     )
@@ -2362,6 +2366,7 @@ async fn resolver_includes_configured_curated_api_key_providers() {
                 enabled: true,
                 base_url: None,
                 vertex_location: None,
+                aws_region: None,
                 models: Vec::new(),
             },
         )
@@ -2509,6 +2514,7 @@ async fn malformed_gemini_service_account_never_advertises_or_builds_a_route() {
             enabled: true,
             base_url: None,
             vertex_location: Some("global".into()),
+            aws_region: None,
             models: Vec::new(),
         },
     )
@@ -2540,6 +2546,89 @@ async fn malformed_gemini_service_account_never_advertises_or_builds_a_route() {
 }
 
 #[tokio::test]
+async fn bedrock_aws_credentials_build_an_explicit_non_fallback_route() {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}/test.db?mode=rwc",
+            dir.path().display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let secrets: Arc<dyn SecretProvider> = Arc::new(MemSecrets::default());
+    providers::write_credential(
+        &*secrets,
+        providers::ProviderKind::Bedrock,
+        &providers::ProviderCredential::AwsCredentials {
+            access_key_id: "AKIAEXAMPLE".into(),
+            secret_access_key: "bedrock-secret".into(),
+            session_token: Some("bedrock-session".into()),
+        },
+    )
+    .await
+    .unwrap();
+    providers::write_config(
+        &*store,
+        providers::ProviderKind::Bedrock,
+        &providers::ProviderConfig {
+            enabled: true,
+            base_url: None,
+            vertex_location: None,
+            aws_region: Some("us-east-1".into()),
+            models: vec![providers::CustomModelConfig {
+                id: "openai.gpt-oss-120b".into(),
+                display_name: Some("GPT OSS 120B".into()),
+                upstream_id: None,
+                context_window: 300_000,
+                max_output_tokens: 10_000,
+                input_modalities: vec![crate::model_registry::InputModality::Text],
+                supports_reasoning: false,
+                reasoning_efforts: Vec::new(),
+            }],
+        },
+    )
+    .await
+    .unwrap();
+
+    let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
+        .await
+        .unwrap();
+    let routes = providers::collect_routes(&*store, &*secrets, None, None, &policy).await;
+    assert_eq!(routes.len(), 1);
+    assert_eq!(routes[0].kind, openwave_router::RouteKind::Bedrock);
+    assert!(routes[0].api_key.is_empty());
+    assert_eq!(routes[0].bedrock.as_ref().unwrap().region(), "us-east-1");
+    let debug = format!("{:?}", routes[0]);
+    assert!(!debug.contains("AKIAEXAMPLE"));
+    assert!(!debug.contains("bedrock-secret"));
+    assert!(!debug.contains("bedrock-session"));
+
+    let router = openwave_router::Router::build(routes);
+    assert_eq!(
+        router.select_for(
+            Some(&openwave_core::ProviderId::new("bedrock")),
+            "anthropic.claude-fable-5"
+        ),
+        Some(openwave_router::RouteKind::Bedrock)
+    );
+    assert_eq!(
+        router.select_for(
+            Some(&openwave_core::ProviderId::new("bedrock")),
+            "openai.gpt-oss-120b"
+        ),
+        Some(openwave_router::RouteKind::Bedrock)
+    );
+    assert_eq!(
+        router.select_for(
+            Some(&openwave_core::ProviderId::new("bedrock")),
+            "unknown-model"
+        ),
+        None
+    );
+}
+
+#[tokio::test]
 async fn openai_compatible_route_is_free_form_fallback() {
     let dir = tempfile::tempdir().unwrap();
     let store: Arc<dyn Store> = Arc::new(
@@ -2565,6 +2654,7 @@ async fn openai_compatible_route_is_free_form_fallback() {
             enabled: true,
             base_url: Some("http://127.0.0.1:1234/v1".into()),
             vertex_location: None,
+            aws_region: None,
             models: Vec::new(),
         },
     )
@@ -2743,6 +2833,7 @@ async fn a_managed_profile_offers_only_the_gateway_route() {
                 enabled: true,
                 base_url,
                 vertex_location: None,
+                aws_region: None,
                 models: Vec::new(),
             },
         )
@@ -2836,6 +2927,7 @@ async fn an_unreadable_policy_fails_the_resolver_closed() {
             enabled: true,
             base_url: None,
             vertex_location: None,
+            aws_region: None,
             models: Vec::new(),
         },
     )
@@ -2896,6 +2988,7 @@ async fn a_misconfigured_policy_gates_the_renderer_and_refuses_a_turn() {
             enabled: true,
             base_url: None,
             vertex_location: None,
+            aws_region: None,
             models: Vec::new(),
         },
     )

--- a/crates/openwave-server/src/tests/image_attachment.rs
+++ b/crates/openwave-server/src/tests/image_attachment.rs
@@ -651,6 +651,7 @@ async fn a_turn_carrying_images_against_a_text_only_model_is_refused() {
             enabled: true,
             base_url: Some("http://127.0.0.1:1234/v1".into()),
             vertex_location: None,
+            aws_region: None,
             models: vec![providers::CustomModelConfig {
                 id: "vendor/model".into(),
                 upstream_id: None,
@@ -770,6 +771,7 @@ async fn a_curated_openai_model_answers_after_receiving_png_and_jpeg_attachments
             enabled: true,
             base_url: Some(format!("http://{address}/v1")),
             vertex_location: None,
+            aws_region: None,
             models: Vec::new(),
         },
     )

--- a/docs-site/content/docs/headless.mdx
+++ b/docs-site/content/docs/headless.mdx
@@ -109,6 +109,15 @@ cargo run -p openwave-cli -- rehome-secrets
 | `OPENWAVE_CONTAINER_EXECUTION_ENABLED` | Enables the container execution backend. Default `false`. |
 | `OPENWAVE_CONTAINER_IMAGE` | Overrides the container image. |
 | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `XAI_API_KEY`, `GEMINI_API_KEY`, `FIREWORKS_API_KEY`, `TOGETHER_API_KEY` | Used as a credential for that provider when nothing is stored in the credential store. |
+| `AWS_BEARER_TOKEN_BEDROCK` | Bedrock API-key fallback when no Bedrock credential is stored. |
+| `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` | Paired AWS access-key fallback for Bedrock SigV4 when no Bedrock credential is stored and no Bedrock API-key fallback is set. Both are required. |
+| `AWS_SESSION_TOKEN` | Optional session token used with the AWS access-key fallback. |
+| `AWS_REGION`, `AWS_DEFAULT_REGION` | Bedrock region fallbacks. A region saved in provider settings wins; otherwise `AWS_REGION` is checked before `AWS_DEFAULT_REGION`. |
+
+The Bedrock environment path is intentionally static. OpenWave does not load
+AWS profiles or SSO, read ECS or EC2 metadata credentials, assume roles, or
+refresh credentials. Configure the exact Mantle model IDs in provider settings;
+the server does not discover models or verify entitlement before a request.
 
 <Callout>
 `openwave serve` defaults to `./.openwave` in your current directory, which is

--- a/docs-site/content/docs/index.mdx
+++ b/docs-site/content/docs/index.mdx
@@ -29,9 +29,9 @@ formats, and behavior change frequently. Expect rough edges.
 - **Produce files, not just answers.** Anything the agent saves to its
   `output/` directory becomes a versioned output you can preview and export
   with a native save dialog.
-- **Use any model.** Anthropic, OpenAI, Google, xAI, and any
-  OpenAI-compatible endpoint, including a local one. You can switch models
-  mid-conversation without losing the thread.
+- **Use any model.** Anthropic, OpenAI, Google, xAI, Amazon Bedrock Mantle,
+  and any OpenAI-compatible endpoint, including a local one. You can switch
+  models mid-conversation without losing the thread.
 - **Decide how much rope to give it.** Every chat has a permission mode, from
   read-only planning up to full autonomy.
 
@@ -39,8 +39,8 @@ formats, and behavior change frequently. Expect rough edges.
 
 People who want an agent that can touch real data and produce real artifacts,
 and who would rather that happen on their own machine than in someone else's
-cloud. It assumes you are comfortable getting an API key from a model provider
-and pasting it into a settings field.
+cloud. It assumes you are comfortable obtaining a model-provider credential
+and entering it in settings.
 
 ## What it is not
 
@@ -56,7 +56,7 @@ subsystems exist in the runtime before they have any UI.
     Download the app, or build it from source.
   </Card>
   <Card title="Quickstart" href="/quickstart">
-    Add a model key and run your first real task.
+    Add a model credential and run your first real task.
   </Card>
   <Card title="Models and providers" href="/models-and-providers">
     Configure credentials and pick a model per chat.

--- a/docs-site/content/docs/models-and-providers.mdx
+++ b/docs-site/content/docs/models-and-providers.mdx
@@ -18,6 +18,7 @@ Open **Settings → Providers**. Each provider is its own section: turn on
 | OpenAI | A ChatGPT subscription (**Sign in with ChatGPT**) or a platform API key |
 | Google Gemini | Gemini Developer API key |
 | Google Vertex AI | Google Cloud service-account JSON containing its project ID; curated routes use the `global` location |
+| Amazon Bedrock Mantle | An AWS region, plus either a Bedrock API key or AWS access keys for SigV4 |
 | xAI | API key, plus the model IDs you want to use |
 | Fireworks AI | API key; OpenWave uses `https://api.fireworks.ai/inference/v1` |
 | Together AI | API key; OpenWave uses `https://api.together.ai/v1` |
@@ -42,24 +43,55 @@ The panel never shows a saved key back to you. It shows a status —
 **No credential**. **Clear** removes the stored credential after a
 confirmation.
 
-Keys go to your operating system's credential store, not to the database and
-not to a config file.
+API keys, service-account JSON, and AWS access keys go to your operating
+system's credential store, not to the database and not to a config file. A
+Bedrock region and configured model rows are non-secret settings.
 
 <Callout>
 If you would rather not store anything, the server also reads
 `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `XAI_API_KEY`, `GEMINI_API_KEY`,
-`FIREWORKS_API_KEY`, and `TOGETHER_API_KEY` from the environment as a fallback
-when no credential is saved.
+`FIREWORKS_API_KEY`, `TOGETHER_API_KEY`, and
+the [documented Bedrock AWS variables](/headless#environment) from the
+environment as fallbacks when no credential is saved.
 </Callout>
+
+## Amazon Bedrock Mantle
+
+The Bedrock section offers two credential modes:
+
+- **Bedrock API key** — paste the key issued for Bedrock Mantle.
+- **AWS access keys (SigV4)** — enter an access-key ID and secret access key,
+  plus a session token when the credentials are temporary.
+
+Both modes require an AWS region. OpenWave derives the production endpoint as
+`https://bedrock-mantle.<region>.api.aws`; there is no configurable Bedrock
+base URL, so a credential cannot redirect a request to another host. Bedrock
+API keys use `x-api-key` on Claude Messages requests and bearer authentication
+on OpenAI Responses requests; AWS access keys sign each request for the
+`bedrock-mantle` service with SigV4. Anthropic model IDs use the Mantle Claude
+Messages route. Other explicitly configured model IDs use the Mantle OpenAI
+Responses route.
+
+OpenWave's Bedrock integration is deliberately limited to these direct Mantle
+routes. It does not use Bedrock Runtime `InvokeModel` or `Converse`, discover
+models, resolve application-inference-profile ARNs, load AWS profiles or SSO,
+read ECS or EC2 metadata credentials, assume roles, refresh credentials, expose
+provider-executed web search, or verify account entitlement before a request.
+Enter the exact model ID your account can call.
 
 ## Curated models
 
-Anthropic, OpenAI, Gemini, Google Vertex AI, Fireworks, and Together ship with a
-curated list of models. Vertex includes provider-qualified native Gemini and
-Claude rows; Fireworks and Together keep their host-specific model IDs and
-capabilities. Nothing to configure — once the provider has a credential, its
-models appear in the picker. The list is versioned with the app and refreshed
-as providers ship new models.
+Anthropic, OpenAI, Gemini, Google Vertex AI, Bedrock, Fireworks, and Together
+ship with a curated list of models. Vertex includes provider-qualified native
+Gemini and Claude rows; Fireworks and Together keep their host-specific model
+IDs and capabilities. Nothing to configure — once the provider has a
+credential (and, for Bedrock, a region), its models appear in the picker. The
+list is versioned with the app and refreshed as providers ship new models.
+
+Bedrock currently includes `anthropic.claude-fable-5` and
+`anthropic.claude-sonnet-5`. These use the native Claude Messages shape over
+Mantle and are marked unverified until that exact provider/model pair has been
+exercised end to end.
 
 Each entry carries what the app actually knows about it: context window,
 maximum output, whether it accepts images, whether it produces a reasoning
@@ -79,11 +111,18 @@ been confirmed on that exact provider/model pair.
 
 ## Custom models
 
-**xAI** and **OpenAI-compatible** do not come with a curated list. You add
-rows yourself under the provider's **Models** section: a model ID, an optional
-display name, context and max-output token counts, and — for xAI — whether the
-model takes image input, whether it is a reasoning model, and which
-reasoning-effort levels it accepts.
+**xAI** and **OpenAI-compatible** do not come with a curated list. **Bedrock**
+has the two curated Claude rows above and also accepts additional exact Mantle
+model IDs. Add rows under the provider's **Models** section: a model ID, an
+optional display name, and context and max-output token counts. For xAI, you
+also declare whether the model takes image input, whether it is a reasoning
+model, and which reasoning-effort levels it accepts.
+
+Custom Bedrock rows start conservatively as text-only, non-reasoning,
+unverified models. IDs beginning with `anthropic.` — including regional forms
+such as `us.anthropic.` — use Claude Messages; other IDs use OpenAI Responses.
+Application-inference-profile ARNs are rejected because OpenWave cannot yet
+resolve them to the underlying model needed for safe routing and replay.
 
 The OpenAI-compatible slot points at any endpoint that speaks the OpenAI
 chat-completions API, including a local one:
@@ -92,8 +131,9 @@ chat-completions API, including a local one:
 base URL: http://127.0.0.1:1234/v1
 ```
 
-You are asserting those capability flags yourself. Get them wrong and turns
-fail at the provider rather than being caught locally.
+For configurable capability fields, you are asserting the provider contract
+yourself. Get it wrong and turns fail at the provider rather than being caught
+locally.
 
 ## Choose the default model
 

--- a/docs-site/content/docs/quickstart.mdx
+++ b/docs-site/content/docs/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: Quickstart
-description: Add a provider key, run your first task, and get a file out of it.
+description: Add a provider credential, run your first task, and get a file out of it.
 ---
 
 This walks through a first real task: attach a file, let the agent run code
@@ -12,8 +12,10 @@ over it, and export what it produces.
 
 ## Add a model credential
 
-Open **Settings → Providers**, turn on the provider you have a key for, paste
-the key, and press **Save configuration**.
+Open **Settings → Providers**, turn on the provider you want, enter its
+credential, and press **Save configuration**. Most providers take an API key;
+Vertex AI takes a Google service-account key, and Amazon Bedrock Mantle takes
+either a Bedrock API key or AWS access keys plus an AWS region.
 
 If you have a ChatGPT Plus or Pro subscription, the OpenAI section offers
 **Sign in with ChatGPT** instead of a key.

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -57,11 +57,11 @@ Major surfaces present today:
 ## `openwave-router` — model providers & routing 🟢
 
 Owns the concrete Anthropic, OpenAI Responses, xAI Responses, Gemini, Google
-Vertex AI, and OpenAI-compatible provider adapters (including Fireworks,
-Together, OpenRouter, vLLM, and LM Studio endpoints) plus a composite `Router`.
-Vertex keeps native Gemini GenerateContent and Claude
-Messages-over-`streamRawPredict` as separate protocol families under one
-explicit provider identity.
+Vertex AI, Amazon Bedrock Mantle, and OpenAI-compatible provider adapters
+(including Fireworks, Together, OpenRouter, vLLM, and LM Studio endpoints)
+plus a composite `Router`. Vertex keeps native Gemini GenerateContent and
+Claude Messages-over-`streamRawPredict` as separate protocol families under
+one explicit provider identity.
 
 The `Router` is itself a `ModelProvider`, so the agent loop holds one provider
 contract and does not depend on a concrete backend. Two things define it:

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -303,11 +303,12 @@ independently reauthorizes its live grant. Resolve checks attachment authority
 again, which discards content if a detach won while the read was in flight. A
 crash after possible broker dispatch becomes a safe unavailable result instead
 of another read.
-The model router supports Anthropic, OpenAI, xAI, Gemini, Google Vertex AI, and
-OpenAI-compatible endpoints. Vertex routes curated Gemini and Claude models
-through their native Google publisher surfaces using a fixed-endpoint,
-short-lived Google bearer. It fails closed: if no enabled provider with a
-usable credential can serve the selected model, no model request is sent.
+The model router supports Anthropic, OpenAI, xAI, Gemini, Google Vertex AI,
+Amazon Bedrock Mantle, and OpenAI-compatible endpoints. Vertex routes curated
+Gemini and Claude models through their native Google publisher surfaces using
+a fixed-endpoint, short-lived Google bearer. It fails closed: if no enabled
+provider with a usable credential can serve the selected model, no model
+request is sent.
 
 ### Tool calls are small state machines too
 

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -61,11 +61,16 @@ a provider-coupled artifact:
 | Provider-executed web search native blocks (e.g. Anthropic `encrypted_content`) | Replay verbatim | Flatten to cleartext titles/URLs (or equivalent host-shaped prose) — never invent a simulated native call |
 | Vendor tool-call ids and cache prefixes | Keep as the adapter requires | Do not translate; the neutral journal already has the durable fact |
 
+Sharing a wire protocol does not merge origins. Amazon Bedrock Mantle can reuse
+the Messages and Responses adapters, but Bedrock-native artifacts still replay
+only for the exact Bedrock provider and model that minted them. Anthropic,
+OpenAI, Gemini, and every other route receive the flattened or empty fallback.
+
 Consequences:
 
-- **No per-pair translation matrix.** Do not build Anthropic↔OpenAI↔Gemini
-  converters for each new feature. Origin-gate native replay; everyone else
-  gets the flattened form.
+- **No per-pair translation matrix.** Do not build
+  Anthropic↔OpenAI↔Gemini↔Amazon Bedrock Mantle converters for each new feature.
+  Origin-gate native replay; everyone else gets the flattened form.
 - **Quality asymmetry is accepted.** A switched-into model may see a slightly
   flatter history. That must not be hidden with fake native shapes, and it
   must never silently break (same refuse-don't-strip posture as unsupported


### PR DESCRIPTION
Summary

- add a first-class Amazon Bedrock provider with region-scoped endpoints, keychain-backed Bedrock API keys or AWS access credentials, and SigV4 signing for the exact serialized request
- route Anthropic model IDs through Bedrock Mantle Messages and explicitly configured text model IDs through Bedrock Mantle Responses, reusing the native request and streaming normalizers
- expose conservative curated/custom model configuration through the server API and desktop settings, preserve origin-gated reasoning replay, and add Bedrock-only utility fallback
- pin protocol-specific request, authentication-header, stream, usage, tool-call, and stop-event fixtures without adding dependencies or changing Cargo.lock or the UI lockfile

Validation

- cargo fmt --all -- --check
- cargo check --workspace --locked
- cargo test -p openwave-router --locked
- cargo test -p openwave-server bedrock --locked
- cargo test -p openwave-server providers::tests --locked
- cargo test -p openwave-server model_registry::tests --locked
- cargo test -p openwave-server model_roles::tests --locked
- cargo test -p openwave-server the_generated_bindings_are_current --locked
- cargo clippy -p openwave-server --tests --locked -- -D warnings
- pnpm --dir crates/openwave-desktop/ui test
- pnpm --dir crates/openwave-desktop/ui build

Unsupported in this slice

- Bedrock Runtime InvokeModel and Converse APIs, OpenAI Chat Completions, model discovery, and arbitrary application inference-profile aliases
- AWS profile, SSO, ECS, EC2 metadata, role-assumption, or automatic temporary-credential refresh; this slice accepts a Bedrock API key, explicit access keys with an optional session token, or the matching process environment variables
- provider-executed web search on the Bedrock route
- live AWS credential and regional entitlement verification; the exact Mantle contracts are fixture-tested locally and curated Bedrock rows remain unverified

No tests were removed.

Closes #1769