### PR TITLE
ci: make Windows PR validation explicit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,9 @@ concurrency:
   # deliberate backstop for those lanes, so an unrelated push must never kill
   # it. During a merge train this runs main pushes in parallel instead of
   # superseding them; that costs runner time, but sccache shares compiler
-  # objects across the runs and correctness of the scoped lanes wins.
+  # objects across the runs and correctness of the scoped lanes wins. A job may
+  # add narrower concurrency only when a newer run provably subsumes the older
+  # one; the Windows lane does that for Rust-scoped pushes to linear main.
   group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.ref) || format('{0}-run-{1}', github.workflow, github.run_id) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
@@ -378,11 +380,18 @@ jobs:
     name: Windows cargo check
     needs: changes
     # A native runner keeps the Windows SDK and MSVC available for native
-    # dependencies such as ring and SQLite. Keep the default PR gate fast; add
-    # `full-ci` for pre-merge validation, while main and scheduled/manual runs
-    # always check every crate that currently contains Windows-gated code.
-    if: ${{ needs.changes.outputs.rust == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')) }}
+    # dependencies such as ring and SQLite. Native Windows validation is an
+    # independent pre-merge choice: `full-ci` does not opt a pull request into
+    # this long-running lane. Add `windows-ci` when the change reaches a Windows
+    # boundary; main and scheduled/manual runs retain the automatic backstop.
+    if: ${{ needs.changes.outputs.rust == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'windows-ci')) }}
     runs-on: windows-latest
+    # Every Rust-scoped main push contains the prior main state, so the newest
+    # Windows run proves everything an older in-progress one would have proven.
+    # PRs, schedules, and manual dispatches remain isolated by run id.
+    concurrency:
+      group: ${{ github.event_name == 'push' && 'windows-check-main' || format('windows-check-run-{0}', github.run_id) }}
+      cancel-in-progress: ${{ github.event_name == 'push' }}
     # The persistence steps below compile openwave-server's test target, which
     # is the heaviest codegen this lane pays; leave headroom over the
     # check-plus-broker baseline.
@@ -390,10 +399,17 @@ jobs:
     env:
       CARGO_INCREMENTAL: 0
       CARGO_PROFILE_DEV_DEBUG: 0
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_RW_MODE: READ_WRITE
+      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install toolchain (honors rust-toolchain.toml)
         run: rustup show
+      - name: Set up compiler cache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.16.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,10 +128,12 @@ Coverage percentage is not a goal and is not tracked. Confidence is.
 
 During active greenfield development, pull requests use a deliberately fast
 default gate. Full validation remains automatic after merge and on scheduled or
-manual runs; add the `full-ci` label when a change warrants full validation
-before merge. Re-running the full workspace suite before every push buys little
-and costs minutes on each iteration. Run a cheap relevant subset locally, push
-early, and let the configured lanes work while you keep going.
+manual runs. Add `full-ci` when a change warrants the heavyweight
+platform-neutral lanes before merge, and add `windows-ci` independently when it
+warrants the native Windows lane. Re-running the full workspace suite before
+every push buys little and costs minutes on each iteration. Run a cheap relevant
+subset locally, push early, and let the configured lanes work while you keep
+going.
 
 The change-scope gate in [`.github/workflows/ci.yml`](.github/workflows/ci.yml)
 is the whole rule, and it is coarse on purpose:
@@ -155,6 +157,15 @@ is the whole rule, and it is coarse on purpose:
   `full-ci` label is added. The always-running change detector rejects
   impossible narrower-scope combinations before conditional jobs consume them.
   There is no serial aggregate wrapper after the slowest job.
+- The native Windows lane checks the Windows-gated crates plus the host-broker,
+  desktop SQLite profile, and Credential Manager contracts. It runs
+  automatically for Rust-scoped pushes to `main`, weekly schedules, and manual
+  dispatches; a pull request runs it only with `windows-ci`. Use that label for
+  Windows-gated code, host-broker or sidecar packaging, desktop persistence or
+  keychain work, Windows release inputs, and native dependency or toolchain
+  changes. `full-ci` does not imply `windows-ci`. Superseded Windows jobs on
+  linear `main` are cancelled because the newer Rust-scoped state covers the
+  older one; pull-request, scheduled, and manual runs remain isolated.
 - The heavyweight `sandbox-resident container e2e` lane is scoped separately on
   merges to `main`. It runs when the sandbox agent/protocol, container driver,
   Dockerfile, or dependency/toolchain inputs change. A weekly scheduled run and
@@ -165,14 +176,17 @@ is the whole rule, and it is coarse on purpose:
 
 An ordinary pull request's heavy-job skips are the intended fast path, backed by
 full validation on `main`. For risky or boundary-crossing changes, add
-`full-ci` and wait for the applicable lanes. Run a cheap subset for fast local
+`full-ci` and wait for the applicable platform-neutral lanes; add `windows-ci`
+too when the Windows boundary is relevant. Run a cheap subset for fast local
 feedback on what you actually touched — `cargo check -p <crate>`, the one test
 module you changed, `tsc` — and push.
 
 **The real trap is confusing the fast gate with full validation.** When a PR has
-`full-ci`, judge by whether every applicable job is present and passed, not by
-the absence of red. A conflicting PR runs nothing but trivial policy checks;
-rebase it before believing its status. `gh pr checks <n>` shows the truth.
+`full-ci`, judge by whether every applicable platform-neutral job is present and
+passed, not by the absence of red. When it also has `windows-ci`, wait for the
+native Windows lane as well. A conflicting PR runs nothing but trivial policy
+checks; rebase it before believing its status. `gh pr checks <n>` shows the
+truth.
 
 Enable auto-merge (`gh pr merge <n> --squash --auto --delete-branch`) so a PR
 lands the moment its lanes go green instead of waiting for you to come back.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -438,9 +438,17 @@ first five run on an ordinary pull request; the compile-heavy lanes (`clippy`,
 behind the `full-ci` label and otherwise report a successful skip, which is what
 lets a required check pass without running. That is the deliberate fast gate
 described in [`CLAUDE.md`](../CLAUDE.md), backed by full validation on every
-push to `main` and on the weekly scheduled run — not a claim that PostgreSQL
-state-machine coverage gates every merge. Keep both sets required so the
-skip-reporting stays wired up, and add any new always-running lane to the list.
+Rust-scoped push to `main` and on the weekly scheduled run — not a claim that
+PostgreSQL state-machine coverage gates every merge. Keep both sets required so
+the skip-reporting stays wired up, and add any new always-running lane to the
+list.
+
+`Windows cargo check` is intentionally separate from the required contexts and
+from `full-ci`. It runs automatically for Rust-scoped pushes to `main`, weekly
+schedules, and manual dispatches, while pull requests opt in with `windows-ci`
+when they touch a native Windows boundary. Keep it non-required so ordinary and
+`full-ci` pull requests do not wait for long-running native platform coverage;
+the post-merge and scheduled runs remain the backstop.
 
 The release-draft workflow uses the built-in `GITHUB_TOKEN`; it does not require
 a personal access token.

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -166,6 +166,30 @@ test("heavy CI is opt-in on pull requests and automatic elsewhere", () => {
   assert.doesNotMatch(desktopCargo, /document-parsers/);
 });
 
+test("native Windows CI is an explicit PR opt-in with a main backstop", () => {
+  const windows = workflowJob(workflows["ci.yml"], "windows-check");
+  const windowsCiGate =
+    /github\.event_name != 'pull_request' \|\| contains\(github\.event\.pull_request\.labels\.\*\.name, 'windows-ci'\)/;
+
+  assert.match(windows, windowsCiGate);
+  assert.doesNotMatch(windows, /'full-ci'/);
+  assert.match(
+    windows,
+    /group: \$\{\{ github\.event_name == 'push' && 'windows-check-main' \|\| format\('windows-check-run-\{0\}', github\.run_id\) \}\}/,
+  );
+  assert.match(
+    windows,
+    /cancel-in-progress: \$\{\{ github\.event_name == 'push' \}\}/,
+  );
+  assert.match(windows, /SCCACHE_GHA_ENABLED: "true"/);
+  assert.match(windows, /SCCACHE_GHA_RW_MODE: READ_WRITE/);
+  assert.match(windows, /RUSTC_WRAPPER: sccache/);
+  assert.match(
+    windows,
+    /uses: mozilla-actions\/sccache-action@[0-9a-f]{40}/,
+  );
+});
+
 test("UI tests and production build each gate the UI lane", () => {
   const ci = workflows["ci.yml"];
   const ui = workflowJob(ci, "ui");
@@ -186,6 +210,7 @@ test("PR compiler caches are writable, isolated, and deleted on close", () => {
   for (const name of [
     "lint",
     "desktop",
+    "windows-check",
     "test",
     "postgres",
   ]) {


### PR DESCRIPTION
## Summary

- make native Windows validation an independent `windows-ci` pull-request opt-in instead of running it for every `full-ci` PR
- keep the Windows lane automatic for Rust-scoped pushes to `main`, schedules, and manual dispatches
- cancel superseded Windows jobs on linear `main` while keeping PR, scheduled, and manual runs isolated
- add the existing sccache setup to the Windows compiler path
- document and regression-test the label, concurrency, and cache policy

## Why

The Windows lane is valuable because it covers Windows-gated compilation plus native host-broker, SQLite profile, and Credential Manager behavior. It is also consistently the slowest pull-request job. Separating the labels preserves targeted pre-merge Windows coverage without making unrelated `full-ci` changes wait for it, while post-merge and scheduled validation remain intact.

The repository labels now describe the split directly: `full-ci` selects heavyweight platform-neutral validation and `windows-ci` selects native Windows validation.

## Verification

- `actionlint .github/workflows/ci.yml`
- `node --test scripts/*.test.mjs` (90 passed)
- `node --test scripts/workflow-security.test.mjs` (21 passed)
- `git diff --check`

This PR carries both `full-ci` and `windows-ci` so CI exercises the new Windows trigger and sccache setup before review.