### PR TITLE
test(host-broker): stabilize interrupted audit rotation recovery

### DIFF
--- a/crates/openwave-host-broker/src/audit.rs
+++ b/crates/openwave-host-broker/src/audit.rs
@@ -754,19 +754,17 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let first = event(AuditTarget::Subject);
         let second = event(AuditTarget::Subject);
-        let first_len = serde_json::to_vec(&first).unwrap().len();
-        let second_len = serde_json::to_vec(&second).unwrap().len();
-        // Rotation triggers on a strict `>` bound. Follow-up events pick up new
-        // UUID/timestamp bytes, so cap the file from the first line and require
-        // later lines to stay within it — otherwise recovery can append into a
-        // fresh active file and spuriously rotate, wiping the archive on Windows.
-        assert!(second_len <= first_len);
-        let line_bytes = first_len as u64 + 1;
+        let first_line_bytes = serde_json::to_vec(&first).unwrap().len() as u64 + 1;
+        let second_line_bytes = serde_json::to_vec(&second).unwrap().len() as u64 + 1;
+        // Either line fits by itself, while the two together must rotate. Using
+        // the same follow-up event across the interrupted append and recovery
+        // keeps variable timestamp precision out of the boundary under test.
+        let line_bytes = first_line_bytes.max(second_line_bytes);
         let sink = JsonlAuditSink::open(temp.path()).with_max_file_bytes(line_bytes);
         sink.record(&first).unwrap();
         sink.writer.lock().unwrap().fail_rotation_after_archive_once = true;
         assert!(matches!(
-            sink.record(&event(AuditTarget::Subject)),
+            sink.record(&second),
             Err(AuditError::PublicationAmbiguous)
         ));
 


### PR DESCRIPTION
## Summary

- Remove the timing-dependent assumption that two freshly generated audit events serialize to non-increasing lengths.
- Size the test file boundary so either concrete event fits alone while both together still force rotation.
- Reuse the follow-up event for the interrupted append and recovery retry so timestamp precision cannot move the boundary under test.

This addresses the host-broker failure in Windows Actions run 31205055045, where Chrono serialized the second timestamp one byte longer than the first.

## Test plan

- [x] `cargo fmt --check --all`
- [x] Targeted recovery test passed 100 consecutive runs
- [x] `cargo test -p openwave-host-broker --lib --locked` (101 passed)
- [x] `cargo clippy -p openwave-host-broker --locked --all-targets -- -D warnings`
- [ ] Windows CI lane