### PR TITLE
fix(ci): restore Bedrock build and provider panel

### DIFF
--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -11,6 +11,13 @@ import { openSignInPage } from "../openSignInPage";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { useConfirm } from "../components/ConfirmDialog";

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -1564,6 +1564,7 @@ mod tests {
                     as std::sync::Arc<dyn crate::BearerTokenSource>
             }),
             vertex: None,
+            bedrock: None,
             chatgpt_account_id: None,
         }])
     }


### PR DESCRIPTION
Restores the current main CI after the Bedrock integration.

- initializes the new `Route::bedrock` field in the OpenAI-compatible test helper
- imports the Select controls rendered by Bedrock credentials UI

Verified:
- `cargo test -p openwave-router --lib --locked`
- `pnpm --dir crates/openwave-desktop/ui exec vitest run src/settings/ProvidersPanel.dom.test.tsx`
- `pnpm --dir crates/openwave-desktop/ui build`
- `cargo fmt --check`