### PR TITLE
docs: consolidate the post-v1 roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,13 +14,15 @@ React/TypeScript under `crates/openwave-desktop/ui`.
   repository, not this one; use this repository's documented Cargo, pnpm, and
   GitHub commands instead.
 - **Branch off `main`; PR back into `main`.** Never commit straight to `main`.
-- **Issues are for deferred or cross-agent work, not for narrating the current
-  task.** Open an issue when work is being set aside for later, or when it needs
-  to be visible to *other* sessions — work another agent might pick up, or a
-  claim on contested scope. Work the user is directing interactively in this
-  session doesn't need an issue; filing one adds tracking overhead without
-  coordinating anyone. If you do pick up substantial parallel-track work, claim
-  its issue **before you start editing** — see below.
+- **Issues are for active or cross-agent work, not for narrating the current
+  task or keeping a someday backlog.** Use an issue when work needs a concrete
+  owner, dependency, or reviewable delivery. Keep deliberately parked product
+  scope in [`docs/deferred.md`](docs/deferred.md), which is the canonical
+  account of what OpenWave does not yet implement and why. Work the user is
+  directing interactively in this session doesn't need an issue; filing one
+  adds tracking overhead without coordinating anyone. If you do pick up
+  substantial parallel-track work, claim its issue **before you start editing**
+  — see below.
 - **Only commit or push when asked.** Don't merge your own PRs unless the request
   was explicitly to merge; default to opening the PR for review.
 
@@ -36,7 +38,6 @@ The workflow labels:
 
 - `in-progress` — claimed; a session is actively working the issue.
 - `blocked` — cannot proceed until a dependency or decision lands.
-- `deferred` — consciously parked; not on any session's active slate.
 
 The conventions:
 
@@ -58,8 +59,11 @@ The conventions:
 - **Reference the issue from the PR** with `Closes #N` so the merge auto-closes
   it.
 - **Keep labels current.** Stale state misleads the team — drop `in-progress`
-  when you park work (and add `deferred` or `blocked` with a comment saying
-  where it stands); treat this as part of the change, not an afterthought.
+  when you park work. If the work is blocked by a concrete dependency, add
+  `blocked` with a comment saying what is needed. If it is deliberately future
+  product scope rather than an active, actionable task, close the issue and
+  update [`docs/deferred.md`](docs/deferred.md) instead; do not add a
+  `deferred` label.
 - **Avoid the GitHub GraphQL API — REST covers this workflow entirely.** All
   agent sessions share one `gh` account, and the GraphQL quota (5000 points/hr)
   is routinely exhausted when sessions run in parallel — REST keeps working

--- a/docs-site/content/docs/meta.json
+++ b/docs-site/content/docs/meta.json
@@ -17,6 +17,7 @@
     "skills-and-plugins",
     "mcp-servers",
     "web-search",
+    "roadmap",
     "---Reference---",
     "headless",
     "troubleshooting"

--- a/docs-site/content/docs/roadmap.mdx
+++ b/docs-site/content/docs/roadmap.mdx
@@ -1,0 +1,82 @@
+---
+title: What comes after v1
+description: The capabilities OpenWave deliberately does not promise in its first stable release, and why.
+---
+
+OpenWave v1 is a local-first coworker for real work: it can use configured
+models, work over user-approved files, call bounded tools, run code in an
+isolation boundary, and produce files you explicitly export. That is a useful
+foundation, not a claim that every kind of automation is already present.
+
+## Not yet, by design
+
+<Cards>
+  <Card title="Scheduled work" href="#a-coworker-that-can-work-later">
+    Future runs will reuse the durable run journal and never turn a schedule
+    into blanket permission.
+  </Card>
+  <Card title="Browser automation" href="#a-browser-without-ambient-computer-control">
+    Browser control needs its own isolated profile and visible, reviewable
+    action boundary.
+  </Card>
+  <Card title="Connected services" href="#connected-services">
+    Managed OAuth integrations belong with gateway entitlements, not a parallel
+    desktop-owned connector catalog.
+  </Card>
+</Cards>
+
+## A coworker that can work later
+
+OpenWave has durable background runs, but it does not schedule work for a
+future time or recurring cadence yet. The first local-first scheduler should
+support one-time, daily, and weekly tasks with visible history, explicit
+enable/disable controls, and bounded catch-up after sleep or offline time. It
+will reuse the existing journal and admission path instead of introducing a
+second automation engine.
+
+A schedule cannot manufacture consent. Actions with external effects will
+remain subject to the applicable approval boundary; future recurring grants
+must be limited to exact, canonicalized destinations.
+
+## A browser without ambient computer control
+
+Browser automation is valuable, but OpenWave will not take over your everyday
+browser profile or silently become general desktop control. A future browser
+capability needs an OpenWave-managed profile with explicit rules for cookies,
+logins, reset, uploads, downloads, cancellation, and a visible foreground
+control surface.
+
+It must keep web-page content separate from model instructions, credentials,
+and host capabilities. Personal-profile access by default, CAPTCHA evasion,
+and password-manager integration are outside this direction.
+
+## Connected services
+
+OpenWave supports local connected folders, MCP servers, web search, and
+user-configured REST definitions. It does not intend to publish and operate a
+separate desktop-owned OAuth catalog for services such as Slack, Google,
+Microsoft 365, Dropbox, or Box.
+
+For services that require a registered OAuth application, the intended managed
+path is a gateway entitlement that OpenWave consumes and explains. Local users
+retain their escape hatches: mounted MCP servers and user-provided REST
+definitions and credentials.
+
+## Further out
+
+Later work can add connected-folder search from the composer, reusable output
+templates, an instruction-only plugin marketplace, and eventually
+capability-bearing plugin components with explicit per-component consent.
+
+Deeper isolation is also planned carefully. Detached background agents require
+scoped model tokens, provider lifetime caps, verified images, no reachable host
+authority, and enforceable credential-egress rules. Until those properties fit
+together, durable background runs remain local and attached.
+
+## What we are finishing now
+
+The v1 foundation still has ordinary implementation work: consolidating the
+pre-v1 schema baseline, closing the remaining self-hosted prompt-inbox ownership
+gap, enforcing Docker's strict network-off policy, surfacing the built-in
+project model, and tightening deletion and audit behavior. These are active,
+buildable slices rather than deferred promises.

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,9 @@ Project documentation, versioned alongside the code.
   administrator deploys to point OpenWave at a managed model gateway.
 - [Releases and versioning](releases.md) — semantic PR titles, native release
   drafts, tag-derived macOS builds, and the deliberate path to `1.0.0`.
+- [What comes after v1](deferred.md) — the deliberately parked product scope,
+  the v1 finishing work that remains actionable, and the conditions that bring
+  future capabilities forward.
 
 More to come as the product surfaces land (running locally, API reference, and
 writing tools).

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -1,0 +1,132 @@
+# What comes after v1
+
+OpenWave's first stable release is deliberately narrow: a local-first coworker
+that can work over user-approved files, use configured models and bounded
+tools, run code in an isolation boundary, and produce files the user explicitly
+exports. The work below is valuable, but it is not silently implied by that
+promise.
+
+This is the canonical record of deliberately parked product scope. It is not a
+ticket queue and it does not make dates or release promises. A concrete task
+with an owner belongs in an issue; a long-horizon capability belongs here until
+the conditions for building it are real.
+
+## Completing the v1 foundation
+
+Several pieces are ordinary implementation work, not deferred product bets.
+They stay as open issues without a `deferred` label because a contributor can
+pick them up now:
+
+- Finish the disposable pre-v1 database baseline: consolidate the migration
+  history and remove obsolete schema paths before compatibility commitments
+  begin at 1.0.
+- Close the remaining multi-principal prompt-inbox ownership gap in the
+  self-hosted profile.
+- Enforce the strict `network off` setting in Docker code execution, then use
+  the existing egress topology to make the other network policies enforceable.
+- Surface the already-built project model in the desktop, including optional
+  chat organization and project-scoped context.
+- Make deletion of a terminal chat erase its background-run workspaces without
+  waiting for the periodic reaper, and add an app actor to the host-folder audit
+  vocabulary.
+
+These are important finishing work, but they do not change the product's basic
+shape. They should be delivered as normal, reviewable slices rather than held
+in a parking label.
+
+## A coworker that can work later
+
+Background agent runs make work durable, but OpenWave does not yet schedule
+work for a future time or recurring cadence. A future local-first scheduler
+should reuse the run journal and admission path rather than create a second
+automation engine. Its first useful shape is deliberately modest: one-time,
+daily, and weekly tasks; explicit enable/disable controls; visible history; and
+bounded catch-up after the computer has been asleep or offline.
+
+Scheduling does not create blanket consent. A task that reaches an external
+effect still needs an applicable approval, and future exact-target recurring
+grants must stay constrained to a tool's canonical destination. Arbitrary cron,
+cloud execution while the user's machine is unavailable, and a separate agent
+runtime are outside that first step.
+
+## A browser without ambient computer control
+
+Browser automation is a major missing capability, but it must not become a way
+to take over the user's everyday browser or desktop. The future browser surface
+needs its own OpenWave-managed profile, clear cookie and login lifetime rules,
+visible foreground control, durable history, cancellation, and a reset path.
+
+The initial contract must distinguish navigation from entering sensitive text,
+uploading files, downloading files, and submitting an external action. It must
+also keep page-authored content separate from model instructions and from host
+credentials and capabilities. General desktop control, personal-profile access
+by default, CAPTCHA evasion, and password-manager integration are not in this
+plan.
+
+## More ways to organize and shape work
+
+The basic chat remains useful on its own. Later work can make it easier to
+organize and direct:
+
+- Search inside an already approved connected folder from the composer, using
+  root-relative paths and bounded discovery rather than exposing absolute host
+  paths.
+- Let a reusable plugin provide an output template as well as a prompt or
+  skill, once there is a settled way to deliver a template into a turn.
+- Install instruction-only plugins from pinned Git sources or public skill
+  indexes, with explicit updates and no background auto-update.
+- Eventually admit capability-bearing plugin components packaged as MCPB
+  bundles, only with component-level consent, keychain-backed configuration,
+  and enforced tool-schema validation.
+
+The marketplace and executable-plugin work follows the simpler
+instruction-only pipeline; it is not a v1 dependency.
+
+## Connected services: local control first, managed entitlements later
+
+OpenWave already has local connected folders, configured MCP servers, web
+search, and a governed REST executor for local apps. It does not plan to become
+the publisher and refresh-token broker for a parallel catalog of Slack, Google,
+Microsoft 365, Dropbox, or Box integrations.
+
+Where a service requires a registered OAuth app, the intended managed path is a
+model gateway entitlement. OpenWave should consume those entitled apps or
+virtual MCP endpoints and explain what a gateway provides, while unmanaged
+users retain local escape hatches such as MCP mounting and user-provided REST
+definitions and credentials. Curated desktop-owned OAuth connectors are not on
+the current path.
+
+Two related capabilities wait on clear boundaries: choosing governed REST
+operations to expose as foreground chat tools, and making gateway-attested MCP
+execution modes visible in Settings. The former needs its own model-tool,
+approval, snapshot, and audit contract; the latter waits for the gateway to
+expose execution-mode metadata. Recording a gateway identity beside turns and
+host-access audit events is likewise a future attribution feature, not local
+access control.
+
+## Deeper isolation and reliability
+
+OpenWave can run code through local and managed execution providers today. The
+more ambitious sandbox-resident agent-run tier remains attached-only and
+opt-in. Detached background execution needs scoped model tokens, provider
+lifetime caps, image verification in the right trust root, no
+host-authority-reachable tools, and enforceable credential egress rules. Until
+those properties hold together, the in-process durable run path is the
+supported one.
+
+Reliability work also remains ahead of the product surface: replayable adapter
+contracts, recorded response decoding, and a protected live canary matrix would
+catch provider API drift before it becomes a user-visible turn failure. MCP app
+and gateway follow-ups are retained as a small, prioritized maintenance list:
+prompt server replies during an HTTP stream, propagate theme changes into app
+views, recover visibly from a transient frame-payload failure, make gateway
+sign-in restartable, and validate the external-app protocol against its SDK.
+
+## What this means for planning
+
+V1 is not a claim that OpenWave has every kind of automation or connector. It
+is a commitment to make the capabilities it does expose legible, local-first,
+and bounded. New ideas should be added here when they describe a deliberate
+product direction or a dependency outside this repository. Once a direction has
+a concrete, buildable slice, turn that slice into a normal issue, claim it, and
+remove it from this document when it ships or is reconsidered.

--- a/docs/sandbox-providers.md
+++ b/docs/sandbox-providers.md
@@ -11,10 +11,10 @@ in [agent runs](agent-runs.md); the broker and capability model this design
 reuses in [host access](host-access.md). This document is the design that
 connects them.
 
-## Status: explicitly deferred
+## Status: deliberately parked
 
-The sandbox-resident run tier is **deferred** as of 2026-08, tracked in
-[#1749](https://github.com/brightwave-inc/openwave/issues/1749). The shipped
+The sandbox-resident run tier is **deliberately parked** as of 2026-08; see
+[What comes after v1](deferred.md) for the product-level record. The shipped
 code — the local Docker backend, the container run driver, the admission gate,
 and their post-merge e2e lane — stays in the tree and is kept green, but no
 further roadmap step below is being built, and the tier remains opt-in


### PR DESCRIPTION
## Summary

- consolidate deliberately parked product scope into a canonical repository roadmap and public docs page
- retire the `deferred` issue workflow in favor of active, actionable issues
- distinguish remaining v1 finishing work from later product directions

## Validation

- `pnpm build` (from `docs-site`)
- `git diff --check`

## Issue housekeeping

The legacy `deferred` label has been retired. Parked roadmap issues were closed with a pointer to the new canonical documentation; concrete implementation-ready items remain open as normal issues. #1112 was intentionally left unchanged.