### PR TITLE
fix(providers): accept hosted catalog API keys

### DIFF
--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -360,6 +360,8 @@ impl ProviderKind {
                     | ProviderKind::Xai
                     | ProviderKind::Gemini
                     | ProviderKind::Bedrock
+                    | ProviderKind::Fireworks
+                    | ProviderKind::Together
                     | ProviderKind::OpenaiCompatible
             ),
             ProviderCredential::Oauth {} => self == ProviderKind::Openai,

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -2181,7 +2181,7 @@ async fn model_roles_resolve_at_read_time_and_honor_an_explicit_pin() {
         .iter()
         .find(|model| model["key"] == "together::moonshotai/Kimi-K3")
         .unwrap();
-    assert!(!kimi["supports_tools"].as_bool().unwrap());
+    assert!(kimi["supports_tools"].as_bool().unwrap());
 
     let kimi_pin = put_role(
         "utility",


### PR DESCRIPTION
Restores the post-merge headless test lane after the Fireworks and Together catalog addition.

- allow API-key credentials for the Fireworks and Together direct-compatible providers
- align the Together Kimi catalog assertion with its declared tool capability

Verified:
- `cargo test -p openwave-server --lib --locked`