### PR TITLE
feat(desktop): complete conversation UI parity

### DIFF
--- a/crates/openwave-desktop/ui/src/AppShell.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.tsx
@@ -20,7 +20,8 @@ import {
 import { useChatListStore } from "./ChatListStore";
 import { useComposerDrafts } from "./ComposerDrafts";
 import { useConfirm } from "./components/ConfirmDialog";
-import { hasMacOverlayTitlebar } from "./host";
+import { useDesktopNavigation } from "./DesktopNavigation";
+import { hasMacOverlayTitlebar, hasNativeHost } from "./host";
 import { useInterfaceZoom } from "./InterfaceZoom";
 import { Logomark } from "./Logomark";
 import { ManagedGate } from "./ManagedGate";
@@ -99,6 +100,7 @@ export function AppShell() {
   const deletionInFlightRef = useRef(false);
   const { confirm, dialog: confirmDialog } = useConfirm();
   const desktopUpdates = useDesktopUpdates();
+  const desktopNavigation = useDesktopNavigation();
   const zoom = useInterfaceZoom();
 
   // The native "Check for Updates…" menu item lands the reader on the
@@ -129,6 +131,12 @@ export function AppShell() {
   // scaling the window all work wherever the reader is. They are installed
   // below the gate, by GatedShellHooks.
   const shellShortcuts: ShellShortcutHandlers = {
+    "history-back": () => {
+      if (desktopNavigation.canGoBack) desktopNavigation.goBack();
+    },
+    "history-forward": () => {
+      if (desktopNavigation.canGoForward) desktopNavigation.goForward();
+    },
     "toggle-sidebar": () => useUiStore.getState().toggleSidebar(),
     "new-chat": () => void onNewChat(),
     "focus-composer": focusComposer,
@@ -364,6 +372,9 @@ export function AppShell() {
     );
   }
 
+  const nativeTitlebar = hasNativeHost();
+  const macOverlayTitlebar = hasMacOverlayTitlebar();
+
   return (
     <ManagedGate client={client}>
       <GatedShellHooks
@@ -392,10 +403,15 @@ export function AppShell() {
           restartForUpdate: onRestartForUpdate,
         }}
       >
-        <div className={`app-shell${hasMacOverlayTitlebar() ? " with-titlebar" : ""}`}>
+        <div className={`app-shell${nativeTitlebar ? " with-titlebar" : ""}`}>
           {confirmDialog}
           <ShortcutsDialog open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
-          {hasMacOverlayTitlebar() && <Titlebar />}
+          {nativeTitlebar && (
+            <Titlebar
+              macOverlay={macOverlayTitlebar}
+              navigation={desktopNavigation}
+            />
+          )}
           {/* Each route renders its own rail beside its content — see RouteFrame. */}
           <div className="app-body">
             <Outlet />

--- a/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
@@ -251,6 +251,28 @@ describe("ChatView", () => {
     scrollIntoView.mockRestore();
   });
 
+  it("keeps a transcript anchor in the URL until returning to the live tail", async () => {
+    useChatSessionStore.getState().update((session) => ({
+      ...session,
+      messages: [{ id: "m1", role: "user", text: "Earlier request" }],
+    }));
+    const user = userEvent.setup();
+    const { router } = await renderWithRouter(
+      <ChatView {...chatViewProps()} />,
+      { initialUrl: "/c/chat-1?at=m1" },
+    );
+
+    expect(
+      await screen.findByRole("button", { name: "Return to latest" }),
+    ).toBeInTheDocument();
+    expect(router.state.location.search).toHaveProperty("at", "m1");
+
+    await user.click(screen.getByRole("button", { name: "Return to latest" }));
+    await waitFor(() =>
+      expect(router.state.location.search).not.toHaveProperty("at"),
+    );
+  });
+
   it("sends an approval decision through its own client", async () => {
     useChatSessionStore.getState().update((session) => ({
       ...session,

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -49,6 +49,10 @@ import {
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { ArrowDown } from "lucide-react";
 import { cn } from "@/lib/utils";
+import {
+  TranscriptNavigation,
+  transcriptNavigationEntries,
+} from "./TranscriptNavigation";
 
 export type ChatViewProps = {
   client: ApiClient;
@@ -180,12 +184,41 @@ export function ChatView({
     }),
     [files, messages],
   );
+  const composerHistory = useMemo(
+    () =>
+      messages.flatMap((message) =>
+        message.role === "user" && message.text.trim() ? [message.text] : [],
+      ).reverse(),
+    [messages],
+  );
 
   const navigate = useNavigate();
-  const focusCallId = (useSearch({ strict: false }) as { focus?: string })
-    .focus;
+  const search = useSearch({ strict: false }) as {
+    focus?: string;
+    at?: string;
+  };
+  const focusCallId = search.focus;
+  const anchoredMessageId = search.at;
+  const navigationSignature = messages
+    .flatMap((message) => {
+      if (message.role === "user") return [message.id, message.text];
+      if (message.role === "tool") {
+        return [message.id, message.name, message.status];
+      }
+      return [];
+    })
+    .join("\0");
+  const navigationEntries = useMemo(
+    () => transcriptNavigationEntries(messages),
+    // Assistant streaming replaces the messages array every token, but does
+    // not change the table of contents. Keep the rail's observers mounted until
+    // one of the user/tool fields it actually presents changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [navigationSignature],
+  );
 
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null);
   /** The composer's slot, which a pending question or plan card takes over. */
   const promptSlotRef = useRef<HTMLDivElement | null>(null);
   const followsLatestRef = useRef(true);
@@ -268,6 +301,7 @@ export function ChatView({
     (element: HTMLDivElement | null) => {
       scrollObserverRef.current?.disconnect();
       scrollRef.current = element;
+      setScrollElement(element);
       if (!element) return;
       const observer = new ResizeObserver(() => {
         element.style.setProperty(
@@ -379,19 +413,89 @@ export function ChatView({
     };
   }, [focusCallId, transcriptVisible, chat.id, navigate]);
 
+  // The router's hash is already occupied by hash history, so a rail jump is
+  // represented by `?at=`. Keeping it in the URL makes an anchored reload land
+  // in the same place; it is cleared only when the reader returns to the tail.
+  useEffect(() => {
+    if (!anchoredMessageId || !transcriptVisible || !scrollElement) return;
+    const frame = window.requestAnimationFrame(() => {
+      const target = Array.from(
+        scrollElement.querySelectorAll<HTMLElement>(
+          "[data-transcript-anchor]",
+        ),
+      ).find(
+        (element) => element.dataset.transcriptAnchor === anchoredMessageId,
+      );
+      if (!target) return;
+      followsLatestRef.current = false;
+      setScrolledAway(true);
+      isProgrammaticRef.current = true;
+      const containerRect = scrollElement.getBoundingClientRect();
+      const targetRect = target.getBoundingClientRect();
+      scrollElement.scrollTo({
+        top: Math.max(
+          0,
+          scrollElement.scrollTop + targetRect.top - containerRect.top - 24,
+        ),
+        behavior: "smooth",
+      });
+      window.setTimeout(() => {
+        isProgrammaticRef.current = false;
+      }, 800);
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [anchoredMessageId, messages, scrollElement, transcriptVisible]);
+
+  const jumpToMessage = useCallback(
+    (anchorId: string) => {
+      void navigate({
+        to: "/c/$chatId",
+        params: { chatId: chat.id },
+        search: (previous: Record<string, unknown>) => ({
+          ...previous,
+          at: anchorId,
+        }),
+        replace: true,
+      });
+    },
+    [chat.id, navigate],
+  );
+
   const jumpToLatest = useCallback(() => {
     followsLatestRef.current = true;
     setScrolledAway(false);
+    if (anchoredMessageId) {
+      void navigate({
+        to: "/c/$chatId",
+        params: { chatId: chat.id },
+        search: (previous: Record<string, unknown>) => ({
+          ...previous,
+          at: undefined,
+        }),
+        replace: true,
+      });
+    }
     scrollToBottom(followScrollBehavior(false));
-  }, [scrollToBottom]);
+  }, [anchoredMessageId, chat.id, navigate, scrollToBottom]);
 
   const handleSend = useCallback(async () => {
     followsLatestRef.current = true;
     setScrolledAway(false);
     setPinLastTurn(true);
+    if (anchoredMessageId) {
+      await navigate({
+        to: "/c/$chatId",
+        params: { chatId: chat.id },
+        search: (previous: Record<string, unknown>) => ({
+          ...previous,
+          at: undefined,
+        }),
+        replace: true,
+      });
+    }
     await onSend();
     scrollToBottom(followScrollBehavior(false));
-  }, [onSend, scrollToBottom]);
+  }, [anchoredMessageId, chat.id, navigate, onSend, scrollToBottom]);
 
   return (
     <section className="chat-pane">
@@ -443,15 +547,22 @@ export function ChatView({
           executionConfigClient={client}
           changeClient={client}
         />
+        <TranscriptNavigation
+          entries={navigationEntries}
+          scrollElement={scrollElement}
+          activeAnchor={anchoredMessageId}
+          onJump={jumpToMessage}
+        />
         <button
           type="button"
           className={cn(
             "absolute z-[1] left-1/2 bottom-3 -translate-x-1/2 inline-flex items-center justify-center rounded-full border border-border p-2 text-foreground bg-background shadow transition-[opacity,background-color] duration-150 ease-in-out opacity-0 pointer-events-none hover:bg-accent motion-reduce:transition-none",
-            scrolledAway && "opacity-100 pointer-events-auto",
+            (scrolledAway || anchoredMessageId) &&
+              "opacity-100 pointer-events-auto",
           )}
-          aria-label="Scroll to latest"
-          aria-hidden={!scrolledAway}
-          tabIndex={scrolledAway ? 0 : -1}
+          aria-label={anchoredMessageId ? "Return to latest" : "Scroll to latest"}
+          aria-hidden={!scrolledAway && !anchoredMessageId}
+          tabIndex={scrolledAway || anchoredMessageId ? 0 : -1}
           onClick={jumpToLatest}
         >
           <ArrowDown size={16} />
@@ -487,6 +598,7 @@ export function ChatView({
             }
             disabled={deletingChat}
             draft={draft}
+            history={composerHistory}
             modelMenu={composerModelMenu}
             permissionMenu={composerPermissionMenu}
             network={composerNetwork}

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -251,6 +251,8 @@ export type ComposerProps = {
   cancelPending: boolean;
   disabled: boolean;
   draft: string;
+  /** Prior user messages, newest first, for terminal-style Up/Down recall. */
+  history?: readonly string[];
   modelMenu?: ReactNode;
   permissionMenu?: ReactNode;
   network?: ComposerNetwork;
@@ -280,6 +282,7 @@ export function Composer({
   cancelPending,
   disabled,
   draft,
+  history = [],
   modelMenu,
   permissionMenu,
   network,
@@ -308,6 +311,8 @@ export function Composer({
   // boolean flickers the drop hint on and off while the file is held still.
   const dragDepthRef = useRef(0);
   const selectionRef = useRef<{ start: number; end: number } | null>(null);
+  const historyIndexRef = useRef<number | null>(null);
+  const savedDraftRef = useRef("");
   const [dragging, setDragging] = useState(false);
   // The `/` token under the caret, as a piece of state rather than a derived
   // value: the caret moves without the draft changing, and a ref would leave
@@ -355,6 +360,8 @@ export function Composer({
   // means nothing in it.
   useLayoutEffect(() => {
     selectionRef.current = null;
+    historyIndexRef.current = null;
+    savedDraftRef.current = "";
     setSlashToken(null);
     setMentionToken(null);
   }, [resetKey]);
@@ -580,6 +587,7 @@ export function Composer({
     if (!canSubmit) return;
     const submissionKey = resetKey;
     await (active ? onSteer() : onSend());
+    historyIndexRef.current = null;
 
     // Restore focus after accepted guidance or a failed request. A new chat or
     // disabled composer must never receive focus from an older submission.
@@ -599,6 +607,9 @@ export function Composer({
   }
 
   function onChange(event: ChangeEvent<HTMLTextAreaElement>) {
+    // A real edit leaves history mode. Programmatic recall calls moveCaret
+    // directly and therefore does not pass through this handler.
+    historyIndexRef.current = null;
     rememberSelection(event.target);
     syncSlashToken(event.target.value, event.target.selectionStart);
     onDraftChange(event.target.value);
@@ -641,6 +652,55 @@ export function Composer({
 
   function onPaste(event: ClipboardEvent<HTMLTextAreaElement>) {
     if (acceptTransfer(event.clipboardData)) event.preventDefault();
+  }
+
+  /** Terminal-style recall, claimed only at the start/end of the textarea. */
+  function handleHistoryKey(
+    event: KeyboardEvent<HTMLTextAreaElement>,
+  ): boolean {
+    if (
+      event.shiftKey ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.altKey ||
+      event.nativeEvent.isComposing
+    ) {
+      return false;
+    }
+    const field = event.currentTarget;
+    const collapsed = field.selectionStart === field.selectionEnd;
+    if (!collapsed) return false;
+
+    if (event.key === "ArrowUp") {
+      const atStart = field.selectionStart === 0;
+      if (draft.trim() && !atStart) return false;
+      const nextIndex =
+        historyIndexRef.current === null ? 0 : historyIndexRef.current + 1;
+      const recalled = history[nextIndex];
+      if (recalled === undefined) return false;
+      if (historyIndexRef.current === null) savedDraftRef.current = draft;
+      historyIndexRef.current = nextIndex;
+      setSlashToken(null);
+      setMentionToken(null);
+      moveCaret(recalled, 0);
+      return true;
+    }
+
+    if (event.key !== "ArrowDown" || historyIndexRef.current === null) {
+      return false;
+    }
+    if (field.selectionEnd !== field.value.length) return false;
+    const nextIndex = historyIndexRef.current - 1;
+    if (nextIndex < 0) {
+      historyIndexRef.current = null;
+      moveCaret(savedDraftRef.current, savedDraftRef.current.length);
+      return true;
+    }
+    const recalled = history[nextIndex];
+    if (recalled === undefined) return false;
+    historyIndexRef.current = nextIndex;
+    moveCaret(recalled, recalled.length);
+    return true;
   }
 
   async function removeFolder(folder: ChatFolderAccess) {
@@ -848,6 +908,10 @@ export function Composer({
         onPaste={onPaste}
         onKeyDown={(event) => {
           if (handleSlashKey(event) || handleMentionKey(event)) {
+            event.preventDefault();
+            return;
+          }
+          if (handleHistoryKey(event)) {
             event.preventDefault();
             return;
           }

--- a/crates/openwave-desktop/ui/src/ComposerHistory.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerHistory.dom.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Composer } from "./Composer";
+
+function HistoryComposer() {
+  const [draft, setDraft] = useState("unfinished draft");
+  return (
+    <Composer
+      activeTurnId={null}
+      busy={false}
+      cancelError={null}
+      cancelPending={false}
+      disabled={false}
+      draft={draft}
+      history={["newest message", "older message"]}
+      onDraftChange={setDraft}
+      onSend={async () => undefined}
+      onSteer={async () => undefined}
+      onStop={async () => undefined}
+      resetKey="chat-1"
+      steerError={null}
+      steerPending={false}
+      steerStatus={null}
+    />
+  );
+}
+
+describe("Composer history", () => {
+  it("walks older messages and restores the saved draft", async () => {
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      callback(0);
+      return 1;
+    });
+    const user = userEvent.setup();
+    render(<HistoryComposer />);
+    const field = screen.getByRole("textbox", {
+      name: "Message",
+    }) as HTMLTextAreaElement;
+
+    field.focus();
+    field.setSelectionRange(0, 0);
+    await user.keyboard("{ArrowUp}");
+    expect(field).toHaveValue("newest message");
+
+    await act(async () => field.setSelectionRange(0, 0));
+    await user.keyboard("{ArrowUp}");
+    expect(field).toHaveValue("older message");
+
+    await act(async () =>
+      field.setSelectionRange(field.value.length, field.value.length),
+    );
+    await user.keyboard("{ArrowDown}");
+    expect(field).toHaveValue("newest message");
+
+    await act(async () =>
+      field.setSelectionRange(field.value.length, field.value.length),
+    );
+    await user.keyboard("{ArrowDown}");
+    expect(field).toHaveValue("unfinished draft");
+  });
+});

--- a/crates/openwave-desktop/ui/src/MessageFooter.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageFooter.test.tsx
@@ -1,6 +1,10 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
-import { formatMessageTimestamp, MessageFooter } from "./MessageFooter";
+import {
+  copyMessageContent,
+  formatMessageTimestamp,
+  MessageFooter,
+} from "./MessageFooter";
 
 describe("MessageFooter", () => {
   it("renders copy and a machine-readable timestamp for a settled assistant message", () => {
@@ -59,5 +63,34 @@ describe("MessageFooter", () => {
     expect(
       formatMessageTimestamp("not-a-date", new Date("2026-07-20T12:00:00Z")),
     ).toBeNull();
+  });
+
+  it("copies rendered HTML beside the message's plain text", async () => {
+    const writes: ClipboardItem[][] = [];
+    class TestClipboardItem {
+      readonly types: string[];
+      constructor(readonly data: Record<string, Blob>) {
+        this.types = Object.keys(data);
+      }
+      async getType(type: string): Promise<Blob> {
+        return this.data[type] ?? new Blob();
+      }
+    }
+    const clipboard = {
+      writeText: async () => undefined,
+      write: async (items: ClipboardItem[]) => {
+        writes.push(items);
+      },
+    };
+
+    await copyMessageContent(
+      "<table><tbody><tr><td>Total</td></tr></tbody></table>",
+      "| Total |",
+      clipboard,
+      TestClipboardItem as unknown as typeof ClipboardItem,
+    );
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0]?.[0]?.types).toEqual(["text/plain", "text/html"]);
   });
 });

--- a/crates/openwave-desktop/ui/src/MessageFooter.tsx
+++ b/crates/openwave-desktop/ui/src/MessageFooter.tsx
@@ -1,11 +1,19 @@
+import type { RefObject } from "react";
 import { WithTooltip } from "@/components/ui/tooltip";
-import { ClipboardCopyButton } from "./ClipboardCopyButton";
+import {
+  ClipboardCopyButton,
+  copyPlainText,
+  copyRichText,
+  type ClipboardWriter,
+} from "./ClipboardCopyButton";
 
 type MessageFooterProps = {
   role: "user" | "assistant";
   text: string;
   createdAt?: string;
   settled?: boolean;
+  /** Rendered assistant Markdown, read only when Copy is clicked. */
+  richContentRef?: RefObject<HTMLElement | null>;
   /** A turn's assistant prose is split into one bubble per activity phase;
    *  the copy action and timestamp belong to the turn, so only the bubble
    *  that closes it carries them. */
@@ -17,6 +25,7 @@ export function MessageFooter({
   text,
   createdAt,
   settled = true,
+  richContentRef,
   sequenceEnd = true,
 }: MessageFooterProps) {
   if (role === "assistant" && !sequenceEnd) return null;
@@ -32,7 +41,9 @@ export function MessageFooter({
     <footer className="message-footer">
       {canCopy && (
         <ClipboardCopyButton
-          value={text}
+          copy={() =>
+            copyMessageContent(richContentRef?.current?.innerHTML ?? "", text)
+          }
           label="Copy"
           copiedAnnouncement="Message copied to clipboard."
           failedAnnouncement="Message could not be copied."
@@ -49,6 +60,20 @@ export function MessageFooter({
       )}
     </footer>
   );
+}
+
+/** Write the rendered message for rich editors and its source text everywhere. */
+export async function copyMessageContent(
+  html: string,
+  text: string,
+  clipboard: ClipboardWriter | undefined = globalThis.navigator?.clipboard,
+  item: typeof ClipboardItem | undefined = globalThis.ClipboardItem,
+): Promise<void> {
+  if (html.trim()) {
+    await copyRichText(html, text, clipboard, item);
+    return;
+  }
+  await copyPlainText(text, clipboard);
 }
 
 export function formatMessageTimestamp(

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -1,4 +1,4 @@
-import { Fragment, memo, useMemo } from "react";
+import { Fragment, memo, useMemo, useRef } from "react";
 import type { ReactNode, Ref, RefCallback, UIEvent } from "react";
 import type {
   ApprovalGrantRung,
@@ -645,6 +645,10 @@ export function groupMessageItems(
     // One phase per contiguous run of activity, however long. A phase that
     // splits at every assistant sentence is not a phase.
     const phase: ChatMessage[] = [];
+    // Activity can resume through several assistant snapshots while remaining
+    // one expandable phase. The collapsed live label should describe only the
+    // latest snapshot; the expanded rail still preserves the whole phase.
+    let latestSnapshotStart = 0;
     while (index < messages.length) {
       if (isActivityMessage(messages[index])) {
         phase.push(messages[index]!);
@@ -663,6 +667,7 @@ export function groupMessageItems(
         let ahead = index + 1;
         while (isInvisibleAssistant(messages[ahead])) ahead += 1;
         if (isActivityMessage(messages[ahead])) {
+          latestSnapshotStart = phase.length;
           index = ahead;
           continue;
         }
@@ -678,6 +683,10 @@ export function groupMessageItems(
       ),
     );
     const activities = phase.filter(
+      (entry): entry is ToolMessage =>
+        entry.role === "tool" && !parked.has(entry.callId),
+    );
+    const latestActivities = phase.slice(latestSnapshotStart).filter(
       (entry): entry is ToolMessage =>
         entry.role === "tool" && !parked.has(entry.callId),
     );
@@ -744,6 +753,14 @@ export function groupMessageItems(
               entry.name !== "wait_for_agents",
           )
         : activities;
+    const latestRailActivities =
+      spawns.length > 0
+        ? latestActivities.filter(
+            (entry) =>
+              entry.name !== "spawn_sandbox_agent" &&
+              entry.name !== "wait_for_agents",
+          )
+        : latestActivities;
 
     // The rail and every card inside carry their own boundary, so this one is
     // only a backstop for the phase's own frame.
@@ -754,6 +771,10 @@ export function groupMessageItems(
       >
         <ToolActivityGroup
           activities={railActivities}
+          labelActivities={latestRailActivities}
+          anchorIds={phase.flatMap((entry) =>
+            entry.role === "tool" ? [entry.id] : [],
+          )}
           groupIndex={groupIndex}
           animate={animateStreaming}
         >
@@ -1005,12 +1026,16 @@ function surfacedCard(entry: ChatMessage, context: CardContext): ReactNode {
 function AssistantMessageBody({
   text,
   streaming,
+  containerRef,
 }: {
   text: string;
   streaming: boolean;
+  containerRef?: React.Ref<HTMLDivElement>;
 }) {
   const displayed = useStreamingTypewriter(text, streaming);
-  return <MessageMarkdown>{displayed}</MessageMarkdown>;
+  return (
+    <MessageMarkdown containerRef={containerRef}>{displayed}</MessageMarkdown>
+  );
 }
 
 /**
@@ -1052,6 +1077,7 @@ function MessageBubbleImpl({
   onRetry?: () => void;
 }) {
   const sourceNav = useSourceNav();
+  const richContentRef = useRef<HTMLDivElement | null>(null);
   // One way into the source panel for both anchors a citation has: the phrase
   // in the prose and the row at the foot of the message open the same place.
   const openSource = useMemo(
@@ -1101,6 +1127,7 @@ function MessageBubbleImpl({
             <AssistantMessageBody
               text={message.text}
               streaming={busy && animateStreaming}
+              containerRef={richContentRef}
             />
           )}
           <AssistantSources
@@ -1114,6 +1141,7 @@ function MessageBubbleImpl({
             text={stripCitationDirectives(message.text)}
             createdAt={message.createdAt}
             settled={!busy}
+            richContentRef={richContentRef}
             sequenceEnd={sequenceEnd}
           />
         </article>
@@ -1124,7 +1152,11 @@ function MessageBubbleImpl({
   if (message.role === "user") {
     return (
       <div className="message-user-frame">
-        <article className="message message-user" aria-label="You">
+        <article
+          className="message message-user"
+          aria-label="You"
+          data-transcript-anchor={message.id}
+        >
           {message.images &&
             message.images.length > 0 &&
             imageClient &&

--- a/crates/openwave-desktop/ui/src/MessageMarkdown.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageMarkdown.test.tsx
@@ -2,6 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import { stripCitationDirectives } from "./citationDirectives";
 import {
+  decodeUnicodeEscapes,
   MessageMarkdown,
   preserveLineBreaks,
   safeMarkdownUrl,
@@ -59,6 +60,16 @@ describe("safeMarkdownUrl", () => {
 });
 
 describe("MessageMarkdown", () => {
+  it("decodes literal Unicode escapes left by a double-serialized payload", () => {
+    expect(decodeUnicodeEscapes("Done \\u2022 \\uD83D\\uDE80")).toBe(
+      "Done • 🚀",
+    );
+    const markup = renderToStaticMarkup(
+      <MessageMarkdown>{"Done \\u2022 \\uD83D\\uDE80"}</MessageMarkdown>,
+    );
+    expect(markup).toContain("Done • 🚀");
+  });
+
   it("renders useful Markdown without emitting embeds or unsafe links", () => {
     const markup = renderToStaticMarkup(
       <MessageMarkdown>

--- a/crates/openwave-desktop/ui/src/MessageMarkdown.tsx
+++ b/crates/openwave-desktop/ui/src/MessageMarkdown.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   type ReactElement,
   type ReactNode,
+  type Ref,
 } from "react";
 import ReactMarkdown, {
   type Components,
@@ -66,6 +67,20 @@ export function preserveLineBreaks(input: string): string {
     from = point;
   }
   return result + input.slice(from);
+}
+
+/**
+ * Decode a literal JSON-style Unicode escape left in model text.
+ *
+ * The API normally hands the renderer real Unicode. This is a narrow failsafe
+ * for a payload that was serialized twice and arrives with `\\uXXXX` still in
+ * the string; adjacent surrogate escapes remain an ordinary JavaScript
+ * surrogate pair and therefore render as the intended astral character.
+ */
+export function decodeUnicodeEscapes(input: string): string {
+  return input.replace(/\\u([0-9a-fA-F]{4})/g, (_match, hex: string) =>
+    String.fromCharCode(Number.parseInt(hex, 16)),
+  );
 }
 
 /**
@@ -349,7 +364,7 @@ const rehypePlugins: NonNullable<Options["rehypePlugins"]> = [
  * Markdown twice.
  */
 export function processMarkdownContent(input: string): string {
-  return preserveLineBreaks(escapeLatexText(input));
+  return preserveLineBreaks(escapeLatexText(decodeUnicodeEscapes(input)));
 }
 
 /**
@@ -416,6 +431,7 @@ function blockRehypePlugins(
   end: number | undefined,
 ): NonNullable<Options["rehypePlugins"]> {
   if (start == null || end == null || end <= start) return rehypePlugins;
+  if (decodeUnicodeEscapes(block) !== block) return rehypePlugins;
   if (escapeLatexText(block) !== block) return rehypePlugins;
   // A block carrying a citation is left alone too: the mark would split the
   // text the citation is read out of, leaving the two passes to argue over the
@@ -509,6 +525,8 @@ function wrappingComponents(
 
 interface MessageMarkdownProps {
   children: string;
+  /** The rendered Markdown root, for consumers such as rich clipboard copy. */
+  containerRef?: Ref<HTMLDivElement>;
   /**
    * Give every heading a slug id, for a caller that means to scroll to one.
    * Off for transcripts, where headings from separate messages would collide.
@@ -532,6 +550,7 @@ interface MessageMarkdownProps {
 
 export const MessageMarkdown = memo(function MessageMarkdown({
   children,
+  containerRef,
   headingIds = false,
   highlightRange,
   wrapBlock,
@@ -540,7 +559,7 @@ export const MessageMarkdown = memo(function MessageMarkdown({
   const blockStarts = useMemo(() => pieceStartOffsets(blocks), [blocks]);
 
   return (
-    <div className="message-markdown">
+    <div className="message-markdown" ref={containerRef}>
       {blocks.map((block, index) => {
         const inBlock = highlightRange
           ? rangeWithinPiece(highlightRange, blockStarts[index]!, block.length)

--- a/crates/openwave-desktop/ui/src/ShellShortcuts.test.ts
+++ b/crates/openwave-desktop/ui/src/ShellShortcuts.test.ts
@@ -59,6 +59,31 @@ describe("shell shortcut resolution", () => {
     }
   });
 
+  it("provides Alt+Arrow history navigation from editable fields", () => {
+    expect(
+      resolveShellShortcut(
+        keyEvent({
+          key: "ArrowLeft",
+          code: "ArrowLeft",
+          metaKey: false,
+          altKey: true,
+        }),
+        context(),
+      )?.id,
+    ).toBe("history-back");
+    expect(
+      resolveShellShortcut(
+        keyEvent({
+          key: "ArrowRight",
+          code: "ArrowRight",
+          metaKey: false,
+          altKey: true,
+        }),
+        context({ command: false }),
+      )?.id,
+    ).toBe("history-forward");
+  });
+
   it("keeps letter shortcuts under the same physical keys on any layout", () => {
     // Dvorak puts "l" where QWERTY puts N. The shortcut belongs to the key
     // position the reader's muscle memory knows, not to the character that

--- a/crates/openwave-desktop/ui/src/ShellShortcuts.ts
+++ b/crates/openwave-desktop/ui/src/ShellShortcuts.ts
@@ -9,6 +9,8 @@ import { useEffect, useRef } from "react";
  * the listener acts on and stay honest about what the keys actually do.
  */
 export type ShellShortcutAction =
+  | "history-back"
+  | "history-forward"
   | "toggle-sidebar"
   | "new-chat"
   | "focus-composer"
@@ -18,10 +20,11 @@ export type ShellShortcutAction =
   | "show-shortcuts";
 
 /** The heading a shortcut sits under in the help dialog. */
-export type ShellShortcutGroup = "Chat" | "View" | "Help";
+export type ShellShortcutGroup = "Navigation" | "Chat" | "View" | "Help";
 
 /** Group headings in the order the help dialog lists them. */
 export const SHELL_SHORTCUT_GROUPS: readonly ShellShortcutGroup[] = [
+  "Navigation",
   "Chat",
   "View",
   "Help",
@@ -58,6 +61,8 @@ export type ShellShortcutDef = ShellShortcutBinding & {
   id: ShellShortcutAction;
   /** Requires the platform command modifier — Cmd on macOS, Ctrl elsewhere. */
   mod: boolean;
+  /** Requires Alt/Option; defaults to must-not. */
+  alt?: boolean;
   /**
    * Whether shift must be held (defaults to must-not). `"any"` for shortcuts
    * whose key is reachable both ways.
@@ -76,6 +81,24 @@ export type ShellShortcutDef = ShellShortcutBinding & {
 };
 
 export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
+  {
+    id: "history-back",
+    keys: ["arrowleft"],
+    mod: false,
+    alt: true,
+    description: "Go back",
+    group: "Navigation",
+    allowInEditable: true,
+  },
+  {
+    id: "history-forward",
+    keys: ["arrowright"],
+    mod: false,
+    alt: true,
+    description: "Go forward",
+    group: "Navigation",
+    allowInEditable: true,
+  },
   {
     id: "new-chat",
     codes: ["KeyN"],
@@ -171,6 +194,7 @@ export function shortcutKeycaps(
 ): string[] {
   const caps: string[] = [];
   if (def.mod) caps.push(command ? "⌘" : "Ctrl");
+  if (def.alt) caps.push(command ? "⌥" : "Alt");
   if (def.shift === true) caps.push(command ? "⇧" : "Shift");
   caps.push(shortcutKeyLabel(def));
   return caps;
@@ -184,6 +208,8 @@ function shortcutKeyLabel(def: ShellShortcutDef): string {
     return label.length === 1 ? label.toUpperCase() : code;
   }
   const key = def.keys[0] ?? "";
+  if (key === "arrowleft") return "←";
+  if (key === "arrowright") return "→";
   return key.length === 1 ? key.toUpperCase() : key;
 }
 
@@ -226,7 +252,7 @@ export function matchesShellShortcut(
   def: ShellShortcutDef,
   command: boolean,
 ): boolean {
-  if (event.altKey) return false;
+  if (event.altKey !== (def.alt ?? false)) return false;
   const hit = def.codes
     ? def.codes.includes(event.code)
     : def.keys.includes(event.key.toLowerCase());

--- a/crates/openwave-desktop/ui/src/Titlebar.tsx
+++ b/crates/openwave-desktop/ui/src/Titlebar.tsx
@@ -3,18 +3,24 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { WithTooltip } from "@/components/ui/tooltip";
-import { useDesktopNavigation } from "./DesktopNavigation";
+import type { DesktopNavigation } from "./DesktopNavigation";
+import { cn } from "@/lib/utils";
 
 /**
- * The macOS overlay titlebar: the strip the traffic lights sit in, which the
- * app has to furnish itself because the system chrome is hidden.
+ * The desktop titlebar: navigation stays available even where the native
+ * window decorations do not provide browser-style history controls.
  *
  * It carries navigation and the app's name and nothing else. The rail's own
  * collapse control stays in the rail — it acts on the rail, and putting a
  * second copy up here left two buttons for one job on adjacent rows.
  */
-export function Titlebar() {
-  const navigation = useDesktopNavigation();
+export function Titlebar({
+  macOverlay,
+  navigation,
+}: {
+  macOverlay: boolean;
+  navigation: DesktopNavigation;
+}) {
   // The host owns the display name: debug builds report "OpenWave [dev]" so a
   // dev window is distinguishable from an installed release. The titlebar only
   // renders inside the native host, where `getName` is always available.
@@ -30,7 +36,10 @@ export function Titlebar() {
   }, []);
 
   return (
-    <div className="titlebar" data-tauri-drag-region>
+    <div
+      className={cn("titlebar", macOverlay && "is-mac-overlay")}
+      data-tauri-drag-region
+    >
       <div className="titlebar-nav">
         <WithTooltip label="Back" side="bottom">
           <button

--- a/crates/openwave-desktop/ui/src/ToolActivityGroup.test.tsx
+++ b/crates/openwave-desktop/ui/src/ToolActivityGroup.test.tsx
@@ -33,6 +33,19 @@ describe("toolActivityGroupPresentation", () => {
     expect(presentation.inProgress).toBe(true);
   });
 
+  it("narrows a live phase label to the latest assistant snapshot", () => {
+    const activities = [
+      { name: "web_search", status: "running" as const },
+      { name: "read_file", status: "completed" as const },
+    ];
+    const presentation = toolActivityGroupPresentation(activities, [
+      activities[0]!,
+    ]);
+
+    expect(presentation.label).toBe("Searching the web");
+    expect(presentation.phase).toBe("active");
+  });
+
   it("aggregates delegation by count and waiting without one", () => {
     expect(
       labelOf([
@@ -60,7 +73,7 @@ describe("toolActivityGroupPresentation", () => {
         { name: "web_search", status: "completed" },
       ]),
     ).toBe(
-      "Searched the web, 2 other tasks, delegated 1 task, and waited for background agents",
+      "Searched the web, waited for background agents, delegated 1 task, and 2 other tasks",
     );
   });
 

--- a/crates/openwave-desktop/ui/src/ToolActivityGroup.tsx
+++ b/crates/openwave-desktop/ui/src/ToolActivityGroup.tsx
@@ -33,6 +33,10 @@ export type ToolActivity = {
 
 type ToolActivityGroupProps = {
   activities: ToolActivity[];
+  /** Latest assistant snapshot, used only for a live phase's collapsed label. */
+  labelActivities?: ToolActivity[];
+  /** Transcript message ids that navigation may land on at this phase. */
+  anchorIds?: readonly string[];
   groupIndex: number;
   /** Whether this active phase arrived live rather than from socket replay. */
   animate?: boolean;
@@ -54,6 +58,8 @@ type ToolActivityGroupProps = {
  */
 export function ToolActivityGroup({
   activities,
+  labelActivities,
+  anchorIds = [],
   groupIndex,
   animate = true,
   children,
@@ -74,6 +80,7 @@ export function ToolActivityGroup({
       >
         <ToolActivityRail
           activities={safeActivities}
+          labelActivities={normalizeActivities(labelActivities ?? activities)}
           groupIndex={groupIndex}
           animate={animate}
         />
@@ -93,6 +100,14 @@ export function ToolActivityGroup({
 
   return (
     <div className="w-full self-start">
+      {anchorIds.map((anchorId) => (
+        <span
+          key={anchorId}
+          className="transcript-anchor"
+          data-transcript-anchor={anchorId}
+          aria-hidden="true"
+        />
+      ))}
       {rail}
       <div
         className={cn(
@@ -111,10 +126,12 @@ export function ToolActivityGroup({
  */
 function ToolActivityRail({
   activities: safeActivities,
+  labelActivities: safeLabelActivities,
   groupIndex,
   animate,
 }: {
   activities: (ToolActivity | null)[];
+  labelActivities: (ToolActivity | null)[];
   groupIndex: number;
   animate: boolean;
 }) {
@@ -124,6 +141,9 @@ function ToolActivityRail({
   // one is a gap in the rail, not a claim about what the agent did.
   const summary = toolActivityGroupPresentation(
     safeActivities.filter(
+      (activity): activity is ToolActivity => activity !== null,
+    ),
+    safeLabelActivities.filter(
       (activity): activity is ToolActivity => activity !== null,
     ),
   );
@@ -333,7 +353,7 @@ const CATEGORY_SPECS: Record<
   },
 };
 
-const CATEGORY_ORDER: Category[] = ["other", "spawn", "wait"];
+const CATEGORY_ORDER: Category[] = ["wait", "spawn", "other"];
 
 function categoryOf(name: string): Category {
   if (name === "spawn_sandbox_agent") return "spawn";
@@ -353,6 +373,7 @@ function categoryOf(name: string): Category {
  */
 export function toolActivityGroupPresentation(
   activities: readonly ToolActivity[],
+  labelActivities: readonly ToolActivity[] = activities,
 ): ToolActivityGroupPresentation {
   if (activities.length === 0) {
     return {
@@ -371,12 +392,18 @@ export function toolActivityGroupPresentation(
   const inProgress = presentations.some(
     ({ tone }) => tone === "running" || tone === "waiting_approval",
   );
+  const labelPresentations = (
+    inProgress && labelActivities.length > 0 ? labelActivities : activities
+  ).map((activity) => ({
+    activity,
+    ...toolCallPresentation(activity.name, activity.status),
+  }));
   const counts: Record<Category, number> = { wait: 0, spawn: 0, other: 0 };
-  for (const { activity } of presentations) {
+  for (const { activity } of labelPresentations) {
     counts[categoryOf(activity.name)] += 1;
   }
 
-  const latest = presentations[presentations.length - 1]!;
+  const latest = labelPresentations[labelPresentations.length - 1]!;
   const leadCategory = categoryOf(latest.activity.name);
   const leadPhrase =
     leadCategory === "other"

--- a/crates/openwave-desktop/ui/src/TranscriptNavigation.test.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptNavigation.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { transcriptNavigationEntries } from "./TranscriptNavigation";
+
+describe("transcriptNavigationEntries", () => {
+  it("builds concise user and tool destinations from the rendered transcript", () => {
+    const entries = transcriptNavigationEntries([
+      {
+        id: "user-1",
+        role: "user",
+        text: "  Compare the quarterly totals\nby region  ",
+      },
+      {
+        id: "tool-1",
+        role: "tool",
+        callId: "call-1",
+        name: "web_search",
+        status: "running",
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        text: "Working on it",
+        sources: [],
+      },
+    ]);
+
+    expect(entries).toEqual([
+      {
+        anchorId: "user-1",
+        kind: "user",
+        label: "Compare the quarterly totals by region",
+        active: false,
+      },
+      {
+        anchorId: "tool-1",
+        kind: "tool",
+        label: "Searching the web",
+        toolName: "web_search",
+        active: true,
+      },
+    ]);
+  });
+});

--- a/crates/openwave-desktop/ui/src/TranscriptNavigation.tsx
+++ b/crates/openwave-desktop/ui/src/TranscriptNavigation.tsx
@@ -1,0 +1,279 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ListTree, MessageSquare } from "lucide-react";
+
+import type { ChatMessage } from "./MessageList";
+import { toolCallPresentation } from "./ToolCallCard";
+import { ToolIcon } from "./ToolIcon";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { WithTooltip } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+const RAIL_STORAGE_KEY = "openwave.transcript-rail-visible";
+const INDICATOR_SIZE = 24;
+const PROXIMITY_THRESHOLD = 400;
+
+export type TranscriptNavigationEntry = {
+  anchorId: string;
+  kind: "user" | "tool";
+  label: string;
+  toolName?: string;
+  active: boolean;
+};
+
+/** Build a local table of contents from the transcript already on screen. */
+export function transcriptNavigationEntries(
+  messages: readonly ChatMessage[],
+): TranscriptNavigationEntry[] {
+  const entries: TranscriptNavigationEntry[] = [];
+  for (const message of messages) {
+    if (message.role === "user") {
+      entries.push({
+        anchorId: message.id,
+        kind: "user",
+        label: compactLabel(message.text, "User message"),
+        active: false,
+      });
+      continue;
+    }
+    if (message.role !== "tool") continue;
+    const presentation = toolCallPresentation(message.name, message.status);
+    entries.push({
+      anchorId: message.id,
+      kind: "tool",
+      label: presentation.title,
+      toolName: message.name,
+      active:
+        presentation.tone === "running" ||
+        presentation.tone === "waiting_approval",
+    });
+  }
+  return entries;
+}
+
+function compactLabel(value: string, fallback: string): string {
+  const compact = value.replace(/\s+/g, " ").trim();
+  if (!compact) return fallback;
+  return compact.length <= 72 ? compact : `${compact.slice(0, 71).trimEnd()}…`;
+}
+
+export function TranscriptNavigation({
+  entries,
+  scrollElement,
+  activeAnchor,
+  onJump,
+}: {
+  entries: readonly TranscriptNavigationEntry[];
+  scrollElement: HTMLDivElement | null;
+  activeAnchor?: string;
+  onJump: (anchorId: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [railVisible, setRailVisible] = useStoredRailVisibility();
+  const indicatorRefs = useRailPositions(scrollElement, entries, railVisible);
+  const setIndicatorRef = useCallback(
+    (anchorId: string, node: HTMLButtonElement | null) => {
+      if (node) indicatorRefs.current.set(anchorId, node);
+      else indicatorRefs.current.delete(anchorId);
+    },
+    [indicatorRefs],
+  );
+
+  if (entries.length === 0) return null;
+
+  return (
+    <>
+      {railVisible && (
+        <div
+          className="pointer-events-none absolute top-0 right-2 bottom-0 z-[2] hidden w-6 p-2 md:block"
+          aria-label="Transcript rail"
+        >
+          {entries.map((entry) => (
+            <WithTooltip key={entry.anchorId} label={entry.label} side="left">
+              <button
+                ref={(node) => setIndicatorRef(entry.anchorId, node)}
+                type="button"
+                className={cn(
+                  "text-muted-foreground hover:text-foreground hover:bg-muted pointer-events-auto absolute right-0 flex size-6 items-center justify-center rounded-full",
+                  activeAnchor === entry.anchorId &&
+                    "bg-accent text-accent-foreground",
+                )}
+                aria-label={entry.label}
+                onClick={() => onJump(entry.anchorId)}
+              >
+                <EntryIcon entry={entry} />
+              </button>
+            </WithTooltip>
+          ))}
+        </div>
+      )}
+
+      <div className="absolute top-2 right-10 z-[3]">
+        <Popover open={open} onOpenChange={setOpen}>
+          <WithTooltip label="Transcript contents" side="left">
+            <PopoverTrigger asChild>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon-8"
+                className="bg-background shadow-sm"
+                aria-label="Transcript contents"
+              >
+                <ListTree size={16} />
+              </Button>
+            </PopoverTrigger>
+          </WithTooltip>
+          <PopoverContent align="end" sideOffset={6} className="w-72 p-0">
+            <label className="flex cursor-pointer items-center gap-2 border-b px-3 py-2.5 text-sm">
+              <Checkbox
+                checked={railVisible}
+                onCheckedChange={(checked) => setRailVisible(checked === true)}
+              />
+              Show rail indicators
+            </label>
+            <div className="max-h-80 overflow-y-auto p-1">
+              {entries.map((entry) => (
+                <button
+                  key={entry.anchorId}
+                  type="button"
+                  className={cn(
+                    "hover:bg-muted flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm",
+                    activeAnchor === entry.anchorId && "bg-accent",
+                  )}
+                  onClick={() => {
+                    onJump(entry.anchorId);
+                    setOpen(false);
+                  }}
+                >
+                  <EntryIcon entry={entry} />
+                  <span className="truncate">{entry.label}</span>
+                  {entry.active && (
+                    <span
+                      className="bg-primary ml-auto size-2 shrink-0 rounded-full"
+                      aria-label="Active"
+                    />
+                  )}
+                </button>
+              ))}
+            </div>
+          </PopoverContent>
+        </Popover>
+      </div>
+    </>
+  );
+}
+
+function EntryIcon({ entry }: { entry: TranscriptNavigationEntry }) {
+  return entry.kind === "user" ? (
+    <MessageSquare className="text-muted-foreground size-3.5 shrink-0" />
+  ) : (
+    <ToolIcon
+      name={entry.toolName ?? "other"}
+      className="text-muted-foreground size-3.5 shrink-0"
+    />
+  );
+}
+
+function useStoredRailVisibility(): [boolean, (visible: boolean) => void] {
+  const [visible, setVisible] = useState(() => {
+    try {
+      return window.localStorage.getItem(RAIL_STORAGE_KEY) !== "false";
+    } catch {
+      return true;
+    }
+  });
+  const update = useCallback((next: boolean) => {
+    setVisible(next);
+    try {
+      window.localStorage.setItem(RAIL_STORAGE_KEY, String(next));
+    } catch {
+      // A locked-down webview can reject storage; the in-memory choice remains.
+    }
+  }, []);
+  return [visible, update];
+}
+
+/** Position indicators beside their rendered transcript anchors without rerendering. */
+function useRailPositions(
+  scrollElement: HTMLDivElement | null,
+  entries: readonly TranscriptNavigationEntry[],
+  visible: boolean,
+) {
+  const refs = useRef<Map<string, HTMLButtonElement>>(new Map());
+  const frameRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!scrollElement || entries.length === 0 || !visible) return;
+
+    const compute = () => {
+      const container = scrollElement.getBoundingClientRect();
+      const anchorRects = new Map<string, DOMRect>();
+      for (const node of scrollElement.querySelectorAll<HTMLElement>(
+        "[data-transcript-anchor]",
+      )) {
+        const id = node.dataset.transcriptAnchor;
+        if (id && !anchorRects.has(id)) {
+          anchorRects.set(id, node.getBoundingClientRect());
+        }
+      }
+
+      for (const entry of entries) {
+        const indicator = refs.current.get(entry.anchorId);
+        if (!indicator) continue;
+        const rect = anchorRects.get(entry.anchorId);
+        if (!rect) {
+          indicator.style.display = "none";
+          continue;
+        }
+        const relativeTop = rect.top - container.top;
+        if (
+          relativeTop < -PROXIMITY_THRESHOLD ||
+          relativeTop > container.height + PROXIMITY_THRESHOLD
+        ) {
+          indicator.style.display = "none";
+          continue;
+        }
+
+        const top = Math.max(
+          0,
+          Math.min(relativeTop, container.height - INDICATOR_SIZE),
+        );
+        const opacity =
+          relativeTop < 0
+            ? 1 - Math.abs(relativeTop) / PROXIMITY_THRESHOLD
+            : relativeTop > container.height
+              ? 1 -
+                (relativeTop - container.height) / PROXIMITY_THRESHOLD
+              : 1;
+        indicator.style.display = "";
+        indicator.style.transform = `translateY(${top}px)`;
+        indicator.style.opacity = String(Math.max(0, opacity));
+      }
+    };
+
+    const schedule = () => {
+      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
+      frameRef.current = requestAnimationFrame(compute);
+    };
+    scrollElement.addEventListener("scroll", schedule, { passive: true });
+    const observer = new ResizeObserver(schedule);
+    observer.observe(scrollElement);
+    const content = scrollElement.firstElementChild;
+    if (content) observer.observe(content);
+    schedule();
+
+    return () => {
+      scrollElement.removeEventListener("scroll", schedule);
+      observer.disconnect();
+      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
+      frameRef.current = null;
+    };
+  }, [entries, scrollElement, visible]);
+
+  return refs;
+}

--- a/crates/openwave-desktop/ui/src/host.ts
+++ b/crates/openwave-desktop/ui/src/host.ts
@@ -148,7 +148,8 @@ export function resolveOutputWritebackRequest(
 /**
  * The native macOS window uses an overlay titlebar (traffic lights over app
  * chrome), so the app renders its own drag strip with controls beside them.
- * Windows/Linux keep standard decorations; the browser has its own chrome.
+ * Windows/Linux also render the app titlebar for history controls, but do not
+ * need the traffic-light inset this predicate describes.
  */
 export function hasMacOverlayTitlebar(): boolean {
   return hasNativeHost() && navigator.userAgent.includes("Mac OS");

--- a/crates/openwave-desktop/ui/src/router.tsx
+++ b/crates/openwave-desktop/ui/src/router.tsx
@@ -26,7 +26,7 @@ const rootRoute = createRootRoute({ component: AppShell });
  * A conversation's URL carries its layout and, when arrived at from the inbox,
  * the parked call the transcript should reveal.
  */
-type ChatSearch = PanelSearch & { focus?: string };
+type ChatSearch = PanelSearch & { focus?: string; at?: string };
 
 /**
  * The layout params, kept as strings for the panel parser to make sense of.
@@ -124,6 +124,10 @@ const chatRoute = createRoute({
     // addressing state like they are, and it is dropped from the URL as soon
     // as it has been honored so a reload does not re-scroll.
     focus: typeof search.focus === "string" ? search.focus : undefined,
+    // Hash history already owns the fragment, so transcript anchoring travels
+    // as query state. Unlike `focus`, it remains until the reader returns to
+    // the live tail, which makes an anchored reload land in the same place.
+    at: typeof search.at === "string" ? search.at : undefined,
   }),
   component: ChatRouteComponent,
 });

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -486,6 +486,13 @@ body {
   min-height: calc(var(--transcript-viewport, 100dvh) - 8rem);
 }
 
+/* Zero-height landing point for transcript rail and table-of-contents jumps. */
+.transcript-anchor {
+  display: block;
+  height: 0;
+  scroll-margin-top: 1.5rem;
+}
+
 /* Scroll-edge fades: soften whichever edges have more content beyond them, so
    the transcript reads as continuing past the frame rather than clipped.
    Painted as overlays on the wrapper rather than a mask-image on `.messages`:
@@ -1377,8 +1384,8 @@ body {
 }
 
 
-/* macOS overlay titlebar: one strip carries the traffic lights, back and
-   forward, the app's name, and drags the window. */
+/* Desktop titlebar: one strip carries back/forward, the app name, and a drag
+   region. macOS reserves additional room for the overlay traffic lights. */
 .app-shell.with-titlebar {
   flex-direction: column;
 }
@@ -1388,9 +1395,13 @@ body {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding-left: 84px;
+  padding-left: 1rem;
   padding-right: 1rem;
   border-bottom: 1px solid var(--color-border);
+}
+
+.titlebar.is-mac-overlay {
+  padding-left: 84px;
 }
 
 .titlebar-nav {

--- a/crates/openwave-desktop/ui/src/test/router.tsx
+++ b/crates/openwave-desktop/ui/src/test/router.tsx
@@ -26,11 +26,12 @@ export async function renderWithRouter(
     path: "/c/$chatId",
     validateSearch: (
       search: Record<string, unknown>,
-    ): PanelSearch & { focus?: string } => ({
+    ): PanelSearch & { focus?: string; at?: string } => ({
       left: typeof search.left === "string" ? search.left : undefined,
       right: typeof search.right === "string" ? search.right : undefined,
       fullscreen: typeof search.fullscreen === "string" ? search.fullscreen : undefined,
       focus: typeof search.focus === "string" ? search.focus : undefined,
+      at: typeof search.at === "string" ? search.at : undefined,
     }),
     component: () => <>{ui}</>,
   });

--- a/crates/openwave-desktop/ui/src/useStreamingTypewriter.test.ts
+++ b/crates/openwave-desktop/ui/src/useStreamingTypewriter.test.ts
@@ -37,7 +37,7 @@ describe("useStreamingTypewriter", () => {
     expect(result.current).toBe("Searching the web and 1 other task");
   });
 
-  it("finishes immediately when a live step settles", async () => {
+  it("drains the remaining buffer smoothly when a live step settles", async () => {
     vi.useFakeTimers();
     const { result, rerender } = renderHook(
       ({ text, live }) => useStreamingTypewriter(text, live),
@@ -48,9 +48,13 @@ describe("useStreamingTypewriter", () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(20);
     });
-    rerender({ text: "Searched the web and 1 other task", live: false });
+    rerender({ text: "Searching the web and 1 other task", live: false });
 
-    expect(result.current).toBe("Searched the web and 1 other task");
+    expect(result.current).not.toBe("Searching the web and 1 other task");
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(result.current).toBe("Searching the web and 1 other task");
   });
 
   // A reconnect replays the active turn's whole journal in a burst (#1716);

--- a/crates/openwave-desktop/ui/src/useStreamingTypewriter.ts
+++ b/crates/openwave-desktop/ui/src/useStreamingTypewriter.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 const TICK_INTERVAL_MS = 20;
 const SMOOTHING_FACTOR = 18;
+const FINISH_SMOOTHING_FACTOR = 5;
 
 /**
  * How far the animation may trail its target before it stops animating and
@@ -43,7 +44,7 @@ export function useStreamingTypewriter(text: string, live: boolean): string {
 
   const tick = useCallback(() => {
     const target = targetRef.current;
-    if (!liveRef.current || document.visibilityState !== "visible") {
+    if (document.visibilityState !== "visible") {
       timerRef.current = null;
       showImmediately(target);
       return;
@@ -69,7 +70,14 @@ export function useStreamingTypewriter(text: string, live: boolean): string {
 
     const nextLength = Math.min(
       target.length,
-      current.length + Math.max(1, Math.ceil(remaining / SMOOTHING_FACTOR)),
+      current.length +
+        Math.max(
+          1,
+          Math.ceil(
+            remaining /
+              (liveRef.current ? SMOOTHING_FACTOR : FINISH_SMOOTHING_FACTOR),
+          ),
+        ),
     );
     showImmediately(target.slice(0, nextLength));
     timerRef.current = window.setTimeout(tick, TICK_INTERVAL_MS);
@@ -77,6 +85,7 @@ export function useStreamingTypewriter(text: string, live: boolean): string {
 
   useEffect(() => {
     const previousTarget = targetRef.current;
+    const wasLive = liveRef.current;
     targetRef.current = text;
     liveRef.current = live;
 
@@ -88,8 +97,17 @@ export function useStreamingTypewriter(text: string, live: boolean): string {
       return;
     }
     if (!live) {
-      stop();
-      showImmediately(text);
+      // A stream that just ended may still have a small presentation buffer.
+      // Drain it quickly instead of snapping the final characters into place.
+      // Ordinary historical updates still render immediately.
+      const canFinishSmoothly =
+        wasLive && text.startsWith(displayedRef.current);
+      if (!canFinishSmoothly) {
+        stop();
+        showImmediately(text);
+      } else if (timerRef.current === null) {
+        tick();
+      }
       return;
     }
     if (text === previousTarget) return;


### PR DESCRIPTION
## Summary

- add a client-derived transcript table of contents, scroll rail, tool navigation, and persistent query-based anchor mode with return-to-tail behavior
- add composer history recall with saved-draft restoration, plus desktop back/forward controls and Alt+Arrow shortcuts on every native platform
- preserve rendered Markdown on rich clipboard copy and smooth the remaining typewriter buffer when streaming ends
- narrow active tool-phase labels to the latest assistant snapshot, append the generic category last, and restore Unicode escape decoding in Markdown

## Verification

- `pnpm exec vitest run src/ChatView.dom.test.tsx src/MessageList.test.tsx src/TranscriptNavigation.test.ts src/ComposerHistory.dom.test.tsx src/useStreamingTypewriter.test.ts src/MessageFooter.test.tsx src/MessageMarkdown.test.tsx src/ShellShortcuts.test.ts src/ToolActivityGroup.test.tsx` — 75 passed
- `pnpm test` — 858 passed; 2 existing failures remain in the unmodified `settings/ProvidersPanel.tsx` because its Bedrock path references missing `Select` imports
- `pnpm exec tsc --noEmit` reaches the same pre-existing `ProvidersPanel.tsx` missing-import errors and reports none in this change
- `git diff --check`

Native Windows/Linux titlebar behavior was not manually driven.

Closes #1112
