### PR TITLE
ci: park the Windows lanes and drop the sandbox-resident container e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,14 @@ concurrency:
   # Every other event gets a unique group (keyed by run id) so nothing cancels
   # it and it cancels nothing: post-merge runs are the full validation for the
   # exact commits they cover — a later merge whose narrower change scope skips
-  # a lane (notably the sandbox-container e2e) must not cancel the earlier run
-  # that was responsible for it, and a manual workflow_dispatch is the
-  # deliberate backstop for those lanes, so an unrelated push must never kill
-  # it. During a merge train this runs main pushes in parallel instead of
-  # superseding them; that costs runner time, but sccache shares compiler
-  # objects across the runs and correctness of the scoped lanes wins. A job may
-  # add narrower concurrency only when a newer run provably subsumes the older
-  # one; the Windows lane does that for Rust-scoped pushes to linear main.
+  # a lane must not cancel the earlier run that was responsible for it, and a
+  # manual workflow_dispatch is the deliberate backstop for those lanes, so an
+  # unrelated push must never kill it. During a merge train this runs main
+  # pushes in parallel instead of superseding them; that costs runner time, but
+  # sccache shares compiler objects across the runs and correctness of the
+  # scoped lanes wins. A job may add narrower concurrency only when a newer run
+  # provably subsumes the older one; the Windows lane does that for Rust-scoped
+  # pushes to linear main.
   group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.ref) || format('{0}-run-{1}', github.workflow, github.run_id) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
@@ -105,7 +105,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       rust: ${{ steps.scope.outputs.rust }}
-      sandbox_container: ${{ steps.scope.outputs.sandbox_container }}
       ui: ${{ steps.scope.outputs.ui }}
       workspace: ${{ steps.scope.outputs.workspace }}
     steps:
@@ -124,7 +123,6 @@ jobs:
           full_validation() {
             {
               echo "rust=true"
-              echo "sandbox_container=true"
               echo "ui=true"
               echo "workspace=true"
             } >> "$GITHUB_OUTPUT"
@@ -164,7 +162,6 @@ jobs:
           # stay false when a change cannot reach them. `workspace` implies
           # `rust`; the gate below asserts that.
           rust=false
-          sandbox_container=false
           ui=false
           workspace=false
           git diff --no-renames --name-only -z "$diff_range" \
@@ -174,15 +171,7 @@ jobs:
               *.md|docs/*|assets/*|.githooks/*|docs-site/*|LICENSE|NOTICE) ;;
               .github/workflows/ci.yml)
                 rust=true
-                sandbox_container=true
                 ui=true
-                workspace=true
-                ;;
-              # These inputs can change dependency resolution or compiler
-              # behavior for the heavyweight sandbox-container capability.
-              .cargo/*|Cargo.lock|Cargo.toml|rust-toolchain.toml)
-                rust=true
-                sandbox_container=true
                 workspace=true
                 ;;
               # Generated from Rust definitions, and a Rust test is what checks
@@ -193,18 +182,6 @@ jobs:
               crates/openwave-desktop/ui/src/generated/*)
                 rust=true; ui=true; workspace=true ;;
               crates/openwave-desktop/ui/*) ui=true ;;
-              crates/openwave-server/Cargo.toml)
-                rust=true
-                sandbox_container=true
-                workspace=true
-                ;;
-              # The real-container lane adds a packaging/runtime boundary over
-              # the loopback coverage that runs in every headless test job.
-              crates/openwave-sandbox-agent/*|crates/openwave-sandbox-protocol/*|crates/openwave-server/src/sandbox_container_run.rs|crates/openwave-server/src/sandbox_container_run/*|crates/openwave-server/src/sandbox_docker.rs)
-                rust=true
-                sandbox_container=true
-                workspace=true
-                ;;
               # Nothing in the workspace depends on openwave-desktop, and the
               # `test` lane already excludes it, so no edit to its own sources
               # can change that lane's result. The desktop lane still covers it.
@@ -220,14 +197,9 @@ jobs:
             echo "workspace scope without Rust scope; the detector is wrong." >&2
             exit 1
           fi
-          if [[ "$sandbox_container" == true && "$workspace" != true ]]; then
-            echo "sandbox-container scope without workspace scope; the detector is wrong." >&2
-            exit 1
-          fi
 
           {
             echo "rust=$rust"
-            echo "sandbox_container=$sandbox_container"
             echo "ui=$ui"
             echo "workspace=$workspace"
           } >> "$GITHUB_OUTPUT"
@@ -388,7 +360,11 @@ jobs:
     # independent pre-merge choice: `full-ci` does not opt a pull request into
     # this long-running lane. Add `windows-ci` when the change reaches a Windows
     # boundary; main and scheduled/manual runs retain the automatic backstop.
-    if: ${{ needs.changes.outputs.rust == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'windows-ci')) }}
+    #
+    # The leading `false` parks the whole lane while Windows packaging is paused
+    # (see docs/deferred.md). The rest of the condition is the live gating
+    # policy, kept intact so resuming is one literal.
+    if: ${{ false && needs.changes.outputs.rust == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'windows-ci')) }}
     runs-on: windows-latest
     # Every Rust-scoped main push contains the prior main state, so the newest
     # Windows run proves everything an older in-progress one would have proven.
@@ -562,61 +538,6 @@ jobs:
         run: >-
           cargo test -p openwave-core --no-default-features --features postgres
           --test postgres_turn_state --locked
-
-  sandbox-container:
-    name: sandbox-resident container e2e
-    needs: changes
-    # Builds the sandbox-agent image (compiling the agent crate's slice of the
-    # workspace inside Docker) and drives a real container end to end. That is
-    # expensive, and the container runtime is a detected capability rather than a
-    # hard dependency, so pay for it after relevant merges and in weekly/manual
-    # backstops instead of once per push to every open PR. The rest of the stack
-    # is covered on every PR by the loopback
-    # tests, which drive the same driver against the real agent over a socket.
-    if: ${{ needs.changes.outputs.sandbox_container == 'true' && github.event_name != 'pull_request' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    env:
-      CARGO_INCREMENTAL: 0
-      CARGO_PROFILE_DEV_DEBUG: 0
-      CARGO_PROFILE_TEST_DEBUG: 0
-      SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_GHA_RW_MODE: READ_ONLY
-      RUSTC_WRAPPER: sccache
-      RUSTFLAGS: -C link-arg=-fuse-ld=mold
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - name: Install toolchain (honors rust-toolchain.toml)
-        run: rustup show
-      - name: Set up compiler cache
-        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
-        with:
-          version: v0.16.0
-      - name: Install headless system deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends mold
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          shared-key: cargo-registry-v3-${{ hashFiles('Cargo.lock') }}
-          add-job-id-key: "false"
-          add-rust-environment-hash-key: "false"
-          cache-bin: false
-          cache-targets: false
-          save-if: false
-      # The runner ships a working Docker daemon; assert it rather than letting
-      # the test skip silently and report a green lane that exercised nothing.
-      - name: The container runtime must be present
-        run: docker version --format '{{.Server.Version}}'
-      # `--ignored` runs the gated Docker tests: the end-to-end drive and the
-      # transport-boundary conformance checks against the packaged image. Both
-      # build the same image tag; one test thread serializes them so the second
-      # build is a cache hit and the containers never race.
-      - name: Drive a sandbox-resident run and conformance checks on a real container
-        run: >-
-          cargo test -p openwave-server --locked
-          sandbox_container_run::tests::docker
-          -- --ignored --nocapture --test-threads=1
 
   ui:
     name: desktop UI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -714,7 +714,11 @@ jobs:
   prepare_windows:
     name: prepare unsigned Windows · ${{ matrix.arch }}
     needs: [validate, inspect_hosted]
-    if: ${{ needs.inspect_hosted.outputs.exists != 'true' }}
+    # Windows packaging is paused; see docs/deferred.md. The leading `false`
+    # parks this job and `build_windows` without disturbing the rest of the
+    # release gating, so resuming Windows is flipping two literals plus the
+    # `windows` descriptor in scripts/create-release-manifests.mjs.
+    if: ${{ false && needs.inspect_hosted.outputs.exists != 'true' }}
     runs-on: windows-latest
     timeout-minutes: 90
     defaults:
@@ -831,7 +835,8 @@ jobs:
     needs: [validate, inspect_hosted, prepare_windows]
     if: >-
       ${{
-        always()
+        false
+        && always()
         && needs.validate.result == 'success'
         && needs.inspect_hosted.result == 'success'
         && needs.inspect_hosted.outputs.exists != 'true'
@@ -1049,6 +1054,8 @@ jobs:
   publish:
     name: publish downloads.brightwave.io
     needs: [validate, inspect_hosted, build_macos, build_windows]
+    # `build_windows` is parked (see docs/deferred.md), so a skipped result is
+    # the expected steady state; only an outright failure may block publishing.
     if: >-
       ${{
         always()
@@ -1058,7 +1065,8 @@ jobs:
           needs.inspect_hosted.outputs.exists == 'true'
           || (
             needs.build_macos.result == 'success'
-            && needs.build_windows.result == 'success'
+            && needs.build_windows.result != 'failure'
+            && needs.build_windows.result != 'cancelled'
           )
         )
       }}
@@ -1114,8 +1122,9 @@ jobs:
           name: openwave-macos-aarch64-${{ needs.validate.outputs.version }}
           path: dist/macos/aarch64
 
+      # Parked with the Windows build; see docs/deferred.md.
       - name: Download Windows artifacts
-        if: ${{ needs.inspect_hosted.outputs.exists != 'true' }}
+        if: ${{ false && needs.inspect_hosted.outputs.exists != 'true' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: openwave-windows-x86_64-${{ needs.validate.outputs.version }}
@@ -1300,9 +1309,8 @@ jobs:
             "$manifest")
 
           dmg_count="$(find downloads -name '*.dmg' -type f | wc -l)"
-          exe_count="$(find downloads -name '*.exe' -type f | wc -l)"
-          (( dmg_count == 1 && exe_count == 1 )) || {
-            echo "Expected one macOS disk image and one Windows installer, found $dmg_count and $exe_count." >&2
+          (( dmg_count == 1 )) || {
+            echo "Expected one macOS disk image, found $dmg_count." >&2
             exit 1
           }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,8 +133,7 @@ Coverage percentage is not a goal and is not tracked. Confidence is.
 During active greenfield development, pull requests use a deliberately fast
 default gate. Full validation remains automatic after merge and on scheduled or
 manual runs. Add `full-ci` when a change warrants the heavyweight
-platform-neutral lanes before merge, and add `windows-ci` independently when it
-warrants the native Windows lane. Re-running the full workspace suite before
+platform-neutral lanes before merge. Re-running the full workspace suite before
 every push buys little and costs minutes on each iteration. Run a cheap relevant
 subset locally, push early, and let the configured lanes work while you keep
 going.
@@ -161,34 +160,23 @@ is the whole rule, and it is coarse on purpose:
   `full-ci` label is added. The always-running change detector rejects
   impossible narrower-scope combinations before conditional jobs consume them.
   There is no serial aggregate wrapper after the slowest job.
-- The native Windows lane checks the Windows-gated crates plus the host-broker,
-  desktop SQLite profile, and Credential Manager contracts. It runs
-  automatically for Rust-scoped pushes to `main`, weekly schedules, and manual
-  dispatches; a pull request runs it only with `windows-ci`. Use that label for
-  Windows-gated code, host-broker or sidecar packaging, desktop persistence or
-  keychain work, Windows release inputs, and native dependency or toolchain
-  changes. `full-ci` does not imply `windows-ci`. Superseded Windows jobs on
-  linear `main` are cancelled because the newer Rust-scoped state covers the
-  older one; pull-request, scheduled, and manual runs remain isolated.
-- The heavyweight `sandbox-resident container e2e` lane is scoped separately on
-  merges to `main`. It runs when the sandbox agent/protocol, container driver,
-  Dockerfile, or dependency/toolchain inputs change. A weekly scheduled run and
-  every `workflow_dispatch` exercise it as a backstop. Pull requests drive the
-  same host driver against the real sandbox agent over loopback, but only the
-  post-merge/scheduled lane proves the Docker packaging and container network
-  boundary.
+- The native Windows lane is **parked**, along with the release workflow's
+  Windows build — see [`docs/deferred.md`](docs/deferred.md). `windows-check`
+  and `prepare_windows`/`build_windows` are each gated behind a literal `false`
+  and never run; the `windows-ci` label currently does nothing. Releases are
+  macOS-only until those literals flip back. Nothing about the Windows boundary
+  has been declared unsupported, so a change that touches Windows-gated code
+  still deserves the same care — it just gets no CI signal right now.
 
 An ordinary pull request's heavy-job skips are the intended fast path, backed by
 full validation on `main`. For risky or boundary-crossing changes, add
-`full-ci` and wait for the applicable platform-neutral lanes; add `windows-ci`
-too when the Windows boundary is relevant. Run a cheap subset for fast local
-feedback on what you actually touched — `cargo check -p <crate>`, the one test
-module you changed, `tsc` — and push.
+`full-ci` and wait for the applicable platform-neutral lanes. Run a cheap subset
+for fast local feedback on what you actually touched — `cargo check -p <crate>`,
+the one test module you changed, `tsc` — and push.
 
 **The real trap is confusing the fast gate with full validation.** When a PR has
 `full-ci`, judge by whether every applicable platform-neutral job is present and
-passed, not by the absence of red. When it also has `windows-ci`, wait for the
-native Windows lane as well. A conflicting PR runs nothing but trivial policy
+passed, not by the absence of red. A conflicting PR runs nothing but trivial policy
 checks; rebase it before believing its status. `gh pr checks <n>` shows the
 truth.
 

--- a/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.dom.test.tsx
@@ -255,34 +255,6 @@ describe("CodeExecutionPanel", () => {
     expect(putCodeExecutionConfig).not.toHaveBeenCalled();
   });
 
-  it("explains per provider why detached runs are unavailable, in plain language", async () => {
-    const { client } = clientFor({
-      provider: "local",
-      timeout_ms: 20_000,
-      available: true,
-      has_credential: false,
-      egress: OPEN_EGRESS,
-      detached_admission: NO_DETACHED,
-    });
-
-    render(<CodeExecutionPanel client={client} />);
-
-    // One "Not available" badge per provider, and the typed denial reasons
-    // are rendered as honest sentences — never raw enum names.
-    expect(await screen.findAllByText("Not available")).toHaveLength(3);
-    expect(
-      screen.getAllByText(/token limited to a single run/i).length,
-    ).toBeGreaterThan(0);
-    expect(
-      screen.getAllByText(/limits how long it can live/i).length,
-    ).toBeGreaterThan(0);
-    expect(
-      screen.getAllByText(/isn't yet verified against a trusted source/i)
-        .length,
-    ).toBeGreaterThan(0);
-    expect(screen.queryByText(/no_scoped_model_token/)).toBeNull();
-  });
-
   it("names why each provider is unusable on a host with no execution at all", async () => {
     const { client } = clientFor({
       provider: undefined,

--- a/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
@@ -229,13 +229,6 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
             />
           </SettingsSection>
 
-          <SettingsSection
-            title="Detached background runs"
-            description="A detached run keeps working in its sandbox even when this app is closed. It is only allowed when every safety precondition holds; until then, background runs stay attached and end with the app."
-          >
-            <DetachedAdmissionDisclosure rows={config.detached_admission} />
-          </SettingsSection>
-
           {/* One save for the whole surface: it stores every key typed above
               and the selection together, so a provider cannot go active in a
               pass that failed to save its key. */}
@@ -268,27 +261,6 @@ type EgressEnforcementRow =
 
 type DetachedAdmissionRow =
   CodeExecutionConfigInfo["detached_admission"][number];
-type DetachedAdmissionDenialReason = DetachedAdmissionRow["denials"][number];
-
-/**
- * Each typed denial reason mapped to an honest sentence: what is missing, and
- * what would change it. The reasons come from the server's real admission
- * evaluator, so this list is exactly what the gate would deny a run for —
- * the surface never composes its own judgement.
- */
-const DETACHED_DENIAL_SENTENCES: Record<DetachedAdmissionDenialReason, string> =
-  {
-    no_scoped_model_token:
-      "The model gateway can't yet issue a token limited to a single run, so a detached run would have to carry a long-lived credential. This clears when the gateway can mint run-scoped tokens.",
-    no_external_lifetime_cap:
-      "Nothing outside the sandbox limits how long it can live, so a run this app never reconnects to would keep running unbounded. This needs a provider that enforces a time limit at creation.",
-    image_not_verified:
-      "The sandbox image isn't yet verified against a trusted source before it runs.",
-    host_authority_tool_surface:
-      "The run's tools could reach an operation that needs your approval mid-run, and a detached run has no one to ask.",
-    credentials_without_external_egress:
-      "The run would carry third-party credentials without an externally enforced network boundary keeping them from leaving.",
-  };
 
 const PROVIDER_SANDBOX_LABEL: Record<
   DetachedAdmissionRow["provider"],
@@ -353,43 +325,6 @@ function ProviderAvailabilityDisclosure({
     </div>
   );
 }
-
-/**
- * Per-provider detached-admission disclosure: for each execution provider,
- * whether a detached run would be allowed, and — when it wouldn't — every
- * unmet precondition in plain language, so the user can see why detached
- * execution is unavailable and what would change it.
- */
-function DetachedAdmissionDisclosure({
-  rows,
-}: {
-  rows: CodeExecutionConfigInfo["detached_admission"];
-}) {
-  return (
-    <div className="flex flex-col gap-3">
-      {rows.map((row) => (
-        <div key={row.provider} className="flex flex-col gap-1 text-sm">
-          <div className="flex items-center gap-2">
-            <Badge variant={row.admitted ? "success" : "warning"} size="sm">
-              {row.admitted ? "Available" : "Not available"}
-            </Badge>
-            <span className="font-medium text-foreground">
-              {PROVIDER_SANDBOX_LABEL[row.provider]}
-            </span>
-          </div>
-          {!row.admitted && (
-            <ul className="ml-5 list-disc text-muted-foreground">
-              {row.denials.map((denial) => (
-                <li key={denial}>{DETACHED_DENIAL_SENTENCES[denial]}</li>
-              ))}
-            </ul>
-          )}
-        </div>
-      ))}
-    </div>
-  );
-}
-
 
 /**
  * How each enforcement status reads: the badge never claims a boundary a

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -114,6 +114,35 @@ host-authority-reachable tools, and enforceable credential egress rules. Until
 those properties hold together, the in-process durable run path is the
 supported one.
 
+Because that tier is parked, the `sandbox-resident container e2e` CI lane has
+been removed rather than left failing against functionality nobody is
+advancing. The loopback tests still drive the same host driver against the real
+sandbox agent over a socket on every run; what is no longer proven is the
+Docker packaging and the container network boundary. Restoring that lane is
+part of picking the tier back up, not a separate task.
+
+## Windows packaging
+
+Windows builds shipped through v0.34.0 as an unsigned x86_64 NSIS installer,
+and the code that produces them is still in the tree. The lanes are parked, not
+deleted: `windows-check` in CI and the `prepare_windows`/`build_windows` jobs
+in the release workflow are each gated behind a literal `false`, and the
+`windows` descriptor in `scripts/create-release-manifests.mjs` is retained
+outside `RELEASE_PLATFORMS`. Releases are macOS-only until those are flipped
+back.
+
+The reason is cost, not a product decision. The native Windows runner is the
+slowest lane in the repo and the release build serializes a prepare and a build
+job behind it, which dominates the time to publish a tag. Nothing about the
+Windows boundary has been declared unsupported, and no Windows behavior has
+been removed.
+
+What resuming has to account for: the `/releases/latest/download/` link in the
+docs site points at an installer that later releases will not carry, and
+`latest.json` no longer publishes a `windows-x86_64` key. The in-app update
+loop runs only on macOS today, so no live updater breaks — but a Windows user
+on v0.34.0 has no upgrade path until the lanes come back.
+
 Reliability work also remains ahead of the product surface: replayable adapter
 contracts, recorded response decoding, and a protected live canary matrix would
 catch provider API drift before it becomes a user-visible turn failure. MCP app

--- a/scripts/create-release-manifests.mjs
+++ b/scripts/create-release-manifests.mjs
@@ -16,9 +16,21 @@ import { parseReleaseTag } from "./check-release-tag.mjs";
 // the single source of truth for what a release contains: it drives the
 // manifest, the `latest.json` platform keys, and the immutable hosting prefix.
 // macOS is Apple Silicon only while the product is in active development; see
-// docs/releases.md. Windows ships one unsigned NSIS installer, which is also
+// docs/releases.md.
+//
+// Windows packaging is paused (see docs/deferred.md), so no release currently
+// carries a Windows artifact. The descriptor is retained rather than deleted:
+// it shipped through v0.34.0, and resuming means moving it back into
+// RELEASE_PLATFORMS. Windows ships one unsigned NSIS installer, which is also
 // its Tauri updater artifact (Tauri v2 installs updates from the installer
 // itself, so the `.sig` covers those exact bytes).
+export const PAUSED_WINDOWS_PLATFORM = {
+  platform: "windows",
+  updaterPlatform: "windows",
+  architectures: ["x86_64"],
+  formats: [{ extension: "-setup.exe", format: "nsis", updater: true }],
+};
+
 export const RELEASE_PLATFORMS = [
   {
     platform: "macos",
@@ -29,12 +41,6 @@ export const RELEASE_PLATFORMS = [
       { extension: ".app.zip", format: "app.zip" },
       { extension: ".app.tar.gz", format: "app.tar.gz", updater: true },
     ],
-  },
-  {
-    platform: "windows",
-    updaterPlatform: "windows",
-    architectures: ["x86_64"],
-    formats: [{ extension: "-setup.exe", format: "nsis", updater: true }],
   },
 ];
 

--- a/scripts/create-release-manifests.test.mjs
+++ b/scripts/create-release-manifests.test.mjs
@@ -51,10 +51,7 @@ test("creates a complete manifest and Tauri updater document", () => {
   const { manifest, latest } = createReleaseManifests({ dist, ...RELEASE });
 
   assert.equal(manifest.artifacts.length, EXPECTED_ARTIFACT_COUNT);
-  assert.deepEqual(Object.keys(latest.platforms), [
-    "darwin-aarch64",
-    "windows-x86_64",
-  ]);
+  assert.deepEqual(Object.keys(latest.platforms), ["darwin-aarch64"]);
   assert.match(
     latest.platforms["darwin-aarch64"].url,
     /releases\/v0\.4\.2\/macos\/aarch64\/OpenWave_0\.4\.2_aarch64\.app\.tar\.gz$/,
@@ -62,14 +59,6 @@ test("creates a complete manifest and Tauri updater document", () => {
   assert.equal(
     latest.platforms["darwin-aarch64"].signature,
     "signature-macos-aarch64",
-  );
-  assert.match(
-    latest.platforms["windows-x86_64"].url,
-    /releases\/v0\.4\.2\/windows\/x86_64\/OpenWave_0\.4\.2_x86_64-setup\.exe$/,
-  );
-  assert.equal(
-    latest.platforms["windows-x86_64"].signature,
-    "signature-windows-x86_64",
   );
 
   const diskManifest = JSON.parse(


### PR DESCRIPTION
The native Windows runner is the slowest lane in the repo, and the release workflow serializes a prepare job and a build job behind it, which dominates the time to publish a tag. This parks both rather than keep paying for them while nothing is advancing on that boundary.

## Windows is disabled, not deleted

Three literal `false` flips bring it back:

- `ci.yml` — `windows-check` is gated off. The rest of its condition is intact, so the gating policy is still readable; the `windows-ci` label currently does nothing.
- `release.yml` — `prepare_windows` and `build_windows` are gated off. `publish` now tolerates a **skipped** `build_windows` while still blocking on a failed or cancelled one, and the Windows artifact download is parked with them.
- `scripts/create-release-manifests.mjs` — the `windows` descriptor moves out of `RELEASE_PLATFORMS` into an exported `PAUSED_WINDOWS_PLATFORM`. This is what actually makes a release macOS-only; it shipped through v0.34.0, so keeping the descriptor beats reconstructing it from history later.

`attach_downloads` no longer asserts exactly one `.exe`. Its manifest-driven loop still handles `windows/x86_64`, so resuming a pre-v0.35 release is unaffected.

**What this costs, recorded in `docs/deferred.md`:** the docs-site `/releases/latest/download/` link points at an installer later releases will not carry, and `latest.json` stops publishing a `windows-x86_64` key. The in-app update loop runs only on macOS today, so no live updater breaks — but a Windows user on v0.34.0 has no upgrade path until this comes back. Nothing about the Windows boundary is declared unsupported; it just gets no CI signal.

## sandbox-resident container e2e, removed

That tier is parked (#1749) and the lane was failing against functionality nobody is advancing. Gone along with the `sandbox_container` detector output, its scope cases, and the scope invariant.

Removing the flag collapsed three change-detector cases — `.cargo/*|Cargo.lock|Cargo.toml|rust-toolchain.toml`, `openwave-server/Cargo.toml`, and the sandbox-agent/protocol paths — into the existing `*)` catch-all. Each was distinguishable only by the flag it set, so the detected scopes are unchanged; leaving them behind would have meant three redundant cases carrying comments about a lane that no longer exists.

The loopback tests still drive the same host driver against the real sandbox agent over a socket on every run. What is no longer proven is the Docker packaging and the container network boundary. `docs/deferred.md` says so, and ties restoring the lane to picking the tier back up.

## Desktop

Drops the "Detached background runs" settings section, which disclosed admission for the same parked tier, along with `DetachedAdmissionDisclosure` and its denial-sentence map. The `detached_admission` wire field is untouched and still populated by the server — only the surface is gone.

## Tests removed

- `workflow-security.test.mjs` — "the container capability lane runs only for relevant merges and scheduled backstops". Asserted only the deleted job's gating and its detector flag.
- `CodeExecutionPanel.dom.test.tsx` — "explains per provider why detached runs are unavailable, in plain language". Asserted only the removed section's copy.
- `create-release-manifests.test.mjs` — the two hardcoded `windows-x86_64` assertions. The rest of that test derives from `RELEASE_PLATFORMS` and adapts on its own.

## Verification

`node --test scripts/*.test.mjs` 89/89, `tsc --noEmit` clean, `pnpm test` 859/859. Both workflows parse and resolve to the expected job sets.

`docs/releases.md` still describes Windows as live (the NSIS build, the hosting layout, `windows-check` as a backstop), as does `docs-site/content/docs/installation.mdx`. Left deliberately — `docs/deferred.md` is the canonical account, and rewriting the release runbook for a pause we intend to undo would churn it twice.
