### PR TITLE
fix(server): erase agent-run workspaces when deleting a chat

### DIFF
--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -782,9 +782,7 @@ pub(in crate::db) async fn delete_chat(
         .map_err(store_err)?;
 
     transaction.commit().await.map_err(store_err)?;
-    Ok(DeleteChatOutcome::Deleted {
-        background_run_ids,
-    })
+    Ok(DeleteChatOutcome::Deleted { background_run_ids })
 }
 
 /// Read the visible transcript and cursor for future journal replay under the

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
-use crate::id::{ChatId, HostRootId, MessageId, ProjectId, TurnId};
+use crate::id::{AgentRunId, ChatId, HostRootId, MessageId, ProjectId, TurnId};
 use crate::model::{
     validate_chat_root_projection, validate_chat_root_projection_against_project, Chat,
     ChatRootAttachment, Message, OwnerId, PermissionMode, ReasoningEffort, Role,
@@ -676,6 +676,18 @@ pub(in crate::db) async fn delete_chat(
         .exec(&transaction)
         .await
         .map_err(store_err)?;
+    // Background runs own host workspaces named `agent-run-<id>`. Capture the
+    // ids here, before the rows go, so the deletion path can destroy those
+    // directories immediately instead of waiting on the orphan reaper.
+    let background_run_ids = entities::agent_run::Entity::find()
+        .filter(entities::agent_run::Column::ChatId.eq(chat_id.0))
+        .filter(entities::agent_run::Column::Tier.eq("background"))
+        .all(&transaction)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(|run| AgentRunId::from(run.id))
+        .collect::<Vec<_>>();
     let agent_runs = entities::agent_run::Entity::find()
         .select_only()
         .column(entities::agent_run::Column::Id)
@@ -770,7 +782,9 @@ pub(in crate::db) async fn delete_chat(
         .map_err(store_err)?;
 
     transaction.commit().await.map_err(store_err)?;
-    Ok(DeleteChatOutcome::Deleted)
+    Ok(DeleteChatOutcome::Deleted {
+        background_run_ids,
+    })
 }
 
 /// Read the visible transcript and cursor for future journal replay under the

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -657,7 +657,10 @@ async fn project_deletion_requires_an_empty_project_and_reports_missing_identity
         DeleteProjectOutcome::NotEmpty
     );
     assert!(store.get_project(with_chat.id).await.unwrap().is_some());
-    assert!(matches!(store.delete_chat(chat.id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
+    assert!(matches!(
+        store.delete_chat(chat.id).await.unwrap(),
+        DeleteChatOutcome::Deleted { .. }
+    ));
     assert_eq!(
         store.delete_project(with_chat.id).await.unwrap(),
         DeleteProjectOutcome::Deleted
@@ -4266,7 +4269,10 @@ async fn user_questions_survive_reconnect_and_answer_exactly_once() {
             .unwrap(),
         crate::FinishTurnCancellationOutcome::Cancelled(_)
     ));
-    assert!(matches!(restarted.delete_chat(chat.id).await.unwrap(), crate::DeleteChatOutcome::Deleted { .. }));
+    assert!(matches!(
+        restarted.delete_chat(chat.id).await.unwrap(),
+        crate::DeleteChatOutcome::Deleted { .. }
+    ));
 }
 
 #[tokio::test]
@@ -4338,7 +4344,10 @@ async fn user_question_answer_validation_and_cancellation_are_closed() {
             .unwrap(),
         crate::AnswerUserQuestionsOutcome::Unavailable
     );
-    assert!(matches!(store.delete_chat(chat.id).await.unwrap(), crate::DeleteChatOutcome::Deleted { .. }));
+    assert!(matches!(
+        store.delete_chat(chat.id).await.unwrap(),
+        crate::DeleteChatOutcome::Deleted { .. }
+    ));
 }
 
 #[tokio::test]
@@ -7597,7 +7606,10 @@ async fn delete_chat_erases_quiesced_history_and_fails_closed_for_live_work_or_r
         )
         .await
         .unwrap();
-    assert!(matches!(store.delete_chat(chat.id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
+    assert!(matches!(
+        store.delete_chat(chat.id).await.unwrap(),
+        DeleteChatOutcome::Deleted { .. }
+    ));
     assert_eq!(store.get_chat(chat.id).await.unwrap(), None);
     assert!(store.list_messages(chat.id).await.unwrap().is_empty());
     assert!(store.list_events(chat.id, 0).await.unwrap().is_empty());
@@ -7663,7 +7675,10 @@ async fn delete_chat_erases_quiesced_history_and_fails_closed_for_live_work_or_r
         .await
         .unwrap()
         .expect("an unclaimed turn has no lease to fence against");
-    assert!(matches!(store.delete_chat(active.id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
+    assert!(matches!(
+        store.delete_chat(active.id).await.unwrap(),
+        DeleteChatOutcome::Deleted { .. }
+    ));
     assert_eq!(store.get_task_plan(active.id).await.unwrap(), None);
 
     // A plan request restricts against the chat, its turn, the proposing call,
@@ -7702,7 +7717,10 @@ async fn delete_chat_erases_quiesced_history_and_fails_closed_for_live_work_or_r
         )
         .await
         .unwrap();
-    assert!(matches!(store.delete_chat(planned.id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
+    assert!(matches!(
+        store.delete_chat(planned.id).await.unwrap(),
+        DeleteChatOutcome::Deleted { .. }
+    ));
     assert!(store
         .list_pending_plan_approvals(planned.id)
         .await
@@ -7793,7 +7811,10 @@ async fn delete_chat_atomically_retires_only_its_owned_sources() {
             .unwrap(),
         vec![owned_id]
     );
-    assert!(matches!(store.delete_chat(chat.id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
+    assert!(matches!(
+        store.delete_chat(chat.id).await.unwrap(),
+        DeleteChatOutcome::Deleted { .. }
+    ));
     assert_eq!(store.get_chat(chat.id).await.unwrap(), None);
     assert_eq!(store.get_document(owned_id).await.unwrap(), None);
     assert_eq!(
@@ -9033,7 +9054,10 @@ async fn delete_chat_erases_a_terminal_approval_receipt_before_its_event() {
         .unwrap()
         .is_some());
 
-    assert!(matches!(store.delete_chat(chat.id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
+    assert!(matches!(
+        store.delete_chat(chat.id).await.unwrap(),
+        DeleteChatOutcome::Deleted { .. }
+    ));
     assert!(store.get_chat(chat.id).await.unwrap().is_none());
     assert!(store.list_events(chat.id, 0).await.unwrap().is_empty());
 }

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -657,10 +657,7 @@ async fn project_deletion_requires_an_empty_project_and_reports_missing_identity
         DeleteProjectOutcome::NotEmpty
     );
     assert!(store.get_project(with_chat.id).await.unwrap().is_some());
-    assert_eq!(
-        store.delete_chat(chat.id).await.unwrap(),
-        DeleteChatOutcome::Deleted
-    );
+    assert!(matches!(store.delete_chat(chat.id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
     assert_eq!(
         store.delete_project(with_chat.id).await.unwrap(),
         DeleteProjectOutcome::Deleted
@@ -4269,10 +4266,7 @@ async fn user_questions_survive_reconnect_and_answer_exactly_once() {
             .unwrap(),
         crate::FinishTurnCancellationOutcome::Cancelled(_)
     ));
-    assert_eq!(
-        restarted.delete_chat(chat.id).await.unwrap(),
-        crate::DeleteChatOutcome::Deleted
-    );
+    assert!(matches!(restarted.delete_chat(chat.id).await.unwrap(), crate::DeleteChatOutcome::Deleted { .. }));
 }
 
 #[tokio::test]
@@ -4344,10 +4338,7 @@ async fn user_question_answer_validation_and_cancellation_are_closed() {
             .unwrap(),
         crate::AnswerUserQuestionsOutcome::Unavailable
     );
-    assert_eq!(
-        store.delete_chat(chat.id).await.unwrap(),
-        crate::DeleteChatOutcome::Deleted
-    );
+    assert!(matches!(store.delete_chat(chat.id).await.unwrap(), crate::DeleteChatOutcome::Deleted { .. }));
 }
 
 #[tokio::test]
@@ -7606,10 +7597,7 @@ async fn delete_chat_erases_quiesced_history_and_fails_closed_for_live_work_or_r
         )
         .await
         .unwrap();
-    assert_eq!(
-        store.delete_chat(chat.id).await.unwrap(),
-        DeleteChatOutcome::Deleted
-    );
+    assert!(matches!(store.delete_chat(chat.id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
     assert_eq!(store.get_chat(chat.id).await.unwrap(), None);
     assert!(store.list_messages(chat.id).await.unwrap().is_empty());
     assert!(store.list_events(chat.id, 0).await.unwrap().is_empty());
@@ -7675,10 +7663,7 @@ async fn delete_chat_erases_quiesced_history_and_fails_closed_for_live_work_or_r
         .await
         .unwrap()
         .expect("an unclaimed turn has no lease to fence against");
-    assert_eq!(
-        store.delete_chat(active.id).await.unwrap(),
-        DeleteChatOutcome::Deleted
-    );
+    assert!(matches!(store.delete_chat(active.id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
     assert_eq!(store.get_task_plan(active.id).await.unwrap(), None);
 
     // A plan request restricts against the chat, its turn, the proposing call,
@@ -7717,10 +7702,7 @@ async fn delete_chat_erases_quiesced_history_and_fails_closed_for_live_work_or_r
         )
         .await
         .unwrap();
-    assert_eq!(
-        store.delete_chat(planned.id).await.unwrap(),
-        DeleteChatOutcome::Deleted
-    );
+    assert!(matches!(store.delete_chat(planned.id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
     assert!(store
         .list_pending_plan_approvals(planned.id)
         .await
@@ -7811,10 +7793,7 @@ async fn delete_chat_atomically_retires_only_its_owned_sources() {
             .unwrap(),
         vec![owned_id]
     );
-    assert_eq!(
-        store.delete_chat(chat.id).await.unwrap(),
-        DeleteChatOutcome::Deleted
-    );
+    assert!(matches!(store.delete_chat(chat.id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
     assert_eq!(store.get_chat(chat.id).await.unwrap(), None);
     assert_eq!(store.get_document(owned_id).await.unwrap(), None);
     assert_eq!(
@@ -9054,10 +9033,7 @@ async fn delete_chat_erases_a_terminal_approval_receipt_before_its_event() {
         .unwrap()
         .is_some());
 
-    assert_eq!(
-        store.delete_chat(chat.id).await.unwrap(),
-        DeleteChatOutcome::Deleted
-    );
+    assert!(matches!(store.delete_chat(chat.id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
     assert!(store.get_chat(chat.id).await.unwrap().is_none());
     assert!(store.list_events(chat.id, 0).await.unwrap().is_empty());
 }

--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -2944,9 +2944,7 @@ async fn a_background_run_keeps_its_own_plan_and_the_chat_can_still_be_deleted()
     settled.update(&store.conn).await.unwrap();
     let deleted = store.delete_chat(chat.id).await.unwrap();
     match deleted {
-        crate::DeleteChatOutcome::Deleted {
-            background_run_ids,
-        } => {
+        crate::DeleteChatOutcome::Deleted { background_run_ids } => {
             let mut ids = background_run_ids;
             ids.sort_by_key(|id| id.as_uuid().as_u128());
             let mut expected = vec![sandbox.id, sibling.id];

--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -2942,10 +2942,19 @@ async fn a_background_run_keeps_its_own_plan_and_the_chat_can_still_be_deleted()
     settled.lease_expires_at = Set(None);
     settled.finished_at = Set(Some(Utc::now()));
     settled.update(&store.conn).await.unwrap();
-    assert_eq!(
-        store.delete_chat(chat.id).await.unwrap(),
-        crate::DeleteChatOutcome::Deleted
-    );
+    let deleted = store.delete_chat(chat.id).await.unwrap();
+    match deleted {
+        crate::DeleteChatOutcome::Deleted {
+            background_run_ids,
+        } => {
+            let mut ids = background_run_ids;
+            ids.sort_by_key(|id| id.as_uuid().as_u128());
+            let mut expected = vec![sandbox.id, sibling.id];
+            expected.sort_by_key(|id| id.as_uuid().as_u128());
+            assert_eq!(ids, expected);
+        }
+        other => panic!("expected deleted chat, got {other:?}"),
+    }
     assert_eq!(
         store.get_agent_run_task_plan(sandbox.id).await.unwrap(),
         None

--- a/crates/openwave-core/src/db/tests/context_checkpoint.rs
+++ b/crates/openwave-core/src/db/tests/context_checkpoint.rs
@@ -156,7 +156,10 @@ async fn deleting_a_chat_removes_its_checkpoint_before_its_source_message() {
         .await
         .unwrap();
 
-    assert!(matches!(store.delete_chat(chat.id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
+    assert!(matches!(
+        store.delete_chat(chat.id).await.unwrap(),
+        DeleteChatOutcome::Deleted { .. }
+    ));
     assert!(store
         .get_context_checkpoint(chat.id)
         .await

--- a/crates/openwave-core/src/db/tests/context_checkpoint.rs
+++ b/crates/openwave-core/src/db/tests/context_checkpoint.rs
@@ -156,10 +156,7 @@ async fn deleting_a_chat_removes_its_checkpoint_before_its_source_message() {
         .await
         .unwrap();
 
-    assert_eq!(
-        store.delete_chat(chat.id).await.unwrap(),
-        DeleteChatOutcome::Deleted
-    );
+    assert!(matches!(store.delete_chat(chat.id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
     assert!(store
         .get_context_checkpoint(chat.id)
         .await

--- a/crates/openwave-core/src/db/tests/message_attachment.rs
+++ b/crates/openwave-core/src/db/tests/message_attachment.rs
@@ -671,7 +671,10 @@ async fn deleting_a_chat_retires_only_the_attachment_blobs_it_still_owns() {
     store.create_chat(&doomed).await.unwrap();
     accept_quiesced_turn_with_images(&store, doomed.id, "about to go", &[shared, private]).await;
 
-    assert!(matches!(store.delete_chat(doomed.id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
+    assert!(matches!(
+        store.delete_chat(doomed.id).await.unwrap(),
+        DeleteChatOutcome::Deleted { .. }
+    ));
     assert!(store
         .list_message_attachments(doomed.id)
         .await
@@ -718,7 +721,10 @@ async fn deleting_a_chat_retires_only_the_attachment_blobs_it_still_owns() {
     );
 
     // Deleting the last conversation holding it finally frees the shared blob.
-    assert!(matches!(store.delete_chat(kept.id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
+    assert!(matches!(
+        store.delete_chat(kept.id).await.unwrap(),
+        DeleteChatOutcome::Deleted { .. }
+    ));
     let later = now + chrono::Duration::seconds(1);
     assert_eq!(
         drain_blob_retirement_claims(&store, later).await,
@@ -756,7 +762,10 @@ async fn an_attachment_blob_shared_with_a_document_survives_either_owner() {
         .is_none());
 
     // Dropping the attachment too finally releases it.
-    assert!(matches!(store.delete_chat(chat.id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
+    assert!(matches!(
+        store.delete_chat(chat.id).await.unwrap(),
+        DeleteChatOutcome::Deleted { .. }
+    ));
     let later = now + chrono::Duration::seconds(1);
     let claimed = store
         .claim_blob_retirement(later, later + chrono::Duration::minutes(5))

--- a/crates/openwave-core/src/db/tests/message_attachment.rs
+++ b/crates/openwave-core/src/db/tests/message_attachment.rs
@@ -671,10 +671,7 @@ async fn deleting_a_chat_retires_only_the_attachment_blobs_it_still_owns() {
     store.create_chat(&doomed).await.unwrap();
     accept_quiesced_turn_with_images(&store, doomed.id, "about to go", &[shared, private]).await;
 
-    assert_eq!(
-        store.delete_chat(doomed.id).await.unwrap(),
-        DeleteChatOutcome::Deleted
-    );
+    assert!(matches!(store.delete_chat(doomed.id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
     assert!(store
         .list_message_attachments(doomed.id)
         .await
@@ -721,10 +718,7 @@ async fn deleting_a_chat_retires_only_the_attachment_blobs_it_still_owns() {
     );
 
     // Deleting the last conversation holding it finally frees the shared blob.
-    assert_eq!(
-        store.delete_chat(kept.id).await.unwrap(),
-        DeleteChatOutcome::Deleted
-    );
+    assert!(matches!(store.delete_chat(kept.id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
     let later = now + chrono::Duration::seconds(1);
     assert_eq!(
         drain_blob_retirement_claims(&store, later).await,
@@ -762,10 +756,7 @@ async fn an_attachment_blob_shared_with_a_document_survives_either_owner() {
         .is_none());
 
     // Dropping the attachment too finally releases it.
-    assert_eq!(
-        store.delete_chat(chat.id).await.unwrap(),
-        DeleteChatOutcome::Deleted
-    );
+    assert!(matches!(store.delete_chat(chat.id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
     let later = now + chrono::Duration::seconds(1);
     let claimed = store
         .claim_blob_retirement(later, later + chrono::Duration::minutes(5))

--- a/crates/openwave-core/src/db/tests/multi_agent_wait.rs
+++ b/crates/openwave-core/src/db/tests/multi_agent_wait.rs
@@ -882,10 +882,7 @@ async fn cancelling_a_multi_wait_fences_children_and_terminal_chat_deletes_clean
             AgentRunStatus::Cancelled
         );
     }
-    assert_eq!(
-        store.delete_chat(chat.id).await.unwrap(),
-        DeleteChatOutcome::Deleted
-    );
+    assert!(matches!(store.delete_chat(chat.id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/db/tests/multi_agent_wait.rs
+++ b/crates/openwave-core/src/db/tests/multi_agent_wait.rs
@@ -882,7 +882,10 @@ async fn cancelling_a_multi_wait_fences_children_and_terminal_chat_deletes_clean
             AgentRunStatus::Cancelled
         );
     }
-    assert!(matches!(store.delete_chat(chat.id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
+    assert!(matches!(
+        store.delete_chat(chat.id).await.unwrap(),
+        DeleteChatOutcome::Deleted { .. }
+    ));
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/db/tests/sandbox_spawn_checkpoint.rs
+++ b/crates/openwave-core/src/db/tests/sandbox_spawn_checkpoint.rs
@@ -913,10 +913,7 @@ async fn completed_spawn_graph_does_not_block_quiescent_chat_deletion() {
         .request_turn_cancellation(turn.id, Utc::now() + Duration::seconds(1))
         .await
         .unwrap();
-    assert_eq!(
-        store.delete_chat(chat.id).await.unwrap(),
-        crate::DeleteChatOutcome::Deleted
-    );
+    assert!(matches!(store.delete_chat(chat.id).await.unwrap(), crate::DeleteChatOutcome::Deleted { .. }));
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/db/tests/sandbox_spawn_checkpoint.rs
+++ b/crates/openwave-core/src/db/tests/sandbox_spawn_checkpoint.rs
@@ -913,7 +913,10 @@ async fn completed_spawn_graph_does_not_block_quiescent_chat_deletion() {
         .request_turn_cancellation(turn.id, Utc::now() + Duration::seconds(1))
         .await
         .unwrap();
-    assert!(matches!(store.delete_chat(chat.id).await.unwrap(), crate::DeleteChatOutcome::Deleted { .. }));
+    assert!(matches!(
+        store.delete_chat(chat.id).await.unwrap(),
+        crate::DeleteChatOutcome::Deleted { .. }
+    ));
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/storage/types.rs
+++ b/crates/openwave-core/src/storage/types.rs
@@ -165,10 +165,17 @@ pub struct InboxItem {
 /// root remains attached. Root detachment is a broker-backed operation, so the
 /// deletion path never tries to revoke native authority as an incidental side
 /// effect.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DeleteChatOutcome {
     /// The conversation and its terminal product history were removed.
-    Deleted,
+    ///
+    /// `background_run_ids` are the chat's former background runs, collected
+    /// before their rows were erased. The deletion path uses them to destroy
+    /// each run's `agent-run-*` workspace immediately; the periodic reaper only
+    /// remains as a backstop for crashes and foreign leftovers.
+    Deleted {
+        background_run_ids: Vec<AgentRunId>,
+    },
     /// No conversation owns this id.
     NotFound,
     /// A foreground turn or sandboxed run can still make progress.

--- a/crates/openwave-core/src/storage/types.rs
+++ b/crates/openwave-core/src/storage/types.rs
@@ -173,9 +173,7 @@ pub enum DeleteChatOutcome {
     /// before their rows were erased. The deletion path uses them to destroy
     /// each run's `agent-run-*` workspace immediately; the periodic reaper only
     /// remains as a backstop for crashes and foreign leftovers.
-    Deleted {
-        background_run_ids: Vec<AgentRunId>,
-    },
+    Deleted { background_run_ids: Vec<AgentRunId> },
     /// No conversation owns this id.
     NotFound,
     /// A foreground turn or sandboxed run can still make progress.

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -409,10 +409,7 @@ async fn cleanup_postgres_sandbox_chat(store: &DbStore, chat_id: ChatId) {
         }
     }
 
-    assert_eq!(
-        store.delete_chat(chat_id).await.unwrap(),
-        DeleteChatOutcome::Deleted
-    );
+    assert!(matches!(store.delete_chat(chat_id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
 }
 
 fn postgres_spawn_checkpoint_request(
@@ -3789,12 +3786,6 @@ async fn postgres_user_questions_resume_exactly_and_serialize_with_cancellation(
         .await
         .unwrap()
         .is_empty());
-    assert_eq!(
-        store.delete_chat(chat.id).await.unwrap(),
-        DeleteChatOutcome::Deleted
-    );
-    assert_eq!(
-        store.delete_chat(race_chat.id).await.unwrap(),
-        DeleteChatOutcome::Deleted
-    );
+    assert!(matches!(store.delete_chat(chat.id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
+    assert!(matches!(store.delete_chat(race_chat.id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
 }

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -409,7 +409,10 @@ async fn cleanup_postgres_sandbox_chat(store: &DbStore, chat_id: ChatId) {
         }
     }
 
-    assert!(matches!(store.delete_chat(chat_id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
+    assert!(matches!(
+        store.delete_chat(chat_id).await.unwrap(),
+        DeleteChatOutcome::Deleted { .. }
+    ));
 }
 
 fn postgres_spawn_checkpoint_request(
@@ -3786,6 +3789,12 @@ async fn postgres_user_questions_resume_exactly_and_serialize_with_cancellation(
         .await
         .unwrap()
         .is_empty());
-    assert!(matches!(store.delete_chat(chat.id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
-    assert!(matches!(store.delete_chat(race_chat.id).await.unwrap(), DeleteChatOutcome::Deleted { .. }));
+    assert!(matches!(
+        store.delete_chat(chat.id).await.unwrap(),
+        DeleteChatOutcome::Deleted { .. }
+    ));
+    assert!(matches!(
+        store.delete_chat(race_chat.id).await.unwrap(),
+        DeleteChatOutcome::Deleted { .. }
+    ));
 }

--- a/crates/openwave-server/src/agent_run_scratch_reaper.rs
+++ b/crates/openwave-server/src/agent_run_scratch_reaper.rs
@@ -26,6 +26,12 @@
 //! `Store::claim_agent_run`), and this sweep picks up the resulting terminal
 //! run on its next pass — no separate orphan detector is needed for that case.
 //!
+//! Chat deletion is the one intentional exception to "wait for the reaper":
+//! deleting a conversation already refuses while any of its runs is
+//! non-terminal, and the run rows are removed in the same transaction, so the
+//! deletion path destroys those workspaces immediately for privacy. This sweep
+//! remains the backstop when that best-effort erase does not finish.
+//!
 //! A run's *published outputs* live under `scratch_root/<chat_id>/outputs/…`,
 //! never under the run's own workspace — that split (and the bug it fixed) is
 //! in `ConfiguredCodeExecutionProvider::publish_output_directory`. Destroying
@@ -228,11 +234,14 @@ impl AgentRunScratchReaper {
                 }
             }
             // No matching run row. Every run row is created durably before its
-            // workspace ever exists, and rows are never deleted, so this can
-            // only be a directory this process does not recognize — most
-            // plausibly leftover from an older naming scheme or a foreign
-            // process. Still gate on the directory's own age so a workspace
-            // whose row insert has not yet become visible is never raced.
+            // workspace ever exists, so a missing row is either a directory this
+            // process does not recognize — leftover from an older naming scheme
+            // or a foreign process — or a workspace whose run was erased with
+            // its conversation and whose immediate cleanup did not finish (host
+            // crash, destroy failure). Still gate on the directory's own age so
+            // a workspace whose row insert has not yet become visible is never
+            // raced, and so a just-deleted chat's in-flight destroy is not
+            // double-driven by this sweep.
             None => {
                 if !self.directory_is_old_enough(run_id, cutoff).await? {
                     return Ok(false);
@@ -262,26 +271,38 @@ impl AgentRunScratchReaper {
     /// mirror directory every provider stages files through, which a remote
     /// provider's own `destroy_workspace` does not touch.
     async fn destroy(&self, run_id: AgentRunId) -> Result<()> {
-        let workspace = ExecutionWorkspaceId::parse(workspace_dir_name(run_id))
-            .map_err(|error| AgentError::msg(format!("invalid agent-run workspace id: {error}")))?;
-        if let Some(configured) = self
-            .code_execution
-            .workspace()
-            .await
-            .map_err(|error| AgentError::msg(error.to_string()))?
-        {
-            configured
-                .destroy_workspace(&workspace)
-                .await
-                .map_err(|error| AgentError::msg(error.to_string()))?;
-        }
-        let path = self.scratch_root.join(workspace.as_str());
-        tokio::task::spawn_blocking(move || remove_dir_all_if_present(&path))
-            .await
-            .map_err(|error| {
-                AgentError::Store(format!("agent-run scratch removal task failed: {error}"))
-            })?
+        destroy_agent_run_workspace(&self.code_execution, self.scratch_root.as_path(), run_id).await
     }
+}
+
+/// Destroy one background run's workspace and host scratch directory.
+///
+/// Shared by the periodic reaper and the chat-deletion path, which erases a
+/// deleted conversation's former runs immediately rather than waiting for the
+/// next sweep. Safe to call when the workspace is already gone.
+pub(crate) async fn destroy_agent_run_workspace(
+    code_execution: &ConfiguredCodeExecutionProvider,
+    scratch_root: &Path,
+    run_id: AgentRunId,
+) -> Result<()> {
+    let workspace = ExecutionWorkspaceId::parse(workspace_dir_name(run_id))
+        .map_err(|error| AgentError::msg(format!("invalid agent-run workspace id: {error}")))?;
+    if let Some(configured) = code_execution
+        .workspace()
+        .await
+        .map_err(|error| AgentError::msg(error.to_string()))?
+    {
+        configured
+            .destroy_workspace(&workspace)
+            .await
+            .map_err(|error| AgentError::msg(error.to_string()))?;
+    }
+    let path = scratch_root.join(workspace.as_str());
+    tokio::task::spawn_blocking(move || remove_dir_all_if_present(&path))
+        .await
+        .map_err(|error| {
+            AgentError::Store(format!("agent-run scratch removal task failed: {error}"))
+        })?
 }
 
 fn next_delay(config: AgentRunScratchReaperConfig, report: &AgentRunScratchReapReport) -> Duration {

--- a/crates/openwave-server/src/routes/projects_chats.rs
+++ b/crates/openwave-server/src/routes/projects_chats.rs
@@ -10,9 +10,9 @@ use serde::{Deserialize, Serialize};
 use std::path::Path as FsPath;
 
 use openwave_core::{
-    Chat, ChatId, DeleteChatOutcome, DeleteProjectOutcome, DocumentId, Message as StoredMessage,
-    MessageId, PermissionMode, Project, ProjectId, ReasoningEffort, Role, TurnId,
-    CONTEXT_CHECKPOINT_FORMAT_V1, CONTEXT_CHECKPOINT_FORMAT_V2,
+    AgentRunId, Chat, ChatId, DeleteChatOutcome, DeleteProjectOutcome, DocumentId,
+    Message as StoredMessage, MessageId, PermissionMode, Project, ProjectId, ReasoningEffort, Role,
+    TurnId, CONTEXT_CHECKPOINT_FORMAT_V1, CONTEXT_CHECKPOINT_FORMAT_V2,
 };
 
 use crate::error::ServerError;
@@ -758,7 +758,9 @@ pub async fn delete_chat(
     Path(id): Path<ChatId>,
 ) -> Result<StatusCode, ServerError> {
     match store.delete_chat(id).await? {
-        DeleteChatOutcome::Deleted => {
+        DeleteChatOutcome::Deleted {
+            background_run_ids,
+        } => {
             state.blob_retirement_wake.notify_one();
             let scratch_root = state.config.data_dir.join("scratch");
             let cleanup =
@@ -774,6 +776,13 @@ pub async fn delete_chat(
                         "openwave: private scratch cleanup task stopped for chat {id}: {error}"
                     );
                 }
+            }
+            // Background-run workspaces are independent of the chat's private
+            // scratch directory. Deletion already refused while any run was
+            // non-terminal, so these directories are quiescent; erase them now
+            // rather than waiting up to a reaper grace period for privacy.
+            if !background_run_ids.is_empty() {
+                erase_deleted_chat_agent_run_workspaces(&state, id, background_run_ids).await;
             }
             Ok(StatusCode::NO_CONTENT)
         }
@@ -834,5 +843,53 @@ fn remove_private_chat_scratch(root: &FsPath, id: ChatId) -> std::io::Result<()>
         )),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(error) => Err(error),
+    }
+}
+
+/// Destroy the former chat's background-run workspaces.
+///
+/// Failures are logged and ignored the same way private-chat scratch cleanup
+/// is: the durable delete has already committed, so a stuck host directory must
+/// not turn a successful response into an ambiguous HTTP failure. The periodic
+/// agent-run scratch reaper remains the backstop.
+async fn erase_deleted_chat_agent_run_workspaces(
+    state: &AppState,
+    chat_id: ChatId,
+    run_ids: Vec<AgentRunId>,
+) {
+    let scratch_root = state.config.data_dir.join("scratch");
+    if let Some(code_execution) = state.code_execution.clone() {
+        for run_id in run_ids {
+            if let Err(error) = crate::agent_run_scratch_reaper::destroy_agent_run_workspace(
+                &code_execution,
+                &scratch_root,
+                run_id,
+            )
+            .await
+            {
+                eprintln!(
+                    "openwave: could not destroy agent-run workspace for chat {chat_id} run {run_id}: {error}"
+                );
+            }
+        }
+        return;
+    }
+    // Route tests assemble AppState without a configured provider; still wipe
+    // the host directories so local cleanup is not gated on provider resolution.
+    let cleanup = tokio::task::spawn_blocking(move || {
+        for run_id in run_ids {
+            let path = scratch_root.join(format!("agent-run-{run_id}"));
+            match std::fs::remove_dir_all(&path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => eprintln!(
+                    "openwave: could not remove agent-run scratch for chat {chat_id} run {run_id}: {error}"
+                ),
+            }
+        }
+    })
+    .await;
+    if let Err(error) = cleanup {
+        eprintln!("openwave: agent-run scratch cleanup task stopped for chat {chat_id}: {error}");
     }
 }

--- a/crates/openwave-server/src/routes/projects_chats.rs
+++ b/crates/openwave-server/src/routes/projects_chats.rs
@@ -758,9 +758,7 @@ pub async fn delete_chat(
     Path(id): Path<ChatId>,
 ) -> Result<StatusCode, ServerError> {
     match store.delete_chat(id).await? {
-        DeleteChatOutcome::Deleted {
-            background_run_ids,
-        } => {
+        DeleteChatOutcome::Deleted { background_run_ids } => {
             state.blob_retirement_wake.notify_one();
             let scratch_root = state.config.data_dir.join("scratch");
             let cleanup =

--- a/crates/openwave-server/src/tests/conversations.rs
+++ b/crates/openwave-server/src/tests/conversations.rs
@@ -1022,7 +1022,10 @@ async fn delete_chat_erases_background_run_workspaces_immediately() {
         .unwrap()
         .expect("the claimed worker acknowledges cancellation");
 
-    let workspace = dir.path().join("scratch").join(format!("agent-run-{}", run.id));
+    let workspace = dir
+        .path()
+        .join("scratch")
+        .join(format!("agent-run-{}", run.id));
     std::fs::create_dir_all(workspace.join("tmp")).unwrap();
     std::fs::write(workspace.join("notes.txt"), b"run-private").unwrap();
     let chat_scratch = dir.path().join("scratch").join(chat.id.to_string());

--- a/crates/openwave-server/src/tests/conversations.rs
+++ b/crates/openwave-server/src/tests/conversations.rs
@@ -977,6 +977,78 @@ async fn delete_chat_removes_a_quiesced_conversation_and_reports_safe_conflicts(
     assert!(store.get_chat(active.id).await.unwrap().is_some());
 }
 
+/// Deleting a chat must erase its background runs' workspaces in the same
+/// request, not leave them for the next agent-run scratch reaper pass.
+#[tokio::test]
+async fn delete_chat_erases_background_run_workspaces_immediately() {
+    // No turn worker: this test claims the turn itself to admit the run.
+    let (router, token, store, dir) = test_app_without_turn_worker().await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let run = admit_sandbox_for_test(&store, chat.id, "write notes").await;
+    let lease = uuid::Uuid::new_v4();
+    assert_eq!(
+        store
+            .claim_agent_run(lease, chrono::Duration::minutes(5), 8, 8)
+            .await
+            .unwrap()
+            .unwrap()
+            .id,
+        run.id
+    );
+    store
+        .submit_agent_run_result(run.id, lease, "done")
+        .await
+        .unwrap();
+    // Deletion refuses while the spawning turn is still live. Cancel and
+    // finish it after the child is terminal: that retires the pending inbox
+    // delivery and leaves a quiesced conversation the delete path accepts.
+    let turn = store
+        .list_turn_runs(chat.id)
+        .await
+        .unwrap()
+        .into_iter()
+        .next()
+        .expect("sandbox admission creates a turn");
+    let turn_lease = turn.lease_token.expect("test claimed the turn");
+    store
+        .request_turn_cancellation(turn.id, chrono::Utc::now())
+        .await
+        .unwrap()
+        .expect("a running origin turn can be cancelled");
+    store
+        .finish_turn_cancellation(turn.id, turn_lease, chrono::Utc::now())
+        .await
+        .unwrap()
+        .expect("the claimed worker acknowledges cancellation");
+
+    let workspace = dir.path().join("scratch").join(format!("agent-run-{}", run.id));
+    std::fs::create_dir_all(workspace.join("tmp")).unwrap();
+    std::fs::write(workspace.join("notes.txt"), b"run-private").unwrap();
+    let chat_scratch = dir.path().join("scratch").join(chat.id.to_string());
+    std::fs::create_dir_all(&chat_scratch).unwrap();
+    std::fs::write(chat_scratch.join("kept-only-until-delete.txt"), b"chat").unwrap();
+
+    let deleted = router
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/chats/{}", chat.id))
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(deleted.status(), StatusCode::NO_CONTENT);
+    assert!(store.get_chat(chat.id).await.unwrap().is_none());
+    assert!(
+        !workspace.exists(),
+        "background-run workspace must not outlive the deleted chat"
+    );
+    assert!(!chat_scratch.exists());
+}
+
 #[tokio::test]
 async fn chat_transcript_replays_only_visible_durable_messages() {
     let (router, token, store, _dir) = test_app().await;


### PR DESCRIPTION
## Summary

Closes #1588.

Deleting a chat already removed `<scratch>/<chat_id>` synchronously, but each background run's `agent-run-<id>` workspace waited for `AgentRunScratchReaper` (up to ~75 minutes with the default grace/interval). Deletion is refused while any run is non-terminal, so those directories are quiescent — this change erases them in the delete path for privacy.

- `DeleteChatOutcome::Deleted` now carries the chat's former background run ids, collected before the rows are removed.
- `DELETE /chats/{id}` destroys those workspaces immediately (best-effort, same failure policy as private-chat scratch cleanup) via a shared helper with the reaper.
- The reaper remains the crash/orphan backstop; its orphan-branch comment no longer claims run rows are never deleted.

## Test plan

- [x] `cargo test -p openwave-core --lib db::tests::delete_chat`
- [x] `cargo test -p openwave-core --lib db::tests::agent_run::a_background_run_keeps_its_own_plan`
- [x] `cargo test -p openwave-server --lib tests::conversations::delete_chat`
- [x] `cargo test -p openwave-server --lib agent_run_scratch_reaper::tests`
- [ ] CI green on the PR