### PR TITLE
refactor(core): collapse three schema tables that mirror their parents

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -646,6 +646,22 @@ pub mod sandbox_spawn_checkpoint {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+pub mod advisory_lock {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "advisory_lock")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub name: String,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub mod agent_run_claim {
     use sea_orm::entity::prelude::*;
 
@@ -659,22 +675,6 @@ pub mod agent_run_claim {
         pub claim_count: Option<i32>,
         pub claimed_at: DateTimeUtc,
         pub lease_expires_at: Option<DateTimeUtc>,
-    }
-
-    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
-    pub enum Relation {}
-
-    impl ActiveModelBehavior for ActiveModel {}
-}
-
-pub mod agent_run_claim_lock {
-    use sea_orm::entity::prelude::*;
-
-    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
-    #[sea_orm(table_name = "agent_run_claim_lock")]
-    pub struct Model {
-        #[sea_orm(primary_key, auto_increment = false)]
-        pub id: i32,
     }
 
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -843,10 +843,6 @@ pub mod turn_agent_run_wait_set {
         pub parent_run_id: Uuid,
         pub turn_id: Uuid,
         pub chat_id: Uuid,
-        pub provider_id: String,
-        pub history_order: i64,
-        #[sea_orm(column_type = "JsonBinary")]
-        pub arguments: Json,
         pub condition: String,
         pub park_lease_token: Uuid,
         pub expected_steer_revision: i64,
@@ -863,22 +859,6 @@ pub mod turn_agent_run_wait_set {
         pub parked_at: DateTimeUtc,
         pub closed_at: Option<DateTimeUtc>,
         pub resume_token: Option<Uuid>,
-    }
-
-    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
-    pub enum Relation {}
-
-    impl ActiveModelBehavior for ActiveModel {}
-}
-
-pub mod turn_agent_run_wait_lock {
-    use sea_orm::entity::prelude::*;
-
-    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
-    #[sea_orm(table_name = "turn_agent_run_wait_lock")]
-    pub struct Model {
-        #[sea_orm(primary_key, auto_increment = false)]
-        pub id: i32,
     }
 
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -968,22 +948,6 @@ pub mod turn_claim {
         pub claim_count: i32,
         pub claimed_at: DateTimeUtc,
         pub lease_expires_at: DateTimeUtc,
-    }
-
-    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
-    pub enum Relation {}
-
-    impl ActiveModelBehavior for ActiveModel {}
-}
-
-pub mod turn_claim_lock {
-    use sea_orm::entity::prelude::*;
-
-    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
-    #[sea_orm(table_name = "turn_claim_lock")]
-    pub struct Model {
-        #[sea_orm(primary_key, auto_increment = false)]
-        pub id: i32,
     }
 
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -1127,9 +1091,6 @@ pub mod user_question {
         pub options: Json,
         pub question_type: String,
         pub allow_free_form: bool,
-        pub answer_option_id: Option<String>,
-        pub answer_free_form: Option<String>,
-        pub answered_at: Option<DateTimeUtc>,
         #[sea_orm(column_type = "JsonBinary")]
         pub answer_selected_option_ids: Option<Json>,
         pub answer_custom_answer: Option<String>,

--- a/crates/openwave-core/src/db/migration/baseline/agent_run.rs
+++ b/crates/openwave-core/src/db/migration/baseline/agent_run.rs
@@ -7,24 +7,6 @@ use crate::model::{
     AgentRunCancellationReason, AgentRunStatus, AgentRunWaitCondition, TurnAgentRunWaitStatus,
 };
 
-/// The single-row advisory lock that serializes agent-run claiming.
-pub(super) fn agent_run_claim_lock_table() -> TableCreateStatement {
-    Table::create()
-        .table(AgentRunClaimLock::Table)
-        .col(
-            ColumnDef::new(AgentRunClaimLock::Id)
-                .integer()
-                .not_null()
-                .primary_key(),
-        )
-        .check(Expr::col(AgentRunClaimLock::Id).eq(1))
-        .to_owned()
-}
-
-pub(super) fn agent_run_claim_lock_indexes() -> Vec<IndexCreateStatement> {
-    vec![]
-}
-
 /// A claim token is either unbound or fully bound to one run attempt: the
 /// disjunction is what keeps a half-populated lease from existing.
 pub(super) fn agent_run_claim_table() -> TableCreateStatement {
@@ -768,25 +750,6 @@ pub(super) fn agent_run_inbox_indexes() -> Vec<IndexCreateStatement> {
     vec![]
 }
 
-/// The single-row advisory lock that serializes parking and resuming turns
-/// that wait on agent runs.
-pub(super) fn turn_agent_run_wait_lock_table() -> TableCreateStatement {
-    Table::create()
-        .table(TurnAgentRunWaitLock::Table)
-        .col(
-            ColumnDef::new(TurnAgentRunWaitLock::Id)
-                .integer()
-                .not_null()
-                .primary_key(),
-        )
-        .check(Expr::col(TurnAgentRunWaitLock::Id).eq(1))
-        .to_owned()
-}
-
-pub(super) fn turn_agent_run_wait_lock_indexes() -> Vec<IndexCreateStatement> {
-    vec![]
-}
-
 /// A parked turn waiting on a *set* of child runs. The row doubles as the
 /// tool call that will be answered on resume, so it carries the call's
 /// identity, arguments, and journal position alongside the park accounting.
@@ -812,21 +775,6 @@ pub(super) fn turn_agent_run_wait_set_table() -> TableCreateStatement {
         .col(
             ColumnDef::new(TurnAgentRunWaitSet::ChatId)
                 .uuid()
-                .not_null(),
-        )
-        .col(
-            ColumnDef::new(TurnAgentRunWaitSet::ProviderId)
-                .text()
-                .not_null(),
-        )
-        .col(
-            ColumnDef::new(TurnAgentRunWaitSet::HistoryOrder)
-                .big_integer()
-                .not_null(),
-        )
-        .col(
-            ColumnDef::new(TurnAgentRunWaitSet::Arguments)
-                .json_binary()
                 .not_null(),
         )
         .col(
@@ -916,11 +864,11 @@ pub(super) fn turn_agent_run_wait_set_table() -> TableCreateStatement {
                 .from_tbl(TurnAgentRunWaitSet::Table)
                 .from_col(TurnAgentRunWaitSet::Id)
                 .from_col(TurnAgentRunWaitSet::ChatId)
-                .from_col(TurnAgentRunWaitSet::HistoryOrder)
+                .from_col(TurnAgentRunWaitSet::TurnId)
                 .to_tbl(ToolCall::Table)
                 .to_col(ToolCall::Id)
                 .to_col(ToolCall::ChatId)
-                .to_col(ToolCall::HistoryOrder)
+                .to_col(ToolCall::TurnId)
                 .on_delete(ForeignKeyAction::Restrict),
         )
         .foreign_key(
@@ -951,12 +899,7 @@ pub(super) fn turn_agent_run_wait_set_table() -> TableCreateStatement {
         )
         .check(Expr::col(TurnAgentRunWaitSet::Condition).eq(AgentRunWaitCondition::All.as_str()))
         .check(Expr::col(TurnAgentRunWaitSet::ExpectedSteerRevision).gte(0))
-        .check(Expr::col(TurnAgentRunWaitSet::HistoryOrder).gt(0))
         .check(Expr::col(TurnAgentRunWaitSet::EventOrdinal).between(2, i32::MAX - 1))
-        .check(
-            Func::char_length(Expr::col(TurnAgentRunWaitSet::ProviderId))
-                .between(1, crate::model::ToolCallRecord::MAX_LABEL_LEN as i32),
-        )
         .check(Expr::col(TurnAgentRunWaitSet::AttemptCount).gte(1))
         .check(
             Expr::col(TurnAgentRunWaitSet::ClaimCount)

--- a/crates/openwave-core/src/db/migration/baseline/mod.rs
+++ b/crates/openwave-core/src/db/migration/baseline/mod.rs
@@ -16,12 +16,14 @@ mod sandbox;
 mod tools;
 mod turn;
 
-/// The seed rows the baseline inserts: single-row advisory-lock tables whose
-/// presence is what serializes the claim paths.
+/// The seed rows the baseline inserts: one `advisory_lock` row per claim path,
+/// whose presence is what serializes it. The names come from
+/// [`crate::db::ops::AdvisoryLockName`], which is what the acquire path filters
+/// on.
 pub(super) const SEED_STATEMENTS: &[&str] = &[
-    "INSERT INTO turn_claim_lock (id) VALUES (1) ON CONFLICT DO NOTHING",
-    "INSERT INTO agent_run_claim_lock (id) VALUES (1) ON CONFLICT DO NOTHING",
-    "INSERT INTO turn_agent_run_wait_lock (id) VALUES (1) ON CONFLICT DO NOTHING",
+    "INSERT INTO advisory_lock (name) VALUES ('turn_claim') ON CONFLICT DO NOTHING",
+    "INSERT INTO advisory_lock (name) VALUES ('agent_run_claim') ON CONFLICT DO NOTHING",
+    "INSERT INTO advisory_lock (name) VALUES ('turn_agent_run_wait') ON CONFLICT DO NOTHING",
 ];
 
 /// A table and the named indexes that belong to it. Implicit indexes come
@@ -62,18 +64,12 @@ pub(super) fn tables() -> Vec<BaselineTable> {
             chat::blob_retirement_table(),
             chat::blob_retirement_indexes(),
         ),
+        // The advisory locks every claim path serializes on.
+        entry(turn::advisory_lock_table(), turn::advisory_lock_indexes()),
         // Turn scheduling.
-        entry(
-            turn::turn_claim_lock_table(),
-            turn::turn_claim_lock_indexes(),
-        ),
         entry(turn::turn_claim_table(), turn::turn_claim_indexes()),
         entry(turn::turn_failure_table(), turn::turn_failure_indexes()),
         // Agent runs.
-        entry(
-            agent_run::agent_run_claim_lock_table(),
-            agent_run::agent_run_claim_lock_indexes(),
-        ),
         entry(
             agent_run::agent_run_claim_table(),
             agent_run::agent_run_claim_indexes(),
@@ -120,10 +116,6 @@ pub(super) fn tables() -> Vec<BaselineTable> {
         entry(
             turn::context_checkpoint_table(),
             turn::context_checkpoint_indexes(),
-        ),
-        entry(
-            agent_run::turn_agent_run_wait_lock_table(),
-            agent_run::turn_agent_run_wait_lock_indexes(),
         ),
         // Documents, outputs, and attachments.
         entry(content::document_table(), content::document_indexes()),

--- a/crates/openwave-core/src/db/migration/baseline/tools.rs
+++ b/crates/openwave-core/src/db/migration/baseline/tools.rs
@@ -772,15 +772,6 @@ pub(super) fn user_question_table() -> TableCreateStatement {
                 .not_null(),
         )
         .col(
-            ColumnDef::new(UserQuestion::AnswerOptionId)
-                .string_len(crate::MAX_QUESTION_OPTION_ID_CHARS as u32),
-        )
-        .col(
-            ColumnDef::new(UserQuestion::AnswerFreeForm)
-                .string_len(crate::MAX_FREE_FORM_ANSWER_CHARS as u32),
-        )
-        .col(ColumnDef::new(UserQuestion::AnsweredAt).timestamp_with_time_zone())
-        .col(
             ColumnDef::new(UserQuestion::QuestionType)
                 .string_len(16)
                 .not_null()
@@ -806,20 +797,6 @@ pub(super) fn user_question_table() -> TableCreateStatement {
                 .on_delete(ForeignKeyAction::Restrict),
         )
         .check(Expr::col(UserQuestion::Position).between(0, crate::MAX_USER_QUESTIONS as i32 - 1))
-        .check(
-            Expr::col(UserQuestion::AnswerOptionId)
-                .is_null()
-                .and(Expr::col(UserQuestion::AnswerFreeForm).is_null())
-                .and(Expr::col(UserQuestion::AnsweredAt).is_null())
-                .or(Expr::col(UserQuestion::AnswerOptionId)
-                    .is_not_null()
-                    .and(Expr::col(UserQuestion::AnswerFreeForm).is_null())
-                    .and(Expr::col(UserQuestion::AnsweredAt).is_not_null()))
-                .or(Expr::col(UserQuestion::AnswerOptionId)
-                    .is_null()
-                    .and(Expr::col(UserQuestion::AnswerFreeForm).is_not_null())
-                    .and(Expr::col(UserQuestion::AnsweredAt).is_not_null())),
-        )
         .to_owned()
 }
 

--- a/crates/openwave-core/src/db/migration/baseline/turn.rs
+++ b/crates/openwave-core/src/db/migration/baseline/turn.rs
@@ -5,21 +5,24 @@ use sea_orm_migration::prelude::*;
 use crate::db::migration::idens::*;
 use crate::model::{TurnClientWaitStatus, TurnRunStatus, TurnSteerStatus};
 
-/// Single-row table serializing claim allocation across workers.
-pub(super) fn turn_claim_lock_table() -> TableCreateStatement {
+/// The advisory locks that serialize the claim paths against each other.
+///
+/// One row per lock name, seeded by [`super::SEED_STATEMENTS`]. Taking a lock
+/// is a no-op `UPDATE` of its row, so the row's *existence* is what serializes
+/// workers — a missing row is a hard error rather than an unserialized path.
+pub(super) fn advisory_lock_table() -> TableCreateStatement {
     Table::create()
-        .table(TurnClaimLock::Table)
+        .table(AdvisoryLock::Table)
         .col(
-            ColumnDef::new(TurnClaimLock::Id)
-                .integer()
+            ColumnDef::new(AdvisoryLock::Name)
+                .string_len(64)
                 .not_null()
                 .primary_key(),
         )
-        .check(Expr::col(TurnClaimLock::Id).eq(1))
         .to_owned()
 }
 
-pub(super) fn turn_claim_lock_indexes() -> Vec<IndexCreateStatement> {
+pub(super) fn advisory_lock_indexes() -> Vec<IndexCreateStatement> {
     vec![]
 }
 

--- a/crates/openwave-core/src/db/migration/idens.rs
+++ b/crates/openwave-core/src/db/migration/idens.rs
@@ -246,6 +246,12 @@ pub(crate) enum SandboxSpawnCheckpoint {
 }
 
 #[derive(DeriveIden)]
+pub(crate) enum AdvisoryLock {
+    Table,
+    Name,
+}
+
+#[derive(DeriveIden)]
 pub(crate) enum AgentRunClaim {
     Table,
     Token,
@@ -254,12 +260,6 @@ pub(crate) enum AgentRunClaim {
     ClaimCount,
     ClaimedAt,
     LeaseExpiresAt,
-}
-
-#[derive(DeriveIden)]
-pub(crate) enum AgentRunClaimLock {
-    Table,
-    Id,
 }
 
 #[derive(DeriveIden)]
@@ -322,9 +322,6 @@ pub(crate) enum TurnAgentRunWaitSet {
     ParentRunId,
     TurnId,
     ChatId,
-    ProviderId,
-    HistoryOrder,
-    Arguments,
     Condition,
     ParkLeaseToken,
     ExpectedSteerRevision,
@@ -341,12 +338,6 @@ pub(crate) enum TurnAgentRunWaitSet {
     ParkedAt,
     ClosedAt,
     ResumeToken,
-}
-
-#[derive(DeriveIden)]
-pub(crate) enum TurnAgentRunWaitLock {
-    Table,
-    Id,
 }
 
 #[derive(DeriveIden)]
@@ -577,12 +568,6 @@ pub(crate) enum TurnClaim {
 }
 
 #[derive(DeriveIden)]
-pub(crate) enum TurnClaimLock {
-    Table,
-    Id,
-}
-
-#[derive(DeriveIden)]
 pub(crate) enum TurnFailure {
     Table,
     LeaseToken,
@@ -744,9 +729,6 @@ pub(crate) enum UserQuestion {
     Options,
     QuestionType,
     AllowFreeForm,
-    AnswerOptionId,
-    AnswerFreeForm,
-    AnsweredAt,
     AnswerSelectedOptionIds,
     AnswerCustomAnswer,
     ResponseRecordedAt,

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -1780,21 +1780,7 @@ pub(in crate::db) async fn acquire_agent_run_claim_lock<C>(conn: &C) -> Result<(
 where
     C: sea_orm::ConnectionTrait,
 {
-    let locked = entities::agent_run_claim_lock::Entity::update_many()
-        .col_expr(
-            entities::agent_run_claim_lock::Column::Id,
-            sea_orm::sea_query::Expr::col(entities::agent_run_claim_lock::Column::Id),
-        )
-        .filter(entities::agent_run_claim_lock::Column::Id.eq(1))
-        .exec(conn)
-        .await
-        .map_err(store_err)?;
-    if locked.rows_affected != 1 {
-        return Err(AgentError::Store(
-            "durable agent-run claim lock is missing".into(),
-        ));
-    }
-    Ok(())
+    super::acquire_advisory_lock(conn, super::AdvisoryLockName::AgentRunClaim).await
 }
 
 async fn find_expired_deadline_on<C>(

--- a/crates/openwave-core/src/db/ops/mod.rs
+++ b/crates/openwave-core/src/db/ops/mod.rs
@@ -32,6 +32,63 @@ pub(in crate::db) mod task_plan;
 pub(in crate::db) mod turn;
 pub(in crate::db) mod user_question;
 
+/// The named advisory locks, one row each in `advisory_lock`.
+///
+/// Each serializes a claim path against every other worker taking the same
+/// name. They are separate names rather than one global lock because the paths
+/// are independent: a turn being claimed does not need to exclude an agent run
+/// being claimed.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub(in crate::db) enum AdvisoryLockName {
+    /// Serializes turn claim allocation across workers.
+    TurnClaim,
+    /// Serializes agent-run claim allocation across workers.
+    AgentRunClaim,
+    /// Serializes parking and resuming turns that wait on agent runs.
+    TurnAgentRunWait,
+}
+
+impl AdvisoryLockName {
+    /// The seeded row's primary key. Must match `SEED_STATEMENTS` in the
+    /// baseline — a name with no row is a hard error at acquire time, not a
+    /// silently unserialized path.
+    pub(in crate::db) const fn as_str(self) -> &'static str {
+        match self {
+            Self::TurnClaim => "turn_claim",
+            Self::AgentRunClaim => "agent_run_claim",
+            Self::TurnAgentRunWait => "turn_agent_run_wait",
+        }
+    }
+}
+
+/// Take one named advisory lock for the rest of the transaction.
+///
+/// The no-op `UPDATE` is what acquires it: every backend we support takes a row
+/// write lock held until commit. The row must exist — a missing seed row would
+/// otherwise read as "acquired" and leave the path unserialized, so it is
+/// reported rather than tolerated.
+pub(in crate::db) async fn acquire_advisory_lock<C>(conn: &C, name: AdvisoryLockName) -> Result<()>
+where
+    C: ConnectionTrait,
+{
+    let locked = entities::advisory_lock::Entity::update_many()
+        .col_expr(
+            entities::advisory_lock::Column::Name,
+            sea_orm::sea_query::Expr::col(entities::advisory_lock::Column::Name),
+        )
+        .filter(entities::advisory_lock::Column::Name.eq(name.as_str()))
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+    if locked.rows_affected != 1 {
+        return Err(AgentError::Store(format!(
+            "durable advisory lock {} is missing",
+            name.as_str()
+        )));
+    }
+    Ok(())
+}
+
 /// Acquire the shared cross-backend write lock for one chat row.
 ///
 /// Turn admission and per-chat event sequence allocation use the same lock so

--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -884,21 +884,7 @@ async fn acquire_turn_claim_write_lock<C>(conn: &C) -> Result<()>
 where
     C: ConnectionTrait,
 {
-    let locked = entities::turn_claim_lock::Entity::update_many()
-        .col_expr(
-            entities::turn_claim_lock::Column::Id,
-            sea_orm::sea_query::Expr::col(entities::turn_claim_lock::Column::Id),
-        )
-        .filter(entities::turn_claim_lock::Column::Id.eq(1))
-        .exec(conn)
-        .await
-        .map_err(store_err)?;
-    if locked.rows_affected != 1 {
-        return Err(AgentError::Store(
-            "durable turn claim lock is missing".into(),
-        ));
-    }
-    Ok(())
+    super::acquire_advisory_lock(conn, super::AdvisoryLockName::TurnClaim).await
 }
 
 async fn append_claim_scan_terminal_event_on<C>(

--- a/crates/openwave-core/src/db/ops/turn/multi_agent_run_wait.rs
+++ b/crates/openwave-core/src/db/ops/turn/multi_agent_run_wait.rs
@@ -70,7 +70,6 @@ JOIN turn_run t
   ON t.id = w.turn_id AND t.chat_id = w.chat_id AND t.agent_run_id = w.parent_run_id
 JOIN tool_call tc
   ON tc.id = w.id AND tc.chat_id = w.chat_id AND tc.turn_id = w.turn_id
- AND tc.history_order = w.history_order
 JOIN agent_run p
   ON p.id = w.parent_run_id AND p.chat_id = w.chat_id AND p.depth = 0
 JOIN turn_agent_run_wait_member m
@@ -105,8 +104,7 @@ WHERE w.status = 'waiting' AND w.condition = 'all'
   AND t.cache_read_input_tokens >= w.cache_read_input_tokens
   AND t.cache_creation_input_tokens >= w.cache_creation_input_tokens
   AND p.tier = 'foreground' AND p.status = 'active' AND p.parent_id IS NULL
-  AND tc.provider_id = w.provider_id AND tc.name = 'wait_for_agents'
-  AND tc.arguments = w.arguments AND tc.execution = 'orchestration'
+  AND tc.name = 'wait_for_agents' AND tc.execution = 'orchestration'
   AND tc.status = 'pending' AND tc.result IS NULL AND tc.error_code IS NULL
   AND tc.error_detail IS NULL AND tc.resolved_at IS NULL
   AND tc.client_executor_id IS NULL AND tc.client_lease_token IS NULL
@@ -208,8 +206,6 @@ pub(in crate::db) async fn park_turn_for_agent_run_wait_set(
             && stored.condition == condition.as_str()
             && stored.park_lease_token == lease_token
             && stored.expected_steer_revision == expected_steer_revision
-            && stored.provider_id == request.provider_id
-            && stored.arguments == request.arguments
             && stored.event_ordinal == request.event_ordinal
             && progress_from_model(&stored)? == progress
             && member_ids(&members) == child_run_ids
@@ -402,9 +398,6 @@ pub(in crate::db) async fn park_turn_for_agent_run_wait_set(
         parent_run_id: Set(turn.agent_run_id),
         turn_id: Set(turn.id),
         chat_id: Set(turn.chat_id),
-        provider_id: Set(request.provider_id.clone()),
-        history_order: Set(history_order),
-        arguments: Set(request.arguments.clone()),
         condition: Set(condition.as_str().into()),
         park_lease_token: Set(lease_token),
         expected_steer_revision: Set(expected_steer_revision),
@@ -741,7 +734,6 @@ pub(in crate::db) async fn resume_turn_for_agent_run_wait_set(
         .filter(entities::tool_call::Column::Id.eq(wait_id.0))
         .filter(entities::tool_call::Column::ChatId.eq(stored.chat_id))
         .filter(entities::tool_call::Column::TurnId.eq(stored.turn_id))
-        .filter(entities::tool_call::Column::HistoryOrder.eq(stored.history_order))
         .filter(
             entities::tool_call::Column::Execution.eq(ToolCallExecution::Orchestration.as_str()),
         )
@@ -1136,21 +1128,8 @@ pub(super) async fn acquire_wait_set_lock<C>(conn: &C) -> Result<()>
 where
     C: sea_orm::ConnectionTrait,
 {
-    let locked = entities::turn_agent_run_wait_lock::Entity::update_many()
-        .col_expr(
-            entities::turn_agent_run_wait_lock::Column::Id,
-            sea_orm::sea_query::Expr::col(entities::turn_agent_run_wait_lock::Column::Id),
-        )
-        .filter(entities::turn_agent_run_wait_lock::Column::Id.eq(1))
-        .exec(conn)
+    crate::db::ops::acquire_advisory_lock(conn, crate::db::ops::AdvisoryLockName::TurnAgentRunWait)
         .await
-        .map_err(store_err)?;
-    if locked.rows_affected != 1 {
-        return Err(AgentError::Store(
-            "agent-run wait serialization lock is missing".into(),
-        ));
-    }
-    Ok(())
 }
 
 fn member_ids(members: &[entities::turn_agent_run_wait_member::Model]) -> Vec<AgentRunId> {
@@ -1219,9 +1198,6 @@ fn wait_from_models(
         parent_run_id: AgentRunId(wait.parent_run_id),
         turn_id: TurnId(wait.turn_id),
         chat_id: crate::ChatId(wait.chat_id),
-        provider_id: wait.provider_id.clone(),
-        history_order: wait.history_order,
-        arguments: wait.arguments.clone(),
         child_run_ids: member_ids(&members),
         condition,
         park_lease_token: wait.park_lease_token,

--- a/crates/openwave-core/src/db/ops/turn/multi_agent_run_wait/tool_receipt.rs
+++ b/crates/openwave-core/src/db/ops/turn/multi_agent_run_wait/tool_receipt.rs
@@ -23,7 +23,6 @@ pub(super) fn exact_wait_call_request(
         && call.chat_id == wait.chat_id
         && call.turn_id == wait.turn_id
         && call.provider_id == request.provider_id
-        && call.history_order == wait.history_order
         && call.name == WAIT_FOR_AGENTS_TOOL
         && call.arguments == request.arguments
         && call.execution == ToolCallExecution::Orchestration.as_str()
@@ -124,10 +123,7 @@ pub(super) fn exact_pending_wait_call_model(
     call.id == wait.id
         && call.chat_id == wait.chat_id
         && call.turn_id == wait.turn_id
-        && call.provider_id == wait.provider_id
-        && call.history_order == wait.history_order
         && call.name == WAIT_FOR_AGENTS_TOOL
-        && call.arguments == wait.arguments
         && call.execution == ToolCallExecution::Orchestration.as_str()
         && call.status == ToolCallStatus::Pending.as_str()
         && call.created_at == wait.parked_at
@@ -147,10 +143,7 @@ pub(super) fn exact_terminal_wait_call(
     call.id == wait.id
         && call.chat_id == wait.chat_id
         && call.turn_id == wait.turn_id
-        && call.provider_id == wait.provider_id
-        && call.history_order == wait.history_order
         && call.name == WAIT_FOR_AGENTS_TOOL
-        && call.arguments == wait.arguments
         && call.execution == ToolCallExecution::Orchestration.as_str()
         && call.status == status.as_str()
         && call.created_at == wait.parked_at

--- a/crates/openwave-core/src/db/ops/user_question.rs
+++ b/crates/openwave-core/src/db/ops/user_question.rs
@@ -64,9 +64,6 @@ where
             options: Set(serde_json::to_value(question.options)?),
             question_type: Set(question.question_type.as_str().into()),
             allow_free_form: Set(question.allow_free_form),
-            answer_option_id: Set(None),
-            answer_free_form: Set(None),
-            answered_at: Set(None),
             answer_selected_option_ids: Set(None),
             answer_custom_answer: Set(None),
             response_recorded_at: Set(None),
@@ -666,24 +663,9 @@ fn stored_answers_match(
             continue;
         }
 
-        // Rows answered before the extension used exactly one of the original
-        // scalar columns. Keep exact retries recoverable after upgrading.
-        let Some(expected_answer) = expected_answer else {
-            return Ok(false);
-        };
-        let legacy_matches = match (
-            &question.answer_option_id,
-            &question.answer_free_form,
-            expected_answer.selected_option_ids.as_slice(),
-            &expected_answer.custom_answer,
-        ) {
-            (Some(stored), None, [expected], None) => stored == expected,
-            (None, Some(stored), [], Some(expected)) => stored == expected,
-            _ => false,
-        };
-        if !legacy_matches || question.answered_at.is_none() {
-            return Ok(false);
-        }
+        // Answering stamps every question row, so an unstamped row means this
+        // request is not the one already recorded.
+        return Ok(false);
     }
     Ok(true)
 }

--- a/crates/openwave-core/src/model/turns.rs
+++ b/crates/openwave-core/src/model/turns.rs
@@ -201,6 +201,10 @@ impl AgentRunWaitCondition {
 ///
 /// Child order is part of immutable request identity. Results are returned in
 /// this order even when the children finish in a different order.
+///
+/// The provider-facing identity of the request — provider id, history order,
+/// and canonical arguments — lives on the `wait_for_agents` tool call this
+/// shares an id with, and is not mirrored here.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TurnAgentRunWaitSet {
     /// Stable model-call identity for this wait request.
@@ -211,12 +215,6 @@ pub struct TurnAgentRunWaitSet {
     pub turn_id: TurnId,
     /// Conversation shared by the turn and every child.
     pub chat_id: ChatId,
-    /// Provider-facing identity for the pending orchestration tool use.
-    pub provider_id: String,
-    /// Stable position of the tool use in reconstructed model history.
-    pub history_order: i64,
-    /// Canonical closed `wait_for_agents` arguments.
-    pub arguments: serde_json::Value,
     /// Bounded, unique children in caller-requested order.
     pub child_run_ids: Vec<crate::id::AgentRunId>,
     /// Completion policy committed as immutable request identity.

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -1188,7 +1188,7 @@ async fn postgres_parent_cancellation_uses_time_after_admission_and_heartbeat_lo
     blocker
         .execute_raw(Statement::from_string(
             DatabaseBackend::Postgres,
-            "UPDATE agent_run_claim_lock SET id = id WHERE id = 1",
+            "UPDATE advisory_lock SET name = name WHERE name = 'agent_run_claim'",
         ))
         .await
         .unwrap();
@@ -1821,7 +1821,7 @@ async fn postgres_sandbox_claim_uses_statement_time_after_scheduler_lock_wait() 
     transaction
         .execute_raw(Statement::from_string(
             DatabaseBackend::Postgres,
-            "UPDATE agent_run_claim_lock SET id = id WHERE id = 1",
+            "UPDATE advisory_lock SET name = name WHERE name = 'agent_run_claim'",
         ))
         .await
         .unwrap();

--- a/crates/openwave-server/src/desktop_schema.rs
+++ b/crates/openwave-server/src/desktop_schema.rs
@@ -25,7 +25,7 @@ const VECTOR_DIRECTORY: &str = "vectors";
 const MAX_MARKER_BYTES: u64 = 1_024;
 
 /// Bump this whenever the pre-v1 schema baseline changes incompatibly.
-const DESKTOP_SCHEMA_EPOCH: u32 = 16;
+const DESKTOP_SCHEMA_EPOCH: u32 = 17;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]


### PR DESCRIPTION
Three side tables that duplicated state they could read from their parent, from #1462 step 6. All three are mechanical; none changes behavior a user can observe.

**Advisory locks.** `turn_claim_lock`, `agent_run_claim_lock`, and `turn_agent_run_wait_lock` were one-row tables whose row's existence was the whole content — taking the lock is a no-op `UPDATE` held to commit. They collapse into `advisory_lock(name)` with three seed rows and one `acquire_advisory_lock` helper keyed by an `AdvisoryLockName` enum. The names stay separate rather than becoming one global lock because the paths are independent: claiming a turn does not need to exclude claiming an agent run. A missing seed row is now a reported error rather than a silent success, which the three per-table helpers could not distinguish.

**Wait-set duplicated columns.** `turn_agent_run_wait_set` stored `provider_id`, `history_order`, and `arguments` copied from the `wait_for_agents` tool call it shares a primary key with, and `exact_pending_wait_call_model` / `exact_terminal_wait_call` existed to check the copies had not drifted. Dropping the columns makes the drift unrepresentable, so those comparisons come out with them. The set's FK onto `tool_call` moves from `(id, chat_id, history_order)` to `(id, chat_id, turn_id)`, which the existing unique `idx_tool_call_wait_identity` already covers. The same three fields come off the `TurnAgentRunWaitSet` projection — every outcome variant already returns the tool call alongside it, and the type is not a wire type.

**User-question legacy answers.** `answer_option_id`, `answer_free_form`, and `answered_at` predate multi-select answers, and were superseded by `answer_selected_option_ids` / `answer_custom_answer` / `response_recorded_at`. They come out with their three-branch CHECK and the fallback read in `stored_answers_match`. No backfill: answering stamps `response_recorded_at` on every question row, so an unstamped row simply is not the request being retried. Pre-v1 rows are discarded by the epoch bump either way — see `docs/decisions/0002-pre-v1-schema-and-persisted-format-mutability.md`.

`DESKTOP_SCHEMA_EPOCH` 16 → 17, in this change rather than at the end of the stack, so nobody running `main` between merges holds a database the baseline no longer describes.

Verified locally: `cargo check --workspace --locked --all-targets`, `cargo clippy -p openwave-core -p openwave-server --all-targets`, `cargo test -p openwave-core` (586 pass), `cargo test -p openwave-server` (678 pass), `cargo fmt --check`.

Labeled `full-ci` for the Postgres lane: this moves a composite foreign key onto a different unique index and drops a multi-branch CHECK, and `crates/openwave-core/tests/postgres_turn_state.rs` — which also exercises the advisory lock directly — runs only there.

Part of #1462.
