### PR TITLE
refactor(core): fold sandbox agent admission onto the run row

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -539,31 +539,12 @@ pub mod agent_run {
         pub finished_at: Option<DateTimeUtc>,
         pub last_error_code: Option<String>,
         pub last_error_detail: Option<String>,
-        pub created_at: DateTimeUtc,
-        pub updated_at: DateTimeUtc,
-    }
-
-    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
-    pub enum Relation {}
-
-    impl ActiveModelBehavior for ActiveModel {}
-}
-
-pub mod sandbox_agent_admission {
-    use sea_orm::entity::prelude::*;
-
-    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
-    #[sea_orm(table_name = "sandbox_agent_admission")]
-    pub struct Model {
-        #[sea_orm(primary_key, auto_increment = false)]
-        pub child_run_id: Uuid,
-        pub parent_run_id: Uuid,
-        pub origin_turn_id: Uuid,
-        pub chat_id: Uuid,
-        pub spawn_call_id: Uuid,
+        pub origin_turn_id: Option<Uuid>,
         pub delegated_root_id: Option<Uuid>,
         pub delegated_relative_path: Option<String>,
-        pub admitted_at: DateTimeUtc,
+        pub admitted_at: Option<DateTimeUtc>,
+        pub created_at: DateTimeUtc,
+        pub updated_at: DateTimeUtc,
     }
 
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/openwave-core/src/db/migration/baseline/agent_run.rs
+++ b/crates/openwave-core/src/db/migration/baseline/agent_run.rs
@@ -74,6 +74,25 @@ pub(super) fn agent_run_claim_indexes() -> Vec<IndexCreateStatement> {
     ]
 }
 
+/// An admitted sandbox child carries the turn that spawned it, and a delegated
+/// root is a pair or nothing at all.
+///
+/// `admitted_at` is the discriminator: it is set exactly on the runs that came
+/// in through a spawn call, and those are the runs that have an origin turn.
+fn agent_run_admission_check() -> SimpleExpr {
+    Expr::col(AgentRun::AdmittedAt)
+        .is_null()
+        .or(Expr::col(AgentRun::OriginTurnId).is_not_null())
+        .and(
+            Expr::col(AgentRun::DelegatedRootId)
+                .is_null()
+                .and(Expr::col(AgentRun::DelegatedRelativePath).is_null())
+                .or(Expr::col(AgentRun::DelegatedRootId)
+                    .is_not_null()
+                    .and(Expr::col(AgentRun::DelegatedRelativePath).is_not_null())),
+        )
+}
+
 pub(super) fn agent_run_table() -> TableCreateStatement {
     Table::create()
         .table(AgentRun::Table)
@@ -116,6 +135,14 @@ pub(super) fn agent_run_table() -> TableCreateStatement {
             ColumnDef::new(AgentRun::LastErrorDetail)
                 .string_len(crate::model::AgentRun::MAX_ERROR_DETAIL_LEN as u32),
         )
+        // The admission facts for a sandbox-hosted child: the turn that spawned
+        // it, the optional delegated root it may reach, and when it was
+        // admitted. Null on every run that was not admitted through a spawn
+        // call, which is what `admitted_at` discriminates on.
+        .col(ColumnDef::new(AgentRun::OriginTurnId).uuid())
+        .col(ColumnDef::new(AgentRun::DelegatedRootId).uuid())
+        .col(ColumnDef::new(AgentRun::DelegatedRelativePath).text())
+        .col(ColumnDef::new(AgentRun::AdmittedAt).timestamp_with_time_zone())
         .col(
             ColumnDef::new(AgentRun::CreatedAt)
                 .timestamp_with_time_zone()
@@ -168,7 +195,14 @@ pub(super) fn agent_run_table() -> TableCreateStatement {
                 .to_col(AgentRunClaim::ClaimCount)
                 .on_delete(ForeignKeyAction::Restrict),
         )
+        // `origin_turn_id` carries no foreign key, unlike the admission row it
+        // replaces. `turn_run` already references `agent_run`, so a key back the
+        // other way is a cycle, and neither engine can add one after both tables
+        // exist — SQLite has no `ALTER TABLE ADD CONSTRAINT` at all. The turn is
+        // read and fenced in the same transaction that admits the child, which
+        // is the only writer that sets this column.
         .check(agent_run_shape_check())
+        .check(agent_run_admission_check())
         .check(agent_run_lease_check())
         .check(agent_run_finished_check())
         .check(agent_run_error_check())
@@ -206,6 +240,26 @@ pub(super) fn agent_run_indexes() -> Vec<IndexCreateStatement> {
             .col(AgentRun::ChatId)
             .col(AgentRun::SpawnCallId)
             .unique()
+            .to_owned(),
+        // Backs `fk_turn_agent_run_wait_member_admission`: a wait member names
+        // the child it waits on together with the turn and parent that admitted
+        // it, and this is what makes that quadruple addressable.
+        Index::create()
+            .name("idx_agent_run_wait_owner")
+            .table(AgentRun::Table)
+            .col(AgentRun::Id)
+            .col(AgentRun::OriginTurnId)
+            .col(AgentRun::ParentId)
+            .col(AgentRun::ChatId)
+            .unique()
+            .to_owned(),
+        // Outstanding admitted children of one turn, oldest first.
+        Index::create()
+            .name("idx_agent_run_admitted_outstanding")
+            .table(AgentRun::Table)
+            .col(AgentRun::OriginTurnId)
+            .col(AgentRun::AdmittedAt)
+            .col(AgentRun::Id)
             .to_owned(),
         Index::create()
             .name("idx_agent_run_spawn_call")
@@ -1027,11 +1081,11 @@ pub(super) fn turn_agent_run_wait_member_table() -> TableCreateStatement {
                 .from_col(TurnAgentRunWaitMember::OriginTurnId)
                 .from_col(TurnAgentRunWaitMember::ParentRunId)
                 .from_col(TurnAgentRunWaitMember::ChatId)
-                .to_tbl(SandboxAgentAdmission::Table)
-                .to_col(SandboxAgentAdmission::ChildRunId)
-                .to_col(SandboxAgentAdmission::OriginTurnId)
-                .to_col(SandboxAgentAdmission::ParentRunId)
-                .to_col(SandboxAgentAdmission::ChatId)
+                .to_tbl(AgentRun::Table)
+                .to_col(AgentRun::Id)
+                .to_col(AgentRun::OriginTurnId)
+                .to_col(AgentRun::ParentId)
+                .to_col(AgentRun::ChatId)
                 .on_delete(ForeignKeyAction::Restrict),
         )
         .check(Expr::col(TurnAgentRunWaitMember::Position).gte(0))

--- a/crates/openwave-core/src/db/migration/baseline/mod.rs
+++ b/crates/openwave-core/src/db/migration/baseline/mod.rs
@@ -152,10 +152,6 @@ pub(super) fn tables() -> Vec<BaselineTable> {
             sandbox::sandbox_provision_indexes(),
         ),
         entry(
-            sandbox::sandbox_agent_admission_table(),
-            sandbox::sandbox_agent_admission_indexes(),
-        ),
-        entry(
             sandbox::sandbox_tool_call_table(),
             sandbox::sandbox_tool_call_indexes(),
         ),
@@ -171,7 +167,7 @@ pub(super) fn tables() -> Vec<BaselineTable> {
             sandbox::exec_file_change_table(),
             sandbox::exec_file_change_indexes(),
         ),
-        // Multi-agent wait sets, which reference sandbox admissions.
+        // Multi-agent wait sets, which reference the admitted child runs.
         entry(
             agent_run::turn_agent_run_wait_set_table(),
             agent_run::turn_agent_run_wait_set_indexes(),

--- a/crates/openwave-core/src/db/migration/baseline/sandbox.rs
+++ b/crates/openwave-core/src/db/migration/baseline/sandbox.rs
@@ -100,107 +100,6 @@ pub(super) fn sandbox_provision_indexes() -> Vec<IndexCreateStatement> {
     vec![]
 }
 
-/// The admission record for a sandbox-hosted child agent run: the spawn call
-/// that admitted it, the parent run and origin turn it belongs to, and the
-/// optional delegated root the child may reach.
-pub(super) fn sandbox_agent_admission_table() -> TableCreateStatement {
-    Table::create()
-        .table(SandboxAgentAdmission::Table)
-        .col(
-            ColumnDef::new(SandboxAgentAdmission::ChildRunId)
-                .uuid()
-                .not_null()
-                .primary_key(),
-        )
-        .col(
-            ColumnDef::new(SandboxAgentAdmission::ParentRunId)
-                .uuid()
-                .not_null(),
-        )
-        .col(
-            ColumnDef::new(SandboxAgentAdmission::OriginTurnId)
-                .uuid()
-                .not_null(),
-        )
-        .col(
-            ColumnDef::new(SandboxAgentAdmission::ChatId)
-                .uuid()
-                .not_null(),
-        )
-        .col(
-            ColumnDef::new(SandboxAgentAdmission::SpawnCallId)
-                .uuid()
-                .not_null()
-                .unique_key(),
-        )
-        .col(ColumnDef::new(SandboxAgentAdmission::DelegatedRootId).uuid())
-        .col(ColumnDef::new(SandboxAgentAdmission::DelegatedRelativePath).text())
-        .col(
-            ColumnDef::new(SandboxAgentAdmission::AdmittedAt)
-                .timestamp_with_time_zone()
-                .not_null(),
-        )
-        .foreign_key(
-            ForeignKey::create()
-                .name("fk_sandbox_agent_admission_child")
-                .from_tbl(SandboxAgentAdmission::Table)
-                .from_col(SandboxAgentAdmission::ChildRunId)
-                .from_col(SandboxAgentAdmission::ParentRunId)
-                .from_col(SandboxAgentAdmission::ChatId)
-                .from_col(SandboxAgentAdmission::SpawnCallId)
-                .to_tbl(AgentRun::Table)
-                .to_col(AgentRun::Id)
-                .to_col(AgentRun::ParentId)
-                .to_col(AgentRun::ChatId)
-                .to_col(AgentRun::SpawnCallId)
-                .on_delete(ForeignKeyAction::Cascade),
-        )
-        .foreign_key(
-            ForeignKey::create()
-                .name("fk_sandbox_agent_admission_origin_turn")
-                .from_tbl(SandboxAgentAdmission::Table)
-                .from_col(SandboxAgentAdmission::OriginTurnId)
-                .from_col(SandboxAgentAdmission::ChatId)
-                .from_col(SandboxAgentAdmission::ParentRunId)
-                .to_tbl(TurnRun::Table)
-                .to_col(TurnRun::Id)
-                .to_col(TurnRun::ChatId)
-                .to_col(TurnRun::AgentRunId)
-                .on_delete(ForeignKeyAction::Cascade),
-        )
-        // A delegated root is a pair or nothing at all.
-        .check(
-            Expr::col(SandboxAgentAdmission::DelegatedRootId)
-                .is_null()
-                .and(Expr::col(SandboxAgentAdmission::DelegatedRelativePath).is_null())
-                .or(Expr::col(SandboxAgentAdmission::DelegatedRootId)
-                    .is_not_null()
-                    .and(Expr::col(SandboxAgentAdmission::DelegatedRelativePath).is_not_null())),
-        )
-        .to_owned()
-}
-
-pub(super) fn sandbox_agent_admission_indexes() -> Vec<IndexCreateStatement> {
-    vec![
-        Index::create()
-            .name("idx_sandbox_agent_admission_outstanding")
-            .table(SandboxAgentAdmission::Table)
-            .col(SandboxAgentAdmission::OriginTurnId)
-            .col(SandboxAgentAdmission::AdmittedAt)
-            .col(SandboxAgentAdmission::ChildRunId)
-            .to_owned(),
-        Index::create()
-            .name("idx_sandbox_agent_admission_wait_owner")
-            .table(SandboxAgentAdmission::Table)
-            .col(SandboxAgentAdmission::ChildRunId)
-            .col(SandboxAgentAdmission::OriginTurnId)
-            .col(SandboxAgentAdmission::ParentRunId)
-            .col(SandboxAgentAdmission::ChatId)
-            .unique()
-            .to_owned(),
-    ]
-}
-
 /// A tool call a sandboxed agent run issued, parked against the claim that
 /// owns the run and leased out to whichever executor picks it up.
 /// `retry_wait` parks one classified-transient failure until its single
@@ -512,11 +411,11 @@ pub(super) fn sandbox_spawn_checkpoint_table() -> TableCreateStatement {
                 .from_col(SandboxSpawnCheckpoint::OriginTurnId)
                 .from_col(SandboxSpawnCheckpoint::ParentRunId)
                 .from_col(SandboxSpawnCheckpoint::ChatId)
-                .to_tbl(SandboxAgentAdmission::Table)
-                .to_col(SandboxAgentAdmission::ChildRunId)
-                .to_col(SandboxAgentAdmission::OriginTurnId)
-                .to_col(SandboxAgentAdmission::ParentRunId)
-                .to_col(SandboxAgentAdmission::ChatId)
+                .to_tbl(AgentRun::Table)
+                .to_col(AgentRun::Id)
+                .to_col(AgentRun::OriginTurnId)
+                .to_col(AgentRun::ParentId)
+                .to_col(AgentRun::ChatId)
                 .on_delete(ForeignKeyAction::Restrict),
         )
         .foreign_key(

--- a/crates/openwave-core/src/db/migration/idens.rs
+++ b/crates/openwave-core/src/db/migration/idens.rs
@@ -201,21 +201,12 @@ pub(crate) enum AgentRun {
     FinishedAt,
     LastErrorCode,
     LastErrorDetail,
-    CreatedAt,
-    UpdatedAt,
-}
-
-#[derive(DeriveIden)]
-pub(crate) enum SandboxAgentAdmission {
-    Table,
-    ChildRunId,
-    ParentRunId,
     OriginTurnId,
-    ChatId,
-    SpawnCallId,
     DelegatedRootId,
     DelegatedRelativePath,
     AdmittedAt,
+    CreatedAt,
+    UpdatedAt,
 }
 
 #[derive(DeriveIden)]

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -67,6 +67,11 @@ where
         finished_at: Set(None),
         last_error_code: Set(None),
         last_error_detail: Set(None),
+        // Only a sandbox child admitted through a spawn call carries these.
+        origin_turn_id: Set(None),
+        delegated_root_id: Set(None),
+        delegated_relative_path: Set(None),
+        admitted_at: Set(None),
         created_at: Set(created_at),
         updated_at: Set(created_at),
     }
@@ -198,6 +203,11 @@ pub(in crate::db) async fn accept_agent_run(
         finished_at: Set(None),
         last_error_code: Set(None),
         last_error_detail: Set(None),
+        // Only a sandbox child admitted through a spawn call carries these.
+        origin_turn_id: Set(None),
+        delegated_root_id: Set(None),
+        delegated_relative_path: Set(None),
+        admitted_at: Set(None),
         created_at: Set(now),
         updated_at: Set(now),
     };
@@ -389,10 +399,10 @@ pub(in crate::db) async fn get_sandbox_agent_admission(
     store: &DbStore,
     child_run_id: AgentRunId,
 ) -> Result<Option<SandboxAgentAdmission>> {
-    entities::sandbox_agent_admission::Entity::find_by_id(child_run_id.0)
-        .one(&store.conn)
-        .await
-        .map_err(store_err)?
+    find_by_id_on(&store.conn, child_run_id)
+        .await?
+        .filter(|run| run.admitted_at.is_some())
+        .as_ref()
         .map(sandbox_agent_admission_from_model)
         .transpose()
 }
@@ -534,28 +544,21 @@ where
         finished_at: Set(None),
         last_error_code: Set(None),
         last_error_detail: Set(None),
+        // The admission facts ride on the run itself. One insert, so a child
+        // row and its admission can no longer disagree.
+        origin_turn_id: Set(Some(origin_turn_id.0)),
+        delegated_root_id: Set(resource.map(|resource| *resource.root_id.as_uuid())),
+        delegated_relative_path: Set(resource.map(|resource| resource.relative_path.clone())),
+        admitted_at: Set(Some(created_at)),
         created_at: Set(created_at),
         updated_at: Set(created_at),
     }
     .insert(conn)
     .await
     .map_err(store_err)?;
-    let admission = entities::sandbox_agent_admission::ActiveModel {
-        child_run_id: Set(child_run_id.0),
-        parent_run_id: Set(parent_id.0),
-        origin_turn_id: Set(origin_turn_id.0),
-        chat_id: Set(chat_id.0),
-        spawn_call_id: Set(spawn_call_id.0),
-        delegated_root_id: Set(resource.map(|resource| *resource.root_id.as_uuid())),
-        delegated_relative_path: Set(resource.map(|resource| resource.relative_path.clone())),
-        admitted_at: Set(created_at),
-    }
-    .insert(conn)
-    .await
-    .map_err(store_err)?;
     Ok(AdmitSandboxAgentRunOutcome::Accepted {
+        admission: sandbox_agent_admission_from_model(&child)?,
         child: agent_run_from_model(child)?,
-        admission: sandbox_agent_admission_from_model(admission)?,
     })
 }
 
@@ -572,42 +575,41 @@ where
     C: sea_orm::ConnectionTrait,
 {
     let child_run_id = AgentRunId::sandbox_for_spawn_call(spawn_call_id);
-    let existing_admission = entities::sandbox_agent_admission::Entity::find()
+    let Some(child) = entities::agent_run::Entity::find()
         .filter(
             Condition::any()
-                .add(entities::sandbox_agent_admission::Column::ChildRunId.eq(child_run_id.0))
-                .add(entities::sandbox_agent_admission::Column::SpawnCallId.eq(spawn_call_id.0)),
+                .add(entities::agent_run::Column::Id.eq(child_run_id.0))
+                .add(entities::agent_run::Column::SpawnCallId.eq(spawn_call_id.0)),
         )
         .one(conn)
         .await
-        .map_err(store_err)?;
-    if let Some(admission) = existing_admission {
-        let child = find_by_id_on(conn, AgentRunId(admission.child_run_id)).await?;
-        let exact = admission.child_run_id == child_run_id.0
-            && admission.parent_run_id == parent_id.0
-            && admission.origin_turn_id == origin_turn_id.0
-            && admission.chat_id == chat_id.0
-            && admission.spawn_call_id == spawn_call_id.0
-            && admission.delegated_root_id == resource.map(|resource| *resource.root_id.as_uuid())
-            && admission.delegated_relative_path.as_deref()
-                == resource.map(|resource| resource.relative_path.as_str())
-            && child.as_ref().is_some_and(|child| {
-                child.chat_id == chat_id.0
-                    && child.parent_id == Some(parent_id.0)
-                    && child.spawn_call_id == Some(spawn_call_id.0)
-                    && child.tier == AgentRunTier::Background.as_str()
-                    && child.input.as_deref() == Some(input)
-            });
-        return Ok(Some(if exact {
-            AdmitSandboxAgentRunOutcome::Existing {
-                child: agent_run_from_model(child.expect("exact admission has child"))?,
-                admission: sandbox_agent_admission_from_model(admission)?,
-            }
-        } else {
-            AdmitSandboxAgentRunOutcome::IdentityConflict
-        }));
-    }
-    Ok(None)
+        .map_err(store_err)?
+        .filter(|run| run.admitted_at.is_some())
+    else {
+        return Ok(None);
+    };
+    // The admission facts are columns of this row now, so the pairwise drift
+    // check the two tables needed is gone: there is nothing left for the run
+    // and its admission to disagree about. What remains is whether this retry
+    // describes the same spawn as the one already admitted.
+    let exact = child.id == child_run_id.0
+        && child.chat_id == chat_id.0
+        && child.parent_id == Some(parent_id.0)
+        && child.origin_turn_id == Some(origin_turn_id.0)
+        && child.spawn_call_id == Some(spawn_call_id.0)
+        && child.delegated_root_id == resource.map(|resource| *resource.root_id.as_uuid())
+        && child.delegated_relative_path.as_deref()
+            == resource.map(|resource| resource.relative_path.as_str())
+        && child.tier == AgentRunTier::Background.as_str()
+        && child.input.as_deref() == Some(input);
+    Ok(Some(if exact {
+        AdmitSandboxAgentRunOutcome::Existing {
+            admission: sandbox_agent_admission_from_model(&child)?,
+            child: agent_run_from_model(child)?,
+        }
+    } else {
+        AdmitSandboxAgentRunOutcome::IdentityConflict
+    }))
 }
 
 pub(in crate::db) async fn get_agent_run(
@@ -653,15 +655,10 @@ pub(in crate::db) async fn claim_agent_run(
                 transaction.commit().await.map_err(store_err)?;
                 return Ok(None);
             };
-            let admitted = entities::sandbox_agent_admission::Entity::find_by_id(agent_run_id)
-                .one(&transaction)
-                .await
-                .map_err(store_err)?
-                .is_some();
             let existing = find_by_id_on(&transaction, AgentRunId(agent_run_id))
                 .await?
                 .filter(|run| {
-                    admitted
+                    run.admitted_at.is_some()
                         && run.tier == AgentRunTier::Background.as_str()
                         && matches!(run.status.as_str(), "running" | "cancelling")
                         && Some(run.attempt_count) == receipt.attempt_count
@@ -927,12 +924,7 @@ pub(in crate::db) async fn claim_container_agent_run(
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
     };
-    let admitted = entities::sandbox_agent_admission::Entity::find_by_id(candidate.id)
-        .one(&transaction)
-        .await
-        .map_err(store_err)?
-        .is_some();
-    let claimable = admitted
+    let claimable = candidate.admitted_at.is_some()
         && candidate.tier == AgentRunTier::Background.as_str()
         && candidate.execution_location == AgentRunExecutionLocation::Container.as_str()
         && candidate.status == AgentRunStatus::Queued.as_str()
@@ -1930,8 +1922,9 @@ where
 
 fn admitted_child_id_subquery() -> sea_orm::sea_query::SelectStatement {
     sea_orm::sea_query::Query::select()
-        .column(entities::sandbox_agent_admission::Column::ChildRunId)
-        .from(entities::sandbox_agent_admission::Entity)
+        .column(entities::agent_run::Column::Id)
+        .from(entities::agent_run::Entity)
+        .and_where(entities::agent_run::Column::AdmittedAt.is_not_null())
         .to_owned()
 }
 
@@ -2281,15 +2274,24 @@ pub(in crate::db) fn agent_run_from_model(model: entities::agent_run::Model) -> 
     })
 }
 
-fn sandbox_agent_admission_from_model(
-    model: entities::sandbox_agent_admission::Model,
+/// Project the admission view of an admitted sandbox child from its run row.
+///
+/// The caller has already established that this run was admitted; the `NOT
+/// NULL` unwraps below are the schema's `admitted_at IS NOT NULL` implies
+/// `origin_turn_id IS NOT NULL` CHECK read back, and a row that violates them
+/// is reported rather than silently reshaped.
+pub(super) fn sandbox_agent_admission_from_model(
+    model: &entities::agent_run::Model,
 ) -> Result<SandboxAgentAdmission> {
-    let resource = match (model.delegated_root_id, model.delegated_relative_path) {
+    let resource = match (
+        model.delegated_root_id,
+        model.delegated_relative_path.as_deref(),
+    ) {
         (Some(root_id), Some(relative_path)) => Some(SandboxAgentFileResource {
             root_id: crate::HostRootId::from_uuid(root_id).map_err(|error| {
                 AgentError::Store(format!("invalid delegated root id: {error}"))
             })?,
-            relative_path,
+            relative_path: relative_path.to_owned(),
         }),
         (None, None) => None,
         _ => {
@@ -2298,14 +2300,15 @@ fn sandbox_agent_admission_from_model(
             ));
         }
     };
+    let invalid = || AgentError::Store("invalid stored sandbox agent admission".into());
     let admission = SandboxAgentAdmission {
-        child_run_id: AgentRunId(model.child_run_id),
-        parent_run_id: AgentRunId(model.parent_run_id),
-        origin_turn_id: TurnId(model.origin_turn_id),
+        child_run_id: AgentRunId(model.id),
+        parent_run_id: AgentRunId(model.parent_id.ok_or_else(invalid)?),
+        origin_turn_id: TurnId(model.origin_turn_id.ok_or_else(invalid)?),
         chat_id: ChatId(model.chat_id),
-        spawn_call_id: CallId(model.spawn_call_id),
+        spawn_call_id: CallId(model.spawn_call_id.ok_or_else(invalid)?),
         resource,
-        admitted_at: model.admitted_at,
+        admitted_at: model.admitted_at.ok_or_else(invalid)?,
     };
     if admission.child_run_id != AgentRunId::sandbox_for_spawn_call(admission.spawn_call_id)
         || admission.parent_run_id.0.is_nil()
@@ -2316,9 +2319,7 @@ fn sandbox_agent_admission_from_model(
             .as_ref()
             .is_some_and(|resource| !resource.is_well_formed())
     {
-        return Err(AgentError::Store(
-            "invalid stored sandbox agent admission".into(),
-        ));
+        return Err(invalid());
     }
     Ok(admission)
 }

--- a/crates/openwave-core/src/db/ops/agent_run/cancellation.rs
+++ b/crates/openwave-core/src/db/ops/agent_run/cancellation.rs
@@ -242,6 +242,30 @@ pub(in crate::db) async fn finish_agent_run_cancellation(
 /// Keeping the outer scheduler lock makes cancellation-request provenance and
 /// the child lifecycle transition one serial decision with worker claims,
 /// direct cancellation, acknowledgements, and reaping.
+/// The admitted sandbox children of one origin turn, oldest admission first.
+///
+/// The parent-run and chat agreement the separate admission table had to be
+/// checked for is now the same row's `parent_id`/`chat_id`, so the filter
+/// states it instead of validating it afterwards.
+async fn admitted_children_of_origin_turn_on<C>(
+    conn: &C,
+    turn: &entities::turn_run::Model,
+) -> Result<Vec<entities::agent_run::Model>>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    entities::agent_run::Entity::find()
+        .filter(entities::agent_run::Column::OriginTurnId.eq(turn.id))
+        .filter(entities::agent_run::Column::AdmittedAt.is_not_null())
+        .filter(entities::agent_run::Column::ParentId.eq(turn.agent_run_id))
+        .filter(entities::agent_run::Column::ChatId.eq(turn.chat_id))
+        .order_by_asc(entities::agent_run::Column::AdmittedAt)
+        .order_by_asc(entities::agent_run::Column::Id)
+        .all(conn)
+        .await
+        .map_err(store_err)
+}
+
 pub(in crate::db) async fn cancel_sandbox_children_for_origin_turn_on<C>(
     conn: &C,
     turn: &entities::turn_run::Model,
@@ -251,33 +275,12 @@ pub(in crate::db) async fn cancel_sandbox_children_for_origin_turn_on<C>(
 where
     C: sea_orm::ConnectionTrait,
 {
-    let admissions = entities::sandbox_agent_admission::Entity::find()
-        .filter(entities::sandbox_agent_admission::Column::OriginTurnId.eq(turn.id))
-        .order_by_asc(entities::sandbox_agent_admission::Column::AdmittedAt)
-        .order_by_asc(entities::sandbox_agent_admission::Column::ChildRunId)
-        .all(conn)
-        .await
-        .map_err(store_err)?;
-    for admission in admissions {
-        if admission.parent_run_id != turn.agent_run_id || admission.chat_id != turn.chat_id {
+    let children = admitted_children_of_origin_turn_on(conn, turn).await?;
+    for child in children {
+        let child_id = AgentRunId(child.id);
+        if child.tier != AgentRunTier::Background.as_str() {
             return Err(AgentError::Store(format!(
-                "sandbox admission {} does not match origin turn {}",
-                admission.child_run_id, turn.id
-            )));
-        }
-        let child_id = AgentRunId(admission.child_run_id);
-        let Some(child) = find_by_id_on(conn, child_id).await? else {
-            return Err(AgentError::Store(format!(
-                "sandbox admission references missing child {child_id}"
-            )));
-        };
-        if child.parent_id != Some(turn.agent_run_id)
-            || child.chat_id != turn.chat_id
-            || child.tier != AgentRunTier::Background.as_str()
-            || child.spawn_call_id != Some(admission.spawn_call_id)
-        {
-            return Err(AgentError::Store(format!(
-                "sandbox child {child_id} does not match its admission"
+                "sandbox child {child_id} is not a background run"
             )));
         }
         agent_run_from_model(child.clone())?;
@@ -364,39 +367,23 @@ where
         )));
     }
 
-    let admissions = entities::sandbox_agent_admission::Entity::find()
-        .filter(entities::sandbox_agent_admission::Column::OriginTurnId.eq(turn.id))
-        .order_by_asc(entities::sandbox_agent_admission::Column::AdmittedAt)
-        .order_by_asc(entities::sandbox_agent_admission::Column::ChildRunId)
-        .all(conn)
-        .await
-        .map_err(store_err)?;
-    let mut unsettled = Vec::with_capacity(admissions.len());
-    for admission in admissions {
-        if admission.parent_run_id != turn.agent_run_id
-            || admission.chat_id != turn.chat_id
-            || AgentRunId(admission.child_run_id)
-                != AgentRunId::sandbox_for_spawn_call(crate::CallId(admission.spawn_call_id))
-        {
+    let children = admitted_children_of_origin_turn_on(conn, turn).await?;
+    let mut unsettled = Vec::with_capacity(children.len());
+    for child in children {
+        let child_id = AgentRunId(child.id);
+        if child.spawn_call_id.is_none_or(|spawn_call_id| {
+            child_id != AgentRunId::sandbox_for_spawn_call(crate::CallId(spawn_call_id))
+        }) {
             return Err(AgentError::Store(format!(
-                "sandbox admission {} does not match origin turn {}",
-                admission.child_run_id, turn.id
+                "sandbox child {child_id} does not derive from its spawn call"
             )));
         }
-        let child_id = AgentRunId(admission.child_run_id);
-        let child = find_by_id_on(conn, child_id).await?.ok_or_else(|| {
-            AgentError::Store(format!(
-                "sandbox admission references missing child {child_id}"
-            ))
-        })?;
-        if child.parent_id != Some(turn.agent_run_id)
-            || child.chat_id != turn.chat_id
+        if child.chat_id != turn.chat_id
             || child.tier != AgentRunTier::Background.as_str()
             || child.depth != 1
-            || child.spawn_call_id != Some(admission.spawn_call_id)
         {
             return Err(AgentError::Store(format!(
-                "sandbox child {child_id} does not match its admission"
+                "sandbox child {child_id} does not match its origin turn"
             )));
         }
         agent_run_from_model(child.clone())?;
@@ -527,14 +514,9 @@ where
             run.id
         )));
     };
-    let admission = entities::sandbox_agent_admission::Entity::find_by_id(run.id)
-        .one(conn)
-        .await
-        .map_err(store_err)?
-        .ok_or_else(|| AgentError::Store(format!("sandbox run {} is missing admission", run.id)))?;
-    if admission.parent_run_id != parent_id || admission.chat_id != run.chat_id {
+    if run.admitted_at.is_none() {
         return Err(AgentError::Store(format!(
-            "sandbox run {} has a mismatched admission",
+            "sandbox run {} was never admitted",
             run.id
         )));
     }
@@ -771,12 +753,8 @@ async fn cancellation_context_on<C>(
 where
     C: sea_orm::ConnectionTrait,
 {
-    let admission = entities::sandbox_agent_admission::Entity::find_by_id(run.id)
-        .one(conn)
-        .await
-        .map_err(store_err)?
-        .ok_or_else(|| AgentError::Store(format!("sandbox run {} is missing admission", run.id)))?;
-    let turn = entities::turn_run::Entity::find_by_id(admission.origin_turn_id)
+    let admission = super::sandbox_agent_admission_from_model(run)?;
+    let turn = entities::turn_run::Entity::find_by_id(admission.origin_turn_id.0)
         .one(conn)
         .await
         .map_err(store_err)?
@@ -786,7 +764,7 @@ where
                 run.id
             ))
         })?;
-    if turn.agent_run_id != admission.parent_run_id || turn.chat_id != admission.chat_id {
+    if turn.agent_run_id != admission.parent_run_id.0 || turn.chat_id != admission.chat_id.0 {
         return Err(AgentError::Store(format!(
             "sandbox admission {} does not match its origin turn",
             run.id
@@ -932,16 +910,7 @@ where
                 run.id
             ))
         })?;
-    let admission = entities::sandbox_agent_admission::Entity::find_by_id(run.id)
-        .one(conn)
-        .await
-        .map_err(store_err)?
-        .ok_or_else(|| {
-            AgentError::Store(format!(
-                "cancelling sandbox run {} is missing admission",
-                run.id
-            ))
-        })?;
+    let admission = super::sandbox_agent_admission_from_model(run)?;
     let valid = run.tier == AgentRunTier::Background.as_str()
         && run.status == AgentRunStatus::Cancelling.as_str()
         && run.lease_token == Some(receipt.lease_token)
@@ -950,8 +919,7 @@ where
         && claim.agent_run_id == Some(run.id)
         && claim.attempt_count == Some(receipt.attempt_count)
         && claim.claim_count == Some(receipt.claim_count)
-        && admission.parent_run_id == run.parent_id.unwrap_or_default()
-        && admission.chat_id == run.chat_id;
+        && Some(admission.parent_run_id.0) == run.parent_id;
     if !valid {
         return Err(AgentError::Store(format!(
             "sandbox cancellation request does not match live run {}",
@@ -988,16 +956,7 @@ where
             run.id
         ))
     })?;
-    let admission = entities::sandbox_agent_admission::Entity::find_by_id(run.id)
-        .one(conn)
-        .await
-        .map_err(store_err)?
-        .ok_or_else(|| {
-            AgentError::Store(format!(
-                "cancelled sandbox run {} is missing admission",
-                run.id
-            ))
-        })?;
+    let admission = super::sandbox_agent_admission_from_model(run)?;
     let result_model = entities::agent_run_result::Entity::find_by_id(run.id)
         .one(conn)
         .await
@@ -1019,7 +978,7 @@ where
                 run.id
             ))
         })?;
-    let origin_turn = entities::turn_run::Entity::find_by_id(admission.origin_turn_id)
+    let origin_turn = entities::turn_run::Entity::find_by_id(admission.origin_turn_id.0)
         .one(conn)
         .await
         .map_err(store_err)?
@@ -1029,18 +988,14 @@ where
                 run.id
             ))
         })?;
-    let inbox_model = find_agent_run_inbox_on(
-        conn,
-        AgentRunId(admission.parent_run_id),
-        AgentRunId(run.id),
-    )
-    .await?
-    .ok_or_else(|| {
-        AgentError::Store(format!(
-            "cancelled sandbox run {} is missing inbox delivery",
-            run.id
-        ))
-    })?;
+    let inbox_model = find_agent_run_inbox_on(conn, admission.parent_run_id, AgentRunId(run.id))
+        .await?
+        .ok_or_else(|| {
+            AgentError::Store(format!(
+                "cancelled sandbox run {} is missing inbox delivery",
+                run.id
+            ))
+        })?;
     let inbox = load_agent_run_inbox_entry_on(conn, inbox_model).await?;
     let inbox_lifecycle_valid = match reason {
         AgentRunCancellationReason::ParentTurnCancelled
@@ -1080,13 +1035,10 @@ where
         && claim.claim_count == Some(receipt.claim_count)
         && result.payload == AgentRunResultPayload::Cancelled { reason }
         && inbox.result == result
-        && inbox.parent_run_id == AgentRunId(admission.parent_run_id)
-        && inbox.chat_id == ChatId(admission.chat_id)
-        && admission.child_run_id == run.id
-        && admission.parent_run_id == run.parent_id.unwrap_or_default()
-        && admission.chat_id == run.chat_id
-        && origin_turn.agent_run_id == admission.parent_run_id
-        && origin_turn.chat_id == admission.chat_id
+        && inbox.parent_run_id == admission.parent_run_id
+        && inbox.chat_id == admission.chat_id
+        && origin_turn.agent_run_id == admission.parent_run_id.0
+        && origin_turn.chat_id == admission.chat_id.0
         && inbox_lifecycle_valid;
     if !valid {
         return Err(AgentError::Store(format!(

--- a/crates/openwave-core/src/db/ops/sandbox_tool.rs
+++ b/crates/openwave-core/src/db/ops/sandbox_tool.rs
@@ -1417,25 +1417,27 @@ async fn delegated_file_resource_on<C>(
 where
     C: ConnectionTrait,
 {
-    let Some(admission) = entities::sandbox_agent_admission::Entity::find_by_id(agent_run_id.0)
+    let Some(run) = entities::agent_run::Entity::find()
+        .filter(entities::agent_run::Column::Id.eq(agent_run_id.0))
         .one(conn)
         .await
         .map_err(store_err)?
     else {
         return Ok(None);
     };
-    if admission.child_run_id != agent_run_id.0
-        || admission.chat_id != chat_id.0
-        || admission.parent_run_id.is_nil()
-        || admission.origin_turn_id.is_nil()
-        || AgentRunId::sandbox_for_spawn_call(CallId(admission.spawn_call_id)) != agent_run_id
+    if run.admitted_at.is_none()
+        || run.chat_id != chat_id.0
+        || run.parent_id.is_none_or(|id| id.is_nil())
+        || run.origin_turn_id.is_none_or(|id| id.is_nil())
+        || run.spawn_call_id.is_none_or(|spawn_call_id| {
+            AgentRunId::sandbox_for_spawn_call(CallId(spawn_call_id)) != agent_run_id
+        })
     {
         return Ok(None);
     }
-    let (Some(root_uuid), Some(relative_path)) = (
-        admission.delegated_root_id,
-        admission.delegated_relative_path,
-    ) else {
+    let (Some(root_uuid), Some(relative_path)) =
+        (run.delegated_root_id, run.delegated_relative_path)
+    else {
         return Ok(None);
     };
     let Ok(root_id) = HostRootId::from_uuid(root_uuid) else {

--- a/crates/openwave-core/src/db/ops/turn/multi_agent_run_wait.rs
+++ b/crates/openwave-core/src/db/ops/turn/multi_agent_run_wait.rs
@@ -75,13 +75,11 @@ JOIN agent_run p
 JOIN turn_agent_run_wait_member m
   ON m.wait_id = w.id AND m.parent_run_id = w.parent_run_id
  AND m.origin_turn_id = w.turn_id AND m.chat_id = w.chat_id
-JOIN sandbox_agent_admission a
-  ON a.child_run_id = m.child_run_id AND a.parent_run_id = w.parent_run_id
- AND a.origin_turn_id = w.turn_id AND a.chat_id = w.chat_id
 JOIN agent_run c
   ON c.id = m.child_run_id AND c.chat_id = w.chat_id AND c.depth = 1
  AND c.parent_id = w.parent_run_id AND c.parent_depth = 0
- AND c.spawn_call_id = a.spawn_call_id
+ AND c.origin_turn_id = w.turn_id AND c.admitted_at IS NOT NULL
+ AND c.spawn_call_id IS NOT NULL
 JOIN agent_run_inbox i
   ON i.child_run_id = m.child_run_id AND i.parent_run_id = w.parent_run_id
  AND i.chat_id = w.chat_id AND i.parent_depth = 0
@@ -295,24 +293,18 @@ pub(in crate::db) async fn park_turn_for_agent_run_wait_set(
         }));
     }
     for child_run_id in child_run_ids {
-        let admission = entities::sandbox_agent_admission::Entity::find_by_id(child_run_id.0)
-            .one(&transaction)
-            .await
-            .map_err(store_err)?;
         let child = entities::agent_run::Entity::find()
             .filter(entities::agent_run::Column::Id.eq(child_run_id.0))
             .one(&transaction)
             .await
             .map_err(store_err)?;
-        let valid = admission.zip(child).is_some_and(|(admission, child)| {
-            admission.origin_turn_id == turn_id.0
-                && admission.parent_run_id == turn.agent_run_id
-                && admission.chat_id == turn.chat_id
-                && admission.child_run_id == child.id
+        let valid = child.is_some_and(|child| {
+            child.admitted_at.is_some()
+                && child.origin_turn_id == Some(turn_id.0)
                 && child.parent_id == Some(turn.agent_run_id)
                 && child.chat_id == turn.chat_id
                 && child.tier == AgentRunTier::Background.as_str()
-                && child.spawn_call_id == Some(admission.spawn_call_id)
+                && child.spawn_call_id.is_some()
         });
         if !valid {
             transaction.commit().await.map_err(store_err)?;

--- a/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
+++ b/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
@@ -464,12 +464,6 @@ where
         .await
         .map_err(store_err)?
         .ok_or_else(|| AgentError::Store("sandbox spawn receipt lost its child".into()))?;
-    let admission =
-        entities::sandbox_agent_admission::Entity::find_by_id(checkpoint.child_run_id.0)
-            .one(conn)
-            .await
-            .map_err(store_err)?
-            .ok_or_else(|| AgentError::Store("sandbox spawn receipt lost its admission".into()))?;
     let call_model = entities::tool_call::Entity::find_by_id(checkpoint.call_id.0)
         .one(conn)
         .await
@@ -513,12 +507,10 @@ where
         && call_model.client_lease_expires_at.is_none();
     let raw_history_order = call_model.history_order;
     let call = tool_call_from_model(call_model)?;
-    if admission.child_run_id != checkpoint.child_run_id.0
-        || admission.parent_run_id != checkpoint.parent_run_id.0
-        || admission.origin_turn_id != checkpoint.origin_turn_id.0
-        || admission.chat_id != checkpoint.chat_id.0
-        || admission.spawn_call_id != checkpoint.call_id.0
-        || admission.admitted_at > checkpoint.committed_at
+    if child.origin_turn_id != Some(checkpoint.origin_turn_id.0)
+        || child
+            .admitted_at
+            .is_none_or(|admitted_at| admitted_at > checkpoint.committed_at)
         || child.id != checkpoint.child_run_id.0
         || child.chat_id != checkpoint.chat_id.0
         || child.parent_id != Some(checkpoint.parent_run_id.0)
@@ -527,12 +519,12 @@ where
         || child.tier != crate::AgentRunTier::Background.as_str()
         || child.depth != i16::from(AgentRun::MAX_DEPTH)
         || child.input.as_deref() != Some(arguments.task.as_str())
-        || admission.delegated_root_id
+        || child.delegated_root_id
             != arguments
                 .resource
                 .as_ref()
                 .map(|resource| *resource.root_id.as_uuid())
-        || admission.delegated_relative_path.as_deref()
+        || child.delegated_relative_path.as_deref()
             != arguments
                 .resource
                 .as_ref()

--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -647,23 +647,21 @@ async fn sandbox_admission_rejects_cross_turn_identity_and_fk_corruption() {
     let (first_turn, first_lease) = live_turn_for_sandbox_test(&store, first_chat.id).await;
     let (second_turn, second_lease) = live_turn_for_sandbox_test(&store, second_chat.id).await;
     let call = CallId::new();
-    let child = match store
-        .admit_sandbox_agent_run(
-            first_turn.id,
-            call,
-            "owned by the first turn",
-            first_lease,
-            first_turn.steer_revision,
-            2,
-            Utc::now(),
-        )
-        .await
-        .unwrap()
-        .unwrap()
-    {
-        crate::AdmitSandboxAgentRunOutcome::Accepted { child, .. } => child,
-        outcome => panic!("unexpected admission outcome: {outcome:?}"),
-    };
+    assert!(matches!(
+        store
+            .admit_sandbox_agent_run(
+                first_turn.id,
+                call,
+                "owned by the first turn",
+                first_lease,
+                first_turn.steer_revision,
+                2,
+                Utc::now(),
+            )
+            .await
+            .unwrap(),
+        Some(crate::AdmitSandboxAgentRunOutcome::Accepted { .. })
+    ));
     assert!(matches!(
         store
             .admit_sandbox_agent_run(
@@ -679,18 +677,6 @@ async fn sandbox_admission_rejects_cross_turn_identity_and_fk_corruption() {
             .unwrap(),
         Some(crate::AdmitSandboxAgentRunOutcome::IdentityConflict)
     ));
-
-    let malformed = crate::db::entities::sandbox_agent_admission::ActiveModel {
-        child_run_id: Set(child.id.0),
-        parent_run_id: Set(second_turn.agent_run_id.0),
-        origin_turn_id: Set(second_turn.id.0),
-        chat_id: Set(second_chat.id.0),
-        spawn_call_id: Set(CallId::new().0),
-        delegated_root_id: Set(None),
-        delegated_relative_path: Set(None),
-        admitted_at: Set(Utc::now()),
-    };
-    assert!(malformed.insert(&store.conn).await.is_err());
 }
 
 #[tokio::test]
@@ -953,6 +939,10 @@ async fn agent_run_schema_rejects_cross_chat_parentage() {
         finished_at: Set(None),
         last_error_code: Set(None),
         last_error_detail: Set(None),
+        origin_turn_id: Set(None),
+        delegated_root_id: Set(None),
+        delegated_relative_path: Set(None),
+        admitted_at: Set(None),
         created_at: Set(now),
         updated_at: Set(now),
     };
@@ -1003,6 +993,10 @@ async fn scheduler_never_claims_a_sandbox_row_without_an_admission_receipt() {
         finished_at: Set(None),
         last_error_code: Set(None),
         last_error_detail: Set(None),
+        origin_turn_id: Set(None),
+        delegated_root_id: Set(None),
+        delegated_relative_path: Set(None),
+        admitted_at: Set(None),
         created_at: Set(now),
         updated_at: Set(now),
     }
@@ -2663,6 +2657,10 @@ async fn active_work_counts_gate_host_quiescence() {
         finished_at: Set(None),
         last_error_code: Set(None),
         last_error_detail: Set(None),
+        origin_turn_id: Set(None),
+        delegated_root_id: Set(None),
+        delegated_relative_path: Set(None),
+        admitted_at: Set(None),
         created_at: Set(now),
         updated_at: Set(now),
     }

--- a/crates/openwave-core/src/db/tests/delegated_file_read.rs
+++ b/crates/openwave-core/src/db/tests/delegated_file_read.rs
@@ -223,14 +223,12 @@ async fn delegated_read_requires_exact_admission_and_empty_arguments() {
 
     let (_third_dir, third_store) = temp_store().await;
     let (_chat, corrupt_run, corrupt_lease, _resource) = delegated_sandbox(&third_store).await;
-    crate::db::entities::sandbox_agent_admission::Entity::update_many()
+    crate::db::entities::agent_run::Entity::update_many()
         .col_expr(
-            crate::db::entities::sandbox_agent_admission::Column::DelegatedRelativePath,
+            crate::db::entities::agent_run::Column::DelegatedRelativePath,
             sea_orm::sea_query::Expr::value(Some("../escaped.txt".to_owned())),
         )
-        .filter(
-            crate::db::entities::sandbox_agent_admission::Column::ChildRunId.eq(corrupt_run.id.0),
-        )
+        .filter(crate::db::entities::agent_run::Column::Id.eq(corrupt_run.id.0))
         .exec(&third_store.conn)
         .await
         .unwrap();

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -1117,28 +1117,14 @@ async fn postgres_parent_cancellation_uses_time_after_admission_and_heartbeat_lo
         .execute_raw(Statement::from_string(
             DatabaseBackend::Postgres,
             format!(
-                "INSERT INTO agent_run (id, chat_id, parent_id, parent_depth, spawn_call_id, tier, execution_location, depth, status, input, attempt_count, max_attempts, claim_count, available_at, deadline_at, lease_token, lease_expires_at, started_at, finished_at, last_error_code, last_error_detail, created_at, updated_at) \
-                 SELECT '{}', '{}', '{}', 0, '{}', 'background', 'in_process', 1, 'queued', 'admitted while cancellation waited', 0, 3, 0, admitted_at, admitted_at + interval '30 minutes', NULL, NULL, NULL, NULL, NULL, NULL, admitted_at, admitted_at \
+                "INSERT INTO agent_run (id, chat_id, parent_id, parent_depth, spawn_call_id, tier, execution_location, depth, status, input, attempt_count, max_attempts, claim_count, available_at, deadline_at, lease_token, lease_expires_at, started_at, finished_at, last_error_code, last_error_detail, origin_turn_id, delegated_root_id, delegated_relative_path, admitted_at, created_at, updated_at) \
+                 SELECT '{}', '{}', '{}', 0, '{}', 'background', 'in_process', 1, 'queued', 'admitted while cancellation waited', 0, 3, 0, admitted_at, admitted_at + interval '30 minutes', NULL, NULL, NULL, NULL, NULL, NULL, '{}', NULL, NULL, admitted_at, admitted_at, admitted_at \
                  FROM (SELECT clock_timestamp() AS admitted_at) AS admission_clock",
                 child_id.0,
                 chat.id.0,
                 AgentRunId::foreground_for_chat(chat.id).0,
                 call.0,
-            ),
-        ))
-        .await
-        .unwrap();
-    blocker
-        .execute_raw(Statement::from_string(
-            DatabaseBackend::Postgres,
-            format!(
-                "INSERT INTO sandbox_agent_admission (child_run_id, parent_run_id, origin_turn_id, chat_id, spawn_call_id, admitted_at) \
-                 VALUES ('{}', '{}', '{}', '{}', '{}', clock_timestamp())",
-                child_id.0,
-                AgentRunId::foreground_for_chat(chat.id).0,
                 origin.id.0,
-                chat.id.0,
-                call.0,
             ),
         ))
         .await

--- a/crates/openwave-server/src/desktop_schema.rs
+++ b/crates/openwave-server/src/desktop_schema.rs
@@ -25,7 +25,7 @@ const VECTOR_DIRECTORY: &str = "vectors";
 const MAX_MARKER_BYTES: u64 = 1_024;
 
 /// Bump this whenever the pre-v1 schema baseline changes incompatibly.
-const DESKTOP_SCHEMA_EPOCH: u32 = 19;
+const DESKTOP_SCHEMA_EPOCH: u32 = 20;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]


### PR DESCRIPTION
Step 3 of #1462, and the step-7 call it asks for.

`sandbox_agent_admission` was PK-shared with the child `agent_run` it described and re-stated four of that row's columns — `child_run_id`, `parent_run_id`, `chat_id`, `spawn_call_id` — behind a four-column composite foreign key and a runtime drift check. The facts it actually added were `origin_turn_id`, the optional delegated root pair, and `admitted_at`.

Those four move onto `agent_run` as nullable columns. `admitted_at` is the discriminator: it is set exactly on runs that came in through a spawn call, and a CHECK requires those runs to carry an origin turn. A second CHECK keeps the delegated root a pair or nothing at all.

Admission becomes a single insert, so a child row and its admission can no longer disagree. The pairwise comparison in `resolve_existing_sandbox_admission_on` is now unrepresentable rather than merely unchecked, and several validation blocks in the cancellation and wait-set paths collapse into filter predicates or vanish as tautologies — including the `JOIN sandbox_agent_admission` in the wait-set recovery scan.

`fk_turn_agent_run_wait_member_admission` and `fk_sandbox_spawn_checkpoint_admission` retarget at `agent_run`, backed by a new unique index on `(id, origin_turn_id, parent_id, chat_id)` replacing `idx_sandbox_agent_admission_wait_owner`.

## The one thing this costs

`origin_turn_id` carries no foreign key, unlike the admission row it replaces. `turn_run` already references `agent_run` for its foreground run, and `baseline/mod.rs` creates `agent_run` first, so a key back the other way is a cycle — and there is no post-pass to add it later: `migration.rs::up()` only issues `create_table`/`create_index`, and SQLite has no `ALTER TABLE ADD CONSTRAINT` at all.

The invariant is held at the single writer instead. `db/ops/turn/sandbox_spawn.rs` is the only code that sets the column; it loads the turn and takes the turn write lock in the same transaction that admits the child. That reasoning is written into the schema comment next to the CHECKs so it is not rediscovered from scratch.

## Step 7: not folding `agent_run_cancellation`

#1462 says do it with step 3 or not at all. It stays a separate table:

- The receipt's value is that it **cannot be rewritten**. An insert-only row with a primary key gives that structurally; a nullable column set on a mutable row gives it only procedurally. Folding here would make the guarantee weaker — the opposite of what steps 3–5 do.
- It duplicates nothing that drifts. `lease_token`/`attempt_count`/`claim_count` on `agent_run` are the *live* segment and deliberately move; the cancellation's copy is a frozen snapshot of a different moment. There is no drift check to delete because there was never one to write.
- Unlike the sandbox receipt in #1819, which was written in the same transaction that moved the call to a terminal status, the cancellation row is written while the run stays live and keeps mutating through acknowledgement, reaping, and retirement.

## Tests

One test came out: the malformed-second-admission insert in `db/tests/agent_run.rs`, which built an admission row disagreeing with its child run. There is no second row to make disagree any more, so the case it covered cannot be constructed. Its surrounding assertion that the first spawn is accepted is kept.

`DESKTOP_SCHEMA_EPOCH` 19 → 20.

`full-ci`: this changes a composite foreign key's target, adds a multi-column CHECK and a composite unique index, and rewrites a raw SQL recovery scan — all places SQLite and PostgreSQL diverge, and `tests/postgres_turn_state.rs` runs only in the Postgres lane.

Locally: `cargo check --workspace --locked --all-targets`, `cargo test -p openwave-core` (587 passed), `cargo test -p openwave-server`, and `cargo clippy --workspace --all-targets -D warnings` all clean.

Not verified here: driving the running desktop app through a spawn → wait → resume cycle against a freshly reset database.

Part of #1462.