### PR TITLE
fix(desktop): pass the permissions destination in the status-chip test

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatStatusChip.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ChatStatusChip.dom.test.tsx
@@ -31,6 +31,7 @@ function renderChip({
   const onOpenOutputs = vi.fn();
   const onOpenFolders = vi.fn();
   const onOpenAgents = vi.fn();
+  const onOpenPermissions = vi.fn();
   render(
     <ChatStatusChip
       outputCount={outputCount}
@@ -39,9 +40,10 @@ function renderChip({
       onOpenOutputs={onOpenOutputs}
       onOpenFolders={onOpenFolders}
       onOpenAgents={onOpenAgents}
+      onOpenPermissions={onOpenPermissions}
     />,
   );
-  return { onOpenOutputs, onOpenFolders, onOpenAgents };
+  return { onOpenOutputs, onOpenFolders, onOpenAgents, onOpenPermissions };
 }
 
 afterEach(() => {
@@ -50,7 +52,7 @@ afterEach(() => {
 });
 
 it("summarizes activity on its face and opens the chat-scoped places", async () => {
-  const { onOpenOutputs, onOpenFolders } = renderChip({ outputCount: 2 });
+  const { onOpenOutputs, onOpenFolders, onOpenPermissions } = renderChip({ outputCount: 2 });
 
   // No live work, so the face falls back to what the chat has produced.
   const chip = screen.getByRole("button", { name: "Chat activity: 2 outputs" });
@@ -63,6 +65,10 @@ it("summarizes activity on its face and opens the chat-scoped places", async () 
   await userEvent.click(chip);
   await userEvent.click(await screen.findByText("Folders"));
   expect(onOpenFolders).toHaveBeenCalled();
+
+  await userEvent.click(chip);
+  await userEvent.click(await screen.findByText("Permissions"));
+  expect(onOpenPermissions).toHaveBeenCalled();
 });
 
 /**


### PR DESCRIPTION
`ChatStatusChip` gained a required `onOpenPermissions` prop when the chip started surfacing chat access (#1815), but `ChatStatusChip.dom.test.tsx` still rendered the old prop set:

```
src/ChatStatusChip.dom.test.tsx(35,6): error TS2741: Property 'onOpenPermissions' is missing
```

That is a hard `tsc` error, and `tsc` runs inside `pnpm before-tauri-build`, so it fails every job that compiles the desktop bundle. On `main` today that is **Warm macOS release cache** (red since 59fca5be) and **Publish desktop release**, which took v0.36.0 down with it. The `CI` workflow itself is green because a Rust-only change does not mark the UI scope, so nothing since has re-run the UI lane.

Ordinary pull requests skip the UI lane, which is how the error reached `main` without a red check on the change that introduced it.

The fix supplies the handler and asserts that clicking the Permissions row calls it — that row is the destination #1815 added, and nothing covered it.

`full-ci` so the UI lane actually runs on this PR; without it the job this fixes is skipped.

Locally: `pnpm exec tsc --noEmit` clean, `pnpm exec vitest run` 128 files / 867 tests passed.