### PR TITLE
refactor(core): drop the retired-tool journal compatibility scaffolding

### DIFF
--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -462,13 +462,11 @@ pub struct ResultEntry {
     /// panel, an [`App`] row the apps library. A kind with nowhere to go
     /// leaves this `None`.
     ///
-    /// Aliased and `default` because retained projections wrote it as
-    /// `output_id`, when a published output was the only place a row could
-    /// point.
+    /// `default` because retained projections predate the field.
     ///
     /// [`Output`]: ResultEntryKind::Output
     /// [`App`]: ResultEntryKind::App
-    #[serde(default, alias = "output_id")]
+    #[serde(default)]
     pub target_id: Option<String>,
     /// The public page this row opens, when it names one.
     ///
@@ -1575,9 +1573,7 @@ mod tests {
         assert_eq!(outputs[1].target_id, None);
         assert_eq!(outputs[1].media_type.as_deref(), Some("image/png"));
 
-        // A pre-outputs journal row deserializes with the field defaulted, and
-        // a row journaled while the target id was still spelled `output_id`
-        // reads back onto the field that replaced it.
+        // A pre-outputs journal row deserializes with the field defaulted.
         let stored: ToolResultPreview = serde_json::from_value(serde_json::json!({
             "tool": "exec",
             "exit_code": 0,
@@ -1591,15 +1587,6 @@ mod tests {
             panic!("stored exec row");
         };
         assert!(outputs.is_empty());
-        let retained: ResultEntry = serde_json::from_value(serde_json::json!({
-            "kind": "output",
-            "label": "report.md",
-            "detail": null,
-            "meta": "v3 · updated",
-            "output_id": "output-report",
-        }))
-        .unwrap();
-        assert_eq!(retained.target_id.as_deref(), Some("output-report"));
     }
 
     #[test]

--- a/crates/openwave-core/src/renderer_tool.rs
+++ b/crates/openwave-core/src/renderer_tool.rs
@@ -157,10 +157,6 @@ mod tests {
             "",
             "SEARCH",
             "other",
-            // Removed 2026-07: journals recorded before the files-first outputs
-            // migration still carry these calls and must render as generic
-            // tools rather than fail the fold.
-            "create_deliverable",
         ] {
             assert_eq!(RendererToolName::from(name), RendererToolName::Other);
         }

--- a/crates/openwave-server/src/desktop_schema.rs
+++ b/crates/openwave-server/src/desktop_schema.rs
@@ -25,7 +25,7 @@ const VECTOR_DIRECTORY: &str = "vectors";
 const MAX_MARKER_BYTES: u64 = 1_024;
 
 /// Bump this whenever the pre-v1 schema baseline changes incompatibly.
-const DESKTOP_SCHEMA_EPOCH: u32 = 20;
+const DESKTOP_SCHEMA_EPOCH: u32 = 21;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]


### PR DESCRIPTION
Step 8 of #1462, the last of the pre-v1 consolidations.

Two pieces of scaffolding existed only so rows written before a rename or a tool removal still read back. [Decision record 0002](../blob/main/docs/decisions/0002-pre-v1-schema-and-persisted-format-mutability.md) suspends that obligation pre-v1 — "No `#[serde(alias)]`, no backfill, and no migration is written to preserve data that the epoch bump deletes" — because any change to a persisted format ships with an epoch bump, which deletes the rows the scaffolding was protecting.

**`ResultEntry::target_id` loses `alias = "output_id"`**, the spelling it carried when a published output was the only thing a result row could point at, along with the test that deserializes a row under the old key. It is the only `serde` alias left in the workspace.

The `default` stays, and the distinction is the point: an alias only ever reads an old spelling, so it is pure back-compat. A `default` also covers a writer that legitimately omits the field, and it degrades to an unrouted row rather than failing a whole chat's history — the same failure mode the record cites for keeping the journal fixture. The other `default`s on this type are there on those terms and stay.

**`an_unregistered_name_folds_to_other` drops its `create_deliverable` case.** `RendererToolName::Other` itself is untouched — it is load-bearing for arbitrary MCP tool names regardless of history — but that case was justified by journals recorded before the files-first outputs migration, which no longer exist. The guard in `tests/documents.rs` that the tool must not reappear in the registry stays: it defends a live decision (exec's `output/` is the creation path), not a read of old data.

Nothing else turned up. I swept for other retired built-ins by name and for read paths branching on names nothing registers; the remaining hits are live (`web_search_prior` is the current provider-executed replay spelling, `read_deliverable` is a Tauri command, `ToolCtx::new_legacy_workspace` is the CLI/MCP constructor).

`DESKTOP_SCHEMA_EPOCH` 20 -> 21, since removing the alias changes how a persisted projection reads.

No `full-ci`: this touches no schema, no foreign key, and no SQL. The changed code is one serde attribute and two tests, all covered by the default `test` lane.

Locally: `cargo test -p openwave-core` (587 passed) and `cargo clippy --workspace --all-targets -D warnings` clean.

Part of #1462.