### PR TITLE
fix(desktop): keep parallel agent runs visible and usable

### DIFF
--- a/crates/openwave-code-execution/src/local.rs
+++ b/crates/openwave-code-execution/src/local.rs
@@ -1166,18 +1166,27 @@ fn macos_profile(
         .map(|grant| sandbox_subpath(grant.overlay.as_ref().unwrap_or(&grant.path)))
         .collect::<Result<Vec<_>, _>>()?
         .join("\n  ");
-    let mut grant_ancestors = folder_grants
-        .iter()
-        .flat_map(|grant| std::iter::once(&grant.path).chain(grant.overlay.as_ref()))
-        .flat_map(|path| path.ancestors().skip(1))
-        .collect::<Vec<_>>();
-    grant_ancestors.sort_unstable();
-    grant_ancestors.dedup();
-    let grant_metadata = grant_ancestors
+    // Runtimes and package managers commonly walk toward the filesystem root
+    // with metadata-only probes while resolving symlinks, prefixes, and
+    // node_modules. Their explicitly allowed subtree is not enough for that
+    // walk when a denied ancestor such as `/Users` remains opaque. Name only
+    // the ancestors of paths the sandbox already receives through cwd, HOME,
+    // PATH, or an explicit grant; their contents stay unreadable.
+    let dynamic_metadata = sandbox_metadata_ancestors(
+        [
+            Some(workspace),
+            Some(env_home),
+            developer_dir,
+            document_scripts_dir,
+            shared_package_cache,
+            managed_node_dir,
+        ]
         .into_iter()
-        .map(sandbox_literal)
-        .collect::<Result<Vec<_>, _>>()?
-        .join("\n  ");
+        .flatten()
+        .chain(folder_grants.iter().flat_map(|grant| {
+            std::iter::once(grant.path.as_path()).chain(grant.overlay.as_deref())
+        })),
+    )?;
     let workspace = sandbox_subpath(workspace)?;
     // The per-chat env home backs the sandboxed process's HOME/TMPDIR. It is
     // writable like the workspace but lives outside the model-visible tree, so
@@ -1195,10 +1204,27 @@ fn macos_profile(
          {network}\n\
          (allow file-read*)\n\
          (deny file-read*\n  {denied})\n\
-         (allow file-read-metadata\n  {runtime_metadata}\n  {grant_metadata})\n\
+         (allow file-read-metadata\n  {runtime_metadata}\n  {dynamic_metadata})\n\
          (allow file-read*\n  {literals}\n  {runtimes}\n  {selected_runtime}\n  {document_scripts}\n  {package_cache}\n  {managed_node}\n  {granted_reads}\n  {workspace}\n  {env_home})\n\
          (allow file-write*\n  {granted_writes}\n  {workspace}\n  {env_home}\n  (literal \"/dev/null\"))\n"
     ))
+}
+
+#[cfg(target_os = "macos")]
+fn sandbox_metadata_ancestors<'a>(
+    paths: impl IntoIterator<Item = &'a Path>,
+) -> Result<String, CodeExecutionError> {
+    let mut ancestors = paths
+        .into_iter()
+        .flat_map(|path| path.ancestors().skip(1))
+        .collect::<Vec<_>>();
+    ancestors.sort_unstable();
+    ancestors.dedup();
+    ancestors
+        .into_iter()
+        .map(sandbox_literal)
+        .collect::<Result<Vec<_>, _>>()
+        .map(|entries| entries.join("\n  "))
 }
 
 #[cfg(target_os = "macos")]
@@ -1781,6 +1807,9 @@ mod tests {
 
         let with_node = profile(Some(node));
         assert!(with_node.contains(&sandbox_subpath(node).unwrap()));
+        assert!(with_node.contains("(literal \"/Users\")"));
+        assert!(with_node
+            .contains("(literal \"/Users/test/Library/Application Support/OpenWave/node\")"));
         let write_rule = with_node
             .split("(allow file-write*")
             .nth(1)
@@ -1825,12 +1854,25 @@ mod tests {
             .unwrap();
         assert_eq!(without.stdout, "no-node");
 
+        let denied_ancestor = runtime
+            .ancestors()
+            .find(|path| *path == Path::new("/private"))
+            .expect("macOS temporary directories resolve below /private")
+            .to_path_buf();
         let provider = provider.with_managed_node(Some(runtime));
+        let script = format!(
+            "node --version; stat -f %N '{}' >/dev/null && printf metadata-ok",
+            denied_ancestor.display()
+        );
         let with = provider
-            .execute(request(workspace, "call-node", script))
+            .execute(request(workspace, "call-node", &script))
             .await
             .unwrap();
-        assert_eq!(with.stdout, "v22.11.0", "stderr: {}", with.stderr);
+        assert_eq!(
+            with.stdout, "v22.11.0metadata-ok",
+            "stderr: {}",
+            with.stderr
+        );
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
@@ -170,6 +170,57 @@ describe("turn_started", () => {
     ).toEqual(["call-approved"]);
     expect(state.provisionalToolCallIds.size).toBe(0);
   });
+
+  it("keeps queued sibling agent spawns across checkpoint resumes", () => {
+    const { state } = play([
+      TURN,
+      {
+        type: "tool_call_started",
+        call_id: "spawn-a",
+        name: "spawn_sandbox_agent",
+      },
+      {
+        type: "tool_call_started",
+        call_id: "spawn-b",
+        name: "spawn_sandbox_agent",
+      },
+      {
+        type: "tool_call_started",
+        call_id: "spawn-c",
+        name: "spawn_sandbox_agent",
+      },
+      {
+        type: "tool_call_completed",
+        call_id: "spawn-a",
+        status: "completed",
+      },
+      TURN,
+      {
+        type: "tool_call_completed",
+        call_id: "spawn-b",
+        status: "completed",
+      },
+      TURN,
+      {
+        type: "tool_call_completed",
+        call_id: "spawn-c",
+        status: "completed",
+      },
+    ]);
+
+    expect(
+      state.messages.flatMap((message) =>
+        message.role === "tool"
+          ? [{ callId: message.callId, status: message.status }]
+          : [],
+      ),
+    ).toEqual([
+      { callId: "spawn-a", status: "completed" },
+      { callId: "spawn-b", status: "completed" },
+      { callId: "spawn-c", status: "completed" },
+    ]);
+    expect(state.provisionalToolCallIds.size).toBe(0);
+  });
 });
 
 describe("text_delta", () => {

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
@@ -143,8 +143,10 @@ export function reduceChatSessionEvent(
       // A resumed attempt starts a new renderer candidate for the same turn.
       // Calls admitted before an approval boundary have already left this set;
       // any IDs still here were only streamed optimistically and will never
-      // receive completion events from the resumed attempt.
-      const messages = discardToolCalls(
+      // receive completion events from the resumed attempt. Sandbox-spawn
+      // siblings are the exception: the server checkpoints them one at a time,
+      // and each resume still owes completion events for the carried tail.
+      const messages = discardUnadmittedToolCallsAtResume(
         state.messages,
         state.provisionalToolCallIds,
       );
@@ -770,4 +772,20 @@ export function discardToolCalls(
   return messages.filter(
     (message) => message.role !== "tool" || !callIds.has(message.callId),
   );
+}
+
+function discardUnadmittedToolCallsAtResume(
+  messages: ChatMessage[],
+  callIds: ReadonlySet<string>,
+): ChatMessage[] {
+  const unadmitted = new Set(
+    messages.flatMap((message) =>
+      message.role === "tool" &&
+      callIds.has(message.callId) &&
+      message.name !== "spawn_sandbox_agent"
+        ? [message.callId]
+        : [],
+    ),
+  );
+  return discardToolCalls(messages, unadmitted);
 }

--- a/crates/openwave-desktop/ui/src/TranscriptNavigation.test.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptNavigation.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { transcriptNavigationEntries } from "./TranscriptNavigation";
+import {
+  layoutRailIndicatorTops,
+  transcriptNavigationEntries,
+} from "./TranscriptNavigation";
 
 describe("transcriptNavigationEntries", () => {
   it("builds concise user and tool destinations from the rendered transcript", () => {
@@ -40,5 +43,50 @@ describe("transcriptNavigationEntries", () => {
         active: true,
       },
     ]);
+  });
+});
+
+describe("layoutRailIndicatorTops", () => {
+  it("stacks indicators that clamp to the same rail edge", () => {
+    expect(
+      [...layoutRailIndicatorTops(
+        [
+          { anchorId: "a", desiredTop: 0, distanceFromViewport: 80 },
+          { anchorId: "b", desiredTop: 0, distanceFromViewport: 40 },
+          { anchorId: "c", desiredTop: 0, distanceFromViewport: 10 },
+        ],
+        120,
+      ).entries()],
+    ).toEqual([
+      ["c", 0],
+      ["b", 24],
+      ["a", 48],
+    ]);
+  });
+
+  it("pulls a bottom cluster upward without overlap", () => {
+    expect(
+      [...layoutRailIndicatorTops(
+        [
+          { anchorId: "a", desiredTop: 96, distanceFromViewport: 0 },
+          { anchorId: "b", desiredTop: 96, distanceFromViewport: 0 },
+          { anchorId: "c", desiredTop: 96, distanceFromViewport: 0 },
+        ],
+        120,
+      ).values()],
+    ).toEqual([48, 72, 96]);
+  });
+
+  it("hides the farthest indicators when the rail cannot fit them", () => {
+    expect(
+      [...layoutRailIndicatorTops(
+        [
+          { anchorId: "onscreen", desiredTop: 20, distanceFromViewport: 0 },
+          { anchorId: "near", desiredTop: 0, distanceFromViewport: 10 },
+          { anchorId: "far", desiredTop: 0, distanceFromViewport: 300 },
+        ],
+        48,
+      ).keys()],
+    ).toEqual(["near", "onscreen"]);
   });
 });

--- a/crates/openwave-desktop/ui/src/TranscriptNavigation.tsx
+++ b/crates/openwave-desktop/ui/src/TranscriptNavigation.tsx
@@ -18,6 +18,12 @@ const RAIL_STORAGE_KEY = "openwave.transcript-rail-visible";
 const INDICATOR_SIZE = 24;
 const PROXIMITY_THRESHOLD = 400;
 
+export type RailIndicatorCandidate = {
+  anchorId: string;
+  desiredTop: number;
+  distanceFromViewport: number;
+};
+
 export type TranscriptNavigationEntry = {
   anchorId: string;
   kind: "user" | "tool";
@@ -222,6 +228,7 @@ function useRailPositions(
         }
       }
 
+      const candidates: RailIndicatorCandidate[] = [];
       for (const entry of entries) {
         const indicator = refs.current.get(entry.anchorId);
         if (!indicator) continue;
@@ -239,10 +246,19 @@ function useRailPositions(
           continue;
         }
 
-        const top = Math.max(
-          0,
-          Math.min(relativeTop, container.height - INDICATOR_SIZE),
-        );
+        candidates.push({
+          anchorId: entry.anchorId,
+          desiredTop: Math.max(
+            0,
+            Math.min(relativeTop, container.height - INDICATOR_SIZE),
+          ),
+          distanceFromViewport:
+            relativeTop < 0
+              ? -relativeTop
+              : relativeTop > container.height
+                ? relativeTop - container.height
+                : 0,
+        });
         const opacity =
           relativeTop < 0
             ? 1 - Math.abs(relativeTop) / PROXIMITY_THRESHOLD
@@ -251,8 +267,19 @@ function useRailPositions(
                 (relativeTop - container.height) / PROXIMITY_THRESHOLD
               : 1;
         indicator.style.display = "";
-        indicator.style.transform = `translateY(${top}px)`;
         indicator.style.opacity = String(Math.max(0, opacity));
+      }
+
+      const tops = layoutRailIndicatorTops(candidates, container.height);
+      for (const candidate of candidates) {
+        const indicator = refs.current.get(candidate.anchorId);
+        if (!indicator) continue;
+        const top = tops.get(candidate.anchorId);
+        if (top === undefined) {
+          indicator.style.display = "none";
+          continue;
+        }
+        indicator.style.transform = `translateY(${top}px)`;
       }
     };
 
@@ -276,4 +303,50 @@ function useRailPositions(
   }, [entries, scrollElement, visible]);
 
   return refs;
+}
+
+/**
+ * Keep fixed-size transcript indicators from landing on top of one another.
+ *
+ * Several offscreen anchors clamp to the same top or bottom edge, and dense
+ * activity can put nearby onscreen anchors less than one icon apart. Prefer
+ * the entries nearest the viewport when there is not room for every button,
+ * then push the retained positions apart while staying inside the rail.
+ */
+export function layoutRailIndicatorTops(
+  candidates: readonly RailIndicatorCandidate[],
+  containerHeight: number,
+): Map<string, number> {
+  const capacity = Math.max(0, Math.floor(containerHeight / INDICATOR_SIZE));
+  if (capacity === 0 || candidates.length === 0) return new Map();
+
+  const retained = [...candidates]
+    .sort(
+      (left, right) =>
+        left.distanceFromViewport - right.distanceFromViewport ||
+        left.desiredTop - right.desiredTop,
+    )
+    .slice(0, capacity)
+    .sort((left, right) => left.desiredTop - right.desiredTop);
+  const maxTop = containerHeight - INDICATOR_SIZE;
+  const tops: number[] = [];
+  for (const candidate of retained) {
+    const previous = tops.at(-1);
+    tops.push(
+      previous === undefined
+        ? candidate.desiredTop
+        : Math.max(candidate.desiredTop, previous + INDICATOR_SIZE),
+    );
+  }
+
+  // The forward pass can push a bottom cluster below the rail. Pull it back
+  // from the end; because retained.length <= capacity, this cannot cross zero.
+  tops[tops.length - 1] = Math.min(tops[tops.length - 1]!, maxTop);
+  for (let index = tops.length - 2; index >= 0; index -= 1) {
+    tops[index] = Math.min(tops[index]!, tops[index + 1]! - INDICATOR_SIZE);
+  }
+
+  return new Map(
+    retained.map((candidate, index) => [candidate.anchorId, tops[index]!] as const),
+  );
 }


### PR DESCRIPTION
## What changed

- preserve queued sibling `spawn_sandbox_agent` rows across foreground checkpoint resumes so every parallel child remains visible and receives its completion update
- lay out transcript rail indicators without overlap, preferring anchors nearest the viewport when the rail cannot fit every icon
- allow metadata-only traversal of ancestors for sandbox paths already exposed through cwd, HOME, PATH, package caches, or explicit grants so managed npm can resolve its runtime under macOS app data paths

## Why

The latest local dev chat durably admitted four background agents within the same second, but the live reducer deleted the three still-carried spawn rows when the first checkpoint resumed the foreground turn. Their later completion events had nothing to update, leaving the UI at “1 background agent.” The same run showed npm failing with `lstat /Users` because Seatbelt allowed the managed Node subtree but denied metadata probes on its ancestors. Transcript navigation indicators also independently clamped to the same rail edge and overlapped.

## Verification

- `pnpm test` — 128 files, 871 tests passed
- `pnpm exec vitest run src/ChatSessionReducer.test.ts src/TranscriptNavigation.test.ts` — 46 tests passed after rebasing onto current `main`
- `cargo test -p openwave-code-execution managed_node_ --locked` — 2 tests passed after rebasing
- `cargo check -p openwave-code-execution --locked`
- `cargo fmt --all -- --check`
- direct Vite production bundle completed successfully

`pnpm build` currently stops on an unrelated error already present on `main`: `ChatStatusChip.dom.test.tsx` does not pass the required `onOpenPermissions` prop.