### PR TITLE
fix(desktop): regenerate wire bindings after the preview doc change

### DIFF
--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -2123,9 +2123,7 @@ media_type: string | null,
  * panel, an [`App`] row the apps library. A kind with nowhere to go
  * leaves this `None`.
  *
- * Aliased and `default` because retained projections wrote it as
- * `output_id`, when a published output was the only place a row could
- * point.
+ * `default` because retained projections predate the field.
  *
  * [`Output`]: ResultEntryKind::Output
  * [`App`]: ResultEntryKind::App


### PR DESCRIPTION
`ResultEntry::target_id`'s doc comment changed in #1824 when its `serde` alias came out. ts-rs copies doc comments into the generated TypeScript, so `wire.ts` went stale and `the_generated_bindings_are_current` has failed on every `main` run since `b12e914e`. This regenerates it.

`full-ci`: the staleness check lives in the headless test lane, which is exactly the lane that did not run on the PR that broke it.