### PR TITLE
feat(broker): audit app-folder I/O under a dedicated app actor

### DIFF
--- a/crates/openwave-desktop/src/host_access.rs
+++ b/crates/openwave-desktop/src/host_access.rs
@@ -307,6 +307,13 @@ fn folder_relative_path(
     RelativePath::parse(path).map_err(|_| openwave_server::host_folders::FolderOpError::InvalidPath)
 }
 
+fn folder_app_id(
+    app: openwave_core::id::AppId,
+) -> Result<openwave_host_broker::AppId, openwave_server::host_folders::FolderOpError> {
+    openwave_host_broker::AppId::from_uuid(*app.as_uuid())
+        .map_err(|_| openwave_server::host_folders::FolderOpError::Failed)
+}
+
 #[async_trait::async_trait]
 impl openwave_server::host_folders::HostFolders for DesktopHostFolders {
     async fn approved_roots(
@@ -337,6 +344,7 @@ impl openwave_server::host_folders::HostFolders for DesktopHostFolders {
 
     async fn list_folder(
         &self,
+        app: openwave_core::id::AppId,
         root: openwave_core::HostRootId,
         path: &str,
     ) -> Result<
@@ -345,6 +353,7 @@ impl openwave_server::host_folders::HostFolders for DesktopHostFolders {
     > {
         use openwave_server::host_folders::FolderOpError;
 
+        let app_id = folder_app_id(app)?;
         let root_id =
             RootId::from_uuid(*root.as_uuid()).map_err(|_| FolderOpError::NotConnected)?;
         let path = folder_relative_path(path)?;
@@ -352,6 +361,7 @@ impl openwave_server::host_folders::HostFolders for DesktopHostFolders {
             .broker()
             .broker
             .control(ControlRequest::ListAppFolder(AppFolderPathRequest {
+                app_id,
                 root_id,
                 path,
             }))
@@ -371,6 +381,7 @@ impl openwave_server::host_folders::HostFolders for DesktopHostFolders {
 
     async fn read_file(
         &self,
+        app: openwave_core::id::AppId,
         root: openwave_core::HostRootId,
         path: &str,
     ) -> Result<Vec<u8>, openwave_server::host_folders::FolderOpError> {
@@ -378,6 +389,7 @@ impl openwave_server::host_folders::HostFolders for DesktopHostFolders {
 
         use openwave_server::host_folders::FolderOpError;
 
+        let app_id = folder_app_id(app)?;
         let root_id =
             RootId::from_uuid(*root.as_uuid()).map_err(|_| FolderOpError::NotConnected)?;
         let path = folder_relative_path(path)?;
@@ -385,6 +397,7 @@ impl openwave_server::host_folders::HostFolders for DesktopHostFolders {
             .broker()
             .broker
             .control(ControlRequest::ReadAppFolderFile(AppFolderPathRequest {
+                app_id,
                 root_id,
                 path,
             }))
@@ -400,6 +413,7 @@ impl openwave_server::host_folders::HostFolders for DesktopHostFolders {
 
     async fn write_file(
         &self,
+        app: openwave_core::id::AppId,
         root: openwave_core::HostRootId,
         path: &str,
         content: &[u8],
@@ -413,6 +427,7 @@ impl openwave_server::host_folders::HostFolders for DesktopHostFolders {
 
         use openwave_server::host_folders::FolderOpError;
 
+        let app_id = folder_app_id(app)?;
         let root_id =
             RootId::from_uuid(*root.as_uuid()).map_err(|_| FolderOpError::NotConnected)?;
         let path = folder_relative_path(path)?;
@@ -420,6 +435,7 @@ impl openwave_server::host_folders::HostFolders for DesktopHostFolders {
             .broker()
             .broker
             .control(ControlRequest::WriteAppFolderFile(AppFolderWriteRequest {
+                app_id,
                 root_id,
                 path,
                 mode: if replace {

--- a/crates/openwave-host-broker/src/audit.rs
+++ b/crates/openwave-host-broker/src/audit.rs
@@ -32,8 +32,8 @@ use thiserror::Error;
 use uuid::Uuid;
 
 use crate::{
-    Capability, ErrorCode, ExecutionContext, GrantId, GrantSubject, OperationId, RelativePath,
-    RequestId, RootId,
+    AppId, Capability, ErrorCode, ExecutionContext, GrantId, GrantSubject, OperationId,
+    RelativePath, RequestId, RootId,
 };
 
 const AUDIT_FILE_NAME: &str = "host-broker-audit.jsonl";
@@ -81,6 +81,9 @@ pub enum AuditOperation {
     ReadFile,
     ReadFileBinary,
     WriteFile,
+    ListAppFolder,
+    ReadAppFolderFile,
+    WriteAppFolderFile,
     ProtocolVersionMismatch,
 }
 
@@ -109,6 +112,12 @@ pub enum AuditActor {
     },
     Operation {
         context: ExecutionContext,
+    },
+    /// A local app acting on its folder grant through the app-folder control
+    /// surface. Consent lives in the server-side app grant, so no grant
+    /// subject applies; the app id is the accountable identity.
+    App {
+        app_id: AppId,
     },
 }
 

--- a/crates/openwave-host-broker/src/broker.rs
+++ b/crates/openwave-host-broker/src/broker.rs
@@ -335,16 +335,47 @@ impl ControlAudit {
             | ControlRequest::ListApprovedRoots
             | ControlRequest::ListGrantStatements
             | ControlRequest::ListUnavailableRoots => None,
-            // The app-folder trio is consented and recorded server-side: the
-            // app grant names the folder and access level, and dispatch is
-            // admitted there before the broker is reached. The broker-side
-            // audit vocabulary is subject-keyed and local apps have no grant
-            // subject; auditing these under a borrowed subject would
-            // misattribute them. An app-actor audit kind is the recorded
-            // follow-up (docs/folder-bindings.md).
-            ControlRequest::ListAppFolder(_)
-            | ControlRequest::ReadAppFolderFile(_)
-            | ControlRequest::WriteAppFolderFile(_) => None,
+            // The app-folder trio is consented server-side — the app grant
+            // names the folder and access level, and dispatch is admitted
+            // there before the broker is reached — but the broker's own
+            // ledger still sees the I/O, attributed to the app actor the
+            // request names. No capability or grant id applies: the broker
+            // holds no grant row for an app, so implying one would overstate
+            // what this record proves.
+            ControlRequest::ListAppFolder(request) => Some(Self {
+                actor: AuditActor::App {
+                    app_id: request.app_id,
+                },
+                mutates: false,
+                operation: AuditOperation::ListAppFolder,
+                grant_id: None,
+                operation_id: None,
+                target: AuditTarget::path(request.root_id, &request.path),
+            }),
+            ControlRequest::ReadAppFolderFile(request) => Some(Self {
+                actor: AuditActor::App {
+                    app_id: request.app_id,
+                },
+                mutates: false,
+                operation: AuditOperation::ReadAppFolderFile,
+                grant_id: None,
+                operation_id: None,
+                target: AuditTarget::path(request.root_id, &request.path),
+            }),
+            // A host mutation: like the agent write operation, the intent
+            // record must be durable before any bytes change. No operation
+            // id — the digest-bound write reconciles a same-content retry by
+            // itself, so there is no separate mutation identity to correlate.
+            ControlRequest::WriteAppFolderFile(request) => Some(Self {
+                actor: AuditActor::App {
+                    app_id: request.app_id,
+                },
+                mutates: true,
+                operation: AuditOperation::WriteAppFolderFile,
+                grant_id: None,
+                operation_id: None,
+                target: AuditTarget::path(request.root_id, &request.path),
+            }),
             ControlRequest::ResolveExecRoots(request) => Some(Self {
                 actor: AuditActor::Control {
                     subject: match request.context.project_id() {

--- a/crates/openwave-host-broker/src/broker/tests.rs
+++ b/crates/openwave-host-broker/src/broker/tests.rs
@@ -3591,12 +3591,16 @@ fn pending_write_recovery_never_replays_an_ambiguous_native_result() {
 /// trusted-host surface with the broker's host-level half intact: only a
 /// live registration answers, transfers keep the byte bounds, and writes are
 /// digest-bound and mode-checked — while no conversation context applies at
-/// all, because consent lives in the caller's app grant.
+/// all, because consent lives in the caller's app grant. Every operation
+/// lands in the audit trail under the app actor, with writes recording a
+/// durable intent first.
 #[test]
 fn app_folder_trio_serves_live_registrations_and_dies_with_the_registration() {
-    let (_temp, broker, root) = setup();
+    let (_temp, broker, root, audit) = audited_setup();
+    std::fs::create_dir(root.join("reports")).unwrap();
     let controller = broker.controller();
     let conversation = Uuid::new_v4();
+    let app_id = crate::AppId::new();
     let registered = register(
         &controller,
         GrantSubject::conversation(conversation).unwrap(),
@@ -3616,6 +3620,7 @@ fn app_folder_trio_serves_live_registrations_and_dies_with_the_registration() {
     // Listing the root and reading a file need no conversation context.
     let ControlResult::ListAppFolder { entries } =
         control(ControlRequest::ListAppFolder(AppFolderPathRequest {
+            app_id,
             root_id,
             path: RelativePath::root(),
         }))
@@ -3632,6 +3637,7 @@ fn app_folder_trio_serves_live_registrations_and_dies_with_the_registration() {
 
     let ControlResult::ReadAppFolderFile(read) =
         control(ControlRequest::ReadAppFolderFile(AppFolderPathRequest {
+            app_id,
             root_id,
             path: RelativePath::parse("note.txt").unwrap(),
         }))
@@ -3649,6 +3655,7 @@ fn app_folder_trio_serves_live_registrations_and_dies_with_the_registration() {
     // replace replaces.
     let write = |mode: WriteFileMode, bytes: &[u8]| {
         control(ControlRequest::WriteAppFolderFile(AppFolderWriteRequest {
+            app_id,
             root_id,
             path: RelativePath::parse("app-state.json").unwrap(),
             mode,
@@ -3685,6 +3692,7 @@ fn app_folder_trio_serves_live_registrations_and_dies_with_the_registration() {
     // A mismatched digest refuses before any I/O.
     assert_eq!(
         control(ControlRequest::WriteAppFolderFile(AppFolderWriteRequest {
+            app_id,
             root_id,
             path: RelativePath::parse("tampered.json").unwrap(),
             mode: WriteFileMode::Create,
@@ -3707,12 +3715,52 @@ fn app_folder_trio_serves_live_registrations_and_dies_with_the_registration() {
     );
     assert_eq!(
         control(ControlRequest::ReadAppFolderFile(AppFolderPathRequest {
+            app_id,
             root_id,
             path: RelativePath::parse("note.txt").unwrap(),
         }))
         .unwrap_err()
         .code,
         ErrorCode::Denied
+    );
+
+    // Every folder operation above is in the trail, attributed to the app
+    // actor — reads as completions, each write as a durable intent paired
+    // with its completion, and the post-revocation read as a denial.
+    let events = audit.events.lock().unwrap();
+    let app_events = events
+        .iter()
+        .filter(|event| event.actor == AuditActor::App { app_id })
+        .map(|event| (event.operation, event.outcome))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        app_events,
+        [
+            (AuditOperation::ListAppFolder, AuditOutcome::Allowed),
+            (AuditOperation::ReadAppFolderFile, AuditOutcome::Allowed),
+            (AuditOperation::WriteAppFolderFile, AuditOutcome::Attempted),
+            (AuditOperation::WriteAppFolderFile, AuditOutcome::Allowed),
+            (AuditOperation::WriteAppFolderFile, AuditOutcome::Attempted),
+            (AuditOperation::WriteAppFolderFile, AuditOutcome::Allowed),
+            (AuditOperation::WriteAppFolderFile, AuditOutcome::Attempted),
+            (AuditOperation::WriteAppFolderFile, AuditOutcome::Failed),
+            (AuditOperation::WriteAppFolderFile, AuditOutcome::Attempted),
+            (AuditOperation::WriteAppFolderFile, AuditOutcome::Allowed),
+            (AuditOperation::WriteAppFolderFile, AuditOutcome::Attempted),
+            (AuditOperation::WriteAppFolderFile, AuditOutcome::Failed),
+            (AuditOperation::ReadAppFolderFile, AuditOutcome::Denied),
+        ]
+    );
+    let write_target = events
+        .iter()
+        .find(|event| event.operation == AuditOperation::WriteAppFolderFile)
+        .map(|event| event.target.clone());
+    assert_eq!(
+        write_target,
+        Some(AuditTarget::Path {
+            root_id,
+            relative: RelativePath::parse("app-state.json").unwrap(),
+        })
     );
 }
 

--- a/crates/openwave-host-broker/src/id.rs
+++ b/crates/openwave-host-broker/src/id.rs
@@ -87,6 +87,10 @@ macro_rules! uuid_id {
 
 uuid_id!(RootId, "Host-local identity for one registered root.");
 uuid_id!(
+    AppId,
+    "Trusted product identity for one local app acting on its folder grant."
+);
+uuid_id!(
     GrantId,
     "Stable identity for one consented capability grant."
 );

--- a/crates/openwave-host-broker/src/lib.rs
+++ b/crates/openwave-host-broker/src/lib.rs
@@ -25,8 +25,8 @@ pub use capability::{
     Capability, ConsentMethod, ConsentRecord, Grant, GrantError, RootAttachment, Scope,
 };
 pub use id::{
-    ExecutionContext, GrantId, GrantSubject, IdError, OperationId, ParseIdError, RequestId, RootId,
-    SubjectKind,
+    AppId, ExecutionContext, GrantId, GrantSubject, IdError, OperationId, ParseIdError, RequestId,
+    RootId, SubjectKind,
 };
 pub use path_policy::{RootPolicy, RootPolicyError, ValidatedRoot};
 pub use protocol::{

--- a/crates/openwave-host-broker/src/protocol.rs
+++ b/crates/openwave-host-broker/src/protocol.rs
@@ -10,12 +10,12 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{
-    Capability, ConsentMethod, ExecutionContext, GrantId, GrantSubject, OperationId, RelativePath,
-    RequestId, RootId, Scope,
+    AppId, Capability, ConsentMethod, ExecutionContext, GrantId, GrantSubject, OperationId,
+    RelativePath, RequestId, RootId, Scope,
 };
 
 /// Current pre-v1 broker protocol. Bump this for incompatible wire changes.
-pub const PROTOCOL_VERSION: u32 = 9;
+pub const PROTOCOL_VERSION: u32 = 10;
 
 /// Largest file the broker returns as opaque bytes.
 ///
@@ -173,6 +173,10 @@ pub struct RegisterRootRequest {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AppFolderPathRequest {
+    /// The app whose grant admitted this dispatch, for the audit trail. The
+    /// broker does not verify app grants — the server already did — so this
+    /// names the accountable actor rather than proving consent.
+    pub app_id: AppId,
     pub root_id: RootId,
     pub path: RelativePath,
 }
@@ -183,6 +187,9 @@ pub struct AppFolderPathRequest {
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AppFolderWriteRequest {
+    /// The app whose grant admitted this dispatch, for the audit trail. See
+    /// [`AppFolderPathRequest::app_id`].
+    pub app_id: AppId,
     pub root_id: RootId,
     pub path: RelativePath,
     pub mode: WriteFileMode,
@@ -195,6 +202,7 @@ impl std::fmt::Debug for AppFolderWriteRequest {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
             .debug_struct("AppFolderWriteRequest")
+            .field("app_id", &self.app_id)
             .field("root_id", &self.root_id)
             .field("path", &self.path)
             .field("mode", &self.mode)

--- a/crates/openwave-server/src/host_folders.rs
+++ b/crates/openwave-server/src/host_folders.rs
@@ -10,7 +10,7 @@
 
 use async_trait::async_trait;
 
-use openwave_core::id::HostRootId;
+use openwave_core::id::{AppId, HostRootId};
 use openwave_core::local_app::FolderAccess;
 
 /// One host-approved connected folder, projected renderer-safe: the stable
@@ -87,21 +87,29 @@ pub trait HostFolders: Send + Sync {
     async fn approved_roots(&self) -> openwave_core::Result<Vec<ApprovedFolder>>;
 
     /// List one directory under an approved folder, within the host's
-    /// listing bounds.
+    /// listing bounds. `app` names the invoking app in the host's audit
+    /// trail; the caller has already enforced its grant.
     async fn list_folder(
         &self,
+        app: AppId,
         root: HostRootId,
         path: &str,
     ) -> Result<Vec<FolderEntry>, FolderOpError>;
 
     /// Read one file under an approved folder as bounded opaque bytes.
-    async fn read_file(&self, root: HostRootId, path: &str) -> Result<Vec<u8>, FolderOpError>;
+    async fn read_file(
+        &self,
+        app: AppId,
+        root: HostRootId,
+        path: &str,
+    ) -> Result<Vec<u8>, FolderOpError>;
 
     /// Write one file under an approved folder, atomically, within the
     /// host's write bound. `replace` selects the create-vs-replace mode; the
     /// caller has already enforced the grant's access level.
     async fn write_file(
         &self,
+        app: AppId,
         root: HostRootId,
         path: &str,
         content: &[u8],

--- a/crates/openwave-server/src/routes/app_invoke.rs
+++ b/crates/openwave-server/src/routes/app_invoke.rs
@@ -312,7 +312,7 @@ pub async fn post_app_invoke(
                 },
             )
             .await?;
-            dispatch_folder_op(&state, folder, &path, op)
+            dispatch_folder_op(&state, app_id, folder, &path, op)
                 .await
                 .map(|result| Json(result).into_response())
         }
@@ -664,6 +664,7 @@ impl AppFolderInvokeResult {
 /// failures.
 async fn dispatch_folder_op(
     state: &AppState,
+    app_id: AppId,
     folder: openwave_core::id::HostRootId,
     path: &str,
     op: FolderOp,
@@ -675,7 +676,7 @@ async fn dispatch_folder_op(
         ));
     };
     Ok(match op {
-        FolderOp::List => match host.list_folder(folder, path).await {
+        FolderOp::List => match host.list_folder(app_id, folder, path).await {
             Ok(entries) => AppFolderInvokeResult {
                 entries: Some(
                     entries
@@ -690,7 +691,7 @@ async fn dispatch_folder_op(
             },
             Err(error) => AppFolderInvokeResult::failure(error),
         },
-        FolderOp::Read => match host.read_file(folder, path).await {
+        FolderOp::Read => match host.read_file(app_id, folder, path).await {
             Ok(bytes) => AppFolderInvokeResult {
                 content_base64: Some(base64::engine::general_purpose::STANDARD.encode(bytes)),
                 ..AppFolderInvokeResult::success()
@@ -707,7 +708,10 @@ async fn dispatch_folder_op(
                     crate::host_folders::FolderOpError::Failed,
                 ));
             };
-            match host.write_file(folder, path, &content, replace).await {
+            match host
+                .write_file(app_id, folder, path, &content, replace)
+                .await
+            {
                 Ok(receipt) => AppFolderInvokeResult {
                     replaced: Some(receipt.replaced),
                     ..AppFolderInvokeResult::success()

--- a/crates/openwave-server/src/tests/app_grant.rs
+++ b/crates/openwave-server/src/tests/app_grant.rs
@@ -310,6 +310,7 @@ async fn folder_bindings_grant_and_fail_closed_when_the_folder_disconnects() {
         // if it ever does keeps this test about the grant object.
         async fn list_folder(
             &self,
+            _app: openwave_core::id::AppId,
             _root: openwave_core::id::HostRootId,
             _path: &str,
         ) -> Result<Vec<crate::host_folders::FolderEntry>, crate::host_folders::FolderOpError>
@@ -319,6 +320,7 @@ async fn folder_bindings_grant_and_fail_closed_when_the_folder_disconnects() {
 
         async fn read_file(
             &self,
+            _app: openwave_core::id::AppId,
             _root: openwave_core::id::HostRootId,
             _path: &str,
         ) -> Result<Vec<u8>, crate::host_folders::FolderOpError> {
@@ -327,6 +329,7 @@ async fn folder_bindings_grant_and_fail_closed_when_the_folder_disconnects() {
 
         async fn write_file(
             &self,
+            _app: openwave_core::id::AppId,
             _root: openwave_core::id::HostRootId,
             _path: &str,
             _content: &[u8],

--- a/crates/openwave-server/src/tests/app_invoke.rs
+++ b/crates/openwave-server/src/tests/app_invoke.rs
@@ -558,6 +558,9 @@ use crate::host_folders::{
 struct FakeFolderHost {
     roots: StdMutex<Vec<ApprovedFolder>>,
     files: StdMutex<StdBTreeMap<String, Vec<u8>>>,
+    /// The app identity each dispatched operation carried, in order — the
+    /// value the host's audit trail will attribute the I/O to.
+    seen_apps: StdMutex<Vec<openwave_core::id::AppId>>,
 }
 
 impl FakeFolderHost {
@@ -578,9 +581,11 @@ impl HostFolders for FakeFolderHost {
 
     async fn list_folder(
         &self,
+        app: openwave_core::id::AppId,
         root: HostRootId,
         _path: &str,
     ) -> Result<Vec<FolderEntry>, FolderOpError> {
+        self.seen_apps.lock().unwrap().push(app);
         if !self.live(root) {
             return Err(FolderOpError::NotConnected);
         }
@@ -596,7 +601,13 @@ impl HostFolders for FakeFolderHost {
             .collect())
     }
 
-    async fn read_file(&self, root: HostRootId, path: &str) -> Result<Vec<u8>, FolderOpError> {
+    async fn read_file(
+        &self,
+        app: openwave_core::id::AppId,
+        root: HostRootId,
+        path: &str,
+    ) -> Result<Vec<u8>, FolderOpError> {
+        self.seen_apps.lock().unwrap().push(app);
         if !self.live(root) {
             return Err(FolderOpError::NotConnected);
         }
@@ -610,11 +621,13 @@ impl HostFolders for FakeFolderHost {
 
     async fn write_file(
         &self,
+        app: openwave_core::id::AppId,
         root: HostRootId,
         path: &str,
         content: &[u8],
         replace: bool,
     ) -> Result<FolderWriteReceipt, FolderOpError> {
+        self.seen_apps.lock().unwrap().push(app);
         if !self.live(root) {
             return Err(FolderOpError::NotConnected);
         }
@@ -696,6 +709,7 @@ async fn folder_invokes_walk_the_ladder_and_round_trip_through_the_seam() {
             "note.txt".to_owned(),
             b"hello".to_vec(),
         )])),
+        seen_apps: StdMutex::new(Vec::new()),
     });
     state.host_folders = Some(host.clone());
     let bearer = format!("Bearer {}", state.token);
@@ -801,4 +815,12 @@ async fn folder_invokes_walk_the_ladder_and_round_trip_through_the_seam() {
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     let info: AgentErrorInfo = json_body(response).await;
     assert_eq!(info.kind, "consent_required");
+
+    // Every dispatched operation carried the invoking app's identity — what
+    // the host's audit trail attributes the I/O to. Refused invokes (pin,
+    // consent, malformed, disconnected) never reached the seam at all.
+    assert_eq!(
+        host.seen_apps.lock().unwrap().as_slice(),
+        [reader, reader, writer, writer]
+    );
 }

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -29,8 +29,7 @@ pick them up now:
   [decision record 1](decisions/0001-project-files-and-attachment-vocabulary.md)
   but not yet built.
 - Make deletion of a terminal chat erase its background-run workspaces without
-  waiting for the periodic reaper, and add an app actor to the host-folder audit
-  vocabulary.
+  waiting for the periodic reaper.
 
 These are important finishing work, but they do not change the product's basic
 shape. They should be delivered as normal, reviewable slices rather than held

--- a/docs/folder-bindings.md
+++ b/docs/folder-bindings.md
@@ -135,7 +135,10 @@ in `authorize()` — was considered and rejected for now: it would duplicate
 the app grant into the broker's ledger (two records of one consent, able
 to disagree) and touch the persisted state format for no enforcement the
 server-side gate does not already provide. Recorded as revisitable if the
-broker ever becomes the sole consent store.
+broker ever becomes the sole consent store. The broker's audit trail still
+sees every folder operation, attributed to a dedicated **app actor**
+carrying the app id — not a borrowed grant subject — with writes recording
+a durable intent before any bytes change, exactly like agent writes.
 
 App writes are the first live user of the broker's bounded write
 operation (chat writebacks resolve paths advisorily and journal through


### PR DESCRIPTION
Follow-up recorded in #1616: the broker's app-folder trio (`ListAppFolder`, `ReadAppFolderFile`, `WriteAppFolderFile`) performed host I/O without touching the audit trail, because the actor vocabulary was subject-keyed (project | conversation) and a local app has no grant subject — recording under a borrowed subject would misattribute. The broker's ledger now sees every app-folder operation under the actor that actually performed it.

- **Broker**: a new `AuditActor::App { app_id }` kind (opaque broker `AppId`, additive to the rotating JSONL format) and three `AuditOperation` names. The trio's requests carry the invoking app id; the protocol version bumps 9→10 for the wire change. No capability or grant id is recorded — the broker holds no grant row for an app, and implying one would overstate what the record proves. Writes keep the existing mutation discipline: a durable `Attempted` intent before any bytes change, refusal when the log can't hold it.
- **Server**: `HostFolders::{list_folder, read_file, write_file}` take the invoking `AppId`; the invoke route passes the app it already admitted.
- **Desktop**: the broker client threads the id into the three control requests.
- **Docs**: `folder-bindings.md` states the attribution; the delivered item comes off `deferred.md`.

**Tests** (net: extended two existing tests, no new test fns): the broker trio's end-to-end test now runs on the collecting audit sink and asserts the exact app-actor event sequence — reads as completions, each write as intent+completion, digest-mismatch as `Failed`, the post-revocation read as `Denied` — plus the de-sensitized path target. The server folder-ladder test asserts each dispatched op carried the real app id and that refused invokes never reached the seam.

`full-ci`: boundary-crossing (broker wire protocol + audit format).

Closes #1624

🤖 Generated with [Claude Code](https://claude.com/claude-code)