### PR TITLE
feat(desktop): let guidance sent mid-turn invoke skills

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -1062,6 +1062,7 @@ pub mod turn_steer {
         pub turn_id: Uuid,
         pub chat_id: Uuid,
         pub content: String,
+        pub invoked_skills: Json,
         pub voice_input_used: bool,
         pub interrupt: bool,
         pub status: String,

--- a/crates/openwave-core/src/db/migration/baseline/turn.rs
+++ b/crates/openwave-core/src/db/migration/baseline/turn.rs
@@ -678,6 +678,15 @@ pub(super) fn turn_steer_table() -> TableCreateStatement {
         .col(ColumnDef::new(TurnSteer::TurnId).uuid().not_null())
         .col(ColumnDef::new(TurnSteer::ChatId).uuid().not_null())
         .col(ColumnDef::new(TurnSteer::Content).text().not_null())
+        // The skills the user named for this steer, as a JSON array of slugs.
+        // Scoped to the one instruction the same way the turn's own list is
+        // scoped to its opening message: invocation is a per-message directive,
+        // so a steer neither inherits nor extends the turn's list.
+        .col(
+            ColumnDef::new(TurnSteer::InvokedSkills)
+                .json_binary()
+                .not_null(),
+        )
         .col(
             ColumnDef::new(TurnSteer::VoiceInputUsed)
                 .boolean()

--- a/crates/openwave-core/src/db/migration/idens.rs
+++ b/crates/openwave-core/src/db/migration/idens.rs
@@ -565,6 +565,7 @@ pub(crate) enum TurnSteer {
     TurnId,
     ChatId,
     Content,
+    InvokedSkills,
     VoiceInputUsed,
     Interrupt,
     Status,

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -1499,15 +1499,18 @@ impl Store for DbStore {
         content: &str,
         interrupt: bool,
     ) -> Result<AcceptTurnSteerOutcome> {
-        ops::turn::accept_turn_steer(self, id, turn_id, chat_id, content, interrupt, false).await
+        ops::turn::accept_turn_steer(self, id, turn_id, chat_id, content, &[], interrupt, false)
+            .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn accept_turn_steer_with_message_context(
         &self,
         id: TurnSteerId,
         turn_id: TurnId,
         chat_id: ChatId,
         content: &str,
+        invoked_skills: &[String],
         interrupt: bool,
         voice_input_used: bool,
     ) -> Result<AcceptTurnSteerOutcome> {
@@ -1517,6 +1520,7 @@ impl Store for DbStore {
             turn_id,
             chat_id,
             content,
+            invoked_skills,
             interrupt,
             voice_input_used,
         )

--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -985,6 +985,14 @@ fn validate_turn_input(
             "turn content must be non-empty and contain no NUL characters".into(),
         ));
     }
+    validate_invoked_skills(invoked_skills)
+}
+
+/// The bounds an invoked-skill list must satisfy to be stored.
+///
+/// Shared by the turn's opening message and by a steer, which carries its own
+/// list under the same budget — one rule, so the two cannot drift apart.
+pub(in crate::db) fn validate_invoked_skills(invoked_skills: &[String]) -> Result<()> {
     if invoked_skills.len() > TurnRun::MAX_INVOKED_SKILLS {
         return Err(AgentError::Store(format!(
             "a turn may invoke at most {} skills",

--- a/crates/openwave-core/src/db/ops/turn/steer.rs
+++ b/crates/openwave-core/src/db/ops/turn/steer.rs
@@ -21,16 +21,18 @@ use super::super::{
 };
 use super::{canonical_db_timestamp, turn_run_status_from_db};
 
+#[allow(clippy::too_many_arguments)]
 pub(in crate::db) async fn accept_turn_steer(
     store: &DbStore,
     id: TurnSteerId,
     turn_id: TurnId,
     chat_id: ChatId,
     content: &str,
+    invoked_skills: &[String],
     interrupt: bool,
     voice_input_used: bool,
 ) -> Result<AcceptTurnSteerOutcome> {
-    validate_steer_input(id, turn_id, chat_id, content)?;
+    validate_steer_input(id, turn_id, chat_id, content, invoked_skills)?;
     if let Some(existing) = entities::turn_steer::Entity::find_by_id(id.0)
         .one(&store.conn)
         .await
@@ -41,6 +43,7 @@ pub(in crate::db) async fn accept_turn_steer(
             turn_id,
             chat_id,
             content,
+            invoked_skills,
             interrupt,
             voice_input_used,
         );
@@ -74,6 +77,7 @@ pub(in crate::db) async fn accept_turn_steer(
             turn_id,
             chat_id,
             content,
+            invoked_skills,
             interrupt,
             voice_input_used,
         )?;
@@ -136,6 +140,7 @@ pub(in crate::db) async fn accept_turn_steer(
                 turn_id,
                 chat_id,
                 content,
+                invoked_skills,
                 interrupt,
                 voice_input_used,
             );
@@ -148,6 +153,7 @@ pub(in crate::db) async fn accept_turn_steer(
         turn_id: Set(turn_id.0),
         chat_id: Set(chat_id.0),
         content: Set(content.to_owned()),
+        invoked_skills: Set(serde_json::json!(invoked_skills)),
         voice_input_used: Set(voice_input_used),
         interrupt: Set(interrupt),
         status: Set(TurnSteerStatus::Pending.as_str().into()),
@@ -173,6 +179,7 @@ pub(in crate::db) async fn accept_turn_steer(
                     turn_id,
                     chat_id,
                     content,
+                    invoked_skills,
                     interrupt,
                     voice_input_used,
                 );
@@ -497,7 +504,7 @@ pub(in crate::db) async fn apply_turn_steer(
             &steer.content,
             &[],
             &[],
-            &[],
+            &invoked_skills_from_steer(&steer)?,
             steer.voice_input_used,
         )),
         reasoning: Set(None),
@@ -636,6 +643,7 @@ fn validate_steer_input(
     turn_id: TurnId,
     chat_id: ChatId,
     content: &str,
+    invoked_skills: &[String],
 ) -> Result<()> {
     let content_len = content.chars().count();
     if id.0.is_nil() || turn_id.0.is_nil() || chat_id.0.is_nil() {
@@ -652,7 +660,7 @@ fn validate_steer_input(
             TurnSteer::MAX_CONTENT_LEN
         )));
     }
-    Ok(())
+    super::validate_invoked_skills(invoked_skills)
 }
 
 fn exact_accepted_steer(
@@ -660,12 +668,17 @@ fn exact_accepted_steer(
     turn_id: TurnId,
     chat_id: ChatId,
     content: &str,
+    invoked_skills: &[String],
     interrupt: bool,
     voice_input_used: bool,
 ) -> Result<AcceptTurnSteerOutcome> {
+    // The skill list is part of the caller's identity: a retry that names
+    // different skills is a different instruction, and reporting it as the
+    // one already accepted would silently drop the skills it asked for.
     if existing.turn_id != turn_id.0
         || existing.chat_id != chat_id.0
         || existing.content != content
+        || invoked_skills_from_steer(&existing)? != invoked_skills
         || existing.interrupt != interrupt
         || existing.voice_input_used != voice_input_used
     {
@@ -687,7 +700,7 @@ where
         &steer.content,
         &[],
         &[],
-        &[],
+        &invoked_skills_from_steer(steer)?,
         steer.voice_input_used,
     );
     let exact = entities::message::Entity::find_by_id(steer.id)
@@ -838,6 +851,7 @@ fn turn_steer_from_model(model: entities::turn_steer::Model) -> Result<TurnSteer
         id: TurnSteerId(model.id),
         turn_id: TurnId(model.turn_id),
         chat_id: ChatId(model.chat_id),
+        invoked_skills: invoked_skills_from_steer(&model)?,
         content: model.content,
         voice_input_used: model.voice_input_used,
         interrupt: model.interrupt,
@@ -846,6 +860,20 @@ fn turn_steer_from_model(model: entities::turn_steer::Model) -> Result<TurnSteer
         message_id: model.message_id.map(MessageId),
         created_at: model.created_at,
         resolved_at: model.resolved_at,
+    })
+}
+
+/// Read back the skills the user named on an accepted steer.
+///
+/// A row whose value is not an array of strings is corrupt rather than merely
+/// unusual: the accepted instruction can no longer be described honestly, so
+/// this fails instead of degrading to "no skills were invoked".
+fn invoked_skills_from_steer(model: &entities::turn_steer::Model) -> Result<Vec<String>> {
+    serde_json::from_value(model.invoked_skills.clone()).map_err(|error| {
+        AgentError::Store(format!(
+            "turn steer {} has unreadable invoked skills: {error}",
+            TurnSteerId(model.id)
+        ))
     })
 }
 

--- a/crates/openwave-core/src/db/tests/turn_steer.rs
+++ b/crates/openwave-core/src/db/tests/turn_steer.rs
@@ -12,6 +12,7 @@ fn pending_turn_steer(
         turn_id: Set(turn.id.0),
         chat_id: Set(turn.chat_id.0),
         content: Set(content.into()),
+        invoked_skills: Set(serde_json::json!([])),
         voice_input_used: Set(false),
         interrupt: Set(false),
         status: Set(TurnSteerStatus::Pending.as_str().into()),
@@ -191,6 +192,7 @@ async fn durable_turn_steer_applies_exactly_and_preserves_transcript_order() {
                 turn.id,
                 chat.id,
                 "change course",
+                &["presentations".to_owned()],
                 false,
                 true,
             )
@@ -199,6 +201,7 @@ async fn durable_turn_steer_applies_exactly_and_preserves_transcript_order() {
     );
     assert_eq!(pending.status, TurnSteerStatus::Pending);
     assert!(pending.voice_input_used);
+    assert_eq!(pending.invoked_skills, vec!["presentations".to_owned()]);
     assert_eq!(pending.message_id, None);
 
     let claim_at = Utc::now();
@@ -320,6 +323,12 @@ async fn durable_turn_steer_applies_exactly_and_preserves_transcript_order() {
         .llm_content
         .as_deref()
         .is_some_and(|content| content.contains("The user dictated this message")));
+    // The steer's own skills reach the model as a directive on the message the
+    // steer became — the whole point of carrying them, and the thing a wrong
+    // argument position in either projection site would silently drop.
+    assert!(messages[2].llm_content.as_deref().is_some_and(|content| {
+        content.contains("explicitly invoked these skills") && content.contains("presentations")
+    }));
 
     let second_id = crate::id::TurnSteerId::new();
     accepted_steer(
@@ -595,7 +604,27 @@ async fn turn_steer_admission_validates_identity_payload_and_monotonic_time() {
     ));
     assert!(matches!(
         store
-            .accept_turn_steer_with_message_context(id, turn.id, chat.id, "exact", false, true,)
+            .accept_turn_steer_with_message_context(
+                id, turn.id, chat.id, "exact", &[], false, true,
+            )
+            .await
+            .unwrap(),
+        AcceptTurnSteerOutcome::IdentityConflict
+    ));
+    // The skills a steer names are part of what was accepted: a retry that
+    // changes them must not be answered with the steer already stored, which
+    // would drop the skills it asked for without saying so.
+    assert!(matches!(
+        store
+            .accept_turn_steer_with_message_context(
+                id,
+                turn.id,
+                chat.id,
+                "exact",
+                &["docx".to_owned()],
+                false,
+                false,
+            )
             .await
             .unwrap(),
         AcceptTurnSteerOutcome::IdentityConflict

--- a/crates/openwave-core/src/model/turns.rs
+++ b/crates/openwave-core/src/model/turns.rs
@@ -414,6 +414,11 @@ pub struct TurnSteer {
     pub chat_id: ChatId,
     /// Byte-exact user instruction.
     pub content: String,
+    /// Skills the user explicitly named for this instruction.
+    ///
+    /// Scoped to the steer alone: invocation is a per-message directive, so a
+    /// steer neither inherits the turn's opening list nor spends its budget.
+    pub invoked_skills: Vec<String>,
     /// Whether the instruction was dictated and transcribed from speech.
     pub voice_input_used: bool,
     /// Whether delivery should preempt the current model stream.

--- a/crates/openwave-core/src/storage/store.rs
+++ b/crates/openwave-core/src/storage/store.rs
@@ -1741,9 +1741,11 @@ pub trait Store: Send + Sync {
     /// Accept a steer with renderer-hidden, message-scoped context needed for
     /// its eventual durable model projection.
     ///
-    /// `voice_input_used` is kept separate from caller-visible content so the
-    /// store derives the canonical model note. Implementations that do not yet
-    /// persist this metadata can continue serving the ordinary false case.
+    /// `voice_input_used` and `invoked_skills` are kept separate from
+    /// caller-visible content so the store derives the canonical model note.
+    /// The skills are the steer's own: a steer neither inherits the turn's
+    /// opening list nor spends its budget. Implementations that do not yet
+    /// persist this metadata can continue serving the ordinary empty case.
     #[allow(clippy::too_many_arguments)]
     async fn accept_turn_steer_with_message_context(
         &self,
@@ -1751,10 +1753,11 @@ pub trait Store: Send + Sync {
         turn_id: TurnId,
         chat_id: ChatId,
         content: &str,
+        invoked_skills: &[String],
         interrupt: bool,
         voice_input_used: bool,
     ) -> Result<AcceptTurnSteerOutcome> {
-        if voice_input_used {
+        if voice_input_used || !invoked_skills.is_empty() {
             return turn_storage_unavailable();
         }
         self.accept_turn_steer(id, turn_id, chat_id, content, interrupt)

--- a/crates/openwave-desktop/ui/src/ActiveTurnSteer.test.ts
+++ b/crates/openwave-desktop/ui/src/ActiveTurnSteer.test.ts
@@ -40,9 +40,30 @@ describe("ActiveTurnSteerFence", () => {
       draftSnapshot: "  change course  ",
       steerId: "steer-1",
       voiceInputUsed: false,
+      invokedSkills: [],
     });
     expect(fence.begin(target, "another direction", createId)).toBeNull();
     expect(createId).toHaveBeenCalledTimes(1);
+  });
+
+  it("allocates a new identity when a retry names different skills", () => {
+    // The server compares the skill list as part of the steer's identity, so
+    // reusing the id would have a changed list reported as already accepted
+    // and quietly dropped.
+    const createId = vi.fn(() => `steer-${createId.mock.calls.length}`);
+    const fence = new ActiveTurnSteerFence();
+    const first = fence.begin(target, "change course", createId, false, [
+      "docx",
+    ])!;
+    fence.fail(first);
+
+    const retry = fence.begin(target, "change course", createId, false, [
+      "docx",
+      "notes",
+    ])!;
+
+    expect(retry.steerId).not.toBe(first.steerId);
+    expect(retry.invokedSkills).toEqual(["docx", "notes"]);
   });
 
   it("reuses the exact identity when unchanged guidance is retried", () => {

--- a/crates/openwave-desktop/ui/src/ActiveTurnSteer.ts
+++ b/crates/openwave-desktop/ui/src/ActiveTurnSteer.ts
@@ -23,6 +23,8 @@ export type ActiveTurnSteerRequest = ActiveTurnTarget & {
   draftSnapshot: string;
   steerId: string;
   voiceInputUsed: boolean;
+  /** Skills named for this guidance alone, under the steer's own budget. */
+  invokedSkills: readonly string[];
 };
 
 export function canBeginActiveTurnSteer(input: {
@@ -36,6 +38,16 @@ export function canBeginActiveTurnSteer(input: {
     input.turnId !== null &&
     input.cancelRequestTurnId === null &&
     !input.deletionInFlight
+  );
+}
+
+function sameSkills(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((skill, index) => skill === right[index])
   );
 }
 
@@ -55,6 +67,7 @@ export class ActiveTurnSteerFence {
     draft: string,
     createId: () => string,
     voiceInputUsed = false,
+    invokedSkills: readonly string[] = [],
   ): ActiveTurnSteerRequest | null {
     const content = draft.trim();
     if (
@@ -70,7 +83,8 @@ export class ActiveTurnSteerFence {
       this.retryable &&
       sameTarget(this.retryable, target) &&
       this.retryable.content === content &&
-      this.retryable.voiceInputUsed === voiceInputUsed
+      this.retryable.voiceInputUsed === voiceInputUsed &&
+      sameSkills(this.retryable.invokedSkills, invokedSkills)
         ? { ...this.retryable, draftSnapshot: draft }
         : {
             ...target,
@@ -78,6 +92,7 @@ export class ActiveTurnSteerFence {
             draftSnapshot: draft,
             steerId: createId(),
             voiceInputUsed,
+            invokedSkills: [...invokedSkills],
           };
     this.retryable = null;
     this.pending = request;

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -142,9 +142,14 @@ export function ChatView({
     draftRef,
     () => {
       onDraftChange("");
+      // Pills go with the text they were attached to: accepted guidance has
+      // already carried them, and leaving them behind would silently re-invoke
+      // the same skills on whatever is typed next.
+      useComposerDrafts.getState().setSkills(chat.id, []);
       onVoiceInputAccepted();
     },
     voiceInputUsed,
+    invokedSkills,
   );
   const messages = useChatSessionStore((session) => session.messages);
   const busy = useChatSessionStore((session) => session.busy);

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -377,7 +377,7 @@ export function Composer({
     : [];
   // Skills vanish from the list at the cap, which would otherwise read as a
   // catalog that has lost them. The note says which bound was reached.
-  const capNote = !active && atSkillCap;
+  const capNote = atSkillCap;
   const slashCapNote = slashToken !== null && capNote;
   // An open list with nothing in it is a panel over the draft saying nothing.
   const slashOpen =
@@ -802,9 +802,6 @@ export function Composer({
               key={name}
               option={skillOption(slash.options, name)}
               name={name}
-              // Steering carries no invocation, so a chip is set aside for as
-              // long as a turn is running rather than silently applying later.
-              inactive={active}
               onRemove={() => slash.onRemove(name)}
             />
           ))}
@@ -1127,22 +1124,17 @@ function skillOption(
 function InvokedSkillChip({
   option,
   name,
-  inactive,
   onRemove,
 }: {
   option: SlashOption | undefined;
   name: string;
-  inactive: boolean;
   onRemove: () => void;
 }) {
   const label = option?.label ?? name;
   const Icon = option ? optionIcon(option) : Wand2;
   return (
     <li
-      className={cn(
-        "relative flex min-w-0 max-w-full items-center gap-2 rounded-full border border-border bg-muted/50 py-1 pl-2 pr-7 text-muted-foreground",
-        inactive && "opacity-60",
-      )}
+      className="relative flex min-w-0 max-w-full items-center gap-2 rounded-full border border-border bg-muted/50 py-1 pl-2 pr-7 text-muted-foreground"
     >
       <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-background">
         <Icon size={14} aria-hidden="true" />
@@ -1153,9 +1145,7 @@ function InvokedSkillChip({
       >
         {label}
       </span>
-      <small className="text-[0.68rem]">
-        {inactive ? "Next message" : "Skill"}
-      </small>
+      <small className="text-[0.68rem]">Skill</small>
       <button
         type="button"
         className="absolute right-1 top-1/2 inline-flex -translate-y-1/2 items-center justify-center rounded-full border-0 bg-transparent p-0.5 text-inherit hover:bg-accent hover:text-foreground"

--- a/crates/openwave-desktop/ui/src/ComposerSlash.test.ts
+++ b/crates/openwave-desktop/ui/src/ComposerSlash.test.ts
@@ -99,10 +99,13 @@ describe("skillsToInvoke", () => {
 describe("availableSlashOptions", () => {
   const options = slashOptionsFromCatalog(CATALOG);
 
-  it("keeps prompts and drops invocations while a turn is running", () => {
+  it("keeps invocations reachable while a turn runs, minus disabled bundles", () => {
+    // A steer carries its own invocation, so skills stay pickable. The
+    // `charts` bundle is off, and picking it mid-turn would flip it on
+    // install-wide and name a manifest this turn never staged.
     expect(
       availableSlashOptions(options, [], { steering: true }).map((o) => o.name),
-    ).toEqual(["weekly-update"]);
+    ).toEqual(["documents", "docx", "notes", "weekly-update"]);
   });
 
   it("drops a bundle only once every member it could add is on the message", () => {

--- a/crates/openwave-desktop/ui/src/ComposerSlash.ts
+++ b/crates/openwave-desktop/ui/src/ComposerSlash.ts
@@ -23,6 +23,12 @@ export type SlashOption = {
   category?: PluginCategory;
   /** A bundle row's invocable member skills, in manifest order. */
   skills?: readonly string[];
+  /**
+   * Whether a bundle row's own flag is on. A row is offered either way at rest,
+   * because picking a disabled one turns it on; mid-turn that is not available,
+   * so the flag is what tells the two cases apart.
+   */
+  enabled?: boolean;
 };
 
 /**
@@ -157,6 +163,7 @@ export function slashOptionsFromCatalog(
         description: plugin.description,
         category: plugin.category,
         skills: members,
+        enabled: plugin.enabled,
       });
     }
     if (!plugin.enabled) continue;
@@ -210,9 +217,11 @@ export function skillsToInvoke(
  * What the panel can still reach, given what this message already carries.
  *
  * A skill already on the message is not offered again, and neither is anything
- * that invokes once the turn's cap is reached, or while a turn is running:
- * steering carries no invocation, so a pill picked there would silently apply
- * to some later message. Prompts are text and stay available throughout.
+ * that invokes once the cap is reached. A steer carries its own invocation
+ * under its own budget, so skills stay reachable while a turn runs — but a
+ * *disabled* bundle's row does not: picking one turns the bundle on
+ * install-wide and names a manifest the running turn's workspace never staged.
+ * Prompts are text and stay available throughout.
  */
 export function availableSlashOptions(
   options: readonly SlashOption[],
@@ -221,7 +230,10 @@ export function availableSlashOptions(
 ): SlashOption[] {
   return options.filter((option) => {
     if (option.kind === "prompt") return true;
-    if (steering || invoked.length >= MAX_INVOKED_SKILLS) return false;
+    if (steering && option.kind === "plugin" && option.enabled === false) {
+      return false;
+    }
+    if (invoked.length >= MAX_INVOKED_SKILLS) return false;
     return skillsToInvoke(option, invoked).length > 0;
   });
 }

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -708,6 +708,7 @@ describe("active turn steering", () => {
       "change course",
       true,
       true,
+      ["docx"],
     );
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -720,6 +721,7 @@ describe("active turn steering", () => {
       content: "change course",
       interrupt: true,
       voice_input_used: true,
+      invoked_skills: ["docx"],
     });
   });
 });

--- a/crates/openwave-desktop/ui/src/api/client.ts
+++ b/crates/openwave-desktop/ui/src/api/client.ts
@@ -1216,6 +1216,7 @@ export class ApiClient {
     content: string,
     interrupt = false,
     voiceInputUsed = false,
+    invokedSkills: readonly string[] = [],
   ): Promise<void> {
     return this.json(`/chats/${chatId}/steer`, {
       method: "POST",
@@ -1226,6 +1227,7 @@ export class ApiClient {
         content,
         interrupt,
         voice_input_used: voiceInputUsed,
+        invoked_skills: invokedSkills,
       }),
     });
   }

--- a/crates/openwave-desktop/ui/src/useTurnControls.test.ts
+++ b/crates/openwave-desktop/ui/src/useTurnControls.test.ts
@@ -38,6 +38,7 @@ function mount(
   draft = "change course",
   chatId = "chat-1",
   voiceInputUsed = false,
+  invokedSkills: readonly string[] = [],
 ) {
   const draftRef = { current: draft };
   const onDraftAccepted = vi.fn(() => {
@@ -51,6 +52,7 @@ function mount(
         draftRef,
         onDraftAccepted,
         voiceInputUsed,
+        invokedSkills,
       ),
     { initialProps: { id: chatId } },
   );
@@ -111,6 +113,7 @@ describe("useTurnControls", () => {
       "go left",
       true,
       false,
+      [],
     );
     expect(onDraftAccepted).toHaveBeenCalledTimes(1);
     expect(draftRef.current).toBe("");
@@ -131,6 +134,27 @@ describe("useTurnControls", () => {
       "change course",
       true,
       true,
+      [],
+    );
+  });
+
+  it("carries the pills on the draft with the guidance", async () => {
+    const client = stubClient();
+    const { result } = mount(client, "use the deck skill", "chat-1", false, [
+      "pptx",
+    ]);
+    act(() => runTurn());
+
+    await act(async () => result.current.steer());
+
+    expect(client.steer).toHaveBeenCalledWith(
+      "chat-1",
+      "turn-1",
+      expect.any(String),
+      "use the deck skill",
+      true,
+      false,
+      ["pptx"],
     );
   });
 

--- a/crates/openwave-desktop/ui/src/useTurnControls.ts
+++ b/crates/openwave-desktop/ui/src/useTurnControls.ts
@@ -35,8 +35,10 @@ export type TurnControls = {
  * @param draftRef the live composer draft, read at the moment guidance is sent
  *   rather than at render, so a keystroke that has not painted yet still counts.
  * @param onDraftAccepted called when accepted guidance was the draft still in
- *   the composer, so the composer can clear it.
+ *   the composer, so the composer can clear it and its pills together.
  * @param voiceInputUsed whether voice transcription contributed to this draft.
+ * @param invokedSkills the pills on the draft, which the steer carries under
+ *   its own budget rather than the turn's.
  */
 export function useTurnControls(
   client: ApiClient | null,
@@ -44,6 +46,7 @@ export function useTurnControls(
   draftRef: RefObject<string>,
   onDraftAccepted: () => void,
   voiceInputUsed = false,
+  invokedSkills: readonly string[] = [],
 ): TurnControls {
   const [cancelPendingTurnId, setCancelPendingTurnId] = useState<string | null>(
     null,
@@ -191,6 +194,7 @@ export function useTurnControls(
       draftRef.current,
       () => crypto.randomUUID(),
       voiceInputUsed,
+      invokedSkills,
     );
     if (!request) return;
 
@@ -206,6 +210,7 @@ export function useTurnControls(
         request.content,
         true,
         request.voiceInputUsed,
+        request.invokedSkills,
       );
       if (!canApplySteerResponse(request)) return;
 

--- a/crates/openwave-server/src/desktop_schema.rs
+++ b/crates/openwave-server/src/desktop_schema.rs
@@ -25,7 +25,7 @@ const VECTOR_DIRECTORY: &str = "vectors";
 const MAX_MARKER_BYTES: u64 = 1_024;
 
 /// Bump this whenever the pre-v1 schema baseline changes incompatibly.
-const DESKTOP_SCHEMA_EPOCH: u32 = 21;
+const DESKTOP_SCHEMA_EPOCH: u32 = 22;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/openwave-server/src/routes/turn_control.rs
+++ b/crates/openwave-server/src/routes/turn_control.rs
@@ -408,6 +408,10 @@ pub struct SteerBody {
     pub turn_id: TurnId,
     /// User text to inject into the running turn.
     pub content: String,
+    /// Skills the user named for this instruction alone. A steer neither
+    /// inherits the turn's opening list nor spends its budget.
+    #[serde(default)]
+    pub invoked_skills: Vec<String>,
     /// When true, preempt the provider stream immediately; otherwise the message
     /// waits for the next step boundary.
     #[serde(default)]
@@ -441,6 +445,7 @@ pub async fn post_steer(
             "steer content must be non-empty, contain no NUL characters, and fit the size limit",
         ));
     }
+    require_invocable_skills(&state, &body.invoked_skills).await?;
     store.require_chat(id).await?;
     match store
         .accept_turn_steer_with_message_context(
@@ -448,6 +453,7 @@ pub async fn post_steer(
             body.turn_id,
             id,
             &body.content,
+            &body.invoked_skills,
             body.interrupt,
             body.voice_input_used,
         )

--- a/crates/openwave-server/src/scoped_store.rs
+++ b/crates/openwave-server/src/scoped_store.rs
@@ -257,12 +257,14 @@ impl ScopedStore {
     }
 
     /// [`Store::accept_turn_steer_with_message_context`].
+    #[allow(clippy::too_many_arguments)]
     pub async fn accept_turn_steer_with_message_context(
         &self,
         id: TurnSteerId,
         turn_id: TurnId,
         chat_id: ChatId,
         content: &str,
+        invoked_skills: &[String],
         interrupt: bool,
         voice_input_used: bool,
     ) -> Result<AcceptTurnSteerOutcome> {
@@ -272,6 +274,7 @@ impl ScopedStore {
                 turn_id,
                 chat_id,
                 content,
+                invoked_skills,
                 interrupt,
                 voice_input_used,
             )

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -4895,6 +4895,130 @@ async fn an_invoked_skill_must_be_enabled_or_the_turn_is_refused() {
     assert_eq!(store.list_turn_runs(chat.id).await.unwrap().len(), 1);
 }
 
+/// POST guidance into a running turn that explicitly invokes skills by name.
+async fn steer_invoking(
+    router: &Router,
+    bearer: &str,
+    chat: ChatId,
+    turn: TurnId,
+    steer_id: TurnSteerId,
+    invoked: &[&str],
+) -> axum::response::Response {
+    router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/chats/{chat}/steer"))
+                .header(header::AUTHORIZATION, bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "steer_id": steer_id,
+                        "turn_id": turn,
+                        "content": "use the deck skill instead",
+                        "invoked_skills": invoked,
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+/// Contract: guidance sent into a running turn may name skills of its own, and
+/// they are held to the same catalog check the opening message is held to.
+///
+/// A steer becomes a real user message, so the names it carries end up in that
+/// message's model projection exactly as the turn's own do. Checking them here
+/// is what stops a name the reader picked moments earlier — and the install has
+/// since switched off — from directing the model at a manifest staging has
+/// already removed.
+#[tokio::test]
+async fn steering_guidance_may_invoke_skills_and_is_held_to_the_same_catalog() {
+    let (dir, store) = temp_db_store("steer-invoked-skills.db").await;
+    let store: Arc<dyn Store> = Arc::new(store);
+    let (router, token) = plugin_app(store.clone(), dir.path());
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+
+    assert_eq!(
+        send_message_invoking(&router, &bearer, chat.id, &[])
+            .await
+            .status(),
+        StatusCode::ACCEPTED
+    );
+    let turn = store.list_turn_runs(chat.id).await.unwrap()[0].id;
+
+    let steer_id = TurnSteerId::new();
+    let accepted = steer_invoking(
+        &router,
+        &bearer,
+        chat.id,
+        turn,
+        steer_id,
+        &["presentations"],
+    )
+    .await;
+    assert_eq!(accepted.status(), StatusCode::ACCEPTED);
+    // The list is durably part of what was accepted, not just prompt material:
+    // the same identity repeated with the same skills is the same instruction,
+    // and repeated with different ones is a different one.
+    assert_eq!(
+        steer_invoking(
+            &router,
+            &bearer,
+            chat.id,
+            turn,
+            steer_id,
+            &["presentations"]
+        )
+        .await
+        .status(),
+        StatusCode::ACCEPTED
+    );
+    assert_eq!(
+        steer_invoking(&router, &bearer, chat.id, turn, steer_id, &["charts"])
+            .await
+            .status(),
+        StatusCode::CONFLICT
+    );
+
+    let unknown = steer_invoking(
+        &router,
+        &bearer,
+        chat.id,
+        turn,
+        TurnSteerId::new(),
+        &["no-such-skill"],
+    )
+    .await;
+    assert_eq!(unknown.status(), StatusCode::BAD_REQUEST);
+    let error: AgentErrorInfo = json_body(unknown).await;
+    assert_eq!(error.kind, "invoked_skill_unavailable");
+
+    let toggled = put_plugins_enabled(
+        &router,
+        &bearer,
+        serde_json::json!({"skills": {"presentations": false}}),
+    )
+    .await;
+    assert_eq!(toggled.status(), StatusCode::OK);
+    let refused = steer_invoking(
+        &router,
+        &bearer,
+        chat.id,
+        turn,
+        TurnSteerId::new(),
+        &["presentations"],
+    )
+    .await;
+    assert_eq!(refused.status(), StatusCode::BAD_REQUEST);
+    let error: AgentErrorInfo = json_body(refused).await;
+    assert_eq!(error.kind, "invoked_skill_unavailable");
+}
+
 /// A stdio MCP server small enough to write into a plugin package: POSIX sh
 /// answering the three requests a connection makes, plus the health probe. It
 /// records the environment it was launched with on startup, which is what

--- a/crates/openwave-server/src/tests/lifecycle.rs
+++ b/crates/openwave-server/src/tests/lifecycle.rs
@@ -471,6 +471,7 @@ async fn interrupt_steer_preempts_a_running_turn_and_continues() {
                 turn_id,
                 chat.id,
                 "change course",
+                &[],
                 true,
                 true,
             )


### PR DESCRIPTION
## What

Opening the plugins panel while a turn is running showed **"Nothing matches."** over a healthy, fully-enabled catalog. `availableSlashOptions` dropped every skill and bundle when `steering` was true and kept only prompts — and an install with no prompts is left with an empty panel that reads as a broken library.

The ban was deliberate: a steer carried no invocation, so a pill picked there would have silently applied to some later message. This makes that premise false rather than papering over the symptom — a steer now carries invoked skills of its own.

This is cheaper than it looks. Skills are staged into the sandbox by *enabled* state, not by invocation (staged at turn start and re-staged on every exec call). Invocation is purely a prompt directive, and a steer already becomes a real user message through the same projection that builds it — which until now passed an empty list in the `invoked_skills` position. Filling that slot is the feature.

## Two rules while a turn runs

- **Only already-enabled entries are offered.** At rest a *bundle* row is shown even when the bundle is off, because picking it turns it on. Mid-turn that would flip a bundle on install-wide and name a `SKILL.md` the running turn's workspace never staged, so those rows are hidden. Enabled bundles, member skills, standalone skills, and prompts all stay reachable.
- **Each steer gets its own budget of 8.** Invocation is a per-message directive, so a steer neither inherits the turn's opening list nor spends its budget.

## Identity

The skill list joins the steer's identity on **both** sides of the retry fence — the client's `ActiveTurnSteerFence` and the server's exact-retry comparison. Without that, a retry naming different skills would come back reported as the instruction already accepted, and the skills it asked for would be dropped in silence.

The route reuses the existing `require_invocable_skills` check, so a skill switched off between the pick and the send refuses the steer rather than directing the model at a manifest staging has removed.

## Schema epoch — this resets local databases

`turn_steer` gains an `invoked_skills` column. Under the pre-1.0 scheme the baseline migration is edited in place and `DESKTOP_SCHEMA_EPOCH` bumps (21 → 22), so `prepare_for_product_major` resets any database written under the lower epoch. **First launch of a build carrying this deletes existing local chat history.** That is the standing pre-v1 posture and was accepted deliberately, but it is worth knowing before installing.

`SteerBody` is `Deserialize`-only rather than a `ts_rs` type, so no `wire.ts` regeneration.

## Tests

- Core: the existing durable-steer test now sends a skill and asserts the applied message's `llm_content` carries the "explicitly invoked these skills" block — the whole point of carrying them, and what a wrong argument position in either of the two projection sites would silently drop. The existing identity test gains a case proving a retry with a changed skill list is an `IdentityConflict`.
- Server: a new route-level test that guidance may invoke skills, that repeating the identity with the same list is idempotent and with a different list conflicts, and that an unknown or since-disabled name refuses with `invoked_skill_unavailable`.
- UI: the `ComposerSlash` steering case now asserts what survives the filter (and that the disabled bundle does not); `ActiveTurnSteer` gains a changed-skills identity case; `useTurnControls` gains a case that the pills on the draft are carried.

No tests removed.

## Verified

`cargo fmt`, `cargo clippy --workspace --all-targets --locked` (clean), `cargo check --workspace --locked` (no lockfile drift), `cargo test -p openwave-core -p openwave-server`, and `pnpm test` + `tsc` in the desktop UI — all green locally.

Not verified: I did not drive the running app. Worth a look at the panel mid-turn, and at the database reset on first launch.