### PR TITLE
feat(desktop): replace stale home starters with outcome-oriented launch tasks

### DIFF
--- a/crates/openwave-desktop/ui/src/WelcomeState.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/WelcomeState.dom.test.tsx
@@ -55,7 +55,7 @@ describe("WelcomeState starters", () => {
     // step aside once the library has something to say.
     expect(screen.queryByText(/Retired brief/)).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "What can you help me with?" }),
+      screen.queryByRole("button", { name: "Write a report from files" }),
     ).not.toBeInTheDocument();
 
     fireEvent.click(card);
@@ -77,10 +77,12 @@ describe("WelcomeState starters", () => {
     // Shown from the first paint, not after the catalog answers: an install
     // with no prompts must never see home flicker or empty out.
     const starter = screen.getByRole("button", {
-      name: "What can you help me with?",
+      name: "Write a report from files",
     });
     await waitFor(() => expect(library.list).toHaveBeenCalled());
     fireEvent.click(starter);
-    expect(onSelectPrompt).toHaveBeenCalledWith("What can you help me with?");
+    expect(onSelectPrompt).toHaveBeenCalledWith(
+      expect.stringContaining("written report"),
+    );
   });
 });

--- a/crates/openwave-desktop/ui/src/WelcomeState.test.tsx
+++ b/crates/openwave-desktop/ui/src/WelcomeState.test.tsx
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   ApiClient,
@@ -21,17 +27,32 @@ function executionClient(
 }
 
 describe("WelcomeState", () => {
-  it("renders the greeting and starter prompts when a handler is provided", () => {
-    render(<WelcomeState onSelectPrompt={vi.fn()} />);
+  it("offers the launch outcomes as starter prompts when a handler is provided", () => {
+    const onSelectPrompt = vi.fn();
+    render(<WelcomeState onSelectPrompt={onSelectPrompt} />);
 
     expect(
       screen.getByRole("heading", { name: "How can I help?" }),
     ).toBeInTheDocument();
-    expect(screen.getByText("What can you help me with?")).toBeInTheDocument();
-    expect(screen.getByText("Draft a plan")).toBeInTheDocument();
-    expect(
-      screen.getByRole("region", { name: "Start a chat" }),
-    ).toBeInTheDocument();
+    for (const label of [
+      "Write a report from files",
+      "Analyze a spreadsheet",
+      "Delegate work in parallel",
+      "Turn a folder into an app",
+    ]) {
+      expect(screen.getByRole("button", { name: label })).toBeInTheDocument();
+    }
+    // Nothing on home offers to search sources any more.
+    expect(screen.queryByText(/search/i)).toBeNull();
+
+    // A prompt has to stand on its own before anything is attached: it asks
+    // for the input it is missing rather than assuming hidden context.
+    fireEvent.click(
+      screen.getByRole("button", { name: "Write a report from files" }),
+    );
+    expect(onSelectPrompt).toHaveBeenCalledWith(
+      expect.stringMatching(/Tell me what to attach/),
+    );
   });
 
   it("omits the starter prompts when no handler is provided", () => {

--- a/crates/openwave-desktop/ui/src/WelcomeState.tsx
+++ b/crates/openwave-desktop/ui/src/WelcomeState.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useState } from "react";
-import { FileSearch, ListChecks, MessageCircle, Sparkles } from "lucide-react";
+import {
+  AppWindow,
+  ChartColumn,
+  FileText,
+  Sparkles,
+  Users,
+} from "lucide-react";
 import type {
   ApiClient,
   CodeExecutionConfigInfo,
@@ -29,26 +35,38 @@ type StarterPrompt = {
   prompt: string;
 };
 
+/**
+ * The starters home falls back to with no prompt library installed.
+ *
+ * Each one names a finished result rather than a chat behavior, and each
+ * prompt stands on its own before anything is attached: it says which input
+ * is missing and what to do first, so a card that is clicked and sent
+ * immediately still starts a real conversation.
+ */
 const STARTER_PROMPTS: StarterPrompt[] = [
   {
-    icon: MessageCircle,
-    label: "What can you help me with?",
-    prompt: "What can you help me with?",
+    icon: FileText,
+    label: "Write a report from files",
+    prompt:
+      "I want a written report I can share, built from my own files. Tell me what to attach and which sections you would cover, then draft it once the files are in.",
   },
   {
-    icon: FileSearch,
-    label: "Search this chat's sources",
-    prompt: "Search the sources in this chat for ",
+    icon: ChartColumn,
+    label: "Analyze a spreadsheet",
+    prompt:
+      "I want a spreadsheet analyzed and the findings charted. Tell me what to attach, then walk the data, call out what actually changed, and build the charts that show it.",
   },
   {
-    icon: Sparkles,
-    label: "Summarize a document",
-    prompt: "Summarize the key points from ",
+    icon: Users,
+    label: "Delegate work in parallel",
+    prompt:
+      "I have work that could run several ways at once. Ask me what the work is, then split it into background tasks you can run in parallel and report back on each.",
   },
   {
-    icon: ListChecks,
-    label: "Draft a plan",
-    prompt: "Help me draft a plan for ",
+    icon: AppWindow,
+    label: "Turn a folder into an app",
+    prompt:
+      "I want a small private app that runs on my own machine over a folder of files. Ask me which folder and what it should do, then build it.",
   },
 ];
 
@@ -156,7 +174,7 @@ export function WelcomeState({
       <div className="welcome-copy">
         <h2>How can I help?</h2>
         <p>
-          Ask a question, search attached sources, or start a task.
+          Ask a question, work through your files, or start a task.
         </p>
         {managedExecutionOnly && <p>{MANAGED_EXECUTION_DISCLOSURE}</p>}
       </div>


### PR DESCRIPTION
The built-in starter cards on home — the set that stands in when no prompt library is installed, or when it is empty or still loading — led with generic chat behavior, and one of them offered to search a chat's sources, a direction the product no longer has.

They now name four supported outcomes instead:

- **Write a report from files** — a written report built from attached files.
- **Analyze a spreadsheet** — the data walked, what changed called out, charts built from it.
- **Delegate work in parallel** — the work split into background tasks run at once.
- **Turn a folder into an app** — a small private app running locally over a folder.

Each prompt is written to be useful before anything is attached: it says what to attach or asks which folder, so a card that is picked and sent straight away still starts a real conversation rather than referring to files that aren't there. The welcome subtitle drops its mention of searching attached sources for the same reason.

The prompt-library precedence and limit behavior added in #1638 is untouched — an install with enabled library prompts still sees those, and the built-ins only stand in behind them.

The set stays at four cards, so the two-column grid still fills evenly and collapses to a single column below 720px as before; the labels are short enough to wrap at most once at that width.

Verified with `pnpm tsc --noEmit` and the two `WelcomeState` test files. The existing tests were updated to assert the new outcomes rather than the old labels, with no new test files: the starter test now also checks that a picked prompt asks for its missing input, and the library-precedence test in `WelcomeState.dom.test.tsx` points at a current label.

Closes #1743