### PR TITLE
ci: run every scope-relevant lane on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,11 +156,11 @@ jobs:
             exit 0
           fi
 
-          # `rust` gates rustfmt plus the full-CI lanes that cover every crate:
-          # clippy and the openwave-desktop tests. `workspace` gates the full-CI
-          # lanes that cover everything *except* openwave-desktop, so it can
-          # stay false when a change cannot reach them. `workspace` implies
-          # `rust`; the gate below asserts that.
+          # `rust` gates rustfmt plus the lanes that cover every crate: clippy
+          # and the openwave-desktop tests. `workspace` gates the lanes that
+          # cover everything *except* openwave-desktop, so it can stay false
+          # when a change cannot reach them. `workspace` implies `rust`; the
+          # gate below asserts that.
           rust=false
           ui=false
           workspace=false
@@ -223,9 +223,9 @@ jobs:
     name: supply-chain advisories (cargo-deny)
     needs: changes
     # cargo-deny resolves the crate graph and reads the RustSec database; it
-    # compiles nothing, so this runs on every Rust-scoped pull request instead
-    # of hiding behind `full-ci`. The weekly scheduled run re-checks an
-    # unchanged lockfile against newly published advisories.
+    # compiles nothing, so it runs on every Rust-scoped pull request. The
+    # weekly scheduled run re-checks an unchanged lockfile against newly
+    # published advisories.
     if: ${{ needs.changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -274,9 +274,9 @@ jobs:
   lint:
     name: clippy
     needs: changes
-    # Keep the default greenfield PR gate fast. Add `full-ci` for pre-merge
-    # validation; pushes to main and scheduled/manual runs always pay this cost.
-    if: ${{ needs.changes.outputs.rust == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')) }}
+    # Every scope-relevant lane runs on every pull request: green PR checks
+    # must mean the same commits stay green on main.
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -332,7 +332,7 @@ jobs:
   desktop:
     name: desktop test
     needs: changes
-    if: ${{ needs.changes.outputs.rust == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')) }}
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -375,10 +375,10 @@ jobs:
     name: Windows cargo check
     needs: changes
     # A native runner keeps the Windows SDK and MSVC available for native
-    # dependencies such as ring and SQLite. Native Windows validation is an
-    # independent pre-merge choice: `full-ci` does not opt a pull request into
-    # this long-running lane. Add `windows-ci` when the change reaches a Windows
-    # boundary; main and scheduled/manual runs retain the automatic backstop.
+    # dependencies such as ring and SQLite. Native Windows validation stays an
+    # explicit pre-merge choice even though every other lane runs by default:
+    # add `windows-ci` when the change reaches a Windows boundary; main and
+    # scheduled/manual runs retain the automatic backstop.
     #
     # The leading `false` parks the whole lane while Windows packaging is paused
     # (see docs/deferred.md). The rest of the condition is the live gating
@@ -468,7 +468,7 @@ jobs:
   test:
     name: test
     needs: changes
-    if: ${{ needs.changes.outputs.workspace == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')) }}
+    if: ${{ needs.changes.outputs.workspace == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -511,7 +511,7 @@ jobs:
   postgres:
     name: postgres state machine
     needs: changes
-    if: ${{ needs.changes.outputs.workspace == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')) }}
+    if: ${{ needs.changes.outputs.workspace == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     services:
@@ -561,7 +561,7 @@ jobs:
   ui:
     name: desktop UI
     needs: changes
-    if: ${{ needs.changes.outputs.ui == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')) }}
+    if: ${{ needs.changes.outputs.ui == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,22 +162,20 @@ Coverage percentage is not a goal and is not tracked. Confidence is.
 
 ## Let CI do the heavy verification
 
-During active greenfield development, pull requests use a deliberately fast
-default gate. Full validation remains automatic after merge and on scheduled or
-manual runs. Add `full-ci` when a change warrants the heavyweight
-platform-neutral lanes before merge. Re-running the full workspace suite before
-every push buys little and costs minutes on each iteration. Run a cheap relevant
-subset locally, push early, and let the configured lanes work while you keep
-going.
+Every platform-neutral lane a change can reach runs on its pull request: a
+green PR means the same commits stay green on `main`. There is no opt-in
+label for heavier validation — the former `full-ci` label is gone and does
+nothing. Re-running the full workspace suite locally before every push buys
+little and costs minutes on each iteration. Run a cheap relevant subset
+locally, push early, and let the lanes work while you keep going.
 
 The change-scope gate in [`.github/workflows/ci.yml`](.github/workflows/ci.yml)
 is the whole rule, and it is coarse on purpose:
 
 - Any changed file outside `*.md`, `docs/`, `assets/`, `.githooks/`, `LICENSE`,
   `NOTICE`, and `crates/openwave-desktop/ui/` marks the change **Rust** —
-  including `Cargo.toml` and `Cargo.lock`. That always runs rustfmt. With
-  `full-ci`, and automatically outside pull requests, it also runs clippy
-  (`--all-targets -D warnings`) and the desktop tests. Every Cargo invocation
+  including `Cargo.toml` and `Cargo.lock`. That runs rustfmt, clippy
+  (`--all-targets -D warnings`), and the desktop tests. Every Cargo invocation
   passes `--locked`, so a lockfile drift fails there too.
 - A Rust change also marks the **workspace** scope, which adds the headless
   workspace tests plus the PostgreSQL turn-state lane, unless every changed file
@@ -186,12 +184,11 @@ is the whole rule, and it is coarse on purpose:
   cannot see such a change. `ui/src/generated/` is not covered by the carve-out
   because its staleness check lives in `openwave-server`.
 - Any file under `crates/openwave-desktop/ui/` marks it **UI**, which runs
-  `pnpm test` and `pnpm build` together during full CI.
-- Branch protection requires the pull-request jobs directly. Heavy jobs report
-  a successful skip on ordinary pull requests and become active when the
-  `full-ci` label is added. The always-running change detector rejects
-  impossible narrower-scope combinations before conditional jobs consume them.
-  There is no serial aggregate wrapper after the slowest job.
+  `pnpm test` and `pnpm build`.
+- Branch protection requires the pull-request jobs directly. A lane outside a
+  change's scope reports a successful skip. The always-running change detector
+  rejects impossible narrower-scope combinations before conditional jobs
+  consume them. There is no serial aggregate wrapper after the slowest job.
 - The native Windows lane is **parked**, along with the release workflow's
   Windows build — see [`docs/deferred.md`](docs/deferred.md). `windows-check`
   and `prepare_windows`/`build_windows` are each gated behind a literal `false`
@@ -200,17 +197,10 @@ is the whole rule, and it is coarse on purpose:
   has been declared unsupported, so a change that touches Windows-gated code
   still deserves the same care — it just gets no CI signal right now.
 
-An ordinary pull request's heavy-job skips are the intended fast path, backed by
-full validation on `main`. For risky or boundary-crossing changes, add
-`full-ci` and wait for the applicable platform-neutral lanes. Run a cheap subset
-for fast local feedback on what you actually touched — `cargo check -p <crate>`,
-the one test module you changed, `tsc` — and push.
-
-**The real trap is confusing the fast gate with full validation.** When a PR has
-`full-ci`, judge by whether every applicable platform-neutral job is present and
-passed, not by the absence of red. A conflicting PR runs nothing but trivial policy
-checks; rebase it before believing its status. `gh pr checks <n>` shows the
-truth.
+**The remaining trap is a PR that ran nothing.** A conflicting PR runs nothing
+but trivial policy checks; rebase it before believing its status. Judge a PR by
+whether every applicable lane is present and passed, not by the absence of red.
+`gh pr checks <n>` shows the truth.
 
 Enable auto-merge (`gh pr merge <n> --squash --auto --delete-branch`) so a PR
 lands the moment its lanes go green instead of waiting for you to come back.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -432,23 +432,21 @@ request title** and **Pull request body**.
 Branch protection on `main` requires the individual CI jobs, not an aggregate
 wrapper — there is none. The required contexts are `change scope`, `semantic PR
 title`, `release policy`, `secret scan (gitleaks)`, `rustfmt`, `clippy`,
-`desktop test`, `test`, `postgres state machine`, and `desktop UI`. Only the
-first five run on an ordinary pull request; the compile-heavy lanes (`clippy`,
-`desktop test`, `test`, `postgres state machine`, `desktop UI`) are opt-in
-behind the `full-ci` label and otherwise report a successful skip, which is what
-lets a required check pass without running. That is the deliberate fast gate
-described in [`CLAUDE.md`](../CLAUDE.md), backed by full validation on every
-Rust-scoped push to `main` and on the weekly scheduled run — not a claim that
-PostgreSQL state-machine coverage gates every merge. Keep both sets required so
+`desktop test`, `test`, `postgres state machine`, and `desktop UI`. Every lane
+a change's scope can reach runs on the pull request itself; a lane outside the
+scope reports a successful skip, which is what lets a required check pass
+without running. Green PR checks are full platform-neutral validation — see
+[`CLAUDE.md`](../CLAUDE.md) — re-backed by the same lanes on every Rust-scoped
+push to `main` and on the weekly scheduled run. Keep the whole set required so
 the skip-reporting stays wired up, and add any new always-running lane to the
 list.
 
-`Windows cargo check` is intentionally separate from the required contexts and
-from `full-ci`. It runs automatically for Rust-scoped pushes to `main`, weekly
-schedules, and manual dispatches, while pull requests opt in with `windows-ci`
-when they touch a native Windows boundary. Keep it non-required so ordinary and
-`full-ci` pull requests do not wait for long-running native platform coverage;
-the post-merge and scheduled runs remain the backstop.
+`Windows cargo check` is intentionally separate from the required contexts. It
+runs automatically for Rust-scoped pushes to `main`, weekly schedules, and
+manual dispatches, while pull requests opt in with `windows-ci` when they touch
+a native Windows boundary. Keep it non-required so pull requests do not wait
+for long-running native platform coverage; the post-merge and scheduled runs
+remain the backstop.
 
 The release-draft workflow uses the built-in `GITHUB_TOKEN`; it does not require
 a personal access token.

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -92,18 +92,12 @@ test("workflow container images are pinned by digest", () => {
   assert.doesNotMatch(workflows["ci.yml"], /gitleaks\/gitleaks:latest/);
 });
 
-test("heavy CI is opt-in on pull requests and automatic elsewhere", () => {
+test("PR lanes are scope-gated, never label-gated", () => {
   const ci = workflows["ci.yml"];
   const changes = workflowJob(ci, "changes");
   const fmt = workflowJob(ci, "fmt");
   const postgres = workflowJob(ci, "postgres");
   const testJob = workflowJob(ci, "test");
-  // Transitional: each lane is gated by its change scope, either alone or
-  // still combined with the legacy `full-ci` opt-in label while that label is
-  // being retired. Once the label-free gating lands on main, this collapses
-  // to scope-only and `full-ci` becomes forbidden outright.
-  const laneGate =
-    /if: \$\{\{ needs\.changes\.outputs\.(?:rust|workspace|ui) == 'true'(?: && \(github\.event_name != 'pull_request' \|\| contains\(github\.event\.pull_request\.labels\.\*\.name, 'full-ci'\)\))? \}\}/;
 
   assert.match(
     ci,
@@ -114,7 +108,11 @@ test("heavy CI is opt-in on pull requests and automatic elsewhere", () => {
     /pull_request:\n\s+types:\n\s+\[[^\]]*labeled, unlabeled[^\]]*\]/,
   );
   assert.doesNotMatch(ci, /^  build:$/m);
-  assert.doesNotMatch(fmt, /full-ci/);
+  // A pull request's green checks must prove the same commits stay green on
+  // main: no platform-neutral lane may hide behind an opt-in label. The
+  // `windows-ci` opt-in below is the one deliberate exception.
+  assert.doesNotMatch(ci, /full-ci/);
+  assert.doesNotMatch(fmt, /github\.event_name/);
   assert.match(postgres, /OPENWAVE_REQUIRE_POSTGRES_TEST: "true"/);
   // The narrower `workspace` scope must imply the `rust` one. Without this the
   // crate-coverage lanes could be gated on a scope that never ran for them.
@@ -125,14 +123,19 @@ test("heavy CI is opt-in on pull requests and automatic elsewhere", () => {
   assert.doesNotMatch(ci, /^  rust:$/m);
   assert.doesNotMatch(ci, /name: fmt · clippy · build · test/);
 
-  for (const job of [
-    workflowJob(ci, "lint"),
-    workflowJob(ci, "desktop"),
-    testJob,
-    postgres,
-    workflowJob(ci, "ui"),
+  for (const [job, scope] of [
+    [workflowJob(ci, "lint"), "rust"],
+    [workflowJob(ci, "desktop"), "rust"],
+    [testJob, "workspace"],
+    [postgres, "workspace"],
+    [workflowJob(ci, "ui"), "ui"],
   ]) {
-    assert.match(job, laneGate);
+    assert.match(
+      job,
+      new RegExp(
+        `if: \\$\\{\\{ needs\\.changes\\.outputs\\.${scope} == 'true' \\}\\}`,
+      ),
+    );
   }
 
   for (const job of [
@@ -176,7 +179,6 @@ test("native Windows CI is an explicit PR opt-in with a main backstop", () => {
     /github\.event_name != 'pull_request' \|\| contains\(github\.event\.pull_request\.labels\.\*\.name, 'windows-ci'\)/;
 
   assert.match(windows, windowsCiGate);
-  assert.doesNotMatch(windows, /'full-ci'/);
   assert.match(
     windows,
     /group: \$\{\{ github\.event_name == 'push' && 'windows-check-main' \|\| format\('windows-check-run-\{0\}', github\.run_id\) \}\}/,


### PR DESCRIPTION
Removes the `full-ci` opt-in as we approach launch readiness: a pull request now runs every platform-neutral lane its change scope can reach, so green PR checks mean the same commits stay green on `main`.

- `clippy`, `desktop test`, `test`, `postgres state machine`, and `desktop UI` are gated only by the change-scope detector; the label condition is gone.
- The change-scope detector itself is unchanged — docs-only PRs still skip the Rust lanes, desktop-only changes still skip the workspace lanes.
- The workflow-security test now asserts the inverse policy: no platform-neutral lane may hide behind an opt-in label. The parked `windows-ci` opt-in remains the one deliberate exception.
- CLAUDE.md and docs/releases.md updated to describe the new policy; the release doc's required-contexts guidance is unchanged in substance (skips still report success for out-of-scope lanes).

After this merges, the `full-ci` label serves no purpose and can be deleted from the repository. Post-merge pushes and the weekly schedule keep re-running the same lanes as before.