### PR TITLE
ci: let the lane-gate policy test accept scope-only gating

### DIFF
--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -98,8 +98,12 @@ test("heavy CI is opt-in on pull requests and automatic elsewhere", () => {
   const fmt = workflowJob(ci, "fmt");
   const postgres = workflowJob(ci, "postgres");
   const testJob = workflowJob(ci, "test");
-  const fullCiGate =
-    /github\.event_name != 'pull_request' \|\| contains\(github\.event\.pull_request\.labels\.\*\.name, 'full-ci'\)/;
+  // Transitional: each lane is gated by its change scope, either alone or
+  // still combined with the legacy `full-ci` opt-in label while that label is
+  // being retired. Once the label-free gating lands on main, this collapses
+  // to scope-only and `full-ci` becomes forbidden outright.
+  const laneGate =
+    /if: \$\{\{ needs\.changes\.outputs\.(?:rust|workspace|ui) == 'true'(?: && \(github\.event_name != 'pull_request' \|\| contains\(github\.event\.pull_request\.labels\.\*\.name, 'full-ci'\)\))? \}\}/;
 
   assert.match(
     ci,
@@ -128,7 +132,7 @@ test("heavy CI is opt-in on pull requests and automatic elsewhere", () => {
     postgres,
     workflowJob(ci, "ui"),
   ]) {
-    assert.match(job, fullCiGate);
+    assert.match(job, laneGate);
   }
 
   for (const job of [


### PR DESCRIPTION
First of two PRs retiring the `full-ci` opt-in label (the follow-up is #1836).

The `release policy` job deliberately judges a PR's workflows with the **base branch's** copy of `workflow-security.test.mjs`, so a gating-policy change cannot land in one PR: #1836 currently fails release policy because main's test still asserts the label gate exists. This PR makes the trusted test transitional — each lane's `if` may be its change scope alone, or the scope combined with the legacy `full-ci` condition. It changes no workflow behavior. Once this merges, #1836 (which removes the label condition from `ci.yml` and carries the strict test forbidding `full-ci`) passes against it.