### PR TITLE
fix(desktop): keep a disabled bundle visible while a turn runs

### DIFF
--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -487,12 +487,15 @@ export function Composer({
    * leaves one per member skill, and turns itself on first if it was off. A
    * prompt is text, so its body goes into the draft — fetched only now, because
    * the catalog deliberately carries no bodies.
+   *
+   * A row the list marked unavailable does nothing: it is shown so the reader
+   * can see it is still installed, and its hint already says what is in the way.
    */
   function pickOption(
     option: SlashOption,
     token: { start: number; query: string } | null,
   ) {
-    if (!slash) return;
+    if (!slash || option.unavailable) return;
     const caret = token ? token.start + 1 + token.query.length : 0;
     if (option.kind === "prompt") {
       void (async () => {
@@ -574,7 +577,9 @@ export function Composer({
     }
     if (event.key === "Enter" || event.key === "Tab") {
       const option = slashMatches[slashIndex];
-      if (option) {
+      // A row that cannot be picked keeps the list up instead of closing on a
+      // key that did nothing, so the reason stays in front of the reader.
+      if (option && !option.unavailable) {
         setSlashToken(null);
         pickOption(option, slashToken);
       }

--- a/crates/openwave-desktop/ui/src/ComposerSlash.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerSlash.dom.test.tsx
@@ -48,15 +48,17 @@ function slash(overrides: Partial<ComposerSlash> = {}): ComposerSlash {
 function ComposerHarness({
   slash: menu,
   onDraftChange,
+  activeTurnId = null,
 }: {
   slash: ComposerSlash;
   onDraftChange?: (draft: string) => void;
+  activeTurnId?: string | null;
 }) {
   const [draft, setDraft] = useState("");
   return (
     <Composer
-      activeTurnId={null}
-      busy={false}
+      activeTurnId={activeTurnId}
+      busy={activeTurnId !== null}
       cancelError={null}
       cancelPending={false}
       disabled={false}
@@ -149,4 +151,34 @@ it("invokes a picked skill and shows it as a chip the reader can drop", async ()
   render(<ComposerHarness slash={slash({ invoked: ["pptx"], onRemove })} />);
   await user.click(screen.getByRole("button", { name: "Remove Pptx" }));
   expect(onRemove).toHaveBeenCalledWith("pptx");
+});
+
+it("shows a bundle a running turn cannot reach, and refuses the pick", async () => {
+  const user = userEvent.setup();
+  const onInvoke = vi.fn();
+  const menu = slash({
+    onInvoke,
+    options: [
+      ...OPTIONS,
+      {
+        kind: "plugin",
+        name: "charts",
+        label: "Charts",
+        description: "Draws figures.",
+        skills: ["charts"],
+        enabled: false,
+      },
+    ],
+  });
+  render(<ComposerHarness slash={menu} activeTurnId="turn-1" />);
+
+  await user.click(screen.getByRole("textbox", { name: "Message" }));
+  await user.keyboard("also /charts");
+  // Visible, so a library seen a moment ago has not silently lost an entry —
+  // and marked, because turning it on mid-turn names a manifest this turn's
+  // workspace never staged.
+  const row = screen.getByRole("option", { name: /Charts/ });
+  expect(row).toHaveAttribute("aria-disabled", "true");
+  await user.click(row);
+  expect(onInvoke).not.toHaveBeenCalled();
 });

--- a/crates/openwave-desktop/ui/src/ComposerSlash.test.ts
+++ b/crates/openwave-desktop/ui/src/ComposerSlash.test.ts
@@ -99,13 +99,22 @@ describe("skillsToInvoke", () => {
 describe("availableSlashOptions", () => {
   const options = slashOptionsFromCatalog(CATALOG);
 
-  it("keeps invocations reachable while a turn runs, minus disabled bundles", () => {
-    // A steer carries its own invocation, so skills stay pickable. The
-    // `charts` bundle is off, and picking it mid-turn would flip it on
-    // install-wide and name a manifest this turn never staged.
+  it("keeps invocations reachable while a turn runs, marking disabled bundles", () => {
+    // A steer carries its own invocation, so skills stay pickable. The `charts`
+    // bundle is off, and picking it mid-turn would flip it on install-wide and
+    // name a manifest this turn never staged — so its row stays, unpickable,
+    // rather than vanishing from a library the reader saw a moment ago.
+    const available = availableSlashOptions(options, [], { steering: true });
+    expect(available.map((o) => o.name)).toEqual([
+      "documents",
+      "charts",
+      "docx",
+      "notes",
+      "weekly-update",
+    ]);
     expect(
-      availableSlashOptions(options, [], { steering: true }).map((o) => o.name),
-    ).toEqual(["documents", "docx", "notes", "weekly-update"]);
+      available.filter((o) => o.unavailable).map((o) => o.name),
+    ).toEqual(["charts"]);
   });
 
   it("drops a bundle only once every member it could add is on the message", () => {

--- a/crates/openwave-desktop/ui/src/ComposerSlash.ts
+++ b/crates/openwave-desktop/ui/src/ComposerSlash.ts
@@ -29,6 +29,12 @@ export type SlashOption = {
    * so the flag is what tells the two cases apart.
    */
   enabled?: boolean;
+  /**
+   * Why this row is visible but cannot be picked right now, absent on a row that
+   * can. A library someone can see at rest and cannot see mid-turn reads as one
+   * that has lost entries, so the row stays and says what is in the way.
+   */
+  unavailable?: string;
 };
 
 /**
@@ -217,26 +223,37 @@ export function skillsToInvoke(
  * What the panel can still reach, given what this message already carries.
  *
  * A skill already on the message is not offered again, and neither is anything
- * that invokes once the cap is reached. A steer carries its own invocation
- * under its own budget, so skills stay reachable while a turn runs — but a
- * *disabled* bundle's row does not: picking one turns the bundle on
- * install-wide and names a manifest the running turn's workspace never staged.
- * Prompts are text and stay available throughout.
+ * that invokes once the cap is reached. A steer carries its own invocation under
+ * its own budget, so skills stay reachable while a turn runs — but a *disabled*
+ * bundle cannot be picked there: doing so turns the bundle on install-wide and
+ * names a manifest the running turn's workspace never staged. Its row is kept
+ * and marked rather than dropped, because a row that quietly disappears when a
+ * turn starts reads as a catalog that has lost it. Prompts are text and stay
+ * available throughout.
  */
 export function availableSlashOptions(
   options: readonly SlashOption[],
   invoked: readonly string[],
   { steering }: { steering: boolean },
 ): SlashOption[] {
-  return options.filter((option) => {
-    if (option.kind === "prompt") return true;
-    if (steering && option.kind === "plugin" && option.enabled === false) {
-      return false;
+  const available: SlashOption[] = [];
+  for (const option of options) {
+    if (option.kind === "prompt") {
+      available.push(option);
+      continue;
     }
-    if (invoked.length >= MAX_INVOKED_SKILLS) return false;
-    return skillsToInvoke(option, invoked).length > 0;
-  });
+    if (steering && option.kind === "plugin" && option.enabled === false) {
+      available.push({ ...option, unavailable: DISABLED_BUNDLE_MID_TURN });
+      continue;
+    }
+    if (invoked.length >= MAX_INVOKED_SKILLS) continue;
+    if (skillsToInvoke(option, invoked).length > 0) available.push(option);
+  }
+  return available;
 }
+
+/** What a bundle row says instead of its kind while a turn is running. */
+export const DISABLED_BUNDLE_MID_TURN = "Off — turn on between turns";
 
 /**
  * Where an arrow key moves the highlight, or `null` when the key is not the

--- a/crates/openwave-desktop/ui/src/components/OptionListbox.tsx
+++ b/crates/openwave-desktop/ui/src/components/OptionListbox.tsx
@@ -18,6 +18,11 @@ export type OptionRow = {
   icon: LucideIcon;
   /** A word on the right saying what picking this row will do. */
   hint?: string;
+  /**
+   * The row is shown for context but cannot be picked. Its `hint` carries the
+   * reason, which is the only thing making a dimmed row worth showing at all.
+   */
+  disabled?: boolean;
 };
 
 /**
@@ -62,15 +67,20 @@ export function OptionListbox({
               id={optionElementId(listId, index)}
               role="option"
               aria-selected={index === activeIndex}
+              aria-disabled={row.disabled || undefined}
               className={cn(
                 "flex w-full items-start gap-2 rounded-sm px-2 py-1.5 text-left text-sm",
                 index === activeIndex && "bg-accent text-accent-foreground",
+                row.disabled && "opacity-50",
               )}
               // Taken on mousedown so the field never loses the caret the
               // insertion is about to be made at.
               onMouseDown={(event) => event.preventDefault()}
               onMouseEnter={() => onHighlight(index)}
-              onClick={() => onPick(index)}
+              onClick={() => {
+                if (row.disabled) return;
+                onPick(index);
+              }}
             >
               <Icon
                 className="mt-0.5 size-4 shrink-0 text-muted-foreground"

--- a/crates/openwave-desktop/ui/src/plugins/PluginsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/plugins/PluginsPanel.tsx
@@ -18,7 +18,8 @@ import { OptionListbox, optionElementId, type OptionRow } from "@/components/Opt
  * tools menu — render these same rows and pick with the same code, so a bundle
  * reached one way behaves exactly as it does the other. A flat list rather than
  * a section per kind: the reader is looking for a name, and the kind only
- * decides what picking does, which the row says on its right.
+ * decides what picking does, which the row says on its right. A row that cannot
+ * be picked right now says why there instead.
  */
 export function pluginOptionRows(
   options: readonly SlashOption[],
@@ -28,7 +29,8 @@ export function pluginOptionRows(
     label: option.label,
     description: option.description,
     icon: optionIcon(option),
-    hint: optionKindLabel(option),
+    hint: option.unavailable ?? optionKindLabel(option),
+    disabled: option.unavailable !== undefined,
   }));
 }
 
@@ -88,6 +90,9 @@ export function PluginsPanel({
       const option = matches[index];
       if (!option) return;
       event.preventDefault();
+      // A row that cannot be picked leaves the panel exactly as it is; its hint
+      // already says what is in the way.
+      if (option.unavailable) return;
       onPick(option);
     }
   }


### PR DESCRIPTION
Opening the plugin library while a turn is running dropped every disabled bundle row outright. The reason behind that is sound — picking one turns the bundle on install-wide and names a manifest the running turn's workspace never staged — but from the reader's side, a library they could see a moment ago has quietly lost entries, with nothing saying why.

Keep the row and mark it instead. `availableSlashOptions` stamps an `unavailable` reason on those rows rather than filtering them out. `OptionListbox` dims a marked row and marks it `aria-disabled`, and the plugin rows show the reason where the row's kind usually sits ("Off — turn on between turns").

Picking is refused at every entry point: click, Enter, and Tab, from both the `/` list in the draft and the panel opened from the tools menu. An Enter on a marked row deliberately leaves the list open rather than closing on a key that did nothing, so the reason stays in front of the reader.

Nothing here changes what a steer can actually invoke — the same bundles were unreachable before, they just vanished instead of explaining themselves.

## Tests

- `ComposerSlash.test.ts` — the steering case now asserts the disabled bundle is present and marked, rather than absent.
- `ComposerSlash.dom.test.tsx` — one new case driving the real composer mid-turn: the row renders `aria-disabled`, and clicking it invokes nothing.

`pnpm tsc` clean; full `pnpm test` green (875 tests). Not driven in the running app.