### PR TITLE
feat(desktop): render a background agent's live progress in the transcript and panel

### DIFF
--- a/crates/openwave-desktop/ui/src/AgentActivityTimeline.tsx
+++ b/crates/openwave-desktop/ui/src/AgentActivityTimeline.tsx
@@ -363,7 +363,8 @@ function activityOutcomeTone(
   }
 }
 
-function formatActivityTime(at: string): string {
+/** The clock time one recorded moment happened, blank if it cannot be read. */
+export function formatActivityTime(at: string): string {
   const parsed = new Date(at);
   if (Number.isNaN(parsed.getTime())) return "";
   return parsed.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });

--- a/crates/openwave-desktop/ui/src/AgentRunProgress.tsx
+++ b/crates/openwave-desktop/ui/src/AgentRunProgress.tsx
@@ -1,0 +1,216 @@
+import { useEffect, useRef, useState } from "react";
+
+import type { AgentRunProgress, AgentRunProgressEntry } from "./api";
+import { formatActivityTime } from "./AgentActivityTimeline";
+import { cn } from "@/lib/utils";
+
+/** How often a live run is asked what it has published since the last page. */
+const PROGRESS_POLL_INTERVAL_MS = 5_000;
+
+/**
+ * How many lines one reader keeps.
+ *
+ * The server bounds the stream by retention; this bounds what a single open
+ * panel accumulates over a long run, so a chatty agent cannot grow the DOM
+ * without limit. The newest lines are the ones worth keeping.
+ */
+const MAX_RETAINED_LINES = 200;
+
+export type AgentRunProgressState = {
+  loading: boolean;
+  error: boolean;
+  loaded: boolean;
+  entries: AgentRunProgressEntry[];
+  /** The most recent line, which is what a status row shows. */
+  latest: AgentRunProgressEntry | null;
+};
+
+/** The held stream, plus the run it is an answer about. */
+type HeldProgress = {
+  runId: string | null;
+  loading: boolean;
+  error: boolean;
+  loaded: boolean;
+  entries: AgentRunProgressEntry[];
+};
+
+const NO_PROGRESS_HELD: HeldProgress = {
+  runId: null,
+  loading: false,
+  error: false,
+  loaded: false,
+  entries: [],
+};
+
+/**
+ * A background run's live progress, resumed from the cursor the reader already
+ * holds.
+ *
+ * Every poll asks only for what has arrived since the last page, so a run that
+ * has published nothing new answers with an empty page rather than the whole
+ * stream. The cursor is held per run and never rewound: re-reading from zero
+ * would re-render lines already on screen and grow with the run.
+ *
+ * Retention bounds the stream server-side, so a reader that arrives late — or
+ * comes back after a long absence — may find the oldest lines gone. A jump in
+ * `sequence` is therefore normal and says nothing went wrong; only the order
+ * is a contract.
+ *
+ * `enabled` gates reading at all; `live` decides whether the read repeats. A
+ * settled run publishes nothing further, so it is read once and left alone.
+ */
+export function useAgentRunProgress(
+  runId: string | null,
+  enabled: boolean,
+  live: boolean,
+  loadProgress: (
+    runId: string,
+    afterSequence: number,
+  ) => Promise<AgentRunProgress>,
+): AgentRunProgressState {
+  const [held, setHeld] = useState<HeldProgress>(NO_PROGRESS_HELD);
+  // The cursor outlives the effect: `live` flipping, or the loader identity
+  // changing, must not send the next poll back to the start of the stream.
+  const cursor = useRef<{ runId: string | null; sequence: number }>({
+    runId: null,
+    sequence: 0,
+  });
+
+  useEffect(() => {
+    if (!enabled || runId === null) return;
+    if (cursor.current.runId !== runId) {
+      cursor.current = { runId, sequence: 0 };
+    }
+    let cancelled = false;
+
+    setHeld((current) =>
+      current.runId === runId
+        ? { ...current, loading: !current.loaded, error: false }
+        : { ...NO_PROGRESS_HELD, runId, loading: true },
+    );
+
+    const read = async () => {
+      const from = cursor.current.sequence;
+      try {
+        const page = await loadProgress(runId, from);
+        if (cancelled || cursor.current.runId !== runId) return;
+        cursor.current = {
+          runId,
+          sequence: Math.max(page.nextSequence, cursor.current.sequence),
+        };
+        setHeld((current) => {
+          const base = current.runId === runId ? current.entries : [];
+          const lastHeld = base[base.length - 1]?.sequence ?? -Infinity;
+          const fresh = page.entries.filter(
+            (entry) => entry.sequence > lastHeld,
+          );
+          return {
+            runId,
+            loading: false,
+            error: false,
+            loaded: true,
+            entries:
+              fresh.length === 0
+                ? base
+                : [...base, ...fresh].slice(-MAX_RETAINED_LINES),
+          };
+        });
+      } catch {
+        // A failed page is not evidence the stream is gone: whatever is held
+        // keeps rendering and the next poll resumes from the same cursor.
+        if (!cancelled) {
+          setHeld((current) =>
+            current.runId === runId
+              ? { ...current, loading: false, error: true }
+              : current,
+          );
+        }
+      }
+    };
+
+    void read();
+    if (!live) {
+      return () => {
+        cancelled = true;
+      };
+    }
+    const interval = window.setInterval(() => void read(), PROGRESS_POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [enabled, runId, live, loadProgress]);
+
+  // Answers about another run are not this run's to show, not even for the one
+  // commit before the effect resets them.
+  const current = held.runId === runId ? held : NO_PROGRESS_HELD;
+  return {
+    loading: current.loading,
+    error: current.error,
+    loaded: current.loaded,
+    entries: current.entries,
+    latest: current.entries[current.entries.length - 1] ?? null,
+  };
+}
+
+/**
+ * The stream in full, beside the run's activity history.
+ *
+ * The lines are the agent's own prose — the same class of text the task plan's
+ * steps carry — so they are rendered as text and wrap rather than being
+ * clipped, and nothing in them is interpreted as markup.
+ */
+export function AgentRunProgressStream({
+  state,
+  className,
+}: {
+  state: AgentRunProgressState;
+  className?: string;
+}) {
+  if (state.entries.length === 0) {
+    // Nothing held: an empty stream is the ordinary case for a run that has
+    // not narrated anything yet, so it does not read as a failure.
+    if (state.loading && !state.loaded) {
+      return (
+        <p className="text-xs text-muted-foreground" role="status">
+          Loading progress…
+        </p>
+      );
+    }
+    if (state.error) {
+      return (
+        <p className="text-xs text-muted-foreground" role="status">
+          Progress is unavailable.
+        </p>
+      );
+    }
+    return (
+      <p className="text-xs text-muted-foreground" role="status">
+        No progress reported yet.
+      </p>
+    );
+  }
+
+  return (
+    <section className={cn("flex flex-col gap-1.5", className)} aria-label="Progress">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+        Progress
+      </p>
+      <ol className="flex flex-col gap-1.5 text-xs" role="list">
+        {state.entries.map((entry) => (
+          <li key={entry.sequence} className="flex min-w-0 items-start gap-2">
+            <time
+              className="shrink-0 tabular-nums text-muted-foreground"
+              dateTime={entry.at}
+            >
+              {formatActivityTime(entry.at)}
+            </time>
+            <span className="min-w-0 break-words text-foreground">
+              {entry.text}
+            </span>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.dom.test.tsx
@@ -1,11 +1,21 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { AgentActivityHistoryEntry, AgentRun } from "./api";
+import type {
+  AgentActivityHistoryEntry,
+  AgentRun,
+  AgentRunProgress,
+} from "./api";
 import { BackgroundAgentList } from "./BackgroundAgentList";
 
 afterEach(cleanup);
+
+/** No run in these tests narrates anything; the cursor comes back unchanged. */
+const noProgress = async (_runId: string, afterSequence: number) => ({
+  entries: [],
+  nextSequence: afterSequence,
+});
 
 function run(status: AgentRun["status"]): AgentRun {
   return {
@@ -51,6 +61,7 @@ describe("BackgroundAgentList activity disclosure", () => {
         onCancel={async () => undefined}
         onLoadActivity={loadActivity}
         onLoadTaskPlan={async () => null}
+        onLoadProgress={noProgress}
       />
     );
 
@@ -85,5 +96,79 @@ describe("BackgroundAgentList activity disclosure", () => {
     });
     expect(settledTrigger.getAttribute("aria-expanded")).toBe("true");
     expect(screen.getByRole("list")).toBeTruthy();
+  });
+});
+
+describe("BackgroundAgentList progress", () => {
+  it("shows a running child's latest line and resumes the poll from the cursor", async () => {
+    vi.useFakeTimers();
+    try {
+      const asked: number[] = [];
+      const pages: Record<number, AgentRunProgress> = {
+        0: {
+          entries: [
+            {
+              sequence: 1,
+              text: "Reading the brief",
+              at: "2026-08-05T18:36:00Z",
+            },
+            {
+              sequence: 2,
+              text: "Drafting the summary",
+              at: "2026-08-05T18:36:30Z",
+            },
+          ],
+          nextSequence: 2,
+        },
+        2: {
+          entries: [
+            {
+              sequence: 3,
+              text: "Checking the figures",
+              at: "2026-08-05T18:37:00Z",
+            },
+          ],
+          nextSequence: 3,
+        },
+      };
+      const loadProgress = async (_runId: string, afterSequence: number) => {
+        asked.push(afterSequence);
+        return (
+          pages[afterSequence] ?? { entries: [], nextSequence: afterSequence }
+        );
+      };
+
+      render(
+        <BackgroundAgentList
+          spawns={[{ callId: "spawn-call", status: "completed" }]}
+          runs={[run("running")]}
+          loading={false}
+          error={null}
+          onRetry={() => undefined}
+          onCancel={async () => undefined}
+          onLoadActivity={async () => []}
+          onLoadTaskPlan={async () => null}
+          onLoadProgress={loadProgress}
+        />,
+      );
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      // The row says what the child is doing, not only that it is doing
+      // something — and it is the newest line, not the first one.
+      expect(screen.getByText("Drafting the summary")).toBeTruthy();
+      expect(screen.queryByText("Reading the brief")).toBeNull();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5_000);
+      });
+      expect(screen.getByText("Checking the figures")).toBeTruthy();
+      // The second read resumes where the first page ended rather than
+      // re-reading the stream from the start.
+      expect(asked).toEqual([0, 2]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.test.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.test.tsx
@@ -4,6 +4,12 @@ import { describe, expect, it } from "vitest";
 import type { AgentRun } from "./api";
 import { BackgroundAgentList } from "./BackgroundAgentList";
 
+/** No run in these tests narrates anything; the cursor comes back unchanged. */
+const noProgress = async (_runId: string, afterSequence: number) => ({
+  entries: [],
+  nextSequence: afterSequence,
+});
+
 function run(
   id: string,
   spawnCallId: string,
@@ -51,6 +57,7 @@ describe("BackgroundAgentList", () => {
         onCancel={noop}
         onLoadActivity={noActivity}
         onLoadTaskPlan={noTaskPlan}
+        onLoadProgress={noProgress}
       />,
     );
 
@@ -78,6 +85,7 @@ describe("BackgroundAgentList", () => {
         onCancel={noop}
         onLoadActivity={noActivity}
         onLoadTaskPlan={noTaskPlan}
+        onLoadProgress={noProgress}
       />,
     );
 
@@ -102,6 +110,7 @@ describe("BackgroundAgentList", () => {
         onCancel={noop}
         onLoadActivity={noActivity}
         onLoadTaskPlan={noTaskPlan}
+        onLoadProgress={noProgress}
       />,
     );
 
@@ -120,6 +129,7 @@ describe("BackgroundAgentList", () => {
         onCancel={noop}
         onLoadActivity={noActivity}
         onLoadTaskPlan={noTaskPlan}
+        onLoadProgress={noProgress}
       />,
     );
 
@@ -137,6 +147,7 @@ describe("BackgroundAgentList", () => {
         onCancel={noop}
         onLoadActivity={noActivity}
         onLoadTaskPlan={noTaskPlan}
+        onLoadProgress={noProgress}
       />,
     );
 
@@ -154,6 +165,7 @@ describe("BackgroundAgentList", () => {
         onCancel={noop}
         onLoadActivity={noActivity}
         onLoadTaskPlan={noTaskPlan}
+        onLoadProgress={noProgress}
       />,
     );
 
@@ -178,6 +190,7 @@ describe("BackgroundAgentList", () => {
         onCancel={noop}
         onLoadActivity={noActivity}
         onLoadTaskPlan={noTaskPlan}
+        onLoadProgress={noProgress}
       />,
     );
 
@@ -195,6 +208,7 @@ describe("BackgroundAgentList", () => {
         onCancel={noop}
         onLoadActivity={noActivity}
         onLoadTaskPlan={noTaskPlan}
+        onLoadProgress={noProgress}
       />,
     );
 

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
@@ -5,9 +5,11 @@ import { toast } from "sonner";
 import type {
   AgentActivityHistoryEntry,
   AgentRun,
+  AgentRunProgress,
   AgentRunTaskPlan,
   ApiClient,
 } from "./api";
+import { useAgentRunProgress } from "./AgentRunProgress";
 import {
   AgentRunTaskPlanChecklist,
   AgentRunTaskPlanProgress,
@@ -49,6 +51,11 @@ type BackgroundAgentListProps = {
   onLoadActivity: (runId: string) => Promise<AgentActivityHistoryEntry[]>;
   /** Fetch a run's full task plan, read only when a row is opened. */
   onLoadTaskPlan: (runId: string) => Promise<AgentRunTaskPlan | null>;
+  /** Read one page of a run's live progress, resuming from a held cursor. */
+  onLoadProgress: (
+    runId: string,
+    afterSequence: number,
+  ) => Promise<AgentRunProgress>;
   /** Open one run's dedicated panel beside the conversation. */
   onOpen?: (runId: string) => void;
   /** Open one file a run submitted, from its pill on the row. */
@@ -71,6 +78,7 @@ export function BackgroundAgentList({
   onCancel,
   onLoadActivity,
   onLoadTaskPlan,
+  onLoadProgress,
   onOpen,
   onOpenOutput,
 }: BackgroundAgentListProps) {
@@ -189,6 +197,7 @@ export function BackgroundAgentList({
                         onCancel={onCancel}
                         onLoadActivity={onLoadActivity}
                         onLoadTaskPlan={onLoadTaskPlan}
+                        onLoadProgress={onLoadProgress}
                         onOpen={onOpen}
                         onOpenOutput={onOpenOutput}
                         expanded={expandedRunIds.has(run.id)}
@@ -254,6 +263,7 @@ function BackgroundAgentRow({
   onCancel,
   onLoadActivity,
   onLoadTaskPlan,
+  onLoadProgress,
   onOpen,
   onOpenOutput,
   expanded,
@@ -267,6 +277,10 @@ function BackgroundAgentRow({
   onCancel: (runId: string) => Promise<void>;
   onLoadActivity: (runId: string) => Promise<AgentActivityHistoryEntry[]>;
   onLoadTaskPlan: (runId: string) => Promise<AgentRunTaskPlan | null>;
+  onLoadProgress: (
+    runId: string,
+    afterSequence: number,
+  ) => Promise<AgentRunProgress>;
   onOpen?: (runId: string) => void;
   onOpenOutput?: (outputId: string) => void;
   expanded: boolean;
@@ -282,6 +296,9 @@ function BackgroundAgentRow({
     onLoadActivity,
   );
   const live = RUNNING_AGENT_STATUSES.has(run.status);
+  // Read while the child is live whether or not the row is open: the latest
+  // line is what the collapsed row says, so it cannot wait on a disclosure.
+  const progress = useAgentRunProgress(run.id, live, live, onLoadProgress);
   // Keyed on the plan's own timestamp rather than the run's: the row re-reads
   // the list when the plan moves on, not on every poll that touches the run.
   const taskPlan = useAgentRunTaskPlan(
@@ -318,6 +335,16 @@ function BackgroundAgentRow({
 
   const contentId = `background-agent-activity-${run.id}`;
 
+  // What the row says the child is up to. A live child that has narrated
+  // something says that, in its own words, rather than repeating the state
+  // its own dot already carries; anything else falls back to the state. The
+  // line is the agent's own prose, so it is rendered as text and held to one
+  // truncated line — it shares the row with the task and the controls.
+  const latestProgress = !showStopping && live ? progress.latest : null;
+  const statusText = showStopping
+    ? "Stopping"
+    : (latestProgress?.text ?? agentRunStatusDetail(run));
+
   return (
     <div className="px-3 py-2.5">
       <div className="flex min-w-0 items-center gap-2">
@@ -352,8 +379,15 @@ function BackgroundAgentRow({
             {run.task ?? "Background agent"}
           </span>
         </button>
-        <span className="shrink-0 text-xs text-muted-foreground">
-          {showStopping ? "Stopping" : agentRunStatusDetail(run)}
+        <span
+          className={cn(
+            "text-xs text-muted-foreground",
+            latestProgress === null
+              ? "shrink-0"
+              : "min-w-0 max-w-[50%] shrink truncate",
+          )}
+        >
+          {statusText}
         </span>
         {client && chatId && (
           <CopyAgentRunDebugButton

--- a/crates/openwave-desktop/ui/src/BackgroundAgentPanel.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentPanel.tsx
@@ -12,6 +12,10 @@ import {
   copyAgentRunDebug,
   fetchAgentRunProgress,
 } from "./AgentRunDebugReport";
+import {
+  AgentRunProgressStream,
+  useAgentRunProgress,
+} from "./AgentRunProgress";
 import { agentRunStatusDetail, RUNNING_AGENT_STATUSES } from "./AgentRunDisplay";
 import {
   AgentRunTaskPlanChecklist,
@@ -71,6 +75,15 @@ export function BackgroundAgentPanel({
     run !== null,
     agentRuns.loadActivity,
   );
+  // The stream is read for any run the panel has, and re-read on a timer only
+  // while the run can still add to it. Each poll resumes from the cursor the
+  // last page returned, so an open panel asks for what it does not have.
+  const progress = useAgentRunProgress(
+    runId,
+    run !== null,
+    run !== null && RUNNING_AGENT_STATUSES.has(run.status),
+    agentRuns.loadProgress,
+  );
   // Opening the panel is the intent the row's chevron stands for, so the full
   // checklist is read here rather than waiting on a second disclosure.
   const taskPlan = useAgentRunTaskPlan(
@@ -120,6 +133,7 @@ export function BackgroundAgentPanel({
         <BackgroundAgentDetail
           run={run}
           activity={activity}
+          progress={progress}
           taskPlan={taskPlan}
           chatId={chatId}
           onOpenOutput={(outputId) => openPanel({ type: "outputs", outputId })}
@@ -153,12 +167,14 @@ export function BackgroundAgentPanel({
 function BackgroundAgentDetail({
   run,
   activity,
+  progress,
   taskPlan,
   chatId,
   onOpenOutput,
 }: {
   run: AgentRun;
   activity: ReturnType<typeof useAgentRunActivity>;
+  progress: ReturnType<typeof useAgentRunProgress>;
   taskPlan: ReturnType<typeof useAgentRunTaskPlan>;
   chatId: string;
   onOpenOutput?: (outputId: string) => void;
@@ -226,6 +242,7 @@ function BackgroundAgentDetail({
         )}
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto p-4" aria-live="polite">
+        <AgentRunProgressStream state={progress} className="mb-4" />
         <AgentActivityTimeline
           key={run.id}
           state={activity}

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -527,6 +527,7 @@ export function ChatView({
           onCancelBackgroundAgentRun={agentRuns.cancel}
           onLoadBackgroundAgentActivity={agentRuns.loadActivity}
           onLoadBackgroundAgentTaskPlan={agentRuns.loadTaskPlan}
+          onLoadBackgroundAgentProgress={agentRuns.loadProgress}
           onOpenBackgroundAgent={onOpenAgentPanel}
           onOpenOutput={onOpenOutput}
           backgroundAgentClient={client}

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -5,6 +5,7 @@ import type {
   ApiClient,
   AgentRun,
   AgentActivityHistoryEntry,
+  AgentRunProgress,
   AgentRunTaskPlan,
   PendingFolderAccessRequest,
   PendingOutputWritebackRequest,
@@ -218,6 +219,10 @@ type MessageListProps = {
   onLoadBackgroundAgentTaskPlan?: (
     runId: string,
   ) => Promise<AgentRunTaskPlan | null>;
+  onLoadBackgroundAgentProgress?: (
+    runId: string,
+    afterSequence: number,
+  ) => Promise<AgentRunProgress>;
   onOpenBackgroundAgent?: (runId: string) => void;
   onOpenOutput?: (outputId: string) => void;
   /** The connected client, so a background agent row can fetch debug info. */
@@ -288,6 +293,10 @@ export function MessageList({
   onCancelBackgroundAgentRun = async () => undefined,
   onLoadBackgroundAgentActivity = async () => [],
   onLoadBackgroundAgentTaskPlan = async () => null,
+  onLoadBackgroundAgentProgress = async (_runId, afterSequence) => ({
+    entries: [],
+    nextSequence: afterSequence,
+  }),
   onOpenBackgroundAgent,
   onOpenOutput,
   busy,
@@ -340,6 +349,7 @@ export function MessageList({
       cancel: onCancelBackgroundAgentRun,
       loadActivity: onLoadBackgroundAgentActivity,
       loadTaskPlan: onLoadBackgroundAgentTaskPlan,
+      loadProgress: onLoadBackgroundAgentProgress,
       open: onOpenBackgroundAgent,
       openOutput: onOpenOutput,
       client: backgroundAgentClient,
@@ -550,6 +560,10 @@ export function groupMessageItems(
     cancel: (runId: string) => Promise<void>;
     loadActivity: (runId: string) => Promise<AgentActivityHistoryEntry[]>;
     loadTaskPlan: (runId: string) => Promise<AgentRunTaskPlan | null>;
+    loadProgress: (
+      runId: string,
+      afterSequence: number,
+    ) => Promise<AgentRunProgress>;
     open?: (runId: string) => void;
     openOutput?: (outputId: string) => void;
     /** The connected client, so a row's "Copy debug info" can fetch its run. */
@@ -562,6 +576,10 @@ export function groupMessageItems(
     cancel: async () => undefined,
     loadActivity: async () => [],
     loadTaskPlan: async () => null,
+    loadProgress: async (_runId: string, afterSequence: number) => ({
+      entries: [],
+      nextSequence: afterSequence,
+    }),
   },
   retry?: { failureId: string; onRetry: () => void },
 ) {
@@ -731,6 +749,7 @@ export function groupMessageItems(
             onCancel={backgroundAgents.cancel}
             onLoadActivity={backgroundAgents.loadActivity}
             onLoadTaskPlan={backgroundAgents.loadTaskPlan}
+            onLoadProgress={backgroundAgents.loadProgress}
             onOpen={backgroundAgents.open}
             onOpenOutput={backgroundAgents.openOutput}
             {...(backgroundAgents.client && chatId

--- a/crates/openwave-desktop/ui/src/useAgentRuns.ts
+++ b/crates/openwave-desktop/ui/src/useAgentRuns.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type {
   AgentActivityHistoryEntry,
   AgentRun,
+  AgentRunProgress,
   AgentRunTaskPlan,
   ApiClient,
 } from "./api";
@@ -51,6 +52,15 @@ export type AgentRuns = {
    * says the plan has moved on.
    */
   loadTaskPlan: (runId: string) => Promise<AgentRunTaskPlan | null>;
+  /**
+   * Read one page of a background run's live progress, resuming from the
+   * caller's cursor. The caller holds the cursor because it is what makes the
+   * poll cheap: a run with nothing new to say answers with an empty page.
+   */
+  loadProgress: (
+    runId: string,
+    afterSequence: number,
+  ) => Promise<AgentRunProgress>;
 };
 
 /**
@@ -158,6 +168,14 @@ export function useAgentRuns(
     [client, chatId],
   );
 
+  const loadProgress = useCallback(
+    async (runId: string, afterSequence: number) => {
+      if (!client || !chatId) return { entries: [], nextSequence: afterSequence };
+      return client.listAgentRunProgress(chatId, runId, afterSequence);
+    },
+    [client, chatId],
+  );
+
   return {
     runs,
     loading,
@@ -166,5 +184,6 @@ export function useAgentRuns(
     cancel,
     loadActivity,
     loadTaskPlan,
+    loadProgress,
   };
 }


### PR DESCRIPTION
The server side of the live progress read model landed some time ago — `GET /chats/{chat_id}/agent-runs/{run_id}/progress` plus the typed client and its defensive parser — but nothing rendered it. A running child in the transcript said only that it was running, and its panel showed the tool-call history without the narration around it.

## What changed

- A running child's row in the transcript shows the run's most recent progress line in place of the state string, falling back to the state until the run has said anything and while a stop is in flight.
- The background-agent panel shows the stream above the per-run activity history.
- Both read through one `useAgentRunProgress` hook. It holds the cursor per run in a ref, so a re-run of its effect (the run settling, a new loader identity) resumes from the page it last received rather than re-reading from zero. A live run is re-read on a 5s timer; a settled run is read once and left alone, since it publishes nothing further.
- Retention bounds the stream server-side, so a gap in `sequence` is taken as ordinary — nothing treats it as an error — and a failed page leaves whatever is held on screen for the next poll to extend. One reader keeps the newest 200 lines so a chatty run cannot grow the DOM without limit.
- The text is the agent's own prose, rendered the way the task plan's steps are: as text, never interpreted as markup, truncated to a single line where it shares the row with the task and the controls, wrapped where it has the width.

`loadProgress` joins `loadActivity`/`loadTaskPlan` on `useAgentRuns` and is threaded through `ChatView` → `MessageList` → `BackgroundAgentList` the same way its siblings are.

## Tests

One test in `BackgroundAgentList.dom.test.tsx`: a running child's row shows the latest line rather than the first or the state string, and the second poll asks from the cursor the first page returned. The existing list tests gained the new prop only.

## Verification

`tsc --noEmit` is clean and the touched test files pass, along with `MessageList.dom`, `useAgentRuns`, and `AgentRunDebugReport`. I did not drive the running app.

Closes #1604.