### PR TITLE
docs: align README launch copy with current product and platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,107 +3,206 @@
 </p>
 
 <p align="center">
-  <strong>An open, local-first agent runtime for real work.</strong><br>
-  The engine behind a production research platform, rebuilt in Rust to run on your machine with your own model keys.
+  <strong>A private AI coworker that runs on your machine.</strong><br>
+  Point it at your files and tools, and it produces finished, versioned work —
+  and reusable local apps — without your data leaving your computer.
 </p>
 
 <p align="center">
   <img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="License: Apache-2.0">
-  <img src="https://img.shields.io/badge/status-pre--alpha-orange.svg" alt="Status: pre-alpha">
+  <img src="https://img.shields.io/badge/status-pre--1.0-orange.svg" alt="Status: pre-1.0">
   <img src="https://img.shields.io/badge/built%20with-Rust-dea584.svg?logo=rust&logoColor=white" alt="Built with Rust">
   <a href="https://github.com/brightwave-inc/openwave/releases/latest"><img src="https://img.shields.io/github/v/release/brightwave-inc/openwave?label=release&color=informational" alt="Latest release"></a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/brightwave-inc/openwave/releases/latest/download/OpenWave-macos-apple-silicon.dmg"><img src="https://img.shields.io/badge/Download%20for%20macOS-Apple%20Silicon-000000.svg?logo=apple&logoColor=white" alt="Download for macOS, Apple Silicon"></a>
+  <a href="https://github.com/brightwave-inc/openwave/releases/latest"><img src="https://img.shields.io/badge/Download%20for%20macOS-Apple%20Silicon-000000.svg?logo=apple&logoColor=white" alt="Download for macOS, Apple Silicon"></a>
 </p>
 
 ---
 
 > [!WARNING]
-> **Early and in active development.** OpenWave is being built in the open, one
-> slice at a time. Interfaces, schema, and crate layout change frequently, and
-> it isn't ready for real-world use yet. Star the repo to follow along — and
-> expect rough edges.
+> **Pre-1.0 and moving fast.** OpenWave is built in the open. Interfaces,
+> schema, and local data layout still change between releases, and the local
+> profile is rebuilt rather than migrated when it does. Expect rough edges.
+
+## What it does
+
+A chat is a workspace. You attach files, connect folders, choose a model, and
+ask for the thing you actually want — a model, a deck, a cleaned dataset, a
+triage view. The agent runs code in a sandbox to build it, and what comes back
+is a file you can open, not a wall of text.
+
+**Finished work, kept as versions.** Files the agent writes to its workspace
+`output/` directory are published into the chat's **Outputs** catalog. Writing
+the same filename again appends a new version rather than overwriting one, so
+every output carries a history of who produced each version — a foreground
+turn, a background agent, or you — and when. Restore is append-only: restoring
+v2 while you're on v5 produces v6, so nothing is rewound or lost, and a restore
+can be undone by another restore. Delete is soft, with an inline undo. Outputs
+stay private app data until you pick a destination through a native **Save
+As…** dialog. Spreadsheets, CSV, Word documents, PDFs, and images preview
+in-app. See [`docs/deliverables.md`](docs/deliverables.md).
+
+**Work that runs in parallel, and survives a restart.** The foreground agent
+can hand independent jobs to background agents — up to four unsettled from one
+turn — each with its own isolated workspace, then join them at one explicit
+point and get results back in the order it asked for. The jobs and their place
+in the conversation are durable database state, so closing the app or
+restarting the server does not lose them. A background panel shows what is
+queued, running, or finished, and lets you stop a run. Background agents cannot
+spawn further agents. See [`docs/agent-runs.md`](docs/agent-runs.md).
+
+**Real folders, on explicit terms.** A folder elsewhere on your machine becomes
+available only after you choose it in a native picker, and authority is
+attached to the exact conversation. A new chat inherits nothing and there is no
+shared fallback workspace. The model sees an opaque root ID and root-relative
+paths, never an absolute host path, and connecting one folder grants nothing
+about its siblings or your home directory. The agent can ask for another
+folder and suggest where to open the picker, but only what you select is
+granted. See [`docs/host-access.md`](docs/host-access.md).
+
+**Local apps you can reopen.** Ask once for something like a triage view over a
+folder of exports, and you get a durable mini-app in the sidebar instead of a
+conversation you re-run. An app is model-authored HTML rendered in a sandboxed
+frame with no network of its own, plus a small manifest pinning exactly which
+connected-app operations and folders it may call. You consent to the manifest,
+not the HTML; the host enforces the pin on every call, and reconfiguring a
+bound server invalidates the grant so consent cannot outlive what it named.
+Apps live in the profile, so they outlive the chat that created them. See
+[`docs/local-apps.md`](docs/local-apps.md).
+
+Alongside those: web search and page extraction through Exa, Tavily, Brave, or
+a self-hosted SearXNG ([`docs/web-search.md`](docs/web-search.md)); MCP servers
+and REST APIs as connected apps ([`docs/connected-apps.md`](docs/connected-apps.md));
+and bundled skills for charts, spreadsheets, presentations, Word documents, and
+PDFs under [`skills/`](skills) and [`plugins/`](plugins).
 
 ## Download
 
-The desktop app ships for macOS, signed and notarized. The two links above
-always resolve to the newest release; the
-[releases page](https://github.com/brightwave-inc/openwave/releases) has the
-notes and earlier versions. An installed build keeps itself current — it checks
-for a newer signed release in the background and asks before restarting.
+OpenWave ships as a signed and notarized macOS app for **Apple Silicon**. Intel
+is paused while the product is in active development, and the release pipeline
+publishes one `aarch64` build ([`docs/releases.md`](docs/releases.md)). The
+[releases page](https://github.com/brightwave-inc/openwave/releases) carries the
+notes for each version.
 
-Each download has a `.sha256` sidecar on the same release if you want to verify
-it:
+Every release is also published to the hosted download root, which is the
+authoritative source for artifact bytes and digests:
 
-```sh
-shasum -a 256 -c OpenWave-macos-apple-silicon.dmg.sha256
+```text
+https://downloads.brightwave.io/openwave/manifest.json
 ```
 
-There are no Windows or Linux builds yet; on those platforms, build from source
-as described under [Building](#building).
+That manifest names the current version's DMG along with its size and SHA-256,
+so you can verify what you downloaded:
+
+```sh
+shasum -a 256 -c OpenWave_<version>_aarch64.dmg.sha256
+```
+
+An installed macOS build keeps itself current: it checks the release feed
+shortly after launch and every five minutes, downloads a newer signed version
+in the background, and waits for you to choose **Restart to update**. It never
+interrupts active work. Development builds do not contact the production feed.
+
+**Windows and Linux have no packaged build right now.** Windows installers
+shipped through v0.34.0, but the Windows CI and release-build lanes are
+currently parked for build-cost reasons — the packaging code is still in the
+tree and nothing about Windows support has been withdrawn, but releases are
+macOS-only until those lanes are turned back on, and a Windows user on v0.34.0
+has no upgrade path in the meantime. Linux has never had a packaged build. On
+both, run from source as described under [Building](#building), and read the
+platform differences below first.
+[`docs/deferred.md`](docs/deferred.md) records the full reasoning.
+
+## Model and provider portability
+
+Provider credentials go in the OS keychain, not in the database and not in a
+config file you might commit. OpenWave talks to Anthropic, OpenAI and
+OpenAI-compatible endpoints, Google (Gemini and Vertex AI), Amazon Bedrock, and
+xAI.
+
+The conversation journal is provider-neutral, so a chat can move from Claude to
+Gemini to GPT and back without starting over — useful when a provider is rate
+limiting you mid-task, and useful for running the cheap model through the
+grind and the strong model through the hard step without forking context.
+Switching routes is a deliberate flattening: provider-native artifacts such as
+thinking-block signatures are origin-gated and degrade to plain content rather
+than being translated pairwise. Providers are explicitly tiered by capability
+rather than assumed equivalent. See
+[`docs/model-providers.md`](docs/model-providers.md).
+
+## How it stays safe
+
+**Four permission modes, per chat.** **Plan** is read-only — mutating calls are
+refused outright rather than parked for approval, so a planning turn cannot
+change anything no matter what you approve. **Ask** (the default) parks every
+uncovered mutating call on an approval card. **Auto** is a standing yes to
+workspace edits while anything leaving the workspace still asks. **Allow all**
+is an explicit per-chat opt-in to full autonomy. One exception overrides every
+mode: replacing a file that already exists in a connected folder always asks,
+because no mode should advertise consent for destroying bytes the agent did not
+write. Approval cards are durable and survive a restart, and "always allow" can
+be scoped from one exact command up to a whole tool for that chat.
+
+**Code runs in a sandbox.** `exec` goes through a provider-neutral contract:
+the native macOS sandbox, a local Docker container, or a managed E2B or
+Daytona workspace. Provider-native responses, credentials, and unbounded logs
+never cross the contract, and absolute host paths are a host-only input the
+model never sees.
+[`docs/code-execution.md`](docs/code-execution.md) documents each backend,
+including how strictly each one can actually enforce a network policy — the
+statuses differ, and the document states them plainly rather than implying
+parity.
+
+**Versioning is the undo.** Because output history is insert-only and restore
+appends, the agent producing a wrong file is a recoverable event rather than a
+lost one. That is what makes an ungated workspace write acceptable in the first
+place.
+
+## Current limitations
+
+Worth knowing before you install:
+
+- **Packaged builds are macOS on Apple Silicon only.** See
+  [Download](#download).
+- **The native execution sandbox is macOS-only.** On Linux or Windows there is
+  no native confinement primitive; the choices are the opt-in local Docker
+  backend or a managed cloud provider that receives the chat's staged files.
+  The Docker backend does not enforce the chat's network policy at all today.
+- **Connected-folder access inside code execution is macOS-only.** Managed
+  providers cannot reach host folders at all.
+- **No semantic search or indexed retrieval.** There is no corpus, no
+  embeddings, and no vector index. Documents are read directly, and files plus
+  code execution are the whole interface to your data. This is a deliberate
+  narrowing, not a gap waiting to be filled.
+- **No scheduled or recurring work.** Background agents make work durable, but
+  nothing runs on a timer yet.
+- **No browser automation.**
+- **One local user.** The loopback bearer token is a capability check on the
+  local process, not a per-user identity. OpenWave is a single-user desktop
+  product today; do not put more than one person behind one server.
+- **Local data is not migrated across pre-1.0 releases.** The desktop schema
+  guard rebuilds the profile when the shape changes.
+
+[`docs/deferred.md`](docs/deferred.md) is the canonical account of what
+OpenWave deliberately does not do yet and why.
 
 ## Where this comes from
 
 Since 2024 we've built [Brightwave](https://brightwave.io), a research platform
-for financial diligence. Hundreds of finance professionals use it for work they
-put their name on, where a missed detail in a data room has real consequences
-and every claim has to trace back to a source.
+for financial diligence used by finance professionals for work they put their
+name on.
 
 Running it in production taught us some things. The agent loop is the easy
 part; the hard part is what happens when a tool call fails halfway through a
-twenty-step task. Sandboxing has to be there from the start. And a user who
-can't switch models is stuck with their vendor's outages and their vendor's
-pricing.
+twenty-step task. Sandboxing has to be there from the start. A user who can't
+switch models is stuck with their vendor's outages and their vendor's pricing.
+And the thing people actually want at the end is a file, not a transcript.
 
-OpenWave is that engine rebuilt in Rust: the agent loop, the tool model,
-sandboxed execution, connectors, and permissions. Apache-2.0, local-first, and
-complete on its own.
-
-## What we believe
-
-**The engine that does the work should belong to you.** Not a cloud service
-that holds your data and meters your tokens. Files stay on your machine, keys
-stay in your keychain, code runs sandboxed, and the agent asks before it
-reaches past what you've granted. Those aren't features; they follow from the
-first sentence.
-
-**A conversation shouldn't care which vendor is on the other end.** So the
-journal is provider-neutral and you can switch providers mid-chat, from Claude
-to GPT to a local model, and keep going. The day your provider has an outage
-and your work doesn't stop, that's the principle paying off.
-
-**Software should work before it asks you to configure it.** OpenWave runs on
-first launch with sensible defaults. Every layer underneath: models, sandboxes,
-tools, and permissions can be swapped out when you need to, and not before.
-
-**The work is the point.** Demos optimize for the first five minutes. We
-optimize for whether the deliverable got done.
-
-## Status
-
-Pre-alpha, built in the open. The current product is conversation-first: each
-chat is its own workspace, with exact conversation-scoped sources rather than a
-shared fallback corpus. Sources can be added from the composer and read directly
-after synchronous text decoding, with model-authored citations. Foreground
-agents can also create bounded text deliverables that remain private to the
-conversation until the user previews and explicitly exports them from the
-native Outputs view. The stack includes local file tools, multi-provider model
-routing, a turn engine with live journaled WebSocket events, a workspace-style
-desktop conversation shell, a bounded foreground/sandbox agent-run foundation,
-and durable synchronous source ingestion and reading — all behind
-`openwave serve`.
-Project records and APIs remain dormant for compatibility and future design
-work, but Projects are not surfaced in the desktop and are not required to
-start working.
-
-See [`docs/deliverables.md`](docs/deliverables.md) for the generated-output and
-native export boundary.
-
-Connectors, richer document parsers, indexed-search MCP wiring, and MCP
-configuration UI remain in development. Expect rapid change and rough edges —
-and see [CONTRIBUTING](CONTRIBUTING.md) if you'd like to help.
+OpenWave is that engine rebuilt in Rust — the agent loop, the tool model,
+sandboxed execution, connected apps, and permissions — Apache-2.0, local-first,
+and complete on its own.
 
 ## Building
 
@@ -112,30 +211,43 @@ cargo build --workspace
 cargo test --workspace
 ```
 
-Requires the Rust toolchain declared in [`rust-toolchain.toml`](rust-toolchain.toml).
+Requires the Rust toolchain declared in
+[`rust-toolchain.toml`](rust-toolchain.toml).
 
 ### Desktop app (Tauri)
 
 The desktop shell lives in [`crates/openwave-desktop`](crates/openwave-desktop).
 It boots the same local API as `openwave serve` inside the process and hosts a
 React UI in a webview. See that crate's README for prerequisites and the two
-local-test paths (`cargo tauri dev`, or browser UI against `openwave serve`).
+local-test paths (`cargo tauri dev`, or the browser UI against
+`openwave serve`).
 
-Headless API without the UI:
+### Headless
 
 ```sh
 ANTHROPIC_API_KEY=sk-... cargo run -p openwave-cli -- serve
 # then: curl -s http://127.0.0.1:PORT/healthz
 #       curl -H "Authorization: Bearer TOKEN" http://127.0.0.1:PORT/chats
+```
 
-# MCP stdio server confined to an explicit workspace (read_file + list_dir):
+The CLI also has an interactive terminal chat (`openwave tui`), a
+non-interactive single turn (`openwave -p "<prompt>"`, with
+`--output-format json` for the turn's NDJSON event stream), and an MCP stdio
+server confined to one explicit workspace:
+
+```sh
 cargo run -p openwave-cli -- mcp /absolute/path/to/workspace
 ```
 
+Note that host-brokered connected folders and the native execution sandbox are
+desktop and macOS features; the headless server does not provide them.
+
 ### External MCP servers
 
-Both `openwave serve` and the desktop app can mount external stdio MCP servers
-at startup. Set `OPENWAVE_MCP_CONFIG` to a JSON file:
+The desktop configures MCP servers under Settings; see
+[`docs/mcp-servers.md`](docs/mcp-servers.md). For headless use, both
+`openwave serve` and the desktop app can also mount external stdio MCP servers
+at startup from a JSON file named by `OPENWAVE_MCP_CONFIG`:
 
 ```json
 {
@@ -172,21 +284,27 @@ server cannot initialize. Its discovered tools are named
 
 This is a single Cargo workspace. Libraries never depend on clients — the
 dependency graph only flows downward toward `openwave-core`. For a fuller
-walkthrough of each crate, see [`docs/crates.md`](docs/crates.md). For an
+walkthrough of each crate, see [`docs/crates.md`](docs/crates.md); for an
 end-to-end, less technical tour of the runtime and its state machines, see
-[`docs/how-openwave-works.md`](docs/how-openwave-works.md). The planned shared
-foreground/background execution model is described in
-[`docs/agent-runs.md`](docs/agent-runs.md).
+[`docs/how-openwave-works.md`](docs/how-openwave-works.md).
 
 | Crate | What it is |
 | --- | --- |
 | [`openwave-core`](crates/openwave-core) | agent loop, tools, event stream, storage traits |
-| [`openwave-router`](crates/openwave-router) | Anthropic, OpenAI, xAI, Gemini, Amazon Bedrock Mantle, and compatible providers + model routing |
-| [`openwave-code-execution`](crates/openwave-code-execution) | provider-neutral command execution + native local sandbox |
+| [`openwave-router`](crates/openwave-router) | Anthropic, OpenAI, Google, Vertex AI, Amazon Bedrock, and xAI providers + model routing |
+| [`openwave-host-broker`](crates/openwave-host-broker) | consented access to folders on the host |
+| [`openwave-code-execution`](crates/openwave-code-execution) | provider-neutral command execution + native, Docker, and managed backends |
+| [`openwave-egress`](crates/openwave-egress) | egress policy decisions for outbound network access |
+| [`openwave-sandbox-protocol`](crates/openwave-sandbox-protocol) | the sandbox-agent wire protocol |
 | [`openwave-server`](crates/openwave-server) | authenticated local HTTP/WebSocket API + durable workers |
-| [`openwave-mcp`](crates/openwave-mcp) | lifecycle-gated MCP server plus external stdio client tool mounting |
+| [`openwave-mcp`](crates/openwave-mcp) | MCP server face plus external stdio client tool mounting |
 | [`openwave-desktop`](crates/openwave-desktop) | desktop app (Tauri) |
-| [`openwave-cli`](crates/openwave-cli) | headless `openwave serve` + `openwave mcp` commands |
+| [`openwave-cli`](crates/openwave-cli) | headless `openwave serve`, `tui`, print mode, and `mcp` |
+
+## Contributing
+
+See [CONTRIBUTING](CONTRIBUTING.md). Design decisions live in
+[`docs/decisions/`](docs/decisions) as numbered records.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/brightwave-inc/openwave/releases/latest"><img src="https://img.shields.io/badge/Download%20for%20macOS-Apple%20Silicon-000000.svg?logo=apple&logoColor=white" alt="Download for macOS, Apple Silicon"></a>
+  <a href="https://github.com/brightwave-inc/openwave/releases/latest/download/OpenWave-macos-apple-silicon.dmg"><img src="https://img.shields.io/badge/Download%20for%20macOS-Apple%20Silicon-000000.svg?logo=apple&logoColor=white" alt="Download for macOS, Apple Silicon"></a>
 </p>
 
 ---
@@ -83,8 +83,9 @@ PDFs under [`skills/`](skills) and [`plugins/`](plugins).
 OpenWave ships as a signed and notarized macOS app for **Apple Silicon**. Intel
 is paused while the product is in active development, and the release pipeline
 publishes one `aarch64` build ([`docs/releases.md`](docs/releases.md)). The
-[releases page](https://github.com/brightwave-inc/openwave/releases) carries the
-notes for each version.
+button above always resolves to the newest release; the
+[releases page](https://github.com/brightwave-inc/openwave/releases) has the
+notes and earlier versions.
 
 Every release is also published to the hosted download root, which is the
 authoritative source for artifact bytes and digests:


### PR DESCRIPTION
Rewrites the public README so it describes the build that ships today rather than an earlier version of the product.

The opening now leads with what a person gets — versioned outputs, durable parallel background work, explicitly connected folders, and reusable local apps — with model/provider portability and the approval/sandbox/versioning safety story as supporting proof, and the crate layout moved to the end.

Every claim was checked against the repo or the published release artifacts. Three things did not match the assumptions in the issue, and the repo's state won.

**Windows is not currently downloadable.** #1614 did ship the installer and `docs/releases.md` still documents it, but #1809 parked the Windows lanes: `windows-check` in CI and `prepare_windows`/`build_windows` in the release workflow are each gated behind a literal `false`, and `docs/deferred.md` states releases are macOS-only until they come back. Windows installers appear only on the v0.33.0 and v0.34.0 releases. The README therefore says packaged builds are macOS on Apple Silicon only, that Windows shipped through v0.34.0 and is parked for build cost rather than withdrawn, and that a Windows user on v0.34.0 has no upgrade path meanwhile.

**GitHub release assets have been missing since v0.34.0, so the download button is currently broken.** v0.35.0, v0.36.0, v0.36.1, and v0.37.0 all carry zero assets: `attach GitHub release downloads` reports `skipped` even on runs where `validate` and `publish` both succeeded, which looks like fallout from the parking change making `publish` conditional. The `releases/latest/download/OpenWave-macos-apple-silicon.dmg` permalink consequently returns 404 today. The hosted CDN side is fine — `downloads.brightwave.io/openwave/manifest.json` and the versioned v0.37.0 artifacts under it are complete and correct.

I filed that as #1841 and this PR is blocked on it rather than working around it. The workaround I tried first — pointing the button at the releases page and the hosted manifest — fails the `release policy` lane, which asserts the README carries that exact permalink, and that guard is deliberately tamper-proof: CI restores the base branch's copy of `scripts/workflow-security.test.mjs` on every pull request, so a PR cannot relax it. Weakening it from here would be the wrong move anyway. The README keeps the permalink, which is correct the moment #1841 lands and the attach job is re-dispatched for the current tag (it pulls bytes from the CDN, so v0.37.0 can be backfilled without a rebuild). **#1841 should merge and the assets be backfilled before this is treated as launch-ready copy.** The download section also names the hosted manifest as the authoritative source for bytes and digests, which works today.

**Citations were more nuanced than "removed".** Semantic search, embeddings, and the vector index are gone, and the README says so explicitly under limitations. Model-authored citations into user-attached documents do still exist, but they are not retrieval-grounded, so per the acceptance criteria the README does not present citation-grounded answers as a capability at all. No document-viewer or wire-compatibility code was touched.

Other claims verified rather than assumed: the four permission modes and the connected-folder replacement exception against `PermissionMode` in `openwave-core`; append-only restore and soft delete against `docs/deliverables.md`; the four-child spawn cap, depth limit, and restart durability against `docs/agent-runs.md`; the provider list against `crates/openwave-router/src`; the search providers against `docs/web-search.md`; the manifest-and-consent model against `docs/local-apps.md`; the opaque-root-ID boundary against `docs/host-access.md`; the updater cadence and Apple Silicon-only build against `docs/releases.md`; and the crate table against the actual `crates/` tree.

The limitations section is deliberately explicit about the platform-specific execution differences, since they change the product materially: the native sandbox is macOS-only, connected-folder access inside `exec` is macOS-only, and the Docker fallback does not enforce the chat's network policy at all.

Docs-only, so only the light lanes run.

Closes #1744
