### PR TITLE
fix(server): scope the pending-prompt inbox to its owner

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -2174,7 +2174,14 @@ impl Store for DbStore {
     }
 
     async fn list_pending_chat_prompts(&self) -> Result<Vec<crate::PendingChatPrompt>> {
-        ops::chat_prompt::list_pending_chat_prompts(self).await
+        ops::chat_prompt::list_pending_chat_prompts(self, None).await
+    }
+
+    async fn list_pending_chat_prompts_scoped(
+        &self,
+        owner: &OwnerId,
+    ) -> Result<Vec<crate::PendingChatPrompt>> {
+        ops::chat_prompt::list_pending_chat_prompts(self, Some(owner)).await
     }
 
     async fn list_inbox_items_scoped(&self, owner: &OwnerId) -> Result<Vec<crate::InboxItem>> {

--- a/crates/openwave-core/src/db/ops/chat_prompt.rs
+++ b/crates/openwave-core/src/db/ops/chat_prompt.rs
@@ -1,11 +1,13 @@
 //! Opaque cross-conversation prompt summaries for shell-level notification.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
 
 use crate::error::Result;
-use crate::model::{ToolCallExecution, ToolCallStatus, TurnClientWaitStatus, TurnRunStatus};
+use crate::model::{
+    OwnerId, ToolCallExecution, ToolCallStatus, TurnClientWaitStatus, TurnRunStatus,
+};
 use crate::storage::{InboxItemKind, PendingChatPrompt};
 use crate::{
     validate_request_folder_access_arguments, validate_write_output_to_connected_folder_arguments,
@@ -26,11 +28,37 @@ pub(in crate::db) struct PendingPromptRow {
 }
 
 /// Fold prompt rows into the per-conversation attention summary.
+///
+/// With an `owner`, the principal's own chats are the scope filter, so a
+/// conversation someone else owns cannot appear in the summary — the same
+/// derivation [`super::inbox::list_inbox_items`] uses for the cross-chat
+/// inbox it shares these rows with.
 pub(in crate::db) async fn list_pending_chat_prompts(
     store: &DbStore,
+    owner: Option<&OwnerId>,
 ) -> Result<Vec<PendingChatPrompt>> {
+    let visible = match owner {
+        Some(owner) => Some(
+            entities::chat::Entity::find()
+                .filter(entities::chat::Column::Owner.eq(owner.as_str()))
+                .all(&store.conn)
+                .await
+                .map_err(store_err)?
+                .into_iter()
+                .map(|chat| chat.id)
+                .collect::<HashSet<_>>(),
+        ),
+        None => None,
+    };
+
     let mut prompts = BTreeMap::<uuid::Uuid, PendingChatPrompt>::new();
     for row in list_pending_prompt_rows(store).await? {
+        if visible
+            .as_ref()
+            .is_some_and(|chat_ids| !chat_ids.contains(&row.chat_id.0))
+        {
+            continue;
+        }
         let entry = prompts
             .entry(row.chat_id.0)
             .or_insert_with(|| PendingChatPrompt {

--- a/crates/openwave-core/src/storage/store.rs
+++ b/crates/openwave-core/src/storage/store.rs
@@ -2490,6 +2490,17 @@ pub trait Store: Send + Sync {
         turn_storage_unavailable()
     }
 
+    /// [`Store::list_pending_chat_prompts`] restricted to conversations that
+    /// belong to `owner`. A cross-chat read, so it is owner-scoped like the
+    /// inbox it projects the same parked rows for.
+    async fn list_pending_chat_prompts_scoped(
+        &self,
+        owner: &OwnerId,
+    ) -> Result<Vec<PendingChatPrompt>> {
+        let _ = owner;
+        self.list_pending_chat_prompts().await
+    }
+
     /// Every item waiting on `owner`, across their conversations, oldest first.
     ///
     /// A read model over the same parked rows the per-chat recovery routes

--- a/crates/openwave-core/src/storage/store.rs
+++ b/crates/openwave-core/src/storage/store.rs
@@ -2493,12 +2493,16 @@ pub trait Store: Send + Sync {
     /// [`Store::list_pending_chat_prompts`] restricted to conversations that
     /// belong to `owner`. A cross-chat read, so it is owner-scoped like the
     /// inbox it projects the same parked rows for.
+    ///
+    /// The default refuses rather than falling back to the unscoped read: this
+    /// is the owner boundary itself, and an implementation that forgets the
+    /// override should fail loudly instead of quietly serving every owner's
+    /// prompts.
     async fn list_pending_chat_prompts_scoped(
         &self,
-        owner: &OwnerId,
+        _owner: &OwnerId,
     ) -> Result<Vec<PendingChatPrompt>> {
-        let _ = owner;
-        self.list_pending_chat_prompts().await
+        turn_storage_unavailable()
     }
 
     /// Every item waiting on `owner`, across their conversations, oldest first.

--- a/crates/openwave-server/src/routes/user_questions.rs
+++ b/crates/openwave-server/src/routes/user_questions.rs
@@ -29,10 +29,12 @@ pub async fn list_pending_user_questions(
 /// The shell uses this single summary read to find parked chats. Detail stays
 /// behind each chat's dedicated prompt-recovery route, so this endpoint never
 /// carries question content, folder-access arguments, or executor metadata.
+/// A cross-chat root read, so it answers only for the requesting principal's
+/// own conversations.
 pub async fn list_pending_chat_prompts(
-    State(state): State<AppState>,
+    store: ScopedStore,
 ) -> Result<Json<Vec<PendingChatPrompt>>, ServerError> {
-    Ok(Json(state.store.list_pending_chat_prompts().await?))
+    Ok(Json(store.list_pending_chat_prompts().await?))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]

--- a/crates/openwave-server/src/scoped_store.rs
+++ b/crates/openwave-server/src/scoped_store.rs
@@ -386,6 +386,15 @@ impl ScopedStore {
         self.store.list_inbox_items_scoped(&self.owner).await
     }
 
+    /// The per-conversation attention summary over the principal's own chats.
+    /// Another owner's parked prompt is not merely unreadable here, it is
+    /// absent, so the summary cannot even reveal that their chat exists.
+    pub async fn list_pending_chat_prompts(&self) -> Result<Vec<openwave_core::PendingChatPrompt>> {
+        self.store
+            .list_pending_chat_prompts_scoped(&self.owner)
+            .await
+    }
+
     /// The standing grants reachable through the principal's own chats and
     /// projects, newest first.
     pub async fn list_standing_tool_grants(

--- a/crates/openwave-server/src/tests/lifecycle.rs
+++ b/crates/openwave-server/src/tests/lifecycle.rs
@@ -3099,6 +3099,7 @@ async fn self_host_tokens_resolve_named_principals() {
 async fn routes_scope_root_aggregates_to_the_requesting_principal() {
     let (dir, store) = temp_db_store("self-host-scoping.db").await;
     let store: Arc<dyn Store> = Arc::new(store);
+    let prompts_store = Arc::clone(&store);
     let tokens_file = dir.path().join("tokens");
     std::fs::write(
         &tokens_file,
@@ -3180,6 +3181,27 @@ async fn routes_scope_root_aggregates_to_the_requesting_principal() {
             "{path} must not answer for another owner's chat"
         );
     }
+
+    // The cross-chat prompt summary is a root read, so it is scoped by owner
+    // rather than by a chat id the caller names: Alice's parked question is
+    // hers alone, and Bob's inbox does not even learn her chat exists.
+    park_user_questions_for_route_test(&*prompts_store, chat.id).await;
+    let alice_prompts: Vec<serde_json::Value> =
+        json_body(get(alice, "/chats/pending-prompts".to_owned()).await).await;
+    assert_eq!(
+        alice_prompts
+            .iter()
+            .filter(|summary| summary["chat_id"] == chat.id.to_string())
+            .count(),
+        1,
+        "the owner still sees her own parked prompt"
+    );
+    let bob_prompts: Vec<serde_json::Value> =
+        json_body(get(bob, "/chats/pending-prompts".to_owned()).await).await;
+    assert!(
+        bob_prompts.is_empty(),
+        "the prompt inbox never carries another owner's parked prompts"
+    );
 
     // Mutations answer the same way: nothing to patch, nothing to delete.
     let patch = router


### PR DESCRIPTION
## The gap

`GET /chats/pending-prompts` was the last root read still going through the
unscoped store handle. `Store` had no `_scoped` variant for it, so the handler
took `State<AppState>` and returned every owner's parked prompts: on a
multi-principal deployment, principal B's shell listed principal A's pending
questions, plan reviews, folder-access asks, and output writebacks — chat ids
and call ids for conversations B cannot open.

## The fix

`list_pending_chat_prompts_scoped` on the `Store` trait, following the shape
`list_standing_tool_grants_scoped` and `list_inbox_items_scoped` already use:
a fail-closed default (`turn_storage_unavailable()`, matching `list_inbox_items_scoped`), overridden on `DbStore` to pass
the owner down to the op. The op resolves the principal's chats first and uses
that set as the scope filter, which is the same derivation
`ops::inbox::list_inbox_items` uses over the same parked rows — the two
cross-chat reads now agree on what a reader may see. `DbStore` is the single
sea-orm implementation behind both SQLite and Postgres, and the added filter is
an ordinary owner equality with no backend-specific SQL, so there is one code
path for both.

The route now extracts `ScopedStore` and calls the pass-through, so the handler
can no longer express the cross-owner query at all. The unscoped trait method
stays for the non-request callers and as the default's fallback.

Closes #1774.

## Test

One assertion pair added to
`routes_scope_root_aggregates_to_the_requesting_principal` in
`src/tests/lifecycle.rs`, the existing two-user self-host router: a question is
parked on Alice's chat, Alice's summary carries it, Bob's is empty. Confirmed it
is load-bearing by pointing the pass-through back at the unscoped read — the
test fails there and passes with the scoped one.

## Verified

`cargo check -p openwave-server --locked` (no lock diff), `cargo fmt --all
--check`, `cargo clippy -p openwave-core -p openwave-server --all-targets
--locked` clean, and both lib suites green (`openwave-server` 731 passed,
`openwave-core` 587 passed). Not labelled `full-ci`: the Postgres lane runs the
same `DbStore` code as the SQLite tests here, so there is no divergent path only
CI can exercise.

## Left alone

The issue's related observation about `routes/root_attachment.rs` is untouched —
it is a design call about whether that surface is executor-scoped or
principal-scoped, not the leak this fixes.

