### PR TITLE
fix(release): keep attaching GitHub assets while the Windows lane is parked

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1272,6 +1272,16 @@ jobs:
   attach_downloads:
     name: attach GitHub release downloads
     needs: [validate, publish]
+    # `publish` inherits the parked `build_windows` skip through its own needs
+    # (see docs/deferred.md), and an implicit `success()` reads that whole
+    # chain — so without this guard the job skips on green runs. Only the two
+    # jobs this one actually depends on decide whether it runs.
+    if: >-
+      ${{
+        always()
+        && needs.validate.result == 'success'
+        && needs.publish.result == 'success'
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
`attach_downloads` declares `needs: [validate, publish]` with no explicit `if:`. GitHub evaluates the implicit `success()` over the whole transitive dependency chain, and `publish` depends on the parked `build_windows`/`prepare_windows` jobs (gated behind a literal `false`, see docs/deferred.md). A skipped ancestor makes `success()` false, so the job skipped on otherwise-green runs — releases v0.35.0 through v0.37.0 published no GitHub assets, and `/releases/latest/download/…` URLs 404 even though the CDN serves the artifacts.

`publish` survives the same chain only because it carries an explicit `always() && …` condition with per-need result checks. This gives `attach_downloads` the same guard, so only the two jobs it actually depends on decide whether it runs.

Assets for the already-published releases still need backfilling; the job re-downloads from the CDN by design, so re-running it attaches them without rebuilding.

Verified with `node --test scripts/*.test.mjs` (89 pass) and a YAML parse of the workflow.

Closes #1844