### PR TITLE
feat(cli): chat and model pickers in the TUI

### DIFF
--- a/crates/openwave-cli/src/main.rs
+++ b/crates/openwave-cli/src/main.rs
@@ -16,9 +16,11 @@
 //! keychain items belong to the running binary's code signature, which is what
 //! stops macOS asking for credentials an earlier build created.
 //!
-//! `openwave tui [--chat <id>]` runs an interactive terminal chat: it boots the
-//! same in-process server as `serve` and drives it over the loopback HTTP+WS
-//! API, starting a fresh chat or resuming an existing one.
+//! `openwave tui [--chat <id> | --new]` runs an interactive terminal chat: it
+//! boots the same in-process server as `serve` and drives it over the loopback
+//! HTTP+WS API. With neither flag it opens a picker over the existing chats, so
+//! a session can be resumed without knowing its id; `--new` skips straight to a
+//! fresh chat, and `--chat` resumes one by id.
 //!
 //! `openwave -p "<prompt>"` runs one turn without a terminal: same engine, no
 //! interaction. stdout carries the assistant's text (or, with
@@ -39,7 +41,7 @@ mod tui;
 use print::OutputFormat;
 
 const USAGE: &str = "usage: openwave serve\n       openwave mcp <workspace>\n       openwave \
-                     rehome-secrets\n       openwave tui [--chat <id>]\n       openwave -p \
+                     rehome-secrets\n       openwave tui [--chat <id> | --new]\n       openwave -p \
                      <prompt> [--chat <id>] [--output-format text|json]";
 
 #[tokio::main]
@@ -86,23 +88,29 @@ async fn run() -> Result<i32> {
             rehome_secrets().await.map(|()| 0)
         }
         Some(command) if command == OsStr::new("tui") => {
-            let chat = match args.next() {
-                None => None,
-                Some(flag) if flag == OsStr::new("--chat") => {
+            let mut open = None;
+            while let Some(flag) = args.next() {
+                if flag == OsStr::new("--chat") {
                     let Some(id) = args.next() else {
                         usage_error("tui --chat requires a chat id");
                     };
-                    match ChatId::from_str(&id.to_string_lossy()) {
-                        Ok(chat) => Some(chat),
-                        Err(_) => usage_error("tui --chat expects a chat UUID"),
+                    let Ok(chat) = ChatId::from_str(&id.to_string_lossy()) else {
+                        usage_error("tui --chat expects a chat UUID");
+                    };
+                    if open.is_some() {
+                        usage_error("tui takes either --chat <id> or --new, not both");
                     }
+                    open = Some(tui::Open::Chat(chat));
+                } else if flag == OsStr::new("--new") {
+                    if open.is_some() {
+                        usage_error("tui takes either --chat <id> or --new, not both");
+                    }
+                    open = Some(tui::Open::New);
+                } else {
+                    usage_error("tui accepts only --chat <id> or --new");
                 }
-                Some(_) => usage_error("tui accepts only an optional --chat <id>"),
-            };
-            if args.next().is_some() {
-                usage_error("tui accepts only an optional --chat <id>");
             }
-            tui::run(chat).await.map(|()| 0)
+            tui::run(open.unwrap_or(tui::Open::Pick)).await.map(|()| 0)
         }
         Some(command) if command == OsStr::new("-p") || command == OsStr::new("--print") => {
             let Some(prompt) = args.next() else {

--- a/crates/openwave-cli/src/tui/app.rs
+++ b/crates/openwave-cli/src/tui/app.rs
@@ -21,7 +21,7 @@ use ratatui::backend::CrosstermBackend;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Clear, Paragraph, Widget, Wrap};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Widget};
 use ratatui::{Terminal, TerminalOptions, Viewport};
 use ratatui_textarea::TextArea;
 use tokio::sync::mpsc;
@@ -747,7 +747,7 @@ impl App {
 
     fn open_chats(&mut self) {
         self.refresh_chat_list();
-        self.overlay = Some(Overlay::Chats(ChatsOverlay::new(self.chat)));
+        self.overlay = Some(Overlay::Chats(ChatsOverlay::new(Some(self.chat))));
     }
 
     fn open_agents(&mut self) {
@@ -1615,14 +1615,20 @@ impl App {
 }
 
 /// Restores the terminal on drop; the panic hook does the same for panics.
-struct TerminalGuard {
-    terminal: Terminal<CrosstermBackend<Stdout>>,
+pub(super) struct TerminalGuard {
+    pub(super) terminal: Terminal<CrosstermBackend<Stdout>>,
     /// The inline viewport's height, clamped to the terminal's rows.
     live_height: u16,
 }
 
 impl TerminalGuard {
     fn new() -> Result<Self> {
+        Self::with_height(LIVE_HEIGHT)
+    }
+
+    /// Raw mode plus an inline viewport `rows` tall (clamped to the terminal).
+    /// The startup picker takes a taller region than the chat's live area.
+    pub(super) fn with_height(rows: u16) -> Result<Self> {
         enable_raw_mode().map_err(terminal_error)?;
         let mut stdout = io::stdout();
         // Bracketed paste keeps pasted newlines from firing sends; the keyboard
@@ -1634,8 +1640,7 @@ impl TerminalGuard {
             PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
         )
         .map_err(terminal_error)?;
-        let live_height =
-            LIVE_HEIGHT.min(crossterm::terminal::size().map_or(LIVE_HEIGHT, |(_, r)| r));
+        let live_height = rows.min(crossterm::terminal::size().map_or(rows, |(_, r)| r));
         let terminal = Terminal::with_options(
             CrosstermBackend::new(stdout),
             TerminalOptions {
@@ -1662,7 +1667,7 @@ impl Drop for TerminalGuard {
     }
 }
 
-fn install_panic_hook() {
+pub(super) fn install_panic_hook() {
     let previous = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
         let _ = disable_raw_mode();
@@ -1676,7 +1681,7 @@ fn install_panic_hook() {
     }));
 }
 
-fn terminal_error(error: io::Error) -> AgentError {
+pub(super) fn terminal_error(error: io::Error) -> AgentError {
     AgentError::msg(format!("terminal error: {error}"))
 }
 
@@ -1976,22 +1981,13 @@ fn render_overlay(overlay: &mut Overlay, frame: &mut ratatui::Frame) {
     let x = (area.width.saturating_sub(width)) / 2;
     let y = (area.height.saturating_sub(height)) / 2;
     let rect = Rect::new(x, y, width, height);
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(theme::border())
-        .style(Style::default().bg(theme::PANEL_BG))
-        .title(Span::styled(format!(" {title} "), theme::accent_bold()));
-    let inner = block.inner(rect);
-    let lines = match overlay {
-        Overlay::Chats(overlay) => overlay.lines(inner.width as usize),
-        Overlay::Agents(overlay) => overlay.lines(inner.width as usize),
-        Overlay::Models(overlay) => overlay.lines(inner.width as usize),
-        Overlay::Mode(overlay) => overlay.lines(inner.width as usize),
-        Overlay::Move(overlay) => overlay.lines(inner.width as usize),
-        Overlay::Questions(overlay) => overlay.lines(inner.width as usize),
-        Overlay::Help(overlay) => overlay.lines(inner.width as usize),
-    };
-    frame.render_widget(Clear, rect);
-    frame.render_widget(block, rect);
-    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
+    super::overlays::panel(frame, rect, title, |width| match overlay {
+        Overlay::Chats(overlay) => overlay.lines(width),
+        Overlay::Agents(overlay) => overlay.lines(width),
+        Overlay::Models(overlay) => overlay.lines(width),
+        Overlay::Mode(overlay) => overlay.lines(width),
+        Overlay::Move(overlay) => overlay.lines(width),
+        Overlay::Questions(overlay) => overlay.lines(width),
+        Overlay::Help(overlay) => overlay.lines(width),
+    });
 }

--- a/crates/openwave-cli/src/tui/mod.rs
+++ b/crates/openwave-cli/src/tui/mod.rs
@@ -10,13 +10,25 @@ mod composer;
 mod markdown;
 mod overlays;
 mod render;
+mod startup;
 mod theme;
 
 use crate::api::client::Client;
 use openwave_core::{ChatId, Result};
 
+/// How the session picks the chat to attach to.
+pub enum Open {
+    /// Resume this exact chat (`--chat <id>`).
+    Chat(ChatId),
+    /// Create a fresh chat without asking (`--new`).
+    New,
+    /// Offer the startup picker, falling back to a new chat when there is
+    /// nothing to resume.
+    Pick,
+}
+
 /// Boot the server, open (or resume) the chat, and run the interactive loop.
-pub async fn run(chat: Option<ChatId>) -> Result<()> {
+pub async fn run(open: Open) -> Result<()> {
     let config = crate::profile_config()?;
     openwave_server::logging::init_logging_file_only(&config.data_dir);
     let server = openwave_server::bind_configured(config).await?;
@@ -27,16 +39,26 @@ pub async fn run(chat: Option<ChatId>) -> Result<()> {
     // session is what keeps the engine running.
     let serve = tokio::spawn(server.serve());
 
-    let client = Client::new(addr, &token)?;
-    let resumed = chat.is_some();
-    let chat = match chat {
-        Some(chat) => {
-            client.require_chat(chat).await?;
-            chat
-        }
-        None => client.create_chat().await?,
-    };
-    let result = app::run(client, chat, resumed).await;
+    let result = attach(Client::new(addr, &token)?, open).await;
     serve.abort();
     result
+}
+
+/// Resolve which chat to attach to, then hand the terminal to the app.
+async fn attach(client: Client, open: Open) -> Result<()> {
+    let (chat, resumed) = match open {
+        Open::Chat(chat) => {
+            client.require_chat(chat).await?;
+            (chat, true)
+        }
+        Open::New => (client.create_chat().await?, false),
+        Open::Pick => match startup::pick_chat(&client).await? {
+            startup::Startup::Resume(chat) => (chat, true),
+            startup::Startup::New => (client.create_chat().await?, false),
+            // The user left at the picker; no chat is created for a session
+            // that never started.
+            startup::Startup::Quit => return Ok(()),
+        },
+    };
+    app::run(client, chat, resumed).await
 }

--- a/crates/openwave-cli/src/tui/overlays.rs
+++ b/crates/openwave-cli/src/tui/overlays.rs
@@ -10,13 +10,36 @@
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use openwave_core::{AgentRunId, ChatId, ProjectId};
+use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 use ratatui_textarea::TextArea;
 
 use super::render;
 use super::theme;
 use crate::api::wire::{AgentRunSnapshot, ChatSummary, ModelInfo, PendingQuestions};
+
+/// Draw one overlay's chrome — bordered, filled, titled — and its lines inside
+/// it. Shared by the in-session overlays and the startup chat picker so both
+/// read as the same surface.
+pub fn panel(
+    frame: &mut ratatui::Frame,
+    rect: Rect,
+    title: &str,
+    lines: impl FnOnce(usize) -> Vec<Line<'static>>,
+) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme::border())
+        .style(Style::default().bg(theme::PANEL_BG))
+        .title(Span::styled(format!(" {title} "), theme::accent_bold()));
+    let inner = block.inner(rect);
+    let lines = lines(inner.width as usize);
+    frame.render_widget(Clear, rect);
+    frame.render_widget(block, rect);
+    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
+}
 
 /// The slash-command table, Claude Code style: `/name args` in the composer.
 /// Each entry is the canonical name plus a one-line blurb the help overlay and
@@ -112,13 +135,16 @@ pub struct ChatsOverlay {
     chats: Vec<ChatSummary>,
     attention: std::collections::HashSet<ChatId>,
     selected: usize,
-    current: ChatId,
+    /// The chat this session is attached to, or `None` at startup, when the
+    /// picker runs before any chat is open. No row is marked current then, and
+    /// dismissing leaves the TUI rather than returning to a chat.
+    current: Option<ChatId>,
     /// Inline rename state: which row and the input.
     renaming: Option<(ChatId, TextArea<'static>)>,
 }
 
 impl ChatsOverlay {
-    pub fn new(current: ChatId) -> Self {
+    pub fn new(current: Option<ChatId>) -> Self {
         Self {
             chats: Vec::new(),
             attention: std::collections::HashSet::new(),
@@ -227,7 +253,7 @@ impl ChatsOverlay {
         }
         for (i, chat) in self.chats.iter().enumerate() {
             let selected = i == self.selected;
-            let marker = if chat.id == self.current {
+            let marker = if Some(chat.id) == self.current {
                 Span::styled("● ", theme::accent())
             } else if self.attention.contains(&chat.id) {
                 Span::styled("⚠ ", theme::warning())
@@ -260,7 +286,11 @@ impl ChatsOverlay {
         }
         out.push(Line::default());
         out.push(Line::from(Span::styled(
-            "↑↓/tab move · enter open · n new · r rename · d delete · esc close",
+            if self.current.is_some() {
+                "↑↓/tab move · enter open · n new · r rename · d delete · esc close"
+            } else {
+                "↑↓/tab move · enter resume · n new chat · r rename · d delete · esc quit"
+            },
             theme::muted(),
         )));
         out

--- a/crates/openwave-cli/src/tui/startup.rs
+++ b/crates/openwave-cli/src/tui/startup.rs
@@ -1,0 +1,182 @@
+//! The startup chat picker.
+//!
+//! `openwave tui` with no `--chat` used to open a fresh chat unconditionally,
+//! which made every earlier conversation reachable only by pasting its UUID.
+//! The picker lists what `GET /chats` returns and lets the user resume one or
+//! start a new chat before the session attaches to anything.
+//!
+//! It reuses [`ChatsOverlay`] — the same list, keys, and panel chrome as the
+//! in-session switcher — so the surface a user learns at startup is the one
+//! `ctrl+o` shows later. The only difference is what dismissing means: there is
+//! no chat to fall back to, so `esc` leaves.
+
+use crossterm::event::{Event, EventStream, KeyCode, KeyEventKind, KeyModifiers};
+use futures::StreamExt;
+use openwave_core::{AgentError, ChatId, Result};
+use ratatui::layout::Rect;
+
+use super::app;
+use super::overlays::{self, ChatsOverlay, OverlayOutcome};
+use crate::api::client::Client;
+
+/// Rows the picker's inline viewport takes. Enough for a page of chats plus
+/// the panel border and key hints; clamped to the terminal by the guard.
+const PICKER_HEIGHT: u16 = 18;
+
+/// What the user chose at startup.
+pub enum Startup {
+    /// Attach to this existing chat.
+    Resume(ChatId),
+    /// Create a fresh chat and attach to that.
+    New,
+    /// Leave without starting a session.
+    Quit,
+}
+
+/// Show the picker and return the choice.
+///
+/// With no chats on record there is nothing to choose between, so this returns
+/// [`Startup::New`] without touching the terminal — a first run drops straight
+/// into a chat.
+pub async fn pick_chat(client: &Client) -> Result<Startup> {
+    let chats = client.list_chats().await?;
+    if chats.is_empty() {
+        return Ok(Startup::New);
+    }
+    let mut overlay = ChatsOverlay::new(None);
+    overlay.set_chats(chats, attention(client).await);
+
+    app::install_panic_hook();
+    let mut guard = app::TerminalGuard::with_height(PICKER_HEIGHT)?;
+    let mut events = EventStream::new();
+    let outcome = loop {
+        draw(&mut guard, &mut overlay)?;
+        let Some(event) = events.next().await else {
+            // stdin closed under us: nothing more can be chosen.
+            break Startup::Quit;
+        };
+        let event = event.map_err(app::terminal_error)?;
+        let Event::Key(key) = event else { continue };
+        if key.kind == KeyEventKind::Release {
+            continue;
+        }
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+            break Startup::Quit;
+        }
+        match overlay.key(key) {
+            OverlayOutcome::Open(chat) => break Startup::Resume(chat),
+            OverlayOutcome::NewChat => break Startup::New,
+            OverlayOutcome::Dismiss => break Startup::Quit,
+            // Rename and delete are the switcher's own keys; honoring them here
+            // keeps the advertised hints true. Both refresh the list, and
+            // deleting the last chat leaves nothing to pick.
+            OverlayOutcome::Rename(chat, title) => {
+                let title = title.trim().to_owned();
+                let title = (!title.is_empty()).then_some(title);
+                client.rename_chat(chat, title.as_deref()).await?;
+                if !reload(client, &mut overlay).await? {
+                    break Startup::New;
+                }
+            }
+            OverlayOutcome::Delete(chat) => {
+                client.delete_chat(chat).await?;
+                if !reload(client, &mut overlay).await? {
+                    break Startup::New;
+                }
+            }
+            _ => {}
+        }
+    };
+    // Wipe the panel so the chat session's own viewport starts clean.
+    guard.terminal.clear().map_err(app::terminal_error)?;
+    Ok(outcome)
+}
+
+/// Refill the list after a mutation. Returns whether any chat is left.
+async fn reload(client: &Client, overlay: &mut ChatsOverlay) -> Result<bool> {
+    let chats = client.list_chats().await?;
+    let remaining = !chats.is_empty();
+    overlay.set_chats(chats, attention(client).await);
+    Ok(remaining)
+}
+
+/// Chats with something parked on the user, for the list's markers. A failure
+/// here only costs the markers, so it degrades to none rather than refusing to
+/// show the picker.
+async fn attention(client: &Client) -> std::collections::HashSet<ChatId> {
+    client
+        .list_inbox()
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .map(|item| item.chat_id)
+        .collect()
+}
+
+fn draw(guard: &mut app::TerminalGuard, overlay: &mut ChatsOverlay) -> Result<()> {
+    guard
+        .terminal
+        .draw(|frame| {
+            let area = frame.area();
+            let width = area.width.clamp(30, 60);
+            let rect = Rect::new(
+                area.x + (area.width.saturating_sub(width)) / 2,
+                area.y,
+                width,
+                area.height,
+            );
+            overlays::panel(frame, rect, "resume a chat", |width| overlay.lines(width));
+        })
+        .map_err(|error| AgentError::msg(format!("terminal error: {error}")))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openwave_core::Config;
+
+    /// The picker's whole job crosses the client/server contract: the rows it
+    /// offers come from `GET /chats`, and the id it hands back has to be one
+    /// the session can actually attach to. This drives both against a real
+    /// server — a change that broke the list shape, its ordering, or the
+    /// resume path would show up here rather than as an empty picker.
+    #[tokio::test]
+    async fn the_picker_resumes_a_chat_the_server_lists() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        // Never touch the developer's real keychain from a test.
+        openwave_core::KeychainSecretProvider::use_mock();
+        let server = openwave_server::bind_configured(Config::desktop(dir.path()))
+            .await
+            .expect("bind the server");
+        let client = Client::new(server.local_addr(), server.token()).expect("build the client");
+        let serve = tokio::spawn(server.serve());
+
+        let older = client.create_chat().await.expect("create the first chat");
+        let newer = client.create_chat().await.expect("create the second chat");
+
+        let listed = client.list_chats().await.expect("list chats");
+        let ids: Vec<_> = listed.iter().map(|chat| chat.id).collect();
+        assert!(
+            ids.contains(&older) && ids.contains(&newer),
+            "the picker's list must offer every chat, got {ids:?}"
+        );
+
+        // Resuming is `require_chat` on the selected row's id.
+        client
+            .require_chat(newer)
+            .await
+            .expect("the selected chat resumes");
+
+        // With no chats at all there is nothing to pick, so the picker must not
+        // take the terminal — it goes straight to a new chat.
+        client.delete_chat(older).await.expect("delete a chat");
+        client.delete_chat(newer).await.expect("delete a chat");
+        assert!(
+            matches!(pick_chat(&client).await.expect("pick"), Startup::New),
+            "an empty chat list starts a new chat without prompting"
+        );
+
+        serve.abort();
+    }
+}

--- a/docs-site/content/docs/headless.mdx
+++ b/docs-site/content/docs/headless.mdx
@@ -21,7 +21,7 @@ the built binary if you have it on your path.
 openwave serve
 openwave mcp <workspace>
 openwave rehome-secrets
-openwave tui [--chat <id>]
+openwave tui [--chat <id> | --new]
 openwave -p <prompt> [--chat <id>] [--output-format text|json]
 ```
 
@@ -56,9 +56,16 @@ over the loopback API.
 ```sh
 cargo run -p openwave-cli -- tui
 cargo run -p openwave-cli -- tui --chat <chat-uuid>
+cargo run -p openwave-cli -- tui --new
 ```
 
-With no `--chat`, it starts a fresh chat.
+With no flags it opens a picker over the existing chats — enter resumes the
+selected one, `n` starts a new chat, `esc` leaves. On a profile with no chats
+yet there is nothing to pick, so it goes straight into a new chat. `--new`
+always skips the picker; `--chat` resumes one by id.
+
+Inside a session, `/chats` (or `ctrl+o`) reopens the same switcher and `/model`
+picks the model for the current chat.
 
 ### `-p` (one-shot)
 


### PR DESCRIPTION
`openwave tui` used to open a fresh chat every launch unless you passed
`--chat <uuid>`, so earlier conversations were reachable only by pasting an id
you had to find some other way. This adds the startup picker the TUI was
missing: with no flags, the session lists what `GET /chats` returns and lets
you resume one or start a new chat before attaching to anything.

The picker reuses the in-session switcher's `ChatsOverlay` — same rows, same
keys (`↑↓`/`tab` move, `enter` open, `n` new, `r` rename, `d` delete), same
panel chrome, now factored into `overlays::panel` and shared with the overlay
renderer. Learning the startup surface teaches the one `ctrl+o` shows later.
The only behavioral difference is what dismissing means: there is no chat to
fall back to, so `esc` leaves without creating one.

`ChatsOverlay`'s current chat becomes `Option<ChatId>` — nothing is current at
startup — and the key-hint footer follows it ("enter resume … esc quit" versus
"enter open … esc close").

Two cases skip the picker entirely: a profile with no chats yet has nothing to
choose between and drops straight into a new chat, and `--new` asks for a fresh
chat explicitly, preserving the old default for scripts and muscle memory.
`--chat <id>` is unchanged. `--chat` and `--new` together are a usage error.

The model half of the issue landed with the rich-TUI work: `/model` opens a
per-chat picker over `GET /models` and writes the selection with
`PATCH /chats/{id}`, matching the desktop's per-chat semantics. Curated model
visibility (decision record 0003) is not in the chat catalog's wire shape yet —
`recommended` exists only for voice transcription models — so the picker still
lists the full catalog. It should adopt the recommended/hidden split when the
registry carries it; that is follow-up work, not something to guess at here.

One test, covering the wiring that crosses the client/server contract: chats
created against a real bound server show up in the list the picker offers, the
selected id resumes, and an empty list returns "start a new chat" without
taking the terminal. Rendering is not asserted.

Verified with `cargo check`, `cargo clippy --all-targets`, `cargo fmt`, and
`cargo test` for `openwave-cli`. The interactive paths — drawing the panel,
key handling, the terminal restore after the picker hands off to the chat
viewport — can't be exercised headlessly and were not driven.

Closes #1683
