### PR TITLE
feat(desktop): picker shows curated models with setup CTAs for unconfigured providers

### DIFF
--- a/crates/openwave-desktop/ui/src/AppContext.tsx
+++ b/crates/openwave-desktop/ui/src/AppContext.tsx
@@ -8,6 +8,7 @@ import type {
   ProviderInfo,
 } from "./api";
 import type { DesktopUpdateState } from "./updates";
+import type { ModelVisibilityOverrides } from "./modelVisibility";
 
 /**
  * What the shell owns and every route needs: the connected client, the model
@@ -32,6 +33,13 @@ export type AppContextValue = {
    */
   defaultModelKey: string | null;
   providers: ProviderInfo[];
+  /**
+   * The reader's per-model visibility deviations from the curated set, as the
+   * settings surface last left them. Empty until settings load, and empty if
+   * they fail — which shows the curated set, the same thing an untouched
+   * install shows, rather than blocking the shell on a preference.
+   */
+  modelVisibilityOverrides: ModelVisibilityOverrides;
   refreshCatalog: () => Promise<void>;
   /** Reload the chat list after a failed fetch — the rail's retry. */
   refreshChats: () => Promise<void>;

--- a/crates/openwave-desktop/ui/src/AppShell.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.tsx
@@ -13,6 +13,7 @@ import {
   type ServerInfo,
 } from "./api";
 import { AppContextProvider } from "./AppContext";
+import type { ModelVisibilityOverrides } from "./modelVisibility";
 import { resolveServerInfo } from "./boot";
 import {
   deletionDescription,
@@ -96,6 +97,8 @@ export function AppShell() {
   const [models, setModels] = useState<ModelInfo[]>([]);
   const [defaultModelKey, setDefaultModelKey] = useState<string | null>(null);
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
+  const [modelVisibilityOverrides, setModelVisibilityOverrides] =
+    useState<ModelVisibilityOverrides>({});
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [status, setStatus] = useState("starting…");
   const openChatId = useActiveChatId();
@@ -179,14 +182,19 @@ export function AppShell() {
     let cancelled = false;
     void (async () => {
       try {
-        const [catalog, providerList] = await Promise.all([
+        const [catalog, providerList, settings] = await Promise.all([
           client.listModels(),
           client.listProviders(),
+          // A preference must not be able to fail the boot the catalog just
+          // succeeded at: without it the picker shows the curated set, which
+          // is what an untouched install shows anyway.
+          client.getSettings().catch(() => null),
         ]);
         if (cancelled) return;
         setModels(catalog.models);
         setDefaultModelKey(resolvedRoleKey(catalog.roles, "chat"));
         setProviders(providerList.providers);
+        setModelVisibilityOverrides(settings?.model_visibility_overrides ?? {});
       } catch (err) {
         if (!cancelled) setBootError(String(err));
       }
@@ -412,13 +420,15 @@ export function AppShell() {
 
   async function refreshCatalog() {
     if (!client) return;
-    const [catalog, providerList] = await Promise.all([
+    const [catalog, providerList, settings] = await Promise.all([
       client.listModels(),
       client.listProviders(),
+      client.getSettings().catch(() => null),
     ]);
     setModels(catalog.models);
     setDefaultModelKey(resolvedRoleKey(catalog.roles, "chat"));
     setProviders(providerList.providers);
+    setModelVisibilityOverrides(settings?.model_visibility_overrides ?? {});
   }
 
   async function onNewChat() {
@@ -589,6 +599,7 @@ export function AppShell() {
           models,
           defaultModelKey,
           providers,
+          modelVisibilityOverrides,
           refreshCatalog,
           refreshChats,
           status,

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -56,7 +56,7 @@ import {
 import { useImageAttachments } from "./useImageAttachments";
 import { modelForSelection } from "./ModelSelection";
 import { ContextUsageIndicator } from "./ContextUsageIndicator";
-import { ModelMenu } from "./ModelMenu";
+import { ModelMenu, useModelSettingsNav } from "./ModelMenu";
 import { PermissionModeMenu } from "./PermissionModeMenu";
 import {
   PICKER_BUSY_MESSAGE,
@@ -108,7 +108,9 @@ const { signal: signalTurnLifecycle } = useTurnLifecycle.getState();
  */
 export function ChatRoute({ chatId }: { chatId: string }) {
   const navigate = useNavigate();
-  const { client, models, defaultModelKey, setStatus } = useApp();
+  const { client, models, defaultModelKey, providers, modelVisibilityOverrides, setStatus } =
+    useApp();
+  const modelSettingsNav = useModelSettingsNav();
   const { layout, openPanel } = usePanelNav();
   const sourceNav = useStableSourceNav(openPanel);
   const chats = useChatListStore((state) => state.chats);
@@ -704,6 +706,10 @@ export function ChatRoute({ chatId }: { chatId: string }) {
               value={chat!.model}
               defaultKey={defaultModelKey}
               disabled={deletingChatId !== null}
+              visibilityOverrides={modelVisibilityOverrides}
+              providers={providers}
+              onManageModels={modelSettingsNav.onManageModels}
+              onSetUpProvider={modelSettingsNav.onSetUpProvider}
               onChange={onModelChange}
             />
           }

--- a/crates/openwave-desktop/ui/src/HomeRoute.tsx
+++ b/crates/openwave-desktop/ui/src/HomeRoute.tsx
@@ -23,7 +23,7 @@ import {
   type ImageAttachment,
   type PickedImage,
 } from "./ImageAttachments";
-import { ModelMenu } from "./ModelMenu";
+import { ModelMenu, useModelSettingsNav } from "./ModelMenu";
 import { modelForSelection } from "./ModelSelection";
 import { effectiveNewChatSettings, useNewChatSettings } from "./NewChatSettings";
 import { PermissionModeMenu } from "./PermissionModeMenu";
@@ -49,7 +49,9 @@ function isImportedDocument(
 
 export function HomeRoute() {
   const navigate = useNavigate();
-  const { client, models, defaultModelKey } = useApp();
+  const { client, models, defaultModelKey, providers, modelVisibilityOverrides } =
+    useApp();
+  const modelSettingsNav = useModelSettingsNav();
   const creatingChat = useChatListStore((state) => state.creatingChat);
   const draft = useComposerDraft(HOME_DRAFT_KEY);
   const composerPlugins = useComposerPlugins(client);
@@ -362,6 +364,10 @@ export function HomeRoute() {
                 value={effective.model}
                 defaultKey={defaultModelKey}
                 disabled={creatingChat}
+                visibilityOverrides={modelVisibilityOverrides}
+                providers={providers}
+                onManageModels={modelSettingsNav.onManageModels}
+                onSetUpProvider={modelSettingsNav.onSetUpProvider}
                 onChange={newChat.setModel}
               />
             }

--- a/crates/openwave-desktop/ui/src/ModelMenu.test.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.test.tsx
@@ -2,14 +2,16 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import {
   firstAvailableModel,
+  hiddenModelCount,
   ModelMenu,
   ModelToolCapabilityChip,
   ModelVerificationChip,
+  notConnectedProviders,
   reasoningEffortOptions,
   visibleModelGroups,
 } from "./ModelMenu";
 import { ProviderIcon } from "./ProviderIcons";
-import type { ModelInfo } from "./api";
+import type { ModelInfo, ProviderInfo } from "./api";
 
 const MODELS: ModelInfo[] = [
   {
@@ -50,12 +52,23 @@ const MODELS: ModelInfo[] = [
   },
 ];
 
+/** An available Anthropic model the catalog does not recommend. */
+const HAIKU: ModelInfo = {
+  ...MODELS[0],
+  key: "anthropic::claude-haiku",
+  id: "claude-haiku",
+  display_name: "Claude Haiku",
+  recommended: false,
+};
+
 function triggerMarkup(value: string | null, defaultKey?: string | null): string {
   return renderToStaticMarkup(
     <ModelMenu
       models={MODELS}
       value={value}
       defaultKey={defaultKey ?? null}
+      onManageModels={() => {}}
+      onSetUpProvider={() => {}}
       onChange={() => {}}
     />,
   );
@@ -86,7 +99,14 @@ describe("ModelMenu", () => {
 
   it("disables the trigger when asked", () => {
     const markup = renderToStaticMarkup(
-      <ModelMenu models={MODELS} value={null} disabled onChange={() => {}} />,
+      <ModelMenu
+        models={MODELS}
+        value={null}
+        disabled
+        onManageModels={() => {}}
+        onSetUpProvider={() => {}}
+        onChange={() => {}}
+      />,
     );
     expect(markup).toContain("disabled");
   });
@@ -172,6 +192,69 @@ describe("visibleModelGroups", () => {
     );
     expect(anthropic?.models).toHaveLength(2);
   });
+
+  it("leaves out a model the catalog does not recommend", () => {
+    const anthropic = visibleModelGroups([MODELS[0], HAIKU], null).find(
+      (group) => group.provider === "anthropic",
+    );
+    expect(anthropic?.models.map((model) => model.key)).toEqual([MODELS[0].key]);
+  });
+
+  it("lists a hidden model the reader overrode back on", () => {
+    const anthropic = visibleModelGroups([MODELS[0], HAIKU], null, {
+      [HAIKU.key]: "show",
+    }).find((group) => group.provider === "anthropic");
+    expect(anthropic?.models.map((model) => model.key)).toContain(HAIKU.key);
+  });
+
+  it("keeps the chat's own model listed however it is hidden", () => {
+    // Hiding is presentation, never a capability: the chat is pinned to this
+    // model and the picker that set it must still show it.
+    const anthropic = visibleModelGroups([MODELS[0], HAIKU], HAIKU.key, {
+      [HAIKU.key]: "hide",
+    }).find((group) => group.provider === "anthropic");
+    expect(anthropic?.models.map((model) => model.key)).toContain(HAIKU.key);
+  });
+});
+
+describe("hiddenModelCount", () => {
+  it("counts what the reader could run but cannot see", () => {
+    expect(hiddenModelCount([MODELS[0], HAIKU], null)).toBe(1);
+    // The chat's own model renders regardless, so counting it reads as a bug.
+    expect(hiddenModelCount([MODELS[0], HAIKU], HAIKU.key)).toBe(0);
+    expect(hiddenModelCount([MODELS[0], HAIKU], null, { [HAIKU.key]: "show" })).toBe(
+      0,
+    );
+  });
+});
+
+describe("notConnectedProviders", () => {
+  const credentialed = (kind: ProviderInfo["kind"]): ProviderInfo => ({
+    kind,
+    enabled: true,
+    has_credential: true,
+    models: [],
+  });
+
+  it("offers setup for a provider whose catalog rows cannot run", () => {
+    const gemini: ModelInfo[] = [
+      { ...MODELS[0], key: "gemini::a", provider: "gemini", available: false },
+      { ...MODELS[0], key: "gemini::b", provider: "gemini", available: false },
+    ];
+    expect(
+      notConnectedProviders([...MODELS, ...gemini], [credentialed("anthropic")]),
+    ).toEqual([{ provider: "gemini", modelCount: 2 }]);
+  });
+
+  it("leaves out the gateway, whose models are policy rather than a key", () => {
+    const gateway: ModelInfo = {
+      ...MODELS[0],
+      key: "model_gateway::claude",
+      provider: "model_gateway",
+      available: false,
+    };
+    expect(notConnectedProviders([gateway], [])).toEqual([]);
+  });
 });
 
 describe("firstAvailableModel", () => {
@@ -219,6 +302,8 @@ describe("model marks", () => {
         models={[gatewayClaude]}
         value={gatewayClaude.key}
         defaultKey={null}
+        onManageModels={() => {}}
+        onSetUpProvider={() => {}}
         onChange={() => {}}
       />,
     );

--- a/crates/openwave-desktop/ui/src/ModelMenu.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.tsx
@@ -1,12 +1,27 @@
 import { useState } from "react";
-import { Atom, Check, ChevronDown, Gauge, Info } from "lucide-react";
+import { useNavigate } from "@tanstack/react-router";
+import {
+  Atom,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Gauge,
+  Info,
+} from "lucide-react";
 import type {
   ModelInfo,
   ModelSelectionKey,
+  ProviderInfo,
   ProviderKind,
   ReasoningEffort,
 } from "./api";
-import { canonicalModelSelection, modelForSelection } from "./ModelSelection";
+import {
+  canonicalModelSelection,
+  modelForSelection,
+  providerLabel,
+} from "./ModelSelection";
+import { isModelVisible, type ModelVisibilityOverrides } from "./modelVisibility";
+import { useUiStore } from "./UiStore";
 import { Button } from "@/components/ui/button";
 import { ProviderIcon } from "./ProviderIcons";
 import {
@@ -102,22 +117,81 @@ function groupByProvider(
 
 /**
  * The groups the composer picker actually shows: providers with at least one
- * model that can run, plus — whatever its availability — the group holding the
- * current selection, so an active override never vanishes from the menu that
- * set it. A provider with nothing usable renders as no group at all rather
- * than a run of disabled rows; discovery of the full registry belongs to the
- * settings Models surface, not here.
+ * model that can run, holding the models that are effectively visible — plus,
+ * whatever its visibility or availability, the row holding the current
+ * selection, so an active override never vanishes from the menu that set it.
+ * A provider with nothing usable renders as no group at all rather than a run
+ * of disabled rows; discovery of the full registry belongs to the settings
+ * Models surface, and the footer points at it.
+ *
+ * Visibility filtering is presentation only. It never changes what a chat is
+ * set to, and a chat pinned to a hidden model keeps running against it.
  */
 export function visibleModelGroups(
   models: readonly ModelInfo[],
   selectedKey: string | null,
+  overrides: ModelVisibilityOverrides = {},
 ): { provider: ProviderKind; models: ModelInfo[] }[] {
-  return groupByProvider(models).filter(
-    (group) =>
-      group.models.some((model) => model.available) ||
-      (selectedKey !== null &&
-        group.models.some((model) => model.key === selectedKey)),
-  );
+  return groupByProvider(models)
+    .map((group) => ({
+      provider: group.provider,
+      models: group.models.filter(
+        (model) =>
+          isModelVisible(model, overrides) || model.key === selectedKey,
+      ),
+    }))
+    .filter(
+      (group) =>
+        group.models.some((model) => model.available) ||
+        (selectedKey !== null &&
+          group.models.some((model) => model.key === selectedKey)),
+    );
+}
+
+/**
+ * Providers the catalog knows models for but that cannot serve any of them —
+ * no credential, or switched off. One row each, so the picker admits the
+ * catalog is larger than a fresh install shows instead of leaving the rest of
+ * it undiscoverable.
+ *
+ * The gateway is left out: what it serves is policy, not a key the reader can
+ * paste in, so a setup CTA would point at nothing they can do.
+ */
+export function notConnectedProviders(
+  models: readonly ModelInfo[],
+  providers: readonly ProviderInfo[],
+): { provider: ProviderKind; modelCount: number }[] {
+  const status = new Map(providers.map((info) => [info.kind, info]));
+  return groupByProvider(models)
+    .filter((group) => {
+      if (group.provider === "model_gateway") return false;
+      // Anything that can already run is connected however it got there.
+      if (group.models.some((model) => model.available)) return false;
+      const info = status.get(group.provider);
+      return !info || !info.enabled || !info.has_credential;
+    })
+    .map((group) => ({
+      provider: group.provider,
+      modelCount: group.models.length,
+    }));
+}
+
+/**
+ * Models that could run right now but are not listed, which is what the footer
+ * offers to undo. The current selection is excluded because the picker renders
+ * it regardless — counting a row the reader can see as hidden reads as a bug.
+ */
+export function hiddenModelCount(
+  models: readonly ModelInfo[],
+  selectedKey: string | null,
+  overrides: ModelVisibilityOverrides = {},
+): number {
+  return models.filter(
+    (model) =>
+      model.available &&
+      model.key !== selectedKey &&
+      !isModelVisible(model, overrides),
+  ).length;
 }
 
 /**
@@ -129,9 +203,10 @@ export function visibleModelGroups(
 export function firstAvailableModel(
   models: readonly ModelInfo[],
   selectedKey: string | null,
+  overrides: ModelVisibilityOverrides = {},
 ): ModelInfo | null {
   return (
-    visibleModelGroups(models, selectedKey)
+    visibleModelGroups(models, selectedKey, overrides)
       .flatMap((group) => group.models)
       .find((model) => model.available) ?? null
   );
@@ -182,6 +257,32 @@ export function DefaultRow({
 }
 
 /**
+ * The picker's two ways out into settings, as one hook so both composers deep
+ * link identically.
+ *
+ * The path is typed through a `string` because the settings sections are
+ * registered from a runtime table: TanStack's generated route union contains
+ * `/settings` but not each literal child. The search params are `providersSearch`
+ * in `settings/sections.tsx` — which card to open, and whether to put the
+ * cursor in its credential field.
+ */
+export function useModelSettingsNav(): {
+  onManageModels: () => void;
+  onSetUpProvider: (provider: ProviderKind) => void;
+} {
+  const navigate = useNavigate();
+  const providerSettingsPath: string = "/settings/providers";
+  return {
+    onManageModels: () => void navigate({ to: providerSettingsPath }),
+    onSetUpProvider: (provider) =>
+      void navigate({
+        to: providerSettingsPath,
+        search: { provider, focus: "credential" },
+      }),
+  };
+}
+
+/**
  * Per-chat model selector for the message bar. `null` means "use the default"
  * — the global default model, or the server's own when none is set.
  *
@@ -189,18 +290,39 @@ export function DefaultRow({
  * so the default can be named rather than described. It is absent only when
  * the server's fallback is not something the catalog can name, and the copy
  * then says nothing rather than guessing.
+ *
+ * The list is the curated one: recommended models, plus whatever the reader
+ * has overridden, plus this chat's own model however it is flagged. The
+ * footer and the "Not connected" rows are what make that acceptable — nothing
+ * the picker leaves out is more than one click away.
  */
 export function ModelMenu({
   models,
   value,
   defaultKey = null,
   disabled,
+  visibilityOverrides = {},
+  providers = [],
+  onManageModels,
+  onSetUpProvider,
   onChange,
 }: {
   models: ModelInfo[];
   value: string | null;
   defaultKey?: string | null;
   disabled?: boolean;
+  /**
+   * The reader's per-model deviations from the curated set. Empty until
+   * settings load, which shows the recommended set — the same thing a reader
+   * who has never touched the setting sees, so the list does not flicker.
+   */
+  visibilityOverrides?: ModelVisibilityOverrides;
+  /** Provider status, for the "Not connected" rows. Empty until it loads. */
+  providers?: ProviderInfo[];
+  /** Open the settings surface that lists every model. */
+  onManageModels: () => void;
+  /** Open the settings card for a provider, on its credential field. */
+  onSetUpProvider: (provider: ProviderKind) => void;
   onChange: (key: ModelSelectionKey | null) => void | Promise<void>;
 }) {
   const known = modelForSelection(models, value);
@@ -208,6 +330,15 @@ export function ModelMenu({
   const isDefault = value === null;
   const resolvedDefault = modelForSelection(models, defaultKey);
   const anyAvailable = models.some((model) => model.available);
+  const groups = visibleModelGroups(models, canonical, visibilityOverrides);
+  const unconfigured = notConnectedProviders(models, providers);
+  const hiddenCount = hiddenModelCount(models, canonical, visibilityOverrides);
+  const notConnectedCollapsed = useUiStore(
+    (state) => state.modelMenuNotConnectedCollapsed,
+  );
+  const toggleNotConnected = useUiStore(
+    (state) => state.toggleModelMenuNotConnected,
+  );
 
   const label = isDefault ? "Default" : (known?.display_name ?? `${value} (unavailable)`);
   // The pill names the default's resolution too: the reader is hovering the
@@ -276,7 +407,11 @@ export function ModelMenu({
               // Turning the default off has to land on something; the first
               // model as the menu renders them, so the check appears at the
               // top of the list rather than mid-scroll.
-              const first = firstAvailableModel(models, canonical);
+              const first = firstAvailableModel(
+                models,
+                canonical,
+                visibilityOverrides,
+              );
               if (first) {
                 void onChange(first.key);
                 setOpen(false);
@@ -293,7 +428,7 @@ export function ModelMenu({
             </div>
           )}
 
-          {visibleModelGroups(models, canonical).map((group) => (
+          {groups.map((group) => (
             <div key={group.provider}>
               <DropdownMenuSeparator />
               {group.models.map((model) => {
@@ -340,7 +475,79 @@ export function ModelMenu({
               </DropdownMenuItem>
             </div>
           )}
+
+          {unconfigured.length > 0 && (
+            <div>
+              <DropdownMenuSeparator />
+              {/* Deliberately a button rather than a menu item: the header and
+                  the setup rows are chrome around the options, and arrowing
+                  through the picker should land on models only. */}
+              <button
+                type="button"
+                aria-expanded={!notConnectedCollapsed}
+                onClick={() => toggleNotConnected()}
+                className="text-muted-foreground hover:text-foreground focus-visible:ring-ring flex w-full items-center gap-1 rounded-sm px-2 py-1.5 text-xs font-medium tracking-wide uppercase focus-visible:ring-2 focus-visible:outline-none"
+              >
+                <ChevronRight
+                  className={cn(
+                    "size-3 transition-transform motion-reduce:transition-none",
+                    !notConnectedCollapsed && "rotate-90",
+                  )}
+                />
+                Not connected
+              </button>
+              {!notConnectedCollapsed &&
+                unconfigured.map((entry) => (
+                  <div
+                    key={entry.provider}
+                    className="flex items-center gap-2 px-2 py-1.5"
+                  >
+                    <ProviderIcon
+                      provider={entry.provider}
+                      className="size-4 shrink-0 opacity-50"
+                    />
+                    <span className="text-muted-foreground truncate text-sm">
+                      {providerLabel(entry.provider)}
+                    </span>
+                    <span className="text-muted-foreground/70 text-xs whitespace-nowrap">
+                      {entry.modelCount}{" "}
+                      {entry.modelCount === 1 ? "model" : "models"}
+                    </span>
+                    <Button
+                      variant="outline"
+                      className="ml-auto h-6 rounded-full px-2.5 text-xs"
+                      disabled={disabled}
+                      onClick={() => {
+                        onSetUpProvider(entry.provider);
+                        setOpen(false);
+                      }}
+                    >
+                      Set up
+                    </Button>
+                  </div>
+                ))}
+            </div>
+          )}
         </div>
+
+        {hiddenCount > 0 && (
+          <div className="border-border flex items-center gap-2 border-t px-3 py-2">
+            <span className="text-muted-foreground text-xs">
+              {hiddenCount} {hiddenCount === 1 ? "model" : "models"} hidden
+            </span>
+            <button
+              type="button"
+              onClick={() => {
+                onManageModels();
+                setOpen(false);
+              }}
+              className="text-muted-foreground hover:text-foreground focus-visible:ring-ring ml-auto flex items-center gap-1 rounded-sm text-xs font-medium focus-visible:ring-2 focus-visible:outline-none"
+            >
+              Manage models
+              <ChevronRight className="size-3" />
+            </button>
+          </div>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/crates/openwave-desktop/ui/src/UiStore.ts
+++ b/crates/openwave-desktop/ui/src/UiStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 
 const SIDEBAR_COLLAPSED_KEY = "openwave.sidebar-collapsed";
+const MODEL_MENU_NOT_CONNECTED_KEY = "openwave.model-menu-not-connected-collapsed";
 
 function readStoredSidebarCollapsed(): boolean {
   try {
@@ -18,6 +19,22 @@ function storeSidebarCollapsed(collapsed: boolean): void {
   }
 }
 
+function readStoredNotConnectedCollapsed(): boolean {
+  try {
+    return window.localStorage.getItem(MODEL_MENU_NOT_CONNECTED_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function storeNotConnectedCollapsed(collapsed: boolean): void {
+  try {
+    window.localStorage.setItem(MODEL_MENU_NOT_CONNECTED_KEY, String(collapsed));
+  } catch {
+    // Preference persistence is best-effort.
+  }
+}
+
 /**
  * Chrome state that belongs to no conversation and does not deserve a URL:
  * whether the sidebar is showing.
@@ -28,6 +45,13 @@ function storeSidebarCollapsed(collapsed: boolean): void {
 export type UiStore = {
   sidebarCollapsed: boolean;
   toggleSidebar: () => void;
+  /**
+   * Whether the model picker's "Not connected" section is folded away. Open by
+   * default — the section exists to be noticed once — and remembered after
+   * that, because a reader who has read it does not need it again.
+   */
+  modelMenuNotConnectedCollapsed: boolean;
+  toggleModelMenuNotConnected: () => void;
 };
 
 export function createUiStore() {
@@ -38,6 +62,13 @@ export function createUiStore() {
         const sidebarCollapsed = !state.sidebarCollapsed;
         storeSidebarCollapsed(sidebarCollapsed);
         return { sidebarCollapsed };
+      }),
+    modelMenuNotConnectedCollapsed: readStoredNotConnectedCollapsed(),
+    toggleModelMenuNotConnected: () =>
+      set((state) => {
+        const collapsed = !state.modelMenuNotConnectedCollapsed;
+        storeNotConnectedCollapsed(collapsed);
+        return { modelMenuNotConnectedCollapsed: collapsed };
       }),
   }));
 }


### PR DESCRIPTION
The picker half of [decision record 3](docs/decisions/0003-curated-model-visibility.md), on top of the wire groundwork from #1834 and the settings page from #1853.

## What changed

- **Effective visibility.** The picker lists models that are available *and* effectively visible, per `isModelVisible` from `modelVisibility.ts` (landed with #1853). Overrides are empty until settings load, which shows the curated set — the same list an untouched install shows, so nothing flickers.
- **The current model always renders.** `visibleModelGroups` filters at model level now rather than group level, and retains the chat's own selection whatever its visibility or availability. Hiding never rejects: a chat pinned to a hidden model keeps running against it and keeps seeing it in the picker that set it.
- **"Not connected" section.** Providers with catalog rows that cannot run — no credential, or switched off — get one row each with their model count and a Set up button navigating to `/settings/providers?provider=<kind>&focus=credential`, the `providersSearch` contract #1853 added. The section header collapses, remembered in `localStorage` alongside the sidebar preference. The gateway is excluded: what it serves is policy, not a key anyone can paste in.
- **Footer.** "N models hidden · Manage models" when at least one runnable model is left out, linking to `/settings/providers`. Absent when nothing is hidden. The count excludes the current selection, since that row is on screen.
- **Keyboard.** The section header, the Set up rows, and the footer are buttons rather than menu items, so arrowing through the picker still lands on models only.
- The Default row and `firstAvailableModel` keep their contract — the first available row *as the menu renders them*. The server invariant that the default model is recommended means that row is always there.

## How the data gets there

Overrides and provider status reach `ModelMenu` the way the catalog already does: `AppShell` fetches them and publishes them on the app context, and `ChatRoute`/`HomeRoute` pass them down. `refreshCatalog` re-reads settings too, which is what `ProvidersPanel`'s existing `onChanged()` call after a visibility write already expects — the two halves meet there. A failing settings fetch degrades to the curated set instead of failing a boot the catalog just succeeded at.

## Tests

- Three added to `ModelMenu.test.tsx` against `visibleModelGroups`: a non-recommended model is absent; an override of `show` brings it back; the chat's own model renders even under an explicit `hide`. The existing availability cases are unchanged.
- `hiddenModelCount`: what the footer claims, including that the on-screen current selection is not counted as hidden.
- `notConnectedProviders`: a provider whose rows cannot run yields one row with its count; the gateway yields none.
- No test for `isModelVisible` on its own — all three of its branches are exercised through the picker cases above, which is the surface that would actually break.

## Verification

`tsc --noEmit`, `pnpm test` (129 files, 891 tests), and `pnpm build` all pass from `crates/openwave-desktop/ui`, rebased on `513abbba`. Not driven in the running app: the Set up deep link's landing behaviour (card expanded, credential field focused) is #1853's code, unexercised from this side.
