### PR TITLE
feat(desktop): /compact command and a compaction settings panel

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -50,7 +50,8 @@ import {
 } from "./useAgentRuns";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { ArrowDown } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { toast } from "sonner";
+import { cn, friendlyErrorMessage } from "@/lib/utils";
 import {
   TranscriptNavigation,
   transcriptNavigationEntries,
@@ -202,13 +203,53 @@ export function ChatView({
   // Built-in `/` commands run here rather than being sent, so each one owns
   // whatever local state it needs — a dialog, in `/usage`'s case.
   const [usageOpen, setUsageOpen] = useState(false);
-  const runSlashCommand = useCallback((name: SlashCommandName) => {
-    switch (name) {
-      case "usage":
-        setUsageOpen(true);
+  const [compactRequested, setCompactRequested] = useState(false);
+  /**
+   * Summarize what is behind this conversation, on request.
+   *
+   * The success path is already told: the server journals the same compaction
+   * events a turn's own pass emits, and the transcript grows its divider. What
+   * needs saying here is the two outcomes the journal is silent about — a chat
+   * with nothing worth summarizing yet, and a request that failed.
+   */
+  const runCompaction = useCallback(
+    async (focus: string) => {
+      if (busy) {
+        toast.error("Wait for the current response to finish before compacting.");
         return;
-    }
-  }, []);
+      }
+      if (compactRequested) return;
+      setCompactRequested(true);
+      try {
+        const run = await client.compactChat(chat.id, focus || undefined);
+        if (run.compacted) {
+          toast.success("Summarized the earlier part of this conversation");
+        } else {
+          toast.message("Nothing to compact yet — this conversation still fits.");
+        }
+      } catch (caught) {
+        toast.error(
+          friendlyErrorMessage(caught, "Could not compact this conversation."),
+        );
+      } finally {
+        setCompactRequested(false);
+      }
+    },
+    [busy, chat.id, client, compactRequested],
+  );
+  const runSlashCommand = useCallback(
+    (name: SlashCommandName, argument: string) => {
+      switch (name) {
+        case "usage":
+          setUsageOpen(true);
+          return;
+        case "compact":
+          void runCompaction(argument);
+          return;
+      }
+    },
+    [runCompaction],
+  );
 
   const navigate = useNavigate();
   const search = useSearch({ strict: false }) as {

--- a/crates/openwave-desktop/ui/src/ComposerCommands.test.ts
+++ b/crates/openwave-desktop/ui/src/ComposerCommands.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   parseSlashCommand,
   withSlashCommands,
+  SLASH_COMMANDS,
   type SlashCommand,
 } from "./ComposerCommands";
 import { filterSlashOptions, type SlashOption } from "./ComposerSlash";
@@ -41,6 +42,14 @@ describe("parseSlashCommand", () => {
   });
 
   it("gives a command that takes one the rest of the line", () => {
+    // `/compact` is the shipped case: everything after the name is what the
+    // summary should keep.
+    expect(
+      parseSlashCommand("/compact  keep the API design "),
+    ).toEqual({
+      command: SLASH_COMMANDS.find((command) => command.name === "compact"),
+      argument: "keep the API design",
+    });
     const commands: readonly SlashCommand[] = [
       { name: "usage", description: "", takesArgument: true },
     ];

--- a/crates/openwave-desktop/ui/src/ComposerCommands.ts
+++ b/crates/openwave-desktop/ui/src/ComposerCommands.ts
@@ -20,7 +20,7 @@ export type SlashCommand = {
   takesArgument: boolean;
 };
 
-export type SlashCommandName = "usage";
+export type SlashCommandName = "usage" | "compact";
 
 /**
  * Every built-in command, in the order the list offers them.
@@ -33,6 +33,12 @@ export const SLASH_COMMANDS: readonly SlashCommand[] = [
     name: "usage",
     description: "Show this chat's context and token usage.",
     takesArgument: false,
+  },
+  {
+    name: "compact",
+    description:
+      "Summarize the earlier part of this chat now. Add what to keep: /compact the API design",
+    takesArgument: true,
   },
 ];
 

--- a/crates/openwave-desktop/ui/src/api/client.ts
+++ b/crates/openwave-desktop/ui/src/api/client.ts
@@ -15,6 +15,7 @@ import {
   type CodeExecutionConfigInfo,
   type CodeExecutionCredentialReadiness,
   type CodeExecutionProviderKind,
+  type CompactionRun,
   type ConnectedAppsInfo,
   type ConsentStatementSnapshot,
   type CustomModelConfig,
@@ -865,6 +866,21 @@ export class ApiClient {
   listChatMessages(chatId: string): Promise<ChatTranscript> {
     return this.json(`/chats/${chatId}/messages`, {
       headers: this.headers(),
+    });
+  }
+
+  /**
+   * Compact this chat now, optionally saying what the summary should keep.
+   *
+   * Runs between turns only; the server refuses while one is running. A
+   * response with `compacted: false` is an ordinary answer — there was nothing
+   * worth summarizing — not a failure.
+   */
+  compactChat(chatId: string, focus?: string): Promise<CompactionRun> {
+    return this.json(`/chats/${encodeURIComponent(chatId)}/compact`, {
+      method: "POST",
+      headers: this.headers(true),
+      body: JSON.stringify(focus ? { focus } : {}),
     });
   }
 

--- a/crates/openwave-desktop/ui/src/api/types.ts
+++ b/crates/openwave-desktop/ui/src/api/types.ts
@@ -68,6 +68,8 @@ import {
   type SkillInstructions as WireSkillInstructions,
   type NetworkPolicy as WireNetworkPolicy,
   type ReasoningEffort as WireReasoningEffort,
+  type CompactionRun,
+  type CompactionSettings,
   type Settings,
   type StickyChatDefaults as WireStickyChatDefaults,
   type WebSearchConfigInfo as WireWebSearchConfigInfo,
@@ -247,8 +249,13 @@ export type ModelCatalog = {
 };
 
 /** Global runtime settings (`GET/PUT /settings`). */
-/** Global runtime settings (`GET/PUT /settings`). */
 export type RuntimeSettings = Settings;
+
+/** Host-global compaction cadence, as `GET/PUT /settings` carries it. */
+export type { CompactionSettings };
+
+/** What one on-demand compaction did (`POST /chats/{id}/compact`). */
+export type { CompactionRun };
 
 export type Project = WireProject;
 

--- a/crates/openwave-desktop/ui/src/settings/CompactionPanel.test.ts
+++ b/crates/openwave-desktop/ui/src/settings/CompactionPanel.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  compactionUpdateFrom,
+  toCompactionForm,
+} from "./CompactionPanel";
+
+const SETTINGS = {
+  threshold_fraction: 0.75,
+  target_fraction: 0.25,
+  min_threshold_tokens: 50_000,
+  protect_recent_messages: 5,
+};
+
+describe("compaction settings form", () => {
+  it("round-trips the stored fractions as whole percentages", () => {
+    const form = toCompactionForm(SETTINGS);
+    expect(form).toEqual({
+      thresholdPercent: "75",
+      targetPercent: "25",
+      protectRecent: "5",
+    });
+    expect(compactionUpdateFrom(form)).toEqual({
+      update: {
+        threshold_fraction: 0.75,
+        target_fraction: 0.25,
+        protect_recent_messages: 5,
+      },
+    });
+  });
+
+  it("refuses what the server would refuse, before the request", () => {
+    // Compacting down to more than the point compaction starts at is a policy
+    // the server rejects outright; the reader hears it from the form instead.
+    const inverted = compactionUpdateFrom({
+      thresholdPercent: "25",
+      targetPercent: "75",
+      protectRecent: "5",
+    });
+    expect(inverted).toEqual({
+      error: "The compaction point must be above what compaction leaves behind.",
+    });
+    expect(
+      compactionUpdateFrom({
+        thresholdPercent: "75",
+        targetPercent: "25",
+        protectRecent: "0",
+      }),
+    ).toHaveProperty("error");
+    expect(
+      compactionUpdateFrom({
+        thresholdPercent: "0",
+        targetPercent: "25",
+        protectRecent: "5",
+      }),
+    ).toHaveProperty("error");
+  });
+});

--- a/crates/openwave-desktop/ui/src/settings/CompactionPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/CompactionPanel.tsx
@@ -1,0 +1,210 @@
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+import type { ApiClient, CompactionSettings } from "../api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { friendlyErrorMessage } from "@/lib/utils";
+import {
+  SettingsError,
+  SettingsField,
+  SettingsPanel,
+  SettingsSection,
+} from "./primitives";
+
+/** The form's own shape: percentages, because that is what the fields show. */
+type CompactionForm = {
+  thresholdPercent: string;
+  targetPercent: string;
+  protectRecent: string;
+};
+
+const MIN_PROTECT_RECENT = 1;
+const MAX_PROTECT_RECENT = 100;
+
+export function toCompactionForm(settings: CompactionSettings): CompactionForm {
+  return {
+    thresholdPercent: String(Math.round(settings.threshold_fraction * 100)),
+    targetPercent: String(Math.round(settings.target_fraction * 100)),
+    protectRecent: String(settings.protect_recent_messages),
+  };
+}
+
+/**
+ * The form as the settings API takes it, or the reason it cannot be sent.
+ *
+ * Both fractions are whole percentages here, which is a deliberate narrowing of
+ * what the server accepts: nobody tunes a compaction threshold to a tenth of a
+ * percent, and a percent field is legible where `0.75` is not. The
+ * threshold-above-target rule is the server's, checked here as well so the
+ * reader is told before the request rather than by it.
+ */
+export function compactionUpdateFrom(
+  form: CompactionForm,
+): { update: Partial<CompactionSettings> } | { error: string } {
+  const threshold = Number(form.thresholdPercent);
+  const target = Number(form.targetPercent);
+  const protectRecent = Number(form.protectRecent);
+  const percent = (value: number) => Number.isInteger(value) && value >= 1 && value <= 100;
+  if (!percent(threshold) || !percent(target)) {
+    return { error: "Enter whole percentages from 1 to 100." };
+  }
+  if (threshold <= target) {
+    return {
+      error: "The compaction point must be above what compaction leaves behind.",
+    };
+  }
+  if (
+    !Number.isInteger(protectRecent) ||
+    protectRecent < MIN_PROTECT_RECENT ||
+    protectRecent > MAX_PROTECT_RECENT
+  ) {
+    return {
+      error: `Keep between ${MIN_PROTECT_RECENT} and ${MAX_PROTECT_RECENT} recent messages.`,
+    };
+  }
+  return {
+    update: {
+      threshold_fraction: threshold / 100,
+      target_fraction: target / 100,
+      protect_recent_messages: protectRecent,
+    },
+  };
+}
+
+/**
+ * When conversations compact themselves, and how much they keep.
+ *
+ * Host-global rather than per-chat: the cadence is a property of the install,
+ * and a per-conversation copy would be one more thing to reason about on every
+ * chat for a setting almost nobody changes twice. The one number worth putting
+ * in front of a reader is where compaction starts; the rest is behind the
+ * disclosure, because changing it badly makes conversations worse in ways that
+ * are hard to attribute.
+ */
+export function CompactionPanel({ client }: { client: ApiClient }) {
+  const [form, setForm] = useState<CompactionForm | null>(null);
+  const [advanced, setAdvanced] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void client
+      .getSettings()
+      .then((settings) => {
+        if (!cancelled) setForm(toCompactionForm(settings.compaction));
+      })
+      .catch((caught) => {
+        if (!cancelled) setError(friendlyErrorMessage(caught, "Could not read settings."));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
+
+  async function save() {
+    if (!form) return;
+    const result = compactionUpdateFrom(form);
+    if ("error" in result) {
+      setError(result.error);
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const settings = await client.putSettings({ compaction: result.update });
+      setForm(toCompactionForm(settings.compaction));
+      toast.success("Saved compaction settings");
+    } catch (caught) {
+      setError(friendlyErrorMessage(caught, "Could not save compaction settings."));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const field = (key: keyof CompactionForm) => ({
+    value: form?.[key] ?? "",
+    disabled: form === null || saving,
+    onChange: (event: React.ChangeEvent<HTMLInputElement>) =>
+      setForm((current) =>
+        current ? { ...current, [key]: event.target.value } : current,
+      ),
+  });
+
+  return (
+    <SettingsPanel
+      title="Context"
+      description="How long conversations run before the agent summarizes what is behind them."
+      busy={form === null}
+    >
+      <SettingsSection>
+        <SettingsField
+          label="Compact when the conversation reaches"
+          hint="Percent of the model's context window. Below this, nothing is summarized. Type /compact in a chat to run it sooner."
+        >
+          <Input
+            type="number"
+            inputMode="numeric"
+            min={1}
+            max={100}
+            step="1"
+            aria-label="Compaction threshold, percent of the context window"
+            {...field("thresholdPercent")}
+          />
+        </SettingsField>
+        <div className="flex flex-col gap-4">
+          <Button
+            type="button"
+            variant="ghost"
+            className="self-start px-0 text-sm text-muted-foreground hover:bg-transparent"
+            aria-expanded={advanced}
+            onClick={() => setAdvanced((open) => !open)}
+          >
+            {advanced ? "Hide advanced" : "Advanced"}
+          </Button>
+          {advanced && (
+            <>
+              <SettingsField
+                label="Compact down to"
+                hint="Percent of the window the raw conversation is reduced to. The gap between this and the threshold is how long a chat runs before compacting again."
+              >
+                <Input
+                  type="number"
+                  inputMode="numeric"
+                  min={1}
+                  max={100}
+                  step="1"
+                  aria-label="Compaction target, percent of the context window"
+                  {...field("targetPercent")}
+                />
+              </SettingsField>
+              <SettingsField
+                label="Recent messages kept in full"
+                hint="Never summarized, however long the conversation gets."
+              >
+                <Input
+                  type="number"
+                  inputMode="numeric"
+                  min={MIN_PROTECT_RECENT}
+                  max={MAX_PROTECT_RECENT}
+                  step="1"
+                  aria-label="Recent messages kept in full"
+                  {...field("protectRecent")}
+                />
+              </SettingsField>
+            </>
+          )}
+        </div>
+        <Button
+          type="button"
+          disabled={form === null || saving}
+          onClick={() => void save()}
+        >
+          {saving ? "Saving…" : "Save settings"}
+        </Button>
+      </SettingsSection>
+      {error && <SettingsError>{error}</SettingsError>}
+    </SettingsPanel>
+  );
+}

--- a/crates/openwave-desktop/ui/src/settings/sections.tsx
+++ b/crates/openwave-desktop/ui/src/settings/sections.tsx
@@ -4,6 +4,7 @@ import {
   Blocks,
   Bot,
   Cpu,
+  Gauge,
   Globe,
   KeyRound,
   Palette,
@@ -21,6 +22,7 @@ import { useTheme } from "@/theme";
 import { AppearancePanel } from "./AppearancePanel";
 import { AgentsPanel } from "./AgentsPanel";
 import { CodeExecutionPanel } from "./CodeExecutionPanel";
+import { CompactionPanel } from "./CompactionPanel";
 import { ConnectedAppsPanel } from "./ConnectedAppsPanel";
 import { GatewayPanel } from "./GatewayPanel";
 import { PermissionsPanel } from "./PermissionsPanel";
@@ -123,6 +125,11 @@ function CodeExecutionSection() {
   return <CodeExecutionPanel client={client} />;
 }
 
+function CompactionSection() {
+  const { client } = useApp();
+  return <CompactionPanel client={client} />;
+}
+
 function AgentsSection() {
   const { client } = useApp();
   return <AgentsPanel client={client} />;
@@ -209,6 +216,10 @@ export const SETTINGS_SECTIONS: SettingsSectionDef[] = [
     unmanagedHidden: true,
   },
   { path: "models", label: "Models", icon: Cpu, Component: ModelsSection },
+  // Next to Models rather than in a section of its own: every number here is a
+  // fraction of the selected model's context window, so a reader who has just
+  // changed models is in the right place to reconsider them.
+  { path: "context", label: "Context", icon: Gauge, Component: CompactionSection },
   { path: "agents", label: "Agents", icon: Bot, Component: AgentsSection },
   {
     path: "voice-transcription",


### PR DESCRIPTION
Two things a reader needs once compaction is something they can ask for: a way
to ask, and somewhere to see when it happens on its own.

**`/compact`** joins the composer's command rail. Everything after the name is
the focus — `/compact keep the API design decisions` — which the server threads
into the summarizer's instructions; with nothing after it, the summary keeps
what it judges load-bearing. The success path is already told by the events the
server journals and the divider the transcript grows, so the command only
speaks for the two outcomes the journal is silent about: a chat with nothing
worth summarizing yet, which says so rather than appearing to do nothing, and a
request that failed. Asking while a turn is running is refused with a toast
before the request, since the server would refuse it anyway.

**Compaction settings** get a Context section in the settings rail, next to
Models — every number here is a fraction of the selected model's context
window, so a reader who has just changed models is in the right place to
reconsider them. Folding it into Models itself would have put a form in the
middle of a catalog list, and it does not belong under Agents, which is about
delegated background work.

The one number in front of the reader is where compaction starts, as a
percentage. What it compacts down to and how many recent messages are never
summarized sit behind an Advanced disclosure: changing them badly makes
conversations worse in ways that are hard to attribute afterwards. Host-global,
matching the setting it edits — there is no per-chat override, and adding one
would mean reasoning about compaction cadence on every conversation for
something almost nobody changes twice. The threshold-above-target rule is the
server's; the form checks it too, so the reader hears it from the field rather
than from a rejected request.

The fractions are edited as whole percentages, which is deliberately narrower
than what the API accepts. Nobody tunes a threshold to a tenth of a percent,
and `75%` is legible where `0.75` is not. The minimum threshold in tokens is
not exposed; a partial update leaves it as it is.

Stacked on #1857 (the command rail) and #1860 (the endpoint), so it should land
after both — this PR's diff includes theirs until they merge.

Tests: the settings form's percentage round-trip and the rules it refuses
before sending, and `/compact` in the shared command-parsing test, which is
where "everything after the name is the argument" is actually pinned down.

Verified: `pnpm test` (130 files, 883 tests) and `vite build` both pass, and
`tsc` reports nothing on the files this changes. The desktop UI lane fails for
a reason that predates this branch: `main`'s model and settings test fixtures
do not typecheck (duplicate object properties, TS1117), which fails `pnpm
build` for every UI change until they are fixed. Behaviour
in the running app was not driven — in particular, nobody has watched a real
`/compact` land its notice.
