### PR TITLE
test(desktop): enforce the native-only tauri command allowlist

### DIFF
--- a/crates/openwave-desktop/native-only-commands.txt
+++ b/crates/openwave-desktop/native-only-commands.txt
@@ -1,0 +1,77 @@
+# Native-only Tauri commands.
+#
+# Decision record 5 (docs/decisions/0005-cli-headless-feature-parity.md) makes
+# the server HTTP/WS API the canonical product surface: a feature has
+# CLI/headless parity when it is reachable through `openwave-server` routes.
+# A `#[tauri::command]` is reserved for what genuinely needs the native shell —
+# OS file/folder pickers, keychain and code-signing plumbing, the auto-updater,
+# native window/attention control, the office-converter and Node runtime
+# installers, local voice capture, and debug-bundle save dialogs. Anything else
+# arriving as a Tauri command is a parity bug.
+#
+# Every `#[tauri::command]` in `crates/openwave-desktop/src/` must appear here
+# with a one-line justification, and every line here must still name a command
+# in the source. `command_parity::allowlist_covers_every_tauri_command` enforces
+# both directions.
+#
+# Adding a line is a conscious amendment, not a formality: if the command is not
+# native-only, it belongs behind a server route instead. Lines marked
+# `TODO(record 5)` are commands that already existed when the gate landed and do
+# not fit the closed native-only set — they are recorded debt to migrate, not
+# precedent for new ones.
+#
+# Format: one `name: justification` per line; `#` starts a comment.
+
+# Shell bootstrap and native window control
+server_info: hands the renderer the embedded server's address and per-launch token — the handshake that makes every HTTP route reachable, so it cannot itself be one.
+request_user_attention: native window attention hint when a parked question needs the user.
+
+# OS pickers, drops, and save dialogs
+attach_chat_files: opens the OS file picker; only the native shell can turn a user's file choice into readable paths.
+attach_dropped_chat_files: claims the operating-system drop this window received and routes the dropped paths through the same ingest.
+export_library_document: writes a source document's bytes wherever the native save dialog sends them.
+export_deliverable: writes an output revision to a destination chosen in the native save dialog.
+save_chat_debug_bundle: writes the untruncated debug bundle to a file chosen in the native save dialog.
+copy_chat_debug_bundle: returns the clipboard-sized bundle on the same user gesture the webview requires for a clipboard write.
+
+# Host folder consent that runs through native pickers and permission dialogs
+connect_folder: native folder picker — the host consent path for attaching a folder to a chat.
+connect_approved_folder: reattaches a previously approved folder behind the native confirmation dialog.
+grant_folder_capability: widens a folder's capability only after the native permission dialog is confirmed.
+
+# Host-side execution of client-executed tool calls
+resolve_folder_access_request: carries the user's in-turn folder decision into the native picker and the host broker that owns the grant.
+resolve_output_writeback_request: executes the approved write into a connected host folder, which only the desktop-side broker can reach.
+
+# Office converter and Node runtime installers
+convert_presentation_to_pdf: drives the user's locally installed LibreOffice.
+install_presentation_converter: installs the local office converter onto this machine.
+cancel_presentation_converter_install: cancels that local installation.
+warm_presentation_converter: warms the locally installed converter process.
+install_node_runtime: installs the local Node runtime the sandbox image expects.
+
+# Auto-updater
+desktop_update_state: reports the native auto-updater's state.
+check_for_update: asks the native auto-updater to check.
+restart_for_update: relaunches the app to apply a staged native update.
+
+# TODO(record 5): commands that predate the gate and do not fit the native-only
+# set. Each should become a server route with a CLI client; until then they are
+# listed so the gate stays honest about what is already owed.
+publish_chat_image: TODO(record 5) — publishes pasted image bytes from the renderer; no native shell involvement, belongs on the ingest routes.
+list_deliverables: TODO(record 5) — reads the store directly; record 5 item 5 moves output listing to server routes.
+read_deliverable: TODO(record 5) — store-direct output preview; belongs on a server route.
+read_deliverable_file: TODO(record 5) — store-direct revision bytes; belongs on a server route.
+list_output_revisions: TODO(record 5) — store-direct revision history; belongs on a server route.
+read_output_revision: TODO(record 5) — store-direct revision read; belongs on a server route.
+restore_output_revision: TODO(record 5) — store-direct revision restore; belongs on a server route.
+save_output_revision: TODO(record 5) — store-direct user revision write; belongs on a server route.
+delete_output: TODO(record 5) — store-direct soft delete; belongs on a server route.
+restore_output: TODO(record 5) — store-direct undelete; belongs on a server route.
+list_connected_folders: TODO(record 5) — broker read with no native UI; headless consumers need the same listing.
+list_approved_folders: TODO(record 5) — broker read with no native UI.
+list_capability_consents: TODO(record 5) — broker read with no native UI; the consent projection should be a route.
+revoke_capability_consent: TODO(record 5) — broker mutation with no native dialog; revocation must be reachable headlessly.
+disconnect_folder: TODO(record 5) — broker mutation with no native dialog; record 5 item 4 gives folders a CLI path.
+forget_folder: TODO(record 5) — broker mutation with no native dialog.
+purge_deleted_conversation_subject: TODO(record 5) — broker cleanup with no native dialog.

--- a/crates/openwave-desktop/src/command_parity.rs
+++ b/crates/openwave-desktop/src/command_parity.rs
@@ -1,0 +1,160 @@
+//! Parity gate for the desktop's Tauri IPC surface.
+//!
+//! Decision record 5 makes the server HTTP/WS API the canonical product
+//! surface and closes the set of features that may legitimately be native-only.
+//! Nothing enforces that in review reliably, so this scans the crate's own
+//! sources for `#[tauri::command]` and holds the result against
+//! `native-only-commands.txt`. A new desktop-only command fails here until it
+//! is either given server routes or consciously added to the allowlist.
+
+/// Where the allowlist lives, relative to the crate root — named in the failure
+/// messages so the fix path needs no searching.
+const ALLOWLIST_FILE: &str = "crates/openwave-desktop/native-only-commands.txt";
+const RECORD: &str = "docs/decisions/0005-cli-headless-feature-parity.md";
+
+const ALLOWLIST: &str = include_str!("../native-only-commands.txt");
+
+/// Command names listed in the allowlist, in file order.
+fn allowlisted() -> Vec<String> {
+    ALLOWLIST
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .filter_map(|line| line.split_once(':'))
+        .map(|(name, _justification)| name.trim().to_owned())
+        .collect()
+}
+
+/// Every `#[tauri::command]` function in the crate's sources, as
+/// `(command name, file it was declared in)`.
+///
+/// Deliberately textual: the alternative is a registry macro, which is more
+/// machinery than a list of names is worth. The scan tolerates the shapes the
+/// crate actually uses — the attribute on its own line, `fn`/`pub fn`/
+/// `pub(crate) fn`, sync or `async`, and doc comments or further attributes
+/// between the two.
+fn declared_commands() -> Vec<(String, String)> {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut found = Vec::new();
+    for file in rust_sources(&root) {
+        let relative = file
+            .strip_prefix(env!("CARGO_MANIFEST_DIR"))
+            .unwrap_or(&file)
+            .display()
+            .to_string();
+        let source = std::fs::read_to_string(&file).expect("desktop source is readable");
+        let lines: Vec<&str> = source.lines().collect();
+        for (index, line) in lines.iter().enumerate() {
+            if !line.trim_start().starts_with("#[tauri::command") {
+                continue;
+            }
+            let name = lines[index + 1..]
+                .iter()
+                .find_map(|line| function_name(line))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "{relative}:{} has a #[tauri::command] with no function after it",
+                        index + 1
+                    )
+                });
+            found.push((name, relative.clone()));
+        }
+    }
+    found
+}
+
+/// The name in a function signature line, if the line declares one.
+fn function_name(line: &str) -> Option<String> {
+    let line = line.trim_start();
+    let rest = ["pub(crate) ", "pub(super) ", "pub "]
+        .iter()
+        .find_map(|visibility| line.strip_prefix(visibility))
+        .unwrap_or(line);
+    let rest = rest.strip_prefix("async ").unwrap_or(rest);
+    let rest = rest.strip_prefix("fn ")?;
+    let name: String = rest
+        .chars()
+        .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+        .collect();
+    (!name.is_empty()).then_some(name)
+}
+
+fn rust_sources(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut files = Vec::new();
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(directory) = pending.pop() {
+        for entry in std::fs::read_dir(&directory).expect("desktop source tree is readable") {
+            let path = entry.expect("directory entry is readable").path();
+            if path.is_dir() {
+                pending.push(path);
+            } else if path.extension().is_some_and(|extension| extension == "rs") {
+                files.push(path);
+            }
+        }
+    }
+    files.sort();
+    files
+}
+
+#[test]
+fn allowlist_covers_every_tauri_command() {
+    let allowlisted = allowlisted();
+    let declared = declared_commands();
+
+    let unlisted: Vec<String> = declared
+        .iter()
+        .filter(|(name, _)| !allowlisted.contains(name))
+        .map(|(name, file)| format!("  {name}  ({file})"))
+        .collect();
+    assert!(
+        unlisted.is_empty(),
+        "these #[tauri::command] handlers are not in {ALLOWLIST_FILE}:\n{}\n\n\
+         Decision record 5 ({RECORD}) makes the server HTTP/WS API the product \
+         surface and closes the set of native-only features. Give the feature \
+         `openwave-server` routes and call them from the UI, or — if it \
+         genuinely needs the native shell — add it to {ALLOWLIST_FILE} with a \
+         justification saying which native capability it needs.",
+        unlisted.join("\n"),
+    );
+
+    let stale: Vec<&String> = allowlisted
+        .iter()
+        .filter(|name| !declared.iter().any(|(declared, _)| declared == *name))
+        .collect();
+    assert!(
+        stale.is_empty(),
+        "{ALLOWLIST_FILE} lists commands that no longer exist: {stale:?}\n\n\
+         A stale entry silently pre-approves a name a later change could reuse. \
+         Remove these lines — see decision record 5 ({RECORD})."
+    );
+
+    let mut seen = allowlisted.clone();
+    seen.sort();
+    seen.dedup();
+    assert_eq!(
+        seen.len(),
+        allowlisted.len(),
+        "{ALLOWLIST_FILE} lists a command twice"
+    );
+}
+
+#[test]
+fn function_name_reads_the_shapes_the_crate_uses() {
+    for line in [
+        "fn plain(app: AppHandle) {",
+        "pub fn exported() {",
+        "    pub(crate) async fn nested(",
+        "async fn bare() {",
+    ] {
+        assert!(
+            function_name(line).is_some(),
+            "signature not recognized: {line}"
+        );
+    }
+    assert_eq!(
+        function_name("    pub(crate) async fn nested(").as_deref(),
+        Some("nested")
+    );
+    assert_eq!(function_name("#[derive(Debug)]"), None);
+    assert_eq!(function_name("/// fn in a doc comment"), None);
+}

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -18,6 +18,8 @@ mod attachments;
 mod broker;
 mod chat_debug;
 mod client_execution;
+#[cfg(test)]
+mod command_parity;
 mod deep_link;
 mod deliverables;
 mod documents;

--- a/docs/decisions/0005-cli-headless-feature-parity.md
+++ b/docs/decisions/0005-cli-headless-feature-parity.md
@@ -1,0 +1,209 @@
+# 5. CLI/Headless Feature Parity: the Server API Is the Product Surface
+
+- Status: Accepted
+- Date: 2026-08-10
+- Owners: cli, server, desktop
+- Related: [`docs-site/content/docs/headless.mdx`](../../docs-site/content/docs/headless.mdx)
+  (current headless documentation),
+  [`docs/crates.md`](../crates.md) (crate boundaries; flags `openwave-cli` as
+  a partial baseline), record 2 (pre-v1 mutability of persisted and wire
+  formats)
+- Supersedes: none
+
+## Context
+
+We want coding agents — and scripts, and CI — to drive OpenWave end to end
+without the desktop app: create a chat, configure a provider, run turns that
+use tools, answer approvals and plans, and read the results back. Today an
+agent can get most of the way there and then hits a wall in exactly the places
+an unattended run needs to keep going.
+
+**What is true today.** The desktop app is a thin Tauri shell around an
+embedded `openwave-server`; the React UI talks to it over the same HTTP+WS API
+(~90 routes in [`crates/openwave-server/src/lib.rs`](../../crates/openwave-server/src/lib.rs))
+that `openwave serve` exposes. Chats, turns, event streaming, models,
+providers, credentials, approvals, plans, questions, permission modes, MCP
+servers, plugins, and settings are all plain HTTP — none of them go through
+Tauri IPC. `openwave-cli` already ships a TUI and a non-interactive print mode
+(`openwave -p`) built on that API. So "parity" is not a rewrite; the engine is
+already headless.
+
+**What is not reachable headlessly.** The gaps are concentrated:
+
+- **Unattended turns die on interaction points.** Print mode auto-rejects
+  every approval ([`crates/openwave-cli/src/print.rs`](../../crates/openwave-cli/src/print.rs))
+  and *cancels the turn* when the agent proposes a plan or asks a question —
+  precisely the events a driving agent could answer if the CLI surfaced them.
+- **Setup requires raw HTTP.** There are no CLI subcommands for provider,
+  credential, model, or settings management; the routes exist but only curl
+  reaches them.
+- **Host folder access has no headless consent path.** Connected folders are
+  brokered by `openwave-host-broker` behind a native picker/dialog. The broker
+  already models an `OperatorConfig` consent method designed for headless
+  provisioning ([`crates/openwave-host-broker/src/capability.rs`](../../crates/openwave-host-broker/src/capability.rs)),
+  but nothing wires it up.
+- **Attachments and output export are Tauri commands.** Attaching local files
+  and exporting deliverables/output revisions live in
+  `crates/openwave-desktop/src/{attachments,deliverables}.rs` as native
+  handlers, though the underlying storage is core/server-side.
+- **Local exec is macOS Seatbelt only.** A headless Linux host has no local
+  sandbox; exec works only through a configured container or remote backend.
+
+**The forces.** Every feature we route through the server API is headless for
+free, forever; every feature we build as a Tauri command opens a parity gap
+that must be noticed and closed by hand. The CLI must stay a client — a second
+implementation of any behavior will drift. And unattended operation must not
+become a permission bypass: a flag that silently auto-approves everything is a
+footgun, but a headless mode that cannot approve anything is useless for the
+stated goal.
+
+## Decision
+
+**1. The server HTTP/WS API is the canonical product surface; parity is
+defined against it.** A feature has CLI/headless parity when it is reachable
+through `openwave-server` routes and exercised by `openwave-cli`. New features
+land as server routes first; a Tauri command is reserved for things that
+genuinely require the native shell. The allowed native-only set is closed and
+explicit: OS file/folder pickers, keychain and code-signing plumbing, the
+auto-updater, native window/attention control, office-converter and Node
+runtime installers, and local voice capture. Anything else appearing as a
+Tauri command is a parity bug.
+
+**2. Print mode becomes a real unattended protocol, not a demo.** `openwave
+-p` gains:
+
+- `--permission-mode ask|auto|allow|plan` per invocation, mapping onto the
+  existing per-chat permission modes — no new permission vocabulary.
+- Structured NDJSON I/O (`--output-format json` today, plus stdin): approval
+  requests, plan proposals, and user questions are emitted as events, and the
+  driving process answers them by writing decision lines back. A turn only
+  blocks on interaction when the caller opted into interactive mode;
+  otherwise the standing policy answers.
+- Non-interactive defaults that are safe and stated: in `ask` mode with no
+  driver attached, approvals are rejected (today's behavior) and plans/
+  questions terminate the turn with a distinct exit code and a machine-readable
+  reason — never a silent cancel.
+
+**3. Setup is scriptable through CLI subcommands that wrap existing routes.**
+`openwave provider|model|settings|mcp` subcommand families cover credential
+set/remove, provider status, model listing/selection, exec-backend and
+web-search configuration. These are thin clients of the HTTP API; they contain
+no logic of their own. Credentials keep flowing through the OS keychain
+exactly as they do today — headless changes the entry path, not the storage.
+
+**4. Folder access gets the operator consent path the broker already
+anticipates.** `openwave folder connect <path>` (and `list`/`disconnect`)
+records grants via `ConsentMethod::OperatorConfig`. This is deliberate,
+explicit provisioning by whoever controls the machine — the CLI never
+auto-grants a folder because an agent asked for it mid-turn. Mid-turn folder
+requests in headless mode fail with the same typed refusal an undecided
+desktop prompt produces.
+
+**5. Attachments and output export move to the server surface.** File
+attachment takes a path argument and feeds the same ingest routes the desktop
+uses; deliverable/output listing, reading, revision history, and export-to-path
+become server routes plus CLI subcommands, replacing the desktop's
+`Store`-direct Tauri handlers with calls to the same new routes so both shells
+share one implementation.
+
+**6. Attach or embed, explicitly.** The CLI keeps its current embed-a-server
+default (own data dir, isolated instance — the right shape for agents trying
+things out), and additionally accepts `--server <url>` / `OPENWAVE_SERVER_URL`
+plus a token to act as a pure client of an already-running `openwave serve` or
+desktop instance. Two processes embedding servers over one data dir remains
+unsupported; the CLI refuses when it can detect it rather than corrupting
+quietly.
+
+**Deliberately excluded:** a headless local sandbox for Linux/Windows (exec on
+headless hosts requires a container or remote backend, and the CLI must say so
+clearly when unconfigured — this is [`docs/deferred.md`](../deferred.md)
+territory, not a parity gap to paper over); any GUI-preview equivalents
+(rendered document/chart viewers — headless consumers read files); the
+auto-updater; local voice; and a second wire protocol (no gRPC, no bespoke
+daemon socket — HTTP+WS is the only transport).
+
+## Alternatives Considered
+
+**Do nothing — document the HTTP API and let agents curl it.** The engine is
+already reachable; a determined script works today. Rejected because the
+blocking gaps are not ergonomic but functional: plans and questions *cancel*
+turns in print mode, folder consent has no headless path at all, and every
+consumer would reimplement event-stream handling and approval plumbing. The
+API-only story also leaves no pressure against new features landing as Tauri
+commands.
+
+**Drive OpenWave through its MCP face instead of a CLI.** `openwave mcp`
+exists and agents speak MCP natively. Rejected as the parity vehicle: the MCP
+server exposes two read-only tools scoped to one workspace, and modeling
+chat/turn/approval lifecycles as MCP tools would be a second, weaker API over
+the first. The MCP face stays what it is — a way for *other* agents to use
+OpenWave's tools — and may grow later, but parity is defined against HTTP.
+
+**A fatter CLI that links the engine crates directly** (bypass the server,
+call `openwave-core` in-process). Rejected: it forks behavior the moment
+server routes gain logic (auth, workers, connectors already live in
+`openwave-server`), and it makes the CLI a second implementation to keep
+honest. The CLI stays a client even when it embeds the server in-process.
+
+**Auto-approve-everything flag for unattended runs** (`--yolo`). Simpler than
+NDJSON driving, and other tools ship it. Rejected as the *only* mechanism: it
+collapses the permission model instead of exercising it, and the stated goal
+is agents that answer approvals, not agents that never see them. `allow` mode
+per invocation covers the legitimate cases with vocabulary we already have.
+
+**Headless folder grants on demand** (agent requests a folder, CLI grants it
+because a flag said yes). Rejected: folder access is host-machine consent, and
+the broker's own design separates operator provisioning from in-turn requests.
+Collapsing them would make every headless run a standing grant to anywhere the
+agent wanders.
+
+## Consequences
+
+- The HTTP/WS API graduates from internal seam to supported contract. Under
+  record 2's pre-v1 rules it may still change freely, but changes now break
+  scripts and agents, not just our own two clients — route changes deserve the
+  same care as persisted formats, and an OpenAPI description (today the route
+  table is the spec) becomes worth generating.
+- Desktop work gets a standing constraint: features land as server routes
+  first. The closed native-only list must be enforced in review; the parity
+  check below makes drift visible.
+- Moving deliverable/attachment handling from Tauri handlers to server routes
+  is real migration work in the desktop, not just CLI addition.
+- The NDJSON driving protocol becomes a wire contract of its own — versioned
+  with the same discipline as the event journal shapes it re-exposes.
+- Operator folder grants create a new provenance of standing grant that
+  security review must treat as first-class (audit surface, revocation,
+  display in the desktop's connected-folders UI).
+- Exec on headless Linux remains backend-dependent; CI and agent harnesses
+  must provision a container backend, and that setup cost is now on the
+  critical path of "agents try stuff out."
+- Revisit if: a non-HTTP consumer appears with needs WS cannot meet (would
+  reopen the single-transport rule); the MCP face grows a real lifecycle
+  surface (would reopen the parity-vehicle choice); or a supported local
+  sandbox lands for Linux (would shrink the excluded set).
+
+## Validation
+
+- End-to-end headless turn: `openwave -p` in `allow` mode runs a real
+  tool-using turn on a fresh data dir and the journal records the completed
+  turn — the highest-value single test, per the testing bar.
+- Interaction protocol: a driven `-p` session receives a plan-proposal event
+  and answers it over stdin; the turn *continues* rather than cancelling. A
+  wrong implementation that merely auto-accepts plans would pass a
+  "turn completed" assertion — the test must assert the decision came from the
+  driver's stdin line, not from policy.
+- Undriven `ask`-mode run that hits a question exits with the documented code
+  and machine-readable reason; asserting on exit status alone would let a
+  silent-cancel regression pass, so the reason payload is part of the
+  assertion.
+- Parity gate: a check that the set of `#[tauri::command]` handlers is a
+  subset of the explicit native-only allowlist, so a new desktop-only feature
+  fails CI until the list is consciously amended or the feature gets routes.
+- Folder consent: an `OperatorConfig` grant made by the CLI is visible and
+  revocable from the desktop's connected-folders UI against the same data dir,
+  and a mid-turn folder request in headless mode produces the typed refusal,
+  never a grant.
+- Setup subcommands are validated by their routes' existing coverage — they
+  are thin clients, and tests that re-walk each route through the CLI would be
+  duplicate coverage under the testing policy; one smoke test that a
+  credential set via CLI is immediately usable by a turn suffices.


### PR DESCRIPTION
Part 1 of decision record 5's enforcement: a check that the set of
`#[tauri::command]` handlers stays a subset of an explicit, in-repo
allowlist, so a new desktop-only feature fails the Rust lane until it is
either given server routes or the list is consciously amended.

**The gate.** `crates/openwave-desktop/native-only-commands.txt` lists every
command as `name: justification`, grouped by which native capability it
needs, with a header explaining the rule. `command_parity.rs` (a
`#[cfg(test)]` module in the desktop crate) walks `src/` textually for
`#[tauri::command]`, resolves the following function name, and fails in both
directions: an unlisted command, and an allowlist entry whose command is
gone. Both failure messages name the allowlist file and the record, so the
fix path needs no searching. The scan tolerates `fn`/`pub fn`/`pub(crate)
fn`, `async`, and doc comments or attributes between the attribute and the
signature. No proc macro, no registry, no CI workflow change — it runs in the
existing desktop test lane.

Verified by adding a throwaway command in an unrelated module: the test fails
and names it with its file.

**Observed debt.** Seeding the list surfaced commands that do not fit the
record's closed native-only set. They are allowlisted with a `TODO(record 5)`
justification rather than refactored here — migrating them is the record's
item 4/5 work, not this change:

- Output/deliverable handling, all `Store`-direct (record item 5 moves these
  to routes): `list_deliverables`, `read_deliverable`, `read_deliverable_file`,
  `list_output_revisions`, `read_output_revision`, `restore_output_revision`,
  `save_output_revision`, `delete_output`, `restore_output`.
- Host-broker reads and mutations with no native dialog (record item 4 gives
  folders a headless consent path): `list_connected_folders`,
  `list_approved_folders`, `list_capability_consents`,
  `revoke_capability_consent`, `disconnect_folder`, `forget_folder`,
  `purge_deleted_conversation_subject`.
- `publish_chat_image`, which publishes pasted image bytes from the renderer
  with no native shell involvement.

Everything else is justified against the closed set: OS pickers and save
dialogs, folder consent dialogs, host-side execution of client-executed tool
calls, the office-converter and Node installers, the auto-updater, native
window attention, and the `server_info` bootstrap that hands the renderer the
address and token every HTTP route is reached through.

Closes #1870
