### PR TITLE
feat(cli): unattended print-mode protocol with permission modes and NDJSON driving

### DIFF
--- a/crates/openwave-cli/src/main.rs
+++ b/crates/openwave-cli/src/main.rs
@@ -23,9 +23,12 @@
 //! fresh chat, and `--chat` resumes one by id.
 //!
 //! `openwave -p "<prompt>"` runs one turn without a terminal: same engine, no
-//! interaction. stdout carries the assistant's text (or, with
+//! terminal. stdout carries the assistant's text (or, with
 //! `--output-format json`, the turn's event stream as NDJSON), and the exit
-//! status says whether the turn completed.
+//! status says whether the turn completed. `--permission-mode` sets the chat's
+//! permission mode for the run, and under `--output-format json` a driving
+//! process answers approvals, plans, and questions over stdin — see
+//! [`print::protocol`].
 
 use std::ffi::OsStr;
 use std::path::PathBuf;
@@ -42,7 +45,8 @@ use print::OutputFormat;
 
 const USAGE: &str = "usage: openwave serve\n       openwave mcp <workspace>\n       openwave \
                      rehome-secrets\n       openwave tui [--chat <id> | --new]\n       openwave -p \
-                     <prompt> [--chat <id>] [--output-format text|json]";
+                     <prompt> [--chat <id>] [--output-format text|json]\n                  \
+                     [--permission-mode ask|auto|allow|plan]";
 
 #[tokio::main]
 async fn main() {
@@ -121,6 +125,7 @@ async fn run() -> Result<i32> {
             };
             let mut chat = None;
             let mut format = OutputFormat::Text;
+            let mut permission_mode = None;
             while let Some(flag) = args.next() {
                 if flag == OsStr::new("--chat") {
                     let Some(id) = args.next() else {
@@ -138,11 +143,23 @@ async fn run() -> Result<i32> {
                         Some(value) => format = value,
                         None => usage_error("--output-format expects text or json"),
                     }
+                } else if flag == OsStr::new("--permission-mode") {
+                    let Some(value) = args.next() else {
+                        usage_error("--permission-mode requires ask, auto, allow, or plan");
+                    };
+                    // The wire tokens are the chat's own permission-mode
+                    // vocabulary; the CLI adds nothing to it.
+                    match value.to_string_lossy().as_ref() {
+                        mode @ ("ask" | "auto" | "allow" | "plan") => {
+                            permission_mode = Some(mode.to_owned());
+                        }
+                        _ => usage_error("--permission-mode expects ask, auto, allow, or plan"),
+                    }
                 } else {
                     usage_error(&format!("unknown print-mode argument {flag:?}"));
                 }
             }
-            print::run(prompt, chat, format).await
+            print::run(prompt, chat, format, permission_mode).await
         }
         Some(other) => {
             usage_error(&format!("unknown command {other:?}"));

--- a/crates/openwave-cli/src/print.rs
+++ b/crates/openwave-cli/src/print.rs
@@ -1,4 +1,4 @@
-//! `openwave -p "<prompt>"` — one non-interactive turn.
+//! `openwave -p "<prompt>"` — one unattended turn.
 //!
 //! Boots the same in-process server `openwave serve` runs and drives one turn
 //! over the loopback API, then exits with a status that says how the turn ended.
@@ -6,13 +6,17 @@
 //! `--output-format json`) and nothing else: logging is file-only and every
 //! notice goes to stderr, so `openwave -p … > answer.txt` is exactly the answer.
 //!
-//! Nothing here can wait for a human. A parked approval is rejected as soon as
-//! it arrives, which lets the model adapt and finish rather than hang; a turn
-//! that asks the user a question or proposes a plan has no answer available at
-//! all, so it is cancelled and reported.
+//! The turn can still reach a point only someone else can settle — an approval,
+//! a proposed plan, a question. Two things answer those. A **driver** — another
+//! process holding this one's stdin, opted in with `--output-format json` — is
+//! asked over the NDJSON protocol in [`protocol`]. With no driver attached, the
+//! standing policy answers instead: approvals are rejected, so the model can
+//! choose another route rather than hang, and a plan or a question ends the run
+//! with a distinct exit status and a machine-readable reason. Nothing is ever
+//! cancelled silently.
 
 use std::collections::HashMap;
-use std::io::Write as _;
+use std::io::{IsTerminal as _, Write as _};
 
 use futures::StreamExt as _;
 use openwave_core::{AgentError, CallId, ChatId, Result, TurnId};
@@ -21,15 +25,23 @@ use tokio_tungstenite::tungstenite::Message;
 use crate::api::client::{Client, EventSocket};
 use crate::api::wire::{ChatFrame, ClientEvent, ToolCallStatus};
 
+mod driver;
+pub mod protocol;
+
+use driver::Driver;
+use protocol::{Decision, Halt, HaltReason, Interaction, Undriven};
+
 /// Exit status for a turn that ended without completing.
 const EXIT_TURN_UNSUCCESSFUL: i32 = 1;
+/// Exit status for a turn that parked on something no driver was there to
+/// answer. Distinct from a failed turn: nothing went wrong, nobody answered.
+const EXIT_INTERACTION_UNDRIVEN: i32 = 3;
+/// Exit status for a decision that was made but could not be applied — the
+/// driver answered and the server refused or was unreachable.
+const EXIT_DECISION_FAILED: i32 = 4;
 /// Exit status for interruption by SIGINT, following the shell's 128+signal
 /// convention.
 const EXIT_INTERRUPTED: i32 = 130;
-
-/// The reason recorded against every approval this mode rejects. It reaches the
-/// model, which is what lets it choose another route rather than retry.
-const REJECTION_REASON: &str = "non-interactive print mode";
 
 /// Attempts to re-open the event socket after it closes mid-turn before giving
 /// up. The server is in-process, so a close means something is badly wrong; the
@@ -58,7 +70,12 @@ impl OutputFormat {
 }
 
 /// Boot the engine, run one turn, and return the process exit status.
-pub async fn run(prompt: String, chat: Option<ChatId>, format: OutputFormat) -> Result<i32> {
+pub async fn run(
+    prompt: String,
+    chat: Option<ChatId>,
+    format: OutputFormat,
+    permission_mode: Option<String>,
+) -> Result<i32> {
     let config = crate::profile_config()?;
     // stdout belongs to the output, so logs go to the profile's log file only.
     openwave_server::logging::init_logging_file_only(&config.data_dir);
@@ -77,8 +94,19 @@ pub async fn run(prompt: String, chat: Option<ChatId>, format: OutputFormat) -> 
         }
         None => client.create_chat().await?,
     };
+    if let Some(mode) = permission_mode.as_deref() {
+        // Fail before the turn starts: a run that asked for `allow` and got
+        // `ask` would quietly do something else.
+        client.set_chat_permission_mode(chat, Some(mode)).await?;
+    }
 
-    let result = one_turn(&client, chat, &prompt, format).await;
+    // Driving needs somewhere to put the events and something on the other end
+    // of stdin. A terminal on stdin means a person ran this by hand, and no
+    // decision lines are coming.
+    let driving = format == OutputFormat::Json && !std::io::stdin().is_terminal();
+    let mut driver = Driver::from_stdin(driving);
+
+    let result = one_turn(&client, chat, &prompt, format, &mut driver).await;
     serve.abort();
     result
 }
@@ -89,6 +117,7 @@ async fn one_turn(
     chat: ChatId,
     prompt: &str,
     format: OutputFormat,
+    driver: &mut Driver<tokio::io::BufReader<tokio::io::Stdin>>,
 ) -> Result<i32> {
     let turn_id = TurnId::new();
     // Subscribe before posting: the turn can start before this returns, and the
@@ -142,30 +171,43 @@ async fn one_turn(
                 printer.tool_completed(call_id, status);
             }
             ClientEvent::ApprovalRequired {
-                call_id, action, ..
+                call_id,
+                action,
+                approval,
+                grant_rungs,
+                preview,
+                ..
             } => {
-                printer.notice(&format!(
-                    "approval for {action} rejected: {REJECTION_REASON}"
-                ));
-                if let Err(error) = client
-                    .decide_approval(chat, call_id, false, REJECTION_REASON, None)
-                    .await
-                {
-                    // A decision that races the approval judge or a cancelled
-                    // call is not this process's failure; the turn continues.
-                    printer.notice(&format!("could not reject the approval: {error}"));
+                let interaction = Interaction::Approval {
+                    call_id,
+                    action,
+                    approval,
+                    grant_rungs,
+                    preview,
+                };
+                if let Some(halt) = settle(client, chat, &interaction, driver, &mut printer).await {
+                    break halted(client, chat, turn_id, &halt, &mut printer).await;
                 }
             }
-            // Neither can be answered without a human. Cancelling is what stops
-            // the parked turn from outliving this process.
-            ClientEvent::UserQuestionsAsked { .. } | ClientEvent::PlanProposed { .. } => {
-                printer.finish();
-                eprintln!(
-                    "openwave: the turn needs an interactive answer, which print mode cannot \
-                     give; cancelling"
-                );
-                let _ = client.cancel_turn(chat, turn_id).await;
-                break EXIT_TURN_UNSUCCESSFUL;
+            // Neither can be answered from the standing policy, so both reach
+            // for the driver first and end the run loudly if there is none.
+            ClientEvent::PlanProposed { call_id } => {
+                if let Some(interaction) = pending_plan(client, chat, call_id).await {
+                    if let Some(halt) =
+                        settle(client, chat, &interaction, driver, &mut printer).await
+                    {
+                        break halted(client, chat, turn_id, &halt, &mut printer).await;
+                    }
+                }
+            }
+            ClientEvent::UserQuestionsAsked { call_id } => {
+                if let Some(interaction) = pending_questions(client, chat, call_id).await {
+                    if let Some(halt) =
+                        settle(client, chat, &interaction, driver, &mut printer).await
+                    {
+                        break halted(client, chat, turn_id, &halt, &mut printer).await;
+                    }
+                }
             }
             ClientEvent::TurnCompleted { .. } => break 0,
             ClientEvent::TurnFailed { category, .. } => {
@@ -190,6 +232,141 @@ async fn one_turn(
 
     printer.finish();
     Ok(outcome)
+}
+
+/// Settle one parked interaction: ask the driver, fall back to the standing
+/// policy, and carry the decision out. `Some(halt)` ends the run.
+async fn settle(
+    client: &Client,
+    chat: ChatId,
+    interaction: &Interaction,
+    driver: &mut Driver<tokio::io::BufReader<tokio::io::Stdin>>,
+    printer: &mut Printer,
+) -> Option<Halt> {
+    let mut control = |event| printer.control(event);
+    let decision = match driver.decide(interaction, &mut control).await {
+        Some(decision) => decision,
+        None => match interaction.undriven() {
+            Undriven::Decide(decision) => {
+                printer.notice(&format!(
+                    "no driver attached; {} answered by standing policy",
+                    interaction.kind()
+                ));
+                decision
+            }
+            Undriven::Halt(halt) => return Some(halt),
+        },
+    };
+    apply(client, chat, interaction, decision, printer).await
+}
+
+/// Send one decision to the route that owns it.
+///
+/// A rejected approval that races the judge or a cancelled call is not this
+/// process's failure — the turn carries on. A plan or answer that cannot be
+/// delivered is different: the turn stays parked forever, so the run ends
+/// rather than hanging.
+async fn apply(
+    client: &Client,
+    chat: ChatId,
+    interaction: &Interaction,
+    decision: Decision,
+    printer: &mut Printer,
+) -> Option<Halt> {
+    let call_id = interaction.call_id();
+    let outcome = match &decision {
+        Decision::Approval {
+            approve,
+            reason,
+            grant,
+        } => {
+            client
+                .decide_approval(chat, call_id, *approve, reason, *grant)
+                .await
+        }
+        Decision::Plan {
+            accept,
+            feedback,
+            permission_mode,
+        } => {
+            client
+                .decide_plan(
+                    chat,
+                    call_id,
+                    *accept,
+                    feedback.as_deref(),
+                    permission_mode.as_deref(),
+                )
+                .await
+        }
+        Decision::Questions { body } => client.answer_questions(chat, call_id, body.clone()).await,
+    };
+    match outcome {
+        Ok(()) => None,
+        Err(error) => {
+            let message = format!(
+                "the {} decision for call {call_id} could not be applied: {error}",
+                interaction.kind()
+            );
+            if matches!(decision, Decision::Approval { .. }) {
+                printer.notice(&message);
+                return None;
+            }
+            Some(Halt {
+                reason: HaltReason::DecisionFailed,
+                call_id: Some(call_id),
+                message,
+            })
+        }
+    }
+}
+
+/// Report a halt in both directions and cancel the parked turn, returning the
+/// exit status it produces.
+async fn halted(
+    client: &Client,
+    chat: ChatId,
+    turn_id: TurnId,
+    halt: &Halt,
+    printer: &mut Printer,
+) -> i32 {
+    printer.finish();
+    printer.notice(&format!(
+        "halted ({}): {}",
+        halt.reason.as_str(),
+        halt.message
+    ));
+    printer.halt(halt.event());
+    // The parked turn must not outlive this process.
+    let _ = client.cancel_turn(chat, turn_id).await;
+    halt.reason.exit_code()
+}
+
+/// The proposed plan behind a `PlanProposed` event. `None` when it is already
+/// settled — a decision raced the event, and there is nothing left to answer.
+async fn pending_plan(
+    client: &Client,
+    chat: ChatId,
+    call_id: Option<CallId>,
+) -> Option<Interaction> {
+    let pending = client.list_pending_plans(chat).await.ok()?;
+    pending
+        .into_iter()
+        .find(|plan| call_id.is_none_or(|id| plan.call_id == id))
+        .map(Interaction::from_plan)
+}
+
+/// The question block behind a `UserQuestionsAsked` event, on the same terms.
+async fn pending_questions(
+    client: &Client,
+    chat: ChatId,
+    call_id: Option<CallId>,
+) -> Option<Interaction> {
+    let pending = client.list_pending_questions(chat).await.ok()?;
+    pending
+        .into_iter()
+        .find(|block| call_id.is_none_or(|id| block.call_id == id))
+        .map(Interaction::from_questions)
 }
 
 /// The event socket plus the cursor a reconnect resumes from.
@@ -313,6 +490,29 @@ impl Printer {
     /// exactly the output the caller asked for.
     fn notice(&self, message: &str) {
         eprintln!("openwave: {message}");
+    }
+
+    /// A protocol event for the driver. Only the NDJSON stream carries these;
+    /// text output has no driver to talk to.
+    fn control(&mut self, event: serde_json::Value) {
+        if self.format != OutputFormat::Json {
+            return;
+        }
+        let mut stdout = std::io::stdout().lock();
+        let _ = writeln!(stdout, "{event}");
+        let _ = stdout.flush();
+    }
+
+    /// The terminating reason. Unlike other control events this one is emitted
+    /// in both formats — a text-mode caller still has to be able to tell a halt
+    /// apart from a failed turn without parsing prose, so the same object goes
+    /// to stderr there.
+    fn halt(&mut self, event: serde_json::Value) {
+        if self.format == OutputFormat::Json {
+            self.control(event);
+        } else {
+            eprintln!("{event}");
+        }
     }
 
     /// Close out stdout before anything is written to stderr or the process

--- a/crates/openwave-cli/src/print/driver.rs
+++ b/crates/openwave-cli/src/print/driver.rs
@@ -1,0 +1,166 @@
+//! The stdin side of the driving protocol.
+//!
+//! A driver is attached when the caller asked for NDJSON output *and* stdin is
+//! something other than a terminal — a pipe, a socket, a file. Reading a
+//! decision from an unattached driver, or from one whose input has ended,
+//! yields nothing, and the caller falls back to the standing policy in
+//! [`super::protocol::Interaction::undriven`]. That is what keeps
+//! `openwave -p … --output-format json < /dev/null` from blocking forever on
+//! an answer nobody is going to write.
+
+use tokio::io::{AsyncBufRead, AsyncBufReadExt as _, BufReader, Lines, Stdin};
+
+use super::protocol::{error_event, parse_decision, Decision, Interaction};
+
+/// The decision channel: either a reader of NDJSON decision lines, or nothing.
+pub struct Driver<R> {
+    lines: Option<Lines<R>>,
+}
+
+impl Driver<BufReader<Stdin>> {
+    /// Attach to stdin when the invocation opted into driving, otherwise not.
+    pub fn from_stdin(driving: bool) -> Self {
+        Self {
+            lines: driving.then(|| BufReader::new(tokio::io::stdin()).lines()),
+        }
+    }
+}
+
+impl<R: AsyncBufRead + Unpin> Driver<R> {
+    /// A driver reading decisions from `reader`. Production attaches to stdin;
+    /// this is how the protocol is exercised over an in-memory channel.
+    #[cfg(test)]
+    pub fn attached(reader: R) -> Self {
+        Self {
+            lines: Some(reader.lines()),
+        }
+    }
+
+    /// Ask the driver to settle `interaction`.
+    ///
+    /// Emits the request event, then reads lines until one decides it.
+    /// `None` means no driver answered — unattached, or the input ended — and
+    /// the standing policy applies. Lines that cannot decide the pending
+    /// request produce an `error` event and are skipped, so one malformed line
+    /// does not lose the session.
+    pub async fn decide(
+        &mut self,
+        interaction: &Interaction,
+        emit: &mut dyn FnMut(serde_json::Value),
+    ) -> Option<Decision> {
+        let lines = self.lines.as_mut()?;
+        emit(interaction.request_event());
+        loop {
+            // An I/O error on stdin is the end of the channel, same as EOF:
+            // there is no answer coming either way.
+            let line = match lines.next_line().await {
+                Ok(Some(line)) => line,
+                Ok(None) | Err(_) => {
+                    // Stop reading: every later interaction takes the standing
+                    // policy rather than re-reading a closed channel.
+                    self.lines = None;
+                    return None;
+                }
+            };
+            if line.trim().is_empty() {
+                continue;
+            }
+            match parse_decision(&line, interaction) {
+                Ok(decision) => return Some(decision),
+                Err(message) => emit(error_event(&message)),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use openwave_core::CallId;
+
+    use super::*;
+    use crate::print::protocol::{HaltReason, Undriven};
+
+    fn plan_interaction(call_id: CallId) -> Interaction {
+        Interaction::Plan {
+            call_id,
+            title: "Rewrite the importer".into(),
+            plan: "1. read\n2. write".into(),
+        }
+    }
+
+    /// The driven path, end to end at the protocol seam: the proposal is
+    /// emitted, a decision line answers it, and the decision the run carries
+    /// out is the one the *line* asked for.
+    ///
+    /// Rejecting with feedback is deliberate: a build that answered plans from
+    /// policy could only accept or halt, so neither could produce this.
+    #[tokio::test]
+    async fn a_driven_plan_proposal_is_settled_by_the_stdin_line() {
+        let call_id = CallId::new();
+        let interaction = plan_interaction(call_id);
+        let input = format!(
+            "{}\n{}\n",
+            r#"{"type":"questions","answers":[]}"#,
+            format_args!(
+                r#"{{"type":"plan","call_id":"{call_id}","decision":"reject","feedback":"split it in two"}}"#
+            ),
+        );
+        let mut driver = Driver::attached(input.as_bytes());
+
+        let mut emitted = Vec::new();
+        let decision = driver
+            .decide(&interaction, &mut |event| emitted.push(event))
+            .await;
+
+        assert_eq!(
+            decision,
+            Some(Decision::Plan {
+                accept: false,
+                feedback: Some("split it in two".into()),
+                permission_mode: None,
+            })
+        );
+        // The proposal reached the driver with its content, and the line that
+        // could not answer it was reported rather than applied.
+        assert_eq!(emitted[0]["type"], "plan_proposal");
+        assert_eq!(emitted[0]["openwave"], "v1");
+        assert_eq!(emitted[0]["title"], "Rewrite the importer");
+        assert_eq!(emitted[1]["type"], "error");
+        assert_eq!(emitted.len(), 2, "{emitted:?}");
+    }
+
+    /// With no driver — and with one whose input ends without answering — a
+    /// question halts the run with the documented, machine-readable reason
+    /// rather than cancelling silently.
+    #[tokio::test]
+    async fn an_unanswered_question_halts_with_its_reason() {
+        let call_id = CallId::new();
+        let interaction = Interaction::Questions {
+            call_id,
+            questions: Vec::new(),
+        };
+
+        for mut driver in [
+            Driver::attached(&b""[..]),
+            Driver {
+                lines: None::<Lines<&[u8]>>,
+            },
+        ] {
+            let mut emitted = Vec::new();
+            let decision = driver
+                .decide(&interaction, &mut |event| emitted.push(event))
+                .await;
+            assert_eq!(decision, None);
+
+            let Undriven::Halt(halt) = interaction.undriven() else {
+                panic!("an unanswered question must halt");
+            };
+            assert_eq!(halt.reason, HaltReason::QuestionsUndriven);
+            let event = halt.event();
+            assert_eq!(event["type"], "halted");
+            assert_eq!(event["reason"], "questions_undriven");
+            assert_eq!(event["exit_code"], 3);
+            assert_eq!(event["call_id"], serde_json::json!(call_id));
+        }
+    }
+}

--- a/crates/openwave-cli/src/print/protocol.rs
+++ b/crates/openwave-cli/src/print/protocol.rs
@@ -1,0 +1,458 @@
+//! The print-mode driving protocol: the events an unattended run emits when it
+//! needs an answer, and the decision lines a driving process writes back.
+//!
+//! This is a wire contract. Both directions are one JSON object per line;
+//! emitted objects carry `"openwave": "v1"` so a consumer can tell a CLI
+//! control event apart from a journal frame (which carries `seq`/`event`) on
+//! the same stream, and so the protocol can be versioned without guessing.
+//!
+//! Unknown fields on a decision line are ignored — a newer driver may send
+//! more than this build reads. Unknown *variants* are not: an unrecognized
+//! `type` or verdict is reported back as an `error` event rather than
+//! silently doing something the driver did not ask for.
+
+use openwave_core::CallId;
+use serde::{Deserialize, Serialize};
+
+use crate::api::wire::{GrantRung, PendingPlan, PendingQuestions};
+
+/// Version tag stamped on every event this module emits.
+pub const PROTOCOL_VERSION: &str = "v1";
+
+/// The reason recorded against an approval rejected by standing policy — no
+/// driver was attached to answer it. It reaches the model, which is what lets
+/// it choose another route rather than retry.
+pub const REJECTION_REASON: &str = "non-interactive print mode";
+
+/// Something the turn parked on, waiting for an answer.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Interaction {
+    Approval {
+        call_id: CallId,
+        action: String,
+        approval: String,
+        grant_rungs: Vec<GrantRung>,
+        preview: Option<serde_json::Value>,
+    },
+    Plan {
+        call_id: CallId,
+        title: String,
+        plan: String,
+    },
+    Questions {
+        call_id: CallId,
+        questions: Vec<QuestionPrompt>,
+    },
+}
+
+/// One question as the driver sees it: enough to answer without reading the
+/// journal.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct QuestionPrompt {
+    pub id: String,
+    pub question: String,
+    pub header: String,
+    pub question_type: String,
+    pub allow_free_form: bool,
+    pub options: Vec<QuestionOptionPrompt>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct QuestionOptionPrompt {
+    pub id: String,
+    pub label: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+impl Interaction {
+    pub fn from_plan(plan: PendingPlan) -> Self {
+        Self::Plan {
+            call_id: plan.call_id,
+            title: plan.title,
+            plan: plan.plan,
+        }
+    }
+
+    pub fn from_questions(pending: PendingQuestions) -> Self {
+        Self::Questions {
+            call_id: pending.call_id,
+            questions: pending
+                .questions
+                .into_iter()
+                .map(|question| QuestionPrompt {
+                    id: question.id,
+                    question: question.question,
+                    header: question.header,
+                    question_type: question.question_type,
+                    allow_free_form: question.allow_free_form,
+                    options: question
+                        .options
+                        .into_iter()
+                        .map(|option| QuestionOptionPrompt {
+                            id: option.id,
+                            label: option.label,
+                            description: option.description,
+                        })
+                        .collect(),
+                })
+                .collect(),
+        }
+    }
+
+    pub fn call_id(&self) -> CallId {
+        match self {
+            Self::Approval { call_id, .. }
+            | Self::Plan { call_id, .. }
+            | Self::Questions { call_id, .. } => *call_id,
+        }
+    }
+
+    /// The `type` of both the request event and the decision line that answers
+    /// it.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::Approval { .. } => "approval",
+            Self::Plan { .. } => "plan",
+            Self::Questions { .. } => "questions",
+        }
+    }
+
+    /// The event emitted to ask the driver for a decision.
+    pub fn request_event(&self) -> serde_json::Value {
+        let mut event = match self {
+            Self::Approval {
+                call_id,
+                action,
+                approval,
+                grant_rungs,
+                preview,
+            } => serde_json::json!({
+                "type": "approval_request",
+                "call_id": call_id,
+                "action": action,
+                "approval": approval,
+                "grant_rungs": grant_rungs,
+                "preview": preview,
+            }),
+            Self::Plan {
+                call_id,
+                title,
+                plan,
+            } => serde_json::json!({
+                "type": "plan_proposal",
+                "call_id": call_id,
+                "title": title,
+                "plan": plan,
+            }),
+            Self::Questions { call_id, questions } => serde_json::json!({
+                "type": "questions_asked",
+                "call_id": call_id,
+                "questions": questions,
+            }),
+        };
+        event["openwave"] = serde_json::json!(PROTOCOL_VERSION);
+        event
+    }
+
+    /// What happens when no driver answers: the standing, documented policy.
+    pub fn undriven(&self) -> Undriven {
+        match self {
+            // Rejecting keeps the turn moving: the model can pick another
+            // route instead of waiting for a human who is not there.
+            Self::Approval { .. } => Undriven::Decide(Decision::Approval {
+                approve: false,
+                reason: REJECTION_REASON.to_owned(),
+                grant: None,
+            }),
+            Self::Plan { call_id, .. } => Undriven::Halt(Halt {
+                reason: HaltReason::PlanUndriven,
+                call_id: Some(*call_id),
+                message: "the turn proposed a plan and no driver is attached to decide it"
+                    .to_owned(),
+            }),
+            Self::Questions { call_id, .. } => Undriven::Halt(Halt {
+                reason: HaltReason::QuestionsUndriven,
+                call_id: Some(*call_id),
+                message:
+                    "the turn asked the user a question and no driver is attached to answer it"
+                        .to_owned(),
+            }),
+        }
+    }
+}
+
+/// The standing answer to an interaction nobody is driving.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Undriven {
+    /// Policy can answer this one on its own.
+    Decide(Decision),
+    /// Policy has no answer; the turn ends, loudly.
+    Halt(Halt),
+}
+
+/// A decision to carry out against the server.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Decision {
+    Approval {
+        approve: bool,
+        reason: String,
+        grant: Option<GrantRung>,
+    },
+    Plan {
+        accept: bool,
+        feedback: Option<String>,
+        permission_mode: Option<String>,
+    },
+    Questions {
+        /// The `{ "answers": [...] }` body the answer route takes.
+        body: serde_json::Value,
+    },
+}
+
+/// Why an unattended run gave up, in a form a caller can branch on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HaltReason {
+    PlanUndriven,
+    QuestionsUndriven,
+    DecisionFailed,
+}
+
+impl HaltReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::PlanUndriven => "plan_undriven",
+            Self::QuestionsUndriven => "questions_undriven",
+            Self::DecisionFailed => "decision_failed",
+        }
+    }
+
+    /// The process exit status this halt produces. Both undriven reasons share
+    /// one code — they are the same fact ("nobody was there to answer") and the
+    /// `reason` field separates them.
+    pub fn exit_code(self) -> i32 {
+        match self {
+            Self::PlanUndriven | Self::QuestionsUndriven => super::EXIT_INTERACTION_UNDRIVEN,
+            Self::DecisionFailed => super::EXIT_DECISION_FAILED,
+        }
+    }
+}
+
+/// A terminating outcome plus the machine-readable reason that explains it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Halt {
+    pub reason: HaltReason,
+    pub call_id: Option<CallId>,
+    pub message: String,
+}
+
+impl Halt {
+    pub fn event(&self) -> serde_json::Value {
+        serde_json::json!({
+            "openwave": PROTOCOL_VERSION,
+            "type": "halted",
+            "reason": self.reason.as_str(),
+            "exit_code": self.reason.exit_code(),
+            "call_id": self.call_id,
+            "message": self.message,
+        })
+    }
+}
+
+/// A driver-facing complaint about a decision line. Emitted, then the next
+/// line is read: a malformed line never decides anything by default.
+pub fn error_event(message: &str) -> serde_json::Value {
+    serde_json::json!({
+        "openwave": PROTOCOL_VERSION,
+        "type": "error",
+        "message": message,
+    })
+}
+
+/// One decision line, as written on stdin.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum DecisionLine {
+    Approval {
+        #[serde(default)]
+        call_id: Option<CallId>,
+        decision: ApprovalVerdict,
+        #[serde(default)]
+        reason: Option<String>,
+        #[serde(default)]
+        grant: Option<GrantRung>,
+    },
+    Plan {
+        #[serde(default)]
+        call_id: Option<CallId>,
+        decision: PlanVerdict,
+        #[serde(default)]
+        feedback: Option<String>,
+        #[serde(default)]
+        permission_mode: Option<String>,
+    },
+    Questions {
+        #[serde(default)]
+        call_id: Option<CallId>,
+        answers: Vec<QuestionAnswer>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ApprovalVerdict {
+    Approve,
+    Reject,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum PlanVerdict {
+    Accept,
+    Reject,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct QuestionAnswer {
+    question_id: String,
+    #[serde(default)]
+    selected_option_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    custom_answer: Option<String>,
+}
+
+impl DecisionLine {
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::Approval { .. } => "approval",
+            Self::Plan { .. } => "plan",
+            Self::Questions { .. } => "questions",
+        }
+    }
+
+    fn call_id(&self) -> Option<CallId> {
+        match self {
+            Self::Approval { call_id, .. }
+            | Self::Plan { call_id, .. }
+            | Self::Questions { call_id, .. } => *call_id,
+        }
+    }
+}
+
+/// Read one decision line as the answer to `interaction`.
+///
+/// `Err` is a message for the driver: the line is rejected, not applied
+/// approximately. A line may omit `call_id`, which answers whatever is parked;
+/// naming a different call is an error rather than a redirect, since only one
+/// interaction is ever outstanding here.
+pub fn parse_decision(
+    line: &str,
+    interaction: &Interaction,
+) -> std::result::Result<Decision, String> {
+    let parsed: DecisionLine = serde_json::from_str(line)
+        .map_err(|error| format!("could not read the decision line: {error}"))?;
+    if parsed.kind() != interaction.kind() {
+        return Err(format!(
+            "a {} decision does not answer the pending {} request",
+            parsed.kind(),
+            interaction.kind()
+        ));
+    }
+    if let Some(named) = parsed.call_id() {
+        if named != interaction.call_id() {
+            return Err(format!(
+                "decision names call {named}, but call {} is pending",
+                interaction.call_id()
+            ));
+        }
+    }
+    Ok(match parsed {
+        DecisionLine::Approval {
+            decision,
+            reason,
+            grant,
+            ..
+        } => Decision::Approval {
+            approve: matches!(decision, ApprovalVerdict::Approve),
+            reason: reason.unwrap_or_else(|| "rejected by the driver".to_owned()),
+            grant,
+        },
+        DecisionLine::Plan {
+            decision,
+            feedback,
+            permission_mode,
+            ..
+        } => Decision::Plan {
+            accept: matches!(decision, PlanVerdict::Accept),
+            feedback,
+            permission_mode,
+        },
+        DecisionLine::Questions { answers, .. } => Decision::Questions {
+            body: serde_json::json!({ "answers": answers }),
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn plan(call_id: CallId) -> Interaction {
+        Interaction::Plan {
+            call_id,
+            title: "Ship it".into(),
+            plan: "1. do the thing".into(),
+        }
+    }
+
+    /// The decision line's own words survive into the decision: a build that
+    /// answered from policy instead would lose the feedback and the mode.
+    #[test]
+    fn a_plan_decision_line_carries_the_drivers_own_words() {
+        let call_id = CallId::new();
+        let decision = parse_decision(
+            &format!(
+                r#"{{"type":"plan","call_id":"{call_id}","decision":"accept","feedback":"go","permission_mode":"allow"}}"#
+            ),
+            &plan(call_id),
+        )
+        .expect("the line answers the pending plan");
+        assert_eq!(
+            decision,
+            Decision::Plan {
+                accept: true,
+                feedback: Some("go".into()),
+                permission_mode: Some("allow".into()),
+            }
+        );
+    }
+
+    /// A line that answers something else is refused rather than applied to
+    /// whatever happens to be parked.
+    #[test]
+    fn mismatched_decision_lines_are_refused() {
+        let call_id = CallId::new();
+        let wrong_kind = parse_decision(
+            r#"{"type":"approval","decision":"approve"}"#,
+            &plan(call_id),
+        );
+        assert!(
+            wrong_kind
+                .as_ref()
+                .is_err_and(|message| message.contains("does not answer")),
+            "{wrong_kind:?}"
+        );
+
+        let other_call = CallId::new();
+        let wrong_call = parse_decision(
+            &format!(r#"{{"type":"plan","call_id":"{other_call}","decision":"accept"}}"#),
+            &plan(call_id),
+        );
+        assert!(
+            wrong_call
+                .as_ref()
+                .is_err_and(|message| message.contains("is pending")),
+            "{wrong_call:?}"
+        );
+    }
+}

--- a/docs-site/content/docs/headless.mdx
+++ b/docs-site/content/docs/headless.mdx
@@ -23,6 +23,7 @@ openwave mcp <workspace>
 openwave rehome-secrets
 openwave tui [--chat <id> | --new]
 openwave -p <prompt> [--chat <id>] [--output-format text|json]
+           [--permission-mode ask|auto|allow|plan]
 ```
 
 A bare `openwave` with no arguments runs `serve`.
@@ -69,16 +70,121 @@ picks the model for the current chat.
 
 ### `-p` (one-shot)
 
-Runs a single turn with no interaction. stdout carries the assistant's text,
-and the exit status says whether the turn completed.
+Runs a single turn without a terminal. stdout carries the assistant's text, and
+the exit status says how the turn ended.
 
 ```sh
 cargo run -p openwave-cli -- -p "summarize the CSV in output/"
 cargo run -p openwave-cli -- -p "…" --output-format json
+cargo run -p openwave-cli -- -p "…" --permission-mode allow
 ```
 
-`--output-format json` emits the turn's event stream as NDJSON instead of
-plain text. `--chat <id>` continues an existing conversation.
+`--output-format json` emits the turn's event stream as NDJSON instead of plain
+text. `--chat <id>` continues an existing conversation.
+
+`--permission-mode` sets the chat's permission mode for the run — the same four
+modes the desktop offers, applied before the turn starts:
+
+| Mode | Effect |
+| --- | --- |
+| `ask` | Default. Uncovered mutating calls park on an approval. |
+| `auto` | Workspace writes proceed; sensitive calls still ask. |
+| `allow` | Nothing asks. Explicit full autonomy for this chat. |
+| `plan` | Read-only exploration; the agent proposes a plan instead of acting. |
+
+The mode is stored on the chat, so `--chat <id>` on a later run inherits
+whatever the last run set unless it passes `--permission-mode` again.
+
+#### Driving a turn
+
+A turn can reach a point only someone else can settle: an approval, a proposed
+plan, a question. Attach a **driver** — a process holding this one's stdin —
+and it answers them over a line protocol. Driving is on when
+`--output-format json` is set and stdin is not a terminal; a terminal on stdin
+means a person ran the command by hand, and no decision lines are coming.
+
+Requests are emitted on stdout, mixed into the NDJSON event stream. Every line
+the CLI authors carries an `openwave` version tag, which is what tells it apart
+from a journal frame (those carry `seq` and `event`):
+
+```json
+{"openwave":"v1","type":"approval_request","call_id":"…","action":"exec","approval":"exec_may_run_networked_command","grant_rungs":["exact_action",{"command_prefix":{"tokens":1}}],"preview":{…}}
+{"openwave":"v1","type":"plan_proposal","call_id":"…","title":"Rewrite the importer","plan":"1. …"}
+{"openwave":"v1","type":"questions_asked","call_id":"…","questions":[{"id":"target","question":"Which environment?","header":"","question_type":"single","allow_free_form":true,"options":[{"id":"staging","label":"Staging"}]}]}
+{"openwave":"v1","type":"error","message":"a plan decision does not answer the pending approval request"}
+{"openwave":"v1","type":"halted","reason":"plan_undriven","exit_code":3,"call_id":"…","message":"…"}
+```
+
+The driver answers by writing one JSON object per line to stdin:
+
+```json
+{"type":"approval","call_id":"…","decision":"approve","grant":"exact_action"}
+{"type":"approval","call_id":"…","decision":"reject","reason":"not in this run"}
+{"type":"plan","call_id":"…","decision":"accept","permission_mode":"auto"}
+{"type":"plan","call_id":"…","decision":"reject","feedback":"split it in two"}
+{"type":"questions","call_id":"…","answers":[{"question_id":"target","selected_option_ids":["staging"],"custom_answer":"canary first"}]}
+```
+
+`call_id` may be omitted — only one interaction is ever outstanding — but
+naming a *different* call is an error, not a redirect. `reason` (approval
+rejections), `feedback` and `permission_mode` (plan), `grant` (approval), and
+`custom_answer` are optional. Unknown fields are ignored so a newer driver can
+send more; an unknown `type` or verdict is refused with an `error` event and
+the next line is read, so one malformed line never decides anything by itself.
+
+#### Undriven defaults
+
+With no driver — text output, a terminal on stdin, or an input stream that ends
+without answering — the standing policy applies:
+
+- **Approvals are rejected**, with the reason `non-interactive print mode`.
+  The model sees the rejection and can choose another route rather than hang.
+- **Plans and questions end the run.** There is no answer to invent, so the
+  turn is cancelled *and reported*: a `halted` object naming the reason, and a
+  distinct exit status.
+
+The `halted` object goes to stdout under `--output-format json` and to stderr
+under text output, so an undriven run is always machine-diagnosable.
+
+#### Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | The turn completed. |
+| `1` | The turn failed, was refused, or was cancelled. |
+| `2` | Usage error — a bad flag or argument. |
+| `3` | The turn parked on a plan or question and no driver answered. `reason` is `plan_undriven` or `questions_undriven`. |
+| `4` | A decision was made but could not be applied. `reason` is `decision_failed`. |
+| `130` | Interrupted (SIGINT). |
+
+#### A dev harness
+
+To drive OpenWave from a script or a coding agent, give it its own data
+directory so it cannot touch the desktop's chats, and let it act without
+parking:
+
+```sh
+export OPENWAVE_DATA_DIR="$(mktemp -d)/openwave"
+export OPENWAVE_KEYCHAIN_MOCK=1   # debug builds only — see below
+export ANTHROPIC_API_KEY=sk-...
+
+cargo run -p openwave-cli -- -p "run the tests and summarize what failed" \
+  --permission-mode allow --output-format json < /dev/null
+```
+
+`OPENWAVE_KEYCHAIN_MOCK=1` keeps credentials in memory instead of the OS
+keychain, which is what stops a headless run prompting for keychain access. It
+is honored by debug builds only; a release binary always uses the real
+keychain. Redirecting stdin from `/dev/null` states plainly that nothing is
+driving, so the run takes the undriven defaults instead of waiting.
+
+To drive it instead, hold both pipes — read stdout line by line, and write a
+decision line when a request arrives:
+
+```sh
+cargo run -p openwave-cli -- -p "plan the migration" \
+  --permission-mode plan --output-format json < decisions.pipe
+```
 
 ### `mcp`
 
@@ -112,6 +218,7 @@ cargo run -p openwave-cli -- rehome-secrets
 | `OPENWAVE_DATABASE_URL` | Required for `self_host`. |
 | `OPENWAVE_AUTH_TOKENS_FILE` | Named bearer tokens for `self_host`. Required there. |
 | `OPENWAVE_MCP_CONFIG` | JSON file of external MCP server definitions to load at boot. |
+| `OPENWAVE_KEYCHAIN_MOCK` | **Debug builds only.** Any non-empty value routes credentials to an in-memory store instead of the OS keychain, so a headless run never triggers a keychain prompt. Secrets do not survive the process. Release binaries ignore it. |
 | `OPENWAVE_MODEL` | Overrides the model the process launches with. |
 | `OPENWAVE_CONTAINER_EXECUTION_ENABLED` | Enables the container execution backend. Default `false`. |
 | `OPENWAVE_CONTAINER_IMAGE` | Overrides the container image. |


### PR DESCRIPTION
Part 2 of decision record 5: `openwave -p` becomes a protocol an agent or script can drive, instead of a demo that dies at the first interaction point. Stacked on #1864 (the record) — base is `adr/cli-headless-parity`.

Before this, print mode auto-rejected every approval and *cancelled the turn* on a plan proposal or a question, with nothing machine-readable saying so. Any scenario touching plans, questions, or ask-mode approvals was unreachable headlessly.

## Permission mode

`-p` takes `--permission-mode ask|auto|allow|plan`, applied to the chat via the existing permission-mode patch before the turn is posted (so a run that asks for `allow` and cannot get it fails rather than quietly running as `ask`). No new permission vocabulary: these are the chat's own four modes.

## Driving protocol

Driving is on when `--output-format json` is set **and** stdin is not a terminal. A terminal on stdin means a person ran the command by hand and no decision lines are coming; an input stream that ends without answering is treated the same as no driver, which is what keeps `… --output-format json < /dev/null` from blocking forever.

Requests go out on stdout, mixed into the NDJSON event stream. Every CLI-authored line carries `"openwave":"v1"` — that tag is what distinguishes a control event from a journal frame (`seq`/`event`) and is how the protocol gets versioned:

```json
{"openwave":"v1","type":"approval_request","call_id":"…","action":"exec","approval":"…","grant_rungs":[…],"preview":{…}}
{"openwave":"v1","type":"plan_proposal","call_id":"…","title":"…","plan":"…"}
{"openwave":"v1","type":"questions_asked","call_id":"…","questions":[{"id":"…","question":"…","options":[…],"question_type":"single","allow_free_form":true}]}
{"openwave":"v1","type":"error","message":"…"}
{"openwave":"v1","type":"halted","reason":"plan_undriven","exit_code":3,"call_id":"…","message":"…"}
```

Decision lines come back on stdin, one JSON object per line, and drive the same approval/plan/question routes the TUI calls:

```json
{"type":"approval","call_id":"…","decision":"approve","grant":"exact_action"}
{"type":"plan","call_id":"…","decision":"reject","feedback":"split it in two"}
{"type":"questions","call_id":"…","answers":[{"question_id":"target","selected_option_ids":["staging"],"custom_answer":"canary first"}]}
```

`call_id` is optional (only one interaction is ever outstanding) but naming a *different* call is an error, not a redirect. Unknown fields are ignored so a newer driver can send more; an unknown `type` or verdict is refused with an `error` event and the next line is read, so a malformed line never decides anything by itself.

## Undriven defaults

Stated, and typed:

- Approvals are still rejected with `non-interactive print mode`, so the model can pick another route instead of hanging.
- A plan or a question ends the run with a `halted` object naming the reason — to stdout under JSON output, to stderr under text output — and the turn is cancelled. Never a silent cancel.

## Exit codes

| Code | Meaning |
| --- | --- |
| `0` | The turn completed. |
| `1` | The turn failed, was refused, or was cancelled. |
| `2` | Usage error. |
| `3` | Parked on a plan or question with no driver (`plan_undriven` / `questions_undriven`). |
| `4` | A decision was made but could not be applied (`decision_failed`). |
| `130` | Interrupted. |

`3` and `4` are new. Both undriven reasons share `3` — it is one fact ("nobody was there to answer") and the `reason` field separates them.

## Tests

Two, both at the protocol seam:

- `a_driven_plan_proposal_is_settled_by_the_stdin_line` — the proposal is emitted with its content, a mismatched line is reported rather than applied, and the decision the run carries out is the one the *line* asked for. It rejects with feedback on purpose: a build that answered plans from policy could only accept or halt, so neither could produce that decision. The turn is not cancelled.
- `an_unanswered_question_halts_with_its_reason` — an unattached driver and one whose input ends both yield no decision, and the resulting halt carries `reason: questions_undriven` and `exit_code: 3`. The reason payload is asserted, not just the code.

Plus two small parser tests covering the contract's refusal rules (wrong kind, wrong call).

What is **not** covered here: a full process-level run that reaches a real plan proposal needs a stub model provider, and the only ones that exist live inside `openwave-server`'s private test module. Record 5's end-to-end validation (`allow`-mode turn on a fresh data dir, journal shows the completed turn) needs that harness and is not in this PR.

## Docs

`docs-site/content/docs/headless.mdx` documents the flags, both directions of the protocol, the undriven defaults, the exit-code table, and a dev-harness recipe (isolated `OPENWAVE_DATA_DIR`, `OPENWAVE_KEYCHAIN_MOCK` with its debug-only caveat, `--permission-mode allow`). `OPENWAVE_KEYCHAIN_MOCK` is now in the environment table.

Closes #1865
