### PR TITLE
feat(server): gate the self-host deployment plane behind an admin role

### DIFF
--- a/crates/openwave-server/src/auth.rs
+++ b/crates/openwave-server/src/auth.rs
@@ -16,19 +16,27 @@
 //! # Self-host token file
 //!
 //! `OPENWAVE_AUTH_TOKENS_FILE` points at a plain-text file, one mapping per
-//! line — `<user-id> <token>`, whitespace-separated. Blank lines and lines
-//! starting with `#` are ignored. A user may hold several tokens (rotation);
-//! a token may name only one user, and duplicates fail the load. Tokens are
-//! opaque secrets matched exactly (no hashing scheme to misconfigure): at
-//! least 16 characters from `[A-Za-z0-9._~-]`, so they stay valid in both the
-//! `Authorization` header and the WebSocket subprotocol below. Generate them
-//! with e.g. `openssl rand -hex 32`. Gateway-derived identity (#578) later
-//! replaces this file behind the same credential-to-principal seam.
+//! line — `<user-id> <token> [admin]`, whitespace-separated. Blank lines and
+//! lines starting with `#` are ignored. A user may hold several tokens
+//! (rotation); a token may name only one user, and duplicates fail the load.
+//! Tokens are opaque secrets matched exactly (no hashing scheme to
+//! misconfigure): at least 32 characters from `[A-Za-z0-9._~-]`, so they stay
+//! valid in both the `Authorization` header and the WebSocket subprotocol
+//! below. Generate them with e.g. `openssl rand -hex 32`. Gateway-derived
+//! identity (#578) later replaces this file behind the same
+//! credential-to-principal seam.
+//!
+//! The optional third field is the user's [`Role`]: `admin` puts them on the
+//! deployment plane (configuration and shared secrets), and its absence makes
+//! them a member. A user's lines must agree about the role, and a file naming
+//! no admin at all fails to load — a deployment nobody can configure must not
+//! start, for the same reason an empty file must not. See
+//! `docs/decisions/0004-self-host-deployment-plane-authorization.md`.
 //!
 //! ```text
-//! # user-id  token
-//! alice  4f9c0e9b2d5a4c1e8f7b6a5d4c3b2a1f
-//! bob    0123456789abcdef0123456789abcdef
+//! # user-id  token                                              role
+//! alice  4f9c0e9b2d5a4c1e8f7b6a5d4c3b2a1f0e9d8c7b6a5f4e3d2c1b0a99  admin
+//! bob    0123456789abcdef0123456789abcdef0123456789abcdef01234567
 //! ```
 //!
 //! Browsers can't set an `Authorization` header on a WebSocket upgrade, so on
@@ -36,7 +44,15 @@
 //! `openwave-token.<token>` (alongside the handshake subprotocol `openwave-v1`).
 //! Non-browser clients keep using `Authorization: Bearer`. Subprotocol auth is
 //! ignored on ordinary HTTP requests.
+//!
+//! Operators should know that this second channel is noisier than the first:
+//! `Sec-WebSocket-Protocol` is an ordinary request header that intermediary
+//! proxies and load balancers log far more readily than `Authorization`, which
+//! their default redaction lists usually cover. A self-host deployment behind
+//! someone else's fronting infrastructure should assume the WebSocket token
+//! can end up in that infrastructure's access logs, and rotate accordingly.
 
+use std::collections::HashMap;
 use std::path::Path;
 
 use axum::extract::{Request, State};
@@ -48,7 +64,7 @@ use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use openwave_core::{AgentError, Profile, Result};
 
-use crate::principal::{AuthContext, Principal, UserId};
+use crate::principal::{AuthContext, Principal, Role, UserId};
 use crate::state::AppState;
 
 /// Handshake subprotocol the server selects when the client offered it.
@@ -108,7 +124,7 @@ fn resolve_principal(state: &AppState, presented: &str) -> Option<Principal> {
         Profile::SelfHost => state
             .principal_tokens
             .resolve(presented)
-            .map(Principal::User),
+            .map(|(id, role)| Principal::User { id, role }),
         _ => None,
     }
 }
@@ -121,13 +137,19 @@ fn resolve_principal(state: &AppState, presented: &str) -> Option<Principal> {
 /// stays "which [`UserId`] is asking".
 #[derive(Debug, Default)]
 pub struct TokenMap {
-    /// `(token, user)` pairs; tokens are unique, users may repeat.
-    entries: Vec<(Box<str>, UserId)>,
+    /// `(token, user, role)` triples; tokens are unique, users may repeat —
+    /// and every line a user holds agrees about their role.
+    entries: Vec<(Box<str>, UserId, Role)>,
 }
 
 /// Tokens shorter than this are refused at load: a guessable credential names
-/// someone without authenticating them.
-const MIN_TOKEN_LEN: usize = 16;
+/// someone without authenticating them. Tokens are operator-generated, so the
+/// floor costs nothing but a longer `openssl rand -hex 32`.
+const MIN_TOKEN_LEN: usize = 32;
+
+/// The third field that marks a line's user as an administrator of the
+/// deployment. Any other value is a parse error rather than a silent member.
+const ADMIN_FIELD: &str = "admin";
 
 impl TokenMap {
     /// Load and validate the token file at `path`.
@@ -142,11 +164,13 @@ impl TokenMap {
     }
 
     /// Parse the token-file format. Rejects malformed lines, invalid ids,
-    /// weak or header-unsafe tokens, duplicate tokens, and a file that names
-    /// nobody — an empty authenticator must fail loudly at boot, not admit
-    /// nobody silently.
+    /// weak or header-unsafe tokens, duplicate tokens, a user whose lines
+    /// disagree about their role, a file that names nobody, and a file that
+    /// names no administrator — an authenticator that admits nobody, and a
+    /// deployment nobody can configure, must both fail loudly at boot.
     pub fn parse(text: &str) -> Result<Self> {
-        let mut entries: Vec<(Box<str>, UserId)> = Vec::new();
+        let mut entries: Vec<(Box<str>, UserId, Role)> = Vec::new();
+        let mut roles: HashMap<UserId, Role> = HashMap::new();
         for (index, raw) in text.lines().enumerate() {
             let line_no = index + 1;
             let line = raw.trim();
@@ -154,11 +178,22 @@ impl TokenMap {
                 continue;
             }
             let mut fields = line.split_whitespace();
-            let (Some(user), Some(token), None) = (fields.next(), fields.next(), fields.next())
+            let (Some(user), Some(token), marker, None) =
+                (fields.next(), fields.next(), fields.next(), fields.next())
             else {
                 return Err(AgentError::config(format!(
-                    "auth tokens file line {line_no}: expected `<user-id> <token>`"
+                    "auth tokens file line {line_no}: expected `<user-id> <token> [admin]`"
                 )));
+            };
+            let role = match marker {
+                None => Role::Member,
+                Some(ADMIN_FIELD) => Role::Admin,
+                Some(other) => {
+                    return Err(AgentError::config(format!(
+                        "auth tokens file line {line_no}: unknown role field {other:?}: the \
+                         optional third field is `admin` or nothing"
+                    )))
+                }
             };
             let user = UserId::new(user)
                 .map_err(|e| AgentError::config(format!("auth tokens file line {line_no}: {e}")))?;
@@ -175,13 +210,28 @@ impl TokenMap {
             }
             if entries
                 .iter()
-                .any(|(existing, _)| existing.as_ref() == token)
+                .any(|(existing, _, _)| existing.as_ref() == token)
             {
                 return Err(AgentError::config(format!(
                     "auth tokens file line {line_no}: duplicate token"
                 )));
             }
-            entries.push((token.into(), user));
+            // One user, one role. Rotation means several lines per user, and
+            // a rotation that silently changed someone's authority — in
+            // whichever direction the last line happened to win — is exactly
+            // the failure this file must not have.
+            match roles.get(&user) {
+                Some(known) if *known != role => {
+                    return Err(AgentError::config(format!(
+                        "auth tokens file line {line_no}: user {user} is listed with conflicting \
+                         roles; every line for a user must agree"
+                    )))
+                }
+                _ => {
+                    roles.insert(user.clone(), role);
+                }
+            }
+            entries.push((token.into(), user, role));
         }
         if entries.is_empty() {
             return Err(AgentError::config(
@@ -189,19 +239,50 @@ impl TokenMap {
                  authenticate to must not start",
             ));
         }
+        if !entries.iter().any(|(_, _, role)| *role == Role::Admin) {
+            return Err(AgentError::config(
+                "auth tokens file names no administrator; a self-host server nobody can \
+                 configure must not start — mark at least one user's lines `admin` \
+                 (`<user-id> <token> admin`)",
+            ));
+        }
         Ok(Self { entries })
     }
 
-    /// The user the presented credential names, if any. Exact match; every
-    /// entry is compared in constant time regardless of where a match lands.
-    pub fn resolve(&self, presented: &str) -> Option<UserId> {
+    /// The user the presented credential names and the role they hold, if
+    /// any. Exact match; every entry is compared in constant time regardless
+    /// of where a match lands.
+    pub fn resolve(&self, presented: &str) -> Option<(UserId, Role)> {
         let mut resolved = None;
-        for (token, user) in &self.entries {
+        for (token, user, role) in &self.entries {
             if constant_time_eq(token.as_bytes(), presented.as_bytes()) && resolved.is_none() {
-                resolved = Some(user.clone());
+                resolved = Some((user.clone(), *role));
             }
         }
         resolved
+    }
+}
+
+/// Require the deployment plane's role over the identity already resolved.
+///
+/// Like [`require_client_executor_token`], this reads the [`AuthContext`] the
+/// bearer middleware attached and never mints one: no context means the
+/// request reached an admin route without ever being authenticated, which is a
+/// `401`, not a defaulted identity. A member's request is a `403` — the route
+/// exists, they may not use it.
+///
+/// This is a router property, not a handler habit: everything assembled into
+/// the deployment-plane sub-router is gated by construction, so a new config
+/// route is admin-gated by where it is registered rather than by whether its
+/// author remembered a check.
+pub async fn require_admin(request: Request, next: Next) -> Response {
+    let Some(auth) = request.extensions().get::<AuthContext>() else {
+        return StatusCode::UNAUTHORIZED.into_response();
+    };
+    if auth.principal.is_admin() {
+        next.run(request).await
+    } else {
+        StatusCode::FORBIDDEN.into_response()
     }
 }
 
@@ -477,26 +558,38 @@ mod tests {
         assert!(host_is_loopback(&HeaderMap::new()));
     }
 
+    /// Tokens are 32 characters at minimum, so the fixtures are too; the
+    /// literals are named rather than inline so the secret scanner has
+    /// nothing high-entropy to trip over.
+    const ALICE_FIRST: &str = "alice-token-one-padded-to-thirty-two";
+    const ALICE_SECOND: &str = "alice-token-two-padded-to-thirty-two";
+    const BOB_TOKEN: &str = "bob-token-padded-out-to-thirty-two-x";
+
     #[test]
     fn token_map_parses_the_documented_format_and_resolves_exactly() {
-        let map = TokenMap::parse(
-            "# staff\n\nalice aaaaaaaaaaaaaaaa\nbob\tbbbbbbbbbbbbbbbb\nalice cccccccccccccccc\n",
-        )
+        let map = TokenMap::parse(&format!(
+            "# staff\n\nalice {ALICE_FIRST} admin\nbob\t{BOB_TOKEN}\nalice {ALICE_SECOND} admin\n"
+        ))
         .unwrap();
         let alice = UserId::new("alice").unwrap();
-        assert_eq!(map.resolve("aaaaaaaaaaaaaaaa"), Some(alice.clone()));
         assert_eq!(
-            map.resolve("cccccccccccccccc"),
-            Some(alice),
+            map.resolve(ALICE_FIRST),
+            Some((alice.clone(), Role::Admin)),
+            "the third field puts the user on the deployment plane"
+        );
+        assert_eq!(
+            map.resolve(ALICE_SECOND),
+            Some((alice, Role::Admin)),
             "a user may hold several tokens"
         );
         assert_eq!(
-            map.resolve("bbbbbbbbbbbbbbbb"),
-            Some(UserId::new("bob").unwrap())
+            map.resolve(BOB_TOKEN),
+            Some((UserId::new("bob").unwrap(), Role::Member)),
+            "no third field is a member"
         );
-        assert_eq!(map.resolve("dddddddddddddddd"), None);
+        assert_eq!(map.resolve("d".repeat(36).as_str()), None);
         assert_eq!(
-            map.resolve("aaaaaaaaaaaaaaa"),
+            map.resolve(&ALICE_FIRST[..ALICE_FIRST.len() - 1]),
             None,
             "prefixes do not match"
         );
@@ -505,20 +598,55 @@ mod tests {
     #[test]
     fn token_map_rejects_files_that_cannot_name_someone_safely() {
         for (text, why) in [
-            ("", "names nobody"),
-            ("# only comments\n", "names nobody"),
-            ("alice\n", "missing token"),
-            ("alice aaaaaaaaaaaaaaaa extra\n", "trailing field"),
-            ("alice short\n", "guessably short token"),
-            ("alice aaaaaaaa,aaaaaaaa\n", "header-unsafe token character"),
-            ("al!ce aaaaaaaaaaaaaaaa\n", "invalid user id"),
+            (String::new(), "names nobody"),
+            ("# only comments\n".into(), "names nobody"),
+            ("alice\n".into(), "missing token"),
             (
-                "alice aaaaaaaaaaaaaaaa\nbob aaaaaaaaaaaaaaaa\n",
+                format!("alice {ALICE_FIRST} admin extra\n"),
+                "trailing field",
+            ),
+            ("alice short\n".into(), "guessably short token"),
+            (
+                format!("alice {}\n", "a".repeat(31)),
+                "token below the 32-character floor",
+            ),
+            (
+                format!("alice {},{}\n", "a".repeat(16), "b".repeat(16)),
+                "header-unsafe token character",
+            ),
+            (format!("al!ce {ALICE_FIRST} admin\n"), "invalid user id"),
+            (
+                format!("alice {ALICE_FIRST} admin\nbob {ALICE_FIRST} admin\n"),
                 "one token must name one user",
             ),
+            (
+                format!("alice {ALICE_FIRST} owner\n"),
+                "the only role field is `admin`",
+            ),
+            (
+                format!("alice {ALICE_FIRST} admin\nalice {ALICE_SECOND}\n"),
+                "a user's lines must agree about their role",
+            ),
+            (
+                format!("alice {ALICE_FIRST}\nbob {BOB_TOKEN}\n"),
+                "a deployment nobody can configure must not start",
+            ),
         ] {
-            assert!(TokenMap::parse(text).is_err(), "{why}: {text:?}");
+            assert!(TokenMap::parse(&text).is_err(), "{why}: {text:?}");
         }
+    }
+
+    /// The two refusals an operator has to act on name the remedy, and the
+    /// zero-admin one is distinguishable from the empty-file one.
+    #[test]
+    fn refusals_that_need_an_operator_edit_say_what_to_add() {
+        let refusal = TokenMap::parse(&format!("alice {ALICE_FIRST}\n"))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            refusal.contains("names no administrator") && refusal.contains("admin"),
+            "the zero-admin refusal must name the fix: {refusal}"
+        );
     }
 
     #[test]

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -279,11 +279,130 @@ pub fn app(state: AppState) -> Router {
         axum::middleware::from_fn_with_state(state.clone(), auth::require_client_executor_token),
     );
 
-    let api = Router::new()
+    // The deployment plane: everything that changes what this deployment *is*
+    // or touches its shared secrets — MCP servers (host processes), provider
+    // and search and execution credentials (writes, deletes, and the presence
+    // reads that reveal their metadata), model roles, global settings writes,
+    // plugin install/enable, and connected-app sign-in/sign-out.
+    //
+    // Membership is decided here rather than in the handlers, so a new config
+    // route is gated by where it is registered. Reads that only tell a client
+    // what the deployment can do stay on the member plane below, including the
+    // `GET` halves of paths whose `PUT` lives here.
+    //
+    // See `docs/decisions/0004-self-host-deployment-plane-authorization.md`.
+    let deployment_api = Router::new()
+        .route("/settings", axum::routing::put(routes::put_settings))
         .route(
-            "/settings",
-            get(routes::get_settings).put(routes::put_settings),
+            // The legacy single-key Anthropic shim writes into the same shared
+            // secret store the typed provider credentials do.
+            "/settings/api-key",
+            axum::routing::put(routes::put_api_key).delete(routes::delete_api_key),
         )
+        .route(
+            "/models/roles/{role}",
+            axum::routing::put(routes::put_model_role),
+        )
+        .route(
+            "/web-search",
+            axum::routing::put(routes::put_web_search_config),
+        )
+        .route(
+            "/web-search/credentials",
+            get(routes::get_web_search_credentials),
+        )
+        .route(
+            "/web-search/credentials/{provider}",
+            axum::routing::put(routes::put_web_search_credential)
+                .delete(routes::delete_web_search_credential)
+                .layer(DefaultBodyLimit::max(MAX_WEB_SEARCH_CREDENTIAL_BODY_BYTES)),
+        )
+        .route(
+            "/code-execution",
+            axum::routing::put(routes::put_code_execution_config)
+                .layer(DefaultBodyLimit::max(MAX_CODE_EXECUTION_CONFIG_BODY_BYTES)),
+        )
+        .route(
+            "/code-execution/credentials",
+            get(routes::get_code_execution_credentials),
+        )
+        .route(
+            "/code-execution/credentials/{provider}",
+            axum::routing::put(routes::put_code_execution_credential)
+                .delete(routes::delete_code_execution_credential)
+                .layer(DefaultBodyLimit::max(
+                    MAX_CODE_EXECUTION_CREDENTIAL_BODY_BYTES,
+                )),
+        )
+        .route(
+            "/mcp/servers",
+            axum::routing::put(routes::put_mcp_servers)
+                .layer(DefaultBodyLimit::max(mcp_config::MAX_CONFIG_BODY_BYTES)),
+        )
+        .route(
+            "/mcp/servers/{name}/reconnect",
+            post(routes::post_mcp_server_reconnect),
+        )
+        .route(
+            "/plugins/install",
+            post(routes::post_plugin_install).layer(DefaultBodyLimit::max(
+                plugin_install::MAX_PLUGIN_INSTALL_BODY_BYTES,
+            )),
+        )
+        .route(
+            "/plugins/enabled",
+            axum::routing::put(routes::put_plugins_enabled)
+                .layer(DefaultBodyLimit::max(routes::MAX_PLUGIN_ENABLE_BODY_BYTES)),
+        )
+        .route(
+            "/connected-apps/rest/{id}",
+            axum::routing::put(routes::put_rest_connected_app)
+                .delete(routes::delete_rest_connected_app)
+                .layer(DefaultBodyLimit::max(
+                    routes::MAX_REST_CONNECTED_APP_BODY_BYTES,
+                )),
+        )
+        .route(
+            "/connected-apps/rest/spec-preview",
+            post(routes::post_rest_spec_preview).layer(DefaultBodyLimit::max(
+                routes::MAX_REST_CONNECTED_APP_BODY_BYTES,
+            )),
+        )
+        .route("/gateway/sign-in", post(routes::post_gateway_sign_in))
+        .route("/gateway/sign-out", post(routes::post_gateway_sign_out))
+        .route(
+            "/gateway/models/sync",
+            post(routes::post_gateway_models_sync),
+        )
+        .route(
+            "/providers/{kind}",
+            axum::routing::put(routes::put_provider),
+        )
+        .route(
+            "/providers/{kind}/credential",
+            axum::routing::delete(routes::delete_provider_credential),
+        )
+        .route(
+            "/providers/openai/chatgpt/sign-in",
+            post(routes::post_openai_chatgpt_sign_in),
+        )
+        .route(
+            "/providers/openai/chatgpt/sign-out",
+            post(routes::post_openai_chatgpt_sign_out),
+        )
+        .route(
+            "/voice-transcription",
+            axum::routing::put(routes::put_voice_transcription)
+                .layer(DefaultBodyLimit::max(voice_transcription::MAX_AUDIO_BYTES)),
+        )
+        .route(
+            "/voice-transcription/install",
+            post(routes::post_voice_transcription_install),
+        )
+        .route_layer(axum::middleware::from_fn(auth::require_admin));
+
+    let api = Router::new()
+        .route("/settings", get(routes::get_settings))
         .route(
             "/projects",
             post(routes::create_project)
@@ -302,75 +421,21 @@ pub fn app(state: AppState) -> Router {
                 )),
         )
         .route("/models", get(routes::list_models))
-        .route(
-            "/models/roles/{role}",
-            axum::routing::put(routes::put_model_role),
-        )
-        .route(
-            "/web-search",
-            get(routes::get_web_search_config).put(routes::put_web_search_config),
-        )
+        .route("/web-search", get(routes::get_web_search_config))
         .route(
             "/code-execution",
             get(routes::get_code_execution_config)
-                .put(routes::put_code_execution_config)
                 .layer(DefaultBodyLimit::max(MAX_CODE_EXECUTION_CONFIG_BODY_BYTES)),
         )
-        .route(
-            "/code-execution/credentials",
-            get(routes::get_code_execution_credentials),
-        )
-        .route(
-            "/code-execution/credentials/{provider}",
-            axum::routing::put(routes::put_code_execution_credential)
-                .delete(routes::delete_code_execution_credential)
-                .layer(DefaultBodyLimit::max(
-                    MAX_CODE_EXECUTION_CREDENTIAL_BODY_BYTES,
-                )),
-        )
-        .route(
-            "/mcp/servers",
-            get(routes::get_mcp_servers)
-                .put(routes::put_mcp_servers)
-                .layer(DefaultBodyLimit::max(mcp_config::MAX_CONFIG_BODY_BYTES)),
-        )
+        .route("/mcp/servers", get(routes::get_mcp_servers))
         .route("/connected-apps", get(routes::get_connected_apps))
         // The installed skill/plugin catalog and its enable flags.
         .route("/plugins", get(routes::get_plugins))
-        .route(
-            "/plugins/install",
-            post(routes::post_plugin_install).layer(DefaultBodyLimit::max(
-                plugin_install::MAX_PLUGIN_INSTALL_BODY_BYTES,
-            )),
-        )
-        .route(
-            "/plugins/enabled",
-            axum::routing::put(routes::put_plugins_enabled)
-                .layer(DefaultBodyLimit::max(routes::MAX_PLUGIN_ENABLE_BODY_BYTES)),
-        )
         .route(
             "/plugins/skills/{name}/instructions",
             get(routes::get_skill_instructions),
         )
         .route("/plugins/prompts/{name}/body", get(routes::get_prompt_body))
-        .route(
-            "/connected-apps/rest/{id}",
-            axum::routing::put(routes::put_rest_connected_app)
-                .delete(routes::delete_rest_connected_app)
-                .layer(DefaultBodyLimit::max(
-                    routes::MAX_REST_CONNECTED_APP_BODY_BYTES,
-                )),
-        )
-        .route(
-            "/connected-apps/rest/spec-preview",
-            post(routes::post_rest_spec_preview).layer(DefaultBodyLimit::max(
-                routes::MAX_REST_CONNECTED_APP_BODY_BYTES,
-            )),
-        )
-        .route(
-            "/mcp/servers/{name}/reconnect",
-            post(routes::post_mcp_server_reconnect),
-        )
         .route(
             "/mcp/servers/{name}/view-session",
             post(routes::post_mcp_view_session),
@@ -402,53 +467,16 @@ pub fn app(state: AppState) -> Router {
         .route("/policy", get(routes::get_policy))
         .route("/gateway/status", get(routes::get_gateway_status))
         .route("/gateway/apps", get(routes::get_gateway_apps))
-        .route("/gateway/sign-in", post(routes::post_gateway_sign_in))
-        .route("/gateway/sign-out", post(routes::post_gateway_sign_out))
         .route(
             "/gateway/pairing/dismiss",
             post(routes::post_gateway_pairing_dismiss),
-        )
-        .route(
-            "/gateway/models/sync",
-            post(routes::post_gateway_models_sync),
-        )
-        .route(
-            "/web-search/credentials",
-            get(routes::get_web_search_credentials),
-        )
-        .route(
-            "/web-search/credentials/{provider}",
-            axum::routing::put(routes::put_web_search_credential)
-                .delete(routes::delete_web_search_credential)
-                .layer(DefaultBodyLimit::max(MAX_WEB_SEARCH_CREDENTIAL_BODY_BYTES)),
         )
         .route("/providers", get(routes::list_providers))
         .route(
             "/voice-transcription",
             get(routes::get_voice_transcription)
-                .put(routes::put_voice_transcription)
                 .post(routes::post_voice_transcription)
                 .layer(DefaultBodyLimit::max(voice_transcription::MAX_AUDIO_BYTES)),
-        )
-        .route(
-            "/voice-transcription/install",
-            post(routes::post_voice_transcription_install),
-        )
-        .route(
-            "/providers/{kind}",
-            axum::routing::put(routes::put_provider),
-        )
-        .route(
-            "/providers/{kind}/credential",
-            axum::routing::delete(routes::delete_provider_credential),
-        )
-        .route(
-            "/providers/openai/chatgpt/sign-in",
-            post(routes::post_openai_chatgpt_sign_in),
-        )
-        .route(
-            "/providers/openai/chatgpt/sign-out",
-            post(routes::post_openai_chatgpt_sign_out),
         )
         .route(
             "/providers/openai/chatgpt/status",
@@ -496,10 +524,6 @@ pub fn app(state: AppState) -> Router {
         .route(
             "/chats/{chat_id}/agent-runs/{run_id}/steer",
             post(routes::post_agent_run_steer),
-        )
-        .route(
-            "/settings/api-key",
-            axum::routing::put(routes::put_api_key).delete(routes::delete_api_key),
         )
         .route("/chats/{id}/messages", post(routes::post_message))
         .route("/chats/{id}/cancel", post(routes::post_cancel))
@@ -557,6 +581,11 @@ pub fn app(state: AppState) -> Router {
         )
         .route("/chats/{id}/events", get(routes::chat_events))
         .merge(client_executor_api)
+        // Merged before the bearer layer, so `require_token` wraps outside
+        // `require_admin`: an unauthenticated request to a deployment-plane
+        // route is a 401 from the bearer check, and only an authenticated
+        // member reaches the role check's 403.
+        .merge(deployment_api)
         .route_layer(axum::middleware::from_fn_with_state(
             state.clone(),
             auth::require_token,

--- a/crates/openwave-server/src/principal.rs
+++ b/crates/openwave-server/src/principal.rs
@@ -15,6 +15,12 @@
 //!   marks a bit on an existing context; it cannot conjure an identity on its
 //!   own. [`ClientExecutor`] types that requirement into handler signatures so
 //!   it survives router refactors.
+//!
+//! A principal also carries a [`Role`]: the split between the member plane
+//! (owner-scoped data and capability discovery) and the deployment plane
+//! (what the deployment *is*, and its shared secrets) is enforced by
+//! [`crate::auth::require_admin`] over the role resolved here — see
+//! `docs/decisions/0004-self-host-deployment-plane-authorization.md`.
 
 use std::fmt;
 use std::sync::Arc;
@@ -23,6 +29,21 @@ use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
 use axum::http::StatusCode;
 use openwave_core::{AgentError, OwnerId, Result};
+
+/// What a principal is permitted to reach.
+///
+/// Two values, deliberately: the concrete gap the split closes is binary —
+/// host command execution and shared-secret custody versus everything else.
+/// A grant vocabulary would be guessed until someone asks for delegated
+/// partial administration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Role {
+    /// May reconfigure the deployment and hold its shared secrets.
+    Admin,
+    /// May use the deployment and see their own data. Everything else is a
+    /// `403`.
+    Member,
+}
 
 /// The authenticated identity a request acts as.
 ///
@@ -39,7 +60,12 @@ pub enum Principal {
     LocalOwner,
     /// A named user on a shared deployment, resolved from a configured
     /// credential (today the self-host token file — see [`crate::auth`]).
-    User(UserId),
+    User {
+        /// Who the credential names.
+        id: UserId,
+        /// What the token file says they may reconfigure.
+        role: Role,
+    },
 }
 
 impl Principal {
@@ -54,8 +80,20 @@ impl Principal {
     pub fn owner_id(&self) -> OwnerId {
         match self {
             Self::LocalOwner => OwnerId::local(),
-            Self::User(id) => OwnerId::new(&format!("user:{id}"))
+            Self::User { id, .. } => OwnerId::new(&format!("user:{id}"))
                 .expect("a validated user id forms a valid owner key"),
+        }
+    }
+
+    /// Whether this principal may reach the deployment plane.
+    ///
+    /// The local owner is unconditionally admin: the desktop profile is one
+    /// person at one machine, and there is nobody to be an administrator over.
+    #[must_use]
+    pub fn is_admin(&self) -> bool {
+        match self {
+            Self::LocalOwner => true,
+            Self::User { role, .. } => *role == Role::Admin,
         }
     }
 }

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -53,6 +53,12 @@ mod workers;
 use conversations::patch_chat;
 use lifecycle::{post_json, post_native_json, steer_turn, steer_turn_with_id};
 
+/// Self-host fixture credentials, named rather than inlined: the token floor
+/// is 32 characters, and inline high-entropy literals trip the secret scan.
+/// Alice administers the fixture deployments; Bob is a member.
+const ALICE_TOKEN: &str = "alice-token-padded-out-to-thirty-two";
+const BOB_TOKEN: &str = "bob-token-padded-out-to-thirty-two-x";
+
 struct MigratedSqliteTemplate {
     _directory: tempfile::TempDir,
     database: std::path::PathBuf,

--- a/crates/openwave-server/src/tests/conformance.rs
+++ b/crates/openwave-server/src/tests/conformance.rs
@@ -16,18 +16,17 @@ use openwave_core::{ApprovalDecision, ApprovalGate, ApprovalRequest};
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 
-const ALICE_TOKEN: &str = "alice-token-0123456789abcdef";
-const BOB_TOKEN: &str = "bob-token-9876543210fedcba";
-
 /// A self-host app over one shared store, authenticating the two named
-/// principals above (and nothing else).
+/// principals above (and nothing else). Alice administers the deployment;
+/// Bob is an ordinary member, which is also what makes this fixture a valid
+/// token file — one that names no admin refuses to load.
 async fn self_host_app() -> (Router, AppState, Arc<dyn Store>, tempfile::TempDir) {
     let (dir, store) = temp_db_store("conformance.db").await;
     let store: Arc<dyn Store> = Arc::new(store);
     let tokens_file = dir.path().join("tokens");
     std::fs::write(
         &tokens_file,
-        format!("alice {ALICE_TOKEN}\nbob {BOB_TOKEN}\n"),
+        format!("alice {ALICE_TOKEN} admin\nbob {BOB_TOKEN}\n"),
     )
     .unwrap();
     let mut config = Config::desktop(dir.path());
@@ -441,4 +440,148 @@ async fn self_host_boot_fails_closed_without_a_principal_naming_authenticator() 
         refusal.contains("names no principals"),
         "an empty authenticator must refuse boot: {refusal}"
     );
+
+    // Nor can it open behind an authenticator nobody can configure through.
+    std::fs::write(
+        config.auth_tokens_file.as_deref().unwrap(),
+        format!("alice {ALICE_TOKEN}\n"),
+    )
+    .unwrap();
+    let refusal = match crate::connect_store(&config).await {
+        Err(refusal) => refusal.to_string(),
+        Ok(_) => panic!("a self-host store must not open with no administrator"),
+    };
+    assert!(
+        refusal.contains("names no administrator"),
+        "a deployment nobody can configure must refuse boot: {refusal}"
+    );
+}
+
+/// The deployment plane, enumerated. This list is the canonical statement of
+/// which routes reconfigure the deployment or touch its shared secrets: a
+/// member is refused every one of them, and an admin passes the gate on every
+/// one of them.
+///
+/// Enumerating the assembled router is the point. A gate that matched path
+/// prefixes in middleware would survive spot checks on the routes someone
+/// remembered, and silently exempt the next config route whose path does not
+/// fit the pattern.
+fn deployment_plane_routes() -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("PUT", "/settings"),
+        ("PUT", "/settings/api-key"),
+        ("DELETE", "/settings/api-key"),
+        ("PUT", "/models/roles/default"),
+        ("PUT", "/web-search"),
+        ("GET", "/web-search/credentials"),
+        ("PUT", "/web-search/credentials/brave"),
+        ("DELETE", "/web-search/credentials/brave"),
+        ("PUT", "/code-execution"),
+        ("GET", "/code-execution/credentials"),
+        ("PUT", "/code-execution/credentials/e2b"),
+        ("DELETE", "/code-execution/credentials/e2b"),
+        ("PUT", "/mcp/servers"),
+        ("POST", "/mcp/servers/example/reconnect"),
+        ("POST", "/plugins/install"),
+        ("PUT", "/plugins/enabled"),
+        ("PUT", "/connected-apps/rest/example"),
+        ("DELETE", "/connected-apps/rest/example"),
+        ("POST", "/connected-apps/rest/spec-preview"),
+        ("POST", "/gateway/sign-in"),
+        ("POST", "/gateway/sign-out"),
+        ("POST", "/gateway/models/sync"),
+        ("PUT", "/providers/anthropic"),
+        ("DELETE", "/providers/anthropic/credential"),
+        ("POST", "/providers/openai/chatgpt/sign-in"),
+        ("POST", "/providers/openai/chatgpt/sign-out"),
+        ("PUT", "/voice-transcription"),
+        ("POST", "/voice-transcription/install"),
+    ]
+}
+
+/// A representative slice of the member plane: reads that only reveal what the
+/// deployment can do, plus the owner-scoped data surface. None of these may
+/// become a `403` when the role gate lands.
+fn member_plane_routes() -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("GET", "/settings"),
+        ("GET", "/models"),
+        ("GET", "/web-search"),
+        ("GET", "/code-execution"),
+        ("GET", "/mcp/servers"),
+        ("GET", "/plugins"),
+        ("GET", "/connected-apps"),
+        ("GET", "/apps"),
+        ("GET", "/policy"),
+        ("GET", "/gateway/status"),
+        ("GET", "/gateway/apps"),
+        ("GET", "/providers"),
+        ("GET", "/providers/openai/chatgpt/status"),
+        ("GET", "/voice-transcription"),
+        ("GET", "/chats"),
+        ("GET", "/projects"),
+        ("GET", "/documents"),
+        ("GET", "/inbox"),
+        ("GET", "/grants"),
+        ("GET", "/consent/statements"),
+    ]
+}
+
+/// The plane split, driven across the real router with a real admin and a real
+/// member. `403` is the only status under test: what a deployment-plane
+/// handler does once the gate lets it through is its own concern, so any other
+/// status counts as having passed.
+#[tokio::test]
+async fn the_deployment_plane_admits_admins_and_refuses_members() {
+    let (router, _state, _store, _dir) = self_host_app().await;
+    let admin = format!("Bearer {ALICE_TOKEN}");
+    let member = format!("Bearer {BOB_TOKEN}");
+    let body = Some(serde_json::json!({}));
+
+    for (method, uri) in deployment_plane_routes() {
+        let response = request(&router, method, uri, &member, body.clone()).await;
+        assert_eq!(
+            response.status(),
+            StatusCode::FORBIDDEN,
+            "{method} {uri} reconfigures the deployment and must refuse a member"
+        );
+        let status = request(&router, method, uri, &admin, body.clone())
+            .await
+            .status();
+        assert!(
+            status != StatusCode::FORBIDDEN && status != StatusCode::UNAUTHORIZED,
+            "{method} {uri} must let an admin past the gate, got {status}"
+        );
+    }
+
+    for (method, uri) in member_plane_routes() {
+        let status = request(&router, method, uri, &member, None).await.status();
+        assert!(
+            status != StatusCode::FORBIDDEN && status != StatusCode::UNAUTHORIZED,
+            "{method} {uri} reveals only capability or the caller's own data, \
+             but answered {status} to a member"
+        );
+    }
+}
+
+/// The plausible wrong implementation: a role gate that defaults an identity
+/// when none was attached would pass every authenticated test above. It must
+/// fail closed instead, exactly like the `AuthContext` extractor.
+#[tokio::test]
+async fn the_role_gate_rejects_a_route_no_auth_middleware_covers() {
+    let app = Router::new()
+        .route("/settings", axum::routing::put(|| async { "leaked" }))
+        .route_layer(axum::middleware::from_fn(crate::auth::require_admin));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/settings")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }

--- a/crates/openwave-server/src/tests/lifecycle.rs
+++ b/crates/openwave-server/src/tests/lifecycle.rs
@@ -3021,7 +3021,11 @@ async fn self_host_tokens_resolve_named_principals() {
     let (dir, store) = temp_db_store("self-host-auth.db").await;
     let store: Arc<dyn Store> = Arc::new(store);
     let tokens_file = dir.path().join("tokens");
-    std::fs::write(&tokens_file, "# staff\nalice aaaaaaaaaaaaaaaa\n").unwrap();
+    std::fs::write(
+        &tokens_file,
+        format!("# staff\nalice {ALICE_TOKEN} admin\n"),
+    )
+    .unwrap();
     let mut config = Config::desktop(dir.path());
     config.profile = openwave_core::Profile::SelfHost;
     config.auth_tokens_file = Some(tokens_file);
@@ -3040,7 +3044,7 @@ async fn self_host_tokens_resolve_named_principals() {
 
     let whoami = |auth: AuthContext| async move {
         match auth.principal {
-            Principal::User(user) => user.to_string(),
+            Principal::User { id, .. } => id.to_string(),
             other => format!("unexpected principal {other:?}"),
         }
     };
@@ -3058,20 +3062,12 @@ async fn self_host_tokens_resolve_named_principals() {
             .unwrap()
     };
 
-    let response = probe
-        .clone()
-        .oneshot(request("aaaaaaaaaaaaaaaa"))
-        .await
-        .unwrap();
+    let response = probe.clone().oneshot(request(ALICE_TOKEN)).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
     let body = to_bytes(response.into_body(), 1024).await.unwrap();
     assert_eq!(&body[..], b"alice", "the named token identifies its user");
 
-    let response = probe
-        .clone()
-        .oneshot(request("bbbbbbbbbbbbbbbb"))
-        .await
-        .unwrap();
+    let response = probe.clone().oneshot(request(BOB_TOKEN)).await.unwrap();
     assert_eq!(
         response.status(),
         StatusCode::UNAUTHORIZED,
@@ -3103,7 +3099,7 @@ async fn routes_scope_root_aggregates_to_the_requesting_principal() {
     let tokens_file = dir.path().join("tokens");
     std::fs::write(
         &tokens_file,
-        "alice aaaaaaaaaaaaaaaa\nbob bbbbbbbbbbbbbbbb\n",
+        format!("alice {ALICE_TOKEN} admin\nbob {BOB_TOKEN}\n"),
     )
     .unwrap();
     let mut config = Config::desktop(dir.path());
@@ -3121,13 +3117,14 @@ async fn routes_scope_root_aggregates_to_the_requesting_principal() {
         },
     );
     let router = app(state);
-    let alice = "Bearer aaaaaaaaaaaaaaaa";
-    let bob = "Bearer bbbbbbbbbbbbbbbb";
+    let alice = format!("Bearer {ALICE_TOKEN}");
+    let bob = format!("Bearer {BOB_TOKEN}");
 
-    let chat = make_chat(&router, alice).await;
+    let chat = make_chat(&router, &alice).await;
 
     // Alice sees her chat; Bob's view holds no trace of it.
-    let get = |bearer: &'static str, uri: String| {
+    let get = |bearer: &str, uri: String| {
+        let bearer = bearer.to_owned();
         let router = router.clone();
         async move {
             router
@@ -3143,22 +3140,22 @@ async fn routes_scope_root_aggregates_to_the_requesting_principal() {
         }
     };
     assert_eq!(
-        get(alice, format!("/chats/{}", chat.id)).await.status(),
+        get(&alice, format!("/chats/{}", chat.id)).await.status(),
         StatusCode::OK
     );
     assert_eq!(
-        get(bob, format!("/chats/{}", chat.id)).await.status(),
+        get(&bob, format!("/chats/{}", chat.id)).await.status(),
         StatusCode::NOT_FOUND,
         "another owner's chat must be indistinguishable from a missing one"
     );
     assert_eq!(
-        get(bob, format!("/chats/{}/messages", chat.id))
+        get(&bob, format!("/chats/{}/messages", chat.id))
             .await
             .status(),
         StatusCode::NOT_FOUND,
         "the transcript behind the chat is equally invisible"
     );
-    let listed: Vec<Chat> = json_body(get(bob, "/chats".to_owned()).await).await;
+    let listed: Vec<Chat> = json_body(get(&bob, "/chats".to_owned()).await).await;
     assert!(
         listed.is_empty(),
         "a listing never carries another owner's rows"
@@ -3168,13 +3165,13 @@ async fn routes_scope_root_aggregates_to_the_requesting_principal() {
     // approval or question set is only reachable through the chat that owns it.
     for path in ["plans/pending", "questions/pending", "task-plan"] {
         assert_eq!(
-            get(alice, format!("/chats/{}/{path}", chat.id))
+            get(&alice, format!("/chats/{}/{path}", chat.id))
                 .await
                 .status(),
             StatusCode::OK
         );
         assert_eq!(
-            get(bob, format!("/chats/{}/{path}", chat.id))
+            get(&bob, format!("/chats/{}/{path}", chat.id))
                 .await
                 .status(),
             StatusCode::NOT_FOUND,
@@ -3187,7 +3184,7 @@ async fn routes_scope_root_aggregates_to_the_requesting_principal() {
     // hers alone, and Bob's inbox does not even learn her chat exists.
     park_user_questions_for_route_test(&*prompts_store, chat.id).await;
     let alice_prompts: Vec<serde_json::Value> =
-        json_body(get(alice, "/chats/pending-prompts".to_owned()).await).await;
+        json_body(get(&alice, "/chats/pending-prompts".to_owned()).await).await;
     assert_eq!(
         alice_prompts
             .iter()
@@ -3197,7 +3194,7 @@ async fn routes_scope_root_aggregates_to_the_requesting_principal() {
         "the owner still sees her own parked prompt"
     );
     let bob_prompts: Vec<serde_json::Value> =
-        json_body(get(bob, "/chats/pending-prompts".to_owned()).await).await;
+        json_body(get(&bob, "/chats/pending-prompts".to_owned()).await).await;
     assert!(
         bob_prompts.is_empty(),
         "the prompt inbox never carries another owner's parked prompts"
@@ -3210,7 +3207,7 @@ async fn routes_scope_root_aggregates_to_the_requesting_principal() {
             Request::builder()
                 .method("PATCH")
                 .uri(format!("/chats/{}", chat.id))
-                .header(header::AUTHORIZATION, bob)
+                .header(header::AUTHORIZATION, &bob)
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from(
                     serde_json::json!({"title": "taken over"}).to_string(),
@@ -3226,7 +3223,7 @@ async fn routes_scope_root_aggregates_to_the_requesting_principal() {
             Request::builder()
                 .method("DELETE")
                 .uri(format!("/chats/{}", chat.id))
-                .header(header::AUTHORIZATION, bob)
+                .header(header::AUTHORIZATION, &bob)
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -3235,7 +3232,7 @@ async fn routes_scope_root_aggregates_to_the_requesting_principal() {
     assert_eq!(delete.status(), StatusCode::NOT_FOUND);
 
     // The chat survives the failed takeover, untouched.
-    let survived = get(alice, format!("/chats/{}", chat.id)).await;
+    let survived = get(&alice, format!("/chats/{}", chat.id)).await;
     assert_eq!(survived.status(), StatusCode::OK);
     let survived: Chat = json_body(survived).await;
     assert_eq!(survived.title, None, "a cross-owner patch changed nothing");

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -788,18 +788,34 @@ The pieces, each enforced where it cannot silently drift:
   unless the principal-naming authenticator is configured and names at least
   one user, so a shared store can never exist behind an API that cannot tell
   its callers apart.
+- **Configuration is admin-only.** Every principal carries a role. A token
+  line's optional third field, `admin`, puts that user on the deployment
+  plane; its absence makes them a member, and a file naming no admin refuses
+  to boot alongside the empty-file refusal. The desktop profile's local owner
+  is unconditionally admin.
 
-One deliberate exception, accepted rather than deferred: **settings are
-deployment-scoped, not per-user.** The settings table configures the
-deployment itself — enabled providers and credentials, model roles,
-web-search and code-execution configuration, managed policy — and the issue
-itself observed that a credential able to reconfigure the app is not
-containable per-user by a row filter. Every named user on a self-host
-deployment shares (and can change) that configuration, so the profile is for
-mutually trusting users of one operator's deployment — a household or a small
-team — not for adversarial tenants. Per-user preference settings can split
-out of the deployment table if that boundary is ever needed; multi-tenant
-isolation is explicitly not claimed.
+**The deployment plane, and what a member keeps.** The API is split in the
+router, not in the handlers: routes that change what the deployment *is* or
+touch its shared secrets — MCP server configuration (host processes), provider,
+web-search and code-execution credentials including the presence reads that
+reveal their metadata, model roles, settings writes, plugin install and enable,
+and connected-app sign-in/sign-out — are assembled into a sub-router behind an
+admin gate, and answer a member `403`. Members keep everything else: their own
+chats, projects, documents and event streams, and the reads that only tell a
+client what the deployment can do (the model list, the plugin catalog, the app
+library, the non-secret configuration reads). A new configuration route is
+admin-gated by where it is registered rather than by whether its author
+remembered a check, and a route-table conformance suite drives one admin and
+one member across the assembled router to keep that classification honest.
+Roles beyond the two, groups, per-capability grants, and per-user provider
+credentials are deliberately excluded — see
+[decision 4](decisions/0004-self-host-deployment-plane-authorization.md).
+
+Configuration remains deployment-scoped rather than per-user: the settings
+table configures the deployment itself, shared credentials are the point of a
+team deployment, and MCP servers are host processes. The profile targets one
+operator's small team, not adversarial tenants; multi-tenant isolation is
+explicitly not claimed.
 
 ## Where the code lives
 


### PR DESCRIPTION
Implements the Decision section of
[`docs/decisions/0004-self-host-deployment-plane-authorization.md`](docs/decisions/0004-self-host-deployment-plane-authorization.md),
stacked on the record's own PR.

## What changed

- **Principals carry a role.** `Role { Admin, Member }` in `principal.rs`;
  `Principal::LocalOwner` is unconditionally admin (desktop is one person at
  one machine), and `Principal::User` became a struct variant carrying the id
  and the role resolved from the token file.
- **The token file grew an optional third field.** `<user-id> <token> [admin]`.
  Absent means member; any other value is a parse error rather than a silent
  demotion. A user whose lines disagree about the role fails parse with the
  line number, and a file naming no admin at all refuses to load next to the
  existing empty-file refusal — the error names the fix. Module docs and the
  worked example are updated.
- **`require_admin` middleware.** Mirrors `require_client_executor_token`: it
  reads the `AuthContext` the bearer middleware already attached, passes
  admins, answers a member `403`, and returns `401` when no context is present.
  It never mints or defaults an identity.
- **Router split.** The deployment-plane routes are assembled into a
  `deployment_api` sub-router carrying the `require_admin` layer, merged into
  the api router before the `require_token` layer goes on — so the bearer check
  wraps outside the role check, and an unauthenticated request to a config
  route is still a `401`.
- **Riders.** `MIN_TOKEN_LEN` 16 → 32. The auth module docs note that the
  WebSocket token rides `Sec-WebSocket-Protocol`, an ordinary request header
  that intermediary proxies log far more readily than `Authorization`, and that
  a self-host deployment behind someone else's fronting should assume it lands
  in their access logs. The Self-host section of `docs/how-openwave-works.md`
  gains a paragraph on the split (and its now-superseded "settings are
  deployment-scoped, every user can change them" exception is rewritten to
  match).

## Plane classification

The line is the record's: the deployment plane is anything that changes what
the deployment *is* or touches its shared secrets — MCP server configuration
(operator-specified `command`+`args` processes on the host), provider,
web-search and code-execution credentials including the presence reads, since
those reveal secret metadata rather than capability, model roles, settings
writes, plugin install and enable, connected-app REST registration and
spec-preview (it fetches an operator-named URL), and gateway/ChatGPT
sign-in/sign-out. The member plane keeps every owner-scoped data route and
every read that only tells a client what the deployment can *do*: the model
list, the plugin catalog and its skill/prompt bodies, the app library and
grants, `/policy`, gateway status and apps, the providers list, and the `GET`
halves of `/settings`, `/web-search`, `/code-execution` and `/mcp/servers`,
none of which carry credential material. `/voice-transcription` splits three
ways for the same reason: `PUT` (which model is installed) is admin, while
`GET` and the `POST` that actually transcribes audio are ordinary use.

One route is gated that the issue discussion's list did not name:
**`PUT`/`DELETE /settings/api-key`**, the legacy single-key Anthropic shim. It
writes and deletes a provider credential in the same shared secret store the
typed `/providers/{kind}` routes use, so leaving it on the member plane would
have left the credential-custody hole open through the older door. It is
enumerated in the conformance table with the rest.

## Splitting a path across the two routers

axum merges method routers for the same path as long as the methods are
disjoint, and `route_layer` applies per-method, so `GET /settings` (member) and
`PUT /settings` (admin) coexist with different layers after the merge. No
per-method layering workaround was needed; the conformance test drives both
halves of every split path to confirm it behaves as well as compiles. Body-size
limits that previously sat on a combined method router moved to the half that
needs them.

## Tests

- **`the_deployment_plane_admits_admins_and_refuses_members`** — the substance.
  Drives one admin and one member across the assembled router. Every one of the
  28 deployment-plane method/path pairs is enumerated in the test as the
  canonical list: a member must get `403`, an admin must get anything other
  than `401`/`403`. A representative 20-route member-plane set must not become
  a `403`. Enumerating the real router is the point — a middleware that gated
  by path prefix would pass spot checks and silently exempt the next config
  route whose path doesn't fit the pattern.
- **`the_role_gate_rejects_a_route_no_auth_middleware_covers`** — the plausible
  wrong implementation. A gate that attached its own default `AuthContext`
  would pass every authenticated assertion above, so this mirrors the existing
  fail-closed extractor test and asserts `401`.
- **`auth::tests::token_map_*`** — the existing parse tables gained the role
  cases (`admin` parses, bogus third field rejected, inconsistent user
  rejected, zero-admin file rejected, sub-32-character token rejected), and one
  small test asserts the zero-admin refusal names the remedy.

Behavior changes to existing tests, one line each:

- `tests/conformance.rs::self_host_app` — the fixture file now marks alice
  `admin` and leaves bob a member. Promoted rather than weakened: a file with
  no admin no longer loads at all, and the pairing is what gives the new
  conformance test its two principals.
- `tests/conformance.rs::self_host_boot_fails_closed_without_a_principal_naming_authenticator`
  — gained a third case: a file that names a user but no administrator is
  refused at `connect_store` the same way an empty one is.
- `tests/lifecycle.rs` self-host fixtures — token literals lengthened past the
  new 32-character floor and hoisted to shared `ALICE_TOKEN`/`BOB_TOKEN`
  consts in `tests.rs` (inline high-entropy strings trip the secret-scan lane);
  the `whoami` probe destructures the struct variant.

No per-route member-denial cases were added outside the conformance table.

Verified locally: `cargo check -p openwave-server --locked`,
`cargo test -p openwave-server --locked` (755 tests, all green),
`cargo fmt --all -- --check`.
