### PR TITLE
feat(server): make the self-host listen address configurable

### DIFF
--- a/crates/openwave-cli/src/main.rs
+++ b/crates/openwave-cli/src/main.rs
@@ -1,13 +1,16 @@
 //! OpenWave CLI — the headless daemon and MCP server.
 //!
-//! `openwave serve` boots the in-process HTTP/WebSocket surface on a loopback
-//! port and prints the address and per-launch bearer token it minted, so a local
-//! client (the desktop shell, or a script) can connect. Configuration comes from
+//! `openwave serve` boots the in-process HTTP/WebSocket surface and prints the
+//! address it bound, so a local client (the desktop shell, or a script) can
+//! connect. It binds a loopback, ephemeral port by default, and prints the
+//! per-launch bearer token it minted alongside the address — except on the
+//! self-host profile, where that token authenticates nobody and the address
+//! may be set with `OPENWAVE_LISTEN_ADDR`. Configuration comes from
 //! the environment via [`Config::from_env`] (`OPENWAVE_PROFILE`,
-//! `OPENWAVE_DATA_DIR`, `OPENWAVE_CONTAINER_EXECUTION_ENABLED`, and
-//! `OPENWAVE_CONTAINER_IMAGE`); the model API key comes from
-//! `ANTHROPIC_API_KEY`, and `OPENWAVE_MCP_CONFIG` may name an external
-//! stdio-server configuration file.
+//! `OPENWAVE_DATA_DIR`, `OPENWAVE_CONTAINER_EXECUTION_ENABLED`,
+//! `OPENWAVE_CONTAINER_IMAGE`, and `OPENWAVE_LISTEN_ADDR`); the model API key
+//! comes from `ANTHROPIC_API_KEY`, and `OPENWAVE_MCP_CONFIG` may name an
+//! external stdio-server configuration file.
 //!
 //! `openwave mcp <workspace>` serves the built-in read-only filesystem tools over
 //! MCP stdio, confined to the explicit workspace directory.
@@ -32,7 +35,9 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use openwave_core::{AgentError, ChatId, Config, ListDir, ReadFile, Result, ToolCtx, ToolRegistry};
+use openwave_core::{
+    AgentError, ChatId, Config, ListDir, Profile, ReadFile, Result, ToolCtx, ToolRegistry,
+};
 
 mod api;
 mod print;
@@ -172,16 +177,24 @@ fn profile_config() -> Result<Config> {
 /// Bind the server and run its accept loop, announcing where to reach it.
 async fn serve() -> Result<()> {
     let config = profile_config()?;
+    let profile = config.profile;
     // Tracing events land in `logs/openwave.log` under the profile data dir
     // (plus stderr in debug builds); see `openwave_server::logging`.
     openwave_server::logging::init_logging(&config.data_dir);
     let server = openwave_server::bind_configured(config).await?;
-    // The address and token are the client's entry point: the parent process that
-    // launched the daemon reads them from stdout to connect. The token is a secret,
-    // so an integrator should capture this process's stdout directly (a piped
-    // child) rather than run the daemon under a logging supervisor.
+    // The address is the client's entry point: the parent process that launched
+    // the daemon reads it from stdout to connect, and a container entrypoint
+    // waits on the same line.
     println!("openwave: listening on http://{}", server.local_addr());
-    println!("openwave: token {}", server.token());
+    // The token is a secret, so an integrator should capture this process's
+    // stdout directly (a piped child) rather than run the daemon under a
+    // logging supervisor. On self-host it is not printed at all: the
+    // per-launch bearer names nobody on a shared deployment and authenticates
+    // nobody there (see the server's `auth` module docs), so printing it into
+    // a container's logs would only invite someone to try it.
+    if profile != Profile::SelfHost {
+        println!("openwave: token {}", server.token());
+    }
     server.serve().await
 }
 

--- a/crates/openwave-core/src/config.rs
+++ b/crates/openwave-core/src/config.rs
@@ -12,6 +12,7 @@
 //!   they change while the app runs, so they don't belong here.
 
 use std::ffi::OsString;
+use std::net::{Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -93,7 +94,21 @@ pub struct Config {
     /// ignores this.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth_tokens_file: Option<PathBuf>,
+    /// The address the API binds, for deployments that must be reachable from
+    /// outside the machine (a container publishing a port, say). `None` — the
+    /// default — keeps the loopback, ephemeral-port bind every profile has
+    /// always used.
+    ///
+    /// Honoured only by [`Profile::SelfHost`]. Setting it on the desktop
+    /// profile is a boot error rather than a silent override: see
+    /// [`Config::bind_addr`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub listen_addr: Option<SocketAddr>,
 }
+
+/// The bind every profile uses when no address is configured: loopback, and
+/// an ephemeral port the OS picks.
+const DEFAULT_BIND: SocketAddr = SocketAddr::new(std::net::IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
 
 impl Config {
     /// The per-install directory user-authored skill packages are read from.
@@ -149,6 +164,7 @@ impl Config {
             container_execution_enabled: false,
             container_image: None,
             auth_tokens_file: None,
+            listen_addr: None,
         }
     }
 
@@ -158,8 +174,9 @@ impl Config {
     /// this to the platform's app-data location),
     /// `OPENWAVE_CONTAINER_EXECUTION_ENABLED` (default `false`),
     /// `OPENWAVE_CONTAINER_IMAGE` (defaulting to the server's default agent
-    /// image), and `OPENWAVE_AUTH_TOKENS_FILE` (self-host only; required
-    /// there).
+    /// image), `OPENWAVE_AUTH_TOKENS_FILE` (self-host only; required there),
+    /// and `OPENWAVE_LISTEN_ADDR` (self-host only; default loopback on an
+    /// ephemeral port).
     pub fn from_env() -> Result<Self> {
         Self::from_vars(
             std::env::var("OPENWAVE_PROFILE").ok(),
@@ -167,6 +184,7 @@ impl Config {
             std::env::var("OPENWAVE_CONTAINER_EXECUTION_ENABLED").ok(),
             std::env::var("OPENWAVE_CONTAINER_IMAGE").ok(),
             std::env::var_os("OPENWAVE_AUTH_TOKENS_FILE"),
+            std::env::var("OPENWAVE_LISTEN_ADDR").ok(),
         )
     }
 
@@ -183,6 +201,7 @@ impl Config {
         container_execution_enabled: Option<String>,
         container_image: Option<String>,
         auth_tokens_file: Option<OsString>,
+        listen_addr: Option<String>,
     ) -> Result<Self> {
         let profile = match profile.filter(|value| !value.is_empty()).as_deref() {
             None | Some("desktop") => Profile::Desktop,
@@ -208,6 +227,15 @@ impl Config {
         let auth_tokens_file = auth_tokens_file
             .filter(|path| !path.is_empty())
             .map(PathBuf::from);
+        let listen_addr = match listen_addr.filter(|value| !value.is_empty()) {
+            None => None,
+            Some(value) => Some(value.parse::<SocketAddr>().map_err(|_| {
+                AgentError::config(format!(
+                    "invalid OPENWAVE_LISTEN_ADDR {value:?}: expected an address and port, \
+                     e.g. `0.0.0.0:8080`"
+                ))
+            })?),
+        };
         Ok(Self {
             profile,
             data_dir,
@@ -220,7 +248,34 @@ impl Config {
             container_execution_enabled,
             container_image,
             auth_tokens_file,
+            listen_addr,
         })
+    }
+
+    /// The socket the API should bind for this config.
+    ///
+    /// Absent configuration means loopback on an ephemeral port, which is what
+    /// every profile did before the address was configurable.
+    ///
+    /// **The desktop profile refuses a configured address rather than
+    /// honouring it.** That server's per-launch bearer is the only thing
+    /// standing between the agent and any other process on the machine, and
+    /// its `Origin`/`Host` checks assume a loopback bind; a desktop server
+    /// listening on a routable interface would be a different security posture
+    /// reached by an environment variable nobody reviewed. Failing the boot is
+    /// the point — silently ignoring the variable would leave an operator
+    /// believing they had published a port.
+    pub fn bind_addr(&self) -> Result<SocketAddr> {
+        match (self.profile, self.listen_addr) {
+            (_, None) => Ok(DEFAULT_BIND),
+            (Profile::SelfHost, Some(addr)) => Ok(addr),
+            (Profile::Desktop, Some(addr)) => Err(AgentError::config(format!(
+                "refusing to bind the desktop profile to {addr}: the desktop server is \
+                 loopback-only, and its per-launch token is the only thing separating the \
+                 agent from other local processes. Unset OPENWAVE_LISTEN_ADDR, or run \
+                 OPENWAVE_PROFILE=self_host to publish a port"
+            ))),
+        }
     }
 
     /// The default `Store` connection URL for this config.
@@ -267,7 +322,8 @@ mod tests {
     fn empty_data_dir_var_falls_back_to_the_default() {
         // `OPENWAVE_DATA_DIR=` (set but empty) must behave like unset, not point
         // the store at `openwave.db` in the current directory.
-        let config = Config::from_vars(None, Some(OsString::new()), None, None, None).unwrap();
+        let config =
+            Config::from_vars(None, Some(OsString::new()), None, None, None, None).unwrap();
         let expected = std::env::current_dir().unwrap().join(".openwave");
         assert_eq!(config.data_dir, expected);
         assert_eq!(config.profile, Profile::Desktop);
@@ -278,6 +334,7 @@ mod tests {
         let config = Config::from_vars(
             Some(String::new()),
             Some(OsString::from("/data")),
+            None,
             None,
             None,
             None,
@@ -294,6 +351,7 @@ mod tests {
             None,
             None,
             Some(OsString::from("/etc/openwave/tokens")),
+            None,
         )
         .unwrap();
         assert_eq!(config.profile, Profile::SelfHost);
@@ -306,7 +364,52 @@ mod tests {
 
     #[test]
     fn unknown_profile_var_is_an_error() {
-        assert!(Config::from_vars(Some("bogus".into()), None, None, None, None).is_err());
+        assert!(Config::from_vars(Some("bogus".into()), None, None, None, None, None).is_err());
+    }
+
+    /// The desktop server is loopback-only by design, so a configured address
+    /// must stop the boot rather than quietly not applying — an operator who
+    /// set the variable would otherwise believe they had published a port.
+    #[test]
+    fn the_desktop_profile_refuses_a_configured_listen_address() {
+        let mut config = Config::desktop("/data");
+        assert_eq!(config.bind_addr().unwrap(), DEFAULT_BIND);
+
+        config.listen_addr = Some("0.0.0.0:8080".parse().unwrap());
+        let refusal = config.bind_addr().unwrap_err().to_string();
+        assert!(
+            refusal.contains("loopback-only") && refusal.contains("self_host"),
+            "the refusal must name the remedy: {refusal}"
+        );
+    }
+
+    #[test]
+    fn self_host_binds_the_configured_address_and_rejects_a_malformed_one() {
+        let config = Config::from_vars(
+            Some("self_host".into()),
+            Some(OsString::from("/data")),
+            None,
+            None,
+            None,
+            Some("0.0.0.0:8080".into()),
+        )
+        .unwrap();
+        assert_eq!(
+            config.bind_addr().unwrap(),
+            "0.0.0.0:8080".parse::<SocketAddr>().unwrap()
+        );
+
+        // A port-less host is the likely typo, and it must not silently fall
+        // back to the loopback default the operator was trying to escape.
+        assert!(Config::from_vars(
+            Some("self_host".into()),
+            None,
+            None,
+            None,
+            None,
+            Some("0.0.0.0".into())
+        )
+        .is_err());
     }
 
     #[test]
@@ -343,6 +446,7 @@ mod tests {
             Some("true".into()),
             Some("openwave-sandbox-agent:dev".into()),
             None,
+            None,
         )
         .unwrap();
         assert!(config.container_execution_enabled);
@@ -350,6 +454,6 @@ mod tests {
             config.container_image.as_deref(),
             Some("openwave-sandbox-agent:dev")
         );
-        assert!(Config::from_vars(None, None, Some("yes".into()), None, None).is_err());
+        assert!(Config::from_vars(None, None, Some("yes".into()), None, None, None).is_err());
     }
 }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -11,6 +11,11 @@
 //! /chats/{id}/messages` to start a turn (one per chat at a time), and
 //! `WS /chats/{id}/events` to watch it — journaled events are replayed on connect
 //! and then streamed live (snapshot → replay → live).
+//!
+//! The loopback bind is the default, not the only option: a self-host
+//! deployment that must be reachable from outside its machine sets
+//! `OPENWAVE_LISTEN_ADDR`. The desktop profile refuses one — see
+//! [`Config::bind_addr`].
 
 mod agent_run_scratch_reaper;
 mod approval_judge;
@@ -87,7 +92,7 @@ pub mod web_search;
 mod wire_types;
 
 use std::fs::{OpenOptions, TryLockError};
-use std::net::{Ipv4Addr, SocketAddr};
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use axum::extract::DefaultBodyLimit;
@@ -922,6 +927,11 @@ async fn bind_inner(
     local_voice: Option<Arc<dyn LocalVoiceRunner>>,
     host_folders: Option<Arc<dyn host_folders::HostFolders>>,
 ) -> Result<Server> {
+    // Resolved first, before the instance lock or the store: a desktop profile
+    // handed `OPENWAVE_LISTEN_ADDR` refuses the boot rather than binding a
+    // routable interface, and that refusal should cost nothing and leave
+    // nothing behind. See [`Config::bind_addr`].
+    let bind_addr = config.bind_addr()?;
     // Desktop live delivery remains process-local. Turns, steering, and tool
     // approvals are durable, while one process still owns the complete data
     // directory and its worker set.
@@ -1177,9 +1187,9 @@ async fn bind_inner(
     let gateway_runtime = state.gateway.clone();
     let router = app(state);
 
-    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+    let listener = TcpListener::bind(bind_addr)
         .await
-        .map_err(|e| AgentError::config(format!("failed to bind loopback: {e}")))?;
+        .map_err(|e| AgentError::config(format!("failed to bind {bind_addr}: {e}")))?;
     let local_addr = listener
         .local_addr()
         .map_err(|e| AgentError::config(format!("no local address: {e}")))?;

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -2,6 +2,7 @@
 
 use super::*;
 
+use std::net::Ipv4Addr;
 use std::ops::Range;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};

--- a/crates/openwave-server/src/tests/conformance.rs
+++ b/crates/openwave-server/src/tests/conformance.rs
@@ -585,3 +585,66 @@ async fn the_role_gate_rejects_a_route_no_auth_middleware_covers() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
+
+/// A desktop server must never open a routable socket. The refusal runs on the
+/// real boot path, before the instance lock or the store, so a misconfigured
+/// launch fails immediately and leaves nothing behind — and it is a refusal
+/// rather than a silent fallback, because an operator who set the variable
+/// would otherwise believe they had published a port.
+#[tokio::test]
+async fn desktop_boot_refuses_a_configured_listen_address() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut config = Config::desktop(dir.path());
+    config.listen_addr = Some("0.0.0.0:8080".parse().unwrap());
+
+    let refusal = match crate::bind(config).await {
+        Err(refusal) => refusal.to_string(),
+        Ok(_) => panic!("the desktop profile must not bind a routable address"),
+    };
+    assert!(
+        refusal.contains("loopback-only") && refusal.contains("self_host"),
+        "the refusal must name the remedy: {refusal}"
+    );
+    assert!(
+        !dir.path().join("openwave.lock").exists(),
+        "the refusal must come before the boot takes the instance lock"
+    );
+}
+
+/// The container-entrypoint contract: a self-host deployment binds the address
+/// it was given, and the liveness probe the entrypoint waits on answers there
+/// without a credential — it sits outside both auth layers, so a packaging
+/// healthcheck never needs a token it has no way to hold.
+///
+/// The address is taken from a configured `Config` rather than the process
+/// environment, which a parallel test binary cannot mutate safely, and bound
+/// on port 0 so the test cannot collide with anything. What it pins is that a
+/// self-host config's `bind_addr` is what the socket ends up on; that
+/// `bind_inner` is the caller of `bind_addr` is pinned by the desktop refusal
+/// above, which travels the real boot path.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_self_host_deployment_serves_liveness_on_its_configured_address() {
+    let (router, state, _store, _dir) = self_host_app().await;
+    let mut config = (*state.config).clone();
+    assert_eq!(config.profile, Profile::SelfHost);
+    config.listen_addr = Some("127.0.0.1:0".parse().unwrap());
+
+    let listener = TcpListener::bind(config.bind_addr().unwrap())
+        .await
+        .unwrap();
+    let addr: SocketAddr = listener.local_addr().unwrap();
+    assert_eq!(
+        addr.ip(),
+        "127.0.0.1".parse::<std::net::IpAddr>().unwrap(),
+        "the configured interface is the one bound"
+    );
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router).await;
+    });
+
+    let response = reqwest::get(format!("http://{addr}/healthz"))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    assert_eq!(response.text().await.unwrap(), "ok");
+}

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -817,6 +817,16 @@ team deployment, and MCP servers are host processes. The profile targets one
 operator's small team, not adversarial tenants; multi-tenant isolation is
 explicitly not claimed.
 
+**Where it listens.** The server binds loopback on an ephemeral port by
+default; a self-host deployment that must be reachable from outside its machine
+— a container publishing a port, say — sets `OPENWAVE_LISTEN_ADDR` to a full
+address and port (`0.0.0.0:8080`), and `openwave serve` announces the bound
+address on stdout as before. The desktop profile refuses to boot if that
+variable is set rather than honouring or ignoring it: that server's per-launch
+token is the only thing separating the agent from other local processes, and
+its `Origin`/`Host` checks assume a loopback bind. On self-host the per-launch
+token is no longer printed at startup, because it authenticates nobody there.
+
 ## Where the code lives
 
 | Area | Start here | What it owns |


### PR DESCRIPTION
Stacked on #1876. `bind_inner` hardcoded `TcpListener::bind((Ipv4Addr::LOCALHOST, 0))`, which is right for the desktop app and unreachable for a self-host deployment inside a container — the packaging work had to bridge it with socat.

## What changed

- **`OPENWAVE_LISTEN_ADDR`** joins the other boot variables in `Config`, read
  in `from_env` and parsed in `from_vars` alongside `OPENWAVE_AUTH_TOKENS_FILE`
  and the rest. It takes a full `SocketAddr` (`0.0.0.0:8080`); a value without
  a port is a boot error naming the expected shape rather than a silent
  fallback to the loopback default the operator was trying to escape. Absent
  (or empty) keeps today's behavior on every profile.
- **`Config::bind_addr()`** is the one place the address is decided, shaped
  like the existing `database_url()`: profile-aware, returns `Result`. No
  configuration means loopback on port 0; self-host with an address gets that
  address.
- **Desktop refuses rather than ignores.** A desktop profile carrying a listen
  address fails the boot with an error naming the remedy. That server's
  per-launch bearer is the only thing between the agent and any other local
  process, and its `Origin`/`Host` checks assume a loopback bind — a desktop
  server on `0.0.0.0` reached by an environment variable nobody reviewed is a
  different security posture, and silently ignoring the variable would leave an
  operator believing they had published a port. The check runs at the top of
  `bind_inner`, before the instance lock and before the store, so the refusal
  costs nothing and leaves nothing behind.
- **Startup output.** The address line is unchanged —
  `openwave: listening on http://{addr}` — since the packaging entrypoint and
  the existing integrations parse liveness from it. The `openwave: token {…}`
  line is now suppressed on the self-host profile only: that per-launch bearer
  names nobody on a shared deployment and authenticates nobody there (see the
  server's `auth` module docs), so printing it into `docker logs` is pure
  confusion. Desktop and CLI output is byte-for-byte identical.

What each profile prints at startup now:

| Profile | stdout |
| --- | --- |
| Desktop (unchanged) | `openwave: listening on http://127.0.0.1:<port>` then `openwave: token <uuid>` |
| Self-host | `openwave: listening on http://<configured addr>` only |
| Desktop with `OPENWAVE_LISTEN_ADDR` | nothing; exits non-zero with the config error on stderr |

## Docs

The Self-host section of `docs/how-openwave-works.md` gains a short "Where it
listens" paragraph covering the variable, the desktop refusal, and the dropped
token line. The refusal is also stated on `Config::bind_addr`'s doc comment
(the accessor that enforces it), on `bind_inner`'s call site, and in the
server and CLI crate-level docs where the loopback bind was previously
described as unconditional.

## Tests

- `the_desktop_profile_refuses_a_configured_listen_address` (core) — the
  decision itself, plus the default when nothing is configured.
- `self_host_binds_the_configured_address_and_rejects_a_malformed_one` (core) —
  the honoured path and the port-less typo.
- `desktop_boot_refuses_a_configured_listen_address` (server) — the same
  refusal through the real `bind()` path, asserting it lands before the
  instance lock exists. This is what pins `bind_inner` to `bind_addr()`: if the
  hardcoded loopback bind ever comes back, this test boots successfully and
  fails.
- `a_self_host_deployment_serves_liveness_on_its_configured_address` (server) —
  the container-entrypoint contract: the configured interface is the one bound,
  and `/healthz` answers there without a credential, since a packaging
  healthcheck holds no token.

Config is constructed directly in every case rather than mutating process
environment, which a parallel test binary cannot do safely; `from_vars` is
already the seam that exists for exactly this. The self-host test binds port 0
so it cannot collide.

Existing `from_vars` call sites in the config tests gained the new argument;
no assertions changed.

Note on coverage: the self-host test serves the assembled router on a listener
bound from `config.bind_addr()` rather than booting through `bind_inner`,
because the self-host store requires PostgreSQL and this lane has none. The two
halves of the wiring are each pinned — `bind_inner` calls `bind_addr()` (the
desktop refusal test travels the real boot path), and `bind_addr()` returns the
configured address (the core tests) — but no single test boots a self-host
server on a published port end to end. That gap belongs to the packaging
branch's integration test, which has a database.

Verified locally: `cargo check --locked --all-targets` for the touched crates,
`cargo test -p openwave-server -p openwave-core --locked`,
`cargo fmt --all -- --check`.
