### PR TITLE
feat(cli): provider, model, and settings subcommands over the server routes

### DIFF
--- a/crates/openwave-cli/src/api/client.rs
+++ b/crates/openwave-cli/src/api/client.rs
@@ -13,7 +13,8 @@ use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
 
 use super::wire::{
     AgentActivityItem, AgentRunSnapshot, ChatSummary, GrantRung, InboxItem, ModelCatalog,
-    PendingApprovalSnapshot, PendingPlan, PendingQuestions, Transcript,
+    PendingApprovalSnapshot, PendingPlan, PendingQuestions, ProviderInfo, ProvidersList,
+    Transcript,
 };
 
 /// The chat event stream once the upgrade completes.
@@ -212,6 +213,159 @@ impl Client {
     /// The selectable model catalog.
     pub async fn list_models(&self) -> Result<ModelCatalog> {
         self.get_json(format!("{}/models", self.base)).await
+    }
+
+    /// Pin a model role to a catalog key, or clear it back to automatic with
+    /// `None`.
+    pub async fn set_model_role(
+        &self,
+        role: &str,
+        selection: Option<&str>,
+    ) -> Result<serde_json::Value> {
+        self.put_json(
+            format!("{}/models/roles/{role}", self.base),
+            &serde_json::json!({ "selection": selection }),
+        )
+        .await
+    }
+
+    /// Every provider kind and its current configuration.
+    pub async fn list_providers(&self) -> Result<Vec<ProviderInfo>> {
+        let list: ProvidersList = self.get_json(format!("{}/providers", self.base)).await?;
+        Ok(list.providers)
+    }
+
+    /// Store an API key for one provider and enable it for routing.
+    ///
+    /// The credential goes straight to the server's secret store (the OS
+    /// keychain on a desktop profile); the response never carries it back.
+    pub async fn set_provider_api_key(&self, kind: &str, key: &str) -> Result<serde_json::Value> {
+        self.put_json(
+            format!("{}/providers/{kind}", self.base),
+            &serde_json::json!({
+                "enabled": true,
+                "credential": { "type": "api_key", "key": key },
+            }),
+        )
+        .await
+    }
+
+    /// Remove a provider's stored credential. The provider's other settings
+    /// are untouched.
+    pub async fn delete_provider_credential(&self, kind: &str) -> Result<()> {
+        self.delete_ok(format!("{}/providers/{kind}/credential", self.base))
+            .await
+    }
+
+    /// Runtime settings (`GET /settings`), verbatim.
+    pub async fn get_settings(&self) -> Result<serde_json::Value> {
+        self.get_json(format!("{}/settings", self.base)).await
+    }
+
+    /// Host web-search selection and readiness.
+    pub async fn get_web_search_config(&self) -> Result<serde_json::Value> {
+        self.get_json(format!("{}/web-search", self.base)).await
+    }
+
+    /// Select the host web-search provider; `None` turns host search off.
+    pub async fn set_web_search_provider(
+        &self,
+        provider: Option<&str>,
+    ) -> Result<serde_json::Value> {
+        self.put_json(
+            format!("{}/web-search", self.base),
+            &serde_json::json!({ "provider": provider }),
+        )
+        .await
+    }
+
+    /// Which web-search provider slots hold a key.
+    pub async fn get_web_search_credentials(&self) -> Result<serde_json::Value> {
+        self.get_json(format!("{}/web-search/credentials", self.base))
+            .await
+    }
+
+    /// Store one web-search provider's key. Selection is unchanged.
+    pub async fn set_web_search_credential(
+        &self,
+        provider: &str,
+        key: &str,
+    ) -> Result<serde_json::Value> {
+        self.put_json(
+            format!("{}/web-search/credentials/{provider}", self.base),
+            &serde_json::json!({ "api_key": key }),
+        )
+        .await
+    }
+
+    /// Remove one web-search provider's key. Selection is unchanged.
+    pub async fn delete_web_search_credential(&self, provider: &str) -> Result<serde_json::Value> {
+        self.delete_json(format!("{}/web-search/credentials/{provider}", self.base))
+            .await
+    }
+
+    /// Code-execution backend selection, readiness, and per-provider detail.
+    pub async fn get_code_execution_config(&self) -> Result<serde_json::Value> {
+        self.get_json(format!("{}/code-execution", self.base)).await
+    }
+
+    /// Select the code-execution backend; `None` disables execution.
+    pub async fn set_code_execution_provider(
+        &self,
+        provider: Option<&str>,
+    ) -> Result<serde_json::Value> {
+        self.put_json(
+            format!("{}/code-execution", self.base),
+            &serde_json::json!({ "provider": provider }),
+        )
+        .await
+    }
+
+    /// Which code-execution provider slots hold a key.
+    pub async fn get_code_execution_credentials(&self) -> Result<serde_json::Value> {
+        self.get_json(format!("{}/code-execution/credentials", self.base))
+            .await
+    }
+
+    /// Store one code-execution provider's key. Selection is unchanged.
+    pub async fn set_code_execution_credential(
+        &self,
+        provider: &str,
+        key: &str,
+    ) -> Result<serde_json::Value> {
+        self.put_json(
+            format!("{}/code-execution/credentials/{provider}", self.base),
+            &serde_json::json!({ "api_key": key }),
+        )
+        .await
+    }
+
+    /// Remove one code-execution provider's key. Selection is unchanged.
+    pub async fn delete_code_execution_credential(
+        &self,
+        provider: &str,
+    ) -> Result<serde_json::Value> {
+        self.delete_json(format!(
+            "{}/code-execution/credentials/{provider}",
+            self.base
+        ))
+        .await
+    }
+
+    /// Every mounted MCP server, configured and plugin-sourced alike.
+    pub async fn get_mcp_servers(&self) -> Result<serde_json::Value> {
+        self.get_json(format!("{}/mcp/servers", self.base)).await
+    }
+
+    /// Replace the user-configured MCP server set wholesale — the only shape
+    /// the route accepts. Plugin-sourced servers are rebuilt by the server and
+    /// must not appear in `servers`.
+    pub async fn put_mcp_servers(&self, servers: serde_json::Value) -> Result<serde_json::Value> {
+        self.put_json(
+            format!("{}/mcp/servers", self.base),
+            &serde_json::json!({ "servers": servers }),
+        )
+        .await
     }
 
     /// Background agent runs for a chat.
@@ -454,6 +608,43 @@ impl Client {
             .json::<T>()
             .await
             .map_err(request_error)
+    }
+
+    /// PUT a JSON body and decode the route's answer.
+    async fn put_json<T: serde::de::DeserializeOwned>(
+        &self,
+        url: String,
+        body: &serde_json::Value,
+    ) -> Result<T> {
+        let response = self
+            .http
+            .put(url)
+            .json(body)
+            .send()
+            .await
+            .map_err(request_error)?;
+        Self::expect_success(response)
+            .await?
+            .json::<T>()
+            .await
+            .map_err(request_error)
+    }
+
+    /// DELETE, decoding the route's answer.
+    async fn delete_json<T: serde::de::DeserializeOwned>(&self, url: String) -> Result<T> {
+        let response = self.http.delete(url).send().await.map_err(request_error)?;
+        Self::expect_success(response)
+            .await?
+            .json::<T>()
+            .await
+            .map_err(request_error)
+    }
+
+    /// DELETE a route that answers `204`.
+    async fn delete_ok(&self, url: String) -> Result<()> {
+        let response = self.http.delete(url).send().await.map_err(request_error)?;
+        Self::expect_success(response).await?;
+        Ok(())
     }
 }
 

--- a/crates/openwave-cli/src/api/wire.rs
+++ b/crates/openwave-cli/src/api/wire.rs
@@ -521,6 +521,79 @@ pub struct ModelInfo {
 pub struct ModelCatalog {
     #[serde(default)]
     pub models: Vec<ModelInfo>,
+    /// Every named model role, its selection, and what it resolves to now.
+    #[serde(default)]
+    pub roles: Vec<ModelRoleInfo>,
+}
+
+/// One named model role, from `GET /models`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ModelRoleInfo {
+    pub role: String,
+    /// The catalog key pinned to this role, or `None` for automatic.
+    #[serde(default)]
+    pub selection: Option<String>,
+    /// What the role resolves to right now, selection or not.
+    #[serde(default)]
+    pub resolved_key: Option<String>,
+}
+
+/// One provider row from `GET /providers`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ProviderInfo {
+    /// Wire form of the provider kind (`anthropic`, `openai_compatible`, …),
+    /// which is also the path segment the write routes take.
+    pub kind: String,
+    #[serde(default)]
+    pub enabled: bool,
+    /// Whether a credential is stored — never the credential itself.
+    #[serde(default)]
+    pub has_credential: bool,
+    /// How the provider is authenticated (`api_key`, `chatgpt`, …), when it is.
+    #[serde(default)]
+    pub auth_mode: Option<String>,
+    #[serde(default)]
+    pub base_url: Option<String>,
+}
+
+/// The `GET /providers` envelope.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ProvidersList {
+    #[serde(default)]
+    pub providers: Vec<ProviderInfo>,
+}
+
+/// One mounted MCP server, from `GET /mcp/servers`. The response flattens each
+/// server's definition into its live projection, so both are read here.
+#[derive(Debug, Clone, Deserialize)]
+pub struct McpServerInfo {
+    pub name: String,
+    #[serde(default)]
+    pub enabled: bool,
+    /// `initializing` / `healthy` / `degraded` / `reconnecting` / `disabled`.
+    #[serde(default)]
+    pub health: String,
+    #[serde(default)]
+    pub tool_count: usize,
+    /// The plugin this server came from, when it is plugin-sourced. Those are
+    /// derived by the server and cannot be edited over the config route.
+    #[serde(default)]
+    pub plugin: Option<String>,
+    #[serde(default)]
+    pub command: Option<String>,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub gateway_endpoint: Option<String>,
+    #[serde(default)]
+    pub diagnostic: Option<String>,
+}
+
+/// The `GET /mcp/servers` envelope.
+#[derive(Debug, Clone, Deserialize)]
+pub struct McpServersInfo {
+    #[serde(default)]
+    pub servers: Vec<McpServerInfo>,
 }
 
 #[cfg(test)]

--- a/crates/openwave-cli/src/main.rs
+++ b/crates/openwave-cli/src/main.rs
@@ -29,8 +29,13 @@
 //! permission mode for the run, and under `--output-format json` a driving
 //! process answers approvals, plans, and questions over stdin — see
 //! [`print::protocol`].
+//!
+//! `openwave provider|model|settings|mcp-server …` configure the profile the
+//! same way the desktop's settings pages do — over the server's own routes.
+//! See [`setup`]; secrets are read from stdin or a named environment variable,
+//! never from a command-line argument.
 
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -39,14 +44,42 @@ use openwave_core::{AgentError, ChatId, Config, ListDir, ReadFile, Result, ToolC
 
 mod api;
 mod print;
+mod setup;
 mod tui;
 
 use print::OutputFormat;
+use setup::{Command as SetupCommand, SecretSource};
 
-const USAGE: &str = "usage: openwave serve\n       openwave mcp <workspace>\n       openwave \
-                     rehome-secrets\n       openwave tui [--chat <id> | --new]\n       openwave -p \
-                     <prompt> [--chat <id>] [--output-format text|json]\n                  \
-                     [--permission-mode ask|auto|allow|plan]";
+const USAGE: &str = "\
+usage: openwave serve
+       openwave mcp <workspace>
+       openwave rehome-secrets
+       openwave tui [--chat <id> | --new]
+       openwave -p <prompt> [--chat <id>] [--output-format text|json]
+                  [--permission-mode ask|auto|allow|plan]
+
+       openwave provider list
+       openwave provider set-key <kind> [--from-env <var>]
+       openwave provider remove-key <kind>
+       openwave model list
+       openwave model roles
+       openwave model select <key|auto> [--role <role>]
+       openwave settings show
+       openwave settings web-search select <provider|off>
+       openwave settings web-search set-key <provider> [--from-env <var>]
+       openwave settings web-search remove-key <provider>
+       openwave settings exec select <provider|off>
+       openwave settings exec set-key <provider> [--from-env <var>]
+       openwave settings exec remove-key <provider>
+       openwave mcp-server list
+       openwave mcp-server add <name> (--command <cmd> [--arg <a>]… | --url <url>)
+                  [--env-from <var>]… [--cwd <dir>] [--bearer-token-env <var>]
+                  [--timeout-ms <ms>] [--disabled]
+       openwave mcp-server remove <name>
+
+The setup commands take --output-format text|json. A key is read from stdin, or
+from the environment variable named by --from-env — never from an argument,
+which every process on the machine can read.";
 
 #[tokio::main]
 async fn main() {
@@ -161,10 +194,243 @@ async fn run() -> Result<i32> {
             }
             print::run(prompt, chat, format, permission_mode).await
         }
+        Some(command)
+            if command == OsStr::new("provider")
+                || command == OsStr::new("model")
+                || command == OsStr::new("settings")
+                || command == OsStr::new("mcp-server") =>
+        {
+            let family = command.to_string_lossy().into_owned();
+            let (command, format) = parse_setup(&family, text_args(args));
+            setup::run(command, format).await.map(|()| 0)
+        }
         Some(other) => {
             usage_error(&format!("unknown command {other:?}"));
         }
     }
+}
+
+/// The remaining arguments as UTF-8. Setup arguments are provider names, model
+/// keys, URLs, and variable names; a path that is not valid UTF-8 is refused
+/// here rather than silently mangled.
+fn text_args(args: impl Iterator<Item = OsString>) -> Vec<String> {
+    args.map(|arg| {
+        arg.into_string()
+            .unwrap_or_else(|arg| usage_error(&format!("{arg:?} is not valid UTF-8")))
+    })
+    .collect()
+}
+
+/// A cursor over one setup subcommand's arguments.
+///
+/// The setup families share a shape — a verb, positional names, then flags —
+/// so they share a reader rather than each re-deriving "the next argument, or
+/// a usage error naming the flag that wanted it".
+struct Cursor {
+    args: Vec<String>,
+    at: usize,
+}
+
+impl Cursor {
+    fn new(args: Vec<String>) -> Self {
+        Self { args, at: 0 }
+    }
+
+    fn next(&mut self) -> Option<String> {
+        let value = self.args.get(self.at).cloned();
+        if value.is_some() {
+            self.at += 1;
+        }
+        value
+    }
+
+    /// The next argument, which must be there and must not be another flag.
+    fn value(&mut self, flag: &str) -> String {
+        match self.next() {
+            Some(value) if !value.starts_with("--") => value,
+            _ => usage_error(&format!("{flag} requires a value")),
+        }
+    }
+
+    /// The next positional argument, named for the error message.
+    fn positional(&mut self, what: &str) -> String {
+        match self.next() {
+            Some(value) if !value.starts_with("--") => value,
+            _ => usage_error(&format!("expected {what}")),
+        }
+    }
+}
+
+/// Parse one `provider`/`model`/`settings`/`mcp-server` invocation.
+fn parse_setup(family: &str, args: Vec<String>) -> (SetupCommand, OutputFormat) {
+    let mut cursor = Cursor::new(args);
+    let verb = cursor.positional(&format!("a {family} subcommand"));
+    let command = match (family, verb.as_str()) {
+        ("provider", "list") => SetupCommand::ProviderList,
+        ("provider", "set-key") => SetupCommand::ProviderSetKey {
+            kind: cursor.positional("a provider kind"),
+            secret: parse_secret_source(&mut cursor),
+        },
+        ("provider", "remove-key") => SetupCommand::ProviderRemoveKey {
+            kind: cursor.positional("a provider kind"),
+        },
+        ("model", "list") => SetupCommand::ModelList,
+        ("model", "roles") => SetupCommand::ModelRoles,
+        ("model", "select") => {
+            let selection = cursor.positional("a model key, or `auto`");
+            let mut role = "chat".to_owned();
+            let mut format = None;
+            while let Some(flag) = cursor.next() {
+                match flag.as_str() {
+                    "--role" => role = cursor.value("--role"),
+                    "--output-format" => format = Some(parse_format(cursor.value(flag.as_str()))),
+                    other => usage_error(&format!("unknown model select argument {other:?}")),
+                }
+            }
+            return (
+                SetupCommand::ModelSelect {
+                    role,
+                    selection: (selection != "auto").then_some(selection),
+                },
+                format.unwrap_or(OutputFormat::Text),
+            );
+        }
+        ("settings", "show") => SetupCommand::SettingsShow,
+        ("settings", "web-search") => match cursor.positional("a web-search subcommand").as_str() {
+            "select" => SetupCommand::WebSearchSelect {
+                provider: parse_selection(cursor.positional("a web-search provider, or `off`")),
+            },
+            "set-key" => SetupCommand::WebSearchSetKey {
+                provider: cursor.positional("a web-search provider"),
+                secret: parse_secret_source(&mut cursor),
+            },
+            "remove-key" => SetupCommand::WebSearchRemoveKey {
+                provider: cursor.positional("a web-search provider"),
+            },
+            other => usage_error(&format!("unknown settings web-search subcommand {other:?}")),
+        },
+        ("settings", "exec") => match cursor.positional("an exec subcommand").as_str() {
+            "select" => SetupCommand::ExecSelect {
+                provider: parse_selection(cursor.positional("an execution provider, or `off`")),
+            },
+            "set-key" => SetupCommand::ExecSetKey {
+                provider: cursor.positional("an execution provider"),
+                secret: parse_secret_source(&mut cursor),
+            },
+            "remove-key" => SetupCommand::ExecRemoveKey {
+                provider: cursor.positional("an execution provider"),
+            },
+            other => usage_error(&format!("unknown settings exec subcommand {other:?}")),
+        },
+        ("mcp-server", "list") => SetupCommand::McpList,
+        ("mcp-server", "add") => SetupCommand::McpAdd {
+            definition: parse_mcp_definition(&mut cursor),
+        },
+        ("mcp-server", "remove") => SetupCommand::McpRemove {
+            name: cursor.positional("an MCP server name"),
+        },
+        (family, other) => usage_error(&format!("unknown {family} subcommand {other:?}")),
+    };
+    let format = parse_trailing_format(&mut cursor, &format!("{family} {verb}"));
+    (command, format)
+}
+
+/// `--from-env <var>` names an environment variable holding the secret;
+/// without it the secret is read from stdin. A value never rides argv.
+fn parse_secret_source(cursor: &mut Cursor) -> SecretSource {
+    match cursor.next().as_deref() {
+        None => SecretSource::Stdin,
+        Some("--from-env") => SecretSource::Env(cursor.value("--from-env")),
+        Some("--output-format") => {
+            // Put it back for the trailing-flag pass.
+            cursor.at -= 1;
+            SecretSource::Stdin
+        }
+        Some(other) => usage_error(&format!(
+            "unknown argument {other:?}; a key is read from stdin or --from-env <var>"
+        )),
+    }
+}
+
+/// A positional selection where `off` (or `none`) clears the setting.
+fn parse_selection(value: String) -> Option<String> {
+    (value != "off" && value != "none").then_some(value)
+}
+
+/// The trailing `--output-format`, the only flag every setup command shares.
+fn parse_trailing_format(cursor: &mut Cursor, context: &str) -> OutputFormat {
+    let mut format = OutputFormat::Text;
+    while let Some(flag) = cursor.next() {
+        match flag.as_str() {
+            "--output-format" => format = parse_format(cursor.value("--output-format")),
+            other => usage_error(&format!("unexpected argument {other:?} after {context}")),
+        }
+    }
+    format
+}
+
+fn parse_format(value: String) -> OutputFormat {
+    match OutputFormat::parse(&value) {
+        Some(format) => format,
+        None => usage_error("--output-format expects text or json"),
+    }
+}
+
+/// Build one MCP server definition from flags, in the shape
+/// `PUT /mcp/servers` takes. Values the server keeps out of its definitions —
+/// environment values, bearer tokens — are named here, never given.
+fn parse_mcp_definition(cursor: &mut Cursor) -> serde_json::Value {
+    let name = cursor.positional("an MCP server name");
+    let mut definition = serde_json::json!({ "name": name });
+    let mut args: Vec<String> = Vec::new();
+    let mut env_from: Vec<String> = Vec::new();
+    let mut transports = 0;
+    while let Some(flag) = cursor.next() {
+        match flag.as_str() {
+            "--command" => {
+                transports += 1;
+                definition["command"] = cursor.value("--command").into();
+            }
+            "--arg" => args.push(cursor.value("--arg")),
+            "--env-from" => env_from.push(cursor.value("--env-from")),
+            "--cwd" => definition["cwd"] = cursor.value("--cwd").into(),
+            "--url" => {
+                transports += 1;
+                definition["url"] = cursor.value("--url").into();
+            }
+            "--bearer-token-env" => {
+                definition["bearer_token_env"] = cursor.value("--bearer-token-env").into();
+            }
+            "--gateway-endpoint" => {
+                transports += 1;
+                definition["gateway_endpoint"] = cursor.value("--gateway-endpoint").into();
+            }
+            "--timeout-ms" => {
+                let value = cursor.value("--timeout-ms");
+                let Ok(timeout) = value.parse::<u64>() else {
+                    usage_error("--timeout-ms expects a whole number of milliseconds");
+                };
+                definition["request_timeout_ms"] = timeout.into();
+            }
+            "--disabled" => definition["enabled"] = false.into(),
+            "--output-format" => {
+                // Belongs to the trailing pass; hand it back.
+                cursor.at -= 1;
+                break;
+            }
+            other => usage_error(&format!("unknown mcp-server add argument {other:?}")),
+        }
+    }
+    if transports != 1 {
+        usage_error("mcp-server add takes exactly one of --command, --url, or --gateway-endpoint");
+    }
+    if !args.is_empty() {
+        definition["args"] = args.into();
+    }
+    if !env_from.is_empty() {
+        definition["env_from"] = env_from.into();
+    }
+    definition
 }
 
 fn usage_error(message: &str) -> ! {

--- a/crates/openwave-cli/src/setup.rs
+++ b/crates/openwave-cli/src/setup.rs
@@ -1,0 +1,556 @@
+//! Scriptable setup: `openwave provider|model|settings|mcp-server`.
+//!
+//! Every command here is a thin client of a route the server already serves —
+//! the same ones the desktop settings pages call — so configuring OpenWave
+//! from a script and configuring it from the app converge on one
+//! implementation. Nothing in this module decides anything: it boots the
+//! in-process server exactly as print mode does, makes the call, and renders
+//! the answer.
+//!
+//! Secrets are read from stdin or from a named environment variable, never
+//! from a command-line argument: argv is readable by every process on the
+//! machine, and a key pasted into a shell command also lands in its history.
+
+use std::io::Read as _;
+
+use openwave_core::{AgentError, Result};
+
+use crate::api::client::Client;
+use crate::api::wire::{McpServerInfo, McpServersInfo};
+use crate::print::OutputFormat;
+
+/// Where a command reads secret material from.
+pub enum SecretSource {
+    /// Everything on stdin, up to EOF (the default).
+    Stdin,
+    /// The value of a named environment variable.
+    Env(String),
+}
+
+impl SecretSource {
+    /// Read the secret, refusing an empty one — an empty key stored silently
+    /// is a provider that fails later for no visible reason.
+    fn read(&self) -> Result<String> {
+        let value = match self {
+            Self::Stdin => {
+                let mut buffer = String::new();
+                std::io::stdin()
+                    .read_to_string(&mut buffer)
+                    .map_err(|error| AgentError::msg(format!("could not read stdin: {error}")))?;
+                buffer
+            }
+            Self::Env(name) => std::env::var(name)
+                .map_err(|_| AgentError::msg(format!("{name} is not set in the environment")))?,
+        };
+        // Trailing newlines come with `echo`, heredocs, and editors; a key
+        // never legitimately has surrounding whitespace.
+        let value = value.trim().to_owned();
+        if value.is_empty() {
+            return Err(AgentError::msg(match self {
+                Self::Stdin => "no secret on stdin".to_owned(),
+                Self::Env(name) => format!("{name} is empty"),
+            }));
+        }
+        Ok(value)
+    }
+}
+
+/// One setup command, already parsed.
+pub enum Command {
+    /// Every provider kind, with credential status.
+    ProviderList,
+    /// Store an API key for a provider and enable it.
+    ProviderSetKey { kind: String, secret: SecretSource },
+    /// Remove a provider's stored credential.
+    ProviderRemoveKey { kind: String },
+    /// The model catalog and its availability.
+    ModelList,
+    /// Every model role, its selection, and what it resolves to.
+    ModelRoles,
+    /// Pin a role to a catalog key, or clear it back to automatic.
+    ModelSelect {
+        role: String,
+        selection: Option<String>,
+    },
+    /// Runtime settings plus web-search and code-execution configuration.
+    SettingsShow,
+    /// Select the host web-search provider, or turn host search off.
+    WebSearchSelect { provider: Option<String> },
+    /// Store a web-search provider's key.
+    WebSearchSetKey {
+        provider: String,
+        secret: SecretSource,
+    },
+    /// Remove a web-search provider's key.
+    WebSearchRemoveKey { provider: String },
+    /// Select the code-execution backend, or disable execution.
+    ExecSelect { provider: Option<String> },
+    /// Store a code-execution provider's key.
+    ExecSetKey {
+        provider: String,
+        secret: SecretSource,
+    },
+    /// Remove a code-execution provider's key.
+    ExecRemoveKey { provider: String },
+    /// Every mounted MCP server.
+    McpList,
+    /// Add one user-configured MCP server.
+    McpAdd { definition: serde_json::Value },
+    /// Remove one user-configured MCP server by name.
+    McpRemove { name: String },
+}
+
+/// Boot the engine, run one setup command against it, and shut it down.
+///
+/// The server is the same one `openwave serve` and `-p` bind, on the same
+/// profile and data directory, so a credential stored here is the credential
+/// the next turn resolves.
+pub async fn run(command: Command, format: OutputFormat) -> Result<()> {
+    let config = crate::profile_config()?;
+    // stdout belongs to the command's output; logs go to the profile's file.
+    openwave_server::logging::init_logging_file_only(&config.data_dir);
+    let server = openwave_server::bind_configured(config).await?;
+    let client = Client::new(server.local_addr(), server.token())?;
+    let serve = tokio::spawn(server.serve());
+    let result = execute(&client, command, format).await;
+    serve.abort();
+    result
+}
+
+/// Make the call and render it. Split from [`run`] so a test can drive several
+/// commands against one server, the way a script drives one profile.
+async fn execute(client: &Client, command: Command, format: OutputFormat) -> Result<()> {
+    match command {
+        Command::ProviderList => {
+            let providers = client.list_providers().await?;
+            if format == OutputFormat::Json {
+                return emit(&serde_json::json!({ "providers": providers_json(&providers) }));
+            }
+            for provider in providers {
+                let credential = match (provider.has_credential, provider.auth_mode.as_deref()) {
+                    (false, _) => "no credential".to_owned(),
+                    (true, Some(mode)) => format!("credential: {mode}"),
+                    (true, None) => "credential: stored".to_owned(),
+                };
+                let base_url = provider
+                    .base_url
+                    .map(|url| format!("  {url}"))
+                    .unwrap_or_default();
+                let enabled = if provider.enabled {
+                    "enabled"
+                } else {
+                    "disabled"
+                };
+                println!("{:<20} {enabled:<9} {credential}{base_url}", provider.kind);
+            }
+        }
+        Command::ProviderSetKey { kind, secret } => {
+            let key = secret.read()?;
+            let info = client.set_provider_api_key(&kind, &key).await?;
+            if format == OutputFormat::Json {
+                return emit(&info);
+            }
+            println!("openwave: stored the {kind} API key and enabled the provider");
+        }
+        Command::ProviderRemoveKey { kind } => {
+            client.delete_provider_credential(&kind).await?;
+            if format == OutputFormat::Json {
+                return emit(&serde_json::json!({ "kind": kind, "has_credential": false }));
+            }
+            println!("openwave: removed the {kind} credential");
+        }
+        Command::ModelList => {
+            let catalog = client.list_models().await?;
+            if format == OutputFormat::Json {
+                return emit(&serde_json::json!({
+                    "models": catalog.models.iter().map(|model| serde_json::json!({
+                        "key": model.key,
+                        "id": model.id,
+                        "display_name": model.display_name,
+                        "provider": model.provider,
+                        "available": model.available,
+                        "context_window": model.context_window,
+                        "reasoning_efforts": model.reasoning_efforts,
+                    })).collect::<Vec<_>>(),
+                }));
+            }
+            for model in catalog.models {
+                let availability = if model.available {
+                    "available"
+                } else {
+                    "unavailable"
+                };
+                println!(
+                    "{:<44} {availability:<12} {}",
+                    model.key, model.display_name
+                );
+            }
+        }
+        Command::ModelRoles => {
+            let catalog = client.list_models().await?;
+            if format == OutputFormat::Json {
+                return emit(&serde_json::json!({
+                    "roles": catalog.roles.iter().map(|role| serde_json::json!({
+                        "role": role.role,
+                        "selection": role.selection,
+                        "resolved_key": role.resolved_key,
+                    })).collect::<Vec<_>>(),
+                }));
+            }
+            for role in catalog.roles {
+                let selection = role.selection.as_deref().unwrap_or("automatic");
+                let resolved = role.resolved_key.as_deref().unwrap_or("nothing");
+                println!("{:<12} {selection:<44} resolves to {resolved}", role.role);
+            }
+        }
+        Command::ModelSelect { role, selection } => {
+            let info = client.set_model_role(&role, selection.as_deref()).await?;
+            if format == OutputFormat::Json {
+                return emit(&info);
+            }
+            match selection {
+                Some(selection) => println!("openwave: {role} now uses {selection}"),
+                None => println!("openwave: {role} is back to automatic"),
+            }
+        }
+        Command::SettingsShow => {
+            let settings = client.get_settings().await?;
+            let web_search = client.get_web_search_config().await?;
+            let web_search_credentials = client.get_web_search_credentials().await?;
+            let code_execution = client.get_code_execution_config().await?;
+            let code_execution_credentials = client.get_code_execution_credentials().await?;
+            if format == OutputFormat::Json {
+                return emit(&serde_json::json!({
+                    "settings": settings,
+                    "web_search": { "config": web_search, "credentials": web_search_credentials },
+                    "code_execution": {
+                        "config": code_execution,
+                        "credentials": code_execution_credentials,
+                    },
+                }));
+            }
+            println!("model                {}", show(&settings["model"]));
+            println!("model credential     {}", show(&settings["has_api_key"]));
+            println!(
+                "background agents    {}",
+                show(&settings["max_active_background_agents"])
+            );
+            println!("web search           {}", show(&web_search["provider"]));
+            println!("  mode               {}", show(&web_search["mode"]));
+            println!("  available          {}", show(&web_search["available"]));
+            println!(
+                "  keys stored        {}",
+                credentialed(&web_search_credentials)
+            );
+            println!("code execution       {}", show(&code_execution["provider"]));
+            println!(
+                "  available          {}",
+                show(&code_execution["available"])
+            );
+            if let Some(reason) = code_execution.get("unavailable_reason") {
+                println!("  unavailable        {}", show(reason));
+            }
+            println!(
+                "  keys stored        {}",
+                credentialed(&code_execution_credentials)
+            );
+        }
+        Command::WebSearchSelect { provider } => {
+            let info = client.set_web_search_provider(provider.as_deref()).await?;
+            if format == OutputFormat::Json {
+                return emit(&info);
+            }
+            match provider {
+                Some(provider) => println!("openwave: web search now uses {provider}"),
+                None => println!("openwave: host web search is off"),
+            }
+        }
+        Command::WebSearchSetKey { provider, secret } => {
+            let key = secret.read()?;
+            let readiness = client.set_web_search_credential(&provider, &key).await?;
+            if format == OutputFormat::Json {
+                return emit(&readiness);
+            }
+            println!("openwave: stored the {provider} web-search key");
+        }
+        Command::WebSearchRemoveKey { provider } => {
+            let readiness = client.delete_web_search_credential(&provider).await?;
+            if format == OutputFormat::Json {
+                return emit(&readiness);
+            }
+            println!("openwave: removed the {provider} web-search key");
+        }
+        Command::ExecSelect { provider } => {
+            let info = client
+                .set_code_execution_provider(provider.as_deref())
+                .await?;
+            if format == OutputFormat::Json {
+                return emit(&info);
+            }
+            match provider {
+                Some(provider) => println!("openwave: code execution now uses {provider}"),
+                None => println!("openwave: code execution is off"),
+            }
+        }
+        Command::ExecSetKey { provider, secret } => {
+            let key = secret.read()?;
+            let readiness = client
+                .set_code_execution_credential(&provider, &key)
+                .await?;
+            if format == OutputFormat::Json {
+                return emit(&readiness);
+            }
+            println!("openwave: stored the {provider} code-execution key");
+        }
+        Command::ExecRemoveKey { provider } => {
+            let readiness = client.delete_code_execution_credential(&provider).await?;
+            if format == OutputFormat::Json {
+                return emit(&readiness);
+            }
+            println!("openwave: removed the {provider} code-execution key");
+        }
+        Command::McpList => {
+            let listing = client.get_mcp_servers().await?;
+            if format == OutputFormat::Json {
+                return emit(&listing);
+            }
+            for server in decode_mcp(&listing)?.servers {
+                print_mcp_server(&server);
+            }
+        }
+        Command::McpAdd { definition } => {
+            let name = definition["name"].as_str().unwrap_or_default().to_owned();
+            let mut servers = configured_servers(&client.get_mcp_servers().await?)?;
+            if servers
+                .iter()
+                .any(|server| server["name"].as_str() == Some(name.as_str()))
+            {
+                return Err(AgentError::msg(format!(
+                    "an MCP server named {name} is already configured; remove it first"
+                )));
+            }
+            servers.push(definition);
+            let listing = client
+                .put_mcp_servers(serde_json::Value::Array(servers))
+                .await?;
+            if format == OutputFormat::Json {
+                return emit(&listing);
+            }
+            println!("openwave: added the MCP server {name}");
+        }
+        Command::McpRemove { name } => {
+            let listing = client.get_mcp_servers().await?;
+            if let Some(plugin) = decode_mcp(&listing)?.servers.iter().find_map(|server| {
+                (server.name == name)
+                    .then(|| server.plugin.clone())
+                    .flatten()
+            }) {
+                return Err(AgentError::msg(format!(
+                    "the MCP server {name} comes from the plugin {plugin}; \
+                     turn that plugin off instead"
+                )));
+            }
+            let mut servers = configured_servers(&listing)?;
+            let before = servers.len();
+            servers.retain(|server| server["name"].as_str() != Some(name.as_str()));
+            if servers.len() == before {
+                return Err(AgentError::msg(format!("no MCP server named {name}")));
+            }
+            let listing = client
+                .put_mcp_servers(serde_json::Value::Array(servers))
+                .await?;
+            if format == OutputFormat::Json {
+                return emit(&listing);
+            }
+            println!("openwave: removed the MCP server {name}");
+        }
+    }
+    Ok(())
+}
+
+/// Write one JSON object on stdout, matching print mode's one-object-per-line
+/// shape so both surfaces can be read by the same consumer.
+fn emit(value: &serde_json::Value) -> Result<()> {
+    println!("{value}");
+    Ok(())
+}
+
+/// Render one settings field for a person: an absent or null value reads as
+/// `none` rather than as `null`.
+fn show(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::Null => "none".to_owned(),
+        serde_json::Value::String(text) => text.clone(),
+        other => other.to_string(),
+    }
+}
+
+/// The provider names in a `{ credentials: [{provider, has_credential}] }`
+/// readiness body that actually hold a key.
+fn credentialed(readiness: &serde_json::Value) -> String {
+    let stored: Vec<&str> = readiness["credentials"]
+        .as_array()
+        .map(|rows| {
+            rows.iter()
+                .filter(|row| row["has_credential"] == serde_json::Value::Bool(true))
+                .filter_map(|row| row["provider"].as_str())
+                .collect()
+        })
+        .unwrap_or_default();
+    if stored.is_empty() {
+        "none".to_owned()
+    } else {
+        stored.join(", ")
+    }
+}
+
+fn print_mcp_server(server: &McpServerInfo) {
+    let transport = server
+        .command
+        .as_deref()
+        .or(server.url.as_deref())
+        .or(server.gateway_endpoint.as_deref())
+        .unwrap_or("-");
+    let source = match &server.plugin {
+        Some(plugin) => format!(" (from the {plugin} plugin)"),
+        None => String::new(),
+    };
+    let state = if server.enabled {
+        server.health.as_str()
+    } else {
+        "disabled"
+    };
+    println!(
+        "{:<24} {state:<14} {:>3} tools  {transport}{source}",
+        server.name, server.tool_count
+    );
+    if let Some(diagnostic) = &server.diagnostic {
+        println!("    {diagnostic}");
+    }
+}
+
+fn decode_mcp(listing: &serde_json::Value) -> Result<McpServersInfo> {
+    serde_json::from_value(listing.clone())
+        .map_err(|error| AgentError::msg(format!("could not read the MCP server list: {error}")))
+}
+
+/// The user-configured servers from a `GET /mcp/servers` body, in the shape
+/// `PUT /mcp/servers` accepts.
+///
+/// The route takes a complete replacement set of *user-configured* servers, so
+/// editing one means sending the others back untouched. Two things have to come
+/// off first: plugin-sourced servers, which the runtime rebuilds and the route
+/// refuses in a body, and the live projection fields (health, tool counts),
+/// which are not part of a definition.
+fn configured_servers(listing: &serde_json::Value) -> Result<Vec<serde_json::Value>> {
+    const PROJECTED: [&str; 4] = ["health", "tool_count", "diagnostic", "curated"];
+    let servers = listing["servers"]
+        .as_array()
+        .ok_or_else(|| AgentError::msg("the MCP server list had no servers array"))?;
+    Ok(servers
+        .iter()
+        .filter(|server| server["plugin"].is_null())
+        .map(|server| {
+            let mut server = server.clone();
+            if let Some(fields) = server.as_object_mut() {
+                for field in PROJECTED {
+                    fields.remove(field);
+                }
+            }
+            server
+        })
+        .collect())
+}
+
+/// Provider rows as JSON, carrying only what the listing shows — the
+/// credential itself never leaves the server.
+fn providers_json(providers: &[crate::api::wire::ProviderInfo]) -> Vec<serde_json::Value> {
+    providers
+        .iter()
+        .map(|provider| {
+            serde_json::json!({
+                "kind": provider.kind,
+                "enabled": provider.enabled,
+                "has_credential": provider.has_credential,
+                "auth_mode": provider.auth_mode,
+                "base_url": provider.base_url,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openwave_core::Config;
+
+    /// The point of the whole family: a credential stored through the CLI is
+    /// live on the profile the next command (and the next turn) resolves
+    /// against. Two commands run against one server, exactly as a setup script
+    /// runs them against one profile — a write that landed somewhere the read
+    /// path does not look would show up here.
+    #[tokio::test]
+    async fn a_key_set_through_the_cli_shows_up_as_a_stored_credential() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        // Never touch the developer's real keychain from a test.
+        openwave_core::KeychainSecretProvider::use_mock();
+        let server = openwave_server::bind_configured(Config::desktop(dir.path()))
+            .await
+            .expect("bind the server");
+        let client = Client::new(server.local_addr(), server.token()).expect("build the client");
+        let serve = tokio::spawn(server.serve());
+
+        let before = client.list_providers().await.expect("list providers");
+        let anthropic = before
+            .iter()
+            .find(|provider| provider.kind == "anthropic")
+            .expect("anthropic is a known provider");
+        assert!(
+            !anthropic.has_credential && !anthropic.enabled,
+            "a fresh profile has no stored Anthropic credential"
+        );
+
+        // The env path rather than stdin: a test cannot hand the process a
+        // stdin of its own, and both paths converge on `SecretSource::read`.
+        std::env::set_var("OPENWAVE_TEST_PROVIDER_KEY", "sk-test-123");
+        execute(
+            &client,
+            Command::ProviderSetKey {
+                kind: "anthropic".to_owned(),
+                secret: SecretSource::Env("OPENWAVE_TEST_PROVIDER_KEY".to_owned()),
+            },
+            OutputFormat::Text,
+        )
+        .await
+        .expect("store the key");
+
+        let after = client.list_providers().await.expect("list providers");
+        let anthropic = after
+            .iter()
+            .find(|provider| provider.kind == "anthropic")
+            .expect("anthropic is a known provider");
+        assert!(
+            anthropic.has_credential && anthropic.enabled,
+            "the stored key must make the provider credentialed and enabled, got {anthropic:?}"
+        );
+
+        execute(
+            &client,
+            Command::ProviderRemoveKey {
+                kind: "anthropic".to_owned(),
+            },
+            OutputFormat::Text,
+        )
+        .await
+        .expect("remove the key");
+        let after = client.list_providers().await.expect("list providers");
+        assert!(
+            !after
+                .iter()
+                .any(|provider| provider.kind == "anthropic" && provider.has_credential),
+            "removing the credential must take it out of the listing"
+        );
+
+        serve.abort();
+    }
+}

--- a/crates/openwave-core/src/keychain.rs
+++ b/crates/openwave-core/src/keychain.rs
@@ -8,7 +8,8 @@
 //! The blocking `keyring` calls run on a blocking thread (`spawn_blocking`) so
 //! they don't stall the async runtime.
 
-use std::sync::Once;
+use std::collections::HashMap;
+use std::sync::{Mutex, Once, OnceLock};
 
 use async_trait::async_trait;
 
@@ -30,6 +31,24 @@ pub struct KeychainSecretProvider {
 
 static MOCK_INIT: Once = Once::new();
 
+/// The mock's credential store, keyed by (service, key).
+///
+/// `keyring`'s own mock keeps a password on the entry object and has no store
+/// behind it, so a value written through one `Entry` is invisible to the next
+/// one — a mocked process could store a credential and never read it back.
+/// Everything that writes a secret then uses it (a headless run configuring a
+/// provider and then taking a turn with it) depends on the two agreeing, so
+/// the mock keeps its own map.
+fn mock_store() -> &'static Mutex<HashMap<(String, String), String>> {
+    static STORE: OnceLock<Mutex<HashMap<(String, String), String>>> = OnceLock::new();
+    STORE.get_or_init(Mutex::default)
+}
+
+/// Whether this process routes secrets to [`mock_store`] instead of the OS.
+fn mocked() -> bool {
+    MOCK_INIT.is_completed()
+}
+
 impl KeychainSecretProvider {
     /// Use the default service name (`openwave`).
     ///
@@ -50,8 +69,8 @@ impl KeychainSecretProvider {
         // Debug-only on purpose. In a shipped build this env var would let
         // anything that can set the app's environment silently swap the OS
         // keychain for a process-local store: secrets written during the run
-        // evaporate, and reads that should have returned a stored credential
-        // return nothing. Only debug-binary tests consume it, so a release
+        // are lost when it exits, and a credential the user stored earlier
+        // reads as absent. Only debug-binary tests consume it, so a release
         // binary has no reason to honor it and every reason not to.
         #[cfg(debug_assertions)]
         if std::env::var("OPENWAVE_KEYCHAIN_MOCK").is_ok_and(|v| !v.is_empty()) {
@@ -62,11 +81,17 @@ impl KeychainSecretProvider {
         }
     }
 
-    /// Route all keyring operations to an in-memory mock. Call this before any
-    /// `KeychainSecretProvider` is used. Safe to call from multiple threads;
-    /// only the first call has effect.
+    /// Route every secret operation to an in-memory store for the rest of the
+    /// process. Call this before any `KeychainSecretProvider` is used. Safe to
+    /// call from multiple threads; only the first call has effect.
+    ///
+    /// Values written this way behave like stored credentials — they read back
+    /// under the same (service, key) — and are gone when the process exits.
     pub fn use_mock() {
         MOCK_INIT.call_once(|| {
+            // Also point `keyring` itself away from the OS credential store,
+            // so nothing that builds an `Entry` some other way can reach a
+            // developer's real keychain from a mocked process.
             keyring::set_default_credential_builder(keyring::mock::default_credential_builder());
         });
     }
@@ -82,6 +107,9 @@ impl Default for KeychainSecretProvider {
 impl SecretProvider for KeychainSecretProvider {
     async fn get_secret(&self, key: &str) -> Result<Option<String>> {
         let (service, key) = (self.service.clone(), key.to_string());
+        if mocked() {
+            return Ok(mock_store().lock().unwrap().get(&(service, key)).cloned());
+        }
         tokio::task::spawn_blocking(move || {
             let entry = keyring::Entry::new(&service, &key).map_err(secret_err)?;
             match entry.get_password() {
@@ -96,6 +124,10 @@ impl SecretProvider for KeychainSecretProvider {
 
     async fn set_secret(&self, key: &str, value: &str) -> Result<()> {
         let (service, key, value) = (self.service.clone(), key.to_string(), value.to_string());
+        if mocked() {
+            mock_store().lock().unwrap().insert((service, key), value);
+            return Ok(());
+        }
         tokio::task::spawn_blocking(move || {
             keyring::Entry::new(&service, &key)
                 .map_err(secret_err)?
@@ -108,6 +140,10 @@ impl SecretProvider for KeychainSecretProvider {
 
     async fn delete_secret(&self, key: &str) -> Result<()> {
         let (service, key) = (self.service.clone(), key.to_string());
+        if mocked() {
+            mock_store().lock().unwrap().remove(&(service, key));
+            return Ok(());
+        }
         tokio::task::spawn_blocking(move || {
             let entry = keyring::Entry::new(&service, &key).map_err(secret_err)?;
             match entry.delete_credential() {
@@ -124,15 +160,29 @@ impl SecretProvider for KeychainSecretProvider {
 mod tests {
     use super::*;
 
+    /// The mock has to behave like a credential store, not just accept writes:
+    /// code that stores a secret and then uses it — a headless run configuring
+    /// a provider before taking a turn — only works if a written value reads
+    /// back.
     #[tokio::test]
-    async fn operations_succeed_and_missing_reads_as_none() {
+    async fn the_mock_stores_what_it_is_given() {
         KeychainSecretProvider::use_mock();
         let secrets = KeychainSecretProvider::with_service("openwave-test");
         let key = "provider.anthropic.api_key";
 
         assert_eq!(secrets.get_secret(key).await.unwrap(), None);
         secrets.set_secret(key, "sk-123").await.unwrap();
-        // Deleting is a no-op when nothing is persisted (mock is per-entry).
+        assert_eq!(
+            secrets.get_secret(key).await.unwrap().as_deref(),
+            Some("sk-123")
+        );
+        // A second service name is a separate namespace, as on the real thing.
+        let other = KeychainSecretProvider::with_service("openwave-test-other");
+        assert_eq!(other.get_secret(key).await.unwrap(), None);
+
+        secrets.delete_secret(key).await.unwrap();
+        assert_eq!(secrets.get_secret(key).await.unwrap(), None);
+        // Deleting an absent entry is a no-op, not an error.
         secrets.delete_secret(key).await.unwrap();
     }
 

--- a/docs-site/content/docs/headless.mdx
+++ b/docs-site/content/docs/headless.mdx
@@ -24,6 +24,23 @@ openwave rehome-secrets
 openwave tui [--chat <id> | --new]
 openwave -p <prompt> [--chat <id>] [--output-format text|json]
            [--permission-mode ask|auto|allow|plan]
+
+openwave provider list
+openwave provider set-key <kind> [--from-env <var>]
+openwave provider remove-key <kind>
+openwave model list
+openwave model roles
+openwave model select <key|auto> [--role <role>]
+openwave settings show
+openwave settings web-search select <provider|off>
+openwave settings web-search set-key <provider> [--from-env <var>]
+openwave settings web-search remove-key <provider>
+openwave settings exec select <provider|off>
+openwave settings exec set-key <provider> [--from-env <var>]
+openwave settings exec remove-key <provider>
+openwave mcp-server list
+openwave mcp-server add <name> (--command <cmd> [--arg <a>]… | --url <url>)
+openwave mcp-server remove <name>
 ```
 
 A bare `openwave` with no arguments runs `serve`.
@@ -185,6 +202,67 @@ decision line when a request arrives:
 cargo run -p openwave-cli -- -p "plan the migration" \
   --permission-mode plan --output-format json < decisions.pipe
 ```
+
+### Setup commands
+
+`provider`, `model`, `settings`, and `mcp-server` configure a profile without
+the desktop app. Each one boots the same in-process server the other commands
+do, calls the route the desktop's settings pages call, and prints the answer —
+they hold no configuration logic of their own, so both surfaces stay in step.
+All of them accept `--output-format text|json`, and `json` prints the route's
+response object on one line.
+
+```sh
+# Providers and credentials
+cargo run -p openwave-cli -- provider list
+cargo run -p openwave-cli -- provider set-key anthropic < key.txt
+ANTHROPIC_KEY=sk-... cargo run -p openwave-cli -- \
+  provider set-key anthropic --from-env ANTHROPIC_KEY
+cargo run -p openwave-cli -- provider remove-key anthropic
+
+# Models
+cargo run -p openwave-cli -- model list
+cargo run -p openwave-cli -- model roles
+cargo run -p openwave-cli -- model select anthropic::claude-opus-5
+cargo run -p openwave-cli -- model select auto --role utility
+
+# Web search and code execution
+cargo run -p openwave-cli -- settings show
+cargo run -p openwave-cli -- settings web-search select exa
+cargo run -p openwave-cli -- settings web-search set-key exa --from-env EXA_KEY
+cargo run -p openwave-cli -- settings exec select e2b
+cargo run -p openwave-cli -- settings exec set-key e2b --from-env E2B_KEY
+
+# MCP servers
+cargo run -p openwave-cli -- mcp-server list
+cargo run -p openwave-cli -- mcp-server add docs \
+  --command npx --arg -y --arg @acme/docs-mcp --env-from ACME_TOKEN
+cargo run -p openwave-cli -- mcp-server remove docs
+```
+
+**A key is never a command-line argument.** `set-key` reads it from stdin, or
+from the environment variable named by `--from-env`. Arguments are visible to
+every process on the machine through the process list and land in shell
+history; a pipe and an exported variable do not. Stored keys go to the same
+place the desktop puts them — the OS keychain on a desktop profile — and no
+command here ever prints one back.
+
+Storing a provider key also enables that provider for routing, matching what
+saving a key in the app does. `model select` writes the same role selections
+the settings page does: a catalog key pins the role, and `auto` returns it to
+automatic resolution.
+
+`settings show` reports the runtime settings alongside web-search and
+code-execution selection, availability, and which credential slots are filled.
+
+`mcp-server add` and `remove` edit the *user-configured* server set. Servers
+that come from an installed plugin appear in `list` and are managed by turning
+that plugin on or off — the server rebuilds them, so the config route refuses
+to edit them. `--command` (with repeatable `--arg`), `--url`, and
+`--gateway-endpoint` are the three transports, and exactly one is required.
+Secret material is named, not given: `--env-from` forwards a variable from the
+parent environment, and `--bearer-token-env` names the variable holding a
+remote server's token. Both are resolved when the server connects.
 
 ### `mcp`
 


### PR DESCRIPTION
Third PR in the CLI/headless parity stack (record 5 → #1864, print protocol → #1873), implementing part 3 of `docs/decisions/0005-cli-headless-feature-parity.md`.

Setup was the remaining part of running OpenWave headlessly that needed raw HTTP. The routes exist and work; only curl against `openwave serve` reached them. This adds subcommand families that are thin clients of those same routes — each boots the in-process server the way print mode does, makes one call, and renders the answer.

```text
openwave provider list
openwave provider set-key <kind> [--from-env <var>]
openwave provider remove-key <kind>
openwave model list
openwave model roles
openwave model select <key|auto> [--role <role>]
openwave settings show
openwave settings web-search select <provider|off>
openwave settings web-search set-key <provider> [--from-env <var>]
openwave settings web-search remove-key <provider>
openwave settings exec select <provider|off>
openwave settings exec set-key <provider> [--from-env <var>]
openwave settings exec remove-key <provider>
openwave mcp-server list
openwave mcp-server add <name> (--command <cmd> [--arg <a>]… | --url <url> | --gateway-endpoint <slug>)
openwave mcp-server remove <name>
```

All of them take `--output-format text|json`, matching print mode's flag; `json` prints the route's response object on one line.

Routes behind each family:

| Command | Route |
| --- | --- |
| `provider list` | `GET /providers` |
| `provider set-key` | `PUT /providers/{kind}` (credential + `enabled: true`) |
| `provider remove-key` | `DELETE /providers/{kind}/credential` |
| `model list`, `model roles` | `GET /models` |
| `model select` | `PUT /models/roles/{role}` |
| `settings show` | `GET /settings`, `/web-search`, `/web-search/credentials`, `/code-execution`, `/code-execution/credentials` |
| `settings web-search select` | `PUT /web-search` |
| `settings web-search set-key`/`remove-key` | `PUT`/`DELETE /web-search/credentials/{provider}` |
| `settings exec select` | `PUT /code-execution` |
| `settings exec set-key`/`remove-key` | `PUT`/`DELETE /code-execution/credentials/{provider}` |
| `mcp-server list` | `GET /mcp/servers` |
| `mcp-server add`/`remove` | `GET` then `PUT /mcp/servers` |

## Secrets

A key is read from stdin (default) or from the environment variable named by `--from-env`. Never from an argument: argv is readable by every process on the machine, and a key pasted into a shell command also lands in its history. The choice is stated in `--help` output and in the docs page. Nothing here prints a stored key back, and storage is unchanged — headless changes the entry path, not the custody.

## MCP servers

`/mcp/servers` is mutable, but only as a complete replacement of the *user-configured* set, so `add`/`remove` read the current list, drop the live projection fields (health, tool counts) and any plugin-sourced entries the route refuses, edit, and put the whole set back. Removing a plugin-sourced server is refused with a message pointing at the plugin. Secret material is named rather than given: `--env-from` forwards a parent variable, `--bearer-token-env` names the variable holding a remote server's token, both resolved at connect time by the server.

## The keychain mock

`keyring`'s mock keeps the password on the entry object with no store behind it, so a value written through one `Entry` was invisible to the next one — a mocked process could store a credential and never read it back. That is precisely what a headless setup run does, and it made the smoke test below impossible to write. `KeychainSecretProvider` now keeps its own process-global map when mocked. Debug-only behavior, unchanged in release builds.

## Tests

One test, per the record's validation note (these are thin clients; re-walking each route through the CLI would be duplicate coverage of the server's own tests):

- `setup::tests::a_key_set_through_the_cli_shows_up_as_a_stored_credential` — stores an Anthropic key through the CLI's own command path against a real server, then asserts the provider listing reports it as credentialed and enabled, and that removing it takes it back out.
- `keychain::tests::the_mock_stores_what_it_is_given` replaces `operations_succeed_and_missing_reads_as_none`, which could only assert that a write did not error because the mock had nowhere to put it.

## Deliberately not covered

Route coverage is pragmatic, not exhaustive: no CLI surface for the ChatGPT OAuth sign-in flow (it needs a browser), voice transcription, gateway model sync, plugins, compaction tuning, model visibility overrides, egress policy, or E2B/Daytona template and snapshot fields. Provider config beyond the API key — base URLs, Vertex/Bedrock regions, custom model lists — is also left to the app for now; the credential is what blocks a headless start.

## Verified

`cargo fmt --all`, `cargo clippy -p openwave-cli --all-targets -D warnings`, `cargo test -p openwave-cli --locked` and the `openwave-core` keychain tests, all clean, no lockfile change. Also driven by hand against a throwaway profile: provider list/set-key, model list/roles, settings show, exec/web-search selection, and adding two MCP servers then removing one (the other survived the replacement).

Closes #1866