### PR TITLE
feat(cli): operator-provisioned folder consent for headless installs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4375,7 +4375,9 @@ dependencies = [
  "chrono",
  "crossterm",
  "futures",
+ "openwave-code-execution",
  "openwave-core",
+ "openwave-host-broker",
  "openwave-mcp",
  "openwave-server",
  "pulldown-cmark",
@@ -4389,6 +4391,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.30.0",
  "unicode-width",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/openwave-cli/Cargo.toml
+++ b/crates/openwave-cli/Cargo.toml
@@ -20,6 +20,12 @@ path = "src/main.rs"
 # built-in file tools for `openwave mcp`; server persistence features still come
 # through `openwave-server`. This avoids directly enabling unrelated defaults.
 openwave-core = { path = "../openwave-core", default-features = false, features = ["tools"] }
+# `openwave folder …` decides local command reach exactly as the desktop does,
+# so an operator-provisioned folder carries the same grants on the same host.
+openwave-code-execution = { path = "../openwave-code-execution" }
+# The capability store behind connected folders. `openwave folder …` opens it
+# in-process the way the desktop's sidecar opens it, against the same data dir.
+openwave-host-broker = { path = "../openwave-host-broker" }
 openwave-mcp = { path = "../openwave-mcp" }
 openwave-server = { path = "../openwave-server" }
 # Timestamps on transcript entries and inbox rows.
@@ -43,6 +49,7 @@ tokio-tungstenite = { workspace = true }
 ratatui-textarea = "=0.9.2"
 # Display-width clipping for lines rendered into fixed scrollback/panel buffers.
 unicode-width = "=0.2.0"
+uuid = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/openwave-cli/src/api/client.rs
+++ b/crates/openwave-cli/src/api/client.rs
@@ -784,6 +784,103 @@ impl Client {
     }
 }
 
+/// The second per-launch credential, presented on the client-executor routes.
+///
+/// These routes exist for the trusted surface that executes a client-owned tool
+/// call — in the desktop, the native shell that opens the folder picker. A
+/// headless run has no such surface, which is exactly why print mode needs
+/// them: it must answer a parked call rather than leave the turn hanging on a
+/// consent flow that can never appear.
+const CLIENT_EXECUTOR_HEADER: &str = "x-openwave-client-executor";
+
+/// One parked client-executed tool call, as much as the CLI acts on.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PendingClientCall {
+    pub id: CallId,
+    pub name: String,
+    #[serde(default)]
+    pub client_executor_id: Option<uuid::Uuid>,
+}
+
+impl Client {
+    /// Every client-owned tool call currently parked on this chat.
+    pub async fn pending_client_executions(
+        &self,
+        executor_token: &str,
+        chat: ChatId,
+    ) -> Result<Vec<PendingClientCall>> {
+        let response = self
+            .http
+            .get(format!(
+                "{}/chats/{chat}/client-executions/pending/raw",
+                self.base
+            ))
+            .header(CLIENT_EXECUTOR_HEADER, executor_token)
+            .send()
+            .await
+            .map_err(request_error)?;
+        Self::expect_success(response)
+            .await?
+            .json::<Vec<PendingClientCall>>()
+            .await
+            .map_err(request_error)
+    }
+
+    /// Take ownership of one parked call so it can be resolved.
+    pub async fn claim_client_execution(
+        &self,
+        executor_token: &str,
+        chat: ChatId,
+        call_id: CallId,
+        executor_id: uuid::Uuid,
+        lease_token: uuid::Uuid,
+    ) -> Result<()> {
+        let response = self
+            .http
+            .post(format!(
+                "{}/chats/{chat}/client-executions/{call_id}/claim",
+                self.base
+            ))
+            .header(CLIENT_EXECUTOR_HEADER, executor_token)
+            .json(&serde_json::json!({
+                "executor_id": executor_id,
+                "lease_token": lease_token,
+            }))
+            .send()
+            .await
+            .map_err(request_error)?;
+        Self::expect_success(response).await?;
+        Ok(())
+    }
+
+    /// Report the terminal, model-facing result of one claimed call.
+    pub async fn resolve_client_execution(
+        &self,
+        executor_token: &str,
+        chat: ChatId,
+        call_id: CallId,
+        lease_token: uuid::Uuid,
+        result: &str,
+    ) -> Result<()> {
+        let response = self
+            .http
+            .post(format!(
+                "{}/chats/{chat}/client-executions/{call_id}/resolve",
+                self.base
+            ))
+            .header(CLIENT_EXECUTOR_HEADER, executor_token)
+            .json(&serde_json::json!({
+                "lease_token": lease_token,
+                "resolution": { "status": "completed", "result": result },
+            }))
+            .send()
+            .await
+            .map_err(request_error)?;
+        Self::expect_success(response).await?;
+        Ok(())
+    }
+}
+
 /// reqwest's `Display` already strips nothing for loopback URLs, but keep the
 /// mapping in one place.
 fn request_error(error: reqwest::Error) -> AgentError {

--- a/crates/openwave-cli/src/connect.rs
+++ b/crates/openwave-cli/src/connect.rs
@@ -109,6 +109,7 @@ fn base_url(value: &str) -> Result<String> {
 pub struct Session {
     client: Client,
     serve: Option<tokio::task::JoinHandle<Result<()>>>,
+    client_executor_token: Option<String>,
 }
 
 impl Session {
@@ -121,9 +122,11 @@ impl Session {
                 openwave_server::logging::init_logging_file_only(&config.data_dir);
                 let server = openwave_server::bind_configured(config).await?;
                 let client = Client::new(server.local_addr(), server.token())?;
+                let client_executor_token = server.client_executor_token().to_owned();
                 Ok(Self {
                     client,
                     serve: Some(tokio::spawn(server.serve())),
+                    client_executor_token: Some(client_executor_token),
                 })
             }
             // Nothing local is touched in attach mode: no data directory, no
@@ -131,12 +134,26 @@ impl Session {
             Server::Attach { base, token } => Ok(Self {
                 client: Client::attach(base.clone(), token)?,
                 serve: None,
+                client_executor_token: None,
             }),
         }
     }
 
     pub fn client(&self) -> &Client {
         &self.client
+    }
+
+    /// The second per-launch credential, for the routes that execute a
+    /// client-owned tool call — present only when this process is the server.
+    ///
+    /// Attaching deliberately gets nothing. That credential is the native-only
+    /// boundary: it says "I am the trusted surface for this server", and a
+    /// client that merely holds a bearer token is not, no matter which process
+    /// started it. The bearer is all `--server` conveys, and there is no flag
+    /// to hand over the executor token — so an attached run cannot execute a
+    /// client tool call on somebody else's server, which is the point.
+    pub fn client_executor_token(&self) -> Option<&str> {
+        self.client_executor_token.as_deref()
     }
 }
 

--- a/crates/openwave-cli/src/folder.rs
+++ b/crates/openwave-cli/src/folder.rs
@@ -1,0 +1,980 @@
+//! `openwave folder …` — operator-provisioned consent for connected folders.
+//!
+//! Connecting a folder is host-machine consent. The desktop captures it in a
+//! native picker and records it as [`ConsentMethod::FolderPicker`]; a headless
+//! installation has no picker, so the person who controls the machine records
+//! it here instead and the broker stamps [`ConsentMethod::OperatorConfig`].
+//! Both land in the same broker state file, mint the same capability grants,
+//! and are revocable from the same surfaces — the provenance is the only thing
+//! that differs, and it is deliberately visible everywhere consent is listed.
+//!
+//! **These commands never run inside a turn.** They are standalone provisioning
+//! that an operator invokes; there is no flag that answers a folder request the
+//! agent made. A mid-turn `request_folder_access` in a headless run gets the
+//! same typed refusal an undecided desktop prompt produces — see
+//! [`crate::print`].
+//!
+//! Both shells hold exclusive locks on the profile data directory (the server's
+//! `openwave.lock` and the broker's `host-broker.lock`), so these commands
+//! refuse rather than write behind a running OpenWave. That is the intended
+//! failure: two owners of one capability store is not a supported arrangement.
+
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::sync::Arc;
+
+use chrono::{DateTime, Timelike, Utc};
+use openwave_core::{
+    AgentError, BeginRootAttachmentChange, BeginRootAttachmentChangeOutcome, Chat, ChatId,
+    FinishRootAttachmentChangeOutcome, HostRootId, Result, RootAttachmentChange,
+    RootAttachmentChangeAction, RootAttachmentChangeId, RootAttachmentChangePhase,
+    RootAttachmentChangeTerminal, Store, MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
+};
+use openwave_host_broker::{
+    Broker, Capability, ConsentMethod, ControlEnvelope, ControlRequest, ControlResult,
+    GrantSubject, OperationId, RegisterRootReceipt, RegisterRootRequest, RequestId, Response,
+    RevokeRootRequest, RootAttachmentMutationKind, RootAttachmentMutationReceipt,
+    RootAttachmentMutationRequest, RootId, RootPolicy, Scope, SubjectKind, PROTOCOL_VERSION,
+};
+use uuid::Uuid;
+
+/// One parsed `openwave folder` invocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Command {
+    /// Record standing operator consent for one folder, in one chat.
+    Connect { chat: ChatId, path: PathBuf },
+    /// Report every capability grant the broker holds, with its provenance.
+    List { chat: Option<ChatId> },
+    /// Withdraw one folder from one chat, and the approval it created.
+    Disconnect { chat: ChatId, target: OsString },
+}
+
+/// Hand-rolled argument parsing, matching the rest of the CLI.
+///
+/// The chat is mandatory for the mutating commands because broker authority is
+/// keyed to a conversation (or its project): there is no installation-wide
+/// subject to hang a grant on, and inventing one would create reach no product
+/// surface could show or withdraw.
+pub fn parse(mut args: impl Iterator<Item = OsString>) -> std::result::Result<Command, String> {
+    let Some(subcommand) = args.next() else {
+        return Err("folder requires connect, list, or disconnect".to_owned());
+    };
+    if subcommand == OsStr::new("connect") || subcommand == OsStr::new("disconnect") {
+        let connect = subcommand == OsStr::new("connect");
+        let noun = if connect { "connect" } else { "disconnect" };
+        let mut target = None;
+        let mut chat = None;
+        while let Some(argument) = args.next() {
+            if argument == OsStr::new("--chat") {
+                let Some(value) = args.next() else {
+                    return Err(format!("folder {noun} --chat requires a chat id"));
+                };
+                if chat.is_some() {
+                    return Err(format!("folder {noun} accepts one --chat"));
+                }
+                chat = Some(parse_chat(&value)?);
+            } else if target.is_none() && !starts_with_dash(&argument) {
+                target = Some(argument);
+            } else {
+                return Err(format!("unexpected folder {noun} argument {argument:?}"));
+            }
+        }
+        let Some(target) = target else {
+            return Err(if connect {
+                "folder connect requires a folder path".to_owned()
+            } else {
+                "folder disconnect requires a folder path or root id".to_owned()
+            });
+        };
+        let Some(chat) = chat else {
+            return Err(format!("folder {noun} requires --chat <id>"));
+        };
+        return Ok(if connect {
+            Command::Connect {
+                chat,
+                path: PathBuf::from(target),
+            }
+        } else {
+            Command::Disconnect { chat, target }
+        });
+    }
+    if subcommand == OsStr::new("list") {
+        let mut chat = None;
+        while let Some(argument) = args.next() {
+            if argument == OsStr::new("--chat") {
+                let Some(value) = args.next() else {
+                    return Err("folder list --chat requires a chat id".to_owned());
+                };
+                if chat.is_some() {
+                    return Err("folder list accepts one --chat".to_owned());
+                }
+                chat = Some(parse_chat(&value)?);
+            } else {
+                return Err(format!("unexpected folder list argument {argument:?}"));
+            }
+        }
+        return Ok(Command::List { chat });
+    }
+    Err(format!("unknown folder subcommand {subcommand:?}"))
+}
+
+fn starts_with_dash(argument: &OsStr) -> bool {
+    argument.to_string_lossy().starts_with('-')
+}
+
+fn parse_chat(value: &OsStr) -> std::result::Result<ChatId, String> {
+    ChatId::from_str(&value.to_string_lossy()).map_err(|_| "--chat expects a chat UUID".to_owned())
+}
+
+/// Run one folder command against the profile's data directory.
+pub async fn run(command: Command) -> Result<()> {
+    let config = crate::profile_config()?;
+    // stdout carries the command's report; logs stay in the profile's log file.
+    openwave_server::logging::init_logging_file_only(&config.data_dir);
+    let data_dir = config.data_dir.clone();
+    // The engine owns the store, its migrations, and the data-directory lock.
+    // Booting it is what makes the CLI's product writes the same writes the
+    // desktop makes, rather than a second opinion about the schema.
+    let server = openwave_server::bind_configured(config).await?;
+    let store = server.store();
+    let broker = open_broker(&data_dir)?;
+
+    match command {
+        Command::Connect { chat, path } => connect(&store, &broker, &data_dir, chat, path).await,
+        Command::List { chat } => list(&store, &broker, chat).await,
+        Command::Disconnect { chat, target } => {
+            disconnect(&store, &broker, &data_dir, chat, &target).await
+        }
+    }
+}
+
+/// Open the same durable broker state the desktop's sidecar opens.
+///
+/// The policy is assembled exactly as the sidecar assembles it: the host's
+/// protected-location rules plus this profile's own data directory, which no
+/// folder may ever cover. Local command reach is decided by the same host
+/// probe, so a folder connected here carries the grants it would have carried
+/// had the desktop's picker connected it on this machine.
+fn open_broker(data_dir: &Path) -> Result<Broker> {
+    let home = std::env::home_dir()
+        .ok_or_else(|| AgentError::config("could not resolve the current user's home directory"))?
+        .canonicalize()
+        .map_err(|error| {
+            AgentError::config(format!("could not resolve the home directory: {error}"))
+        })?;
+    let data_dir = data_dir.canonicalize().map_err(|error| {
+        AgentError::config(format!("could not resolve the data directory: {error}"))
+    })?;
+    let policy = RootPolicy::for_host(home)
+        .and_then(|policy| policy.with_private_directory(&data_dir))
+        .map_err(|error| {
+            AgentError::config(format!("could not initialize the folder policy: {error}"))
+        })?;
+    let execute_commands = openwave_code_execution::LocalExecutionProvider::availability().is_ok();
+    Broker::open_with_execute_commands(policy, &data_dir, execute_commands).map_err(|error| {
+        AgentError::config(format!(
+            "could not open connected-folder state: {error}. Close OpenWave before running \
+             `openwave folder`"
+        ))
+    })
+}
+
+/// The broker subject a chat's host authority belongs to.
+///
+/// Identical to the desktop's derivation: a chat inside a project shares that
+/// project's standing consent, and a loose chat owns its own.
+fn subject_for(chat: &Chat) -> Result<GrantSubject> {
+    match chat.project_id {
+        Some(project_id) => GrantSubject::project(project_id.0),
+        None => GrantSubject::conversation(chat.id.0),
+    }
+    .map_err(|_| AgentError::msg("chat has an invalid conversation identity"))
+}
+
+async fn load_chat(store: &Arc<dyn Store>, chat: ChatId) -> Result<Chat> {
+    store
+        .get_chat(chat)
+        .await?
+        .ok_or_else(|| AgentError::msg(format!("chat {chat} not found")))
+}
+
+fn control(broker: &Broker, request: ControlRequest) -> Result<ControlResult> {
+    let response = broker.controller().handle(ControlEnvelope {
+        protocol_version: PROTOCOL_VERSION,
+        request_id: RequestId::new(),
+        request,
+    });
+    match response.response {
+        Response::Ok(result) => Ok(result),
+        // The broker's messages are already safe for display: they never carry
+        // an absolute path or raw OS error text.
+        Response::Error(error) => Err(AgentError::msg(format!(
+            "connected-folder request refused ({:?}): {}",
+            error.code, error.message
+        ))),
+    }
+}
+
+/// Resolve an operator-supplied folder argument to an absolute path.
+///
+/// Canonicalization here is deliberate and matches what the broker does with
+/// the path afterwards ([`RootPolicy::open_root`] canonicalizes and pins a
+/// descriptor): a symlink argument names the directory it resolves to, and a
+/// path that does not exist is rejected before any state is touched. Doing it
+/// twice is harmless — resolving an already-canonical path is a fixed point —
+/// and it lets the CLI say "no such folder" instead of surfacing a broker
+/// error code for a typo.
+fn canonical_folder(path: &Path) -> Result<PathBuf> {
+    let canonical = path
+        .canonicalize()
+        .map_err(|error| AgentError::msg(format!("could not open {}: {error}", path.display())))?;
+    if !canonical.is_dir() {
+        return Err(AgentError::msg(format!(
+            "{} is not a folder",
+            path.display()
+        )));
+    }
+    Ok(canonical)
+}
+
+async fn connect(
+    store: &Arc<dyn Store>,
+    broker: &Broker,
+    data_dir: &Path,
+    chat_id: ChatId,
+    path: PathBuf,
+) -> Result<()> {
+    let path = canonical_folder(&path)?;
+    let chat = load_chat(store, chat_id).await?;
+    let subject = subject_for(&chat)?;
+    let executor_id = executor_identity(data_dir)?;
+    // A change left awaiting the broker by an interrupted run blocks the chat.
+    // Drive it to a terminal before starting new work rather than reporting a
+    // conflict the operator cannot act on.
+    settle_pending_changes(store, broker, &chat, subject, executor_id).await?;
+    // Settling advances the projection's revision, so the CAS fence the attach
+    // below carries has to come from a fresh read.
+    let chat = load_chat(store, chat_id).await?;
+    if subject_for(&chat)? != subject {
+        return Err(AgentError::msg(
+            "the chat's authority changed while the folder was being connected",
+        ));
+    }
+
+    // Registration mints the standing grants and the broker-side attachment in
+    // one durable operation; `OperatorConfig` is the provenance stamped on all
+    // of them. The broker refuses any consent method it did not expect here,
+    // so this is the only place the CLI can create host reach.
+    let operation_id = OperationId::new();
+    let root = match control(
+        broker,
+        ControlRequest::RegisterRoot(RegisterRootRequest {
+            operation_id,
+            subject,
+            conversation_id: chat.id.0,
+            path,
+            consent_method: ConsentMethod::OperatorConfig,
+        }),
+    )? {
+        ControlResult::RegisterRoot(result) => result.root,
+        _ => return Err(unexpected_broker_response()),
+    };
+    // Read the durable receipt back rather than trusting the response: it is
+    // the same authority the desktop's reconciler consults, and it reports a
+    // registration that was revoked between commit and reply.
+    match lookup_registration(broker, operation_id, subject, chat.id.0)? {
+        RegisterRootReceipt::Completed { root: recorded } if recorded == root => {}
+        _ => {
+            return Err(AgentError::msg(
+                "the folder was not durably connected; nothing was granted",
+            ))
+        }
+    }
+
+    // The product projection is what makes the folder reachable in a turn and
+    // visible in the desktop's connected-folders panel. If it cannot be
+    // committed, withdraw the approval instead of leaving standing host reach
+    // no surface can show.
+    let attached = attach_to_chat(store, broker, &chat, subject, root.root_id, executor_id).await;
+    if let Err(error) = attached {
+        let revoked = control(
+            broker,
+            ControlRequest::RevokeRoot(RevokeRootRequest {
+                operation_id: OperationId::new(),
+                subject,
+                root_id: root.root_id,
+            }),
+        );
+        return Err(match revoked {
+            Ok(_) => AgentError::msg(format!("{error}; the folder approval was withdrawn")),
+            Err(cleanup) => AgentError::msg(format!(
+                "{error}; the folder approval could not be withdrawn either ({cleanup}) — review \
+                 `openwave folder list`"
+            )),
+        });
+    }
+
+    println!(
+        "openwave: connected {} to chat {} (root {}, operator configuration)",
+        safe_label(&root.display_name),
+        chat_id,
+        root.root_id
+    );
+    Ok(())
+}
+
+fn lookup_registration(
+    broker: &Broker,
+    operation_id: OperationId,
+    subject: GrantSubject,
+    conversation_id: Uuid,
+) -> Result<RegisterRootReceipt> {
+    match control(
+        broker,
+        ControlRequest::LookupRegisterRootReceipt(
+            openwave_host_broker::LookupRegisterRootReceiptRequest {
+                operation_id,
+                subject,
+                conversation_id,
+            },
+        ),
+    )? {
+        ControlResult::LookupRegisterRootReceipt(result) if result.operation_id == operation_id => {
+            Ok(result.receipt)
+        }
+        _ => Err(unexpected_broker_response()),
+    }
+}
+
+async fn list(store: &Arc<dyn Store>, broker: &Broker, chat: Option<ChatId>) -> Result<()> {
+    // `ListGrantStatements` is the same query the desktop's Permissions surface
+    // reads (`list_capability_consents`), so the two shells cannot disagree
+    // about what is granted or how it was granted.
+    let ControlResult::ListGrantStatements { grants } =
+        control(broker, ControlRequest::ListGrantStatements)?
+    else {
+        return Err(unexpected_broker_response());
+    };
+    let filter = match chat {
+        Some(chat) => Some(subject_for(&load_chat(store, chat).await?)?),
+        None => None,
+    };
+    let mut shown = 0usize;
+    for grant in grants {
+        if filter.is_some_and(|subject| subject != grant.subject) {
+            continue;
+        }
+        let subject = match grant.subject.kind() {
+            SubjectKind::Conversation => format!("chat {}", grant.subject.id()),
+            SubjectKind::Project => format!("project {}", grant.subject.id()),
+        };
+        let scope = match &grant.scope {
+            Scope::Subject => "all connected folders".to_owned(),
+            Scope::Root { root_id } => folder_label(grant.root_display_name.as_deref(), *root_id),
+            Scope::PathSubtree { root_id, relative } => format!(
+                "{}/{}",
+                folder_label(grant.root_display_name.as_deref(), *root_id),
+                relative.as_str()
+            ),
+            _ => "unrecognized scope".to_owned(),
+        };
+        println!(
+            "{}\t{}\t{}\t{}\t{}\t{}",
+            grant.grant_id,
+            subject,
+            capability_label(grant.capability),
+            scope,
+            consent_label(grant.consent_method),
+            grant.granted_at.to_rfc3339(),
+        );
+        shown += 1;
+    }
+    if shown == 0 {
+        eprintln!("openwave: no connected-folder grants");
+    }
+    Ok(())
+}
+
+fn folder_label(display_name: Option<&str>, root_id: RootId) -> String {
+    display_name.map_or_else(|| format!("folder {root_id}"), safe_label)
+}
+
+/// A folder name is a host filename: it can contain tabs, newlines, and
+/// bidirectional overrides. This listing is tab-separated and read by people
+/// and scripts alike, so a name never gets to invent a column or a row.
+fn safe_label(value: &str) -> String {
+    value
+        .chars()
+        .take(80)
+        .map(|character| {
+            if character.is_control()
+                || character == '\t'
+                || matches!(character, '\u{202a}'..='\u{202e}' | '\u{2066}'..='\u{2069}')
+            {
+                '\u{fffd}'
+            } else {
+                character
+            }
+        })
+        .collect()
+}
+
+fn capability_label(capability: Capability) -> &'static str {
+    match capability {
+        Capability::ListRoots => "list-folders",
+        Capability::ReadFiles => "read",
+        Capability::WriteFiles => "write",
+        Capability::ExecuteCommands => "exec",
+        _ => "unrecognized",
+    }
+}
+
+fn consent_label(method: ConsentMethod) -> &'static str {
+    match method {
+        ConsentMethod::FolderPicker => "folder-picker",
+        ConsentMethod::PermissionDialog => "permission-dialog",
+        ConsentMethod::OperatorConfig => "operator-config",
+        ConsentMethod::CarriedForward => "carried-forward",
+        _ => "unrecognized",
+    }
+}
+
+async fn disconnect(
+    store: &Arc<dyn Store>,
+    broker: &Broker,
+    data_dir: &Path,
+    chat_id: ChatId,
+    target: &OsStr,
+) -> Result<()> {
+    let chat = load_chat(store, chat_id).await?;
+    let subject = subject_for(&chat)?;
+    let executor_id = executor_identity(data_dir)?;
+    settle_pending_changes(store, broker, &chat, subject, executor_id).await?;
+    let chat = load_chat(store, chat_id).await?;
+    let root_id = resolve_target(broker, &chat, target)?;
+
+    detach_from_chat(store, broker, &chat, subject, root_id, executor_id).await?;
+    println!("openwave: disconnected {root_id} from chat {chat_id}");
+
+    // Detaching leaves the host approval standing, which is right when another
+    // conversation still holds it and wrong when nothing does — an operator
+    // would have no way to withdraw it. Withdraw it exactly when this chat's
+    // subject is the only one with root-scoped grants on the folder, and say
+    // so plainly when it is not.
+    if sole_grant_holder(broker, root_id, subject)? {
+        match control(
+            broker,
+            ControlRequest::RevokeRoot(RevokeRootRequest {
+                operation_id: OperationId::new(),
+                subject,
+                root_id,
+            }),
+        )? {
+            ControlResult::RevokeRoot(result) if result.revoked => {
+                println!("openwave: withdrew the folder approval");
+            }
+            ControlResult::RevokeRoot(_) => {}
+            _ => return Err(unexpected_broker_response()),
+        }
+    } else {
+        eprintln!(
+            "openwave: the folder approval still reaches other subjects and was left in place; \
+             see `openwave folder list`"
+        );
+    }
+    Ok(())
+}
+
+/// Whether `subject` is the only holder of root-scoped grants on `root_id`.
+fn sole_grant_holder(broker: &Broker, root_id: RootId, subject: GrantSubject) -> Result<bool> {
+    let ControlResult::ListGrantStatements { grants } =
+        control(broker, ControlRequest::ListGrantStatements)?
+    else {
+        return Err(unexpected_broker_response());
+    };
+    let mut holders = grants.iter().filter(|grant| match &grant.scope {
+        Scope::Root { root_id: scoped } => *scoped == root_id,
+        Scope::PathSubtree {
+            root_id: scoped, ..
+        } => *scoped == root_id,
+        _ => false,
+    });
+    Ok(holders.all(|grant| grant.subject == subject))
+}
+
+/// Resolve a folder argument to one root attached to this chat.
+///
+/// A root id is exact. A path is matched by the leaf name the broker reports,
+/// because the broker deliberately never exposes a root's absolute path — so an
+/// ambiguous name is refused rather than guessed at.
+fn resolve_target(broker: &Broker, chat: &Chat, target: &OsStr) -> Result<RootId> {
+    let attached = chat
+        .root_attachments
+        .iter()
+        .map(|attachment| *attachment.root_id.as_uuid())
+        .collect::<std::collections::HashSet<_>>();
+    let ControlResult::ListApprovedRoots { roots } =
+        control(broker, ControlRequest::ListApprovedRoots)?
+    else {
+        return Err(unexpected_broker_response());
+    };
+    let roots = roots
+        .into_iter()
+        .filter(|root| attached.contains(&root.root_id.as_uuid()))
+        .collect::<Vec<_>>();
+
+    let text = target.to_string_lossy();
+    if let Ok(root_id) = RootId::from_str(&text) {
+        return if roots.iter().any(|root| root.root_id == root_id) {
+            Ok(root_id)
+        } else {
+            Err(AgentError::msg(format!(
+                "folder {root_id} is not connected to this chat"
+            )))
+        };
+    }
+
+    let path = canonical_folder(Path::new(target))?;
+    let name = path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .ok_or_else(|| AgentError::msg("the folder path has no name to match"))?;
+    let matches = roots
+        .iter()
+        .filter(|root| root.display_name == name)
+        .collect::<Vec<_>>();
+    match matches.as_slice() {
+        [root] => Ok(root.root_id),
+        [] => Err(AgentError::msg(format!(
+            "no folder named {name} is connected to this chat"
+        ))),
+        many => Err(AgentError::msg(format!(
+            "{} connected folders are named {name}; disconnect one by root id ({})",
+            many.len(),
+            many.iter()
+                .map(|root| root.root_id.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ))),
+    }
+}
+
+async fn attach_to_chat(
+    store: &Arc<dyn Store>,
+    broker: &Broker,
+    chat: &Chat,
+    subject: GrantSubject,
+    root_id: RootId,
+    executor_id: Uuid,
+) -> Result<()> {
+    drive_change(
+        store,
+        broker,
+        chat,
+        subject,
+        root_id,
+        executor_id,
+        RootAttachmentChangeAction::Attach,
+    )
+    .await
+}
+
+async fn detach_from_chat(
+    store: &Arc<dyn Store>,
+    broker: &Broker,
+    chat: &Chat,
+    subject: GrantSubject,
+    root_id: RootId,
+    executor_id: Uuid,
+) -> Result<()> {
+    let product_root = HostRootId::from_uuid(root_id.as_uuid())
+        .map_err(|_| AgentError::msg("invalid connected-folder identity"))?;
+    if !chat
+        .root_attachments
+        .iter()
+        .any(|attachment| attachment.root_id == product_root)
+    {
+        return Err(AgentError::msg("that folder is not connected to this chat"));
+    }
+    drive_change(
+        store,
+        broker,
+        chat,
+        subject,
+        root_id,
+        executor_id,
+        RootAttachmentChangeAction::Detach,
+    )
+    .await
+}
+
+/// Commit one product-side attachment intent, then converge the broker to it.
+///
+/// This is the desktop reconciler's sequence, minus its crash-recovery receipt
+/// store: product intent is durable first, the broker mutation carries the
+/// change id as its idempotency identity, and the terminal receipt is read back
+/// before the change is finished. An interrupted run leaves a change awaiting
+/// the broker, which the next invocation settles.
+async fn drive_change(
+    store: &Arc<dyn Store>,
+    broker: &Broker,
+    chat: &Chat,
+    subject: GrantSubject,
+    root_id: RootId,
+    executor_id: Uuid,
+    action: RootAttachmentChangeAction,
+) -> Result<()> {
+    let product_root = HostRootId::from_uuid(root_id.as_uuid())
+        .map_err(|_| AgentError::msg("invalid connected-folder identity"))?;
+    let request = BeginRootAttachmentChange {
+        id: RootAttachmentChangeId::new(),
+        chat_id: chat.id,
+        executor_id,
+        root_id: product_root,
+        action,
+        expected_attachment_revision: chat.attachment_revision,
+        created_at: canonical_now(),
+    };
+    let change = match store.begin_root_attachment_change(&request).await? {
+        BeginRootAttachmentChangeOutcome::Begun(change)
+        | BeginRootAttachmentChangeOutcome::Existing(change) => change,
+        BeginRootAttachmentChangeOutcome::ChatNotFound => {
+            return Err(AgentError::msg("chat not found"))
+        }
+        BeginRootAttachmentChangeOutcome::ChatBusy => {
+            return Err(AgentError::msg(
+                "another connected-folder change is in progress for this chat",
+            ))
+        }
+        outcome => {
+            return Err(AgentError::msg(format!(
+                "the connected-folder projection refused this change ({outcome:?})"
+            )))
+        }
+    };
+    settle_change(store, broker, subject, chat.id.0, executor_id, change).await
+}
+
+/// Bring one durable change to a terminal phase and report what it means.
+async fn settle_change(
+    store: &Arc<dyn Store>,
+    broker: &Broker,
+    subject: GrantSubject,
+    conversation_id: Uuid,
+    executor_id: Uuid,
+    change: RootAttachmentChange,
+) -> Result<()> {
+    let change = if change.phase == RootAttachmentChangePhase::AwaitingBroker {
+        let terminal = converge_broker(broker, subject, conversation_id, &change)?;
+        match store
+            .finish_root_attachment_change(change.id, executor_id, &terminal, canonical_now())
+            .await?
+        {
+            FinishRootAttachmentChangeOutcome::Finished(change)
+            | FinishRootAttachmentChangeOutcome::Existing(change) => change,
+            outcome => {
+                return Err(AgentError::msg(format!(
+                    "the connected-folder projection could not be finished ({outcome:?})"
+                )))
+            }
+        }
+    } else {
+        change
+    };
+    match change.phase {
+        RootAttachmentChangePhase::Completed => Ok(()),
+        RootAttachmentChangePhase::Failed => Err(AgentError::msg(change.failure.map_or_else(
+            || "the connected-folder change failed".to_owned(),
+            |failure| failure.message,
+        ))),
+        RootAttachmentChangePhase::AwaitingBroker => Err(AgentError::msg(
+            "the connected-folder change has no durable host outcome yet",
+        )),
+    }
+}
+
+/// Dispatch (or recover) the broker half of one product change.
+fn converge_broker(
+    broker: &Broker,
+    subject: GrantSubject,
+    conversation_id: Uuid,
+    change: &RootAttachmentChange,
+) -> Result<RootAttachmentChangeTerminal> {
+    let root_id = RootId::from_uuid(*change.root_id.as_uuid())
+        .map_err(|_| AgentError::msg("invalid connected-folder identity"))?;
+    let operation_id = OperationId::from_uuid(*change.id.as_uuid())
+        .map_err(|_| AgentError::msg("invalid connected-folder change identity"))?;
+    let mutation = match change.action {
+        RootAttachmentChangeAction::Attach => RootAttachmentMutationKind::Attach,
+        RootAttachmentChangeAction::Detach => RootAttachmentMutationKind::Detach,
+    };
+    let mut receipt = lookup_mutation(
+        broker,
+        subject,
+        conversation_id,
+        root_id,
+        operation_id,
+        mutation,
+    )?;
+    if matches!(receipt, RootAttachmentMutationReceipt::Unknown) {
+        let request = RootAttachmentMutationRequest {
+            operation_id,
+            subject,
+            conversation_id,
+            root_id,
+            // Attach carries this command's own provenance; detach carries
+            // none, which the broker requires.
+            consent_method: match change.action {
+                RootAttachmentChangeAction::Attach => Some(ConsentMethod::OperatorConfig),
+                RootAttachmentChangeAction::Detach => None,
+            },
+        };
+        let dispatched = control(
+            broker,
+            match change.action {
+                RootAttachmentChangeAction::Attach => ControlRequest::AttachRoot(request),
+                RootAttachmentChangeAction::Detach => ControlRequest::DetachRoot(request),
+            },
+        );
+        // The receipt below is the authoritative post-effect check, exactly as
+        // in the desktop reconciler: a failed dispatch may still have landed.
+        match dispatched {
+            Ok(ControlResult::AttachRoot(_) | ControlResult::DetachRoot(_)) | Err(_) => {}
+            Ok(_) => return Err(unexpected_broker_response()),
+        }
+        receipt = lookup_mutation(
+            broker,
+            subject,
+            conversation_id,
+            root_id,
+            operation_id,
+            mutation,
+        )?;
+    }
+    mutation_terminal(receipt, root_id, change.action)?.ok_or_else(|| {
+        AgentError::msg("the connected-folder change has no durable host outcome yet")
+    })
+}
+
+fn lookup_mutation(
+    broker: &Broker,
+    subject: GrantSubject,
+    conversation_id: Uuid,
+    root_id: RootId,
+    operation_id: OperationId,
+    mutation: RootAttachmentMutationKind,
+) -> Result<RootAttachmentMutationReceipt> {
+    match control(
+        broker,
+        ControlRequest::LookupRootAttachmentReceipt(
+            openwave_host_broker::LookupRootAttachmentReceiptRequest {
+                operation_id,
+                subject,
+                conversation_id,
+                root_id,
+                mutation,
+            },
+        ),
+    )? {
+        ControlResult::LookupRootAttachmentReceipt(result)
+            if result.operation_id == operation_id =>
+        {
+            Ok(result.receipt)
+        }
+        _ => Err(unexpected_broker_response()),
+    }
+}
+
+/// Map a durable broker receipt onto the product's terminal vocabulary.
+///
+/// A rejected mutation still settles on what the broker holds now rather than
+/// reporting "unknown": nothing re-drives a terminal change, and an unknown
+/// observation would leave the conversation permanently unresolvable.
+fn mutation_terminal(
+    receipt: RootAttachmentMutationReceipt,
+    root_id: RootId,
+    action: RootAttachmentChangeAction,
+) -> Result<Option<RootAttachmentChangeTerminal>> {
+    let desired = action == RootAttachmentChangeAction::Attach;
+    let expected = match action {
+        RootAttachmentChangeAction::Attach => RootAttachmentMutationKind::Attach,
+        RootAttachmentChangeAction::Detach => RootAttachmentMutationKind::Detach,
+    };
+    match receipt {
+        RootAttachmentMutationReceipt::Unknown => Ok(None),
+        RootAttachmentMutationReceipt::Completed {
+            result,
+            currently_attached,
+        } => {
+            if result.root_id != root_id || result.mutation != expected {
+                return Err(AgentError::msg(
+                    "the host receipt contradicts the requested connected-folder change",
+                ));
+            }
+            Ok(Some(if currently_attached == desired {
+                RootAttachmentChangeTerminal::Completed {
+                    broker_changed: result.changed,
+                    broker_currently_attached: currently_attached,
+                }
+            } else {
+                RootAttachmentChangeTerminal::Failed {
+                    broker_changed: Some(result.changed),
+                    broker_currently_attached: Some(currently_attached),
+                    failure: safe_failure(
+                        "broker_attachment_superseded",
+                        "The folder attachment changed before synchronization completed.",
+                    ),
+                }
+            }))
+        }
+        RootAttachmentMutationReceipt::Failed {
+            currently_attached, ..
+        } if currently_attached == desired => Ok(Some(RootAttachmentChangeTerminal::Completed {
+            broker_changed: false,
+            broker_currently_attached: currently_attached,
+        })),
+        RootAttachmentMutationReceipt::Failed {
+            currently_attached, ..
+        } => Ok(Some(RootAttachmentChangeTerminal::Failed {
+            broker_changed: Some(false),
+            broker_currently_attached: Some(currently_attached),
+            failure: safe_failure(
+                "broker_attachment_failed",
+                "The host could not complete this connected-folder change.",
+            ),
+        })),
+        _ => Err(AgentError::msg("unsupported host attachment receipt")),
+    }
+}
+
+fn safe_failure(code: &str, message: &str) -> openwave_core::RootAttachmentChangeFailure {
+    openwave_core::RootAttachmentChangeFailure {
+        code: code.to_owned(),
+        message: message.to_owned(),
+        retryable: false,
+    }
+}
+
+/// Settle changes this CLI executor left awaiting the broker for one chat.
+///
+/// The desktop's recovery loop only sees changes owned by its own executor, so
+/// a run interrupted between product intent and its host mutation is this
+/// command's to finish — and until it is finished, the chat refuses new ones.
+async fn settle_pending_changes(
+    store: &Arc<dyn Store>,
+    broker: &Broker,
+    chat: &Chat,
+    subject: GrantSubject,
+    executor_id: Uuid,
+) -> Result<()> {
+    let pending = store
+        .list_pending_root_attachment_changes(executor_id, MAX_PENDING_ROOT_ATTACHMENT_CHANGES)
+        .await?;
+    for change in pending {
+        if change.chat_id != chat.id {
+            continue;
+        }
+        settle_change(store, broker, subject, chat.id.0, executor_id, change).await?;
+    }
+    Ok(())
+}
+
+/// This CLI's stable native-executor identity for attachment changes.
+///
+/// It must survive across invocations: only the executor that began a change
+/// may finish it, so a fresh identity per run would strand an interrupted one.
+/// It is not a credential — it names who owns pending work — but it lives with
+/// the rest of the private profile state and inherits its permissions.
+fn executor_identity(data_dir: &Path) -> Result<Uuid> {
+    let path = data_dir.join("cli-folder-executor");
+    let read = |path: &Path| -> Result<Uuid> {
+        let text = std::fs::read_to_string(path).map_err(|error| {
+            AgentError::config(format!(
+                "could not read the folder-executor identity: {error}"
+            ))
+        })?;
+        Uuid::from_str(text.trim())
+            .map_err(|_| AgentError::config("the stored folder-executor identity is unreadable"))
+    };
+    if path.exists() {
+        return read(&path);
+    }
+    write_private(&path, &Uuid::new_v4().to_string()).map_err(|error| {
+        AgentError::config(format!(
+            "could not record the folder-executor identity: {error}"
+        ))
+    })?;
+    // Always read the identity back: a concurrent invocation may have written
+    // first, and the one on disk is the one that owns pending work.
+    read(&path)
+}
+
+fn write_private(path: &Path, contents: &str) -> std::io::Result<()> {
+    use std::io::Write as _;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+    match options.open(path) {
+        Ok(mut file) => {
+            file.write_all(contents.as_bytes())?;
+            file.sync_all()
+        }
+        // Another invocation won the race; its identity is the one to use.
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+/// Microsecond-truncated, matching the timestamp grain the store persists.
+fn canonical_now() -> DateTime<Utc> {
+    let now = Utc::now();
+    now.with_nanosecond((now.nanosecond() / 1_000) * 1_000)
+        .unwrap_or(now)
+}
+
+fn unexpected_broker_response() -> AgentError {
+    AgentError::msg("the connected-folder store returned an unexpected response")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(values: &[&str]) -> impl Iterator<Item = OsString> {
+        values
+            .iter()
+            .map(|value| OsString::from(*value))
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
+
+    /// The mutating commands must name a conversation: broker authority has no
+    /// installation-wide subject, and a grant nothing can show is a one-way
+    /// door. A path that looks like a flag must not be swallowed as one either.
+    #[test]
+    fn mutating_commands_require_an_explicit_chat() {
+        let chat = ChatId::new();
+        assert_eq!(
+            parse(args(&["connect", "/srv/data", "--chat", &chat.to_string()])).unwrap(),
+            Command::Connect {
+                chat,
+                path: PathBuf::from("/srv/data"),
+            }
+        );
+        assert!(parse(args(&["connect", "/srv/data"])).is_err());
+        assert!(parse(args(&["disconnect", "/srv/data"])).is_err());
+        assert!(parse(args(&["connect", "--chat", &chat.to_string()])).is_err());
+        assert!(parse(args(&["connect", "--yes", "--chat", &chat.to_string()])).is_err());
+        assert_eq!(
+            parse(args(&["list"])).unwrap(),
+            Command::List { chat: None }
+        );
+        assert!(parse(args(&["approve"])).is_err());
+    }
+}

--- a/crates/openwave-cli/src/main.rs
+++ b/crates/openwave-cli/src/main.rs
@@ -43,6 +43,14 @@
 //! See [`setup`]; secrets are read from stdin or a named environment variable,
 //! never from a command-line argument.
 //!
+//! `openwave folder connect|list|disconnect` is the headless equivalent of the
+//! desktop's folder picker: an operator records standing consent for a host
+//! folder, which the broker stamps as operator configuration. It is deliberate
+//! provisioning only — nothing here answers a folder request an agent made
+//! during a turn. See [`folder`]. Unlike the client commands it works on local
+//! broker state and the local data directory, so it embeds and takes no
+//! `--server`.
+//!
 //! Every client command above embeds its own server by default. `--server
 //! <url>` (or `OPENWAVE_SERVER_URL`) makes it a pure client of one that is
 //! already running instead, with the bearer token coming from
@@ -61,6 +69,7 @@ use openwave_core::{
 
 mod api;
 mod connect;
+mod folder;
 mod outputs;
 mod print;
 mod setup;
@@ -102,6 +111,10 @@ usage: openwave serve
                   [--timeout-ms <ms>] [--disabled]
        openwave mcp-server remove <name>
 
+       openwave folder connect <path> --chat <id>
+       openwave folder list [--chat <id>]
+       openwave folder disconnect <path-or-root-id> --chat <id>
+
 The setup commands take --output-format text|json. A key is read from stdin, or
 from the environment variable named by --from-env — never from an argument,
 which every process on the machine can read.
@@ -109,7 +122,8 @@ which every process on the machine can read.
 tui, -p, output, attach, and the setup commands also take --server <url>
 [--server-token-env <var>], which talks to a server that is already running
 instead of embedding one. The token comes from OPENWAVE_SERVER_TOKEN, or from the named variable;
-it is never an argument either.";
+it is never an argument either. The folder commands do not: they provision
+local host consent in this machine's own broker state.";
 
 #[tokio::main]
 async fn main() {
@@ -273,6 +287,17 @@ async fn run() -> Result<i32> {
             setup::run(command, format, server_flags.resolve()?)
                 .await
                 .map(|()| 0)
+        }
+        // Folder consent is host-machine state: the broker's own state file and
+        // this profile's data directory. There is nothing to point at another
+        // server, and pointing at one would say the grant lands somewhere it
+        // does not — so `--server` is refused rather than ignored.
+        Some(command) if command == OsStr::new("folder") => {
+            server_flags.refuse("folder");
+            match folder::parse(args) {
+                Ok(command) => folder::run(command).await.map(|()| 0),
+                Err(message) => usage_error(&message),
+            }
         }
         Some(other) => {
             usage_error(&format!("unknown command {other:?}"));

--- a/crates/openwave-cli/src/print.rs
+++ b/crates/openwave-cli/src/print.rs
@@ -15,12 +15,25 @@
 //! choose another route rather than hang, and a plan or a question ends the run
 //! with a distinct exit status and a machine-readable reason. Nothing is ever
 //! cancelled silently.
+//!
+//! A request for another host folder is deliberately **not** one of those.
+//! Folder access is host-machine consent, and the driving protocol has no way
+//! to give it: no request event is emitted for it, it never becomes an
+//! [`Interaction`], and no decision line can name it — the protocol's closed
+//! vocabulary is approval, plan, and questions. A driven run refuses a folder
+//! request exactly as an undriven one does, with the folder contract's own
+//! `declined` result, the same answer an undecided desktop prompt gives.
+//! Standing folder consent comes from `openwave folder connect` and nowhere
+//! else. See [`crate::folder`].
 
 use std::collections::HashMap;
 use std::io::{IsTerminal as _, Write as _};
 
 use futures::StreamExt as _;
-use openwave_core::{AgentError, CallId, ChatId, Result, TurnId};
+use openwave_core::{
+    AgentError, CallId, ChatId, RequestFolderAccessResult, Result, TurnId,
+    REQUEST_FOLDER_ACCESS_TOOL,
+};
 use tokio_tungstenite::tungstenite::Message;
 
 use crate::api::client::{Client, EventSocket};
@@ -49,6 +62,12 @@ const EXIT_INTERRUPTED: i32 = 130;
 /// server is in-process, a dropped connection when it is not.
 const RECONNECT_ATTEMPTS: usize = 3;
 const RECONNECT_DELAY: std::time::Duration = std::time::Duration::from_millis(200);
+
+/// How long to wait for a folder request to become claimable after its tool
+/// call is announced. The call is checkpointed just after the provider streams
+/// it, so this only covers that gap.
+const FOLDER_REQUEST_SETTLE: std::time::Duration = std::time::Duration::from_secs(10);
+const FOLDER_REQUEST_POLL: std::time::Duration = std::time::Duration::from_millis(100);
 
 /// How the turn is written to stdout.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -84,6 +103,9 @@ pub async fn run(
     // with it the turn worker.
     let session = crate::connect::Session::open(&server).await?;
     let client = session.client().clone();
+    // Present only when this process is the server. Answering a client-owned
+    // tool call is the trusted surface's job, and an attached run is not it.
+    let executor_token = session.client_executor_token().map(str::to_owned);
     let chat = match chat {
         Some(chat) => {
             client.require_chat(chat).await?;
@@ -103,12 +125,21 @@ pub async fn run(
     let driving = format == OutputFormat::Json && !std::io::stdin().is_terminal();
     let mut driver = Driver::from_stdin(driving);
 
-    one_turn(&client, chat, &prompt, format, &mut driver).await
+    one_turn(
+        &client,
+        executor_token.as_deref(),
+        chat,
+        &prompt,
+        format,
+        &mut driver,
+    )
+    .await
 }
 
 /// Post the message and follow the event stream until the turn ends.
 async fn one_turn(
     client: &Client,
+    executor_token: Option<&str>,
     chat: ChatId,
     prompt: &str,
     format: OutputFormat,
@@ -159,7 +190,17 @@ async fn one_turn(
 
         match event {
             ClientEvent::TextDelta { text } => printer.text(&text),
-            ClientEvent::ToolCallStarted { call_id, name } => printer.tool_started(call_id, name),
+            ClientEvent::ToolCallStarted { call_id, name } => {
+                // Refused here, never routed through `settle`: a folder request
+                // is not an `Interaction`, so the driver is never asked and no
+                // decision line can answer it. Whoever is driving gets the same
+                // outcome an unattended run gets.
+                if name == REQUEST_FOLDER_ACCESS_TOOL {
+                    decline_folder_request(client, executor_token, chat, call_id, &mut printer)
+                        .await;
+                }
+                printer.tool_started(call_id, name);
+            }
             ClientEvent::ToolCallCompleted {
                 call_id, status, ..
             } => {
@@ -362,6 +403,87 @@ async fn pending_questions(
         .into_iter()
         .find(|block| call_id.is_none_or(|id| block.call_id == id))
         .map(Interaction::from_questions)
+}
+
+/// Refuse one parked `request_folder_access` call with the typed declined
+/// result.
+///
+/// The refusal is deliberately the folder contract's existing `Declined`
+/// variant and not a new failure code: to the model, a headless run must be
+/// indistinguishable from a user who closed the picker, so no prompt-shaped
+/// retry looks worthwhile and no path exists that could end in a grant. This
+/// never consults the driver — folder access is host-machine consent, and
+/// `openwave folder connect` is the only thing that gives it.
+///
+/// Reporting only, never fatal: a folder request the CLI could not answer is
+/// the server owner's to settle, and cancelling someone else's turn over it
+/// would be worse than saying so.
+async fn decline_folder_request(
+    client: &Client,
+    executor_token: Option<&str>,
+    chat: ChatId,
+    call_id: CallId,
+    printer: &mut Printer,
+) {
+    // Attach mode has no client-executor credential and is not the trusted
+    // surface for this server — the process that owns it is, and if that is a
+    // desktop it will show the user a picker. Say so and leave the call alone
+    // rather than pretending to be it.
+    let Some(executor_token) = executor_token else {
+        printer.notice(&format!(
+            "folder request {call_id} left for the attached server's own client executor; \
+             this process holds no executor credential"
+        ));
+        return;
+    };
+    match decline(client, executor_token, chat, call_id).await {
+        Ok(()) => printer.notice(
+            "folder access declined: headless runs connect folders with `openwave folder \
+             connect`, never mid-turn",
+        ),
+        Err(error) => printer.notice(&format!("could not decline the folder request: {error}")),
+    }
+}
+
+/// Claim the parked call and resolve it declined, or say why not.
+async fn decline(
+    client: &Client,
+    executor_token: &str,
+    chat: ChatId,
+    call_id: CallId,
+) -> Result<()> {
+    let deadline = std::time::Instant::now() + FOLDER_REQUEST_SETTLE;
+    loop {
+        let pending = client
+            .pending_client_executions(executor_token, chat)
+            .await?;
+        match pending.into_iter().find(|call| call.id == call_id) {
+            Some(call) if call.name != REQUEST_FOLDER_ACCESS_TOOL => {
+                return Err(AgentError::msg("the parked call is not a folder request"));
+            }
+            Some(call) if call.client_executor_id.is_some() => {
+                // Something else owns the call. Never race it: this process has
+                // no way to grant anything, so leaving it alone is safe.
+                return Err(AgentError::msg("the folder request is already claimed"));
+            }
+            Some(_) => break,
+            None if std::time::Instant::now() >= deadline => {
+                return Err(AgentError::msg("the folder request never parked"));
+            }
+            None => tokio::time::sleep(FOLDER_REQUEST_POLL).await,
+        }
+    }
+
+    let executor_id = uuid::Uuid::new_v4();
+    let lease_token = uuid::Uuid::new_v4();
+    client
+        .claim_client_execution(executor_token, chat, call_id, executor_id, lease_token)
+        .await?;
+    let declined = serde_json::to_string(&RequestFolderAccessResult::Declined)
+        .map_err(|error| AgentError::msg(format!("could not encode the refusal: {error}")))?;
+    client
+        .resolve_client_execution(executor_token, chat, call_id, lease_token, &declined)
+        .await
 }
 
 /// The event socket plus the cursor a reconnect resumes from.

--- a/crates/openwave-cli/src/print/protocol.rs
+++ b/crates/openwave-cli/src/print/protocol.rs
@@ -455,4 +455,31 @@ mod tests {
             "{wrong_call:?}"
         );
     }
+
+    /// Host folder access is not something a driver may grant. The protocol's
+    /// vocabulary is closed at approval/plan/questions, so no stdin line can
+    /// resolve a `request_folder_access` call however it is spelled — a driven
+    /// run refuses folders exactly like an undriven one, and standing consent
+    /// comes only from `openwave folder connect`.
+    ///
+    /// If a folder verb is ever added here, this fails first and on purpose:
+    /// it is the guard on that decision, not an accident of the parser.
+    #[test]
+    fn no_decision_line_can_grant_a_folder() {
+        let call_id = CallId::new();
+        for line in [
+            r#"{"type":"folder","decision":"allow"}"#,
+            r#"{"type":"folder_access","decision":"approve","path":"/srv/data"}"#,
+            r#"{"type":"request_folder_access","decision":"approve"}"#,
+            // An approval-shaped line must not be repurposed either: it can only
+            // ever answer a pending approval, and a folder request never is one.
+            r#"{"type":"approval","decision":"approve","path":"/srv/data"}"#,
+        ] {
+            let parsed = parse_decision(line, &plan(call_id));
+            assert!(
+                parsed.is_err(),
+                "a driver line was accepted as a folder decision: {line}"
+            );
+        }
+    }
 }

--- a/crates/openwave-cli/tests/folder.rs
+++ b/crates/openwave-cli/tests/folder.rs
@@ -1,0 +1,266 @@
+//! Operator-provisioned folder consent, end to end at the process boundary.
+//!
+//! These exercise the one thing the CLI is uniquely responsible for: that a
+//! grant it records is the same record the desktop reads and revokes, not a
+//! parallel one. The desktop side is represented by the broker query its
+//! consent surface runs (`ListGrantStatements`, behind
+//! `list_capability_consents`) against the same data directory.
+//!
+//! The connected folder lives under the real home directory because that is
+//! what the host root policy allows: on macOS a temporary directory
+//! canonicalizes under `/private`, which the policy refuses by design.
+#![cfg(unix)]
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpStream;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+
+use openwave_host_broker::{
+    Broker, Capability, ConsentMethod, ControlEnvelope, ControlRequest, ControlResult, GrantId,
+    GrantStatementSummary, GrantSubject, RequestId, Response, RevokeGrantRequest, RootPolicy,
+    Scope, PROTOCOL_VERSION,
+};
+
+/// Kills the daemon on drop, including on an assertion panic.
+struct Reaper(Child);
+
+impl Drop for Reaper {
+    fn drop(&mut self) {
+        self.0.kill().ok();
+        self.0.wait().ok();
+    }
+}
+
+fn openwave(data_dir: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_openwave"));
+    command
+        .env("OPENWAVE_DATA_DIR", data_dir)
+        .env("OPENWAVE_KEYCHAIN_MOCK", "1")
+        .env_remove("OPENWAVE_MCP_CONFIG")
+        .env_remove("ANTHROPIC_API_KEY");
+    command
+}
+
+fn home() -> PathBuf {
+    PathBuf::from(std::env::var_os("HOME").expect("HOME"))
+        .canonicalize()
+        .expect("canonical home")
+}
+
+/// Create one chat through the running server, then stop it: the folder
+/// commands need the data directory's locks for themselves.
+fn create_chat(data_dir: &Path) -> String {
+    let mut child = openwave(data_dir)
+        .arg("serve")
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn openwave serve");
+    let stdout = child.stdout.take().unwrap();
+    let mut reaper = Reaper(child);
+    let mut lines = BufReader::new(stdout).lines();
+    let addr_line = lines.next().unwrap().unwrap();
+    let token_line = lines.next().unwrap().unwrap();
+    let addr = addr_line
+        .rsplit("http://")
+        .next()
+        .unwrap()
+        .trim()
+        .to_owned();
+    let token = token_line
+        .trim_start_matches("openwave: token ")
+        .trim()
+        .to_owned();
+
+    let mut stream = TcpStream::connect(&addr).unwrap();
+    let body = "{}";
+    stream
+        .write_all(
+            format!(
+                "POST /chats HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer {token}\r\n\
+                 Content-Type: application/json\r\nContent-Length: {}\r\n\
+                 Connection: close\r\n\r\n{body}",
+                body.len()
+            )
+            .as_bytes(),
+        )
+        .unwrap();
+    let mut response = String::new();
+    stream.read_to_string(&mut response).unwrap();
+    assert!(response.contains("201 Created"), "response: {response}");
+    let payload = response.split("\r\n\r\n").nth(1).unwrap();
+    let start = payload.find('{').expect("chat body");
+    let chat: serde_json::Value = serde_json::from_str(&payload[start..])
+        .unwrap_or_else(|error| panic!("chat body {payload:?}: {error}"));
+    let id = chat["id"].as_str().expect("chat id").to_owned();
+
+    reaper.0.kill().ok();
+    reaper.0.wait().ok();
+    id
+}
+
+fn desktop_broker(data_dir: &Path) -> Broker {
+    let policy = RootPolicy::for_host(home())
+        .unwrap()
+        .with_private_directory(&data_dir.canonicalize().unwrap())
+        .unwrap();
+    Broker::open_with_execute_commands(policy, data_dir, false).unwrap()
+}
+
+/// The grant statements the desktop's consent surface reads, from the same
+/// state file the CLI wrote.
+fn desktop_grant_statements(data_dir: &Path) -> Vec<GrantStatementSummary> {
+    let broker = desktop_broker(data_dir);
+    let response = broker.controller().handle(ControlEnvelope {
+        protocol_version: PROTOCOL_VERSION,
+        request_id: RequestId::new(),
+        request: ControlRequest::ListGrantStatements,
+    });
+    match response.response {
+        Response::Ok(ControlResult::ListGrantStatements { grants }) => grants,
+        other => panic!("unexpected broker response: {other:?}"),
+    }
+}
+
+/// Revoke one grant the way the desktop's Permissions surface does.
+fn desktop_revoke(data_dir: &Path, subject: GrantSubject, grant_id: GrantId) {
+    let broker = desktop_broker(data_dir);
+    let response = broker.controller().handle(ControlEnvelope {
+        protocol_version: PROTOCOL_VERSION,
+        request_id: RequestId::new(),
+        request: ControlRequest::RevokeGrant(RevokeGrantRequest { subject, grant_id }),
+    });
+    match response.response {
+        Response::Ok(ControlResult::RevokeGrant(result)) => assert!(result.revoked),
+        other => panic!("unexpected broker response: {other:?}"),
+    }
+}
+
+fn run(data_dir: &Path, args: &[&str]) -> (bool, String, String) {
+    let output = openwave(data_dir)
+        .args(args)
+        .stdin(Stdio::null())
+        .output()
+        .expect("run openwave folder");
+    (
+        output.status.success(),
+        String::from_utf8(output.stdout).unwrap(),
+        String::from_utf8(output.stderr).unwrap(),
+    )
+}
+
+/// The provisioning grant is one record: the CLI lists it, the desktop's own
+/// query returns it with operator provenance, and a revocation from either side
+/// is a revocation for both. A symlinked argument resolves to the directory it
+/// names, matching what the broker pins.
+#[test]
+fn an_operator_grant_is_one_record_both_shells_read_and_either_side_can_revoke() {
+    let base = tempfile::tempdir_in(home()).unwrap();
+    let data = tempfile::tempdir().unwrap();
+    let data_dir = data.path().join("profile");
+    let reports = base.path().join("reports");
+    std::fs::create_dir_all(&reports).unwrap();
+    let link = base.path().join("link");
+    std::os::unix::fs::symlink(&reports, &link).unwrap();
+
+    let chat = create_chat(&data_dir);
+
+    let (ok, stdout, stderr) = run(
+        &data_dir,
+        &["folder", "connect", link.to_str().unwrap(), "--chat", &chat],
+    );
+    assert!(ok, "connect failed: {stderr}");
+    // Canonicalization resolved the link: the folder is named for its target.
+    assert!(
+        stdout.contains("connected reports to chat") && stdout.contains("operator configuration"),
+        "stdout: {stdout}"
+    );
+
+    let (ok, listed, stderr) = run(&data_dir, &["folder", "list", "--chat", &chat]);
+    assert!(ok, "list failed: {stderr}");
+    assert!(
+        listed.contains("operator-config") && listed.contains("\tread\treports\t"),
+        "listing: {listed}"
+    );
+
+    let statements = desktop_grant_statements(&data_dir);
+    let read_grant = statements
+        .iter()
+        .find(|grant| {
+            grant.capability == Capability::ReadFiles && matches!(grant.scope, Scope::Root { .. })
+        })
+        .expect("the desktop consent query must see the operator grant");
+    assert_eq!(read_grant.consent_method, ConsentMethod::OperatorConfig);
+    assert!(
+        listed.contains(&read_grant.grant_id.to_string()),
+        "{listed}"
+    );
+
+    // Disconnected from the CLI side: nothing the desktop reads still names
+    // the folder.
+    let (ok, _, stderr) = run(
+        &data_dir,
+        &[
+            "folder",
+            "disconnect",
+            reports.to_str().unwrap(),
+            "--chat",
+            &chat,
+        ],
+    );
+    assert!(ok, "disconnect failed: {stderr}");
+    let statements = desktop_grant_statements(&data_dir);
+    assert!(
+        statements
+            .iter()
+            .all(|grant| !matches!(grant.scope, Scope::Root { .. })),
+        "the withdrawn folder still has grants: {statements:?}"
+    );
+
+    // And the other direction: a grant withdrawn on the desktop's Permissions
+    // surface is gone from the CLI's listing too.
+    let (ok, _, stderr) = run(
+        &data_dir,
+        &[
+            "folder",
+            "connect",
+            reports.to_str().unwrap(),
+            "--chat",
+            &chat,
+        ],
+    );
+    assert!(ok, "reconnect failed: {stderr}");
+    let read_grant = desktop_grant_statements(&data_dir)
+        .into_iter()
+        .find(|grant| {
+            grant.capability == Capability::ReadFiles && matches!(grant.scope, Scope::Root { .. })
+        })
+        .expect("the reconnected folder must have a read grant");
+    desktop_revoke(&data_dir, read_grant.subject, read_grant.grant_id);
+    let (ok, listed, stderr) = run(&data_dir, &["folder", "list", "--chat", &chat]);
+    assert!(ok, "list failed: {stderr}");
+    assert!(
+        !listed.contains(&read_grant.grant_id.to_string()),
+        "a revoked grant is still listed: {listed}"
+    );
+}
+
+/// `--server` points a client command at somebody else's server. Folder consent
+/// is not a client command: it writes this machine's broker state and this
+/// profile's data directory, so accepting the flag would say the grant lands
+/// somewhere it does not. It is refused, not ignored.
+#[test]
+fn folder_commands_refuse_to_pretend_they_target_another_server() {
+    let data = tempfile::tempdir().unwrap();
+    let output = openwave(data.path())
+        .args(["folder", "list", "--server", "http://127.0.0.1:9"])
+        .stdin(Stdio::null())
+        .output()
+        .expect("run openwave folder --server");
+    assert_eq!(output.status.code(), Some(2), "expected a usage error");
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("folder") && stderr.contains("--server"),
+        "stderr: {stderr}"
+    );
+}

--- a/crates/openwave-server/src/tests/lifecycle.rs
+++ b/crates/openwave-server/src/tests/lifecycle.rs
@@ -3373,3 +3373,176 @@ async fn a_turn_replaces_its_task_plan_and_journals_only_a_refresh_hint() {
         "the second call replaced the first list rather than merging into it"
     );
 }
+
+/// A headless run has no folder-consent surface, so `openwave -p` answers a
+/// mid-turn `request_folder_access` itself with the contract's own `Declined`
+/// result — the same answer a desktop prompt gives when the user closes it.
+///
+/// This is the shape the CLI's refusal has to keep: the turn resumes instead of
+/// hanging on consent that can never arrive, the model is told access was
+/// declined rather than that something failed, and nothing in the sequence can
+/// end in a grant — declining is the only terminal a headless run can reach.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_headless_folder_request_resumes_the_turn_with_the_declined_result() {
+    struct FolderRequestThenFinishProvider {
+        requests: Arc<std::sync::Mutex<Vec<ChatRequest>>>,
+    }
+
+    #[async_trait]
+    impl ModelProvider for FolderRequestThenFinishProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("folder-request-then-finish")
+        }
+
+        async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            let mut requests = self.requests.lock().unwrap();
+            requests.push(req);
+            let first = requests.len() == 1;
+            drop(requests);
+            let events = if first {
+                vec![
+                    ProviderEvent::ToolCallStarted {
+                        index: 0,
+                        id: "folder_1".into(),
+                        name: openwave_core::REQUEST_FOLDER_ACCESS_TOOL.into(),
+                    },
+                    ProviderEvent::ToolCallArgsDelta {
+                        index: 0,
+                        fragment:
+                            r#"{"reason":"Read the quarterly reports","requested_capabilities":["read_files"]}"#
+                                .into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::ToolUse,
+                    },
+                ]
+            } else {
+                vec![
+                    ProviderEvent::TextDelta {
+                        text: "continuing without that folder".into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::EndTurn,
+                    },
+                ]
+            };
+            Ok(stream::iter(events).boxed())
+        }
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let requests = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let mut tools = ToolRegistry::new();
+    tools.register_validated_client(
+        openwave_core::request_folder_access_tool_spec(),
+        openwave_core::ApprovalClass::ReadOnly,
+        openwave_core::validate_request_folder_access_arguments,
+    );
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(Arc::new(FolderRequestThenFinishProvider {
+            requests: requests.clone(),
+        }))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(tools),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let token = state.token.clone();
+    spawn_turn_worker(&state);
+    let router = app(state.clone());
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let turn_id = TurnId::new();
+    assert_eq!(
+        send_message_with_id(&router, &bearer, chat.id, turn_id, "read my reports").await,
+        StatusCode::ACCEPTED
+    );
+
+    let call = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if let Some(call) = store
+                .list_pending_client_tool_calls(chat.id)
+                .await
+                .unwrap()
+                .into_iter()
+                .next()
+            {
+                break call;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("the folder request should park the turn");
+    assert_eq!(call.name, openwave_core::REQUEST_FOLDER_ACCESS_TOOL);
+    assert_eq!(
+        store.get_turn_run(turn_id).await.unwrap().unwrap().status,
+        TurnRunStatus::WaitingForClient
+    );
+
+    // Exactly what `openwave -p` does on seeing the call: claim it, then
+    // resolve it with the typed declined result.
+    let lease_token = uuid::Uuid::new_v4();
+    let claim = post_native_json(
+        &router,
+        &bearer,
+        &format!("/chats/{}/client-executions/{}/claim", chat.id, call.id),
+        serde_json::json!({
+            "executor_id": uuid::Uuid::new_v4(),
+            "lease_token": lease_token,
+        }),
+    )
+    .await;
+    assert_eq!(claim.status(), StatusCode::OK);
+    let declined =
+        serde_json::to_string(&openwave_core::RequestFolderAccessResult::Declined).unwrap();
+    assert_eq!(declined, r#"{"status":"declined"}"#);
+    let resolved = post_native_json(
+        &router,
+        &bearer,
+        &format!("/chats/{}/client-executions/{}/resolve", chat.id, call.id),
+        serde_json::json!({
+            "lease_token": lease_token,
+            "resolution": { "status": "completed", "result": declined },
+        }),
+    )
+    .await;
+    assert_eq!(resolved.status(), StatusCode::OK);
+    state.turn_job_wake.notify_one();
+
+    let events = wait_for_turn(&store, chat.id).await;
+    assert!(
+        matches!(
+            events.last().map(|event| &event.event),
+            Some(AgentEvent::TurnCompleted { .. })
+        ),
+        "the turn did not resume: {:?}",
+        events.last()
+    );
+    let requests = requests.lock().unwrap();
+    assert_eq!(requests.len(), 2);
+    assert!(
+        requests[1].messages.iter().any(|message| {
+            message.content.iter().any(|block| {
+                matches!(
+                    block,
+                    openwave_core::ContentBlock::ToolResult { tool_use_id, content, .. }
+                        if tool_use_id == "folder_1" && content == r#"{"status":"declined"}"#
+                )
+            })
+        }),
+        "the model was not told the folder request was declined"
+    );
+}


### PR DESCRIPTION
Implements part 4 of decision record 5: connected folders get the headless
consent path the broker already anticipated.

Stacked on #1880 (`feat/headless-outputs-attachments`); merge that first.

`openwave folder connect <path> --chat <id>` records standing consent for one
host folder; `openwave folder list [--chat <id>]` reports every grant with its
provenance; `openwave folder disconnect <path-or-root-id> --chat <id>` takes it
back. Hand-rolled argument parsing, no new third-party dependencies.

## Security invariants and how each is enforced

**The grant is the desktop's grant, not a parallel one.** `connect` calls the
broker's own `RegisterRoot` against the same `host-broker-state.json` and the
same policy the desktop's sidecar builds (host protected locations plus the
profile's private directory), with `ConsentMethod::OperatorConfig`. The broker
mints the same `ListRoots`/`ReadFiles`/`WriteFiles` grants — plus
`ExecuteCommands` when the same host probe the desktop uses says local exec is
available — so a folder connected here carries exactly the reach the picker
would have given it on that machine. The CLI cannot stamp any other consent
method: `prepare_registration` accepts only `FolderPicker` and
`OperatorConfig`, and attach accepts nothing that describes a migration.

**The CLI never grants a folder because an agent asked, and no driver can
either.** These are standalone provisioning commands; there is no flag, and no
code path, from a mid-turn request to a grant. `openwave -p` refuses a parked
`request_folder_access` with `RequestFolderAccessResult::Declined` —
byte-identical to what an undecided desktop prompt produces — claiming the call
only while it is still unclaimed and still that tool, and never reaching any
other resolution.

Critically, this sits *outside* the stdin driving protocol #1873 introduced.
Approvals, plans, and questions become an `Interaction` and go through
`settle()`, where a driver may answer them. A folder request does not: the
`ToolCallStarted` arm calls `decline_folder_request` directly, that function
takes no `Driver` argument, and `Interaction` is a closed three-variant enum
with no folder case — so no request event is emitted for a folder and
`parse_decision` rejects any line that tries to answer one. A driven session
declines exactly like an undriven one. Folder access is host-machine consent,
and `openwave folder connect` is the only thing that gives it.

**Attach mode cannot decline, and does not pretend to.** `Session` now carries
the client-executor token, and it is `Some` only when embedding. That
credential is the native-only boundary — it asserts "I am the trusted surface
for this server" — and `--server` conveys only a bearer, with no flag to hand
the executor token to an arbitrary attaching client. An attached run therefore
emits a notice naming the call and leaves it for the server's own client
executor, which on a desktop is the process that will show the user a picker;
cancelling somebody else's turn over it would be worse than saying so. The
limitation is real and stated below.

**`openwave folder` refuses `--server`.** It writes this machine's broker state
and this profile's data directory; accepting the flag would claim the grant
lands somewhere it does not. It follows `serve`/`mcp`/`rehome-secrets` with
`server_flags.refuse("folder")`.

**Product state and host authority converge or neither stands.** `connect`
commits product intent first, carries the change id as the broker mutation's
idempotency identity, and reads the durable receipt back before finishing —
the desktop reconciler's sequence. If the product attachment cannot be
committed, the host approval is withdrawn rather than left as standing reach no
surface can show; if the withdrawal also fails, the command says so and points
at `folder list`.

**Two owners of one capability store is refused, not merged.** Both the
server's `openwave.lock` and the broker's `host-broker.lock` are exclusive, so
these commands fail with a stated reason while OpenWave is running rather than
writing behind it.

**Nothing host-shaped reaches the terminal.** Broker error text is already free
of absolute paths and raw OS errors. Folder display names are host filenames,
so the listing bounds them and replaces control characters, tabs, and
bidirectional overrides — a directory cannot invent a column or a row in
tab-separated output.

**Audit is the existing one.** Opening the broker installs the same
`JsonlAuditSink` under the data directory, so registration, attach, detach, and
revocation land in the audit log the desktop's sidecar writes, with no second
audit system and no gap.

## Path handling

The path argument is canonicalized before anything is touched: a nonexistent
path is rejected with a plain message, a non-directory is rejected, and a
symlink resolves to the directory it names. That is deliberately the same
answer the broker's `RootPolicy::open_root` produces — it canonicalizes and
then pins a descriptor — so the CLI adds an earlier, clearer error rather than
a different policy. `disconnect` takes a root id exactly, or a path matched by
the leaf name the broker reports; the broker never exposes a root's absolute
path, so an ambiguous name is refused with the candidate ids rather than
guessed at.

## Cross-shell visibility

No UI change was needed. The desktop's Permissions surface already renders
`operator_config` as "by operator configuration", and the connected-folders
panel is a grouping of the same consent statements. An operator grant appears
there, and revoking it there removes the reach — verified against the store, not
in the running app.

## Scope decision worth review

`disconnect` detaches the folder from the chat and then withdraws the host
approval when that chat's subject is the only holder of root-scoped grants on
it, leaving it in place otherwise and saying so. Detach-only would leave a
headless installation able to create standing grants it could never withdraw;
unconditional revocation would take a folder away from a sibling chat in the
same project.

## Tests

- `openwave-cli/tests/folder.rs::an_operator_grant_is_one_record_both_shells_read_and_either_side_can_revoke`
  — connect through a symlink, assert the folder is named for its target, then
  assert the CLI listing and the broker query behind `list_capability_consents`
  describe the same grant with operator provenance; disconnect from the CLI and
  a fresh grant revoked from the desktop side each disappear from both.
- `openwave-cli/tests/folder.rs::folder_commands_refuse_to_pretend_they_target_another_server`
  — `folder list --server …` exits with a usage error rather than silently
  provisioning locally.
- `print::protocol::tests::no_decision_line_can_grant_a_folder` — folder-shaped
  and approval-shaped decision lines are all refused by `parse_decision`. It
  fails first, on purpose, if a folder verb is ever added to the protocol.
- `openwave-server` `a_headless_folder_request_resumes_the_turn_with_the_declined_result`
  — a real turn parks `request_folder_access`, the refusal sequence print mode
  performs is applied, and the model is handed `{"status":"declined"}` while the
  turn resumes.
- `folder::tests::mutating_commands_require_an_explicit_chat` — the mutating
  commands refuse to run without a conversation, and a flag-shaped argument is
  never swallowed as a path.

## Verified / not verified

`cargo fmt --all`, `cargo clippy -p openwave-cli -p openwave-host-broker
--all-targets -D warnings`, `cargo test -p openwave-cli -p
openwave-host-broker --locked`, the new server test, and `cargo check -p
openwave-desktop --locked` all pass on this base. The lockfile changes only by
the new workspace path dependencies and `uuid`; no version moved.

Not verified: seeing the grant in the running desktop app. The assertions are
against the same store query the folders and Permissions panels read, not the
rendered UI.

Known limitation, stated rather than papered over: an attached (`--server`) run
against a server that has no client executor of its own can wait on a folder
request, because this process holds no executor credential and declining on that
server's behalf is not its call. That is the attached server's missing executor,
not a decision the CLI can make for it.

Closes #1867
