### PR TITLE
feat(cli): attach to a running server and guard the data dir against double embedding

### DIFF
--- a/crates/openwave-cli/src/api/client.rs
+++ b/crates/openwave-cli/src/api/client.rs
@@ -42,7 +42,17 @@ struct ChatCreated {
 }
 
 impl Client {
+    /// A client for a server bound in this process.
     pub fn new(addr: SocketAddr, token: &str) -> Result<Self> {
+        Self::attach(format!("http://{addr}"), token)
+    }
+
+    /// A client for a server running somewhere else, named by its base URL.
+    ///
+    /// `base` is already normalized (scheme present, no trailing slash) — see
+    /// [`crate::connect`], which is the only thing that builds one from user
+    /// input.
+    pub fn attach(base: String, token: &str) -> Result<Self> {
         let mut headers = reqwest::header::HeaderMap::new();
         let mut value = reqwest::header::HeaderValue::from_str(&format!("Bearer {token}"))
             .map_err(|error| AgentError::msg(format!("invalid server token: {error}")))?;
@@ -56,7 +66,7 @@ impl Client {
             })?;
         Ok(Self {
             http,
-            base: format!("http://{addr}"),
+            base,
             token: token.to_owned(),
         })
     }

--- a/crates/openwave-cli/src/connect.rs
+++ b/crates/openwave-cli/src/connect.rs
@@ -1,0 +1,184 @@
+//! Attach or embed — how a command reaches a server.
+//!
+//! Every client command (`tui`, `-p`, and the setup families) needs an
+//! `openwave-server` to talk to, and there are two honest ways to get one. By
+//! default the CLI **embeds**: it binds the server in-process over its own data
+//! directory, which is the right shape for a script or an agent trying things
+//! out in isolation. With `--server <url>` (or `OPENWAVE_SERVER_URL`) it
+//! **attaches** instead, becoming a pure HTTP+WS client of an already-running
+//! `openwave serve` — the same client the desktop webview is.
+//!
+//! Attaching is what a second process on one data directory must do. A data
+//! directory belongs to exactly one server process (`openwave-server` holds an
+//! advisory lock on it for the life of the process), so pointing a second
+//! embedding CLI at a directory the desktop or a running daemon already owns is
+//! refused rather than allowed to race the database.
+//!
+//! The token never rides argv. It comes from `OPENWAVE_SERVER_TOKEN`, or from
+//! the variable `--server-token-env <var>` names — a command line is readable
+//! by every process on the machine and lands in shell history, and a per-launch
+//! bearer token is full authority over the profile.
+
+use openwave_core::{AgentError, Result};
+
+use crate::api::client::Client;
+
+/// Names the server to attach to instead of embedding one.
+pub const SERVER_URL_ENV: &str = "OPENWAVE_SERVER_URL";
+/// Holds the bearer token for that server, unless `--server-token-env` names
+/// another variable.
+pub const SERVER_TOKEN_ENV: &str = "OPENWAVE_SERVER_TOKEN";
+
+/// Where a command's server comes from.
+pub enum Server {
+    /// Bind one in-process over the configured data directory (the default).
+    Embed,
+    /// Talk to one that is already running.
+    Attach { base: String, token: String },
+}
+
+impl Server {
+    /// Resolve the choice from the `--server` / `--server-token-env` flags and
+    /// the environment. The flag wins over `OPENWAVE_SERVER_URL`, so a script
+    /// with the variable exported can still target one invocation elsewhere.
+    pub fn resolve(url_flag: Option<String>, token_env: Option<String>) -> Result<Self> {
+        let url = match url_flag {
+            Some(url) => Some(url),
+            None => std::env::var(SERVER_URL_ENV)
+                .ok()
+                .filter(|value| !value.trim().is_empty()),
+        };
+        let Some(url) = url else {
+            if let Some(var) = token_env {
+                return Err(AgentError::config(format!(
+                    "--server-token-env {var} names a token for a server to attach to, \
+                     but no --server <url> (or {SERVER_URL_ENV}) was given"
+                )));
+            }
+            return Ok(Self::Embed);
+        };
+        let base = base_url(&url)?;
+        let var = token_env.as_deref().unwrap_or(SERVER_TOKEN_ENV);
+        let token = std::env::var(var)
+            .ok()
+            .map(|token| token.trim().to_owned())
+            .filter(|token| !token.is_empty())
+            .ok_or_else(|| {
+                AgentError::config(format!(
+                    "{var} is not set; attaching to {base} needs the bearer token that \
+                     server printed at startup"
+                ))
+            })?;
+        Ok(Self::Attach { base, token })
+    }
+}
+
+/// Normalize `--server` into the base every route is formatted against.
+///
+/// Deliberately strict about the scheme: the event socket is derived from this
+/// string, and a bare `127.0.0.1:8080` would silently produce a URL nothing can
+/// connect to.
+fn base_url(value: &str) -> Result<String> {
+    let value = value.trim();
+    let rest = value
+        .strip_prefix("http://")
+        .or_else(|| value.strip_prefix("https://"))
+        .ok_or_else(|| {
+            AgentError::config(format!(
+                "--server expects an http:// or https:// URL, got {value:?}"
+            ))
+        })?;
+    if rest.is_empty() || rest.starts_with('/') {
+        return Err(AgentError::config(format!(
+            "--server URL {value:?} has no host"
+        )));
+    }
+    if rest.contains('?') || rest.contains('#') {
+        return Err(AgentError::config(format!(
+            "--server expects a base URL without a query or fragment, got {value:?}"
+        )));
+    }
+    Ok(value.trim_end_matches('/').to_owned())
+}
+
+/// A live client plus, when embedding, the engine keeping it answering.
+///
+/// Dropping the session aborts the embedded accept loop; dropping the `Server`
+/// it owns aborts the background workers with it. Attach mode owns nothing —
+/// the process on the other end keeps running when this one exits.
+pub struct Session {
+    client: Client,
+    serve: Option<tokio::task::JoinHandle<Result<()>>>,
+}
+
+impl Session {
+    /// Bind or attach, whichever `server` asks for.
+    pub async fn open(server: &Server) -> Result<Self> {
+        match server {
+            Server::Embed => {
+                let config = crate::profile_config()?;
+                // stdout belongs to the command's output, so logs are file-only.
+                openwave_server::logging::init_logging_file_only(&config.data_dir);
+                let server = openwave_server::bind_configured(config).await?;
+                let client = Client::new(server.local_addr(), server.token())?;
+                Ok(Self {
+                    client,
+                    serve: Some(tokio::spawn(server.serve())),
+                })
+            }
+            // Nothing local is touched in attach mode: no data directory, no
+            // log file, no keychain. This process is only a client.
+            Server::Attach { base, token } => Ok(Self {
+                client: Client::attach(base.clone(), token)?,
+                serve: None,
+            }),
+        }
+    }
+
+    pub fn client(&self) -> &Client {
+        &self.client
+    }
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        if let Some(serve) = &self.serve {
+            serve.abort();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The parsing rules worth stating: a base URL is normalized, junk is
+    /// refused before a request is built against it, and a token variable
+    /// without a server is a mistake rather than a silent embed.
+    #[test]
+    fn a_server_url_is_normalized_or_refused() {
+        assert_eq!(
+            base_url("http://127.0.0.1:8080/").unwrap(),
+            "http://127.0.0.1:8080"
+        );
+        assert_eq!(
+            base_url(" https://box.local:9000 ").unwrap(),
+            "https://box.local:9000"
+        );
+        assert!(
+            base_url("127.0.0.1:8080").is_err(),
+            "the scheme is required"
+        );
+        assert!(base_url("http://").is_err(), "a host is required");
+        assert!(base_url("http://host/?a=1").is_err(), "no query string");
+
+        std::env::remove_var(SERVER_URL_ENV);
+        let Err(error) = Server::resolve(None, Some("SOME_VAR".to_owned())) else {
+            panic!("a token variable alone is not enough to attach");
+        };
+        assert!(
+            error.to_string().contains("--server"),
+            "error should name the missing flag: {error}"
+        );
+    }
+}

--- a/crates/openwave-cli/src/main.rs
+++ b/crates/openwave-cli/src/main.rs
@@ -34,6 +34,13 @@
 //! same way the desktop's settings pages do — over the server's own routes.
 //! See [`setup`]; secrets are read from stdin or a named environment variable,
 //! never from a command-line argument.
+//!
+//! Every client command above embeds its own server by default. `--server
+//! <url>` (or `OPENWAVE_SERVER_URL`) makes it a pure client of one that is
+//! already running instead, with the bearer token coming from
+//! `OPENWAVE_SERVER_TOKEN` — see [`connect`]. That is how a second process
+//! reaches a data directory a desktop app or daemon already owns; two processes
+//! embedding servers over one data directory is refused.
 
 use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
@@ -43,6 +50,7 @@ use std::sync::Arc;
 use openwave_core::{AgentError, ChatId, Config, ListDir, ReadFile, Result, ToolCtx, ToolRegistry};
 
 mod api;
+mod connect;
 mod print;
 mod setup;
 mod tui;
@@ -79,7 +87,12 @@ usage: openwave serve
 
 The setup commands take --output-format text|json. A key is read from stdin, or
 from the environment variable named by --from-env — never from an argument,
-which every process on the machine can read.";
+which every process on the machine can read.
+
+tui, -p, and the setup commands also take --server <url> [--server-token-env
+<var>], which talks to a server that is already running instead of embedding
+one. The token comes from OPENWAVE_SERVER_TOKEN, or from the named variable;
+it is never an argument either.";
 
 #[tokio::main]
 async fn main() {
@@ -99,17 +112,23 @@ async fn main() {
 /// reports anything but `0`, since only it distinguishes a failure of the
 /// command from a failure of the work the command drove.
 async fn run() -> Result<i32> {
-    let mut args = std::env::args_os().skip(1);
+    let (args, server_flags) = take_server_flags(std::env::args_os().skip(1).collect());
+    let mut args = args.into_iter();
     match args.next().as_deref() {
         // Default to `serve` so a bare `openwave` runs the daemon.
-        None => serve().await.map(|()| 0),
+        None => {
+            server_flags.refuse("serve");
+            serve().await.map(|()| 0)
+        }
         Some(command) if command == OsStr::new("serve") => {
+            server_flags.refuse("serve");
             if args.next().is_some() {
                 usage_error("serve does not accept arguments");
             }
             serve().await.map(|()| 0)
         }
         Some(command) if command == OsStr::new("mcp") => {
+            server_flags.refuse("mcp");
             let Some(workspace) = args.next() else {
                 usage_error("mcp requires a workspace path");
             };
@@ -119,6 +138,7 @@ async fn run() -> Result<i32> {
             serve_mcp(workspace.into()).await.map(|()| 0)
         }
         Some(command) if command == OsStr::new("rehome-secrets") => {
+            server_flags.refuse("rehome-secrets");
             if args.next().is_some() {
                 usage_error("rehome-secrets does not accept arguments");
             }
@@ -147,7 +167,9 @@ async fn run() -> Result<i32> {
                     usage_error("tui accepts only --chat <id> or --new");
                 }
             }
-            tui::run(open.unwrap_or(tui::Open::Pick)).await.map(|()| 0)
+            tui::run(open.unwrap_or(tui::Open::Pick), server_flags.resolve()?)
+                .await
+                .map(|()| 0)
         }
         Some(command) if command == OsStr::new("-p") || command == OsStr::new("--print") => {
             let Some(prompt) = args.next() else {
@@ -192,7 +214,14 @@ async fn run() -> Result<i32> {
                     usage_error(&format!("unknown print-mode argument {flag:?}"));
                 }
             }
-            print::run(prompt, chat, format, permission_mode).await
+            print::run(
+                prompt,
+                chat,
+                format,
+                permission_mode,
+                server_flags.resolve()?,
+            )
+            .await
         }
         Some(command)
             if command == OsStr::new("provider")
@@ -202,12 +231,74 @@ async fn run() -> Result<i32> {
         {
             let family = command.to_string_lossy().into_owned();
             let (command, format) = parse_setup(&family, text_args(args));
-            setup::run(command, format).await.map(|()| 0)
+            setup::run(command, format, server_flags.resolve()?)
+                .await
+                .map(|()| 0)
         }
         Some(other) => {
             usage_error(&format!("unknown command {other:?}"));
         }
     }
+}
+
+/// The `--server` / `--server-token-env` pair, lifted out of the arguments.
+struct ServerFlags {
+    url: Option<String>,
+    token_env: Option<String>,
+}
+
+impl ServerFlags {
+    /// Turn the flags plus the environment into the choice to embed or attach.
+    fn resolve(self) -> Result<connect::Server> {
+        connect::Server::resolve(self.url, self.token_env)
+    }
+
+    /// Refuse the flags on a command that has no client to point elsewhere.
+    ///
+    /// Only the explicit flag is an error. `OPENWAVE_SERVER_URL` is ambient —
+    /// a shell that exports it so its `-p` runs attach must still be able to
+    /// start a daemon.
+    fn refuse(&self, command: &str) {
+        if self.url.is_some() || self.token_env.is_some() {
+            usage_error(&format!(
+                "{command} runs a server rather than connecting to one, so it takes no --server"
+            ));
+        }
+    }
+}
+
+/// Pull `--server <url>` and `--server-token-env <var>` out of the arguments
+/// wherever they appear, leaving the rest for the per-command parsers.
+///
+/// A pre-pass rather than an option on each parser: the flags apply to every
+/// client command, and no command takes a value beginning with `--` (each
+/// parser rejects one), so nothing else can legitimately be spelled this way.
+fn take_server_flags(args: Vec<OsString>) -> (Vec<OsString>, ServerFlags) {
+    let mut flags = ServerFlags {
+        url: None,
+        token_env: None,
+    };
+    let mut rest = Vec::with_capacity(args.len());
+    let mut args = args.into_iter();
+    while let Some(arg) = args.next() {
+        let slot = if arg == OsStr::new("--server") {
+            &mut flags.url
+        } else if arg == OsStr::new("--server-token-env") {
+            &mut flags.token_env
+        } else {
+            rest.push(arg);
+            continue;
+        };
+        let name = arg.to_string_lossy().into_owned();
+        match args.next() {
+            Some(value) => match value.into_string() {
+                Ok(value) if !value.starts_with("--") => *slot = Some(value),
+                _ => usage_error(&format!("{name} requires a value")),
+            },
+            None => usage_error(&format!("{name} requires a value")),
+        }
+    }
+    (rest, flags)
 }
 
 /// The remaining arguments as UTF-8. Setup arguments are provider names, model

--- a/crates/openwave-cli/src/print.rs
+++ b/crates/openwave-cli/src/print.rs
@@ -1,7 +1,8 @@
 //! `openwave -p "<prompt>"` — one unattended turn.
 //!
-//! Boots the same in-process server `openwave serve` runs and drives one turn
-//! over the loopback API, then exits with a status that says how the turn ended.
+//! Boots the same in-process server `openwave serve` runs — or, with
+//! `--server`, attaches to one already running — and drives one turn over the
+//! HTTP+WS API, then exits with a status that says how the turn ended.
 //! stdout carries the output (assistant text, or the raw event stream under
 //! `--output-format json`) and nothing else: logging is file-only and every
 //! notice goes to stderr, so `openwave -p … > answer.txt` is exactly the answer.
@@ -44,8 +45,8 @@ const EXIT_DECISION_FAILED: i32 = 4;
 const EXIT_INTERRUPTED: i32 = 130;
 
 /// Attempts to re-open the event socket after it closes mid-turn before giving
-/// up. The server is in-process, so a close means something is badly wrong; the
-/// retries only cover a transient accept-loop hiccup.
+/// up. The retries cover a transient hiccup — an accept-loop stumble when the
+/// server is in-process, a dropped connection when it is not.
 const RECONNECT_ATTEMPTS: usize = 3;
 const RECONNECT_DELAY: std::time::Duration = std::time::Duration::from_millis(200);
 
@@ -75,18 +76,14 @@ pub async fn run(
     chat: Option<ChatId>,
     format: OutputFormat,
     permission_mode: Option<String>,
+    server: crate::connect::Server,
 ) -> Result<i32> {
-    let config = crate::profile_config()?;
-    // stdout belongs to the output, so logs go to the profile's log file only.
-    openwave_server::logging::init_logging_file_only(&config.data_dir);
-    let server = openwave_server::bind_configured(config).await?;
-    let addr = server.local_addr();
-    let token = server.token().to_owned();
-    // Dropping the Server aborts its background workers, the turn worker
-    // included; this handle is what keeps the engine alive for the turn.
-    let serve = tokio::spawn(server.serve());
-
-    let client = Client::new(addr, &token)?;
+    // Either binds the engine in-process (the default) or attaches to one that
+    // is already running; the turn below is identical either way. The session
+    // keeps an embedded engine alive — dropping it aborts the accept loop and
+    // with it the turn worker.
+    let session = crate::connect::Session::open(&server).await?;
+    let client = session.client().clone();
     let chat = match chat {
         Some(chat) => {
             client.require_chat(chat).await?;
@@ -106,9 +103,7 @@ pub async fn run(
     let driving = format == OutputFormat::Json && !std::io::stdin().is_terminal();
     let mut driver = Driver::from_stdin(driving);
 
-    let result = one_turn(&client, chat, &prompt, format, &mut driver).await;
-    serve.abort();
-    result
+    one_turn(&client, chat, &prompt, format, &mut driver).await
 }
 
 /// Post the message and follow the event stream until the turn ends.

--- a/crates/openwave-cli/src/setup.rs
+++ b/crates/openwave-cli/src/setup.rs
@@ -3,8 +3,8 @@
 //! Every command here is a thin client of a route the server already serves —
 //! the same ones the desktop settings pages call — so configuring OpenWave
 //! from a script and configuring it from the app converge on one
-//! implementation. Nothing in this module decides anything: it boots the
-//! in-process server exactly as print mode does, makes the call, and renders
+//! implementation. Nothing in this module decides anything: it opens a session
+//! (embedded by default, attached with `--server`), makes the call, and renders
 //! the answer.
 //!
 //! Secrets are read from stdin or from a named environment variable, never
@@ -100,21 +100,21 @@ pub enum Command {
     McpRemove { name: String },
 }
 
-/// Boot the engine, run one setup command against it, and shut it down.
+/// Run one setup command against the profile's server, and shut down anything
+/// this process started for it.
 ///
-/// The server is the same one `openwave serve` and `-p` bind, on the same
-/// profile and data directory, so a credential stored here is the credential
-/// the next turn resolves.
-pub async fn run(command: Command, format: OutputFormat) -> Result<()> {
-    let config = crate::profile_config()?;
-    // stdout belongs to the command's output; logs go to the profile's file.
-    openwave_server::logging::init_logging_file_only(&config.data_dir);
-    let server = openwave_server::bind_configured(config).await?;
-    let client = Client::new(server.local_addr(), server.token())?;
-    let serve = tokio::spawn(server.serve());
-    let result = execute(&client, command, format).await;
-    serve.abort();
-    result
+/// The embedded server is the same one `openwave serve` and `-p` bind, on the
+/// same profile and data directory, so a credential stored here is the
+/// credential the next turn resolves. With `--server` the command runs against
+/// a server already holding that data directory instead — the same routes, the
+/// same effect on the same profile.
+pub async fn run(
+    command: Command,
+    format: OutputFormat,
+    server: crate::connect::Server,
+) -> Result<()> {
+    let session = crate::connect::Session::open(&server).await?;
+    execute(session.client(), command, format).await
 }
 
 /// Make the call and render it. Split from [`run`] so a test can drive several

--- a/crates/openwave-cli/src/tui/mod.rs
+++ b/crates/openwave-cli/src/tui/mod.rs
@@ -1,9 +1,10 @@
 //! `openwave tui` — interactive terminal chat.
 //!
 //! Boots the same in-process server `openwave serve` runs, spawns its accept
-//! loop on a background task, and drives it over the loopback HTTP+WebSocket
-//! API with the per-launch bearer token — the contract the desktop webview
-//! consumes. Logging is file-only: the TUI owns the terminal.
+//! loop on a background task, and drives it over the HTTP+WebSocket API with
+//! the per-launch bearer token — the contract the desktop webview consumes.
+//! With `--server` it skips the boot and drives a server already running
+//! instead. Logging is file-only: the TUI owns the terminal.
 
 mod app;
 mod composer;
@@ -28,20 +29,12 @@ pub enum Open {
 }
 
 /// Boot the server, open (or resume) the chat, and run the interactive loop.
-pub async fn run(open: Open) -> Result<()> {
-    let config = crate::profile_config()?;
-    openwave_server::logging::init_logging_file_only(&config.data_dir);
-    let server = openwave_server::bind_configured(config).await?;
-    let addr = server.local_addr();
-    let token = server.token().to_owned();
-    // `serve` takes ownership of the Server, whose drop aborts the background
-    // workers (turn worker etc.); keeping this JoinHandle alive for the whole
-    // session is what keeps the engine running.
-    let serve = tokio::spawn(server.serve());
-
-    let result = attach(Client::new(addr, &token)?, open).await;
-    serve.abort();
-    result
+pub async fn run(open: Open, server: crate::connect::Server) -> Result<()> {
+    // The session owns an embedded server's accept loop, and with it the
+    // background workers; holding it for the whole TUI session is what keeps
+    // the engine running. Attached, it owns nothing.
+    let session = crate::connect::Session::open(&server).await?;
+    attach(session.client().clone(), open).await
 }
 
 /// Resolve which chat to attach to, then hand the terminal to the app.

--- a/crates/openwave-cli/tests/serve.rs
+++ b/crates/openwave-cli/tests/serve.rs
@@ -2,6 +2,7 @@
 
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpStream;
+use std::path::Path;
 use std::process::{Child, Command, Output, Stdio};
 use std::time::{Duration, Instant};
 
@@ -312,4 +313,116 @@ fn print_mode_fails_with_clean_stdout_when_no_model_provider_is_configured() {
         stderr.contains("provider") && stderr.contains("credential"),
         "stderr: {stderr}"
     );
+}
+
+/// Start `openwave serve` on `dir` and read back where it is and how to
+/// authenticate. Both lines are printed only after the listener is bound, so
+/// this also synchronizes with a server ready to accept.
+fn spawn_serve(dir: &Path) -> (Reaper, String, String) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_openwave"))
+        .arg("serve")
+        .env("OPENWAVE_DATA_DIR", dir)
+        .env("OPENWAVE_KEYCHAIN_MOCK", "1")
+        .env_remove("OPENWAVE_MCP_CONFIG")
+        .env_remove("OPENWAVE_SERVER_URL")
+        .env_remove("ANTHROPIC_API_KEY")
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn openwave serve");
+    let stdout = child.stdout.take().unwrap();
+    let reaper = Reaper(child);
+    let mut lines = BufReader::new(stdout).lines();
+    let addr_line = lines.next().unwrap().unwrap();
+    let token_line = lines.next().unwrap().unwrap();
+    let url = format!(
+        "http://{}",
+        addr_line.rsplit("http://").next().unwrap().trim()
+    );
+    let token = token_line
+        .strip_prefix("openwave: token ")
+        .expect("token line")
+        .trim()
+        .to_owned();
+    (reaper, url, token)
+}
+
+/// Attach mode's whole point: a second process reaches a data directory the
+/// first one owns by being its client, and the call is the real thing — a
+/// route answering over HTTP against the running server's state. The attaching
+/// process is pointed at the *same* data directory on purpose: a client that
+/// quietly embedded a server of its own would hit the ownership guard and fail
+/// here rather than pass by accident.
+#[test]
+fn a_setup_command_attaches_to_a_running_server() {
+    let dir = tempfile::tempdir().unwrap();
+    let (_server, url, token) = spawn_serve(dir.path());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_openwave"))
+        .args(["provider", "list", "--output-format", "json", "--server"])
+        .arg(&url)
+        .env("OPENWAVE_SERVER_TOKEN", &token)
+        .env("OPENWAVE_DATA_DIR", dir.path())
+        .env_remove("OPENWAVE_SERVER_URL")
+        .stdin(Stdio::null())
+        .output()
+        .expect("run an attached provider list");
+
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(output.status.success(), "stderr: {stderr}");
+    let listed: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("the route's answer on one line");
+    assert!(
+        listed["providers"]
+            .as_array()
+            .is_some_and(|providers| providers
+                .iter()
+                .any(|provider| provider["kind"] == "anthropic")),
+        "stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+/// The other half of the same rule: a second process that tries to *embed* a
+/// server over an owned data directory is refused before it touches the
+/// database, and told what to do instead.
+#[test]
+fn a_second_process_embedding_the_same_data_directory_is_refused() {
+    let dir = tempfile::tempdir().unwrap();
+    let (_server, _url, _token) = spawn_serve(dir.path());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_openwave"))
+        .args(["provider", "list"])
+        .env("OPENWAVE_DATA_DIR", dir.path())
+        .env("OPENWAVE_KEYCHAIN_MOCK", "1")
+        .env_remove("OPENWAVE_SERVER_URL")
+        .stdin(Stdio::null())
+        .output()
+        .expect("run a second embedding command");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("already running") && stderr.contains("--server"),
+        "the refusal must name attach mode: {stderr}"
+    );
+}
+
+/// The claim must be honest across a crash. A killed server runs no shutdown
+/// path at all, so if ownership were recorded as something the next process
+/// reads back, the directory would stay locked forever; the OS lock it actually
+/// uses dies with the process that held it.
+#[test]
+fn a_killed_server_leaves_its_data_directory_usable() {
+    let dir = tempfile::tempdir().unwrap();
+    let (mut server, _url, _token) = spawn_serve(dir.path());
+    // SIGKILL: no unwinding, no destructors, no clean shutdown.
+    server.0.kill().unwrap();
+    server.0.wait().unwrap();
+    assert!(
+        dir.path().join("openwave.lock").exists(),
+        "the marker file outlives the process that made it"
+    );
+
+    let (_reclaimed, url, _token) = spawn_serve(dir.path());
+    assert!(url.starts_with("http://127.0.0.1:"), "url: {url}");
 }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -661,6 +661,13 @@ pub struct Server {
     _instance_lock: InstanceLock,
 }
 
+/// The claim one process makes on a data directory for as long as it serves it.
+///
+/// An OS advisory lock on a file in the directory, held open for the process's
+/// lifetime. The kernel drops it when the file descriptor closes, which happens
+/// on a clean exit and on a crash alike — so a stale `openwave.lock` left on
+/// disk by a killed process never bricks the directory the way a PID file
+/// would. The file's contents are irrelevant; only the lock is.
 struct InstanceLock {
     _file: std::fs::File,
 }
@@ -681,8 +688,15 @@ impl InstanceLock {
             })?;
         match file.try_lock() {
             Ok(()) => Ok(Self { _file: file }),
+            // Two servers over one directory would race the database with
+            // nothing but SQLite's own locking between them, so this refuses
+            // instead. The second process's way in is to be a client of the
+            // first rather than a second server.
             Err(TryLockError::WouldBlock) => Err(AgentError::config(format!(
-                "another OpenWave server already owns {}",
+                "another OpenWave process is already running on the data directory {}. \
+                 Connect to it instead (the CLI's --server <url>, with that server's token \
+                 in OPENWAVE_SERVER_TOKEN), quit the running one, or point \
+                 OPENWAVE_DATA_DIR somewhere else.",
                 config.data_dir.display()
             ))),
             Err(TryLockError::Error(error)) => Err(AgentError::config(format!(

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -2223,15 +2223,29 @@ async fn malformed_requests_get_json_errors_not_plaintext() {
     assert_eq!(info.kind, "bad_request");
 }
 
+/// One process owns a data directory at a time, and the claim is honest across
+/// a crash: the lock lives on an open file descriptor, so it goes away with the
+/// process whether or not anything ran on the way out. A leftover
+/// `openwave.lock` on disk must therefore be reclaimable, and the refusal must
+/// point at the way in that does work — attaching as a client.
 #[test]
 fn one_server_process_owns_a_desktop_data_directory() {
     let dir = tempfile::tempdir().unwrap();
     let config = Config::desktop(dir.path());
     let first = InstanceLock::acquire(&config).unwrap();
-    assert!(InstanceLock::acquire(&config).is_err());
+    let Err(refused) = InstanceLock::acquire(&config) else {
+        panic!("a second claim must be refused");
+    };
+    assert!(
+        refused.to_string().contains("--server"),
+        "the refusal must point at attach mode: {refused}"
+    );
 
     drop(first);
-    InstanceLock::acquire(&config).expect("dropping the server releases its directory lock");
+    let reclaimed = InstanceLock::acquire(&config)
+        .expect("a released directory is reclaimable even though the lock file is still there");
+    assert!(dir.path().join("openwave.lock").exists());
+    drop(reclaimed);
 }
 
 /// The MCP App view frame contract, at the HTTP boundary: minting requires

--- a/docs-site/content/docs/headless.mdx
+++ b/docs-site/content/docs/headless.mdx
@@ -45,6 +45,9 @@ openwave mcp-server remove <name>
 
 A bare `openwave` with no arguments runs `serve`.
 
+`tui`, `-p`, and the setup commands additionally take `--server <url>` and
+`--server-token-env <var>` — see [Attaching to a running server](#attaching-to-a-running-server).
+
 ### `serve`
 
 Starts the local API on an ephemeral loopback port and prints the address and a
@@ -287,11 +290,73 @@ under the running binary's signature.
 cargo run -p openwave-cli -- rehome-secrets
 ```
 
+## Attaching to a running server
+
+**One data directory, one server.** A server claims its data directory when it
+starts and holds the claim for as long as the process lives. A second process
+that tries to start its own server over the same directory is refused outright,
+because two engines writing one database race each other in ways nothing else
+would catch:
+
+```text
+openwave: configuration error: another OpenWave process is already running on
+the data directory /Users/me/.openwave. Connect to it instead …
+```
+
+The claim is an OS advisory lock on `openwave.lock` inside the directory, so it
+is honest across a crash: a killed process releases it the moment it dies, and
+the leftover file never has to be cleaned up by hand.
+
+The way in is to *attach* — to be a client of the server that is already there
+rather than a second one:
+
+```sh
+export OPENWAVE_SERVER_TOKEN=<the token that server printed>
+cargo run -p openwave-cli -- --server http://127.0.0.1:53421 provider list
+cargo run -p openwave-cli -- -p "what changed today?" --server http://127.0.0.1:53421
+cargo run -p openwave-cli -- tui --server http://127.0.0.1:53421
+```
+
+`--server` works on `tui`, `-p`, and every setup command. `OPENWAVE_SERVER_URL`
+sets the same thing for a whole shell, and the flag wins over it. An attached
+command reads no local data directory, writes no log file, and touches no
+keychain — it is only an HTTP+WebSocket client, so `OPENWAVE_DATA_DIR` and the
+rest of the profile environment are ignored.
+
+`serve`, `mcp`, and `rehome-secrets` reject `--server`: the first two *are*
+servers, and the third rewrites local keychain items. (They ignore
+`OPENWAVE_SERVER_URL`, so a shell that exports it can still start a daemon.)
+
+### Getting a token
+
+The bearer token is per-launch and is full authority over the profile, so it is
+never a command-line argument — every process on the machine can read those, and
+they land in shell history. It comes from `OPENWAVE_SERVER_TOKEN`, or from the
+variable `--server-token-env <var>` names.
+
+**From `openwave serve`:** the token is the second line it prints. Capture the
+daemon's stdout directly:
+
+```sh
+cargo run -p openwave-cli -- serve > server.log &
+export OPENWAVE_SERVER_URL=http://$(grep -m1 'listening on http://' server.log | sed 's|.*http://||')
+export OPENWAVE_SERVER_TOKEN=$(grep -m1 'token ' server.log | sed 's|.*token ||')
+```
+
+**From the desktop app: not currently possible.** The desktop mints its own
+per-launch token and hands it straight to its webview; nothing displays or
+writes it out, so there is no supported way to attach to a running desktop
+instance today. To drive the desktop's chats from the CLI, quit the app first
+and run `openwave serve` (or the CLI command) against its data directory — while
+the app is running, that directory is claimed.
+
 ## Environment
 
 | Variable | Effect |
 | --- | --- |
-| `OPENWAVE_DATA_DIR` | Where the database, blobs, and logs live. Defaults to `./.openwave` under the current directory. |
+| `OPENWAVE_DATA_DIR` | Where the database, blobs, and logs live. Defaults to `./.openwave` under the current directory. Ignored when attaching to a running server. |
+| `OPENWAVE_SERVER_URL` | Attach to the server at this base URL instead of embedding one. `--server <url>` overrides it, and `serve`/`mcp`/`rehome-secrets` ignore it. |
+| `OPENWAVE_SERVER_TOKEN` | Bearer token for that server, unless `--server-token-env <var>` names a different variable. |
 | `OPENWAVE_PROFILE` | `desktop` (default, SQLite) or `self_host` (PostgreSQL). |
 | `OPENWAVE_DATABASE_URL` | Required for `self_host`. |
 | `OPENWAVE_AUTH_TOKENS_FILE` | Named bearer tokens for `self_host`. Required there. |
@@ -314,7 +379,10 @@ the server does not discover models or verify entitlement before a request.
 <Callout>
 `openwave serve` defaults to `./.openwave` in your current directory, which is
 **not** the desktop app's data directory. Point `OPENWAVE_DATA_DIR` at the
-desktop's application data directory if you want the CLI to see the same chats.
+desktop's application data directory if you want the CLI to see the same chats —
+and quit the app first, since a running desktop instance claims that directory
+and the CLI will refuse to start a second server over it. See
+[Attaching to a running server](#attaching-to-a-running-server).
 </Callout>
 
 Logs are written to `logs/openwave.log` under the data directory.


### PR DESCRIPTION
Part 6 of decision record 5 — the last of the four stacked CLI/headless PRs (#1864 → #1873 → #1878 → this).

## Attach mode

`--server <url>`, or `OPENWAVE_SERVER_URL`, makes `tui`, `-p`, and every setup command a pure HTTP+WS client of a server that is already running instead of embedding one. The flag wins over the variable. The loopback client already spoke the entire protocol, so this is a base URL and a token in place of a `bind_configured` boot: a new `connect::Session` either binds the engine in-process (unchanged default, and it still owns the accept loop for the command's lifetime) or builds a client against a remote base. An attached command reads no data directory, writes no log file, and touches no keychain.

The token comes from `OPENWAVE_SERVER_TOKEN`, or from the variable `--server-token-env <var>` names. It is never an argument — argv is readable by every process on the machine and lands in shell history, and the token is full authority over the profile. `serve`, `mcp`, and `rehome-secrets` reject the flag; the first two are servers and the third rewrites local keychain items. They ignore the environment variable, so a shell that exports it for its `-p` runs can still start a daemon.

The flags are lifted out of argv in a pre-pass rather than added to each parser. They apply to every client command, and no command takes a value that begins with `--` (each parser rejects one), so nothing else can legitimately be spelled this way.

## Embed guard

`openwave-server` has claimed its data directory since #144 — an advisory lock on `openwave.lock` acquired in `bind_inner`, which every `bind*` entry point goes through, so `openwave serve`, the CLI's embedded boots, and the desktop's `boot_server` are all already covered. What was missing was the message: it said a directory was owned without saying what to do about it. It now names attach mode, and the desktop needs no change to honor it.

The lock is the right mechanism rather than a PID file precisely because it is honest across a crash: the kernel releases it when the file descriptor closes, which happens on a clean exit and a `SIGKILL` alike, so a leftover marker file never has to be reasoned about or cleaned up. `std::fs::File::try_lock` is `flock` on Unix and `LockFileEx` on Windows — no new dependency, and `Cargo.lock` is unchanged.

## Tests

Three at the process boundary in `crates/openwave-cli/tests/serve.rs`, which is where the interesting behavior actually lives — two real processes:

- `a_setup_command_attaches_to_a_running_server` — spawns `serve`, then runs `provider list --server <url>` against it with the token in the environment, and reads the route's answer. The attaching process is pointed at the *same* `OPENWAVE_DATA_DIR` on purpose: a client that quietly embedded a server of its own would hit the guard and fail rather than pass by accident.
- `a_second_process_embedding_the_same_data_directory_is_refused` — the other half; asserts the refusal names `--server`.
- `a_killed_server_leaves_its_data_directory_usable` — the crash case. `SIGKILL` the daemon (no unwinding, no destructors, no shutdown path), confirm the lock file is still on disk, and start a second server on the directory successfully.

`one_server_process_owns_a_desktop_data_directory` in `openwave-server` keeps its in-process claim/refuse/reclaim coverage and now also asserts the refusal points at attach mode.

One unit test in `connect` covers base-URL normalization and the refusals that happen before any request is built.

## Docs

`docs-site/content/docs/headless.mdx` gains an "Attaching to a running server" section — the one-server-per-directory rule, the flags, and how to get a token — plus `OPENWAVE_SERVER_URL` and `OPENWAVE_SERVER_TOKEN` in the environment table.

On tokens the docs say what is true rather than what would be convenient: `openwave serve` prints one, and there is a snippet that captures it. **The desktop's is not reachable** — it mints a per-launch token and hands it straight to its webview, and nothing displays or writes it out, so attaching to a running desktop instance is not possible today. The documented answer is to quit the app and run against its data directory. The existing callout suggesting `OPENWAVE_DATA_DIR` be pointed at the desktop's directory now says the app has to be closed first, which is what the guard enforces.

Closes #1869