### PR TITLE
feat(server): queue messages sent mid-turn and promote them FIFO

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -555,6 +555,39 @@ pub mod agent_run {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+pub mod queued_turn {
+    use sea_orm::entity::prelude::*;
+
+    /// One message accepted while its chat had a live turn, waiting to become
+    /// a real turn when the chat is free. The row id is the client-generated
+    /// turn id the promotion will accept under, so an ambiguous promotion
+    /// retry lands on `AcceptTurnOutcome::Existing` instead of a duplicate.
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "queued_turn")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub chat_id: Uuid,
+        pub content: String,
+        /// Image-attachment ids, JSON array of UUID strings.
+        pub attachments_json: String,
+        /// Chat-owned document ids, JSON array of UUID strings.
+        pub file_attachments_json: String,
+        /// Invoked skill names, JSON array of strings.
+        pub invoked_skills_json: String,
+        pub voice_input_used: bool,
+        /// FIFO order within the chat; reorder rewrites positions.
+        pub position: i32,
+        pub created_at: DateTimeUtc,
+        pub updated_at: DateTimeUtc,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub mod sandbox_spawn_checkpoint {
     use sea_orm::entity::prelude::*;
 

--- a/crates/openwave-core/src/db/migration/baseline/mod.rs
+++ b/crates/openwave-core/src/db/migration/baseline/mod.rs
@@ -89,6 +89,7 @@ pub(super) fn tables() -> Vec<BaselineTable> {
         ),
         // Turn runs and the journal.
         entry(turn::turn_run_table(), turn::turn_run_indexes()),
+        entry(turn::queued_turn_table(), turn::queued_turn_indexes()),
         entry(chat::event_table(), chat::event_indexes()),
         entry(
             agent_run::agent_run_inbox_table(),

--- a/crates/openwave-core/src/db/migration/baseline/turn.rs
+++ b/crates/openwave-core/src/db/migration/baseline/turn.rs
@@ -1022,3 +1022,71 @@ pub(super) fn context_checkpoint_table() -> TableCreateStatement {
 pub(super) fn context_checkpoint_indexes() -> Vec<IndexCreateStatement> {
     vec![]
 }
+
+/// Messages waiting to become turns, FIFO per chat.
+pub(super) fn queued_turn_table() -> TableCreateStatement {
+    Table::create()
+        .table(QueuedTurn::Table)
+        .col(
+            ColumnDef::new(QueuedTurn::Id)
+                .uuid()
+                .not_null()
+                .primary_key(),
+        )
+        .col(ColumnDef::new(QueuedTurn::ChatId).uuid().not_null())
+        .col(ColumnDef::new(QueuedTurn::Content).text().not_null())
+        .col(
+            ColumnDef::new(QueuedTurn::AttachmentsJson)
+                .text()
+                .not_null()
+                .default("[]"),
+        )
+        .col(
+            ColumnDef::new(QueuedTurn::FileAttachmentsJson)
+                .text()
+                .not_null()
+                .default("[]"),
+        )
+        .col(
+            ColumnDef::new(QueuedTurn::InvokedSkillsJson)
+                .text()
+                .not_null()
+                .default("[]"),
+        )
+        .col(
+            ColumnDef::new(QueuedTurn::VoiceInputUsed)
+                .boolean()
+                .not_null()
+                .default(false),
+        )
+        .col(ColumnDef::new(QueuedTurn::Position).integer().not_null())
+        .col(
+            ColumnDef::new(QueuedTurn::CreatedAt)
+                .timestamp_with_time_zone()
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(QueuedTurn::UpdatedAt)
+                .timestamp_with_time_zone()
+                .not_null(),
+        )
+        .foreign_key(
+            ForeignKey::create()
+                .name("fk_queued_turn_chat")
+                .from(QueuedTurn::Table, QueuedTurn::ChatId)
+                .to(Chat::Table, Chat::Id)
+                .on_delete(ForeignKeyAction::Cascade),
+        )
+        .check(Func::char_length(Expr::col(QueuedTurn::Content)).gt(0))
+        .check(Expr::col(QueuedTurn::Position).gte(0))
+        .to_owned()
+}
+
+pub(super) fn queued_turn_indexes() -> Vec<IndexCreateStatement> {
+    vec![Index::create()
+        .name("ix_queued_turn_chat_position")
+        .table(QueuedTurn::Table)
+        .col(QueuedTurn::ChatId)
+        .col(QueuedTurn::Position)
+        .to_owned()]
+}

--- a/crates/openwave-core/src/db/migration/idens.rs
+++ b/crates/openwave-core/src/db/migration/idens.rs
@@ -730,3 +730,18 @@ pub(crate) enum Event {
     Payload,
     CreatedAt,
 }
+
+#[derive(DeriveIden)]
+pub(crate) enum QueuedTurn {
+    Table,
+    Id,
+    ChatId,
+    Content,
+    AttachmentsJson,
+    FileAttachmentsJson,
+    InvokedSkillsJson,
+    VoiceInputUsed,
+    Position,
+    CreatedAt,
+    UpdatedAt,
+}

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -36,8 +36,8 @@ use crate::model::{
     AgentRunWaitSetCandidate, BeginRootAttachmentChange, BlobRetirement, BlobRetirementStatus,
     Chat, DocumentBlob, DocumentListCursor, DocumentRecord, DocumentScope, DocumentSourceUpsert,
     DocumentSummaryRecord, DocumentUpsert, Message, MessageAttachment, MessageDocumentAttachment,
-    NetworkPolicy, OwnerId, PermissionMode, Project, ReasoningEffort, RootAttachmentChange,
-    RootAttachmentChangeTerminal, SandboxToolCall, SandboxToolCallParkEntry,
+    NetworkPolicy, OwnerId, PermissionMode, Project, QueuedTurn, ReasoningEffort,
+    RootAttachmentChange, RootAttachmentChangeTerminal, SandboxToolCall, SandboxToolCallParkEntry,
     SandboxToolCallReceipt, ToolCallRecord, ToolCallResolution, TurnCheckpointProgress,
     TurnFailureRetry, TurnRun, MAX_ROOT_ATTACHMENTS,
 };
@@ -1518,6 +1518,32 @@ impl Store for DbStore {
         now: chrono::DateTime<Utc>,
     ) -> Result<TurnLeaseFence> {
         ops::turn::fence_turn_lease(self, id, lease_token, now).await
+    }
+
+    async fn enqueue_queued_turn(&self, queued: &QueuedTurn) -> Result<QueuedTurn> {
+        ops::turn::queued::enqueue_turn(self, queued).await
+    }
+
+    async fn list_queued_turns(&self, chat_id: ChatId) -> Result<Vec<QueuedTurn>> {
+        ops::turn::queued::list_queued_turns(self, chat_id).await
+    }
+
+    async fn chats_with_queued_turns(&self) -> Result<Vec<ChatId>> {
+        ops::turn::queued::chats_with_queued_turns(self).await
+    }
+
+    async fn delete_queued_turn(&self, chat_id: ChatId, id: TurnId) -> Result<bool> {
+        ops::turn::queued::delete_queued_turn(self, chat_id, id).await
+    }
+
+    async fn update_queued_turn(
+        &self,
+        chat_id: ChatId,
+        id: TurnId,
+        content: Option<&str>,
+        position: Option<i32>,
+    ) -> Result<Option<QueuedTurn>> {
+        ops::turn::queued::update_queued_turn(self, chat_id, id, content, position).await
     }
 
     async fn accept_turn_steer(

--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -26,6 +26,7 @@ use super::{
 
 mod client_wait;
 mod multi_agent_run_wait;
+pub(in crate::db) mod queued;
 mod resolution;
 mod sandbox_spawn;
 pub(in crate::db) mod steer;

--- a/crates/openwave-core/src/db/ops/turn/queued.rs
+++ b/crates/openwave-core/src/db/ops/turn/queued.rs
@@ -1,0 +1,224 @@
+//! Durable queued-message operations: messages accepted while a chat had a
+//! live turn, promoted into real turns strictly FIFO once the chat is free.
+//!
+//! Promotion itself deliberately lives with the caller: the promoter *tries*
+//! the ordinary idempotent turn acceptance under the queued row's own id and
+//! deletes the row only on success, so there is no fenced two-table dance
+//! here — `ChatBusy` simply leaves the row for the next attempt, and a crash
+//! between acceptance and deletion re-runs into `Existing`.
+
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder, Set,
+    TransactionTrait,
+};
+
+use crate::error::{AgentError, Result};
+use crate::id::{ChatId, DocumentId, TurnId};
+use crate::model::QueuedTurn;
+
+use super::super::super::{entities, store_err, DbStore};
+use super::super::agent_run::database_now;
+
+fn queued_turn_from_model(model: entities::queued_turn::Model) -> Result<QueuedTurn> {
+    let parse = |json: &str| -> Result<Vec<uuid::Uuid>> {
+        serde_json::from_str(json)
+            .map_err(|_| AgentError::Store("invalid stored queued-turn attachment list".into()))
+    };
+    Ok(QueuedTurn {
+        id: TurnId(model.id),
+        chat_id: ChatId(model.chat_id),
+        content: model.content,
+        attachments: parse(&model.attachments_json)?,
+        file_attachments: parse(&model.file_attachments_json)?
+            .into_iter()
+            .map(DocumentId)
+            .collect(),
+        invoked_skills: serde_json::from_str(&model.invoked_skills_json)
+            .map_err(|_| AgentError::Store("invalid stored queued-turn skill list".into()))?,
+        voice_input_used: model.voice_input_used,
+        position: model.position,
+        created_at: model.created_at,
+        updated_at: model.updated_at,
+    })
+}
+
+pub(in crate::db) async fn enqueue_turn(
+    store: &DbStore,
+    queued: &QueuedTurn,
+) -> Result<QueuedTurn> {
+    if queued.id.0.is_nil() || queued.content.trim().is_empty() || queued.content.contains('\0') {
+        return Err(AgentError::Store("invalid queued turn".into()));
+    }
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    let now = database_now(&transaction).await?;
+    if let Some(existing) = entities::queued_turn::Entity::find_by_id(queued.id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    {
+        // An ambiguous retry of the same enqueue is the row it made.
+        let existing = queued_turn_from_model(existing)?;
+        transaction.commit().await.map_err(store_err)?;
+        if existing.chat_id == queued.chat_id && existing.content == queued.content {
+            return Ok(existing);
+        }
+        return Err(AgentError::Store(
+            "queued turn id was already used with different content".into(),
+        ));
+    }
+    let count = entities::queued_turn::Entity::find()
+        .filter(entities::queued_turn::Column::ChatId.eq(queued.chat_id.0))
+        .count(&transaction)
+        .await
+        .map_err(store_err)?;
+    if count >= QueuedTurn::MAX_PER_CHAT as u64 {
+        transaction.commit().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!(
+            "a chat may queue at most {} messages",
+            QueuedTurn::MAX_PER_CHAT
+        )));
+    }
+    let position = entities::queued_turn::Entity::find()
+        .filter(entities::queued_turn::Column::ChatId.eq(queued.chat_id.0))
+        .order_by_desc(entities::queued_turn::Column::Position)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .map_or(0, |last| last.position + 1);
+    entities::queued_turn::ActiveModel {
+        id: Set(queued.id.0),
+        chat_id: Set(queued.chat_id.0),
+        content: Set(queued.content.clone()),
+        attachments_json: Set(serde_json::to_string(&queued.attachments).map_err(store_err)?),
+        file_attachments_json: Set(serde_json::to_string(
+            &queued
+                .file_attachments
+                .iter()
+                .map(|id| id.0)
+                .collect::<Vec<_>>(),
+        )
+        .map_err(store_err)?),
+        invoked_skills_json: Set(serde_json::to_string(&queued.invoked_skills).map_err(store_err)?),
+        voice_input_used: Set(queued.voice_input_used),
+        position: Set(position),
+        created_at: Set(now),
+        updated_at: Set(now),
+    }
+    .insert(&transaction)
+    .await
+    .map_err(store_err)?;
+    let inserted = entities::queued_turn::Entity::find_by_id(queued.id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| AgentError::Store("queued turn disappeared".into()))?;
+    let inserted = queued_turn_from_model(inserted)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(inserted)
+}
+
+pub(in crate::db) async fn list_queued_turns(
+    store: &DbStore,
+    chat_id: ChatId,
+) -> Result<Vec<QueuedTurn>> {
+    entities::queued_turn::Entity::find()
+        .filter(entities::queued_turn::Column::ChatId.eq(chat_id.0))
+        .order_by_asc(entities::queued_turn::Column::Position)
+        .order_by_asc(entities::queued_turn::Column::CreatedAt)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(queued_turn_from_model)
+        .collect()
+}
+
+/// Chats that currently hold at least one queued message, for the promoter's
+/// scan. Bounded output: distinct chat ids only.
+pub(in crate::db) async fn chats_with_queued_turns(store: &DbStore) -> Result<Vec<ChatId>> {
+    use sea_orm::QuerySelect;
+    Ok(entities::queued_turn::Entity::find()
+        .select_only()
+        .column(entities::queued_turn::Column::ChatId)
+        .distinct()
+        .into_tuple::<uuid::Uuid>()
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(ChatId)
+        .collect())
+}
+
+pub(in crate::db) async fn delete_queued_turn(
+    store: &DbStore,
+    chat_id: ChatId,
+    id: TurnId,
+) -> Result<bool> {
+    let deleted = entities::queued_turn::Entity::delete_many()
+        .filter(entities::queued_turn::Column::Id.eq(id.0))
+        .filter(entities::queued_turn::Column::ChatId.eq(chat_id.0))
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(deleted.rows_affected == 1)
+}
+
+/// Edit a queued message's content and/or move it to a new position. Rewrites
+/// every position in the chat so the order stays dense and total.
+pub(in crate::db) async fn update_queued_turn(
+    store: &DbStore,
+    chat_id: ChatId,
+    id: TurnId,
+    content: Option<&str>,
+    position: Option<i32>,
+) -> Result<Option<QueuedTurn>> {
+    if let Some(content) = content {
+        if content.trim().is_empty() || content.contains('\0') {
+            return Err(AgentError::Store("invalid queued-turn content".into()));
+        }
+    }
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    let now = database_now(&transaction).await?;
+    let mut rows = entities::queued_turn::Entity::find()
+        .filter(entities::queued_turn::Column::ChatId.eq(chat_id.0))
+        .order_by_asc(entities::queued_turn::Column::Position)
+        .order_by_asc(entities::queued_turn::Column::CreatedAt)
+        .all(&transaction)
+        .await
+        .map_err(store_err)?;
+    let Some(index) = rows.iter().position(|row| row.id == id.0) else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    if let Some(target) = position {
+        let target = usize::try_from(target.max(0))
+            .unwrap_or(0)
+            .min(rows.len() - 1);
+        let row = rows.remove(index);
+        rows.insert(target, row);
+    }
+    for (ordinal, row) in rows.iter().enumerate() {
+        let is_edited = row.id == id.0;
+        let mut active = entities::queued_turn::ActiveModel {
+            id: Set(row.id),
+            position: Set(i32::try_from(ordinal).unwrap_or(i32::MAX)),
+            ..Default::default()
+        };
+        if is_edited {
+            if let Some(content) = content {
+                active.content = Set(content.to_owned());
+            }
+            active.updated_at = Set(now);
+        }
+        active.update(&transaction).await.map_err(store_err)?;
+    }
+    let updated = entities::queued_turn::Entity::find_by_id(id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| AgentError::Store("queued turn disappeared".into()))?;
+    let updated = queued_turn_from_model(updated)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(Some(updated))
+}

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -185,7 +185,7 @@ pub use model::{
     DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, ExecFileChange, ExecFileRejection,
     ExecFileRejectionReason, ExecFileRejectionRecord, ExecFileSnapshot, ExecFileSnapshotRecord,
     ExecUndoState, Message, MessageAttachment, MessageDocumentAttachment, NetworkPolicy, OwnerId,
-    PermissionMode, Project, ReasoningEffort, Role, RootAttachmentChange,
+    PermissionMode, Project, QueuedTurn, ReasoningEffort, Role, RootAttachmentChange,
     RootAttachmentChangeAction, RootAttachmentChangeFailure, RootAttachmentChangePhase,
     RootAttachmentChangeTerminal, RootAttachmentOrigin, RootAttachmentSubjectKind,
     SandboxAgentAdmission, SandboxSpawnCheckpoint, SandboxSpawnCheckpointRequest, SandboxToolCall,

--- a/crates/openwave-core/src/model/mod.rs
+++ b/crates/openwave-core/src/model/mod.rs
@@ -47,9 +47,9 @@ pub use runs::{
 };
 pub use turns::{
     AgentRunWaitCondition, AgentRunWaitSetCandidate, AgentRunWaitSetCheckpointRequest,
-    ClientToolCallRequest, TurnAgentRunWaitSet, TurnAgentRunWaitStatus, TurnCheckpointProgress,
-    TurnClientWait, TurnClientWaitStatus, TurnFailureReceipt, TurnFailureRetry, TurnRun,
-    TurnRunStatus, TurnSteer, TurnSteerStatus,
+    ClientToolCallRequest, QueuedTurn, TurnAgentRunWaitSet, TurnAgentRunWaitStatus,
+    TurnCheckpointProgress, TurnClientWait, TurnClientWaitStatus, TurnFailureReceipt,
+    TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteer, TurnSteerStatus,
 };
 
 pub(crate) use messages::user_message_llm_content;

--- a/crates/openwave-core/src/model/turns.rs
+++ b/crates/openwave-core/src/model/turns.rs
@@ -403,6 +403,41 @@ impl TurnClientWaitStatus {
     }
 }
 
+/// One message accepted while its chat had a live turn, waiting its turn.
+///
+/// The id is the client-generated turn id promotion will accept under, so an
+/// ambiguous promotion retry resolves to `Existing` rather than a duplicate
+/// turn. Rows are FIFO by `position` within a chat and fully durable: a queue
+/// survives restarts and is visible to every client on the chat.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
+pub struct QueuedTurn {
+    /// The turn id this row becomes when promoted.
+    pub id: TurnId,
+    /// Owning chat.
+    pub chat_id: ChatId,
+    /// Byte-exact user message.
+    pub content: String,
+    /// Image-attachment ids, in display order.
+    pub attachments: Vec<uuid::Uuid>,
+    /// Chat-owned document ids.
+    pub file_attachments: Vec<crate::id::DocumentId>,
+    /// Skills the user explicitly invoked.
+    pub invoked_skills: Vec<String>,
+    /// Whether the message was dictated.
+    pub voice_input_used: bool,
+    /// FIFO order within the chat.
+    pub position: i32,
+    /// When the message was queued.
+    pub created_at: DateTime<Utc>,
+    /// When it was last edited or reordered.
+    pub updated_at: DateTime<Utc>,
+}
+
+impl QueuedTurn {
+    /// Maximum queued messages one chat may hold.
+    pub const MAX_PER_CHAT: usize = 32;
+}
+
 /// One durably accepted steering instruction for an active turn.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TurnSteer {

--- a/crates/openwave-core/src/storage/store.rs
+++ b/crates/openwave-core/src/storage/store.rs
@@ -18,9 +18,9 @@ use crate::model::{
     Chat, ClientToolCallRequest, DocumentListCursor, DocumentRecord, DocumentScope,
     DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, ExecFileRejection,
     ExecFileRejectionRecord, ExecFileSnapshot, ExecFileSnapshotRecord, Message, MessageAttachment,
-    MessageDocumentAttachment, NetworkPolicy, OwnerId, PermissionMode, Project, ReasoningEffort,
-    RootAttachmentChange, RootAttachmentChangeTerminal, ToolCallRecord, ToolCallResolution,
-    TurnCheckpointProgress, TurnFailureRetry, TurnRun, TurnSteer,
+    MessageDocumentAttachment, NetworkPolicy, OwnerId, PermissionMode, Project, QueuedTurn,
+    ReasoningEffort, RootAttachmentChange, RootAttachmentChangeTerminal, ToolCallRecord,
+    ToolCallResolution, TurnCheckpointProgress, TurnFailureRetry, TurnRun, TurnSteer,
 };
 use crate::provider::{RefusalOutcome, StopReason, Usage};
 use crate::semantic_checkpoint::{ContextCheckpoint, SaveContextCheckpointOutcome};
@@ -1773,6 +1773,38 @@ pub trait Store: Send + Sync {
     /// Queued, running, resuming, and retry-wait turns accept instructions;
     /// cancelling or terminal turns return
     /// [`AcceptTurnSteerOutcome::TurnUnavailable`].
+    /// Durably queue a message to run as its own turn once the chat is free.
+    /// An exact ambiguous retry returns the original row.
+    async fn enqueue_queued_turn(&self, _queued: &QueuedTurn) -> Result<QueuedTurn> {
+        turn_storage_unavailable()
+    }
+
+    /// The chat's queued messages, FIFO.
+    async fn list_queued_turns(&self, _chat_id: ChatId) -> Result<Vec<QueuedTurn>> {
+        turn_storage_unavailable()
+    }
+
+    /// Chats currently holding queued messages, for the promoter's scan.
+    async fn chats_with_queued_turns(&self) -> Result<Vec<ChatId>> {
+        turn_storage_unavailable()
+    }
+
+    /// Retract one queued message. `false` when no such row exists.
+    async fn delete_queued_turn(&self, _chat_id: ChatId, _id: TurnId) -> Result<bool> {
+        turn_storage_unavailable()
+    }
+
+    /// Edit a queued message and/or move it, keeping positions dense.
+    async fn update_queued_turn(
+        &self,
+        _chat_id: ChatId,
+        _id: TurnId,
+        _content: Option<&str>,
+        _position: Option<i32>,
+    ) -> Result<Option<QueuedTurn>> {
+        turn_storage_unavailable()
+    }
+
     async fn accept_turn_steer(
         &self,
         _id: TurnSteerId,

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -358,6 +358,28 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   }
 
   /**
+   * Durably queue the draft to run as its own turn once the active one
+   * finishes. Same validated body as an ordinary send, parked server-side —
+   * the tray above the composer shows and manages the rows.
+   */
+  async function onQueue() {
+    const content = draftRef.current.trim();
+    if (!chat || !content) return;
+    await client.postMessage(
+      chatId,
+      crypto.randomUUID(),
+      content,
+      readyImageAttachmentIds(images.attachments),
+      files.map((file) => file.documentId),
+      invokedSkills(),
+      voice.inputUsed,
+      true,
+    );
+    setComposerDraft("");
+    voice.resetInputUsed();
+  }
+
+  /**
    * The one path a message takes. Home writes the first message of a new chat
    * but does not post it, so this has to be reachable with text that was never
    * in this route's draft.
@@ -740,6 +762,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
             voice.resetInputUsed();
           }}
           onSend={onSend}
+          onQueue={onQueue}
           onRetryTurn={retryTurn}
           onOpenAgentPanel={(runId) => openPanel({ type: "agent", runId })}
           onOpenOutput={(outputId) => openPanel({ type: "outputs", outputId })}

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -37,6 +37,7 @@ import { useFolderAccessRequests } from "./useFolderAccessRequests";
 import { useOutputWritebackRequests } from "./useOutputWritebackRequests";
 import { useToolApprovals } from "./useToolApprovals";
 import { useStreamStalled } from "./useStreamStalled";
+import { QueueTray } from "./QueueTray";
 import { useTurnControls } from "./useTurnControls";
 import { usePlanApprovals } from "./usePlanApprovals";
 import { useTaskPlan } from "./useTaskPlan";
@@ -82,6 +83,8 @@ export type ChatViewProps = {
   onDraftChange: (value: string) => void;
   onSelectPrompt: (prompt: string) => void;
   onSend: () => Promise<void>;
+  /** Queue the draft to run after the active turn; absent disables queueing. */
+  onQueue?: () => Promise<void>;
   /** Put a failed turn back on the wire, unchanged, as a new turn. */
   onRetryTurn?: (turn: RetryableTurn) => void;
   /** Open one background run's panel beside the conversation. */
@@ -118,6 +121,7 @@ export function ChatView({
   onDraftChange,
   onSelectPrompt,
   onSend,
+  onQueue,
   onRetryTurn,
   onOpenAgentPanel,
   onOpenOutput,
@@ -659,7 +663,9 @@ export function ChatView({
             onPlanCancel={planApprovals.cancel}
           />
         ) : (
-          <Composer
+          <>
+            <QueueTray client={client} chatId={chat.id} active={activeTurnId !== null} />
+            <Composer
             activeTurnId={activeTurnId}
             busy={busy}
             cancelError={turnControls.cancelError}
@@ -704,6 +710,7 @@ export function ChatView({
               onDraftChange(value);
             }}
             onSend={handleSend}
+            onQueue={onQueue}
             onSteer={turnControls.steer}
             onStop={turnControls.cancel}
             resetKey={chat.id}
@@ -713,7 +720,8 @@ export function ChatView({
               turnControls.steerPendingTurnId === activeTurnId
             }
             steerStatus={turnControls.steerStatus}
-          />
+            />
+          </>
         )}
       </div>
     </section>

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -16,6 +16,8 @@ import {
   Square,
   Wand2,
   X,
+  CornerUpRight,
+  ListPlus,
 } from "lucide-react";
 import { MAX_STEER_CHARACTERS } from "./ActiveTurnSteer";
 import {
@@ -282,12 +284,29 @@ export type ComposerProps = {
   onDraftChange: (draft: string) => void;
   onSend: () => Promise<void>;
   onSteer: () => Promise<void>;
+  /**
+   * Queue the draft to run as its own turn after the active one finishes.
+   * Absent when the surface has no queue (e.g. a chat that does not exist
+   * yet); then a mid-turn Enter steers as before.
+   */
+  onQueue?: () => Promise<void>;
   onStop: () => Promise<void>;
   resetKey: string;
   steerError: string | null;
   steerPending: boolean;
   steerStatus: string | null;
 };
+
+/** The mid-turn Enter behavior, remembered per install. */
+const SEND_MODE_KEY = "openwave.composer.sendMode";
+
+function storedSendMode(): "queue" | "steer" {
+  try {
+    return window.localStorage.getItem(SEND_MODE_KEY) === "steer" ? "steer" : "queue";
+  } catch {
+    return "queue";
+  }
+}
 
 export function Composer({
   activeTurnId,
@@ -312,6 +331,7 @@ export function Composer({
   onDraftChange,
   onSend,
   onSteer,
+  onQueue,
   onStop,
   resetKey,
   steerError,
@@ -349,6 +369,16 @@ export function Composer({
   const { confirm, dialog: confirmDialog } = useConfirm();
   const inputDisabled = disabled;
   const active = busy && activeTurnId !== null;
+  const [sendMode, setSendMode] = useState<"queue" | "steer">(storedSendMode);
+  const queueAvailable = onQueue !== undefined;
+  function pickSendMode(mode: "queue" | "steer") {
+    setSendMode(mode);
+    try {
+      window.localStorage.setItem(SEND_MODE_KEY, mode);
+    } catch {
+      // Preference-only; losing it costs one extra click.
+    }
+  }
   const hasDraft = Boolean(draft.trim());
   const steerHasUnsupportedCharacter = active && draft.includes("\0");
   const steerTooLong =
@@ -629,7 +659,11 @@ export function Composer({
       return;
     }
     const submissionKey = resetKey;
-    await (active ? onSteer() : onSend());
+    await (active
+      ? queueAvailable && sendMode === "queue"
+        ? onQueue()
+        : onSteer()
+      : onSend());
     historyIndexRef.current = null;
 
     // Restore focus after accepted guidance or a failed request. A new chat or
@@ -1040,16 +1074,51 @@ export function Composer({
           {active ? (
             <>
               {(hasDraft || steerPending) && (
-                <Button
-                  type="submit"
-                  variant="default"
-                  size="sm"
-                  className="min-w-[5rem]"
-                  aria-label="Redirect active response"
-                  disabled={!canSubmit}
-                >
-                  {steerPending ? "Sending…" : "Redirect"}
-                </Button>
+                <div className="flex items-center gap-1">
+                  <Button
+                    type="submit"
+                    variant="default"
+                    size="sm"
+                    className="min-w-[5rem]"
+                    aria-label={
+                      queueAvailable && sendMode === "queue"
+                        ? "Queue message for after this response"
+                        : "Redirect active response"
+                    }
+                    disabled={!canSubmit}
+                  >
+                    {steerPending
+                      ? "Sending…"
+                      : queueAvailable && sendMode === "queue"
+                        ? "Queue"
+                        : "Redirect"}
+                  </Button>
+                  {queueAvailable && (
+                    <WithTooltip
+                      label={
+                        sendMode === "queue"
+                          ? "Switch to Redirect: interject into the running response"
+                          : "Switch to Queue: run after this response finishes"
+                      }
+                    >
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon-8"
+                        aria-label="Switch send mode"
+                        onClick={() =>
+                          pickSendMode(sendMode === "queue" ? "steer" : "queue")
+                        }
+                      >
+                        {sendMode === "queue" ? (
+                          <CornerUpRight size={14} />
+                        ) : (
+                          <ListPlus size={14} />
+                        )}
+                      </Button>
+                    </WithTooltip>
+                  )}
+                </div>
               )}
               <WithTooltip label={cancelPending ? "Stopping…" : "Stop"}>
                 <Button

--- a/crates/openwave-desktop/ui/src/QueueTray.tsx
+++ b/crates/openwave-desktop/ui/src/QueueTray.tsx
@@ -1,0 +1,209 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ChevronDown, ChevronUp, Pause, Pencil, Play, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+
+import type { ApiClient, QueuedTurn } from "./api";
+import { friendlyErrorMessage } from "./lib/utils";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+
+/**
+ * The durable message queue, rendered directly above the composer.
+ *
+ * Every row is a `queued_turn` the server owns: reorder, edit, and delete are
+ * real API calls, the queue survives restarts, and promotion happens
+ * server-side the moment the chat is free — this component only observes.
+ * Hidden entirely while the queue is empty, so the ordinary composer is
+ * untouched until the first mid-turn send.
+ */
+export function QueueTray({
+  client,
+  chatId,
+  active,
+}: {
+  client: ApiClient;
+  chatId: string;
+  active: boolean;
+}) {
+  const [queued, setQueued] = useState<QueuedTurn[]>([]);
+  const [paused, setPaused] = useState(false);
+  const [editing, setEditing] = useState<string | null>(null);
+  const [editDraft, setEditDraft] = useState("");
+  const [busy, setBusy] = useState(false);
+  const timerRef = useRef<number | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!client) return;
+    try {
+      const snapshot = await client.listQueuedTurns(chatId);
+      setQueued(snapshot.queued);
+      setPaused(snapshot.paused);
+    } catch {
+      // Poll again on the next tick; a queue read is never worth a toast.
+    }
+  }, [client, chatId]);
+
+  useEffect(() => {
+    void refresh();
+    // Poll while a turn is live (promotion imminent) or rows remain visible.
+    if (!active && queued.length === 0) return;
+    timerRef.current = window.setInterval(() => void refresh(), 1500);
+    return () => {
+      if (timerRef.current !== null) window.clearInterval(timerRef.current);
+    };
+  }, [refresh, active, queued.length > 0]);
+
+  async function act(action: () => Promise<unknown>, failure: string) {
+    setBusy(true);
+    try {
+      await action();
+      await refresh();
+    } catch (error) {
+      toast.error(friendlyErrorMessage(error, failure));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (queued.length === 0) return null;
+
+  return (
+    <section
+      aria-label="Queued messages"
+      className="mx-auto mb-2 w-full max-w-3xl rounded-xl border border-border bg-card shadow-sm"
+    >
+      <header className="flex items-center gap-2 border-b border-border px-3 py-1.5">
+        <span className="text-xs font-semibold">
+          Queued <span className="font-normal text-muted-foreground">{queued.length}</span>
+          {paused && (
+            <span className="ml-2 rounded-full border border-warning-border/45 bg-warning-background px-2 py-px text-[11px] font-medium text-warning-foreground">
+              Paused
+            </span>
+          )}
+        </span>
+        <div className="ml-auto">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-6 gap-1 px-2 text-xs text-muted-foreground"
+            disabled={busy}
+            onClick={() =>
+              void act(
+                () => client.putQueuePaused(chatId, !paused),
+                "Could not update the queue",
+              )
+            }
+          >
+            {paused ? <Play className="size-3" /> : <Pause className="size-3" />}
+            {paused ? "Resume" : "Pause"}
+          </Button>
+        </div>
+      </header>
+      <ul className="flex flex-col gap-px p-1.5">
+        {queued.map((row, index) => (
+          <li
+            key={row.id}
+            className="group flex items-center gap-1.5 rounded-md px-1.5 py-1 hover:bg-accent"
+          >
+            <span className="w-4 shrink-0 text-right text-[11px] tabular-nums text-muted-foreground">
+              {index + 1}
+            </span>
+            {editing === row.id ? (
+              <Textarea
+                rows={1}
+                autoFocus
+                className="min-h-7 flex-1 py-1 text-sm"
+                value={editDraft}
+                onChange={(event) => setEditDraft(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" && !event.shiftKey) {
+                    event.preventDefault();
+                    const content = editDraft.trim();
+                    setEditing(null);
+                    if (content && content !== row.content) {
+                      void act(
+                        () => client.patchQueuedTurn(chatId, row.id, { content }),
+                        "Could not edit the queued message",
+                      );
+                    }
+                  }
+                  if (event.key === "Escape") setEditing(null);
+                }}
+                onBlur={() => setEditing(null)}
+              />
+            ) : (
+              <span className="flex-1 truncate text-sm" title={row.content}>
+                {row.content}
+              </span>
+            )}
+            <span className="hidden shrink-0 items-center group-hover:inline-flex">
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-8"
+                className="size-6"
+                aria-label="Move up"
+                disabled={busy || index === 0}
+                onClick={() =>
+                  void act(
+                    () => client.patchQueuedTurn(chatId, row.id, { position: index - 1 }),
+                    "Could not reorder the queue",
+                  )
+                }
+              >
+                <ChevronUp className="size-3.5" />
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-8"
+                className="size-6"
+                aria-label="Move down"
+                disabled={busy || index === queued.length - 1}
+                onClick={() =>
+                  void act(
+                    () => client.patchQueuedTurn(chatId, row.id, { position: index + 1 }),
+                    "Could not reorder the queue",
+                  )
+                }
+              >
+                <ChevronDown className="size-3.5" />
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-8"
+                className="size-6"
+                aria-label="Edit queued message"
+                disabled={busy}
+                onClick={() => {
+                  setEditing(row.id);
+                  setEditDraft(row.content);
+                }}
+              >
+                <Pencil className="size-3.5" />
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-8"
+                className="size-6 hover:text-destructive"
+                aria-label="Delete queued message"
+                disabled={busy}
+                onClick={() =>
+                  void act(
+                    () => client.deleteQueuedTurn(chatId, row.id),
+                    "Could not delete the queued message",
+                  )
+                }
+              >
+                <Trash2 className="size-3.5" />
+              </Button>
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -691,6 +691,7 @@ describe("sending a message", () => {
       file_attachments: ["doc-1"],
       invoked_skills: ["pptx"],
       voice_input_used: true,
+      queue: false,
     });
   });
 });

--- a/crates/openwave-desktop/ui/src/api/client.ts
+++ b/crates/openwave-desktop/ui/src/api/client.ts
@@ -37,6 +37,7 @@ import {
   type ModelVisibility,
   type NetworkPolicy,
   type PendingFolderAccessRequest,
+  type QueuedTurn,
   type PendingOutputWritebackRequest,
   type PendingPlanApproval,
   type PendingToolApproval,
@@ -1235,6 +1236,7 @@ export class ApiClient {
     fileAttachments: readonly string[] = [],
     invokedSkills: readonly string[] = [],
     voiceInputUsed = false,
+    queue = false,
   ): Promise<void> {
     return this.json(`/chats/${chatId}/messages`, {
       method: "POST",
@@ -1246,8 +1248,53 @@ export class ApiClient {
         file_attachments: fileAttachments,
         invoked_skills: invokedSkills,
         voice_input_used: voiceInputUsed,
+        queue,
       }),
     });
+  }
+
+  /** The chat's queued messages, FIFO, plus whether promotion is paused. */
+  listQueuedTurns(
+    chatId: string,
+  ): Promise<{ queued: QueuedTurn[]; paused: boolean }> {
+    return this.json(`/chats/${encodeURIComponent(chatId)}/queued`, {
+      headers: this.headers(),
+    });
+  }
+
+  patchQueuedTurn(
+    chatId: string,
+    turnId: string,
+    update: { content?: string; position?: number },
+  ): Promise<QueuedTurn> {
+    return this.json(
+      `/chats/${encodeURIComponent(chatId)}/queued/${encodeURIComponent(turnId)}`,
+      {
+        method: "PATCH",
+        headers: this.headers(true),
+        body: JSON.stringify(update),
+      },
+    );
+  }
+
+  async deleteQueuedTurn(chatId: string, turnId: string): Promise<void> {
+    await this.json<unknown>(
+      `/chats/${encodeURIComponent(chatId)}/queued/${encodeURIComponent(turnId)}`,
+      { method: "DELETE", headers: this.headers() },
+      204,
+    );
+  }
+
+  async putQueuePaused(chatId: string, paused: boolean): Promise<void> {
+    await this.json<unknown>(
+      `/chats/${encodeURIComponent(chatId)}/queue-paused`,
+      {
+        method: "PUT",
+        headers: this.headers(true),
+        body: JSON.stringify({ paused }),
+      },
+      204,
+    );
   }
 
   steer(

--- a/crates/openwave-desktop/ui/src/api/types.ts
+++ b/crates/openwave-desktop/ui/src/api/types.ts
@@ -49,6 +49,7 @@ import {
   type ModelInfo as WireModelInfo,
   type ModelRole as WireModelRole,
   type ModelVisibility as WireModelVisibility,
+  type QueuedTurn as WireQueuedTurn,
   type ModelRoleInfo as WireModelRoleInfo,
   type Project as WireProject,
   type ProviderInfo as WireProviderInfo,
@@ -173,6 +174,9 @@ export type ModelSelectionKey = `${ProviderKind}::${string}`;
 
 /** A reader's deviation from a model's curated `recommended` default. */
 export type ModelVisibility = WireModelVisibility;
+
+/** One message waiting to run as its own turn once the chat is free. */
+export type QueuedTurn = WireQueuedTurn;
 
 /** How hard a reasoning-capable model should think before answering. */
 export type ReasoningEffort = WireReasoningEffort;

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1967,6 +1967,56 @@ models: Array<CustomModelConfig>, aws_region?: string, };
 export type ProviderKind = "anthropic" | "openai" | "xai" | "gemini" | "vertex" | "bedrock" | "fireworks" | "together" | "openai_compatible" | "model_gateway";
 
 /**
+ * One message accepted while its chat had a live turn, waiting its turn.
+ *
+ * The id is the client-generated turn id promotion will accept under, so an
+ * ambiguous promotion retry resolves to `Existing` rather than a duplicate
+ * turn. Rows are FIFO by `position` within a chat and fully durable: a queue
+ * survives restarts and is visible to every client on the chat.
+ */
+export type QueuedTurn = { 
+/**
+ * The turn id this row becomes when promoted.
+ */
+id: TurnId, 
+/**
+ * Owning chat.
+ */
+chat_id: ChatId, 
+/**
+ * Byte-exact user message.
+ */
+content: string, 
+/**
+ * Image-attachment ids, in display order.
+ */
+attachments: Array<string>, 
+/**
+ * Chat-owned document ids.
+ */
+file_attachments: Array<DocumentId>, 
+/**
+ * Skills the user explicitly invoked.
+ */
+invoked_skills: Array<string>, 
+/**
+ * Whether the message was dictated.
+ */
+voice_input_used: boolean, 
+/**
+ * FIFO order within the chat.
+ */
+position: number, 
+/**
+ * When the message was queued.
+ */
+created_at: string, 
+/**
+ * When it was last edited or reordered.
+ */
+updated_at: string, };
+
+/**
  * How hard a reasoning-capable model should think before answering.
  *
  * The scale runs from [`Self::None`] to [`Self::Max`] and the ordering is the

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -530,6 +530,15 @@ pub fn app(state: AppState) -> Router {
             "/chats/{chat_id}/agent-runs/{run_id}/resume",
             post(routes::post_agent_run_resume),
         )
+        .route("/chats/{chat_id}/queued", get(routes::list_queued_turns))
+        .route(
+            "/chats/{chat_id}/queued/{turn_id}",
+            axum::routing::patch(routes::patch_queued_turn).delete(routes::delete_queued_turn),
+        )
+        .route(
+            "/chats/{chat_id}/queue-paused",
+            axum::routing::put(routes::put_queue_paused),
+        )
         .route(
             "/chats/{chat_id}/agent-runs/{run_id}/steer",
             post(routes::post_agent_run_steer),
@@ -1205,6 +1214,24 @@ async fn bind_inner(
             sandbox_container_run_worker::SandboxContainerRunWorkerConfig::default(),
         )
     };
+
+    // Queued-message promotion: a light sweep, wake-driven with a slow floor.
+    // Try-based on the idempotent turn acceptance, so it needs no lease of its
+    // own — see `routes::promote_queued_turns`.
+    let queued_turn_promoter = {
+        let state = state.clone();
+        tokio::spawn(async move {
+            let mut tick = tokio::time::interval(std::time::Duration::from_millis(750));
+            tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                tick.tick().await;
+                if let Err(error) = routes::promote_queued_turns(&state).await {
+                    eprintln!("openwave: queued-turn promotion failed: {error:?}");
+                }
+            }
+        })
+    };
+    drop(queued_turn_promoter);
     let server_store = state.store.clone();
     let mcp_runtime = state.mcp.clone();
     let gateway_runtime = state.gateway.clone();

--- a/crates/openwave-server/src/routes/turn_control.rs
+++ b/crates/openwave-server/src/routes/turn_control.rs
@@ -51,6 +51,13 @@ pub struct PostMessage {
     /// submit arbitrary hidden prompt text.
     #[serde(default)]
     pub voice_input_used: bool,
+    /// Queue instead of refusing when the chat has a live turn.
+    ///
+    /// With this set, `ChatBusy` durably parks the validated message as a
+    /// [`openwave_core::QueuedTurn`]; the promoter runs it as its own turn
+    /// once the chat is free. An idle chat sends immediately either way.
+    #[serde(default)]
+    pub queue: bool,
 }
 
 /// Refuse a turn that invokes a skill the install cannot actually run.
@@ -393,11 +400,134 @@ pub async fn post_message(
                 )))
             }
         }
-        AcceptTurnOutcome::ChatBusy(active) => Err(ServerError::conflict(format!(
-            "chat {id} already has active turn {}",
-            active.id
+        AcceptTurnOutcome::ChatBusy(active) => {
+            if body.queue {
+                store
+                    .enqueue_queued_turn(&openwave_core::QueuedTurn {
+                        id: body.turn_id,
+                        chat_id: id,
+                        content: body.content.clone(),
+                        attachments: body.attachments.clone(),
+                        file_attachments: body.file_attachments.clone(),
+                        invoked_skills: body.invoked_skills.clone(),
+                        voice_input_used: body.voice_input_used,
+                        // Assigned durably at insert; echoes back in the row.
+                        position: 0,
+                        created_at: Utc::now(),
+                        updated_at: Utc::now(),
+                    })
+                    .await?;
+                return Ok(StatusCode::ACCEPTED);
+            }
+            Err(ServerError::conflict(format!(
+                "chat {id} already has active turn {}",
+                active.id
+            )))
+        }
+    }
+}
+
+/// Response of `GET /chats/{chat_id}/queued`.
+#[derive(Debug, serde::Serialize)]
+pub struct QueuedTurnsSnapshot {
+    pub queued: Vec<openwave_core::QueuedTurn>,
+    pub paused: bool,
+}
+
+fn queue_paused_setting(chat_id: ChatId) -> String {
+    format!("chats.{chat_id}.queue_paused")
+}
+
+pub(crate) async fn read_queue_paused(
+    store: &dyn openwave_core::Store,
+    chat_id: ChatId,
+) -> openwave_core::Result<bool> {
+    Ok(store
+        .get_setting(&queue_paused_setting(chat_id))
+        .await?
+        .and_then(|value| serde_json::from_value::<bool>(value).ok())
+        .unwrap_or(false))
+}
+
+/// `GET /chats/{chat_id}/queued` — the chat's queued messages, FIFO.
+pub async fn list_queued_turns(
+    State(state): State<AppState>,
+    store: ScopedStore,
+    Path(id): Path<ChatId>,
+) -> Result<Json<QueuedTurnsSnapshot>, ServerError> {
+    store.require_chat(id).await?;
+    Ok(Json(QueuedTurnsSnapshot {
+        queued: state.store.list_queued_turns(id).await?,
+        paused: read_queue_paused(&*state.store, id).await?,
+    }))
+}
+
+/// Body of `PATCH /chats/{chat_id}/queued/{turn_id}`.
+#[derive(Debug, Default, serde::Deserialize)]
+pub struct QueuedTurnUpdate {
+    #[serde(default)]
+    pub content: Option<String>,
+    #[serde(default)]
+    pub position: Option<i32>,
+}
+
+/// `PATCH /chats/{chat_id}/queued/{turn_id}` — edit or reorder one queued
+/// message.
+pub async fn patch_queued_turn(
+    State(state): State<AppState>,
+    store: ScopedStore,
+    Path((id, turn_id)): Path<(ChatId, TurnId)>,
+    Json(body): Json<QueuedTurnUpdate>,
+) -> Result<Json<openwave_core::QueuedTurn>, ServerError> {
+    store.require_chat(id).await?;
+    match state
+        .store
+        .update_queued_turn(id, turn_id, body.content.as_deref(), body.position)
+        .await?
+    {
+        Some(updated) => Ok(Json(updated)),
+        None => Err(ServerError::not_found(format!(
+            "queued turn {turn_id} not found"
         ))),
     }
+}
+
+/// `DELETE /chats/{chat_id}/queued/{turn_id}` — retract one queued message.
+pub async fn delete_queued_turn(
+    State(state): State<AppState>,
+    store: ScopedStore,
+    Path((id, turn_id)): Path<(ChatId, TurnId)>,
+) -> Result<StatusCode, ServerError> {
+    store.require_chat(id).await?;
+    if state.store.delete_queued_turn(id, turn_id).await? {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(ServerError::not_found(format!(
+            "queued turn {turn_id} not found"
+        )))
+    }
+}
+
+/// Body of `PUT /chats/{chat_id}/queue-paused`.
+#[derive(Debug, serde::Deserialize)]
+pub struct QueuePausedBody {
+    pub paused: bool,
+}
+
+/// `PUT /chats/{chat_id}/queue-paused` — stop or restart automatic promotion
+/// for this chat; queued rows stay put while paused.
+pub async fn put_queue_paused(
+    State(state): State<AppState>,
+    store: ScopedStore,
+    Path(id): Path<ChatId>,
+    Json(body): Json<QueuePausedBody>,
+) -> Result<StatusCode, ServerError> {
+    store.require_chat(id).await?;
+    state
+        .store
+        .set_setting(&queue_paused_setting(id), &serde_json::json!(body.paused))
+        .await?;
+    Ok(StatusCode::NO_CONTENT)
 }
 
 /// Body of `POST /chats/{id}/steer`.
@@ -553,4 +683,98 @@ pub async fn post_cancel(
     // truth if this notification is lost.
     state.agent_run_wake.notify_one();
     Ok(StatusCode::ACCEPTED)
+}
+
+/// One promotion sweep: for every chat holding queued messages and no live
+/// turn, try to accept the oldest row as a real turn and delete it on
+/// success.
+///
+/// Promotion is deliberately try-based rather than fenced: acceptance is
+/// idempotent under the queued row's own turn id, so `ChatBusy` leaves the
+/// row for the next sweep, a crash between acceptance and deletion re-runs
+/// into `Existing`, and a row whose id was somehow reused for different input
+/// is dropped rather than retried forever. A row whose attachments or skills
+/// no longer resolve is dropped too — its turn could never be accepted.
+pub(crate) async fn promote_queued_turns(state: &AppState) -> Result<(), ServerError> {
+    for chat_id in state.store.chats_with_queued_turns().await? {
+        if read_queue_paused(&*state.store, chat_id).await? {
+            continue;
+        }
+        let Some(chat) = state.store.get_chat(chat_id).await? else {
+            continue;
+        };
+        let Some(next) = state
+            .store
+            .list_queued_turns(chat_id)
+            .await?
+            .into_iter()
+            .next()
+        else {
+            continue;
+        };
+        let selected = resolve_chat_model(&*state.store, &chat, &state.agent_config.model).await?;
+        let managed = crate::managed_policy::resolve(&*state.store, &*state.os_policy).await?;
+        let selected = if managed.managed && chat.model.is_none() {
+            model_roles::effective_chat_policy(&*state.store, &*state.secrets, &managed, &selected)
+                .await?
+                .map_or(selected, |policy| policy.key)
+        } else {
+            selected
+        };
+        let dropped = |reason: &str| {
+            eprintln!(
+                "openwave: dropping queued message {} for chat {chat_id}: {reason}",
+                next.id
+            );
+        };
+        let model = match validate_model_selection(state, &selected, true).await {
+            Ok(model) => model,
+            Err(_) => {
+                // The chat's model became unusable; leave the row so fixing
+                // the model releases the queue rather than losing messages.
+                continue;
+            }
+        };
+        if require_invocable_skills(state, &next.invoked_skills)
+            .await
+            .is_err()
+        {
+            dropped("an invoked skill is no longer available");
+            state.store.delete_queued_turn(chat_id, next.id).await?;
+            continue;
+        }
+        let images = match resolve_message_attachments(state, &next.attachments).await {
+            Ok(images) => images,
+            Err(_) => {
+                dropped("an image attachment no longer resolves");
+                state.store.delete_queued_turn(chat_id, next.id).await?;
+                continue;
+            }
+        };
+        match state
+            .store
+            .accept_turn_with_message_context(
+                next.id,
+                chat_id,
+                &model,
+                &next.content,
+                &images,
+                &next.file_attachments,
+                &next.invoked_skills,
+                next.voice_input_used,
+            )
+            .await?
+        {
+            AcceptTurnOutcome::Accepted(_) | AcceptTurnOutcome::Existing(_) => {
+                state.store.delete_queued_turn(chat_id, next.id).await?;
+                state.turn_job_wake.notify_one();
+            }
+            AcceptTurnOutcome::ChatBusy(_) => {}
+            AcceptTurnOutcome::IdentityConflict => {
+                dropped("its turn id was already used with different input");
+                state.store.delete_queued_turn(chat_id, next.id).await?;
+            }
+        }
+    }
+    Ok(())
 }

--- a/crates/openwave-server/src/scoped_store.rs
+++ b/crates/openwave-server/src/scoped_store.rs
@@ -315,6 +315,14 @@ impl ScopedStore {
         self.store.get_agent_run_result(id).await
     }
 
+    /// [`Store::enqueue_queued_turn`].
+    pub async fn enqueue_queued_turn(
+        &self,
+        queued: &openwave_core::QueuedTurn,
+    ) -> Result<openwave_core::QueuedTurn> {
+        self.store.enqueue_queued_turn(queued).await
+    }
+
     /// [`Store::resume_agent_run_from_checkin`].
     pub async fn resume_agent_run_from_checkin(
         &self,

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -353,6 +353,7 @@ mod tests {
         // types with the conversation path, but one generated module keeps the
         // renderer importing from a single place.
         generate::collect_from::<crate::routes::Settings>(&cfg, &mut out);
+        generate::collect_from::<openwave_core::QueuedTurn>(&cfg, &mut out);
         generate::collect_from::<crate::routes::ModelInfo>(&cfg, &mut out);
         generate::collect_from::<crate::routes::ModelRoleInfo>(&cfg, &mut out);
         generate::collect_from::<crate::routes::ChatTranscript>(&cfg, &mut out);

--- a/docs/decisions/0006-queued-turns.md
+++ b/docs/decisions/0006-queued-turns.md
@@ -1,0 +1,80 @@
+# 6. Mid-turn sends queue by default; steering is the explicit alternative
+
+- Status: Accepted
+- Date: 2026-08-10
+- Owners: chat turn lifecycle, desktop composer
+- Related: [0005](0005-checkin-needs-input.md); `crates/openwave-core/src/db/ops/turn/queued.rs`
+- Supersedes: —
+
+## Context
+
+Sending while a turn is active had exactly one meaning: steer. The composer's
+Enter always redirected the running model (`interrupt: true`), and
+`POST /chats/{id}/messages` refused a busy chat with `409 ChatBusy` — nothing
+queued anywhere, so a user with three follow-ups either derailed the current
+turn three times or babysat the spinner. Steering is fully durable and
+boundary-applied server-side; queueing did not exist in any layer.
+
+## Decision
+
+**Queue is the default mid-turn send; steer is the deliberate alternative.**
+
+- A durable `queued_turn` row per queued message: the row id *is* the client
+  turn id promotion will accept under. `POST /messages` gains `queue: true`,
+  turning `ChatBusy` into a durable park of the already-validated body.
+  FIFO by a dense per-chat `position`; capped at 32 per chat.
+- **Promotion is try-based, not fenced.** A sweep (750 ms) walks chats holding
+  queued rows and *tries* the ordinary idempotent turn acceptance under the
+  row's own id, deleting the row only on success. `ChatBusy` leaves it for
+  the next sweep; a crash between acceptance and deletion re-runs into
+  `Existing`; a row whose attachments or skills no longer resolve is dropped
+  (its turn could never be accepted), while an unusable chat model leaves the
+  queue intact so fixing the model releases it.
+- The tray above the composer renders the rows with edit, delete, reorder,
+  and per-chat pause (a settings key, `chats.{id}.queue_paused` — promotion
+  skips paused chats).
+- The composer's mid-turn button is mode-switched (Queue ↔ Redirect), and the
+  choice persists per install (localStorage): this is composer posture, not
+  chat state, and does not merit a server setting yet.
+
+Deliberately excluded: "send now" on a queued row steering its content into
+the live turn (retract + steer compose today by hand); drag reordering
+(buttons cover it); steering switched to `interrupt: false` (Redirect keeps
+its meaning until the queue default has soaked).
+
+## Alternatives Considered
+
+- **Client-side draft buffer** that auto-sends when the chat frees. Rejected:
+  lost on quit, invisible to other clients, and racing the 409 it papers over.
+- **Fenced server-side promotion** (a lease-holding promoter committing
+  acceptance and deletion atomically). Rejected: acceptance is already
+  idempotent under the row's id, which makes try-then-delete crash-safe for
+  free; a new fenced path would re-prove what `AcceptTurnOutcome::Existing`
+  already proves.
+- **Steer-by-default, queue as the modifier** (today's behavior, softened).
+  Rejected: Enter mid-turn derailing the model is the papercut this exists to
+  fix; interjecting should be the deliberate act.
+
+## Consequences
+
+- A queued message runs later under settings resolved *at promotion* (model,
+  managed policy) — the honest reading of "run this when you're free".
+- Dropped rows (dead attachment, removed skill) are logged, not surfaced in
+  the transcript yet; the tray simply stops showing them. Revisit if users
+  report silent loss in practice.
+- The promoter is poll-based at 750 ms; if that cadence ever matters, wire it
+  to the turn-resolution wake instead.
+
+Revisit if: multiple clients need a shared send-mode default (promote the
+localStorage choice to a setting), or promotion-order guarantees beyond FIFO
+are wanted (priorities, scheduling).
+
+## Validation
+
+- Store: enqueue caps and idempotent retry; FIFO promotion order; retract and
+  reorder keep positions dense.
+- End-to-end: queue two messages mid-turn, watch both run in order after the
+  live turn resolves; pause holds promotion, resume releases it.
+- The wrong implementation to guard against: promotion deleting the row
+  before acceptance commits — a crash there loses a message; the delete must
+  follow `Accepted`/`Existing`.


### PR DESCRIPTION
## What

Conductor-style queue-vs-steer, per [decision 0006](docs/decisions/0006-queued-turns.md). Stacked follow-on to #1858/#1879.

- **`POST /chats/{id}/messages` gains `queue: true`**: a busy chat durably parks the already-validated message as a `queued_turn` row instead of 409ing. The row id is the client turn id promotion accepts under, so retries and crashes resolve through the existing idempotent acceptance (`Existing`), never a duplicate turn.
- **Try-based promotion**, no new fenced path: a 750 ms sweep tries the oldest row per unpaused chat, deleting only on `Accepted`/`Existing`. `ChatBusy` waits; dead attachments/skills drop the row (logged); an unusable chat model leaves the queue intact so fixing the model releases it. Model and managed policy resolve at promotion time.
- **Queue tray** above the composer: FIFO rows with inline edit, up/down reorder, delete, and per-chat Pause/Resume (settings key; promotion skips paused chats). Hidden when empty.
- **Composer mid-turn default is now Queue**, with a one-click switch back to Redirect (steer); the choice persists per install. An idle chat sends immediately regardless.
- Cap: 32 queued per chat. New routes: `GET /chats/{id}/queued`, `PATCH`/`DELETE /chats/{id}/queued/{turn_id}`, `PUT /chats/{id}/queue-paused`. `wire.ts` regenerated (`QueuedTurn`).

Deliberately out (in the record): send-now-as-steer on a row, drag reorder, changing Redirect to `interrupt: false`.

## Verification

- `cargo test -p openwave-core` (589) and `-p openwave-server` (738; the known `heartbeats_the_lease` timing flake failed once under full load, passes in isolation and on rerun), clippy `-D warnings`, fmt, `cargo check --workspace --locked` with no lock diff — all after full source-touch rebuilds to defeat the shared-target staleness seen earlier today.
- UI: 893 tests, `tsc` clean.
- Not verified by driving the app: the visible queue flow (Enter mid-turn → tray → promotion when the turn ends). Worth a manual pass.

Labelled `full-ci`: new baseline table + promotion touching turn acceptance — the PostgreSQL lane is the coverage I cannot run locally.