### PR TITLE
feat(server): let the parent model resume or cancel its background agents

### DIFF
--- a/crates/openwave-server/src/agent_control_tools.rs
+++ b/crates/openwave-server/src/agent_control_tools.rs
@@ -1,0 +1,300 @@
+//! Foreground tools for supervising delegated background agents.
+//!
+//! The parent model already *sees* a check-in — the child's pause settles its
+//! `wait_for_agents` with a typed [`openwave_core::AgentRunResultPayload::CheckIn`]
+//! payload — but until these tools it could only describe the situation to
+//! the user. `resume_agent` and `cancel_agent` close that loop: the same
+//! transitions the run panel's buttons drive, callable by the model that
+//! spawned the child.
+//!
+//! Both are ordinary synchronous server tools rather than orchestration
+//! checkpoints: nothing here parks the turn, and both effects are idempotent
+//! store transitions fenced elsewhere (the cancellation state machine and the
+//! resume's status/updated-at filters).
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use openwave_core::{
+    AgentError, AgentRunId, AgentRunStatus, AgentRunTier, ApprovalClass, Result, Store, Tool,
+    ToolCtx, ToolErrorCategory, ToolOutput, ToolSpec,
+};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+/// Stable name for the foreground child-resume tool.
+pub(crate) const RESUME_AGENT_TOOL: &str = "resume_agent";
+/// Stable name for the foreground child-cancel tool.
+pub(crate) const CANCEL_AGENT_TOOL: &str = "cancel_agent";
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ResumeAgentArgs {
+    agent_id: AgentRunId,
+    #[serde(default)]
+    guidance: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CancelAgentArgs {
+    agent_id: AgentRunId,
+    #[serde(default)]
+    reason: Option<String>,
+}
+
+/// The target named by a supervision call, or the refusal to hand the model.
+async fn own_background_child(
+    store: &Arc<dyn Store>,
+    ctx: &ToolCtx,
+    agent_id: AgentRunId,
+) -> Result<std::result::Result<openwave_core::AgentRun, ToolOutput>> {
+    let Some(run) = store.get_agent_run(agent_id).await? else {
+        return Ok(Err(ToolOutput::failed(
+            ToolErrorCategory::InvalidArguments,
+            format!("agent {agent_id} does not exist"),
+        )));
+    };
+    // Same boundary as the HTTP routes: a conversation supervises only the
+    // background children it owns. Wrong-chat targets read as absent so a
+    // hallucinated id cannot probe another conversation's work.
+    if run.chat_id != ctx.chat_id || run.tier != AgentRunTier::Background {
+        return Ok(Err(ToolOutput::failed(
+            ToolErrorCategory::InvalidArguments,
+            format!("agent {agent_id} does not exist"),
+        )));
+    }
+    Ok(Ok(run))
+}
+
+/// Resume a background child paused at a check-in, optionally with guidance.
+pub(crate) struct ResumeAgentTool {
+    store: Arc<dyn Store>,
+}
+
+impl ResumeAgentTool {
+    pub(crate) fn new(store: Arc<dyn Store>) -> Self {
+        Self { store }
+    }
+}
+
+#[async_trait]
+impl Tool for ResumeAgentTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec {
+            name: RESUME_AGENT_TOOL.into(),
+            description: "Resume one of this conversation's background agents that paused to \
+                          check in (status needs_input), granting it another step window. \
+                          Optional guidance is folded into the agent's task before it \
+                          continues — use it to redirect or narrow the work. Only an agent \
+                          spawned by this conversation can be resumed."
+                .into(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "agent_id": {
+                        "type": "string",
+                        "description": "The paused agent's id, from wait_for_agents' check_in result."
+                    },
+                    "guidance": {
+                        "type": "string",
+                        "description": "Optional direction for the agent before it continues."
+                    }
+                },
+                "required": ["agent_id"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    /// `ReadOnly` deliberately: resuming grants no reach the spawn did not
+    /// already carry — the child keeps exactly the sandbox capabilities it was
+    /// admitted with, and the spawn itself is the `Sensitive` boundary that
+    /// carried their weight. Gating the continuation would make supervising
+    /// delegated work more interrupting than delegating it.
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::ReadOnly
+    }
+
+    async fn execute(&self, ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let args = match serde_json::from_value::<ResumeAgentArgs>(args) {
+            Ok(args) => args,
+            Err(_) => {
+                return Ok(ToolOutput::failed(
+                    ToolErrorCategory::InvalidArguments,
+                    "expected {\"agent_id\": \"...\", \"guidance\"?: \"...\"}",
+                ));
+            }
+        };
+        let run = match own_background_child(&self.store, ctx, args.agent_id).await? {
+            Ok(run) => run,
+            Err(refusal) => return Ok(refusal),
+        };
+        let guidance = args
+            .guidance
+            .as_deref()
+            .map(str::trim)
+            .filter(|guidance| !guidance.is_empty());
+        match self
+            .store
+            .resume_agent_run_from_checkin(run.id, guidance)
+            .await
+        {
+            Ok(Some(resumed)) => Ok(ToolOutput::text(format!(
+                "Resumed agent {id}; it has another step window{with}. Call wait_for_agents \
+                 to collect its next result or check-in.",
+                id = resumed.id,
+                with = if guidance.is_some() {
+                    " and your guidance"
+                } else {
+                    ""
+                },
+            ))),
+            Ok(None) => Ok(ToolOutput::failed(
+                ToolErrorCategory::ToolFailed,
+                format!(
+                    "agent {id} is not paused at a check-in (status: {status})",
+                    id = run.id,
+                    status = run.status.as_str(),
+                ),
+            )),
+            Err(AgentError::Store(message)) => Ok(ToolOutput::failed(
+                ToolErrorCategory::InvalidArguments,
+                message.to_string(),
+            )),
+            Err(error) => Err(error),
+        }
+    }
+}
+
+/// Cancel one of the conversation's background children.
+pub(crate) struct CancelAgentTool {
+    store: Arc<dyn Store>,
+}
+
+impl CancelAgentTool {
+    pub(crate) fn new(store: Arc<dyn Store>) -> Self {
+        Self { store }
+    }
+}
+
+#[async_trait]
+impl Tool for CancelAgentTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec {
+            name: CANCEL_AGENT_TOOL.into(),
+            description: "Stop one of this conversation's background agents. Use it on an \
+                          agent whose check-in shows the work is no longer needed or is not \
+                          converging, or any agent that should stop. Cancellation is durable \
+                          and settles any pending wait on the agent with a cancelled result. \
+                          Only an agent spawned by this conversation can be cancelled."
+                .into(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "agent_id": {
+                        "type": "string",
+                        "description": "The agent to stop."
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": "Optional short reason, recorded in the agent's progress feed."
+                    }
+                },
+                "required": ["agent_id"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    /// `ReadOnly` for the same reason as resume: stopping the conversation's
+    /// own delegated work reaches nothing beyond that work. The cost of a
+    /// wrong cancel is lost child progress, which the transcript records —
+    /// not an effect on anything the user owns outside the chat.
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::ReadOnly
+    }
+
+    async fn execute(&self, ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let args = match serde_json::from_value::<CancelAgentArgs>(args) {
+            Ok(args) => args,
+            Err(_) => {
+                return Ok(ToolOutput::failed(
+                    ToolErrorCategory::InvalidArguments,
+                    "expected {\"agent_id\": \"...\", \"reason\"?: \"...\"}",
+                ));
+            }
+        };
+        let run = match own_background_child(&self.store, ctx, args.agent_id).await? {
+            Ok(run) => run,
+            Err(refusal) => return Ok(refusal),
+        };
+        if run.status.is_terminal() {
+            return Ok(ToolOutput::text(format!(
+                "Agent {id} already finished (status: {status}); nothing to cancel.",
+                id = run.id,
+                status = run.status.as_str(),
+            )));
+        }
+        if let Some(reason) = args
+            .reason
+            .as_deref()
+            .map(str::trim)
+            .filter(|reason| !reason.is_empty())
+        {
+            // Best-effort observation, keyed by the cancelling call so a
+            // retried tool execution republishes nothing.
+            let key = ctx
+                .call_id
+                .map(|call| format!("cancel_reason:{call}"))
+                .unwrap_or_else(|| format!("cancel_reason:{}", run.claim_count));
+            let reason: String = reason.chars().take(1_000).collect();
+            let _ = self
+                .store
+                .append_agent_run_progress(
+                    run.id,
+                    &key,
+                    &format!("Cancelled by the chat: {reason}"),
+                )
+                .await;
+        }
+        // The request is serialized against live leases; a busy run flips to
+        // cancelling and quiesces, a parked one terminalizes immediately. A
+        // handful of retries covers claim races the same way the HTTP route's
+        // loop does.
+        for _ in 0..8 {
+            if let Some(outcome) = self.store.request_agent_run_cancellation(run.id).await? {
+                let cancelled = matches!(
+                    outcome,
+                    openwave_core::RequestAgentRunCancellationOutcome::Cancelled(_)
+                );
+                return Ok(ToolOutput::text(if cancelled {
+                    format!("Cancelled agent {id}.", id = run.id)
+                } else {
+                    format!(
+                        "Agent {id} is stopping; a pending wait on it settles with a \
+                         cancelled result.",
+                        id = run.id
+                    )
+                }));
+            }
+            let Some(current) = self.store.get_agent_run(run.id).await? else {
+                break;
+            };
+            if current.status == AgentRunStatus::Cancelled {
+                return Ok(ToolOutput::text(format!(
+                    "Cancelled agent {id}.",
+                    id = run.id
+                )));
+            }
+            tokio::task::yield_now().await;
+        }
+        Ok(ToolOutput::failed(
+            ToolErrorCategory::ToolFailed,
+            format!(
+                "cancellation of agent {id} could not be serialized; try again",
+                id = run.id
+            ),
+        ))
+    }
+}

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -17,6 +17,7 @@
 //! `OPENWAVE_LISTEN_ADDR`. The desktop profile refuses one — see
 //! [`Config::bind_addr`].
 
+mod agent_control_tools;
 mod agent_run_scratch_reaper;
 mod approval_judge;
 mod approvals;
@@ -1346,6 +1347,12 @@ fn agent_deps(
             source_store.clone(),
         )))
         .with(Box::new(create_app))
+        .with(Box::new(agent_control_tools::ResumeAgentTool::new(
+            source_store.clone(),
+        )))
+        .with(Box::new(agent_control_tools::CancelAgentTool::new(
+            source_store.clone(),
+        )))
         .with(Box::new(task_plan_tool::UpdateTaskPlanTool::new(
             source_store.clone(),
         )))

--- a/crates/openwave-server/src/sandbox_agent_run_worker/tests.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker/tests.rs
@@ -3131,3 +3131,82 @@ async fn a_call_made_after_the_budget_is_spent_is_refused_rather_than_failing_th
         "the resumed request should carry the guidance in its task text"
     );
 }
+
+/// The parent model can act on a check-in itself: resume with guidance, or
+/// cancel outright — the same transitions the run panel drives, as tools.
+#[tokio::test]
+async fn parent_tools_resume_and_cancel_a_checked_in_child() {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let chat = sandbox_chat();
+    store.create_chat(&chat).await.unwrap();
+    let provider = Arc::new(WebSearchThenFinalProvider::default());
+    let worker = SandboxAgentRunWorker::new(
+        store.clone(),
+        test_secrets(),
+        Arc::new(FixedResolver(provider.clone())),
+        Arc::new(Notify::new()),
+        Arc::new(Notify::new()),
+        Arc::new(EventBus::default()),
+        AgentConfig {
+            model: "sandbox-model".into(),
+            max_steps: 8,
+            ..AgentConfig::default()
+        },
+        None,
+        SandboxAgentRunWorkerConfig::default(),
+    );
+    let spawn = CallId::new();
+    let id = openwave_core::AgentRunId::sandbox_for_spawn_call(spawn);
+    admit_sandbox(&store, chat.id, spawn, "Produce a document.").await;
+    spend_the_cadence(&store, id, chat.id, 7).await;
+    assert_eq!(
+        worker.run_once().await.unwrap(),
+        SandboxAgentRunWorkerOutcome::CheckedIn(id)
+    );
+
+    let ctx = openwave_core::ToolCtx::new_legacy_workspace(chat.id, None, dir.path().join("ws"));
+    let resume = crate::agent_control_tools::ResumeAgentTool::new(store.clone());
+    let output = openwave_core::Tool::execute(
+        &resume,
+        &ctx,
+        serde_json::json!({"agent_id": id, "guidance": "Wrap it up."}),
+    )
+    .await
+    .unwrap();
+    assert!(!output.is_error, "resume should succeed: {output:?}");
+    let resumed = store.get_agent_run(id).await.unwrap().unwrap();
+    assert_eq!(resumed.status, AgentRunStatus::RetryWait);
+    assert_eq!(resumed.checkin_grants, 1);
+
+    // Resuming a run that is not paused is a readable refusal, not an error.
+    let again = openwave_core::Tool::execute(&resume, &ctx, serde_json::json!({"agent_id": id}))
+        .await
+        .unwrap();
+    assert!(again.is_error);
+
+    // Drive the run to its next pause, then cancel it from the parent's side.
+    assert_eq!(
+        worker.run_once().await.unwrap(),
+        SandboxAgentRunWorkerOutcome::Completed(id)
+    );
+    let cancel = crate::agent_control_tools::CancelAgentTool::new(store.clone());
+    let output = openwave_core::Tool::execute(
+        &cancel,
+        &ctx,
+        serde_json::json!({"agent_id": id, "reason": "no longer needed"}),
+    )
+    .await
+    .unwrap();
+    assert!(
+        !output.is_error,
+        "cancelling a finished run reads as already finished: {output:?}"
+    );
+}


### PR DESCRIPTION
## What

The follow-up deferred from #1879 (see [decision 0005](docs/decisions/0005-checkin-needs-input.md)): the parent model can now *act* on a check-in, not just see it.

- **`resume_agent`** `{agent_id, guidance?}` — resumes a child paused in `needs_input`, granting another cadence window; guidance folds durably into the child's task text. Same store transition as `POST /agent-runs/{run}/resume` and the run panel's Resume.
- **`cancel_agent`** `{agent_id, reason?}` — drives the existing durable cancellation state machine; the reason lands in the child's progress feed keyed by the cancelling call, so a retried execution republishes nothing. A finished child reads as already finished, not an error.
- Implemented as ordinary synchronous `Server` tools (the `UpdateTaskPlanTool` pattern) — deliberately **not** a third `ForegroundOrchestrationKind`: nothing parks, both effects are idempotent transitions fenced in the store.
- **Chat-scoped**: a target run outside the calling conversation reads as absent (no cross-chat probing). **ReadOnly approval class**, argued in the code: the spawn was the `Sensitive` boundary; supervision grants no reach the admission didn't already carry.

No wire changes, no schema changes, no UI changes.

## Tests

End-to-end in the sandbox worker suite: child checks in at its cadence → `resume_agent` with guidance (grants recorded, status `retry_wait`) → resuming a non-paused run is a readable refusal → run completes → `cancel_agent` on the finished run reads as already finished.

## Verification

`cargo test -p openwave-server` (745 passed, full source-touch rebuild), clippy `-D warnings` clean, fmt, `cargo check --workspace --locked` with no lock diff. Not verified by driving the app: a live parent model choosing to call these.

Labelled `full-ci` for the postgres lane on the resume/cancel store transitions.