### PR TITLE
test(cli): pin that --server reaches the attached server for output and attach

### DIFF
--- a/crates/openwave-cli/tests/serve.rs
+++ b/crates/openwave-cli/tests/serve.rs
@@ -4,6 +4,7 @@ use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpStream;
 use std::path::Path;
 use std::process::{Child, Command, Output, Stdio};
+use std::str::FromStr;
 use std::time::{Duration, Instant};
 
 const PROCESS_EXIT_TIMEOUT: Duration = Duration::from_secs(15);
@@ -380,6 +381,84 @@ fn a_setup_command_attaches_to_a_running_server() {
         "stdout: {}",
         String::from_utf8_lossy(&output.stdout)
     );
+}
+
+/// The same rule for the families that read and write a conversation's files.
+/// Their failure mode when `--server` is ignored is not a broken flag but a
+/// silently wrong target: the command reads the local data directory while the
+/// caller believes it reached the deployment. The client here is pointed at a
+/// *different, empty* data directory from the one the server owns, so an
+/// embedding command would answer about a database that has never heard of this
+/// chat — only a command that actually attached can find it.
+#[test]
+fn the_output_and_attach_families_reach_the_attached_server() {
+    let served = tempfile::tempdir().unwrap();
+    let elsewhere = tempfile::tempdir().unwrap();
+    let (_server, url, token) = spawn_serve(served.path());
+    let chat = create_chat(&url, &token);
+
+    let source = elsewhere.path().join("contract.txt");
+    std::fs::write(&source, b"the terms are as follows\n").unwrap();
+    let attached = Command::new(env!("CARGO_BIN_EXE_openwave"))
+        .args(["attach", &chat])
+        .arg(&source)
+        .arg("--server")
+        .arg(&url)
+        .env("OPENWAVE_SERVER_TOKEN", &token)
+        .env("OPENWAVE_DATA_DIR", elsewhere.path())
+        .env("OPENWAVE_KEYCHAIN_MOCK", "1")
+        .env_remove("OPENWAVE_SERVER_URL")
+        .stdin(Stdio::null())
+        .output()
+        .expect("run an attached attach");
+    let stderr = String::from_utf8_lossy(&attached.stderr).into_owned();
+    assert!(attached.status.success(), "stderr: {stderr}");
+    let ingested = String::from_utf8_lossy(&attached.stdout).trim().to_owned();
+    assert!(
+        openwave_core::DocumentId::from_str(&ingested).is_ok(),
+        "the new document's id belongs on stdout, got {ingested:?}"
+    );
+
+    let listed = Command::new(env!("CARGO_BIN_EXE_openwave"))
+        .args(["output", "list", &chat, "--server"])
+        .arg(&url)
+        .env("OPENWAVE_SERVER_TOKEN", &token)
+        .env("OPENWAVE_DATA_DIR", elsewhere.path())
+        .env("OPENWAVE_KEYCHAIN_MOCK", "1")
+        .env_remove("OPENWAVE_SERVER_URL")
+        .stdin(Stdio::null())
+        .output()
+        .expect("run an attached output list");
+    let stderr = String::from_utf8_lossy(&listed.stderr).into_owned();
+    assert!(listed.status.success(), "stderr: {stderr}");
+    assert!(
+        stderr.contains("no outputs"),
+        "the attached chat exists and has produced nothing yet: {stderr}"
+    );
+}
+
+/// Create a chat on the running server and return its id, so a command under
+/// test has something on the *server's* side to name.
+fn create_chat(url: &str, token: &str) -> String {
+    let body = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            reqwest::Client::new()
+                .post(format!("{url}/chats"))
+                .bearer_auth(token)
+                .json(&serde_json::json!({}))
+                .send()
+                .await
+                .expect("create a chat")
+                .error_for_status()
+                .expect("the create route answers 2xx")
+                .json::<serde_json::Value>()
+                .await
+                .expect("the created chat")
+        });
+    body["id"].as_str().expect("the chat's id").to_owned()
 }
 
 /// The other half of the same rule: a second process that tries to *embed* a


### PR DESCRIPTION
The reported gap is already closed in code: `output` and
`attach` both go through `server_flags.resolve()?` in `run()`'s dispatch, and
`outputs::run`/`outputs::attach` open a `connect::Session` and drive its client,
exactly like the provider/model/settings families. That wiring came in with
#1880's rebase commit; the review comment and #1889 that flagged it were
both written against the state before that push. `USAGE` and
`docs-site/content/docs/headless.mdx` already list `output` and `attach` among
the commands that take `--server`.

What was missing was any assertion that it stays true. That is the part worth
having: the failure mode #1889 describes is not a broken flag but a *silently
wrong target* — `openwave output export --server https://team.internal …`
quietly reading the local database — which passes every existing test and is
invisible until a user reports the wrong bytes. It was one refactor away from
coming back unnoticed.

## The test

`the_output_and_attach_families_reach_the_attached_server` in
`crates/openwave-cli/tests/serve.rs`, built on #1885's `spawn_serve` harness.

The discrimination is deliberate: the client runs with `OPENWAVE_DATA_DIR`
pointing at a **different, empty** directory from the one the served process
owns, rather than at the same one. The same-directory form the setup test uses
proves only that the command did not embed — it leans on the ownership guard.
Pointing elsewhere proves the stronger thing, that the command read the
*attached server's* state: a chat created over HTTP on the running server exists
nowhere else, so an embedding command answers about a database that has never
heard of it.

One test covering both families, no per-subcommand duplication: `attach` posts a
file's bytes and prints the new document id, and `output list` finds the chat
and reports it has produced nothing yet. Reintroducing the bug (passing
`Server::Embed` for both) fails it with
`404 Not Found: chat … not found` — the exact symptom the issue names.
`OPENWAVE_KEYCHAIN_MOCK` is set on the client so that regression fails rather
than blocks on a keychain prompt.

## No refusal path is needed

I checked every subcommand for something that cannot work attached, since the
issue's fallback option was `refuse()`:

- `list`, `show`, `revisions` — plain HTTP reads of the output routes.
- `export` — the route serves the bytes and the CLI writes them to the path
  argument. That is correct attached, not merely tolerable: the path is on the
  caller's machine, which is the only thing a path on a caller's command line
  can mean. `write_export` is local `std::fs` and consumes
  `read_output_bytes`, so there is no embed-only detour to fix.
- `attach` — reads the local file, sniffs its media type in-process, and posts
  it. Reading the caller's file is likewise the right meaning.

Nothing here needs the client-executor credential or host-filesystem authority,
so there is no subcommand to degrade loudly and no second test. The
consent-style degradation #1881 needs is specific to that branch's folder
surface and is not reachable from these commands.

Closes #1889

Written against #1880's branch, which merged while this was in progress; rebased
onto `main` and retargeted there.

## Verification

`cargo check -p openwave-cli -p openwave-server --locked`,
`cargo test -p openwave-cli -p openwave-server --locked` (779 passing), and
`cargo fmt --all -- --check` are green, and the `serve` suite was re-run after
the rebase onto `main`. No dependency or lockfile change — the
test uses `reqwest`, `tokio`, and `serde_json`, all already dependencies of the
crate. Single-package invocations resolve fine on this tree, so the
workspace-form caveat in #1880's description did not apply here.
