### PR TITLE
fix(execution): harden preview reads and local egress broker

### DIFF
--- a/crates/openwave-code-execution/src/network.rs
+++ b/crates/openwave-code-execution/src/network.rs
@@ -220,14 +220,26 @@ where
     C: AsyncRead + AsyncWrite + Unpin,
     U: AsyncRead + AsyncWrite + Unpin,
 {
-    let mut client_open = true;
-    let mut upstream_open = true;
-    let mut client_buffer = [0_u8; 16 * 1024];
-    let mut upstream_buffer = [0_u8; 16 * 1024];
+    let (client_reader, client_writer) = tokio::io::split(client);
+    let (upstream_reader, upstream_writer) = tokio::io::split(upstream);
+    let (activity, mut latest_activity) = tokio::sync::watch::channel(Instant::now());
+    let client_to_upstream = relay_direction(
+        client_reader,
+        upstream_writer,
+        idle_timeout,
+        activity.clone(),
+    );
+    let upstream_to_client =
+        relay_direction(upstream_reader, client_writer, idle_timeout, activity);
+    tokio::pin!(client_to_upstream, upstream_to_client);
+
+    let mut activity_open = true;
+    let mut client_to_upstream_open = true;
+    let mut upstream_to_client_open = true;
     let idle = tokio::time::sleep(idle_timeout);
     tokio::pin!(idle);
 
-    while client_open || upstream_open {
+    while client_to_upstream_open || upstream_to_client_open {
         tokio::select! {
             () = &mut idle => {
                 return Err(io::Error::new(
@@ -235,31 +247,47 @@ where
                     "egress tunnel was idle for too long",
                 ));
             }
-            read = client.read(&mut client_buffer), if client_open => {
-                let read = read?;
-                if read == 0 {
-                    client_open = false;
-                    shutdown_with_timeout(upstream, idle_timeout).await?;
-                    continue;
+            changed = latest_activity.changed(), if activity_open => {
+                match changed {
+                    Ok(()) => {
+                        idle.as_mut().reset(*latest_activity.borrow_and_update() + idle_timeout);
+                    }
+                    Err(_) => activity_open = false,
                 }
-                idle.as_mut().reset(Instant::now() + idle_timeout);
-                write_all_with_timeout(upstream, &client_buffer[..read], idle_timeout).await?;
-                idle.as_mut().reset(Instant::now() + idle_timeout);
             }
-            read = upstream.read(&mut upstream_buffer), if upstream_open => {
-                let read = read?;
-                if read == 0 {
-                    upstream_open = false;
-                    shutdown_with_timeout(client, idle_timeout).await?;
-                    continue;
-                }
-                idle.as_mut().reset(Instant::now() + idle_timeout);
-                write_all_with_timeout(client, &upstream_buffer[..read], idle_timeout).await?;
-                idle.as_mut().reset(Instant::now() + idle_timeout);
+            result = &mut client_to_upstream, if client_to_upstream_open => {
+                result?;
+                client_to_upstream_open = false;
+            }
+            result = &mut upstream_to_client, if upstream_to_client_open => {
+                result?;
+                upstream_to_client_open = false;
             }
         }
     }
     Ok(())
+}
+
+async fn relay_direction<R, W>(
+    mut reader: R,
+    mut writer: W,
+    timeout: Duration,
+    activity: tokio::sync::watch::Sender<Instant>,
+) -> io::Result<()>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut buffer = [0_u8; 16 * 1024];
+    loop {
+        let read = reader.read(&mut buffer).await?;
+        if read == 0 {
+            return shutdown_with_timeout(&mut writer, timeout).await;
+        }
+        activity.send_replace(Instant::now());
+        write_all_with_timeout(&mut writer, &buffer[..read], timeout).await?;
+        activity.send_replace(Instant::now());
+    }
 }
 
 async fn write_all_with_timeout<W>(
@@ -561,5 +589,73 @@ mod tests {
 
         assert_eq!(error.kind(), io::ErrorKind::TimedOut);
         assert_eq!(error.to_string(), "egress tunnel was idle for too long");
+    }
+
+    #[tokio::test]
+    async fn half_close_allows_the_reverse_direction_to_finish() {
+        let (mut client, mut broker_client) = tokio::io::duplex(256);
+        let (mut broker_upstream, mut upstream) = tokio::io::duplex(256);
+        let relay = tokio::spawn(async move {
+            relay_bidirectional(
+                &mut broker_client,
+                &mut broker_upstream,
+                Duration::from_secs(5),
+            )
+            .await
+        });
+
+        client.write_all(b"ping").await.unwrap();
+        client.shutdown().await.unwrap();
+        let mut request = Vec::new();
+        upstream.read_to_end(&mut request).await.unwrap();
+        assert_eq!(&request, b"ping");
+
+        upstream.write_all(b"pong").await.unwrap();
+        upstream.shutdown().await.unwrap();
+        let mut response = Vec::new();
+        client.read_to_end(&mut response).await.unwrap();
+        assert_eq!(&response, b"pong");
+
+        tokio::time::timeout(Duration::from_secs(1), relay)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn backpressured_write_does_not_block_reverse_traffic() {
+        let (mut client, mut broker_client) = tokio::io::duplex(1);
+        let (mut broker_upstream, mut upstream) = tokio::io::duplex(1);
+        let relay = tokio::spawn(async move {
+            relay_bidirectional(
+                &mut broker_client,
+                &mut broker_upstream,
+                Duration::from_secs(5),
+            )
+            .await
+        });
+
+        client.write_all(b"ab").await.unwrap();
+        upstream.write_all(b"R").await.unwrap();
+
+        let mut reverse = [0_u8; 1];
+        tokio::time::timeout(Duration::from_secs(1), client.read_exact(&mut reverse))
+            .await
+            .expect("reverse traffic stalled behind the backpressured write")
+            .unwrap();
+        assert_eq!(&reverse, b"R");
+
+        let mut forward = [0_u8; 2];
+        upstream.read_exact(&mut forward).await.unwrap();
+        assert_eq!(&forward, b"ab");
+
+        client.shutdown().await.unwrap();
+        upstream.shutdown().await.unwrap();
+        tokio::time::timeout(Duration::from_secs(1), relay)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
     }
 }

--- a/crates/openwave-code-execution/src/network.rs
+++ b/crates/openwave-code-execution/src/network.rs
@@ -7,18 +7,24 @@
 
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::sync::Arc;
 use std::time::Duration;
 
 use openwave_core::NetworkPolicy;
 use openwave_egress::{DomainPattern, EgressDestination};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::{lookup_host, TcpListener, TcpStream};
+use tokio::sync::Semaphore;
 use tokio::task::{JoinHandle, JoinSet};
+use tokio::time::Instant;
 
 use crate::{CodeExecutionError, PACKAGE_MANAGER_DOMAINS};
 
 const MAX_CONNECT_HEADERS: usize = 16 * 1024;
+const MAX_CONCURRENT_CONNECTIONS: usize = 32;
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const CONNECT_HEADER_TIMEOUT: Duration = Duration::from_secs(5);
+const TUNNEL_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// One execution-scoped broker. Dropping it closes the listener and every
 /// tunnel, so network authority cannot outlive the command that received it.
@@ -57,6 +63,15 @@ impl Drop for LocalEgressBroker {
 }
 
 async fn serve(listener: TcpListener, policy: NetworkPolicy) {
+    serve_with_permits(
+        listener,
+        policy,
+        Arc::new(Semaphore::new(MAX_CONCURRENT_CONNECTIONS)),
+    )
+    .await;
+}
+
+async fn serve_with_permits(listener: TcpListener, policy: NetworkPolicy, permits: Arc<Semaphore>) {
     let mut connections = JoinSet::new();
     loop {
         tokio::select! {
@@ -64,8 +79,14 @@ async fn serve(listener: TcpListener, policy: NetworkPolicy) {
                 let Ok((stream, peer)) = accepted else {
                     break;
                 };
+                let Ok(permit) = Arc::clone(&permits).try_acquire_owned() else {
+                    tracing::debug!(%peer, "local egress broker connection cap reached");
+                    drop(stream);
+                    continue;
+                };
                 let policy = policy.clone();
                 connections.spawn(async move {
+                    let _permit = permit;
                     if let Err(error) = handle_connection(stream, &policy).await {
                         tracing::debug!(%peer, %error, "local egress broker connection ended");
                     }
@@ -77,7 +98,8 @@ async fn serve(listener: TcpListener, policy: NetworkPolicy) {
 }
 
 async fn handle_connection(mut client: TcpStream, policy: &NetworkPolicy) -> Result<(), io::Error> {
-    let request = match read_connect_request(&mut client).await {
+    let request = match read_connect_request_with_timeout(&mut client, CONNECT_HEADER_TIMEOUT).await
+    {
         Ok(request) => request,
         Err(reason) => {
             audit(None, None, false, reason);
@@ -125,15 +147,31 @@ async fn handle_connection(mut client: TcpStream, policy: &NetworkPolicy) -> Res
         .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
         .await?;
     let mut upstream = upstream;
-    let _ = tokio::io::copy_bidirectional(&mut client, &mut upstream).await?;
-    Ok(())
+    relay_bidirectional(&mut client, &mut upstream, TUNNEL_IDLE_TIMEOUT).await
 }
 
+#[derive(Debug)]
 struct ConnectRequest {
     authority: String,
 }
 
-async fn read_connect_request(stream: &mut TcpStream) -> Result<ConnectRequest, &'static str> {
+async fn read_connect_request_with_timeout<S>(
+    stream: &mut S,
+    timeout: Duration,
+) -> Result<ConnectRequest, &'static str>
+where
+    S: AsyncRead + Unpin,
+{
+    match tokio::time::timeout(timeout, read_connect_request(stream)).await {
+        Ok(result) => result,
+        Err(_) => Err("CONNECT headers timed out"),
+    }
+}
+
+async fn read_connect_request<S>(stream: &mut S) -> Result<ConnectRequest, &'static str>
+where
+    S: AsyncRead + Unpin,
+{
     let mut bytes = Vec::with_capacity(1024);
     let mut buffer = [0_u8; 1024];
     loop {
@@ -148,6 +186,9 @@ async fn read_connect_request(stream: &mut TcpStream) -> Result<ConnectRequest, 
             return Err("CONNECT request ended before its headers");
         }
         bytes.extend_from_slice(&buffer[..read]);
+        if bytes.len() > MAX_CONNECT_HEADERS {
+            return Err("CONNECT headers exceed the size limit");
+        }
         if bytes.windows(4).any(|window| window == b"\r\n\r\n") {
             break;
         }
@@ -168,6 +209,79 @@ async fn read_connect_request(stream: &mut TcpStream) -> Result<ConnectRequest, 
     Ok(ConnectRequest {
         authority: authority.to_owned(),
     })
+}
+
+async fn relay_bidirectional<C, U>(
+    client: &mut C,
+    upstream: &mut U,
+    idle_timeout: Duration,
+) -> io::Result<()>
+where
+    C: AsyncRead + AsyncWrite + Unpin,
+    U: AsyncRead + AsyncWrite + Unpin,
+{
+    let mut client_open = true;
+    let mut upstream_open = true;
+    let mut client_buffer = [0_u8; 16 * 1024];
+    let mut upstream_buffer = [0_u8; 16 * 1024];
+    let idle = tokio::time::sleep(idle_timeout);
+    tokio::pin!(idle);
+
+    while client_open || upstream_open {
+        tokio::select! {
+            () = &mut idle => {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "egress tunnel was idle for too long",
+                ));
+            }
+            read = client.read(&mut client_buffer), if client_open => {
+                let read = read?;
+                if read == 0 {
+                    client_open = false;
+                    shutdown_with_timeout(upstream, idle_timeout).await?;
+                    continue;
+                }
+                idle.as_mut().reset(Instant::now() + idle_timeout);
+                write_all_with_timeout(upstream, &client_buffer[..read], idle_timeout).await?;
+                idle.as_mut().reset(Instant::now() + idle_timeout);
+            }
+            read = upstream.read(&mut upstream_buffer), if upstream_open => {
+                let read = read?;
+                if read == 0 {
+                    upstream_open = false;
+                    shutdown_with_timeout(client, idle_timeout).await?;
+                    continue;
+                }
+                idle.as_mut().reset(Instant::now() + idle_timeout);
+                write_all_with_timeout(client, &upstream_buffer[..read], idle_timeout).await?;
+                idle.as_mut().reset(Instant::now() + idle_timeout);
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn write_all_with_timeout<W>(
+    writer: &mut W,
+    bytes: &[u8],
+    timeout: Duration,
+) -> io::Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    tokio::time::timeout(timeout, writer.write_all(bytes))
+        .await
+        .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "egress tunnel write timed out"))?
+}
+
+async fn shutdown_with_timeout<W>(writer: &mut W, timeout: Duration) -> io::Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    tokio::time::timeout(timeout, writer.shutdown())
+        .await
+        .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "egress tunnel shutdown timed out"))?
 }
 
 fn parse_authority(authority: &str) -> Option<(String, u16)> {
@@ -367,5 +481,85 @@ mod tests {
         assert!(String::from_utf8(response)
             .unwrap()
             .starts_with("HTTP/1.1 403"));
+    }
+
+    #[tokio::test]
+    async fn incomplete_connect_headers_time_out() {
+        let (mut client, mut broker_side) = tokio::io::duplex(256);
+        client
+            .write_all(b"CONNECT example.com:443 HTTP/1.1\r\n")
+            .await
+            .unwrap();
+
+        let reason = read_connect_request_with_timeout(&mut broker_side, Duration::from_millis(10))
+            .await
+            .unwrap_err();
+
+        assert_eq!(reason, "CONNECT headers timed out");
+    }
+
+    #[tokio::test]
+    async fn oversized_connect_headers_are_rejected() {
+        let (mut client, mut broker_side) = tokio::io::duplex(MAX_CONNECT_HEADERS + 1024);
+        client
+            .write_all(&vec![b'a'; MAX_CONNECT_HEADERS + 1])
+            .await
+            .unwrap();
+
+        let reason = read_connect_request(&mut broker_side).await.unwrap_err();
+
+        assert_eq!(reason, "CONNECT headers exceed the size limit");
+    }
+
+    #[tokio::test]
+    async fn broker_closes_connections_above_its_concurrency_cap() {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let permits = Arc::new(Semaphore::new(1));
+        let task = tokio::spawn(serve_with_permits(
+            listener,
+            NetworkPolicy::Open,
+            Arc::clone(&permits),
+        ));
+
+        let mut occupying = TcpStream::connect(address).await.unwrap();
+        occupying
+            .write_all(b"CONNECT example.com:443 HTTP/1.1\r\n")
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while permits.available_permits() != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+
+        let mut excess = TcpStream::connect(address).await.unwrap();
+        let mut byte = [0_u8; 1];
+        let read = tokio::time::timeout(Duration::from_secs(1), excess.read(&mut byte))
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(read, 0);
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn an_idle_tunnel_is_closed() {
+        let (mut client_side, _client_peer) = tokio::io::duplex(256);
+        let (mut upstream_side, _upstream_peer) = tokio::io::duplex(256);
+
+        let error = relay_bidirectional(
+            &mut client_side,
+            &mut upstream_side,
+            Duration::from_millis(10),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        assert_eq!(error.to_string(), "egress tunnel was idle for too long");
     }
 }

--- a/crates/openwave-code-execution/src/preview.rs
+++ b/crates/openwave-code-execution/src/preview.rs
@@ -1,8 +1,10 @@
 use std::cmp::Ordering;
-use std::fs;
-use std::io::Cursor;
-use std::path::{Path, PathBuf};
+use std::io::{Cursor, Read as _};
+use std::path::Path;
 
+use cap_fs_ext::{DirExt as _, FollowSymlinks, OpenOptionsFollowExt as _};
+use cap_std::ambient_authority;
+use cap_std::fs::{Dir, OpenOptions};
 use image::imageops::FilterType;
 use image::{GenericImageView, ImageFormat};
 use openwave_core::{DocumentBlob, ImageData, ImageMediaType, ImageRef, MAX_IMAGE_BYTES};
@@ -24,7 +26,13 @@ pub struct PreviewScan {
 #[derive(Debug)]
 struct Candidate {
     name: String,
-    path: PathBuf,
+}
+
+#[derive(Debug)]
+enum PreviewDirectoryError {
+    Missing,
+    NotPrivate,
+    Unavailable,
 }
 
 /// Read, prioritize, resize, and bound images directly under `preview/`.
@@ -33,28 +41,28 @@ struct Candidate {
 /// are named in a compact note so the model can repair the preview and rerun.
 pub fn scan_preview_directory(preview_dir: &Path) -> PreviewScan {
     let mut scan = PreviewScan::default();
-    // Skipping symlinked *entries* below is not enough on its own: the
-    // directory itself is opened by path, and local exec is confined to the
-    // scratch tree but can plant `<scratch>/preview -> ~/Pictures` there. The
-    // traversal has already happened by the time entries are filtered, so
-    // images from an arbitrary host directory would be attached to the chat.
-    match fs::symlink_metadata(preview_dir) {
-        Ok(metadata) if metadata.is_dir() => {}
-        Ok(_) => {
+    // Pin the containing scratch directory, then open preview/ relative to it
+    // without following the final component. Every candidate is subsequently
+    // opened relative to this descriptor with the same no-follow rule. A
+    // sandbox process can rename or replace either pathname after this point,
+    // but it cannot redirect the descriptor or the file handle we actually
+    // inspect and decode.
+    let directory = match open_preview_directory(preview_dir) {
+        Ok(directory) => directory,
+        Err(PreviewDirectoryError::Missing) => return scan,
+        Err(PreviewDirectoryError::NotPrivate) => {
             scan.notes
                 .push("preview images unavailable: preview/ is not a private workspace directory. Remove it and rerun.".into());
             return scan;
         }
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return scan,
-        Err(_) => {
+        Err(PreviewDirectoryError::Unavailable) => {
             scan.notes
                 .push("preview images unavailable: preview/ could not be read".into());
             return scan;
         }
-    }
-    let entries = match fs::read_dir(preview_dir) {
+    };
+    let entries = match directory.entries() {
         Ok(entries) => entries,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return scan,
         Err(_) => {
             scan.notes
                 .push("preview images unavailable: preview/ could not be read".into());
@@ -63,22 +71,22 @@ pub fn scan_preview_directory(preview_dir: &Path) -> PreviewScan {
     };
     let mut candidates = Vec::new();
     for entry in entries.flatten() {
-        let Ok(metadata) = entry.metadata() else {
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        // Classify relative to the pinned directory and without following a
+        // symlink. The later no-follow open remains the enforcing operation;
+        // this check only avoids treating known non-files as candidates.
+        let Ok(metadata) = directory.symlink_metadata(&name) else {
             continue;
         };
         if !metadata.is_file() || metadata.len() == 0 {
             continue;
         }
-        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
-            continue;
-        };
         if preview_media_type_from_extension(&name).is_none() {
             continue;
         }
-        candidates.push(Candidate {
-            name,
-            path: entry.path(),
-        });
+        candidates.push(Candidate { name });
     }
     candidates.sort_by(|left, right| {
         preview_priority(&left.name)
@@ -93,7 +101,7 @@ pub fn scan_preview_directory(preview_dir: &Path) -> PreviewScan {
             omitted.push(candidate.name);
             continue;
         }
-        match prepare_preview(&candidate) {
+        match prepare_preview(&directory, &candidate) {
             Ok(image) => scan.images.push(image),
             Err(()) => rejected.push(candidate.name),
         }
@@ -113,12 +121,50 @@ pub fn scan_preview_directory(preview_dir: &Path) -> PreviewScan {
     scan
 }
 
-fn prepare_preview(candidate: &Candidate) -> Result<(ImageRef, ImageData), ()> {
-    let metadata = fs::metadata(&candidate.path).map_err(|_| ())?;
-    if metadata.len() > MAX_WORKSPACE_FILE_BYTES as u64 || metadata.len() > MAX_IMAGE_BYTES {
+fn open_preview_directory(preview_dir: &Path) -> Result<Dir, PreviewDirectoryError> {
+    let parent_path = preview_dir
+        .parent()
+        .ok_or(PreviewDirectoryError::Unavailable)?;
+    let name = preview_dir
+        .file_name()
+        .ok_or(PreviewDirectoryError::Unavailable)?;
+    let parent = Dir::open_ambient_dir(parent_path, ambient_authority())
+        .map_err(|_| PreviewDirectoryError::Unavailable)?;
+    match parent.open_dir_nofollow(name) {
+        Ok(directory) => Ok(directory),
+        Err(_) => match parent.symlink_metadata(name) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                Err(PreviewDirectoryError::Missing)
+            }
+            Ok(metadata) if metadata.is_symlink() || !metadata.is_dir() => {
+                Err(PreviewDirectoryError::NotPrivate)
+            }
+            Ok(_) | Err(_) => Err(PreviewDirectoryError::Unavailable),
+        },
+    }
+}
+
+fn prepare_preview(directory: &Dir, candidate: &Candidate) -> Result<(ImageRef, ImageData), ()> {
+    let mut options = OpenOptions::new();
+    options.read(true).follow(FollowSymlinks::No);
+    let file = directory
+        .open_with(&candidate.name, &options)
+        .map_err(|_| ())?;
+    let metadata = file.metadata().map_err(|_| ())?;
+    let max_bytes = (MAX_WORKSPACE_FILE_BYTES as u64).min(MAX_IMAGE_BYTES);
+    if !metadata.is_file() || metadata.len() == 0 || metadata.len() > max_bytes {
         return Err(());
     }
-    let bytes = fs::read(&candidate.path).map_err(|_| ())?;
+    // Bound the read itself rather than trusting the earlier length. A writer
+    // may extend the already-open file after metadata() returns; reading one
+    // byte past the ceiling detects that race without allocating unboundedly.
+    let mut bytes = Vec::with_capacity(usize::try_from(metadata.len()).map_err(|_| ())?);
+    file.take(max_bytes.saturating_add(1))
+        .read_to_end(&mut bytes)
+        .map_err(|_| ())?;
+    if bytes.is_empty() || bytes.len() as u64 > max_bytes {
+        return Err(());
+    }
     let fallback = preview_media_type_from_extension(&candidate.name).ok_or(())?;
     let media_type = ImageMediaType::sniff(&bytes).unwrap_or(fallback);
     let format = match media_type {
@@ -235,6 +281,56 @@ mod tests {
         assert!(scan.images.is_empty());
         assert_eq!(scan.notes.len(), 1);
         assert!(scan.notes[0].contains("not a private workspace directory"));
+    }
+
+    /// A model-controlled symlink inside a legitimate preview directory must
+    /// not make the unsandboxed host read an otherwise inaccessible image.
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_preview_file_cannot_disclose_an_outside_image() {
+        let elsewhere = tempfile::tempdir().unwrap();
+        write_png(elsewhere.path(), "private.png", 19, 17);
+        let private_bytes = std::fs::read(elsewhere.path().join("private.png")).unwrap();
+
+        let preview = tempfile::tempdir().unwrap();
+        write_png(preview.path(), "safe.png", 8, 6);
+        std::os::unix::fs::symlink(
+            elsewhere.path().join("private.png"),
+            preview.path().join("leak.png"),
+        )
+        .unwrap();
+
+        let scan = scan_preview_directory(preview.path());
+
+        assert_eq!(scan.images.len(), 1);
+        assert_eq!(scan.images[0].0.width, 8);
+        assert_eq!(scan.images[0].0.height, 6);
+        assert_ne!(scan.images[0].1.bytes(), private_bytes);
+    }
+
+    /// The no-follow open, rather than the earlier directory listing, is the
+    /// enforcement point for a file replaced after it was selected.
+    #[cfg(unix)]
+    #[test]
+    fn a_preview_replaced_by_a_symlink_before_open_is_refused() {
+        let elsewhere = tempfile::tempdir().unwrap();
+        write_png(elsewhere.path(), "private.png", 19, 17);
+
+        let preview = tempfile::tempdir().unwrap();
+        write_png(preview.path(), "candidate.png", 8, 6);
+        let directory = open_preview_directory(preview.path()).unwrap();
+        let candidate = Candidate {
+            name: "candidate.png".into(),
+        };
+
+        std::fs::remove_file(preview.path().join("candidate.png")).unwrap();
+        std::os::unix::fs::symlink(
+            elsewhere.path().join("private.png"),
+            preview.path().join("candidate.png"),
+        )
+        .unwrap();
+
+        assert!(prepare_preview(&directory, &candidate).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- open preview directories and image candidates through pinned capability descriptors without following final symlinks
- bound preview reads even when a selected file grows after metadata inspection
- bound local CONNECT handling with header deadlines and limits, a concurrent-connection cap, and idle/write/shutdown tunnel timeouts
- add regressions for symlinked preview entries, final-component symlink replacement, oversized and incomplete headers, idle tunnels, and the connection cap

## Tests

- `cargo test -p openwave-code-execution preview::tests --locked`
- `cargo test -p openwave-code-execution network::tests --locked`
- `cargo check -p openwave-code-execution --all-targets --locked`
- `cargo clippy -p openwave-code-execution --all-targets --no-deps --locked -- -D warnings`
- `cargo fmt --all`
- `git diff --check HEAD`

Note: strict clippy without `--no-deps` reaches pre-existing unused-code warnings in `openwave-core`; package-local clippy passes with warnings denied.

Closes #1896