### PR TITLE
fix(release): harden CI and publication inputs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,36 @@ updates:
           - minor
           - patch
 
+  # Public documentation is a deployed Next.js application with its own
+  # production dependency graph and lockfile, not prose-only content.
+  - package-ecosystem: npm
+    directory: "/docs-site"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    versioning-strategy: increase
+    commit-message:
+      prefix: deps
+      include: scope
+    groups:
+      docs-site-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # Release-only JavaScript tooling is isolated from the product dependency
+  # graphs, but its exact CLI pin and lockfile still need an automated update
+  # path.
+  - package-ecosystem: npm
+    directory: "/.github/e2b-cli"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    versioning-strategy: increase
+    commit-message:
+      prefix: ci
+      include: scope
+
   # GitHub Actions used by our workflows.
   - package-ecosystem: github-actions
     directory: "/"

--- a/.github/e2b-cli/.npmrc
+++ b/.github/e2b-cli/.npmrc
@@ -1,0 +1,2 @@
+save-exact=true
+ignore-scripts=true

--- a/.github/e2b-cli/package.json
+++ b/.github/e2b-cli/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "openwave-e2b-publish-tooling",
+  "version": "0.0.0",
+  "private": true,
+  "packageManager": "pnpm@10.18.3",
+  "dependencies": {
+    "@e2b/cli": "2.16.1"
+  }
+}

--- a/.github/e2b-cli/pnpm-lock.yaml
+++ b/.github/e2b-cli/pnpm-lock.yaml
@@ -1,0 +1,1132 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@e2b/cli':
+        specifier: 2.16.1
+        version: 2.16.1
+
+packages:
+
+  '@bufbuild/protobuf@2.13.0':
+    resolution: {integrity: sha512-acq7c49vxfm1ggJ95P70TX7ABDM0vxr1SYD3BB0o0jnBLB4OAqeHyKuN+cD3w80gXEDQ2zxHpR6CUeA+O/aU9g==}
+
+  '@connectrpc/connect-web@2.1.2':
+    resolution: {integrity: sha512-1tfaK85MU+gJjwwmL31d2rzdf0XCYX99chZf63uG89SGBUd4XuZ4ZzhGo2u79TPXOE6nLIZQ2okrpyey42PYdg==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.7.0
+      '@connectrpc/connect': 2.1.2
+
+  '@connectrpc/connect@2.1.2':
+    resolution: {integrity: sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.7.0
+
+  '@e2b/cli@2.16.1':
+    resolution: {integrity: sha512-DwbQk7MeGyy1NmTWviyiACLYKdA3I4D7YdzqYHKSOYybI/XHxt1wxB/xTpc0/re6CUO5b+lwOxRWkb4H+Wt7bQ==}
+    engines: {node: '>=20.18.1 <21 || >=22.9.0'}
+    hasBin: true
+
+  '@gar/promise-retry@1.0.3':
+    resolution: {integrity: sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@iarna/toml@2.2.5':
+    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
+
+  '@inquirer/ansi@1.0.2':
+    resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/checkbox@4.3.2':
+    resolution: {integrity: sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@5.1.21':
+    resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.3.2':
+    resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@4.2.23':
+    resolution: {integrity: sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@4.0.23':
+    resolution: {integrity: sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/external-editor@1.0.3':
+    resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@1.0.15':
+    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
+    engines: {node: '>=18'}
+
+  '@inquirer/input@4.3.1':
+    resolution: {integrity: sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@3.0.23':
+    resolution: {integrity: sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@4.0.23':
+    resolution: {integrity: sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@7.10.1':
+    resolution: {integrity: sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@4.1.11':
+    resolution: {integrity: sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@3.2.2':
+    resolution: {integrity: sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@4.4.2':
+    resolution: {integrity: sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@3.0.10':
+    resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
+  '@npmcli/git@7.0.2':
+    resolution: {integrity: sha512-oeolHDjExNAJAnlYP2qzNjMX/Xi9bmu78C9dIGr4xjobrSKbuMYCph8lTzn4vnW3NjIqVmw/f8BCfouqyJXlRg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/package-json@7.0.5':
+    resolution: {integrity: sha512-iVuTlG3ORq2iaVa1IWUxAO/jIp77tUKBhoMjuzYW2kL4MLN1bi/ofqkZ7D7OOwh8coAx1/S2ge0rMdGv8sLSOQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/promise-spawn@9.0.1':
+    resolution: {integrity: sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  ansi-align@3.0.1:
+    resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  async-listen@3.1.0:
+    resolution: {integrity: sha512-TkOhqze98lP+6e7SPbrBpyhTpfvqqX8VYKGn4uckrgPan4WQIHnTaUD2zZzZS18eVVDj4rHPcIZa1PGgvo1DfA==}
+    engines: {node: '>= 14'}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  boxen@7.1.1:
+    resolution: {integrity: sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==}
+    engines: {node: '>=14.16'}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
+
+  camelcase@7.0.1:
+    resolution: {integrity: sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==}
+    engines: {node: '>=14.16'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  chardet@2.2.0:
+    resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
+
+  cli-boxes@3.0.0:
+    resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
+    engines: {node: '>=10'}
+
+  cli-highlight@2.1.11:
+    resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
+    engines: {node: '>=8.0.0', npm: '>=5.0.0'}
+    hasBin: true
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@11.1.0:
+    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
+    engines: {node: '>=16'}
+
+  compare-versions@6.1.1:
+    resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
+
+  console-table-printer@2.16.1:
+    resolution: {integrity: sha512-Sc9FRJ4O9xKGNrvulNdPfK5SyBcZ6lcaRnDE4AQ/uw6IDtjHhsqyzzqcnMikjyGaiOOF2tNOKoBhbVjRvFy9Lw==}
+
+  dockerfile-ast@0.7.1:
+    resolution: {integrity: sha512-oX/A4I0EhSkGqrFv0YuvPkBUSYp1XiY8O8zAKc8Djglx8ocz+JfOr8gP0ryRMC2myqvDLagmnZaU9ot1vG2ijw==}
+
+  e2b@2.38.3:
+    resolution: {integrity: sha512-0tOokTvlltpYGO4UAMNcoSSkFEn2VHAGaJtZsMVhPf5GMmdE9RNcfla/KwCpaE8ef7cFKpSXCs+UUDyE/r/fMQ==}
+    engines: {node: '>=20.18.1 <21 || >=22'}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
+    engines: {node: '>=0.4.7'}
+    hasBin: true
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+
+  hosted-git-info@9.0.3:
+    resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
+
+  ini@6.0.0:
+    resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  inquirer@12.11.1:
+    resolution: {integrity: sha512-9VF7mrY+3OmsAfjH3yKz/pLbJ5z22E23hENKw3/LNSaA/sAt3v49bDRY+Ygct1xwuKT+U+cBfTzjCPySna69Qw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  isexe@4.0.0:
+    resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
+    engines: {node: '>=20'}
+
+  json-parse-even-better-errors@5.0.0:
+    resolution: {integrity: sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  npm-install-checks@8.0.0:
+    resolution: {integrity: sha512-ScAUdMpyzkbpxoNekQ3tNRdFI8SJ86wgKZSQZdUxT+bj0wVFpsEMWnkXP0twVe1gJyNF5apBWDJhhIbgrIViRA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  npm-normalize-package-bin@5.0.0:
+    resolution: {integrity: sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  npm-package-arg@13.0.2:
+    resolution: {integrity: sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  npm-pick-manifest@11.0.3:
+    resolution: {integrity: sha512-buzyCfeoGY/PxKqmBqn1IUJrZnUi1VVJTdSSRPGI60tJdUhUoSQFhs0zycJokDdOznQentgrpf8LayEHyyYlqQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  openapi-fetch@0.14.1:
+    resolution: {integrity: sha512-l7RarRHxlEZYjMLd/PR0slfMVse2/vvIAGm75/F7J6MlQ8/b9uUQmUF2kCPrQhJqMXSxmYWObVgeYXbFYzZR+A==}
+
+  openapi-typescript-helpers@0.0.15:
+    resolution: {integrity: sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==}
+
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
+
+  parse5@5.1.1:
+    resolution: {integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==}
+
+  parse5@6.0.1:
+    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
+
+  proc-log@6.1.0:
+    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  property-expr@2.0.6:
+    resolution: {integrity: sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  run-async@4.0.6:
+    resolution: {integrity: sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==}
+    engines: {node: '>=0.12.0'}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  simple-update-notifier@2.0.0:
+    resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
+    engines: {node: '>=10'}
+
+  simple-wcswidth@1.1.2:
+    resolution: {integrity: sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@4.0.0:
+    resolution: {integrity: sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==}
+
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
+    engines: {node: '>=18'}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tiny-case@1.0.3:
+    resolution: {integrity: sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==}
+
+  toposort@2.0.2:
+    resolution: {integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type-fest@2.19.0:
+    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
+    engines: {node: '>=12.20'}
+
+  uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
+    engines: {node: '>=0.8.0'}
+    hasBin: true
+
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
+
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
+
+  validate-npm-package-name@7.0.2:
+    resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  vscode-languageserver-textdocument@1.0.12:
+    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+
+  vscode-languageserver-types@3.18.0:
+    resolution: {integrity: sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==}
+
+  which@6.0.1:
+    resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  widest-line@4.0.1:
+    resolution: {integrity: sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==}
+    engines: {node: '>=12'}
+
+  wordwrap@1.0.0:
+    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
+
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
+
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
+  yargs@16.2.2:
+    resolution: {integrity: sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==}
+    engines: {node: '>=10'}
+
+  yoctocolors-cjs@2.1.3:
+    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
+    engines: {node: '>=18'}
+
+  yup@1.7.1:
+    resolution: {integrity: sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw==}
+
+snapshots:
+
+  '@bufbuild/protobuf@2.13.0': {}
+
+  '@connectrpc/connect-web@2.1.2(@bufbuild/protobuf@2.13.0)(@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.13.0))':
+    dependencies:
+      '@bufbuild/protobuf': 2.13.0
+      '@connectrpc/connect': 2.1.2(@bufbuild/protobuf@2.13.0)
+
+  '@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.13.0)':
+    dependencies:
+      '@bufbuild/protobuf': 2.13.0
+
+  '@e2b/cli@2.16.1':
+    dependencies:
+      '@iarna/toml': 2.2.5
+      '@inquirer/prompts': 7.10.1
+      '@npmcli/package-json': 7.0.5
+      async-listen: 3.1.0
+      boxen: 7.1.1
+      chalk: 5.6.2
+      cli-highlight: 2.1.11
+      commander: 11.1.0
+      console-table-printer: 2.16.1
+      e2b: 2.38.3
+      handlebars: 4.7.9
+      inquirer: 12.11.1
+      simple-update-notifier: 2.0.0
+      statuses: 2.0.2
+      yup: 1.7.1
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@gar/promise-retry@1.0.3': {}
+
+  '@iarna/toml@2.2.5': {}
+
+  '@inquirer/ansi@1.0.2': {}
+
+  '@inquirer/checkbox@4.3.2':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10
+      yoctocolors-cjs: 2.1.3
+
+  '@inquirer/confirm@5.1.21':
+    dependencies:
+      '@inquirer/core': 10.3.2
+      '@inquirer/type': 3.0.10
+
+  '@inquirer/core@10.3.2':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+
+  '@inquirer/editor@4.2.23':
+    dependencies:
+      '@inquirer/core': 10.3.2
+      '@inquirer/external-editor': 1.0.3
+      '@inquirer/type': 3.0.10
+
+  '@inquirer/expand@4.0.23':
+    dependencies:
+      '@inquirer/core': 10.3.2
+      '@inquirer/type': 3.0.10
+      yoctocolors-cjs: 2.1.3
+
+  '@inquirer/external-editor@1.0.3':
+    dependencies:
+      chardet: 2.2.0
+      iconv-lite: 0.7.3
+
+  '@inquirer/figures@1.0.15': {}
+
+  '@inquirer/input@4.3.1':
+    dependencies:
+      '@inquirer/core': 10.3.2
+      '@inquirer/type': 3.0.10
+
+  '@inquirer/number@3.0.23':
+    dependencies:
+      '@inquirer/core': 10.3.2
+      '@inquirer/type': 3.0.10
+
+  '@inquirer/password@4.0.23':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2
+      '@inquirer/type': 3.0.10
+
+  '@inquirer/prompts@7.10.1':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2
+      '@inquirer/confirm': 5.1.21
+      '@inquirer/editor': 4.2.23
+      '@inquirer/expand': 4.0.23
+      '@inquirer/input': 4.3.1
+      '@inquirer/number': 3.0.23
+      '@inquirer/password': 4.0.23
+      '@inquirer/rawlist': 4.1.11
+      '@inquirer/search': 3.2.2
+      '@inquirer/select': 4.4.2
+
+  '@inquirer/rawlist@4.1.11':
+    dependencies:
+      '@inquirer/core': 10.3.2
+      '@inquirer/type': 3.0.10
+      yoctocolors-cjs: 2.1.3
+
+  '@inquirer/search@3.2.2':
+    dependencies:
+      '@inquirer/core': 10.3.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10
+      yoctocolors-cjs: 2.1.3
+
+  '@inquirer/select@4.4.2':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10
+      yoctocolors-cjs: 2.1.3
+
+  '@inquirer/type@3.0.10': {}
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
+
+  '@npmcli/git@7.0.2':
+    dependencies:
+      '@gar/promise-retry': 1.0.3
+      '@npmcli/promise-spawn': 9.0.1
+      ini: 6.0.0
+      lru-cache: 11.5.2
+      npm-pick-manifest: 11.0.3
+      proc-log: 6.1.0
+      semver: 7.8.5
+      which: 6.0.1
+
+  '@npmcli/package-json@7.0.5':
+    dependencies:
+      '@npmcli/git': 7.0.2
+      glob: 13.0.6
+      hosted-git-info: 9.0.3
+      json-parse-even-better-errors: 5.0.0
+      proc-log: 6.1.0
+      semver: 7.8.5
+      spdx-expression-parse: 4.0.0
+
+  '@npmcli/promise-spawn@9.0.1':
+    dependencies:
+      which: 6.0.1
+
+  ansi-align@3.0.1:
+    dependencies:
+      string-width: 4.2.3
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
+
+  any-promise@1.3.0: {}
+
+  async-listen@3.1.0: {}
+
+  balanced-match@4.0.4: {}
+
+  boxen@7.1.1:
+    dependencies:
+      ansi-align: 3.0.1
+      camelcase: 7.0.1
+      chalk: 5.6.2
+      cli-boxes: 3.0.0
+      string-width: 5.1.2
+      type-fest: 2.19.0
+      widest-line: 4.0.1
+      wrap-ansi: 8.1.0
+
+  brace-expansion@5.0.9:
+    dependencies:
+      balanced-match: 4.0.4
+
+  camelcase@7.0.1: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  chalk@5.6.2: {}
+
+  chardet@2.2.0: {}
+
+  chownr@3.0.0: {}
+
+  cli-boxes@3.0.0: {}
+
+  cli-highlight@2.1.11:
+    dependencies:
+      chalk: 4.1.2
+      highlight.js: 10.7.3
+      mz: 2.7.0
+      parse5: 5.1.1
+      parse5-htmlparser2-tree-adapter: 6.0.1
+      yargs: 16.2.2
+
+  cli-width@4.1.0: {}
+
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  commander@11.1.0: {}
+
+  compare-versions@6.1.1: {}
+
+  console-table-printer@2.16.1:
+    dependencies:
+      simple-wcswidth: 1.1.2
+
+  dockerfile-ast@0.7.1:
+    dependencies:
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.18.0
+
+  e2b@2.38.3:
+    dependencies:
+      '@bufbuild/protobuf': 2.13.0
+      '@connectrpc/connect': 2.1.2(@bufbuild/protobuf@2.13.0)
+      '@connectrpc/connect-web': 2.1.2(@bufbuild/protobuf@2.13.0)(@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.13.0))
+      chalk: 5.6.2
+      compare-versions: 6.1.1
+      dockerfile-ast: 0.7.1
+      glob: 13.0.6
+      openapi-fetch: 0.14.1
+      platform: 1.3.6
+      tar: 7.5.22
+      undici: 7.29.0
+    optionalDependencies:
+      undici8: undici@8.10.0
+
+  eastasianwidth@0.2.0: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
+
+  escalade@3.2.0: {}
+
+  get-caller-file@2.0.5: {}
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.6
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
+  handlebars@4.7.9:
+    dependencies:
+      minimist: 1.2.8
+      neo-async: 2.6.2
+      source-map: 0.6.1
+      wordwrap: 1.0.0
+    optionalDependencies:
+      uglify-js: 3.19.3
+
+  has-flag@4.0.0: {}
+
+  highlight.js@10.7.3: {}
+
+  hosted-git-info@9.0.3:
+    dependencies:
+      lru-cache: 11.5.2
+
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  ini@6.0.0: {}
+
+  inquirer@12.11.1:
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2
+      '@inquirer/prompts': 7.10.1
+      '@inquirer/type': 3.0.10
+      mute-stream: 2.0.0
+      run-async: 4.0.6
+      rxjs: 7.8.2
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  isexe@4.0.0: {}
+
+  json-parse-even-better-errors@5.0.0: {}
+
+  lru-cache@11.5.2: {}
+
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.9
+
+  minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
+  mute-stream@2.0.0: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  neo-async@2.6.2: {}
+
+  npm-install-checks@8.0.0:
+    dependencies:
+      semver: 7.8.5
+
+  npm-normalize-package-bin@5.0.0: {}
+
+  npm-package-arg@13.0.2:
+    dependencies:
+      hosted-git-info: 9.0.3
+      proc-log: 6.1.0
+      semver: 7.8.5
+      validate-npm-package-name: 7.0.2
+
+  npm-pick-manifest@11.0.3:
+    dependencies:
+      npm-install-checks: 8.0.0
+      npm-normalize-package-bin: 5.0.0
+      npm-package-arg: 13.0.2
+      semver: 7.8.5
+
+  object-assign@4.1.1: {}
+
+  openapi-fetch@0.14.1:
+    dependencies:
+      openapi-typescript-helpers: 0.0.15
+
+  openapi-typescript-helpers@0.0.15: {}
+
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    dependencies:
+      parse5: 6.0.1
+
+  parse5@5.1.1: {}
+
+  parse5@6.0.1: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.2
+      minipass: 7.1.3
+
+  platform@1.3.6: {}
+
+  proc-log@6.1.0: {}
+
+  property-expr@2.0.6: {}
+
+  require-directory@2.1.1: {}
+
+  run-async@4.0.6: {}
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
+  safer-buffer@2.1.2: {}
+
+  semver@7.8.5: {}
+
+  signal-exit@4.1.0: {}
+
+  simple-update-notifier@2.0.0:
+    dependencies:
+      semver: 7.8.5
+
+  simple-wcswidth@1.1.2: {}
+
+  source-map@0.6.1: {}
+
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@4.0.0:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
+  spdx-license-ids@3.0.23: {}
+
+  statuses@2.0.2: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  tar@7.5.22:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tiny-case@1.0.3: {}
+
+  toposort@2.0.2: {}
+
+  tslib@2.8.1: {}
+
+  type-fest@2.19.0: {}
+
+  uglify-js@3.19.3:
+    optional: true
+
+  undici@7.29.0: {}
+
+  undici@8.10.0:
+    optional: true
+
+  validate-npm-package-name@7.0.2: {}
+
+  vscode-languageserver-textdocument@1.0.12: {}
+
+  vscode-languageserver-types@3.18.0: {}
+
+  which@6.0.1:
+    dependencies:
+      isexe: 4.0.0
+
+  widest-line@4.0.1:
+    dependencies:
+      string-width: 5.1.2
+
+  wordwrap@1.0.0: {}
+
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
+
+  y18n@5.0.8: {}
+
+  yallist@5.0.0: {}
+
+  yargs-parser@20.2.9: {}
+
+  yargs@16.2.2:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
+
+  yoctocolors-cjs@2.1.3: {}
+
+  yup@1.7.1:
+    dependencies:
+      property-expr: 2.0.6
+      tiny-case: 1.0.3
+      toposort: 2.0.2
+      type-fest: 2.19.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,10 @@ jobs:
             echo "This job must not fall back to the pull request's own copy." >&2
             exit 1
           fi
-          cp "$trusted" "$GITHUB_WORKSPACE/scripts/workflow-security.test.mjs"
+          cp "$trusted" "$GITHUB_WORKSPACE/scripts/.trusted-workflow-security.test.mjs"
+      - name: Test trusted base-branch release policy
+        if: ${{ github.event_name == 'pull_request' }}
+        run: node --test scripts/.trusted-workflow-security.test.mjs
       - name: Test semantic title and tag policy
         run: node --test scripts/*.test.mjs
 
@@ -105,6 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       docs_site: ${{ steps.scope.outputs.docs_site }}
+      e2b_cli: ${{ steps.scope.outputs.e2b_cli }}
       rust: ${{ steps.scope.outputs.rust }}
       ui: ${{ steps.scope.outputs.ui }}
       workspace: ${{ steps.scope.outputs.workspace }}
@@ -124,6 +128,7 @@ jobs:
           full_validation() {
             {
               echo "docs_site=true"
+              echo "e2b_cli=true"
               echo "rust=true"
               echo "ui=true"
               echo "workspace=true"
@@ -164,6 +169,7 @@ jobs:
           # when a change cannot reach them. `workspace` implies `rust`; the
           # gate below asserts that.
           docs_site=false
+          e2b_cli=false
           rust=false
           ui=false
           workspace=false
@@ -172,9 +178,12 @@ jobs:
           while IFS= read -r -d '' file; do
             case "$file" in
               docs-site/*) docs_site=true ;;
+              .github/e2b-cli/*|.github/workflows/publish-e2b-template.yml)
+                e2b_cli=true ;;
               *.md|docs/*|assets/*|.githooks/*|LICENSE|NOTICE) ;;
               .github/workflows/ci.yml)
                 docs_site=true
+                e2b_cli=true
                 rust=true
                 ui=true
                 workspace=true
@@ -205,6 +214,7 @@ jobs:
 
           {
             echo "docs_site=$docs_site"
+            echo "e2b_cli=$e2b_cli"
             echo "rust=$rust"
             echo "ui=$ui"
             echo "workspace=$workspace"
@@ -225,6 +235,33 @@ jobs:
             ghcr.io/gitleaks/gitleaks@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f \
             detect --source=/repo --redact --verbose
 
+  e2b-cli:
+    name: E2B publication tooling
+    needs: changes
+    if: ${{ needs.changes.outputs.e2b_cli == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        with:
+          version: 10.18.3
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: .github/e2b-cli/pnpm-lock.yaml
+      - name: Install the locked E2B CLI
+        run: pnpm --dir .github/e2b-cli install --frozen-lockfile --ignore-scripts
+      - name: Verify the local E2B CLI pin
+        run: |
+          expected="$(node -p "require('./.github/e2b-cli/package.json').dependencies['@e2b/cli']")"
+          actual="$(.github/e2b-cli/node_modules/.bin/e2b --version)"
+          [[ "$actual" == "$expected" ]] || {
+            echo "Expected E2B CLI $expected, got $actual" >&2
+            exit 1
+          }
+
   advisories:
     name: supply-chain advisories (cargo-deny)
     needs: changes
@@ -244,7 +281,7 @@ jobs:
       # Posture and exceptions live in deny.toml. `--all-features` covers
       # optional dependencies that a default-feature graph would miss.
       - name: Check advisories, licenses, and dependency sources
-        run: cargo deny --all-features check advisories licenses sources
+        run: cargo deny --all-features --locked check advisories licenses sources
 
 
   unused-deps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
     name: change scope
     runs-on: ubuntu-latest
     outputs:
+      docs_site: ${{ steps.scope.outputs.docs_site }}
       rust: ${{ steps.scope.outputs.rust }}
       ui: ${{ steps.scope.outputs.ui }}
       workspace: ${{ steps.scope.outputs.workspace }}
@@ -122,6 +123,7 @@ jobs:
         run: |
           full_validation() {
             {
+              echo "docs_site=true"
               echo "rust=true"
               echo "ui=true"
               echo "workspace=true"
@@ -161,6 +163,7 @@ jobs:
           # cover everything *except* openwave-desktop, so it can stay false
           # when a change cannot reach them. `workspace` implies `rust`; the
           # gate below asserts that.
+          docs_site=false
           rust=false
           ui=false
           workspace=false
@@ -168,8 +171,10 @@ jobs:
             > "$RUNNER_TEMP/changed-files"
           while IFS= read -r -d '' file; do
             case "$file" in
-              *.md|docs/*|assets/*|.githooks/*|docs-site/*|LICENSE|NOTICE) ;;
+              docs-site/*) docs_site=true ;;
+              *.md|docs/*|assets/*|.githooks/*|LICENSE|NOTICE) ;;
               .github/workflows/ci.yml)
+                docs_site=true
                 rust=true
                 ui=true
                 workspace=true
@@ -199,6 +204,7 @@ jobs:
           fi
 
           {
+            echo "docs_site=$docs_site"
             echo "rust=$rust"
             echo "ui=$ui"
             echo "workspace=$workspace"
@@ -237,8 +243,8 @@ jobs:
           tool: cargo-deny@0.20.2
       # Posture and exceptions live in deny.toml. `--all-features` covers
       # optional dependencies that a default-feature graph would miss.
-      - name: Check RustSec advisories
-        run: cargo deny --all-features check advisories
+      - name: Check advisories, licenses, and dependency sources
+        run: cargo deny --all-features check advisories licenses sources
 
 
   unused-deps:
@@ -581,5 +587,33 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Test
         run: pnpm test
+      - name: Build
+        run: pnpm build
+
+  docs-site:
+    name: documentation site
+    needs: changes
+    if: ${{ needs.changes.outputs.docs_site == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: docs-site
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        with:
+          version: 10.18.3
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: docs-site/pnpm-lock.yaml
+      - name: Install documentation dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Type-check
+        run: pnpm types:check
+      - name: Lint
+        run: pnpm lint
       - name: Build
         run: pnpm build

--- a/.github/workflows/publish-e2b-template.yml
+++ b/.github/workflows/publish-e2b-template.yml
@@ -56,9 +56,18 @@ on:
     branches: [main]
     paths:
       - "crates/openwave-sandbox-agent/e2b/**"
+      - ".github/e2b-cli/**"
       - ".github/workflows/publish-e2b-template.yml"
   workflow_dispatch:
     inputs:
+      release_tag:
+        description: >-
+          Optional published vX.Y.Z release whose template definition should
+          be rebuilt. The workflow itself must still be dispatched from the
+          repository's current default branch.
+        required: false
+        default: ""
+        type: string
       force_rebuild:
         description: >-
           Rebuild and republish even when the alias is already public. Use
@@ -78,7 +87,8 @@ env:
   # The E2B management API the client crate also talks to
   # (`E2B_API_BASE` in crates/openwave-code-execution/src/e2b.rs).
   E2B_API_BASE: https://api.e2b.app
-  TEMPLATE_DIR: crates/openwave-sandbox-agent/e2b
+  TEMPLATE_PATH: crates/openwave-sandbox-agent/e2b
+  SOURCE_TEMPLATE_DIR: .release-source/crates/openwave-sandbox-agent/e2b
 
 jobs:
   # Reads the template definition and decides whether anything needs building.
@@ -96,53 +106,76 @@ jobs:
       cpu_count: ${{ steps.definition.outputs.cpu_count }}
       memory_mb: ${{ steps.definition.outputs.memory_mb }}
       publish: ${{ steps.state.outputs.publish }}
+      source_sha: ${{ steps.source.outputs.sha }}
       # The template ID the alias already resolves to, when it does. Empty on
       # a 404; the publish job's own verification supplies it in that case.
       template_id: ${{ steps.state.outputs.template_id }}
     steps:
+      # This first checkout is always the revision that supplied the running
+      # workflow. Manual runs are rejected unless that revision came from the
+      # current default branch; a requested release is only data for the
+      # separate sparse checkout below.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       - name: Validate the publication source
+        id: source
         env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           EVENT_NAME: ${{ github.event_name }}
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
           SOURCE_REF: ${{ github.ref }}
           SOURCE_REF_NAME: ${{ github.ref_name }}
           SOURCE_SHA: ${{ github.sha }}
         run: |
-          git fetch --no-tags origin main:refs/remotes/origin/main
+          [[ -n "$DEFAULT_BRANCH" ]] || {
+            echo "The repository event did not identify a default branch." >&2
+            exit 1
+          }
+          git fetch --no-tags origin \
+            "$DEFAULT_BRANCH:refs/remotes/origin/$DEFAULT_BRANCH"
+          [[ "$(git rev-parse HEAD)" == "$SOURCE_SHA" ]] || {
+            echo "The trusted checkout does not match the workflow revision $SOURCE_SHA." >&2
+            exit 1
+          }
 
           case "$EVENT_NAME" in
             push)
-              [[ "$SOURCE_REF" == refs/heads/main && "$SOURCE_REF_NAME" == main ]] || {
-                echo "Automatic E2B publication must run from main, got $SOURCE_REF ($SOURCE_REF_NAME)" >&2
+              [[ "$SOURCE_REF" == "refs/heads/$DEFAULT_BRANCH" &&
+                "$SOURCE_REF_NAME" == "$DEFAULT_BRANCH" ]] || {
+                echo "Automatic E2B publication must run from $DEFAULT_BRANCH, got $SOURCE_REF ($SOURCE_REF_NAME)" >&2
                 exit 1
               }
+              [[ -z "$RELEASE_TAG" ]] || {
+                echo "Automatic E2B publication cannot select a release tag." >&2
+                exit 1
+              }
+              template_sha="$SOURCE_SHA"
               ;;
             workflow_dispatch)
-              if [[ "$SOURCE_REF" == refs/heads/main && "$SOURCE_REF_NAME" == main ]]; then
-                :
-              elif [[ "$SOURCE_REF" == "refs/tags/$SOURCE_REF_NAME" ]]; then
-                node scripts/check-release-tag.mjs "$SOURCE_REF_NAME"
+              [[ "$SOURCE_REF" == "refs/heads/$DEFAULT_BRANCH" &&
+                "$SOURCE_REF_NAME" == "$DEFAULT_BRANCH" ]] || {
+                echo "Manual E2B publication must dispatch the current $DEFAULT_BRANCH workflow, got $SOURCE_REF ($SOURCE_REF_NAME)" >&2
+                exit 1
+              }
+              if [[ -n "$RELEASE_TAG" ]]; then
+                node scripts/check-release-tag.mjs "$RELEASE_TAG"
                 release_json="$(gh api \
                   -H 'Accept: application/vnd.github+json' \
-                  "repos/$GITHUB_REPOSITORY/releases/tags/$SOURCE_REF_NAME")"
-                [[ "$(jq -r .tag_name <<<"$release_json")" == "$SOURCE_REF_NAME" &&
+                  "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG")"
+                [[ "$(jq -r .tag_name <<<"$release_json")" == "$RELEASE_TAG" &&
                   "$(jq -r .draft <<<"$release_json")" == false &&
                   "$(jq -r .prerelease <<<"$release_json")" == false ]] || {
                   echo "Manual E2B publication requires a published, non-prerelease GitHub Release." >&2
                   exit 1
                 }
-                tag_sha="$(git rev-parse "refs/tags/$SOURCE_REF_NAME^{commit}")"
-                [[ "$tag_sha" == "$SOURCE_SHA" ]] || {
-                  echo "Selected release tag $SOURCE_REF_NAME resolves to $tag_sha, not $SOURCE_SHA" >&2
-                  exit 1
-                }
+                git fetch --force --no-tags origin \
+                  "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+                template_sha="$(git rev-parse "refs/tags/$RELEASE_TAG^{commit}")"
               else
-                echo "Manual E2B publication must select main or a vX.Y.Z release tag, got $SOURCE_REF" >&2
-                exit 1
+                template_sha="$SOURCE_SHA"
               fi
               ;;
             *)
@@ -151,10 +184,21 @@ jobs:
               ;;
           esac
 
-          git merge-base --is-ancestor "$SOURCE_SHA" origin/main || {
-            echo "Refusing to publish E2B content not contained in main: $SOURCE_SHA" >&2
+          git merge-base --is-ancestor "$template_sha" "origin/$DEFAULT_BRANCH" || {
+            echo "Refusing to publish E2B content not contained in $DEFAULT_BRANCH: $template_sha" >&2
             exit 1
           }
+          echo "sha=$template_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Check out the validated template source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ steps.source.outputs.sha }}
+          path: .release-source
+          fetch-depth: 1
+          sparse-checkout: |
+            crates/openwave-sandbox-agent/e2b
+          sparse-checkout-cone-mode: false
 
       - name: Require the E2B credential
         env:
@@ -185,7 +229,7 @@ jobs:
           import re
           import sys
 
-          directory = os.environ["TEMPLATE_DIR"]
+          directory = os.environ["SOURCE_TEMPLATE_DIR"]
           with open(f"{directory}/e2b.toml") as handle:
               config = handle.read()
 
@@ -298,7 +342,21 @@ jobs:
     env:
       ALIAS: ${{ needs.resolve.outputs.alias }}
     steps:
+      # Trusted workflow/tooling checkout. The selected release can only
+      # populate the sparse template-source checkout that follows.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Check out the validated template source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.resolve.outputs.source_sha }}
+          path: .release-source
+          fetch-depth: 1
+          sparse-checkout: |
+            crates/openwave-sandbox-agent/e2b
+          sparse-checkout-cone-mode: false
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         with:
@@ -316,13 +374,18 @@ jobs:
       - name: Install the locked E2B CLI
         run: |
           pnpm --dir .github/e2b-cli install --frozen-lockfile --ignore-scripts
-          .github/e2b-cli/node_modules/.bin/e2b --version
+          expected="$(node -p "require('./.github/e2b-cli/package.json').dependencies['@e2b/cli']")"
+          actual="$(.github/e2b-cli/node_modules/.bin/e2b --version)"
+          [[ "$actual" == "$expected" ]] || {
+            echo "Expected E2B CLI $expected, got $actual" >&2
+            exit 1
+          }
 
       # `e2b template create` takes no config file: it reads the Dockerfile and
       # takes sizing as flags, so e2b.toml's numbers are passed explicitly
       # rather than duplicated here.
       - name: Build the template
-        working-directory: ${{ env.TEMPLATE_DIR }}
+        working-directory: ${{ env.SOURCE_TEMPLATE_DIR }}
         env:
           CPU_COUNT: ${{ needs.resolve.outputs.cpu_count }}
           E2B_ACCESS_TOKEN: ${{ secrets.E2B_ACCESS_TOKEN }}
@@ -339,7 +402,7 @@ jobs:
       # alias only resolves inside the OpenWave team — so a user who has
       # pasted nothing but their own API key gets the documents image.
       - name: Publish the template
-        working-directory: ${{ env.TEMPLATE_DIR }}
+        working-directory: ${{ env.SOURCE_TEMPLATE_DIR }}
         env:
           E2B_ACCESS_TOKEN: ${{ secrets.E2B_ACCESS_TOKEN }}
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
@@ -434,7 +497,7 @@ jobs:
           import re
           import sys
 
-          directory = os.environ["TEMPLATE_DIR"]
+          directory = os.environ["TEMPLATE_PATH"]
           alias = os.environ["ALIAS"]
           template_id = os.environ["TEMPLATE_ID"]
 

--- a/.github/workflows/publish-e2b-template.yml
+++ b/.github/workflows/publish-e2b-template.yml
@@ -479,6 +479,7 @@ jobs:
       # From whichever job actually resolved the alias: `publish` when this
       # run built the template, `resolve` when it was already public.
       TEMPLATE_ID: ${{ needs.publish.outputs.template_id || needs.resolve.outputs.template_id }}
+      SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
       PIN_BRANCH: automation/e2b-template-pin
       GH_TOKEN: ${{ github.token }}
     steps:
@@ -486,18 +487,36 @@ jobs:
         with:
           ref: main
 
+      # Keep provenance tied to the exact tree that resolve validated. `main`
+      # above is only the branch the automation PR will modify; it must never
+      # supply the image reference claimed for an older publication run.
+      - name: Check out the validated template provenance
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.resolve.outputs.source_sha }}
+          path: .release-source
+          fetch-depth: 1
+          sparse-checkout: |
+            crates/openwave-sandbox-agent/e2b
+          sparse-checkout-cone-mode: false
+
       - name: Point the client at the published template
         run: |
           if [[ -z "$TEMPLATE_ID" ]]; then
             echo "No template ID reached the pin job; refusing to guess." >&2
             exit 1
           fi
+          git diff --quiet --no-index ".release-source/$TEMPLATE_PATH" "$TEMPLATE_PATH" || {
+            echo "The template source advanced on main after $SOURCE_SHA; the newer publication run owns the pin." \
+              >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          }
           python3 - <<'EOF'
           import os
           import re
           import sys
 
-          directory = os.environ["TEMPLATE_PATH"]
+          directory = f".release-source/{os.environ['TEMPLATE_PATH']}"
           alias = os.environ["ALIAS"]
           template_id = os.environ["TEMPLATE_ID"]
 

--- a/.github/workflows/publish-e2b-template.yml
+++ b/.github/workflows/publish-e2b-template.yml
@@ -79,12 +79,6 @@ env:
   # (`E2B_API_BASE` in crates/openwave-code-execution/src/e2b.rs).
   E2B_API_BASE: https://api.e2b.app
   TEMPLATE_DIR: crates/openwave-sandbox-agent/e2b
-  # Pinned exactly, like every other direct dependency in this repository.
-  # 2.16.1 (published 2026-07-31) is the current release of the v2 CLI, the
-  # line that carries Build System 2.0 — `template create`, which builds on
-  # E2B's infrastructure instead of shelling out to a local Docker daemon the
-  # way the v1 `template build` did.
-  E2B_CLI_VERSION: 2.16.1
 
 jobs:
   # Reads the template definition and decides whether anything needs building.
@@ -107,6 +101,60 @@ jobs:
       template_id: ${{ steps.state.outputs.template_id }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Validate the publication source
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_REF: ${{ github.ref }}
+          SOURCE_REF_NAME: ${{ github.ref_name }}
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          git fetch --no-tags origin main:refs/remotes/origin/main
+
+          case "$EVENT_NAME" in
+            push)
+              [[ "$SOURCE_REF" == refs/heads/main && "$SOURCE_REF_NAME" == main ]] || {
+                echo "Automatic E2B publication must run from main, got $SOURCE_REF ($SOURCE_REF_NAME)" >&2
+                exit 1
+              }
+              ;;
+            workflow_dispatch)
+              if [[ "$SOURCE_REF" == refs/heads/main && "$SOURCE_REF_NAME" == main ]]; then
+                :
+              elif [[ "$SOURCE_REF" == "refs/tags/$SOURCE_REF_NAME" ]]; then
+                node scripts/check-release-tag.mjs "$SOURCE_REF_NAME"
+                release_json="$(gh api \
+                  -H 'Accept: application/vnd.github+json' \
+                  "repos/$GITHUB_REPOSITORY/releases/tags/$SOURCE_REF_NAME")"
+                [[ "$(jq -r .tag_name <<<"$release_json")" == "$SOURCE_REF_NAME" &&
+                  "$(jq -r .draft <<<"$release_json")" == false &&
+                  "$(jq -r .prerelease <<<"$release_json")" == false ]] || {
+                  echo "Manual E2B publication requires a published, non-prerelease GitHub Release." >&2
+                  exit 1
+                }
+                tag_sha="$(git rev-parse "refs/tags/$SOURCE_REF_NAME^{commit}")"
+                [[ "$tag_sha" == "$SOURCE_SHA" ]] || {
+                  echo "Selected release tag $SOURCE_REF_NAME resolves to $tag_sha, not $SOURCE_SHA" >&2
+                  exit 1
+                }
+              else
+                echo "Manual E2B publication must select main or a vX.Y.Z release tag, got $SOURCE_REF" >&2
+                exit 1
+              fi
+              ;;
+            *)
+              echo "Unsupported publication event: $EVENT_NAME" >&2
+              exit 1
+              ;;
+          esac
+
+          git merge-base --is-ancestor "$SOURCE_SHA" origin/main || {
+            echo "Refusing to publish E2B content not contained in main: $SOURCE_SHA" >&2
+            exit 1
+          }
 
       - name: Require the E2B credential
         env:
@@ -249,22 +297,26 @@ jobs:
       template_id: ${{ steps.verify.outputs.template_id }}
     env:
       ALIAS: ${{ needs.resolve.outputs.alias }}
-      E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
-      # Optional; deprecated in E2B's API in favour of the API key, but still
-      # accepted by team-scoped endpoints. Passed through when the secret is
-      # set and simply absent when it is not.
-      E2B_ACCESS_TOKEN: ${{ secrets.E2B_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        with:
+          version: 10.18.3
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
+          cache: pnpm
+          cache-dependency-path: .github/e2b-cli/pnpm-lock.yaml
 
-      - name: Install the E2B CLI
+      # The checked lockfile pins the CLI's entire transitive graph and
+      # lifecycle scripts stay disabled. No E2B credential is in this step's
+      # environment.
+      - name: Install the locked E2B CLI
         run: |
-          npm install --global "@e2b/cli@$E2B_CLI_VERSION"
-          e2b --version
+          pnpm --dir .github/e2b-cli install --frozen-lockfile --ignore-scripts
+          .github/e2b-cli/node_modules/.bin/e2b --version
 
       # `e2b template create` takes no config file: it reads the Dockerfile and
       # takes sizing as flags, so e2b.toml's numbers are passed explicitly
@@ -273,9 +325,11 @@ jobs:
         working-directory: ${{ env.TEMPLATE_DIR }}
         env:
           CPU_COUNT: ${{ needs.resolve.outputs.cpu_count }}
+          E2B_ACCESS_TOKEN: ${{ secrets.E2B_ACCESS_TOKEN }}
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
           MEMORY_MB: ${{ needs.resolve.outputs.memory_mb }}
         run: |
-          e2b template create "$ALIAS" \
+          "$GITHUB_WORKSPACE/.github/e2b-cli/node_modules/.bin/e2b" template create "$ALIAS" \
             --dockerfile e2b.Dockerfile \
             --cpu-count "$CPU_COUNT" \
             --memory-mb "$MEMORY_MB"
@@ -286,7 +340,11 @@ jobs:
       # pasted nothing but their own API key gets the documents image.
       - name: Publish the template
         working-directory: ${{ env.TEMPLATE_DIR }}
-        run: e2b template publish "$ALIAS" --yes
+        env:
+          E2B_ACCESS_TOKEN: ${{ secrets.E2B_ACCESS_TOKEN }}
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+        run: |
+          "$GITHUB_WORKSPACE/.github/e2b-cli/node_modules/.bin/e2b" template publish "$ALIAS" --yes
 
       # Confirms the publish took from the account that performed it. It cannot
       # prove the other half of the claim — that a *different* E2B account can
@@ -295,6 +353,8 @@ jobs:
       # keeps that as a manual one-liner.
       - name: Verify the alias resolves and is public
         id: verify
+        env:
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
         run: |
           body="$RUNNER_TEMP/alias.json"
           status="$(curl --silent --show-error --location \

--- a/deny.toml
+++ b/deny.toml
@@ -1,9 +1,6 @@
-# Supply-chain advisory policy for `cargo deny check advisories`.
-#
-# Scope is deliberately narrow: this is the RustSec advisory gate, not a
-# license or dependency-ban policy. Only the `advisories` check is wired into
-# CI (`.github/workflows/ci.yml`), so the other sections cargo-deny supports
-# are intentionally absent.
+# Rust dependency policy enforced by `cargo deny` in CI. Keep exceptions
+# explicit and reviewable: the lockfile is immutable during checks, but a pin
+# alone does not establish that its license and source are acceptable.
 
 [advisories]
 # Security advisories and unsound APIs always fail. These are the findings we
@@ -26,3 +23,37 @@ yanked = "warn"
 # Keep this list short and dated; an entry that outlives its justification is
 # worse than no gate at all.
 ignore = []
+
+[licenses]
+version = 2
+confidence-threshold = 0.93
+
+# SPDX licenses present in the current resolved workspace graph and accepted
+# for distribution. Compound expressions still have to be satisfiable using
+# this set; adding a dependency with another license fails CI until it receives
+# an explicit review here.
+allow = [
+  "0BSD",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "BSL-1.0",
+  "CC0-1.0",
+  "CDLA-Permissive-2.0",
+  "ISC",
+  "MIT",
+  "MIT-0",
+  "MPL-2.0",
+  "Unicode-3.0",
+  "Unlicense",
+  "Zlib",
+]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+
+# Symphonia is temporarily patched to a specific upstream commit for the WebM
+# MediaRecorder fix documented beside `[patch.crates-io]` in Cargo.toml.
+allow-git = ["https://github.com/pdeljanov/Symphonia"]

--- a/deploy/self-host/Dockerfile
+++ b/deploy/self-host/Dockerfile
@@ -9,7 +9,10 @@
 # Build context is the WORKSPACE ROOT, so the whole Cargo workspace and the
 # committed Cargo.lock are visible to a `--locked` build:
 #
-#   docker build -f deploy/self-host/Dockerfile -t openwave-self-host .
+#   context="$(mktemp -d)"
+#   scripts/stage-self-host-build-context.sh "$context"
+#   docker build -f "$context/deploy/self-host/Dockerfile" -t openwave-self-host "$context"
+#   rm -rf "$context"
 #
 # The deployment posture this image assumes is decision record 4: the server
 # and its PostgreSQL database run inside the operator's own network, and TLS

--- a/deploy/self-host/Dockerfile.dockerignore
+++ b/deploy/self-host/Dockerfile.dockerignore
@@ -8,23 +8,42 @@
 !Cargo.lock
 !rust-toolchain.toml
 
-# Cargo must be able to discover every workspace member. The final rules below
-# still reject credential-shaped files even if one is accidentally created
-# inside a crate directory.
+# Cargo must be able to discover every workspace member, but the build only
+# receives manifests, Rust source trees, build scripts, and the few data files
+# embedded by the selected package closure. Do not broaden these back to
+# `!crates/**`: that would upload unrelated untracked files to remote builders.
 !crates/
-!crates/**
+!crates/*/
+!crates/*/Cargo.toml
+!crates/*/build.rs
+!crates/*/src/
+!crates/*/src/**
+!crates/openwave-code-execution/baseline_python_deps.txt
+!crates/openwave-sandbox-agent/documents-requirements.txt
 
-# Source-time files referenced by the server dependency closure.
+# Built-in manifests are source inputs for compile-time contract checks. Admit
+# only the reviewed manifest names, not arbitrary files beside them.
 !skills/
-!skills/**
+!skills/*/
+!skills/*/SKILL.md
 !plugins/
-!plugins/**
+!plugins/*/
+!plugins/*/PLUGIN.md
 
-# Never admit local credentials or application state, even below an allowed
-# source directory. Keep these after the allow rules so they win.
+# Never admit hidden files or common credential files, even below an allowed
+# source directory. Keep these after the allow rules so they win. The explicit
+# credential names are defense in depth for future changes to the hidden-file
+# rule and document the exact probes enforced by workflow-security.test.mjs.
+**/.npmrc
+**/.netrc
+**/.pypirc
+**/.cargo/credentials
+**/.cargo/credentials.toml
+**/id_*
+**/credentials
+**/credentials.*
 **/.env
 **/.env.*
-!**/.env.example
 **/*.pem
 **/*.key
 **/*.p12
@@ -38,6 +57,8 @@
 **/.ssh/**
 **/.openwave
 **/.openwave/**
+**/.*
+**/.*/**
 
 # Generated and dependency trees are never source inputs.
 **/target

--- a/deploy/self-host/Dockerfile.dockerignore
+++ b/deploy/self-host/Dockerfile.dockerignore
@@ -1,8 +1,52 @@
-# Build-context exclusions for deploy/self-host/Dockerfile (BuildKit reads the
-# file named after the Dockerfile). Build artifacts and installed JavaScript
-# dependencies are large and never part of a `cargo build --locked`.
-.git
-target
+# Deny by default. This Dockerfile is built from the workspace root, and Git's
+# ignore rules do not stop Docker from uploading untracked files to a daemon or
+# remote BuildKit cache.
+**
+
+# Workspace manifests and lock state.
+!Cargo.toml
+!Cargo.lock
+!rust-toolchain.toml
+
+# Cargo must be able to discover every workspace member. The final rules below
+# still reject credential-shaped files even if one is accidentally created
+# inside a crate directory.
+!crates/
+!crates/**
+
+# Source-time files referenced by the server dependency closure.
+!skills/
+!skills/**
+!plugins/
+!plugins/**
+
+# Never admit local credentials or application state, even below an allowed
+# source directory. Keep these after the allow rules so they win.
+**/.env
+**/.env.*
+!**/.env.example
+**/*.pem
+**/*.key
+**/*.p12
+**/*.pfx
+**/*.keystore
+**/secrets.toml
+**/credentials.json
+**/.aws
+**/.aws/**
+**/.ssh
+**/.ssh/**
+**/.openwave
+**/.openwave/**
+
+# Generated and dependency trees are never source inputs.
+**/target
+**/target/**
 **/node_modules
-crates/openwave-desktop/ui/dist
-docs-site/.next
+**/node_modules/**
+**/dist
+**/dist/**
+**/.next
+**/.next/**
+**/.git
+**/.git/**

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -2,13 +2,14 @@
   "name": "openwave-docs",
   "version": "0.0.0",
   "private": true,
+  "packageManager": "pnpm@10.18.3",
   "scripts": {
     "predev": "node scripts/generate-search-index.mjs",
     "dev": "next dev",
     "prebuild": "node scripts/generate-search-index.mjs",
     "build": "next build",
     "start": "serve out",
-    "types:check": "tsc --noEmit",
+    "types:check": "next typegen && tsc --noEmit",
     "lint": "eslint"
   },
   "dependencies": {

--- a/scripts/stage-self-host-build-context.sh
+++ b/scripts/stage-self-host-build-context.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Materialize the self-host Docker context from Git, never from the caller's
+# working tree. Docker uploads a local context before evaluating COPY, so a
+# .dockerignore alone cannot make arbitrary untracked files safe.
+set -euo pipefail
+
+destination="${1:?usage: stage-self-host-build-context.sh DESTINATION [REVISION]}"
+revision="${2:-HEAD}"
+root="$(git rev-parse --show-toplevel)"
+
+mkdir -p "$destination"
+git -C "$root" archive --format=tar "$revision" | tar -x -C "$destination"

--- a/scripts/workflow-security-mutations.test.mjs
+++ b/scripts/workflow-security-mutations.test.mjs
@@ -1,0 +1,204 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const policyTest = join(repositoryRoot, "scripts", "workflow-security.test.mjs");
+const fixturePaths = [
+  ".github/workflows",
+  ".github/release-drafter.yml",
+  ".github/e2b-cli/package.json",
+  "crates/openwave-desktop/tauri.conf.json",
+  "crates/openwave-desktop/Cargo.toml",
+  "crates/openwave-desktop/src/lib.rs",
+  "crates/openwave-desktop/src/updater.rs",
+  "deploy/self-host/Dockerfile.dockerignore",
+  "deny.toml",
+  "README.md",
+];
+
+function policyFixture() {
+  const root = mkdtempSync(join(tmpdir(), "openwave-policy-mutation-"));
+  for (const path of fixturePaths) {
+    const source = join(repositoryRoot, path);
+    const target = join(root, path);
+    mkdirSync(dirname(target), { recursive: true });
+    cpSync(source, target, { recursive: true });
+  }
+  return root;
+}
+
+function edit(root, path, mutate) {
+  const target = join(root, path);
+  const before = readFileSync(target, "utf8");
+  const after = mutate(before);
+  assert.notEqual(after, before, `mutation did not change ${path}`);
+  writeFileSync(target, after);
+}
+
+function runPolicy(root) {
+  const env = {
+    ...process.env,
+    OPENWAVE_POLICY_ROOT: root,
+    OPENWAVE_SKIP_DOCKER_CONTEXT_PROBE: "1",
+  };
+  delete env.NODE_TEST_CONTEXT;
+  // Running the file directly still executes node:test, while avoiding the
+  // recursive test-runner guard when this mutation harness itself runs under
+  // `node --test scripts/*.test.mjs`.
+  return spawnSync(process.execPath, [policyTest], {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+    env,
+  });
+}
+
+test("the mirrored workflow-security fixture passes before mutation", () => {
+  const root = policyFixture();
+  try {
+    const result = runPolicy(root);
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+const mutations = [
+  {
+    name: "default-branch dispatch guard",
+    file: ".github/workflows/publish-e2b-template.yml",
+    expected: "production secrets remain isolated",
+    mutate: (source) =>
+      source.replace(
+        /(workflow_dispatch\)\n)\s+\[\[ "\$SOURCE_REF" == "refs\/heads\/\$DEFAULT_BRANCH" &&\n\s+"\$SOURCE_REF_NAME" == "\$DEFAULT_BRANCH" \]\] \|\| \{[\s\S]*?\n\s+\}\n/,
+        "$1              true\n",
+      ),
+  },
+  {
+    name: "release-tag syntax validation",
+    file: ".github/workflows/publish-e2b-template.yml",
+    expected: "production secrets remain isolated",
+    mutate: (source) =>
+      source.replace(
+        '                node scripts/check-release-tag.mjs "$RELEASE_TAG"\n',
+        "",
+      ),
+  },
+  {
+    name: "validated source-only checkout",
+    file: ".github/workflows/publish-e2b-template.yml",
+    expected: "production secrets remain isolated",
+    mutate: (source) =>
+      source.replace(
+        "          ref: ${{ needs.resolve.outputs.source_sha }}",
+        "          ref: ${{ github.sha }}",
+      ),
+  },
+  {
+    name: "source validation without credentials",
+    file: ".github/workflows/publish-e2b-template.yml",
+    expected: "production secrets remain isolated",
+    mutate: (source) =>
+      source.replace(
+        "          GH_TOKEN: ${{ github.token }}\n",
+        "          GH_TOKEN: ${{ github.token }}\n          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}\n",
+      ),
+  },
+  {
+    name: "publish-job credential isolation",
+    file: ".github/workflows/publish-e2b-template.yml",
+    expected: "production secrets remain isolated",
+    mutate: (source) =>
+      source.replace(
+        "    env:\n      ALIAS: ${{ needs.resolve.outputs.alias }}\n",
+        "    env:\n      ALIAS: ${{ needs.resolve.outputs.alias }}\n      E2B_API_KEY: ${{ secrets.E2B_API_KEY }}\n",
+      ),
+  },
+  {
+    name: "frozen local E2B CLI installation",
+    file: ".github/workflows/publish-e2b-template.yml",
+    expected: "production secrets remain isolated",
+    mutate: (source) =>
+      source.replace(
+        "pnpm --dir .github/e2b-cli install --frozen-lockfile --ignore-scripts",
+        "npm install --global @e2b/cli@latest",
+      ),
+  },
+  {
+    name: "E2B tooling publication trigger",
+    file: ".github/workflows/publish-e2b-template.yml",
+    expected: "production secrets remain isolated",
+    mutate: (source) => source.replace('      - ".github/e2b-cli/**"\n', ""),
+  },
+  {
+    name: "E2B tooling PR scope",
+    file: ".github/workflows/ci.yml",
+    expected: "PR lanes are scope-gated",
+    mutate: (source) => source.replace(".github/e2b-cli/*|", ""),
+  },
+  {
+    name: "E2B tooling execution lane",
+    file: ".github/workflows/ci.yml",
+    expected: "PR lanes are scope-gated",
+    mutate: (source) =>
+      source.replace(/\n  e2b-cli:\n[\s\S]*?(?=\n  advisories:)/, ""),
+  },
+  {
+    name: "documentation-site execution lane",
+    file: ".github/workflows/ci.yml",
+    expected: "PR lanes are scope-gated",
+    mutate: (source) => source.replace(/\n  docs-site:\n[\s\S]*$/, ""),
+  },
+  {
+    name: "locked cargo-deny graph",
+    file: ".github/workflows/ci.yml",
+    expected: "dependency policy covers",
+    mutate: (source) => source.replace("--all-features --locked", "--all-features"),
+  },
+  {
+    name: "Docker deny-all baseline",
+    file: "deploy/self-host/Dockerfile.dockerignore",
+    expected: "Docker context is allowlisted",
+    mutate: (source) => source.replace("\n**\n", "\n"),
+  },
+  {
+    name: "Docker arbitrary hidden-file denial",
+    file: "deploy/self-host/Dockerfile.dockerignore",
+    expected: "Docker context is allowlisted",
+    mutate: (source) => source.replace("**/.*\n", ""),
+  },
+  {
+    name: "Docker private-key filename denial",
+    file: "deploy/self-host/Dockerfile.dockerignore",
+    expected: "Docker context is allowlisted",
+    mutate: (source) => source.replace("**/id_*\n", ""),
+  },
+];
+
+test("workflow-security controls fail closed under targeted mutations", async (t) => {
+  for (const mutation of mutations) {
+    await t.test(mutation.name, () => {
+      const root = policyFixture();
+      try {
+        edit(root, mutation.file, mutation.mutate);
+        const result = runPolicy(root);
+        const output = `${result.stdout}\n${result.stderr}`;
+        assert.notEqual(result.status, 0, `mutation passed unexpectedly:\n${output}`);
+        assert.match(output, new RegExp(mutation.expected));
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+  }
+});

--- a/scripts/workflow-security-mutations.test.mjs
+++ b/scripts/workflow-security-mutations.test.mjs
@@ -24,6 +24,7 @@ const fixturePaths = [
   "crates/openwave-desktop/src/lib.rs",
   "crates/openwave-desktop/src/updater.rs",
   "deploy/self-host/Dockerfile.dockerignore",
+  "scripts/stage-self-host-build-context.sh",
   "deny.toml",
   "README.md",
 ];
@@ -106,6 +107,16 @@ const mutations = [
       ),
   },
   {
+    name: "E2B pin provenance source checkout",
+    file: ".github/workflows/publish-e2b-template.yml",
+    expected: "E2B template pin provenance",
+    mutate: (source) =>
+      source.replace(
+        "          ref: ${{ needs.resolve.outputs.source_sha }}\n          path: .release-source\n          fetch-depth: 1\n          sparse-checkout: |\n            crates/openwave-sandbox-agent/e2b\n          sparse-checkout-cone-mode: false\n\n      - name: Point the client at the published template",
+        "          ref: main\n          path: .release-source\n          fetch-depth: 1\n          sparse-checkout: |\n            crates/openwave-sandbox-agent/e2b\n          sparse-checkout-cone-mode: false\n\n      - name: Point the client at the published template",
+      ),
+  },
+  {
     name: "source validation without credentials",
     file: ".github/workflows/publish-e2b-template.yml",
     expected: "production secrets remain isolated",
@@ -177,6 +188,12 @@ const mutations = [
     file: "deploy/self-host/Dockerfile.dockerignore",
     expected: "Docker context is allowlisted",
     mutate: (source) => source.replace("**/.*\n", ""),
+  },
+  {
+    name: "Docker tracked-context staging",
+    file: "scripts/stage-self-host-build-context.sh",
+    expected: "self-host build context excludes",
+    mutate: (source) => source.replace("git -C \"$root\" archive --format=tar \"$revision\"", "tar -cf - \"$root\""),
   },
   {
     name: "Docker private-key filename denial",

--- a/scripts/workflow-security-mutations.test.mjs
+++ b/scripts/workflow-security-mutations.test.mjs
@@ -23,6 +23,7 @@ const fixturePaths = [
   "crates/openwave-desktop/Cargo.toml",
   "crates/openwave-desktop/src/lib.rs",
   "crates/openwave-desktop/src/updater.rs",
+  "crates/openwave-desktop/src/broker.rs",
   "deploy/self-host/Dockerfile.dockerignore",
   "scripts/stage-self-host-build-context.sh",
   "deny.toml",

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -443,6 +443,17 @@ test("dependency policy covers advisories, licenses, sources, and the locked gra
   );
 });
 
+test("E2B template pin provenance and writes share the validated source revision", () => {
+  const pin = workflowJob(workflows["publish-e2b-template.yml"], "pin");
+
+  assert.match(pin, /SOURCE_SHA: \$\{\{ needs\.resolve\.outputs\.source_sha \}\}/);
+  assert.match(pin, /name: Check out the validated template provenance/);
+  assert.match(pin, /ref: \$\{\{ needs\.resolve\.outputs\.source_sha \}\}/);
+  assert.match(pin, /path: \.release-source/);
+  assert.match(pin, /git diff --quiet --no-index "\.release-source\/\$TEMPLATE_PATH" "\$TEMPLATE_PATH"/);
+  assert.match(pin, /directory = f"\.release-source\/\{os\.environ\['TEMPLATE_PATH'\]\}"/);
+});
+
 test("the self-host Docker context is allowlisted and denies hidden credentials", () => {
   assert.match(dockerIgnore, /^\*\*$/m);
   assert.doesNotMatch(dockerIgnore, /^!crates\/\*\*$/m);
@@ -478,10 +489,14 @@ test("the self-host Docker context is allowlisted and denies hidden credentials"
   ]) {
     assert.ok(dockerIgnore.includes(`${denied}\n`), `missing deny rule ${denied}`);
   }
+  assert.match(
+    readFileSync(repositoryFile("scripts", "stage-self-host-build-context.sh"), "utf8"),
+    /git -C "\$root" archive --format=tar "\$revision" \| tar -x -C "\$destination"/,
+  );
 });
 
 test(
-  "BuildKit excludes exact hidden and credential probes from allowed source paths",
+  "BuildKit admits only exact source inputs from allowed source paths",
   { skip: process.env.OPENWAVE_SKIP_DOCKER_CONTEXT_PROBE === "1" },
   () => {
     const context = mkdtempSync(join(tmpdir(), "openwave-docker-context-"));
@@ -552,6 +567,32 @@ test(
         );
       }
     } finally {
+      rmSync(context, { recursive: true, force: true });
+      rmSync(output, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "the self-host build context excludes arbitrary untracked source files",
+  { skip: process.env.OPENWAVE_SKIP_DOCKER_CONTEXT_PROBE === "1" },
+  () => {
+    const context = mkdtempSync(join(tmpdir(), "openwave-self-host-context-"));
+    const output = mkdtempSync(join(tmpdir(), "openwave-self-host-output-"));
+    const probe = repositoryFile("crates", "openwave-cli", "src", "cloud-token.txt");
+    try {
+      writeFileSync(probe, "untracked probe\n");
+      execFileSync("bash", [repositoryFile("scripts", "stage-self-host-build-context.sh"), context]);
+      writeFileSync(join(context, "Probe.Dockerfile"), "FROM scratch\nCOPY . /context\n");
+      execFileSync(
+        "docker",
+        ["buildx", "build", "--file", join(context, "Probe.Dockerfile"), "--output", `type=local,dest=${output}`, context],
+        { stdio: "pipe" },
+      );
+      assert.ok(existsSync(join(output, "context", "crates", "openwave-cli", "src", "main.rs")));
+      assert.ok(!existsSync(join(output, "context", "crates", "openwave-cli", "src", "cloud-token.txt")));
+    } finally {
+      rmSync(probe, { force: true });
       rmSync(context, { recursive: true, force: true });
       rmSync(output, { recursive: true, force: true });
     }

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1,38 +1,63 @@
 import assert from "node:assert/strict";
-import { readdirSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
-const workflowDirectory = new URL("../.github/workflows/", import.meta.url);
+const repositoryRoot = resolve(
+  process.env.OPENWAVE_POLICY_ROOT ??
+    fileURLToPath(new URL("..", import.meta.url)),
+);
+const repositoryFile = (...parts) => join(repositoryRoot, ...parts);
+const workflowDirectory = repositoryFile(".github", "workflows");
 const workflows = Object.fromEntries(
   readdirSync(workflowDirectory)
     .filter((name) => name.endsWith(".yml") || name.endsWith(".yaml"))
-    .map((name) => [name, readFileSync(new URL(name, workflowDirectory), "utf8")]),
+    .map((name) => [name, readFileSync(join(workflowDirectory, name), "utf8")]),
 );
 const releaseDrafterConfig = readFileSync(
-  new URL("../.github/release-drafter.yml", import.meta.url),
+  repositoryFile(".github", "release-drafter.yml"),
   "utf8",
 );
 const tauriConfig = JSON.parse(
   readFileSync(
-    new URL("../crates/openwave-desktop/tauri.conf.json", import.meta.url),
+    repositoryFile("crates", "openwave-desktop", "tauri.conf.json"),
     "utf8",
   ),
 );
 const desktopCargo = readFileSync(
-  new URL("../crates/openwave-desktop/Cargo.toml", import.meta.url),
+  repositoryFile("crates", "openwave-desktop", "Cargo.toml"),
   "utf8",
 );
 const desktopHost = readFileSync(
-  new URL("../crates/openwave-desktop/src/lib.rs", import.meta.url),
+  repositoryFile("crates", "openwave-desktop", "src", "lib.rs"),
   "utf8",
 );
 const desktopUpdater = readFileSync(
-  new URL("../crates/openwave-desktop/src/updater.rs", import.meta.url),
+  repositoryFile("crates", "openwave-desktop", "src", "updater.rs"),
   "utf8",
 );
 const desktopBroker = readFileSync(
-  new URL("../crates/openwave-desktop/src/broker.rs", import.meta.url),
+  repositoryFile("crates", "openwave-desktop", "src", "broker.rs"),
   "utf8",
+);
+const dockerIgnore = readFileSync(
+  repositoryFile("deploy", "self-host", "Dockerfile.dockerignore"),
+  "utf8",
+);
+const denyConfig = readFileSync(repositoryFile("deny.toml"), "utf8");
+const e2bPackage = JSON.parse(
+  readFileSync(repositoryFile(".github", "e2b-cli", "package.json"), "utf8"),
 );
 
 function workflowJob(source, name) {
@@ -99,6 +124,8 @@ test("workflow container images are pinned by digest", () => {
 test("PR lanes are scope-gated, never label-gated", () => {
   const ci = workflows["ci.yml"];
   const changes = workflowJob(ci, "changes");
+  const docsSite = workflowJob(ci, "docs-site");
+  const e2bCli = workflowJob(ci, "e2b-cli");
   const fmt = workflowJob(ci, "fmt");
   const postgres = workflowJob(ci, "postgres");
   const testJob = workflowJob(ci, "test");
@@ -112,6 +139,19 @@ test("PR lanes are scope-gated, never label-gated", () => {
     /pull_request:\n\s+types:\n\s+\[[^\]]*labeled, unlabeled[^\]]*\]/,
   );
   assert.doesNotMatch(ci, /^  build:$/m);
+  assert.match(
+    ci,
+    /cp "\$trusted" "\$GITHUB_WORKSPACE\/scripts\/\.trusted-workflow-security\.test\.mjs"/,
+  );
+  assert.match(
+    ci,
+    /node --test scripts\/\.trusted-workflow-security\.test\.mjs/,
+  );
+  assert.match(ci, /node --test scripts\/\*\.test\.mjs/);
+  assert.doesNotMatch(
+    ci,
+    /cp "\$trusted" "\$GITHUB_WORKSPACE\/scripts\/workflow-security\.test\.mjs"/,
+  );
   // A pull request's green checks must prove the same commits stay green on
   // main: no platform-neutral lane may hide behind an opt-in label. The
   // `windows-ci` opt-in below is the one deliberate exception.
@@ -133,6 +173,8 @@ test("PR lanes are scope-gated, never label-gated", () => {
     [testJob, "workspace"],
     [postgres, "workspace"],
     [workflowJob(ci, "ui"), "ui"],
+    [docsSite, "docs_site"],
+    [e2bCli, "e2b_cli"],
   ]) {
     assert.match(
       job,
@@ -164,6 +206,38 @@ test("PR lanes are scope-gated, never label-gated", () => {
   assert.doesNotMatch(ci, /^  parsers:$/m);
   assert.doesNotMatch(ci, /outputs\.parsers|echo "parsers=/);
   assert.match(changes, /\*\.md\|docs\/\*\|assets\/\*\|\.githooks\/\*/);
+
+  // Documentation and publication tooling each have a pre-merge execution
+  // lane. A tooling-only Dependabot update must not fall through to unrelated
+  // Rust jobs, and edits to either workflow force its own lane.
+  assert.match(changes, /docs-site\/\*\) docs_site=true/);
+  assert.match(
+    changes,
+    /\.github\/e2b-cli\/\*\|\.github\/workflows\/publish-e2b-template\.yml\)\n\s+e2b_cli=true/,
+  );
+  assert.match(changes, /echo "docs_site=true"/);
+  assert.match(changes, /echo "e2b_cli=true"/);
+  assert.match(docsSite, /pnpm install --frozen-lockfile/);
+  assert.match(docsSite, /run: pnpm types:check/);
+  assert.match(docsSite, /run: pnpm lint/);
+  assert.match(docsSite, /run: pnpm build/);
+
+  assert.equal(e2bPackage.packageManager, "pnpm@10.18.3");
+  assert.match(e2bCli, /version: 10\.18\.3/);
+  assert.match(e2bCli, /node-version: 22/);
+  assert.match(
+    e2bCli,
+    /pnpm --dir \.github\/e2b-cli install --frozen-lockfile --ignore-scripts/,
+  );
+  assert.match(
+    e2bCli,
+    /\.github\/e2b-cli\/node_modules\/\.bin\/e2b --version/,
+  );
+  assert.match(
+    e2bCli,
+    /dependencies\['@e2b\/cli'\]/,
+  );
+  assert.doesNotMatch(e2bCli, /npm install|@latest/);
 
   const desktop = workflowJob(ci, "desktop");
   assert.match(
@@ -262,8 +336,15 @@ test("production secrets remain isolated to the release workflow", () => {
   // to main touching the template definition, plus manual dispatch. Its
   // credential is scoped to E2B — it must not reach the signing secrets.
   const e2b = workflows["publish-e2b-template.yml"];
+  const resolveJob = workflowJob(e2b, "resolve");
+  const publishJob = workflowJob(e2b, "publish");
   assert.match(e2b, /^on:\n  push:\n    branches: \[main\]\n    paths:\n/m);
+  assert.match(e2b, /^      - "\.github\/e2b-cli\/\*\*"$/m);
   assert.match(e2b, /^  workflow_dispatch:\n/m);
+  assert.match(
+    e2b,
+    /^      release_tag:\n(?:        .*\n)+?        type: string$/m,
+  );
   assert.doesNotMatch(e2b, /^\s*pull_request(?:_target)?:/m);
   assert.match(e2b, /^permissions:\n  contents: read$/m);
   assert.deepEqual(
@@ -272,7 +353,210 @@ test("production secrets remain isolated to the release workflow", () => {
     // secret-shaped names reads as a credential to the secret scanner.
     ["ACCESS_TOKEN", "API_KEY"].map((suffix) => `secrets.E2B_${suffix}`),
   );
+
+  // A manual run must execute the current default-branch workflow. A release
+  // tag is validated as input and resolved to a commit for a sparse source-only
+  // checkout; it can never supply the workflow or locked CLI definition.
+  assert.match(resolveJob, /DEFAULT_BRANCH: \$\{\{ github\.event\.repository\.default_branch \}\}/);
+  assert.equal(
+    resolveJob.match(
+      /SOURCE_REF" == "refs\/heads\/\$DEFAULT_BRANCH" &&\n\s+"\$SOURCE_REF_NAME" == "\$DEFAULT_BRANCH"/g,
+    )?.length,
+    2,
+    "both push and workflow_dispatch must require the default-branch ref",
+  );
+  assert.doesNotMatch(resolveJob, /SOURCE_REF" == "refs\/tags\//);
+  assert.match(resolveJob, /RELEASE_TAG: \$\{\{ inputs\.release_tag \}\}/);
+  assert.match(resolveJob, /node scripts\/check-release-tag\.mjs "\$RELEASE_TAG"/);
+  assert.match(
+    resolveJob,
+    /repos\/\$GITHUB_REPOSITORY\/releases\/tags\/\$RELEASE_TAG/,
+  );
+  assert.match(resolveJob, /refs\/tags\/\$RELEASE_TAG\^\{commit\}/);
+  assert.match(
+    resolveJob,
+    /git merge-base --is-ancestor "\$template_sha" "origin\/\$DEFAULT_BRANCH"/,
+  );
+  assert.match(resolveJob, /echo "sha=\$template_sha" >> "\$GITHUB_OUTPUT"/);
+  assert.match(resolveJob, /ref: \$\{\{ steps\.source\.outputs\.sha \}\}/);
+  assert.match(
+    resolveJob,
+    /sparse-checkout: \|\n\s+crates\/openwave-sandbox-agent\/e2b/,
+  );
+  assert.match(publishJob, /ref: \$\{\{ github\.sha \}\}/);
+  assert.match(
+    publishJob,
+    /ref: \$\{\{ needs\.resolve\.outputs\.source_sha \}\}/,
+  );
+  assert.match(
+    publishJob,
+    /working-directory: \$\{\{ env\.SOURCE_TEMPLATE_DIR \}\}/,
+  );
+
+  // Source validation and all dependency setup happen before any secret-bearing
+  // step. Credentials remain step-scoped to the API calls that require them.
+  assert.ok(
+    resolveJob.indexOf("Validate the publication source") <
+      resolveJob.indexOf("Require the E2B credential"),
+  );
+  assert.ok(
+    resolveJob.indexOf("Check out the validated template source") <
+      resolveJob.indexOf("Require the E2B credential"),
+  );
+  const sourceValidationStep = resolveJob.match(
+    /- name: Validate the publication source[\s\S]*?(?=\n\s+- name:)/,
+  )?.[0];
+  const sourceCheckoutStep = resolveJob.match(
+    /- name: Check out the validated template source[\s\S]*?(?=\n\s+- name:)/,
+  )?.[0];
+  assert.ok(sourceValidationStep);
+  assert.ok(sourceCheckoutStep);
+  assert.doesNotMatch(sourceValidationStep, /secrets\./);
+  assert.doesNotMatch(sourceCheckoutStep, /secrets\./);
+  assert.doesNotMatch(
+    publishJob.match(/^    env:\n[\s\S]*?(?=^    steps:)/m)?.[0] ?? "",
+    /secrets\./,
+  );
+  assert.ok(
+    publishJob.indexOf("Install the locked E2B CLI") <
+      publishJob.indexOf("secrets."),
+  );
+  assert.match(
+    publishJob,
+    /pnpm --dir \.github\/e2b-cli install --frozen-lockfile --ignore-scripts/,
+  );
+  assert.match(
+    publishJob,
+    /\.github\/e2b-cli\/node_modules\/\.bin\/e2b --version/,
+  );
+  assert.doesNotMatch(publishJob, /npm install|@latest/);
 });
+
+test("dependency policy covers advisories, licenses, sources, and the locked graph", () => {
+  const advisories = workflowJob(workflows["ci.yml"], "advisories");
+  assert.match(denyConfig, /^\[advisories\]$/m);
+  assert.match(denyConfig, /^\[licenses\]$/m);
+  assert.match(denyConfig, /^\[sources\]$/m);
+  assert.match(
+    advisories,
+    /cargo deny --all-features --locked check advisories licenses sources/,
+  );
+});
+
+test("the self-host Docker context is allowlisted and denies hidden credentials", () => {
+  assert.match(dockerIgnore, /^\*\*$/m);
+  assert.doesNotMatch(dockerIgnore, /^!crates\/\*\*$/m);
+  assert.doesNotMatch(dockerIgnore, /^!skills\/\*\*$/m);
+  assert.doesNotMatch(dockerIgnore, /^!plugins\/\*\*$/m);
+
+  for (const required of [
+    "!Cargo.toml",
+    "!Cargo.lock",
+    "!rust-toolchain.toml",
+    "!crates/*/Cargo.toml",
+    "!crates/*/build.rs",
+    "!crates/*/src/**",
+    "!crates/openwave-code-execution/baseline_python_deps.txt",
+    "!crates/openwave-sandbox-agent/documents-requirements.txt",
+    "!skills/*/SKILL.md",
+    "!plugins/*/PLUGIN.md",
+  ]) {
+    assert.ok(dockerIgnore.includes(`${required}\n`), `missing allow rule ${required}`);
+  }
+
+  for (const denied of [
+    "**/.npmrc",
+    "**/.netrc",
+    "**/.pypirc",
+    "**/.cargo/credentials",
+    "**/.cargo/credentials.toml",
+    "**/id_*",
+    "**/credentials",
+    "**/credentials.*",
+    "**/.*",
+    "**/.*/**",
+  ]) {
+    assert.ok(dockerIgnore.includes(`${denied}\n`), `missing deny rule ${denied}`);
+  }
+});
+
+test(
+  "BuildKit excludes exact hidden and credential probes from allowed source paths",
+  { skip: process.env.OPENWAVE_SKIP_DOCKER_CONTEXT_PROBE === "1" },
+  () => {
+    const context = mkdtempSync(join(tmpdir(), "openwave-docker-context-"));
+    const output = mkdtempSync(join(tmpdir(), "openwave-docker-output-"));
+    const write = (path, contents = "probe\n") => {
+      const target = join(context, path);
+      mkdirSync(dirname(target), { recursive: true });
+      writeFileSync(target, contents);
+    };
+
+    const included = [
+      "Cargo.toml",
+      "Cargo.lock",
+      "rust-toolchain.toml",
+      "crates/demo/Cargo.toml",
+      "crates/demo/build.rs",
+      "crates/demo/src/lib.rs",
+      "crates/openwave-code-execution/baseline_python_deps.txt",
+      "crates/openwave-sandbox-agent/documents-requirements.txt",
+      "skills/demo/SKILL.md",
+      "plugins/demo/PLUGIN.md",
+    ];
+    const excluded = [
+      "crates/demo/.npmrc",
+      "crates/demo/src/.netrc",
+      "crates/demo/src/deep/.pypirc",
+      "crates/demo/src/id_rsa",
+      "crates/demo/src/deep/id_ed25519",
+      "crates/demo/src/.cargo/credentials",
+      "crates/demo/src/.cargo/credentials.toml",
+      "crates/demo/src/deep/.harmless-hidden-file",
+      "skills/demo/.draft",
+      "plugins/demo/credentials.json",
+      "outside/secret.txt",
+    ];
+
+    try {
+      for (const path of [...included, ...excluded]) {
+        write(path);
+      }
+      writeFileSync(
+        join(context, "Dockerfile"),
+        "FROM scratch\nCOPY . /context\n",
+      );
+      writeFileSync(join(context, "Dockerfile.dockerignore"), dockerIgnore);
+
+      execFileSync(
+        "docker",
+        [
+          "buildx",
+          "build",
+          "--file",
+          join(context, "Dockerfile"),
+          "--output",
+          `type=local,dest=${output}`,
+          context,
+        ],
+        { stdio: "pipe" },
+      );
+
+      for (const path of included) {
+        assert.ok(existsSync(join(output, "context", path)), `missing ${path}`);
+      }
+      for (const path of excluded) {
+        assert.ok(
+          !existsSync(join(output, "context", path)),
+          `credential probe escaped the context: ${path}`,
+        );
+      }
+    } finally {
+      rmSync(context, { recursive: true, force: true });
+      rmSync(output, { recursive: true, force: true });
+    }
+  },
+);
 
 test("sandbox image publishing is tag-driven, immutable, and secret-free", () => {
   const publish = workflows["publish-sandbox-image.yml"];
@@ -762,7 +1046,7 @@ test("GitHub release downloads are copied from the hosted release", () => {
   assert.match(attachJob, /gh release upload "\$RELEASE_TAG"/);
 
   assert.match(
-    readFileSync(new URL("../README.md", import.meta.url), "utf8"),
+    readFileSync(repositoryFile("README.md"), "utf8"),
     /releases\/latest\/download\/OpenWave-macos-apple-silicon\.dmg/,
     "the README download link must match the published asset name",
   );


### PR DESCRIPTION
## Summary

- add scoped docs-site install, type-check, lint, and build CI plus Dependabot coverage
- make the self-host Docker build context deny-by-default while retaining only required workspace inputs
- restrict E2B publication to main or a validated published release tag, pin the CLI through an isolated lockfile, and keep credentials out of setup steps
- extend cargo-deny to enforce reviewed licenses and dependency sources

## Validation

- `actionlint .github/workflows/*.yml`
- `node --test scripts/*.test.mjs` (89 passed)
- YAML parse checks for GitHub configuration and self-host Compose
- frozen/offline pnpm installs for docs-site and E2B tooling
- `pnpm types:check`, `pnpm lint`, and `pnpm build` in `docs-site`
- locked E2B CLI reports `2.16.1`
- `cargo deny --all-features check advisories licenses sources`
- `docker buildx build --check --file deploy/self-host/Dockerfile .`
- `git diff --cached --check`

## Follow-up

Deterministic third-party notice generation and release packaging is split to #1903. This PR removes the incomplete dangling CI references rather than asserting coverage from a partial generator.

Closes #1901