### PR TITLE
fix(router): preserve provider failure details

### DIFF
--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -1095,12 +1095,6 @@ impl RawAssistantBlocks {
         }
     }
 
-    fn set(&mut self, index: u32, key: &str, value: &str) {
-        if let Some(block) = self.open.get_mut(&index) {
-            block[key] = json!(value);
-        }
-    }
-
     fn append_json(&mut self, index: u32, fragment: &str) {
         self.partial_json
             .entry(index)
@@ -1307,7 +1301,7 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
                         raw.append_text(index, "thinking", &str_at(delta, "thinking"));
                     }
                     Some("signature_delta") => {
-                        raw.set(index, "signature", &str_at(delta, "signature"));
+                        raw.append_text(index, "signature", &str_at(delta, "signature"));
                     }
                     Some("input_json_delta") => {
                         raw.append_json(index, &str_at(delta, "partial_json"));
@@ -1331,7 +1325,7 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
                 // it the thinking text is display-only.
                 Some("signature_delta") => {
                     if let Some(block) = state.pending_reasoning.get_mut(&index) {
-                        block["signature"] = json!(str_at(delta, "signature"));
+                        append_str_field(block, "signature", &str_at(delta, "signature"));
                     }
                     Vec::new()
                 }
@@ -2139,6 +2133,87 @@ mod tests {
     }
 
     #[test]
+    fn split_reasoning_signature_survives_agent_persistence_and_parallel_tool_replay() {
+        let events = run(&[
+            json!({"type": "content_block_start", "index": 0, "content_block": {"type": "thinking", "thinking": ""}}),
+            json!({"type": "content_block_delta", "index": 0, "delta": {"type": "thinking_delta", "thinking": "check both sources"}}),
+            json!({"type": "content_block_delta", "index": 0, "delta": {"type": "signature_delta", "signature": "signed-"}}),
+            json!({"type": "content_block_delta", "index": 0, "delta": {"type": "signature_delta", "signature": "tail"}}),
+            json!({"type": "content_block_stop", "index": 0}),
+            json!({"type": "content_block_start", "index": 1, "content_block": {"type": "redacted_thinking", "data": "opaque"}}),
+            json!({"type": "content_block_stop", "index": 1}),
+        ]);
+        let captured: Vec<Value> = events
+            .into_iter()
+            .filter_map(|event| match event {
+                ProviderEvent::ReasoningBlock { data } => Some(data),
+                _ => None,
+            })
+            .collect();
+        let expected = vec![
+            json!({
+                "type": "thinking",
+                "thinking": "check both sources",
+                "signature": "signed-tail",
+            }),
+            json!({"type": "redacted_thinking", "data": "opaque"}),
+        ];
+        assert_eq!(captured, expected);
+
+        // The agent persists MessageReasoning separately from ChatMessage and
+        // reconstructs it before the next provider step. Exercise that same
+        // serde boundary before replaying a parallel tool batch.
+        let origin = ReasoningOrigin {
+            provider: Some(ProviderId::new("anthropic")),
+            model: "claude-opus-5".into(),
+        };
+        let stored = serde_json::to_value(MessageReasoning::captured(origin, captured)).unwrap();
+        let restored: MessageReasoning = serde_json::from_value(stored).unwrap();
+        let mut req = reasoning_request("claude-opus-5", None);
+        req.messages = vec![
+            ChatMessage::text(Role::User, "compare these"),
+            ChatMessage {
+                role: Role::Assistant,
+                content: vec![
+                    ContentBlock::ToolUse {
+                        id: "toolu_1".into(),
+                        name: "web_extract".into(),
+                        input: json!({"url": "https://example.com/one"}),
+                    },
+                    ContentBlock::ToolUse {
+                        id: "toolu_2".into(),
+                        name: "web_extract".into(),
+                        input: json!({"url": "https://example.com/two"}),
+                    },
+                ],
+                reasoning: restored,
+            },
+            ChatMessage {
+                role: Role::User,
+                content: vec![
+                    ContentBlock::ToolResult {
+                        tool_use_id: "toolu_1".into(),
+                        content: "first".into(),
+                        is_error: false,
+                    },
+                    ContentBlock::ToolResult {
+                        tool_use_id: "toolu_2".into(),
+                        content: "second".into(),
+                        is_error: false,
+                    },
+                ],
+                reasoning: MessageReasoning::default(),
+            },
+        ];
+
+        let body = build_request_json(&req).unwrap();
+        let replayed = body["messages"][1]["content"].as_array().unwrap();
+        assert_eq!(replayed[..expected.len()], expected);
+        assert_eq!(replayed[2]["id"], "toolu_1");
+        assert_eq!(replayed[3]["id"], "toolu_2");
+    }
+
+    #[test]
     fn captured_reasoning_is_replayed_verbatim_ahead_of_its_content() {
         let reasoning = vec![
             json!({"type": "thinking", "thinking": "plan: read first", "signature": "sig-1"}),
@@ -2908,6 +2983,42 @@ mod tests {
                 "title": "A",
                 "encrypted_content": "opaque",
             }]));
+            if leg == 1 {
+                // Thinking must stay first in the assistant content, so make
+                // room ahead of the search blocks before streaming a split
+                // signature through the raw pause-turn capture path.
+                for frame in &mut frames {
+                    if let Some(index) = frame.get_mut("index") {
+                        *index = json!(index.as_u64().unwrap() + 1);
+                    }
+                }
+                frames.splice(
+                    0..0,
+                    [
+                        json!({
+                            "type": "content_block_start",
+                            "index": 0,
+                            "content_block": {"type": "thinking", "thinking": ""},
+                        }),
+                        json!({
+                            "type": "content_block_delta",
+                            "index": 0,
+                            "delta": {"type": "thinking_delta", "thinking": "check the source"},
+                        }),
+                        json!({
+                            "type": "content_block_delta",
+                            "index": 0,
+                            "delta": {"type": "signature_delta", "signature": "signed-"},
+                        }),
+                        json!({
+                            "type": "content_block_delta",
+                            "index": 0,
+                            "delta": {"type": "signature_delta", "signature": "tail"},
+                        }),
+                        json!({"type": "content_block_stop", "index": 0}),
+                    ],
+                );
+            }
             // The first response pauses mid-turn; the second finishes it.
             frames.push(json!({
                 "type": "message_delta",
@@ -2970,9 +3081,18 @@ mod tests {
         assert_eq!(messages.len(), 2);
         assert_eq!(messages[1]["role"], "assistant");
         let blocks = messages[1]["content"].as_array().unwrap();
-        assert_eq!(blocks[0], json!({"type": "text", "text": "Let me check."}));
         assert_eq!(
-            blocks[1],
+            blocks[0],
+            json!({
+                "type": "thinking",
+                "thinking": "check the source",
+                "signature": "signed-tail",
+            }),
+            "the raw continuation preserves the complete split signature"
+        );
+        assert_eq!(blocks[1], json!({"type": "text", "text": "Let me check."}));
+        assert_eq!(
+            blocks[2],
             json!({
                 "type": "server_tool_use",
                 "id": "srvtoolu_1",
@@ -2980,9 +3100,9 @@ mod tests {
                 "input": {"query": "rust 2027"},
             })
         );
-        assert_eq!(blocks[2]["type"], "web_search_tool_result");
+        assert_eq!(blocks[3]["type"], "web_search_tool_result");
         assert_eq!(
-            blocks[2]["content"][0]["encrypted_content"], "opaque",
+            blocks[3]["content"][0]["encrypted_content"], "opaque",
             "the provider validates the resumed turn against what it sent"
         );
     }

--- a/crates/openwave-router/src/openai.rs
+++ b/crates/openwave-router/src/openai.rs
@@ -1605,6 +1605,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn native_provider_surfaces_bounded_openai_detail_error() {
+        use axum::http::StatusCode;
+        use axum::routing::post;
+        use axum::Router;
+
+        async fn reject() -> (StatusCode, &'static str) {
+            (
+                StatusCode::BAD_REQUEST,
+                include_str!("../tests/fixtures/openai/detail_error.response.json"),
+            )
+        }
+
+        let app = Router::new().route("/v1/responses", post(reject));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let provider = OpenAiProvider::new("key").with_base_url(format!("http://{address}/v1"));
+        let result = provider
+            .stream(ChatRequest {
+                model: "gpt-5.6-sol".into(),
+                messages: vec![ChatMessage::text(Role::User, "hey hows it going")],
+                ..Default::default()
+            })
+            .await;
+        let Err(error) = result else {
+            panic!("expected the provider request to fail");
+        };
+
+        assert!(matches!(error, AgentError::InvalidRequest(_)));
+        assert_eq!(
+            error.to_string(),
+            "invalid provider request: openai returned 400: The requested model is not available for this account."
+        );
+    }
+
+    #[tokio::test]
     async fn chatgpt_oauth_sends_bearer_account_and_originator_headers() {
         use std::sync::Arc;
 

--- a/crates/openwave-router/src/sse.rs
+++ b/crates/openwave-router/src/sse.rs
@@ -126,20 +126,15 @@ pub fn safe_http_error_redacting(
     sensitive_values: &[&str],
 ) -> String {
     let parsed = serde_json::from_str::<serde_json::Value>(body).ok();
-    let error = parsed
-        .as_ref()
-        .map(|value| value.get("error").unwrap_or(value));
-    let raw_code = error
-        .and_then(|error| error.get("type").or_else(|| error.get("code")))
-        .and_then(serde_json::Value::as_str);
+    let raw_code = parsed.as_ref().and_then(provider_error_code);
     let code = raw_code
         .filter(|code| safe_error_code(code) && !contains_sensitive_value(code, sensitive_values));
     let message = raw_code
         .is_none_or(safe_error_code)
         .then(|| {
-            error
-                .and_then(|error| error.get("message"))
-                .and_then(serde_json::Value::as_str)
+            parsed
+                .as_ref()
+                .and_then(provider_error_message)
                 .and_then(|message| safe_error_message(message, sensitive_values))
         })
         .flatten();
@@ -153,6 +148,69 @@ pub fn safe_http_error_redacting(
         result.push_str(&message);
     }
     result
+}
+
+/// Extract the stable enum-like identifier from provider JSON.
+///
+/// OpenAI's public API normally nests this under `error`, while its adjacent
+/// gateways also use top-level and `detail` envelopes. Check every candidate
+/// independently: a present-but-null `code` must not hide a useful `type`.
+fn provider_error_code(value: &serde_json::Value) -> Option<&str> {
+    let error = value.get("error").filter(|error| error.is_object());
+    let detail = value.get("detail").filter(|detail| detail.is_object());
+    [error, detail, Some(value)]
+        .into_iter()
+        .flatten()
+        .flat_map(|container| [container.get("type"), container.get("code")])
+        .flatten()
+        .find_map(serde_json::Value::as_str)
+        .or_else(|| {
+            value
+                .get("error")
+                .and_then(serde_json::Value::as_str)
+                .filter(|code| safe_error_code(code))
+        })
+}
+
+/// Prefer the provider's specific `code` for behavioral classification, then
+/// fall back to its broader `type`.
+fn provider_error_classification_code(value: &serde_json::Value) -> Option<&str> {
+    let error = value.get("error").filter(|error| error.is_object());
+    let detail = value.get("detail").filter(|detail| detail.is_object());
+    [error, detail, Some(value)]
+        .into_iter()
+        .flatten()
+        .flat_map(|container| [container.get("code"), container.get("type")])
+        .flatten()
+        .find_map(serde_json::Value::as_str)
+        .or_else(|| {
+            value
+                .get("error")
+                .and_then(serde_json::Value::as_str)
+                .filter(|code| safe_error_code(code))
+        })
+}
+
+/// Extract a human diagnostic from the bounded provider body.
+///
+/// In addition to the canonical `{ "error": { "message": ... } }` shape,
+/// OpenAI-facing services return top-level `message`, string `error`, string
+/// `detail`, and OAuth-style `error_description` fields. Only this selected
+/// scalar is considered; arrays and arbitrary JSON are never rendered.
+fn provider_error_message(value: &serde_json::Value) -> Option<&str> {
+    let error = value.get("error");
+    let detail = value.get("detail");
+    [
+        error.and_then(|error| error.get("message")),
+        value.get("message"),
+        detail.and_then(|detail| detail.get("message")),
+        detail.filter(|detail| detail.is_string()),
+        value.get("error_description"),
+        error.filter(|error| error.is_string()),
+    ]
+    .into_iter()
+    .flatten()
+    .find_map(serde_json::Value::as_str)
 }
 
 /// Classify an error delivered *inside* a 200 stream — the in-band counterpart
@@ -373,16 +431,13 @@ pub fn classify_provider_error_redacting(
     use openwave_core::error::{AgentError, ProviderFailure};
 
     let parsed = serde_json::from_str::<serde_json::Value>(body).ok();
-    let error = parsed
+    let code = parsed
         .as_ref()
-        .map(|value| value.get("error").unwrap_or(value));
-    let code = error
-        .and_then(|error| error.get("code").or_else(|| error.get("type")))
-        .and_then(serde_json::Value::as_str)
+        .and_then(provider_error_classification_code)
         .unwrap_or("");
-    let message = error
-        .and_then(|error| error.get("message"))
-        .and_then(serde_json::Value::as_str)
+    let message = parsed
+        .as_ref()
+        .and_then(provider_error_message)
         .unwrap_or("");
     let safe = || safe_http_error_redacting(provider, status, body, sensitive_values);
 
@@ -597,6 +652,54 @@ mod tests {
         assert_eq!(
             safe_http_error("gemini", 400, secret),
             "gemini returned 400"
+        );
+    }
+
+    #[test]
+    fn safe_http_error_handles_openai_adjacent_error_envelopes() {
+        assert_eq!(
+            safe_http_error(
+                "openai",
+                400,
+                r#"{"error":{"message":"Unsupported parameter: temperature","type":"invalid_request_error","param":"temperature","code":null}}"#,
+            ),
+            "openai returned 400 (invalid_request_error): Unsupported parameter: temperature"
+        );
+        assert_eq!(
+            safe_http_error(
+                "openai",
+                400,
+                r#"{"detail":"Model gpt-example is not available for this account"}"#,
+            ),
+            "openai returned 400: Model gpt-example is not available for this account"
+        );
+        assert_eq!(
+            safe_http_error(
+                "openai",
+                400,
+                r#"{"error":"invalid_request","error_description":"The requested model is unavailable"}"#,
+            ),
+            "openai returned 400 (invalid_request): The requested model is unavailable"
+        );
+    }
+
+    #[test]
+    fn safe_http_error_redacts_fallback_openai_messages() {
+        assert_eq!(
+            safe_http_error(
+                "openai",
+                400,
+                r#"{"detail":"Request rejected for bearer sk-secret"}"#,
+            ),
+            "openai returned 400"
+        );
+        assert_eq!(
+            safe_http_error(
+                "openai",
+                400,
+                r#"{"detail":[{"msg":"echoed request must not be rendered"}]}"#,
+            ),
+            "openai returned 400"
         );
     }
 

--- a/crates/openwave-router/tests/fixtures/openai/detail_error.response.json
+++ b/crates/openwave-router/tests/fixtures/openai/detail_error.response.json
@@ -1,0 +1,3 @@
+{
+  "detail": "The requested model is not available for this account."
+}


### PR DESCRIPTION
## Summary

- append fragmented Anthropic `signature_delta` values before persisting or replaying signed reasoning blocks
- cover durable reasoning replay through parallel tool results and raw `pause_turn` continuation
- surface bounded, redaction-safe diagnostics from additional OpenAI error envelopes without rendering arbitrary response bodies
- preserve specific provider error codes for behavioral classification while retaining stable display codes

## Why

Anthropic can split a thinking signature across multiple stream events. Replacing rather than appending those fragments corrupted the signed block and caused the next tool-loop continuation to fail with an invalid-request error. Separately, valid OpenAI-facing 400 envelopes such as string `detail` responses lost their useful diagnostic and surfaced only `openai returned 400`.

## Verification

- `cargo fmt --all --check`
- `cargo test -p openwave-router --lib --locked` (159 passed)
- `cargo test -p openwave-router --test replay_contracts --locked` (9 passed)
- fresh adversarial reviews found no P1/P2 findings

Closes #1891
Closes #1892