### PR TITLE
fix(desktop): make updates and debug exports fail safely

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4461,6 +4461,7 @@ dependencies = [
  "cap-std",
  "chrono",
  "futures",
+ "libc",
  "openwave-code-execution",
  "openwave-core",
  "openwave-host-broker",

--- a/crates/openwave-desktop/Cargo.toml
+++ b/crates/openwave-desktop/Cargo.toml
@@ -67,3 +67,6 @@ tauri-plugin-single-instance = { version = "=2.4.3", features = ["deep-link"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_SystemServices"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+libc.workspace = true

--- a/crates/openwave-desktop/Cargo.toml
+++ b/crates/openwave-desktop/Cargo.toml
@@ -66,4 +66,4 @@ zip.workspace = true
 tauri-plugin-single-instance = { version = "=2.4.3", features = ["deep-link"] }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }
+windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_SystemServices"] }

--- a/crates/openwave-desktop/src/broker.rs
+++ b/crates/openwave-desktop/src/broker.rs
@@ -49,7 +49,17 @@ const MINIMAL_ENV_KEYS: &[&str] = &[
 /// Serializes the synchronous sidecar protocol behind one lazy child process.
 pub(crate) struct BrokerClient {
     commands: mpsc::Sender<BrokerCommand>,
+    admission: StdMutex<BrokerAdmission>,
     task: StdMutex<Option<JoinHandle<()>>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BrokerAdmission {
+    Running,
+    Quiescing,
+    Quiesced,
+    Resuming,
+    Shutdown,
 }
 
 impl BrokerClient {
@@ -63,11 +73,13 @@ impl BrokerClient {
                 execute_commands: openwave_code_execution::LocalExecutionProvider::availability()
                     .is_ok(),
                 session: None,
+                allow_session_start: true,
             }
             .run(receiver),
         );
         Self {
             commands,
+            admission: StdMutex::new(BrokerAdmission::Running),
             task: StdMutex::new(Some(task)),
         }
     }
@@ -96,14 +108,12 @@ impl BrokerClient {
         dispatch_deadline: Option<Instant>,
     ) -> Result<ControlResult, BrokerClientError> {
         let (reply, result) = oneshot::channel();
-        self.commands
-            .try_send(BrokerCommand::Control {
-                request,
-                retry,
-                dispatch_deadline,
-                reply,
-            })
-            .map_err(map_admission_error)?;
+        self.admit(BrokerCommand::Control {
+            request,
+            retry,
+            dispatch_deadline,
+            reply,
+        })?;
         result.await.map_err(|_| BrokerClientError::Closed)?
     }
 
@@ -112,13 +122,128 @@ impl BrokerClient {
         envelope: OperationEnvelope,
     ) -> Result<OperationResult, BrokerClientError> {
         let (reply, result) = oneshot::channel();
-        self.commands
-            .try_send(BrokerCommand::Operation { envelope, reply })
-            .map_err(map_admission_error)?;
+        self.admit(BrokerCommand::Operation { envelope, reply })?;
         result.await.map_err(|_| BrokerClientError::Closed)?
     }
 
+    fn admit(&self, command: BrokerCommand) -> Result<(), BrokerClientError> {
+        let admission = self
+            .admission
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if *admission != BrokerAdmission::Running {
+            return Err(BrokerClientError::Quiesced);
+        }
+        // Keep the admission lock through enqueue. Once quiesce changes the
+        // state, every accepted command is already ordered before its barrier.
+        self.commands.try_send(command).map_err(map_admission_error)
+    }
+
+    /// Close admission, drain every command accepted before the barrier, and
+    /// pin an old-bundle sidecar process across app replacement.
+    pub(crate) async fn quiesce_for_update(&self) -> Result<(), BrokerClientError> {
+        self.begin_transition(BrokerAdmission::Running, BrokerAdmission::Quiescing)?;
+        let (reply, result) = oneshot::channel();
+        if self
+            .commands
+            .send(BrokerCommand::Quiesce { reply })
+            .await
+            .is_err()
+        {
+            self.set_admission(BrokerAdmission::Shutdown);
+            return Err(BrokerClientError::Closed);
+        }
+        let result = match result.await {
+            Ok(result) => result,
+            Err(_) => {
+                self.set_admission(BrokerAdmission::Shutdown);
+                return Err(BrokerClientError::Closed);
+            }
+        };
+        match result {
+            Ok(()) => {
+                if self.finish_transition(BrokerAdmission::Quiescing, BrokerAdmission::Quiesced) {
+                    Ok(())
+                } else {
+                    Err(BrokerClientError::Closed)
+                }
+            }
+            Err(error) => {
+                self.finish_transition(BrokerAdmission::Quiescing, BrokerAdmission::Running);
+                Err(error)
+            }
+        }
+    }
+
+    /// Reopen admission after installation failed, but keep the worker pinned
+    /// to the old sidecar process. If that process later dies, host operations
+    /// fail safely until relaunch instead of resolving a binary from a bundle
+    /// the failed installer may have partially replaced.
+    pub(crate) async fn resume_after_failed_update(&self) -> Result<(), BrokerClientError> {
+        self.begin_transition(BrokerAdmission::Quiesced, BrokerAdmission::Resuming)?;
+        let (reply, result) = oneshot::channel();
+        if self
+            .commands
+            .send(BrokerCommand::ResumeAfterFailedUpdate { reply })
+            .await
+            .is_err()
+        {
+            self.set_admission(BrokerAdmission::Shutdown);
+            return Err(BrokerClientError::Closed);
+        }
+        if result.await.is_err() {
+            self.set_admission(BrokerAdmission::Shutdown);
+            return Err(BrokerClientError::Closed);
+        }
+        if self.finish_transition(BrokerAdmission::Resuming, BrokerAdmission::Running) {
+            Ok(())
+        } else {
+            Err(BrokerClientError::Closed)
+        }
+    }
+
+    fn begin_transition(
+        &self,
+        expected: BrokerAdmission,
+        next: BrokerAdmission,
+    ) -> Result<(), BrokerClientError> {
+        let mut admission = self
+            .admission
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if *admission != expected {
+            return Err(if *admission == BrokerAdmission::Shutdown {
+                BrokerClientError::Closed
+            } else {
+                BrokerClientError::Quiesced
+            });
+        }
+        *admission = next;
+        Ok(())
+    }
+
+    fn finish_transition(&self, expected: BrokerAdmission, next: BrokerAdmission) -> bool {
+        let mut admission = self
+            .admission
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if *admission == expected {
+            *admission = next;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn set_admission(&self, next: BrokerAdmission) {
+        *self
+            .admission
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = next;
+    }
+
     pub(crate) async fn shutdown(&self) {
+        self.set_admission(BrokerAdmission::Shutdown);
         let (reply, finished) = oneshot::channel();
         let acknowledged = matches!(
             timeout(SHUTDOWN_TIMEOUT + SHUTDOWN_TIMEOUT, async {
@@ -156,6 +281,12 @@ enum BrokerCommand {
         envelope: OperationEnvelope,
         reply: oneshot::Sender<Result<OperationResult, BrokerClientError>>,
     },
+    Quiesce {
+        reply: oneshot::Sender<Result<(), BrokerClientError>>,
+    },
+    ResumeAfterFailedUpdate {
+        reply: oneshot::Sender<()>,
+    },
     Shutdown {
         reply: oneshot::Sender<()>,
     },
@@ -174,6 +305,7 @@ struct BrokerWorker {
     home_dir: PathBuf,
     execute_commands: bool,
     session: Option<Session>,
+    allow_session_start: bool,
 }
 
 impl BrokerWorker {
@@ -202,6 +334,19 @@ impl BrokerWorker {
                             ExchangeResult::Control(_) => Err(BrokerClientError::Protocol),
                         });
                     let _ = reply.send(result);
+                }
+                BrokerCommand::Quiesce { reply } => {
+                    // The command itself is the queue barrier. Admission was
+                    // closed before it was enqueued, so all earlier work and
+                    // any retry it performs have completed. Starting here is
+                    // still from the old bundle and gives a failed install a
+                    // coherent process to resume without path resolution.
+                    let result = self.ensure_session().await.map(|_| ());
+                    let _ = reply.send(result);
+                }
+                BrokerCommand::ResumeAfterFailedUpdate { reply } => {
+                    self.allow_session_start = false;
+                    let _ = reply.send(());
                 }
                 BrokerCommand::Shutdown { reply } => {
                     self.stop_session().await;
@@ -261,17 +406,7 @@ impl BrokerWorker {
         if dispatch_deadline.is_some_and(|deadline| Instant::now() >= deadline) {
             return Err(BrokerClientError::DispatchExpired);
         }
-        if self.session.is_none() {
-            self.session = Some(
-                Session::start(
-                    &self.app,
-                    &self.data_dir,
-                    &self.home_dir,
-                    self.execute_commands,
-                )
-                .await?,
-            );
-        }
+        self.ensure_session().await?;
         if dispatch_deadline.is_some_and(|deadline| Instant::now() >= deadline) {
             return Err(BrokerClientError::DispatchExpired);
         }
@@ -297,6 +432,24 @@ impl BrokerWorker {
             self.stop_session().await;
         }
         result
+    }
+
+    async fn ensure_session(&mut self) -> Result<&mut Session, BrokerClientError> {
+        if self.session.is_none() {
+            if !self.allow_session_start {
+                return Err(BrokerClientError::UpdateRecovery);
+            }
+            self.session = Some(
+                Session::start(
+                    &self.app,
+                    &self.data_dir,
+                    &self.home_dir,
+                    self.execute_commands,
+                )
+                .await?,
+            );
+        }
+        Ok(self.session.as_mut().expect("session initialized"))
     }
 
     async fn stop_session(&mut self) {
@@ -523,6 +676,10 @@ pub(crate) enum BrokerClientError {
     Start,
     #[error("host broker is busy; try again")]
     Busy,
+    #[error("host broker is paused while OpenWave updates")]
+    Quiesced,
+    #[error("host broker is unavailable until OpenWave restarts after a failed update")]
+    UpdateRecovery,
     #[error("host broker mutation could not start before its authority deadline")]
     DispatchExpired,
     #[error("host broker connection closed")]
@@ -569,6 +726,53 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn quiesce_closes_admission_before_its_queue_barrier() {
+        let (commands, mut receiver) = mpsc::channel(COMMAND_QUEUE_CAPACITY);
+        let client = BrokerClient {
+            commands,
+            admission: StdMutex::new(BrokerAdmission::Running),
+            task: StdMutex::new(None),
+        };
+        let (first_reply, _first_finished) = oneshot::channel();
+        client
+            .admit(BrokerCommand::Shutdown { reply: first_reply })
+            .unwrap();
+        client
+            .begin_transition(BrokerAdmission::Running, BrokerAdmission::Quiescing)
+            .unwrap();
+        let (barrier_reply, _barrier_finished) = oneshot::channel();
+        client
+            .commands
+            .try_send(BrokerCommand::Quiesce {
+                reply: barrier_reply,
+            })
+            .unwrap();
+        let (late_reply, _late_finished) = oneshot::channel();
+        assert!(matches!(
+            client.admit(BrokerCommand::Shutdown { reply: late_reply }),
+            Err(BrokerClientError::Quiesced)
+        ));
+
+        assert!(matches!(
+            receiver.try_recv(),
+            Ok(BrokerCommand::Shutdown { .. })
+        ));
+        assert!(matches!(
+            receiver.try_recv(),
+            Ok(BrokerCommand::Quiesce { .. })
+        ));
+        assert!(receiver.try_recv().is_err());
+
+        client.set_admission(BrokerAdmission::Shutdown);
+        assert!(!client.finish_transition(BrokerAdmission::Quiescing, BrokerAdmission::Quiesced));
+    }
+
+    #[test]
+    fn failed_update_recovery_never_retries_into_a_new_sidecar() {
+        assert!(!BrokerClientError::UpdateRecovery.retryable_control());
+    }
 
     #[test]
     fn validates_channel_version_and_correlation() {

--- a/crates/openwave-desktop/src/chat_debug.rs
+++ b/crates/openwave-desktop/src/chat_debug.rs
@@ -382,8 +382,13 @@ fn redact_private_key_blocks(input: &str) -> String {
         let label_start = begin + BEGIN.len();
         let line_end = find_line_end(input, label_start);
         let Some(relative_label_end) = input[label_start..line_end].find(MARKER_END) else {
-            // Preserve the malformed candidate, but resume searching after its
-            // prefix so it cannot consume a later valid BEGIN marker.
+            // A damaged private-key BEGIN marker must redact its body through
+            // EOF. A non-private marker still yields to a later valid key.
+            if input[label_start..line_end].contains("PRIVATE KEY") {
+                out.push_str(&input[cursor..begin]);
+                out.push_str(REDACTED);
+                return out;
+            }
             out.push_str(&input[cursor..label_start]);
             cursor = label_start;
             continue;
@@ -435,9 +440,7 @@ fn redact_credential_urls(input: &str) -> String {
             continue;
         }
 
-        let url_end = input[separator + 3..]
-            .find(is_url_boundary)
-            .map_or(input.len(), |offset| separator + 3 + offset);
+        let url_end = find_url_end(input, separator + 3);
         let candidate = &input[scheme_start..url_end];
         let has_credentials = url::Url::parse(candidate)
             .ok()
@@ -453,6 +456,21 @@ fn redact_credential_urls(input: &str) -> String {
 
     out.push_str(&input[cursor..]);
     out
+}
+
+/// Find a URL boundary without mistaking brackets around an IPv6 authority
+/// host for surrounding prose delimiters.
+fn find_url_end(input: &str, authority_start: usize) -> usize {
+    let mut in_ipv6_host = false;
+    for (offset, character) in input[authority_start..].char_indices() {
+        match character {
+            '[' => in_ipv6_host = true,
+            ']' if in_ipv6_host => in_ipv6_host = false,
+            _ if !in_ipv6_host && is_url_boundary(character) => return authority_start + offset,
+            _ => {}
+        }
+    }
+    input.len()
 }
 
 const fn is_url_scheme_char(character: char) -> bool {
@@ -1073,6 +1091,8 @@ fn write_bundle(destination: &Path, content: &[u8]) -> Result<(), String> {
             }
             directory.open_with(&temporary, &options)?
         };
+        #[cfg(target_os = "macos")]
+        clear_macos_extended_acl(&file)?;
         file.write_all(content)?;
         file.sync_all()?;
         drop(file);
@@ -1085,6 +1105,72 @@ fn write_bundle(destination: &Path, content: &[u8]) -> Result<(), String> {
         let _ = directory.remove_file(&temporary);
     }
     result.map_err(|_| "Could not write the debug bundle".to_owned())
+}
+
+/// macOS inherits extended ACL entries even when the new file has mode 0600.
+/// Clear and verify them before sensitive content reaches the file.
+#[cfg(target_os = "macos")]
+fn clear_macos_extended_acl(file: &cap_std::fs::File) -> std::io::Result<()> {
+    use std::os::fd::AsRawFd as _;
+
+    let acl = unsafe { acl_init(1) };
+    if acl.is_null() {
+        return Err(std::io::Error::last_os_error());
+    }
+    let status = unsafe { acl_set_fd_np(file.as_raw_fd(), acl, ACL_TYPE_EXTENDED) };
+    unsafe { acl_free(acl) };
+    if status != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if macos_file_has_extended_acl(file)? {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "the selected filesystem did not clear inherited export ACLs",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn macos_file_has_extended_acl(file: &cap_std::fs::File) -> std::io::Result<bool> {
+    use std::os::fd::AsRawFd as _;
+
+    let acl = unsafe { acl_get_fd_np(file.as_raw_fd(), ACL_TYPE_EXTENDED) };
+    if acl.is_null() {
+        let error = std::io::Error::last_os_error();
+        return if error.raw_os_error() == Some(libc::ENOENT) {
+            Ok(false)
+        } else {
+            Err(error)
+        };
+    }
+    let mut entry = std::ptr::null_mut();
+    let status = unsafe { acl_get_entry(acl, ACL_FIRST_ENTRY, &mut entry) };
+    unsafe { acl_free(acl) };
+    match status {
+        0 => Ok(true),
+        1 => Ok(false),
+        _ => Err(std::io::Error::last_os_error()),
+    }
+}
+
+#[cfg(target_os = "macos")]
+const ACL_TYPE_EXTENDED: libc::c_int = 0x0000_0100;
+#[cfg(target_os = "macos")]
+const ACL_FIRST_ENTRY: libc::c_int = 0;
+
+#[cfg(target_os = "macos")]
+unsafe extern "C" {
+    fn acl_init(count: libc::c_int) -> *mut libc::c_void;
+    fn acl_free(acl: *mut libc::c_void) -> libc::c_int;
+    fn acl_set_fd_np(fd: libc::c_int, acl: *mut libc::c_void, acl_type: libc::c_int)
+        -> libc::c_int;
+    fn acl_get_fd_np(fd: libc::c_int, acl_type: libc::c_int) -> *mut libc::c_void;
+    fn acl_get_entry(
+        acl: *mut libc::c_void,
+        entry_id: libc::c_int,
+        entry: *mut *mut libc::c_void,
+    ) -> libc::c_int;
 }
 
 /// Create the temporary export with a protected DACL before any sensitive byte
@@ -1540,9 +1626,18 @@ mod tests {
             "-----BEGIN CERTIFICATE\ntruncated\n[redacted]"
         );
 
+        let damaged_private = "-----BEGIN PRIVATE KEY\nLIVEPRIVATEKEYBODY";
+        assert_eq!(scrub_credentials(damaged_private), "[redacted]");
+
         let password = "correct-horse-battery-staple";
         let connection = format!("database=postgres://alice:{password}@db.example.test/openwave");
         assert_eq!(scrub_credentials(&connection), "database=[redacted]");
+
+        let ipv4_connection = format!("database=postgres://alice:{password}@127.0.0.1/openwave");
+        assert_eq!(scrub_credentials(&ipv4_connection), "database=[redacted]");
+
+        let ipv6_connection = format!("database=postgres://alice:{password}@[::1]/openwave");
+        assert_eq!(scrub_credentials(&ipv6_connection), "database=[redacted]");
 
         let token_url = "remote=https://ghp_abcdefghijklmnopqrstuvwxyz@github.com/openwave.git";
         assert_eq!(scrub_credentials(token_url), "remote=[redacted]");
@@ -1551,6 +1646,29 @@ mod tests {
             scrub_credentials("docs=https://example.test/reference"),
             "docs=https://example.test/reference"
         );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn debug_bundle_export_clears_inherited_macos_acl() {
+        use std::process::Command;
+
+        let directory = tempfile::tempdir().unwrap();
+        let acl =
+            "everyone allow read,readattr,readextattr,readsecurity,file_inherit,directory_inherit";
+        assert!(Command::new("chmod")
+            .args(["+a", acl, directory.path().to_str().unwrap()])
+            .status()
+            .unwrap()
+            .success());
+
+        let destination = directory.path().join("bundle.md");
+        write_bundle(&destination, b"private").unwrap();
+        let file = Dir::open_ambient_dir(directory.path(), ambient_authority())
+            .unwrap()
+            .open("bundle.md")
+            .unwrap();
+        assert!(!macos_file_has_extended_acl(&file).unwrap());
     }
 
     #[test]

--- a/crates/openwave-desktop/src/chat_debug.rs
+++ b/crates/openwave-desktop/src/chat_debug.rs
@@ -23,8 +23,12 @@
 //! below returns provider credentials.
 
 use std::fmt::Write as _;
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
+use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
+use cap_std::ambient_authority;
+use cap_std::fs::{Dir, OpenOptions};
 use chrono::{DateTime, Utc};
 use openwave_core::event::{AgentEvent, SequencedEvent};
 use openwave_core::model::{Chat, Message, TurnRun};
@@ -133,11 +137,13 @@ const SECRET_KEY_SUFFIXES: &[&str] = &[
 /// token in a bug report, a false negative publishes a live key.
 #[must_use]
 pub(crate) fn scrub_credentials(input: &str) -> String {
+    let input = redact_private_key_blocks(input);
+    let input = redact_credential_urls(&input);
     let mut out = String::with_capacity(input.len());
     // The token that could name the value about to be read, if the separators
     // since have all been "still the same key/value pair" characters.
     let mut key: Option<String> = None;
-    let mut rest = input;
+    let mut rest = input.as_str();
     while let Some(next) = rest.chars().next() {
         if is_token_char(next) {
             let end = rest.find(|c| !is_token_char(c)).unwrap_or(rest.len());
@@ -159,6 +165,102 @@ pub(crate) fn scrub_credentials(input: &str) -> String {
         }
     }
     out
+}
+
+/// Remove complete PEM/OpenSSH/PGP private-key blocks before token scanning.
+/// Their base64 bodies have no vendor prefix, and JSON rendering may represent
+/// their newlines as `\n`, so line-based token heuristics cannot recognize them
+/// reliably. An unterminated block is redacted through EOF rather than risking
+/// disclosure of a damaged or partially copied key.
+fn redact_private_key_blocks(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut cursor = 0;
+    const BEGIN: &str = "-----BEGIN ";
+    const MARKER_END: &str = "-----";
+
+    while let Some(relative_begin) = input[cursor..].find(BEGIN) {
+        let begin = cursor + relative_begin;
+        let label_start = begin + BEGIN.len();
+        let Some(relative_label_end) = input[label_start..].find(MARKER_END) else {
+            break;
+        };
+        let label_end = label_start + relative_label_end;
+        let label = &input[label_start..label_end];
+        let begin_end = label_end + MARKER_END.len();
+        if !label.contains("PRIVATE KEY") {
+            out.push_str(&input[cursor..begin_end]);
+            cursor = begin_end;
+            continue;
+        }
+
+        out.push_str(&input[cursor..begin]);
+        out.push_str(REDACTED);
+        let end_marker = format!("-----END {label}-----");
+        let Some(relative_end) = input[begin_end..].find(&end_marker) else {
+            return out;
+        };
+        cursor = begin_end + relative_end + end_marker.len();
+    }
+
+    out.push_str(&input[cursor..]);
+    out
+}
+
+/// Redact URLs whose authority embeds userinfo. Database, message-broker,
+/// proxy, and ordinary HTTP URLs all use this standard syntax for passwords or
+/// bearer tokens, and retaining the hostname is less important than making a
+/// copied connection string safe to share.
+fn redact_credential_urls(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut cursor = 0;
+
+    while let Some(relative_separator) = input[cursor..].find("://") {
+        let separator = cursor + relative_separator;
+        let scheme_start = input[..separator]
+            .rfind(|character: char| !is_url_scheme_char(character))
+            .map_or(0, |index| index + 1);
+        let scheme = &input[scheme_start..separator];
+        if scheme.is_empty()
+            || !scheme
+                .chars()
+                .next()
+                .is_some_and(|character| character.is_ascii_alphabetic())
+        {
+            out.push_str(&input[cursor..separator + 3]);
+            cursor = separator + 3;
+            continue;
+        }
+
+        let url_end = input[separator + 3..]
+            .find(is_url_boundary)
+            .map_or(input.len(), |offset| separator + 3 + offset);
+        let candidate = &input[scheme_start..url_end];
+        let has_credentials = url::Url::parse(candidate)
+            .ok()
+            .is_some_and(|url| !url.username().is_empty() || url.password().is_some());
+        if has_credentials {
+            out.push_str(&input[cursor..scheme_start]);
+            out.push_str(REDACTED);
+        } else {
+            out.push_str(&input[cursor..url_end]);
+        }
+        cursor = url_end;
+    }
+
+    out.push_str(&input[cursor..]);
+    out
+}
+
+const fn is_url_scheme_char(character: char) -> bool {
+    character.is_ascii_alphanumeric() || matches!(character, '+' | '-' | '.')
+}
+
+const fn is_url_boundary(character: char) -> bool {
+    character.is_ascii_whitespace()
+        || matches!(
+            character,
+            '"' | '\'' | '<' | '>' | '(' | ')' | '[' | ']' | '{' | '}' | '`' | '\\'
+        )
 }
 
 /// Whether a character continues the current token. `:` and `=` are excluded
@@ -280,9 +382,9 @@ fn render_header(
     let _ = writeln!(
         out,
         "This bundle contains the full conversation — every message, tool \
-         argument, tool result, and file path in this chat. API keys and \
-         other credential-shaped tokens are removed; nothing else is. Read \
-         it before sharing it.\n",
+         argument, tool result, and file path in this chat. Credential \
+         redaction is best-effort, including common tokens, credential URLs, \
+         and private-key blocks. Read the entire bundle before sharing it.\n",
     );
     let _ = writeln!(out, "## Chat\n");
     let _ = writeln!(out, "| Field | Value |");
@@ -760,7 +862,46 @@ fn write_bundle(destination: &Path, content: &[u8]) -> Result<(), String> {
     if !destination.is_absolute() {
         return Err("The save destination is invalid".to_owned());
     }
-    std::fs::write(destination, content).map_err(|_| "Could not write the debug bundle".to_owned())
+    let parent = destination
+        .parent()
+        .ok_or_else(|| "The save destination is invalid".to_owned())?;
+    let filename = destination
+        .file_name()
+        .ok_or_else(|| "The save destination is invalid".to_owned())?;
+    let directory = Dir::open_ambient_dir(parent, ambient_authority())
+        .map_err(|_| "Could not open the selected folder".to_owned())?;
+    match directory.symlink_metadata(filename) {
+        Ok(metadata) if metadata.is_file() && !metadata.file_type().is_symlink() => {}
+        Ok(_) => return Err("The selected destination is not a regular file".to_owned()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(_) => return Err("Could not inspect the selected destination".to_owned()),
+    }
+
+    let temporary = format!(".openwave-debug-export-{}.tmp", Uuid::new_v4());
+    let result = (|| -> std::io::Result<()> {
+        let mut options = OpenOptions::new();
+        options
+            .write(true)
+            .create_new(true)
+            .follow(FollowSymlinks::No);
+        #[cfg(unix)]
+        {
+            use cap_std::fs::OpenOptionsExt as _;
+            options.mode(0o600);
+        }
+        let mut file = directory.open_with(&temporary, &options)?;
+        file.write_all(content)?;
+        file.sync_all()?;
+        drop(file);
+        directory.rename(&temporary, &directory, filename)?;
+        #[cfg(unix)]
+        directory.open(".")?.sync_all()?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = directory.remove_file(&temporary);
+    }
+    result.map_err(|_| "Could not write the debug bundle".to_owned())
 }
 
 #[cfg(test)]
@@ -1011,6 +1152,88 @@ mod tests {
             "dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk",
         );
         assert_eq!(scrub_credentials(&jwt), "[redacted]");
+    }
+
+    #[test]
+    fn private_key_blocks_and_credential_urls_are_redacted() {
+        for label in [
+            "PRIVATE KEY",
+            "RSA PRIVATE KEY",
+            "OPENSSH PRIVATE KEY",
+            "PGP PRIVATE KEY BLOCK",
+        ] {
+            let begin = format!("-----BEGIN {label}-----");
+            let end = format!("-----END {label}-----");
+            let private_key = format!("before\n{begin}\nopaque-key-material\n{end}\nafter");
+            assert_eq!(
+                scrub_credentials(&private_key),
+                "before\n[redacted]\nafter",
+                "redacting {label}"
+            );
+        }
+
+        let begin = format!("-----BEGIN {} KEY-----", "OPENSSH PRIVATE");
+        let unterminated = format!("before\n{begin}\nopaque-key-material");
+        assert_eq!(scrub_credentials(&unterminated), "before\n[redacted]");
+
+        let escaped = r#"{"output":"-----BEGIN PRIVATE KEY-----\nopaque-key-material\n-----END PRIVATE KEY-----"}"#;
+        assert_eq!(scrub_credentials(escaped), r#"{"output":"[redacted]"}"#);
+
+        let password = "correct-horse-battery-staple";
+        let connection = format!("database=postgres://alice:{password}@db.example.test/openwave");
+        assert_eq!(scrub_credentials(&connection), "database=[redacted]");
+
+        let token_url = "remote=https://ghp_abcdefghijklmnopqrstuvwxyz@github.com/openwave.git";
+        assert_eq!(scrub_credentials(token_url), "remote=[redacted]");
+
+        assert_eq!(
+            scrub_credentials("docs=https://example.test/reference"),
+            "docs=https://example.test/reference"
+        );
+    }
+
+    #[test]
+    fn debug_bundle_export_is_private_and_atomic() {
+        let directory = tempfile::tempdir().unwrap();
+        let destination = directory.path().join("bundle.md");
+        write_bundle(&destination, b"first").unwrap();
+        assert_eq!(std::fs::read(&destination).unwrap(), b"first");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(&destination, std::fs::Permissions::from_mode(0o644)).unwrap();
+        }
+        write_bundle(&destination, b"replacement").unwrap();
+        assert_eq!(std::fs::read(&destination).unwrap(), b"replacement");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            assert_eq!(
+                std::fs::metadata(&destination)
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn debug_bundle_export_rejects_destination_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("target.md");
+        let destination = directory.path().join("bundle.md");
+        std::fs::write(&target, b"private target").unwrap();
+        symlink(&target, &destination).unwrap();
+
+        assert!(write_bundle(&destination, b"replacement").is_err());
+        assert_eq!(std::fs::read(&target).unwrap(), b"private target");
     }
 
     /// The scrubber runs over the rendered document, not only over the

--- a/crates/openwave-desktop/src/chat_debug.rs
+++ b/crates/openwave-desktop/src/chat_debug.rs
@@ -139,28 +139,227 @@ const SECRET_KEY_SUFFIXES: &[&str] = &[
 pub(crate) fn scrub_credentials(input: &str) -> String {
     let input = redact_private_key_blocks(input);
     let input = redact_credential_urls(&input);
+    let input = redact_keyed_values(&input);
+    redact_intrinsic_tokens(&input)
+}
+
+/// Redact the complete scalar introduced by a credential key. Treating a
+/// keyed value as one token is unsafe: authorization schemes and quoted shell,
+/// JSON, or TOML values can all contain spaces and punctuation.
+fn redact_keyed_values(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
-    // The token that could name the value about to be read, if the separators
-    // since have all been "still the same key/value pair" characters.
-    let mut key: Option<String> = None;
-    let mut rest = input.as_str();
+    let mut copied_through = 0;
+    let mut cursor = 0;
+
+    while cursor < input.len() {
+        let next = input[cursor..]
+            .chars()
+            .next()
+            .expect("cursor remains on a character boundary");
+        if !is_token_char(next) {
+            cursor += next.len_utf8();
+            continue;
+        }
+        let token_end = input[cursor..]
+            .find(|character| !is_token_char(character))
+            .map_or(input.len(), |offset| cursor + offset);
+        let key = input[cursor..token_end].to_ascii_lowercase();
+        if is_secret_key_name(&key) {
+            if let Some(value) = keyed_value(input, token_end, &key) {
+                if let Some(redacted) = redact_scalar(&key, &input[value.start..value.end]) {
+                    out.push_str(&input[copied_through..value.start]);
+                    out.push_str(&redacted);
+                    copied_through = value.end;
+                    cursor = value.end;
+                    continue;
+                }
+            }
+        }
+        cursor = token_end;
+    }
+
+    out.push_str(&input[copied_through..]);
+    out
+}
+
+#[derive(Clone, Copy)]
+struct ScalarRange {
+    start: usize,
+    end: usize,
+}
+
+fn keyed_value(input: &str, key_end: usize, key: &str) -> Option<ScalarRange> {
+    let mut cursor = key_end;
+    cursor = skip_horizontal_space(input, cursor);
+    cursor = skip_quote_delimiter(input, cursor);
+    cursor = skip_horizontal_space(input, cursor);
+    let delimiter = input[cursor..].chars().next()?;
+    if !matches!(delimiter, ':' | '=') {
+        return None;
+    }
+    cursor += delimiter.len_utf8();
+    cursor = skip_horizontal_space(input, cursor);
+
+    if input[cursor..].starts_with("\\\"") || input[cursor..].starts_with("\\'") {
+        let quote = input[cursor + 1..]
+            .chars()
+            .next()
+            .expect("escaped quote exists");
+        let start = cursor + 2;
+        let end = find_rendered_quote(input, start, quote).unwrap_or(input.len());
+        return Some(ScalarRange { start, end });
+    }
+    if matches!(input[cursor..].chars().next(), Some('"' | '\'')) {
+        let quote = input[cursor..].chars().next().expect("quote exists");
+        let start = cursor + quote.len_utf8();
+        let end = find_unescaped_quote(input, start, quote).unwrap_or(input.len());
+        return Some(ScalarRange { start, end });
+    }
+
+    let end = if delimiter == ':' || is_authorization_key(key) {
+        find_line_end(input, cursor)
+    } else {
+        input[cursor..]
+            .find(is_unquoted_value_boundary)
+            .map_or(input.len(), |offset| cursor + offset)
+    };
+    Some(ScalarRange { start: cursor, end })
+}
+
+fn skip_horizontal_space(input: &str, mut cursor: usize) -> usize {
+    while matches!(input[cursor..].chars().next(), Some(' ' | '\t')) {
+        cursor += 1;
+    }
+    cursor
+}
+
+fn skip_quote_delimiter(input: &str, cursor: usize) -> usize {
+    if input[cursor..].starts_with("\\\"") || input[cursor..].starts_with("\\'") {
+        cursor + 2
+    } else if matches!(input[cursor..].chars().next(), Some('"' | '\'')) {
+        cursor + 1
+    } else {
+        cursor
+    }
+}
+
+fn find_unescaped_quote(input: &str, start: usize, quote: char) -> Option<usize> {
+    let mut backslashes = 0;
+    for (offset, character) in input[start..].char_indices() {
+        if character == quote && backslashes % 2 == 0 {
+            return Some(start + offset);
+        }
+        if character == '\\' {
+            backslashes += 1;
+        } else {
+            backslashes = 0;
+        }
+    }
+    None
+}
+
+/// Find the closing quote in text that has itself been escaped for rendering,
+/// such as `\"password\": \"value\"`. A quote preceded by three or more
+/// backslashes is content escaped inside that scalar, not its terminator.
+fn find_rendered_quote(input: &str, start: usize, quote: char) -> Option<usize> {
+    let mut backslashes = 0;
+    for (offset, character) in input[start..].char_indices() {
+        if character == quote && backslashes == 1 {
+            return Some(start + offset - 1);
+        }
+        if character == '\\' {
+            backslashes += 1;
+        } else {
+            backslashes = 0;
+        }
+    }
+    None
+}
+
+fn find_line_end(input: &str, start: usize) -> usize {
+    let mut cursor = start;
+    while cursor < input.len() {
+        if input[cursor..].starts_with("\\n") || input[cursor..].starts_with("\\r") {
+            return cursor;
+        }
+        let character = input[cursor..]
+            .chars()
+            .next()
+            .expect("cursor remains on a character boundary");
+        if matches!(character, '\n' | '\r') {
+            return cursor;
+        }
+        cursor += character.len_utf8();
+    }
+    input.len()
+}
+
+const fn is_unquoted_value_boundary(character: char) -> bool {
+    // Unquoted `=` assignments end at shell whitespace or common collection
+    // punctuation. Values containing those characters need quotes; header and
+    // YAML-style `:` values are instead consumed through the line ending.
+    character.is_ascii_whitespace() || matches!(character, ',' | ';' | ')' | ']' | '}' | '"' | '\'')
+}
+
+fn redact_scalar(key: &str, value: &str) -> Option<String> {
+    if is_authorization_key(key) {
+        let trailing_start = value.trim_end_matches([' ', '\t']).len();
+        let (credential, trailing) = value.split_at(trailing_start);
+        let scheme_end = credential.find(char::is_whitespace);
+        if let Some(scheme_end) = scheme_end {
+            let scheme = &credential[..scheme_end];
+            let separator_end = credential[scheme_end..]
+                .find(|character: char| !character.is_whitespace())
+                .map_or(credential.len(), |offset| scheme_end + offset);
+            if is_preserved_authorization_scheme(scheme) && separator_end < credential.len() {
+                return Some(format!(
+                    "{}{}{}{}",
+                    scheme,
+                    &credential[scheme_end..separator_end],
+                    REDACTED,
+                    trailing
+                ));
+            }
+        }
+        return (!credential.is_empty()).then(|| format!("{REDACTED}{trailing}"));
+    }
+
+    (value.trim().len() >= MIN_KEYED_SECRET_LEN).then(|| REDACTED.to_owned())
+}
+
+fn is_secret_key_name(key: &str) -> bool {
+    SECRET_KEYS.contains(&key)
+        || SECRET_KEY_SUFFIXES
+            .iter()
+            .any(|suffix| key.ends_with(suffix))
+}
+
+fn is_authorization_key(key: &str) -> bool {
+    matches!(key, "authorization" | "proxy-authorization")
+}
+
+fn is_preserved_authorization_scheme(scheme: &str) -> bool {
+    matches!(
+        scheme.to_ascii_lowercase().as_str(),
+        "bearer" | "basic" | "digest" | "negotiate" | "token"
+    )
+}
+
+fn redact_intrinsic_tokens(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut rest = input;
     while let Some(next) = rest.chars().next() {
         if is_token_char(next) {
             let end = rest.find(|c| !is_token_char(c)).unwrap_or(rest.len());
             let (token, tail) = rest.split_at(end);
-            if is_secret(token, key.as_deref()) {
+            if is_intrinsic_secret(token) {
                 out.push_str(REDACTED);
-                key = None;
             } else {
                 out.push_str(token);
-                key = Some(token.to_ascii_lowercase());
             }
             rest = tail;
         } else {
             out.push(next);
-            if !matches!(next, '"' | '\'' | ':' | '=' | ' ' | '\t' | '\\') {
-                key = None;
-            }
             rest = &rest[next.len_utf8()..];
         }
     }
@@ -181,8 +380,13 @@ fn redact_private_key_blocks(input: &str) -> String {
     while let Some(relative_begin) = input[cursor..].find(BEGIN) {
         let begin = cursor + relative_begin;
         let label_start = begin + BEGIN.len();
-        let Some(relative_label_end) = input[label_start..].find(MARKER_END) else {
-            break;
+        let line_end = find_line_end(input, label_start);
+        let Some(relative_label_end) = input[label_start..line_end].find(MARKER_END) else {
+            // Preserve the malformed candidate, but resume searching after its
+            // prefix so it cannot consume a later valid BEGIN marker.
+            out.push_str(&input[cursor..label_start]);
+            cursor = label_start;
+            continue;
         };
         let label_end = label_start + relative_label_end;
         let label = &input[label_start..label_end];
@@ -271,33 +475,7 @@ const fn is_token_char(c: char) -> bool {
     c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | '+' | '/' | '~')
 }
 
-fn is_secret(token: &str, key: Option<&str>) -> bool {
-    // An HTTP auth scheme word names the credential that follows it; redacting
-    // the word itself would consume the naming and leave the actual token in
-    // the clear. `Token` is a scheme in its own right (`Authorization: Token
-    // …`), and is also a key name below.
-    if matches!(
-        token.to_ascii_lowercase().as_str(),
-        "bearer" | "basic" | "digest" | "negotiate" | "token"
-    ) {
-        return false;
-    }
-    if token.len() >= MIN_KEYED_SECRET_LEN {
-        if let Some(key) = key {
-            // `Bearer <token>` / `Basic <token>`: the scheme word names the
-            // value the same way a JSON key does.
-            if key == "bearer"
-                || key == "basic"
-                || key == "digest"
-                || SECRET_KEYS.contains(&key)
-                || SECRET_KEY_SUFFIXES
-                    .iter()
-                    .any(|suffix| key.ends_with(suffix))
-            {
-                return true;
-            }
-        }
-    }
+fn is_intrinsic_secret(token: &str) -> bool {
     if SECRET_PREFIXES.iter().any(|prefix| {
         token.starts_with(prefix) && token.len() >= prefix.len() + MIN_PREFIXED_SECRET_TAIL
     }) {
@@ -879,17 +1057,22 @@ fn write_bundle(destination: &Path, content: &[u8]) -> Result<(), String> {
 
     let temporary = format!(".openwave-debug-export-{}.tmp", Uuid::new_v4());
     let result = (|| -> std::io::Result<()> {
-        let mut options = OpenOptions::new();
-        options
-            .write(true)
-            .create_new(true)
-            .follow(FollowSymlinks::No);
-        #[cfg(unix)]
-        {
-            use cap_std::fs::OpenOptionsExt as _;
-            options.mode(0o600);
-        }
-        let mut file = directory.open_with(&temporary, &options)?;
+        #[cfg(windows)]
+        let mut file = create_private_windows_file(parent, &temporary)?;
+        #[cfg(not(windows))]
+        let mut file = {
+            let mut options = OpenOptions::new();
+            options
+                .write(true)
+                .create_new(true)
+                .follow(FollowSymlinks::No);
+            #[cfg(unix)]
+            {
+                use cap_std::fs::OpenOptionsExt as _;
+                options.mode(0o600);
+            }
+            directory.open_with(&temporary, &options)?
+        };
         file.write_all(content)?;
         file.sync_all()?;
         drop(file);
@@ -902,6 +1085,157 @@ fn write_bundle(destination: &Path, content: &[u8]) -> Result<(), String> {
         let _ = directory.remove_file(&temporary);
     }
     result.map_err(|_| "Could not write the debug bundle".to_owned())
+}
+
+/// Create the temporary export with a protected DACL before any sensitive byte
+/// is written. `OW` is the Windows Owner Rights SID; the creator owns this new
+/// file, while LocalSystem and administrators retain recovery access.
+#[cfg(windows)]
+fn create_private_windows_file(parent: &Path, temporary: &str) -> std::io::Result<std::fs::File> {
+    use std::os::windows::ffi::OsStrExt as _;
+    use std::os::windows::io::{FromRawHandle as _, RawHandle};
+
+    use windows_sys::Win32::Foundation::{
+        LocalFree, GENERIC_READ, GENERIC_WRITE, INVALID_HANDLE_VALUE,
+    };
+    use windows_sys::Win32::Security::Authorization::{
+        ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
+    };
+    use windows_sys::Win32::Security::{PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES};
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, FILE_FLAG_OPEN_REPARSE_POINT,
+        FILE_SHARE_NONE,
+    };
+
+    let path: Vec<u16> = parent
+        .join(temporary)
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let sddl: Vec<u16> = "D:P(A;;FA;;;SY)(A;;FA;;;BA)(A;;FA;;;OW)"
+        .encode_utf16()
+        .chain(std::iter::once(0))
+        .collect();
+    let mut descriptor: PSECURITY_DESCRIPTOR = std::ptr::null_mut();
+    // SAFETY: Windows owns the descriptor allocated by the conversion call;
+    // it remains live through CreateFileW and is released exactly once below.
+    unsafe {
+        if ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            sddl.as_ptr(),
+            SDDL_REVISION_1,
+            &mut descriptor,
+            std::ptr::null_mut(),
+        ) == 0
+        {
+            return Err(std::io::Error::last_os_error());
+        }
+        let attributes = SECURITY_ATTRIBUTES {
+            nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
+            lpSecurityDescriptor: descriptor,
+            bInheritHandle: 0,
+        };
+        let handle = CreateFileW(
+            path.as_ptr(),
+            GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_NONE,
+            &attributes,
+            CREATE_NEW,
+            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT,
+            std::ptr::null_mut(),
+        );
+        let result = if handle == INVALID_HANDLE_VALUE {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(std::fs::File::from_raw_handle(handle as RawHandle))
+        };
+        LocalFree(descriptor);
+        let file = result?;
+        if !windows_file_has_private_dacl(&file)? {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "the selected filesystem did not preserve the private export ACL",
+            ));
+        }
+        Ok(file)
+    }
+}
+
+#[cfg(windows)]
+fn windows_file_has_private_dacl(file: &std::fs::File) -> std::io::Result<bool> {
+    use std::os::windows::io::AsRawHandle as _;
+
+    use windows_sys::Win32::Foundation::{LocalFree, ERROR_SUCCESS};
+    use windows_sys::Win32::Security::Authorization::{GetSecurityInfo, SE_FILE_OBJECT};
+    use windows_sys::Win32::Security::{
+        GetAce, GetSecurityDescriptorControl, IsWellKnownSid, WinBuiltinAdministratorsSid,
+        WinCreatorOwnerRightsSid, WinLocalSystemSid, ACCESS_ALLOWED_ACE, DACL_SECURITY_INFORMATION,
+        PSECURITY_DESCRIPTOR, SE_DACL_PROTECTED,
+    };
+    use windows_sys::Win32::Storage::FileSystem::FILE_ALL_ACCESS;
+    use windows_sys::Win32::System::SystemServices::ACCESS_ALLOWED_ACE_TYPE;
+
+    let mut dacl = std::ptr::null_mut();
+    let mut descriptor: PSECURITY_DESCRIPTOR = std::ptr::null_mut();
+    // SAFETY: GetSecurityInfo owns the descriptor allocation. Every pointer
+    // read below is part of that descriptor and remains live until LocalFree.
+    unsafe {
+        let status = GetSecurityInfo(
+            file.as_raw_handle().cast(),
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            &mut dacl,
+            std::ptr::null_mut(),
+            &mut descriptor,
+        );
+        if status != ERROR_SUCCESS {
+            return Err(std::io::Error::from_raw_os_error(status as i32));
+        }
+        let result = (|| -> std::io::Result<bool> {
+            let mut control = 0;
+            let mut revision = 0;
+            if GetSecurityDescriptorControl(descriptor, &mut control, &mut revision) == 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if control & SE_DACL_PROTECTED == 0 || dacl.is_null() || (*dacl).AceCount != 3 {
+                return Ok(false);
+            }
+
+            let mut allowed = [false; 3];
+            for index in 0..u32::from((*dacl).AceCount) {
+                let mut raw_ace = std::ptr::null_mut();
+                if GetAce(dacl, index, &mut raw_ace) == 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                let ace = &*raw_ace.cast::<ACCESS_ALLOWED_ACE>();
+                if u32::from(ace.Header.AceType) != ACCESS_ALLOWED_ACE_TYPE
+                    || ace.Header.AceFlags != 0
+                    || ace.Mask != FILE_ALL_ACCESS
+                {
+                    return Ok(false);
+                }
+                let sid = std::ptr::addr_of!(ace.SidStart).cast_mut().cast();
+                let slot = if IsWellKnownSid(sid, WinLocalSystemSid) != 0 {
+                    0
+                } else if IsWellKnownSid(sid, WinBuiltinAdministratorsSid) != 0 {
+                    1
+                } else if IsWellKnownSid(sid, WinCreatorOwnerRightsSid) != 0 {
+                    2
+                } else {
+                    return Ok(false);
+                };
+                if allowed[slot] {
+                    return Ok(false);
+                }
+                allowed[slot] = true;
+            }
+            Ok(allowed.into_iter().all(|present| present))
+        })();
+        LocalFree(descriptor);
+        result
+    }
 }
 
 #[cfg(test)]
@@ -1128,6 +1462,27 @@ mod tests {
                 "Authorization: Token abcdef123456",
                 "Authorization: Token [redacted]",
             ),
+            (
+                "Authorization: Negotiate YIIGeAYGKwYBBQUCoIIGbDCCBmg=",
+                "Authorization: Negotiate [redacted]",
+            ),
+            (
+                "Authorization: ApiKey supersecretvalue",
+                "Authorization: [redacted]",
+            ),
+            (
+                "password=\"correct horse battery staple\"",
+                "password=\"[redacted]\"",
+            ),
+            ("secret=p@$$w0rd:with/slashes", "secret=[redacted]"),
+            (
+                r#"{\"proxy-authorization\": \"Negotiate opaque credential value\"}"#,
+                r#"{\"proxy-authorization\": \"Negotiate [redacted]\"}"#,
+            ),
+            (
+                r#"{\"password\": \"correct \\\"horse\\\" battery staple\"}"#,
+                r#"{\"password\": \"[redacted]\"}"#,
+            ),
             // Ordinary conversation and file paths are left alone: the chat
             // is the diagnostic.
             (
@@ -1179,6 +1534,12 @@ mod tests {
         let escaped = r#"{"output":"-----BEGIN PRIVATE KEY-----\nopaque-key-material\n-----END PRIVATE KEY-----"}"#;
         assert_eq!(scrub_credentials(escaped), r#"{"output":"[redacted]"}"#);
 
+        let malformed_then_private = "-----BEGIN CERTIFICATE\ntruncated\n-----BEGIN PRIVATE KEY-----\nLIVEPRIVATEKEYBODY\n-----END PRIVATE KEY-----";
+        assert_eq!(
+            scrub_credentials(malformed_then_private),
+            "-----BEGIN CERTIFICATE\ntruncated\n[redacted]"
+        );
+
         let password = "correct-horse-battery-staple";
         let connection = format!("database=postgres://alice:{password}@db.example.test/openwave");
         assert_eq!(scrub_credentials(&connection), "database=[redacted]");
@@ -1218,6 +1579,12 @@ mod tests {
                     & 0o777,
                 0o600
             );
+        }
+
+        #[cfg(windows)]
+        {
+            let file = std::fs::File::open(&destination).unwrap();
+            assert!(windows_file_has_private_dacl(&file).unwrap());
         }
     }
 

--- a/crates/openwave-desktop/src/host_access.rs
+++ b/crates/openwave-desktop/src/host_access.rs
@@ -187,6 +187,20 @@ impl HostAccess {
     pub(crate) async fn shutdown(&self) {
         self.broker.shutdown().await;
     }
+
+    pub(crate) async fn quiesce_for_update(&self) -> Result<(), String> {
+        self.broker
+            .quiesce_for_update()
+            .await
+            .map_err(|error| error.to_string())
+    }
+
+    pub(crate) async fn resume_after_failed_update(&self) -> Result<(), String> {
+        self.broker
+            .resume_after_failed_update()
+            .await
+            .map_err(|error| error.to_string())
+    }
 }
 
 /// Native bridge for server-owned exec requests.

--- a/crates/openwave-desktop/src/updater.rs
+++ b/crates/openwave-desktop/src/updater.rs
@@ -17,6 +17,7 @@
 //! so an unfocused window is not sufficient consent to replace and restart the
 //! application.
 
+use std::future::Future;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 use std::time::Duration;
@@ -407,26 +408,51 @@ struct InstallResolutionError {
     message: &'static str,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum InstallDisposition {
-    Restart,
-    PreserveForRetry,
-}
-
-fn install_disposition<T, E>(result: &Result<T, E>) -> InstallDisposition {
-    if result.is_ok() {
-        InstallDisposition::Restart
-    } else {
-        InstallDisposition::PreserveForRetry
-    }
-}
-
 fn retryable_update_state(version: String, message: &'static str) -> DesktopUpdateState {
     DesktopUpdateState {
         status: DesktopUpdateStatus::Ready,
         version: Some(version),
         error: Some(message.to_owned()),
         enabled: updates_enabled(),
+    }
+}
+
+struct FailedInstall<E> {
+    install_error: E,
+    resume_error: Option<String>,
+}
+
+/// Run the synchronous bundle replacement only after the broker's admission
+/// barrier has drained. The closures keep the ordering contract directly
+/// testable without constructing a packaged Tauri updater in unit tests.
+async fn install_behind_broker_barrier<E, Q, QF, I, R, RF, S, SF>(
+    quiesce: Q,
+    install: I,
+    resume: R,
+    shutdown: S,
+) -> Result<Result<(), FailedInstall<E>>, String>
+where
+    Q: FnOnce() -> QF,
+    QF: Future<Output = Result<(), String>>,
+    I: FnOnce() -> Result<(), E>,
+    R: FnOnce() -> RF,
+    RF: Future<Output = Result<(), String>>,
+    S: FnOnce() -> SF,
+    SF: Future<Output = ()>,
+{
+    quiesce().await?;
+    match install() {
+        Ok(()) => {
+            shutdown().await;
+            Ok(Ok(()))
+        }
+        Err(install_error) => {
+            let resume_error = resume().await.err();
+            Ok(Err(FailedInstall {
+                install_error,
+                resume_error,
+            }))
+        }
     }
 }
 
@@ -481,24 +507,46 @@ async fn take_staged_and_restart(app: AppHandle) -> Result<(), String> {
     };
 
     let version = staged.update.version.clone();
-    let install_result = staged.update.install(&staged.bytes);
-    if let Err(error) = &install_result {
-        eprintln!("openwave-desktop: update installation failed: {error}");
-    }
-    if install_disposition(&install_result) == InstallDisposition::PreserveForRetry {
-        store_staged(&app, Some(staged));
-        set_update_state(&app, retryable_update_state(version, UPDATE_INSTALL_ERROR));
-        app.state::<UpdateManager>()
-            .busy
-            .store(false, Ordering::Release);
-        return Err(UPDATE_INSTALL_ERROR.to_owned());
-    }
+    let host_access = app.state::<HostAccess>();
+    let install_result = install_behind_broker_barrier(
+        || host_access.quiesce_for_update(),
+        || staged.update.install(&staged.bytes),
+        || host_access.resume_after_failed_update(),
+        || host_access.shutdown(),
+    )
+    .await;
 
-    // The bundle has been replaced successfully. Close the old broker only
-    // now, immediately before relaunch, so a failed installation leaves the
-    // current process fully usable and the staged bytes available for retry.
-    app.state::<HostAccess>().shutdown().await;
-    app.restart();
+    match install_result {
+        Err(error) => {
+            eprintln!("openwave-desktop: could not quiesce host broker for update: {error}");
+            store_staged(&app, Some(staged));
+            set_update_state(&app, retryable_update_state(version, UPDATE_PREPARE_ERROR));
+            app.state::<UpdateManager>()
+                .busy
+                .store(false, Ordering::Release);
+            Err(UPDATE_PREPARE_ERROR.to_owned())
+        }
+        Ok(Err(failure)) => {
+            eprintln!(
+                "openwave-desktop: update installation failed: {}",
+                failure.install_error
+            );
+            if let Some(error) = failure.resume_error {
+                eprintln!(
+                    "openwave-desktop: old host broker could not resume after update failure: {error}"
+                );
+            }
+            store_staged(&app, Some(staged));
+            set_update_state(&app, retryable_update_state(version, UPDATE_INSTALL_ERROR));
+            app.state::<UpdateManager>()
+                .busy
+                .store(false, Ordering::Release);
+            Err(UPDATE_INSTALL_ERROR.to_owned())
+        }
+        Ok(Ok(())) => {
+            app.restart();
+        }
+    }
 }
 
 #[cfg(test)]
@@ -592,21 +640,91 @@ mod tests {
     }
 
     #[test]
-    fn install_result_controls_restart_and_retry_state() {
+    fn failed_install_state_remains_retryable() {
         let mut state = retryable_update_state("1.2.3".to_owned(), UPDATE_INSTALL_ERROR);
 
-        assert_eq!(
-            install_disposition(&Ok::<(), ()>(())),
-            InstallDisposition::Restart
-        );
-        assert_eq!(
-            install_disposition(&Err::<(), ()>(())),
-            InstallDisposition::PreserveForRetry
-        );
         assert_eq!(state.enabled, updates_enabled());
         state.enabled = true;
         assert!(can_restart(&state, true));
         assert_eq!(state.version.as_deref(), Some("1.2.3"));
         assert_eq!(state.error.as_deref(), Some(UPDATE_INSTALL_ERROR));
+    }
+
+    #[tokio::test]
+    async fn broker_barrier_drains_before_install_and_resumes_only_on_failure() {
+        let events = std::sync::Arc::new(Mutex::new(Vec::new()));
+        let quiesce_events = events.clone();
+        let install_events = events.clone();
+        let resume_events = events.clone();
+        let shutdown_events = events.clone();
+
+        let result = install_behind_broker_barrier(
+            move || async move {
+                let mut events = quiesce_events.lock().unwrap();
+                events.push("in-flight finished");
+                events.push("queued finished");
+                events.push("admission closed");
+                Ok(())
+            },
+            move || {
+                install_events.lock().unwrap().push("install");
+                Err("injected install failure")
+            },
+            move || async move {
+                resume_events.lock().unwrap().push("resume pinned broker");
+                Ok(())
+            },
+            move || async move {
+                shutdown_events.lock().unwrap().push("shutdown");
+            },
+        )
+        .await
+        .unwrap()
+        .unwrap_err();
+
+        assert_eq!(result.install_error, "injected install failure");
+        assert!(result.resume_error.is_none());
+        assert_eq!(
+            *events.lock().unwrap(),
+            [
+                "in-flight finished",
+                "queued finished",
+                "admission closed",
+                "install",
+                "resume pinned broker",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn successful_install_permanently_shuts_down_before_restart() {
+        let events = std::sync::Arc::new(Mutex::new(Vec::new()));
+        let quiesce_events = events.clone();
+        let install_events = events.clone();
+        let resume_events = events.clone();
+        let shutdown_events = events.clone();
+
+        let result = install_behind_broker_barrier(
+            move || async move {
+                quiesce_events.lock().unwrap().push("quiesce");
+                Ok(())
+            },
+            move || {
+                install_events.lock().unwrap().push("install");
+                Ok::<(), &'static str>(())
+            },
+            move || async move {
+                resume_events.lock().unwrap().push("resume");
+                Ok(())
+            },
+            move || async move {
+                shutdown_events.lock().unwrap().push("shutdown");
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(result.is_ok());
+        assert_eq!(*events.lock().unwrap(), ["quiesce", "install", "shutdown"]);
     }
 }

--- a/crates/openwave-desktop/src/updater.rs
+++ b/crates/openwave-desktop/src/updater.rs
@@ -12,13 +12,10 @@
 //! more at click time so the app never installs an older artifact than the
 //! newest published release it can reach.
 //!
-//! A staged update is also installed autonomously, but only when doing so
-//! cannot interrupt work: the app must be quiescent (the embedded server
-//! reports no non-terminal turns and no live background runs — in-process
-//! background runs do not survive a restart) and unfocused (no window has
-//! focus, so nobody is typing into it), sustained across consecutive samples.
-//! While the app stays busy or in use, the update waits for the explicit
-//! restart button exactly as before.
+//! Installation is always an explicit user action. Native quiescence cannot
+//! prove that renderer-only drafts, dialogs, or editor state have been saved,
+//! so an unfocused window is not sufficient consent to replace and restart the
+//! application.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
@@ -40,13 +37,9 @@ const UPDATE_CHECK_STARTUP_DELAY: Duration = Duration::from_secs(15);
 const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(5 * 60);
 const UPDATE_CHECK_ERROR: &str = "Could not check for updates. Try again later.";
 const UPDATE_PREPARE_ERROR: &str = "Could not prepare the update. Try again later.";
+const UPDATE_INSTALL_ERROR: &str = "Could not install the update. Try again later.";
 const UPDATE_WITHDRAWN_ERROR: &str =
     "The downloaded update is no longer published. OpenWave will keep checking.";
-const AUTO_RESTART_POLL_INTERVAL: Duration = Duration::from_secs(60);
-/// Consecutive clean samples required before an autonomous restart, so a
-/// restart never fires on the instant between a user's send and the turn row
-/// becoming visible, or right as focus is returning.
-const AUTO_RESTART_REQUIRED_STREAK: u32 = 2;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -118,27 +111,20 @@ enum StagedAction {
     Discard,
 }
 
-/// True when `candidate` should supersede the staged version.
-///
-/// Versions are published as semver tags; when either side fails to parse,
-/// the feed is treated as authoritative and any *different* advertised
-/// version replaces the staged one. Equal or older versions never do, so a
-/// check that raced a release cannot downgrade what is already staged.
-fn is_newer(candidate: &str, staged: &str) -> bool {
-    match (
-        semver::Version::parse(candidate),
-        semver::Version::parse(staged),
-    ) {
-        (Ok(candidate), Ok(staged)) => candidate > staged,
-        _ => candidate != staged,
-    }
-}
-
 fn reconcile_staged(feed_version: Option<&str>, staged_version: &str) -> StagedAction {
     match feed_version {
         None => StagedAction::Discard,
-        Some(feed) if is_newer(feed, staged_version) => StagedAction::Replace,
-        Some(_) => StagedAction::Keep,
+        Some(feed) if feed == staged_version => StagedAction::Keep,
+        Some(feed) => match (
+            semver::Version::parse(feed),
+            semver::Version::parse(staged_version),
+        ) {
+            (Ok(feed), Ok(staged)) if feed > staged => StagedAction::Replace,
+            // An older feed version is an intentional rollback/withdrawal as
+            // far as this client can prove. Malformed unequal versions also
+            // fail closed rather than preserving an unadvertised artifact.
+            _ => StagedAction::Discard,
+        },
     }
 }
 
@@ -347,70 +333,6 @@ pub(crate) fn spawn_update_loop(app: AppHandle) {
             }
         }
     });
-    tauri::async_runtime::spawn(async move {
-        let mut streak = 0u32;
-        loop {
-            tokio::time::sleep(AUTO_RESTART_POLL_INTERVAL).await;
-            let (next, fire) = advance_auto_restart_streak(streak, auto_restart_gate(&app).await);
-            streak = next;
-            if fire {
-                // On success this call never returns: the process relaunches.
-                if let Err(error) = take_staged_and_restart(app.clone()).await {
-                    eprintln!("openwave-desktop: autonomous update restart deferred: {error}");
-                    streak = 0;
-                }
-            }
-        }
-    });
-}
-
-/// One autonomous-restart sample: an installable update is staged, the
-/// embedded server supervises no in-flight work, and no window has focus.
-/// Every failure to know is treated as "in use".
-async fn auto_restart_gate(app: &AppHandle) -> bool {
-    {
-        let manager = app.state::<UpdateManager>();
-        let state = manager
-            .state
-            .lock()
-            .expect("update state mutex poisoned")
-            .clone();
-        let has_staged = manager
-            .staged
-            .lock()
-            .expect("staged update mutex poisoned")
-            .is_some();
-        if !can_restart(&state, has_staged) {
-            return false;
-        }
-    }
-
-    if app
-        .webview_windows()
-        .values()
-        .any(|window| window.is_focused().unwrap_or(true))
-    {
-        return false;
-    }
-
-    match app.state::<HostAccess>().store() {
-        Some(store) => store
-            .count_active_work()
-            .await
-            .map(|snapshot| snapshot.is_quiescent())
-            .unwrap_or(false),
-        None => false,
-    }
-}
-
-/// Advance the consecutive-clean-sample counter; fire only once the streak
-/// reaches [`AUTO_RESTART_REQUIRED_STREAK`]. Any dirty sample resets it.
-fn advance_auto_restart_streak(streak: u32, sample_ok: bool) -> (u32, bool) {
-    if !sample_ok {
-        return (0, false);
-    }
-    let next = streak.saturating_add(1);
-    (next, next >= AUTO_RESTART_REQUIRED_STREAK)
 }
 
 #[tauri::command]
@@ -435,7 +357,7 @@ fn can_restart(state: &DesktopUpdateState, has_staged_update: bool) -> bool {
 async fn resolve_latest_for_install(
     app: &AppHandle,
     staged: StagedUpdate,
-) -> Result<StagedUpdate, String> {
+) -> Result<StagedUpdate, InstallResolutionError> {
     let updater = match app.updater() {
         Ok(updater) => updater,
         Err(error) => {
@@ -463,14 +385,48 @@ async fn resolve_latest_for_install(
                 Ok(bytes) => Ok(StagedUpdate { update, bytes }),
                 Err(error) => {
                     eprintln!("openwave-desktop: install-time update download failed: {error}");
-                    Ok(staged)
+                    Err(InstallResolutionError {
+                        staged: Some(staged),
+                        message: UPDATE_PREPARE_ERROR,
+                    })
                 }
             }
         }
-        StagedAction::Discard => {
-            set_update_state(app, DesktopUpdateState::idle());
-            Err(UPDATE_WITHDRAWN_ERROR.to_owned())
-        }
+        StagedAction::Discard => Err(InstallResolutionError {
+            staged: None,
+            message: UPDATE_WITHDRAWN_ERROR,
+        }),
+    }
+}
+
+struct InstallResolutionError {
+    /// A still-published staged artifact that can be retried later. Withdrawn
+    /// artifacts are deliberately omitted so no subsequent action can install
+    /// them without downloading them from a newly authoritative feed.
+    staged: Option<StagedUpdate>,
+    message: &'static str,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum InstallDisposition {
+    Restart,
+    PreserveForRetry,
+}
+
+fn install_disposition<T, E>(result: &Result<T, E>) -> InstallDisposition {
+    if result.is_ok() {
+        InstallDisposition::Restart
+    } else {
+        InstallDisposition::PreserveForRetry
+    }
+}
+
+fn retryable_update_state(version: String, message: &'static str) -> DesktopUpdateState {
+    DesktopUpdateState {
+        status: DesktopUpdateStatus::Ready,
+        version: Some(version),
+        error: Some(message.to_owned()),
+        enabled: updates_enabled(),
     }
 }
 
@@ -480,9 +436,17 @@ pub(crate) async fn restart_for_update(app: AppHandle) -> Result<(), String> {
 }
 
 /// Take the staged update, converge it on the newest published release, and
-/// restart into it. Shared by the explicit restart button and the autonomous
-/// quiescent-restart path. On success this never returns.
+/// restart into it. This is reached only from the explicit restart command. On
+/// success this never returns.
 async fn take_staged_and_restart(app: AppHandle) -> Result<(), String> {
+    if app
+        .state::<UpdateManager>()
+        .busy
+        .swap(true, Ordering::AcqRel)
+    {
+        return Err("An update check is already in progress".to_owned());
+    }
+
     let staged = {
         let manager = app.state::<UpdateManager>();
         let state = manager
@@ -492,41 +456,48 @@ async fn take_staged_and_restart(app: AppHandle) -> Result<(), String> {
             .clone();
         let mut staged = manager.staged.lock().expect("staged update mutex poisoned");
         if !can_restart(&state, staged.is_some()) {
+            manager.busy.store(false, Ordering::Release);
             return Err("no update is ready to install".to_owned());
         }
         staged.take().expect("ready update must have staged bytes")
     };
 
-    // Block the background loop from starting a new check while the install
-    // proceeds; on success the process restarts, and every error path below
-    // returns through `release_busy`.
-    let was_busy = app
-        .state::<UpdateManager>()
-        .busy
-        .swap(true, Ordering::AcqRel);
-
     let staged = match resolve_latest_for_install(&app, staged).await {
         Ok(staged) => staged,
-        Err(message) => {
-            if !was_busy {
-                app.state::<UpdateManager>()
-                    .busy
-                    .store(false, Ordering::Release);
+        Err(error) => {
+            if let Some(staged) = error.staged {
+                let version = staged.update.version.clone();
+                store_staged(&app, Some(staged));
+                set_update_state(&app, retryable_update_state(version, error.message));
+            } else {
+                store_staged(&app, None);
+                set_update_state(&app, DesktopUpdateState::failed(error.message));
             }
-            return Err(message);
+            app.state::<UpdateManager>()
+                .busy
+                .store(false, Ordering::Release);
+            return Err(error.message.to_owned());
         }
     };
 
-    // Once the bundle is replaced, every new sidecar process would come from
-    // the new app. Close the old host's broker permanently before installation
-    // so it cannot respawn a mismatched sidecar in the install/restart window.
-    app.state::<HostAccess>().shutdown().await;
-    if let Err(error) = staged.update.install(&staged.bytes) {
+    let version = staged.update.version.clone();
+    let install_result = staged.update.install(&staged.bytes);
+    if let Err(error) = &install_result {
         eprintln!("openwave-desktop: update installation failed: {error}");
     }
+    if install_disposition(&install_result) == InstallDisposition::PreserveForRetry {
+        store_staged(&app, Some(staged));
+        set_update_state(&app, retryable_update_state(version, UPDATE_INSTALL_ERROR));
+        app.state::<UpdateManager>()
+            .busy
+            .store(false, Ordering::Release);
+        return Err(UPDATE_INSTALL_ERROR.to_owned());
+    }
 
-    // Relaunch even if installation failed so the current app gets a fresh,
-    // usable broker instead of remaining alive after its broker was closed.
+    // The bundle has been replaced successfully. Close the old broker only
+    // now, immediately before relaunch, so a failed installation leaves the
+    // current process fully usable and the staged bytes available for retry.
+    app.state::<HostAccess>().shutdown().await;
     app.restart();
 }
 
@@ -577,15 +548,6 @@ mod tests {
     }
 
     #[test]
-    fn autonomous_restart_requires_a_sustained_clean_window() {
-        assert_eq!(advance_auto_restart_streak(0, false), (0, false));
-        assert_eq!(advance_auto_restart_streak(0, true), (1, false));
-        assert_eq!(advance_auto_restart_streak(1, true), (2, true));
-        // Any dirty sample resets the streak entirely.
-        assert_eq!(advance_auto_restart_streak(1, false), (0, false));
-    }
-
-    #[test]
     fn a_newer_release_replaces_the_staged_artifact() {
         // The double-release window: v0.4.1 was staged, v0.4.2 shipped before
         // the user acted. The stale artifact must be replaced, never installed.
@@ -602,31 +564,49 @@ mod tests {
     #[test]
     fn the_staged_artifact_is_kept_when_still_newest() {
         assert_eq!(reconcile_staged(Some("0.4.1"), "0.4.1"), StagedAction::Keep);
-        // A check that raced a release and resolved the *older* feed must not
-        // downgrade what is already staged.
-        assert_eq!(reconcile_staged(Some("0.4.0"), "0.4.1"), StagedAction::Keep);
+    }
+
+    #[test]
+    fn a_withdrawn_or_rolled_back_release_is_discarded_not_installed() {
+        assert_eq!(reconcile_staged(None, "0.4.1"), StagedAction::Discard);
+        assert_eq!(
+            reconcile_staged(Some("0.4.0"), "0.4.1"),
+            StagedAction::Discard
+        );
         assert_eq!(
             reconcile_staged(Some("0.4.2-rc.1"), "0.4.2"),
-            StagedAction::Keep
+            StagedAction::Discard
         );
     }
 
     #[test]
-    fn a_withdrawn_release_is_discarded_not_installed() {
-        assert_eq!(reconcile_staged(None, "0.4.1"), StagedAction::Discard);
-    }
-
-    #[test]
-    fn unparseable_versions_defer_to_the_feed() {
-        // The feed is authoritative when tags are not semver: any different
-        // advertised version replaces the staged one, an identical one stays.
+    fn unparseable_versions_fail_closed_unless_they_match_exactly() {
         assert_eq!(
             reconcile_staged(Some("build-124"), "build-123"),
-            StagedAction::Replace
+            StagedAction::Discard
         );
         assert_eq!(
             reconcile_staged(Some("build-123"), "build-123"),
             StagedAction::Keep
         );
+    }
+
+    #[test]
+    fn install_result_controls_restart_and_retry_state() {
+        let mut state = retryable_update_state("1.2.3".to_owned(), UPDATE_INSTALL_ERROR);
+
+        assert_eq!(
+            install_disposition(&Ok::<(), ()>(())),
+            InstallDisposition::Restart
+        );
+        assert_eq!(
+            install_disposition(&Err::<(), ()>(())),
+            InstallDisposition::PreserveForRetry
+        );
+        assert_eq!(state.enabled, updates_enabled());
+        state.enabled = true;
+        assert!(can_restart(&state, true));
+        assert_eq!(state.version.as_deref(), Some("1.2.3"));
+        assert_eq!(state.error.as_deref(), Some(UPDATE_INSTALL_ERROR));
     }
 }

--- a/crates/openwave-desktop/ui/src/settings/UpdatesPanel.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/UpdatesPanel.test.tsx
@@ -40,6 +40,10 @@ describe("UpdatesPanel", () => {
 
     expect(updateStateSummary(state)).toContain("Version 1.2.3");
     expect(markup).toContain("Restart to update");
+    expect(markup).toContain(
+      "installs only after you choose Restart to update",
+    );
+    expect(markup).not.toContain("installs on its own");
     expect(markup).not.toContain("Check for updates");
   });
 

--- a/crates/openwave-desktop/ui/src/settings/UpdatesPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/UpdatesPanel.tsx
@@ -61,7 +61,7 @@ export function UpdatesPanel({
   return (
     <SettingsPanel
       title="Updates"
-      description="OpenWave checks shortly after launch and every five minutes, and downloads updates in the background. A downloaded update installs on its own once nothing is running and the app is in the background; while agent work is in flight or the app is in use, it waits for you to restart."
+      description="OpenWave checks shortly after launch and every five minutes, and downloads updates in the background. A downloaded update installs only after you choose Restart to update."
       busy={busy}
     >
       <SettingsSection title="Automatic updates">


### PR DESCRIPTION
## Summary

- require explicit user consent before installing desktop updates and discard staged artifacts that the feed has withdrawn or rolled back
- preserve staged update bytes and a retryable ready state when preparation or installation fails, and only shut down the broker/restart after a successful install
- write debug exports through a no-follow 0600 temporary file, fsync, and atomic rename, while expanding credential redaction to private-key blocks and credential-bearing URLs

## Verification

- `cargo fmt --all`
- `cargo test -p openwave-desktop --locked updater::tests`
- `cargo test -p openwave-desktop --locked chat_debug::tests`
- `cargo clippy -p openwave-desktop --all-targets --locked -- -D warnings`
- `cargo check -p openwave-desktop --all-targets --locked`
- `git diff --check HEAD`

Closes #1897
