### PR TITLE
fix(ui): make permission and consent interactions scope-safe

### DIFF
--- a/crates/openwave-desktop/tauri.conf.json
+++ b/crates/openwave-desktop/tauri.conf.json
@@ -28,7 +28,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' customprotocol: asset:; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* ws://127.0.0.1:* http://localhost:* ws://localhost:*; img-src 'self' asset: blob: data: https://icons.duckduckgo.com; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; worker-src 'self' blob:; frame-src http://127.0.0.1:* http://localhost:*; object-src 'none'"
+      "csp": "default-src 'self' customprotocol: asset:; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* ws://127.0.0.1:* http://localhost:* ws://localhost:*; img-src 'self' asset: blob: data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; worker-src 'self' blob:; frame-src http://127.0.0.1:* http://localhost:*; object-src 'none'"
     }
   },
   "plugins": {

--- a/crates/openwave-desktop/ui/src/ApprovalCard.tsx
+++ b/crates/openwave-desktop/ui/src/ApprovalCard.tsx
@@ -48,10 +48,9 @@ type ApprovalCardProps = {
  * being decided; the longer sentence about what the action can reach explains
  * rather than asks, so it sits underneath. Below that, the exact action.
  *
- * The options are a keyboard-navigable list rather than a row of buttons,
- * ordered narrowest grant first with the decline last. Scope is easy to widen
- * by accident and hard to notice afterwards, so the cheapest keystroke has to
- * be the one that grants the least.
+ * The choices are selectable buttons followed by an explicit Submit action,
+ * ordered narrowest grant first with the decline last. Exploring or selecting
+ * a choice never executes the tool or persists a grant by itself.
  */
 export function ApprovalCard({
   callId,
@@ -76,7 +75,7 @@ export function ApprovalCard({
     grantRungs,
   );
   const [highlight, setHighlight] = useState(0);
-  const rowRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const rowRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const hasAutoFocused = useRef(false);
   const safeHighlight = Math.min(highlight, options.length - 1);
   const ask = approvalAsk(preview, summary);
@@ -94,14 +93,14 @@ export function ApprovalCard({
       (active.isContentEditable ||
         active.tagName === "INPUT" ||
         active.tagName === "TEXTAREA" ||
-        active.closest('[role="listbox"]') !== null);
+        active.closest('[aria-label="Approval choices"]') !== null);
     if (focusedElsewhere) return;
     // preventScroll: the point is to arm the keys, not to drag the transcript
     // to a card that may have mounted off-screen.
     rowRefs.current[0]?.focus({ preventScroll: true });
   }, [deciding]);
 
-  const commit = (index: number) => {
+  const activate = (index: number) => {
     const option = options[index];
     if (!option || deciding) return;
     if (option.kind === "more") {
@@ -113,23 +112,25 @@ export function ApprovalCard({
       rowRefs.current[0]?.focus();
       return;
     }
+    setHighlight(index);
+  };
+
+  const submitSelected = () => {
+    const option = options[safeHighlight];
+    if (!option || option.kind !== "decide" || deciding) return;
     onDecide(callId, option.decision, option.grant);
   };
 
   const focusRow = (to: number) => {
     const wrapped = ((to % options.length) + options.length) % options.length;
+    if (options[wrapped]?.kind === "decide") setHighlight(wrapped);
     rowRefs.current[wrapped]?.focus();
   };
 
-  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>, index: number) => {
+  const onKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
     if (event.key === "ArrowDown" || event.key === "ArrowUp") {
       event.preventDefault();
       focusRow(index + (event.key === "ArrowDown" ? 1 : -1));
-      return;
-    }
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      commit(index);
       return;
     }
     if (/^[1-9]$/.test(event.key)) {
@@ -164,27 +165,31 @@ export function ApprovalCard({
         </ScrollableContainer>
       )}
       <div
-        role="listbox"
-        aria-label="What should happen"
+        role="group"
+        aria-label="Approval choices"
         className="flex flex-col gap-0.5"
       >
         {options.map((option, index) => (
-          <div
+          <button
+            type="button"
             key={option.key}
             ref={(node) => {
               rowRefs.current[index] = node;
             }}
-            role="option"
-            aria-selected={index === safeHighlight}
-            tabIndex={deciding ? -1 : 0}
-            onClick={() => commit(index)}
-            onFocus={() => setHighlight(index)}
+            aria-pressed={
+              option.kind === "decide" ? index === safeHighlight : undefined
+            }
+            disabled={deciding}
+            onClick={() => activate(index)}
+            onFocus={() => {
+              if (option.kind === "decide") setHighlight(index);
+            }}
             onMouseEnter={(event) => event.currentTarget.focus()}
             onKeyDown={(event) => onKeyDown(event, index)}
             className={cn(
               "focus-visible:ring-ring flex cursor-pointer items-baseline gap-2.5 rounded-md px-3 py-2.5 text-sm outline-hidden focus-visible:ring-2",
               index === safeHighlight ? "bg-muted" : "hover:bg-muted/60",
-              deciding && "pointer-events-none opacity-60",
+              deciding && "opacity-60",
             )}
           >
             <span className="text-muted-foreground w-4 shrink-0 text-xs tabular-nums">
@@ -201,7 +206,7 @@ export function ApprovalCard({
             >
               {option.label}
             </span>
-          </div>
+          </button>
         ))}
       </div>
       {canRemember && grantScope === "project" && (
@@ -212,12 +217,12 @@ export function ApprovalCard({
       )}
       <div className="flex items-center justify-between gap-2 text-xs">
         <span className="text-muted-foreground">
-          ↑↓ choose · 1–{Math.min(options.length, 9)} jump · ↵ submit
+          ↑↓ choose · 1–{Math.min(options.length, 9)} jump · Submit confirms
         </span>
         <Button
           size="sm"
           disabled={deciding}
-          onClick={() => commit(safeHighlight)}
+          onClick={submitSelected}
         >
           Submit
         </Button>

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -737,6 +737,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
           }
           composerPermissionMenu={
             <PermissionModeMenu
+              scopeKey={chatId}
               value={chat!.permission_mode}
               disabled={deletingChatId !== null}
               onChange={onPermissionModeChange}

--- a/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, cleanup, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -289,7 +289,12 @@ describe("ChatView", () => {
     }));
     await renderChatView();
 
-    await userEvent.click(screen.getAllByRole("option")[0]!);
+    const choices = within(
+      screen.getByRole("group", { name: "Approval choices" }),
+    ).getAllByRole("button");
+    await userEvent.click(choices[0]!);
+    expect(client.decideApproval).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByRole("button", { name: "Submit" }));
 
     await waitFor(() =>
       expect(client.decideApproval).toHaveBeenCalledWith(

--- a/crates/openwave-desktop/ui/src/DomainFavicon.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/DomainFavicon.dom.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { DomainFavicon } from "./DomainFavicon";
@@ -8,29 +8,18 @@ import { ToolEntriesList } from "./ToolEntriesList";
 afterEach(cleanup);
 
 describe("DomainFavicon", () => {
-  it("asks DuckDuckGo for the page's host icon", () => {
-    render(<DomainFavicon url="https://www.cnbc.com/2026/07/31/story.html" />);
-    const image = screen.getByRole("presentation", { hidden: true });
-    expect(image.getAttribute("src")).toBe(
-      "https://icons.duckduckgo.com/ip3/cnbc.com.ico",
-    );
-  });
-
-  it("falls back to the globe when the icon cannot load", () => {
+  it("uses a local globe without issuing a third-party image request", () => {
     const { container } = render(
       <DomainFavicon url="https://example.com/page" />,
     );
-    const image = container.querySelector("img");
-    expect(image).not.toBeNull();
-    fireEvent.error(image!);
     expect(container.querySelector("img")).toBeNull();
     expect(container.querySelector("svg")).not.toBeNull();
   });
 });
 
 describe("ToolEntriesList link marks", () => {
-  it("shows a site favicon for each linked result", () => {
-    render(
+  it("shows a local source mark for each linked result", () => {
+    const { container } = render(
       <ToolEntriesList
         name="web_search"
         result={{
@@ -51,9 +40,7 @@ describe("ToolEntriesList link marks", () => {
         }}
       />,
     );
-    const image = screen.getByRole("presentation", { hidden: true });
-    expect(image.getAttribute("src")).toBe(
-      "https://icons.duckduckgo.com/ip3/cnbc.com.ico",
-    );
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector("svg")).not.toBeNull();
   });
 });

--- a/crates/openwave-desktop/ui/src/DomainFavicon.tsx
+++ b/crates/openwave-desktop/ui/src/DomainFavicon.tsx
@@ -1,50 +1,22 @@
 import { Globe } from "lucide-react";
-import { useState } from "react";
 
 import { cn } from "./lib/utils";
 
 type DomainFaviconProps = {
-  /** Public page whose host supplies the icon. */
+  /** Public page represented by the local fallback. */
   url: string;
   className?: string;
 };
 
 /**
- * Site mark for a public page, keyed off its host.
- *
- * Loads from DuckDuckGo's icon service so one CSP origin covers every
- * domain. When the fetch fails — unknown host, offline, blocked — the
- * same globe every link used to show stands in, so a missing mark never
- * leaves a hole in the list.
+ * Privacy-preserving site mark. Rendering a source must not disclose its host
+ * or the user's address to a third-party favicon service.
  */
-export function DomainFavicon({ url, className }: DomainFaviconProps) {
-  const [failed, setFailed] = useState(false);
-  const domain = hostOf(url);
-  if (domain === null || failed) {
-    return (
-      <Globe
-        className={cn("text-muted-foreground size-4 shrink-0", className)}
-        aria-hidden="true"
-      />
-    );
-  }
+export function DomainFavicon({ url: _url, className }: DomainFaviconProps) {
   return (
-    <img
-      src={`https://icons.duckduckgo.com/ip3/${encodeURIComponent(domain)}.ico`}
-      alt=""
-      className={cn("size-4 shrink-0 rounded-sm object-contain", className)}
-      onError={() => setFailed(true)}
+    <Globe
+      className={cn("text-muted-foreground size-4 shrink-0", className)}
+      aria-hidden="true"
     />
   );
-}
-
-/** Bare host used as the icon key; `www.` is noise for the lookup. */
-function hostOf(url: string): string | null {
-  try {
-    const host = new URL(url).hostname.toLowerCase();
-    if (host.length === 0) return null;
-    return host.replace(/^www\./, "");
-  } catch {
-    return null;
-  }
 }

--- a/crates/openwave-desktop/ui/src/HomeRoute.test.ts
+++ b/crates/openwave-desktop/ui/src/HomeRoute.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { applyPendingChatSettings } from "./HomeRoute";
+
+const pendingChat = {
+  id: "pending-chat",
+  title: null,
+  model: null,
+  reasoning_effort: null,
+  permission_mode: "allow",
+  network_policy: { mode: "open" as const },
+  project_id: null,
+  created_at: "2026-08-10T00:00:00Z",
+  attachment_revision: 0,
+  root_attachments: [],
+};
+
+describe("home attachment settings", () => {
+  it("applies attachment → restrict → send settings to the pending server chat", async () => {
+    const patchChatPermissionMode = vi.fn(async () => ({
+      ...pendingChat,
+      permission_mode: "plan" as const,
+    }));
+    const patchChatNetworkPolicy = vi.fn(async () => ({
+      ...pendingChat,
+      permission_mode: "plan" as const,
+      network_policy: { mode: "off" as const },
+    }));
+
+    // Attaching created this chat with the prior, permissive home settings.
+    await applyPendingChatSettings(
+      { patchChatPermissionMode, patchChatNetworkPolicy },
+      pendingChat.id,
+      // The user restricts both controls before sending their first message.
+      { permissionMode: "plan", networkPolicy: { mode: "off" } },
+    );
+
+    expect(patchChatPermissionMode).toHaveBeenCalledWith("pending-chat", "plan");
+    expect(patchChatNetworkPolicy).toHaveBeenCalledWith("pending-chat", {
+      mode: "off",
+    });
+    expect(patchChatPermissionMode).toHaveBeenCalledBefore(patchChatNetworkPolicy);
+  });
+
+  it("surfaces a rejected pending-chat update to the sender", async () => {
+    const patchChatPermissionMode = vi.fn(async () => {
+      throw new Error("permission update rejected");
+    });
+    const patchChatNetworkPolicy = vi.fn();
+
+    await expect(
+      applyPendingChatSettings(
+        { patchChatPermissionMode, patchChatNetworkPolicy },
+        pendingChat.id,
+        { permissionMode: "plan", networkPolicy: { mode: "off" } },
+      ),
+    ).rejects.toThrow("permission update rejected");
+    expect(patchChatNetworkPolicy).not.toHaveBeenCalled();
+  });
+});

--- a/crates/openwave-desktop/ui/src/HomeRoute.tsx
+++ b/crates/openwave-desktop/ui/src/HomeRoute.tsx
@@ -373,6 +373,7 @@ export function HomeRoute() {
             }
             permissionMenu={
               <PermissionModeMenu
+                scopeKey="new-chat"
                 value={effective.permissionMode}
                 disabled={creatingChat}
                 onChange={newChat.setPermissionMode}

--- a/crates/openwave-desktop/ui/src/HomeRoute.tsx
+++ b/crates/openwave-desktop/ui/src/HomeRoute.tsx
@@ -41,6 +41,30 @@ const chatListActions = useChatListStore.getState();
 const composerDraftActions = useComposerDrafts.getState();
 const firstMessageActions = useFirstMessage.getState();
 
+/**
+ * A file picker creates a chat before there is a first message. Reconcile the
+ * home pickers immediately before that first message is held so changes made
+ * while the attachment strip was open govern the turn that follows.
+ */
+export async function applyPendingChatSettings(
+  client: Pick<
+    typeof import("./api").ApiClient.prototype,
+    "patchChatPermissionMode" | "patchChatNetworkPolicy"
+  >,
+  chatId: string,
+  settings: {
+    permissionMode: import("./api").PermissionMode | null;
+    networkPolicy: import("./api").NetworkPolicy;
+  },
+): Promise<void> {
+  chatListActions.replaceChat(
+    await client.patchChatPermissionMode(chatId, settings.permissionMode),
+  );
+  chatListActions.replaceChat(
+    await client.patchChatNetworkPolicy(chatId, settings.networkPolicy),
+  );
+}
+
 function isImportedDocument(
   result: { status: string },
 ): result is LibraryImportSuccess {
@@ -237,6 +261,11 @@ export function HomeRoute() {
         chatListActions.prependChat(created);
         chatListActions.setChatsError(null);
         chatId = created.id;
+      } else {
+        await applyPendingChatSettings(client, chatId, {
+          permissionMode: effective.permissionMode,
+          networkPolicy: effective.networkPolicy,
+        });
       }
       firstMessageActions.hold(chatId, {
         text: content,

--- a/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
@@ -45,6 +45,12 @@ function card(overrides: Partial<Parameters<typeof ApprovalCard>[0]> = {}) {
   );
 }
 
+function approvalChoices() {
+  return within(
+    screen.getByRole("group", { name: "Approval choices" }),
+  ).getAllByRole("button");
+}
+
 const ONCE = "1.Yes, allow it once";
 const REMEMBER = "2.Yes, and don't ask again in this chat";
 
@@ -62,12 +68,12 @@ afterEach(() => {
 });
 
 describe("approval card interactions", () => {
-  it("propagates each decision with the grant it names", async () => {
+  it("submits only the selected decision with the grant it names", async () => {
     const user = userEvent.setup();
     const onDecide = vi.fn();
     render(card({ onDecide }));
 
-    const options = screen.getAllByRole("option");
+    const options = approvalChoices();
     expect(options.map((option) => option.textContent)).toEqual([
       ONCE,
       REMEMBER,
@@ -75,27 +81,33 @@ describe("approval card interactions", () => {
     ]);
 
     await user.click(options[0]!);
+    expect(onDecide).not.toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: "Submit" }));
     expect(onDecide).toHaveBeenLastCalledWith("call-1", "approve", null);
 
     await user.click(options[1]!);
+    expect(onDecide).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByRole("button", { name: "Submit" }));
     expect(onDecide).toHaveBeenLastCalledWith("call-1", "approve", "whole_tool");
 
     await user.click(options[2]!);
+    expect(onDecide).toHaveBeenCalledTimes(2);
+    await user.click(screen.getByRole("button", { name: "Submit" }));
     expect(onDecide).toHaveBeenLastCalledWith("call-1", "reject", null);
   });
 
   it("starts on the narrowest grant so a stray Enter cannot widen scope", () => {
     render(card());
 
-    const options = screen.getAllByRole("option");
-    expect(options[0]).toHaveAttribute("aria-selected", "true");
+    const options = approvalChoices();
+    expect(options[0]).toHaveAttribute("aria-pressed", "true");
     expect(options[0]?.textContent).toBe(ONCE);
   });
 
   it("arms its keyboard shortcuts without needing a click first", () => {
     render(card());
 
-    expect(document.activeElement).toBe(screen.getAllByRole("option")[0]);
+    expect(document.activeElement).toBe(approvalChoices()[0]);
   });
 
   it("leaves focus alone when the user is typing elsewhere", () => {
@@ -109,15 +121,20 @@ describe("approval card interactions", () => {
     composer.remove();
   });
 
-  it("submits the highlighted option from the keyboard", async () => {
+  it("selects from the keyboard and waits for explicit submit", async () => {
     const user = userEvent.setup();
     const onDecide = vi.fn();
     render(card({ onDecide }));
 
     await user.keyboard("{ArrowDown}{Enter}");
+    expect(onDecide).not.toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: "Submit" }));
     expect(onDecide).toHaveBeenLastCalledWith("call-1", "approve", "whole_tool");
 
+    approvalChoices()[1]?.focus();
     await user.keyboard("3{Enter}");
+    expect(onDecide).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByRole("button", { name: "Submit" }));
     expect(onDecide).toHaveBeenLastCalledWith("call-1", "reject", null);
   });
 
@@ -127,6 +144,8 @@ describe("approval card interactions", () => {
     render(card({ onDecide }));
 
     await user.keyboard("{ArrowUp}{Enter}");
+    expect(onDecide).not.toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: "Submit" }));
     expect(onDecide).toHaveBeenLastCalledWith("call-1", "reject", null);
   });
 
@@ -135,7 +154,7 @@ describe("approval card interactions", () => {
     const onDecide = vi.fn();
     render(card({ onDecide, deciding: true }));
 
-    for (const option of screen.getAllByRole("option")) {
+    for (const option of approvalChoices()) {
       await user.click(option);
     }
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
@@ -152,7 +171,8 @@ describe("approval card interactions", () => {
     expect(screen.getByRole("alert")).toHaveTextContent(
       "Could not send your decision",
     );
-    await user.click(screen.getAllByRole("option")[0]!);
+    await user.click(approvalChoices()[0]!);
+    await user.click(screen.getByRole("button", { name: "Submit" }));
     expect(onDecide).toHaveBeenCalledWith("call-1", "approve", null);
   });
 
@@ -160,7 +180,7 @@ describe("approval card interactions", () => {
     render(card({ canApprove: false }));
 
     expect(
-      screen.getAllByRole("option").map((option) => option.textContent),
+      approvalChoices().map((option) => option.textContent),
     ).toEqual(["1.No, don't allow this"]);
   });
 
@@ -168,7 +188,7 @@ describe("approval card interactions", () => {
     render(card({ canRemember: false }));
 
     expect(
-      screen.getAllByRole("option").map((option) => option.textContent),
+      approvalChoices().map((option) => option.textContent),
     ).toEqual([ONCE, "2.No, don't allow this"]);
   });
 
@@ -188,7 +208,7 @@ describe("approval card interactions", () => {
     );
 
     expect(
-      screen.getAllByRole("option").map((option) => option.textContent),
+      approvalChoices().map((option) => option.textContent),
     ).toEqual(["1.Yes, run it once", "2.No, don't allow this"]);
   });
 
@@ -217,7 +237,7 @@ describe("approval card interactions", () => {
     // Every option on screen is one keystroke away, so the narrowest grants are
     // inline and the widest ones are not.
     expect(
-      screen.getAllByRole("option").map((option) => option.textContent),
+      approvalChoices().map((option) => option.textContent),
     ).toEqual([
       "1.Yes, run it once",
       "2.Yes, and always allow exactly \u201ccargo test\u201d",
@@ -228,7 +248,7 @@ describe("approval card interactions", () => {
 
     await user.click(screen.getByText(MORE));
     expect(
-      screen.getAllByRole("option").map((option) => option.textContent),
+      approvalChoices().map((option) => option.textContent),
     ).toEqual([
       "1.Yes, run it once",
       "2.Yes, and always allow exactly \u201ccargo test\u201d",
@@ -264,7 +284,7 @@ describe("approval card interactions", () => {
     );
 
     expect(
-      screen.getAllByRole("option").map((option) => option.textContent),
+      approvalChoices().map((option) => option.textContent),
     ).toEqual([
       "1.Yes, run it once",
       "2.Yes, and always allow exactly \u201ccargo test\u201d",
@@ -279,7 +299,7 @@ describe("approval card interactions", () => {
     render(card({ grantScope: "project" }));
 
     expect(
-      screen.getAllByRole("option").map((row) => row.textContent),
+      approvalChoices().map((row) => row.textContent),
     ).toEqual([ONCE, REMEMBER_IN_PROJECT, "3.No, don't allow this"]);
     // And says once, in full, what the rows cannot say without becoming
     // three long lines.
@@ -305,11 +325,13 @@ describe("approval card interactions", () => {
     // "More options" sat at row 4; expanding puts a broader grant there. A
     // stray Enter must not commit whatever moved under the cursor.
     await user.keyboard("4{Enter}");
-    expect(screen.getAllByRole("option")[0]).toHaveAttribute(
-      "aria-selected",
+    expect(approvalChoices()[0]).toHaveAttribute(
+      "aria-pressed",
       "true",
     );
     await user.keyboard("{Enter}");
+    expect(onDecide).not.toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: "Submit" }));
     expect(onDecide).toHaveBeenCalledWith("call-1", "approve", null);
   });
 
@@ -334,7 +356,7 @@ describe("approval card interactions", () => {
     // The ladder used to be exec-shaped, so this card's only standing option
     // was the widest rung there is.
     expect(
-      screen.getAllByRole("option").map((option) => option.textContent),
+      approvalChoices().map((option) => option.textContent),
     ).toEqual([
       ONCE,
       "2.Yes, and always allow exactly “quarterly filings”",
@@ -345,7 +367,9 @@ describe("approval card interactions", () => {
     // them alongside the query it leads with.
     expect(screen.getByText(/# limited to sec.gov/)).toBeInTheDocument();
 
-    await user.click(screen.getAllByRole("option")[1]!);
+    await user.click(approvalChoices()[1]!);
+    expect(onDecide).not.toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: "Submit" }));
     expect(onDecide).toHaveBeenLastCalledWith(
       "call-1",
       "approve",
@@ -369,7 +393,7 @@ describe("approval card interactions", () => {
 
     // A natural-language query runs to hundreds of characters; the unabridged
     // one is in the block above, which is where it is meant to be read.
-    expect(screen.getAllByRole("option")[1]?.textContent).toBe(
+    expect(approvalChoices()[1]?.textContent).toBe(
       "2.Yes, and always allow exactly “what did the company say about revenue recogniti…”",
     );
   });
@@ -380,9 +404,9 @@ describe("approval card interactions", () => {
 
     expect(screen.queryByText(MORE)).not.toBeInTheDocument();
     expect(
-      screen.getAllByRole("option").map((option) => option.textContent),
+      approvalChoices().map((option) => option.textContent),
     ).toEqual([ONCE, REMEMBER, "3.No, don't allow this"]);
-    await user.click(screen.getAllByRole("option")[1]!);
+    await user.click(approvalChoices()[1]!);
   });
 
   it("asks about the command rather than about commands in general", () => {
@@ -411,7 +435,7 @@ describe("approval card interactions", () => {
     ).toBeInTheDocument();
     // The class-of-egress sentence becomes the subheading, not the ask.
     expect(screen.getByText(/may reach the network/)).toBeInTheDocument();
-    expect(screen.getAllByRole("option")[0]).toHaveTextContent(
+    expect(approvalChoices()[0]).toHaveTextContent(
       "Yes, run it once",
     );
   });

--- a/crates/openwave-desktop/ui/src/MessageList.isolation.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.isolation.dom.test.tsx
@@ -94,7 +94,7 @@ describe("a tool result that cannot render", () => {
     // phase-wide boundary took this card down with its sibling, which leaves
     // the reader unable to answer and unable to see why.
     expect(
-      screen.getByRole("option", { name: /Yes, run it once/ }),
+      screen.getByRole("button", { name: /Yes, run it once/ }),
     ).toBeTruthy();
   });
 });
@@ -139,7 +139,7 @@ describe("a continuation card that cannot render", () => {
       1,
     );
     expect(
-      screen.getByRole("option", { name: /Yes, run it once/ }),
+      screen.getByRole("button", { name: /Yes, run it once/ }),
     ).toBeTruthy();
   });
 });

--- a/crates/openwave-desktop/ui/src/NetworkPolicyDialog.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/NetworkPolicyDialog.dom.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { NetworkPolicyDialog } from "./NetworkPolicyDialog";
@@ -8,7 +9,8 @@ import { NetworkPolicyDialog } from "./NetworkPolicyDialog";
 afterEach(cleanup);
 
 describe("NetworkPolicyDialog", () => {
-  it("offers the package-registry class as one per-chat choice", () => {
+  it("selects a package-registry policy without applying it until submit", async () => {
+    const user = userEvent.setup();
     const onChange = vi.fn();
     render(
       <NetworkPolicyDialog
@@ -19,10 +21,12 @@ describe("NetworkPolicyDialog", () => {
       />,
     );
 
-    fireEvent.click(
-      screen
-        .getByText(/Only curated package registries are reachable/i)
-        .closest("button")!,
+    await user.click(
+      screen.getByRole("radio", { name: /Package installs/i }),
+    );
+    expect(onChange).not.toHaveBeenCalled();
+    await user.click(
+      screen.getByRole("button", { name: "Apply network policy" }),
     );
 
     expect(onChange).toHaveBeenCalledWith({ mode: "package_managers" });
@@ -43,7 +47,10 @@ describe("NetworkPolicyDialog", () => {
       target: { value: "api.example.com, api.example.com\nfiles.example.com" },
     });
     fireEvent.click(screen.getByText("Also allow package registries"));
-    fireEvent.click(screen.getByRole("button", { name: "Use custom policy" }));
+    expect(onChange).not.toHaveBeenCalled();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Apply network policy" }),
+    );
 
     expect(onChange).toHaveBeenCalledWith({
       mode: "allowed_hosts",
@@ -68,13 +75,16 @@ describe("NetworkPolicyDialog", () => {
       />,
     );
 
-    const internetAccess = screen
-      .getByText(/Reach public internet destinations/i)
-      .closest("button")!;
+    const internetAccess = screen.getByRole("radio", {
+      name: /Internet access/i,
+    });
     expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
 
     fireEvent.click(internetAccess);
-    fireEvent.click(internetAccess);
+    expect(onChange).not.toHaveBeenCalled();
+    const apply = screen.getByRole("button", { name: "Apply network policy" });
+    fireEvent.click(apply);
+    fireEvent.click(apply);
 
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(internetAccess).toBeDisabled();

--- a/crates/openwave-desktop/ui/src/NetworkPolicyDialog.tsx
+++ b/crates/openwave-desktop/ui/src/NetworkPolicyDialog.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import {
-  Check,
   Globe2,
   Package,
   ShieldOff,
@@ -17,6 +16,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Textarea } from "@/components/ui/textarea";
 
 const OPTIONS = [
@@ -80,8 +80,15 @@ export function NetworkPolicyDialog({
 }) {
   // Seeded from the stored policy each time the dialog opens, so an abandoned
   // edit does not survive into the next visit.
-  const [hosts, setHosts] = useState("");
-  const [includePackages, setIncludePackages] = useState(false);
+  const [selectedMode, setSelectedMode] = useState<NetworkPolicy["mode"]>(
+    value.mode,
+  );
+  const [hosts, setHosts] = useState(
+    value.mode === "allowed_hosts" ? value.allowed_hosts.join("\n") : "",
+  );
+  const [includePackages, setIncludePackages] = useState(
+    value.mode === "allowed_hosts" && value.package_managers,
+  );
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const controlsDisabled = disabled || saving;
@@ -89,9 +96,14 @@ export function NetworkPolicyDialog({
   function openAndHydrate(next: boolean) {
     if (!next && saving) return;
     if (!next) setSaveError(null);
-    if (next && value.mode === "allowed_hosts") {
-      setHosts(value.allowed_hosts.join("\n"));
-      setIncludePackages(value.package_managers);
+    if (next) {
+      setSelectedMode(value.mode);
+      setHosts(
+        value.mode === "allowed_hosts" ? value.allowed_hosts.join("\n") : "",
+      );
+      setIncludePackages(
+        value.mode === "allowed_hosts" && value.package_managers,
+      );
     }
     onOpenChange(next);
   }
@@ -111,7 +123,11 @@ export function NetworkPolicyDialog({
     }
   }
 
-  function saveCustom() {
+  function saveSelection() {
+    if (selectedMode !== "allowed_hosts") {
+      void select({ mode: selectedMode });
+      return;
+    }
     const allowedHosts = [
       ...new Set(
         hosts
@@ -141,67 +157,94 @@ export function NetworkPolicyDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-1">
+        <RadioGroup
+          value={selectedMode}
+          onValueChange={(mode) =>
+            setSelectedMode(mode as NetworkPolicy["mode"])
+          }
+          aria-label="Network access policy"
+          disabled={controlsDisabled}
+          className="gap-1"
+        >
           {OPTIONS.filter((option) => option.mode !== "allowed_hosts").map(
             (option) => {
-              const selected = value.mode === option.mode;
               const Icon = option.icon;
+              const id = `network-policy-${option.mode}`;
               return (
-                <button
+                <label
                   key={option.mode}
-                  type="button"
-                  className="flex w-full items-start gap-2 rounded-md p-2 text-left hover:bg-muted"
-                  disabled={controlsDisabled}
-                  onClick={() => void select({ mode: option.mode })}
+                  htmlFor={id}
+                  className="flex w-full cursor-pointer items-start gap-2 rounded-md p-2 text-left hover:bg-muted"
                 >
+                  <RadioGroupItem
+                    id={id}
+                    value={option.mode}
+                    className="mt-0.5"
+                  />
                   <Icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
                   <span className="min-w-0 flex-1">
-                    <span className="block text-sm font-medium">{option.label}</span>
+                    <span className="block text-sm font-medium">
+                      {option.label}
+                    </span>
                     <span className="block text-xs text-muted-foreground">
                       {option.description}
                     </span>
                   </span>
-                  {selected && <Check className="mt-0.5 size-4" />}
-                </button>
+                </label>
               );
             },
           )}
-        </div>
 
-        <div className="space-y-2 border-t pt-3">
-          <div className="flex items-center gap-2">
-            <SlidersHorizontal className="size-4 text-muted-foreground" />
-            <span className="text-sm font-medium">Custom hosts</span>
-            {value.mode === "allowed_hosts" && (
-              <Check className="ml-auto size-4" />
-            )}
-          </div>
-          <Textarea
-            aria-label="Allowed network hosts"
-            value={hosts}
-            disabled={controlsDisabled}
-            onChange={(event) => setHosts(event.target.value)}
-            placeholder={"api.example.com\nfiles.example.com"}
-            className="min-h-20 font-mono text-xs"
-          />
-          <label className="flex items-center gap-2 text-xs">
-            <Checkbox
-              checked={includePackages}
+          <div className="space-y-2 border-t pt-3">
+            <label
+              htmlFor="network-policy-allowed-hosts"
+              className="flex cursor-pointer items-center gap-2"
+            >
+              <RadioGroupItem
+                id="network-policy-allowed-hosts"
+                value="allowed_hosts"
+              />
+              <SlidersHorizontal className="size-4 text-muted-foreground" />
+              <span className="text-sm font-medium">Custom hosts</span>
+            </label>
+            <Textarea
+              aria-label="Allowed network hosts"
+              value={hosts}
               disabled={controlsDisabled}
-              onCheckedChange={(checked) => setIncludePackages(checked === true)}
+              onChange={(event) => {
+                setSelectedMode("allowed_hosts");
+                setHosts(event.target.value);
+              }}
+              placeholder={"api.example.com\nfiles.example.com"}
+              className="min-h-20 font-mono text-xs"
             />
-            Also allow package registries
-          </label>
-          <Button
-            type="button"
-            size="sm"
-            className="w-full"
-            disabled={controlsDisabled || (!hosts.trim() && !includePackages)}
-            onClick={saveCustom}
-          >
-            Use custom policy
-          </Button>
-        </div>
+            <label className="flex items-center gap-2 text-xs">
+              <Checkbox
+                checked={includePackages}
+                disabled={controlsDisabled}
+                onCheckedChange={(checked) => {
+                  setSelectedMode("allowed_hosts");
+                  setIncludePackages(checked === true);
+                }}
+              />
+              Also allow package registries
+            </label>
+          </div>
+        </RadioGroup>
+        <Button
+          type="button"
+          size="sm"
+          className="w-full"
+          disabled={
+            controlsDisabled ||
+            (selectedMode === "allowed_hosts" &&
+              !hosts.trim() &&
+              !includePackages)
+          }
+          onClick={saveSelection}
+        >
+          Apply network policy
+        </Button>
         {saving && (
           <p className="text-muted-foreground text-sm" role="status">
             Saving network policy…

--- a/crates/openwave-desktop/ui/src/PermissionModeMenu.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/PermissionModeMenu.dom.test.tsx
@@ -1,10 +1,13 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
 import { afterEach, expect, it, vi } from "vitest";
 import type { ManagedPolicy, PermissionMode } from "./api";
 import { ManagedPolicyContext } from "./managedPolicy";
 import { PermissionModeMenu } from "./PermissionModeMenu";
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn() } }));
 
 afterEach(() => {
   cleanup();
@@ -115,4 +118,41 @@ it("lets a new chat save while an old chat write is still settling", async () =>
 
   resolveOld();
   await waitFor(() => expect(onChange).toHaveBeenCalledTimes(2));
+});
+
+it("does not toast a failed write after keyed chat navigation unmounts it", async () => {
+  let rejectOld!: (reason: Error) => void;
+  const oldWrite = new Promise<void>((_resolve, reject) => {
+    rejectOld = reject;
+  });
+  const onChange = vi.fn().mockReturnValue(oldWrite);
+  const oldChat = render(
+    <PermissionModeMenu
+      scopeKey="chat-1"
+      value="ask"
+      onChange={onChange}
+    />,
+  );
+
+  await userEvent.click(
+    screen.getByRole("button", { name: "Permissions: Ask" }),
+  );
+  await userEvent.click(
+    await screen.findByRole("menuitem", { name: /Allow all/ }),
+  );
+  oldChat.unmount();
+  render(
+    <PermissionModeMenu
+      scopeKey="chat-2"
+      value="ask"
+      onChange={vi.fn()}
+    />,
+  );
+
+  await act(async () => rejectOld(new Error("old chat write failed")));
+
+  expect(toast.error).not.toHaveBeenCalled();
+  expect(
+    screen.getByRole("button", { name: "Permissions: Ask" }),
+  ).toBeEnabled();
 });

--- a/crates/openwave-desktop/ui/src/PermissionModeMenu.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/PermissionModeMenu.dom.test.tsx
@@ -2,7 +2,7 @@
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, expect, it, vi } from "vitest";
-import type { ManagedPolicy } from "./api";
+import type { ManagedPolicy, PermissionMode } from "./api";
 import { ManagedPolicyContext } from "./managedPolicy";
 import { PermissionModeMenu } from "./PermissionModeMenu";
 
@@ -17,7 +17,9 @@ afterEach(() => {
  */
 it("applies the chosen mode and closes", async () => {
   const onChange = vi.fn();
-  render(<PermissionModeMenu value={null} onChange={onChange} />);
+  render(
+    <PermissionModeMenu scopeKey="chat-1" value={null} onChange={onChange} />,
+  );
 
   await userEvent.click(screen.getByRole("button", { name: "Permissions: Ask" }));
   await userEvent.click(await screen.findByRole("menuitem", { name: /Allow all/ }));
@@ -44,7 +46,11 @@ it("locks modes above a managed ceiling", async () => {
   const onChange = vi.fn();
   render(
     <ManagedPolicyContext.Provider value={capped}>
-      <PermissionModeMenu value="allow" onChange={onChange} />
+      <PermissionModeMenu
+        scopeKey="chat-1"
+        value="allow"
+        onChange={onChange}
+      />
     </ManagedPolicyContext.Provider>,
   );
 
@@ -59,4 +65,54 @@ it("locks modes above a managed ceiling", async () => {
 
   await userEvent.click(locked);
   expect(onChange).not.toHaveBeenCalled();
+});
+
+it("lets a new chat save while an old chat write is still settling", async () => {
+  let resolveOld!: () => void;
+  const oldWrite = new Promise<void>((resolve) => {
+    resolveOld = resolve;
+  });
+  const onChange = vi
+    .fn<(mode: PermissionMode) => Promise<void>>()
+    .mockImplementationOnce(() => oldWrite)
+    .mockResolvedValueOnce(undefined);
+  const { rerender } = render(
+    <PermissionModeMenu
+      scopeKey="chat-1"
+      value="ask"
+      onChange={onChange}
+    />,
+  );
+
+  await userEvent.click(
+    screen.getByRole("button", { name: "Permissions: Ask" }),
+  );
+  await userEvent.click(
+    await screen.findByRole("menuitem", { name: /Allow all/ }),
+  );
+  expect(screen.getByRole("button", { name: "Permissions: Ask" })).toBeDisabled();
+
+  rerender(
+    <PermissionModeMenu
+      scopeKey="chat-2"
+      value="ask"
+      onChange={onChange}
+    />,
+  );
+  await waitFor(() =>
+    expect(
+      screen.getByRole("button", { name: "Permissions: Ask" }),
+    ).not.toBeDisabled(),
+  );
+
+  await userEvent.click(
+    screen.getByRole("button", { name: "Permissions: Ask" }),
+  );
+  await userEvent.click(
+    await screen.findByRole("menuitem", { name: /Plan/ }),
+  );
+  expect(onChange).toHaveBeenLastCalledWith("plan");
+
+  resolveOld();
+  await waitFor(() => expect(onChange).toHaveBeenCalledTimes(2));
 });

--- a/crates/openwave-desktop/ui/src/PermissionModeMenu.tsx
+++ b/crates/openwave-desktop/ui/src/PermissionModeMenu.tsx
@@ -7,6 +7,8 @@ import {
   Sparkles,
   Zap,
 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 import type { PermissionMode } from "./api";
 import { useManagedPolicy } from "./managedPolicy";
 import { Button } from "@/components/ui/button";
@@ -103,14 +105,55 @@ export function permissionModeOption(mode: PermissionMode | null) {
  * under.
  */
 export function PermissionModeMenu({
+  scopeKey,
   value,
   disabled,
   onChange,
 }: {
+  /** Identity of the chat or draft whose setting is being changed. */
+  scopeKey: string;
   value: PermissionMode | null;
   disabled?: boolean;
   onChange: (mode: PermissionMode) => void | Promise<void>;
 }) {
+  const [saving, setSaving] = useState(false);
+  const savingRef = useRef(false);
+  const operationGenerationRef = useRef(0);
+  const scopeKeyRef = useRef(scopeKey);
+  scopeKeyRef.current = scopeKey;
+
+  useEffect(() => {
+    operationGenerationRef.current += 1;
+    savingRef.current = false;
+    setSaving(false);
+  }, [scopeKey]);
+
+  async function selectMode(mode: PermissionMode) {
+    if (savingRef.current) return;
+    const startingScope = scopeKey;
+    const generation = ++operationGenerationRef.current;
+    savingRef.current = true;
+    setSaving(true);
+    try {
+      await onChange(mode);
+    } catch {
+      if (
+        scopeKeyRef.current === startingScope &&
+        operationGenerationRef.current === generation
+      ) {
+        toast.error("Could not update permissions. Try again.");
+      }
+    } finally {
+      if (
+        scopeKeyRef.current === startingScope &&
+        operationGenerationRef.current === generation
+      ) {
+        savingRef.current = false;
+        setSaving(false);
+      }
+    }
+  }
+
   const ceiling = useManagedPolicy().permission_mode_ceiling ?? null;
   const ceilingRank = ceiling === null ? null : autonomyRank(ceiling);
   const overCeiling = (mode: PermissionMode) =>
@@ -120,14 +163,16 @@ export function PermissionModeMenu({
     : value;
   const current = permissionModeOption(effective);
   const CurrentIcon = current.icon;
+  const controlsDisabled = disabled || saving;
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button
           variant="ghost"
           className={cn("h-8 gap-1.5", current.elevated && "text-warning-foreground")}
-          disabled={disabled}
+          disabled={controlsDisabled}
           aria-label={`Permissions: ${current.label}`}
+          aria-busy={saving}
         >
           <CurrentIcon
             className={cn(
@@ -147,10 +192,10 @@ export function PermissionModeMenu({
           return (
             <DropdownMenuItem
               key={option.value}
-              disabled={disabled || locked}
+              disabled={controlsDisabled || locked}
               onSelect={() => {
                 if (selected) return;
-                void onChange(option.value);
+                void selectMode(option.value);
               }}
               className="flex flex-col items-start gap-0.5 py-3"
             >

--- a/crates/openwave-desktop/ui/src/PermissionModeMenu.tsx
+++ b/crates/openwave-desktop/ui/src/PermissionModeMenu.tsx
@@ -126,6 +126,10 @@ export function PermissionModeMenu({
     operationGenerationRef.current += 1;
     savingRef.current = false;
     setSaving(false);
+    return () => {
+      operationGenerationRef.current += 1;
+      savingRef.current = false;
+    };
   }, [scopeKey]);
 
   async function selectMode(mode: PermissionMode) {

--- a/crates/openwave-desktop/ui/src/apps/AppDetailView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppDetailView.dom.test.tsx
@@ -1,5 +1,13 @@
 // @vitest-environment jsdom
-import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { AppInvokeRefusalError, type AppDetail, type AppGrantState } from "@/api";
@@ -253,6 +261,97 @@ describe("AppDetailView", () => {
       await screen.findByRole("button", { name: "Allow access" }),
     ).toBeInTheDocument();
     expect(screen.queryByTitle(/^App:/)).not.toBeInTheDocument();
+  });
+
+  it("lets revoke own busy state and its grant refresh during a consent_required refusal", async () => {
+    const revoke = deferred<void>();
+    const apis = apisWith(GRANTED);
+    apis.revoke = vi.fn().mockReturnValue(revoke.promise);
+    apis.grantState = vi
+      .fn()
+      .mockResolvedValueOnce(GRANTED)
+      .mockResolvedValue(STALE);
+    apis.invokeOperation = vi
+      .fn()
+      .mockRejectedValue(
+        new AppInvokeRefusalError("consent_required", "Consent required"),
+      );
+    render(<AppDetailView appId="app-1" apis={apis} onBack={() => {}} />);
+
+    const frame = (await screen.findByTitle(
+      "App: Fixture app",
+    )) as HTMLIFrameElement;
+    fireEvent.click(screen.getByRole("button", { name: "Revoke access" }));
+    expect(apis.revoke).toHaveBeenCalledWith("app-1");
+
+    const contentWindow = frame.contentWindow!;
+    const posted = vi.spyOn(contentWindow, "postMessage");
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: {
+          jsonrpc: "2.0",
+          id: 7,
+          method: "operations/call",
+          params: { operation_id: "listIssues" },
+        },
+        source: contentWindow,
+      }),
+    );
+    await waitFor(() => expect(posted).toHaveBeenCalled());
+    expect(apis.grantState).toHaveBeenCalledTimes(1);
+
+    await act(async () => revoke.resolve(undefined));
+
+    expect(
+      await screen.findByRole("button", { name: "Allow access" }),
+    ).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Delete app" })).toBeEnabled();
+    expect(apis.grantState).toHaveBeenCalledTimes(2);
+  });
+
+  it("lets delete complete during a consent_required refusal", async () => {
+    const deletion = deferred<void>();
+    const onBack = vi.fn();
+    const apis = apisWith(GRANTED);
+    apis.deleteApp = vi.fn().mockReturnValue(deletion.promise);
+    apis.invokeOperation = vi
+      .fn()
+      .mockRejectedValue(
+        new AppInvokeRefusalError("consent_required", "Consent required"),
+      );
+    render(<AppDetailView appId="app-1" apis={apis} onBack={onBack} />);
+
+    const frame = (await screen.findByTitle(
+      "App: Fixture app",
+    )) as HTMLIFrameElement;
+    fireEvent.click(screen.getByRole("button", { name: "Delete app" }));
+    const confirmation = await screen.findByRole("alertdialog");
+    fireEvent.click(
+      within(confirmation).getByRole("button", { name: "Delete app" }),
+    );
+    await waitFor(() => expect(apis.deleteApp).toHaveBeenCalledWith("app-1"));
+
+    const contentWindow = frame.contentWindow!;
+    const posted = vi.spyOn(contentWindow, "postMessage");
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: {
+          jsonrpc: "2.0",
+          id: 8,
+          method: "operations/call",
+          params: { operation_id: "listIssues" },
+        },
+        source: contentWindow,
+      }),
+    );
+    await waitFor(() => expect(posted).toHaveBeenCalled());
+    expect(apis.grantState).toHaveBeenCalledTimes(1);
+
+    await act(async () => deletion.resolve(undefined));
+
+    await waitFor(() => expect(onBack).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole("button", { name: "Revoke access" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Delete app" })).toBeEnabled();
   });
 
   it("gates an ungranted app behind the sheet, marks staleness, and consents body-less", async () => {

--- a/crates/openwave-desktop/ui/src/apps/AppDetailView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppDetailView.dom.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { AppInvokeRefusalError, type AppDetail, type AppGrantState } from "@/api";
@@ -80,6 +80,14 @@ function apisWith(grant: AppGrantState): AppsApis {
       is_error: false,
     }),
   };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
 }
 
 afterEach(() => {
@@ -310,5 +318,37 @@ describe("AppDetailView", () => {
         "This app can read 'Tax documents' and send data to 'issues'.",
       ),
     ).toBeInTheDocument();
+  });
+
+  it("ignores an earlier app load that resolves after navigation", async () => {
+    const oldDetail = deferred<AppDetail>();
+    const oldGrant = deferred<AppGrantState>();
+    const currentDetail: AppDetail = {
+      ...DETAIL,
+      id: "app-2",
+      name: "Current app",
+    };
+    const apis = apisWith(GRANTED);
+    apis.get = vi
+      .fn()
+      .mockReturnValueOnce(oldDetail.promise)
+      .mockResolvedValueOnce(currentDetail);
+    apis.grantState = vi
+      .fn()
+      .mockReturnValueOnce(oldGrant.promise)
+      .mockResolvedValueOnce(GRANTED);
+    const { rerender } = render(
+      <AppDetailView appId="app-1" apis={apis} onBack={() => {}} />,
+    );
+
+    rerender(<AppDetailView appId="app-2" apis={apis} onBack={() => {}} />);
+    expect(await screen.findByTitle("App: Current app")).toBeInTheDocument();
+
+    await act(async () => {
+      oldDetail.resolve(DETAIL);
+      oldGrant.resolve(GRANTED);
+    });
+    expect(screen.getByTitle("App: Current app")).toBeInTheDocument();
+    expect(screen.queryByTitle("App: Fixture app")).not.toBeInTheDocument();
   });
 });

--- a/crates/openwave-desktop/ui/src/apps/AppDetailView.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppDetailView.tsx
@@ -54,26 +54,48 @@ export function AppDetailView({
   const [actionError, setActionError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const generationRef = useRef(0);
-  const actionGenerationRef = useRef(0);
+  const mutationGenerationRef = useRef(0);
+  const refreshGenerationRef = useRef(0);
+  const mutationInFlightRef = useRef(false);
   const appIdRef = useRef(appId);
   appIdRef.current = appId;
   const { confirm, dialog } = useConfirm();
 
-  function actionIsCurrent(
-    targetAppId: string,
-    scopeGeneration: number,
-    actionGeneration: number,
-  ) {
+  function scopeIsCurrent(targetAppId: string, scopeGeneration: number) {
     return (
       appIdRef.current === targetAppId &&
-      generationRef.current === scopeGeneration &&
-      actionGenerationRef.current === actionGeneration
+      generationRef.current === scopeGeneration
+    );
+  }
+
+  function mutationIsCurrent(
+    targetAppId: string,
+    scopeGeneration: number,
+    mutationGeneration: number,
+  ) {
+    return (
+      scopeIsCurrent(targetAppId, scopeGeneration) &&
+      mutationGenerationRef.current === mutationGeneration
+    );
+  }
+
+  function refreshIsCurrent(
+    targetAppId: string,
+    scopeGeneration: number,
+    refreshGeneration: number,
+  ) {
+    return (
+      scopeIsCurrent(targetAppId, scopeGeneration) &&
+      !mutationInFlightRef.current &&
+      refreshGenerationRef.current === refreshGeneration
     );
   }
 
   useEffect(() => {
     const generation = ++generationRef.current;
-    actionGenerationRef.current += 1;
+    mutationGenerationRef.current += 1;
+    refreshGenerationRef.current += 1;
+    mutationInFlightRef.current = false;
     setDetail(null);
     setGrant(null);
     setLoadError(null);
@@ -99,44 +121,64 @@ export function AppDetailView({
   }, [apis, appId]);
 
   async function onConsent() {
+    if (mutationInFlightRef.current) return;
     const targetAppId = appId;
     const scopeGeneration = generationRef.current;
-    const actionGeneration = ++actionGenerationRef.current;
+    const mutationGeneration = ++mutationGenerationRef.current;
+    refreshGenerationRef.current += 1;
+    mutationInFlightRef.current = true;
     setBusy(true);
     setActionError(null);
     try {
       const nextGrant = await apis.consent(targetAppId);
-      if (actionIsCurrent(targetAppId, scopeGeneration, actionGeneration)) {
+      if (
+        mutationIsCurrent(targetAppId, scopeGeneration, mutationGeneration)
+      ) {
         setGrant(nextGrant);
       }
     } catch (caught) {
-      if (actionIsCurrent(targetAppId, scopeGeneration, actionGeneration)) {
+      if (
+        mutationIsCurrent(targetAppId, scopeGeneration, mutationGeneration)
+      ) {
         setActionError(friendlyAppsError(caught, "Could not record consent."));
       }
     } finally {
-      if (actionIsCurrent(targetAppId, scopeGeneration, actionGeneration)) {
+      if (
+        mutationIsCurrent(targetAppId, scopeGeneration, mutationGeneration)
+      ) {
+        mutationInFlightRef.current = false;
         setBusy(false);
       }
     }
   }
 
   async function onRevoke() {
+    if (mutationInFlightRef.current) return;
     const targetAppId = appId;
     const scopeGeneration = generationRef.current;
-    const actionGeneration = ++actionGenerationRef.current;
+    const mutationGeneration = ++mutationGenerationRef.current;
+    refreshGenerationRef.current += 1;
+    mutationInFlightRef.current = true;
     setBusy(true);
     try {
       await apis.revoke(targetAppId);
       const nextGrant = await apis.grantState(targetAppId);
-      if (actionIsCurrent(targetAppId, scopeGeneration, actionGeneration)) {
+      if (
+        mutationIsCurrent(targetAppId, scopeGeneration, mutationGeneration)
+      ) {
         setGrant(nextGrant);
       }
     } catch (caught) {
-      if (actionIsCurrent(targetAppId, scopeGeneration, actionGeneration)) {
+      if (
+        mutationIsCurrent(targetAppId, scopeGeneration, mutationGeneration)
+      ) {
         toast.error(friendlyAppsError(caught, "Could not revoke access."));
       }
     } finally {
-      if (actionIsCurrent(targetAppId, scopeGeneration, actionGeneration)) {
+      if (
+        mutationIsCurrent(targetAppId, scopeGeneration, mutationGeneration)
+      ) {
+        mutationInFlightRef.current = false;
         setBusy(false);
       }
     }
@@ -146,16 +188,19 @@ export function AppDetailView({
   // server reconfigured underneath the grant) drops the frame back behind
   // the sheet with the server's fresh projection.
   async function onConsentRequired() {
+    // A refusal from an operation issued before revoke/delete began is stale
+    // relative to that mutation. The mutation's result owns the next state.
+    if (mutationInFlightRef.current) return;
     const targetAppId = appId;
     const scopeGeneration = generationRef.current;
-    const actionGeneration = ++actionGenerationRef.current;
+    const refreshGeneration = ++refreshGenerationRef.current;
     try {
       const nextGrant = await apis.grantState(targetAppId);
-      if (actionIsCurrent(targetAppId, scopeGeneration, actionGeneration)) {
+      if (refreshIsCurrent(targetAppId, scopeGeneration, refreshGeneration)) {
         setGrant(nextGrant);
       }
     } catch {
-      if (actionIsCurrent(targetAppId, scopeGeneration, actionGeneration)) {
+      if (refreshIsCurrent(targetAppId, scopeGeneration, refreshGeneration)) {
         setGrant((current) =>
           current ? { ...current, granted: false } : current,
         );
@@ -180,19 +225,29 @@ export function AppDetailView({
     ) {
       return;
     }
-    const actionGeneration = ++actionGenerationRef.current;
+    if (mutationInFlightRef.current) return;
+    const mutationGeneration = ++mutationGenerationRef.current;
+    refreshGenerationRef.current += 1;
+    mutationInFlightRef.current = true;
     setBusy(true);
     try {
       await apis.deleteApp(targetAppId);
-      if (actionIsCurrent(targetAppId, scopeGeneration, actionGeneration)) {
+      if (
+        mutationIsCurrent(targetAppId, scopeGeneration, mutationGeneration)
+      ) {
         onBack();
       }
     } catch (caught) {
-      if (actionIsCurrent(targetAppId, scopeGeneration, actionGeneration)) {
+      if (
+        mutationIsCurrent(targetAppId, scopeGeneration, mutationGeneration)
+      ) {
         toast.error(friendlyAppsError(caught, "Could not delete this app."));
       }
     } finally {
-      if (actionIsCurrent(targetAppId, scopeGeneration, actionGeneration)) {
+      if (
+        mutationIsCurrent(targetAppId, scopeGeneration, mutationGeneration)
+      ) {
+        mutationInFlightRef.current = false;
         setBusy(false);
       }
     }

--- a/crates/openwave-desktop/ui/src/apps/AppDetailView.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppDetailView.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import type { AppDetail, AppGrantState } from "@/api";
+import { useConfirm } from "@/components/ConfirmDialog";
 import { PanelSecondaryHeader } from "@/components/PanelHeader";
 import { Button } from "@/components/ui/button";
 import { AppConsentSheet } from "./AppConsentSheet";
@@ -53,13 +54,31 @@ export function AppDetailView({
   const [actionError, setActionError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const generationRef = useRef(0);
+  const actionGenerationRef = useRef(0);
+  const appIdRef = useRef(appId);
+  appIdRef.current = appId;
+  const { confirm, dialog } = useConfirm();
+
+  function actionIsCurrent(
+    targetAppId: string,
+    scopeGeneration: number,
+    actionGeneration: number,
+  ) {
+    return (
+      appIdRef.current === targetAppId &&
+      generationRef.current === scopeGeneration &&
+      actionGenerationRef.current === actionGeneration
+    );
+  }
 
   useEffect(() => {
     const generation = ++generationRef.current;
+    actionGenerationRef.current += 1;
     setDetail(null);
     setGrant(null);
     setLoadError(null);
     setActionError(null);
+    setBusy(false);
     void (async () => {
       try {
         const [loadedDetail, loadedGrant] = await Promise.all([
@@ -80,26 +99,46 @@ export function AppDetailView({
   }, [apis, appId]);
 
   async function onConsent() {
+    const targetAppId = appId;
+    const scopeGeneration = generationRef.current;
+    const actionGeneration = ++actionGenerationRef.current;
     setBusy(true);
     setActionError(null);
     try {
-      setGrant(await apis.consent(appId));
+      const nextGrant = await apis.consent(targetAppId);
+      if (actionIsCurrent(targetAppId, scopeGeneration, actionGeneration)) {
+        setGrant(nextGrant);
+      }
     } catch (caught) {
-      setActionError(friendlyAppsError(caught, "Could not record consent."));
+      if (actionIsCurrent(targetAppId, scopeGeneration, actionGeneration)) {
+        setActionError(friendlyAppsError(caught, "Could not record consent."));
+      }
     } finally {
-      setBusy(false);
+      if (actionIsCurrent(targetAppId, scopeGeneration, actionGeneration)) {
+        setBusy(false);
+      }
     }
   }
 
   async function onRevoke() {
+    const targetAppId = appId;
+    const scopeGeneration = generationRef.current;
+    const actionGeneration = ++actionGenerationRef.current;
     setBusy(true);
     try {
-      await apis.revoke(appId);
-      setGrant(await apis.grantState(appId));
+      await apis.revoke(targetAppId);
+      const nextGrant = await apis.grantState(targetAppId);
+      if (actionIsCurrent(targetAppId, scopeGeneration, actionGeneration)) {
+        setGrant(nextGrant);
+      }
     } catch (caught) {
-      toast.error(friendlyAppsError(caught, "Could not revoke access."));
+      if (actionIsCurrent(targetAppId, scopeGeneration, actionGeneration)) {
+        toast.error(friendlyAppsError(caught, "Could not revoke access."));
+      }
     } finally {
-      setBusy(false);
+      if (actionIsCurrent(targetAppId, scopeGeneration, actionGeneration)) {
+        setBusy(false);
+      }
     }
   }
 
@@ -107,23 +146,55 @@ export function AppDetailView({
   // server reconfigured underneath the grant) drops the frame back behind
   // the sheet with the server's fresh projection.
   async function onConsentRequired() {
+    const targetAppId = appId;
+    const scopeGeneration = generationRef.current;
+    const actionGeneration = ++actionGenerationRef.current;
     try {
-      setGrant(await apis.grantState(appId));
+      const nextGrant = await apis.grantState(targetAppId);
+      if (actionIsCurrent(targetAppId, scopeGeneration, actionGeneration)) {
+        setGrant(nextGrant);
+      }
     } catch {
-      setGrant((current) =>
-        current ? { ...current, granted: false } : current,
-      );
+      if (actionIsCurrent(targetAppId, scopeGeneration, actionGeneration)) {
+        setGrant((current) =>
+          current ? { ...current, granted: false } : current,
+        );
+      }
     }
   }
 
   async function onDelete() {
+    const targetAppId = appId;
+    const scopeGeneration = generationRef.current;
+    const confirmed = await confirm({
+      title: `Delete ${detail?.name ?? "this app"}?`,
+      description:
+        "The app will be removed from the library and can no longer be opened.",
+      confirmLabel: "Delete app",
+      destructive: true,
+    });
+    if (
+      !confirmed ||
+      appIdRef.current !== targetAppId ||
+      generationRef.current !== scopeGeneration
+    ) {
+      return;
+    }
+    const actionGeneration = ++actionGenerationRef.current;
     setBusy(true);
     try {
-      await apis.deleteApp(appId);
-      onBack();
+      await apis.deleteApp(targetAppId);
+      if (actionIsCurrent(targetAppId, scopeGeneration, actionGeneration)) {
+        onBack();
+      }
     } catch (caught) {
-      toast.error(friendlyAppsError(caught, "Could not delete this app."));
-      setBusy(false);
+      if (actionIsCurrent(targetAppId, scopeGeneration, actionGeneration)) {
+        toast.error(friendlyAppsError(caught, "Could not delete this app."));
+      }
+    } finally {
+      if (actionIsCurrent(targetAppId, scopeGeneration, actionGeneration)) {
+        setBusy(false);
+      }
     }
   }
 
@@ -246,6 +317,7 @@ export function AppDetailView({
           </>
         )}
       </div>
+      {dialog}
     </div>
   );
 }

--- a/crates/openwave-desktop/ui/src/apps/AppsPage.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppsPage.tsx
@@ -26,6 +26,7 @@ export function AppsPage({ appId }: { appId?: string }) {
       <div className="content-container flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden">
         {appId ? (
           <AppDetailView
+            key={appId}
             appId={appId}
             apis={apis}
             onBack={() => void navigate({ to: "/apps" })}

--- a/crates/openwave-desktop/ui/src/components/ConfirmDialog.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/components/ConfirmDialog.dom.test.tsx
@@ -19,9 +19,14 @@ function ConfirmationQueueHarness() {
         onClick={() => {
           const first = confirm({
             title: "First confirmation",
-            confirmLabel: "Confirm first",
+            confirmLabel: "Delete first",
+            destructive: true,
           });
-          const second = confirm({ title: "Second confirmation" });
+          const second = confirm({
+            title: "Second confirmation",
+            confirmLabel: "Delete second",
+            destructive: true,
+          });
           void Promise.all([first, second]).then(setResults);
         }}
       >
@@ -33,7 +38,7 @@ function ConfirmationQueueHarness() {
   );
 }
 
-it("settles overlapping confirmations in FIFO order", async () => {
+it("closes between queued confirmations and puts focus on the next cancel", async () => {
   const user = userEvent.setup();
   render(<ConfirmationQueueHarness />);
 
@@ -45,11 +50,13 @@ it("settles overlapping confirmations in FIFO order", async () => {
     screen.queryByRole("heading", { name: "Second confirmation" }),
   ).not.toBeInTheDocument();
 
-  await user.click(screen.getByRole("button", { name: "Confirm first" }));
+  await user.click(screen.getByRole("button", { name: "Delete first" }));
   expect(
     await screen.findByRole("heading", { name: "Second confirmation" }),
   ).toBeInTheDocument();
 
-  await user.click(screen.getByRole("button", { name: "Cancel" }));
+  const cancel = screen.getByRole("button", { name: "Cancel" });
+  await waitFor(() => expect(cancel).toHaveFocus());
+  await user.keyboard("[Space]");
   await waitFor(() => expect(screen.getByText("[true,false]")).toBeVisible());
 });

--- a/crates/openwave-desktop/ui/src/components/ConfirmDialog.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/components/ConfirmDialog.dom.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { afterEach, expect, it } from "vitest";
+
+import { useConfirm } from "./ConfirmDialog";
+
+afterEach(cleanup);
+
+function ConfirmationQueueHarness() {
+  const { confirm, dialog } = useConfirm();
+  const [results, setResults] = useState<boolean[] | null>(null);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          const first = confirm({
+            title: "First confirmation",
+            confirmLabel: "Confirm first",
+          });
+          const second = confirm({ title: "Second confirmation" });
+          void Promise.all([first, second]).then(setResults);
+        }}
+      >
+        Queue confirmations
+      </button>
+      {results && <output>{JSON.stringify(results)}</output>}
+      {dialog}
+    </>
+  );
+}
+
+it("settles overlapping confirmations in FIFO order", async () => {
+  const user = userEvent.setup();
+  render(<ConfirmationQueueHarness />);
+
+  await user.click(screen.getByRole("button", { name: "Queue confirmations" }));
+  expect(
+    await screen.findByRole("heading", { name: "First confirmation" }),
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByRole("heading", { name: "Second confirmation" }),
+  ).not.toBeInTheDocument();
+
+  await user.click(screen.getByRole("button", { name: "Confirm first" }));
+  expect(
+    await screen.findByRole("heading", { name: "Second confirmation" }),
+  ).toBeInTheDocument();
+
+  await user.click(screen.getByRole("button", { name: "Cancel" }));
+  await waitFor(() => expect(screen.getByText("[true,false]")).toBeVisible());
+});

--- a/crates/openwave-desktop/ui/src/components/ConfirmDialog.tsx
+++ b/crates/openwave-desktop/ui/src/components/ConfirmDialog.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useRef, useState, type ReactElement } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactElement,
+} from "react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -23,10 +29,9 @@ type PendingConfirm = ConfirmOptions & {
 };
 
 /**
- * Promise-based confirmation backed by the shared AlertDialog. Replaces
- * `window.confirm`, which renders a native OS dialog that breaks visually from
- * the rest of the app. Returns a `confirm()` that resolves to the user's choice
- * plus a `dialog` element to render once at the app root.
+ * Promise-based confirmation backed by the shared AlertDialog. Overlapping
+ * requests are queued in call order so every returned promise is settled by
+ * the dialog that belongs to it.
  */
 export function useConfirm(): {
   confirm: (options: ConfirmOptions) => Promise<boolean>;
@@ -34,25 +39,48 @@ export function useConfirm(): {
 } {
   const [pending, setPending] = useState<PendingConfirm | null>(null);
   const pendingRef = useRef<PendingConfirm | null>(null);
-  pendingRef.current = pending;
+  const queueRef = useRef<PendingConfirm[]>([]);
+  const buttonResultRef = useRef<boolean | null>(null);
+
+  const activateNext = useCallback(() => {
+    const next = queueRef.current.shift() ?? null;
+    pendingRef.current = next;
+    setPending(next);
+  }, []);
 
   const confirm = useCallback((options: ConfirmOptions) => {
     return new Promise<boolean>((resolve) => {
-      setPending({ ...options, resolve });
+      queueRef.current.push({ ...options, resolve });
+      if (pendingRef.current === null) activateNext();
     });
-  }, []);
+  }, [activateNext]);
 
   const settle = useCallback((result: boolean) => {
     const current = pendingRef.current;
-    if (current) current.resolve(result);
-    setPending(null);
-  }, []);
+    if (!current) return;
+    pendingRef.current = null;
+    current.resolve(result);
+    activateNext();
+  }, [activateNext]);
+
+  useEffect(
+    () => () => {
+      pendingRef.current?.resolve(false);
+      pendingRef.current = null;
+      for (const queued of queueRef.current.splice(0)) queued.resolve(false);
+    },
+    [],
+  );
 
   const dialog = (
     <AlertDialog
       open={pending !== null}
       onOpenChange={(open) => {
-        if (!open) settle(false);
+        if (!open) {
+          const result = buttonResultRef.current ?? false;
+          buttonResultRef.current = null;
+          settle(result);
+        }
       }}
     >
       {pending && (
@@ -66,12 +94,18 @@ export function useConfirm(): {
             )}
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel onClick={() => settle(false)}>
+            <AlertDialogCancel
+              onClick={() => {
+                buttonResultRef.current = false;
+              }}
+            >
               {pending.cancelLabel ?? "Cancel"}
             </AlertDialogCancel>
             <AlertDialogAction
               variant={pending.destructive ? "destructive" : "default"}
-              onClick={() => settle(true)}
+              onClick={() => {
+                buttonResultRef.current = true;
+              }}
             >
               {pending.confirmLabel ?? "Confirm"}
             </AlertDialogAction>

--- a/crates/openwave-desktop/ui/src/components/ConfirmDialog.tsx
+++ b/crates/openwave-desktop/ui/src/components/ConfirmDialog.tsx
@@ -25,6 +25,7 @@ export type ConfirmOptions = {
 };
 
 type PendingConfirm = ConfirmOptions & {
+  id: number;
   resolve: (value: boolean) => void;
 };
 
@@ -41,17 +42,20 @@ export function useConfirm(): {
   const pendingRef = useRef<PendingConfirm | null>(null);
   const queueRef = useRef<PendingConfirm[]>([]);
   const buttonResultRef = useRef<boolean | null>(null);
+  const nextIdRef = useRef(0);
+  const phaseRef = useRef<"idle" | "open" | "closing">("idle");
 
   const activateNext = useCallback(() => {
     const next = queueRef.current.shift() ?? null;
     pendingRef.current = next;
+    phaseRef.current = next ? "open" : "idle";
     setPending(next);
   }, []);
 
   const confirm = useCallback((options: ConfirmOptions) => {
     return new Promise<boolean>((resolve) => {
-      queueRef.current.push({ ...options, resolve });
-      if (pendingRef.current === null) activateNext();
+      queueRef.current.push({ ...options, id: ++nextIdRef.current, resolve });
+      if (phaseRef.current === "idle") activateNext();
     });
   }, [activateNext]);
 
@@ -59,14 +63,24 @@ export function useConfirm(): {
     const current = pendingRef.current;
     if (!current) return;
     pendingRef.current = null;
+    phaseRef.current = "closing";
+    setPending(null);
     current.resolve(result);
-    activateNext();
-  }, [activateNext]);
+  }, []);
+
+  // Render a fully closed dialog before activating the next queued request.
+  // This gives Radix a close commit in which to restore focus, so the next
+  // request starts on its safe Cancel control instead of reusing the previous
+  // destructive action button.
+  useEffect(() => {
+    if (pending === null && phaseRef.current === "closing") activateNext();
+  }, [activateNext, pending]);
 
   useEffect(
     () => () => {
       pendingRef.current?.resolve(false);
       pendingRef.current = null;
+      phaseRef.current = "idle";
       for (const queued of queueRef.current.splice(0)) queued.resolve(false);
     },
     [],
@@ -84,7 +98,7 @@ export function useConfirm(): {
       }}
     >
       {pending && (
-        <AlertDialogContent>
+        <AlertDialogContent key={pending.id}>
           <AlertDialogHeader>
             <AlertDialogTitle>{pending.title}</AlertDialogTitle>
             {pending.description && (

--- a/crates/openwave-desktop/ui/src/settings/PermissionsPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/PermissionsPanel.dom.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ApiClient, ConsentStatementSnapshot } from "../api";
@@ -56,6 +56,14 @@ function api(overrides: Partial<Record<keyof ApiClient, unknown>> = {}) {
     revokeStandingGrant: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   } as unknown as ApiClient;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
 }
 
 beforeEach(() => {
@@ -161,6 +169,106 @@ describe("PermissionsPanel", () => {
     render(<PermissionsPanel client={client} />);
     await screen.findByText(/Nothing saved yet/);
     expect(client.listConsentStatements).toHaveBeenCalled();
+  });
+
+  it("ignores a previous chat load that resolves after the current chat", async () => {
+    const oldChatId = "22222222-2222-2222-2222-222222222222";
+    const newChatId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    const newStatement: ConsentStatementSnapshot = {
+      ...execStatement,
+      handle: {
+        kind: "tool_grant",
+        call_id: "99999999-9999-9999-9999-999999999999",
+      },
+      level: { level: "chat", chat_id: newChatId },
+      level_title: "Current chat",
+      resource: {
+        kind: "action_scope",
+        scope: { scope: "any_args_for", command: "pnpm" },
+      },
+    };
+    const oldLoad = deferred<ConsentStatementSnapshot[]>();
+    const newLoad = deferred<ConsentStatementSnapshot[]>();
+    const client = api({
+      listConsentStatements: vi
+        .fn()
+        .mockReturnValueOnce(oldLoad.promise)
+        .mockReturnValueOnce(newLoad.promise),
+    });
+    const { rerender } = render(
+      <PermissionsPanel
+        client={client}
+        chat={{ id: oldChatId, project_id: null }}
+      />,
+    );
+
+    rerender(
+      <PermissionsPanel
+        client={client}
+        chat={{ id: newChatId, project_id: null }}
+      />,
+    );
+    await act(async () => newLoad.resolve([newStatement]));
+    expect(await screen.findByText("pnpm …")).toBeInTheDocument();
+
+    await act(async () => oldLoad.resolve([execStatement]));
+    expect(screen.getByText("pnpm …")).toBeInTheDocument();
+    expect(screen.queryByText("cargo …")).not.toBeInTheDocument();
+  });
+
+  it("does not reload a previous chat after its revocation finishes", async () => {
+    const oldChatId = "22222222-2222-2222-2222-222222222222";
+    const newChatId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    const currentStatement: ConsentStatementSnapshot = {
+      ...execStatement,
+      handle: {
+        kind: "tool_grant",
+        call_id: "99999999-9999-9999-9999-999999999999",
+      },
+      level: { level: "chat", chat_id: newChatId },
+      level_title: "Current chat",
+      resource: {
+        kind: "action_scope",
+        scope: { scope: "any_args_for", command: "pnpm" },
+      },
+    };
+    const revokeDone = deferred<void>();
+    const listConsentStatements = vi
+      .fn()
+      .mockResolvedValueOnce([execStatement])
+      .mockResolvedValue([currentStatement]);
+    const client = api({
+      listConsentStatements,
+      revokeStandingGrant: vi.fn(() => revokeDone.promise),
+    });
+    const { rerender } = render(
+      <PermissionsPanel
+        client={client}
+        chat={{ id: oldChatId, project_id: null }}
+      />,
+    );
+
+    await screen.findByText("cargo …");
+    await userEvent.click(screen.getByRole("button", { name: "Revoke" }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Revoke", hidden: false }),
+    );
+    await waitFor(() =>
+      expect(client.revokeStandingGrant).toHaveBeenCalledTimes(1),
+    );
+
+    rerender(
+      <PermissionsPanel
+        client={client}
+        chat={{ id: newChatId, project_id: null }}
+      />,
+    );
+    expect(await screen.findByText("pnpm …")).toBeInTheDocument();
+
+    await act(async () => revokeDone.resolve());
+    expect(listConsentStatements).toHaveBeenCalledTimes(2);
+    expect(screen.getByText("pnpm …")).toBeInTheDocument();
+    expect(screen.queryByText("cargo …")).not.toBeInTheDocument();
   });
 });
 

--- a/crates/openwave-desktop/ui/src/settings/PermissionsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/PermissionsPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import type {
   ApiClient,
@@ -306,6 +306,7 @@ export function PermissionsPanel({
   const [error, setError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
   const { confirm, dialog } = useConfirm();
+  const reloadGenerationRef = useRef(0);
   const known =
     knownChatIds || knownProjectIds
       ? { chatIds: knownChatIds, projectIds: knownProjectIds }
@@ -313,13 +314,20 @@ export function PermissionsPanel({
 
   const chatId = chat?.id ?? null;
   const chatProjectId = chat?.project_id ?? null;
+  const scopeKey = chatId
+    ? `chat:${chatId}:project:${chatProjectId ?? "none"}`
+    : "global";
+  const scopeKeyRef = useRef(scopeKey);
+  scopeKeyRef.current = scopeKey;
 
   const reload = useCallback(async () => {
+    const generation = ++reloadGenerationRef.current;
     try {
       const [tool, capability] = await Promise.all([
         client.listConsentStatements(),
         listCapabilityConsents(),
       ]);
+      if (generation !== reloadGenerationRef.current) return;
       const all = [...tool, ...capability];
       setStatements(
         chatId
@@ -328,15 +336,23 @@ export function PermissionsPanel({
       );
       setError(null);
     } catch {
+      if (generation !== reloadGenerationRef.current) return;
       setError("Saved approvals could not be loaded.");
     }
   }, [client, chatId, chatProjectId]);
 
   useEffect(() => {
+    setStatements(null);
+    setError(null);
+    setBusyId(null);
     void reload();
-  }, [reload]);
+    return () => {
+      reloadGenerationRef.current += 1;
+    };
+  }, [reload, scopeKey]);
 
   async function revoke(statement: ConsentStatementSnapshot) {
+    const startingScope = scopeKey;
     const confirmed = await confirm({
       title: "Revoke this approval?",
       description:
@@ -356,7 +372,7 @@ export function PermissionsPanel({
       confirmLabel: "Revoke",
       destructive: true,
     });
-    if (!confirmed) return;
+    if (!confirmed || scopeKeyRef.current !== startingScope) return;
     setBusyId(handleKey(statement));
     try {
       if (statement.handle.kind === "tool_grant") {
@@ -364,14 +380,17 @@ export function PermissionsPanel({
       } else {
         await revokeCapabilityConsent(statement);
       }
+      if (scopeKeyRef.current !== startingScope) return;
       // Reload rather than filter locally: revoking a folder's read access
       // also withdraws its dependent command access, and the list should show
       // exactly what the broker now holds.
       await reload();
     } catch {
-      setError("The approval could not be revoked. Try again.");
+      if (scopeKeyRef.current === startingScope) {
+        setError("The approval could not be revoked. Try again.");
+      }
     } finally {
-      setBusyId(null);
+      if (scopeKeyRef.current === startingScope) setBusyId(null);
     }
   }
 

--- a/crates/openwave-desktop/ui/src/tauriSecurityPolicy.test.ts
+++ b/crates/openwave-desktop/ui/src/tauriSecurityPolicy.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { expect, it } from "vitest";
+
+it("keeps remote favicon hosts out of the desktop image policy", () => {
+  const config = JSON.parse(
+    readFileSync(new URL("../../tauri.conf.json", import.meta.url), "utf8"),
+  ) as { app: { security: { csp: string } } };
+  const imagePolicy = config.app.security.csp
+    .split(";")
+    .map((directive) => directive.trim())
+    .find((directive) => directive.startsWith("img-src "));
+
+  expect(imagePolicy).toBe("img-src 'self' asset: blob: data:");
+});


### PR DESCRIPTION
## Summary

- require explicit submission after choosing tool approval and network policy options
- keep permission, consent, revoke, and app actions scoped to the chat or app that initiated them
- queue overlapping confirmations and confirm app deletion in the shared UI
- avoid third-party favicon requests by retaining the local source mark
- add focused interaction, stale-response, and confirmation-queue regressions

## Validation

- pnpm install --frozen-lockfile
- pnpm exec tsc --noEmit
- pnpm exec vitest run src/MessageList.dom.test.tsx src/MessageList.isolation.dom.test.tsx src/ChatView.dom.test.tsx src/NetworkPolicyDialog.dom.test.tsx src/PermissionModeMenu.dom.test.tsx src/settings/PermissionsPanel.dom.test.tsx src/apps/AppDetailView.dom.test.tsx src/components/ConfirmDialog.dom.test.tsx src/DomainFavicon.dom.test.tsx
- pnpm test
- pnpm build
- git diff --check

Closes #1900