### PR TITLE
fix(router): bound provider streams and secure MCP HTTP credentials

### DIFF
--- a/crates/openwave-mcp/src/http.rs
+++ b/crates/openwave-mcp/src/http.rs
@@ -232,7 +232,7 @@ impl HttpWire {
         };
         validate_parsed_http_url(
             &self.url,
-            authorization.is_some() || !self.configured.is_empty(),
+            authorization.is_some() || !self.configured.is_empty() || self.session_id.is_some(),
         )?;
         // One map, built configured-first and then overwritten by every
         // client-generated header, so a configured entry can never displace
@@ -254,8 +254,9 @@ impl HttpWire {
             headers.insert(reqwest::header::AUTHORIZATION, value);
         }
         if let Some(session_id) = &self.session_id {
-            let value = reqwest::header::HeaderValue::from_str(session_id)
+            let mut value = reqwest::header::HeaderValue::from_str(session_id)
                 .map_err(|_| mcp_message("external server session id is not header-safe"))?;
+            value.set_sensitive(true);
             headers.insert(
                 reqwest::header::HeaderName::from_static(SESSION_ID_HEADER),
                 value,
@@ -434,7 +435,15 @@ impl SseParser {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
     use super::*;
+    use axum::extract::State;
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    use axum::routing::post;
+    use axum::Router;
     use reqwest::header::{HeaderMap, HeaderName};
 
     #[test]
@@ -530,6 +539,65 @@ mod tests {
             .await
             .expect_err("dynamic credentials must not cross remote cleartext HTTP");
         assert!(error.to_string().contains("must use https"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn server_issued_session_is_not_sent_over_remote_cleartext_http() {
+        async fn handler(State(requests): State<Arc<AtomicUsize>>) -> impl IntoResponse {
+            requests.fetch_add(1, Ordering::SeqCst);
+            (
+                StatusCode::OK,
+                [
+                    ("content-type", "application/json"),
+                    (SESSION_ID_HEADER, "session-secret"),
+                ],
+                serde_json::json!({"jsonrpc":"2.0","id":1,"result":{}}).to_string(),
+            )
+        }
+
+        let requests = Arc::new(AtomicUsize::new(0));
+        let app = Router::new()
+            .route("/mcp", post(handler))
+            .with_state(Arc::clone(&requests));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let mut wire = HttpWire {
+            client: reqwest::Client::builder()
+                .no_proxy()
+                .resolve("remote.example", address)
+                .redirect(reqwest::redirect::Policy::none())
+                .build()
+                .unwrap(),
+            url: reqwest::Url::parse(&format!("http://remote.example:{}/mcp", address.port()))
+                .unwrap(),
+            authorization: None,
+            configured: HeaderMap::new(),
+            session_id: None,
+        };
+        let mut tools_list_changed = false;
+        wire.request(
+            1,
+            &serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}),
+            &mut tools_list_changed,
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(requests.load(Ordering::SeqCst), 1);
+
+        let error = wire
+            .notify(&serde_json::json!({
+                "jsonrpc":"2.0",
+                "method":"notifications/initialized"
+            }))
+            .await
+            .expect_err("the session credential must not cross remote cleartext HTTP");
+        assert!(error.to_string().contains("must use https"), "{error}");
+        assert_eq!(requests.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/crates/openwave-mcp/src/http.rs
+++ b/crates/openwave-mcp/src/http.rs
@@ -76,8 +76,22 @@ pub(crate) fn static_headers(
 /// Exposed so configuration layers can reject an invalid URL before accepting
 /// a definition, with the same rules the transport applies.
 pub fn validate_http_url(url: &str) -> Result<()> {
+    validate_http_url_with_credentials(url, false)
+}
+
+/// Validate an MCP HTTP endpoint with its credential posture.
+///
+/// Cleartext HTTP is accepted only without credentials, or when the URL names
+/// a literal loopback address. A hostname such as `localhost` is not sufficient
+/// evidence here: static bearer/configured headers must not depend on ambient
+/// DNS or hosts-file configuration to remain on-machine.
+pub fn validate_http_url_with_credentials(url: &str, has_credentials: bool) -> Result<()> {
     let parsed =
         reqwest::Url::parse(url).map_err(|_| mcp_message("external server URL is invalid"))?;
+    validate_parsed_http_url(&parsed, has_credentials)
+}
+
+fn validate_parsed_http_url(parsed: &reqwest::Url, has_credentials: bool) -> Result<()> {
     if !matches!(parsed.scheme(), "http" | "https") {
         return Err(mcp_message("external server URL must use http or https"));
     }
@@ -89,7 +103,23 @@ pub fn validate_http_url(url: &str) -> Result<()> {
     if parsed.host_str().is_none() {
         return Err(mcp_message("external server URL must name a host"));
     }
+    if has_credentials && parsed.scheme() == "http" && !is_literal_loopback(parsed) {
+        return Err(mcp_message(
+            "credentialed external server URLs must use https unless they name a literal loopback address",
+        ));
+    }
     Ok(())
+}
+
+fn is_literal_loopback(url: &reqwest::Url) -> bool {
+    url.host_str()
+        .map(|host| {
+            host.strip_prefix('[')
+                .and_then(|host| host.strip_suffix(']'))
+                .unwrap_or(host)
+        })
+        .and_then(|host| host.parse::<std::net::IpAddr>().ok())
+        .is_some_and(|address| address.is_loopback())
 }
 
 impl HttpWire {
@@ -98,9 +128,9 @@ impl HttpWire {
         bearer_token: Option<&str>,
         configured: reqwest::header::HeaderMap,
     ) -> Result<Self> {
-        validate_http_url(url)?;
         let url =
             reqwest::Url::parse(url).map_err(|_| mcp_message("external server URL is invalid"))?;
+        validate_parsed_http_url(&url, bearer_token.is_some() || !configured.is_empty())?;
         if bearer_token.is_some_and(|token| {
             token.is_empty() || token.bytes().any(|byte| byte.is_ascii_control())
         }) {
@@ -200,6 +230,10 @@ impl HttpWire {
             }
             None => self.authorization.clone(),
         };
+        validate_parsed_http_url(
+            &self.url,
+            authorization.is_some() || !self.configured.is_empty(),
+        )?;
         // One map, built configured-first and then overwritten by every
         // client-generated header, so a configured entry can never displace
         // what this transport says about itself — whatever the builder's
@@ -433,6 +467,7 @@ mod tests {
     #[test]
     fn url_validation_rejects_unsupported_shapes() {
         assert!(validate_http_url("http://127.0.0.1:9000/mcp").is_ok());
+        assert!(validate_http_url("http://remote.example/mcp").is_ok());
         assert!(validate_http_url("https://gateway.example/mcp/tools").is_ok());
         for url in [
             "ftp://host/mcp",
@@ -442,6 +477,59 @@ mod tests {
         ] {
             assert!(validate_http_url(url).is_err(), "{url} must be rejected");
         }
+    }
+
+    #[test]
+    fn credentialed_http_requires_a_literal_loopback_address() {
+        for url in [
+            "http://127.0.0.1:9000/mcp",
+            "http://127.27.4.9/mcp",
+            "http://[::1]:9000/mcp",
+            "https://gateway.example/mcp",
+        ] {
+            assert!(
+                validate_http_url_with_credentials(url, true).is_ok(),
+                "{url} should be accepted"
+            );
+        }
+        for url in [
+            "http://gateway.example/mcp",
+            "http://192.0.2.10/mcp",
+            "http://localhost:9000/mcp",
+        ] {
+            assert!(
+                validate_http_url_with_credentials(url, true).is_err(),
+                "{url} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn transport_rejects_remote_cleartext_credentials() {
+        assert!(HttpWire::with_headers(
+            "http://gateway.example/mcp",
+            Some("secret"),
+            HeaderMap::new(),
+        )
+        .is_err());
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static("x-api-key"),
+            reqwest::header::HeaderValue::from_static("secret"),
+        );
+        assert!(HttpWire::with_headers("http://gateway.example/mcp", None, headers).is_err());
+    }
+
+    #[tokio::test]
+    async fn dynamic_bearer_rejects_an_otherwise_uncredentialed_remote_http_url() {
+        let wire =
+            HttpWire::with_headers("http://gateway.example/mcp", None, HeaderMap::new()).unwrap();
+        let error = wire
+            .post(&serde_json::json!({}), Some("dynamic-secret"))
+            .await
+            .expect_err("dynamic credentials must not cross remote cleartext HTTP");
+        assert!(error.to_string().contains("must use https"), "{error}");
     }
 
     #[test]

--- a/crates/openwave-mcp/src/lib.rs
+++ b/crates/openwave-mcp/src/lib.rs
@@ -53,7 +53,7 @@ pub use client::{
     CallBearerSource, McpClient, McpProbe, McpServerInfo, ResourceContent, DEFAULT_REQUEST_TIMEOUT,
     MAX_SERVER_NAME_BYTES,
 };
-pub use http::validate_http_url;
+pub use http::{validate_http_url, validate_http_url_with_credentials};
 pub use protocol::PROTOCOL_VERSION;
 pub use server::McpServer;
 pub use stdio::{serve, serve_stdio};

--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -24,8 +24,7 @@ use openwave_core::{ImageAttachments, ReasoningEffort, Role};
 use crate::google::{valid_resource_segment, valid_vertex_location};
 use crate::sse::{
     classify_in_band_error, classify_in_band_error_redacting, classify_provider_error,
-    classify_provider_error_redacting, finish_frame, frame_data, push_frames,
-    read_bounded_error_body,
+    classify_provider_error_redacting, frame_data, read_bounded_error_body, SseFramer,
 };
 
 const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
@@ -228,7 +227,7 @@ impl ModelProvider for AnthropicProvider {
                 futures::pin_mut!(bytes);
                 // Accumulate raw BYTES, not a String: a chunk may split a multi-byte
                 // UTF-8 character, so we only decode once a whole frame is buffered.
-                let mut buffer: Vec<u8> = Vec::new();
+                let mut framer = SseFramer::default();
                 while let Some(chunk) = bytes.next().await {
                     // A mid-stream transport error must not read as a clean end:
                     // the accumulated tool-call arguments may be truncated
@@ -244,7 +243,7 @@ impl ModelProvider for AnthropicProvider {
                             return;
                         }
                     };
-                    let frames = match push_frames(&mut buffer, &chunk) {
+                    let frames = match framer.push(&chunk) {
                         Ok(frames) => frames,
                         Err(error) => {
                             yield ProviderEvent::Failed {
@@ -264,7 +263,7 @@ impl ModelProvider for AnthropicProvider {
                     }
                 }
                 // Flush a final frame that wasn't terminated by a blank line.
-                let final_frame = match finish_frame(&mut buffer) {
+                let final_frame = match framer.finish() {
                     Ok(frame) => frame,
                     Err(error) => {
                         yield ProviderEvent::Failed {
@@ -1180,14 +1179,16 @@ fn stream_index(
     data: &Value,
     state: &mut StreamState,
 ) -> std::result::Result<u32, ProviderErrorInfo> {
-    let Some(index) = data.get("index").and_then(Value::as_u64) else {
-        return Ok(0);
-    };
-    u32::try_from(index).map_err(|_| {
-        let provider = stream_provider_label(state).to_string();
-        state.terminal = true;
-        ProviderErrorInfo::provider(format!("{provider} returned an invalid stream block index"))
-    })
+    data.get("index")
+        .and_then(Value::as_u64)
+        .and_then(|index| u32::try_from(index).ok())
+        .ok_or_else(|| {
+            let provider = stream_provider_label(state).to_string();
+            state.terminal = true;
+            ProviderErrorInfo::provider(format!(
+                "{provider} returned an invalid stream block index"
+            ))
+        })
 }
 
 /// Map one parsed Anthropic stream event into zero or more `ProviderEvent`s.
@@ -2010,6 +2011,45 @@ mod tests {
             "content_block": {"type": "tool_use", "id": "toolu_1", "name": "read_file"}
         })]);
         assert!(matches!(events.as_slice(), [ProviderEvent::Failed { .. }]));
+    }
+
+    #[test]
+    fn missing_or_non_unsigned_structural_indices_cannot_alias_an_open_block() {
+        let invalid_indices = [
+            Some(json!(-1)),
+            Some(json!(1.5)),
+            Some(json!("0")),
+            Some(Value::Null),
+            None,
+        ];
+        for invalid in invalid_indices {
+            let mut invalid_delta = json!({
+                "type": "content_block_delta",
+                "delta": {"type": "input_json_delta", "partial_json": "a\"}"}
+            });
+            if let Some(invalid) = invalid {
+                invalid_delta["index"] = invalid;
+            }
+            let mut state = StreamState::default();
+            let events: Vec<ProviderEvent> = [
+                json!({"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"read_file"}}),
+                json!({"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"path\":\""}}),
+                invalid_delta,
+            ]
+            .iter()
+            .flat_map(|frame| normalize(frame, &mut state))
+            .collect();
+
+            assert!(matches!(
+                events.as_slice(),
+                [
+                    ProviderEvent::ToolCallStarted { index: 0, .. },
+                    ProviderEvent::ToolCallArgsDelta { index: 0, fragment },
+                    ProviderEvent::Failed { .. },
+                ] if fragment == "{\"path\":\""
+            ));
+            assert!(state.terminal);
+        }
     }
 
     fn search_origin(model: &str) -> ReasoningOrigin {

--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -24,7 +24,8 @@ use openwave_core::{ImageAttachments, ReasoningEffort, Role};
 use crate::google::{valid_resource_segment, valid_vertex_location};
 use crate::sse::{
     classify_in_band_error, classify_in_band_error_redacting, classify_provider_error,
-    classify_provider_error_redacting, drain_frames, frame_data, read_bounded_error_body,
+    classify_provider_error_redacting, finish_frame, frame_data, push_frames,
+    read_bounded_error_body,
 };
 
 const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
@@ -243,8 +244,18 @@ impl ModelProvider for AnthropicProvider {
                             return;
                         }
                     };
-                    buffer.extend_from_slice(&chunk);
-                    for frame in drain_frames(&mut buffer) {
+                    let frames = match push_frames(&mut buffer, &chunk) {
+                        Ok(frames) => frames,
+                        Err(error) => {
+                            yield ProviderEvent::Failed {
+                                error: ProviderErrorInfo::provider(format!(
+                                    "{provider_name} {error}"
+                                )),
+                            };
+                            return;
+                        }
+                    };
+                    for frame in frames {
                         if let Some(data) = frame_data(&frame) {
                             for event in normalize(&data, &mut state) {
                                 yield event;
@@ -253,8 +264,18 @@ impl ModelProvider for AnthropicProvider {
                     }
                 }
                 // Flush a final frame that wasn't terminated by a blank line.
-                if !buffer.is_empty() {
-                    let frame = String::from_utf8_lossy(&buffer).into_owned();
+                let final_frame = match finish_frame(&mut buffer) {
+                    Ok(frame) => frame,
+                    Err(error) => {
+                        yield ProviderEvent::Failed {
+                            error: ProviderErrorInfo::provider(format!(
+                                "{provider_name} {error}"
+                            )),
+                        };
+                        return;
+                    }
+                };
+                if let Some(frame) = final_frame {
                     if let Some(data) = frame_data(&frame) {
                         for event in normalize(&data, &mut state) {
                             yield event;
@@ -1151,8 +1172,22 @@ fn end_of_stream(state: &StreamState) -> Option<ProviderEvent> {
     })
 }
 
-fn u32_at(value: &Value, key: &str) -> u32 {
-    value.get(key).and_then(Value::as_u64).unwrap_or(0) as u32
+fn usage_u32_at(value: &Value, key: &str) -> u32 {
+    u32::try_from(value.get(key).and_then(Value::as_u64).unwrap_or(0)).unwrap_or(u32::MAX)
+}
+
+fn stream_index(
+    data: &Value,
+    state: &mut StreamState,
+) -> std::result::Result<u32, ProviderErrorInfo> {
+    let Some(index) = data.get("index").and_then(Value::as_u64) else {
+        return Ok(0);
+    };
+    u32::try_from(index).map_err(|_| {
+        let provider = stream_provider_label(state).to_string();
+        state.terminal = true;
+        ProviderErrorInfo::provider(format!("{provider} returned an invalid stream block index"))
+    })
 }
 
 /// Map one parsed Anthropic stream event into zero or more `ProviderEvent`s.
@@ -1180,14 +1215,18 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
         }
         Some("message_start") => {
             if let Some(usage) = data.get("message").and_then(|m| m.get("usage")) {
-                state.input_tokens = u32_at(usage, "input_tokens");
-                state.cache_read_input_tokens = u32_at(usage, "cache_read_input_tokens");
-                state.cache_creation_input_tokens = u32_at(usage, "cache_creation_input_tokens");
+                state.input_tokens = usage_u32_at(usage, "input_tokens");
+                state.cache_read_input_tokens = usage_u32_at(usage, "cache_read_input_tokens");
+                state.cache_creation_input_tokens =
+                    usage_u32_at(usage, "cache_creation_input_tokens");
             }
             Vec::new()
         }
         Some("content_block_start") => {
-            let index = u32_at(data, "index");
+            let index = match stream_index(data, state) {
+                Ok(index) => index,
+                Err(error) => return vec![ProviderEvent::Failed { error }],
+            };
             let block = data.get("content_block");
             // Capture before normalizing: a continuation replays the provider's
             // own blocks, not this adapter's reading of them.
@@ -1295,7 +1334,10 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
             }
         }
         Some("content_block_delta") => {
-            let index = u32_at(data, "index");
+            let index = match stream_index(data, state) {
+                Ok(index) => index,
+                Err(error) => return vec![ProviderEvent::Failed { error }],
+            };
             let delta = match data.get("delta") {
                 Some(delta) => delta,
                 None => return Vec::new(),
@@ -1360,7 +1402,10 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
             }
         }
         Some("content_block_stop") => {
-            let index = u32_at(data, "index");
+            let index = match stream_index(data, state) {
+                Ok(index) => index,
+                Err(error) => return vec![ProviderEvent::Failed { error }],
+            };
             state.open_tool_blocks.remove(&index);
             // A closed server tool call has its whole argument JSON; park it
             // under the id its result block will name.
@@ -1377,7 +1422,7 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
             if let Some(usage) = data.get("usage") {
                 events.push(ProviderEvent::Usage(Usage {
                     input_tokens: state.input_tokens,
-                    output_tokens: u32_at(usage, "output_tokens"),
+                    output_tokens: usage_u32_at(usage, "output_tokens"),
                     cache_read_input_tokens: state.cache_read_input_tokens,
                     cache_creation_input_tokens: state.cache_creation_input_tokens,
                 }));
@@ -1932,6 +1977,39 @@ mod tests {
             .iter()
             .flat_map(|e| normalize(e, &mut state))
             .collect()
+    }
+
+    #[test]
+    fn usage_counts_saturate_instead_of_wrapping() {
+        let events = run(&[
+            json!({
+                "type": "message_start",
+                "message": {"usage": {"input_tokens": u64::from(u32::MAX) + 1}}
+            }),
+            json!({
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn"},
+                "usage": {"output_tokens": u64::MAX}
+            }),
+        ]);
+        assert!(events.iter().any(|event| matches!(
+            event,
+            ProviderEvent::Usage(Usage {
+                input_tokens: u32::MAX,
+                output_tokens: u32::MAX,
+                ..
+            })
+        )));
+    }
+
+    #[test]
+    fn oversized_structural_index_fails_the_stream() {
+        let events = run(&[json!({
+            "type": "content_block_start",
+            "index": u64::from(u32::MAX) + 1,
+            "content_block": {"type": "tool_use", "id": "toolu_1", "name": "read_file"}
+        })]);
+        assert!(matches!(events.as_slice(), [ProviderEvent::Failed { .. }]));
     }
 
     fn search_origin(model: &str) -> ReasoningOrigin {

--- a/crates/openwave-router/src/gemini.rs
+++ b/crates/openwave-router/src/gemini.rs
@@ -29,8 +29,8 @@ use openwave_core::{ImageAttachments, ReasoningEffort, Role};
 use crate::google::{valid_resource_segment, valid_vertex_location};
 use crate::sse::{
     classify_in_band_error, classify_in_band_error_redacting, classify_provider_error,
-    classify_provider_error_redacting, drain_frames, frame_data_raw, read_bounded_error_body,
-    safe_http_error, safe_http_error_redacting,
+    classify_provider_error_redacting, finish_frame, frame_data_raw, push_frames,
+    read_bounded_error_body, safe_http_error, safe_http_error_redacting,
 };
 use crate::BearerTokenSource;
 
@@ -336,8 +336,16 @@ impl ModelProvider for GeminiProvider {
                         return;
                     }
                 };
-                buffer.extend_from_slice(&chunk);
-                for frame in drain_frames(&mut buffer) {
+                let frames = match push_frames(&mut buffer, &chunk) {
+                    Ok(frames) => frames,
+                    Err(error) => {
+                        yield ProviderEvent::Failed {
+                            error: ProviderErrorInfo::provider(format!("{provider} {error}")),
+                        };
+                        return;
+                    }
+                };
+                for frame in frames {
                     let Some(data) = frame_data_raw(&frame) else {
                         continue;
                     };
@@ -360,8 +368,16 @@ impl ModelProvider for GeminiProvider {
                     }
                 }
             }
-            if !buffer.is_empty() {
-                let frame = String::from_utf8_lossy(&buffer).into_owned();
+            let final_frame = match finish_frame(&mut buffer) {
+                Ok(frame) => frame,
+                Err(error) => {
+                    yield ProviderEvent::Failed {
+                        error: ProviderErrorInfo::provider(format!("{provider} {error}")),
+                    };
+                    return;
+                }
+            };
+            if let Some(frame) = final_frame {
                 if let Some(data) = frame_data_raw(&frame) {
                     let data = match serde_json::from_str::<Value>(&data) {
                         Ok(data) => data,
@@ -1410,25 +1426,27 @@ fn emit_usage(state: &mut StreamState, events: &mut Vec<ProviderEvent>) {
 }
 
 fn gemini_usage(metadata: &Value) -> Usage {
-    let prompt = u32_at(metadata, "promptTokenCount");
-    let cached = u32_at(metadata, "cachedContentTokenCount");
+    let prompt = u64_at(metadata, "promptTokenCount");
+    let cached = u64_at(metadata, "cachedContentTokenCount");
     Usage {
         // Gemini's prompt count includes the cached portion.
-        input_tokens: prompt.saturating_sub(cached),
+        input_tokens: saturating_u32(prompt.saturating_sub(cached)),
         // Thoughts are billed output in addition to candidate tokens.
-        output_tokens: u32_at(metadata, "candidatesTokenCount")
-            .saturating_add(u32_at(metadata, "thoughtsTokenCount")),
-        cache_read_input_tokens: cached,
+        output_tokens: saturating_u32(
+            u64_at(metadata, "candidatesTokenCount")
+                .saturating_add(u64_at(metadata, "thoughtsTokenCount")),
+        ),
+        cache_read_input_tokens: saturating_u32(cached),
         cache_creation_input_tokens: 0,
     }
 }
 
-fn u32_at(value: &Value, key: &str) -> u32 {
-    value
-        .get(key)
-        .and_then(Value::as_u64)
-        .unwrap_or(0)
-        .min(u64::from(u32::MAX)) as u32
+fn u64_at(value: &Value, key: &str) -> u64 {
+    value.get(key).and_then(Value::as_u64).unwrap_or(0)
+}
+
+fn saturating_u32(value: u64) -> u32 {
+    u32::try_from(value).unwrap_or(u32::MAX)
 }
 
 fn refusal_details(reason: &str) -> RefusalDetails {
@@ -2015,6 +2033,24 @@ mod tests {
                     reason: StopReason::ToolUse
                 },
             ]
+        );
+    }
+
+    #[test]
+    fn usage_counts_subtract_before_saturating() {
+        assert_eq!(
+            gemini_usage(&json!({
+                "promptTokenCount": u64::from(u32::MAX) + 1,
+                "cachedContentTokenCount": 1,
+                "candidatesTokenCount": u64::MAX,
+                "thoughtsTokenCount": 1,
+            })),
+            Usage {
+                input_tokens: u32::MAX,
+                output_tokens: u32::MAX,
+                cache_read_input_tokens: 1,
+                cache_creation_input_tokens: 0,
+            }
         );
     }
 

--- a/crates/openwave-router/src/gemini.rs
+++ b/crates/openwave-router/src/gemini.rs
@@ -29,8 +29,8 @@ use openwave_core::{ImageAttachments, ReasoningEffort, Role};
 use crate::google::{valid_resource_segment, valid_vertex_location};
 use crate::sse::{
     classify_in_band_error, classify_in_band_error_redacting, classify_provider_error,
-    classify_provider_error_redacting, finish_frame, frame_data_raw, push_frames,
-    read_bounded_error_body, safe_http_error, safe_http_error_redacting,
+    classify_provider_error_redacting, frame_data_raw, read_bounded_error_body, safe_http_error,
+    safe_http_error_redacting, SseFramer,
 };
 use crate::BearerTokenSource;
 
@@ -317,7 +317,7 @@ impl ModelProvider for GeminiProvider {
         let stream = async_stream::stream! {
             let bytes = crate::http::with_stream_deadline(response.bytes_stream(), ceiling);
             futures::pin_mut!(bytes);
-            let mut buffer = Vec::new();
+            let mut framer = SseFramer::default();
             let mut state = StreamState {
                 vertex_project_id,
                 ..StreamState::default()
@@ -336,7 +336,7 @@ impl ModelProvider for GeminiProvider {
                         return;
                     }
                 };
-                let frames = match push_frames(&mut buffer, &chunk) {
+                let frames = match framer.push(&chunk) {
                     Ok(frames) => frames,
                     Err(error) => {
                         yield ProviderEvent::Failed {
@@ -368,7 +368,7 @@ impl ModelProvider for GeminiProvider {
                     }
                 }
             }
-            let final_frame = match finish_frame(&mut buffer) {
+            let final_frame = match framer.finish() {
                 Ok(frame) => frame,
                 Err(error) => {
                     yield ProviderEvent::Failed {

--- a/crates/openwave-router/src/openai.rs
+++ b/crates/openwave-router/src/openai.rs
@@ -18,7 +18,7 @@ use openwave_core::tool::{strict_json_schema, OptionalProperties};
 use openwave_core::Role;
 
 use crate::sse::{
-    classify_in_band_error, classify_provider_error, drain_frames, frame_data,
+    classify_in_band_error, classify_provider_error, finish_frame, frame_data, push_frames,
     read_bounded_error_body, safe_http_error,
 };
 use crate::BearerTokenSource;
@@ -254,8 +254,18 @@ impl ModelProvider for OpenAiProvider {
                         return;
                     }
                 };
-                buffer.extend_from_slice(&chunk);
-                for frame in drain_frames(&mut buffer) {
+                let frames = match push_frames(&mut buffer, &chunk) {
+                    Ok(frames) => frames,
+                    Err(error) => {
+                        yield ProviderEvent::Failed {
+                            error: ProviderErrorInfo::provider(format!(
+                                "{provider_label} {error}"
+                            )),
+                        };
+                        return;
+                    }
+                };
+                for frame in frames {
                     if let Some(data) = frame_data(&frame) {
                         for event in normalize_for(&data, &mut state, wire_provider) {
                             yield event;
@@ -263,8 +273,18 @@ impl ModelProvider for OpenAiProvider {
                     }
                 }
             }
-            if !buffer.is_empty() {
-                let frame = String::from_utf8_lossy(&buffer).into_owned();
+            let final_frame = match finish_frame(&mut buffer) {
+                Ok(frame) => frame,
+                Err(error) => {
+                    yield ProviderEvent::Failed {
+                        error: ProviderErrorInfo::provider(format!(
+                            "{provider_label} {error}"
+                        )),
+                    };
+                    return;
+                }
+            };
+            if let Some(frame) = final_frame {
                 if let Some(data) = frame_data(&frame) {
                     for event in normalize_for(&data, &mut state, wire_provider) {
                         yield event;

--- a/crates/openwave-router/src/openai.rs
+++ b/crates/openwave-router/src/openai.rs
@@ -18,8 +18,8 @@ use openwave_core::tool::{strict_json_schema, OptionalProperties};
 use openwave_core::Role;
 
 use crate::sse::{
-    classify_in_band_error, classify_provider_error, finish_frame, frame_data, push_frames,
-    read_bounded_error_body, safe_http_error,
+    classify_in_band_error, classify_provider_error, frame_data, read_bounded_error_body,
+    safe_http_error, SseFramer,
 };
 use crate::BearerTokenSource;
 
@@ -239,7 +239,7 @@ impl ModelProvider for OpenAiProvider {
         let stream = async_stream::stream! {
             let bytes = crate::http::with_stream_deadline(response.bytes_stream(), ceiling);
             futures::pin_mut!(bytes);
-            let mut buffer = Vec::new();
+            let mut framer = SseFramer::default();
             let mut state = StreamState {
                 provider_label,
                 ..StreamState::default()
@@ -254,7 +254,7 @@ impl ModelProvider for OpenAiProvider {
                         return;
                     }
                 };
-                let frames = match push_frames(&mut buffer, &chunk) {
+                let frames = match framer.push(&chunk) {
                     Ok(frames) => frames,
                     Err(error) => {
                         yield ProviderEvent::Failed {
@@ -273,7 +273,7 @@ impl ModelProvider for OpenAiProvider {
                     }
                 }
             }
-            let final_frame = match finish_frame(&mut buffer) {
+            let final_frame = match framer.finish() {
                 Ok(frame) => frame,
                 Err(error) => {
                     yield ProviderEvent::Failed {

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -23,8 +23,7 @@ use openwave_core::tool::{strict_json_schema, OptionalProperties};
 use openwave_core::{ImageAttachments, Role};
 
 use crate::sse::{
-    classify_in_band_error, classify_provider_error, finish_frame, frame_data, push_frames,
-    read_bounded_error_body,
+    classify_in_band_error, classify_provider_error, frame_data, read_bounded_error_body, SseFramer,
 };
 
 const DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
@@ -180,7 +179,7 @@ impl ModelProvider for OpenAiCompatProvider {
         let stream = async_stream::stream! {
             let bytes = crate::http::with_stream_deadline(response.bytes_stream(), ceiling);
             futures::pin_mut!(bytes);
-            let mut buffer: Vec<u8> = Vec::new();
+            let mut framer = SseFramer::default();
             let mut state = StreamState::new(provider_id);
             while let Some(chunk) = bytes.next().await {
                 // A mid-stream transport error must not read as a clean end:
@@ -197,7 +196,7 @@ impl ModelProvider for OpenAiCompatProvider {
                         return;
                     }
                 };
-                let frames = match push_frames(&mut buffer, &chunk) {
+                let frames = match framer.push(&chunk) {
                     Ok(frames) => frames,
                     Err(error) => {
                         yield ProviderEvent::Failed {
@@ -216,7 +215,7 @@ impl ModelProvider for OpenAiCompatProvider {
                     }
                 }
             }
-            let final_frame = match finish_frame(&mut buffer) {
+            let final_frame = match framer.finish() {
                 Ok(frame) => frame,
                 Err(error) => {
                     yield ProviderEvent::Failed {
@@ -800,16 +799,19 @@ fn stream_index(
     data: &Value,
     state: &mut StreamState,
 ) -> std::result::Result<u32, ProviderErrorInfo> {
-    let Some(index) = data.get("index").and_then(Value::as_u64) else {
+    let Some(value) = data.get("index") else {
         return Ok(0);
     };
-    u32::try_from(index).map_err(|_| {
-        state.terminal = true;
-        ProviderErrorInfo::provider(format!(
-            "{} returned an invalid tool-call index",
-            state.provider_id
-        ))
-    })
+    value
+        .as_u64()
+        .and_then(|index| u32::try_from(index).ok())
+        .ok_or_else(|| {
+            state.terminal = true;
+            ProviderErrorInfo::provider(format!(
+                "{} returned an invalid tool-call index",
+                state.provider_id
+            ))
+        })
 }
 
 fn map_stop_reason(reason: &str) -> StopReason {
@@ -1156,6 +1158,30 @@ mod tests {
             }]}}]
         })]);
         assert!(matches!(events.as_slice(), [ProviderEvent::Failed { .. }]));
+    }
+
+    #[test]
+    fn present_non_unsigned_tool_call_indices_cannot_alias_an_open_call() {
+        for invalid in [json!(-1), json!(1.5), json!("0"), Value::Null] {
+            let mut state = StreamState::new("together");
+            let events: Vec<ProviderEvent> = [
+                json!({"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"read_file","arguments":"{\"path\":\""}}]}}]}),
+                json!({"choices":[{"delta":{"tool_calls":[{"index":invalid,"function":{"arguments":"a\"}"}}]}}]}),
+            ]
+            .iter()
+            .flat_map(|chunk| normalize(chunk, &mut state))
+            .collect();
+
+            assert!(matches!(
+                events.as_slice(),
+                [
+                    ProviderEvent::ToolCallStarted { index: 0, .. },
+                    ProviderEvent::ToolCallArgsDelta { index: 0, fragment },
+                    ProviderEvent::Failed { .. },
+                ] if fragment == "{\"path\":\""
+            ));
+            assert!(state.terminal);
+        }
     }
 
     #[test]

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -23,7 +23,7 @@ use openwave_core::tool::{strict_json_schema, OptionalProperties};
 use openwave_core::{ImageAttachments, Role};
 
 use crate::sse::{
-    classify_in_band_error, classify_provider_error, drain_frames, frame_data,
+    classify_in_band_error, classify_provider_error, finish_frame, frame_data, push_frames,
     read_bounded_error_body,
 };
 
@@ -197,8 +197,18 @@ impl ModelProvider for OpenAiCompatProvider {
                         return;
                     }
                 };
-                buffer.extend_from_slice(&chunk);
-                for frame in drain_frames(&mut buffer) {
+                let frames = match push_frames(&mut buffer, &chunk) {
+                    Ok(frames) => frames,
+                    Err(error) => {
+                        yield ProviderEvent::Failed {
+                            error: ProviderErrorInfo::provider(format!(
+                                "{} {error}", state.provider_id
+                            )),
+                        };
+                        return;
+                    }
+                };
+                for frame in frames {
                     if let Some(data) = frame_data(&frame) {
                         for event in normalize(&data, &mut state) {
                             yield event;
@@ -206,8 +216,18 @@ impl ModelProvider for OpenAiCompatProvider {
                     }
                 }
             }
-            if !buffer.is_empty() {
-                let frame = String::from_utf8_lossy(&buffer).into_owned();
+            let final_frame = match finish_frame(&mut buffer) {
+                Ok(frame) => frame,
+                Err(error) => {
+                    yield ProviderEvent::Failed {
+                        error: ProviderErrorInfo::provider(format!(
+                            "{} {error}", state.provider_id
+                        )),
+                    };
+                    return;
+                }
+            };
+            if let Some(frame) = final_frame {
                 if let Some(data) = frame_data(&frame) {
                     for event in normalize(&data, &mut state) {
                         yield event;
@@ -654,15 +674,15 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
         // either way; if the stream already stopped, this trailing chunk is the
         // only chance to emit it. OpenAI's `prompt_tokens` is the full prompt;
         // cached details are optional.
-        let prompt = u32_at(usage, "prompt_tokens");
+        let prompt = usage_u64_at(usage, "prompt_tokens");
         let cached = usage
             .get("prompt_tokens_details")
-            .map(|d| u32_at(d, "cached_tokens"))
+            .map(|d| usage_u64_at(d, "cached_tokens"))
             .unwrap_or(0);
         state.usage = Usage {
-            input_tokens: prompt.saturating_sub(cached),
-            output_tokens: u32_at(usage, "completion_tokens"),
-            cache_read_input_tokens: cached,
+            input_tokens: saturating_u32(prompt.saturating_sub(cached)),
+            output_tokens: saturating_u32(usage_u64_at(usage, "completion_tokens")),
+            cache_read_input_tokens: saturating_u32(cached),
             cache_creation_input_tokens: 0,
         };
         if state.stopped && state.has_unemitted_usage() {
@@ -700,7 +720,10 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
         }
         if let Some(tool_calls) = delta.get("tool_calls").and_then(Value::as_array) {
             for tc in tool_calls {
-                let index = u32_at(tc, "index");
+                let index = match stream_index(tc, state) {
+                    Ok(index) => index,
+                    Err(error) => return vec![ProviderEvent::Failed { error }],
+                };
                 let buf = state.tool_calls.entry(index).or_default();
                 if let Some(id) = tc.get("id").and_then(Value::as_str) {
                     if !id.is_empty() {
@@ -765,8 +788,28 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
     events
 }
 
-fn u32_at(value: &Value, key: &str) -> u32 {
-    value.get(key).and_then(Value::as_u64).unwrap_or(0) as u32
+fn usage_u64_at(value: &Value, key: &str) -> u64 {
+    value.get(key).and_then(Value::as_u64).unwrap_or(0)
+}
+
+fn saturating_u32(value: u64) -> u32 {
+    u32::try_from(value).unwrap_or(u32::MAX)
+}
+
+fn stream_index(
+    data: &Value,
+    state: &mut StreamState,
+) -> std::result::Result<u32, ProviderErrorInfo> {
+    let Some(index) = data.get("index").and_then(Value::as_u64) else {
+        return Ok(0);
+    };
+    u32::try_from(index).map_err(|_| {
+        state.terminal = true;
+        ProviderErrorInfo::provider(format!(
+            "{} returned an invalid tool-call index",
+            state.provider_id
+        ))
+    })
 }
 
 fn map_stop_reason(reason: &str) -> StopReason {
@@ -1080,6 +1123,39 @@ mod tests {
             .iter()
             .flat_map(|c| normalize(c, &mut state))
             .collect()
+    }
+
+    #[test]
+    fn usage_counts_saturate_instead_of_wrapping() {
+        let events = run(&[json!({
+            "usage": {
+                "prompt_tokens": u64::from(u32::MAX) + 1,
+                "prompt_tokens_details": {"cached_tokens": 1},
+                "completion_tokens": u64::from(u32::MAX) + 1
+            },
+            "choices": [{"delta": {}, "finish_reason": "stop"}]
+        })]);
+        assert!(events.iter().any(|event| matches!(
+            event,
+            ProviderEvent::Usage(Usage {
+                input_tokens: u32::MAX,
+                output_tokens: u32::MAX,
+                cache_read_input_tokens: 1,
+                ..
+            })
+        )));
+    }
+
+    #[test]
+    fn oversized_tool_call_index_fails_the_stream() {
+        let events = run(&[json!({
+            "choices": [{"delta": {"tool_calls": [{
+                "index": u64::from(u32::MAX) + 1,
+                "id": "call_1",
+                "function": {"name": "read_file", "arguments": "{}"}
+            }]}}]
+        })]);
+        assert!(matches!(events.as_slice(), [ProviderEvent::Failed { .. }]));
     }
 
     #[test]

--- a/crates/openwave-router/src/sse.rs
+++ b/crates/openwave-router/src/sse.rs
@@ -64,8 +64,8 @@ where
     String::from_utf8_lossy(&body).into_owned()
 }
 
-fn find_frame_delimiter(buffer: &[u8]) -> Option<(usize, usize)> {
-    for index in 0..buffer.len() {
+fn find_frame_delimiter(buffer: &[u8], start: usize) -> Option<(usize, usize)> {
+    for index in start..buffer.len() {
         let remaining = &buffer[index..];
         if remaining.starts_with(b"\n\n") {
             return Some((index, 2));
@@ -77,27 +77,20 @@ fn find_frame_delimiter(buffer: &[u8]) -> Option<(usize, usize)> {
     None
 }
 
-/// Drain all complete SSE frames from `buffer`, returning each frame's decoded
-/// text and leaving any incomplete trailing bytes behind.
+/// Incremental provider SSE framer with a retained delimiter scan position.
 ///
 /// Frames are separated by a blank line (`\n\n` or `\r\n\r\n`). Decoding to UTF-8
 /// happens only on a complete frame, so a multi-byte character split across
-/// network chunks is never decoded until all its bytes have arrived.
-pub fn drain_frames(buffer: &mut Vec<u8>) -> Vec<String> {
-    let mut frames = Vec::new();
-    let mut frame_start = 0;
-    loop {
-        let remaining = &buffer[frame_start..];
-        let Some((content_end, delimiter_len)) = find_frame_delimiter(remaining) else {
-            break;
-        };
-        frames.push(String::from_utf8_lossy(&remaining[..content_end]).into_owned());
-        frame_start += content_end + delimiter_len;
-    }
-    if frame_start != 0 {
-        buffer.drain(..frame_start);
-    }
-    frames
+/// network chunks is never decoded until all its bytes have arrived. The scan
+/// resumes at the first byte that could participate in a delimiter completed
+/// by the next chunk, so an unterminated frame split into tiny chunks remains
+/// linear rather than rescanning its whole prefix after every append.
+#[derive(Default)]
+pub struct SseFramer {
+    buffer: Vec<u8>,
+    scan_from: usize,
+    #[cfg(test)]
+    inspected_bytes: usize,
 }
 
 fn residual_fits_frame_limit(buffer: &[u8]) -> bool {
@@ -110,68 +103,99 @@ fn residual_fits_frame_limit(buffer: &[u8]) -> bool {
     )
 }
 
-/// Append one network chunk without allowing either a complete frame or the
-/// incomplete residual to grow beyond [`MAX_PROVIDER_SSE_FRAME_BYTES`].
-///
-/// The chunk is admitted in bounded slices, draining complete frames between
-/// slices. This matters because one HTTP body chunk can itself be much larger
-/// than the frame ceiling; extending the residual with the whole chunk before
-/// checking would merely move the unbounded allocation one layer earlier.
-pub fn push_frames(
-    buffer: &mut Vec<u8>,
-    mut chunk: &[u8],
-) -> Result<Vec<String>, SseFrameTooLarge> {
+impl SseFramer {
     const MAX_PARTIAL_DELIMITER_BYTES: usize = 3;
 
-    let mut frames = Vec::new();
-    while !chunk.is_empty() {
-        let hard_buffer_limit = MAX_PROVIDER_SSE_FRAME_BYTES + MAX_PARTIAL_DELIMITER_BYTES;
-        let room = hard_buffer_limit.saturating_sub(buffer.len());
-        if room == 0 {
-            // The only valid residual at this length is an exact-size frame
-            // followed by the first three bytes of a CRLF delimiter. Admit
-            // its final newline directly, then drain the now-complete frame.
-            if residual_fits_frame_limit(buffer) && chunk.first() == Some(&b'\n') {
-                buffer.push(b'\n');
-                chunk = &chunk[1..];
+    /// Append one network chunk without allowing either a complete frame or
+    /// the incomplete residual to grow beyond
+    /// [`MAX_PROVIDER_SSE_FRAME_BYTES`].
+    ///
+    /// The chunk is admitted in bounded slices, draining complete frames
+    /// between slices. This matters because one HTTP body chunk can itself be
+    /// much larger than the frame ceiling; extending the residual with the
+    /// whole chunk before checking would merely move the unbounded allocation
+    /// one layer earlier.
+    pub fn push(&mut self, mut chunk: &[u8]) -> Result<Vec<String>, SseFrameTooLarge> {
+        let mut frames = Vec::new();
+        while !chunk.is_empty() {
+            let hard_buffer_limit =
+                MAX_PROVIDER_SSE_FRAME_BYTES + Self::MAX_PARTIAL_DELIMITER_BYTES;
+            let room = hard_buffer_limit.saturating_sub(self.buffer.len());
+            if room == 0 {
+                // The only valid residual at this length is an exact-size frame
+                // followed by the first three bytes of a CRLF delimiter. Admit
+                // its final newline directly, then drain the now-complete frame.
+                if residual_fits_frame_limit(&self.buffer) && chunk.first() == Some(&b'\n') {
+                    self.buffer.push(b'\n');
+                    chunk = &chunk[1..];
+                } else {
+                    return Err(SseFrameTooLarge);
+                }
             } else {
+                let take = room.min(chunk.len());
+                self.buffer.extend_from_slice(&chunk[..take]);
+                chunk = &chunk[take..];
+            }
+
+            frames.extend(self.drain()?);
+
+            // Bytes beyond an exact-size frame are admissible only when they
+            // are a partial delimiter. This rejects oversized content
+            // immediately rather than treating any arbitrary three-byte
+            // suffix as framing overhead.
+            if !residual_fits_frame_limit(&self.buffer) {
                 return Err(SseFrameTooLarge);
             }
-        } else {
-            let take = room.min(chunk.len());
-            buffer.extend_from_slice(&chunk[..take]);
-            chunk = &chunk[take..];
         }
+        Ok(frames)
+    }
 
-        for frame in drain_frames(buffer) {
-            if frame.len() > MAX_PROVIDER_SSE_FRAME_BYTES {
+    fn drain(&mut self) -> Result<Vec<String>, SseFrameTooLarge> {
+        let mut frames = Vec::new();
+        let mut frame_start = 0;
+        let mut search_from = self.scan_from;
+        while let Some((content_end, delimiter_len)) = self.find_delimiter(search_from) {
+            if content_end.saturating_sub(frame_start) > MAX_PROVIDER_SSE_FRAME_BYTES {
                 return Err(SseFrameTooLarge);
             }
-            frames.push(frame);
+            frames
+                .push(String::from_utf8_lossy(&self.buffer[frame_start..content_end]).into_owned());
+            frame_start = content_end + delimiter_len;
+            search_from = frame_start;
         }
+        if frame_start != 0 {
+            self.buffer.drain(..frame_start);
+        }
+        self.scan_from = self
+            .buffer
+            .len()
+            .saturating_sub(Self::MAX_PARTIAL_DELIMITER_BYTES);
+        Ok(frames)
+    }
 
-        // Bytes beyond an exact-size frame are admissible only when they are a
-        // partial delimiter. This rejects oversized content immediately rather
-        // than treating any arbitrary three-byte suffix as framing overhead.
-        if !residual_fits_frame_limit(buffer) {
+    fn find_delimiter(&mut self, start: usize) -> Option<(usize, usize)> {
+        #[cfg(test)]
+        {
+            self.inspected_bytes = self
+                .inspected_bytes
+                .saturating_add(self.buffer.len().saturating_sub(start));
+        }
+        find_frame_delimiter(&self.buffer, start)
+    }
+
+    /// Decode an unterminated final SSE frame after applying the same byte
+    /// ceiling as [`Self::push`].
+    pub fn finish(self) -> Result<Option<String>, SseFrameTooLarge> {
+        if self.buffer.is_empty() {
+            return Ok(None);
+        }
+        if self.buffer.len() > MAX_PROVIDER_SSE_FRAME_BYTES {
             return Err(SseFrameTooLarge);
         }
+        Ok(Some(
+            String::from_utf8_lossy(self.buffer.as_slice()).into_owned(),
+        ))
     }
-    Ok(frames)
-}
-
-/// Decode an unterminated final SSE frame after applying the same byte ceiling
-/// as [`push_frames`].
-pub fn finish_frame(buffer: &mut Vec<u8>) -> Result<Option<String>, SseFrameTooLarge> {
-    if buffer.is_empty() {
-        return Ok(None);
-    }
-    if buffer.len() > MAX_PROVIDER_SSE_FRAME_BYTES {
-        return Err(SseFrameTooLarge);
-    }
-    Ok(Some(
-        String::from_utf8_lossy(std::mem::take(buffer).as_slice()).into_owned(),
-    ))
 }
 
 /// Extract the concatenated `data:` payload from one SSE frame.
@@ -528,17 +552,17 @@ mod tests {
 
     #[test]
     fn drain_frames_handles_lf_crlf_and_partial_tail() {
-        let mut buf = b"data: {\"a\":1}\n\ndata: partial".to_vec();
-        let frames = drain_frames(&mut buf);
+        let mut framer = SseFramer::default();
+        let frames = framer.push(b"data: {\"a\":1}\n\ndata: partial").unwrap();
         assert_eq!(frames.len(), 1);
         assert!(frames[0].contains("{\"a\":1}"));
-        assert_eq!(buf, b"data: partial");
+        assert_eq!(framer.buffer, b"data: partial");
 
-        let mut buf = b"event: x\r\ndata: {\"b\":2}\r\n\r\n".to_vec();
-        let frames = drain_frames(&mut buf);
+        let mut framer = SseFramer::default();
+        let frames = framer.push(b"event: x\r\ndata: {\"b\":2}\r\n\r\n").unwrap();
         assert_eq!(frames.len(), 1);
         assert_eq!(frame_data(&frames[0]).unwrap()["b"], 2);
-        assert!(buf.is_empty());
+        assert!(framer.buffer.is_empty());
     }
 
     #[test]
@@ -547,10 +571,12 @@ mod tests {
         let split = full.iter().position(|&b| b == 0xC3).unwrap() + 1;
         let (head, tail) = full.split_at(split);
 
-        let mut buf = head.to_vec();
-        assert!(drain_frames(&mut buf).is_empty(), "no complete frame yet");
-        buf.extend_from_slice(tail);
-        let frames = drain_frames(&mut buf);
+        let mut framer = SseFramer::default();
+        assert!(
+            framer.push(head).unwrap().is_empty(),
+            "no complete frame yet"
+        );
+        let frames = framer.push(tail).unwrap();
         assert_eq!(frames.len(), 1);
         assert_eq!(frame_data(&frames[0]).unwrap()["t"], "café");
     }
@@ -560,42 +586,46 @@ mod tests {
         let frame = b"data: {\"ok\":true}\n\n";
         let repetitions = MAX_PROVIDER_SSE_FRAME_BYTES / frame.len() + 2;
         let chunk = frame.repeat(repetitions);
-        let mut buffer = Vec::new();
-        let frames = push_frames(&mut buffer, &chunk).unwrap();
+        let mut framer = SseFramer::default();
+        let frames = framer.push(&chunk).unwrap();
         assert_eq!(frames.len(), repetitions);
-        assert!(buffer.is_empty());
+        assert!(framer.buffer.is_empty());
     }
 
     #[test]
     fn bounded_push_rejects_an_oversized_delimited_frame() {
         let mut chunk = vec![b'x'; MAX_PROVIDER_SSE_FRAME_BYTES + 1];
         chunk.extend_from_slice(b"\n\n");
-        let mut buffer = Vec::new();
-        assert_eq!(push_frames(&mut buffer, &chunk), Err(SseFrameTooLarge));
-        assert!(buffer.len() <= MAX_PROVIDER_SSE_FRAME_BYTES + 3);
+        let mut framer = SseFramer::default();
+        assert_eq!(framer.push(&chunk), Err(SseFrameTooLarge));
+        assert!(framer.buffer.len() <= MAX_PROVIDER_SSE_FRAME_BYTES + 3);
     }
 
     #[test]
     fn bounded_push_rejects_an_oversized_unterminated_residual() {
         let chunk = vec![b'x'; MAX_PROVIDER_SSE_FRAME_BYTES + 4];
-        let mut buffer = Vec::new();
-        assert_eq!(push_frames(&mut buffer, &chunk), Err(SseFrameTooLarge));
-        assert!(buffer.len() <= MAX_PROVIDER_SSE_FRAME_BYTES + 3);
+        let mut framer = SseFramer::default();
+        assert_eq!(framer.push(&chunk), Err(SseFrameTooLarge));
+        assert!(framer.buffer.len() <= MAX_PROVIDER_SSE_FRAME_BYTES + 3);
     }
 
     #[test]
     fn exact_size_frames_accept_split_lf_and_crlf_delimiters() {
         for delimiter in [b"\n\n".as_slice(), b"\r\n\r\n".as_slice()] {
-            let mut buffer = vec![b'x'; MAX_PROVIDER_SSE_FRAME_BYTES];
+            let mut framer = SseFramer::default();
+            assert!(framer
+                .push(&vec![b'x'; MAX_PROVIDER_SSE_FRAME_BYTES])
+                .unwrap()
+                .is_empty());
             for (index, byte) in delimiter.iter().enumerate() {
-                let frames = push_frames(&mut buffer, std::slice::from_ref(byte)).unwrap();
+                let frames = framer.push(std::slice::from_ref(byte)).unwrap();
                 if index + 1 == delimiter.len() {
                     assert_eq!(frames, vec!["x".repeat(MAX_PROVIDER_SSE_FRAME_BYTES)]);
                 } else {
                     assert!(frames.is_empty());
                 }
             }
-            assert!(buffer.is_empty());
+            assert!(framer.buffer.is_empty());
         }
     }
 
@@ -603,21 +633,42 @@ mod tests {
     fn delimiter_does_not_excuse_oversized_frame_content() {
         let mut chunk = vec![b'x'; MAX_PROVIDER_SSE_FRAME_BYTES + 1];
         chunk.extend_from_slice(b"\r\n\r\n");
-        let mut buffer = Vec::new();
-        assert_eq!(push_frames(&mut buffer, &chunk), Err(SseFrameTooLarge));
+        let mut framer = SseFramer::default();
+        assert_eq!(framer.push(&chunk), Err(SseFrameTooLarge));
     }
 
     #[test]
     fn final_frame_obeys_the_same_ceiling() {
-        let mut exact = vec![b'x'; MAX_PROVIDER_SSE_FRAME_BYTES];
+        let mut exact = SseFramer::default();
+        assert!(exact
+            .push(&vec![b'x'; MAX_PROVIDER_SSE_FRAME_BYTES])
+            .unwrap()
+            .is_empty());
         assert_eq!(
-            finish_frame(&mut exact).unwrap().unwrap().len(),
+            exact.finish().unwrap().unwrap().len(),
             MAX_PROVIDER_SSE_FRAME_BYTES
         );
-        assert!(exact.is_empty());
 
-        let mut oversized = vec![b'x'; MAX_PROVIDER_SSE_FRAME_BYTES + 1];
-        assert_eq!(finish_frame(&mut oversized), Err(SseFrameTooLarge));
+        let oversized = SseFramer {
+            buffer: vec![b'x'; MAX_PROVIDER_SSE_FRAME_BYTES + 1],
+            ..SseFramer::default()
+        };
+        assert_eq!(oversized.finish(), Err(SseFrameTooLarge));
+    }
+
+    #[test]
+    fn delimiter_free_tiny_chunks_are_scanned_linearly() {
+        let payload = vec![b'x'; 64 * 1024];
+        let mut framer = SseFramer::default();
+        for byte in &payload {
+            assert!(framer.push(std::slice::from_ref(byte)).unwrap().is_empty());
+        }
+        assert!(
+            framer.inspected_bytes <= payload.len() * 4,
+            "inspected {} bytes for a {}-byte payload",
+            framer.inspected_bytes,
+            payload.len()
+        );
     }
 
     #[test]

--- a/crates/openwave-router/src/sse.rs
+++ b/crates/openwave-router/src/sse.rs
@@ -16,6 +16,28 @@ use futures::{Stream, StreamExt};
 /// client-visible failure.
 pub const MAX_PROVIDER_ERROR_BODY_BYTES: usize = 8 * 1024;
 
+/// Largest one provider SSE frame retained before normalization.
+///
+/// Provider frames are untrusted successful-response bytes. A missing blank-line
+/// delimiter must not turn the residual buffer into an unbounded allocation,
+/// and a delimited frame receives the same ceiling before UTF-8 decoding and
+/// JSON parsing. One MiB leaves ample room for ordinary provider events while
+/// staying well below the larger durable turn payload limits.
+pub const MAX_PROVIDER_SSE_FRAME_BYTES: usize = 1024 * 1024;
+
+/// A provider SSE frame or unterminated residual exceeded the fixed ceiling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SseFrameTooLarge;
+
+impl std::fmt::Display for SseFrameTooLarge {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "stream frame exceeds the {MAX_PROVIDER_SSE_FRAME_BYTES}-byte limit"
+        )
+    }
+}
+
 /// Consume at most [`MAX_PROVIDER_ERROR_BODY_BYTES`] from an HTTP byte stream.
 ///
 /// The caller drops the remaining response stream after this returns. Invalid
@@ -42,12 +64,17 @@ where
     String::from_utf8_lossy(&body).into_owned()
 }
 
-/// Naive byte-substring search.
-fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    if needle.is_empty() || haystack.len() < needle.len() {
-        return None;
+fn find_frame_delimiter(buffer: &[u8]) -> Option<(usize, usize)> {
+    for index in 0..buffer.len() {
+        let remaining = &buffer[index..];
+        if remaining.starts_with(b"\n\n") {
+            return Some((index, 2));
+        }
+        if remaining.starts_with(b"\r\n\r\n") {
+            return Some((index, 4));
+        }
     }
-    haystack.windows(needle.len()).position(|w| w == needle)
+    None
 }
 
 /// Drain all complete SSE frames from `buffer`, returning each frame's decoded
@@ -58,25 +85,93 @@ fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
 /// network chunks is never decoded until all its bytes have arrived.
 pub fn drain_frames(buffer: &mut Vec<u8>) -> Vec<String> {
     let mut frames = Vec::new();
+    let mut frame_start = 0;
     loop {
-        let lf = find_subslice(buffer, b"\n\n");
-        let crlf = find_subslice(buffer, b"\r\n\r\n");
-        let (content_end, consume_to) = match (lf, crlf) {
-            (Some(i), Some(j)) => {
-                if i <= j {
-                    (i, i + 2)
-                } else {
-                    (j, j + 4)
-                }
-            }
-            (Some(i), None) => (i, i + 2),
-            (None, Some(j)) => (j, j + 4),
-            (None, None) => break,
+        let remaining = &buffer[frame_start..];
+        let Some((content_end, delimiter_len)) = find_frame_delimiter(remaining) else {
+            break;
         };
-        frames.push(String::from_utf8_lossy(&buffer[..content_end]).into_owned());
-        buffer.drain(..consume_to);
+        frames.push(String::from_utf8_lossy(&remaining[..content_end]).into_owned());
+        frame_start += content_end + delimiter_len;
+    }
+    if frame_start != 0 {
+        buffer.drain(..frame_start);
     }
     frames
+}
+
+fn residual_fits_frame_limit(buffer: &[u8]) -> bool {
+    if buffer.len() <= MAX_PROVIDER_SSE_FRAME_BYTES {
+        return true;
+    }
+    matches!(
+        &buffer[MAX_PROVIDER_SSE_FRAME_BYTES..],
+        b"\n" | b"\r" | b"\r\n" | b"\r\n\r"
+    )
+}
+
+/// Append one network chunk without allowing either a complete frame or the
+/// incomplete residual to grow beyond [`MAX_PROVIDER_SSE_FRAME_BYTES`].
+///
+/// The chunk is admitted in bounded slices, draining complete frames between
+/// slices. This matters because one HTTP body chunk can itself be much larger
+/// than the frame ceiling; extending the residual with the whole chunk before
+/// checking would merely move the unbounded allocation one layer earlier.
+pub fn push_frames(
+    buffer: &mut Vec<u8>,
+    mut chunk: &[u8],
+) -> Result<Vec<String>, SseFrameTooLarge> {
+    const MAX_PARTIAL_DELIMITER_BYTES: usize = 3;
+
+    let mut frames = Vec::new();
+    while !chunk.is_empty() {
+        let hard_buffer_limit = MAX_PROVIDER_SSE_FRAME_BYTES + MAX_PARTIAL_DELIMITER_BYTES;
+        let room = hard_buffer_limit.saturating_sub(buffer.len());
+        if room == 0 {
+            // The only valid residual at this length is an exact-size frame
+            // followed by the first three bytes of a CRLF delimiter. Admit
+            // its final newline directly, then drain the now-complete frame.
+            if residual_fits_frame_limit(buffer) && chunk.first() == Some(&b'\n') {
+                buffer.push(b'\n');
+                chunk = &chunk[1..];
+            } else {
+                return Err(SseFrameTooLarge);
+            }
+        } else {
+            let take = room.min(chunk.len());
+            buffer.extend_from_slice(&chunk[..take]);
+            chunk = &chunk[take..];
+        }
+
+        for frame in drain_frames(buffer) {
+            if frame.len() > MAX_PROVIDER_SSE_FRAME_BYTES {
+                return Err(SseFrameTooLarge);
+            }
+            frames.push(frame);
+        }
+
+        // Bytes beyond an exact-size frame are admissible only when they are a
+        // partial delimiter. This rejects oversized content immediately rather
+        // than treating any arbitrary three-byte suffix as framing overhead.
+        if !residual_fits_frame_limit(buffer) {
+            return Err(SseFrameTooLarge);
+        }
+    }
+    Ok(frames)
+}
+
+/// Decode an unterminated final SSE frame after applying the same byte ceiling
+/// as [`push_frames`].
+pub fn finish_frame(buffer: &mut Vec<u8>) -> Result<Option<String>, SseFrameTooLarge> {
+    if buffer.is_empty() {
+        return Ok(None);
+    }
+    if buffer.len() > MAX_PROVIDER_SSE_FRAME_BYTES {
+        return Err(SseFrameTooLarge);
+    }
+    Ok(Some(
+        String::from_utf8_lossy(std::mem::take(buffer).as_slice()).into_owned(),
+    ))
 }
 
 /// Extract the concatenated `data:` payload from one SSE frame.
@@ -458,6 +553,71 @@ mod tests {
         let frames = drain_frames(&mut buf);
         assert_eq!(frames.len(), 1);
         assert_eq!(frame_data(&frames[0]).unwrap()["t"], "café");
+    }
+
+    #[test]
+    fn bounded_push_accepts_many_frames_in_one_large_chunk() {
+        let frame = b"data: {\"ok\":true}\n\n";
+        let repetitions = MAX_PROVIDER_SSE_FRAME_BYTES / frame.len() + 2;
+        let chunk = frame.repeat(repetitions);
+        let mut buffer = Vec::new();
+        let frames = push_frames(&mut buffer, &chunk).unwrap();
+        assert_eq!(frames.len(), repetitions);
+        assert!(buffer.is_empty());
+    }
+
+    #[test]
+    fn bounded_push_rejects_an_oversized_delimited_frame() {
+        let mut chunk = vec![b'x'; MAX_PROVIDER_SSE_FRAME_BYTES + 1];
+        chunk.extend_from_slice(b"\n\n");
+        let mut buffer = Vec::new();
+        assert_eq!(push_frames(&mut buffer, &chunk), Err(SseFrameTooLarge));
+        assert!(buffer.len() <= MAX_PROVIDER_SSE_FRAME_BYTES + 3);
+    }
+
+    #[test]
+    fn bounded_push_rejects_an_oversized_unterminated_residual() {
+        let chunk = vec![b'x'; MAX_PROVIDER_SSE_FRAME_BYTES + 4];
+        let mut buffer = Vec::new();
+        assert_eq!(push_frames(&mut buffer, &chunk), Err(SseFrameTooLarge));
+        assert!(buffer.len() <= MAX_PROVIDER_SSE_FRAME_BYTES + 3);
+    }
+
+    #[test]
+    fn exact_size_frames_accept_split_lf_and_crlf_delimiters() {
+        for delimiter in [b"\n\n".as_slice(), b"\r\n\r\n".as_slice()] {
+            let mut buffer = vec![b'x'; MAX_PROVIDER_SSE_FRAME_BYTES];
+            for (index, byte) in delimiter.iter().enumerate() {
+                let frames = push_frames(&mut buffer, std::slice::from_ref(byte)).unwrap();
+                if index + 1 == delimiter.len() {
+                    assert_eq!(frames, vec!["x".repeat(MAX_PROVIDER_SSE_FRAME_BYTES)]);
+                } else {
+                    assert!(frames.is_empty());
+                }
+            }
+            assert!(buffer.is_empty());
+        }
+    }
+
+    #[test]
+    fn delimiter_does_not_excuse_oversized_frame_content() {
+        let mut chunk = vec![b'x'; MAX_PROVIDER_SSE_FRAME_BYTES + 1];
+        chunk.extend_from_slice(b"\r\n\r\n");
+        let mut buffer = Vec::new();
+        assert_eq!(push_frames(&mut buffer, &chunk), Err(SseFrameTooLarge));
+    }
+
+    #[test]
+    fn final_frame_obeys_the_same_ceiling() {
+        let mut exact = vec![b'x'; MAX_PROVIDER_SSE_FRAME_BYTES];
+        assert_eq!(
+            finish_frame(&mut exact).unwrap().unwrap().len(),
+            MAX_PROVIDER_SSE_FRAME_BYTES
+        );
+        assert!(exact.is_empty());
+
+        let mut oversized = vec![b'x'; MAX_PROVIDER_SSE_FRAME_BYTES + 1];
+        assert_eq!(finish_frame(&mut oversized), Err(SseFrameTooLarge));
     }
 
     #[test]

--- a/crates/openwave-server/src/mcp_config/validation.rs
+++ b/crates/openwave-server/src/mcp_config/validation.rs
@@ -37,8 +37,11 @@ pub(super) fn validate_servers(servers: &[McpServerDefinition]) -> Result<()> {
             }
             (None, Some(url), None) => {
                 validate_process_string(&server.name, "url", url)?;
-                openwave_mcp::validate_http_url(url)
-                    .map_err(|error| server_error(&server.name, error))?;
+                openwave_mcp::validate_http_url_with_credentials(
+                    url,
+                    server.bearer_token_env.is_some(),
+                )
+                .map_err(|error| server_error(&server.name, error))?;
                 validate_no_process_fields(server)?;
                 if let Some(bearer_name) = &server.bearer_token_env {
                     validate_environment_name(&server.name, bearer_name)?;
@@ -239,4 +242,44 @@ pub(super) fn connection_diagnostic(
 
 pub(super) fn server_error(name: &str, message: impl std::fmt::Display) -> AgentError {
     AgentError::config(format!("invalid external MCP server {name:?}: {message}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    use super::*;
+
+    fn http_server(url: &str, bearer_token_env: Option<&str>) -> McpServerDefinition {
+        McpServerDefinition {
+            name: "docs".to_string(),
+            command: None,
+            args: Vec::new(),
+            env: BTreeSet::new(),
+            env_values: BTreeMap::new(),
+            env_from: Vec::new(),
+            cwd: None,
+            url: Some(url.to_string()),
+            bearer_token_env: bearer_token_env.map(str::to_string),
+            gateway_endpoint: None,
+            request_timeout_ms: DEFAULT_REQUEST_TIMEOUT_MS,
+            enabled: true,
+            plugin: None,
+            launch: None,
+        }
+    }
+
+    #[test]
+    fn remote_cleartext_http_rejects_environment_bearers_at_validation() {
+        assert!(validate_servers(&[http_server("http://remote.example/mcp", None)]).is_ok());
+        assert!(
+            validate_servers(&[http_server("http://127.0.0.1:9000/mcp", Some("MCP_TOKEN"))])
+                .is_ok()
+        );
+
+        let error =
+            validate_servers(&[http_server("http://remote.example/mcp", Some("MCP_TOKEN"))])
+                .expect_err("remote cleartext bearer configuration must be rejected");
+        assert!(error.to_string().contains("must use https"), "{error}");
+    }
 }


### PR DESCRIPTION
## Summary

- cap provider SSE frames at 1 MiB across Anthropic, Gemini, OpenAI Responses, and OpenAI-compatible adapters, including exact LF/CRLF delimiter boundaries and unterminated tails
- saturate usage counters without wrapping, subtract cached input before clamping, and fail oversized structural stream indices while preserving the existing missing-index fallback
- require HTTPS for credentialed remote MCP HTTP endpoints, including configured headers, connection bearers, and dynamically resolved per-call bearers; literal IPv4/IPv6 loopback remains allowed over HTTP

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p openwave-router sse::tests --locked -- --test-threads=1`
- `cargo test -p openwave-router usage_counts --locked`
- `cargo test -p openwave-router oversized_ --locked`
- `cargo test -p openwave-mcp http::tests --locked`
- `cargo check -p openwave-router -p openwave-mcp --all-targets --locked`
- `cargo clippy -p openwave-router -p openwave-mcp --all-targets --locked --no-deps -- -D warnings`
- `git diff --cached --check`

No server/core integration changes are included; configuration consumers can adopt `validate_http_url_with_credentials` separately.

Closes #1898