### PR TITLE
feat: user-consented gateway disconnect via openwave://deprovision

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -2309,6 +2309,14 @@ impl Store for DbStore {
         Ok(())
     }
 
+    async fn delete_setting(&self, key: &str) -> Result<()> {
+        entities::setting::Entity::delete_by_id(key.to_string())
+            .exec(&self.conn)
+            .await
+            .map_err(store_err)?;
+        Ok(())
+    }
+
     async fn append_event(&self, chat_id: ChatId, event: &AgentEvent) -> Result<i64> {
         ops::conversation::append_event(self, chat_id, event).await
     }

--- a/crates/openwave-core/src/storage/store.rs
+++ b/crates/openwave-core/src/storage/store.rs
@@ -2653,6 +2653,9 @@ pub trait Store: Send + Sync {
     /// Write a setting.
     async fn set_setting(&self, key: &str, value: &Value) -> Result<()>;
 
+    /// Delete a setting. Deleting an absent key is not an error.
+    async fn delete_setting(&self, key: &str) -> Result<()>;
+
     /// Append an event for the legacy direct-execution path.
     ///
     /// Sequence numbers are per-chat and monotonic (starting at 1). This method

--- a/crates/openwave-core/src/storage/tests.rs
+++ b/crates/openwave-core/src/storage/tests.rs
@@ -1076,6 +1076,10 @@ impl Store for MemStore {
             .insert(key.to_string(), value.clone());
         Ok(())
     }
+    async fn delete_setting(&self, key: &str) -> Result<()> {
+        self.settings.lock().unwrap().remove(key);
+        Ok(())
+    }
     async fn append_event(&self, chat_id: ChatId, event: &AgentEvent) -> Result<i64> {
         let mut events = self.events.lock().unwrap();
         let seq = events.iter().filter(|(id, _)| *id == chat_id).count() as i64 + 1;

--- a/crates/openwave-desktop/src/deep_link.rs
+++ b/crates/openwave-desktop/src/deep_link.rs
@@ -341,7 +341,10 @@ fn spawn_deprovision(app: tauri::AppHandle) {
                 log_pairing(&app, "ignored a disconnect link: nothing to disconnect");
             }
             Ok(DeprovisionTarget::Misconfigured { .. }) => {
-                log_pairing(&app, "disconnect refused: the managed policy is misconfigured");
+                log_pairing(
+                    &app,
+                    "disconnect refused: the managed policy is misconfigured",
+                );
                 show_disconnect_failure(
                     &app,
                     &PairingError::Other(openwave_core::AgentError::config(
@@ -652,7 +655,10 @@ mod tests {
     /// cases honest: a link must fail the whole contract, not merely the
     /// provision half of it.
     fn parsed_provision(link: &str) -> Option<super::ProvisionLink> {
-        match tauri::Url::parse(link).ok().map(|url| parse_deep_link(&url)) {
+        match tauri::Url::parse(link)
+            .ok()
+            .map(|url| parse_deep_link(&url))
+        {
             Some(Ok(DeepLink::Provision(link))) => Some(link),
             _ => None,
         }
@@ -769,7 +775,9 @@ mod tests {
             ("https://deprovision", false),
         ];
         for (link, accepted) in cases {
-            let parsed = tauri::Url::parse(link).ok().map(|url| parse_deep_link(&url));
+            let parsed = tauri::Url::parse(link)
+                .ok()
+                .map(|url| parse_deep_link(&url));
             assert_eq!(
                 matches!(parsed, Some(Ok(DeepLink::Deprovision))),
                 *accepted,

--- a/crates/openwave-desktop/src/deep_link.rs
+++ b/crates/openwave-desktop/src/deep_link.rs
@@ -1,6 +1,7 @@
 //! `openwave://` deep-link handling: gateway pairing.
 //!
-//! One link shape is recognized: `openwave://provision?gateway=<url>`. macOS
+//! Two link shapes are recognized: `openwave://provision?gateway=<url>` and
+//! the payload-free `openwave://deprovision`. macOS
 //! delivers opened URLs through the runtime's opened-URL events, which the
 //! deep-link plugin re-emits; on Windows and Linux the OS launches a second
 //! app instance with the link as its only argument, and the single-instance
@@ -33,13 +34,26 @@
 //! direction only: after a registration parks a pairing, the shell emits a
 //! best-effort [`PAIRING_CHANGED_EVENT`] nudge so the gate refetches policy
 //! immediately instead of waiting out its poll tick.
+//!
+//! `openwave://deprovision` is the reverse ceremony, with the native
+//! confirmation as its consent: the dialog names the provisioned gateway,
+//! and only an explicit confirmation runs the compare-and-swap'd delete
+//! ([`openwave_server::deprovision_provisioned_gateway`]) — anchored to the
+//! URL the dialog named, so a row that moved in between refuses. An OS (MDM)
+//! asserted gateway refuses outright (that tier is never locally removable),
+//! and on an unmanaged profile the link is a logged no-op, so a drive-by
+//! link buys at most one dialog that defaults to changing nothing. The link
+//! deliberately carries no payload: the dialog names whatever policy
+//! resolves, rather than trusting a URL the link asserted. The same
+//! [`PAIRING_CHANGED_EVENT`] nudge makes the gate re-read policy and unlock
+//! without a restart.
 
 use tauri::{Emitter, Manager};
 use tauri_plugin_deep_link::DeepLinkExt;
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 use tokio::sync::{oneshot, watch};
 
-use openwave_server::{PairingError, PairingHandle, PendingRegistration};
+use openwave_server::{DeprovisionTarget, PairingError, PairingHandle, PendingRegistration};
 
 /// Where the pairing handler waits for the embedded server's pairing handle:
 /// filled once boot has bound the server. A provision link commonly
@@ -98,15 +112,19 @@ pub(crate) fn install(app: &tauri::AppHandle) {
     }
 }
 
-/// Handle every URL in one delivery. Only a link that parses as a provision
-/// link surfaces the window and registers the pending pairing; a malformed
-/// link is logged bounded — never echoing the link — and changes nothing.
+/// Handle every URL in one delivery. Only a link that parses as one of the
+/// recognized shapes surfaces the window and acts; a malformed link is
+/// logged bounded — never echoing the link — and changes nothing.
 fn handle_deep_link_urls(app: &tauri::AppHandle, urls: &[tauri::Url]) {
     for url in urls {
-        match provision_link(url) {
-            Ok(link) => {
+        match parse_deep_link(url) {
+            Ok(DeepLink::Provision(link)) => {
                 focus_main_window(app);
                 spawn_pairing(app.clone(), link);
+            }
+            Ok(DeepLink::Deprovision) => {
+                focus_main_window(app);
+                spawn_deprovision(app.clone());
             }
             Err(reason) => log_pairing(app, &format!("ignored a deep link: {reason}")),
         }
@@ -123,19 +141,30 @@ pub(crate) fn focus_main_window(app: &tauri::AppHandle) {
     }
 }
 
-/// Parse and validate a provision link.
+/// A recognized deep link, parsed and validated whole.
+#[derive(Debug, PartialEq, Eq)]
+enum DeepLink {
+    /// `openwave://provision?gateway=<url>`: park a pairing for sign-in.
+    Provision(ProvisionLink),
+    /// `openwave://deprovision`, payload-free: ask to disconnect from the
+    /// provisioned gateway. Carrying anything at all — a query, userinfo, a
+    /// port, extra path — refuses the link whole.
+    Deprovision,
+}
+
+/// Parse and validate a deep link.
 ///
 /// The contract is strict — scheme `openwave` (dev builds also answer
-/// `openwave-dev`), action `provision` with no userinfo, port, or extra
-/// path, exactly one query parameter named `gateway`, and a gateway value
-/// that is an https URL (http only on loopback) with no userinfo, query, or
-/// fragment — so a
-/// malformed or hostile link is refused whole rather than partially honored.
-/// Near-miss gateway values matter: the conflict check on the write path
-/// compares normalized URL strings, so accepting a decorated variant would
-/// mint a distinct, permanently conflicting policy value. The gateway URL is
-/// additionally held to the connectors contract server-side.
-fn provision_link(url: &tauri::Url) -> Result<ProvisionLink, String> {
+/// `openwave-dev`) with no userinfo or port, and an action of `provision`
+/// (with exactly one query parameter named `gateway`, whose value is an
+/// https URL — http only on loopback — with no userinfo, query, or fragment)
+/// or `deprovision` (with no query at all) — so a malformed or hostile link
+/// is refused whole rather than partially honored. Near-miss gateway values
+/// matter: the conflict check on the write path compares normalized URL
+/// strings, so accepting a decorated variant would mint a distinct,
+/// permanently conflicting policy value. The gateway URL is additionally
+/// held to the connectors contract server-side.
+fn parse_deep_link(url: &tauri::Url) -> Result<DeepLink, String> {
     if url.scheme() != "openwave" && !(cfg!(debug_assertions) && url.scheme() == DEV_SCHEME) {
         return Err("not an openwave:// link".into());
     }
@@ -154,9 +183,22 @@ fn provision_link(url: &tauri::Url) -> Result<ProvisionLink, String> {
         (None, path) => path.to_string(),
         (Some(host), path) => format!("{host}/{path}"),
     };
-    if action != "provision" {
-        return Err("not a provision link".into());
+    match action.as_str() {
+        "provision" => provision_link(url).map(DeepLink::Provision),
+        "deprovision" => {
+            if url.query().is_some() {
+                return Err("the deprovision link must carry no parameters".into());
+            }
+            Ok(DeepLink::Deprovision)
+        }
+        _ => Err("not a recognized openwave link".into()),
     }
+}
+
+/// The provision half of the contract: exactly one query parameter named
+/// `gateway`, holding a credible gateway URL. Scheme, userinfo, port, and
+/// action shape were already checked by [`parse_deep_link`].
+fn provision_link(url: &tauri::Url) -> Result<ProvisionLink, String> {
     let mut pairs = url.query_pairs();
     let Some((key, value)) = pairs.next() else {
         return Err("the provision link carries no gateway parameter".into());
@@ -266,6 +308,91 @@ fn spawn_pairing(app: tauri::AppHandle, link: ProvisionLink) {
     });
 }
 
+/// The deprovision flow: probe what the link would act on, and only a
+/// user-consented provisioned row gets the confirmation dialog — which is
+/// the consent the CAS'd delete then anchors to. Every other state is a
+/// refusal dialog or a logged no-op; nothing here loops or retries.
+fn spawn_deprovision(app: tauri::AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        let handle = match wait_pairing_handle(&app).await {
+            Ok(handle) => handle,
+            Err(reason) => {
+                log_pairing(&app, &format!("disconnect failed: {reason}"));
+                return;
+            }
+        };
+        match openwave_server::deprovision_target(&handle).await {
+            Ok(DeprovisionTarget::Provisioned { gateway_url }) => {
+                confirm_and_disconnect(&app, &handle, &gateway_url).await;
+            }
+            Ok(DeprovisionTarget::OsManaged { gateway_url }) => {
+                log_pairing(&app, "disconnect refused: an OS policy asserts the gateway");
+                show_disconnect_failure(
+                    &app,
+                    &PairingError::Conflict {
+                        provisioned_url: gateway_url.unwrap_or_default(),
+                        replaceable: false,
+                    },
+                );
+            }
+            Ok(DeprovisionTarget::Unprovisioned) => {
+                // A drive-by link on an unmanaged install must stay quiet,
+                // symmetric with the provision path's no-dialog happy path.
+                log_pairing(&app, "ignored a disconnect link: nothing to disconnect");
+            }
+            Ok(DeprovisionTarget::Misconfigured { .. }) => {
+                log_pairing(&app, "disconnect refused: the managed policy is misconfigured");
+                show_disconnect_failure(
+                    &app,
+                    &PairingError::Other(openwave_core::AgentError::config(
+                        "the managed policy is misconfigured",
+                    )),
+                );
+            }
+            Err(error) => {
+                log_pairing(&app, &format!("disconnect failed: {error}"));
+                show_disconnect_failure(&app, &PairingError::Other(error));
+            }
+        }
+    });
+}
+
+/// Escalate to the user's explicit choice: a native dialog naming the
+/// provisioned origin, defaulting to changing nothing. Confirmation runs the
+/// delete anchored to exactly the URL the dialog named; a row that moved in
+/// between surfaces as one failure dialog, never a retry loop.
+async fn confirm_and_disconnect(app: &tauri::AppHandle, handle: &PairingHandle, gateway_url: &str) {
+    let origin = origin_of(gateway_url);
+    if PAIRING_DIALOG_SHOWING.swap(true, std::sync::atomic::Ordering::SeqCst) {
+        log_pairing(app, "a pairing dialog is already up; logged only");
+        return;
+    }
+    let approved = ask_confirmation(
+        app,
+        "Disconnect this device?",
+        &disconnect_prompt(&origin),
+        "Disconnect",
+    )
+    .await;
+    PAIRING_DIALOG_SHOWING.store(false, std::sync::atomic::Ordering::SeqCst);
+    if !approved {
+        log_pairing(app, &format!("disconnecting from {origin} declined"));
+        return;
+    }
+    match openwave_server::deprovision_provisioned_gateway(handle, gateway_url).await {
+        Ok(()) => {
+            log_pairing(app, &format!("disconnected from {origin}"));
+            // The live unlock: the gate refetches `/policy`, resolves
+            // unmanaged, and renders the open experience without a restart.
+            notify_pairing_changed(app);
+        }
+        Err(failure) => {
+            log_pairing(app, &format!("disconnect refused for {origin}: {failure}"));
+            show_disconnect_failure(app, &failure);
+        }
+    }
+}
+
 /// Escalate a replaceable conflict to the user's explicit choice: a native
 /// dialog naming both origins, defaulting to changing nothing. Confirmation
 /// parks the replacing pairing — still nothing durable; the sign-in the gate
@@ -319,15 +446,20 @@ async fn confirm_and_replace(
 /// the dialog's answer arrives on a callback, and a channel that drops
 /// unanswered reads as a decline — the failure direction of every path here
 /// is "change nothing".
-async fn ask_to_repair(app: &tauri::AppHandle, message: &str) -> bool {
+async fn ask_confirmation(
+    app: &tauri::AppHandle,
+    title: &str,
+    message: &str,
+    confirm_label: &str,
+) -> bool {
     let (tx, rx) = oneshot::channel();
     let mut dialog = app
         .dialog()
         .message(message)
-        .title("Re-pair this device?")
+        .title(title)
         .kind(MessageDialogKind::Warning)
         .buttons(MessageDialogButtons::OkCancelCustom(
-            "Re-pair".to_owned(),
+            confirm_label.to_owned(),
             "Cancel".to_owned(),
         ));
     if let Some(window) = app.get_webview_window("main") {
@@ -337,6 +469,10 @@ async fn ask_to_repair(app: &tauri::AppHandle, message: &str) -> bool {
         let _ = tx.send(approved);
     });
     rx.await.unwrap_or(false)
+}
+
+async fn ask_to_repair(app: &tauri::AppHandle, message: &str) -> bool {
+    ask_confirmation(app, "Re-pair this device?", message, "Re-pair").await
 }
 
 /// Reduce a stored gateway base URL to its origin — the only form
@@ -359,6 +495,58 @@ fn repair_prompt(new_origin: &str, old_origin: &str) -> String {
          which models and settings are available. You'll complete a sign-in to \
          {new_origin} to finish — until then, nothing changes."
     )
+}
+
+/// The disconnect question, pure like [`repair_prompt`]: what the
+/// confirmation claims — the origin being left, that the session is signed
+/// out, and that re-pairing stays possible — must be testable without a GUI.
+fn disconnect_prompt(origin: &str) -> String {
+    format!(
+        "Disconnect this device from {origin}?\n\n\
+         OpenWave will sign out of {origin} and stop being managed by it. \
+         You can pair again later from your gateway's page."
+    )
+}
+
+/// The one user-facing line per disconnect refusal class, pure like
+/// [`refusal_message`]. An OS (MDM) asserted gateway names itself and points
+/// at the administrator — that tier is never locally removable. A replaceable
+/// conflict only reaches this dialog when the confirmation raced a change to
+/// the provisioned row, so it says the state moved and leaves the retry to
+/// the user. Any other refusal stays generic — the raw reason is in
+/// `pairing.log` — and says nothing changed.
+fn disconnect_refusal_message(failure: &PairingError) -> String {
+    match failure {
+        PairingError::Conflict {
+            provisioned_url,
+            replaceable: false,
+        } => format!(
+            "This device is managed by {} through your organization's \
+             device policy. Contact your administrator to disconnect.",
+            origin_of(provisioned_url)
+        ),
+        PairingError::Conflict { .. } => "The gateway managing this device changed while \
+             disconnecting. Nothing was changed; try again from the new state."
+            .to_string(),
+        _ => "OpenWave could not disconnect this device. Nothing was changed; \
+             details are in pairing.log."
+            .to_string(),
+    }
+}
+
+/// One bounded error dialog per refused disconnect, same posture as
+/// [`show_pairing_failure`]: no retry affordance, no loop.
+fn show_disconnect_failure(app: &tauri::AppHandle, failure: &PairingError) {
+    if PAIRING_DIALOG_SHOWING.swap(true, std::sync::atomic::Ordering::SeqCst) {
+        log_pairing(app, "a pairing dialog is already up; logged only");
+        return;
+    }
+    app.dialog()
+        .message(disconnect_refusal_message(failure))
+        .title("Disconnect refused")
+        .kind(MessageDialogKind::Error)
+        .blocking_show();
+    PAIRING_DIALOG_SHOWING.store(false, std::sync::atomic::Ordering::SeqCst);
 }
 
 /// The one user-facing line per refusal class, pure so the choice of what a
@@ -455,7 +643,20 @@ fn log_pairing(app: &tauri::AppHandle, message: &str) {
 
 #[cfg(test)]
 mod tests {
-    use super::{origin_of, provision_link, refusal_message, repair_prompt, PairingError};
+    use super::{
+        disconnect_prompt, disconnect_refusal_message, origin_of, parse_deep_link, refusal_message,
+        repair_prompt, DeepLink, PairingError,
+    };
+
+    /// Parse through the one entry the handler uses, keeping the hostile
+    /// cases honest: a link must fail the whole contract, not merely the
+    /// provision half of it.
+    fn parsed_provision(link: &str) -> Option<super::ProvisionLink> {
+        match tauri::Url::parse(link).ok().map(|url| parse_deep_link(&url)) {
+            Some(Ok(DeepLink::Provision(link))) => Some(link),
+            _ => None,
+        }
+    }
 
     #[test]
     fn provision_links_are_held_to_the_contract() {
@@ -539,12 +740,39 @@ mod tests {
             ),
         ];
         for (link, expected) in cases {
-            let parsed = tauri::Url::parse(link)
-                .ok()
-                .and_then(|url| provision_link(&url).ok());
+            let parsed = parsed_provision(link);
             assert_eq!(
                 parsed.as_ref().map(|link| link.gateway_url.as_str()),
                 *expected,
+                "{link}"
+            );
+        }
+    }
+
+    /// The deprovision link's whole contract: the bare action in either URL
+    /// spelling, and nothing else — any query at all, userinfo, a port, a
+    /// trailing path segment, a percent-encoded action, or a foreign scheme
+    /// refuses the link whole.
+    #[test]
+    fn deprovision_links_are_held_to_the_contract() {
+        let cases: &[(&str, bool)] = &[
+            ("openwave://deprovision", true),
+            ("openwave://deprovision/", true),
+            ("openwave:deprovision", true),
+            ("openwave://deprovision?gateway=https://gw.example", false),
+            ("openwave://deprovision?", false),
+            ("openwave://deprovision?x=1", false),
+            ("openwave://user:pw@deprovision", false),
+            ("openwave://deprovision:9999", false),
+            ("openwave://deprovision/extra", false),
+            ("openwave://depro%76ision", false),
+            ("https://deprovision", false),
+        ];
+        for (link, accepted) in cases {
+            let parsed = tauri::Url::parse(link).ok().map(|url| parse_deep_link(&url));
+            assert_eq!(
+                matches!(parsed, Some(Ok(DeepLink::Deprovision))),
+                *accepted,
                 "{link}"
             );
         }
@@ -555,8 +783,17 @@ mod tests {
     /// build profile, which is exactly the contract.
     #[test]
     fn the_dev_scheme_is_a_debug_only_alias() {
-        let url = tauri::Url::parse("openwave-dev://provision?gateway=https://gw.example").unwrap();
-        assert_eq!(provision_link(&url).is_ok(), cfg!(debug_assertions));
+        for link in [
+            "openwave-dev://provision?gateway=https://gw.example",
+            "openwave-dev://deprovision",
+        ] {
+            let url = tauri::Url::parse(link).unwrap();
+            assert_eq!(
+                parse_deep_link(&url).is_ok(),
+                cfg!(debug_assertions),
+                "{link}"
+            );
+        }
     }
 
     /// The refusal dialog's one line per failure class: an MDM-asserted
@@ -622,5 +859,49 @@ mod tests {
             origin_of("https://gw.example:8443/base/path/"),
             "https://gw.example:8443"
         );
+    }
+
+    /// The disconnect confirmation's load-bearing claims: the origin being
+    /// left by name, that the session is signed out, and that pairing again
+    /// stays possible — disconnecting is not a one-way door.
+    #[test]
+    fn the_disconnect_prompt_names_the_origin_and_the_way_back() {
+        let prompt = disconnect_prompt("https://gw.example");
+        assert!(prompt.contains("Disconnect this device from https://gw.example?"));
+        assert!(prompt.contains("sign out of https://gw.example"));
+        assert!(prompt.contains("pair again"));
+    }
+
+    /// The disconnect refusal's one line per failure class: an OS-asserted
+    /// gateway names itself — reduced to its origin — and points at the
+    /// administrator; a raced replaceable conflict says the state moved; a
+    /// generic failure keeps the raw reason in pairing.log. Every class says
+    /// or implies nothing changed.
+    #[test]
+    fn the_disconnect_refusal_names_the_right_authority() {
+        let os = disconnect_refusal_message(&PairingError::Conflict {
+            provisioned_url: "https://mdm.example/base/".to_string(),
+            replaceable: false,
+        });
+        assert!(os.contains("managed by https://mdm.example"));
+        assert!(os.contains("administrator"));
+        assert!(!os.contains("/base"));
+
+        let raced = disconnect_refusal_message(&PairingError::Conflict {
+            provisioned_url: "https://third.example/".to_string(),
+            replaceable: true,
+        });
+        assert!(raced.contains("changed while"));
+        assert!(raced.contains("Nothing was changed"));
+        assert!(
+            !raced.contains("administrator"),
+            "a user-replaceable row must not be blamed on an administrator"
+        );
+
+        let other = disconnect_refusal_message(&PairingError::Other(
+            openwave_core::AgentError::config("reader failed: token=shh"),
+        ));
+        assert!(other.contains("pairing.log"));
+        assert!(!other.contains("token=shh"));
     }
 }

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -463,6 +463,30 @@ impl GatewayRuntime {
         Ok(())
     }
 
+    /// Invalidate any in-flight browser sign-in and drop the pending pairing
+    /// — the disconnect epilogue. Same discipline as sign-out: an exchange
+    /// that completes afterwards serializes behind the state lock, observes
+    /// the generation bump, and abandons rather than re-saving the session
+    /// it just minted.
+    pub(crate) async fn abandon_sign_in_and_pairing(&self) {
+        let mut sign_in = self.sign_in.lock().await;
+        self.sign_in_generation
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        *self.pending_pairing.lock().await = None;
+        *sign_in = SignInProgress::Idle;
+    }
+
+    /// Retire the stored session against the current resolved policy: after
+    /// a deprovision the profile is unmanaged, so [`sign_out`](Self::sign_out)
+    /// (managed-only) cannot run, but the keychain session must still be
+    /// revoked (best-effort) and cleared (unconditionally). Thin wrapper so
+    /// callers without the secrets handle can reach
+    /// [`retire_superseded_gateway_session`].
+    pub(crate) async fn retire_session_for_current_policy(&self) -> Result<()> {
+        let policy = self.policy().await?;
+        retire_superseded_gateway_session(self.secrets.clone(), &policy).await
+    }
+
     /// The connection for the policy's gateway, or `None` when the profile is
     /// unmanaged (or the managed policy is misconfigured).
     ///

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -131,7 +131,8 @@ use resolver::KeyedResolver;
 pub use durable_oplog::DurableOperationStore;
 pub use error::ServerError;
 pub use pairing::{
-    register_pending_pairing, register_replacing_pairing, PairingError, PairingHandle,
+    deprovision_provisioned_gateway, deprovision_target, register_pending_pairing,
+    register_replacing_pairing, DeprovisionTarget, PairingError, PairingHandle,
     PendingRegistration,
 };
 pub use state::{AppState, LocalVoiceError, LocalVoiceRunner, LocalVoiceState, LocalVoiceStatus};

--- a/crates/openwave-server/src/managed_policy.rs
+++ b/crates/openwave-server/src/managed_policy.rs
@@ -827,6 +827,24 @@ pub(crate) async fn reprovision(
         .await
 }
 
+/// Delete the sticky provisioned row, compare-and-swap style: the delete
+/// lands only if the row still holds `expected_current` — the URL the user's
+/// disconnect confirmation actually named. A row that changed in between
+/// refuses rather than deletes, because the consent on record was given
+/// against a different state. Callers serialize the read-check-write under
+/// the pairing lock; this check is the belt to that suspender.
+///
+/// The OS authority is untouched by design: resolution precedence means an
+/// MDM-asserted gateway still wins after the row underneath is gone.
+pub(crate) async fn deprovision(store: &dyn Store, expected_current: &str) -> Result<()> {
+    if provisioned_url(store).await?.as_deref() != Some(expected_current) {
+        return Err(AgentError::config(
+            "the gateway managing this profile changed while disconnecting; nothing was changed",
+        ));
+    }
+    store.delete_setting(SETTING_KEY).await
+}
+
 /// The provisioned gateway URL currently on record, if readable.
 ///
 /// Unreadable stored state reads as `None`, not as an error: [`provision`]
@@ -945,6 +963,31 @@ mod tests {
             .await
             .is_err());
         assert!(!resolve(&*store, &NoOsPolicy).await.unwrap().managed);
+    }
+
+    /// Deprovision shares reprovision's CAS discipline: it deletes only the
+    /// row its confirmation named, refuses one that moved, and leaves the
+    /// profile open (never misconfigured) once the row is gone.
+    #[tokio::test]
+    async fn deprovision_deletes_only_the_row_the_confirmation_named() {
+        let (store, _directory) = test_store().await;
+        provision(&*store, "https://corp.gateway").await.unwrap();
+
+        let error = deprovision(&*store, "https://other.example")
+            .await
+            .err()
+            .unwrap();
+        assert!(error.to_string().contains("changed while disconnecting"));
+        let policy = resolve(&*store, &NoOsPolicy).await.unwrap();
+        assert_eq!(policy.gateway_url.as_deref(), Some("https://corp.gateway/"));
+
+        deprovision(&*store, "https://corp.gateway/").await.unwrap();
+        let policy = resolve(&*store, &NoOsPolicy).await.unwrap();
+        assert!(!policy.managed && !policy.misconfigured);
+        assert!(store.get_setting(SETTING_KEY).await.unwrap().is_none());
+
+        // With no row left, any expectation refuses rather than pretends.
+        assert!(deprovision(&*store, "https://corp.gateway/").await.is_err());
     }
 
     #[tokio::test]

--- a/crates/openwave-server/src/pairing.rs
+++ b/crates/openwave-server/src/pairing.rs
@@ -236,6 +236,108 @@ pub async fn register_replacing_pairing(
     Ok(PendingRegistration::Registered)
 }
 
+/// What a deprovision link would act on, for the shell's dialog.
+///
+/// A probe, not a lock: the shell reads this to decide which dialog to show,
+/// and [`deprovision_provisioned_gateway`] re-checks everything under the
+/// pairing lock before deleting anything.
+#[derive(Debug, PartialEq, Eq)]
+pub enum DeprovisionTarget {
+    /// The sticky provisioned row: user-consented state the shell may
+    /// confirm-and-disconnect. Carries the normalized base URL the
+    /// confirmation must name — and the CAS anchors to.
+    Provisioned {
+        /// The normalized base URL this profile is provisioned to.
+        gateway_url: String,
+    },
+    /// The OS (MDM) asserts the gateway: never locally removable.
+    OsManaged {
+        /// The asserted base URL, when the artifact is readable.
+        gateway_url: Option<String>,
+    },
+    /// Nothing to disconnect: the open, bring-your-own-key experience.
+    Unprovisioned,
+    /// An authority asserts management but its state cannot be honored —
+    /// there is no URL a confirmation could name, so the shell surfaces a
+    /// repair message instead of a disconnect.
+    Misconfigured {
+        /// Whether the broken authority is the OS (MDM) tier.
+        source_is_os: bool,
+    },
+}
+
+/// Resolve what an `openwave://deprovision` link would act on.
+pub async fn deprovision_target(handle: &PairingHandle) -> Result<DeprovisionTarget> {
+    let policy = handle.gateway.policy().await?;
+    let source_is_os = policy.source == crate::managed_policy::ManagedPolicySource::Os;
+    Ok(if !policy.managed {
+        DeprovisionTarget::Unprovisioned
+    } else if source_is_os {
+        DeprovisionTarget::OsManaged {
+            gateway_url: policy.gateway_url,
+        }
+    } else {
+        match policy.gateway_url {
+            Some(gateway_url) => DeprovisionTarget::Provisioned { gateway_url },
+            None => DeprovisionTarget::Misconfigured { source_is_os },
+        }
+    })
+}
+
+/// Delete the provisioned row the user's native confirmation named, and
+/// retire everything that stood on it: the pending pairing, any in-flight
+/// sign-in, and the stored gateway session (best-effort revoke, unconditional
+/// local clear).
+///
+/// The consent ceremony mirrors provisioning's: as the browser sign-in is
+/// the consent to provision, the shell's native confirmation — which named
+/// `expected_current` — is the consent to deprovision, and the delete is
+/// compare-and-swap on exactly that URL under the same pairing lock as every
+/// other policy write. An OS (MDM) assertion refuses as the non-replaceable
+/// [`PairingError::Conflict`]; a row that moved since the confirmation
+/// refuses as the replaceable one, naming what the row now holds; a profile
+/// already unmanaged is a raced success, not an error.
+pub async fn deprovision_provisioned_gateway(
+    handle: &PairingHandle,
+    expected_current: &str,
+) -> Result<(), PairingError> {
+    let _guard = PAIRING.lock().await;
+    let policy = handle.gateway.policy().await?;
+    if policy.source == crate::managed_policy::ManagedPolicySource::Os {
+        return Err(PairingError::Conflict {
+            provisioned_url: policy.gateway_url.unwrap_or_default(),
+            replaceable: false,
+        });
+    }
+    if !policy.managed {
+        // The row vanished between the confirmation and this call (a
+        // profile reset): what the user asked for is already true.
+        return Ok(());
+    }
+    match policy.gateway_url {
+        Some(existing) if existing != expected_current => {
+            return Err(PairingError::Conflict {
+                provisioned_url: existing,
+                replaceable: true,
+            })
+        }
+        Some(_) => {}
+        None => {
+            return Err(PairingError::Other(AgentError::config(
+                "this device's managed policy is misconfigured; contact your administrator",
+            )))
+        }
+    }
+    managed_policy::deprovision(&*handle.store, expected_current).await?;
+    handle.gateway.abandon_sign_in_and_pairing().await;
+    // Retire against the newly-open policy. A revoke that fails must not
+    // resurrect the disconnect — the local clear inside is unconditional and
+    // the server-side session dies at refresh-token expiry — so only a store
+    // read could error here, and that is worth surfacing.
+    handle.gateway.retire_session_for_current_policy().await?;
+    Ok(())
+}
+
 /// Provision the profile a finished sign-in consented to.
 ///
 /// Called from the sign-in exchange task with a session already minted for
@@ -881,6 +983,191 @@ mod tests {
         assert_eq!(
             info.servers[0].diagnostic.as_deref(),
             Some(MANAGED_DISABLED_DIAGNOSTIC)
+        );
+    }
+
+    /// The disconnect's whole write: the CAS'd delete lands, resolution
+    /// returns the open experience, and the parked pairing an earlier link
+    /// left behind is dropped so the gate has nothing to stand on.
+    #[tokio::test]
+    async fn a_deprovision_deletes_the_row_and_drops_the_pending_pairing() {
+        let (store, _directory) = test_store().await;
+        let (handle, mcp, gateway) = test_handle_with_runtimes(&store);
+        managed_policy::provision(&*store, "https://managed.invalid/")
+            .await
+            .unwrap();
+        gateway
+            .register_pending_pairing("https://parked.invalid/".to_string(), mcp.clone(), None)
+            .await;
+
+        assert_eq!(
+            deprovision_target(&handle).await.unwrap(),
+            DeprovisionTarget::Provisioned {
+                gateway_url: "https://managed.invalid/".to_string()
+            }
+        );
+        deprovision_provisioned_gateway(&handle, "https://managed.invalid/")
+            .await
+            .unwrap();
+
+        let policy = resolve(&*store, &NoOsPolicy).await.unwrap();
+        assert!(!policy.managed && !policy.misconfigured);
+        assert!(store
+            .get_setting("managed_policy_v1")
+            .await
+            .unwrap()
+            .is_none());
+        assert_eq!(gateway.pending_pairing_url().await, None);
+        assert_eq!(
+            deprovision_target(&handle).await.unwrap(),
+            DeprovisionTarget::Unprovisioned
+        );
+    }
+
+    /// An OS (MDM) assertion refuses disconnection outright — the probe says
+    /// so and the write path refuses the same way — and a sticky row parked
+    /// underneath survives untouched.
+    #[tokio::test]
+    async fn a_deprovision_refuses_an_os_asserted_gateway() {
+        struct OsAsserted;
+
+        impl crate::managed_policy::OsPolicySource for OsAsserted {
+            fn gateway_url(&self) -> Result<Option<String>> {
+                Ok(Some("https://mdm.invalid/".to_string()))
+            }
+        }
+
+        let (store, _directory) = test_store().await;
+        managed_policy::provision(&*store, "https://sticky.invalid/")
+            .await
+            .unwrap();
+        let mcp = Arc::new(McpRuntime::new(
+            Arc::new(ToolRegistry::new()),
+            store.clone(),
+            Arc::new(TestSecrets::default()),
+            Arc::new(NoGateway),
+            Arc::new(OsAsserted),
+        ));
+        let gateway = crate::gateway_runtime::GatewayRuntime::new(
+            store.clone(),
+            test_secrets(),
+            Arc::new(OsAsserted),
+        );
+        let handle = PairingHandle::new(store.clone(), mcp, gateway);
+
+        assert_eq!(
+            deprovision_target(&handle).await.unwrap(),
+            DeprovisionTarget::OsManaged {
+                gateway_url: Some("https://mdm.invalid/".to_string())
+            }
+        );
+        for expected in ["https://mdm.invalid/", "https://sticky.invalid/"] {
+            let error = deprovision_provisioned_gateway(&handle, expected)
+                .await
+                .err()
+                .unwrap();
+            match &error {
+                PairingError::Conflict {
+                    provisioned_url,
+                    replaceable: false,
+                } => assert_eq!(provisioned_url, "https://mdm.invalid/"),
+                other => panic!("expected the non-replaceable conflict, got {other:?}"),
+            }
+        }
+        assert_eq!(
+            managed_policy::provisioned_url(&*store).await.unwrap(),
+            Some("https://sticky.invalid/".to_string()),
+            "an MDM refusal must not consume the sticky row underneath"
+        );
+    }
+
+    /// The compare-and-swap the confirmation rests on, in the delete
+    /// direction: a row that moved since the dialog named it refuses —
+    /// naming what the row now holds — and deletes nothing; a row that
+    /// vanished entirely is a raced success.
+    #[tokio::test]
+    async fn a_deprovision_refuses_a_row_that_moved_and_tolerates_one_that_vanished() {
+        let (store, _directory) = test_store().await;
+        let (handle, _mcp, _gateway) = test_handle_with_runtimes(&store);
+        managed_policy::provision(&*store, "https://managed.invalid/")
+            .await
+            .unwrap();
+
+        let error = deprovision_provisioned_gateway(&handle, "https://elsewhere.invalid/")
+            .await
+            .err()
+            .unwrap();
+        match &error {
+            PairingError::Conflict {
+                provisioned_url,
+                replaceable: true,
+            } => assert_eq!(provisioned_url, "https://managed.invalid/"),
+            other => panic!("expected the replaceable conflict, got {other:?}"),
+        }
+        assert_eq!(
+            managed_policy::provisioned_url(&*store).await.unwrap(),
+            Some("https://managed.invalid/".to_string())
+        );
+
+        store.delete_setting("managed_policy_v1").await.unwrap();
+        deprovision_provisioned_gateway(&handle, "https://managed.invalid/")
+            .await
+            .unwrap();
+    }
+
+    /// Disconnecting retires the stored session the way a re-pair retires a
+    /// superseded one: revoked at the gateway it was minted by, and gone
+    /// locally. Composes with sign-out — which deliberately does not
+    /// deprovision — so the sign-out-first path ends in the same open state.
+    #[tokio::test]
+    async fn a_deprovision_retires_the_stored_session() {
+        let (base, revoked) = serve_revocable_gateway().await;
+        let gateway_url = format!("{base}/");
+        let (store, _directory) = test_store().await;
+        managed_policy::provision(&*store, &gateway_url).await.unwrap();
+        let secrets = test_secrets();
+        let mcp = Arc::new(McpRuntime::new(
+            Arc::new(ToolRegistry::new()),
+            store.clone(),
+            Arc::new(TestSecrets::default()),
+            Arc::new(NoGateway),
+            Arc::new(NoOsPolicy),
+        ));
+        let gateway = crate::gateway_runtime::GatewayRuntime::new(
+            store.clone(),
+            secrets.clone(),
+            Arc::new(NoOsPolicy),
+        );
+        let handle = PairingHandle::new(store.clone(), mcp, gateway);
+        let credentials: crate::connectors::GatewayCredentials = serde_json::from_value(json!({
+            "base_url": gateway_url,
+            "installation_id": "install-1",
+            "user_id": "user-1",
+            "refresh_token": "mg_rt_disconnect",
+            "access_tokens": {}
+        }))
+        .unwrap();
+        crate::connectors::CredentialVault::new(secrets.clone())
+            .save(&credentials)
+            .await
+            .unwrap();
+
+        deprovision_provisioned_gateway(&handle, &gateway_url)
+            .await
+            .unwrap();
+
+        assert!(!resolve(&*store, &NoOsPolicy).await.unwrap().managed);
+        assert!(
+            revoked
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|body| body.contains("mg_rt_disconnect")),
+            "the session's refresh token must be revoked at the gateway"
+        );
+        assert!(
+            !crate::connectors::has_stored_credentials(&*secrets).await,
+            "the keychain session must not survive the disconnect"
         );
     }
 }

--- a/crates/openwave-server/src/pairing.rs
+++ b/crates/openwave-server/src/pairing.rs
@@ -1124,7 +1124,9 @@ mod tests {
         let (base, revoked) = serve_revocable_gateway().await;
         let gateway_url = format!("{base}/");
         let (store, _directory) = test_store().await;
-        managed_policy::provision(&*store, &gateway_url).await.unwrap();
+        managed_policy::provision(&*store, &gateway_url)
+            .await
+            .unwrap();
         let secrets = test_secrets();
         let mcp = Arc::new(McpRuntime::new(
             Arc::new(ToolRegistry::new()),

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -1632,6 +1632,9 @@ impl Store for PauseTerminalStore {
     async fn set_setting(&self, key: &str, value: &serde_json::Value) -> Result<()> {
         self.inner.set_setting(key, value).await
     }
+    async fn delete_setting(&self, key: &str) -> Result<()> {
+        self.inner.delete_setting(key).await
+    }
     async fn append_event(&self, chat_id: ChatId, event: &AgentEvent) -> Result<i64> {
         if matches!(
             event,


### PR DESCRIPTION
## Why

Completing a gateway sign-in permanently converts an install to managed mode: sign-out deliberately does not deprovision, and the only exits are pairing to a *different* gateway or deleting the profile data directory. This adds the missing user-consented exit without weakening the design's core invariant — the policy write path remains crate-internal and unreachable from any renderer route.

## Design

Mirrors the provision ceremony in reverse. As the browser sign-in is the consent to provision, a **native confirmation dialog** is the consent to deprovision:

- `openwave://deprovision` (payload-free; any query/userinfo/port/extra path refuses the link whole). No installer or scheme-registration changes — only the action parse is new.
- The dialog names whatever gateway **resolved policy** holds, and the delete is compare-and-swap'd on exactly that URL under the same pairing lock as every other policy write (`managed_policy::deprovision`, the belt to `reprovision`'s suspender).
- An OS (MDM) asserted gateway refuses as the non-replaceable conflict ("contact your administrator"); resolution precedence means the sticky row can't shadow MDM even in principle. A row that moved since the dialog refuses naming what it now holds; an already-unmanaged profile is a raced success. Drive-by links get at most one default-decline dialog (`PAIRING_DIALOG_SHOWING`), and on an unmanaged install the link is a logged no-op.
- On success: pending pairing dropped, in-flight sign-in invalidated (generation bump, so a completing exchange abandons rather than re-saving the session it minted), keychain session retired (best-effort bounded revoke + unconditional local clear, via the existing `retire_superseded_gateway_session`), and `gateway:pairing-changed` emitted — ManagedGate already refetches `/policy` on that event, so the app unlocks live with zero renderer changes.

Companion: `modelctl openwave disconnect` (model-gateway repo) opens this link; the consent still lives here.

## Changes

- `openwave-core`: `Store::delete_setting` (trait, `DbStore`, mock stores) — deleting the row is the only representation of "unprovisioned"; writing null would resolve managed-misconfigured.
- `openwave-server`: `managed_policy::deprovision` (CAS delete); `GatewayRuntime::{abandon_sign_in_and_pairing, retire_session_for_current_policy}`; exported `pairing::{deprovision_target, deprovision_provisioned_gateway, DeprovisionTarget}`.
- `openwave-desktop`: `parse_deep_link` (provision contract unchanged, pinned by the existing table test), `spawn_deprovision` + confirmation/refusal dialogs, pure `disconnect_prompt`/`disconnect_refusal_message` copy.

## Tests

- CAS discipline in both `managed_policy` and `pairing` seams; MDM refusal leaves the sticky row untouched; session retirement asserts the refresh token hit `/oauth/revoke` and the vault is empty; sign-out-then-deprovision composes with the "sign-out must not deprovision" invariant; deprovision link-contract table incl. dev-scheme flips; dialog copy tests.
- `openwave-server` 759 pass, `openwave-desktop` 116 pass, `openwave-core` 590 pass + 1 pre-existing failure (`output_writeback_filename_resolves_to_the_newest_live_output`, fails identically on pristine `main`).

## Follow-ups

- A managed-but-undecodable provisioned row can't be CAS'd by URL; it gets a refusal dialog today and needs an explicit repair path.
- Verify manual MCP servers re-enable after deprovision without an app restart (`enforce_manual_lockdown` is a no-op on unmanaged; the supervisor sweep should cover it).