### PR TITLE
ci: trust broker-barrier desktop update contract

### DIFF
--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -30,6 +30,10 @@ const desktopUpdater = readFileSync(
   new URL("../crates/openwave-desktop/src/updater.rs", import.meta.url),
   "utf8",
 );
+const desktopBroker = readFileSync(
+  new URL("../crates/openwave-desktop/src/broker.rs", import.meta.url),
+  "utf8",
+);
 
 function workflowJob(source, name) {
   const marker = `  ${name}:\n`;
@@ -822,9 +826,26 @@ test("the packaged desktop activates the signed updater feed", () => {
   assert.match(desktopUpdater, /updater\.check\(\)\.await/);
   assert.match(desktopUpdater, /update\.download\(/);
   assert.doesNotMatch(desktopUpdater, /download_and_install/);
+  assert.match(desktopUpdater, /install_behind_broker_barrier\(/);
   assert.match(
     desktopUpdater,
-    /state::<HostAccess>\(\)\.shutdown\(\)\.await[\s\S]*staged\.update\.install\(&staged\.bytes\)/,
+    /quiesce\(\)\.await\?;[\s\S]*match install\(\)[\s\S]*Ok\(\(\)\) => \{[\s\S]*shutdown\(\)\.await[\s\S]*Err\(install_error\) => \{[\s\S]*resume\(\)\.await/,
+  );
+  assert.match(
+    desktopUpdater,
+    /\|\| host_access\.quiesce_for_update\(\)[\s\S]*\|\| staged\.update\.install\(&staged\.bytes\)[\s\S]*\|\| host_access\.resume_after_failed_update\(\)[\s\S]*\|\| host_access\.shutdown\(\)/,
+  );
+  assert.match(
+    desktopBroker,
+    /if \*admission != BrokerAdmission::Running[\s\S]*self\.commands\.try_send\(command\)/,
+  );
+  assert.match(
+    desktopBroker,
+    /BrokerCommand::Quiesce \{ reply \} => \{[\s\S]*self\.ensure_session\(\)\.await/,
+  );
+  assert.match(
+    desktopBroker,
+    /BrokerCommand::ResumeAfterFailedUpdate \{ reply \} => \{[\s\S]*self\.allow_session_start = false/,
   );
   assert.match(desktopUpdater, /app\.restart\(\)/);
   assert.match(


### PR DESCRIPTION
## Summary

- Update `scripts/workflow-security.test.mjs` to assert the broker-barrier desktop update install path (`install_behind_broker_barrier`, quiesce/resume/shutdown callbacks, and broker admission guards) instead of the direct `HostAccess.shutdown()` → `install()` sequence.
- This is the trusted-test half of the two-step merge required by the release-policy job: CI restores the base branch copy of this file, so the contract change and its assertions cannot land in the same PR as #1907.

## Test plan

- [ ] CI `release policy` passes on this PR (restores current main test; only the test file changes, so current updater code still matches).
- [ ] Merge this PR before #1907.
- [ ] After merge, rebase #1907 and confirm its `release policy` job passes with the updated trusted test.

**Note:** `main` will briefly fail `release policy` between this merge and #1907 landing, because push runs use the merged test against code that still implements the old install path.

Made with [Cursor](https://cursor.com)