### PR TITLE
fix(ci): ignore the credential-scrubber PEM fixtures in secret scan

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,6 @@
+# Test fixtures for the debug-export credential scrubber: literal PEM
+# markers around placeholder bodies, asserted to come out `[redacted]`.
+# The fingerprint is pinned to the commit that introduced the fixture;
+# rewriting the file cannot clear it because the secret-scan lane walks
+# the full history.
+92ee76f115a6d8dbe2602151007ca7b188f7606c:crates/openwave-desktop/src/chat_debug.rs:private-key:1620


### PR DESCRIPTION
## Summary

The scrub_credentials tests that #1907 merged carry literal PEM begin/end markers around placeholder bodies, and the secret-scan lane now flags them on every pull request. The lane scans full history, so the finding is pinned to the commit that introduced the fixture and rewriting the file cannot clear it; this adds a `.gitleaksignore` entry for that fingerprint.

## Verification

- `gitleaks detect --source=. --redact` — 2959 commits scanned, no leaks found