### PR TITLE
fix(desktop-ui): name provider groups in the model picker and drop the Unverified tag

### DIFF
--- a/crates/openwave-desktop/ui/src/ModelMenu.test.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.test.tsx
@@ -5,7 +5,6 @@ import {
   hiddenModelCount,
   ModelMenu,
   ModelToolCapabilityChip,
-  ModelVerificationChip,
   notConnectedProviders,
   reasoningEffortOptions,
   visibleModelGroups,
@@ -109,26 +108,6 @@ describe("ModelMenu", () => {
       />,
     );
     expect(markup).toContain("disabled");
-  });
-
-  it("labels an unverified model with its explanation", () => {
-    const markup = renderToStaticMarkup(
-      <ModelVerificationChip
-        model={{
-          ...MODELS[1],
-          key: "openai_compatible::local-model",
-          id: "local-model",
-          display_name: "Local Model",
-          provider: "openai_compatible",
-          vendor: null,
-          verification: "unverified",
-        }}
-      />,
-    );
-    expect(markup).toContain("Unverified");
-    expect(markup).toContain(
-      "Unverified. OpenWave hasn&#x27;t verified tool-calling and streaming for this model; issues are likely the model or provider, not the app",
-    );
   });
 
   it("explains chat-only routing without blaming provider capability", () => {

--- a/crates/openwave-desktop/ui/src/ModelMenu.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.tsx
@@ -56,23 +56,6 @@ const PROVIDER_ORDER: readonly ProviderKind[] = [
   "together",
 ];
 
-const UNVERIFIED_TOOLTIP =
-  "OpenWave hasn't verified tool-calling and streaming for this model; issues are likely the model or provider, not the app";
-
-export function ModelVerificationChip({ model }: { model: ModelInfo }) {
-  if (model.verification !== "unverified") return null;
-  return (
-    <WithTooltip label={UNVERIFIED_TOOLTIP} side="top">
-      <span
-        className="text-muted-foreground border-border rounded-full border px-1.5 py-0.5 text-[0.65rem] leading-none"
-        aria-label={`Unverified. ${UNVERIFIED_TOOLTIP}`}
-      >
-        Unverified
-      </span>
-    </WithTooltip>
-  );
-}
-
 /** Honest warning for routes OpenWave must run without host tools. */
 export function ModelToolCapabilityChip({ model }: { model: ModelInfo }) {
   if (model.supports_tools) return null;
@@ -440,6 +423,13 @@ export function ModelMenu({
           {groups.map((group) => (
             <div key={group.provider}>
               <DropdownMenuSeparator />
+              {/* A plain header rather than a menu item: it names the run, and
+                  arrowing through the picker should land on models only. The
+                  same vendor can arrive from two providers (natively and via
+                  the gateway), so the divider alone reads as a duplicate. */}
+              <div className="text-muted-foreground px-2 py-1.5 text-xs font-medium tracking-wide uppercase">
+                {providerLabel(group.provider)}
+              </div>
               {group.models.map((model) => {
                 const selected = !isDefault && canonical === model.key;
                 return (
@@ -466,7 +456,6 @@ export function ModelMenu({
                       className="size-4 shrink-0"
                     />
                     <span className="text-sm">{model.display_name}</span>
-                    <ModelVerificationChip model={model} />
                     <ModelToolCapabilityChip model={model} />
                     {selected && <Check className="ml-auto size-4" />}
                   </DropdownMenuItem>


### PR DESCRIPTION
Two changes to the composer's model picker.

**Provider group headers.** Groups were separated only by a divider, so when the same vendor is served by two providers (e.g. Gemini natively and via the gateway) the list showed what looked like a duplicate run of models. Each group now opens with a small non-interactive header naming the provider via the existing `providerLabel` helper, styled like the "Not connected" header text. It is a plain `div`, not a button or menu item, so arrowing through the menu still lands on models only.

**Removed the Unverified tag.** The chip told the reader a model's tool-calling and streaming had not been verified, but that hedge lived on nearly every non-flagship row and trained people to ignore it; the new provider headers now carry the useful part of that signal (where the model is actually being served from). `ModelVerificationChip` and its tooltip constant are deleted along with the usage in the model row; `ModelToolCapabilityChip` ("Chat only"), which reports an actual routing behavior, is untouched.

Tests: removed the `ModelVerificationChip` rendering test since the component it covered no longer exists; no new test for the header text, which is presentation. Verified locally with `tsc --noEmit`, `pnpm test` (903 passing), and `pnpm build`.