### PR TITLE
test(cli): end-to-end scripted turn through the print-mode protocol

### DIFF
--- a/crates/openwave-cli/Cargo.toml
+++ b/crates/openwave-cli/Cargo.toml
@@ -52,4 +52,8 @@ unicode-width = "=0.2.2"
 uuid = { workspace = true }
 
 [dev-dependencies]
+# The scripted model provider the end-to-end print-mode test drives the turn
+# with. Enabling it here compiles it into the `openwave` binary the test spawns,
+# and only when the tests are built.
+openwave-server = { path = "../openwave-server", features = ["scripted-provider"] }
 tempfile = { workspace = true }

--- a/crates/openwave-cli/tests/serve.rs
+++ b/crates/openwave-cli/tests/serve.rs
@@ -8,6 +8,9 @@ use std::str::FromStr;
 use std::time::{Duration, Instant};
 
 const PROCESS_EXIT_TIMEOUT: Duration = Duration::from_secs(15);
+/// A turn boots the engine and runs the tool loop, so it is given more room
+/// than a process that only has to refuse and exit.
+const TURN_EXIT_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Kills the daemon on drop — including on an assertion panic, since
 /// `std::process::Child` does not reap on its own.
@@ -313,6 +316,81 @@ fn print_mode_fails_with_clean_stdout_when_no_model_provider_is_configured() {
     assert!(
         stderr.contains("provider") && stderr.contains("credential"),
         "stderr: {stderr}"
+    );
+}
+
+/// The headless run record 5 exists for: one unattended `-p` turn, in `allow`
+/// mode, on a data directory that has never been used, that calls a tool for
+/// real and finishes. The model is scripted (`OPENWAVE_SCRIPTED_PROVIDER`, see
+/// `openwave-server`'s `scripted_provider` module) so the turn is deterministic
+/// without egressing; everything under it — the embedded engine, the turn
+/// worker, the tool registry, the journal, and the event stream the CLI reads
+/// back — is the production path. Under `--output-format json` stdout *is* the
+/// journal of this turn, so what the run printed is what was recorded.
+#[test]
+fn a_scripted_tool_using_turn_completes_in_allow_mode() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = serde_json::json!([
+        {
+            "tool": "update_task_plan",
+            "input": {"steps": [{"content": "Record the plan", "status": "in_progress"}]}
+        },
+        {"text": "plan recorded"}
+    ]);
+    let child = Command::new(env!("CARGO_BIN_EXE_openwave"))
+        .args([
+            "-p",
+            "make a plan",
+            "--permission-mode",
+            "allow",
+            "--output-format",
+            "json",
+        ])
+        .env("OPENWAVE_DATA_DIR", dir.path())
+        .env("OPENWAVE_KEYCHAIN_MOCK", "1")
+        .env("OPENWAVE_SCRIPTED_PROVIDER", script.to_string())
+        .env_remove("OPENWAVE_MCP_CONFIG")
+        .env_remove("OPENWAVE_SERVER_URL")
+        .env_remove("ANTHROPIC_API_KEY")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn a scripted openwave -p");
+    let mut child = Reaper(child);
+
+    let output = child.wait_with_output(TURN_EXIT_TIMEOUT);
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout: {stdout}\nstderr: {stderr}"
+    );
+
+    // Each line is one journal frame: `seq` plus the event itself.
+    let events: Vec<serde_json::Value> = stdout
+        .lines()
+        .map(|line| {
+            serde_json::from_str::<serde_json::Value>(line)
+                .expect("every printed line is one JSON frame")["event"]
+                .clone()
+        })
+        .collect();
+    assert!(
+        events.iter().any(
+            |event| event["type"] == "tool_call_started" && event["name"] == "update_task_plan"
+        ),
+        "stdout: {stdout}"
+    );
+    let completed = events
+        .iter()
+        .find(|event| event["type"] == "tool_call_completed")
+        .unwrap_or_else(|| panic!("the scripted tool call never completed\nstdout: {stdout}"));
+    assert_eq!(completed["status"], "completed", "stdout: {stdout}");
+    assert!(
+        events.iter().any(|event| event["type"] == "turn_completed"),
+        "stdout: {stdout}"
     );
 }
 

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -15,6 +15,10 @@ workspace = true
 # `OPENWAVE_DATABASE_URL` names. Off by default: the desktop profile is
 # SQLite-only and the driver is a heavy build-time dependency.
 postgres = ["openwave-core/postgres"]
+# Compile the scripted model provider in, so a test in another crate can drive
+# a real turn through the binary. Off by default and never enabled by a release
+# build: see `src/scripted_provider.rs`.
+scripted-provider = []
 
 [dependencies]
 openwave-shell-policy = { path = "../openwave-shell-policy" }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -86,6 +86,8 @@ mod sandbox_task_plan_worker;
 mod sandbox_web_search_worker;
 mod scoped_model_token;
 mod scoped_store;
+#[cfg(feature = "scripted-provider")]
+mod scripted_provider;
 /// Rewriting stored credentials so the running binary owns their keychain items.
 pub mod secret_rehome;
 mod source_tools;
@@ -1057,6 +1059,12 @@ async fn bind_inner(
         chatgpt.clone(),
         os_policy.clone(),
     ));
+    // Under the `scripted-provider` feature only — absent from every released
+    // binary — a scripted provider stands in for configured routing so a test
+    // in another crate can drive a real turn. See [`scripted_provider`].
+    let resolver: Arc<dyn resolver::ProviderResolver> = resolver;
+    #[cfg(feature = "scripted-provider")]
+    let resolver = scripted_provider::resolver_from_env()?.unwrap_or(resolver);
     let blobs: Arc<dyn BlobStore> = Arc::new(FsBlobStore::new(config.data_dir.join("blobs")));
     // The same lock root `AppState` uses. `BlobWriteGuard` rendezvouses through
     // permanent lock files, so a second handle over the directory excludes

--- a/crates/openwave-server/src/scripted_provider.rs
+++ b/crates/openwave-server/src/scripted_provider.rs
@@ -1,0 +1,133 @@
+//! A model provider that replays a script, for driving the real engine from a
+//! test in another crate.
+//!
+//! Every stub provider in this crate is private to a `#[cfg(test)]` module, so
+//! nothing outside can run a turn end to end: `openwave-cli`'s process-level
+//! tests spawn the `openwave` binary, and no in-process handle reaches into it.
+//! This module is the one seam that does, and it stays deliberately small — a
+//! list of steps in, provider events out.
+//!
+//! It is compiled only under the `scripted-provider` feature, which
+//! `openwave-cli` enables from its dev-dependencies. A released binary never
+//! contains it, so the environment variable below cannot divert a real
+//! installation's model traffic.
+//!
+//! `OPENWAVE_SCRIPTED_PROVIDER` holds the script as a JSON array, one entry per
+//! model step:
+//!
+//! ```json
+//! [{"tool": "update_task_plan", "input": {"steps": []}}, {"text": "done"}]
+//! ```
+//!
+//! A `tool` step streams that call and stops with `tool_use`, so the host runs
+//! the tool for real and comes back for the next step. A `text` step streams
+//! the text and ends the turn. Steps past the end of the script end the turn
+//! too, so a script that mispredicts how many completions a turn needs cannot
+//! loop forever.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::stream::{self, BoxStream, StreamExt as _};
+
+use openwave_core::{
+    AgentError, ChatRequest, ModelProvider, ProviderEvent, ProviderId, Result, StopReason,
+};
+
+use crate::resolver::ProviderResolver;
+
+/// The environment variable carrying the script.
+const SCRIPT_VAR: &str = "OPENWAVE_SCRIPTED_PROVIDER";
+
+/// One model step.
+#[derive(Debug, serde::Deserialize)]
+#[serde(untagged)]
+enum Step {
+    /// Call `tool` with `input`, then wait for its result.
+    Tool {
+        tool: String,
+        #[serde(default)]
+        input: serde_json::Value,
+    },
+    /// Answer with `text` and end the turn.
+    Text { text: String },
+}
+
+/// Replays [`Step`]s, one per completion.
+struct ScriptedProvider {
+    steps: Vec<Step>,
+    calls: AtomicUsize,
+}
+
+#[async_trait]
+impl ModelProvider for ScriptedProvider {
+    fn id(&self) -> ProviderId {
+        ProviderId::new("scripted")
+    }
+
+    async fn stream(&self, _request: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+        let step = self.calls.fetch_add(1, Ordering::SeqCst);
+        let events = match self.steps.get(step) {
+            Some(Step::Tool { tool, input }) => vec![
+                ProviderEvent::ToolCallStarted {
+                    index: 0,
+                    id: format!("scripted_{step}"),
+                    name: tool.clone(),
+                },
+                ProviderEvent::ToolCallArgsDelta {
+                    index: 0,
+                    fragment: input.to_string(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::ToolUse,
+                },
+            ],
+            Some(Step::Text { text }) => vec![
+                ProviderEvent::TextDelta { text: text.clone() },
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                },
+            ],
+            None => vec![
+                ProviderEvent::TextDelta {
+                    text: "the script ended".to_owned(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                },
+            ],
+        };
+        Ok(stream::iter(events).boxed())
+    }
+}
+
+/// Hands the scripted provider to every turn.
+struct ScriptedResolver(Arc<ScriptedProvider>);
+
+#[async_trait]
+impl ProviderResolver for ScriptedResolver {
+    async fn resolve(&self) -> Arc<dyn ModelProvider> {
+        self.0.clone()
+    }
+}
+
+/// The resolver [`SCRIPT_VAR`] asks for, or `None` when it is unset.
+///
+/// A malformed script is an error rather than a silent fall-through to
+/// configured routing: a test whose script did not parse would otherwise run
+/// against whatever credentials the host happens to have.
+pub(crate) fn resolver_from_env() -> Result<Option<Arc<dyn ProviderResolver>>> {
+    let Ok(script) = std::env::var(SCRIPT_VAR) else {
+        return Ok(None);
+    };
+    let steps: Vec<Step> = serde_json::from_str(&script).map_err(|error| {
+        AgentError::config(format!("{SCRIPT_VAR} is not a valid script: {error}"))
+    })?;
+    Ok(Some(Arc::new(ScriptedResolver(Arc::new(
+        ScriptedProvider {
+            steps,
+            calls: AtomicUsize::new(0),
+        },
+    )))))
+}


### PR DESCRIPTION
Record 5's headless validation asks for one unattended `-p` turn — allow mode, fresh data dir, a real tool call, journal shows completion. PR #1873 could not add it: every stub model provider in the tree is inside an `openwave-server` `#[cfg(test)]` module, and a process-level CLI test spawns the `openwave` binary, where no in-process handle reaches.

## The harness

`openwave-server` gains `src/scripted_provider.rs` behind a new `scripted-provider` feature. `openwave-cli` enables that feature from its `[dev-dependencies]`, so it is compiled into the binary the test spawns and into nothing else — a released build has no such code and the environment variable below cannot divert a real installation's model traffic. There is no existing cross-crate test-support pattern in the workspace (no `test-support` features, no test-util crate), so this is the smallest thing that works: a feature gate plus one env-read at the single boot seam in `bind_inner`, where the configured resolver is built.

`OPENWAVE_SCRIPTED_PROVIDER` carries the script as a JSON array, one entry per model step:

```json
[{"tool": "update_task_plan", "input": {"steps": []}}, {"text": "done"}]
```

A `tool` step streams that call and stops with `tool_use`, so the host runs the tool for real and comes back for the next step; a `text` step ends the turn. Steps past the end of the script end the turn too, so a script that mispredicts how many completions a turn needs cannot loop forever. A script that fails to parse fails the boot rather than falling through to configured routing — otherwise a test whose script was malformed would quietly run against whatever credentials the host happens to have.

## The test

One test, `a_scripted_tool_using_turn_completes_in_allow_mode` in `crates/openwave-cli/tests/serve.rs`: `openwave -p --permission-mode allow --output-format json` on a fresh `OPENWAVE_DATA_DIR`, scripting `update_task_plan` and then a final answer. It asserts the process exits 0 and that the frames it printed contain the tool call started for `update_task_plan`, the call completed, and the turn completed. Under `--output-format json` stdout *is* the journal of the turn, so what the run printed is what was recorded.

Everything between is the production path — the embedded engine, the turn worker, the tool registry, the journal, and the event stream the CLI reads back. Nothing else was added: the protocol seams are already covered in `print::driver` / `print::protocol`, and the neighbouring test that a `-p` run with no configured provider exits 1 is what proves the scripted route is doing the work here.

No new dependencies, no lockfile change.

Closes #1874
