### PR TITLE
fix(desktop): prevent pnpm 11 lockfile drift

### DIFF
--- a/crates/openwave-desktop/ui/package.json
+++ b/crates/openwave-desktop/ui/package.json
@@ -74,10 +74,5 @@
     "typescript": "5.8.3",
     "vite": "7.3.6",
     "vitest": "3.2.7"
-  },
-  "pnpm": {
-    "overrides": {
-      "nanoid@5.1.11": "5.1.16"
-    }
   }
 }

--- a/crates/openwave-desktop/ui/pnpm-workspace.yaml
+++ b/crates/openwave-desktop/ui/pnpm-workspace.yaml
@@ -1,5 +1,7 @@
 # Build-script approvals in both formats: `allowBuilds` for pnpm >= 11,
 # `onlyBuiltDependencies` for pnpm 10 (what CI pins). Keep the lists in sync.
+overrides:
+  nanoid@5.1.11: 5.1.16
 allowBuilds:
   canvas: true
   esbuild: true


### PR DESCRIPTION
## Summary

- move the targeted Nano ID override from the deprecated `package.json` `pnpm` field into `pnpm-workspace.yaml`
- keep the existing lockfile resolution stable under both pnpm 10 and pnpm 11
- prevent pnpm 11 installs from silently restoring Univer's vulnerable Nano ID 5.1.11 pin

## Verification

- `CI=true corepack pnpm@10.18.3 --dir crates/openwave-desktop/ui install --frozen-lockfile --ignore-scripts`
- `CI=true corepack pnpm@11.20.0 --dir crates/openwave-desktop/ui install --frozen-lockfile --ignore-scripts`
- confirmed `pnpm-lock.yaml` remained byte-for-byte unchanged after both installs
- `git diff --check`
