### PR TITLE
feat(cli): execute connected-folder tool calls headlessly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4361,6 +4361,7 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 name = "openwave-cli"
 version = "0.0.0"
 dependencies = [
+ "base64 0.23.1",
  "chrono",
  "crossterm",
  "futures",
@@ -4379,6 +4380,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-tungstenite 0.30.0",
+ "tracing",
  "unicode-width",
  "uuid",
 ]

--- a/crates/openwave-cli/Cargo.toml
+++ b/crates/openwave-cli/Cargo.toml
@@ -28,6 +28,9 @@ openwave-code-execution = { path = "../openwave-code-execution" }
 openwave-host-broker = { path = "../openwave-host-broker" }
 openwave-mcp = { path = "../openwave-mcp" }
 openwave-server = { path = "../openwave-server" }
+# Decoding the broker's binary file reads, whose protocol shape is base64 —
+# `import_connected_file` publishes those bytes as a conversation source.
+base64 = { workspace = true }
 # Timestamps on transcript entries and inbox rows.
 chrono = { workspace = true }
 crossterm = { version = "=0.29.0", features = ["event-stream"] }
@@ -46,6 +49,9 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "signal", "sync", "time"] }
 tokio-tungstenite = { workspace = true }
+# The connected-folder executor's diagnostics. They belong in the profile's log
+# file: it polls, so stderr would flood a print run and overwrite the TUI.
+tracing = { workspace = true }
 ratatui-textarea = "=0.9.2"
 # Display-width clipping for lines rendered into fixed scrollback/panel buffers.
 unicode-width = "=0.2.2"

--- a/crates/openwave-cli/src/api/client.rs
+++ b/crates/openwave-cli/src/api/client.rs
@@ -6,7 +6,7 @@ use std::net::SocketAddr;
 use openwave_core::{
     AgentError, AgentRunId, CallId, ChatId, OutputId, OutputRevisionId, Result, TurnId,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::net::TcpStream;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::http::header::SEC_WEBSOCKET_PROTOCOL;
@@ -41,6 +41,16 @@ struct ErrorBody {
 #[derive(Deserialize)]
 struct ChatCreated {
     id: ChatId,
+}
+
+/// What the ingest route says about one published source.
+#[derive(Debug, Clone, Copy, Deserialize)]
+pub struct IngestedSource {
+    /// Derived from the origin URI when one was given, so a repeat publish of
+    /// the same origin names the same source.
+    pub document_id: uuid::Uuid,
+    /// Whether the stored source has text a reader can be given.
+    pub readiness: openwave_core::DocumentReadiness,
 }
 
 impl Client {
@@ -684,27 +694,51 @@ impl Client {
         media_type: &str,
         bytes: Vec<u8>,
     ) -> Result<String> {
+        Ok(self
+            .publish_document_source(chat, Some(title), None, media_type, bytes)
+            .await?
+            .document_id
+            .to_string())
+    }
+
+    /// Publish one source into a conversation through the ingest route.
+    ///
+    /// `uri` is the source's durable provenance, and the server derives the
+    /// document id from it — so publishing the same origin twice recovers the one
+    /// source instead of adding a second. `title` is metadata the route
+    /// validates and may refuse; it never becomes a path.
+    pub async fn publish_document_source(
+        &self,
+        chat: ChatId,
+        title: Option<&str>,
+        uri: Option<&str>,
+        media_type: &str,
+        bytes: Vec<u8>,
+    ) -> Result<IngestedSource> {
+        let mut url = format!("{}/chats/{chat}/documents/raw", self.base);
+        let mut separator = '?';
+        for (name, value) in [("title", title), ("uri", uri)] {
+            if let Some(value) = value {
+                url.push(separator);
+                url.push_str(name);
+                url.push('=');
+                url.push_str(&urlencode(value));
+                separator = '&';
+            }
+        }
         let response = self
             .http
-            .post(format!(
-                "{}/chats/{chat}/documents/raw?title={}",
-                self.base,
-                urlencode(title)
-            ))
+            .post(url)
             .header(reqwest::header::CONTENT_TYPE, media_type)
             .body(bytes)
             .send()
             .await
             .map_err(request_error)?;
-        let value = Self::expect_success(response)
+        Self::expect_success(response)
             .await?
-            .json::<serde_json::Value>()
+            .json::<IngestedSource>()
             .await
-            .map_err(request_error)?;
-        value["document_id"]
-            .as_str()
-            .map(str::to_owned)
-            .ok_or_else(|| AgentError::msg("ingest answered without a document id"))
+            .map_err(request_error)
     }
 
     /// Publish one local image for a conversation, returning the identity a
@@ -802,13 +836,87 @@ pub struct PendingClientCall {
     pub client_executor_id: Option<uuid::Uuid>,
 }
 
+/// The canonical call one claim installed, plus the receipt needed to operate
+/// it.
+///
+/// The record is the server's own checkpointed `ToolCallRecord`: it is where an
+/// executor reads the arguments it is to act on, rather than trusting a
+/// restatement from whatever announced the work.
+#[derive(Debug, Deserialize)]
+pub struct ClaimedClientCall {
+    pub call: openwave_core::ToolCallRecord,
+    pub lease_token: uuid::Uuid,
+}
+
+/// The terminal answer an executor publishes for one claimed call.
+///
+/// The variants and field names are the server's `ClientExecutionResolution`
+/// wire shape. `rows` is the card projection the server rebuilds against the
+/// call's own stored name, so a completed call may report entries and a refusal
+/// reports none.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum ClientExecutionOutcome {
+    Completed {
+        result: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        rows: Option<serde_json::Value>,
+    },
+    Failed {
+        result: String,
+        error_code: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error_detail: Option<String>,
+    },
+    Cancelled {
+        result: String,
+    },
+}
+
+/// Why one client-execution request failed.
+///
+/// A conflict is separated from everything else because it is the lifecycle's
+/// own answer rather than a fault: the call is already claimed, already
+/// terminal, or no longer owned by this lease. An executor must recognize it to
+/// stand down instead of racing whoever does own the work.
+#[derive(Debug)]
+pub enum ClientExecutionError {
+    Conflict(AgentError),
+    Failed(AgentError),
+}
+
+impl ClientExecutionError {
+    #[must_use]
+    pub fn is_conflict(&self) -> bool {
+        matches!(self, Self::Conflict(_))
+    }
+}
+
+impl From<ClientExecutionError> for AgentError {
+    fn from(error: ClientExecutionError) -> Self {
+        match error {
+            ClientExecutionError::Conflict(error) | ClientExecutionError::Failed(error) => error,
+        }
+    }
+}
+
+impl std::fmt::Display for ClientExecutionError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Conflict(error) | Self::Failed(error) => error.fmt(formatter),
+        }
+    }
+}
+
+type ExecutionResult<T> = std::result::Result<T, ClientExecutionError>;
+
 impl Client {
     /// Every client-owned tool call currently parked on this chat.
     pub async fn pending_client_executions(
         &self,
         executor_token: &str,
         chat: ChatId,
-    ) -> Result<Vec<PendingClientCall>> {
+    ) -> ExecutionResult<Vec<PendingClientCall>> {
         let response = self
             .http
             .get(format!(
@@ -818,15 +926,20 @@ impl Client {
             .header(CLIENT_EXECUTOR_HEADER, executor_token)
             .send()
             .await
-            .map_err(request_error)?;
-        Self::expect_success(response)
+            .map_err(|error| ClientExecutionError::Failed(request_error(error)))?;
+        Self::expect_execution_success(response)
             .await?
             .json::<Vec<PendingClientCall>>()
             .await
-            .map_err(request_error)
+            .map_err(|error| ClientExecutionError::Failed(request_error(error)))
     }
 
     /// Take ownership of one parked call so it can be resolved.
+    ///
+    /// The same `(executor_id, lease_token)` pair recovers an existing claim,
+    /// which is how an executor picks its own interrupted work back up. No other
+    /// executor can ever claim it, so a conflict means the work is not this
+    /// caller's.
     pub async fn claim_client_execution(
         &self,
         executor_token: &str,
@@ -834,7 +947,7 @@ impl Client {
         call_id: CallId,
         executor_id: uuid::Uuid,
         lease_token: uuid::Uuid,
-    ) -> Result<()> {
+    ) -> ExecutionResult<ClaimedClientCall> {
         let response = self
             .http
             .post(format!(
@@ -848,8 +961,34 @@ impl Client {
             }))
             .send()
             .await
-            .map_err(request_error)?;
-        Self::expect_success(response).await?;
+            .map_err(|error| ClientExecutionError::Failed(request_error(error)))?;
+        Self::expect_execution_success(response)
+            .await?
+            .json::<ClaimedClientCall>()
+            .await
+            .map_err(|error| ClientExecutionError::Failed(request_error(error)))
+    }
+
+    /// Renew the lease on a claim before work that will take a while.
+    pub async fn heartbeat_client_execution(
+        &self,
+        executor_token: &str,
+        chat: ChatId,
+        call_id: CallId,
+        lease_token: uuid::Uuid,
+    ) -> ExecutionResult<()> {
+        let response = self
+            .http
+            .post(format!(
+                "{}/chats/{chat}/client-executions/{call_id}/heartbeat",
+                self.base
+            ))
+            .header(CLIENT_EXECUTOR_HEADER, executor_token)
+            .json(&serde_json::json!({ "lease_token": lease_token }))
+            .send()
+            .await
+            .map_err(|error| ClientExecutionError::Failed(request_error(error)))?;
+        Self::expect_execution_success(response).await?;
         Ok(())
     }
 
@@ -860,8 +999,8 @@ impl Client {
         chat: ChatId,
         call_id: CallId,
         lease_token: uuid::Uuid,
-        result: &str,
-    ) -> Result<()> {
+        outcome: &ClientExecutionOutcome,
+    ) -> ExecutionResult<()> {
         let response = self
             .http
             .post(format!(
@@ -871,13 +1010,25 @@ impl Client {
             .header(CLIENT_EXECUTOR_HEADER, executor_token)
             .json(&serde_json::json!({
                 "lease_token": lease_token,
-                "resolution": { "status": "completed", "result": result },
+                "resolution": outcome,
             }))
             .send()
             .await
-            .map_err(request_error)?;
-        Self::expect_success(response).await?;
+            .map_err(|error| ClientExecutionError::Failed(request_error(error)))?;
+        Self::expect_execution_success(response).await?;
         Ok(())
+    }
+
+    /// [`Self::expect_success`], keeping the lifecycle's conflict distinct.
+    async fn expect_execution_success(
+        response: reqwest::Response,
+    ) -> ExecutionResult<reqwest::Response> {
+        let conflict = response.status() == reqwest::StatusCode::CONFLICT;
+        match Self::expect_success(response).await {
+            Ok(response) => Ok(response),
+            Err(error) if conflict => Err(ClientExecutionError::Conflict(error)),
+            Err(error) => Err(ClientExecutionError::Failed(error)),
+        }
     }
 }
 

--- a/crates/openwave-cli/src/folder.rs
+++ b/crates/openwave-cli/src/folder.rs
@@ -156,7 +156,11 @@ pub async fn run(command: Command) -> Result<()> {
 /// folder may ever cover. Local command reach is decided by the same host
 /// probe, so a folder connected here carries the grants it would have carried
 /// had the desktop's picker connected it on this machine.
-fn open_broker(data_dir: &Path) -> Result<Broker> {
+///
+/// Also the handle [`crate::folder_executor`] reads through: one capability
+/// store, opened one way, whether an operator is provisioning a folder or a turn
+/// is reading one.
+pub(crate) fn open_broker(data_dir: &Path) -> Result<Broker> {
     let home = std::env::home_dir()
         .ok_or_else(|| AgentError::config("could not resolve the current user's home directory"))?
         .canonicalize()
@@ -880,13 +884,16 @@ async fn settle_pending_changes(
     Ok(())
 }
 
-/// This CLI's stable native-executor identity for attachment changes.
+/// This CLI's stable native-executor identity for this profile.
 ///
 /// It must survive across invocations: only the executor that began a change
-/// may finish it, so a fresh identity per run would strand an interrupted one.
-/// It is not a credential — it names who owns pending work — but it lives with
-/// the rest of the private profile state and inherits its permissions.
-fn executor_identity(data_dir: &Path) -> Result<Uuid> {
+/// may finish it, and only the executor that claimed a client tool call may
+/// recover it, so a fresh identity per run would strand interrupted work in
+/// either case. Both uses are the same claim — "this profile's CLI owns that
+/// pending work" — so they share one identity rather than inventing a second.
+/// It is not a credential, but it lives with the rest of the private profile
+/// state and inherits its permissions.
+pub(crate) fn executor_identity(data_dir: &Path) -> Result<Uuid> {
     let path = data_dir.join("cli-folder-executor");
     let read = |path: &Path| -> Result<Uuid> {
         let text = std::fs::read_to_string(path).map_err(|error| {

--- a/crates/openwave-cli/src/folder_executor.rs
+++ b/crates/openwave-cli/src/folder_executor.rs
@@ -1,0 +1,1053 @@
+//! Headless executor for the client-executed connected-folder tools.
+//!
+//! `list_connected_folders`, `list_folder`, `read_connected_file`,
+//! `import_connected_file`, and `write_output_to_connected_folder` are parked by
+//! the server for a *trusted client* to run. On the desktop that client is the
+//! native process (`openwave-desktop`'s `client_execution::folder_operations`).
+//! A headless install had no such client at all, so a turn that used a folder
+//! an operator had connected parked forever. This module is that client for the
+//! processes that own broker state on this machine: `openwave serve`, and the
+//! engine `openwave -p` and `openwave tui` embed.
+//!
+//! **It is not a second authority.** Every folder operation goes to
+//! [`openwave_host_broker`]'s capability-checked operation surface, which
+//! re-authorizes the conversation against its live grants before any byte is
+//! read. This module chooses no path, caches no decision, and has no branch
+//! that can answer a folder request from anything other than the broker's
+//! answer.
+//!
+//! **It never widens a grant.** The tools here read folders that are *already*
+//! connected. `request_folder_access` — the only tool that asks for a new one —
+//! is deliberately not in this module's dispatch table; it keeps the typed
+//! refusal [`crate::print`] gives it, and standing consent still comes only
+//! from `openwave folder connect`. See [`crate::folder`].
+//!
+//! **Only the process that owns the broker runs it.** The executor needs the
+//! server's client-executor credential, which [`crate::connect::Session`] holds
+//! only when it embedded the engine. An attached (`--server`) run has no such
+//! credential and starts no executor: the call belongs to whichever process owns
+//! that server's host state, and now — if that process is `openwave serve`, an
+//! embedded `openwave -p`, or `openwave tui` — it is actually answered there.
+//!
+//! ## Recovery
+//!
+//! The desktop's executor persists a receipt before it claims, because the
+//! server hands a claimed call to no other executor: only the exact
+//! `(executor_id, lease_token)` pair can ever recover or resolve it
+//! (`claim_client_tool_call` refuses a second executor outright, expired lease
+//! or not). Without a durable receipt a crash between claim and resolve would
+//! strand the call permanently — the same hang this module exists to remove. So
+//! it keeps the same receipt, in the same shape and with the same policy:
+//!
+//! - The lease token is chosen and written to disk *before* the claim, so a
+//!   later run retries the exact claim rather than leaving a live lease nobody
+//!   can operate.
+//! - `dispatch_started` is written *before* any host I/O. After an
+//!   interruption a read is terminalized with a typed failure rather than
+//!   replayed — the broker keeps no read receipt to reconcile against, so a
+//!   second read would be a second disclosure this process cannot account for.
+//!   An import is the one operation that may be retried, because the server
+//!   derives its document id from the request, so a repeat converges on the one
+//!   source instead of adding another.
+//! - The terminal outcome is written before it is published, so a crash in
+//!   between republishes the same result instead of computing a new one.
+//!
+//! ## What headless cannot do, and says so
+//!
+//! `write_output_to_connected_folder` writes host bytes through the exec
+//! write-overlay materializer, which a headless embedding does not have
+//! (`bind_configured` installs no `ExecFolderGrantResolver`, so no connected
+//! folder is ever staged). Rather than improvise a second write path with no
+//! snapshot, no trash, and no undo, the executor fails the call closed with the
+//! same `output_writeback_authority_unavailable` code the desktop produces when
+//! its own materializer is missing. The turn continues; nothing is written.
+//!
+//! That same absence is why nothing here consults a staged folder view: with no
+//! folder-grant resolver there is no per-turn copy for the broker's answer to
+//! disagree with. An embedding that gains one must extend this module in the
+//! same change, exactly as the desktop's executor had to.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use openwave_core::{
+    validate_import_connected_file_arguments, validate_list_connected_folders_arguments,
+    validate_list_folder_arguments, validate_read_connected_file_arguments,
+    validate_write_output_to_connected_folder_arguments, AgentError, CallId, ChatId,
+    GrantedFolderCapability, ImportConnectedFileArgs, ImportConnectedFileResult, ListFolderArgs,
+    ReadConnectedFileArgs, Result, ResultEntry, ResultEntryKind, ToolCallExecution, ToolCallRecord,
+    ToolCallStatus, IMPORT_CONNECTED_FILE_TOOL, LIST_CONNECTED_FOLDERS_TOOL, LIST_FOLDER_TOOL,
+    READ_CONNECTED_FILE_TOOL, WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL,
+};
+use openwave_host_broker::{
+    Broker, Capability, EntryKind, ExecutionContext, OperationEnvelope, OperationRequest,
+    OperationResult, PathRequest, RelativePath, RequestId, Response, RootId, PROTOCOL_VERSION,
+};
+use uuid::Uuid;
+
+use crate::api::client::{Client, ClientExecutionOutcome};
+
+mod receipts;
+
+use receipts::{DispatchRecovery, Receipt, ReceiptStore};
+
+/// How often the executor looks for parked folder work.
+///
+/// A print-mode run is waiting on the answer, so it polls tightly over the one
+/// chat it drives. `serve` walks every conversation it can see and takes the
+/// desktop executor's cadence.
+const DRIVEN_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
+const DAEMON_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// Bounds on what one folder answer may carry back to the model. These match
+/// the desktop executor's (`client_execution::folder_operations`) so a
+/// conversation reads the same either side of the same data directory.
+const MAX_DIRECTORY_ENTRIES: usize = 128;
+const MAX_RESULT_CONTENT_BYTES: usize = 60 * 1024;
+const MAX_FILE_CONTENT_BYTES: usize = 56 * 1024;
+
+/// Scheme for the durable identity of a source imported from a connected root.
+///
+/// `{scheme}:{opaque root id}/{root-relative path}` — the pathless vocabulary
+/// the broker's audit trail uses, never an absolute host path. The server
+/// derives the document id from this string and the chat, so importing the same
+/// file twice converges on one source. It is the desktop executor's scheme
+/// verbatim: the two shells must name the same source for the same file.
+const CONNECTED_FOLDER_URI_SCHEME: &str = "connected-folder";
+
+/// Which conversations this executor answers for.
+pub enum Scope {
+    /// The one chat a print-mode run is driving.
+    Chat(ChatId),
+    /// Every conversation the daemon's own credential can see.
+    AllChats,
+}
+
+/// The headless client executor.
+pub struct FolderExecutor {
+    client: Client,
+    /// The server's native-only executor credential. Holding it is what makes
+    /// this process the trusted surface for that server; an attached run has
+    /// none and never constructs a `FolderExecutor`.
+    executor_token: String,
+    /// This profile's stable executor identity, shared with `openwave folder`.
+    /// It must survive restarts: only the executor that claimed a call may
+    /// recover it.
+    executor_id: Uuid,
+    receipts: ReceiptStore,
+    data_dir: PathBuf,
+    /// Opened on first use only. A run that never touches a connected folder
+    /// must not take the broker's exclusive lock, write its state file, or fail
+    /// to boot on a host whose home directory cannot be resolved.
+    broker: tokio::sync::OnceCell<Arc<Broker>>,
+}
+
+impl FolderExecutor {
+    /// Build an executor over an embedded engine, or `None` when this process is
+    /// not the one that owns the server's host state.
+    ///
+    /// `executor_token` is the whole gate: [`crate::connect::Session`] returns
+    /// it only for an embedded engine, and no flag hands it to an attaching
+    /// client.
+    pub fn new(
+        client: Client,
+        executor_token: Option<&str>,
+        data_dir: &Path,
+    ) -> Result<Option<Self>> {
+        let Some(executor_token) = executor_token else {
+            return Ok(None);
+        };
+        Ok(Some(Self {
+            client,
+            executor_token: executor_token.to_owned(),
+            executor_id: crate::folder::executor_identity(data_dir)?,
+            receipts: ReceiptStore::open(data_dir)?,
+            data_dir: data_dir.to_path_buf(),
+            broker: tokio::sync::OnceCell::new(),
+        }))
+    }
+
+    /// Poll for parked folder work until the task is dropped.
+    ///
+    /// Every failure is transient by construction: nothing is removed from the
+    /// receipt store until the server has the terminal result, so the next pass
+    /// picks the work up again. Diagnostics go to the profile's log file rather
+    /// than stderr — this loop polls, and a repeating notice would flood a print
+    /// run's stderr and overwrite the TUI's terminal.
+    pub async fn run(self, scope: Scope) {
+        let interval = match scope {
+            Scope::Chat(_) => DRIVEN_POLL_INTERVAL,
+            Scope::AllChats => DAEMON_POLL_INTERVAL,
+        };
+        loop {
+            if let Err(error) = self.sweep(&scope).await {
+                tracing::warn!(%error, "connected-folder work deferred");
+            }
+            tokio::time::sleep(interval).await;
+        }
+    }
+
+    /// One pass: finish what an earlier run left behind, then take up new work.
+    ///
+    /// One conversation's failure never hides another's: the daemon walks every
+    /// chat it can see, and a chat that cannot be read this pass is reported and
+    /// retried on the next.
+    async fn sweep(&self, scope: &Scope) -> Result<()> {
+        let recovered = self.recover().await?;
+        for chat in self.chats(scope).await? {
+            if let Err(error) = self.discover(chat, &recovered).await {
+                tracing::warn!(%error, "connected-folder work deferred");
+            }
+        }
+        Ok(())
+    }
+
+    async fn chats(&self, scope: &Scope) -> Result<Vec<ChatId>> {
+        match scope {
+            Scope::Chat(chat) => Ok(vec![*chat]),
+            Scope::AllChats => Ok(self
+                .client
+                .list_chats()
+                .await?
+                .into_iter()
+                .map(|chat| chat.id)
+                .collect()),
+        }
+    }
+
+    /// Drive every persisted receipt to a terminal result, and report which
+    /// calls they covered so discovery cannot start a second attempt on one.
+    async fn recover(&self) -> Result<HashSet<CallId>> {
+        let receipts = self.receipts.load()?;
+        let covered = receipts.iter().map(|receipt| receipt.call_id).collect();
+        for receipt in receipts {
+            if let Err(error) = self.execute(receipt).await {
+                tracing::warn!(%error, "connected-folder recovery deferred");
+            }
+        }
+        Ok(covered)
+    }
+
+    /// Claim and run the folder calls parked on one chat.
+    async fn discover(&self, chat: ChatId, covered: &HashSet<CallId>) -> Result<()> {
+        let pending = self
+            .client
+            .pending_client_executions(&self.executor_token, chat)
+            .await?;
+        for call in pending {
+            if covered.contains(&call.id) || !handles(&call.name) {
+                continue;
+            }
+            // Never race another executor. The server hands a claimed call to
+            // nobody else, so a call already owned is either being run by its
+            // owner or is that owner's to recover from its own receipt.
+            if call.client_executor_id.is_some() {
+                continue;
+            }
+            let receipt =
+                Receipt::new(chat, call.id, self.executor_id, recovery_policy(&call.name));
+            self.receipts.save(&receipt)?;
+            if let Err(error) = self.execute(receipt).await {
+                tracing::warn!(%error, "connected-folder execution deferred");
+            }
+        }
+        Ok(())
+    }
+
+    /// Take one receipt from wherever it stopped to a published terminal result.
+    async fn execute(&self, mut receipt: Receipt) -> Result<()> {
+        if let Some(outcome) = receipt.outcome.clone() {
+            return self.publish(&receipt, &outcome).await;
+        }
+        // Host I/O had started and its outcome was never recorded. For a read
+        // there is nothing to reconcile against, so close the call out rather
+        // than disclose the file a second time.
+        if receipt.dispatch_started && receipt.recovery == DispatchRecovery::Terminalize {
+            return self.terminalize(&mut receipt, interrupted()).await;
+        }
+
+        let claim = match self
+            .client
+            .claim_client_execution(
+                &self.executor_token,
+                receipt.chat_id,
+                receipt.call_id,
+                receipt.executor_id,
+                receipt.lease_token,
+            )
+            .await
+        {
+            Ok(claim) => claim,
+            Err(error) if error.is_conflict() => {
+                return self.recover_after_claim_conflict(&receipt).await;
+            }
+            Err(error) => return Err(error.into()),
+        };
+        // The claim response is the authoritative statement of what was claimed.
+        // Canonical arguments come from it — the checkpointed call the server
+        // holds — and never from a restatement by whoever announced the work.
+        // The recovery policy is checked against that same record rather than
+        // the name discovery saw, so the crash rules can never be applied to a
+        // different operation than the one that runs.
+        let call = &claim.call;
+        if call.chat_id != receipt.chat_id
+            || call.id != receipt.call_id
+            || claim.lease_token != receipt.lease_token
+            || call.client_executor_id != Some(receipt.executor_id)
+            || !is_canonical_folder_call(call)
+            || recovery_policy(&call.name) != receipt.recovery
+        {
+            return Err(AgentError::msg(
+                "the server returned an invalid connected-folder claim",
+            ));
+        }
+
+        self.client
+            .heartbeat_client_execution(
+                &self.executor_token,
+                receipt.chat_id,
+                receipt.call_id,
+                receipt.lease_token,
+            )
+            .await?;
+        // The last durable fence before host I/O.
+        receipt.dispatch_started = true;
+        self.receipts.save(&receipt)?;
+        let outcome = self.run_call(receipt.chat_id, call).await;
+        self.terminalize(&mut receipt, outcome).await
+    }
+
+    /// The claim was refused. Decide from the server's own pending set whether
+    /// this receipt still describes live work.
+    ///
+    /// A conflict is not proof the claim was lost: the route answers it whenever
+    /// the call is not claimable *right now*, which includes a conversation
+    /// another writer momentarily holds. So the pending set decides, and the
+    /// default is to keep the receipt:
+    ///
+    /// - Gone from the pending set: the call is settled and the receipt is spent.
+    /// - Parked and owned by a different executor: that executor's to finish,
+    ///   and nothing here may run or resolve it. Only this case discards a
+    ///   receipt without settling the call, and only because it now belongs to
+    ///   somebody else.
+    /// - Parked and still this executor's — or still unclaimed: the refusal was
+    ///   transient. The receipt is kept so the next pass retries the exact claim,
+    ///   with `dispatch_started` still deciding whether the operation may run.
+    async fn recover_after_claim_conflict(&self, receipt: &Receipt) -> Result<()> {
+        let pending = self
+            .client
+            .pending_client_executions(&self.executor_token, receipt.chat_id)
+            .await?;
+        let Some(call) = pending.into_iter().find(|call| call.id == receipt.call_id) else {
+            return self.receipts.remove(receipt.call_id);
+        };
+        if call
+            .client_executor_id
+            .is_some_and(|owner| owner != receipt.executor_id)
+        {
+            self.receipts.remove(receipt.call_id)?;
+            return Err(AgentError::msg(
+                "the connected-folder call is owned by another executor",
+            ));
+        }
+        Err(AgentError::msg(
+            "the connected-folder claim could not be taken yet",
+        ))
+    }
+
+    async fn terminalize(
+        &self,
+        receipt: &mut Receipt,
+        outcome: ClientExecutionOutcome,
+    ) -> Result<()> {
+        receipt.outcome = Some(outcome.clone());
+        self.receipts.save(receipt)?;
+        self.publish(receipt, &outcome).await
+    }
+
+    /// Hand the terminal result to the server, then forget the receipt.
+    ///
+    /// A conflict is only final once the call is no longer parked: the route
+    /// answers it both for a different terminal result already committed and for
+    /// a conversation another writer holds. Dropping the receipt on the second
+    /// would strand the call for good, so the pending set decides again.
+    async fn publish(&self, receipt: &Receipt, outcome: &ClientExecutionOutcome) -> Result<()> {
+        match self
+            .client
+            .resolve_client_execution(
+                &self.executor_token,
+                receipt.chat_id,
+                receipt.call_id,
+                receipt.lease_token,
+                outcome,
+            )
+            .await
+        {
+            Ok(()) => self.receipts.remove(receipt.call_id),
+            Err(error) if error.is_conflict() => {
+                let still_parked = self
+                    .client
+                    .pending_client_executions(&self.executor_token, receipt.chat_id)
+                    .await?
+                    .into_iter()
+                    .any(|call| call.id == receipt.call_id);
+                if still_parked {
+                    Err(AgentError::msg(
+                        "the connected-folder result was not accepted yet",
+                    ))
+                } else {
+                    self.receipts.remove(receipt.call_id)
+                }
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    /// Run one claimed call, returning the model-facing terminal outcome.
+    async fn run_call(&self, chat: ChatId, call: &ToolCallRecord) -> ClientExecutionOutcome {
+        // The one call a headless install cannot honor. It needs the exec
+        // write-overlay materializer, which no headless embedding installs, so
+        // it fails closed with the desktop's own code for that state rather than
+        // reaching the host by another route. Decided before any authority is
+        // derived, because none of it applies.
+        if call.name == WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL {
+            return ClientExecutionOutcome::Failed {
+                result: "That output could not be written to the connected folder.".to_owned(),
+                error_code: "output_writeback_authority_unavailable".to_owned(),
+                error_detail: None,
+            };
+        }
+        // Derived here, from the conversation's current authority, immediately
+        // before the broker is asked. It is never carried across calls.
+        let context = match self.execution_context(chat).await {
+            Ok(context) => context,
+            Err(_) => return folder_unavailable(),
+        };
+        if call.name == IMPORT_CONNECTED_FILE_TOOL {
+            return self.import(chat, context, call).await;
+        }
+        let Ok(request) = broker_request(call) else {
+            return unavailable("invalid_request", "The folder request was not available.");
+        };
+        match self.broker_operation(context, request).await {
+            Ok(result) => serialize_result(call, result),
+            // Broker transport and host errors deliberately do not reach the
+            // model: authorization is the broker's to state, and everything else
+            // is host detail.
+            Err(_) => folder_unavailable(),
+        }
+    }
+
+    /// Import one connected file as a conversation source.
+    ///
+    /// The bytes are read through the broker (so the read is authorized at read
+    /// time) and published through the same ingest route `openwave attach` and
+    /// the desktop use. The server derives the document id from the origin URI,
+    /// which is what makes a repeated import recover the one source.
+    async fn import(
+        &self,
+        chat: ChatId,
+        context: ExecutionContext,
+        call: &ToolCallRecord,
+    ) -> ClientExecutionOutcome {
+        let Ok(args) = serde_json::from_value::<ImportConnectedFileArgs>(call.arguments.clone())
+        else {
+            return import_unavailable("That file could not be read.");
+        };
+        let Ok((root_id, path)) = root_and_path(args.root_id, &args.path, false) else {
+            return import_unavailable("That file could not be read.");
+        };
+        let Some(title) = path.as_str().rsplit('/').next().map(str::to_owned) else {
+            return import_unavailable("That file could not be read.");
+        };
+        let request = OperationRequest::ReadFileBinary(PathRequest {
+            root_id,
+            path: path.clone(),
+        });
+        let bytes = match self.broker_operation(context, request).await {
+            Ok(OperationResult::ReadFileBinary(file)) => {
+                use base64::Engine as _;
+
+                match base64::engine::general_purpose::STANDARD.decode(&file.content_base64) {
+                    Ok(bytes) => bytes,
+                    Err(_) => return import_unavailable("That file could not be read."),
+                }
+            }
+            Ok(_) => return import_unavailable("That file could not be read."),
+            Err(_) => {
+                return import_unavailable(
+                    "That file is not available to this conversation. It may be too large, or \
+                     the folder may no longer be connected.",
+                )
+            }
+        };
+        if bytes.is_empty() {
+            return import_unavailable("That file is empty, so there is nothing to import.");
+        }
+
+        let media_type =
+            openwave_server::media_type::sniff_media_type(&bytes, Some(title.as_str()));
+        let byte_len = bytes.len() as u64;
+        let uri = format!(
+            "{CONNECTED_FOLDER_URI_SCHEME}:{}/{}",
+            root_id.as_uuid(),
+            path.as_str()
+        );
+        // The ingest route owns title policy and refuses one it will not store,
+        // so a host filename never becomes display text by passing through here.
+        let Ok(ingested) = self
+            .client
+            .publish_document_source(chat, Some(title.as_str()), Some(&uri), &media_type, bytes)
+            .await
+        else {
+            return import_unavailable("That file could not be added to this conversation.");
+        };
+        let result = ImportConnectedFileResult::Imported {
+            document_id: ingested.document_id,
+            title: title.clone(),
+            media_type,
+            bytes: byte_len,
+            readiness: ingested.readiness,
+        };
+        match serde_json::to_string(&result) {
+            Ok(result) => ClientExecutionOutcome::Completed {
+                result,
+                rows: Some(serde_json::json!({
+                    "entries": [ResultEntry::new(ResultEntryKind::Source, title)],
+                })),
+            },
+            Err(_) => import_unavailable("That file could not be added to this conversation."),
+        }
+    }
+
+    /// Ask the broker for one operation, on the conversation's own authority.
+    ///
+    /// This is the only path to a connected folder in this module. The broker
+    /// authorizes the request against the conversation's live grants, opens the
+    /// root through its own pinned descriptor, and re-authorizes after the read
+    /// — none of which this process can influence, skip, or cache.
+    async fn broker_operation(
+        &self,
+        context: ExecutionContext,
+        request: OperationRequest,
+    ) -> Result<OperationResult> {
+        let broker = self.broker().await?;
+        let envelope = OperationEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: RequestId::new(),
+            context,
+            request,
+        };
+        // The in-process broker does real, blocking host I/O.
+        let response =
+            tokio::task::spawn_blocking(move || broker.operator().handle(envelope).response)
+                .await
+                .map_err(|_| AgentError::msg("the connected-folder operation did not complete"))?;
+        match response {
+            Response::Ok(result) => Ok(result),
+            Response::Error(error) => Err(AgentError::msg(format!(
+                "connected-folder operation refused ({:?})",
+                error.code
+            ))),
+        }
+    }
+
+    /// Open the profile's broker state on first use.
+    async fn broker(&self) -> Result<Arc<Broker>> {
+        let broker = self
+            .broker
+            .get_or_try_init(|| async {
+                let data_dir = self.data_dir.clone();
+                tokio::task::spawn_blocking(move || crate::folder::open_broker(&data_dir))
+                    .await
+                    .map_err(|_| {
+                        AgentError::msg("could not open the connected-folder capability store")
+                    })?
+                    .map(Arc::new)
+            })
+            .await?;
+        Ok(broker.clone())
+    }
+
+    /// The broker execution context a conversation's folder reads run under.
+    ///
+    /// A chat inside a project reads on that project's standing consent; a loose
+    /// chat reads on its own. This is the desktop's derivation, read live from
+    /// the chat rather than remembered, so a chat moved between projects cannot
+    /// carry the old authority into a later call.
+    async fn execution_context(&self, chat: ChatId) -> Result<ExecutionContext> {
+        let summary = self.client.get_chat(chat).await?;
+        match summary.project_id {
+            Some(project) => ExecutionContext::project_chat(chat.0, project.0),
+            None => ExecutionContext::standalone(chat.0),
+        }
+        .map_err(|_| AgentError::msg("invalid conversation context"))
+    }
+}
+
+/// Whether this executor answers for a tool.
+///
+/// `request_folder_access` is deliberately absent: it asks for consent this
+/// process cannot give, and print mode's typed refusal remains the only answer
+/// a headless run has for it.
+fn handles(name: &str) -> bool {
+    matches!(
+        name,
+        LIST_CONNECTED_FOLDERS_TOOL
+            | LIST_FOLDER_TOOL
+            | READ_CONNECTED_FILE_TOOL
+            | IMPORT_CONNECTED_FILE_TOOL
+            | WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL
+    )
+}
+
+/// Recovery policy for one connected-folder tool, matching the desktop's.
+///
+/// A read has no durable host outcome to reconcile against, so an interrupted
+/// one is closed out. An import derives its source identity from the exact
+/// request, so running it again converges on the same single source. A
+/// write-back never reaches the host from here at all, so replaying its
+/// fail-closed answer is free.
+fn recovery_policy(name: &str) -> DispatchRecovery {
+    match name {
+        IMPORT_CONNECTED_FILE_TOOL | WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL => {
+            DispatchRecovery::Retry
+        }
+        _ => DispatchRecovery::Terminalize,
+    }
+}
+
+/// Whether a claimed record really is the pending, well-formed folder call this
+/// executor may run. The argument validators are the same ones the server
+/// applied before the call was checkpointed, re-run here so a stored payload
+/// that could no longer pass them never reaches a host operation.
+fn is_canonical_folder_call(call: &ToolCallRecord) -> bool {
+    if call.execution != ToolCallExecution::Client || call.status != ToolCallStatus::Pending {
+        return false;
+    }
+    match call.name.as_str() {
+        LIST_CONNECTED_FOLDERS_TOOL => validate_list_connected_folders_arguments(&call.arguments),
+        LIST_FOLDER_TOOL => validate_list_folder_arguments(&call.arguments),
+        READ_CONNECTED_FILE_TOOL => validate_read_connected_file_arguments(&call.arguments),
+        IMPORT_CONNECTED_FILE_TOOL => validate_import_connected_file_arguments(&call.arguments),
+        WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL => {
+            validate_write_output_to_connected_folder_arguments(&call.arguments)
+        }
+        _ => false,
+    }
+}
+
+/// Recover the broker request behind one read-shaped folder call.
+///
+/// The path grammar is parsed by the broker's own [`RelativePath`], so a payload
+/// the broker would refuse is refused here instead of being handed to it.
+fn broker_request(call: &ToolCallRecord) -> std::result::Result<OperationRequest, ()> {
+    match call.name.as_str() {
+        LIST_CONNECTED_FOLDERS_TOOL => Ok(OperationRequest::ListRoots),
+        LIST_FOLDER_TOOL => {
+            let args: ListFolderArgs =
+                serde_json::from_value(call.arguments.clone()).map_err(|_| ())?;
+            let (root_id, path) = root_and_path(args.root_id, &args.path, true)?;
+            Ok(OperationRequest::ListDirectory(PathRequest {
+                root_id,
+                path,
+            }))
+        }
+        READ_CONNECTED_FILE_TOOL => {
+            let args: ReadConnectedFileArgs =
+                serde_json::from_value(call.arguments.clone()).map_err(|_| ())?;
+            let (root_id, path) = root_and_path(args.root_id, &args.path, false)?;
+            Ok(OperationRequest::ReadFile(PathRequest { root_id, path }))
+        }
+        _ => Err(()),
+    }
+}
+
+/// Parse a model-proposed root and path into the broker's own vocabulary.
+/// `allow_root` distinguishes a directory listing, which may name the root
+/// itself, from a file operation, which may not.
+fn root_and_path(
+    root_id: Uuid,
+    path: &str,
+    allow_root: bool,
+) -> std::result::Result<(RootId, RelativePath), ()> {
+    let root_id = RootId::from_uuid(root_id).map_err(|_| ())?;
+    let path = RelativePath::parse(path).map_err(|_| ())?;
+    if path.is_root() && !allow_root {
+        return Err(());
+    }
+    Ok((root_id, path))
+}
+
+/// Project one broker result into the model-facing payload and the card's rows.
+///
+/// This mirrors the desktop executor's `serialize_result`
+/// (`openwave-desktop/src/client_execution/folder_operations.rs`) field for
+/// field and bound for bound: one conversation may be opened by either shell
+/// against the same data directory, and a `list_folder` that answered
+/// differently in each would be a defect in whichever one the reader was not
+/// using. A change to either payload is a change to both.
+fn serialize_result(call: &ToolCallRecord, result: OperationResult) -> ClientExecutionOutcome {
+    // The rows are built from the same values the model-facing payload is, so
+    // the card and the model can never disagree about what the folder held.
+    let (result, rows) = match result {
+        OperationResult::ListRoots { roots } => {
+            let roots: Vec<_> = roots.into_iter().take(MAX_DIRECTORY_ENTRIES).collect();
+            let rows = roots
+                .iter()
+                .map(|root| ResultEntry::new(ResultEntryKind::Folder, root.display_name.clone()))
+                .collect::<Vec<_>>();
+            (
+                serde_json::json!({
+                    "status": "ok",
+                    "folders": roots.iter().map(|root| serde_json::json!({
+                        "root_id": root.root_id,
+                        "display_name": root.display_name,
+                        "capabilities": granted_folder_capabilities(&root.capabilities),
+                    })).collect::<Vec<_>>(),
+                }),
+                rows,
+            )
+        }
+        OperationResult::ListDirectory { entries } => {
+            let entries: Vec<_> = entries.into_iter().take(MAX_DIRECTORY_ENTRIES).collect();
+            let rows = entries
+                .iter()
+                .map(|entry| {
+                    let kind = if entry.kind == EntryKind::Directory {
+                        ResultEntryKind::Folder
+                    } else {
+                        ResultEntryKind::File
+                    };
+                    ResultEntry::new(kind, entry.name.clone())
+                })
+                .collect();
+            (
+                serde_json::json!({
+                    "status": "ok",
+                    "entries": entries.iter().map(|entry| serde_json::json!({
+                        "name": entry.name,
+                        "kind": entry.kind,
+                    })).collect::<Vec<_>>(),
+                }),
+                rows,
+            )
+        }
+        OperationResult::ReadFile(file) => {
+            let (content, truncated) = truncate_utf8(&file.content, MAX_FILE_CONTENT_BYTES);
+            // The file's text is what the model reads and far too much for a
+            // card, so the row reports the read rather than replaying it. The
+            // name comes from the request: a read result is bytes, and only the
+            // arguments say which file they came from.
+            let path = serde_json::from_value::<ReadConnectedFileArgs>(call.arguments.clone())
+                .map(|args| args.path)
+                .unwrap_or_default();
+            let mut row = ResultEntry::new(ResultEntryKind::File, read_file_name(&path))
+                .with_meta(openwave_core::format_bytes(content.len() as u64));
+            if truncated {
+                row = row.with_detail("truncated at the read limit");
+            }
+            (
+                serde_json::json!({
+                    "status": "ok",
+                    "content": content,
+                    "truncated": truncated,
+                }),
+                vec![row],
+            )
+        }
+        _ => {
+            return unavailable(
+                "unsupported_result",
+                "The connected-folder operation is not available.",
+            )
+        }
+    };
+    match serde_json::to_string(&result) {
+        Ok(result) if result.len() <= MAX_RESULT_CONTENT_BYTES => {
+            ClientExecutionOutcome::Completed {
+                result,
+                rows: Some(serde_json::json!({ "entries": rows })),
+            }
+        }
+        _ => unavailable(
+            "result_too_large",
+            "The connected-folder result was too large to return.",
+        ),
+    }
+}
+
+/// The model-facing names for what the broker currently grants on a folder.
+fn granted_folder_capabilities(capabilities: &[Capability]) -> Vec<GrantedFolderCapability> {
+    capabilities
+        .iter()
+        .filter_map(|capability| match capability {
+            Capability::ReadFiles => Some(GrantedFolderCapability::ReadFiles),
+            Capability::WriteFiles => Some(GrantedFolderCapability::WriteFiles),
+            Capability::ExecuteCommands => Some(GrantedFolderCapability::ExecuteCommands),
+            Capability::ListRoots => None,
+            // `Capability` is non-exhaustive. Unknown future per-folder reach is
+            // intentionally under-reported until this conversion and the
+            // model-facing vocabulary are extended together.
+            _ => None,
+        })
+        .collect()
+}
+
+fn truncate_utf8(value: &str, max_bytes: usize) -> (String, bool) {
+    if value.len() <= max_bytes {
+        return (value.to_owned(), false);
+    }
+    let mut end = max_bytes;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    (value[..end].to_owned(), true)
+}
+
+/// The last segment of a connected-folder path, so a row leads with the file.
+fn read_file_name(path: &str) -> String {
+    let name = path
+        .rsplit('/')
+        .find(|segment| !segment.is_empty())
+        .unwrap_or(path);
+    if name.is_empty() {
+        "file".to_owned()
+    } else {
+        name.to_owned()
+    }
+}
+
+fn unavailable(code: &str, message: &str) -> ClientExecutionOutcome {
+    ClientExecutionOutcome::Failed {
+        result: serde_json::json!({ "status": "unavailable", "message": message }).to_string(),
+        error_code: code.to_owned(),
+        error_detail: None,
+    }
+}
+
+fn folder_unavailable() -> ClientExecutionOutcome {
+    unavailable(
+        "folder_unavailable",
+        "That connected folder is no longer available to this conversation. You can ask the user \
+         to connect a folder again.",
+    )
+}
+
+fn import_unavailable(message: &str) -> ClientExecutionOutcome {
+    let result = ImportConnectedFileResult::Unavailable {
+        message: message.to_owned(),
+    };
+    ClientExecutionOutcome::Failed {
+        result: serde_json::to_string(&result)
+            .unwrap_or_else(|_| r#"{"status":"unavailable","message":"unavailable"}"#.to_owned()),
+        error_code: "import_unavailable".to_owned(),
+        error_detail: None,
+    }
+}
+
+fn interrupted() -> ClientExecutionOutcome {
+    unavailable(
+        "folder_operation_interrupted",
+        "The folder operation could not be safely resumed after an interruption. Please try again.",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openwave_core::{TurnId, REQUEST_FOLDER_ACCESS_TOOL};
+
+    fn call(name: &str, arguments: serde_json::Value) -> ToolCallRecord {
+        ToolCallRecord {
+            id: CallId::new(),
+            chat_id: ChatId::new(),
+            turn_id: TurnId::new(),
+            provider_id: "tool-1".into(),
+            name: name.into(),
+            arguments,
+            raw_arguments: None,
+            execution: ToolCallExecution::Client,
+            status: ToolCallStatus::Pending,
+            result: None,
+            result_preview: None,
+            provider_replay: None,
+            error_code: None,
+            error_detail: None,
+            client_executor_id: None,
+            client_lease_expires_at: None,
+            created_at: chrono::Utc::now(),
+            resolved_at: None,
+        }
+    }
+
+    /// The boundary between "a folder this conversation already has" and "ask
+    /// for another one". A headless run answers the first and must never answer
+    /// the second: `request_folder_access` has no route into this executor, so
+    /// print mode's typed refusal stays the only answer to it and no folder
+    /// grant can be created or widened from a parked call.
+    #[test]
+    fn the_executor_never_answers_a_request_for_new_folder_access() {
+        assert!(!handles(REQUEST_FOLDER_ACCESS_TOOL));
+        assert!(!is_canonical_folder_call(&call(
+            REQUEST_FOLDER_ACCESS_TOOL,
+            serde_json::json!({
+                "reason": "Read reports",
+                "requested_capabilities": ["read_files"],
+            }),
+        )));
+        // Nor by any other name: dispatch is a closed match, and a name it does
+        // not know produces no broker request at all.
+        assert!(broker_request(&call("exec", serde_json::json!({}))).is_err());
+        for name in [
+            LIST_CONNECTED_FOLDERS_TOOL,
+            LIST_FOLDER_TOOL,
+            READ_CONNECTED_FILE_TOOL,
+            IMPORT_CONNECTED_FILE_TOOL,
+            WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL,
+        ] {
+            assert!(handles(name), "{name}");
+        }
+    }
+
+    /// Model-proposed paths reach the broker only in the broker's own grammar.
+    /// Anything the broker would refuse — traversal, an absolute path, a root
+    /// where a file is required — is refused before a host operation exists,
+    /// and an import is never routed through the read dispatch table.
+    #[test]
+    fn a_path_the_broker_would_refuse_never_becomes_a_host_operation() {
+        let root = Uuid::new_v4();
+        for path in ["../secret", "reports/../secret", "/etc/passwd", "a\\b"] {
+            assert!(
+                broker_request(&call(
+                    LIST_FOLDER_TOOL,
+                    serde_json::json!({ "root_id": root, "path": path })
+                ))
+                .is_err(),
+                "{path}"
+            );
+            assert!(root_and_path(root, path, true).is_err(), "{path}");
+        }
+        // A listing may name the folder itself; a file read may not.
+        assert!(broker_request(&call(
+            LIST_FOLDER_TOOL,
+            serde_json::json!({ "root_id": root, "path": "" })
+        ))
+        .is_ok());
+        assert!(broker_request(&call(
+            READ_CONNECTED_FILE_TOOL,
+            serde_json::json!({ "root_id": root, "path": "" })
+        ))
+        .is_err());
+        // A nil root id is not a root.
+        assert!(root_and_path(Uuid::nil(), "notes.md", false).is_err());
+        // An import is resolved by its own path, not this table.
+        assert!(broker_request(&call(
+            IMPORT_CONNECTED_FILE_TOOL,
+            serde_json::json!({ "root_id": root, "path": "reports/q3.pdf" })
+        ))
+        .is_err());
+    }
+
+    /// Every terminal answer is bounded and carries no host detail: not the
+    /// path, not an OS error, not the file's bytes in the card.
+    #[test]
+    fn terminal_answers_are_bounded_and_free_of_host_detail() {
+        let read = call(
+            READ_CONNECTED_FILE_TOOL,
+            serde_json::json!({ "root_id": Uuid::new_v4(), "path": "reports/q3.md" }),
+        );
+        let outcome = serialize_result(
+            &read,
+            OperationResult::ReadFile(openwave_host_broker::ReadFileResult {
+                content: "x".repeat(MAX_FILE_CONTENT_BYTES + 1),
+                bytes: MAX_FILE_CONTENT_BYTES + 1,
+            }),
+        );
+        let ClientExecutionOutcome::Completed { result, rows } = outcome else {
+            panic!("a bounded read completes");
+        };
+        assert!(result.len() <= MAX_RESULT_CONTENT_BYTES);
+        assert!(result.contains("\"truncated\":true"));
+        let rows = rows.expect("a completed read reports its row");
+        assert_eq!(rows["entries"][0]["label"], "q3.md");
+        assert_eq!(rows["entries"][0]["detail"], "truncated at the read limit");
+        // The card reports the read rather than replaying the file.
+        assert!(!rows.to_string().contains('x'));
+
+        for failure in [
+            interrupted(),
+            folder_unavailable(),
+            import_unavailable("That file could not be read."),
+        ] {
+            let ClientExecutionOutcome::Failed {
+                result,
+                error_code,
+                error_detail,
+            } = failure
+            else {
+                panic!("a refusal is terminal");
+            };
+            assert!(!error_code.is_empty());
+            assert!(
+                error_detail.is_none(),
+                "no host diagnostics reach the model"
+            );
+            assert!(!result.contains('/'), "{result}");
+        }
+    }
+
+    /// The recovery table this module's crash safety rests on. A read that may
+    /// already have reached the broker is closed out rather than repeated; an
+    /// import, whose source identity the server derives from the request, may
+    /// converge on the same source by running again.
+    #[test]
+    fn only_a_convergent_operation_may_be_repeated_after_an_interruption() {
+        for read_only in [
+            LIST_CONNECTED_FOLDERS_TOOL,
+            LIST_FOLDER_TOOL,
+            READ_CONNECTED_FILE_TOOL,
+        ] {
+            assert_eq!(
+                recovery_policy(read_only),
+                DispatchRecovery::Terminalize,
+                "{read_only}"
+            );
+        }
+        assert_eq!(
+            recovery_policy(IMPORT_CONNECTED_FILE_TOOL),
+            DispatchRecovery::Retry
+        );
+    }
+
+    /// The folder listing must tell the model what the broker actually grants,
+    /// because that is what decides whether it tries to write or execute. The
+    /// vocabulary is the model-facing one, not the broker's internal set.
+    #[test]
+    fn the_folder_listing_reports_the_brokers_own_capabilities() {
+        let outcome = serialize_result(
+            &call(LIST_CONNECTED_FOLDERS_TOOL, serde_json::json!({})),
+            OperationResult::ListRoots {
+                roots: vec![openwave_host_broker::RootAccess {
+                    root_id: RootId::new(),
+                    display_name: "reports".into(),
+                    capabilities: vec![
+                        Capability::ListRoots,
+                        Capability::ReadFiles,
+                        Capability::WriteFiles,
+                        Capability::ExecuteCommands,
+                    ],
+                }],
+            },
+        );
+        let ClientExecutionOutcome::Completed { result, .. } = outcome else {
+            panic!("a listing completes");
+        };
+        let result: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(
+            result["folders"][0]["capabilities"],
+            serde_json::json!(["read_files", "write_files", "execute_commands"])
+        );
+    }
+}

--- a/crates/openwave-cli/src/folder_executor/receipts.rs
+++ b/crates/openwave-cli/src/folder_executor/receipts.rs
@@ -1,0 +1,236 @@
+//! Durable receipts for the headless folder executor.
+//!
+//! The server hands a claimed client call to no other executor: only the exact
+//! `(executor_id, lease_token)` pair that claimed it can recover or resolve it,
+//! whether or not the lease has expired. So the executor must be able to
+//! remember its own claim across a crash, or a killed process would leave a
+//! parked call nothing can ever settle — the same hang the executor exists to
+//! remove.
+//!
+//! One small JSON file per claim, in a private directory beside the profile's
+//! other executor state. The file is written before the claim and again before
+//! host I/O, and removed only once the server holds a terminal result. It
+//! carries no folder path, no file content, and no credential: an identity, a
+//! lease token, a phase, and — once known — the same model-facing outcome the
+//! server will be given.
+
+use std::path::{Path, PathBuf};
+
+use openwave_core::{AgentError, CallId, ChatId, Result};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::api::client::ClientExecutionOutcome;
+
+/// What may be done with a claim whose host I/O had already begun.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum DispatchRecovery {
+    /// Close the call out with a typed failure. A read has no durable host
+    /// outcome to reconcile against, so repeating it would be a second
+    /// disclosure this process cannot account for.
+    Terminalize,
+    /// Run it again. The operation's effect is identified by the request, so a
+    /// repeat converges on the one effect rather than adding another.
+    Retry,
+}
+
+/// One claim this executor owns, as much of it as must survive a crash.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct Receipt {
+    pub(super) chat_id: ChatId,
+    pub(super) call_id: CallId,
+    pub(super) executor_id: Uuid,
+    /// Chosen before the claim and never regenerated: it is the only key that
+    /// can recover this claim.
+    pub(super) lease_token: Uuid,
+    pub(super) recovery: DispatchRecovery,
+    /// Whether the host operation had been dispatched. Written durably before
+    /// the first byte crosses into the broker.
+    #[serde(default)]
+    pub(super) dispatch_started: bool,
+    /// The terminal answer, once computed. Present means the work is done and
+    /// only publication remains, so recovery republishes it rather than running
+    /// the operation a second time.
+    #[serde(default)]
+    pub(super) outcome: Option<ClientExecutionOutcome>,
+}
+
+impl Receipt {
+    pub(super) fn new(
+        chat_id: ChatId,
+        call_id: CallId,
+        executor_id: Uuid,
+        recovery: DispatchRecovery,
+    ) -> Self {
+        Self {
+            chat_id,
+            call_id,
+            executor_id,
+            lease_token: Uuid::new_v4(),
+            recovery,
+            dispatch_started: false,
+            outcome: None,
+        }
+    }
+}
+
+/// The receipt directory for one profile.
+pub(super) struct ReceiptStore {
+    root: PathBuf,
+}
+
+impl ReceiptStore {
+    pub(super) fn open(data_dir: &Path) -> Result<Self> {
+        let root = data_dir.join("folder-executions");
+        create_private_dir(&root).map_err(|error| {
+            AgentError::config(format!(
+                "could not open the connected-folder executor state: {error}"
+            ))
+        })?;
+        Ok(Self { root })
+    }
+
+    /// Every receipt on disk. An unreadable or unparsable file is reported
+    /// rather than skipped: silently ignoring one would strand its call, and the
+    /// operator can see and remove it.
+    pub(super) fn load(&self) -> Result<Vec<Receipt>> {
+        let entries = std::fs::read_dir(&self.root).map_err(private_state_error)?;
+        let mut receipts = Vec::new();
+        for entry in entries {
+            let path = entry.map_err(private_state_error)?.path();
+            if path.extension().is_none_or(|extension| extension != "json") {
+                continue;
+            }
+            let text = std::fs::read_to_string(&path).map_err(private_state_error)?;
+            let receipt: Receipt = serde_json::from_str(&text).map_err(|_| {
+                AgentError::msg(
+                    "a connected-folder executor receipt is unreadable; \
+                     remove it to let the conversation continue",
+                )
+            })?;
+            // The name is derived from the identity, so a file that does not
+            // match its own contents is not this store's.
+            if path.file_name() != Some(self.path(receipt.call_id).file_name().unwrap_or_default())
+            {
+                return Err(AgentError::msg(
+                    "a connected-folder executor receipt does not match its own identity",
+                ));
+            }
+            receipts.push(receipt);
+        }
+        Ok(receipts)
+    }
+
+    /// Write one receipt so it is durable before the step it fences.
+    pub(super) fn save(&self, receipt: &Receipt) -> Result<()> {
+        let text = serde_json::to_vec(receipt)
+            .map_err(|_| AgentError::msg("could not encode a connected-folder executor receipt"))?;
+        write_private_atomic(&self.path(receipt.call_id), &text).map_err(private_state_error)
+    }
+
+    pub(super) fn remove(&self, call_id: CallId) -> Result<()> {
+        match std::fs::remove_file(self.path(call_id)) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(private_state_error(error)),
+        }
+    }
+
+    fn path(&self, call_id: CallId) -> PathBuf {
+        self.root.join(format!("{call_id}.json"))
+    }
+}
+
+/// Private state, not a credential — but it names this profile's pending host
+/// work, so it inherits the data directory's own permissions rather than the
+/// process umask.
+fn create_private_dir(path: &Path) -> std::io::Result<()> {
+    let mut builder = std::fs::DirBuilder::new();
+    builder.recursive(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt as _;
+        builder.mode(0o700);
+    }
+    match builder.create(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+/// Replace a receipt atomically and durably.
+///
+/// The rename is what makes a torn write impossible: a reader either sees the
+/// previous phase or the new one, never half of either. Both the file and its
+/// directory are synced, because a phase that only reached the page cache is a
+/// phase a power loss can lose — and losing the `dispatch_started` fence is
+/// exactly what would let a read be repeated.
+fn write_private_atomic(path: &Path, contents: &[u8]) -> std::io::Result<()> {
+    use std::io::Write as _;
+
+    let directory = path.parent().unwrap_or_else(|| Path::new("."));
+    let temporary = path.with_extension("json.tmp");
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+    let mut file = options.open(&temporary)?;
+    file.write_all(contents)?;
+    file.sync_all()?;
+    drop(file);
+    std::fs::rename(&temporary, path)?;
+    // Best effort: not every platform lets a directory be opened for sync.
+    if let Ok(directory) = std::fs::File::open(directory) {
+        let _ = directory.sync_all();
+    }
+    Ok(())
+}
+
+fn private_state_error(_error: std::io::Error) -> AgentError {
+    AgentError::msg("could not update the connected-folder executor's recovery state")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The store's whole job: a phase written before a step is still there
+    /// afterwards, so a process that died mid-operation is recognizable to the
+    /// next one — and a published receipt leaves nothing behind to re-run.
+    #[test]
+    fn a_receipt_survives_the_process_that_wrote_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ReceiptStore::open(dir.path()).unwrap();
+        assert!(store.load().unwrap().is_empty());
+
+        let mut receipt = Receipt::new(
+            ChatId::new(),
+            CallId::new(),
+            Uuid::new_v4(),
+            DispatchRecovery::Terminalize,
+        );
+        store.save(&receipt).unwrap();
+        // A fresh store over the same directory is what the next run has.
+        let recovered = ReceiptStore::open(dir.path()).unwrap().load().unwrap();
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].call_id, receipt.call_id);
+        // The lease token is the only key that can recover the claim, so it must
+        // come back byte for byte rather than being regenerated.
+        assert_eq!(recovered[0].lease_token, receipt.lease_token);
+        assert!(!recovered[0].dispatch_started);
+
+        receipt.dispatch_started = true;
+        store.save(&receipt).unwrap();
+        assert!(store.load().unwrap()[0].dispatch_started);
+
+        store.remove(receipt.call_id).unwrap();
+        assert!(store.load().unwrap().is_empty());
+        // Removing what is already gone is how a republished result settles.
+        store.remove(receipt.call_id).unwrap();
+    }
+}

--- a/crates/openwave-cli/src/main.rs
+++ b/crates/openwave-cli/src/main.rs
@@ -51,6 +51,10 @@
 //! broker state and the local data directory, so it embeds and takes no
 //! `--server`.
 //!
+//! Once a folder is connected, the tools that read it are executed by whichever
+//! process owns that broker state — `serve`, or the engine `-p` embeds. See
+//! [`folder_executor`].
+//!
 //! Every client command above embeds its own server by default. `--server
 //! <url>` (or `OPENWAVE_SERVER_URL`) makes it a pure client of one that is
 //! already running instead, with the bearer token coming from
@@ -70,6 +74,7 @@ use openwave_core::{
 mod api;
 mod connect;
 mod folder;
+mod folder_executor;
 mod outputs;
 mod print;
 mod setup;
@@ -694,10 +699,24 @@ fn profile_config() -> Result<Config> {
 async fn serve() -> Result<()> {
     let config = profile_config()?;
     let profile = config.profile;
+    let data_dir = config.data_dir.clone();
     // Tracing events land in `logs/openwave.log` under the profile data dir
     // (plus stderr in debug builds); see `openwave_server::logging`.
     openwave_server::logging::init_logging(&config.data_dir);
     let server = openwave_server::bind_configured(config).await?;
+    // The daemon is the trusted client for its own connected-folder tool calls:
+    // it holds this machine's broker state, so a turn that reads a folder an
+    // operator connected is executed here rather than parked for a shell that
+    // does not exist. It is the same executor `openwave -p` runs, over every
+    // conversation this credential can see. See [`folder_executor`].
+    let folder_executor = folder_executor::FolderExecutor::new(
+        api::client::Client::new(server.local_addr(), server.token())?,
+        Some(server.client_executor_token()),
+        &data_dir,
+    )?;
+    if let Some(executor) = folder_executor {
+        tokio::spawn(executor.run(folder_executor::Scope::AllChats));
+    }
     // The address is the client's entry point: the parent process that launched
     // the daemon reads it from stdout to connect, and a container entrypoint
     // waits on the same line.

--- a/crates/openwave-cli/src/print.rs
+++ b/crates/openwave-cli/src/print.rs
@@ -25,6 +25,12 @@
 //! `declined` result, the same answer an undecided desktop prompt gives.
 //! Standing folder consent comes from `openwave folder connect` and nowhere
 //! else. See [`crate::folder`].
+//!
+//! *Using* a folder an operator already connected is a different matter, and it
+//! works: an embedded run starts [`crate::folder_executor`] over the chat it is
+//! driving, which claims the parked folder tool calls and runs them through the
+//! host broker's capability checks. That executor answers only for folders that
+//! are already connected; it has no path to a new grant.
 
 use std::collections::HashMap;
 use std::io::{IsTerminal as _, Write as _};
@@ -36,7 +42,7 @@ use openwave_core::{
 };
 use tokio_tungstenite::tungstenite::Message;
 
-use crate::api::client::{Client, EventSocket};
+use crate::api::client::{Client, ClientExecutionOutcome, EventSocket};
 use crate::api::wire::{ChatFrame, ClientEvent, ToolCallStatus};
 
 mod driver;
@@ -125,7 +131,27 @@ pub async fn run(
     let driving = format == OutputFormat::Json && !std::io::stdin().is_terminal();
     let mut driver = Driver::from_stdin(driving);
 
-    one_turn(
+    // The folder tools the agent may use on a folder an operator already
+    // connected execute in this process, because this process is the one that
+    // owns the broker state they read. Scoped to this run's chat: a print run
+    // answers for the conversation it drives and no other. An attached run has
+    // no executor credential and starts nothing — it touches no local data
+    // directory either, which is why the profile is only resolved here.
+    let folder_executor = match executor_token.as_deref() {
+        Some(executor_token) => crate::folder_executor::FolderExecutor::new(
+            client.clone(),
+            Some(executor_token),
+            &crate::profile_config()?.data_dir,
+        )?
+        .map(|executor| {
+            FolderExecutorTask(tokio::spawn(
+                executor.run(crate::folder_executor::Scope::Chat(chat)),
+            ))
+        }),
+        None => None,
+    };
+
+    let outcome = one_turn(
         &client,
         executor_token.as_deref(),
         chat,
@@ -133,7 +159,18 @@ pub async fn run(
         format,
         &mut driver,
     )
-    .await
+    .await;
+    drop(folder_executor);
+    outcome
+}
+
+/// Aborts the folder executor when the turn is over, however it ended.
+struct FolderExecutorTask(tokio::task::JoinHandle<()>);
+
+impl Drop for FolderExecutorTask {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
 }
 
 /// Post the message and follow the event stream until the turn ends.
@@ -482,8 +519,20 @@ async fn decline(
     let declined = serde_json::to_string(&RequestFolderAccessResult::Declined)
         .map_err(|error| AgentError::msg(format!("could not encode the refusal: {error}")))?;
     client
-        .resolve_client_execution(executor_token, chat, call_id, lease_token, &declined)
-        .await
+        .resolve_client_execution(
+            executor_token,
+            chat,
+            call_id,
+            lease_token,
+            // The same `{"status":"completed","result":…}` body this has always
+            // sent: `rows` is omitted rather than sent as null.
+            &ClientExecutionOutcome::Completed {
+                result: declined,
+                rows: None,
+            },
+        )
+        .await?;
+    Ok(())
 }
 
 /// The event socket plus the cursor a reconnect resumes from.

--- a/crates/openwave-cli/src/tui/mod.rs
+++ b/crates/openwave-cli/src/tui/mod.rs
@@ -34,7 +34,29 @@ pub async fn run(open: Open, server: crate::connect::Server) -> Result<()> {
     // background workers; holding it for the whole TUI session is what keeps
     // the engine running. Attached, it owns nothing.
     let session = crate::connect::Session::open(&server).await?;
-    attach(session.client().clone(), open).await
+    // An embedded TUI is the same trusted client for its own connected-folder
+    // tool calls that `-p` and `serve` are, for the same reason: it owns this
+    // machine's broker state for the length of the session. Without this a turn
+    // that read a connected folder would park here too. Attached, it starts
+    // nothing — see [`crate::folder_executor`].
+    let folder_executor = match session.client_executor_token() {
+        Some(executor_token) => crate::folder_executor::FolderExecutor::new(
+            session.client().clone(),
+            Some(executor_token),
+            &crate::profile_config()?.data_dir,
+        )?
+        .map(|executor| {
+            // Any conversation, not just the one opened at startup: the session
+            // can move between chats.
+            tokio::spawn(executor.run(crate::folder_executor::Scope::AllChats))
+        }),
+        None => None,
+    };
+    let outcome = attach(session.client().clone(), open).await;
+    if let Some(executor) = folder_executor {
+        executor.abort();
+    }
+    outcome
 }
 
 /// Resolve which chat to attach to, then hand the terminal to the app.

--- a/crates/openwave-cli/tests/folder.rs
+++ b/crates/openwave-cli/tests/folder.rs
@@ -1,10 +1,13 @@
 //! Operator-provisioned folder consent, end to end at the process boundary.
 //!
-//! These exercise the one thing the CLI is uniquely responsible for: that a
-//! grant it records is the same record the desktop reads and revokes, not a
-//! parallel one. The desktop side is represented by the broker query its
-//! consent surface runs (`ListGrantStatements`, behind
-//! `list_capability_consents`) against the same data directory.
+//! Two things are exercised here, both of which only a whole process can show.
+//! First, that a grant the CLI records is the same record the desktop reads and
+//! revokes rather than a parallel one — the desktop side represented by the
+//! broker query its consent surface runs (`ListGrantStatements`, behind
+//! `list_capability_consents`) against the same data directory. Second, that an
+//! unattended turn can then *use* that folder: the folder tools are executed by
+//! whichever process owns the broker state, and a headless install has to
+//! answer them or the turn parks forever.
 //!
 //! The connected folder lives under the real home directory because that is
 //! what the host root policy allows: on macOS a temporary directory
@@ -14,7 +17,8 @@
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, Command, Output, Stdio};
+use std::time::{Duration, Instant};
 
 use openwave_host_broker::{
     Broker, Capability, ConsentMethod, ControlEnvelope, ControlRequest, ControlResult, GrantId,
@@ -24,6 +28,35 @@ use openwave_host_broker::{
 
 /// Kills the daemon on drop, including on an assertion panic.
 struct Reaper(Child);
+
+impl Reaper {
+    fn wait_with_output(&mut self, timeout: Duration) -> Output {
+        let deadline = Instant::now() + timeout;
+        let status = loop {
+            if let Some(status) = self.0.try_wait().unwrap() {
+                break status;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "child did not exit within {timeout:?}"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        };
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        if let Some(mut pipe) = self.0.stdout.take() {
+            pipe.read_to_end(&mut stdout).unwrap();
+        }
+        if let Some(mut pipe) = self.0.stderr.take() {
+            pipe.read_to_end(&mut stderr).unwrap();
+        }
+        Output {
+            status,
+            stdout,
+            stderr,
+        }
+    }
+}
 
 impl Drop for Reaper {
     fn drop(&mut self) {
@@ -263,4 +296,217 @@ fn folder_commands_refuse_to_pretend_they_target_another_server() {
         stderr.contains("folder") && stderr.contains("--server"),
         "stderr: {stderr}"
     );
+}
+
+/// A turn boots the engine and runs the tool loop, so it is given more room
+/// than a command that only has to refuse and exit. Generous rather than tight:
+/// the failure this bounds is a parked call that never resolves, and there is
+/// nothing to gain from declaring it early.
+const TURN_EXIT_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Connect one folder as an operator and return its opaque root id.
+fn connect_folder(data_dir: &Path, path: &Path, chat: &str) -> String {
+    let (ok, stdout, stderr) = run(
+        data_dir,
+        &["folder", "connect", path.to_str().unwrap(), "--chat", chat],
+    );
+    assert!(ok, "connect failed: {stderr}");
+    // "openwave: connected <name> to chat <id> (root <root id>, operator …)"
+    let root = stdout
+        .split("(root ")
+        .nth(1)
+        .and_then(|rest| rest.split(',').next())
+        .expect("the connect report names the root id")
+        .trim()
+        .to_owned();
+    assert!(
+        uuid::Uuid::parse_str(&root).is_ok(),
+        "unexpected root id {root:?} in {stdout:?}"
+    );
+    root
+}
+
+/// Every client-executed folder tool the executor answers, in one script: list
+/// the folder, read a file out of it as text, import that file as a source, then
+/// answer. Each tool step parks a client-executed call, which is exactly what
+/// used to hang.
+fn folder_reading_script(root: &str) -> String {
+    serde_json::json!([
+        {"tool": "list_folder", "input": {"root_id": root, "path": ""}},
+        {"tool": "read_connected_file", "input": {"root_id": root, "path": "q3.md"}},
+        {"tool": "import_connected_file", "input": {"root_id": root, "path": "q3.md"}},
+        {"text": "read the report"}
+    ])
+    .to_string()
+}
+
+/// The folder tools whose calls the script above parks. Every one must come back
+/// completed: a single parked call is the whole failure this closes.
+const SCRIPTED_FOLDER_TOOLS: &[&str] = &[
+    "list_folder",
+    "read_connected_file",
+    "import_connected_file",
+];
+
+/// The journal frames one print-mode run wrote, decoded from its stdout.
+fn journal_events(stdout: &str) -> Vec<serde_json::Value> {
+    stdout
+        .lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .filter_map(|frame| frame.get("event").cloned())
+        .collect()
+}
+
+/// Assert the scripted turn ran every folder tool for real and finished.
+fn assert_folder_tools_completed(stdout: &str, stderr: &str) {
+    let events = journal_events(stdout);
+    for tool in SCRIPTED_FOLDER_TOOLS {
+        let call = events
+            .iter()
+            .find(|event| event["type"] == "tool_call_started" && event["name"] == *tool)
+            .unwrap_or_else(|| {
+                panic!("{tool} was never called\nstdout: {stdout}\nstderr: {stderr}")
+            });
+        let call_id = call["call_id"].clone();
+        let completed = events
+            .iter()
+            .find(|event| event["type"] == "tool_call_completed" && event["call_id"] == call_id)
+            .unwrap_or_else(|| {
+                panic!("{tool} never completed — it parked\nstdout: {stdout}\nstderr: {stderr}")
+            });
+        assert_eq!(
+            completed["status"], "completed",
+            "{tool} did not succeed\nstdout: {stdout}\nstderr: {stderr}"
+        );
+    }
+    assert!(
+        events.iter().any(|event| event["type"] == "turn_completed"),
+        "the turn never completed\nstdout: {stdout}\nstderr: {stderr}"
+    );
+}
+
+/// The gap #1884 closed, driven end to end: an operator connects a folder, and
+/// an unattended turn *uses* it. `list_folder` and `read_connected_file` are
+/// client-executed calls with no client on a headless install, so before this
+/// executor existed they parked and the run hung until it was killed. The model
+/// is scripted, but the engine, the turn worker, the parked-call lifecycle, the
+/// host broker's capability checks, and the journal are all the production path.
+#[test]
+fn an_unattended_turn_reads_a_folder_the_operator_connected() {
+    let base = tempfile::tempdir_in(home()).unwrap();
+    let data = tempfile::tempdir().unwrap();
+    let data_dir = data.path().join("profile");
+    let reports = base.path().join("reports");
+    std::fs::create_dir_all(&reports).unwrap();
+    std::fs::write(reports.join("q3.md"), "revenue held flat\n").unwrap();
+
+    let chat = create_chat(&data_dir);
+    let root = connect_folder(&data_dir, &reports, &chat);
+
+    let output = openwave(&data_dir)
+        .args([
+            "-p",
+            "summarize the report",
+            "--chat",
+            &chat,
+            "--permission-mode",
+            "allow",
+            "--output-format",
+            "json",
+        ])
+        .env("OPENWAVE_SCRIPTED_PROVIDER", folder_reading_script(&root))
+        .env_remove("OPENWAVE_SERVER_URL")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn a scripted openwave -p");
+    let mut child = Reaper(output);
+    let output = child.wait_with_output(TURN_EXIT_TIMEOUT);
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert_folder_tools_completed(&stdout, &stderr);
+    // Nothing was written back into the folder: these tools only read it.
+    assert_eq!(
+        std::fs::read_to_string(reports.join("q3.md")).unwrap(),
+        "revenue held flat\n"
+    );
+}
+
+/// The other half of the scoping decision, and the reason an attached client
+/// needs no new authority: the executor belongs to the process that owns the
+/// broker state. Here that process is `openwave serve`, and the run driving the
+/// turn is a plain `--server` client holding only a bearer token. It cannot
+/// execute a folder call — it has no executor credential and no flag grants it
+/// one — and it does not have to, because the daemon does.
+#[test]
+fn a_serve_daemon_executes_folder_calls_for_an_attached_client() {
+    let base = tempfile::tempdir_in(home()).unwrap();
+    let data = tempfile::tempdir().unwrap();
+    let data_dir = data.path().join("profile");
+    let reports = base.path().join("reports");
+    std::fs::create_dir_all(&reports).unwrap();
+    std::fs::write(reports.join("q3.md"), "revenue held flat\n").unwrap();
+
+    let chat = create_chat(&data_dir);
+    let root = connect_folder(&data_dir, &reports, &chat);
+
+    // The script belongs to the engine, which now lives in the daemon.
+    let mut daemon = openwave(&data_dir)
+        .arg("serve")
+        .env("OPENWAVE_SCRIPTED_PROVIDER", folder_reading_script(&root))
+        .env_remove("OPENWAVE_SERVER_URL")
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn openwave serve");
+    let stdout = daemon.stdout.take().unwrap();
+    let _daemon = Reaper(daemon);
+    let mut lines = BufReader::new(stdout).lines();
+    let addr_line = lines.next().unwrap().unwrap();
+    let token_line = lines.next().unwrap().unwrap();
+    let url = format!(
+        "http://{}",
+        addr_line.rsplit("http://").next().unwrap().trim()
+    );
+    let token = token_line
+        .trim_start_matches("openwave: token ")
+        .trim()
+        .to_owned();
+
+    let attached = openwave(&data_dir)
+        .args([
+            "-p",
+            "summarize the report",
+            "--chat",
+            &chat,
+            "--permission-mode",
+            "allow",
+            "--output-format",
+            "json",
+            "--server",
+        ])
+        .arg(&url)
+        .env("OPENWAVE_SERVER_TOKEN", &token)
+        .env_remove("OPENWAVE_SERVER_URL")
+        .env_remove("OPENWAVE_SCRIPTED_PROVIDER")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn an attached openwave -p");
+    let mut attached = Reaper(attached);
+    let output = attached.wait_with_output(TURN_EXIT_TIMEOUT);
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert_folder_tools_completed(&stdout, &stderr);
 }

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -145,6 +145,25 @@ in front of it. That case would justify the cloud-credential plumbing again,
 and it would need a verified route and a live check, not a route curated on
 documentation alone.
 
+## Writing outputs back into a connected folder, headlessly
+
+A headless install can read a folder an operator connected — list it, read text
+out of it, import a file from it as a source. Publishing an output *into* one is
+deliberately refused there, with a stable `output_writeback_authority_unavailable`
+result rather than a second write path.
+
+Writing into a user's folder is not just a host write. On the desktop it goes
+through the exec write overlay, which snapshots the destination, routes a
+replacement through the trash, and leaves the change reversible from the
+conversation. A headless embedding installs no folder-grant resolver, so it has
+none of that: no staged copy, no snapshot, no undo. Improvising one would be a
+second, weaker way to overwrite a file the operator cannot take back, which is
+worse than declining.
+
+Lifting this means giving the headless engine the same overlay and write-back
+machinery the desktop has, and a headless surface for the approval that a
+replacement always requires — not relaxing the refusal.
+
 ## Windows packaging
 
 Windows builds shipped through v0.34.0 as an unsigned x86_64 NSIS installer,


### PR DESCRIPTION
Follow-up to #1867 / #1881. Operator folder consent works headlessly, but the
folder tools that *use* a connected folder — `list_connected_folders`,
`list_folder`, `read_connected_file`, `import_connected_file`,
`write_output_to_connected_folder` — are client-executed calls, and a headless
install had no client to execute them. The server parked the call and the turn
hung until the run was killed. #1881 only covered `request_folder_access`.

This adds the missing executor to the processes that own this machine's broker
state: `openwave serve`, and the engine `openwave -p` and `openwave tui` embed.
It polls for parked folder calls, claims them, runs each operation through
`openwave-host-broker`, and publishes the terminal result the model reads.

## Where the executor lives, and how claims work

`crates/openwave-cli/src/folder_executor.rs` is one implementation with two
scopes: `Scope::Chat` for a print run (its own conversation, polled tightly) and
`Scope::AllChats` for `serve` and the TUI, which may see any conversation. Each
pass finishes what a previous run left behind, then takes up new work.

Per call: write a receipt (`folder_executor/receipts.rs`) → claim → verify the
claim → heartbeat → mark `dispatch_started` durably → run the broker operation →
record the outcome → resolve → drop the receipt.

The receipt is not optional. `claim_client_tool_call` hands a claimed call to no
other executor — only the exact `(executor_id, lease_token)` pair can recover or
resolve it, expired lease or not — so a crash between claim and resolve would
strand the call permanently, which is the same hang this PR removes. The
executor identity is the profile's existing `cli-folder-executor` file, shared
with `openwave folder`, because both mean "this profile's CLI owns that pending
work".

## Security invariants and how each is enforced

**1. Broker authority.** `FolderExecutor::broker_operation`
(`folder_executor.rs:529`) is the only path to a connected folder in the module:
it builds an `OperationEnvelope` and hands it to `Broker::operator().handle`.
Every other function either produces a request or shapes a result. The CLI makes
no authorization decision, caches none, and has no fallback when the broker
refuses — `run_call` maps any broker error to a typed `folder_unavailable`
without inspecting it (`folder_executor.rs:432`). The execution context is
derived per call from the chat read live (`execution_context`,
`folder_executor.rs:579`), so a chat moved between projects cannot carry old
authority into a later call. Model-proposed paths are parsed by the broker's own
`RelativePath` before a request exists (`root_and_path`,
`folder_executor.rs:665`), so a payload the broker would refuse never reaches it.

**2. Canonical arguments from the server's parked state.** Discovery reads only
`id`, `name`, and `client_executor_id` from the pending list. The arguments come
from the claim response's `ToolCallRecord` — the server's checkpointed call —
and the claim is fenced on chat id, call id, lease token, executor ownership,
`is_canonical_folder_call` (execution, status, name, and the server's own
argument validators re-run), and that the recovery policy derived from the
claimed name matches the receipt's (`folder_executor.rs:286`). Nothing is taken
from a claimant's restatement.

**3. The executor runs only where broker state lives.** `FolderExecutor::new`
returns `Ok(None)` without a client-executor token (`folder_executor.rs:153`),
and `connect::Session::client_executor_token()` is `Some` only when the session
embedded the engine — unchanged from #1881, and there is still no flag that
hands that credential to an attached client. `print.rs`, `tui/mod.rs`, and
`serve()` each construct the executor only from a token they own. An attached
`--server` run gains nothing: it still emits the #1881 notice for a folder
request and now simply gets its folder *reads* answered by the server process,
which is the one that has the state.

**4. No new grant paths.** `handles()` (`folder_executor.rs:594`) is a closed
match over the five already-connected-folder tools;
`REQUEST_FOLDER_ACCESS_TOOL` is absent, so a folder request is never claimed,
never dispatched, and never resolved here. `is_canonical_folder_call` rejects it
too. #1881's refusal path is behaviourally unchanged: `decline_folder_request`
and `decline` are the same sequence, and the resolve body is still
`{"status":"completed","result":…}` — the new `ClientExecutionOutcome` type
omits `rows` rather than sending null, so the wire bytes are identical. The
`folder_executor::tests::the_executor_never_answers_a_request_for_new_folder_access`
test fails if a folder-request name is ever added to the dispatch table.

**5. Crash recovery does not regress, and fails closed where it cannot match.**
The desktop's policy is mirrored exactly. The lease token is chosen and synced
to disk before the claim. `dispatch_started` is synced before any host I/O; on
recovery an interrupted **read** is terminalized with
`folder_operation_interrupted` rather than replayed, because the broker keeps no
read receipt to reconcile against. An **import** may be retried, because the
server derives its document id from the origin URI, so a repeat converges on the
one source. The terminal outcome is written before it is published, so a crash in
between republishes the same result. A claim conflict and a resolve conflict are
both decided against the server's pending set rather than assumed final — a 409
is also what a momentarily locked conversation returns, and discarding a receipt
on one would strand the call.

`write_output_to_connected_folder` is the case the CLI **cannot** honor: it
writes host bytes through the exec write overlay (snapshot, trash, undo), and a
headless embedding installs no `ExecFolderGrantResolver`, so it has none of that.
Rather than improvise a second, unreversible write path, the executor fails it
closed with `output_writeback_authority_unavailable` — the same code the desktop
emits when its own materializer is missing. The turn continues; nothing is
written. `docs/deferred.md` records why and what lifting it would take.

That same absence is why nothing here consults a staged folder view: with no
folder-grant resolver, no connected folder is ever staged, so there is no
per-turn copy for the broker's answer to disagree with. The module says an
embedding that gains one must extend the executor in the same change.

## Deliberate trade-offs worth review

- **The model-facing payload shaping is duplicated from the desktop executor**
  (`serialize_result`, the three byte bounds, the capability vocabulary). It is
  not shared because there is nowhere to put it: `openwave-host-broker` is a
  leaf, `openwave-core` does not depend on it, and `openwave-server`
  deliberately does not either. The alternative — a feature-gated
  broker-payload module in `openwave-core` — adds a cross-crate edge and
  rewrites the desktop's reviewed executor, which is more blast radius than this
  change should carry. Both copies are pinned by tests and cross-reference each
  other in comments.
- **`openwave tui` is included** though the issue named print mode and `serve`.
  It embeds the same engine and had the identical hang, and it is six lines. Say
  so if you would rather it were separate.
- **Two new dependency edges**, `base64` and `tracing`, both already
  workspace-pinned. `Cargo.lock` changes by exactly those two lines; no version
  moved. Diagnostics go through `tracing` rather than stderr because the loop
  polls — a repeating `eprintln!` would flood a print run's stderr and overwrite
  the TUI's terminal.
- **`serve` walks every conversation it can see each pass**, as the desktop
  executor does. There is no cross-chat route for parked client calls, and
  adding one is more server surface than this needs.

## Tests

- `openwave-cli/tests/folder.rs::an_unattended_turn_reads_a_folder_the_operator_connected`
  — connect a folder as an operator, then run an unattended `-p` turn (scripted
  provider) that calls `list_folder`, `read_connected_file`, and
  `import_connected_file` against it. Asserts every call completed, the turn
  completed, exit 0, and the folder was not modified. **Verified to fail without
  the executor**: with `FolderExecutor::new` forced to `None` the run hangs and
  the test times out, which is the reported bug exactly.
- `…::a_serve_daemon_executes_folder_calls_for_an_attached_client` — the same
  turn driven by a plain `--server` client against `openwave serve`. The client
  holds only a bearer token and cannot execute anything; the daemon does. Covers
  the `serve` half and the attach boundary in one turn.
- `folder_executor::tests` — five unit tests: no route from the executor to
  `request_folder_access`; a path the broker would refuse never becomes a host
  operation; every terminal answer is bounded and free of host detail; only a
  convergent operation may be repeated after an interruption; and the folder
  listing reports the broker's own capabilities.
- `folder_executor::receipts::tests::a_receipt_survives_the_process_that_wrote_it`
  — the phase and the exact lease token come back from a fresh store over the
  same directory, and a published receipt leaves nothing to re-run.

No tests were deleted.

## Verified / not verified

Passing locally: `cargo test -p openwave-cli --locked` (33 tests),
`cargo fmt --all -- --check`,
`cargo clippy -p openwave-cli -p openwave-server --all-targets`,
`cargo check --workspace --locked` (no lock drift).

Not verified: the desktop app rendering a conversation whose folder calls this
executor answered. The result payload and card rows are asserted against the
shapes the desktop's own executor produces, not against the rendered UI. The
executor also acts only where the server's launch bearer resolves to a
principal, so on the shared self-host profile — where that bearer names nobody —
it sees no conversations and does nothing, which is the correct failure for a
deployment that has no operator-connected host folders of its own.

Closes #1884
