### PR TITLE
feat(core): gateway connected-app binding vocabulary for local apps

### DIFF
--- a/crates/openwave-core/src/local_app.rs
+++ b/crates/openwave-core/src/local_app.rs
@@ -8,7 +8,8 @@
 //!
 //! Each revision pairs an untrusted HTML bundle (bytes on disk, recorded here
 //! as length + digest) with a trusted, structurally validated manifest naming
-//! the connected-app operations and folders the app may call.
+//! the connected-app operations, folders, and gateway-app operations the app
+//! may call.
 
 use std::path::PathBuf;
 
@@ -52,6 +53,15 @@ pub const MAX_APP_NAME_CHARS: usize = 120;
 /// one. Duplicated here rather than imported because the manifest contract
 /// must not depend on server code.
 pub const MAX_OPERATION_ID_BYTES: usize = 128;
+/// Largest gateway connected-app id a gateway binding may name, in bytes.
+///
+/// The id is the gateway's own identifier for the app — opaque here, and
+/// deliberately not parsed as any particular identity shape: today's gateway
+/// mints UUIDs, and a manifest that pinned that assumption would break the
+/// day it mints anything else. The bound and charset only keep an id
+/// printable, loggable, and small enough to store beside the rest of the
+/// manifest.
+pub const MAX_GATEWAY_APP_ID_BYTES: usize = 128;
 
 /// Profile-data location of one immutable revision's bundle bytes.
 ///
@@ -196,9 +206,10 @@ pub struct CreateApp {
 }
 
 /// The durable consent object for one app: the granted binding set —
-/// `(app, operation_ids[])` per bound connected app, or `(folder, access)`
-/// per bound folder — with each bound connected app pinned to a fingerprint
-/// of its definition as it was configured at consent time.
+/// `(app, operation_ids[])` per bound connected app, `(folder, access)` per
+/// bound folder, or `(gateway_app, operation_ids[])` per bound gateway app —
+/// with each bound target pinned to a fingerprint of its definition as it
+/// stood at consent time.
 ///
 /// One grant per app, replaced wholesale by a fresh consent and deleted by
 /// revocation. The fingerprint is what keeps consent honest: a Settings edit
@@ -220,9 +231,10 @@ pub struct AppGrant {
 /// One granted binding: the capabilities the user consented to under one
 /// connected app, pinned to the definition that record carried at consent.
 ///
-/// Untagged, mirroring [`AppBinding`]: the variants differ in exactly one
-/// field name, and unknown fields refuse both shapes, so a persisted grant
-/// binding deserializes to exactly the vocabulary it was granted under.
+/// Untagged, mirroring [`AppBinding`]: the variants are told apart by the
+/// field naming their target (`app`, `folder`, `gateway_app`), and unknown
+/// fields refuse every shape, so a persisted grant binding deserializes to
+/// exactly the vocabulary it was granted under.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum AppGrantBinding {
@@ -230,16 +242,30 @@ pub enum AppGrantBinding {
     Operations(AppOperationsGrantBinding),
     /// `{ folder, access, fingerprint }` — granted folder access.
     Folder(AppFolderGrantBinding),
+    /// `{ gateway_app, operation_ids[], fingerprint }` — granted operations
+    /// of a connected app the model gateway holds.
+    GatewayOperations(AppGatewayOperationsGrantBinding),
 }
 
 impl AppGrantBinding {
-    /// The connected app the grant binding names, when it names one — a
-    /// folder grant binding names a broker root instead.
+    /// The locally configured connected app the grant binding names, when it
+    /// names one — a folder grant binding names a broker root and a gateway
+    /// grant binding names an app the gateway holds, neither of which is a
+    /// local record.
     #[must_use]
     pub fn app(&self) -> Option<ConnectedAppId> {
         match self {
             Self::Operations(binding) => Some(binding.app),
-            Self::Folder(_) => None,
+            Self::Folder(_) | Self::GatewayOperations(_) => None,
+        }
+    }
+
+    /// The gateway connected app the grant binding names, when it names one.
+    #[must_use]
+    pub fn gateway_app(&self) -> Option<&str> {
+        match self {
+            Self::GatewayOperations(binding) => Some(&binding.gateway_app),
+            Self::Operations(_) | Self::Folder(_) => None,
         }
     }
 
@@ -249,6 +275,7 @@ impl AppGrantBinding {
         match self {
             Self::Operations(binding) => binding.fingerprint,
             Self::Folder(binding) => binding.fingerprint,
+            Self::GatewayOperations(binding) => binding.fingerprint,
         }
     }
 }
@@ -282,6 +309,31 @@ pub struct AppFolderGrantBinding {
     /// SHA-256 fingerprint over the folder grant's canonical form — the root
     /// id and access level, never a path or display name. Persisted as
     /// lowercase hex.
+    #[serde(with = "hex_fingerprint")]
+    pub fingerprint: [u8; 32],
+}
+
+/// The granted operations of one connected app the model gateway holds.
+///
+/// The twin of [`AppGatewayOperationsBinding`], pinned like every other grant
+/// binding: consent named a gateway app *as the gateway described it*, so a
+/// re-ingested catalog or a re-pairing to a different gateway moves the
+/// fingerprint and re-prompts. Entitlement is deliberately outside the pin —
+/// it is the gateway's live predicate, re-evaluated per call, and losing it
+/// fails the call rather than revoking the consent.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AppGatewayOperationsGrantBinding {
+    /// Gateway connected-app id the consent names, matching the manifest
+    /// binding it covers.
+    pub gateway_app: String,
+    /// Operation ids the grant covers, as the gateway's catalog declares
+    /// them.
+    pub operation_ids: Vec<String>,
+    /// SHA-256 fingerprint over the gateway app's canonical form — the
+    /// gateway's origin, the app id, and the hash of the operation catalog it
+    /// declared at consent time, never a credential (none exists locally for
+    /// a gateway app). Persisted as lowercase hex.
     #[serde(with = "hex_fingerprint")]
     pub fingerprint: [u8; 32],
 }
@@ -331,6 +383,10 @@ pub fn validate_app_grant(grant: &AppGrant) -> Result<serde_json::Value, String>
             BindingKey::Folder(binding.folder),
             BindingCapabilities::Folder,
         ),
+        AppGrantBinding::GatewayOperations(binding) => (
+            BindingKey::GatewayApp(&binding.gateway_app),
+            BindingCapabilities::Operations(&binding.operation_ids),
+        ),
     }))?;
     serde_json::to_value(&grant.bindings).map_err(|error| format!("unencodable app grant: {error}"))
 }
@@ -354,8 +410,8 @@ pub struct AppManifest {
 }
 
 /// The capabilities one binding contributes to a local app: declared REST
-/// operations of a `rest_api` connected app, or bounded access to a
-/// connected folder.
+/// operations of a `rest_api` connected app, bounded access to a connected
+/// folder, or declared operations of a connected app the model gateway holds.
 ///
 /// Untagged and closed: the shapes are distinguished by their differing
 /// field names, each variant refuses unknown fields, and a body mixing
@@ -368,16 +424,29 @@ pub enum AppBinding {
     Operations(AppOperationsBinding),
     /// `{ folder, access }` — bounded access to a connected folder.
     Folder(AppFolderBinding),
+    /// `{ gateway_app, operation_ids[] }` — declared operations of a
+    /// connected app the model gateway holds.
+    GatewayOperations(AppGatewayOperationsBinding),
 }
 
 impl AppBinding {
-    /// The connected app the binding names, when it names one — a folder
-    /// binding names a broker root instead.
+    /// The locally configured connected app the binding names, when it names
+    /// one — a folder binding names a broker root and a gateway binding names
+    /// an app the gateway holds, neither of which is a local record.
     #[must_use]
     pub fn app(&self) -> Option<ConnectedAppId> {
         match self {
             Self::Operations(binding) => Some(binding.app),
-            Self::Folder(_) => None,
+            Self::Folder(_) | Self::GatewayOperations(_) => None,
+        }
+    }
+
+    /// The gateway connected app the binding names, when it names one.
+    #[must_use]
+    pub fn gateway_app(&self) -> Option<&str> {
+        match self {
+            Self::GatewayOperations(binding) => Some(&binding.gateway_app),
+            Self::Operations(_) | Self::Folder(_) => None,
         }
     }
 }
@@ -395,6 +464,27 @@ pub struct AppOperationsBinding {
     /// document.
     #[schemars(description = "OpenAPI operationIds declared by the bound rest_api \
                        connected app's catalog.")]
+    pub operation_ids: Vec<String>,
+}
+
+/// The declared operations one connected app of the model gateway
+/// contributes to a local app.
+///
+/// The gateway app is named by the gateway's own connected-app id — the same
+/// identifier the gateway's shared-app manifests bind — and nothing about it
+/// resolves locally: no definition, no catalog, and no credential exists on
+/// this machine. A binding here is a network binding, executed by relaying to
+/// the gateway as the signed-in user.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AppGatewayOperationsBinding {
+    /// Id of the gateway connected app the operations belong to, opaque to
+    /// OpenWave.
+    #[schemars(description = "Id of the gateway connected app these operations belong to.")]
+    pub gateway_app: String,
+    /// Operation ids of the bound gateway app's declared catalog.
+    #[schemars(description = "Operation ids declared by the bound gateway connected \
+                       app's catalog.")]
     pub operation_ids: Vec<String>,
 }
 
@@ -496,6 +586,10 @@ pub fn validate_app_manifest(manifest: &AppManifest) -> Result<serde_json::Value
             BindingKey::Folder(binding.folder),
             BindingCapabilities::Folder,
         ),
+        AppBinding::GatewayOperations(binding) => (
+            BindingKey::GatewayApp(&binding.gateway_app),
+            BindingCapabilities::Operations(&binding.operation_ids),
+        ),
     }))?;
     let json =
         serde_json::to_value(manifest).map_err(|error| format!("unencodable manifest: {error}"))?;
@@ -509,11 +603,14 @@ pub fn validate_app_manifest(manifest: &AppManifest) -> Result<serde_json::Value
 }
 
 /// One binding's identity for the duplicate check: the connected app it
-/// binds, or the folder root it binds.
+/// binds, the folder root it binds, or the gateway app it binds. The three
+/// namespaces are disjoint by construction — a gateway app id that happens to
+/// spell a local record's id is still a different key.
 #[derive(PartialEq, Eq, Hash)]
-enum BindingKey {
+enum BindingKey<'a> {
     App(ConnectedAppId),
     Folder(HostRootId),
+    GatewayApp(&'a str),
 }
 
 /// One binding's capability list, by vocabulary, for the shared grammar check.
@@ -523,16 +620,17 @@ enum BindingCapabilities<'a> {
 }
 
 /// The binding grammar shared by manifests and grants: no duplicate connected
-/// apps or folders (one binding per record or root, whichever vocabulary),
-/// and every operation id within the ingest module's `operationId` grammar. A
-/// folder binding has no list to validate — its access level is closed by
-/// type.
+/// apps, folders, or gateway apps (one binding per record, root, or gateway
+/// app, whichever vocabulary), and every operation id within the ingest
+/// module's `operationId` grammar. A folder binding has no list to validate —
+/// its access level is closed by type.
 ///
 /// The grammar here is structural only; the catalog membership check for
 /// operation ids belongs to the host layers that resolve ids (the
-/// `create_app` door, grant computation, the invoke gate).
+/// `create_app` door, grant computation, the invoke gate), and for a gateway
+/// app the gateway resolves both the app and its catalog.
 fn validate_binding_set<'a>(
-    bindings: impl Iterator<Item = (BindingKey, BindingCapabilities<'a>)>,
+    bindings: impl Iterator<Item = (BindingKey<'a>, BindingCapabilities<'a>)>,
 ) -> Result<(), String> {
     let mut keys = std::collections::HashSet::new();
     for (key, capabilities) in bindings {
@@ -545,6 +643,23 @@ fn validate_binding_set<'a>(
             BindingKey::Folder(folder) => {
                 if keys.contains(&key) {
                     return Err(format!("duplicate binding for folder {folder}"));
+                }
+            }
+            BindingKey::GatewayApp(gateway_app) => {
+                // The id is the gateway's, so it is bounded and kept
+                // printable rather than parsed: OpenWave never interprets it.
+                if gateway_app.is_empty()
+                    || gateway_app.len() > MAX_GATEWAY_APP_ID_BYTES
+                    || !gateway_app.bytes().all(|byte| byte.is_ascii_graphic())
+                {
+                    return Err(format!(
+                        "gateway app id {gateway_app:?} must be 1 to \
+                         {MAX_GATEWAY_APP_ID_BYTES} bytes of printable, non-whitespace \
+                         ASCII"
+                    ));
+                }
+                if keys.contains(&key) {
+                    return Err(format!("duplicate binding for gateway app {gateway_app}"));
                 }
             }
         }
@@ -739,6 +854,118 @@ mod tests {
                 "{body}"
             );
         }
+    }
+
+    /// The gateway vocabulary joins the same untagged, closed grammar: its
+    /// shape parses to its own arm, mixing it with a local app-keyed shape
+    /// matches nothing, its id lives in its own namespace for the duplicate
+    /// check, and its grant twin round-trips with the pinned fingerprint.
+    #[test]
+    fn gateway_bindings_parse_closed_and_keep_their_own_namespace() {
+        use serde_json::json;
+
+        let app = ConnectedAppId::new();
+        let gateway_app = "0f6d2f6a-1f0d-4a0e-9f6a-6f9d1d2f3a4b";
+        let binding: AppBinding = serde_json::from_value(
+            json!({ "gateway_app": gateway_app, "operation_ids": ["listIssues"] }),
+        )
+        .unwrap();
+        let AppBinding::GatewayOperations(gateway) = &binding else {
+            panic!("a gateway shape must parse as a gateway binding");
+        };
+        assert_eq!(gateway.gateway_app, gateway_app);
+        // A gateway binding names no local record; it names the gateway's.
+        assert!(binding.app().is_none());
+        assert_eq!(binding.gateway_app(), Some(gateway_app));
+
+        // Closed on every edge: a mixed shape, a bare id, and an unknown
+        // field all refuse.
+        for body in [
+            json!({ "gateway_app": gateway_app, "app": app, "operation_ids": [] }),
+            json!({ "gateway_app": gateway_app, "operation_ids": [], "extra": true }),
+            json!({ "gateway_app": gateway_app }),
+        ] {
+            assert!(
+                serde_json::from_value::<AppBinding>(body.clone()).is_err(),
+                "{body}"
+            );
+        }
+
+        // The id grammar is bounded and printable, and its operation ids obey
+        // the same grammar the local operations arm does.
+        let manifest = |gateway_app: &str, operation_ids: &[&str]| AppManifest {
+            name: "Org issues".into(),
+            bindings: vec![AppBinding::GatewayOperations(AppGatewayOperationsBinding {
+                gateway_app: gateway_app.to_owned(),
+                operation_ids: operation_ids.iter().map(|id| (*id).to_owned()).collect(),
+            })],
+        };
+        assert!(validate_app_manifest(&manifest(gateway_app, &["listIssues"])).is_ok());
+        for bad_id in ["", "has space", &"x".repeat(MAX_GATEWAY_APP_ID_BYTES + 1)] {
+            assert!(
+                validate_app_manifest(&manifest(bad_id, &[])).is_err(),
+                "{bad_id:?}"
+            );
+        }
+        assert!(validate_app_manifest(&manifest(gateway_app, &["bad id"])).is_err());
+        assert!(
+            validate_app_manifest(&AppManifest {
+                name: "Twice".into(),
+                bindings: vec![
+                    AppBinding::GatewayOperations(AppGatewayOperationsBinding {
+                        gateway_app: gateway_app.to_owned(),
+                        operation_ids: Vec::new(),
+                    }),
+                    AppBinding::GatewayOperations(AppGatewayOperationsBinding {
+                        gateway_app: gateway_app.to_owned(),
+                        operation_ids: Vec::new(),
+                    }),
+                ],
+            })
+            .is_err(),
+            "duplicate gateway-app bindings are refused"
+        );
+        // The namespaces are disjoint: a gateway id that spells a local
+        // record's id binds a different thing, and the two coexist.
+        assert!(validate_app_manifest(&AppManifest {
+            name: "Both".into(),
+            bindings: vec![
+                AppBinding::Operations(AppOperationsBinding {
+                    app,
+                    operation_ids: vec!["listIssues".into()],
+                }),
+                AppBinding::GatewayOperations(AppGatewayOperationsBinding {
+                    gateway_app: app.to_string(),
+                    operation_ids: vec!["listIssues".into()],
+                }),
+            ],
+        })
+        .is_ok());
+
+        // The grant twin round-trips with its pinned fingerprint, keeps the
+        // untagged discrimination, and refuses the unpinned shape.
+        let fingerprint = "ef".repeat(32);
+        let granted: AppGrantBinding = serde_json::from_value(json!({
+            "gateway_app": gateway_app,
+            "operation_ids": ["listIssues"],
+            "fingerprint": fingerprint,
+        }))
+        .unwrap();
+        assert!(matches!(granted, AppGrantBinding::GatewayOperations(_)));
+        assert!(granted.app().is_none());
+        assert_eq!(granted.gateway_app(), Some(gateway_app));
+        assert_eq!(granted.fingerprint(), [0xef; 32]);
+        assert!(serde_json::from_value::<AppGrantBinding>(
+            json!({ "gateway_app": gateway_app, "operation_ids": [] })
+        )
+        .is_err());
+        // A local operations grant never reads as a gateway grant, whichever
+        // way the ids happen to spell.
+        let local: AppGrantBinding = serde_json::from_value(
+            json!({ "app": app, "operation_ids": [], "fingerprint": fingerprint }),
+        )
+        .unwrap();
+        assert!(local.gateway_app().is_none());
     }
 
     /// The folder vocabulary joins the same untagged, closed grammar: its

--- a/crates/openwave-core/src/tools/create_app.rs
+++ b/crates/openwave-core/src/tools/create_app.rs
@@ -120,6 +120,10 @@ impl CreateAppTool {
     /// approved folder and speaks a live vocabulary: operation bindings
     /// resolve to a `rest_api` record with each pinned `operationId` declared
     /// by its ingested catalog.
+    ///
+    /// A gateway binding names an app only the model gateway can resolve, and
+    /// this door has no roster to resolve it against, so it is refused here:
+    /// admitting one would author a pin the consent surface could not grant.
     async fn check_bindings(&self, manifest: &AppManifest) -> std::result::Result<(), String> {
         if manifest.bindings.is_empty() {
             return Ok(());
@@ -130,6 +134,15 @@ impl CreateAppTool {
             .await
             .map_err(|_| "could not read the configured connected apps".to_owned())?;
         for binding in &manifest.bindings {
+            // A gateway app is the gateway's record, not a local one: nothing
+            // here can name it, and nothing local could grant it.
+            if let AppBinding::GatewayOperations(binding) = binding {
+                return Err(format!(
+                    "gateway app {:?} cannot be bound here; only configured \
+                     connected apps and approved connected folders are bindable",
+                    binding.gateway_app
+                ));
+            }
             // A folder binding resolves against the host's approved
             // connected folders — when this embedding has none, the door
             // says so instead of admitting an ungrantable pin.
@@ -166,7 +179,7 @@ impl CreateAppTool {
             }
             let binding_app = binding
                 .app()
-                .expect("only folder bindings lack a connected app");
+                .expect("folder and gateway bindings returned above");
             let Some(app) = connected.iter().find(|app| app.id == binding_app) else {
                 let configured: Vec<String> = connected
                     .iter()
@@ -185,9 +198,9 @@ impl CreateAppTool {
                 });
             };
             match binding {
-                // Handled above — a folder binding has no connected app to
-                // resolve.
-                AppBinding::Folder(_) => {}
+                // Handled above — neither a folder nor a gateway binding has
+                // a local connected app to resolve.
+                AppBinding::Folder(_) | AppBinding::GatewayOperations(_) => {}
                 AppBinding::Operations(binding) => {
                     if app.kind != ConnectedAppKind::RestApi {
                         return Err(format!(

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -272,11 +272,15 @@ revisions: Array<AppRevisionSummary>, };
 /**
  * One current-manifest binding, projected for the consent sheet.
  *
- * Exactly one of `app` and `folder` is present, matching what the binding
- * names. An app-keyed row carries `operation_ids`; a folder row carries
- * `access`. The sheet derives the combined-consent exfiltration warning
+ * Exactly one of `app` and `folder` is present for the two locally resolved
+ * vocabularies, matching what the binding names. An app-keyed row carries
+ * `operation_ids`; a folder row carries `access`. A gateway binding carries
+ * its operation ids and, once one reads back, the gateway app's display
+ * name — it names neither a local record nor a root, so both id fields stay
+ * absent until this projection carries the gateway's own id. The sheet
+ * derives the combined-consent exfiltration warning
  * (docs/folder-bindings.md) from the rows themselves: a manifest with both a
- * folder row and an operations row can read files and reach the network.
+ * folder row and a network row can read files and reach the network.
  */
 export type AppGrantBindingState = { 
 /**

--- a/crates/openwave-server/src/connected_apps.rs
+++ b/crates/openwave-server/src/connected_apps.rs
@@ -150,6 +150,97 @@ pub(crate) struct AppFingerprint {
     pub(crate) fingerprint: [u8; 32],
 }
 
+/// SHA-256 fingerprint of one gateway connected app as the gateway currently
+/// describes it — the value an app grant pins a gateway binding to.
+///
+/// The digest is taken over the UTF-8 bytes of a compact JSON object with
+/// **exactly these keys, in exactly this order** (serde serializes struct
+/// fields in declaration order, and every key is always present):
+///
+/// ```json
+/// {"v":2,
+///  "kind":"gateway_app",
+///  "gateway_base_url":string,
+///  "gateway_app_id":string,
+///  "catalog_sha256":string}
+/// ```
+///
+/// `gateway_base_url` is the origin of the gateway that served the app, so
+/// re-pairing this profile to a different gateway makes every gateway grant
+/// stale rather than silently carrying consent across deployments.
+/// `catalog_sha256` is the hash of the operation catalog the gateway declared
+/// for the app, so a re-ingested app re-prompts. Entitlement is deliberately
+/// absent: it is the gateway's live predicate, re-evaluated on every call, and
+/// losing it must fail the call rather than revoke the consent. No credential
+/// enters the form because none exists locally — the gateway injects the
+/// viewer's own. `kind` roots the form in the connected-app vocabulary so no
+/// two kinds can collide on a canonical serialization, and `v:2` matches the
+/// `rest_api` and `mcp_server` forms' current version.
+///
+/// **This canonical form is a compatibility surface.** Persisted grants store
+/// the digest; changing the form (or the meaning of any field in it)
+/// invalidates every existing grant and must bump `v`.
+pub(crate) fn gateway_app_fingerprint(
+    gateway_base_url: &str,
+    gateway_app_id: &str,
+    catalog_sha256: &str,
+) -> [u8; 32] {
+    use sha2::Digest as _;
+
+    #[derive(Serialize)]
+    struct CanonicalGatewayApp<'a> {
+        v: u32,
+        kind: &'static str,
+        gateway_base_url: &'a str,
+        gateway_app_id: &'a str,
+        catalog_sha256: &'a str,
+    }
+
+    let canonical = CanonicalGatewayApp {
+        v: 2,
+        kind: "gateway_app",
+        gateway_base_url,
+        gateway_app_id,
+        catalog_sha256,
+    };
+    let bytes = serde_json::to_vec(&canonical)
+        .expect("a canonical definition serializes infallibly to JSON");
+    sha2::Sha256::digest(&bytes).into()
+}
+
+/// Hash of a gateway app's operation catalog, derived from the operation ids
+/// it declares: lowercase hex SHA-256 over the sorted ids joined by newlines.
+///
+/// A local stand-in, not a protocol: the gateway's catalog read carries no
+/// document hash today, so the ids it declares are the only stable
+/// description of the catalog available to pin. Sorting makes the digest
+/// independent of the order the gateway happens to list them in. When the
+/// gateway serves a catalog-document hash, this derivation is replaced by it
+/// — which moves every gateway fingerprint, so that change must bump the
+/// canonical form's `v`.
+pub(crate) fn catalog_sha256_from_operation_ids(operation_ids: &[String]) -> String {
+    use sha2::Digest as _;
+    use std::fmt::Write as _;
+
+    let mut sorted: Vec<&str> = operation_ids.iter().map(String::as_str).collect();
+    sorted.sort_unstable();
+    sorted.dedup();
+    let digest = sha2::Sha256::digest(sorted.join("\n").as_bytes());
+    let mut hex = String::with_capacity(64);
+    for byte in digest {
+        let _ = write!(hex, "{byte:02x}");
+    }
+    hex
+}
+
+/// One gateway connected app's display name and current fingerprint — the
+/// gateway-side twin of [`AppFingerprint`], keyed by the gateway's app id
+/// rather than a local record id.
+pub(crate) struct GatewayAppFingerprint {
+    pub(crate) name: String,
+    pub(crate) fingerprint: [u8; 32],
+}
+
 /// The current fingerprint of every configured connected app, across kinds.
 ///
 /// `mcp_server` entries come from the live MCP runtime; `rest_api` entries
@@ -198,12 +289,18 @@ pub(crate) struct CurrentFingerprints {
     /// this embedding has no host-folder seam, so every folder binding fails
     /// closed to "not connected".
     pub(crate) folders: BTreeMap<HostRootId, String>,
+    /// Gateway connected apps this profile can currently read, by the
+    /// gateway's app id. Empty when nothing readable answers — no gateway, no
+    /// session, or no catalog — so every gateway binding fails closed to
+    /// re-consent rather than matching a fingerprint over a catalog nobody
+    /// read.
+    pub(crate) gateway_apps: BTreeMap<String, GatewayAppFingerprint>,
 }
 
 impl CurrentFingerprints {
     /// Whether one granted binding still pins what its target carries right
-    /// now. A missing record or a disconnected folder is a mismatch, never a
-    /// match.
+    /// now. A missing record, a disconnected folder, or a gateway app that
+    /// does not currently read back is a mismatch, never a match.
     pub(crate) fn grant_binding_current(&self, binding: &AppGrantBinding) -> bool {
         match binding {
             AppGrantBinding::Operations(binding) => self
@@ -214,6 +311,10 @@ impl CurrentFingerprints {
                 self.folders.contains_key(&binding.folder)
                     && folder_fingerprint(binding.folder, binding.access) == binding.fingerprint
             }
+            AppGrantBinding::GatewayOperations(binding) => self
+                .gateway_apps
+                .get(&binding.gateway_app)
+                .is_some_and(|app| app.fingerprint == binding.fingerprint),
         }
     }
 }
@@ -229,7 +330,61 @@ pub(crate) async fn current_fingerprints(
             folders.insert(folder.root_id, folder.display_name);
         }
     }
-    Ok(CurrentFingerprints { apps, folders })
+    let gateway_apps = current_gateway_app_fingerprints(state).await?;
+    Ok(CurrentFingerprints {
+        apps,
+        folders,
+        gateway_apps,
+    })
+}
+
+/// One gateway connected app as a live read describes it: the origin that
+/// served it, the gateway's id for it, its display name, and the operation
+/// ids its catalog declares — exactly the fingerprint inputs.
+// Nothing constructs this yet: [`current_gateway_app_catalogs`] deliberately
+// reads nothing until the gateway serves per-app operation catalogs, and the
+// empty read is what keeps gateway grants failing closed. The shape is here
+// because it is the contract that read must answer in.
+#[allow(dead_code)]
+pub(crate) struct GatewayAppCatalog {
+    pub(crate) gateway_base_url: String,
+    pub(crate) id: String,
+    pub(crate) name: String,
+    pub(crate) operation_ids: Vec<String>,
+}
+
+/// The gateway connected apps this profile could bind, read live.
+///
+/// Answers empty: the gateway's entitled-apps listing carries no operation
+/// catalogs, and fingerprinting an app over a catalog nobody read would pin
+/// consent to a fiction. Reading nothing is the fail-closed direction —
+/// [`CurrentFingerprints::grant_binding_current`] treats a missing entry as
+/// stale, so a gateway grant re-prompts instead of matching.
+async fn current_gateway_app_catalogs(
+    state: &AppState,
+) -> openwave_core::Result<Vec<GatewayAppCatalog>> {
+    let _ = state;
+    Ok(Vec::new())
+}
+
+/// The current fingerprint of every readable gateway connected app, by the
+/// gateway's app id.
+async fn current_gateway_app_fingerprints(
+    state: &AppState,
+) -> openwave_core::Result<BTreeMap<String, GatewayAppFingerprint>> {
+    let mut current = BTreeMap::new();
+    for app in current_gateway_app_catalogs(state).await? {
+        let catalog_sha256 = catalog_sha256_from_operation_ids(&app.operation_ids);
+        let fingerprint = gateway_app_fingerprint(&app.gateway_base_url, &app.id, &catalog_sha256);
+        current.insert(
+            app.id,
+            GatewayAppFingerprint {
+                name: app.name,
+                fingerprint,
+            },
+        );
+    }
+    Ok(current)
 }
 
 /// Every stored `rest_api` record whose definition parses, read live.
@@ -394,6 +549,89 @@ mod tests {
             },
         );
         assert_eq!(rest_api_fingerprint(&with_operations), baseline);
+    }
+
+    /// The gateway canonical form pins exactly the three inputs the record
+    /// names: the gateway origin, the app id, and the catalog hash. Moving
+    /// any one moves the digest, and the catalog hash follows the declared
+    /// operation ids as a set rather than the order they arrive in.
+    #[test]
+    fn gateway_fingerprints_derive_from_origin_app_and_catalog_only() {
+        let ids = |ids: &[&str]| -> Vec<String> { ids.iter().map(|id| (*id).to_owned()).collect() };
+        let catalog = catalog_sha256_from_operation_ids(&ids(&["listIssues", "getIssue"]));
+        let baseline = gateway_app_fingerprint("https://gw.example.com", "app-1", &catalog);
+
+        // The same three inputs always fingerprint the same, and the catalog
+        // hash is order-independent: the gateway may list operations in any
+        // order without re-prompting the user.
+        assert_eq!(
+            gateway_app_fingerprint(
+                "https://gw.example.com",
+                "app-1",
+                &catalog_sha256_from_operation_ids(&ids(&["getIssue", "listIssues"])),
+            ),
+            baseline
+        );
+
+        // Re-pairing to another gateway, naming another app, or a catalog
+        // that gained, lost, or renamed an operation each change what the
+        // user consented to.
+        for changed in [
+            gateway_app_fingerprint("https://other.example.com", "app-1", &catalog),
+            gateway_app_fingerprint("https://gw.example.com", "app-2", &catalog),
+            gateway_app_fingerprint(
+                "https://gw.example.com",
+                "app-1",
+                &catalog_sha256_from_operation_ids(&ids(&["listIssues"])),
+            ),
+            gateway_app_fingerprint(
+                "https://gw.example.com",
+                "app-1",
+                &catalog_sha256_from_operation_ids(&ids(&[
+                    "listIssues",
+                    "getIssue",
+                    "createIssue",
+                ])),
+            ),
+        ] {
+            assert_ne!(changed, baseline);
+        }
+
+        // No form collides across kinds even when the inputs coincide: the
+        // `kind` key roots each canonical form in its own vocabulary.
+        assert_ne!(
+            baseline,
+            rest_api_fingerprint(&definition("https://gw.example.com", &catalog, None))
+        );
+    }
+
+    /// A gateway grant reads stale against the surface this build can see:
+    /// nothing populates the gateway map yet, and a missing entry is a
+    /// mismatch — so a gateway binding re-prompts rather than matching.
+    #[test]
+    fn gateway_grants_read_stale_against_an_unread_gateway_surface() {
+        let current = CurrentFingerprints {
+            apps: BTreeMap::new(),
+            folders: BTreeMap::new(),
+            gateway_apps: BTreeMap::new(),
+        };
+        let granted = |fingerprint: [u8; 32]| {
+            AppGrantBinding::GatewayOperations(
+                openwave_core::local_app::AppGatewayOperationsGrantBinding {
+                    gateway_app: "app-1".into(),
+                    operation_ids: vec!["listIssues".into()],
+                    fingerprint,
+                },
+            )
+        };
+        assert!(
+            !current.grant_binding_current(&granted(gateway_app_fingerprint(
+                "https://gw.example.com",
+                "app-1",
+                &catalog_sha256_from_operation_ids(&["listIssues".to_owned()]),
+            )))
+        );
+        assert!(!current.grant_binding_current(&granted([0; 32])));
     }
 
     /// The definition fails closed: unknown fields, missing fields, and a

--- a/crates/openwave-server/src/routes/app_grant.rs
+++ b/crates/openwave-server/src/routes/app_grant.rs
@@ -17,8 +17,8 @@ use serde::Serialize;
 
 use openwave_core::id::{AppId, ConnectedAppId, HostRootId};
 use openwave_core::local_app::{
-    AppBinding, AppFolderGrantBinding, AppGrant, AppGrantBinding, AppManifest,
-    AppOperationsGrantBinding, AppRecord, AppRevision, FolderAccess,
+    AppBinding, AppFolderGrantBinding, AppGatewayOperationsGrantBinding, AppGrant, AppGrantBinding,
+    AppManifest, AppOperationsGrantBinding, AppRecord, AppRevision, FolderAccess,
 };
 
 use crate::connected_apps::{current_fingerprints, current_rest_definitions, CurrentFingerprints};
@@ -48,11 +48,15 @@ pub struct AppGrantState {
 
 /// One current-manifest binding, projected for the consent sheet.
 ///
-/// Exactly one of `app` and `folder` is present, matching what the binding
-/// names. An app-keyed row carries `operation_ids`; a folder row carries
-/// `access`. The sheet derives the combined-consent exfiltration warning
+/// Exactly one of `app` and `folder` is present for the two locally resolved
+/// vocabularies, matching what the binding names. An app-keyed row carries
+/// `operation_ids`; a folder row carries `access`. A gateway binding carries
+/// its operation ids and, once one reads back, the gateway app's display
+/// name — it names neither a local record nor a root, so both id fields stay
+/// absent until this projection carries the gateway's own id. The sheet
+/// derives the combined-consent exfiltration warning
 /// (docs/folder-bindings.md) from the rows themselves: a manifest with both a
-/// folder row and an operations row can read files and reach the network.
+/// folder row and a network row can read files and reach the network.
 #[derive(Debug, Serialize, ts_rs::TS)]
 pub struct AppGrantBindingState {
     /// Connected app the manifest binds, by record id, for an app-keyed
@@ -128,6 +132,26 @@ pub async fn post_app_grant(
                     access: binding.access,
                     fingerprint: folder_fingerprint(binding.folder, binding.access),
                 }));
+            }
+            AppBinding::GatewayOperations(binding) => {
+                // A gateway binding pins an app the gateway describes. With
+                // nothing readable answering to the id there is no catalog to
+                // fingerprint, so there is nothing coherent to consent to —
+                // the same fail-closed reading as an unconfigured connected
+                // app or a folder that is no longer approved.
+                let Some(gateway_app) = current.gateway_apps.get(&binding.gateway_app) else {
+                    return Err(ServerError::conflict(format!(
+                        "gateway app {} is not available, so this app cannot be granted",
+                        binding.gateway_app
+                    )));
+                };
+                bindings.push(AppGrantBinding::GatewayOperations(
+                    AppGatewayOperationsGrantBinding {
+                        gateway_app: binding.gateway_app.clone(),
+                        operation_ids: binding.operation_ids.clone(),
+                        fingerprint: gateway_app.fingerprint,
+                    },
+                ));
             }
             AppBinding::Operations(binding) => {
                 // A binding whose connected app is not configured cannot be
@@ -240,13 +264,20 @@ fn binding_covered(pinned: &AppBinding, granted: &AppGrantBinding) -> bool {
             granted.folder == pinned.folder
                 && (granted.access == pinned.access || granted.access == FolderAccess::ReadWrite)
         }
+        (AppBinding::GatewayOperations(pinned), AppGrantBinding::GatewayOperations(granted)) => {
+            granted.gateway_app == pinned.gateway_app
+                && pinned
+                    .operation_ids
+                    .iter()
+                    .all(|operation| granted.operation_ids.iter().any(|held| held == operation))
+        }
         _ => false,
     }
 }
 
 /// The grant binding covering one manifest binding's target, when the grant
 /// names it: app-keyed bindings match by record id, folder bindings by root
-/// id.
+/// id, and gateway bindings by the gateway's app id.
 fn granted_binding_for<'a>(
     grant: Option<&'a AppGrant>,
     binding: &AppBinding,
@@ -256,7 +287,10 @@ fn granted_binding_for<'a>(
         AppBinding::Folder(binding) => {
             matches!(candidate, AppGrantBinding::Folder(granted) if granted.folder == binding.folder)
         }
-        _ => binding.app().is_some() && candidate.app() == binding.app(),
+        AppBinding::GatewayOperations(binding) => candidate
+            .gateway_app()
+            .is_some_and(|granted| granted == binding.gateway_app),
+        AppBinding::Operations(binding) => candidate.app() == Some(binding.app),
     })
 }
 
@@ -282,14 +316,20 @@ pub(crate) fn grant_state(
                 granted_binding.is_some_and(|granted| current.grant_binding_current(granted));
             let (operation_ids, access) = match binding {
                 AppBinding::Operations(binding) => (Some(binding.operation_ids.clone()), None),
+                AppBinding::GatewayOperations(binding) => {
+                    (Some(binding.operation_ids.clone()), None)
+                }
                 AppBinding::Folder(binding) => (None, Some(binding.access)),
             };
             let name = match binding {
                 AppBinding::Folder(binding) => current.folders.get(&binding.folder).cloned(),
-                _ => binding
-                    .app()
-                    .and_then(|app| current.apps.get(&app))
+                AppBinding::GatewayOperations(binding) => current
+                    .gateway_apps
+                    .get(&binding.gateway_app)
                     .map(|app| app.name.clone()),
+                AppBinding::Operations(binding) => {
+                    current.apps.get(&binding.app).map(|app| app.name.clone())
+                }
             };
             AppGrantBindingState {
                 app: binding.app(),

--- a/crates/openwave-server/src/routes/app_invoke.rs
+++ b/crates/openwave-server/src/routes/app_invoke.rs
@@ -361,7 +361,11 @@ fn require_pinned_operation(
                 .operation_ids
                 .iter()
                 .any(|pinned| pinned == operation_id),
-            AppBinding::Folder(_) => false,
+            // A gateway binding pins operation ids too, but of an app only
+            // the gateway can execute. This surface dispatches to a local
+            // `rest_api` record, so a gateway pin must never admit a call to
+            // it — the relay is its own surface.
+            AppBinding::Folder(_) | AppBinding::GatewayOperations(_) => false,
         });
     if pinned {
         return Ok(());
@@ -390,7 +394,7 @@ fn require_pinned_folder(
                     && (!writes
                         || binding.access == openwave_core::local_app::FolderAccess::ReadWrite)
             }
-            AppBinding::Operations(_) => false,
+            AppBinding::Operations(_) | AppBinding::GatewayOperations(_) => false,
         });
     if pinned {
         return Ok(());
@@ -519,14 +523,20 @@ async fn require_app_grant(
         // a reconfigured connected app or a disconnected folder invalidates
         // the whole grant, failing closed to re-consent.
         if !current.grant_binding_current(binding) {
-            return Err(consent_required(match binding.app() {
-                Some(app) => format!(
-                    "connected app {app} was reconfigured after consent; the grant is \
-                     stale"
+            return Err(consent_required(match binding {
+                AppGrantBinding::Operations(binding) => format!(
+                    "connected app {} was reconfigured after consent; the grant is \
+                     stale",
+                    binding.app
                 ),
-                None => {
+                AppGrantBinding::Folder(_) => {
                     "a granted folder was disconnected after consent; the grant is stale".to_owned()
                 }
+                AppGrantBinding::GatewayOperations(binding) => format!(
+                    "gateway app {} no longer reads as it did at consent; the grant \
+                     is stale",
+                    binding.gateway_app
+                ),
             }));
         }
     }

--- a/crates/openwave-server/src/routes/connected_apps.rs
+++ b/crates/openwave-server/src/routes/connected_apps.rs
@@ -513,7 +513,9 @@ async fn connected_apps_info(state: &AppState) -> Result<ConnectedAppsInfo, Serv
         std::collections::BTreeMap::new();
     for grant in state.store.list_live_app_grants().await? {
         for binding in &grant.bindings {
-            // Folder grant bindings name broker roots, not connected apps.
+            // Folder grant bindings name broker roots and gateway grant
+            // bindings name apps the gateway holds; neither is a record on
+            // this surface, and `app()` answers `None` for both.
             if let Some(app) = binding.app() {
                 *used_by.entry(app).or_default() += 1;
             }

--- a/docs/connected-apps.md
+++ b/docs/connected-apps.md
@@ -80,6 +80,13 @@ SHA-256 over base URL + OpenAPI document hash + credential *reference* +
 placement. Rotating the credential value behind the same reference does not
 invalidate consent; repointing the reference does.
 
+A manifest may also bind `{ gateway_app, operation_ids[] }` — an app the
+model gateway holds, named by the gateway's own id (record 7). It is not a
+connected-app record and nothing about it resolves locally, so it keys off
+its own namespace, carries its own canonical fingerprint form, and is refused
+by the authoring door until the gateway roster, consent, and relay surfaces
+exist.
+
 The consent sheet leads with the app's display name ("Sentry") and lists
 pinned capabilities under it — a legibility improvement over leading with
 mounted tool names.

--- a/docs/local-apps.md
+++ b/docs/local-apps.md
@@ -34,9 +34,16 @@ An app revision is an untrusted **bundle** and a trusted **manifest**:
 - The manifest is small, structural JSON: a display name and
   `bindings: [{ app, operation_ids[] }]` naming declared operations under the
   connected-app records ([connected-apps.md](connected-apps.md)) that
-  contribute them, or `{ folder, access }` naming a connected folder. The
-  manifest — not the bundle — is what the user consents to and what the host
-  enforces per call.
+  contribute them, `{ folder, access }` naming a connected folder, or
+  `{ gateway_app, operation_ids[] }` naming a connected app the model gateway
+  holds (record 7). The manifest — not the bundle — is what the user consents
+  to and what the host enforces per call.
+
+  The gateway shape is vocabulary today: the type, its grant twin, and its
+  fingerprint exist, but nothing reads the gateway's app catalogs yet, so no
+  gateway app resolves, the authoring door refuses the shape, and any gateway
+  grant reads stale — fail-closed in every direction until the roster,
+  consent, and relay surfaces land.
 
 The containment story is inherited from MCP App views and unchanged: the frame
 is served by the host with its own strict CSP (`default-src 'none'`,
@@ -182,13 +189,14 @@ where a team-scoped copy is stored, served, and brokered by the gateway under
 each viewer's own entitlements. Three properties keep that door open without
 building anything now:
 
-- **The binding vocabulary maps.** An operation binding against a
-  gateway-hosted API translates mechanically to the gateway's manifest
-  vocabulary (endpoint slug, proxied operation set). Promotion walks the
-  bindings and refuses with a precise list when any binding is not
-  gateway-resolvable — an app bound to a purely local API cannot promote, by
-  construction. (Retiring tool bindings, above, removed the widest class of
-  unpromotable bindings outright.)
+- **The binding vocabulary maps.** A gateway binding already names what the
+  gateway's own shared-app manifests name, so promotion is a copy rather than
+  a translation — record 7 rejected the translate-at-publish design that this
+  bullet originally assumed, because a manifest that has to be rewritten at
+  share time was never run the way its viewers will run it. An app bound to a
+  purely local API still cannot promote, by construction. (Retiring tool
+  bindings, above, removed the widest class of unpromotable bindings
+  outright.)
 - **Revision identity carries.** Digests, ordinals, and producer provenance
   become the published revision's provenance.
 - **Attestation flips from limitation to benefit.** Once the gateway brokers


### PR DESCRIPTION
The vocabulary half of the gateway app bindings design
(`docs/decisions/0007-gateway-app-bindings.md`): the third `AppBinding`
arm, `{ gateway_app, operation_ids[] }`, naming a connected app the model
gateway holds.

The arm joins the existing untagged, closed grammar unchanged — field
names discriminate, unknown fields refuse, and the duplicate check gives
gateway ids their own namespace, so a gateway id that spells a local
record's id binds a different thing. `AppGrantBinding` gains the matching
pinned twin.

Server-side, `gateway_app_fingerprint` states the canonical form grants
pin — gateway origin, app id, catalog hash, with entitlement deliberately
outside it — and `CurrentFingerprints` gains the gateway map the grant,
invoke, and library surfaces already compare against.

Nothing populates that map yet: no gateway serves per-app operation
catalogs, and fingerprinting an app over a catalog nobody read would pin
consent to a fiction. The empty read is the fail-closed direction in every
direction that matters — a gateway grant never reads current, consent
conflicts rather than granting, the authoring door refuses the shape, and
the local invoke surface never admits an operation a gateway binding pins.

Adding an arm to a closed enum means every match over the binding
vocabulary had to be audited by hand rather than left to the compiler,
because several of them dispatch on an extracted field rather than on the
variant. That sweep found a real defect: `create_app`'s binding loop
extracted a connected-app id with `.expect("only folder bindings lack a
connected app")`, an assumption a gateway binding breaks — it would have
panicked the tool call. The loop now refuses the gateway arm before that
point, with a message naming what is bindable here, and the assertion's
text no longer claims something untrue.

Tests: one closed-parse test covers the third arm end to end — the arm
parses, mixed-shape bindings refuse, unknown fields refuse, and the same
spelling in the gateway and local namespaces stays two distinct bindings;
one fingerprint test pins that the digest derives from exactly base URL,
app id, and catalog hash, moving when any of the three moves and not
otherwise; and one pins the fail-closed reading, that a gateway grant
reads stale against a surface nothing has read. The generated wire file
follows a doc-comment change on the grant projection; no field moved.

Stacked: PR 2 of 6, on top of #1932. PR 3 builds on this one.
