### PR TITLE
feat(server): gateway app roster and catalog discovery for local-app authoring

### DIFF
--- a/crates/openwave-core/src/local_app.rs
+++ b/crates/openwave-core/src/local_app.rs
@@ -571,6 +571,31 @@ pub trait ApprovedFolderSource: Send + Sync {
     async fn approved_folders(&self) -> Vec<(HostRootId, String)>;
 }
 
+/// One connected app of the model gateway, as the authoring door sees it.
+pub struct GatewayAuthoringApp {
+    /// The gateway's connected-app id — what a manifest binding names.
+    pub id: String,
+    /// Display name, for the refusal that lists what is bindable.
+    pub name: String,
+    /// The operation ids the gateway's catalog declares for the app.
+    pub operation_ids: Vec<String>,
+}
+
+/// Best-effort authoring-time lookup of the gateway connected apps this
+/// profile could bind, for the `create_app` door and its roster.
+///
+/// Legibility, not the gate: the consent and invoke surfaces resolve live
+/// against the gateway. The core crate cannot see the gateway session, so the
+/// server injects this.
+#[async_trait::async_trait]
+pub trait GatewayAppSource: Send + Sync {
+    /// Every bindable gateway app, or `None` when this profile has no gateway
+    /// session to answer with — which is a different statement from
+    /// `Some(vec![])`, a session that answered with nothing entitled. The door
+    /// refuses either way, but only the first can be fixed by signing in.
+    async fn entitled_apps(&self) -> Option<Vec<GatewayAuthoringApp>>;
+}
+
 /// Validate an app manifest structurally and return the JSON to store.
 ///
 /// Checks the display name, the grammar of every binding, and the serialized

--- a/crates/openwave-core/src/tools/create_app.rs
+++ b/crates/openwave-core/src/tools/create_app.rs
@@ -40,6 +40,9 @@ pub struct CreateAppTool {
     /// Authoring-time lookup of approved connected folders, when this
     /// embedding has one. Absent, folder bindings refuse at the door.
     folders: Option<Arc<dyn crate::local_app::ApprovedFolderSource>>,
+    /// Authoring-time lookup of the gateway's connected apps, when this
+    /// embedding has one. Absent, gateway bindings refuse at the door.
+    gateway_apps: Option<Arc<dyn crate::local_app::GatewayAppSource>>,
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -54,9 +57,12 @@ pub(super) struct Arguments {
                        capabilities it may call, grouped by binding. A binding \
                        either names a rest_api connected app by id with the \
                        declared OpenAPI operationIds it may execute \
-                       (`{app, operation_ids}`), or an approved connected folder \
+                       (`{app, operation_ids}`), an approved connected folder \
                        by root id with an access level \
-                       (`{folder, access: \"read\"|\"read_write\"}`). The tool \
+                       (`{folder, access: \"read\"|\"read_write\"}`), or a \
+                       connected app of the model gateway by its gateway id \
+                       with the operation ids it declares \
+                       (`{gateway_app, operation_ids}`). The tool \
                        description lists the available ids. Mounted MCP tools \
                        cannot be bound.")]
     manifest: AppManifest,
@@ -78,6 +84,7 @@ impl CreateAppTool {
             store,
             profile_data_dir,
             folders: None,
+            gateway_apps: None,
         }
     }
 
@@ -89,6 +96,17 @@ impl CreateAppTool {
         folders: Arc<dyn crate::local_app::ApprovedFolderSource>,
     ) -> Self {
         self.folders = Some(folders);
+        self
+    }
+
+    /// Let the door resolve gateway bindings against the connected apps the
+    /// model gateway holds for this profile.
+    #[must_use]
+    pub fn with_gateway_apps(
+        mut self,
+        gateway_apps: Arc<dyn crate::local_app::GatewayAppSource>,
+    ) -> Self {
+        self.gateway_apps = Some(gateway_apps);
         self
     }
 
@@ -116,14 +134,12 @@ impl CreateAppTool {
             .ok_or_else(|| ToolOutput::error("this call is not recorded in this conversation"))
     }
 
-    /// Check that every manifest binding names a configured connected app or
-    /// approved folder and speaks a live vocabulary: operation bindings
-    /// resolve to a `rest_api` record with each pinned `operationId` declared
-    /// by its ingested catalog.
-    ///
-    /// A gateway binding names an app only the model gateway can resolve, and
-    /// this door has no roster to resolve it against, so it is refused here:
-    /// admitting one would author a pin the consent surface could not grant.
+    /// Check that every manifest binding names a configured connected app,
+    /// approved folder, or entitled gateway app and speaks a live vocabulary:
+    /// operation bindings resolve to a `rest_api` record with each pinned
+    /// `operationId` declared by its ingested catalog, and gateway bindings
+    /// resolve to an app the gateway currently declares, with each pinned
+    /// operation id in the catalog it declares for it.
     async fn check_bindings(&self, manifest: &AppManifest) -> std::result::Result<(), String> {
         if manifest.bindings.is_empty() {
             return Ok(());
@@ -133,15 +149,64 @@ impl CreateAppTool {
             .list_connected_apps()
             .await
             .map_err(|_| "could not read the configured connected apps".to_owned())?;
+        // Resolved once for the whole manifest: a manifest may carry several
+        // gateway bindings and the lookup is a live read across the network.
+        // `None` covers both no seam and no session — the door cannot tell
+        // them apart and does not need to, because the fix for both is the
+        // same sentence.
+        let gateway_apps = match &self.gateway_apps {
+            Some(source)
+                if manifest
+                    .bindings
+                    .iter()
+                    .any(|binding| binding.gateway_app().is_some()) =>
+            {
+                source.entitled_apps().await
+            }
+            _ => None,
+        };
         for binding in &manifest.bindings {
-            // A gateway app is the gateway's record, not a local one: nothing
-            // here can name it, and nothing local could grant it.
+            // A gateway binding names an app only the gateway can resolve:
+            // no definition, no catalog, and no credential for it exists on
+            // this machine.
             if let AppBinding::GatewayOperations(binding) = binding {
-                return Err(format!(
-                    "gateway app {:?} cannot be bound here; only configured \
-                     connected apps and approved connected folders are bindable",
-                    binding.gateway_app
-                ));
+                let Some(entitled) = &gateway_apps else {
+                    return Err(
+                        "this profile has no gateway session, so gateway app bindings \
+                         cannot be authored"
+                            .to_owned(),
+                    );
+                };
+                let Some(app) = entitled.iter().find(|app| app.id == binding.gateway_app) else {
+                    let available: Vec<String> = entitled
+                        .iter()
+                        .map(|app| format!("{} ({})", app.id, app.name))
+                        .collect();
+                    return Err(if available.is_empty() {
+                        format!(
+                            "gateway app {:?} is not available to this profile, and no \
+                             gateway apps are",
+                            binding.gateway_app
+                        )
+                    } else {
+                        format!(
+                            "gateway app {:?} is not available to this profile; bind one \
+                             of: {}",
+                            binding.gateway_app,
+                            available.join(", ")
+                        )
+                    });
+                };
+                for operation_id in &binding.operation_ids {
+                    if !app.operation_ids.contains(operation_id) {
+                        return Err(format!(
+                            "operation {operation_id:?} is not declared by gateway app \
+                             {} ({})",
+                            app.id, app.name
+                        ));
+                    }
+                }
+                continue;
             }
             // A folder binding resolves against the host's approved
             // connected folders — when this embedding has none, the door
@@ -823,6 +888,116 @@ mod tests {
         let (_, ctx) = sourced.recorded_call().await;
         let created = tool
             .execute(&ctx, folder_manifest(*approved.as_uuid()))
+            .await
+            .unwrap();
+        assert!(!created.is_error, "{}", created.content);
+    }
+
+    /// The door resolves gateway bindings against the profile's gateway
+    /// session: no session refuses with the one fix the user has (sign in),
+    /// an unentitled id refuses with what is bindable spelled out, an
+    /// undeclared operation names the app it is not declared by, and a
+    /// declared pin publishes (docs/decisions/0007).
+    #[tokio::test]
+    async fn gateway_bindings_resolve_against_the_gateway_session_at_the_door() {
+        use crate::local_app::{GatewayAppSource, GatewayAuthoringApp};
+
+        struct StaticGateway(Option<Vec<GatewayAuthoringApp>>);
+
+        #[async_trait]
+        impl GatewayAppSource for StaticGateway {
+            async fn entitled_apps(&self) -> Option<Vec<GatewayAuthoringApp>> {
+                self.0.as_ref().map(|apps| {
+                    apps.iter()
+                        .map(|app| GatewayAuthoringApp {
+                            id: app.id.clone(),
+                            name: app.name.clone(),
+                            operation_ids: app.operation_ids.clone(),
+                        })
+                        .collect()
+                })
+            }
+        }
+
+        let gateway_manifest = |gateway_app: &str, operation_ids: &[&str]| {
+            json!({
+                "bundle_html": "<!doctype html><h1>Incidents</h1>",
+                "manifest": {
+                    "name": "Incident board",
+                    "bindings": [{
+                        "gateway_app": gateway_app,
+                        "operation_ids": operation_ids,
+                    }],
+                },
+            })
+        };
+        let entitled = || {
+            vec![GatewayAuthoringApp {
+                id: "app-incident".into(),
+                name: "Incident API".into(),
+                operation_ids: vec!["listIncidents".into()],
+            }]
+        };
+
+        // No source at all, and a source reporting no session, are the same
+        // refusal: the fix for both is a gateway session.
+        for source in [None, Some(Arc::new(StaticGateway(None)))] {
+            let fixture = fixture().await;
+            let tool = match source {
+                Some(source) => {
+                    CreateAppTool::new(fixture.store.clone(), fixture.profile_dir.clone())
+                        .with_gateway_apps(source)
+                }
+                None => CreateAppTool::new(fixture.store.clone(), fixture.profile_dir.clone()),
+            };
+            let (_, ctx) = fixture.recorded_call().await;
+            let refused = tool
+                .execute(&ctx, gateway_manifest("app-incident", &["listIncidents"]))
+                .await
+                .unwrap();
+            assert!(refused.is_error);
+            assert!(
+                refused.content.contains("no gateway session"),
+                "{}",
+                refused.content
+            );
+        }
+
+        let fixture = fixture().await;
+        let tool = CreateAppTool::new(fixture.store.clone(), fixture.profile_dir.clone())
+            .with_gateway_apps(Arc::new(StaticGateway(Some(entitled()))));
+
+        // An id the session does not answer to refuses with the alternatives.
+        let (_, ctx) = fixture.recorded_call().await;
+        let refused = tool
+            .execute(&ctx, gateway_manifest("app-ghost", &["listIncidents"]))
+            .await
+            .unwrap();
+        assert!(refused.is_error);
+        assert!(
+            refused.content.contains("Incident API"),
+            "{}",
+            refused.content
+        );
+
+        // An operation the gateway's catalog does not declare refuses naming
+        // the app it is not declared by.
+        let (_, ctx) = fixture.recorded_call().await;
+        let refused = tool
+            .execute(&ctx, gateway_manifest("app-incident", &["ghostOp"]))
+            .await
+            .unwrap();
+        assert!(refused.is_error);
+        assert!(
+            refused.content.contains("not declared by gateway app"),
+            "{}",
+            refused.content
+        );
+
+        // A declared pin on an entitled app publishes.
+        let (_, ctx) = fixture.recorded_call().await;
+        let created = tool
+            .execute(&ctx, gateway_manifest("app-incident", &["listIncidents"]))
             .await
             .unwrap();
         assert!(!created.is_error, "{}", created.content);

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1137,7 +1137,13 @@ export type FolderAccess = "read" | "read_write";
  * One entitled connected app, with the slugs of the MCP endpoints that
  * aggregate it — the `mcp:<slug>` resources a mount would request.
  */
-export type GatewayAppInfo = { id: string, name: string, app_kind: string, enabled: boolean, mcp_endpoint_slugs: Array<string>, };
+export type GatewayAppInfo = { id: string, name: string, app_kind: string, enabled: boolean, mcp_endpoint_slugs: Array<string>, 
+/**
+ * How many live local-app grants bind this gateway app — the same
+ * "Used by N local apps" line the connected-apps page carries per record,
+ * so a user can see what a revocation here would break.
+ */
+used_by_app_count: number, };
 
 /**
  * Renderer-safe list of the connected apps the signed-in user is entitled

--- a/crates/openwave-desktop/ui/src/settings/ConnectedAppsPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ConnectedAppsPanel.dom.test.tsx
@@ -109,6 +109,7 @@ function signedInOverrides() {
           app_kind: "mcp_server",
           enabled: true,
           mcp_endpoint_slugs: ["primary"],
+          used_by_app_count: 0,
         },
       ],
     }),

--- a/crates/openwave-desktop/ui/src/settings/ConnectedAppsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ConnectedAppsPanel.tsx
@@ -25,6 +25,7 @@ import {
   SettingsField,
   SettingsPanel,
   SettingsSection,
+  usedByLabel,
 } from "./primitives";
 
 type RestEntry = Extract<ConnectedAppInfo, { kind: "rest_api" }>;
@@ -126,11 +127,6 @@ function mcpTitle(entry: McpEntry): string {
   return entry.gateway_endpoint !== null && entry.gateway_apps.length > 0
     ? entry.gateway_apps.join(", ")
     : entry.name;
-}
-
-/** The one line naming how many local mini-apps bind an entry. */
-function usedByLabel(count: number): string {
-  return `Used by ${count} local app${count === 1 ? "" : "s"}`;
 }
 
 /**

--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
@@ -179,6 +179,7 @@ describe("GatewayPanel", () => {
             app_kind: "rest_api",
             enabled: true,
             mcp_endpoint_slugs: ["example-security-tools"],
+            used_by_app_count: 2,
           },
         ],
       }),
@@ -187,6 +188,8 @@ describe("GatewayPanel", () => {
 
     expect(await screen.findByText("Incident API")).toBeInTheDocument();
     expect(screen.getByText(/via example-security-tools/)).toBeInTheDocument();
+    // What a revocation here would break: the local apps bound to this app.
+    expect(screen.getByText("Used by 2 local apps")).toBeInTheDocument();
 
     cleanup();
     // A gateway that predates the JSON apps surface: no section, no error.
@@ -217,6 +220,7 @@ describe("GatewayPanel", () => {
             app_kind: "rest_api",
             enabled: true,
             mcp_endpoint_slugs: ["example-security-tools"],
+            used_by_app_count: 2,
           },
         ],
       }),

--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
@@ -9,6 +9,7 @@ import {
   SettingsPanel,
   SettingsSection,
   SettingsStatus,
+  usedByLabel,
 } from "./primitives";
 
 const SIGN_IN_POLL_MS = 2_000;
@@ -332,6 +333,11 @@ function ManagedGatewayPanel({
                     {app.mcp_endpoint_slugs.length > 0 && (
                       <p className="text-muted-foreground text-xs">
                         via {app.mcp_endpoint_slugs.join(", ")}
+                      </p>
+                    )}
+                    {app.used_by_app_count > 0 && (
+                      <p className="text-muted-foreground text-xs">
+                        {usedByLabel(app.used_by_app_count)}
                       </p>
                     )}
                   </li>

--- a/crates/openwave-desktop/ui/src/settings/McpPanel.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/McpPanel.test.tsx
@@ -84,6 +84,7 @@ const incidentApps = {
       app_kind: "rest_api",
       enabled: true,
       mcp_endpoint_slugs: ["example-security-tools"],
+      used_by_app_count: 0,
     },
   ],
 };

--- a/crates/openwave-desktop/ui/src/settings/primitives.tsx
+++ b/crates/openwave-desktop/ui/src/settings/primitives.tsx
@@ -120,3 +120,12 @@ export function SettingsError({ children }: { children: ReactNode }) {
     </p>
   );
 }
+
+/**
+ * The one line naming how many local mini-apps bind a capability — a
+ * connected-app record or a gateway app alike. Shared so the two pages that
+ * carry the count cannot drift into two spellings of the same sentence.
+ */
+export function usedByLabel(count: number): string {
+  return `Used by ${count} local app${count === 1 ? "" : "s"}`;
+}

--- a/crates/openwave-server/src/connected_apps.rs
+++ b/crates/openwave-server/src/connected_apps.rs
@@ -9,7 +9,7 @@
 //! request — never cached across one — so enforcement always judges the
 //! definition an id resolves to *now*.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -320,8 +320,14 @@ impl CurrentFingerprints {
 }
 
 /// Read the whole current fingerprint surface, live per request.
+///
+/// `needed_gateway_apps` bounds the gateway half: each gateway app's catalog
+/// is a separate live read, so callers name exactly the ids the bindings they
+/// are about to judge mention. An id nothing readable answers to is simply
+/// absent from the result, which reads as stale.
 pub(crate) async fn current_fingerprints(
     state: &AppState,
+    needed_gateway_apps: &BTreeSet<String>,
 ) -> openwave_core::Result<CurrentFingerprints> {
     let apps = current_app_fingerprints(state).await?;
     let mut folders = BTreeMap::new();
@@ -330,7 +336,7 @@ pub(crate) async fn current_fingerprints(
             folders.insert(folder.root_id, folder.display_name);
         }
     }
-    let gateway_apps = current_gateway_app_fingerprints(state).await?;
+    let gateway_apps = current_gateway_app_fingerprints(state, needed_gateway_apps).await;
     Ok(CurrentFingerprints {
         apps,
         folders,
@@ -338,53 +344,85 @@ pub(crate) async fn current_fingerprints(
     })
 }
 
-/// One gateway connected app as a live read describes it: the origin that
-/// served it, the gateway's id for it, its display name, and the operation
-/// ids its catalog declares — exactly the fingerprint inputs.
-// Nothing constructs this yet: [`current_gateway_app_catalogs`] deliberately
-// reads nothing until the gateway serves per-app operation catalogs, and the
-// empty read is what keeps gateway grants failing closed. The shape is here
-// because it is the contract that read must answer in.
-#[allow(dead_code)]
+/// The gateway app ids a set of manifest bindings names.
+pub(crate) fn gateway_apps_bound_by<'a>(
+    bindings: impl IntoIterator<Item = &'a openwave_core::local_app::AppBinding>,
+) -> BTreeSet<String> {
+    bindings
+        .into_iter()
+        .filter_map(|binding| binding.gateway_app().map(str::to_owned))
+        .collect()
+}
+
+/// The gateway app ids a set of grant bindings names.
+pub(crate) fn gateway_apps_granted_by<'a>(
+    bindings: impl IntoIterator<Item = &'a AppGrantBinding>,
+) -> BTreeSet<String> {
+    bindings
+        .into_iter()
+        .filter_map(|binding| binding.gateway_app().map(str::to_owned))
+        .collect()
+}
+
+/// One gateway connected app's catalog as a live read describes it: the
+/// display name and the operation ids the gateway declares — the fingerprint
+/// input and the consent-sheet label, and nothing else. No URL, no credential
+/// material, and no upstream detail crosses this seam.
 pub(crate) struct GatewayAppCatalog {
-    pub(crate) gateway_base_url: String,
-    pub(crate) id: String,
     pub(crate) name: String,
     pub(crate) operation_ids: Vec<String>,
 }
 
-/// The gateway connected apps this profile could bind, read live.
+/// The live per-app gateway catalog read the fingerprint surface depends on.
 ///
-/// Answers empty: the gateway's entitled-apps listing carries no operation
-/// catalogs, and fingerprinting an app over a catalog nobody read would pin
-/// consent to a fiction. Reading nothing is the fail-closed direction —
-/// [`CurrentFingerprints::grant_binding_current`] treats a missing entry as
-/// stale, so a gateway grant re-prompts instead of matching.
-async fn current_gateway_app_catalogs(
-    state: &AppState,
-) -> openwave_core::Result<Vec<GatewayAppCatalog>> {
-    let _ = state;
-    Ok(Vec::new())
+/// A seam rather than a direct call into the gateway runtime for the reason
+/// [`RestOperationDispatcher`] is one: the grant, invoke, and library surfaces
+/// are driven end to end in tests, and they cannot each stand up an OAuth
+/// session against a fake deployment to do it. Production is the gateway
+/// runtime itself.
+#[async_trait]
+pub(crate) trait GatewayCatalogSource: Send + Sync {
+    /// The gateway's deployment URL and the catalog of each requested app
+    /// that is enabled, entitled, and catalog-readable.
+    ///
+    /// `None` means this profile has no gateway session to answer with at all
+    /// — unmanaged, misconfigured, signed out, or a gateway too old to serve
+    /// catalogs. A present pair with an id missing from the map means the
+    /// session answered and that app is not bindable, which reads the same way
+    /// downstream: fingerprints fail closed either way.
+    async fn gateway_app_catalogs(
+        &self,
+        needed: &BTreeSet<String>,
+    ) -> Option<(String, BTreeMap<String, GatewayAppCatalog>)>;
 }
 
-/// The current fingerprint of every readable gateway connected app, by the
-/// gateway's app id.
+/// The current fingerprint of every readable gateway connected app among
+/// `needed`, by the gateway's app id.
 async fn current_gateway_app_fingerprints(
     state: &AppState,
-) -> openwave_core::Result<BTreeMap<String, GatewayAppFingerprint>> {
-    let mut current = BTreeMap::new();
-    for app in current_gateway_app_catalogs(state).await? {
-        let catalog_sha256 = catalog_sha256_from_operation_ids(&app.operation_ids);
-        let fingerprint = gateway_app_fingerprint(&app.gateway_base_url, &app.id, &catalog_sha256);
-        current.insert(
-            app.id,
-            GatewayAppFingerprint {
-                name: app.name,
-                fingerprint,
-            },
-        );
+    needed: &BTreeSet<String>,
+) -> BTreeMap<String, GatewayAppFingerprint> {
+    if needed.is_empty() {
+        return BTreeMap::new();
     }
-    Ok(current)
+    let Some((base_url, catalogs)) = state.gateway_catalogs.gateway_app_catalogs(needed).await
+    else {
+        return BTreeMap::new();
+    };
+    catalogs
+        .into_iter()
+        .map(|(id, catalog)| {
+            let catalog_sha256 = catalog_sha256_from_operation_ids(&catalog.operation_ids);
+            let fingerprint = gateway_app_fingerprint(&base_url, &id, &catalog_sha256);
+            (
+                id,
+                GatewayAppFingerprint {
+                    name: catalog.name,
+                    fingerprint,
+                },
+            )
+        })
+        .collect()
 }
 
 /// Every stored `rest_api` record whose definition parses, read live.
@@ -605,9 +643,10 @@ mod tests {
         );
     }
 
-    /// A gateway grant reads stale against the surface this build can see:
-    /// nothing populates the gateway map yet, and a missing entry is a
-    /// mismatch — so a gateway binding re-prompts rather than matching.
+    /// A gateway grant reads stale against a surface that answers nothing:
+    /// an unread gateway map is the shape a profile with no session (or an
+    /// app that lost its entitlement) produces, and a missing entry is a
+    /// mismatch — so the binding re-prompts rather than matching.
     #[test]
     fn gateway_grants_read_stale_against_an_unread_gateway_surface() {
         let current = CurrentFingerprints {

--- a/crates/openwave-server/src/connectors/gateway.rs
+++ b/crates/openwave-server/src/connectors/gateway.rs
@@ -186,6 +186,25 @@ pub struct GatewayApp {
     pub mcp_endpoint_slugs: Vec<String>,
 }
 
+/// One operation a gateway connected app declares, from
+/// `/api/v1/cli/apps/{app_id}/operations`.
+///
+/// Deliberately open (no `deny_unknown_fields`): the gateway's catalog read is
+/// additive and still growing — a catalog-document hash is the field most
+/// likely to arrive next — and a client that refused an enriched payload would
+/// break on the deployment's next release rather than ignoring what it does not
+/// yet use.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct GatewayOperationSummary {
+    /// The operation id a manifest binding pins.
+    pub operation_id: String,
+    /// The HTTP method the gateway executes it with, for display.
+    pub method: String,
+    /// The gateway's own one-line description, when it has one.
+    #[serde(default)]
+    pub summary: Option<String>,
+}
+
 /// One minted access/refresh pair, resource-bound.
 #[derive(Clone, PartialEq, Eq)]
 pub struct TokenSet {
@@ -503,6 +522,37 @@ impl GatewayAuth {
         }
         let list: AppListResponse = decode_json(response, "app request").await?;
         Ok(Some(list.apps))
+    }
+
+    /// The operations one entitled connected app declares, or `None` against a
+    /// gateway that predates the per-app catalog read.
+    ///
+    /// The id is the gateway's own and opaque here, so it is validated against
+    /// the binding grammar and appended as one percent-encoded path segment: a
+    /// value carrying `/` or `..` can never rewrite the request path.
+    pub async fn app_operations(
+        &self,
+        access_token: &str,
+        app_id: &str,
+    ) -> Result<Option<Vec<GatewayOperationSummary>>> {
+        validate_gateway_app_id(app_id)?;
+        let mut url = self.endpoint("/api/v1/cli/apps")?;
+        url.path_segments_mut()
+            .map_err(|()| gateway_error("configuration", "could not build endpoint URL"))?
+            .push(app_id)
+            .push("operations");
+        let response = self
+            .http
+            .get(url)
+            .bearer_auth(access_token)
+            .send()
+            .await
+            .map_err(|error| gateway_error("app catalog request", error.without_url()))?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        let list: OperationListResponse = decode_json(response, "app catalog request").await?;
+        Ok(Some(list.into_operations()))
     }
 
     async fn exchange_code(
@@ -973,6 +1023,16 @@ impl GatewayConnection {
         self.auth.apps(&token).await
     }
 
+    /// One entitled app's declared operations with a `control` token; `None`
+    /// when the gateway predates the per-app catalog read.
+    pub async fn app_operations(
+        &self,
+        app_id: &str,
+    ) -> Result<Option<Vec<GatewayOperationSummary>>> {
+        let token = self.access_token(RESOURCE_CONTROL).await?;
+        self.auth.app_operations(&token, app_id).await
+    }
+
     /// The gateway's MCP endpoint URL for `slug`, under the configured base.
     pub fn mcp_endpoint_url(&self, slug: &str) -> Result<String> {
         validate_mcp_endpoint_slug(slug)?;
@@ -1086,6 +1146,49 @@ struct ModelListResponse {
 #[derive(Deserialize)]
 struct AppListResponse {
     apps: Vec<GatewayApp>,
+}
+
+/// The per-app catalog read's body, in either shape the gateway may serve:
+/// an object keyed by `operations`, or the bare array. Both are accepted
+/// because the surface is being built against this client — pinning one shape
+/// here would make the two repositories' merge order load-bearing — and the
+/// object form leaves room for the catalog-document hash the record expects
+/// to arrive later.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum OperationListResponse {
+    Wrapped {
+        #[serde(default)]
+        operations: Vec<GatewayOperationSummary>,
+    },
+    Bare(Vec<GatewayOperationSummary>),
+}
+
+impl OperationListResponse {
+    fn into_operations(self) -> Vec<GatewayOperationSummary> {
+        match self {
+            Self::Wrapped { operations } | Self::Bare(operations) => operations,
+        }
+    }
+}
+
+/// The gateway app-id contract a request path may carry, mirroring the
+/// manifest binding grammar
+/// ([`openwave_core::local_app::MAX_GATEWAY_APP_ID_BYTES`]): 1–128 bytes of
+/// printable, non-whitespace ASCII. The id is the gateway's and OpenWave never
+/// interprets it; this only bounds what may be appended to a URL.
+fn validate_gateway_app_id(app_id: &str) -> Result<()> {
+    // Pure-dot segments pass the printable-ASCII check but would read as
+    // path navigation to any origin that normalizes dot-segments, routing a
+    // control bearer at a different route.
+    if app_id.is_empty()
+        || app_id.len() > openwave_core::local_app::MAX_GATEWAY_APP_ID_BYTES
+        || !app_id.bytes().all(|byte| byte.is_ascii_graphic())
+        || app_id.bytes().all(|byte| byte == b'.')
+    {
+        return Err(gateway_error("configuration", "invalid gateway app id"));
+    }
+    Ok(())
 }
 
 /// The gateway's endpoint-slug contract: 1–127 bytes of ASCII alphanumerics,

--- a/crates/openwave-server/src/connectors/mod.rs
+++ b/crates/openwave-server/src/connectors/mod.rs
@@ -38,5 +38,5 @@ pub use gateway::{
     has_stored_credentials, has_stored_credentials_for, is_sign_in_required,
     validate_mcp_endpoint_slug, AuthorizedSession, CredentialVault, GatewayApp, GatewayAuth,
     GatewayAuthConfig, GatewayConnection, GatewayCredentials, GatewayIdentity, GatewayMeta,
-    GatewayModel, PendingSignIn, TokenSet, RESOURCE_CONTROL, RESOURCE_LLM,
+    GatewayModel, GatewayOperationSummary, PendingSignIn, TokenSet, RESOURCE_CONTROL, RESOURCE_LLM,
 };

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -13,7 +13,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::connectors::{
-    CredentialVault, GatewayAuth, GatewayAuthConfig, GatewayConnection, RESOURCE_LLM,
+    is_sign_in_required, CredentialVault, GatewayApp, GatewayAuth, GatewayAuthConfig,
+    GatewayConnection, GatewayOperationSummary, RESOURCE_LLM,
 };
 use async_trait::async_trait;
 use openwave_core::{AgentError, Result, SecretProvider, Store};
@@ -131,6 +132,10 @@ pub(crate) struct GatewayAppInfo {
     pub(crate) app_kind: String,
     pub(crate) enabled: bool,
     pub(crate) mcp_endpoint_slugs: Vec<String>,
+    /// How many live local-app grants bind this gateway app — the same
+    /// "Used by N local apps" line the connected-apps page carries per record,
+    /// so a user can see what a revocation here would break.
+    pub(crate) used_by_app_count: usize,
 }
 
 impl GatewayRuntime {
@@ -238,24 +243,46 @@ impl GatewayRuntime {
     /// gateway without the JSON apps surface reports `supported: false`.
     pub(crate) async fn apps(&self) -> Result<GatewayApps> {
         let connection = self.managed_connection().await?;
-        Ok(match connection.apps().await? {
-            Some(apps) => GatewayApps {
-                supported: true,
-                apps: apps
-                    .into_iter()
-                    .map(|app| GatewayAppInfo {
-                        id: app.id,
-                        name: app.name,
-                        app_kind: app.app_kind,
-                        enabled: app.enabled,
-                        mcp_endpoint_slugs: app.mcp_endpoint_slugs,
-                    })
-                    .collect(),
-            },
-            None => GatewayApps {
+        let Some(apps) = connection.apps().await? else {
+            return Ok(GatewayApps {
                 supported: false,
                 apps: Vec::new(),
-            },
+            });
+        };
+        // How many local mini-apps currently bind each gateway app: distinct
+        // live grants naming the id. The binding grammar forbids a grant
+        // naming one gateway app twice, so grants and apps count one-to-one.
+        // Best-effort, like every other projection field here — an unreadable
+        // grant table leaves the counts at zero rather than failing the list.
+        let mut used_by: std::collections::BTreeMap<String, usize> =
+            std::collections::BTreeMap::new();
+        match self.store.list_live_app_grants().await {
+            Ok(grants) => {
+                for grant in grants {
+                    for binding in &grant.bindings {
+                        if let Some(gateway_app) = binding.gateway_app() {
+                            *used_by.entry(gateway_app.to_owned()).or_default() += 1;
+                        }
+                    }
+                }
+            }
+            Err(error) => {
+                tracing::warn!("could not count local apps bound to gateway apps: {error}");
+            }
+        }
+        Ok(GatewayApps {
+            supported: true,
+            apps: apps
+                .into_iter()
+                .map(|app| GatewayAppInfo {
+                    used_by_app_count: used_by.get(&app.id).copied().unwrap_or_default(),
+                    id: app.id,
+                    name: app.name,
+                    app_kind: app.app_kind,
+                    enabled: app.enabled,
+                    mcp_endpoint_slugs: app.mcp_endpoint_slugs,
+                })
+                .collect(),
         })
     }
 
@@ -299,6 +326,106 @@ impl GatewayRuntime {
             tracing::info!("auto-mounted newly entitled gateway MCP endpoints");
         }
         Ok(())
+    }
+
+    /// The gateway's deployment URL and the apps the signed-in user is
+    /// entitled to, or `None` when this profile cannot answer that question.
+    ///
+    /// The non-refusing twin of [`apps`](Self::apps): every state where there
+    /// is nothing to read — unmanaged profile, misconfigured policy, no
+    /// session for the policy's deployment, a session the gateway has since
+    /// revoked, a gateway predating the apps surface — answers `None` rather
+    /// than an error, exactly as [`reconcile_endpoint_mounts`] treats them as
+    /// "nothing to do". Callers use this where a gateway that cannot answer
+    /// must degrade (an authoring roster) or fail closed (a fingerprint read),
+    /// never fault.
+    ///
+    /// The URL is the resolved policy's, the same string every other gateway
+    /// identity is stamped with — so a fingerprint taken from it moves when
+    /// and only when the profile is re-paired.
+    pub(crate) async fn entitled_apps_if_signed_in(
+        &self,
+    ) -> Result<Option<(String, Vec<GatewayApp>)>> {
+        let policy = self.policy().await?;
+        let Some(base_url) = policy.gateway_url.clone().filter(|_| policy.managed) else {
+            return Ok(None);
+        };
+        let Some(connection) = self.connection_for(&policy).await? else {
+            return Ok(None);
+        };
+        if connection.stored_credentials().await?.is_none() {
+            return Ok(None);
+        }
+        match connection.apps().await {
+            Ok(Some(apps)) => Ok(Some((base_url, apps))),
+            Ok(None) => Ok(None),
+            // A revoked or expired session is "signed out", not a fault: the
+            // stored blob outlives the gateway's own session record.
+            Err(error) if is_sign_in_required(&error) => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+
+    /// One entitled app's declared operation catalog, under the same gating as
+    /// [`entitled_apps_if_signed_in`](Self::entitled_apps_if_signed_in): a
+    /// profile that cannot read it answers `None`, never an error.
+    pub(crate) async fn app_catalog(
+        &self,
+        app_id: &str,
+    ) -> Result<Option<Vec<GatewayOperationSummary>>> {
+        let policy = self.policy().await?;
+        let Some(connection) = self.connection_for(&policy).await? else {
+            return Ok(None);
+        };
+        if connection.stored_credentials().await?.is_none() {
+            return Ok(None);
+        }
+        match connection.app_operations(app_id).await {
+            Ok(catalog) => Ok(catalog),
+            Err(error) if is_sign_in_required(&error) => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+
+    /// Every bindable gateway connected app with the operation ids its
+    /// catalog declares — the one live read both the `create_app` roster and
+    /// the authoring door work from.
+    ///
+    /// `None` is "this profile has no gateway session to ask", which the door
+    /// turns into a teachable refusal; `Some(vec![])` is a session that
+    /// answered with nothing bindable. An app whose catalog cannot be read is
+    /// left out: nothing about it could be pinned, so listing it would only
+    /// invite a refusal one step later.
+    pub(crate) async fn app_roster(&self) -> Option<Vec<crate::mcp_config::GatewayRosterApp>> {
+        let entitled = match self.entitled_apps_if_signed_in().await {
+            Ok(Some((_, entitled))) => entitled,
+            Ok(None) => return None,
+            Err(error) => {
+                tracing::warn!("could not read the gateway's entitled apps: {error}");
+                return None;
+            }
+        };
+        let mut roster = Vec::new();
+        for app in entitled.into_iter().filter(|app| app.enabled) {
+            match self.app_catalog(&app.id).await {
+                Ok(Some(operations)) => roster.push(crate::mcp_config::GatewayRosterApp {
+                    id: app.id,
+                    name: app.name,
+                    operation_ids: operations
+                        .into_iter()
+                        .map(|operation| operation.operation_id)
+                        .collect(),
+                }),
+                Ok(None) => {}
+                Err(error) => {
+                    tracing::warn!(
+                        gateway_app = %app.id,
+                        "could not read a gateway app's operation catalog: {error}"
+                    );
+                }
+            }
+        }
+        Some(roster)
     }
 
     /// Start a browser sign-in and return the URL to open.
@@ -389,6 +516,12 @@ impl GatewayRuntime {
                                      (the background sync will retry): {error}"
                                 );
                             }
+                            // The `create_app` roster's gateway section reads
+                            // through this same session, so a fresh sign-in
+                            // has to republish it — otherwise the door keeps
+                            // telling the model there is no gateway session
+                            // until something unrelated rebuilds the registry.
+                            mcp.refresh_connected_app_roster().await;
                             SignInProgress::Idle
                         }
                         Err(error) => SignInProgress::Failed {
@@ -740,6 +873,72 @@ impl crate::mcp_config::GatewayEndpoints for GatewayRuntime {
         connection
             .attested_mcp_access_token(slug, &chat.to_string())
             .await
+    }
+
+    /// The gateway apps the `create_app` roster lists, read live through the
+    /// stored session. Best-effort throughout: no session, an unreachable
+    /// gateway, or a gateway predating either read all answer empty, which
+    /// renders as an absent roster section rather than a failed registry
+    /// rebuild.
+    async fn entitled_app_catalogs(&self) -> Vec<crate::mcp_config::GatewayRosterApp> {
+        self.app_roster().await.unwrap_or_default()
+    }
+}
+
+#[async_trait]
+impl crate::connected_apps::GatewayCatalogSource for GatewayRuntime {
+    /// Resolve the requested gateway apps against the live session: one
+    /// entitled-apps read, then one catalog read per requested id that the
+    /// session actually reaches.
+    ///
+    /// Fail-closed and quiet. A profile that cannot answer at all — unmanaged,
+    /// signed out, a gateway predating either read — answers `None`, and any
+    /// single app that is disabled, unentitled, or catalog-less is simply
+    /// absent from the map. Both readings make a grant naming it stale rather
+    /// than matching a fingerprint over a catalog nobody read.
+    async fn gateway_app_catalogs(
+        &self,
+        needed: &std::collections::BTreeSet<String>,
+    ) -> Option<(
+        String,
+        std::collections::BTreeMap<String, crate::connected_apps::GatewayAppCatalog>,
+    )> {
+        let (base_url, entitled) = match self.entitled_apps_if_signed_in().await {
+            Ok(Some(answered)) => answered,
+            Ok(None) => return None,
+            Err(error) => {
+                tracing::warn!("could not read the gateway's entitled apps: {error}");
+                return None;
+            }
+        };
+        let mut catalogs = std::collections::BTreeMap::new();
+        for app in entitled
+            .into_iter()
+            .filter(|app| app.enabled && needed.contains(&app.id))
+        {
+            match self.app_catalog(&app.id).await {
+                Ok(Some(operations)) => {
+                    catalogs.insert(
+                        app.id,
+                        crate::connected_apps::GatewayAppCatalog {
+                            name: app.name,
+                            operation_ids: operations
+                                .into_iter()
+                                .map(|operation| operation.operation_id)
+                                .collect(),
+                        },
+                    );
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    tracing::warn!(
+                        gateway_app = %app.id,
+                        "could not read a gateway app's operation catalog: {error}"
+                    );
+                }
+            }
+        }
+        Some((base_url, catalogs))
     }
 }
 

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -1100,6 +1100,7 @@ async fn bind_inner(
         store.clone(),
         config.data_dir.clone(),
         host_folders.clone(),
+        gateway.clone(),
     );
     let tools = Arc::new(tools);
     // The resolver, the /gateway routes, and MCP dispatch must share ONE
@@ -1350,6 +1351,7 @@ fn agent_deps(
     source_store: Arc<dyn Store>,
     profile_data_dir: std::path::PathBuf,
     host_folders: Option<Arc<dyn host_folders::HostFolders>>,
+    gateway: Arc<gateway_runtime::GatewayRuntime>,
 ) -> (ToolRegistry, AgentConfig) {
     /// The host-folder seam folded into `create_app`'s authoring-time folder
     /// lookup: approved roots as (id, name) pairs, empty on any error —
@@ -1372,8 +1374,36 @@ fn agent_deps(
         }
     }
 
+    /// The gateway session folded into `create_app`'s authoring-time gateway
+    /// lookup, over the same live reads the roster and the consent surface
+    /// use. `None` — no session, or a gateway that cannot answer — is what
+    /// makes the door refuse gateway bindings with a sentence the user can
+    /// act on.
+    struct GatewayAuthoringSource(Arc<gateway_runtime::GatewayRuntime>);
+
+    #[async_trait::async_trait]
+    impl openwave_core::local_app::GatewayAppSource for GatewayAuthoringSource {
+        async fn entitled_apps(
+            &self,
+        ) -> Option<Vec<openwave_core::local_app::GatewayAuthoringApp>> {
+            Some(
+                self.0
+                    .app_roster()
+                    .await?
+                    .into_iter()
+                    .map(|app| openwave_core::local_app::GatewayAuthoringApp {
+                        id: app.id,
+                        name: app.name,
+                        operation_ids: app.operation_ids,
+                    })
+                    .collect(),
+            )
+        }
+    }
+
     let create_app = {
-        let tool = CreateAppTool::new(source_store.clone(), profile_data_dir);
+        let tool = CreateAppTool::new(source_store.clone(), profile_data_dir)
+            .with_gateway_apps(Arc::new(GatewayAuthoringSource(gateway)));
         match host_folders {
             Some(host) => tool.with_approved_folders(Arc::new(HostFolderAuthoringSource(host))),
             None => tool,

--- a/crates/openwave-server/src/mcp_config/runtime.rs
+++ b/crates/openwave-server/src/mcp_config/runtime.rs
@@ -1083,7 +1083,8 @@ impl McpRuntime {
     ) {
         let rest = self.rest_roster().await;
         let folders = self.folder_roster().await;
-        let registry = self.registry_with(&servers, &rest, &folders);
+        let gateway = self.gateway.entitled_app_catalogs().await;
+        let registry = self.registry_with(&servers, &rest, &folders, &gateway);
         let mut state = self.state.lock().await;
         state.definitions = definitions;
         state.ids = ids;
@@ -1149,7 +1150,8 @@ impl McpRuntime {
     async fn registry_for(&self, state: &RuntimeState) -> ToolRegistry {
         let rest = self.rest_roster().await;
         let folders = self.folder_roster().await;
-        self.registry_with(&state.servers, &rest, &folders)
+        let gateway = self.gateway.entitled_app_catalogs().await;
+        self.registry_with(&state.servers, &rest, &folders, &gateway)
     }
 
     /// Every approved connected folder, for the roster's folders section.
@@ -1175,6 +1177,7 @@ impl McpRuntime {
         servers: &HashMap<String, ManagedServer>,
         rest: &[RestRosterApp],
         folders: &[crate::host_folders::ApprovedFolder],
+        gateway: &[GatewayRosterApp],
     ) -> ToolRegistry {
         let mut registry = self.base_tools.clone();
         for (name, server) in servers {
@@ -1194,7 +1197,7 @@ impl McpRuntime {
         if let Some(inner) = registry.server_tool(CREATE_APP_TOOL) {
             registry.register(Box::new(CreateAppWithRoster {
                 inner,
-                roster: connected_app_roster(rest, folders),
+                roster: connected_app_roster(rest, folders, gateway),
             }));
         }
         registry

--- a/crates/openwave-server/src/mcp_config/tests.rs
+++ b/crates/openwave-server/src/mcp_config/tests.rs
@@ -720,11 +720,48 @@ async fn signed_out_gateway_mounts_degrade_to_a_sign_in_diagnostic() {
     // as "nothing bindable", not as a bindable app with a caveat.
     let state = runtime.state.lock().await;
     assert!(!state.definitions.is_empty());
-    let roster = connected_app_roster(&[], &[]);
+    let roster = connected_app_roster(&[], &[], &[]);
     assert!(
         roster.contains("No rest_api connected apps are configured"),
         "{roster}"
     );
+}
+
+/// The roster's gateway section is where a model learns the ids a gateway
+/// binding names, so it must spell out the binding shape, elide a long
+/// catalog instead of pasting it into every tool description, and be absent
+/// entirely without a gateway session — which is the same thing the door's
+/// refusal says.
+#[test]
+fn the_create_app_roster_lists_gateway_apps_and_elides_long_catalogs() {
+    let operation_ids: Vec<String> = (0..ROSTER_OPERATION_IDS + 5)
+        .map(|index| format!("op{index}"))
+        .collect();
+    let roster = connected_app_roster(
+        &[],
+        &[],
+        &[GatewayRosterApp {
+            id: "app-incident".into(),
+            name: "Incident API".into(),
+            operation_ids: operation_ids.clone(),
+        }],
+    );
+    assert!(
+        roster.contains("app-incident — Incident API (gateway app)"),
+        "{roster}"
+    );
+    assert!(roster.contains("\"gateway_app\": id"), "{roster}");
+    assert!(roster.contains("op0"), "{roster}");
+    assert!(roster.contains('…'), "{roster}");
+    assert!(
+        !roster.contains(operation_ids.last().unwrap().as_str()),
+        "{roster}"
+    );
+
+    // No session, no section: the roster never implies a binding vocabulary
+    // this profile could not resolve.
+    let signed_out = connected_app_roster(&[], &[], &[]);
+    assert!(!signed_out.contains("gateway app"), "{signed_out}");
 }
 
 /// The two non-sign-in gateway failures are different problems with
@@ -958,7 +995,7 @@ async fn replaces_with_a_streamable_http_server_and_mounts_its_tools() {
     // Even a healthy, connected server contributes nothing bindable to
     // the create_app roster: tool bindings are retired (#1332).
     {
-        let roster = connected_app_roster(&[], &[]);
+        let roster = connected_app_roster(&[], &[], &[]);
         assert!(!roster.contains("mcp__gateway__"), "{roster}");
         assert!(
             roster.contains("No rest_api connected apps are configured"),

--- a/crates/openwave-server/src/mcp_config/types.rs
+++ b/crates/openwave-server/src/mcp_config/types.rs
@@ -285,6 +285,17 @@ pub(crate) trait GatewayEndpoints: Send + Sync {
         let _ = chat;
         Ok(self.endpoint(slug).await?.bearer_token)
     }
+
+    /// The gateway connected apps this profile could bind, with the operation
+    /// ids the gateway declares for each — the `create_app` roster's gateway
+    /// section.
+    ///
+    /// Best-effort and never load-bearing: the default answers empty, which is
+    /// exactly what a profile with no gateway session should say. Implementors
+    /// degrade the same way rather than failing a registry rebuild.
+    async fn entitled_app_catalogs(&self) -> Vec<GatewayRosterApp> {
+        Vec::new()
+    }
 }
 
 /// [`openwave_mcp::CallBearerSource`] over the gateway resolver for one
@@ -788,41 +799,47 @@ pub(crate) struct RestRosterApp {
     pub(crate) operation_ids: Vec<String>,
 }
 
+/// One gateway connected app's roster inputs: the gateway's own id a binding
+/// names and the operation ids the gateway declares for it.
+pub(crate) struct GatewayRosterApp {
+    pub(crate) id: String,
+    pub(crate) name: String,
+    pub(crate) operation_ids: Vec<String>,
+}
+
 /// The roster text appended to `create_app`'s description: every configured
 /// `rest_api` connected app with the id a manifest binding names and a
-/// bounded sample of its declared operation ids, plus every approved
-/// connected folder with the root id a folder binding names.
+/// bounded sample of its declared operation ids, every approved connected
+/// folder with the root id a folder binding names, and — when this profile
+/// holds a gateway session — every gateway connected app with the id a
+/// gateway binding names.
 ///
 /// `mcp_server` records are deliberately absent: mounted-tool bindings are
 /// retired (#1332), so listing them would invite the model to author
-/// manifests the door refuses.
+/// manifests the door refuses. A profile with no gateway session lists no
+/// gateway section at all, rather than an empty one: absence is what the
+/// door's refusal already says.
 pub(super) fn connected_app_roster(
     rest: &[RestRosterApp],
     folders: &[crate::host_folders::ApprovedFolder],
+    gateway: &[GatewayRosterApp],
 ) -> String {
-    if rest.is_empty() && folders.is_empty() {
+    if rest.is_empty() && folders.is_empty() && gateway.is_empty() {
         return "\n\nNo rest_api connected apps are configured and no folders are \
                 connected, so only manifests with an empty bindings list can be \
                 created."
             .to_owned();
     }
-    let mut roster =
-        String::from("\n\nAvailable bindings (set each binding's `app` or `folder` to an id):");
+    let mut roster = String::from(
+        "\n\nAvailable bindings (set each binding's `app`, `folder`, or `gateway_app` \
+         to an id):",
+    );
     for app in rest {
-        let mut listed: Vec<&str> = app
-            .operation_ids
-            .iter()
-            .take(ROSTER_OPERATION_IDS)
-            .map(String::as_str)
-            .collect();
-        if app.operation_ids.len() > ROSTER_OPERATION_IDS {
-            listed.push("…");
-        }
         roster.push_str(&format!(
             "\n- {id} — {name} (rest_api): bind with `operation_ids` from: {operations}",
             id = app.id,
             name = app.name,
-            operations = listed.join(", ")
+            operations = listed_operation_ids(&app.operation_ids).join(", ")
         ));
     }
     for folder in folders {
@@ -833,5 +850,28 @@ pub(super) fn connected_app_roster(
             name = folder.display_name,
         ));
     }
+    for app in gateway {
+        roster.push_str(&format!(
+            "\n- {id} — {name} (gateway app): bind with `{{\"gateway_app\": id, \
+             \"operation_ids\": [...]}}` from: {operations}",
+            id = app.id,
+            name = app.name,
+            operations = listed_operation_ids(&app.operation_ids).join(", ")
+        ));
+    }
     roster
+}
+
+/// The operation ids one roster line prints, elided past
+/// [`ROSTER_OPERATION_IDS`].
+fn listed_operation_ids(operation_ids: &[String]) -> Vec<&str> {
+    let mut listed: Vec<&str> = operation_ids
+        .iter()
+        .take(ROSTER_OPERATION_IDS)
+        .map(String::as_str)
+        .collect();
+    if operation_ids.len() > ROSTER_OPERATION_IDS {
+        listed.push("…");
+    }
+    listed
 }

--- a/crates/openwave-server/src/routes/app_grant.rs
+++ b/crates/openwave-server/src/routes/app_grant.rs
@@ -91,7 +91,11 @@ pub async fn get_app_grant_state(
 ) -> Result<Json<AppGrantState>, ServerError> {
     let (app, revision) = current_live_app(&state, app_id).await?;
     let grant = state.store.get_app_grant(app.id).await?;
-    let current = current_fingerprints(&state).await?;
+    let current = current_fingerprints(
+        &state,
+        &crate::connected_apps::gateway_apps_bound_by(&revision.manifest.bindings),
+    )
+    .await?;
     Ok(Json(grant_state(
         &revision.manifest,
         grant.as_ref(),
@@ -110,7 +114,11 @@ pub async fn post_app_grant(
     Path(app_id): Path<AppId>,
 ) -> Result<Json<AppGrantState>, ServerError> {
     let (app, revision) = current_live_app(&state, app_id).await?;
-    let current = current_fingerprints(&state).await?;
+    let current = current_fingerprints(
+        &state,
+        &crate::connected_apps::gateway_apps_bound_by(&revision.manifest.bindings),
+    )
+    .await?;
     let rest_definitions = current_rest_definitions(&state).await?;
     let mut bindings = Vec::with_capacity(revision.manifest.bindings.len());
     for binding in &revision.manifest.bindings {

--- a/crates/openwave-server/src/routes/app_invoke.rs
+++ b/crates/openwave-server/src/routes/app_invoke.rs
@@ -517,7 +517,11 @@ async fn require_app_grant(
             pinned.description()
         )));
     }
-    let current = current_fingerprints(state).await?;
+    let current = current_fingerprints(
+        state,
+        &crate::connected_apps::gateway_apps_granted_by(&grant.bindings),
+    )
+    .await?;
     for binding in &grant.bindings {
         // Every granted binding must still pin what its target carries now:
         // a reconfigured connected app or a disconnected folder invalidates

--- a/crates/openwave-server/src/routes/app_library.rs
+++ b/crates/openwave-server/src/routes/app_library.rs
@@ -74,18 +74,32 @@ pub async fn get_app_library(
     State(state): State<AppState>,
 ) -> Result<Json<AppLibrary>, ServerError> {
     let records = state.store.list_apps(MAX_LISTED_APPS).await?;
-    let current = crate::connected_apps::current_fingerprints(&state).await?;
+    // The current revisions first, so the fingerprint read knows which gateway
+    // apps the listing actually needs — each one is a live catalog read, and
+    // the listing must not fetch the whole entitled set to badge apps that
+    // bind none of it. An app whose current revision cannot be read fails
+    // closed below: it lists, but never as granted.
+    let mut revisions = Vec::with_capacity(records.len());
+    for record in &records {
+        revisions.push(
+            state
+                .store
+                .get_app_revision(record.current_revision)
+                .await?,
+        );
+    }
+    let needed = crate::connected_apps::gateway_apps_bound_by(
+        revisions
+            .iter()
+            .flatten()
+            .flat_map(|revision| &revision.manifest.bindings),
+    );
+    let current = crate::connected_apps::current_fingerprints(&state, &needed).await?;
     let mut apps = Vec::with_capacity(records.len());
-    for record in records {
+    for (record, revision) in records.into_iter().zip(revisions) {
         // The same computation the grant surface performs, so the badge is
-        // the invoke gate's verdict rather than a cached approximation. An
-        // app whose current revision cannot be read fails closed: it lists,
-        // but never as granted.
-        let granted = match state
-            .store
-            .get_app_revision(record.current_revision)
-            .await?
-        {
+        // the invoke gate's verdict rather than a cached approximation.
+        let granted = match revision {
             Some(revision) => {
                 let grant = state.store.get_app_grant(record.id).await?;
                 super::grant_state(&revision.manifest, grant.as_ref(), &current).granted

--- a/crates/openwave-server/src/routes/mcp_gateway.rs
+++ b/crates/openwave-server/src/routes/mcp_gateway.rs
@@ -212,6 +212,10 @@ pub async fn post_gateway_sign_out(
     State(state): State<AppState>,
 ) -> Result<Json<crate::gateway_runtime::GatewayStatus>, ServerError> {
     state.gateway.sign_out().await?;
+    // The `create_app` roster's gateway section is read through the session
+    // that just ended; republish so the door stops offering bindings nothing
+    // can resolve any more.
+    state.mcp.refresh_connected_app_roster().await;
     Ok(Json(state.gateway.status().await?))
 }
 

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -131,6 +131,11 @@ pub struct AppState {
     /// resolver ([`crate::connected_apps::governed_rest_dispatcher`]); tests
     /// substitute a fake transport behind the same governed validation.
     pub(crate) rest_dispatch: Arc<dyn crate::connected_apps::RestOperationDispatcher>,
+    /// Reads the operation catalog of a gateway connected app a manifest
+    /// binds, live per request. The production assembly is the one gateway
+    /// runtime below; tests substitute a static roster behind the same seam
+    /// rather than standing up an OAuth session against a fake deployment.
+    pub(crate) gateway_catalogs: Arc<dyn crate::connected_apps::GatewayCatalogSource>,
     /// Outstanding single-use tokens redeemed by the sandboxed view frames —
     /// prefetched MCP views and stored local-app revisions alike.
     pub(crate) view_frames: Arc<ViewFrameTokens>,
@@ -339,6 +344,7 @@ impl AppState {
             os_policy.clone(),
         ));
         let rest_dispatch = crate::connected_apps::governed_rest_dispatcher(secrets.clone());
+        let gateway_catalogs = gateway.clone();
         Ok(Self {
             config: Arc::new(config),
             store: store.clone(),
@@ -348,6 +354,7 @@ impl AppState {
             tools,
             mcp,
             rest_dispatch,
+            gateway_catalogs,
             view_frames: Arc::default(),
             gateway,
             chatgpt,

--- a/crates/openwave-server/src/tests/documents.rs
+++ b/crates/openwave-server/src/tests/documents.rs
@@ -1580,6 +1580,7 @@ async fn agent_deps_registers_server_tools_and_closed_foreground_capabilities() 
         .unwrap(),
     );
     let extract_store = store.clone();
+    let store_for_gateway = store.clone();
     let (mut tools, config) = agent_deps(
         Arc::new(UnavailableCodeExecution),
         web_search::foreground_tool(store.clone(), Arc::new(MemSecrets::default())),
@@ -1587,6 +1588,11 @@ async fn agent_deps_registers_server_tools_and_closed_foreground_capabilities() 
         store,
         dir.path().join("profile-data"),
         None,
+        crate::gateway_runtime::GatewayRuntime::new(
+            store_for_gateway,
+            Arc::new(MemSecrets::default()),
+            Arc::new(crate::managed_policy::NoOsPolicy),
+        ),
     );
     assert!(
         config.system_prompt.is_none(),

--- a/crates/openwave-server/tests/connectors_gateway_flow.rs
+++ b/crates/openwave-server/tests/connectors_gateway_flow.rs
@@ -65,6 +65,9 @@ struct FakeGateway {
     corrupt_state: AtomicBool,
     /// Serve 404 for `/api/v1/cli/apps`, like a gateway that predates it.
     apps_unsupported: AtomicBool,
+    /// Serve 404 for the per-app catalog read, like a gateway that predates
+    /// it while still listing entitlements.
+    catalogs_unsupported: AtomicBool,
     /// Attestation context ids observed on refresh grants, in order.
     contexts_seen: Mutex<Vec<String>>,
     /// Reject the next unseen attestation context with `invalid_target`,
@@ -310,6 +313,31 @@ async fn apps(State(gateway): State<Arc<FakeGateway>>, headers: HeaderMap) -> Re
     .into_response()
 }
 
+async fn app_operations(
+    State(gateway): State<Arc<FakeGateway>>,
+    axum::extract::Path(app_id): axum::extract::Path<String>,
+    headers: HeaderMap,
+) -> Response {
+    if gateway.catalogs_unsupported.load(Ordering::SeqCst) {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    if bearer_resource(&gateway, &headers).as_deref() != Some("control") {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    if app_id != "app-incident" {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    Json(json!({
+        "operations": [
+            { "operation_id": "listIncidents", "method": "GET", "summary": "List incidents" },
+            // No summary, and a field this client does not know: the catalog
+            // read is additive at the gateway and must stay parseable here.
+            { "operation_id": "createIncident", "method": "POST", "document_sha256": "abc" },
+        ]
+    }))
+    .into_response()
+}
+
 async fn serve_fake_gateway(gateway: Arc<FakeGateway>) -> SocketAddr {
     let app = Router::new()
         .route("/api/v1/meta", get(meta))
@@ -319,6 +347,7 @@ async fn serve_fake_gateway(gateway: Arc<FakeGateway>) -> SocketAddr {
         .route("/api/v1/cli/me", get(me))
         .route("/api/v1/cli/models", get(models))
         .route("/api/v1/cli/apps", get(apps))
+        .route("/api/v1/cli/apps/{app_id}/operations", get(app_operations))
         .with_state(gateway);
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();
@@ -595,4 +624,46 @@ async fn apps_lists_entitlements_and_degrades_when_the_surface_is_missing() {
     // error and not an empty entitlement list.
     gateway.apps_unsupported.store(true, Ordering::SeqCst);
     assert_eq!(connection.apps().await.unwrap(), None);
+}
+
+/// The per-app catalog read is what a gateway binding's fingerprint is taken
+/// over, so it has to answer with the ids a manifest pins — under a `control`
+/// bearer — and it has to degrade rather than fault against a deployment that
+/// does not serve it yet, since the gateway half is still shipping.
+#[tokio::test]
+async fn app_catalogs_read_declared_operations_and_degrade_when_the_surface_is_missing() {
+    let (gateway, connection) = signed_in_connection().await;
+
+    let operations = connection
+        .app_operations("app-incident")
+        .await
+        .unwrap()
+        .unwrap();
+    let ids: Vec<&str> = operations
+        .iter()
+        .map(|operation| operation.operation_id.as_str())
+        .collect();
+    assert_eq!(ids, ["listIncidents", "createIncident"]);
+    assert_eq!(operations[0].method, "GET");
+    assert_eq!(operations[0].summary.as_deref(), Some("List incidents"));
+    assert_eq!(operations[1].summary, None);
+
+    // An id nothing is entitled to reads as "no catalog" rather than an
+    // error, so a grant naming it fails closed to re-consent.
+    assert_eq!(
+        connection.app_operations("app-unknown").await.unwrap(),
+        None
+    );
+    // An id outside the binding grammar never reaches the wire at all, and a
+    // traversal-shaped one is a single escaped path segment — it can only
+    // ever address a missing app, never another CLI route.
+    assert!(connection.app_operations("").await.is_err());
+    assert_eq!(connection.app_operations("../models").await.unwrap(), None);
+
+    // A gateway predating the catalog read degrades the same way.
+    gateway.catalogs_unsupported.store(true, Ordering::SeqCst);
+    assert_eq!(
+        connection.app_operations("app-incident").await.unwrap(),
+        None
+    );
 }

--- a/docs/connected-apps.md
+++ b/docs/connected-apps.md
@@ -83,9 +83,11 @@ invalidate consent; repointing the reference does.
 A manifest may also bind `{ gateway_app, operation_ids[] }` — an app the
 model gateway holds, named by the gateway's own id (record 7). It is not a
 connected-app record and nothing about it resolves locally, so it keys off
-its own namespace, carries its own canonical fingerprint form, and is refused
-by the authoring door until the gateway roster, consent, and relay surfaces
-exist.
+its own namespace and carries its own canonical fingerprint form: the gateway
+origin, the app id, and a hash of the operation catalog the gateway declared.
+Both the authoring roster and that fingerprint are read live from the
+signed-in session — no gateway catalog is ever cached here — so a profile
+with no session can neither author nor grant one.
 
 The consent sheet leads with the app's display name ("Sentry") and lists
 pinned capabilities under it — a legibility improvement over leading with

--- a/docs/local-apps.md
+++ b/docs/local-apps.md
@@ -39,11 +39,15 @@ An app revision is an untrusted **bundle** and a trusted **manifest**:
   holds (record 7). The manifest — not the bundle — is what the user consents
   to and what the host enforces per call.
 
-  The gateway shape is vocabulary today: the type, its grant twin, and its
-  fingerprint exist, but nothing reads the gateway's app catalogs yet, so no
-  gateway app resolves, the authoring door refuses the shape, and any gateway
-  grant reads stale — fail-closed in every direction until the roster,
-  consent, and relay surfaces land.
+  The gateway shape resolves against the signed-in gateway session: the
+  `create_app` roster lists each entitled app with the operation ids the
+  gateway declares for it, the door refuses an unknown id or an undeclared
+  operation, and consent pins the gateway origin, the app id, and a hash of
+  that catalog. Every input is read live per request — nothing about a gateway
+  app is cached locally — so a profile with no session, an app that loses its
+  entitlement, or a re-ingested catalog all fail closed to re-consent. Invoke
+  still has no relay: a gateway binding can be authored and granted, but
+  calling it is the next slice.
 
 The containment story is inherited from MCP App views and unchanged: the frame
 is served by the host with its own strict CSP (`default-src 'none'`,


### PR DESCRIPTION
Turns the binding vocabulary from PR #1933 into something a profile can
actually author and consent to, following
`docs/decisions/0007-gateway-app-bindings.md`.

The gateway connector gains the per-app catalog read
(`GET /api/v1/cli/apps/{id}/operations`, on a control-audience bearer),
the gateway runtime gains the non-refusing predicates every surface here
needs, and the three places that resolve a binding — the `create_app`
door, its roster, and the fingerprint surface grants pin against — read
through them.

The client is deliberately tolerant, because the gateway half is shipping
in parallel: the body parses as either the `{"operations": [...]}` object
or the bare array, operation entries do not deny unknown fields (a
catalog-document hash is the field most likely to arrive next), and a 404
reads as "this deployment does not serve catalogs yet" rather than an
error. The app id is validated against the manifest binding grammar and
appended as one percent-encoded path segment, so an id carrying `/`, `..`,
or any pure-dot spelling can never rewrite the request path.

`entitled_apps_if_signed_in` and `app_catalog` answer `None` for every
state where there is nothing to read — unmanaged profile, misconfigured
policy, no stored session, a session the gateway has since revoked, a
gateway predating either read — mirroring how `reconcile_endpoint_mounts`
already treats those states as "nothing to do". That is what lets the
roster degrade to an absent section and the fingerprint read fail closed,
without either faulting.

Fingerprints go through a `GatewayCatalogSource` seam on `AppState`, for
the reason the REST dispatcher is a seam: the grant, invoke, and library
surfaces are driven end to end in tests and cannot each stand up an OAuth
session against a fake deployment. `current_fingerprints` now takes the
set of gateway app ids the bindings under judgement name, so a library
listing does not fetch catalogs for apps that bind none.

The `create_app` door replaces its blanket refusal with real resolution:
no session refuses with the one fix the user has, an unentitled id refuses
with what is bindable spelled out, and an operation the gateway's catalog
does not declare names the app it is not declared by. The roster gains a
gateway section, elided past the same bound the REST section uses, and
republishes on sign-in and sign-out so the door never claims a session
state that ended. Settings surfaces the count of live grants binding each
gateway app, the same "Used by N local apps" line connected-app records
carry; the helper moves into the shared settings primitives rather than
being duplicated.

Invoke is unchanged here: a gateway binding can now be authored and
granted, but the relay is a later slice.

Tests: the fake gateway grows the catalog route, and one test covers the
read, its 404 degradation, and the id grammar including the path-rewriting
spellings; one `create_app` test drives the door through all four gateway
outcomes against a static source; one roster test pins the gateway
section's render, its elision past the bound, and its absence with no
session.

Stacked: PR 3 of 6, on top of #1933. PR 4 builds on this one.
