### PR TITLE
feat(server): consent and grants for gateway app bindings

### DIFF
--- a/crates/openwave-desktop/ui/src/apps/AppConsentSheet.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppConsentSheet.tsx
@@ -23,7 +23,11 @@ import { Button } from "@/components/ui/button";
  *
  * A manifest that binds both a folder and API operations gets the explicit
  * combined-consent warning (docs/folder-bindings.md): the app can read files
- * and send data out, and the sheet says so before the user agrees.
+ * and send data out, and the sheet says so before the user agrees. A gateway
+ * app's operations are network access exactly as a locally configured app's
+ * are, and count the same way; the row carries a qualifier because who
+ * executes the call differs — the organization's gateway, as the signed-in
+ * user, with no credential held here.
  *
  * The sheet never renders for a manifest with no bindings: the server reports
  * such an app as granted vacuously — there is nothing to consent to.
@@ -62,7 +66,13 @@ export function AppConsentSheet({
         <ul className="flex flex-col gap-2" aria-label="Requested access">
           {state.bindings.map((binding) => (
             <li
-              key={binding.app ?? binding.folder ?? binding.name ?? ""}
+              key={
+                binding.app ??
+                binding.folder ??
+                binding.gateway_app ??
+                binding.name ??
+                ""
+              }
               className="flex flex-col gap-1"
             >
               <div className="flex items-center gap-2 text-sm">
@@ -76,7 +86,9 @@ export function AppConsentSheet({
                   {binding.name ??
                     (binding.folder !== null
                       ? "Unknown folder"
-                      : "Unknown connected app")}
+                      : binding.gateway_app !== null
+                        ? "Unknown gateway app"
+                        : "Unknown connected app")}
                 </span>
                 {binding.granted && (
                   <span className="text-muted-foreground flex items-center gap-1 text-xs">
@@ -93,6 +105,11 @@ export function AppConsentSheet({
                   </span>
                 )}
               </div>
+              {binding.gateway_app !== null && (
+                <span className="text-muted-foreground pl-1 text-xs">
+                  Runs through your organization&rsquo;s gateway, as you
+                </span>
+              )}
               {binding.access !== null && (
                 <div className="flex flex-col gap-0.5">
                   <span className="text-muted-foreground flex items-center gap-1.5 pl-1 text-xs">

--- a/crates/openwave-desktop/ui/src/apps/AppDetailView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppDetailView.dom.test.tsx
@@ -32,6 +32,7 @@ const GRANTED: AppGrantState = {
     {
       app: "22222222-2222-4222-8222-222222222222",
       folder: null,
+      gateway_app: null,
       access: null,
       name: "issues",
       operation_ids: ["listIssues"],
@@ -47,6 +48,7 @@ const STALE: AppGrantState = {
     {
       app: "11111111-1111-4111-8111-111111111111",
       folder: null,
+      gateway_app: null,
       access: null,
       name: "cmd",
       operation_ids: ["doThing"],
@@ -56,6 +58,7 @@ const STALE: AppGrantState = {
     {
       app: "22222222-2222-4222-8222-222222222222",
       folder: null,
+      gateway_app: null,
       access: null,
       name: "issues",
       operation_ids: ["listIssues"],
@@ -384,6 +387,7 @@ describe("AppDetailView", () => {
         {
           app: null,
           folder: "33333333-3333-4333-8333-333333333333",
+          gateway_app: null,
           access: "read_write",
           name: "Tax documents",
           operation_ids: null,
@@ -393,6 +397,7 @@ describe("AppDetailView", () => {
         {
           app: "22222222-2222-4222-8222-222222222222",
           folder: null,
+          gateway_app: null,
           access: null,
           name: "issues",
           operation_ids: ["listIssues"],
@@ -449,5 +454,50 @@ describe("AppDetailView", () => {
     });
     expect(screen.getByTitle("App: Current app")).toBeInTheDocument();
     expect(screen.queryByTitle("App: Fixture app")).not.toBeInTheDocument();
+  });
+
+  it("counts a gateway row as network access and marks who executes it", async () => {
+    const mixed: AppGrantState = {
+      granted: false,
+      bindings: [
+        {
+          app: null,
+          folder: "33333333-3333-4333-8333-333333333333",
+          gateway_app: null,
+          access: "read",
+          name: "Tax documents",
+          operation_ids: null,
+          granted: false,
+          definition_changed: false,
+        },
+        {
+          app: null,
+          folder: null,
+          gateway_app: "gw-issues",
+          access: null,
+          name: "Issues (gateway)",
+          operation_ids: ["listIssues"],
+          granted: false,
+          definition_changed: false,
+        },
+      ],
+    };
+    render(
+      <AppDetailView appId="app-1" apis={apisWith(mixed)} onBack={() => {}} />,
+    );
+
+    // A gateway app is network access exactly as a local one is, so the
+    // combined-consent warning fires on a folder row plus a gateway row.
+    expect(
+      await screen.findByText(
+        "This app can read 'Tax documents' and send data to 'Issues (gateway)'.",
+      ),
+    ).toBeInTheDocument();
+    // The row still says who runs the call: the org's gateway, not this
+    // machine holding a credential for it.
+    expect(
+      screen.getByText("Runs through your organization’s gateway, as you"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("listIssues")).toBeInTheDocument();
   });
 });

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -272,15 +272,16 @@ revisions: Array<AppRevisionSummary>, };
 /**
  * One current-manifest binding, projected for the consent sheet.
  *
- * Exactly one of `app` and `folder` is present for the two locally resolved
- * vocabularies, matching what the binding names. An app-keyed row carries
- * `operation_ids`; a folder row carries `access`. A gateway binding carries
- * its operation ids and, once one reads back, the gateway app's display
- * name — it names neither a local record nor a root, so both id fields stay
- * absent until this projection carries the gateway's own id. The sheet
- * derives the combined-consent exfiltration warning
- * (docs/folder-bindings.md) from the rows themselves: a manifest with both a
- * folder row and a network row can read files and reach the network.
+ * Exactly one of `app`, `folder`, and `gateway_app` is present, matching what
+ * the binding names: a local record id, a broker root id, or the gateway's
+ * own connected-app id. An app-keyed or gateway row carries `operation_ids`;
+ * a folder row carries `access`. A gateway row names the gateway's app and
+ * the operations pinned under it, and — once the live read answers — that
+ * app's display name; the gateway's deployment URL is never projected, the
+ * same names-only posture the `rest_api` rows hold. The sheet derives the
+ * combined-consent exfiltration warning (docs/folder-bindings.md) from the
+ * rows themselves: a manifest with both a folder row and a network row —
+ * local or gateway — can read files and reach the network.
  */
 export type AppGrantBindingState = { 
 /**
@@ -294,18 +295,24 @@ app: ConnectedAppId | null,
  */
 folder: HostRootId | null, 
 /**
+ * Gateway connected app the manifest binds, by the gateway's own app id,
+ * for a gateway binding. The id alone — never the gateway that serves
+ * it.
+ */
+gateway_app: string | null, 
+/**
  * The access level a folder binding requests.
  */
 access: FolderAccess | null, 
 /**
- * The bound connected app's or folder's display name, absent when
- * nothing configured or approved answers to the id — the sheet says so
- * instead of showing a raw id alone.
+ * The bound connected app's, folder's, or gateway app's display name,
+ * absent when nothing configured, approved, or readable answers to the
+ * id — the sheet says so instead of showing a raw id alone.
  */
 name: string | null, 
 /**
  * Catalog `operationId`s the current manifest pins under this app, for a
- * `rest_api` binding.
+ * `rest_api` or gateway binding.
  */
 operation_ids: Array<string> | null, 
 /**

--- a/crates/openwave-server/src/connected_apps.rs
+++ b/crates/openwave-server/src/connected_apps.rs
@@ -233,11 +233,17 @@ pub(crate) fn catalog_sha256_from_operation_ids(operation_ids: &[String]) -> Str
     hex
 }
 
-/// One gateway connected app's display name and current fingerprint — the
-/// gateway-side twin of [`AppFingerprint`], keyed by the gateway's app id
-/// rather than a local record id.
+/// One gateway connected app's display name, live operation catalog, and
+/// current fingerprint — the gateway-side twin of [`AppFingerprint`], keyed
+/// by the gateway's app id rather than a local record id.
+///
+/// `operation_ids` is the catalog the fingerprint was taken over, kept beside
+/// it so consent can check a manifest's pins against what the gateway
+/// currently declares — the gateway-side twin of the `rest_api` catalog
+/// lookup, without a second live read.
 pub(crate) struct GatewayAppFingerprint {
     pub(crate) name: String,
+    pub(crate) operation_ids: Vec<String>,
     pub(crate) fingerprint: [u8; 32],
 }
 
@@ -295,6 +301,12 @@ pub(crate) struct CurrentFingerprints {
     /// re-consent rather than matching a fingerprint over a catalog nobody
     /// read.
     pub(crate) gateway_apps: BTreeMap<String, GatewayAppFingerprint>,
+    /// Whether a gateway session answered the catalog read at all. False
+    /// means the profile has no session to ask — unmanaged, signed out, or a
+    /// gateway too old to serve catalogs — which consent reports differently
+    /// from a session that answered and did not name the app. Vacuously true
+    /// when no gateway app was needed, since nothing was read.
+    pub(crate) gateway_session: bool,
 }
 
 impl CurrentFingerprints {
@@ -336,11 +348,13 @@ pub(crate) async fn current_fingerprints(
             folders.insert(folder.root_id, folder.display_name);
         }
     }
-    let gateway_apps = current_gateway_app_fingerprints(state, needed_gateway_apps).await;
+    let gateway = current_gateway_app_fingerprints(state, needed_gateway_apps).await;
+    let gateway_session = gateway.is_some();
     Ok(CurrentFingerprints {
         apps,
         folders,
-        gateway_apps,
+        gateway_apps: gateway.unwrap_or_default(),
+        gateway_session,
     })
 }
 
@@ -398,31 +412,34 @@ pub(crate) trait GatewayCatalogSource: Send + Sync {
 
 /// The current fingerprint of every readable gateway connected app among
 /// `needed`, by the gateway's app id.
+///
+/// `None` carries the source's own `None` through: no session answered, as
+/// distinct from a session that answered without naming an app.
 async fn current_gateway_app_fingerprints(
     state: &AppState,
     needed: &BTreeSet<String>,
-) -> BTreeMap<String, GatewayAppFingerprint> {
+) -> Option<BTreeMap<String, GatewayAppFingerprint>> {
     if needed.is_empty() {
-        return BTreeMap::new();
+        return Some(BTreeMap::new());
     }
-    let Some((base_url, catalogs)) = state.gateway_catalogs.gateway_app_catalogs(needed).await
-    else {
-        return BTreeMap::new();
-    };
-    catalogs
-        .into_iter()
-        .map(|(id, catalog)| {
-            let catalog_sha256 = catalog_sha256_from_operation_ids(&catalog.operation_ids);
-            let fingerprint = gateway_app_fingerprint(&base_url, &id, &catalog_sha256);
-            (
-                id,
-                GatewayAppFingerprint {
-                    name: catalog.name,
-                    fingerprint,
-                },
-            )
-        })
-        .collect()
+    let (base_url, catalogs) = state.gateway_catalogs.gateway_app_catalogs(needed).await?;
+    Some(
+        catalogs
+            .into_iter()
+            .map(|(id, catalog)| {
+                let catalog_sha256 = catalog_sha256_from_operation_ids(&catalog.operation_ids);
+                let fingerprint = gateway_app_fingerprint(&base_url, &id, &catalog_sha256);
+                (
+                    id,
+                    GatewayAppFingerprint {
+                        name: catalog.name,
+                        operation_ids: catalog.operation_ids,
+                        fingerprint,
+                    },
+                )
+            })
+            .collect(),
+    )
 }
 
 /// Every stored `rest_api` record whose definition parses, read live.
@@ -653,6 +670,7 @@ mod tests {
             apps: BTreeMap::new(),
             folders: BTreeMap::new(),
             gateway_apps: BTreeMap::new(),
+            gateway_session: false,
         };
         let granted = |fingerprint: [u8; 32]| {
             AppGrantBinding::GatewayOperations(

--- a/crates/openwave-server/src/routes/app_grant.rs
+++ b/crates/openwave-server/src/routes/app_grant.rs
@@ -3,12 +3,14 @@
 //!
 //! The renderer never supplies grant content. Consent (`POST`) is a bare
 //! affirmative — the server computes the grant from the app's *current*
-//! manifest and the connected-app definitions and folder registrations
-//! *current* at that moment, so a stale sheet can never grant capabilities
-//! the manifest no longer pins or pin a definition that has since changed.
+//! manifest and the connected-app definitions, folder registrations, and
+//! gateway catalogs *current* at that moment, so a stale sheet can never
+//! grant capabilities the manifest no longer pins or pin a definition that
+//! has since changed.
 //! State (`GET`) is renderer-safe metadata: connected-app, folder, and
 //! operation *names* with coverage/staleness booleans, never definitions,
-//! never paths, and never environment or credential values.
+//! never paths, never the gateway deployment behind a gateway app, and never
+//! environment or credential values.
 
 use axum::extract::State;
 use axum::http::StatusCode;
@@ -48,15 +50,16 @@ pub struct AppGrantState {
 
 /// One current-manifest binding, projected for the consent sheet.
 ///
-/// Exactly one of `app` and `folder` is present for the two locally resolved
-/// vocabularies, matching what the binding names. An app-keyed row carries
-/// `operation_ids`; a folder row carries `access`. A gateway binding carries
-/// its operation ids and, once one reads back, the gateway app's display
-/// name — it names neither a local record nor a root, so both id fields stay
-/// absent until this projection carries the gateway's own id. The sheet
-/// derives the combined-consent exfiltration warning
-/// (docs/folder-bindings.md) from the rows themselves: a manifest with both a
-/// folder row and a network row can read files and reach the network.
+/// Exactly one of `app`, `folder`, and `gateway_app` is present, matching what
+/// the binding names: a local record id, a broker root id, or the gateway's
+/// own connected-app id. An app-keyed or gateway row carries `operation_ids`;
+/// a folder row carries `access`. A gateway row names the gateway's app and
+/// the operations pinned under it, and — once the live read answers — that
+/// app's display name; the gateway's deployment URL is never projected, the
+/// same names-only posture the `rest_api` rows hold. The sheet derives the
+/// combined-consent exfiltration warning (docs/folder-bindings.md) from the
+/// rows themselves: a manifest with both a folder row and a network row —
+/// local or gateway — can read files and reach the network.
 #[derive(Debug, Serialize, ts_rs::TS)]
 pub struct AppGrantBindingState {
     /// Connected app the manifest binds, by record id, for an app-keyed
@@ -65,14 +68,18 @@ pub struct AppGrantBindingState {
     /// Connected folder the manifest binds, by broker root id, for a folder
     /// binding.
     pub folder: Option<HostRootId>,
+    /// Gateway connected app the manifest binds, by the gateway's own app id,
+    /// for a gateway binding. The id alone — never the gateway that serves
+    /// it.
+    pub gateway_app: Option<String>,
     /// The access level a folder binding requests.
     pub access: Option<FolderAccess>,
-    /// The bound connected app's or folder's display name, absent when
-    /// nothing configured or approved answers to the id — the sheet says so
-    /// instead of showing a raw id alone.
+    /// The bound connected app's, folder's, or gateway app's display name,
+    /// absent when nothing configured, approved, or readable answers to the
+    /// id — the sheet says so instead of showing a raw id alone.
     pub name: Option<String>,
     /// Catalog `operationId`s the current manifest pins under this app, for a
-    /// `rest_api` binding.
+    /// `rest_api` or gateway binding.
     pub operation_ids: Option<Vec<String>>,
     /// Whether the live grant covers every listed capability under this
     /// binding and its target still matches the granted fingerprint.
@@ -142,17 +149,41 @@ pub async fn post_app_grant(
                 }));
             }
             AppBinding::GatewayOperations(binding) => {
-                // A gateway binding pins an app the gateway describes. With
-                // nothing readable answering to the id there is no catalog to
-                // fingerprint, so there is nothing coherent to consent to —
-                // the same fail-closed reading as an unconfigured connected
-                // app or a folder that is no longer approved.
+                // A gateway binding pins an app only the gateway describes,
+                // so consent needs a live read to pin. With no session there
+                // is nothing to ask, and with nothing answering to the id
+                // there is no catalog to fingerprint — both leave nothing
+                // coherent to consent to, the same fail-closed reading as an
+                // unconfigured connected app or a folder that is no longer
+                // approved.
+                if !current.gateway_session {
+                    return Err(ServerError::conflict(format!(
+                        "there is no gateway session, so gateway app {} cannot be \
+                         granted",
+                        binding.gateway_app
+                    )));
+                }
                 let Some(gateway_app) = current.gateway_apps.get(&binding.gateway_app) else {
                     return Err(ServerError::conflict(format!(
                         "gateway app {} is not available, so this app cannot be granted",
                         binding.gateway_app
                     )));
                 };
+                // Every pinned operation must exist in the app's live
+                // catalog, exactly as a `rest_api` pin must exist in the
+                // record's — a pin the gateway no longer declares leaves
+                // nothing coherent to consent to.
+                if let Some(operation_id) = binding
+                    .operation_ids
+                    .iter()
+                    .find(|operation_id| !gateway_app.operation_ids.contains(operation_id))
+                {
+                    return Err(ServerError::conflict(format!(
+                        "operation {operation_id:?} is not declared by gateway app \
+                         {:?}, so this app cannot be granted",
+                        gateway_app.name
+                    )));
+                }
                 bindings.push(AppGrantBinding::GatewayOperations(
                     AppGatewayOperationsGrantBinding {
                         gateway_app: binding.gateway_app.clone(),
@@ -345,6 +376,7 @@ pub(crate) fn grant_state(
                     AppBinding::Folder(binding) => Some(binding.folder),
                     _ => None,
                 },
+                gateway_app: binding.gateway_app().map(str::to_owned),
                 access,
                 name,
                 operation_ids,

--- a/crates/openwave-server/src/tests/app_grant.rs
+++ b/crates/openwave-server/src/tests/app_grant.rs
@@ -235,6 +235,237 @@ async fn body_string(response: axum::response::Response) -> String {
     String::from_utf8(bytes.to_vec()).unwrap()
 }
 
+/// What a fake gateway session holds: the deployment's base URL and one
+/// entry per readable app — id, display name, declared operation ids. `None`
+/// is a profile with no session at all.
+type FakeGatewaySession = Option<(String, Vec<(String, String, Vec<String>)>)>;
+
+/// A gateway catalog source standing in for a live session: `None` is a
+/// profile with no session at all, and a present roster answers only the ids
+/// it holds.
+struct FakeGatewayCatalogs(std::sync::Mutex<FakeGatewaySession>);
+
+impl FakeGatewayCatalogs {
+    fn signed_in(base_url: &str, apps: &[(&str, &str, &[&str])]) -> Self {
+        Self(std::sync::Mutex::new(Some((
+            base_url.to_owned(),
+            Self::roster(apps),
+        ))))
+    }
+
+    fn roster(apps: &[(&str, &str, &[&str])]) -> Vec<(String, String, Vec<String>)> {
+        apps.iter()
+            .map(|(id, name, operations)| {
+                (
+                    (*id).to_owned(),
+                    (*name).to_owned(),
+                    operations.iter().map(|op| (*op).to_owned()).collect(),
+                )
+            })
+            .collect()
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::connected_apps::GatewayCatalogSource for FakeGatewayCatalogs {
+    async fn gateway_app_catalogs(
+        &self,
+        needed: &std::collections::BTreeSet<String>,
+    ) -> Option<(
+        String,
+        std::collections::BTreeMap<String, crate::connected_apps::GatewayAppCatalog>,
+    )> {
+        let held = self.0.lock().unwrap();
+        let (base_url, apps) = held.as_ref()?;
+        let catalogs = apps
+            .iter()
+            .filter(|(id, _, _)| needed.contains(id))
+            .map(|(id, name, operation_ids)| {
+                (
+                    id.clone(),
+                    crate::connected_apps::GatewayAppCatalog {
+                        name: name.clone(),
+                        operation_ids: operation_ids.clone(),
+                    },
+                )
+            })
+            .collect();
+        Some((base_url.clone(), catalogs))
+    }
+}
+
+/// Build a profile whose gateway catalog reads come from `catalogs`, holding
+/// one app that binds `operation_ids` of the gateway app `gateway_app`.
+async fn gateway_bound_app(
+    catalogs: Arc<FakeGatewayCatalogs>,
+    gateway_app: &str,
+    operation_ids: &[&str],
+) -> (Router, String, AppId, tempfile::TempDir) {
+    use openwave_core::local_app::AppGatewayOperationsBinding;
+
+    let (dir, store) = temp_db_store("gateway-grant.db").await;
+    let store: Arc<dyn Store> = Arc::new(store);
+    let mut state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    state.gateway_catalogs = catalogs;
+    let bearer = format!("Bearer {}", state.token);
+    let router = app(state);
+
+    let app_id = AppId::new();
+    store
+        .create_app(&CreateApp {
+            id: app_id,
+            revision: NewAppRevision {
+                id: AppRevisionId::new(),
+                manifest: AppManifest {
+                    name: "Gateway fixture".into(),
+                    bindings: vec![AppBinding::GatewayOperations(AppGatewayOperationsBinding {
+                        gateway_app: gateway_app.to_owned(),
+                        operation_ids: operation_ids.iter().map(|id| (*id).to_owned()).collect(),
+                    })],
+                },
+                byte_len: 1,
+                sha256: [0; 32],
+                turn_id: None,
+                producing_run_id: None,
+                chat_id: None,
+                created_at: chrono::Utc::now(),
+            },
+        })
+        .await
+        .unwrap();
+    (router, bearer, app_id, dir)
+}
+
+/// The gateway consent lifecycle: an app the live read names grants at its
+/// pinned operations, the projection carries the gateway's app id, that app's
+/// display name, and the pinned ids — never the gateway that served them, and
+/// never a catalog entry the manifest did not pin — and a re-ingested catalog
+/// invalidates the grant on the next read.
+#[tokio::test]
+async fn gateway_bindings_grant_and_fail_closed_when_the_catalog_changes() {
+    let catalogs = Arc::new(FakeGatewayCatalogs::signed_in(
+        "https://gateway.internal.example.com",
+        &[(
+            "gw-issues",
+            "Issues (gateway)",
+            &["listIssues", "createIssue", "deleteEverything"],
+        )],
+    ));
+    let (router, bearer, app_id, _dir) =
+        gateway_bound_app(catalogs.clone(), "gw-issues", &["listIssues"]).await;
+
+    let mut responses = Vec::new();
+    let state = grant_request(&router, &bearer, "GET", app_id).await;
+    assert_eq!(state.status(), StatusCode::OK);
+    responses.push(("GET", body_string(state).await));
+    let consented = grant_request(&router, &bearer, "POST", app_id).await;
+    assert_eq!(consented.status(), StatusCode::OK);
+    responses.push(("POST", body_string(consented).await));
+
+    // Names only, on the raw serialized JSON: the gateway's origin, the
+    // catalog hash the fingerprint is taken over, and the operations the
+    // manifest did not pin all stay server-side.
+    let catalog_hash = crate::connected_apps::catalog_sha256_from_operation_ids(&[
+        "listIssues".to_owned(),
+        "createIssue".to_owned(),
+        "deleteEverything".to_owned(),
+    ]);
+    for (method, body) in &responses {
+        assert!(
+            body.contains("\"Issues (gateway)\"")
+                && body.contains("listIssues")
+                && body.contains("gw-issues"),
+            "{method}: the sheet needs the gateway app's id, name, and pinned \
+             operations: {body}"
+        );
+        for leaked in [
+            "gateway.internal.example.com",
+            "deleteEverything",
+            "createIssue",
+            catalog_hash.as_str(),
+        ] {
+            assert!(
+                !body.contains(leaked),
+                "{method}: {leaked:?} must not reach the renderer: {body}"
+            );
+        }
+    }
+    let before: serde_json::Value = serde_json::from_str(&responses[0].1).unwrap();
+    assert_eq!(before["granted"], json!(false));
+    assert_eq!(before["bindings"][0]["gateway_app"], json!("gw-issues"));
+    assert_eq!(before["bindings"][0]["name"], json!("Issues (gateway)"));
+    assert_eq!(
+        before["bindings"][0]["operation_ids"],
+        json!(["listIssues"])
+    );
+    assert_eq!(before["bindings"][0]["app"], json!(null));
+    assert_eq!(before["bindings"][0]["folder"], json!(null));
+    let after: serde_json::Value = serde_json::from_str(&responses[1].1).unwrap();
+    assert_eq!(after["granted"], json!(true));
+    assert_eq!(after["bindings"][0]["granted"], json!(true));
+
+    // A re-ingested app — the same id and name, a different catalog — moves
+    // the fingerprint, so the grant reads changed-since-you-agreed rather
+    // than carrying consent across it.
+    *catalogs.0.lock().unwrap() = Some((
+        "https://gateway.internal.example.com".to_owned(),
+        FakeGatewayCatalogs::roster(&[("gw-issues", "Issues (gateway)", &["listIssues"])]),
+    ));
+    let stale = grant_request(&router, &bearer, "GET", app_id).await;
+    let stale: serde_json::Value = serde_json::from_str(&body_string(stale).await).unwrap();
+    assert_eq!(stale["granted"], json!(false));
+    assert_eq!(stale["bindings"][0]["definition_changed"], json!(true));
+    assert_eq!(stale["bindings"][0]["name"], json!("Issues (gateway)"));
+}
+
+/// Consent refuses rather than pinning something nobody read: with no gateway
+/// session there is nothing to ask, and a session that answers without
+/// declaring a pinned operation leaves that pin ungrantable. Both name what
+/// is wrong, and neither records a grant.
+#[tokio::test]
+async fn gateway_consent_conflicts_without_a_session_or_with_an_undeclared_pin() {
+    // No session at all: the read answers nothing, and the refusal says so
+    // rather than reporting the app as merely unavailable.
+    let signed_out = Arc::new(FakeGatewayCatalogs(std::sync::Mutex::new(None)));
+    let (router, bearer, app_id, _dir) =
+        gateway_bound_app(signed_out, "gw-issues", &["listIssues"]).await;
+    let refused = grant_request(&router, &bearer, "POST", app_id).await;
+    assert_eq!(refused.status(), StatusCode::CONFLICT);
+    let info: AgentErrorInfo = json_body(refused).await;
+    assert!(
+        info.message.contains("no gateway session"),
+        "{}",
+        info.message
+    );
+
+    // A session that answers, but the manifest pins an operation the live
+    // catalog does not declare: the refusal names the operation and the app.
+    let catalogs = Arc::new(FakeGatewayCatalogs::signed_in(
+        "https://gateway.internal.example.com",
+        &[("gw-issues", "Issues (gateway)", &["listIssues"])],
+    ));
+    let (router, bearer, app_id, _dir) =
+        gateway_bound_app(catalogs, "gw-issues", &["listIssues", "deleteEverything"]).await;
+    let refused = grant_request(&router, &bearer, "POST", app_id).await;
+    assert_eq!(refused.status(), StatusCode::CONFLICT);
+    let info: AgentErrorInfo = json_body(refused).await;
+    assert!(
+        info.message.contains("deleteEverything") && info.message.contains("Issues (gateway)"),
+        "{}",
+        info.message
+    );
+}
+
 /// Without a host-folder seam — headless serve, generic embeddings — a
 /// manifest carrying a folder binding reads ungranted and consent conflicts:
 /// the folder cannot resolve, honestly, instead of parking or half-granting

--- a/docs/local-apps.md
+++ b/docs/local-apps.md
@@ -107,7 +107,13 @@ object, designed against the same threat:
   credential reference for `rest_api`; namespace, command, args, cwd,
   selected env names, URL for the retired `mcp_server` vocabulary).
 - The grant is created by explicit user consent on a sheet that lists every
-  binding. It is revocable from the Apps library.
+  binding. It is revocable from the Apps library. A gateway row is presented
+  as the network access it is — it counts toward the combined-consent
+  exfiltration warning exactly as a local operations row does — and carries a
+  qualifier saying the call runs through the organization's gateway as the
+  signed-in user. The row names the gateway app's id, its display name, and
+  the pinned operation ids; the gateway's own URL never reaches the renderer,
+  the same names-only posture the `rest_api` rows hold.
 - Every invoke checks, live: the tool is in the current revision's manifest,
   the manifest entry is covered by the grant, **and** the bound server's
   current definition still matches the granted fingerprint. A reconfigured


### PR DESCRIPTION
Consent now computes a gateway grant from a live catalog read rather than
just refusing what it cannot see, following
`docs/decisions/0007-gateway-app-bindings.md`.

`CurrentFingerprints` keeps each gateway app's declared operation ids
beside its fingerprint, and records whether a session answered the read at
all, so the grant route can tell "no gateway session to ask" from "the
session answered and does not name this app". `POST /apps/{id}/grant`
refuses both, and refuses a manifest pin the live catalog no longer
declares, naming the operation and the app — the same ladder the
`rest_api` arm already walks.

The grant projection gains `gateway_app`, so a consent row can name the
gateway's own app id alongside its display name and the pinned operation
ids. The gateway's deployment URL, the catalog hash behind the
fingerprint, and any operation the manifest did not pin all stay
server-side: the names-only leak posture the `rest_api` rows already hold,
and the reason the projection is asserted against raw serialized JSON
rather than a typed struct — a field added later leaks by appearing, not
by failing to parse.

The sheet presents a gateway row as the network access it is. It counts
toward the combined-consent exfiltration warning exactly as a local
operations row does — a manifest carrying a folder row and a gateway row
can read files and send data out, and the sheet says so in prose naming
both sides — with a qualifier saying the call runs through the
organization's gateway as the signed-in user, since no credential for it
is held here.

Tests: one leak pin asserts the serialized gateway grant projection
carries display name, opaque app id, and pinned operation ids and nothing
else — no gateway base URL, no catalog hash, no undeclared operation; the
grant-route tests cover the three refusals (no session, session that does
not name the app, pin the catalog no longer declares) and the passing
case; and one desktop test drives a folder row plus a gateway row through
the sheet, pinning both the combined-exfiltration warning naming the
gateway app and the row's who-executes qualifier.

Stacked: PR 4 of 6, on top of #1934. PR 5 builds on this one.
