### PR TITLE
feat(server): relay gateway app bindings through the gateway invoke route

### DIFF
--- a/crates/openwave-desktop/ui/src/McpAppBridge.test.ts
+++ b/crates/openwave-desktop/ui/src/McpAppBridge.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
+
+import { AppInvokeRefusalError } from "./api";
 import {
   createMcpAppBridge,
   MCP_APPS_PROTOCOL_VERSION,
@@ -15,6 +17,9 @@ const PAYLOAD: McpAppPayload = {
 function harness(
   theme: "light" | "dark" = "dark",
   invokeOperation?: Parameters<typeof createMcpAppBridge>[0]["invokeOperation"],
+  invokeGatewayOperation?: Parameters<
+    typeof createMcpAppBridge
+  >[0]["invokeGatewayOperation"],
 ) {
   const postMessage = vi.fn();
   const frame = { postMessage } as unknown as Window;
@@ -25,6 +30,7 @@ function harness(
     theme: () => currentTheme,
     onHeight,
     invokeOperation,
+    invokeGatewayOperation,
   });
   const fromView = (data: unknown, source: unknown = frame) =>
     bridge.handleMessage({ data, source } as MessageEvent);
@@ -154,6 +160,77 @@ describe("createMcpAppBridge", () => {
       { jsonrpc: "2.0", id: 3, error: { code: -32601, message: "Method not found" } },
     ]);
     expect(invokeOperation).not.toHaveBeenCalled();
+  });
+
+  it("routes operations/call by connected_app_id and surfaces the refusal kind", async () => {
+    const invokeOperation = vi.fn().mockResolvedValue({ is_error: false });
+    const invokeGatewayOperation = vi
+      .fn()
+      .mockRejectedValue(
+        new AppInvokeRefusalError(
+          "gateway_authorization_required",
+          "connect Issues (gateway) at your model gateway to continue",
+        ),
+      );
+    const { fromView, sent } = harness(
+      "dark",
+      invokeOperation,
+      invokeGatewayOperation,
+    );
+
+    // A `connected_app_id` names a gateway connected app — the gateway
+    // shell's own invoke vocabulary — so the same method reaches the relay
+    // leg with the gateway's field names, and never the local one.
+    fromView({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "operations/call",
+      params: {
+        connected_app_id: "gw-issues",
+        operation_id: "listIssues",
+        path_parameters: { id: "7" },
+        query: { state: "open" },
+        body: { note: "hi" },
+      },
+    });
+    expect(invokeGatewayOperation).toHaveBeenCalledWith(
+      "gw-issues",
+      "listIssues",
+      { id: "7" },
+      { state: "open" },
+      { note: "hi" },
+    );
+    expect(invokeOperation).not.toHaveBeenCalled();
+
+    // The refusal crosses machine-readably: the view branches on
+    // `error.data.kind`, never on the prose.
+    await vi.waitFor(() =>
+      expect(sent()).toEqual([
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          error: {
+            code: -32000,
+            message: "connect Issues (gateway) at your model gateway to continue",
+            data: { kind: "gateway_authorization_required" },
+          },
+        },
+      ]),
+    );
+
+    // A legacy call without the field stays local, unchanged.
+    fromView({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "operations/call",
+      params: { operation_id: "listIssues", parameters: { q: "open" } },
+    });
+    expect(invokeOperation).toHaveBeenCalledWith(
+      "listIssues",
+      { q: "open" },
+      undefined,
+    );
+    expect(invokeGatewayOperation).toHaveBeenCalledTimes(1);
   });
 
   it("answers ping and clamps size-changed heights", () => {

--- a/crates/openwave-desktop/ui/src/McpAppBridge.ts
+++ b/crates/openwave-desktop/ui/src/McpAppBridge.ts
@@ -43,6 +43,25 @@ export type AppOperationInvoker = (
 ) => Promise<AppRestInvokeResult>;
 
 /**
+ * Executes one granted gateway operation on the embedded view's behalf — the
+ * same `operations/call` method, routed by the presence of
+ * `connected_app_id` in the call's params.
+ *
+ * That field is the gateway shell's own invoke vocabulary (its ADR 0036), and
+ * naming it the same here is the whole point: a bundle written against this
+ * bridge runs unmodified in the gateway's shell, and one written there runs
+ * unmodified here. The two hosts differ in where a binding resolves, not in
+ * what the bundle speaks.
+ */
+export type AppGatewayOperationInvoker = (
+  gatewayApp: string,
+  operationId: string,
+  pathParameters: unknown,
+  query: unknown,
+  body: unknown,
+) => Promise<AppRestInvokeResult>;
+
+/**
  * Executes one granted folder operation on the embedded view's behalf — the
  * `fs/*` sibling of the operation invoker, wired to the same invoke route.
  * Content crosses base64-encoded in both directions; rejections map to
@@ -82,6 +101,12 @@ export function createMcpAppBridge(options: {
    * methods its host deliberately declared.
    */
   invokeOperation?: AppOperationInvoker;
+  /**
+   * When present, an `operations/call` naming a `connected_app_id` is routed
+   * here instead — the gateway leg, under the same capability-by-presence
+   * rule. Absent, such a call refuses like any other undeclared capability.
+   */
+  invokeGatewayOperation?: AppGatewayOperationInvoker;
   /**
    * When present, the view may call `fs/list`, `fs/read`, and `fs/write`
    * and the bridge forwards them here — the folder sibling, under the same
@@ -155,7 +180,18 @@ export function createMcpAppBridge(options: {
           post({ jsonrpc: "2.0", id, result: {} });
           break;
         case "operations/call": {
-          const invoke = options.invokeOperation;
+          const params = isRecord(message.params) ? message.params : {};
+          // A `connected_app_id` names a gateway connected app, so the call
+          // is a relay rather than a local execution. Legacy calls without it
+          // stay local; both are the same method, because a bundle should not
+          // have to know which host it is running in.
+          const gatewayApp =
+            typeof params.connected_app_id === "string"
+              ? params.connected_app_id
+              : null;
+          const invoke = gatewayApp
+            ? options.invokeGatewayOperation
+            : options.invokeOperation;
           if (!invoke) {
             post({
               jsonrpc: "2.0",
@@ -164,7 +200,6 @@ export function createMcpAppBridge(options: {
             });
             break;
           }
-          const params = isRecord(message.params) ? message.params : {};
           const operationId =
             typeof params.operation_id === "string" ? params.operation_id : null;
           if (!operationId) {
@@ -178,24 +213,25 @@ export function createMcpAppBridge(options: {
             });
             break;
           }
-          // Parameters, body, and the REST result are opaque passthrough the
+          // Every argument half and the result are opaque passthrough the
           // bridge never interprets; the result object crosses back verbatim.
           // The reply is asynchronous; `post` already refuses after dispose.
-          void invoke(operationId, params.parameters, params.body).then(
+          const call = gatewayApp
+            ? (invoke as AppGatewayOperationInvoker)(
+                gatewayApp,
+                operationId,
+                params.path_parameters,
+                params.query,
+                params.body,
+              )
+            : (invoke as AppOperationInvoker)(
+                operationId,
+                params.parameters,
+                params.body,
+              );
+          void call.then(
             (result) => post({ jsonrpc: "2.0", id, result }),
-            (error: unknown) =>
-              post({
-                jsonrpc: "2.0",
-                id,
-                error:
-                  error instanceof AppInvokeRefusalError
-                    ? {
-                        code: -32000,
-                        message: error.message,
-                        data: { kind: error.kind },
-                      }
-                    : { code: -32000, message: String(error) },
-              }),
+            (error: unknown) => post({ jsonrpc: "2.0", id, error: rpcError(error) }),
           );
           break;
         }
@@ -235,19 +271,7 @@ export function createMcpAppBridge(options: {
           // asynchronous; `post` already refuses after dispose.
           void invoke(folder, op, path, contentBase64, replace).then(
             (result) => post({ jsonrpc: "2.0", id, result }),
-            (error: unknown) =>
-              post({
-                jsonrpc: "2.0",
-                id,
-                error:
-                  error instanceof AppInvokeRefusalError
-                    ? {
-                        code: -32000,
-                        message: error.message,
-                        data: { kind: error.kind },
-                      }
-                    : { code: -32000, message: String(error) },
-              }),
+            (error: unknown) => post({ jsonrpc: "2.0", id, error: rpcError(error) }),
           );
           break;
         }
@@ -300,4 +324,21 @@ export function createMcpAppBridge(options: {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * One rejected invoke as a JSON-RPC error. A typed
+ * {@link AppInvokeRefusalError} keeps its machine-readable kind in
+ * `error.data` — the refusal envelope is host-authored, so surfacing it is
+ * not interpretation, and it is how the view tells "connect this app at the
+ * gateway" from "this call failed".
+ */
+function rpcError(error: unknown): {
+  code: number;
+  message: string;
+  data?: { kind: string };
+} {
+  return error instanceof AppInvokeRefusalError
+    ? { code: -32000, message: error.message, data: { kind: error.kind } }
+    : { code: -32000, message: String(error) };
 }

--- a/crates/openwave-desktop/ui/src/api/client.ts
+++ b/crates/openwave-desktop/ui/src/api/client.ts
@@ -651,6 +651,31 @@ export class ApiClient {
   }
 
   /**
+   * Execute one operation of an app's granted gateway binding — the same
+   * invoke route, relayed by the server to the model gateway as the signed-in
+   * user. The field names are the gateway's own invoke vocabulary, so a
+   * bundle authored here speaks the same shape to the gateway's shell;
+   * `path_parameters`, `query`, `body`, and the result are opaque passthrough.
+   */
+  async invokeAppGatewayOperation(
+    appId: string,
+    gatewayApp: string,
+    operationId: string,
+    pathParameters?: unknown,
+    query?: unknown,
+    body?: unknown,
+  ): Promise<AppRestInvokeResult> {
+    const request: Record<string, unknown> = {
+      gateway_app: gatewayApp,
+      operation_id: operationId,
+    };
+    if (pathParameters !== undefined) request.path_parameters = pathParameters;
+    if (query !== undefined) request.query = query;
+    if (body !== undefined) request.body = body;
+    return (await this.postAppInvoke(appId, request)) as AppRestInvokeResult;
+  }
+
+  /**
    * Execute one folder operation of an app's granted folder binding — the
    * `folder` sibling of {@link invokeAppOperation}, with the same refusal
    * contract. File content crosses base64-encoded in both directions;

--- a/crates/openwave-desktop/ui/src/api/types.ts
+++ b/crates/openwave-desktop/ui/src/api/types.ts
@@ -727,6 +727,8 @@ export const APP_INVOKE_REFUSAL_KINDS: readonly AppInvokeRefusalKind[] = [
   "not_pinned",
   "consent_required",
   "unknown_tool",
+  "gateway_unavailable",
+  "gateway_authorization_required",
 ];
 
 /**

--- a/crates/openwave-desktop/ui/src/apps/AppDetailView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppDetailView.dom.test.tsx
@@ -86,10 +86,17 @@ function apisWith(grant: AppGrantState): AppsApis {
       body_base64: "e30=",
       is_error: false,
     }),
+    invokeGatewayOperation: vi.fn().mockResolvedValue({
+      status: 200,
+      content_type: "application/json",
+      body_base64: "e30=",
+      is_error: false,
+    }),
     invokeFolder: vi.fn().mockResolvedValue({
       entries: [{ name: "note.txt", directory: false }],
       is_error: false,
     }),
+    gatewayBaseUrl: vi.fn().mockResolvedValue("https://gateway.example.com"),
   };
 }
 
@@ -499,5 +506,79 @@ describe("AppDetailView", () => {
       screen.getByText("Runs through your organization’s gateway, as you"),
     ).toBeInTheDocument();
     expect(screen.getByText("listIssues")).toBeInTheDocument();
+  });
+
+  it("offers a connect affordance when the gateway refuses a relay for want of the viewer's credential", async () => {
+    const apis = apisWith(GRANTED);
+    apis.invokeGatewayOperation = vi
+      .fn()
+      .mockRejectedValue(
+        new AppInvokeRefusalError(
+          "gateway_authorization_required",
+          "connect Issues (gateway) at your model gateway to continue: sign in",
+        ),
+      );
+    render(<AppDetailView appId="app-1" apis={apis} onBack={() => {}} />);
+
+    const frame = (await screen.findByTitle(
+      "App: Fixture app",
+    )) as HTMLIFrameElement;
+    const contentWindow = frame.contentWindow!;
+    const posted = vi.spyOn(contentWindow, "postMessage");
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: {
+          jsonrpc: "2.0",
+          id: 9,
+          method: "operations/call",
+          params: {
+            connected_app_id: "gw-issues",
+            operation_id: "listIssues",
+            query: { state: "open" },
+          },
+        },
+        source: contentWindow,
+      }),
+    );
+
+    // The frame's own call is routed to the gateway leg and refused
+    // machine-readably; the host answers with the affordance only the viewer
+    // can act on, and the frame stays mounted — nothing local was revoked.
+    await waitFor(() =>
+      expect(posted).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 9,
+          error: expect.objectContaining({
+            data: { kind: "gateway_authorization_required" },
+          }),
+        }),
+        "*",
+      ),
+    );
+    expect(apis.invokeGatewayOperation).toHaveBeenCalledWith(
+      "app-1",
+      "gw-issues",
+      "listIssues",
+      undefined,
+      { state: "open" },
+      undefined,
+    );
+    const connect = await screen.findByRole("button", {
+      name: "Connect at gateway",
+    });
+    expect(
+      screen.getByText(/connect Issues \(gateway\) at your model gateway/),
+    ).toBeInTheDocument();
+    expect(screen.getByTitle("App: Fixture app")).toBeInTheDocument();
+
+    // The button sends the viewer to the gateway's own origin — the gateway's
+    // SSO is the handoff — and the banner clears once it has.
+    fireEvent.click(connect);
+    await waitFor(() => expect(apis.gatewayBaseUrl).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: "Connect at gateway" }),
+      ).not.toBeInTheDocument(),
+    );
   });
 });

--- a/crates/openwave-desktop/ui/src/apps/AppDetailView.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppDetailView.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, ShieldCheck, Trash2 } from "lucide-react";
+import { ChevronLeft, ExternalLink, ShieldCheck, Trash2, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
@@ -6,6 +6,7 @@ import type { AppDetail, AppGrantState } from "@/api";
 import { useConfirm } from "@/components/ConfirmDialog";
 import { PanelSecondaryHeader } from "@/components/PanelHeader";
 import { Button } from "@/components/ui/button";
+import { openSignInPage } from "@/openSignInPage";
 import { AppConsentSheet } from "./AppConsentSheet";
 import { AppFrame } from "./AppFrame";
 import { friendlyAppsError, updatedLabel } from "./AppsView";
@@ -37,6 +38,11 @@ function revisionSummary(detail: AppDetail): string {
  * decides whether the frame mounts or the sheet renders, and the frame's own
  * `consent_required` refusals fold back into the same gate — the sheet is the
  * one way through, and the server recomputes what it grants.
+ *
+ * A gateway binding adds one affordance the sheet cannot cover: a relayed
+ * call the gateway refused for want of the viewer's own credential. Nothing
+ * local can supply it, so the banner over the frame just sends the viewer to
+ * the gateway to connect the app there.
  */
 export function AppDetailView({
   appId,
@@ -53,6 +59,10 @@ export function AppDetailView({
   const [loadError, setLoadError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  // The server's message from the last gateway_authorization_required
+  // refusal, or null once dismissed. It names the bound app, so the banner
+  // does not have to guess which one needs connecting.
+  const [connectPrompt, setConnectPrompt] = useState<string | null>(null);
   const generationRef = useRef(0);
   const mutationGenerationRef = useRef(0);
   const refreshGenerationRef = useRef(0);
@@ -101,6 +111,7 @@ export function AppDetailView({
     setLoadError(null);
     setActionError(null);
     setBusy(false);
+    setConnectPrompt(null);
     void (async () => {
       try {
         const [loadedDetail, loadedGrant] = await Promise.all([
@@ -208,6 +219,24 @@ export function AppDetailView({
     }
   }
 
+  // The gateway's own SSO is the handoff: the system browser opens its
+  // origin and the viewer's IdP session authenticates there. No credential of
+  // ours travels with it — a URL-borne bearer is exactly what the gateway's
+  // design rejects.
+  async function onConnectAtGateway() {
+    try {
+      const baseUrl = await apis.gatewayBaseUrl();
+      if (!baseUrl) {
+        toast.error("This profile is not paired with a model gateway.");
+        return;
+      }
+      await openSignInPage(baseUrl);
+      setConnectPrompt(null);
+    } catch (caught) {
+      toast.error(friendlyAppsError(caught, "Could not open your gateway."));
+    }
+  }
+
   async function onDelete() {
     const targetAppId = appId;
     const scopeGeneration = generationRef.current;
@@ -280,12 +309,39 @@ export function AppDetailView({
         {detail && grant && (
           <>
             {grant.granted ? (
-              <AppFrame
-                appId={appId}
-                name={detail.name}
-                apis={apis}
-                onConsentRequired={() => void onConsentRequired()}
-              />
+              <>
+                {connectPrompt && (
+                  <div
+                    className="border-warning/40 bg-warning/10 mx-4 flex items-start gap-3 rounded-lg border p-3"
+                    role="alert"
+                  >
+                    <p className="min-w-0 flex-1 text-sm">{connectPrompt}</p>
+                    <Button
+                      variant="outline"
+                      size="xs"
+                      onClick={() => void onConnectAtGateway()}
+                    >
+                      <ExternalLink className="size-3.5" aria-hidden="true" />
+                      Connect at gateway
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      onClick={() => setConnectPrompt(null)}
+                    >
+                      <X className="size-4" />
+                      <span className="sr-only">Dismiss</span>
+                    </Button>
+                  </div>
+                )}
+                <AppFrame
+                  appId={appId}
+                  name={detail.name}
+                  apis={apis}
+                  onConsentRequired={() => void onConsentRequired()}
+                  onGatewayConnectRequired={setConnectPrompt}
+                />
+              </>
             ) : (
               <AppConsentSheet
                 state={grant}

--- a/crates/openwave-desktop/ui/src/apps/AppFrame.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppFrame.tsx
@@ -16,7 +16,9 @@ import type { AppsApis } from "./appsApis";
  *
  * A `consent_required` refusal mid-session (revoked, or a server reconfigured
  * while the app was open) is reported upward so the host can re-present the
- * consent sheet; the frame itself just sees a rejected call.
+ * consent sheet; a `gateway_authorization_required` refusal is reported the
+ * same way so the host can offer a connect prompt. The frame itself just sees
+ * a rejected call in both cases.
  *
  * Unlike the inline MCP App card, this frame fills whatever space the panel
  * gives it — the bridge's app-reported height is ignored and tall content
@@ -32,12 +34,20 @@ export function AppFrame({
   name,
   apis,
   onConsentRequired,
+  onGatewayConnectRequired,
 }: {
   appId: string;
   /** Display name, for the frame's accessible title only. */
   name: string;
   apis: AppsApis;
   onConsentRequired?: () => void;
+  /**
+   * The gateway refused a relayed call for want of a credential only the
+   * viewer can supply, and only at the gateway. Reported upward with the
+   * server's message so the host can offer the connect affordance; nothing
+   * here can resolve it.
+   */
+  onGatewayConnectRequired?: (message: string) => void;
 }) {
   const { resolved: resolvedTheme } = useTheme();
   const [state, setState] = useState<FrameState>({ kind: "loading" });
@@ -48,51 +58,50 @@ export function AppFrame({
   themeRef.current = resolvedTheme;
   const onConsentRequiredRef = useRef(onConsentRequired);
   onConsentRequiredRef.current = onConsentRequired;
+  const onGatewayConnectRequiredRef = useRef(onGatewayConnectRequired);
+  onGatewayConnectRequiredRef.current = onGatewayConnectRequired;
 
   // One bridge per mount, created before the frame's document runs — the
   // same ordering contract as McpAppCard, for the same reason.
   useEffect(() => {
+    // Every leg reports the two refusals the host acts on and rethrows: the
+    // frame still sees a rejected call either way.
+    const reportRefusals = (error: unknown) => {
+      if (error instanceof AppInvokeRefusalError) {
+        if (error.kind === "consent_required") onConsentRequiredRef.current?.();
+        if (error.kind === "gateway_authorization_required")
+          onGatewayConnectRequiredRef.current?.(error.message);
+      }
+      throw error;
+    };
     const bridge = createMcpAppBridge({
       frame: () => frameRef.current?.contentWindow ?? null,
       theme: () => themeRef.current,
-      invokeOperation: async (operationId, parameters, body) => {
-        try {
-          return await apis.invokeOperation(
+      invokeOperation: (operationId, parameters, body) =>
+        apis
+          .invokeOperation(appId, operationId, parameters, body)
+          .catch(reportRefusals),
+      invokeGatewayOperation: (
+        gatewayApp,
+        operationId,
+        pathParameters,
+        query,
+        body,
+      ) =>
+        apis
+          .invokeGatewayOperation(
             appId,
+            gatewayApp,
             operationId,
-            parameters,
+            pathParameters,
+            query,
             body,
-          );
-        } catch (error) {
-          if (
-            error instanceof AppInvokeRefusalError &&
-            error.kind === "consent_required"
-          ) {
-            onConsentRequiredRef.current?.();
-          }
-          throw error;
-        }
-      },
-      invokeFolder: async (folder, op, path, contentBase64, replace) => {
-        try {
-          return await apis.invokeFolder(
-            appId,
-            folder,
-            op,
-            path,
-            contentBase64,
-            replace,
-          );
-        } catch (error) {
-          if (
-            error instanceof AppInvokeRefusalError &&
-            error.kind === "consent_required"
-          ) {
-            onConsentRequiredRef.current?.();
-          }
-          throw error;
-        }
-      },
+          )
+          .catch(reportRefusals),
+      invokeFolder: (folder, op, path, contentBase64, replace) =>
+        apis
+          .invokeFolder(appId, folder, op, path, contentBase64, replace)
+          .catch(reportRefusals),
     });
     bridgeRef.current = bridge;
     window.addEventListener("message", bridge.handleMessage);

--- a/crates/openwave-desktop/ui/src/apps/appsApis.ts
+++ b/crates/openwave-desktop/ui/src/apps/appsApis.ts
@@ -30,6 +30,14 @@ export type AppsApis = {
     parameters?: unknown,
     body?: unknown,
   ): Promise<AppRestInvokeResult>;
+  invokeGatewayOperation(
+    appId: string,
+    gatewayApp: string,
+    operationId: string,
+    pathParameters?: unknown,
+    query?: unknown,
+    body?: unknown,
+  ): Promise<AppRestInvokeResult>;
   invokeFolder(
     appId: string,
     folder: string,
@@ -38,6 +46,15 @@ export type AppsApis = {
     contentBase64?: string,
     replace?: boolean,
   ): Promise<AppFolderInvokeResult>;
+  /**
+   * The paired model gateway's origin, or `null` when this profile has none.
+   *
+   * Only a connect prompt reads it: the gateway's typed
+   * `authorization_required` can be resolved nowhere but at the gateway
+   * itself, and the handoff is its own SSO in the system browser — no token
+   * ever crosses from here.
+   */
+  gatewayBaseUrl(): Promise<string | null>;
 };
 
 export function appsApisFromClient(client: ApiClient): AppsApis {
@@ -52,7 +69,25 @@ export function appsApisFromClient(client: ApiClient): AppsApis {
     viewSession: (appId) => client.createAppViewFrame(appId),
     invokeOperation: (appId, operationId, parameters, body) =>
       client.invokeAppOperation(appId, operationId, parameters, body),
+    invokeGatewayOperation: (
+      appId,
+      gatewayApp,
+      operationId,
+      pathParameters,
+      query,
+      body,
+    ) =>
+      client.invokeAppGatewayOperation(
+        appId,
+        gatewayApp,
+        operationId,
+        pathParameters,
+        query,
+        body,
+      ),
     invokeFolder: (appId, folder, op, path, contentBase64, replace) =>
       client.invokeAppFolder(appId, folder, op, path, contentBase64, replace),
+    gatewayBaseUrl: async () =>
+      (await client.getGatewayStatus()).base_url ?? null,
   };
 }

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -374,7 +374,7 @@ export type AppInvokeRefusal = { kind: AppInvokeRefusalKind, message: string, };
  * open the grant sheet — so the kind is a closed generated union rather than
  * a free-form string.
  */
-export type AppInvokeRefusalKind = "app_not_found" | "not_pinned" | "consent_required" | "unknown_tool";
+export type AppInvokeRefusalKind = "app_not_found" | "not_pinned" | "consent_required" | "unknown_tool" | "gateway_unavailable" | "gateway_authorization_required";
 
 /**
  * The library listing: every live app, newest activity first.

--- a/crates/openwave-server/src/connected_apps.rs
+++ b/crates/openwave-server/src/connected_apps.rs
@@ -502,6 +502,100 @@ pub(crate) fn governed_rest_dispatcher(
     ))
 }
 
+/// One shared-app operation call, as the invoke route assembled it.
+///
+/// The field names are the gateway's own invoke vocabulary (ADR 0036) rather
+/// than a second spelling of it: `gateway_app` is what crosses the wire as
+/// `connected_app_id`, and the three passthrough halves are opaque JSON the
+/// server never interprets — a bundle authored against a harness frame speaks
+/// exactly this shape to the gateway shell.
+pub(crate) struct GatewayOperationRequest {
+    /// The gateway connected app whose operation is being called.
+    pub gateway_app: String,
+    /// The operation id, as the app's catalog declares it.
+    pub operation_id: String,
+    /// Path-template values for the operation, when it takes any.
+    pub path_parameters: Option<serde_json::Value>,
+    /// Query values for the operation, when it takes any.
+    pub query: Option<serde_json::Value>,
+    /// JSON request body, when the operation declares one.
+    pub body: Option<serde_json::Value>,
+}
+
+/// Why a gateway relay could not happen at all — as distinct from a call the
+/// gateway answered, which is a [`GatewayInvokeOutcome`].
+///
+/// Closed on purpose: the invoke route turns each of these into a typed
+/// refusal, and a fourth reading would need its own refusal kind rather than a
+/// free-form message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum GatewayDispatchError {
+    /// This profile has no gateway session to relay as — unmanaged, signed
+    /// out, or pointed at a deployment it never signed into.
+    NoSession,
+    /// Nothing at the gateway answers for this app: no draft is registered
+    /// for it, or the deployment predates the shared-app invoke route.
+    NotRegistered,
+    /// The gateway was reachable in principle but the call failed —
+    /// transport, protocol, or an answer this client could not read. The
+    /// message is host-authored and bounded; it carries no URL and no
+    /// credential material.
+    Unreachable(String),
+}
+
+/// Dispatch seam for one gateway shared-app relay, so the invoke route can be
+/// driven end to end in tests without an OAuth session against a fake
+/// deployment — the gateway twin of [`RestOperationDispatcher`]. Production is
+/// the relay over the one gateway runtime.
+#[async_trait]
+pub(crate) trait GatewayInvokeDispatcher: Send + Sync {
+    /// Relay `request` on behalf of the local app `app`, which the route has
+    /// already checked the pin, the grant, and the fingerprint currency of.
+    async fn dispatch(
+        &self,
+        app: openwave_core::id::AppId,
+        request: &GatewayOperationRequest,
+    ) -> Result<crate::connectors::GatewayInvokeOutcome, GatewayDispatchError>;
+}
+
+/// Resolves the gateway-side draft a local app was registered as, at the
+/// deployment `gateway_base_url` names.
+///
+/// The seam exists so the registration lifecycle is the only thing a later
+/// slice has to build: invoke already asks the right question, and answering
+/// it differently is an implementation swap rather than a reshaping of the
+/// ladder. Keyed by the gateway's base URL as well as the app, because a
+/// registration belongs to one deployment — a re-paired profile has no draft
+/// there, exactly as it has no current gateway grant.
+#[async_trait]
+pub(crate) trait GatewayDraftSource: Send + Sync {
+    async fn draft_shared_app_id(
+        &self,
+        app: openwave_core::id::AppId,
+        gateway_base_url: &str,
+    ) -> openwave_core::Result<Option<String>>;
+}
+
+/// The v1 draft source: nothing is registered, ever.
+///
+/// Draft registration is its own slice. Until it lands, a gateway binding
+/// walks the whole local ladder — pin, grant, fingerprint currency — and then
+/// refuses with a typed, teachable "not registered at the gateway" rather than
+/// relaying somewhere that could not answer. Replacing this implementation is
+/// all that slice has to do on the invoke path.
+pub(crate) struct NoRegisteredDrafts;
+
+#[async_trait]
+impl GatewayDraftSource for NoRegisteredDrafts {
+    async fn draft_shared_app_id(
+        &self,
+        _app: openwave_core::id::AppId,
+        _gateway_base_url: &str,
+    ) -> openwave_core::Result<Option<String>> {
+        Ok(None)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use serde_json::json;

--- a/crates/openwave-server/src/connectors/gateway.rs
+++ b/crates/openwave-server/src/connectors/gateway.rs
@@ -205,6 +205,33 @@ pub struct GatewayOperationSummary {
     pub summary: Option<String>,
 }
 
+/// What one shared-app invoke relay came back as.
+///
+/// Three outcomes, because the frame has three different things to do with
+/// them: render the response, prompt the viewer to connect the bound app at
+/// the gateway, or report a refusal. Nothing else is representable — a
+/// transport or protocol failure is the `Err` half, and a `404` on the route
+/// is `None`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GatewayInvokeOutcome {
+    /// The gateway executed the operation. Status, content type, and body are
+    /// the upstream API's, passed through: the body is base64 so binary
+    /// responses survive JSON, exactly as the local REST path returns them.
+    Executed {
+        status: u16,
+        content_type: Option<String>,
+        body_base64: String,
+    },
+    /// The viewer has no credential the gateway could resolve for the bound
+    /// app — its typed `authorization_required`. The viewer must connect the
+    /// app at the gateway; no local action can supply it.
+    AuthorizationRequired { message: String },
+    /// The gateway refused the call for any other typed reason (an
+    /// unconsented shared app, a manifest the operation is not in, a
+    /// credential resolution failure). The message is the gateway's own.
+    Refused { message: String },
+}
+
 /// One minted access/refresh pair, resource-bound.
 #[derive(Clone, PartialEq, Eq)]
 pub struct TokenSet {
@@ -553,6 +580,50 @@ impl GatewayAuth {
         }
         let list: OperationListResponse = decode_json(response, "app catalog request").await?;
         Ok(Some(list.into_operations()))
+    }
+
+    /// Relay one shared-app operation call to the gateway as the signed-in
+    /// user — the data-plane half of a local app's gateway binding.
+    ///
+    /// `request` is the invoke body verbatim (`connected_app_id`,
+    /// `operation_id`, `path_parameters`, `query`, `body`); the caller owns
+    /// its assembly, and nothing here interprets the passthrough halves. The
+    /// bearer is the ordinary `control`-audience session token — the same one
+    /// `/api/v1/cli/*` reads carry — never an attested one: these are
+    /// human-initiated frame calls with no model-emitted observation behind
+    /// them.
+    ///
+    /// `Ok(None)` is the route answering `404`: a gateway that does not serve
+    /// shared-app invokes yet, or an id it holds no app for. That reads as
+    /// "nothing answers this pin", the same degradation
+    /// [`apps`](Self::apps) and [`app_operations`](Self::app_operations) use,
+    /// rather than a fault.
+    pub async fn invoke_shared_app(
+        &self,
+        access_token: &str,
+        shared_app_id: &str,
+        request: &serde_json::Value,
+    ) -> Result<Option<GatewayInvokeOutcome>> {
+        validate_gateway_app_id(shared_app_id)?;
+        let mut url = self.endpoint("/api/apps/shared")?;
+        url.path_segments_mut()
+            .map_err(|()| gateway_error("configuration", "could not build endpoint URL"))?
+            .push(shared_app_id)
+            .push("invoke");
+        let response = self
+            .http
+            .post(url)
+            .bearer_auth(access_token)
+            .json(request)
+            .send()
+            .await
+            .map_err(|error| gateway_error("shared app invoke", error.without_url()))?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        let status = response.status();
+        let body = read_bounded(response, "shared app invoke").await?;
+        decode_shared_app_invoke(status, &body).map(Some)
     }
 
     async fn exchange_code(
@@ -1033,6 +1104,19 @@ impl GatewayConnection {
         self.auth.app_operations(&token, app_id).await
     }
 
+    /// Relay one shared-app operation call with a `control` token; `None`
+    /// when the gateway does not serve the invoke route or holds no such app.
+    pub async fn invoke_shared_app(
+        &self,
+        shared_app_id: &str,
+        request: &serde_json::Value,
+    ) -> Result<Option<GatewayInvokeOutcome>> {
+        let token = self.access_token(RESOURCE_CONTROL).await?;
+        self.auth
+            .invoke_shared_app(&token, shared_app_id, request)
+            .await
+    }
+
     /// The gateway's MCP endpoint URL for `slug`, under the configured base.
     pub fn mcp_endpoint_url(&self, slug: &str) -> Result<String> {
         validate_mcp_endpoint_slug(slug)?;
@@ -1206,6 +1290,184 @@ pub fn validate_mcp_endpoint_slug(slug: &str) -> Result<()> {
         return Err(gateway_error("configuration", "invalid MCP endpoint slug"));
     }
     Ok(())
+}
+
+/// The most a single gateway response body may occupy in memory. Matches the
+/// governed REST executor's response cap, so a relayed call is bounded exactly
+/// as a locally executed one is.
+const MAX_GATEWAY_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
+
+/// Read a response body with a hard byte bound.
+///
+/// An honest oversized `Content-Length` is refused before a byte is read; a
+/// lying one is caught by the check-before-extend, so neither turns into an
+/// unbounded allocation. The same shape [`crate::rest_executor`] uses for the
+/// bodies it brings back from third-party APIs.
+async fn read_bounded(response: reqwest::Response, operation: &str) -> Result<Vec<u8>> {
+    use futures::StreamExt as _;
+
+    let too_large = || gateway_error(operation, "response exceeded its byte budget");
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAX_GATEWAY_RESPONSE_BYTES as u64)
+    {
+        return Err(too_large());
+    }
+    let mut body = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|error| gateway_error(operation, error.without_url()))?;
+        if body.len().saturating_add(chunk.len()) > MAX_GATEWAY_RESPONSE_BYTES {
+            return Err(too_large());
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+/// Read the gateway's shared-app invoke answer, tolerantly — the one place
+/// that knows the wire shape.
+///
+/// **The gateway contract is still settling.** The shared-app invoke route is
+/// being built against this client in a separate repository, so pinning one
+/// exact envelope here would make the two repositories' merge order
+/// load-bearing. Every shape below is accepted instead, and this function is
+/// the only thing that has to change when the contract lands:
+///
+/// - **Typed failures** are read from `{"error": {"code", "message"}}`,
+///   `{"error": "<code>"}` with a sibling `message` or `error_description`,
+///   or a bare top-level `{"code", "message"}`. The code
+///   `authorization_required` becomes [`GatewayInvokeOutcome::AuthorizationRequired`]
+///   — the one outcome the frame must branch on — and every other code
+///   (including `consent_required`, which a first-open viewer may hit) becomes
+///   [`GatewayInvokeOutcome::Refused`] carrying the gateway's own message. A
+///   failure envelope is looked for on any non-2xx answer, and on a 2xx answer
+///   only when the body has an `error` member and no `status` member, so a
+///   passthrough response body can never be misread as one.
+/// - **Executed responses** come from `{operation_id, status, content_type,
+///   headers?, body}` or `{status, content_type, body_base64}`. `status`
+///   falls back to the HTTP status, and `content_type` to a `content-type`
+///   entry in `headers`. `body_base64` is taken verbatim (it must decode);
+///   a `body` string is the response text unless `body_encoding` says
+///   `base64`, and a `body` of any other JSON type is re-serialized compact.
+///   Guessing whether an arbitrary string "looks like" base64 is deliberately
+///   not attempted: it silently corrupts short text bodies.
+fn decode_shared_app_invoke(
+    status: reqwest::StatusCode,
+    body: &[u8],
+) -> Result<GatewayInvokeOutcome> {
+    const OPERATION: &str = "shared app invoke";
+
+    let Ok(payload) = serde_json::from_slice::<serde_json::Value>(body) else {
+        if status.is_success() {
+            return Err(gateway_error(OPERATION, "invalid response body"));
+        }
+        return Err(gateway_error(
+            OPERATION,
+            format!("HTTP status {}", status.as_u16()),
+        ));
+    };
+    let object = payload.as_object();
+    let looks_like_failure = !status.is_success()
+        || object.is_some_and(|payload| {
+            payload.contains_key("error") && !payload.contains_key("status")
+        });
+    if looks_like_failure {
+        if let Some((code, message)) = failure_envelope(&payload) {
+            let message = message.unwrap_or_else(|| code.clone());
+            return Ok(if code == "authorization_required" {
+                GatewayInvokeOutcome::AuthorizationRequired { message }
+            } else {
+                GatewayInvokeOutcome::Refused { message }
+            });
+        }
+        if !status.is_success() {
+            return Err(gateway_error(
+                OPERATION,
+                format!("HTTP status {}", status.as_u16()),
+            ));
+        }
+    }
+    let Some(payload) = object else {
+        return Err(gateway_error(OPERATION, "invalid response body"));
+    };
+    let executed_status = payload
+        .get("status")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|status| u16::try_from(status).ok())
+        .unwrap_or_else(|| status.as_u16());
+    let content_type = payload
+        .get("content_type")
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            payload
+                .get("headers")?
+                .as_object()?
+                .iter()
+                .find(|(name, _)| name.eq_ignore_ascii_case("content-type"))?
+                .1
+                .as_str()
+                .map(ToOwned::to_owned)
+        });
+    let body_base64 = if let Some(encoded) = payload.get("body_base64") {
+        let encoded = encoded
+            .as_str()
+            .ok_or_else(|| gateway_error(OPERATION, "invalid response body"))?;
+        base64::engine::general_purpose::STANDARD
+            .decode(encoded)
+            .map_err(|_| gateway_error(OPERATION, "invalid response body"))?;
+        encoded.to_owned()
+    } else {
+        let base64_encoded = payload
+            .get("body_encoding")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|encoding| encoding.eq_ignore_ascii_case("base64"));
+        let bytes = match payload.get("body") {
+            None | Some(serde_json::Value::Null) => Vec::new(),
+            Some(serde_json::Value::String(text)) if base64_encoded => {
+                base64::engine::general_purpose::STANDARD
+                    .decode(text)
+                    .map_err(|_| gateway_error(OPERATION, "invalid response body"))?
+            }
+            Some(serde_json::Value::String(text)) => text.clone().into_bytes(),
+            Some(value) => serde_json::to_vec(value)
+                .map_err(|_| gateway_error(OPERATION, "invalid response body"))?,
+        };
+        base64::engine::general_purpose::STANDARD.encode(bytes)
+    };
+    Ok(GatewayInvokeOutcome::Executed {
+        status: executed_status,
+        content_type,
+        body_base64,
+    })
+}
+
+/// The `(code, message)` of a typed gateway failure, in any of the shapes the
+/// route may carry it in — see [`decode_shared_app_invoke`].
+fn failure_envelope(payload: &serde_json::Value) -> Option<(String, Option<String>)> {
+    let text = |value: Option<&serde_json::Value>| {
+        value
+            .and_then(serde_json::Value::as_str)
+            .map(ToOwned::to_owned)
+    };
+    let (holder, code) = match payload.get("error") {
+        Some(serde_json::Value::Object(error)) => (
+            Some(error),
+            text(error.get("code")).or_else(|| text(error.get("error")))?,
+        ),
+        Some(serde_json::Value::String(code)) => (None, code.clone()),
+        _ => (None, text(payload.get("code"))?),
+    };
+    let message = holder
+        .and_then(|error| {
+            text(error.get("message"))
+                .or_else(|| text(error.get("detail")))
+                .or_else(|| text(error.get("description")))
+        })
+        .or_else(|| text(payload.get("message")))
+        .or_else(|| text(payload.get("error_description")));
+    Some((code, message))
 }
 
 async fn decode_json<T: for<'de> Deserialize<'de>>(

--- a/crates/openwave-server/src/connectors/mod.rs
+++ b/crates/openwave-server/src/connectors/mod.rs
@@ -37,6 +37,7 @@ pub use chatgpt::{
 pub use gateway::{
     has_stored_credentials, has_stored_credentials_for, is_sign_in_required,
     validate_mcp_endpoint_slug, AuthorizedSession, CredentialVault, GatewayApp, GatewayAuth,
-    GatewayAuthConfig, GatewayConnection, GatewayCredentials, GatewayIdentity, GatewayMeta,
-    GatewayModel, GatewayOperationSummary, PendingSignIn, TokenSet, RESOURCE_CONTROL, RESOURCE_LLM,
+    GatewayAuthConfig, GatewayConnection, GatewayCredentials, GatewayIdentity,
+    GatewayInvokeOutcome, GatewayMeta, GatewayModel, GatewayOperationSummary, PendingSignIn,
+    TokenSet, RESOURCE_CONTROL, RESOURCE_LLM,
 };

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -942,6 +942,130 @@ impl crate::connected_apps::GatewayCatalogSource for GatewayRuntime {
     }
 }
 
+/// The production gateway relay: the one gateway runtime plus the draft-id
+/// seam, wired behind [`GatewayInvokeDispatcher`].
+///
+/// Two lookups before any network call, both fail-closed: the profile must
+/// hold a session at the deployment policy names, and the local app must have
+/// a registered draft there. Only then is the invoke body assembled and
+/// relayed on a `control` bearer.
+pub(crate) struct GatewayRelayDispatcher {
+    runtime: Arc<GatewayRuntime>,
+    drafts: Arc<dyn crate::connected_apps::GatewayDraftSource>,
+}
+
+/// The relay as production assembles it: over the process's one gateway
+/// runtime, with no draft registration yet (see
+/// [`crate::connected_apps::NoRegisteredDrafts`]).
+pub(crate) fn gateway_relay_dispatcher(
+    runtime: Arc<GatewayRuntime>,
+) -> Arc<dyn crate::connected_apps::GatewayInvokeDispatcher> {
+    Arc::new(GatewayRelayDispatcher {
+        runtime,
+        drafts: Arc::new(crate::connected_apps::NoRegisteredDrafts),
+    })
+}
+
+#[async_trait]
+impl crate::connected_apps::GatewayInvokeDispatcher for GatewayRelayDispatcher {
+    async fn dispatch(
+        &self,
+        app: openwave_core::id::AppId,
+        request: &crate::connected_apps::GatewayOperationRequest,
+    ) -> std::result::Result<
+        crate::connectors::GatewayInvokeOutcome,
+        crate::connected_apps::GatewayDispatchError,
+    > {
+        use crate::connected_apps::GatewayDispatchError;
+
+        // A read that faults is reported as unreachable rather than as "no
+        // session": the distinction the route draws is whether a session
+        // exists, and a failed policy or vault read does not answer that.
+        let unreachable = |context: &'static str| {
+            move |error: openwave_core::AgentError| {
+                tracing::warn!("gateway relay could not {context}: {error}");
+                GatewayDispatchError::Unreachable(format!(
+                    "the gateway could not be reached to {context}"
+                ))
+            }
+        };
+        let policy = self
+            .runtime
+            .policy()
+            .await
+            .map_err(unreachable("read this profile's gateway policy"))?;
+        let Some(base_url) = policy.gateway_url.clone().filter(|_| policy.managed) else {
+            return Err(GatewayDispatchError::NoSession);
+        };
+        let Some(connection) = self
+            .runtime
+            .connection_for(&policy)
+            .await
+            .map_err(unreachable("open a gateway connection"))?
+        else {
+            return Err(GatewayDispatchError::NoSession);
+        };
+        if connection
+            .stored_credentials()
+            .await
+            .map_err(unreachable("read the stored gateway session"))?
+            .is_none()
+        {
+            return Err(GatewayDispatchError::NoSession);
+        }
+        let Some(shared_app_id) = self
+            .drafts
+            .draft_shared_app_id(app, &base_url)
+            .await
+            .map_err(unreachable("resolve this app's gateway draft"))?
+        else {
+            return Err(GatewayDispatchError::NotRegistered);
+        };
+        let body = shared_app_invoke_body(request);
+        match connection.invoke_shared_app(&shared_app_id, &body).await {
+            Ok(Some(outcome)) => Ok(outcome),
+            Ok(None) => Err(GatewayDispatchError::NotRegistered),
+            // A session the gateway no longer honors is "no session" here, the
+            // same reading every other gateway read gives it.
+            Err(error) if is_sign_in_required(&error) => Err(GatewayDispatchError::NoSession),
+            Err(error) => {
+                tracing::warn!("gateway shared-app invoke failed: {error}");
+                Err(GatewayDispatchError::Unreachable(
+                    "the gateway could not complete this call".to_owned(),
+                ))
+            }
+        }
+    }
+}
+
+/// The gateway's own invoke vocabulary, verbatim. Absent halves are omitted
+/// rather than sent as null: the gateway's argument fields default when
+/// missing but refuse an explicit null, matching its `proxy_api` tool's
+/// schema — a null here makes every relayed call an `invalid_request`.
+fn shared_app_invoke_body(
+    request: &crate::connected_apps::GatewayOperationRequest,
+) -> serde_json::Value {
+    let mut body = serde_json::Map::new();
+    body.insert(
+        "connected_app_id".into(),
+        serde_json::Value::String(request.gateway_app.clone()),
+    );
+    body.insert(
+        "operation_id".into(),
+        serde_json::Value::String(request.operation_id.clone()),
+    );
+    if let Some(path_parameters) = &request.path_parameters {
+        body.insert("path_parameters".into(), path_parameters.clone());
+    }
+    if let Some(query) = &request.query {
+        body.insert("query".into(), query.clone());
+    }
+    if let Some(request_body) = &request.body {
+        body.insert("body".into(), request_body.clone());
+    }
+    serde_json::Value::Object(body)
+}
+
 /// Retire a stored gateway session the resolved policy no longer stands
 /// behind.
 ///
@@ -1079,6 +1203,43 @@ mod tests {
     use serde_json::{json, Value};
 
     use super::*;
+
+    /// The relay body is the gateway's `proxy_api` vocabulary: absent halves
+    /// must be absent keys, never null — the gateway's `serde(default)`
+    /// argument maps refuse an explicit null, so a regression here fails
+    /// every relayed call while passing any test that fakes the dispatcher.
+    #[test]
+    fn invoke_body_omits_absent_argument_halves() {
+        let bare = shared_app_invoke_body(&crate::connected_apps::GatewayOperationRequest {
+            gateway_app: "app-1".into(),
+            operation_id: "listMonitors".into(),
+            path_parameters: None,
+            query: None,
+            body: None,
+        });
+        assert_eq!(
+            bare,
+            json!({"connected_app_id": "app-1", "operation_id": "listMonitors"})
+        );
+
+        let full = shared_app_invoke_body(&crate::connected_apps::GatewayOperationRequest {
+            gateway_app: "app-1".into(),
+            operation_id: "getMonitor".into(),
+            path_parameters: Some(json!({"monitor_id": "7"})),
+            query: Some(json!({"verbose": true})),
+            body: Some(json!({"note": "hi"})),
+        });
+        assert_eq!(
+            full,
+            json!({
+                "connected_app_id": "app-1",
+                "operation_id": "getMonitor",
+                "path_parameters": {"monitor_id": "7"},
+                "query": {"verbose": true},
+                "body": {"note": "hi"},
+            })
+        );
+    }
 
     #[derive(Default)]
     struct MockSecrets(std::sync::Mutex<HashMap<String, String>>);

--- a/crates/openwave-server/src/routes/app_invoke.rs
+++ b/crates/openwave-server/src/routes/app_invoke.rs
@@ -1,5 +1,6 @@
 //! `POST /apps/{id}/invoke` — out-of-turn invocation of a local app's pinned
-//! capabilities: declared REST operations of `rest_api` connected apps.
+//! capabilities: declared REST operations of `rest_api` connected apps,
+//! connected folders, and operations of gateway connected apps.
 //!
 //! The first tool execution outside a model turn: the sandboxed app frame
 //! posts a call to the trusted renderer, the renderer forwards it here on its
@@ -10,6 +11,12 @@
 //! manifest bindings, and a live app grant must cover the call — including
 //! that every granted connected app's current definition still matches the
 //! fingerprint recorded at consent.
+//!
+//! A gateway binding is the one surface that leaves the machine: it is
+//! relayed to the gateway's shared-app invoke route as the signed-in user, and
+//! the gateway re-enforces entitlement, its own manifest pin, and the viewer's
+//! credential live on every call. The local ladder runs first regardless, so
+//! an ungranted or stale call never reaches the network.
 //!
 //! Chat approval gates, permission modes, and plan mode deliberately do not
 //! apply: there is no chat. The app grant is the whole policy.
@@ -24,7 +31,10 @@ use openwave_core::id::AppId;
 use openwave_core::local_app::{AppBinding, AppGrantBinding, AppRecord, AppRevision};
 use openwave_core::AgentError;
 
-use crate::connected_apps::{current_fingerprints, current_rest_definitions};
+use crate::connected_apps::{
+    current_fingerprints, current_rest_definitions, GatewayDispatchError, GatewayOperationRequest,
+};
+use crate::connectors::GatewayInvokeOutcome;
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
 use crate::rest_executor::{RestExecuteError, RestOperationRequest};
@@ -37,23 +47,35 @@ pub(crate) const MAX_APP_INVOKE_BODY_BYTES: usize = 256 * 1024;
 
 /// Body of `POST /apps/{id}/invoke` — one of the invocable surfaces.
 ///
-/// Either `operation_id` (with optional `parameters`/`body`) for a declared
-/// REST operation, or `folder` (with `op` and its fields) for a connected
-/// folder — never both, never neither. The passthrough halves (`parameters`,
-/// `body`) are opaque JSON authored inside the sandboxed app frame; the
-/// server hands them to the executor verbatim and the renderer never
-/// interprets them, so — like [`super::McpAppPayload`] — this request has a
-/// hand-written TS twin rather than a generated wire type: the generator's
-/// precision guard rightly refuses `any`-shaped fields.
+/// Exactly one of three: `operation_id` (with optional `parameters`/`body`)
+/// for a declared REST operation of a local `rest_api` record, `gateway_app`
+/// plus `operation_id` (with optional `path_parameters`/`query`/`body`) for a
+/// gateway connected app's operation, or `folder` (with `op` and its fields)
+/// for a connected folder. The passthrough halves (`parameters`,
+/// `path_parameters`, `query`, `body`) are opaque JSON authored inside the
+/// sandboxed app frame; the server hands them to the executor or the gateway
+/// verbatim and the renderer never interprets them, so — like
+/// [`super::McpAppPayload`] — this request has a hand-written TS twin rather
+/// than a generated wire type: the generator's precision guard rightly refuses
+/// `any`-shaped fields.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AppInvokeRequest {
-    /// Catalog `operationId` of the pinned REST operation to execute.
+    /// Catalog `operationId` of the pinned operation to execute — of a local
+    /// `rest_api` record, or of `gateway_app` when that is present.
     pub operation_id: Option<String>,
-    /// Declared parameter values for the operation, name → JSON scalar.
+    /// Declared parameter values for a local REST operation, name → JSON
+    /// scalar.
     pub parameters: Option<serde_json::Value>,
     /// JSON request body, only when the operation declares one.
     pub body: Option<serde_json::Value>,
+    /// The gateway's connected-app id, for a gateway operation. Crosses to
+    /// the gateway as `connected_app_id`, the name its own invoke route uses.
+    pub gateway_app: Option<String>,
+    /// Path-template values for a gateway operation.
+    pub path_parameters: Option<serde_json::Value>,
+    /// Query values for a gateway operation.
+    pub query: Option<serde_json::Value>,
     /// Root id of the pinned connected folder, for a folder operation.
     pub folder: Option<openwave_core::id::HostRootId>,
     /// Folder operation: `list`, `read`, or `write`.
@@ -118,6 +140,14 @@ pub enum AppInvokeRefusalKind {
     /// The pinned name does not resolve to a declared catalog operation or an
     /// available connected folder right now.
     UnknownTool,
+    /// The manifest pins a gateway operation but nothing at the gateway
+    /// answers for it: no session, no registered draft, or a deployment that
+    /// does not serve shared-app invokes. The message says which.
+    GatewayUnavailable,
+    /// The gateway reached the bound app and had no credential for this
+    /// viewer. Only the viewer can fix it, and only at the gateway — so the
+    /// frame renders a connect prompt rather than an error.
+    GatewayAuthorizationRequired,
 }
 
 /// The typed refusal body — the `{ kind, message }` shape every route error
@@ -132,12 +162,17 @@ impl AppInvokeRefusal {
     fn status(&self) -> StatusCode {
         match self.kind {
             AppInvokeRefusalKind::AppNotFound => StatusCode::NOT_FOUND,
-            AppInvokeRefusalKind::NotPinned | AppInvokeRefusalKind::ConsentRequired => {
-                StatusCode::FORBIDDEN
-            }
+            AppInvokeRefusalKind::NotPinned
+            | AppInvokeRefusalKind::ConsentRequired
+            // The call was authorized here and refused there, for want of a
+            // credential only the viewer can supply: forbidden, not a
+            // conflict with local state.
+            | AppInvokeRefusalKind::GatewayAuthorizationRequired => StatusCode::FORBIDDEN,
             // The manifest pin exists but nothing configured answers to it —
             // a conflict with current state, not a bad request.
-            AppInvokeRefusalKind::UnknownTool => StatusCode::CONFLICT,
+            AppInvokeRefusalKind::UnknownTool | AppInvokeRefusalKind::GatewayUnavailable => {
+                StatusCode::CONFLICT
+            }
         }
     }
 }
@@ -176,6 +211,7 @@ impl IntoResponse for AppInvokeError {
 /// Which surface one admitted request names.
 enum InvokeSurface {
     Operation(RestOperationRequest),
+    Gateway(GatewayOperationRequest),
     Folder {
         folder: openwave_core::id::HostRootId,
         path: String,
@@ -200,6 +236,12 @@ impl FolderOp {
 }
 
 /// Read the request's surface, refusing a body that names several or none.
+///
+/// The three surfaces take three disjoint field sets, and each refuses the
+/// others' outright rather than ignoring them: a caller that sent `query` to a
+/// local operation, or `parameters` to a gateway one, meant something the
+/// server would not have done, and silently dropping the field is how a call
+/// ends up wider or narrower than its author believed.
 fn requested_surface(request: AppInvokeRequest) -> Result<InvokeSurface, AppInvokeError> {
     let invalid = |message: &str| {
         AppInvokeError::Failed(ServerError::unprocessable_kind(
@@ -207,13 +249,33 @@ fn requested_surface(request: AppInvokeRequest) -> Result<InvokeSurface, AppInvo
             message,
         ))
     };
-    match (request.operation_id, request.folder) {
-        (Some(operation_id), None) => {
-            if request.op.is_some()
-                || request.path.is_some()
-                || request.content_base64.is_some()
-                || request.replace.is_some()
-            {
+    let folder_fields = request.op.is_some()
+        || request.path.is_some()
+        || request.content_base64.is_some()
+        || request.replace.is_some();
+    match (request.operation_id, request.folder, request.gateway_app) {
+        (Some(operation_id), None, Some(gateway_app)) => {
+            if folder_fields || request.parameters.is_some() {
+                return Err(invalid(
+                    "a gateway_app invoke takes operation_id, path_parameters, query, \
+                     and body and nothing else",
+                ));
+            }
+            Ok(InvokeSurface::Gateway(GatewayOperationRequest {
+                gateway_app,
+                operation_id,
+                path_parameters: request.path_parameters,
+                query: request.query,
+                body: request.body,
+            }))
+        }
+        (Some(operation_id), None, None) => {
+            // `path_parameters` and `query` are the gateway's vocabulary. A
+            // local operation takes its values through `parameters`, which the
+            // catalog validates against declared parameter locations, so
+            // admitting the gateway spellings here would widen the local
+            // surface with fields nothing enforces.
+            if folder_fields || request.path_parameters.is_some() || request.query.is_some() {
                 return Err(invalid(
                     "an operation_id invoke takes parameters and body and nothing else",
                 ));
@@ -226,8 +288,12 @@ fn requested_surface(request: AppInvokeRequest) -> Result<InvokeSurface, AppInvo
                 body: request.body,
             }))
         }
-        (None, Some(folder)) => {
-            if request.parameters.is_some() || request.body.is_some() {
+        (None, Some(folder), None) => {
+            if request.parameters.is_some()
+                || request.body.is_some()
+                || request.path_parameters.is_some()
+                || request.query.is_some()
+            {
                 return Err(invalid(
                     "a folder invoke takes op, path, content_base64, and replace \
                      and nothing else",
@@ -266,8 +332,10 @@ fn requested_surface(request: AppInvokeRequest) -> Result<InvokeSurface, AppInvo
             };
             Ok(InvokeSurface::Folder { folder, path, op })
         }
+        (None, None, Some(_)) => Err(invalid("a gateway_app invoke needs an operation_id")),
         _ => Err(invalid(
-            "exactly one of operation_id or folder must be provided",
+            "exactly one of operation_id (optionally with gateway_app) or folder \
+             must be provided",
         )),
     }
 }
@@ -297,6 +365,34 @@ pub async fn post_app_invoke(
             )
             .await?;
             dispatch_rest_operation(&state, &revision, &request)
+                .await
+                .map(|result| Json(result).into_response())
+        }
+        InvokeSurface::Gateway(request) => {
+            require_pinned_gateway_operation(
+                &revision,
+                &request.gateway_app,
+                &request.operation_id,
+            )?;
+            let current = require_app_grant(
+                &state,
+                &app,
+                &revision,
+                &Pinned::GatewayOperation {
+                    gateway_app: &request.gateway_app,
+                    operation_id: &request.operation_id,
+                },
+            )
+            .await?;
+            // The consent sheet's label for the app, when the currency read
+            // that just passed carried one — every refusal below names the app
+            // the viewer would recognize, not the gateway's opaque id.
+            let display_name = current
+                .gateway_apps
+                .get(&request.gateway_app)
+                .map_or(request.gateway_app.as_str(), |app| app.name.as_str())
+                .to_owned();
+            dispatch_gateway_operation(&state, app_id, &request, &display_name)
                 .await
                 .map(|result| Json(result).into_response())
         }
@@ -409,9 +505,50 @@ fn require_pinned_folder(
     ))
 }
 
+/// Refuse any gateway operation the current revision's manifest does not pin
+/// under that exact gateway app.
+///
+/// The pin is the pair, never the operation id alone: two gateway apps may
+/// well declare the same id, and a manifest that binds one of them must not
+/// admit a call to the other.
+fn require_pinned_gateway_operation(
+    revision: &AppRevision,
+    gateway_app: &str,
+    operation_id: &str,
+) -> Result<(), AppInvokeError> {
+    let pinned = revision
+        .manifest
+        .bindings
+        .iter()
+        .any(|binding| match binding {
+            AppBinding::GatewayOperations(binding) => {
+                binding.gateway_app == gateway_app
+                    && binding
+                        .operation_ids
+                        .iter()
+                        .any(|pinned| pinned == operation_id)
+            }
+            AppBinding::Operations(_) | AppBinding::Folder(_) => false,
+        });
+    if pinned {
+        return Ok(());
+    }
+    Err(AppInvokeError::refused(
+        AppInvokeRefusalKind::NotPinned,
+        format!(
+            "operation {operation_id:?} of gateway app {gateway_app} is not pinned in \
+             this app's current manifest"
+        ),
+    ))
+}
+
 /// The invoked capability, for the grant gate.
 enum Pinned<'a> {
     Operation(&'a str),
+    GatewayOperation {
+        gateway_app: &'a str,
+        operation_id: &'a str,
+    },
     Folder {
         folder: openwave_core::id::HostRootId,
         writes: bool,
@@ -422,6 +559,10 @@ impl Pinned<'_> {
     fn description(&self) -> String {
         match self {
             Self::Operation(operation_id) => format!("operation {operation_id:?}"),
+            Self::GatewayOperation {
+                gateway_app,
+                operation_id,
+            } => format!("operation {operation_id:?} of gateway app {gateway_app}"),
             Self::Folder { folder, writes } => {
                 if *writes {
                     format!("writing folder {folder}")
@@ -449,13 +590,18 @@ impl Pinned<'_> {
 ///    it. The `mcp_server` fingerprint covers the namespace and the
 ///    `rest_api` fingerprint the base URL, document hash, and credential
 ///    reference, so a repointed record can never keep a grant that now
-///    describes different capabilities.
+///    describes different capabilities. A gateway grant pins the deployment,
+///    the app id, and the catalog hash, so a re-paired profile or a
+///    re-ingested app re-prompts before anything is relayed.
+///
+/// The currency read is returned so callers can label a refusal with what the
+/// gateway currently calls an app, without a second live read.
 async fn require_app_grant(
     state: &AppState,
     app: &AppRecord,
     revision: &AppRevision,
     pinned: &Pinned<'_>,
-) -> Result<(), AppInvokeError> {
+) -> Result<crate::connected_apps::CurrentFingerprints, AppInvokeError> {
     let consent_required =
         |message: String| AppInvokeError::refused(AppInvokeRefusalKind::ConsentRequired, message);
     let Some(grant) = state.store.get_app_grant(app.id).await? else {
@@ -481,7 +627,24 @@ async fn require_app_grant(
                                 == openwave_core::local_app::FolderAccess::ReadWrite)
             )
         }),
-        _ => {
+        // A gateway capability is keyed by the gateway's app id, which the
+        // grant carries directly — there is no local record to resolve it
+        // through, so the pair is matched as bound.
+        Pinned::GatewayOperation {
+            gateway_app,
+            operation_id,
+        } => grant.bindings.iter().any(|binding| {
+            matches!(
+                binding,
+                AppGrantBinding::GatewayOperations(granted)
+                    if granted.gateway_app == *gateway_app
+                        && granted
+                            .operation_ids
+                            .iter()
+                            .any(|granted| granted == operation_id)
+            )
+        }),
+        Pinned::Operation(_) => {
             let connected_app = revision
                 .manifest
                 .bindings
@@ -544,7 +707,7 @@ async fn require_app_grant(
             }));
         }
     }
-    Ok(())
+    Ok(current)
 }
 
 /// Resolve the pinned operation's `rest_api` record and run the governed
@@ -610,6 +773,68 @@ async fn dispatch_rest_operation(
             is_error: true,
             error: Some(error.to_string()),
         }),
+    }
+}
+
+/// Relay one granted gateway operation through the dispatch seam.
+///
+/// Everything local has already passed: the manifest pins the pair, the grant
+/// covers it, and the gateway's catalog still reads as it did at consent. What
+/// is left is the gateway's own live enforcement — entitlement, its manifest,
+/// and the viewer's credential — so its answers map by who can act on them.
+/// An executed call is passthrough, identical to the local REST path. A typed
+/// `authorization_required` is a refusal the *viewer* resolves, at the gateway
+/// and nowhere else, so it crosses machine-readably rather than as prose. Any
+/// other gateway refusal is the app's to present, as an `is_error` result in
+/// the gateway's own words. And a relay that could not happen at all is
+/// `gateway_unavailable`, whose message says which of the two reasons it was.
+async fn dispatch_gateway_operation(
+    state: &AppState,
+    app_id: AppId,
+    request: &GatewayOperationRequest,
+    display_name: &str,
+) -> Result<AppRestInvokeResult, AppInvokeError> {
+    let failure = |error: String| AppRestInvokeResult {
+        status: None,
+        content_type: None,
+        body_base64: None,
+        is_error: true,
+        error: Some(error),
+    };
+    match state.gateway_dispatch.dispatch(app_id, request).await {
+        Ok(GatewayInvokeOutcome::Executed {
+            status,
+            content_type,
+            body_base64,
+        }) => Ok(AppRestInvokeResult {
+            status: Some(status),
+            content_type,
+            body_base64: Some(body_base64),
+            is_error: false,
+            error: None,
+        }),
+        Ok(GatewayInvokeOutcome::AuthorizationRequired { message }) => {
+            Err(AppInvokeError::refused(
+                AppInvokeRefusalKind::GatewayAuthorizationRequired,
+                format!("connect {display_name} at your model gateway to continue: {message}"),
+            ))
+        }
+        Ok(GatewayInvokeOutcome::Refused { message }) => Ok(failure(message)),
+        Err(GatewayDispatchError::NoSession) => Err(AppInvokeError::refused(
+            AppInvokeRefusalKind::GatewayUnavailable,
+            format!(
+                "{display_name} is served by your model gateway, and this profile has no \
+                 gateway session to call it with"
+            ),
+        )),
+        Err(GatewayDispatchError::NotRegistered) => Err(AppInvokeError::refused(
+            AppInvokeRefusalKind::GatewayUnavailable,
+            format!(
+                "this app is not registered at your model gateway, so {display_name} \
+                 cannot be called yet"
+            ),
+        )),
+        Err(GatewayDispatchError::Unreachable(error)) => Ok(failure(error)),
     }
 }
 

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -136,6 +136,13 @@ pub struct AppState {
     /// runtime below; tests substitute a static roster behind the same seam
     /// rather than standing up an OAuth session against a fake deployment.
     pub(crate) gateway_catalogs: Arc<dyn crate::connected_apps::GatewayCatalogSource>,
+    /// Relays one pinned gateway operation to the gateway's shared-app invoke
+    /// route as the signed-in user. The production assembly is the relay over
+    /// the one gateway runtime
+    /// ([`crate::gateway_runtime::gateway_relay_dispatcher`]); tests
+    /// substitute a fake so the whole refusal ladder is drivable without a
+    /// deployment.
+    pub(crate) gateway_dispatch: Arc<dyn crate::connected_apps::GatewayInvokeDispatcher>,
     /// Outstanding single-use tokens redeemed by the sandboxed view frames —
     /// prefetched MCP views and stored local-app revisions alike.
     pub(crate) view_frames: Arc<ViewFrameTokens>,
@@ -345,6 +352,7 @@ impl AppState {
         ));
         let rest_dispatch = crate::connected_apps::governed_rest_dispatcher(secrets.clone());
         let gateway_catalogs = gateway.clone();
+        let gateway_dispatch = crate::gateway_runtime::gateway_relay_dispatcher(gateway.clone());
         Ok(Self {
             config: Arc::new(config),
             store: store.clone(),
@@ -355,6 +363,7 @@ impl AppState {
             mcp,
             rest_dispatch,
             gateway_catalogs,
+            gateway_dispatch,
             view_frames: Arc::default(),
             gateway,
             chatgpt,

--- a/crates/openwave-server/src/tests/app_grant.rs
+++ b/crates/openwave-server/src/tests/app_grant.rs
@@ -238,22 +238,22 @@ async fn body_string(response: axum::response::Response) -> String {
 /// What a fake gateway session holds: the deployment's base URL and one
 /// entry per readable app — id, display name, declared operation ids. `None`
 /// is a profile with no session at all.
-type FakeGatewaySession = Option<(String, Vec<(String, String, Vec<String>)>)>;
+pub(super) type FakeGatewaySession = Option<(String, Vec<(String, String, Vec<String>)>)>;
 
 /// A gateway catalog source standing in for a live session: `None` is a
 /// profile with no session at all, and a present roster answers only the ids
 /// it holds.
-struct FakeGatewayCatalogs(std::sync::Mutex<FakeGatewaySession>);
+pub(super) struct FakeGatewayCatalogs(pub(super) std::sync::Mutex<FakeGatewaySession>);
 
 impl FakeGatewayCatalogs {
-    fn signed_in(base_url: &str, apps: &[(&str, &str, &[&str])]) -> Self {
+    pub(super) fn signed_in(base_url: &str, apps: &[(&str, &str, &[&str])]) -> Self {
         Self(std::sync::Mutex::new(Some((
             base_url.to_owned(),
             Self::roster(apps),
         ))))
     }
 
-    fn roster(apps: &[(&str, &str, &[&str])]) -> Vec<(String, String, Vec<String>)> {
+    pub(super) fn roster(apps: &[(&str, &str, &[&str])]) -> Vec<(String, String, Vec<String>)> {
         apps.iter()
             .map(|(id, name, operations)| {
                 (

--- a/crates/openwave-server/src/tests/app_invoke.rs
+++ b/crates/openwave-server/src/tests/app_invoke.rs
@@ -540,6 +540,304 @@ async fn a_widened_manifest_requires_fresh_consent_for_the_new_operations() {
     assert_eq!(response.status(), StatusCode::OK);
 }
 
+// --- Gateway operation bindings ---
+
+use openwave_core::local_app::AppGatewayOperationsBinding;
+
+use crate::connected_apps::{
+    GatewayDispatchError, GatewayInvokeDispatcher, GatewayOperationRequest,
+};
+use crate::connectors::GatewayInvokeOutcome;
+use crate::tests::app_grant::FakeGatewayCatalogs;
+
+/// What the fake relay should answer next.
+enum GatewayAnswer {
+    Executed,
+    AuthorizationRequired,
+    NoSession,
+    NotRegistered,
+}
+
+/// A relay seam standing in for the gateway's shared-app invoke route,
+/// recording exactly what crossed it.
+struct FakeGatewayDispatch {
+    /// One entry per dispatched call: the invoking app and the five fields of
+    /// the gateway's own invoke vocabulary.
+    calls: StdMutex<Vec<serde_json::Value>>,
+    answer: StdMutex<GatewayAnswer>,
+}
+
+impl FakeGatewayDispatch {
+    fn new() -> Self {
+        Self {
+            calls: StdMutex::new(Vec::new()),
+            answer: StdMutex::new(GatewayAnswer::Executed),
+        }
+    }
+
+    fn answers(&self, answer: GatewayAnswer) {
+        *self.answer.lock().unwrap() = answer;
+    }
+}
+
+#[async_trait]
+impl GatewayInvokeDispatcher for FakeGatewayDispatch {
+    async fn dispatch(
+        &self,
+        app: AppId,
+        request: &GatewayOperationRequest,
+    ) -> Result<GatewayInvokeOutcome, GatewayDispatchError> {
+        self.calls.lock().unwrap().push(json!({
+            "app": app,
+            "gateway_app": request.gateway_app,
+            "operation_id": request.operation_id,
+            "path_parameters": request.path_parameters,
+            "query": request.query,
+            "body": request.body,
+        }));
+        match *self.answer.lock().unwrap() {
+            GatewayAnswer::Executed => Ok(GatewayInvokeOutcome::Executed {
+                status: 201,
+                content_type: Some("application/json".into()),
+                body_base64: base64::engine::general_purpose::STANDARD.encode(br#"{"ok":true}"#),
+            }),
+            GatewayAnswer::AuthorizationRequired => {
+                Ok(GatewayInvokeOutcome::AuthorizationRequired {
+                    message: "sign in to Issues to continue".into(),
+                })
+            }
+            GatewayAnswer::NoSession => Err(GatewayDispatchError::NoSession),
+            GatewayAnswer::NotRegistered => Err(GatewayDispatchError::NotRegistered),
+        }
+    }
+}
+
+/// A profile whose gateway catalog reads and relay both come from fakes,
+/// holding one app that pins `operation_ids` of the gateway app `gateway_app`.
+async fn gateway_test_app(
+    catalogs: Arc<FakeGatewayCatalogs>,
+    relay: Arc<FakeGatewayDispatch>,
+    gateway_app: &str,
+    operation_ids: &[&str],
+) -> (Router, String, AppId, tempfile::TempDir) {
+    let (dir, store) = temp_db_store("gateway-invoke.db").await;
+    let store: Arc<dyn Store> = Arc::new(store);
+    let mut state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    state.gateway_catalogs = catalogs;
+    state.gateway_dispatch = relay;
+    let bearer = format!("Bearer {}", state.token);
+    let router = app(state);
+
+    let app_id = AppId::new();
+    store
+        .create_app(&CreateApp {
+            id: app_id,
+            revision: NewAppRevision {
+                id: AppRevisionId::new(),
+                manifest: AppManifest {
+                    name: "Gateway fixture".into(),
+                    bindings: vec![AppBinding::GatewayOperations(AppGatewayOperationsBinding {
+                        gateway_app: gateway_app.to_owned(),
+                        operation_ids: operation_ids.iter().map(|id| (*id).to_owned()).collect(),
+                    })],
+                },
+                byte_len: 1,
+                sha256: [0; 32],
+                turn_id: None,
+                producing_run_id: None,
+                chat_id: None,
+                created_at: chrono::Utc::now(),
+            },
+        })
+        .await
+        .unwrap();
+    (router, bearer, app_id, dir)
+}
+
+/// The gateway ladder end to end over the API: the local gates all run before
+/// anything leaves the machine, the relay receives exactly the gateway's own
+/// five-field invoke vocabulary, an executed call crosses back as opaque
+/// passthrough, and the two ways nothing can answer are distinguishable —
+/// `gateway_authorization_required` is the viewer's to fix at the gateway,
+/// `gateway_unavailable` is a pin nothing answers. A moved catalog closes the
+/// gate again without a network call.
+#[tokio::test]
+async fn gateway_invokes_walk_the_ladder_before_anything_leaves_the_machine() {
+    let catalogs = Arc::new(FakeGatewayCatalogs::signed_in(
+        "https://gateway.internal.example.com",
+        &[(
+            "gw-issues",
+            "Issues (gateway)",
+            &["listIssues", "createIssue"],
+        )],
+    ));
+    let relay = Arc::new(FakeGatewayDispatch::new());
+    let (router, bearer, app_id, _dir) = gateway_test_app(
+        catalogs.clone(),
+        relay.clone(),
+        "gw-issues",
+        &["listIssues"],
+    )
+    .await;
+    let calls = || relay.calls.lock().unwrap().len();
+
+    // Fail closed before consent, and on every unpinned or malformed shape.
+    // The local and gateway surfaces stay disjoint: `parameters` is the local
+    // operation vocabulary and `query` the gateway's, and neither is quietly
+    // dropped when it lands on the other.
+    let refusals = [
+        (
+            json!({"gateway_app": "gw-issues", "operation_id": "createIssue"}),
+            StatusCode::FORBIDDEN,
+            "not_pinned",
+        ),
+        (
+            json!({"gateway_app": "gw-elsewhere", "operation_id": "listIssues"}),
+            StatusCode::FORBIDDEN,
+            "not_pinned",
+        ),
+        (
+            json!({"gateway_app": "gw-issues", "operation_id": "listIssues"}),
+            StatusCode::FORBIDDEN,
+            "consent_required",
+        ),
+        (
+            json!({"gateway_app": "gw-issues"}),
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "invalid_invoke_request",
+        ),
+        (
+            json!({"gateway_app": "gw-issues", "operation_id": "listIssues",
+                   "parameters": {"q": "open"}}),
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "invalid_invoke_request",
+        ),
+        (
+            json!({"operation_id": "listIssues", "query": {"q": "open"}}),
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "invalid_invoke_request",
+        ),
+    ];
+    for (body, status, kind) in refusals {
+        let response = invoke(&router, &bearer, app_id, body.clone()).await;
+        assert_eq!(response.status(), status, "{body}");
+        let info: AgentErrorInfo = json_body(response).await;
+        assert_eq!(info.kind, kind, "{body}");
+    }
+    assert_eq!(calls(), 0, "no local refusal may reach the gateway");
+
+    // Granted and current: the relay receives the gateway's own vocabulary
+    // verbatim — the bound app id, the operation, and the three passthrough
+    // halves — attributed to the invoking app, and the answer crosses back as
+    // opaque passthrough.
+    consent(&router, &bearer, app_id).await;
+    let response = invoke(
+        &router,
+        &bearer,
+        app_id,
+        json!({"gateway_app": "gw-issues", "operation_id": "listIssues",
+               "path_parameters": {"id": "7"}, "query": {"state": "open"},
+               "body": {"note": "hi"}}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let result: serde_json::Value = json_body(response).await;
+    assert_eq!(result["status"], json!(201));
+    assert_eq!(result["content_type"], json!("application/json"));
+    assert_eq!(result["is_error"], json!(false));
+    assert_eq!(
+        base64::engine::general_purpose::STANDARD
+            .decode(result["body_base64"].as_str().unwrap())
+            .unwrap(),
+        br#"{"ok":true}"#
+    );
+    assert_eq!(
+        relay.calls.lock().unwrap().as_slice(),
+        [json!({
+            "app": app_id,
+            "gateway_app": "gw-issues",
+            "operation_id": "listIssues",
+            "path_parameters": {"id": "7"},
+            "query": {"state": "open"},
+            "body": {"note": "hi"},
+        })]
+    );
+
+    // The gateway's typed `authorization_required` crosses machine-readably
+    // and names the app the viewer would recognize — never the gateway's id
+    // alone, and never as prose the frame would have to match on.
+    relay.answers(GatewayAnswer::AuthorizationRequired);
+    let response = invoke(
+        &router,
+        &bearer,
+        app_id,
+        json!({"gateway_app": "gw-issues", "operation_id": "listIssues"}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let info: AgentErrorInfo = json_body(response).await;
+    assert_eq!(info.kind, "gateway_authorization_required");
+    assert!(
+        info.message.contains("Issues (gateway)"),
+        "{}",
+        info.message
+    );
+
+    // A pin nothing can answer is a conflict with current state, and the
+    // message says which of the two reasons it was.
+    for (answer, expected) in [
+        (GatewayAnswer::NoSession, "no gateway session"),
+        (GatewayAnswer::NotRegistered, "not registered"),
+    ] {
+        relay.answers(answer);
+        let response = invoke(
+            &router,
+            &bearer,
+            app_id,
+            json!({"gateway_app": "gw-issues", "operation_id": "listIssues"}),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let info: AgentErrorInfo = json_body(response).await;
+        assert_eq!(info.kind, "gateway_unavailable");
+        assert!(info.message.contains(expected), "{}", info.message);
+    }
+
+    // A re-ingested catalog moves the fingerprint, so consent is stale and the
+    // call stops at the grant gate — before the relay, not after it.
+    let before = calls();
+    *catalogs.0.lock().unwrap() = Some((
+        "https://gateway.internal.example.com".to_owned(),
+        FakeGatewayCatalogs::roster(&[("gw-issues", "Issues (gateway)", &["listIssues"])]),
+    ));
+    relay.answers(GatewayAnswer::Executed);
+    let response = invoke(
+        &router,
+        &bearer,
+        app_id,
+        json!({"gateway_app": "gw-issues", "operation_id": "listIssues"}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let info: AgentErrorInfo = json_body(response).await;
+    assert_eq!(info.kind, "consent_required");
+    assert_eq!(
+        calls(),
+        before,
+        "a stale grant must stop the call before the relay"
+    );
+}
+
 // --- Folder bindings ---
 
 use std::collections::BTreeMap as StdBTreeMap;

--- a/crates/openwave-server/tests/connectors_gateway_flow.rs
+++ b/crates/openwave-server/tests/connectors_gateway_flow.rs
@@ -19,7 +19,7 @@ use base64::Engine;
 use openwave_core::{Result as CoreResult, SecretProvider};
 use openwave_server::connectors::{
     is_sign_in_required, CredentialVault, GatewayAuth, GatewayAuthConfig, GatewayConnection,
-    RESOURCE_CONTROL, RESOURCE_LLM,
+    GatewayInvokeOutcome, RESOURCE_CONTROL, RESOURCE_LLM,
 };
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
@@ -68,6 +68,14 @@ struct FakeGateway {
     /// Serve 404 for the per-app catalog read, like a gateway that predates
     /// it while still listing entitlements.
     catalogs_unsupported: AtomicBool,
+    /// Serve 404 for the shared-app invoke route, like a gateway that predates
+    /// shared apps entirely.
+    shared_apps_unsupported: AtomicBool,
+    /// Answer the next shared-app invoke with the typed
+    /// `authorization_required` failure instead of executing it.
+    shared_app_needs_authorization: AtomicBool,
+    /// Shared-app invoke bodies observed, with the bearer's resource.
+    shared_app_invokes: Mutex<Vec<(String, Option<String>, Value)>>,
     /// Attestation context ids observed on refresh grants, in order.
     contexts_seen: Mutex<Vec<String>>,
     /// Reject the next unseen attestation context with `invalid_target`,
@@ -338,6 +346,51 @@ async fn app_operations(
     .into_response()
 }
 
+/// The shared-app invoke route (ADR 0036): the SPA-tier data plane, reached
+/// here on a harness's `control`-audience PKCE session.
+async fn shared_app_invoke(
+    State(gateway): State<Arc<FakeGateway>>,
+    axum::extract::Path(shared_app_id): axum::extract::Path<String>,
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> Response {
+    if gateway.shared_apps_unsupported.load(Ordering::SeqCst) {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    let resource = bearer_resource(&gateway, &headers);
+    gateway
+        .shared_app_invokes
+        .lock()
+        .unwrap()
+        .push((shared_app_id, resource.clone(), body));
+    if resource.as_deref() != Some("control") {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    if gateway
+        .shared_app_needs_authorization
+        .load(Ordering::SeqCst)
+    {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({
+                "error": {
+                    "code": "authorization_required",
+                    "message": "Connect Incident API to continue",
+                }
+            })),
+        )
+            .into_response();
+    }
+    Json(json!({
+        "operation_id": "listIncidents",
+        "status": 200,
+        "content_type": "application/json",
+        "headers": { "x-request-id": "abc" },
+        "body": { "incidents": [] },
+    }))
+    .into_response()
+}
+
 async fn serve_fake_gateway(gateway: Arc<FakeGateway>) -> SocketAddr {
     let app = Router::new()
         .route("/api/v1/meta", get(meta))
@@ -348,6 +401,10 @@ async fn serve_fake_gateway(gateway: Arc<FakeGateway>) -> SocketAddr {
         .route("/api/v1/cli/models", get(models))
         .route("/api/v1/cli/apps", get(apps))
         .route("/api/v1/cli/apps/{app_id}/operations", get(app_operations))
+        .route(
+            "/api/apps/shared/{shared_app_id}/invoke",
+            post(shared_app_invoke),
+        )
         .with_state(gateway);
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();
@@ -666,4 +723,78 @@ async fn app_catalogs_read_declared_operations_and_degrade_when_the_surface_is_m
         connection.app_operations("app-incident").await.unwrap(),
         None
     );
+}
+
+/// The shared-app invoke relay: the data-plane half of a gateway app binding.
+/// It has to reach the route with the ordinary `control` session bearer and
+/// the gateway's own five-field body, surface the typed
+/// `authorization_required` as its own outcome rather than as prose, and read
+/// a deployment that does not serve the route as unavailable rather than a
+/// fault — the gateway half is still shipping.
+#[tokio::test]
+async fn shared_app_invokes_relay_on_the_control_session_and_degrade_when_unserved() {
+    let (gateway, connection) = signed_in_connection().await;
+    // The production relay omits absent argument halves entirely (the
+    // gateway's serde defaults refuse an explicit null); the fixture body
+    // mirrors the real wire shape.
+    let request = json!({
+        "connected_app_id": "app-incident",
+        "operation_id": "listIncidents",
+        "query": { "state": "open" },
+    });
+
+    let outcome = connection
+        .invoke_shared_app("shared-1", &request)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        outcome,
+        GatewayInvokeOutcome::Executed {
+            status: 200,
+            content_type: Some("application/json".into()),
+            body_base64: base64::engine::general_purpose::STANDARD.encode(br#"{"incidents":[]}"#),
+        }
+    );
+    let seen = gateway.shared_app_invokes.lock().unwrap().clone();
+    assert_eq!(seen.len(), 1);
+    assert_eq!(seen[0].0, "shared-1");
+    assert_eq!(
+        seen[0].1.as_deref(),
+        Some("control"),
+        "the relay carries the ordinary control session bearer, never an \
+         attested or endpoint-scoped one"
+    );
+    assert_eq!(seen[0].2, request);
+
+    // The one failure the frame must branch on keeps its own outcome, with
+    // the gateway's own message.
+    gateway
+        .shared_app_needs_authorization
+        .store(true, Ordering::SeqCst);
+    assert_eq!(
+        connection
+            .invoke_shared_app("shared-1", &request)
+            .await
+            .unwrap()
+            .unwrap(),
+        GatewayInvokeOutcome::AuthorizationRequired {
+            message: "Connect Incident API to continue".into(),
+        }
+    );
+
+    // A deployment that does not serve the route reads as "nothing answers
+    // this pin", the same degradation the entitlement and catalog reads use.
+    gateway
+        .shared_apps_unsupported
+        .store(true, Ordering::SeqCst);
+    assert_eq!(
+        connection
+            .invoke_shared_app("shared-1", &request)
+            .await
+            .unwrap(),
+        None
+    );
+    // An id outside the binding grammar never reaches the wire at all.
+    assert!(connection.invoke_shared_app("", &request).await.is_err());
 }

--- a/docs/local-apps.md
+++ b/docs/local-apps.md
@@ -46,8 +46,14 @@ An app revision is an untrusted **bundle** and a trusted **manifest**:
   that catalog. Every input is read live per request — nothing about a gateway
   app is cached locally — so a profile with no session, an app that loses its
   entitlement, or a re-ingested catalog all fail closed to re-consent. Invoke
-  still has no relay: a gateway binding can be authored and granted, but
-  calling it is the next slice.
+  relays the call to the gateway's shared-app route on a `control`-audience
+  session bearer — after the local ladder passes, never before — and the
+  gateway re-enforces entitlement, its own manifest pin, and credential
+  resolution live per call. A viewer who still needs to connect the bound
+  app at the gateway gets the typed `gateway_authorization_required`
+  refusal (the detail page offers the connect affordance); a profile whose
+  gateway session, deployment, or draft registration cannot answer gets
+  `gateway_unavailable`, with the message naming which.
 
 The containment story is inherited from MCP App views and unchanged: the frame
 is served by the host with its own strict CSP (`default-src 'none'`,


### PR DESCRIPTION
A manifest's gateway binding could be pinned and consented but never
executed. This adds the dispatch half from
`docs/decisions/0007-gateway-app-bindings.md`: the invoke route grows a
third surface that relays a pinned operation to the gateway's shared-app
invoke route as the signed-in user, after the whole local ladder — pin,
grant, fingerprint currency — has already passed.

The relay is a seam (`GatewayInvokeDispatcher`) beside the REST one, so
the ladder is drivable end to end without an OAuth session against a fake
deployment. Production is the one gateway runtime plus a draft-id seam
(`GatewayDraftSource`) whose implementation here registers nothing: a
gateway call refuses as `gateway_unavailable` with a teachable message
until draft registration lands, and that slice replaces only this
implementation.

Two refusal kinds join the closed union. `gateway_authorization_required`
(403) is the gateway's typed failure for a viewer it holds no credential
for — it crosses machine-readably so the frame can render a connect
prompt, and the desktop offers one over the frame that opens the gateway
in the system browser. No token travels with it; the gateway's own SSO is
the handoff. `gateway_unavailable` (409) is a pin nothing answers.

The client's decode of the invoke answer is deliberately tolerant and
lives in one documented function. The gateway half is still shipping in
its own repository, so pinning one envelope here would make the two
repositories' merge order load-bearing; the decode reads the fields it
needs and treats a shape it does not recognize as an unserved pin rather
than an error.

The relay body is the gateway's invoke vocabulary verbatim, and absent
argument halves are omitted rather than sent as null: the gateway's
argument fields default when missing but refuse an explicit null, so a
null makes every relayed call an `invalid_request`. That contract lives in
one function.

The frame bridge routes `operations/call` by the presence of
`connected_app_id` — the gateway shell's own invoke vocabulary — so a
bundle authored here runs unmodified there and vice versa. Legacy calls
without it stay local, and the local surface is not widened: the two field
sets refuse each other rather than being quietly dropped.

Tests: the ladder-order test is the one worth reading — it asserts that an
unpinned, ungranted, or stale call refuses before the dispatcher is ever
reached, and that the relay is attempted only once pin, grant, and
currency have all passed, which is exactly what a naive happy-path invoke
test leaves green. Beside it, the fake gateway's flow test covers the
relay and its degradations, a unit test pins the omit-absent-halves body
contract (a faked dispatcher cannot catch a regression there), and the
desktop tests cover the bridge's routing by `connected_app_id`, the local
surface refusing a mixed field set, and the connect prompt rendering from
a typed `gateway_authorization_required`.

The path was also exercised end to end against a live gateway fixture
deployment, including from the desktop app.

Stacked: PR 5 of 6, on top of #1935. PR 6 builds on this one.
