### PR TITLE
chore(server): development draft-source pin for gateway relay testing

### DIFF
--- a/crates/openwave-server/src/connected_apps.rs
+++ b/crates/openwave-server/src/connected_apps.rs
@@ -596,6 +596,65 @@ impl GatewayDraftSource for NoRegisteredDrafts {
     }
 }
 
+/// A development stand-in for draft registration, fed by
+/// `OPENWAVE_GATEWAY_DRAFT_APPS` (`<local app id>=<shared app id>`,
+/// comma-separated).
+///
+/// Registration is a coming slice; until it lands there is no way to exercise
+/// the relay against a real gateway. This source lets a developer pin the
+/// mapping by hand after registering the draft out of band. It deliberately
+/// ignores the deployment key — a hand-maintained map is already scoped to
+/// the one gateway the developer is driving — and it is only consulted when
+/// the variable is set, so production behavior is byte-identical without it.
+///
+/// Debug builds only: a release daemon's process environment must never be
+/// able to redirect a consented invoke.
+#[cfg(debug_assertions)]
+pub(crate) struct EnvPinnedDrafts {
+    map: std::collections::BTreeMap<String, String>,
+}
+
+#[cfg(debug_assertions)]
+impl EnvPinnedDrafts {
+    /// The env-pinned map, or `None` when the variable is unset or empty.
+    pub(crate) fn from_env() -> Option<Self> {
+        let raw = std::env::var("OPENWAVE_GATEWAY_DRAFT_APPS").ok()?;
+        let map: std::collections::BTreeMap<String, String> = raw
+            .split(',')
+            .filter_map(|pair| {
+                let (app, draft) = pair.split_once('=')?;
+                let (app, draft) = (app.trim(), draft.trim());
+                (!app.is_empty() && !draft.is_empty()).then(|| (app.to_string(), draft.to_string()))
+            })
+            .collect();
+        if map.is_empty() {
+            tracing::warn!(
+                "OPENWAVE_GATEWAY_DRAFT_APPS is set but holds no `<app id>=<shared app id>` \
+                 pairs; gateway draft pinning is off"
+            );
+            return None;
+        }
+        tracing::info!(
+            "gateway draft pins loaded for {} local app(s): {:?}",
+            map.len(),
+            map.keys().collect::<Vec<_>>(),
+        );
+        Some(Self { map })
+    }
+}
+
+#[cfg(debug_assertions)]
+#[async_trait]
+impl GatewayDraftSource for EnvPinnedDrafts {
+    async fn draft_shared_app_id(
+        &self,
+        app: openwave_core::id::AppId,
+        _gateway_base_url: &str,
+    ) -> openwave_core::Result<Option<String>> {
+        Ok(self.map.get(&app.to_string()).cloned())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use serde_json::json;

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -956,14 +956,23 @@ pub(crate) struct GatewayRelayDispatcher {
 
 /// The relay as production assembles it: over the process's one gateway
 /// runtime, with no draft registration yet (see
-/// [`crate::connected_apps::NoRegisteredDrafts`]).
+/// [`crate::connected_apps::NoRegisteredDrafts`]). Debug builds alone may
+/// pin a mapping via `OPENWAVE_GATEWAY_DRAFT_APPS` (see
+/// [`crate::connected_apps::EnvPinnedDrafts`]) — a release daemon must not
+/// let its process environment redirect consented invokes.
 pub(crate) fn gateway_relay_dispatcher(
     runtime: Arc<GatewayRuntime>,
 ) -> Arc<dyn crate::connected_apps::GatewayInvokeDispatcher> {
-    Arc::new(GatewayRelayDispatcher {
-        runtime,
-        drafts: Arc::new(crate::connected_apps::NoRegisteredDrafts),
-    })
+    #[cfg(debug_assertions)]
+    let drafts: Arc<dyn crate::connected_apps::GatewayDraftSource> =
+        match crate::connected_apps::EnvPinnedDrafts::from_env() {
+            Some(pinned) => Arc::new(pinned),
+            None => Arc::new(crate::connected_apps::NoRegisteredDrafts),
+        };
+    #[cfg(not(debug_assertions))]
+    let drafts: Arc<dyn crate::connected_apps::GatewayDraftSource> =
+        Arc::new(crate::connected_apps::NoRegisteredDrafts);
+    Arc::new(GatewayRelayDispatcher { runtime, drafts })
 }
 
 #[async_trait]


### PR DESCRIPTION
Draft registration is a later slice, so nothing yet maps a local app to
the shared app the gateway holds — which leaves the relay landed in
#1936 with no way to be exercised against a real deployment.

`OPENWAVE_GATEWAY_DRAFT_APPS` pins that mapping by hand
(`<local app id>=<shared app id>`, comma-separated) after a draft has been
registered out of band, so the whole ladder can be driven end to end
against a live gateway.

The shim is debug-builds-only — the source and its wiring are both behind
`cfg(debug_assertions)`, so a release daemon's process environment can
never redirect a consented invoke — and it is inert unless the variable is
set: without it, production assembles the same `NoRegisteredDrafts` source
as before, byte for byte. It logs what it loaded at boot, and warns when
the variable is set but parses to no pairs, because a silent no-op here
reads exactly like a gateway refusing the call.

This exists until draft registration lands, and comes out when it does.

Tests: none. The shim is development scaffolding that no shipped build
runs; a test here would pin the scaffolding's own shape and would have to
be deleted along with it. The relay it feeds is covered in #1936.

Stacked: PR 6 of 6, on top of #1936.
