### PR TITLE
chore(cli): scratch keychain-service override for headless dev daemons

### DIFF
--- a/crates/openwave-cli/src/main.rs
+++ b/crates/openwave-cli/src/main.rs
@@ -685,7 +685,17 @@ fn profile_config() -> Result<Config> {
     let mut config = Config::from_env()?;
     #[cfg(debug_assertions)]
     {
-        config.keychain_service = Some("openwave.dev".into());
+        // `OPENWAVE_KEYCHAIN_SERVICE` lets a headless rig point a debug daemon
+        // at a scratch keychain service. A freshly re-linked binary reading the
+        // shared `openwave.dev` items trips the macOS ACL prompt, which blocks
+        // a session with no UI forever; a scratch service starts empty and
+        // every item it creates is owned by this binary, so nothing prompts.
+        config.keychain_service = Some(
+            std::env::var("OPENWAVE_KEYCHAIN_SERVICE")
+                .ok()
+                .filter(|service| !service.is_empty())
+                .unwrap_or_else(|| "openwave.dev".into()),
+        );
     }
     Ok(config)
 }


### PR DESCRIPTION
Debug builds pin the keychain service to `openwave.dev`, which is right
for a developer's own daemon and wrong for a headless one: a freshly
re-linked binary reading the shared `openwave.dev` items trips the macOS
ACL prompt, and a session with no UI to answer it blocks forever.

`OPENWAVE_KEYCHAIN_SERVICE` points such a daemon at a scratch service
instead. A scratch service starts empty and every item it creates is owned
by the binary that created it, so nothing prompts.

The override is debug builds only — it sits inside the existing
`cfg(debug_assertions)` block that sets the development service in the
first place — and falls back to `openwave.dev` when the variable is unset
or empty, so the ordinary developer path is unchanged.

Tests: none. This is a development-only default inside an existing
debug-only block; a test would assert that an env read reads the env.

Independent of the gateway app bindings stack; it applies directly to
`main`.
