### PR TITLE
feat(models): prioritize OpenAI curated models

### DIFF
--- a/crates/openwave-desktop/ui/src/ModelMenu.test.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.test.tsx
@@ -247,11 +247,11 @@ describe("notConnectedProviders", () => {
 
 describe("firstAvailableModel", () => {
   it("lands in render order, not catalog order", () => {
-    // OpenAI first in the catalog, but Anthropic renders first — the toggle
+    // Anthropic first in the catalog, but OpenAI renders first — the toggle
     // must land where the reader sees the check appear.
     const [sonnet, gpt] = MODELS;
     expect(firstAvailableModel([gpt, sonnet], null)?.key).toBe(
-      "anthropic::claude-sonnet-4",
+      "openai::gpt-4o",
     );
   });
 

--- a/crates/openwave-desktop/ui/src/ModelMenu.test.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.test.tsx
@@ -155,7 +155,7 @@ describe("visibleModelGroups", () => {
       withAvailability({ anthropic: true, openai: false }),
       "openai::gpt-4o",
     );
-    expect(groups.map((group) => group.provider)).toEqual(["anthropic", "openai"]);
+    expect(groups.map((group) => group.provider)).toEqual(["openai", "anthropic"]);
   });
 
   it("keeps a partially available provider intact", () => {
@@ -247,11 +247,11 @@ describe("notConnectedProviders", () => {
 
 describe("firstAvailableModel", () => {
   it("lands in render order, not catalog order", () => {
-    // Anthropic first in the catalog, but OpenAI renders first — the toggle
-    // must land where the reader sees the check appear.
+    // This fixture's OpenAI row is intentionally non-recommended, so the
+    // first visible row remains Anthropic even though OpenAI renders first.
     const [sonnet, gpt] = MODELS;
     expect(firstAvailableModel([gpt, sonnet], null)?.key).toBe(
-      "openai::gpt-4o",
+      "anthropic::claude-sonnet-4",
     );
   });
 

--- a/crates/openwave-desktop/ui/src/ModelMenu.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.tsx
@@ -46,8 +46,8 @@ import { cn } from "@/lib/utils";
  * model — muscle memory is worth more here than catalog order.
  */
 const PROVIDER_ORDER: readonly ProviderKind[] = [
-  "anthropic",
   "openai",
+  "anthropic",
   "xai",
   "gemini",
   "fireworks",

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -485,7 +485,7 @@ function ProviderRow({
                 {models.length === 0 && (
                   <p className="text-xs text-muted-foreground">
                     {info.kind === "xai"
-                      ? "Add each xAI model available to this API key, including its limits and supported capabilities."
+                      ? "Grok 4.5 is ready when you connect xAI. Add any additional account models here, including their limits and supported capabilities."
                       : "Add each model this endpoint serves. Custom models start with conservative text-only, non-reasoning capabilities."}
                   </p>
                 )}
@@ -720,8 +720,7 @@ function ProviderRow({
                       info.kind !== "openai_compatible" &&
                       !key.trim()) ||
                     (hasConfigurableModels &&
-                      models.some((model) => !model.id.trim())) ||
-                    (info.kind === "xai" && models.length === 0)
+                      models.some((model) => !model.id.trim()))
                   }
                   onClick={() => void save(true)}
                 >

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -855,7 +855,7 @@ impl Server {
 
 /// Default model when none is configured via settings or per-chat. Overridable
 /// with `OPENWAVE_MODEL`.
-const DEFAULT_MODEL: &str = "claude-opus-5";
+const DEFAULT_MODEL: &str = "gpt-5.6-sol";
 
 /// Wire the store from `config` and bind the API to an ephemeral loopback port.
 ///

--- a/crates/openwave-server/src/model_registry.rs
+++ b/crates/openwave-server/src/model_registry.rs
@@ -83,6 +83,12 @@ const EFFORT_LOW_TO_HIGH: &[ReasoningEffort] = &[
     ReasoningEffort::Medium,
     ReasoningEffort::High,
 ];
+const EFFORT_LOW_TO_XHIGH: &[ReasoningEffort] = &[
+    ReasoningEffort::Low,
+    ReasoningEffort::Medium,
+    ReasoningEffort::High,
+    ReasoningEffort::XHigh,
+];
 const EFFORT_LOW_TO_MAX: &[ReasoningEffort] = &[
     ReasoningEffort::Low,
     ReasoningEffort::Medium,
@@ -448,6 +454,23 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         supports_vendor_web_search: false,
         reasoning_efforts: EFFORT_NONE_TO_XHIGH,
     },
+    // xAI publishes a 500,000-token input limit for Grok 4.5 but no output
+    // ceiling. Keep the output cap conservative until the exact model is
+    // exercised end to end. Its first-party Responses route carries image
+    // input and a low-through-xhigh reasoning scale.
+    ModelSpec {
+        id: "grok-4.5",
+        display_name: "Grok 4.5",
+        provider: ProviderKind::Xai,
+        verification: VerificationTier::Unverified,
+        recommended: true,
+        context_window: 500_000,
+        max_output_tokens: 32_768,
+        input_modalities: TEXT_AND_IMAGE,
+        supports_reasoning: true,
+        supports_vendor_web_search: false,
+        reasoning_efforts: EFFORT_LOW_TO_XHIGH,
+    },
     // Gemini rows are intentionally limited to ids currently published by
     // Google. All four accept images, expose thinking levels through `high`,
     // and have 1,048,576 input / 65,536 output token limits; the Flash rows
@@ -471,7 +494,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         display_name: "Gemini 3.5 Flash",
         provider: ProviderKind::Gemini,
         verification: VerificationTier::Verified,
-        recommended: false,
+        recommended: true,
         context_window: 1_048_576,
         max_output_tokens: 65_536,
         input_modalities: TEXT_AND_IMAGE,
@@ -1021,11 +1044,11 @@ mod tests {
     #[test]
     fn the_built_in_default_is_the_first_curated_row_of_its_provider() {
         let spec = find(crate::DEFAULT_MODEL).expect("the default model must be curated");
-        assert_eq!(spec.provider, ProviderKind::Anthropic);
+        assert_eq!(spec.provider, ProviderKind::Openai);
         // The default has to be the current generation, not a pin that happened
         // to be current when it was written down.
         assert_eq!(
-            models_for(ProviderKind::Anthropic).next().map(|s| s.id),
+            models_for(ProviderKind::Openai).next().map(|s| s.id),
             Some(crate::DEFAULT_MODEL),
         );
         // A default the picker hides by default would be selected for every
@@ -1046,6 +1069,22 @@ mod tests {
                  credentials it renders an empty provider"
             );
         }
+    }
+
+    #[test]
+    fn grok_4_5_and_gemini_3_5_flash_are_curated_defaults() {
+        let grok = find_for(ProviderKind::Xai, "grok-4.5").unwrap();
+        assert_eq!(grok.context_window, 500_000);
+        assert_eq!(grok.max_output_tokens, 32_768);
+        assert!(grok.recommended);
+        assert!(grok.accepts(InputModality::Image));
+        assert_eq!(grok.reasoning_efforts, EFFORT_LOW_TO_XHIGH);
+
+        assert!(
+            find_for(ProviderKind::Gemini, "gemini-3.5-flash")
+                .unwrap()
+                .recommended
+        );
     }
 
     #[test]

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -270,8 +270,8 @@ pub enum ProviderKind {
 impl ProviderKind {
     /// All kinds the server knows about, in display order.
     pub const ALL: &'static [ProviderKind] = &[
-        ProviderKind::Anthropic,
         ProviderKind::Openai,
+        ProviderKind::Anthropic,
         ProviderKind::Xai,
         ProviderKind::Gemini,
         ProviderKind::Fireworks,
@@ -431,10 +431,10 @@ pub struct ProviderConfig {
     pub base_url: Option<String>,
     /// Explicit model rows served by a configurable endpoint.
     ///
-    /// OpenAI-compatible and xAI catalogs can change independently of an
-    /// OpenWave release, so their configured rows live beside the
-    /// endpoint. Other curated providers ignore this field and obtain their
-    /// models from the host registry.
+    /// OpenAI-compatible endpoints and extra xAI account models can change
+    /// independently of an OpenWave release, so their configured rows live
+    /// beside the endpoint. Other curated providers ignore this field and
+    /// obtain their models from the host registry.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub models: Vec<CustomModelConfig>,
 }
@@ -1139,12 +1139,6 @@ pub async fn update_provider(
             "openai_compatible requires a base_url when enabled",
         ));
     }
-    if kind == ProviderKind::Xai && config.enabled && config.models.is_empty() {
-        return Err(ServerError::bad_request(
-            "xai requires at least one configured model when enabled",
-        ));
-    }
-
     if let Some(credential) = update.credential {
         write_credential(secrets, kind, &credential).await?;
     }
@@ -1503,9 +1497,6 @@ pub async fn collect_routes(
         if kind == ProviderKind::OpenaiCompatible && base_url.is_none() {
             continue;
         }
-        if kind == ProviderKind::Xai && config.models.is_empty() {
-            continue;
-        }
         if kind.uses_openai_compatible_transport() {
             let base = base_url.as_deref().unwrap_or("");
             if !(base.starts_with("https://") || base.starts_with("http://")) {
@@ -1664,9 +1655,6 @@ pub async fn provider_is_usable(
         if !(base.starts_with("https://") || base.starts_with("http://")) {
             return Ok(false);
         }
-    }
-    if kind == ProviderKind::Xai && config.models.is_empty() {
-        return Ok(false);
     }
     Ok(true)
 }

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -1328,7 +1328,7 @@ async fn models_catalog_includes_enabled_credentialed_providers() {
 }
 
 #[tokio::test]
-async fn xai_settings_publish_explicit_model_capabilities() {
+async fn xai_settings_publish_curated_and_explicit_model_capabilities() {
     let (router, token, _store, _dir) = test_app().await;
     let bearer = format!("Bearer {token}");
 
@@ -1349,7 +1349,7 @@ async fn xai_settings_publish_explicit_model_capabilities() {
         .unwrap();
     assert_eq!(endpoint_override.status(), StatusCode::BAD_REQUEST);
 
-    let missing_models = router
+    let key_only = router
         .clone()
         .oneshot(
             Request::builder()
@@ -1369,7 +1369,9 @@ async fn xai_settings_publish_explicit_model_capabilities() {
         )
         .await
         .unwrap();
-    assert_eq!(missing_models.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(key_only.status(), StatusCode::OK);
+    let configured: serde_json::Value = json_body(key_only).await;
+    assert_eq!(configured["models"], serde_json::json!([]));
 
     let put = router
         .clone()
@@ -1413,6 +1415,13 @@ async fn xai_settings_publish_explicit_model_capabilities() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
     let catalog: serde_json::Value = json_body(response).await;
+    let grok = catalog["models"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|model| model["key"] == "xai::grok-4.5")
+        .unwrap();
+    assert!(grok["available"].as_bool().unwrap());
     let model = catalog["models"]
         .as_array()
         .unwrap()

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -1460,24 +1460,7 @@ async fn xai_config_builds_a_provider_qualified_native_route() {
             // row or direct write could still contain it. Route collection
             // must not let it redirect the credential.
             base_url: Some("https://attacker.invalid/v1".into()),
-            models: vec![providers::CustomModelConfig {
-                id: "grok-account-model".into(),
-                context_window: 500_000,
-                max_output_tokens: 32_768,
-                input_modalities: vec![
-                    crate::model_registry::InputModality::Text,
-                    crate::model_registry::InputModality::Image,
-                ],
-                supports_reasoning: true,
-                reasoning_efforts: vec![
-                    openwave_core::ReasoningEffort::None,
-                    openwave_core::ReasoningEffort::Low,
-                    openwave_core::ReasoningEffort::Medium,
-                    openwave_core::ReasoningEffort::High,
-                    openwave_core::ReasoningEffort::XHigh,
-                ],
-                ..Default::default()
-            }],
+            models: Vec::new(),
         },
     )
     .await
@@ -1490,13 +1473,13 @@ async fn xai_config_builds_a_provider_qualified_native_route() {
     assert_eq!(routes.len(), 1);
     assert_eq!(routes[0].kind, openwave_router::RouteKind::Xai);
     assert_eq!(routes[0].base_url, None);
-    assert_eq!(routes[0].curated_models, ["grok-account-model"]);
+    assert_eq!(routes[0].curated_models, ["grok-4.5"]);
 
-    let configured = providers::resolve_model_policy(&*store, "grok-account-model", false)
+    let grok = providers::resolve_model_policy(&*store, "grok-4.5", false)
         .await
         .unwrap()
-        .expect("a bare configured xAI id resolves to its sole owner");
-    assert_eq!(configured.provider, providers::ProviderKind::Xai);
+        .expect("a bare curated xAI id resolves to its direct provider");
+    assert_eq!(grok.provider, providers::ProviderKind::Xai);
     let curated = providers::resolve_model_policy(&*store, "gpt-5.6-sol", false)
         .await
         .unwrap()
@@ -1505,17 +1488,11 @@ async fn xai_config_builds_a_provider_qualified_native_route() {
 
     let router = openwave_router::Router::build(routes);
     assert_eq!(
-        router.select_for(
-            Some(&openwave_core::ProviderId::new("xai")),
-            "grok-account-model"
-        ),
+        router.select_for(Some(&openwave_core::ProviderId::new("xai")), "grok-4.5"),
         Some(openwave_router::RouteKind::Xai)
     );
     assert_eq!(
-        router.select_for(
-            Some(&openwave_core::ProviderId::new("openai")),
-            "grok-account-model"
-        ),
+        router.select_for(Some(&openwave_core::ProviderId::new("openai")), "grok-4.5"),
         None
     );
 }

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -154,13 +154,13 @@ reports what each role resolves to so a client can label the automatic choice.
 
 OpenAI-compatible endpoints can register custom model IDs and their context and
 output limits in provider settings. Those models enter the same catalog with
-conservative text-only, non-reasoning capabilities. xAI also uses explicit
-configured model rows because the models available to an API key can change
-independently of an OpenWave release; each row records its own limits, image
-input support, reasoning support, and accepted effort levels. Existing
-unqualified model settings are migrated at the API boundary when exactly one
-configured provider owns the ID. Ambiguous IDs fail closed and must be
-reselected with their provider, so routing never depends on registry order.
+conservative text-only, non-reasoning capabilities. xAI has the curated Grok
+4.5 row plus optional configured account models; each configured row records
+its own limits, image input support, reasoning support, and accepted effort
+levels. Existing unqualified model settings are migrated at the API boundary
+when exactly one configured provider owns the ID. Ambiguous IDs fail closed and
+must be reselected with their provider, so routing never depends on registry
+order.
 
 ## What happens during a chat turn
 


### PR DESCRIPTION
## Summary

- place OpenAI first in provider settings and the model picker, and use GPT-5.6 Sol as the built-in default
- curate Grok 4.5 for xAI so an API key alone enables a working xAI route; retain configurable account-specific xAI models
- recommend Gemini 3.5 Flash by default

## Validation

- `cargo test -p openwave-server --locked grok_4_5_and_gemini_3_5_flash_are_curated_defaults`
- `cargo test -p openwave-server --locked xai_config_builds_a_provider_qualified_native_route`
- `cargo test -p openwave-server --locked the_built_in_default_is_the_first_curated_row_of_its_provider`
- `git diff --check`

The targeted UI Vitest command could not run in this worktree because `crates/openwave-desktop/ui/node_modules` is absent (`vitest: command not found`).