### PR TITLE
feat(server): store-backed gateway draft registration with auto-relayed author consent

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -1501,6 +1501,52 @@ pub mod app_grant {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+pub mod app_gateway_draft {
+    use sea_orm::entity::prelude::*;
+
+    // One row per (local app, gateway deployment): the shared app the local
+    // app is registered as there, the gateway revision that registration
+    // currently serves, and the local revision it was projected from. The
+    // deployment is part of the key, so a re-paired profile reads no
+    // registration rather than a stale one.
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "app_gateway_draft")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub app_id: Uuid,
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub gateway_base_url: String,
+        pub shared_app_id: String,
+        pub gateway_revision_id: String,
+        pub synced_revision_id: Uuid,
+        pub updated_at: DateTimeUtc,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter)]
+    pub enum Relation {
+        App,
+    }
+
+    impl RelationTrait for Relation {
+        fn def(&self) -> RelationDef {
+            match self {
+                Self::App => Entity::belongs_to(super::app::Entity)
+                    .from(Column::AppId)
+                    .to(super::app::Column::Id)
+                    .into(),
+            }
+        }
+    }
+
+    impl Related<super::app::Entity> for Entity {
+        fn to() -> RelationDef {
+            Relation::App.def()
+        }
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub mod event {
     use sea_orm::entity::prelude::*;
 

--- a/crates/openwave-core/src/db/migration/baseline/content.rs
+++ b/crates/openwave-core/src/db/migration/baseline/content.rs
@@ -653,6 +653,65 @@ pub(super) fn app_grant_indexes() -> Vec<IndexCreateStatement> {
     Vec::new()
 }
 
+/// The gateway-side registration one local app holds at one deployment: the
+/// shared app it was registered as, the gateway revision that registration is
+/// currently serving, and the local revision that revision was projected from.
+///
+/// The key is `(app_id, gateway_base_url)` because a registration belongs to
+/// one deployment. A profile re-paired to a different gateway finds no row
+/// there and registers afresh; the rows the previous pairing left are orphaned
+/// rather than misread, and nothing sweeps them — they die with the app row.
+pub(super) fn app_gateway_draft_table() -> TableCreateStatement {
+    Table::create()
+        .table(AppGatewayDraft::Table)
+        .col(ColumnDef::new(AppGatewayDraft::AppId).uuid().not_null())
+        .col(
+            ColumnDef::new(AppGatewayDraft::GatewayBaseUrl)
+                .text()
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(AppGatewayDraft::SharedAppId)
+                .text()
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(AppGatewayDraft::GatewayRevisionId)
+                .text()
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(AppGatewayDraft::SyncedRevisionId)
+                .uuid()
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(AppGatewayDraft::UpdatedAt)
+                .timestamp_with_time_zone()
+                .not_null(),
+        )
+        .primary_key(
+            Index::create()
+                .col(AppGatewayDraft::AppId)
+                .col(AppGatewayDraft::GatewayBaseUrl),
+        )
+        .foreign_key(
+            ForeignKey::create()
+                .name("fk_app_gateway_draft_app")
+                .from(AppGatewayDraft::Table, AppGatewayDraft::AppId)
+                .to(App::Table, App::Id)
+                .on_delete(ForeignKeyAction::Cascade),
+        )
+        .check(Expr::col(AppGatewayDraft::GatewayBaseUrl).ne(""))
+        .check(Expr::col(AppGatewayDraft::SharedAppId).ne(""))
+        .check(Expr::col(AppGatewayDraft::GatewayRevisionId).ne(""))
+        .to_owned()
+}
+
+pub(super) fn app_gateway_draft_indexes() -> Vec<IndexCreateStatement> {
+    Vec::new()
+}
+
 /// The profile-scoped connected-app record (docs/connected-apps.md), including
 /// the persisted MCP server configuration: one `mcp_server`-kind row per
 /// server.

--- a/crates/openwave-core/src/db/migration/baseline/mod.rs
+++ b/crates/openwave-core/src/db/migration/baseline/mod.rs
@@ -144,6 +144,10 @@ pub(super) fn tables() -> Vec<BaselineTable> {
         ),
         entry(content::app_grant_table(), content::app_grant_indexes()),
         entry(
+            content::app_gateway_draft_table(),
+            content::app_gateway_draft_indexes(),
+        ),
+        entry(
             content::connected_app_table(),
             content::connected_app_indexes(),
         ),

--- a/crates/openwave-core/src/db/migration/idens.rs
+++ b/crates/openwave-core/src/db/migration/idens.rs
@@ -103,6 +103,17 @@ pub(crate) enum AppGrant {
 }
 
 #[derive(DeriveIden)]
+pub(crate) enum AppGatewayDraft {
+    Table,
+    AppId,
+    GatewayBaseUrl,
+    SharedAppId,
+    GatewayRevisionId,
+    SyncedRevisionId,
+    UpdatedAt,
+}
+
+#[derive(DeriveIden)]
 pub(crate) enum ConnectedApp {
     Table,
     Id,

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -28,7 +28,9 @@ use crate::id::{
     OutputRevisionId, ProjectId, RootAttachmentChangeId, TurnId, TurnSteerId,
 };
 use crate::image::ImageRef;
-use crate::local_app::{AppGrant, AppRecord, AppRevision, CreateApp, NewAppRevision};
+use crate::local_app::{
+    AppGatewayDraft, AppGrant, AppRecord, AppRevision, CreateApp, NewAppRevision,
+};
 #[cfg(test)]
 use crate::model::Role;
 use crate::model::{
@@ -871,6 +873,18 @@ impl Store for DbStore {
 
     async fn get_app_grant(&self, app_id: AppId) -> Result<Option<AppGrant>> {
         ops::app::get_app_grant(self, app_id).await
+    }
+
+    async fn put_app_gateway_draft(&self, draft: &AppGatewayDraft) -> Result<()> {
+        ops::app::put_app_gateway_draft(self, draft).await
+    }
+
+    async fn get_app_gateway_draft(
+        &self,
+        app_id: AppId,
+        gateway_base_url: &str,
+    ) -> Result<Option<AppGatewayDraft>> {
+        ops::app::get_app_gateway_draft(self, app_id, gateway_base_url).await
     }
 
     async fn delete_app_grant(&self, app_id: AppId) -> Result<bool> {

--- a/crates/openwave-core/src/db/ops/app.rs
+++ b/crates/openwave-core/src/db/ops/app.rs
@@ -16,8 +16,9 @@ use sea_orm::{
 use crate::error::{AgentError, Result};
 use crate::id::{AppId, AppRevisionId};
 use crate::local_app::{
-    validate_app_grant, validate_app_manifest, AppGrant, AppGrantBinding, AppManifest, AppRecord,
-    AppRevision, CreateApp, NewAppRevision, MAX_APP_BUNDLE_BYTES, MAX_APP_REVISIONS,
+    validate_app_gateway_draft, validate_app_grant, validate_app_manifest, AppGatewayDraft,
+    AppGrant, AppGrantBinding, AppManifest, AppRecord, AppRevision, CreateApp, NewAppRevision,
+    MAX_APP_BUNDLE_BYTES, MAX_APP_REVISIONS,
 };
 
 use super::super::{entities, store_err, DbStore};
@@ -306,6 +307,73 @@ pub(in crate::db) async fn list_live_app_grants(store: &DbStore) -> Result<Vec<A
         .into_iter()
         .map(grant_from_model)
         .collect()
+}
+
+pub(in crate::db) async fn put_app_gateway_draft(
+    store: &DbStore,
+    draft: &AppGatewayDraft,
+) -> Result<()> {
+    validate_app_gateway_draft(draft)
+        .map_err(|message| AgentError::Store(format!("invalid gateway registration: {message}")))?;
+    let updated_at = canonical_db_timestamp(draft.updated_at)?;
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    // The app row's write lock serializes replacement of the registration the
+    // same way it serializes revision appends: two invokes racing a first
+    // registration must not both insert.
+    if !acquire_app_write_lock(&transaction, draft.app_id).await? {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!("app {} not found", draft.app_id)));
+    }
+    let existing = require_app_on(&transaction, draft.app_id).await?;
+    if existing.deleted_at.is_some() {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!(
+            "app {} is deleted",
+            draft.app_id
+        )));
+    }
+    entities::app_gateway_draft::Entity::delete_many()
+        .filter(entities::app_gateway_draft::Column::AppId.eq(draft.app_id.0))
+        .filter(
+            entities::app_gateway_draft::Column::GatewayBaseUrl.eq(draft.gateway_base_url.clone()),
+        )
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
+    entities::app_gateway_draft::ActiveModel {
+        app_id: Set(draft.app_id.0),
+        gateway_base_url: Set(draft.gateway_base_url.clone()),
+        shared_app_id: Set(draft.shared_app_id.clone()),
+        gateway_revision_id: Set(draft.gateway_revision_id.clone()),
+        synced_revision_id: Set(draft.synced_revision_id.0),
+        updated_at: Set(updated_at),
+    }
+    .insert(&transaction)
+    .await
+    .map_err(store_err)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(())
+}
+
+pub(in crate::db) async fn get_app_gateway_draft(
+    store: &DbStore,
+    app_id: AppId,
+    gateway_base_url: &str,
+) -> Result<Option<AppGatewayDraft>> {
+    Ok(
+        entities::app_gateway_draft::Entity::find_by_id((app_id.0, gateway_base_url.to_owned()))
+            .one(&store.conn)
+            .await
+            .map_err(store_err)?
+            .map(|model| AppGatewayDraft {
+                app_id: AppId(model.app_id),
+                gateway_base_url: model.gateway_base_url,
+                shared_app_id: model.shared_app_id,
+                gateway_revision_id: model.gateway_revision_id,
+                synced_revision_id: AppRevisionId(model.synced_revision_id),
+                updated_at: model.updated_at,
+            }),
+    )
 }
 
 fn grant_from_model(model: entities::app_grant::Model) -> Result<AppGrant> {

--- a/crates/openwave-core/src/local_app.rs
+++ b/crates/openwave-core/src/local_app.rs
@@ -391,6 +391,75 @@ pub fn validate_app_grant(grant: &AppGrant) -> Result<serde_json::Value, String>
     serde_json::to_value(&grant.bindings).map_err(|error| format!("unencodable app grant: {error}"))
 }
 
+/// The gateway-side registration one local app holds at one deployment.
+///
+/// Registration is per deployment, not per profile: the gateway a profile is
+/// paired to owns the shared app, so the base URL is half the identity. A
+/// profile re-paired elsewhere holds no registration there and registers
+/// afresh — exactly as it holds no gateway grant there.
+///
+/// `gateway_revision_id` is the gateway's own id for the revision the shared
+/// app currently serves, and `synced_revision_id` is the local revision that
+/// revision was projected from. The pair is what makes the sync lazy and
+/// idempotent: a local revision the gateway has never seen is recognized by
+/// `synced_revision_id` no longer matching the app's current revision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppGatewayDraft {
+    /// Local app the registration belongs to.
+    pub app_id: AppId,
+    /// Gateway deployment the registration lives at, normalized by the
+    /// caller to the same form the session's base URL is compared in.
+    pub gateway_base_url: String,
+    /// The gateway's id for the shared app this local app was registered as.
+    /// Opaque here, and held to the same grammar a manifest binding's gateway
+    /// app id is: bounded, printable, and never interpreted.
+    pub shared_app_id: String,
+    /// The gateway's id for the revision the shared app currently serves.
+    pub gateway_revision_id: String,
+    /// The local revision `gateway_revision_id` was projected from.
+    pub synced_revision_id: AppRevisionId,
+    /// Host-stamped time of the last create or revision append.
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Largest gateway deployment URL a registration row may record.
+pub const MAX_GATEWAY_BASE_URL_BYTES: usize = 2048;
+
+/// Validate a gateway registration structurally, at the storage door.
+///
+/// The three opaque halves are the gateway's own identifiers, so they are
+/// bounded and kept printable rather than parsed — the same posture a
+/// manifest's gateway app id is held to, and the same reason: OpenWave never
+/// interprets them, but it does put them in URLs and logs.
+pub fn validate_app_gateway_draft(draft: &AppGatewayDraft) -> Result<(), String> {
+    if draft.gateway_base_url.is_empty()
+        || draft.gateway_base_url.len() > MAX_GATEWAY_BASE_URL_BYTES
+    {
+        return Err(format!(
+            "gateway base URL must be 1 to {MAX_GATEWAY_BASE_URL_BYTES} bytes"
+        ));
+    }
+    validate_gateway_identifier("shared app id", &draft.shared_app_id)?;
+    validate_gateway_identifier("gateway revision id", &draft.gateway_revision_id)
+}
+
+/// The bound and charset every opaque gateway identifier is held to.
+fn validate_gateway_identifier(what: &str, value: &str) -> Result<(), String> {
+    // Pure-dot values pass the printable-ASCII check but read as path
+    // navigation to any origin that normalizes dot segments.
+    if value.is_empty()
+        || value.len() > MAX_GATEWAY_APP_ID_BYTES
+        || !value.bytes().all(|byte| byte.is_ascii_graphic())
+        || value.bytes().all(|byte| byte == b'.')
+    {
+        return Err(format!(
+            "{what} {value:?} must be 1 to {MAX_GATEWAY_APP_ID_BYTES} bytes of printable, \
+             non-whitespace ASCII"
+        ));
+    }
+    Ok(())
+}
+
 /// The trusted half of an app revision: a display name and the exact
 /// capabilities the app may call.
 ///

--- a/crates/openwave-core/src/storage/store.rs
+++ b/crates/openwave-core/src/storage/store.rs
@@ -11,7 +11,9 @@ use crate::id::{
     OutputRevisionId, ProjectId, RootAttachmentChangeId, TurnId, TurnSteerId,
 };
 use crate::image::ImageRef;
-use crate::local_app::{AppGrant, AppRecord, AppRevision, CreateApp, NewAppRevision};
+use crate::local_app::{
+    AppGatewayDraft, AppGrant, AppRecord, AppRevision, CreateApp, NewAppRevision,
+};
 use crate::model::{
     AgentRun, AgentRunInboxEntry, AgentRunProgressEntry, AgentRunResult, AgentRunTier,
     AgentRunWaitSetCandidate, BeginRootAttachmentChange, BlobRetirement, BlobRetirementStatus,
@@ -841,6 +843,29 @@ pub trait Store: Send + Sync {
     /// excluded: it can no longer be exercised, so surfaces built on this
     /// must not count it.
     async fn list_live_app_grants(&self) -> Result<Vec<AppGrant>> {
+        app_storage_unavailable()
+    }
+
+    /// Record the gateway-side registration one app holds at one deployment,
+    /// replacing any registration it already held there.
+    ///
+    /// Keyed by `(app_id, gateway_base_url)`: registering the same app at a
+    /// second gateway adds a row rather than moving one, so a re-paired
+    /// profile never reads another deployment's shared app. Implementations
+    /// validate the opaque gateway identifiers and refuse a missing or
+    /// deleted app.
+    async fn put_app_gateway_draft(&self, _draft: &AppGatewayDraft) -> Result<()> {
+        app_storage_unavailable()
+    }
+
+    /// Fetch one app's gateway registration at `gateway_base_url`, when it
+    /// holds one there. A registration made against a different deployment is
+    /// simply absent, never a near match.
+    async fn get_app_gateway_draft(
+        &self,
+        _app_id: AppId,
+        _gateway_base_url: &str,
+    ) -> Result<Option<AppGatewayDraft>> {
         app_storage_unavailable()
     }
 

--- a/crates/openwave-server/src/connected_apps.rs
+++ b/crates/openwave-server/src/connected_apps.rs
@@ -558,101 +558,72 @@ pub(crate) trait GatewayInvokeDispatcher: Send + Sync {
     ) -> Result<crate::connectors::GatewayInvokeOutcome, GatewayDispatchError>;
 }
 
-/// Resolves the gateway-side draft a local app was registered as, at the
-/// deployment `gateway_base_url` names.
+/// The registration lifecycle of one local app at one gateway deployment.
 ///
-/// The seam exists so the registration lifecycle is the only thing a later
-/// slice has to build: invoke already asks the right question, and answering
-/// it differently is an implementation swap rather than a reshaping of the
-/// ladder. Keyed by the gateway's base URL as well as the app, because a
-/// registration belongs to one deployment — a re-paired profile has no draft
-/// there, exactly as it has no current gateway grant.
+/// A local app's gateway bindings are relayed to a shared app the gateway
+/// holds, so the app has to exist there before anything can be relayed. This
+/// seam is what establishes and advances that, keyed by the deployment as
+/// well as the app: a registration belongs to one gateway, so a re-paired
+/// profile has no registration there, exactly as it has no current gateway
+/// grant. Production is the store-backed
+/// [`crate::gateway_drafts::GatewayDraftRegistry`]; tests drive the whole
+/// ladder against a fake without an OAuth session.
 #[async_trait]
 pub(crate) trait GatewayDraftSource: Send + Sync {
-    async fn draft_shared_app_id(
+    /// Ensure `app` is registered at `gateway_base_url` and that the revision
+    /// the gateway serves is the app's current local one, registering or
+    /// appending as needed.
+    async fn ensure_registered(
         &self,
         app: openwave_core::id::AppId,
         gateway_base_url: &str,
-    ) -> openwave_core::Result<Option<String>>;
-}
+    ) -> openwave_core::Result<GatewayRegistration>;
 
-/// The v1 draft source: nothing is registered, ever.
-///
-/// Draft registration is its own slice. Until it lands, a gateway binding
-/// walks the whole local ladder — pin, grant, fingerprint currency — and then
-/// refuses with a typed, teachable "not registered at the gateway" rather than
-/// relaying somewhere that could not answer. Replacing this implementation is
-/// all that slice has to do on the invoke path.
-pub(crate) struct NoRegisteredDrafts;
-
-#[async_trait]
-impl GatewayDraftSource for NoRegisteredDrafts {
-    async fn draft_shared_app_id(
-        &self,
-        _app: openwave_core::id::AppId,
-        _gateway_base_url: &str,
-    ) -> openwave_core::Result<Option<String>> {
-        Ok(None)
-    }
-}
-
-/// A development stand-in for draft registration, fed by
-/// `OPENWAVE_GATEWAY_DRAFT_APPS` (`<local app id>=<shared app id>`,
-/// comma-separated).
-///
-/// Registration is a coming slice; until it lands there is no way to exercise
-/// the relay against a real gateway. This source lets a developer pin the
-/// mapping by hand after registering the draft out of band. It deliberately
-/// ignores the deployment key — a hand-maintained map is already scoped to
-/// the one gateway the developer is driving — and it is only consulted when
-/// the variable is set, so production behavior is byte-identical without it.
-///
-/// Debug builds only: a release daemon's process environment must never be
-/// able to redirect a consented invoke.
-#[cfg(debug_assertions)]
-pub(crate) struct EnvPinnedDrafts {
-    map: std::collections::BTreeMap<String, String>,
-}
-
-#[cfg(debug_assertions)]
-impl EnvPinnedDrafts {
-    /// The env-pinned map, or `None` when the variable is unset or empty.
-    pub(crate) fn from_env() -> Option<Self> {
-        let raw = std::env::var("OPENWAVE_GATEWAY_DRAFT_APPS").ok()?;
-        let map: std::collections::BTreeMap<String, String> = raw
-            .split(',')
-            .filter_map(|pair| {
-                let (app, draft) = pair.split_once('=')?;
-                let (app, draft) = (app.trim(), draft.trim());
-                (!app.is_empty() && !draft.is_empty()).then(|| (app.to_string(), draft.to_string()))
-            })
-            .collect();
-        if map.is_empty() {
-            tracing::warn!(
-                "OPENWAVE_GATEWAY_DRAFT_APPS is set but holds no `<app id>=<shared app id>` \
-                 pairs; gateway draft pinning is off"
-            );
-            return None;
-        }
-        tracing::info!(
-            "gateway draft pins loaded for {} local app(s): {:?}",
-            map.len(),
-            map.keys().collect::<Vec<_>>(),
-        );
-        Some(Self { map })
-    }
-}
-
-#[cfg(debug_assertions)]
-#[async_trait]
-impl GatewayDraftSource for EnvPinnedDrafts {
-    async fn draft_shared_app_id(
+    /// Relay the author's consent for `app`'s registration, pinned to the
+    /// revision the gateway is serving.
+    ///
+    /// Safe to relay without asking again because the local grant ladder has
+    /// already run: the consent sheet displayed exactly the binding set this
+    /// names, and the gateway computes the consented bindings server-side
+    /// from the live revision, accepting only a revision pin from here.
+    async fn relay_consent(
         &self,
         app: openwave_core::id::AppId,
-        _gateway_base_url: &str,
-    ) -> openwave_core::Result<Option<String>> {
-        Ok(self.map.get(&app.to_string()).cloned())
-    }
+        gateway_base_url: &str,
+    ) -> openwave_core::Result<GatewayConsentRelay>;
+}
+
+/// Where a local app stands at one gateway deployment.
+///
+/// Closed on purpose, and deliberately not a `Result`: "this deployment does
+/// not hold shared apps" and "the gateway said no" are both answers, and the
+/// invoke ladder turns each into a different refusal. A gateway that could
+/// not be reached at all is the `Err` half.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum GatewayRegistration {
+    /// The gateway holds the app, serving `revision_id`.
+    Registered {
+        shared_app_id: String,
+        revision_id: String,
+    },
+    /// Nothing at this deployment holds the app and nothing there can: the
+    /// gateway predates shared-app registration, or it holds no app for this
+    /// user to append to.
+    NotRegistered,
+    /// The gateway refused to register or advance the app, in its own words.
+    Refused { message: String },
+}
+
+/// What relaying the author's consent came back as.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum GatewayConsentRelay {
+    /// The gateway recorded consent for the registered revision.
+    Consented,
+    /// Nothing at this deployment holds the app — see
+    /// [`GatewayRegistration::NotRegistered`].
+    NotRegistered,
+    /// The gateway refused the consent, in its own words.
+    Refused { message: String },
 }
 
 #[cfg(test)]

--- a/crates/openwave-server/src/connectors/gateway.rs
+++ b/crates/openwave-server/src/connectors/gateway.rs
@@ -254,8 +254,10 @@ pub enum GatewayRegistrationOutcome {
         revision_id: String,
     },
     /// The requested slug is already taken at this deployment — the one
-    /// failure the caller can resolve by asking again differently.
-    SlugTaken,
+    /// failure the caller can resolve by asking again differently. The
+    /// message is the gateway's own, so a caller that cannot resolve it can
+    /// still report it in the gateway's words.
+    SlugTaken { message: String },
     /// The gateway refused for any other typed reason (a disabled app, a
     /// manifest it will not accept). The message is the gateway's own.
     Refused { message: String },
@@ -1662,7 +1664,7 @@ fn decode_shared_app_registration(
         };
         let message = message.unwrap_or_else(|| code.clone());
         return Ok(if code == "slug_taken" {
-            GatewayRegistrationOutcome::SlugTaken
+            GatewayRegistrationOutcome::SlugTaken { message }
         } else {
             GatewayRegistrationOutcome::Refused { message }
         });

--- a/crates/openwave-server/src/connectors/gateway.rs
+++ b/crates/openwave-server/src/connectors/gateway.rs
@@ -226,9 +226,53 @@ pub enum GatewayInvokeOutcome {
     /// app — its typed `authorization_required`. The viewer must connect the
     /// app at the gateway; no local action can supply it.
     AuthorizationRequired { message: String },
+    /// The gateway holds no consent for this shared app — its typed
+    /// `consent_required`. Unlike the two above, the *host* can resolve this
+    /// without the viewer: the local grant ladder has already run, so the
+    /// relay re-states the author's consent to the gateway and calls again.
+    ConsentRequired { message: String },
     /// The gateway refused the call for any other typed reason (an
     /// unconsented shared app, a manifest the operation is not in, a
     /// credential resolution failure). The message is the gateway's own.
+    Refused { message: String },
+}
+
+/// What one shared-app registration call — a create or a revision append —
+/// came back as.
+///
+/// Closed on purpose: the registry turns each of these into a durable
+/// decision (persist the mapping, retry once under a suffixed slug, or give
+/// up honestly), and a fourth reading would need its own decision rather than
+/// a free-form message. A `404` is the `Ok(None)` half, as everywhere else on
+/// this client: a deployment that does not serve registration yet.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GatewayRegistrationOutcome {
+    /// The gateway holds the shared app at `shared_app_id`, currently serving
+    /// revision `revision_id`.
+    Registered {
+        shared_app_id: String,
+        revision_id: String,
+    },
+    /// The requested slug is already taken at this deployment — the one
+    /// failure the caller can resolve by asking again differently.
+    SlugTaken,
+    /// The gateway refused for any other typed reason (a disabled app, a
+    /// manifest it will not accept). The message is the gateway's own.
+    Refused { message: String },
+}
+
+/// What one shared-app consent relay came back as.
+///
+/// `RevisionMoved` is the only outcome the caller acts on beyond success: the
+/// pinned revision is no longer the one the gateway serves, so the pin has to
+/// be re-established before consent can name it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GatewayConsentOutcome {
+    /// The gateway recorded consent for the named revision.
+    Consented,
+    /// The pinned revision is stale; the gateway serves another one.
+    RevisionMoved,
+    /// The gateway refused for any other typed reason, in its own words.
     Refused { message: String },
 }
 
@@ -624,6 +668,119 @@ impl GatewayAuth {
         let status = response.status();
         let body = read_bounded(response, "shared app invoke").await?;
         decode_shared_app_invoke(status, &body).map(Some)
+    }
+
+    /// Register one local app at the gateway as a shared app draft — the
+    /// control-plane half of a local app's gateway bindings.
+    ///
+    /// `request` is the registration body verbatim (`name`, optional `slug`,
+    /// `manifest`, optional `bundle_base64`, `client_name`); the caller owns
+    /// its assembly, including the projection of the local manifest into the
+    /// gateway's own manifest vocabulary.
+    ///
+    /// `Ok(None)` is the route answering `404`: a deployment that does not
+    /// serve shared-app registration yet. That reads as "nothing there can
+    /// hold this app", the same degradation [`apps`](Self::apps) and
+    /// [`invoke_shared_app`](Self::invoke_shared_app) use, rather than a
+    /// fault.
+    pub async fn create_shared_app(
+        &self,
+        access_token: &str,
+        request: &serde_json::Value,
+    ) -> Result<Option<GatewayRegistrationOutcome>> {
+        const OPERATION: &str = "shared app registration";
+
+        let response = self
+            .http
+            .post(self.endpoint("/api/v1/cli/shared-apps")?)
+            .bearer_auth(access_token)
+            .json(request)
+            .send()
+            .await
+            .map_err(|error| gateway_error(OPERATION, error.without_url()))?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        let status = response.status();
+        let body = read_bounded(response, OPERATION).await?;
+        decode_shared_app_registration(OPERATION, status, &body, None).map(Some)
+    }
+
+    /// Append a revision to an already-registered shared app.
+    ///
+    /// `Ok(None)` covers both `404` readings — a deployment without the route
+    /// and an app this user does not own — because neither leaves anything
+    /// here to append to.
+    pub async fn create_shared_app_revision(
+        &self,
+        access_token: &str,
+        shared_app_id: &str,
+        request: &serde_json::Value,
+    ) -> Result<Option<GatewayRegistrationOutcome>> {
+        const OPERATION: &str = "shared app revision";
+
+        validate_gateway_app_id(shared_app_id)?;
+        let mut url = self.endpoint("/api/v1/cli/shared-apps")?;
+        url.path_segments_mut()
+            .map_err(|()| gateway_error("configuration", "could not build endpoint URL"))?
+            .push(shared_app_id)
+            .push("revision");
+        let response = self
+            .http
+            .post(url)
+            .bearer_auth(access_token)
+            .json(request)
+            .send()
+            .await
+            .map_err(|error| gateway_error(OPERATION, error.without_url()))?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        let status = response.status();
+        let body = read_bounded(response, OPERATION).await?;
+        decode_shared_app_registration(OPERATION, status, &body, Some(shared_app_id)).map(Some)
+    }
+
+    /// Record the author's consent for one shared app, optionally pinned to
+    /// the revision the caller believes is current.
+    ///
+    /// `Ok(None)` is the route answering `404`: nothing at this deployment
+    /// holds the app.
+    pub async fn consent_shared_app(
+        &self,
+        access_token: &str,
+        shared_app_id: &str,
+        revision_id: Option<&str>,
+    ) -> Result<Option<GatewayConsentOutcome>> {
+        const OPERATION: &str = "shared app consent";
+
+        validate_gateway_app_id(shared_app_id)?;
+        let mut url = self.endpoint("/api/apps/shared")?;
+        url.path_segments_mut()
+            .map_err(|()| gateway_error("configuration", "could not build endpoint URL"))?
+            .push(shared_app_id)
+            .push("consent");
+        let mut request = serde_json::Map::new();
+        if let Some(revision_id) = revision_id {
+            request.insert(
+                "revision_id".into(),
+                serde_json::Value::String(revision_id.to_owned()),
+            );
+        }
+        let response = self
+            .http
+            .post(url)
+            .bearer_auth(access_token)
+            .json(&serde_json::Value::Object(request))
+            .send()
+            .await
+            .map_err(|error| gateway_error(OPERATION, error.without_url()))?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        let status = response.status();
+        let body = read_bounded(response, OPERATION).await?;
+        decode_shared_app_consent(OPERATION, status, &body).map(Some)
     }
 
     async fn exchange_code(
@@ -1117,6 +1274,42 @@ impl GatewayConnection {
             .await
     }
 
+    /// Register one local app as a shared app with a `control` token; `None`
+    /// when the gateway does not serve shared-app registration.
+    pub async fn create_shared_app(
+        &self,
+        request: &serde_json::Value,
+    ) -> Result<Option<GatewayRegistrationOutcome>> {
+        let token = self.access_token(RESOURCE_CONTROL).await?;
+        self.auth.create_shared_app(&token, request).await
+    }
+
+    /// Append a revision to a registered shared app with a `control` token;
+    /// `None` when nothing at the gateway answers for the app.
+    pub async fn create_shared_app_revision(
+        &self,
+        shared_app_id: &str,
+        request: &serde_json::Value,
+    ) -> Result<Option<GatewayRegistrationOutcome>> {
+        let token = self.access_token(RESOURCE_CONTROL).await?;
+        self.auth
+            .create_shared_app_revision(&token, shared_app_id, request)
+            .await
+    }
+
+    /// Relay the author's consent for a registered shared app with a
+    /// `control` token; `None` when nothing at the gateway answers for it.
+    pub async fn consent_shared_app(
+        &self,
+        shared_app_id: &str,
+        revision_id: Option<&str>,
+    ) -> Result<Option<GatewayConsentOutcome>> {
+        let token = self.access_token(RESOURCE_CONTROL).await?;
+        self.auth
+            .consent_shared_app(&token, shared_app_id, revision_id)
+            .await
+    }
+
     /// The gateway's MCP endpoint URL for `slug`, under the configured base.
     pub fn mcp_endpoint_url(&self, slug: &str) -> Result<String> {
         validate_mcp_endpoint_slug(slug)?;
@@ -1338,9 +1531,11 @@ async fn read_bounded(response: reqwest::Response, operation: &str) -> Result<Ve
 ///   `{"error": "<code>"}` with a sibling `message` or `error_description`,
 ///   or a bare top-level `{"code", "message"}`. The code
 ///   `authorization_required` becomes [`GatewayInvokeOutcome::AuthorizationRequired`]
-///   — the one outcome the frame must branch on — and every other code
-///   (including `consent_required`, which a first-open viewer may hit) becomes
-///   [`GatewayInvokeOutcome::Refused`] carrying the gateway's own message. A
+///   and `consent_required` becomes [`GatewayInvokeOutcome::ConsentRequired`]
+///   — the two outcomes a caller can act on, the first by sending the viewer
+///   to the gateway and the second by re-stating the author's consent — and
+///   every other code becomes [`GatewayInvokeOutcome::Refused`] carrying the
+///   gateway's own message. A
 ///   failure envelope is looked for on any non-2xx answer, and on a 2xx answer
 ///   only when the body has an `error` member and no `status` member, so a
 ///   passthrough response body can never be misread as one.
@@ -1375,10 +1570,10 @@ fn decode_shared_app_invoke(
     if looks_like_failure {
         if let Some((code, message)) = failure_envelope(&payload) {
             let message = message.unwrap_or_else(|| code.clone());
-            return Ok(if code == "authorization_required" {
-                GatewayInvokeOutcome::AuthorizationRequired { message }
-            } else {
-                GatewayInvokeOutcome::Refused { message }
+            return Ok(match code.as_str() {
+                "authorization_required" => GatewayInvokeOutcome::AuthorizationRequired { message },
+                "consent_required" => GatewayInvokeOutcome::ConsentRequired { message },
+                _ => GatewayInvokeOutcome::Refused { message },
             });
         }
         if !status.is_success() {
@@ -1440,6 +1635,84 @@ fn decode_shared_app_invoke(
         status: executed_status,
         content_type,
         body_base64,
+    })
+}
+
+/// Read the gateway's answer to a shared-app create or revision append.
+///
+/// Success must name the revision the gateway now serves; a create must also
+/// name the app it minted, while an append answers about an app the caller
+/// already knows the id of (`known_id`). Failures are read with the same
+/// tolerant envelope reader the invoke route uses, so the one code the caller
+/// branches on — `slug_taken` — is recognized in every shape the gateway may
+/// carry it.
+fn decode_shared_app_registration(
+    operation: &'static str,
+    status: reqwest::StatusCode,
+    body: &[u8],
+    known_id: Option<&str>,
+) -> Result<GatewayRegistrationOutcome> {
+    let payload = serde_json::from_slice::<serde_json::Value>(body).ok();
+    if !status.is_success() {
+        let Some((code, message)) = payload.as_ref().and_then(failure_envelope) else {
+            return Err(gateway_error(
+                operation,
+                format!("HTTP status {}", status.as_u16()),
+            ));
+        };
+        let message = message.unwrap_or_else(|| code.clone());
+        return Ok(if code == "slug_taken" {
+            GatewayRegistrationOutcome::SlugTaken
+        } else {
+            GatewayRegistrationOutcome::Refused { message }
+        });
+    }
+    let invalid = || gateway_error(operation, "invalid response body");
+    let payload = payload.ok_or_else(invalid)?;
+    let text = |key: &str| {
+        payload
+            .get(key)
+            .and_then(serde_json::Value::as_str)
+            .map(ToOwned::to_owned)
+    };
+    let shared_app_id = text("id")
+        .or_else(|| known_id.map(ToOwned::to_owned))
+        .ok_or_else(invalid)?;
+    let revision_id = text("revision_id").ok_or_else(invalid)?;
+    Ok(GatewayRegistrationOutcome::Registered {
+        shared_app_id,
+        revision_id,
+    })
+}
+
+/// Read the gateway's answer to a shared-app consent relay. The response body
+/// echoes the bindings consent covers, which nothing here needs: the gateway
+/// computes them server-side from the live revision, and the caller only ever
+/// pins which revision it meant.
+fn decode_shared_app_consent(
+    operation: &'static str,
+    status: reqwest::StatusCode,
+    body: &[u8],
+) -> Result<GatewayConsentOutcome> {
+    if status.is_success() {
+        return Ok(GatewayConsentOutcome::Consented);
+    }
+    let Some((code, message)) = serde_json::from_slice::<serde_json::Value>(body)
+        .ok()
+        .as_ref()
+        .and_then(failure_envelope)
+    else {
+        return Err(gateway_error(
+            operation,
+            format!("HTTP status {}", status.as_u16()),
+        ));
+    };
+    Ok(if code == "revision_moved" {
+        GatewayConsentOutcome::RevisionMoved
+    } else {
+        GatewayConsentOutcome::Refused {
+            message: message.unwrap_or(code),
+        }
     })
 }
 
@@ -1573,6 +1846,39 @@ mod tests {
             .bytes()
             .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-'));
         assert_ne!(random_token(), random_token());
+    }
+
+    /// The two invoke refusals a caller acts on have to survive the wire as
+    /// themselves: `authorization_required` is the viewer's to resolve at the
+    /// gateway, and `consent_required` is the host's to heal by re-stating
+    /// the author's consent. Anything else is the app's to present.
+    #[test]
+    fn actionable_invoke_refusals_decode_to_their_own_arms() {
+        let decode = |code: &str| {
+            decode_shared_app_invoke(
+                reqwest::StatusCode::FORBIDDEN,
+                format!(r#"{{"error":{{"code":"{code}","message":"nope"}}}}"#).as_bytes(),
+            )
+            .unwrap()
+        };
+        assert_eq!(
+            decode("consent_required"),
+            GatewayInvokeOutcome::ConsentRequired {
+                message: "nope".into()
+            }
+        );
+        assert_eq!(
+            decode("authorization_required"),
+            GatewayInvokeOutcome::AuthorizationRequired {
+                message: "nope".into()
+            }
+        );
+        assert_eq!(
+            decode("app_disabled"),
+            GatewayInvokeOutcome::Refused {
+                message: "nope".into()
+            }
+        );
     }
 
     #[test]

--- a/crates/openwave-server/src/connectors/mod.rs
+++ b/crates/openwave-server/src/connectors/mod.rs
@@ -37,7 +37,7 @@ pub use chatgpt::{
 pub use gateway::{
     has_stored_credentials, has_stored_credentials_for, is_sign_in_required,
     validate_mcp_endpoint_slug, AuthorizedSession, CredentialVault, GatewayApp, GatewayAuth,
-    GatewayAuthConfig, GatewayConnection, GatewayCredentials, GatewayIdentity,
-    GatewayInvokeOutcome, GatewayMeta, GatewayModel, GatewayOperationSummary, PendingSignIn,
-    TokenSet, RESOURCE_CONTROL, RESOURCE_LLM,
+    GatewayAuthConfig, GatewayConnection, GatewayConsentOutcome, GatewayCredentials,
+    GatewayIdentity, GatewayInvokeOutcome, GatewayMeta, GatewayModel, GatewayOperationSummary,
+    GatewayRegistrationOutcome, PendingSignIn, TokenSet, RESOURCE_CONTROL, RESOURCE_LLM,
 };

--- a/crates/openwave-server/src/desktop_schema.rs
+++ b/crates/openwave-server/src/desktop_schema.rs
@@ -25,7 +25,7 @@ const VECTOR_DIRECTORY: &str = "vectors";
 const MAX_MARKER_BYTES: u64 = 1_024;
 
 /// Bump this whenever the pre-v1 schema baseline changes incompatibly.
-const DESKTOP_SCHEMA_EPOCH: u32 = 23;
+const DESKTOP_SCHEMA_EPOCH: u32 = 24;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/openwave-server/src/gateway_drafts.rs
+++ b/crates/openwave-server/src/gateway_drafts.rs
@@ -182,9 +182,12 @@ impl GatewayDraftClient for GatewayConnectorDraftClient {
         let Some(connection) = self.connection_at(gateway_base_url).await? else {
             return Ok(None);
         };
+        // Stamped per revision, not once per app: provenance that only the
+        // first revision carries says nothing about the ones after it.
         let body = serde_json::json!({
             "manifest": projection.manifest,
             "bundle_base64": projection.bundle_base64,
+            "client_name": CLIENT_NAME,
         });
         connection
             .create_shared_app_revision(shared_app_id, &body)

--- a/crates/openwave-server/src/gateway_drafts.rs
+++ b/crates/openwave-server/src/gateway_drafts.rs
@@ -114,17 +114,41 @@ impl GatewayConnectorDraftClient {
     pub(crate) fn new(runtime: Arc<GatewayRuntime>) -> Self {
         Self { runtime }
     }
+
+    /// The connection for `gateway_base_url`, and only for it.
+    ///
+    /// The runtime resolves its connection from policy, which can move
+    /// between the moment a caller read the deployment and the moment the
+    /// call goes out — a re-pairing is exactly that. Registering against a
+    /// deployment other than the one the mapping is keyed to would mint a
+    /// shared app nothing ever reads again, so a mismatch refuses instead:
+    /// the caller's ladder reports it as unreachable, and the next attempt
+    /// resolves the new deployment from the start.
+    async fn connection_at(
+        &self,
+        gateway_base_url: &str,
+    ) -> Result<Option<Arc<crate::connectors::GatewayConnection>>> {
+        let Some(resolved) = registration_base_url(&self.runtime).await else {
+            return Ok(None);
+        };
+        if normalized_gateway_base_url(&resolved) != gateway_base_url {
+            return Err(AgentError::Store(
+                "this profile's gateway moved while the app was being registered".into(),
+            ));
+        }
+        self.runtime.connection().await
+    }
 }
 
 #[async_trait]
 impl GatewayDraftClient for GatewayConnectorDraftClient {
     async fn create(
         &self,
-        _gateway_base_url: &str,
+        gateway_base_url: &str,
         slug: Option<&str>,
         projection: &SharedAppProjection,
     ) -> Result<Option<GatewayRegistrationOutcome>> {
-        let Some(connection) = self.runtime.connection().await? else {
+        let Some(connection) = self.connection_at(gateway_base_url).await? else {
             return Ok(None);
         };
         let mut body = serde_json::Map::new();
@@ -151,11 +175,11 @@ impl GatewayDraftClient for GatewayConnectorDraftClient {
 
     async fn append(
         &self,
-        _gateway_base_url: &str,
+        gateway_base_url: &str,
         shared_app_id: &str,
         projection: &SharedAppProjection,
     ) -> Result<Option<GatewayRegistrationOutcome>> {
-        let Some(connection) = self.runtime.connection().await? else {
+        let Some(connection) = self.connection_at(gateway_base_url).await? else {
             return Ok(None);
         };
         let body = serde_json::json!({
@@ -169,11 +193,11 @@ impl GatewayDraftClient for GatewayConnectorDraftClient {
 
     async fn consent(
         &self,
-        _gateway_base_url: &str,
+        gateway_base_url: &str,
         shared_app_id: &str,
         revision_id: &str,
     ) -> Result<Option<GatewayConsentOutcome>> {
-        let Some(connection) = self.runtime.connection().await? else {
+        let Some(connection) = self.connection_at(gateway_base_url).await? else {
             return Ok(None);
         };
         connection
@@ -189,6 +213,16 @@ pub(crate) struct GatewayDraftRegistry {
     /// Profile data directory the write-once bundle bytes live under.
     data_dir: PathBuf,
     client: Arc<dyn GatewayDraftClient>,
+    /// One lock per app, so the read-then-register decision is serialized.
+    ///
+    /// Without it two concurrent invokes of an unregistered app both read no
+    /// mapping and both create: the loser retries under a suffixed slug and
+    /// succeeds, so the gateway mints two shared apps and one of them is a
+    /// permanent orphan nothing will ever read again. Holding the lock across
+    /// the whole decision means the second caller reads the mapping the first
+    /// persisted. The map is keyed by app and bounded by the library, so it
+    /// is not swept.
+    app_locks: tokio::sync::Mutex<std::collections::HashMap<AppId, Arc<tokio::sync::Mutex<()>>>>,
 }
 
 impl GatewayDraftRegistry {
@@ -201,7 +235,13 @@ impl GatewayDraftRegistry {
             store,
             data_dir,
             client,
+            app_locks: tokio::sync::Mutex::default(),
         }
+    }
+
+    /// The registration lock for one app.
+    async fn app_lock(&self, app: AppId) -> Arc<tokio::sync::Mutex<()>> {
+        self.app_locks.lock().await.entry(app).or_default().clone()
     }
 
     /// Register `app` at `base_url` for the first time.
@@ -221,7 +261,7 @@ impl GatewayDraftRegistry {
         let projection = self.project(record, revision).await?;
         let outcome = self.client.create(base_url, None, &projection).await?;
         let outcome = match outcome {
-            Some(GatewayRegistrationOutcome::SlugTaken) => {
+            Some(GatewayRegistrationOutcome::SlugTaken { .. }) => {
                 let slug = suffixed_slug(&projection.name, record.id);
                 self.client
                     .create(base_url, Some(&slug), &projection)
@@ -242,9 +282,13 @@ impl GatewayDraftRegistry {
                     revision_id,
                 })
             }
-            Some(GatewayRegistrationOutcome::SlugTaken) => Ok(GatewayRegistration::Refused {
-                message: "this app's name is already taken at your model gateway".to_owned(),
-            }),
+            // The host knows something the gateway's message cannot: this was
+            // the second attempt, under a slug the host chose to be unique.
+            Some(GatewayRegistrationOutcome::SlugTaken { .. }) => {
+                Ok(GatewayRegistration::Refused {
+                    message: "this app's name is already taken at your model gateway".to_owned(),
+                })
+            }
             Some(GatewayRegistrationOutcome::Refused { message }) => {
                 Ok(GatewayRegistration::Refused { message })
             }
@@ -281,11 +325,12 @@ impl GatewayDraftRegistry {
                     revision_id,
                 })
             }
-            // A slug is not part of a revision append; a gateway answering
-            // this way is refusing in a shape this client cannot act on.
-            Some(GatewayRegistrationOutcome::SlugTaken) => Ok(GatewayRegistration::Refused {
-                message: "your model gateway refused this app's new revision".to_owned(),
-            }),
+            // A slug is not part of a revision append, so this arm should be
+            // unreachable — which is exactly why it carries the gateway's own
+            // words rather than a guess at what it meant.
+            Some(GatewayRegistrationOutcome::SlugTaken { message }) => {
+                Ok(GatewayRegistration::Refused { message })
+            }
             Some(GatewayRegistrationOutcome::Refused { message }) => {
                 Ok(GatewayRegistration::Refused { message })
             }
@@ -314,9 +359,18 @@ impl GatewayDraftRegistry {
     }
 
     /// The app and the revision it currently presents.
+    ///
+    /// A soft-deleted app answers as missing, exactly as it does on the
+    /// consent and invoke surfaces. An invoke racing a deletion must not mint
+    /// a shared app at the gateway for something the library no longer holds:
+    /// the store refuses the mapping write for the same reason, and refusing
+    /// here means the network call never happens in the first place.
     async fn current(&self, app: AppId) -> Result<(AppRecord, AppRevision)> {
         let missing = || AgentError::Store(format!("app {app} not found"));
         let record = self.store.get_app(app).await?.ok_or_else(missing)?;
+        if record.deleted_at.is_some() {
+            return Err(missing());
+        }
         let revision = self
             .store
             .get_app_revision(record.current_revision)
@@ -353,6 +407,9 @@ impl GatewayDraftSource for GatewayDraftRegistry {
         gateway_base_url: &str,
     ) -> Result<GatewayRegistration> {
         let base_url = normalized_gateway_base_url(gateway_base_url);
+        // Serialize the read-then-register decision per app; see `app_locks`.
+        let lock = self.app_lock(app).await;
+        let _guard = lock.lock().await;
         let (record, revision) = self.current(app).await?;
         match self.store.get_app_gateway_draft(app, &base_url).await? {
             // The gateway is already serving this exact local revision.

--- a/crates/openwave-server/src/gateway_drafts.rs
+++ b/crates/openwave-server/src/gateway_drafts.rs
@@ -1,0 +1,697 @@
+//! The registration lifecycle of a local app at the model gateway.
+//!
+//! A local app's gateway bindings are relayed to a *shared app* the gateway
+//! holds, so before anything can be relayed the app has to exist there. This
+//! module owns that: it projects the local manifest into the gateway's own
+//! manifest vocabulary, registers the app the first time one of its gateway
+//! bindings is consented to or invoked, appends a revision whenever the local
+//! app has moved on, and relays the author's consent so the gateway's own
+//! consent gate does not stand between an author and the app they just
+//! granted.
+//!
+//! Two seams keep this drivable in tests. [`GatewayDraftClient`] is the
+//! network half — the same rationale as
+//! [`crate::connected_apps::RestOperationDispatcher`]: the registration
+//! ladder is worth driving end to end, and no test can stand up an OAuth
+//! session against a fake deployment to do it. [`GatewayDraftRegistry`] is
+//! the durable half, and is what production wires behind
+//! [`crate::connected_apps::GatewayDraftSource`].
+//!
+//! The mapping is stored per `(app, deployment)`, so a profile re-paired to a
+//! different gateway holds no registration there and registers afresh; the
+//! rows the old pairing left are orphaned rather than misread, and they die
+//! with the app row.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use base64::Engine as _;
+
+use openwave_core::id::AppId;
+use openwave_core::local_app::{
+    app_revision_relative_path, AppBinding, AppGatewayDraft, AppManifest, AppRecord, AppRevision,
+    MAX_APP_NAME_CHARS,
+};
+use openwave_core::{AgentError, Result, Store};
+
+use crate::connected_apps::{
+    GatewayConsentRelay, GatewayDispatchError, GatewayDraftSource, GatewayRegistration,
+};
+use crate::connectors::{GatewayConsentOutcome, GatewayInvokeOutcome, GatewayRegistrationOutcome};
+use crate::gateway_runtime::GatewayRuntime;
+
+/// The client name every registration this host makes is stamped with, so a
+/// gateway operator can tell where a shared app came from.
+const CLIENT_NAME: &str = "OpenWave";
+
+/// The longest title the gateway's shared-app manifest accepts.
+///
+/// Every name a local manifest can carry has to survive the projection
+/// unchanged: a title the gateway would truncate or refuse silently renames
+/// the app there, or fails a registration for a name the author was allowed
+/// to choose. The two bounds are compatible today, and this build fails the
+/// day either one moves so that they are not.
+const MAX_GATEWAY_TITLE_CHARS: usize = 120;
+const _: () = assert!(MAX_APP_NAME_CHARS <= MAX_GATEWAY_TITLE_CHARS);
+
+/// One local revision, projected into what a shared-app create or revision
+/// append carries.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SharedAppProjection {
+    /// Display name — the gateway manifest's `title` and the create body's
+    /// `name`.
+    pub(crate) name: String,
+    /// The gateway's manifest vocabulary: `{title, bindings, parameters}`.
+    pub(crate) manifest: serde_json::Value,
+    /// The revision's bundle bytes, base64 as the gateway takes them.
+    pub(crate) bundle_base64: String,
+}
+
+/// The network half of registration, so the whole ladder is drivable against
+/// a fake instead of a deployment.
+///
+/// Every method answers `Ok(None)` for "nothing at this deployment can hold
+/// this app" — the route is absent (a gateway that predates shared-app
+/// registration), the app is not this user's, or there is no session to ask
+/// with. That is the same `Ok(None)`-on-404 reading the rest of the gateway
+/// client uses, and it is a degradation rather than a fault.
+#[async_trait]
+pub(crate) trait GatewayDraftClient: Send + Sync {
+    /// Register a new shared app. `slug` is only sent when the caller is
+    /// asking for a specific one; otherwise the gateway derives it.
+    async fn create(
+        &self,
+        gateway_base_url: &str,
+        slug: Option<&str>,
+        projection: &SharedAppProjection,
+    ) -> Result<Option<GatewayRegistrationOutcome>>;
+
+    /// Append a revision to an already-registered shared app.
+    async fn append(
+        &self,
+        gateway_base_url: &str,
+        shared_app_id: &str,
+        projection: &SharedAppProjection,
+    ) -> Result<Option<GatewayRegistrationOutcome>>;
+
+    /// Record consent for a registered shared app, pinned to `revision_id`.
+    async fn consent(
+        &self,
+        gateway_base_url: &str,
+        shared_app_id: &str,
+        revision_id: &str,
+    ) -> Result<Option<GatewayConsentOutcome>>;
+}
+
+/// The production client: the three registration calls over the one gateway
+/// runtime's connection.
+pub(crate) struct GatewayConnectorDraftClient {
+    runtime: Arc<GatewayRuntime>,
+}
+
+impl GatewayConnectorDraftClient {
+    pub(crate) fn new(runtime: Arc<GatewayRuntime>) -> Self {
+        Self { runtime }
+    }
+}
+
+#[async_trait]
+impl GatewayDraftClient for GatewayConnectorDraftClient {
+    async fn create(
+        &self,
+        _gateway_base_url: &str,
+        slug: Option<&str>,
+        projection: &SharedAppProjection,
+    ) -> Result<Option<GatewayRegistrationOutcome>> {
+        let Some(connection) = self.runtime.connection().await? else {
+            return Ok(None);
+        };
+        let mut body = serde_json::Map::new();
+        body.insert(
+            "name".into(),
+            serde_json::Value::String(projection.name.clone()),
+        );
+        if let Some(slug) = slug {
+            body.insert("slug".into(), serde_json::Value::String(slug.to_owned()));
+        }
+        body.insert("manifest".into(), projection.manifest.clone());
+        body.insert(
+            "bundle_base64".into(),
+            serde_json::Value::String(projection.bundle_base64.clone()),
+        );
+        body.insert(
+            "client_name".into(),
+            serde_json::Value::String(CLIENT_NAME.to_owned()),
+        );
+        connection
+            .create_shared_app(&serde_json::Value::Object(body))
+            .await
+    }
+
+    async fn append(
+        &self,
+        _gateway_base_url: &str,
+        shared_app_id: &str,
+        projection: &SharedAppProjection,
+    ) -> Result<Option<GatewayRegistrationOutcome>> {
+        let Some(connection) = self.runtime.connection().await? else {
+            return Ok(None);
+        };
+        let body = serde_json::json!({
+            "manifest": projection.manifest,
+            "bundle_base64": projection.bundle_base64,
+        });
+        connection
+            .create_shared_app_revision(shared_app_id, &body)
+            .await
+    }
+
+    async fn consent(
+        &self,
+        _gateway_base_url: &str,
+        shared_app_id: &str,
+        revision_id: &str,
+    ) -> Result<Option<GatewayConsentOutcome>> {
+        let Some(connection) = self.runtime.connection().await? else {
+            return Ok(None);
+        };
+        connection
+            .consent_shared_app(shared_app_id, Some(revision_id))
+            .await
+    }
+}
+
+/// The store-backed registration lifecycle: the durable `(app, deployment) →
+/// shared app` mapping plus the calls that establish and advance it.
+pub(crate) struct GatewayDraftRegistry {
+    store: Arc<dyn Store>,
+    /// Profile data directory the write-once bundle bytes live under.
+    data_dir: PathBuf,
+    client: Arc<dyn GatewayDraftClient>,
+}
+
+impl GatewayDraftRegistry {
+    pub(crate) fn new(
+        store: Arc<dyn Store>,
+        data_dir: PathBuf,
+        client: Arc<dyn GatewayDraftClient>,
+    ) -> Self {
+        Self {
+            store,
+            data_dir,
+            client,
+        }
+    }
+
+    /// Register `app` at `base_url` for the first time.
+    ///
+    /// The slug is the gateway's to derive on the first attempt. A taken slug
+    /// is the one failure worth asking again about, and exactly once: the
+    /// retry names a slug suffixed with the app's own identity, which no
+    /// other app of this profile can collide with. A second refusal is
+    /// reported rather than retried — a registration loop against a gateway
+    /// that keeps saying no is worse than an honest refusal.
+    async fn register(
+        &self,
+        record: &AppRecord,
+        revision: &AppRevision,
+        base_url: &str,
+    ) -> Result<GatewayRegistration> {
+        let projection = self.project(record, revision).await?;
+        let outcome = self.client.create(base_url, None, &projection).await?;
+        let outcome = match outcome {
+            Some(GatewayRegistrationOutcome::SlugTaken) => {
+                let slug = suffixed_slug(&projection.name, record.id);
+                self.client
+                    .create(base_url, Some(&slug), &projection)
+                    .await?
+            }
+            other => other,
+        };
+        match outcome {
+            None => Ok(GatewayRegistration::NotRegistered),
+            Some(GatewayRegistrationOutcome::Registered {
+                shared_app_id,
+                revision_id,
+            }) => {
+                self.persist(record, revision, base_url, &shared_app_id, &revision_id)
+                    .await?;
+                Ok(GatewayRegistration::Registered {
+                    shared_app_id,
+                    revision_id,
+                })
+            }
+            Some(GatewayRegistrationOutcome::SlugTaken) => Ok(GatewayRegistration::Refused {
+                message: "this app's name is already taken at your model gateway".to_owned(),
+            }),
+            Some(GatewayRegistrationOutcome::Refused { message }) => {
+                Ok(GatewayRegistration::Refused { message })
+            }
+        }
+    }
+
+    /// Push `revision` to an already-registered shared app and re-point the
+    /// mapping at what the gateway now serves.
+    async fn append(
+        &self,
+        draft: &AppGatewayDraft,
+        record: &AppRecord,
+        revision: &AppRevision,
+        base_url: &str,
+    ) -> Result<GatewayRegistration> {
+        let projection = self.project(record, revision).await?;
+        match self
+            .client
+            .append(base_url, &draft.shared_app_id, &projection)
+            .await?
+        {
+            None => Ok(GatewayRegistration::NotRegistered),
+            Some(GatewayRegistrationOutcome::Registered { revision_id, .. }) => {
+                self.persist(
+                    record,
+                    revision,
+                    base_url,
+                    &draft.shared_app_id,
+                    &revision_id,
+                )
+                .await?;
+                Ok(GatewayRegistration::Registered {
+                    shared_app_id: draft.shared_app_id.clone(),
+                    revision_id,
+                })
+            }
+            // A slug is not part of a revision append; a gateway answering
+            // this way is refusing in a shape this client cannot act on.
+            Some(GatewayRegistrationOutcome::SlugTaken) => Ok(GatewayRegistration::Refused {
+                message: "your model gateway refused this app's new revision".to_owned(),
+            }),
+            Some(GatewayRegistrationOutcome::Refused { message }) => {
+                Ok(GatewayRegistration::Refused { message })
+            }
+        }
+    }
+
+    /// Record what the gateway now holds for this app at this deployment.
+    async fn persist(
+        &self,
+        record: &AppRecord,
+        revision: &AppRevision,
+        base_url: &str,
+        shared_app_id: &str,
+        gateway_revision_id: &str,
+    ) -> Result<()> {
+        self.store
+            .put_app_gateway_draft(&AppGatewayDraft {
+                app_id: record.id,
+                gateway_base_url: base_url.to_owned(),
+                shared_app_id: shared_app_id.to_owned(),
+                gateway_revision_id: gateway_revision_id.to_owned(),
+                synced_revision_id: revision.id,
+                updated_at: chrono::Utc::now(),
+            })
+            .await
+    }
+
+    /// The app and the revision it currently presents.
+    async fn current(&self, app: AppId) -> Result<(AppRecord, AppRevision)> {
+        let missing = || AgentError::Store(format!("app {app} not found"));
+        let record = self.store.get_app(app).await?.ok_or_else(missing)?;
+        let revision = self
+            .store
+            .get_app_revision(record.current_revision)
+            .await?
+            .ok_or_else(missing)?;
+        Ok((record, revision))
+    }
+
+    /// Project one local revision into the gateway's registration vocabulary.
+    async fn project(
+        &self,
+        record: &AppRecord,
+        revision: &AppRevision,
+    ) -> Result<SharedAppProjection> {
+        let path = self
+            .data_dir
+            .join(app_revision_relative_path(record.id, revision.id));
+        let bundle = tokio::fs::read(&path).await.map_err(|error| {
+            AgentError::Store(format!("could not read the app's bundle bytes: {error}"))
+        })?;
+        Ok(SharedAppProjection {
+            name: revision.manifest.name.clone(),
+            manifest: gateway_manifest(&revision.manifest),
+            bundle_base64: base64::engine::general_purpose::STANDARD.encode(bundle),
+        })
+    }
+}
+
+#[async_trait]
+impl GatewayDraftSource for GatewayDraftRegistry {
+    async fn ensure_registered(
+        &self,
+        app: AppId,
+        gateway_base_url: &str,
+    ) -> Result<GatewayRegistration> {
+        let base_url = normalized_gateway_base_url(gateway_base_url);
+        let (record, revision) = self.current(app).await?;
+        match self.store.get_app_gateway_draft(app, &base_url).await? {
+            // The gateway is already serving this exact local revision.
+            Some(draft) if draft.synced_revision_id == revision.id => {
+                Ok(GatewayRegistration::Registered {
+                    shared_app_id: draft.shared_app_id,
+                    revision_id: draft.gateway_revision_id,
+                })
+            }
+            // Registered, but the app has moved on locally. The sync is lazy
+            // by design: revisions nobody ever invoked are never pushed, so
+            // the gateway's history is what was servable when it was used.
+            Some(draft) => self.append(&draft, &record, &revision, &base_url).await,
+            None => self.register(&record, &revision, &base_url).await,
+        }
+    }
+
+    async fn relay_consent(
+        &self,
+        app: AppId,
+        gateway_base_url: &str,
+    ) -> Result<GatewayConsentRelay> {
+        let base_url = normalized_gateway_base_url(gateway_base_url);
+        let (shared_app_id, revision_id) = match self.ensure_registered(app, &base_url).await? {
+            GatewayRegistration::Registered {
+                shared_app_id,
+                revision_id,
+            } => (shared_app_id, revision_id),
+            GatewayRegistration::NotRegistered => return Ok(GatewayConsentRelay::NotRegistered),
+            GatewayRegistration::Refused { message } => {
+                return Ok(GatewayConsentRelay::Refused { message })
+            }
+        };
+        match self
+            .client
+            .consent(&base_url, &shared_app_id, &revision_id)
+            .await?
+        {
+            None => Ok(GatewayConsentRelay::NotRegistered),
+            Some(GatewayConsentOutcome::Consented) => Ok(GatewayConsentRelay::Consented),
+            Some(GatewayConsentOutcome::Refused { message }) => {
+                Ok(GatewayConsentRelay::Refused { message })
+            }
+            // The gateway serves a revision this host did not pin — something
+            // else appended one. Re-establish the pin from the current local
+            // revision and consent to that, once.
+            Some(GatewayConsentOutcome::RevisionMoved) => {
+                let (record, revision) = self.current(app).await?;
+                let draft = self.store.get_app_gateway_draft(app, &base_url).await?;
+                let Some(draft) = draft else {
+                    return Ok(GatewayConsentRelay::NotRegistered);
+                };
+                let revision_id = match self.append(&draft, &record, &revision, &base_url).await? {
+                    GatewayRegistration::Registered { revision_id, .. } => revision_id,
+                    GatewayRegistration::NotRegistered => {
+                        return Ok(GatewayConsentRelay::NotRegistered)
+                    }
+                    GatewayRegistration::Refused { message } => {
+                        return Ok(GatewayConsentRelay::Refused { message })
+                    }
+                };
+                match self
+                    .client
+                    .consent(&base_url, &shared_app_id, &revision_id)
+                    .await?
+                {
+                    None => Ok(GatewayConsentRelay::NotRegistered),
+                    Some(GatewayConsentOutcome::Consented) => Ok(GatewayConsentRelay::Consented),
+                    Some(GatewayConsentOutcome::Refused { message }) => {
+                        Ok(GatewayConsentRelay::Refused { message })
+                    }
+                    Some(GatewayConsentOutcome::RevisionMoved) => {
+                        Ok(GatewayConsentRelay::Refused {
+                            message: "your model gateway is serving a different revision of \
+                                      this app"
+                                .to_owned(),
+                        })
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Relay one shared-app call, healing the gateway's own consent gate at most
+/// once.
+///
+/// A local app reaches here only after the whole local ladder has passed: the
+/// manifest pins the operation, the grant covers it, and the bound gateway
+/// app still reads as it did at consent. So a `consent_required` from the
+/// gateway is not a second decision for the user to make — the consent sheet
+/// already displayed exactly the binding set the gateway consent names, and
+/// the gateway recomputes that set server-side from the live revision,
+/// accepting only a revision pin from here. Re-stating it and calling again
+/// is what keeps a granted app from dead-ending on an invisible second
+/// consent surface.
+///
+/// Exactly one retry, and only after a consent relay that actually succeeded.
+/// A second `consent_required` is the gateway's answer and is returned as
+/// such: a relay that kept re-consenting would spin against a deployment that
+/// has decided no.
+pub(crate) async fn relay_with_consent_self_heal<F, Fut>(
+    drafts: &dyn GatewayDraftSource,
+    app: AppId,
+    gateway_base_url: &str,
+    relay: F,
+) -> std::result::Result<GatewayInvokeOutcome, GatewayDispatchError>
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<
+        Output = std::result::Result<GatewayInvokeOutcome, GatewayDispatchError>,
+    >,
+{
+    let outcome = relay().await?;
+    if !matches!(outcome, GatewayInvokeOutcome::ConsentRequired { .. }) {
+        return Ok(outcome);
+    }
+    match drafts.relay_consent(app, gateway_base_url).await {
+        Ok(GatewayConsentRelay::Consented) => {}
+        Ok(refused) => {
+            tracing::info!("this app's gateway consent could not be relayed: {refused:?}");
+            return Ok(outcome);
+        }
+        Err(error) => {
+            tracing::warn!("could not relay this app's gateway consent: {error}");
+            return Ok(outcome);
+        }
+    }
+    relay().await
+}
+
+/// The deployment a registration belongs to, when this profile is managed
+/// with a gateway URL — read exactly as the invoke dispatcher reads it, so
+/// the grant and invoke paths can never key a mapping differently.
+pub(crate) async fn registration_base_url(runtime: &GatewayRuntime) -> Option<String> {
+    let policy = runtime.policy().await.ok()?;
+    policy.gateway_url.filter(|_| policy.managed)
+}
+
+/// The deployment key a registration is stored under.
+///
+/// Normalized the way [`crate::connectors::GatewayCredentials`] compares base
+/// URLs, so the same deployment retyped with or without a trailing slash is
+/// one key rather than two registrations. A URL that does not parse is used
+/// as given: it will not match a session either, and inventing a key for it
+/// would be worse than keying it verbatim.
+pub(crate) fn normalized_gateway_base_url(base_url: &str) -> String {
+    match reqwest::Url::parse(base_url) {
+        Ok(url) => {
+            let mut normalized = url.to_string();
+            if !normalized.ends_with('/') {
+                normalized.push('/');
+            }
+            normalized
+        }
+        Err(_) => base_url.to_owned(),
+    }
+}
+
+/// Project a local manifest into the gateway's shared-app manifest.
+///
+/// A transcription, not a translation. Gateway bindings carry across
+/// verbatim — the manifest's `gateway_app` *is* the gateway's
+/// `connected_app_id`, and the operation ids are the gateway's own. Folder
+/// and local `rest_api` bindings are dropped: they name capabilities that
+/// exist only on this machine, and a gateway asked to hold them would be
+/// asked to hold something it cannot serve. `operation_policies` is never
+/// emitted — the operations a shared app may call are exactly the ones its
+/// bindings name. `parameters` is empty because a local app takes none.
+fn gateway_manifest(manifest: &AppManifest) -> serde_json::Value {
+    let bindings: Vec<serde_json::Value> = manifest
+        .bindings
+        .iter()
+        .filter_map(|binding| match binding {
+            AppBinding::GatewayOperations(binding) => Some(serde_json::json!({
+                "connected_app_id": binding.gateway_app,
+                "operation_ids": binding.operation_ids,
+            })),
+            AppBinding::Operations(_) | AppBinding::Folder(_) => None,
+        })
+        .collect();
+    serde_json::json!({
+        "title": manifest.name,
+        "bindings": bindings,
+        "parameters": [],
+    })
+}
+
+/// The slug a second registration attempt asks for: the app's name, plus
+/// enough of its own identity that no other app of this profile can collide
+/// with it.
+fn suffixed_slug(name: &str, app: AppId) -> String {
+    let identity = app.0.simple().to_string();
+    format!("{}-{}", slug_stem(name), &identity[..8])
+}
+
+/// A lowercase, hyphen-separated stem of a display name, bounded so the
+/// suffix always survives. A name with nothing slug-able in it (an entirely
+/// non-ASCII title) falls back to a fixed stem rather than an empty one.
+fn slug_stem(name: &str) -> String {
+    let mut stem = String::new();
+    for character in name.chars() {
+        if character.is_ascii_alphanumeric() {
+            stem.push(character.to_ascii_lowercase());
+        } else if !stem.ends_with('-') {
+            stem.push('-');
+        }
+        if stem.len() >= 48 {
+            break;
+        }
+    }
+    let stem = stem.trim_matches('-');
+    if stem.is_empty() {
+        "app".to_owned()
+    } else {
+        stem.to_owned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use openwave_core::local_app::{
+        AppFolderBinding, AppGatewayOperationsBinding, AppOperationsBinding, FolderAccess,
+    };
+    use serde_json::json;
+
+    use super::*;
+
+    /// A registration seam that only ever answers the consent relay.
+    struct ScriptedDrafts {
+        relayed: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl GatewayDraftSource for ScriptedDrafts {
+        async fn ensure_registered(
+            &self,
+            _app: AppId,
+            _base_url: &str,
+        ) -> Result<GatewayRegistration> {
+            unreachable!("the relay resolves registration before the self-heal runs")
+        }
+
+        async fn relay_consent(&self, _app: AppId, _base_url: &str) -> Result<GatewayConsentRelay> {
+            self.relayed.fetch_add(1, Ordering::SeqCst);
+            Ok(GatewayConsentRelay::Consented)
+        }
+    }
+
+    /// The gateway's consent gate is healed exactly once. Healing at all is
+    /// what keeps a granted app from dead-ending on a second, invisible
+    /// consent surface; healing *once* is what keeps a deployment that has
+    /// decided no from being asked forever.
+    #[tokio::test]
+    async fn a_consent_refusal_is_healed_once_and_never_looped() {
+        let refusal = || GatewayInvokeOutcome::ConsentRequired {
+            message: "consent required".to_owned(),
+        };
+
+        let drafts = ScriptedDrafts {
+            relayed: AtomicUsize::new(0),
+        };
+        let attempts = AtomicUsize::new(0);
+        let outcome =
+            relay_with_consent_self_heal(&drafts, AppId::new(), "https://gw.example/", || {
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                async move {
+                    Ok(if attempt == 0 {
+                        GatewayInvokeOutcome::ConsentRequired {
+                            message: "consent required".to_owned(),
+                        }
+                    } else {
+                        GatewayInvokeOutcome::Executed {
+                            status: 200,
+                            content_type: None,
+                            body_base64: String::new(),
+                        }
+                    })
+                }
+            })
+            .await
+            .unwrap();
+        assert!(matches!(outcome, GatewayInvokeOutcome::Executed { .. }));
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        assert_eq!(drafts.relayed.load(Ordering::SeqCst), 1);
+
+        let drafts = ScriptedDrafts {
+            relayed: AtomicUsize::new(0),
+        };
+        let attempts = AtomicUsize::new(0);
+        let outcome =
+            relay_with_consent_self_heal(&drafts, AppId::new(), "https://gw.example/", || {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                async { Ok(refusal()) }
+            })
+            .await
+            .unwrap();
+        assert!(
+            matches!(outcome, GatewayInvokeOutcome::ConsentRequired { .. }),
+            "a second refusal is the gateway's answer, carried back as one"
+        );
+        assert_eq!(attempts.load(Ordering::SeqCst), 2, "never a third call");
+    }
+
+    /// The projection is the whole contract between a local manifest and the
+    /// gateway's shared-app manifest, and two of its rules are silent
+    /// failures if they ever move: a dropped-arm binding that leaks across
+    /// asks the gateway to hold a capability only this machine has, and an
+    /// emitted `operation_policies` would widen what the shared app may call
+    /// beyond what its bindings name. (The third — that every local app name
+    /// survives as a title — is checked at compile time above.)
+    #[test]
+    fn the_gateway_manifest_carries_gateway_bindings_and_nothing_else() {
+        let manifest = AppManifest {
+            name: "Issue triage".into(),
+            bindings: vec![
+                AppBinding::GatewayOperations(AppGatewayOperationsBinding {
+                    gateway_app: "gw-issues".into(),
+                    operation_ids: vec!["listIssues".into()],
+                }),
+                AppBinding::Operations(AppOperationsBinding {
+                    app: openwave_core::id::ConnectedAppId::new(),
+                    operation_ids: vec!["localOnly".into()],
+                }),
+                AppBinding::Folder(AppFolderBinding {
+                    folder: openwave_core::id::HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap(),
+                    access: FolderAccess::Read,
+                }),
+            ],
+        };
+        assert_eq!(
+            gateway_manifest(&manifest),
+            json!({
+                "title": "Issue triage",
+                "bindings": [{"connected_app_id": "gw-issues", "operation_ids": ["listIssues"]}],
+                "parameters": [],
+            })
+        );
+    }
+}

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -942,37 +942,55 @@ impl crate::connected_apps::GatewayCatalogSource for GatewayRuntime {
     }
 }
 
-/// The production gateway relay: the one gateway runtime plus the draft-id
-/// seam, wired behind [`GatewayInvokeDispatcher`].
+/// The production gateway relay: the one gateway runtime plus the
+/// registration seam, wired behind [`GatewayInvokeDispatcher`].
 ///
-/// Two lookups before any network call, both fail-closed: the profile must
-/// hold a session at the deployment policy names, and the local app must have
-/// a registered draft there. Only then is the invoke body assembled and
-/// relayed on a `control` bearer.
+/// Two gates before any operation is relayed, both fail-closed: the profile
+/// must hold a session at the deployment policy names, and the app must be
+/// registered there — which the registration seam establishes on the spot
+/// when it is not, so a granted app self-heals into a servable one on its
+/// first call.
 pub(crate) struct GatewayRelayDispatcher {
     runtime: Arc<GatewayRuntime>,
     drafts: Arc<dyn crate::connected_apps::GatewayDraftSource>,
 }
 
 /// The relay as production assembles it: over the process's one gateway
-/// runtime, with no draft registration yet (see
-/// [`crate::connected_apps::NoRegisteredDrafts`]). Debug builds alone may
-/// pin a mapping via `OPENWAVE_GATEWAY_DRAFT_APPS` (see
-/// [`crate::connected_apps::EnvPinnedDrafts`]) — a release daemon must not
-/// let its process environment redirect consented invokes.
+/// runtime and the store-backed registration registry.
 pub(crate) fn gateway_relay_dispatcher(
     runtime: Arc<GatewayRuntime>,
+    drafts: Arc<dyn crate::connected_apps::GatewayDraftSource>,
 ) -> Arc<dyn crate::connected_apps::GatewayInvokeDispatcher> {
-    #[cfg(debug_assertions)]
-    let drafts: Arc<dyn crate::connected_apps::GatewayDraftSource> =
-        match crate::connected_apps::EnvPinnedDrafts::from_env() {
-            Some(pinned) => Arc::new(pinned),
-            None => Arc::new(crate::connected_apps::NoRegisteredDrafts),
-        };
-    #[cfg(not(debug_assertions))]
-    let drafts: Arc<dyn crate::connected_apps::GatewayDraftSource> =
-        Arc::new(crate::connected_apps::NoRegisteredDrafts);
     Arc::new(GatewayRelayDispatcher { runtime, drafts })
+}
+
+impl GatewayRelayDispatcher {
+    /// One relay attempt against an already-resolved shared app.
+    async fn relay(
+        &self,
+        connection: &crate::connectors::GatewayConnection,
+        shared_app_id: &str,
+        body: &serde_json::Value,
+    ) -> std::result::Result<
+        crate::connectors::GatewayInvokeOutcome,
+        crate::connected_apps::GatewayDispatchError,
+    > {
+        use crate::connected_apps::GatewayDispatchError;
+
+        match connection.invoke_shared_app(shared_app_id, body).await {
+            Ok(Some(outcome)) => Ok(outcome),
+            Ok(None) => Err(GatewayDispatchError::NotRegistered),
+            // A session the gateway no longer honors is "no session" here, the
+            // same reading every other gateway read gives it.
+            Err(error) if is_sign_in_required(&error) => Err(GatewayDispatchError::NoSession),
+            Err(error) => {
+                tracing::warn!("gateway shared-app invoke failed: {error}");
+                Err(GatewayDispatchError::Unreachable(
+                    "the gateway could not complete this call".to_owned(),
+                ))
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -1022,28 +1040,27 @@ impl crate::connected_apps::GatewayInvokeDispatcher for GatewayRelayDispatcher {
         {
             return Err(GatewayDispatchError::NoSession);
         }
-        let Some(shared_app_id) = self
+        let shared_app_id = match self
             .drafts
-            .draft_shared_app_id(app, &base_url)
+            .ensure_registered(app, &base_url)
             .await
-            .map_err(unreachable("resolve this app's gateway draft"))?
-        else {
-            return Err(GatewayDispatchError::NotRegistered);
+            .map_err(unreachable("register this app at the gateway"))?
+        {
+            crate::connected_apps::GatewayRegistration::Registered { shared_app_id, .. } => {
+                shared_app_id
+            }
+            crate::connected_apps::GatewayRegistration::NotRegistered => {
+                return Err(GatewayDispatchError::NotRegistered)
+            }
+            crate::connected_apps::GatewayRegistration::Refused { message } => {
+                return Err(GatewayDispatchError::Unreachable(message))
+            }
         };
         let body = shared_app_invoke_body(request);
-        match connection.invoke_shared_app(&shared_app_id, &body).await {
-            Ok(Some(outcome)) => Ok(outcome),
-            Ok(None) => Err(GatewayDispatchError::NotRegistered),
-            // A session the gateway no longer honors is "no session" here, the
-            // same reading every other gateway read gives it.
-            Err(error) if is_sign_in_required(&error) => Err(GatewayDispatchError::NoSession),
-            Err(error) => {
-                tracing::warn!("gateway shared-app invoke failed: {error}");
-                Err(GatewayDispatchError::Unreachable(
-                    "the gateway could not complete this call".to_owned(),
-                ))
-            }
-        }
+        crate::gateway_drafts::relay_with_consent_self_heal(&*self.drafts, app, &base_url, || {
+            self.relay(&connection, &shared_app_id, &body)
+        })
+        .await
     }
 }
 

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -42,6 +42,7 @@ mod event_projection;
 mod exec_write_snapshot;
 mod extract;
 mod foreground_prompt;
+mod gateway_drafts;
 mod gateway_runtime;
 pub mod host_folders;
 pub mod logging;

--- a/crates/openwave-server/src/routes/app_grant.rs
+++ b/crates/openwave-server/src/routes/app_grant.rs
@@ -243,6 +243,7 @@ pub async fn post_app_grant(
         created_at: Utc::now(),
     };
     state.store.put_app_grant(&grant).await?;
+    register_at_the_gateway(&state, app.id, &revision.manifest).await;
     Ok(Json(grant_state(
         &revision.manifest,
         Some(&grant),
@@ -264,6 +265,40 @@ pub async fn delete_app_grant(
     }
     state.store.delete_app_grant(app_id).await?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+/// Register a just-granted app at the gateway and relay the author's consent
+/// for it — best effort, after the grant is already durable.
+///
+/// Consent to a gateway binding is consent to relay through a shared app the
+/// gateway holds, so the registration is part of making the grant usable
+/// rather than something to ask about separately. It is deliberately not part
+/// of the transaction: the grant is a local decision, and a gateway that is
+/// down, unreachable, or too old must never fail it. Everything here is
+/// re-attempted on the first invoke, which registers and consents on the spot
+/// if this could not, so the only cost of a failure is that the first call
+/// pays for it.
+///
+/// Nothing is attempted for a manifest that binds no gateway app: there is
+/// nothing at the gateway for it to be.
+async fn register_at_the_gateway(state: &AppState, app_id: AppId, manifest: &AppManifest) {
+    if crate::connected_apps::gateway_apps_bound_by(&manifest.bindings).is_empty() {
+        return;
+    }
+    let Some(base_url) = crate::gateway_drafts::registration_base_url(&state.gateway).await else {
+        return;
+    };
+    match state.gateway_drafts.relay_consent(app_id, &base_url).await {
+        Ok(crate::connected_apps::GatewayConsentRelay::Consented) => {}
+        Ok(outcome) => tracing::info!(
+            %app_id,
+            "this app is not registered at the gateway yet: {outcome:?}"
+        ),
+        Err(error) => tracing::warn!(
+            %app_id,
+            "could not register this app at the gateway: {error}"
+        ),
+    }
 }
 
 /// Resolve a live app and its current revision, or 404.

--- a/crates/openwave-server/src/routes/app_grant.rs
+++ b/crates/openwave-server/src/routes/app_grant.rs
@@ -243,7 +243,7 @@ pub async fn post_app_grant(
         created_at: Utc::now(),
     };
     state.store.put_app_grant(&grant).await?;
-    register_at_the_gateway(&state, app.id, &revision.manifest).await;
+    register_at_the_gateway(&state, app.id, &revision.manifest);
     Ok(Json(grant_state(
         &revision.manifest,
         Some(&grant),
@@ -268,37 +268,42 @@ pub async fn delete_app_grant(
 }
 
 /// Register a just-granted app at the gateway and relay the author's consent
-/// for it — best effort, after the grant is already durable.
+/// for it — off the request, after the grant is already durable.
 ///
 /// Consent to a gateway binding is consent to relay through a shared app the
 /// gateway holds, so the registration is part of making the grant usable
-/// rather than something to ask about separately. It is deliberately not part
-/// of the transaction: the grant is a local decision, and a gateway that is
-/// down, unreachable, or too old must never fail it. Everything here is
-/// re-attempted on the first invoke, which registers and consents on the spot
-/// if this could not, so the only cost of a failure is that the first call
-/// pays for it.
+/// rather than something to ask about separately. It is deliberately neither
+/// part of the transaction nor part of the response: the grant is a local
+/// decision that a gateway which is down, unreachable, or slow must never
+/// fail — and must never hold the consent sheet open while it times out.
+/// Everything here is re-attempted on the first invoke, which registers and
+/// consents on the spot if this could not, so the only cost of a failure is
+/// that the first call pays for it.
 ///
 /// Nothing is attempted for a manifest that binds no gateway app: there is
 /// nothing at the gateway for it to be.
-async fn register_at_the_gateway(state: &AppState, app_id: AppId, manifest: &AppManifest) {
+fn register_at_the_gateway(state: &AppState, app_id: AppId, manifest: &AppManifest) {
     if crate::connected_apps::gateway_apps_bound_by(&manifest.bindings).is_empty() {
         return;
     }
-    let Some(base_url) = crate::gateway_drafts::registration_base_url(&state.gateway).await else {
-        return;
-    };
-    match state.gateway_drafts.relay_consent(app_id, &base_url).await {
-        Ok(crate::connected_apps::GatewayConsentRelay::Consented) => {}
-        Ok(outcome) => tracing::info!(
-            %app_id,
-            "this app is not registered at the gateway yet: {outcome:?}"
-        ),
-        Err(error) => tracing::warn!(
-            %app_id,
-            "could not register this app at the gateway: {error}"
-        ),
-    }
+    let state = state.clone();
+    tokio::spawn(async move {
+        let Some(base_url) = crate::gateway_drafts::registration_base_url(&state.gateway).await
+        else {
+            return;
+        };
+        match state.gateway_drafts.relay_consent(app_id, &base_url).await {
+            Ok(crate::connected_apps::GatewayConsentRelay::Consented) => {}
+            Ok(outcome) => tracing::info!(
+                %app_id,
+                "this app is not registered at the gateway yet: {outcome:?}"
+            ),
+            Err(error) => tracing::warn!(
+                %app_id,
+                "could not register this app at the gateway: {error}"
+            ),
+        }
+    });
 }
 
 /// Resolve a live app and its current revision, or 404.

--- a/crates/openwave-server/src/routes/app_invoke.rs
+++ b/crates/openwave-server/src/routes/app_invoke.rs
@@ -819,7 +819,12 @@ async fn dispatch_gateway_operation(
                 format!("connect {display_name} at your model gateway to continue: {message}"),
             ))
         }
-        Ok(GatewayInvokeOutcome::Refused { message }) => Ok(failure(message)),
+        // Consent the relay could not heal: it re-states the author's consent
+        // and calls again exactly once, so reaching here means the gateway
+        // refused twice. That is the app's to present, in the gateway's own
+        // words, like any other refusal.
+        Ok(GatewayInvokeOutcome::ConsentRequired { message })
+        | Ok(GatewayInvokeOutcome::Refused { message }) => Ok(failure(message)),
         Err(GatewayDispatchError::NoSession) => Err(AppInvokeError::refused(
             AppInvokeRefusalKind::GatewayUnavailable,
             format!(

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -143,6 +143,13 @@ pub struct AppState {
     /// substitute a fake so the whole refusal ladder is drivable without a
     /// deployment.
     pub(crate) gateway_dispatch: Arc<dyn crate::connected_apps::GatewayInvokeDispatcher>,
+    /// Establishes and advances the gateway-side registration a local app's
+    /// gateway bindings are relayed through, and relays the author's consent
+    /// for it. The production assembly is the store-backed registry over the
+    /// one gateway runtime ([`crate::gateway_drafts::GatewayDraftRegistry`]);
+    /// tests substitute a fake so the grant path's best-effort posture is
+    /// drivable without a deployment.
+    pub(crate) gateway_drafts: Arc<dyn crate::connected_apps::GatewayDraftSource>,
     /// Outstanding single-use tokens redeemed by the sandboxed view frames —
     /// prefetched MCP views and stored local-app revisions alike.
     pub(crate) view_frames: Arc<ViewFrameTokens>,
@@ -352,7 +359,18 @@ impl AppState {
         ));
         let rest_dispatch = crate::connected_apps::governed_rest_dispatcher(secrets.clone());
         let gateway_catalogs = gateway.clone();
-        let gateway_dispatch = crate::gateway_runtime::gateway_relay_dispatcher(gateway.clone());
+        let gateway_drafts: Arc<dyn crate::connected_apps::GatewayDraftSource> =
+            Arc::new(crate::gateway_drafts::GatewayDraftRegistry::new(
+                store.clone(),
+                config.data_dir.clone(),
+                Arc::new(crate::gateway_drafts::GatewayConnectorDraftClient::new(
+                    gateway.clone(),
+                )),
+            ));
+        let gateway_dispatch = crate::gateway_runtime::gateway_relay_dispatcher(
+            gateway.clone(),
+            gateway_drafts.clone(),
+        );
         Ok(Self {
             config: Arc::new(config),
             store: store.clone(),
@@ -364,6 +382,7 @@ impl AppState {
             rest_dispatch,
             gateway_catalogs,
             gateway_dispatch,
+            gateway_drafts,
             view_frames: Arc::default(),
             gateway,
             chatgpt,

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -45,6 +45,7 @@ mod conformance;
 mod connected_apps;
 mod conversations;
 mod documents;
+mod gateway_drafts;
 mod image_attachment;
 mod lifecycle;
 mod outputs;

--- a/crates/openwave-server/src/tests/gateway_drafts.rs
+++ b/crates/openwave-server/src/tests/gateway_drafts.rs
@@ -1,0 +1,484 @@
+//! The gateway registration lifecycle: what the registry establishes, when it
+//! pushes a revision, and what happens when the gateway cannot or will not
+//! hold the app.
+//!
+//! The relay itself is covered in [`super::app_invoke`]; this module drives
+//! the half that runs before a relay is possible at all.
+
+use std::collections::VecDeque;
+use std::sync::Mutex as StdMutex;
+
+use openwave_core::id::{AppId, AppRevisionId};
+use openwave_core::local_app::{
+    app_revision_relative_path, AppBinding, AppGatewayOperationsBinding, AppManifest, CreateApp,
+    NewAppRevision,
+};
+
+use base64::Engine as _;
+
+use crate::connected_apps::{GatewayConsentRelay, GatewayDraftSource, GatewayRegistration};
+use crate::connectors::{GatewayConsentOutcome, GatewayRegistrationOutcome};
+use crate::gateway_drafts::{GatewayDraftClient, GatewayDraftRegistry, SharedAppProjection};
+
+use super::*;
+
+const GATEWAY_A: &str = "https://gateway-a.internal.example.com/";
+const GATEWAY_B: &str = "https://gateway-b.internal.example.com/";
+
+/// A gateway that answers registration calls from a script, recording every
+/// call so a test can assert what crossed and in what order.
+#[derive(Default)]
+struct FakeGateway {
+    calls: StdMutex<Vec<String>>,
+    creates: StdMutex<VecDeque<Option<GatewayRegistrationOutcome>>>,
+    appends: StdMutex<VecDeque<Option<GatewayRegistrationOutcome>>>,
+    consents: StdMutex<VecDeque<Option<GatewayConsentOutcome>>>,
+    projections: StdMutex<Vec<SharedAppProjection>>,
+}
+
+impl FakeGateway {
+    fn registered(id: &str, revision: &str) -> Option<GatewayRegistrationOutcome> {
+        Some(GatewayRegistrationOutcome::Registered {
+            shared_app_id: id.to_owned(),
+            revision_id: revision.to_owned(),
+        })
+    }
+
+    fn creates(
+        self,
+        answers: impl IntoIterator<Item = Option<GatewayRegistrationOutcome>>,
+    ) -> Self {
+        *self.creates.lock().unwrap() = answers.into_iter().collect();
+        self
+    }
+
+    fn appends(
+        self,
+        answers: impl IntoIterator<Item = Option<GatewayRegistrationOutcome>>,
+    ) -> Self {
+        *self.appends.lock().unwrap() = answers.into_iter().collect();
+        self
+    }
+
+    fn consents(self, answers: impl IntoIterator<Item = Option<GatewayConsentOutcome>>) -> Self {
+        *self.consents.lock().unwrap() = answers.into_iter().collect();
+        self
+    }
+
+    fn calls(&self) -> Vec<String> {
+        self.calls.lock().unwrap().clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl GatewayDraftClient for FakeGateway {
+    async fn create(
+        &self,
+        gateway_base_url: &str,
+        slug: Option<&str>,
+        projection: &SharedAppProjection,
+    ) -> openwave_core::Result<Option<GatewayRegistrationOutcome>> {
+        self.calls.lock().unwrap().push(format!(
+            "create {gateway_base_url} slug={}",
+            slug.unwrap_or("-")
+        ));
+        self.projections.lock().unwrap().push(projection.clone());
+        Ok(self
+            .creates
+            .lock()
+            .unwrap()
+            .pop_front()
+            .unwrap_or_else(|| Self::registered("shared-1", "gw-rev-1")))
+    }
+
+    async fn append(
+        &self,
+        gateway_base_url: &str,
+        shared_app_id: &str,
+        projection: &SharedAppProjection,
+    ) -> openwave_core::Result<Option<GatewayRegistrationOutcome>> {
+        self.calls
+            .lock()
+            .unwrap()
+            .push(format!("append {gateway_base_url} {shared_app_id}"));
+        self.projections.lock().unwrap().push(projection.clone());
+        Ok(self
+            .appends
+            .lock()
+            .unwrap()
+            .pop_front()
+            .unwrap_or_else(|| Self::registered(shared_app_id, "gw-rev-2")))
+    }
+
+    async fn consent(
+        &self,
+        gateway_base_url: &str,
+        shared_app_id: &str,
+        revision_id: &str,
+    ) -> openwave_core::Result<Option<GatewayConsentOutcome>> {
+        self.calls.lock().unwrap().push(format!(
+            "consent {gateway_base_url} {shared_app_id} {revision_id}"
+        ));
+        Ok(self
+            .consents
+            .lock()
+            .unwrap()
+            .pop_front()
+            .unwrap_or(Some(GatewayConsentOutcome::Consented)))
+    }
+}
+
+/// A profile holding one app that binds one gateway app, with its bundle
+/// bytes published where the projection reads them.
+struct Fixture {
+    _dir: tempfile::TempDir,
+    store: Arc<dyn Store>,
+    data_dir: std::path::PathBuf,
+    app_id: AppId,
+}
+
+impl Fixture {
+    async fn new() -> Self {
+        let (dir, store) = temp_db_store("gateway-drafts.db").await;
+        let store: Arc<dyn Store> = Arc::new(store);
+        let data_dir = dir.path().to_path_buf();
+        let app_id = AppId::new();
+        let revision_id = AppRevisionId::new();
+        publish_bundle(&data_dir, app_id, revision_id, b"<html>one</html>");
+        store
+            .create_app(&CreateApp {
+                id: app_id,
+                revision: revision(revision_id, b"<html>one</html>"),
+            })
+            .await
+            .unwrap();
+        Self {
+            _dir: dir,
+            store,
+            data_dir,
+            app_id,
+        }
+    }
+
+    fn registry(&self, gateway: Arc<FakeGateway>) -> GatewayDraftRegistry {
+        GatewayDraftRegistry::new(self.store.clone(), self.data_dir.clone(), gateway)
+    }
+
+    /// Append a fresh local revision, as an app edit would.
+    async fn revise(&self, bundle: &[u8]) -> AppRevisionId {
+        let revision_id = AppRevisionId::new();
+        publish_bundle(&self.data_dir, self.app_id, revision_id, bundle);
+        self.store
+            .append_app_revision(self.app_id, &revision(revision_id, bundle))
+            .await
+            .unwrap();
+        revision_id
+    }
+
+    async fn held(
+        &self,
+        gateway_base_url: &str,
+    ) -> Option<openwave_core::local_app::AppGatewayDraft> {
+        self.store
+            .get_app_gateway_draft(self.app_id, gateway_base_url)
+            .await
+            .unwrap()
+    }
+}
+
+fn publish_bundle(
+    data_dir: &std::path::Path,
+    app_id: AppId,
+    revision_id: AppRevisionId,
+    bundle: &[u8],
+) {
+    let path = data_dir.join(app_revision_relative_path(app_id, revision_id));
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, bundle).unwrap();
+}
+
+fn revision(id: AppRevisionId, bundle: &[u8]) -> NewAppRevision {
+    use sha2::Digest as _;
+
+    NewAppRevision {
+        id,
+        manifest: AppManifest {
+            name: "Issue triage".into(),
+            bindings: vec![AppBinding::GatewayOperations(AppGatewayOperationsBinding {
+                gateway_app: "gw-issues".into(),
+                operation_ids: vec!["listIssues".into()],
+            })],
+        },
+        byte_len: bundle.len() as u64,
+        sha256: sha2::Sha256::digest(bundle).into(),
+        turn_id: None,
+        producing_run_id: None,
+        chat_id: None,
+        created_at: chrono::Utc::now(),
+    }
+}
+
+fn shared_app_id(registration: &GatewayRegistration) -> &str {
+    match registration {
+        GatewayRegistration::Registered { shared_app_id, .. } => shared_app_id,
+        other => panic!("expected a registration, got {other:?}"),
+    }
+}
+
+/// The first relay of a granted app is what registers it, and the mapping it
+/// leaves is what keeps every later relay from registering again. A slug the
+/// deployment already holds is the one refusal worth asking about differently
+/// — once, under a name carrying the app's own identity.
+#[tokio::test]
+async fn a_first_registration_persists_and_retries_a_taken_slug_once() {
+    let fixture = Fixture::new().await;
+    let gateway = Arc::new(FakeGateway::default().creates([
+        Some(GatewayRegistrationOutcome::SlugTaken),
+        FakeGateway::registered("shared-1", "gw-rev-1"),
+    ]));
+    let registry = fixture.registry(gateway.clone());
+
+    let registration = registry
+        .ensure_registered(fixture.app_id, GATEWAY_A)
+        .await
+        .unwrap();
+    assert_eq!(shared_app_id(&registration), "shared-1");
+
+    let calls = gateway.calls();
+    assert_eq!(
+        calls.len(),
+        2,
+        "a taken slug is retried exactly once: {calls:?}"
+    );
+    assert!(
+        calls[0].ends_with("slug=-"),
+        "the gateway derives the first slug: {calls:?}"
+    );
+    let identity = fixture.app_id.0.simple().to_string();
+    assert!(
+        calls[1].ends_with(&format!("slug=issue-triage-{}", &identity[..8])),
+        "the retry names a slug the app's own identity makes unique: {calls:?}"
+    );
+
+    let held = fixture
+        .held(GATEWAY_A)
+        .await
+        .expect("the mapping is durable");
+    assert_eq!(held.shared_app_id, "shared-1");
+    assert_eq!(held.gateway_revision_id, "gw-rev-1");
+
+    // A second relay reads the mapping rather than registering again.
+    registry
+        .ensure_registered(fixture.app_id, GATEWAY_A)
+        .await
+        .unwrap();
+    assert_eq!(
+        gateway.calls().len(),
+        2,
+        "a registered app is not registered twice"
+    );
+}
+
+/// A registration belongs to one deployment. A profile re-paired elsewhere
+/// holds nothing there and registers afresh — it must never relay a consented
+/// invoke at a shared app another gateway minted.
+#[tokio::test]
+async fn a_registration_at_one_gateway_never_answers_for_another() {
+    let fixture = Fixture::new().await;
+    let gateway = Arc::new(FakeGateway::default().creates([
+        FakeGateway::registered("shared-a", "gw-rev-a"),
+        FakeGateway::registered("shared-b", "gw-rev-b"),
+    ]));
+    let registry = fixture.registry(gateway.clone());
+
+    let first = registry
+        .ensure_registered(fixture.app_id, GATEWAY_A)
+        .await
+        .unwrap();
+    let second = registry
+        .ensure_registered(fixture.app_id, GATEWAY_B)
+        .await
+        .unwrap();
+
+    assert_eq!(shared_app_id(&first), "shared-a");
+    assert_eq!(shared_app_id(&second), "shared-b");
+    assert_eq!(
+        fixture.held(GATEWAY_A).await.unwrap().shared_app_id,
+        "shared-a",
+        "registering elsewhere must not move the first deployment's mapping"
+    );
+}
+
+/// The revision sync is lazy: an app that has been edited since its last
+/// relay pushes the revision it is about to serve, and only that one.
+#[tokio::test]
+async fn an_edited_app_pushes_its_current_revision_before_the_next_relay() {
+    let fixture = Fixture::new().await;
+    let gateway = Arc::new(FakeGateway::default());
+    let registry = fixture.registry(gateway.clone());
+    registry
+        .ensure_registered(fixture.app_id, GATEWAY_A)
+        .await
+        .unwrap();
+
+    // Two local edits; only the current one is ever pushed.
+    fixture.revise(b"<html>two</html>").await;
+    let current = fixture.revise(b"<html>three</html>").await;
+    let registration = registry
+        .ensure_registered(fixture.app_id, GATEWAY_A)
+        .await
+        .unwrap();
+
+    assert_eq!(shared_app_id(&registration), "shared-1");
+    let calls = gateway.calls();
+    assert_eq!(
+        calls.len(),
+        2,
+        "one create and one append — the skipped revision is never pushed: {calls:?}"
+    );
+    assert!(calls[1].starts_with("append"), "{calls:?}");
+    let pushed = gateway.projections.lock().unwrap().last().unwrap().clone();
+    assert_eq!(
+        base64::engine::general_purpose::STANDARD
+            .decode(&pushed.bundle_base64)
+            .unwrap(),
+        b"<html>three</html>",
+        "the pushed bundle is the revision about to be served"
+    );
+    let held = fixture.held(GATEWAY_A).await.unwrap();
+    assert_eq!(held.synced_revision_id, current);
+    assert_eq!(held.gateway_revision_id, "gw-rev-2");
+}
+
+/// A deployment that does not serve shared-app registration leaves the app
+/// unregistered rather than half-registered: nothing is persisted, so the next
+/// attempt is a first attempt again.
+#[tokio::test]
+async fn a_gateway_that_cannot_hold_the_app_records_no_mapping() {
+    let fixture = Fixture::new().await;
+    let gateway = Arc::new(FakeGateway::default().creates([None]));
+    let registry = fixture.registry(gateway.clone());
+
+    let registration = registry
+        .ensure_registered(fixture.app_id, GATEWAY_A)
+        .await
+        .unwrap();
+    assert_eq!(registration, GatewayRegistration::NotRegistered);
+    assert!(fixture.held(GATEWAY_A).await.is_none());
+}
+
+/// Consent names a revision. When the gateway reports the pin has moved, the
+/// registration is re-established from the current local revision and consent
+/// is re-stated against what the gateway now serves — once.
+#[tokio::test]
+async fn a_moved_revision_pin_is_re_synced_before_consent_is_relayed_again() {
+    let fixture = Fixture::new().await;
+    let gateway = Arc::new(
+        FakeGateway::default()
+            .consents([
+                Some(GatewayConsentOutcome::RevisionMoved),
+                Some(GatewayConsentOutcome::Consented),
+            ])
+            .appends([FakeGateway::registered("shared-1", "gw-rev-9")]),
+    );
+    let registry = fixture.registry(gateway.clone());
+
+    let relayed = registry
+        .relay_consent(fixture.app_id, GATEWAY_A)
+        .await
+        .unwrap();
+
+    assert_eq!(relayed, GatewayConsentRelay::Consented);
+    let calls = gateway.calls();
+    assert_eq!(
+        calls
+            .iter()
+            .map(|call| call.split(' ').next().unwrap())
+            .collect::<Vec<_>>(),
+        ["create", "consent", "append", "consent"],
+        "{calls:?}"
+    );
+    assert!(
+        calls[3].ends_with("gw-rev-9"),
+        "the second consent pins what the gateway now serves: {calls:?}"
+    );
+}
+
+/// The grant is a local decision. Registration runs after it is durable and
+/// is allowed to fail: a gateway that is down, unreachable, or too old must
+/// never cost the user their consent — the first invoke registers instead.
+#[tokio::test]
+async fn a_grant_survives_a_registration_the_gateway_refuses() {
+    struct UnreachableGateway;
+
+    #[async_trait::async_trait]
+    impl GatewayDraftSource for UnreachableGateway {
+        async fn ensure_registered(
+            &self,
+            _app: AppId,
+            _gateway_base_url: &str,
+        ) -> openwave_core::Result<GatewayRegistration> {
+            Err(openwave_core::AgentError::Store(
+                "the gateway is down".into(),
+            ))
+        }
+
+        async fn relay_consent(
+            &self,
+            _app: AppId,
+            _gateway_base_url: &str,
+        ) -> openwave_core::Result<GatewayConsentRelay> {
+            Err(openwave_core::AgentError::Store(
+                "the gateway is down".into(),
+            ))
+        }
+    }
+
+    let (dir, store) = temp_db_store("gateway-drafts-grant.db").await;
+    let store: Arc<dyn Store> = Arc::new(store);
+    let mut state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    state.gateway_catalogs = Arc::new(super::app_grant::FakeGatewayCatalogs::signed_in(
+        "https://gateway.internal.example.com",
+        &[("gw-issues", "Issues (gateway)", &["listIssues"])],
+    ));
+    state.gateway_drafts = Arc::new(UnreachableGateway);
+    let bearer = format!("Bearer {}", state.token);
+    let router = app(state);
+
+    let app_id = AppId::new();
+    store
+        .create_app(&CreateApp {
+            id: app_id,
+            revision: revision(AppRevisionId::new(), b"<html>one</html>"),
+        })
+        .await
+        .unwrap();
+
+    let consented = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/apps/{app_id}/grant"))
+                .header("authorization", &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(consented.status(), StatusCode::OK);
+    assert!(
+        store.get_app_grant(app_id).await.unwrap().is_some(),
+        "the grant is durable even though nothing could be registered"
+    );
+}

--- a/crates/openwave-server/src/tests/gateway_drafts.rs
+++ b/crates/openwave-server/src/tests/gateway_drafts.rs
@@ -233,7 +233,9 @@ fn shared_app_id(registration: &GatewayRegistration) -> &str {
 async fn a_first_registration_persists_and_retries_a_taken_slug_once() {
     let fixture = Fixture::new().await;
     let gateway = Arc::new(FakeGateway::default().creates([
-        Some(GatewayRegistrationOutcome::SlugTaken),
+        Some(GatewayRegistrationOutcome::SlugTaken {
+            message: "that slug is taken".into(),
+        }),
         FakeGateway::registered("shared-1", "gw-rev-1"),
     ]));
     let registry = fixture.registry(gateway.clone());
@@ -404,12 +406,18 @@ async fn a_moved_revision_pin_is_re_synced_before_consent_is_relayed_again() {
     );
 }
 
-/// The grant is a local decision. Registration runs after it is durable and
-/// is allowed to fail: a gateway that is down, unreachable, or too old must
-/// never cost the user their consent — the first invoke registers instead.
+/// The grant is a local decision, and registration is neither part of the
+/// transaction nor part of the response: a gateway that is down must not cost
+/// the user their consent, and a gateway that is slow must not hold the
+/// consent sheet open. The registration seam is still reached — that is what
+/// makes this a failure that was survived rather than a path never taken.
 #[tokio::test]
 async fn a_grant_survives_a_registration_the_gateway_refuses() {
-    struct UnreachableGateway;
+    /// A registration seam that fails every call, counting what reached it.
+    #[derive(Default)]
+    struct UnreachableGateway {
+        relayed: std::sync::atomic::AtomicUsize,
+    }
 
     #[async_trait::async_trait]
     impl GatewayDraftSource for UnreachableGateway {
@@ -428,6 +436,8 @@ async fn a_grant_survives_a_registration_the_gateway_refuses() {
             _app: AppId,
             _gateway_base_url: &str,
         ) -> openwave_core::Result<GatewayConsentRelay> {
+            self.relayed
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Err(openwave_core::AgentError::Store(
                 "the gateway is down".into(),
             ))
@@ -436,6 +446,11 @@ async fn a_grant_survives_a_registration_the_gateway_refuses() {
 
     let (dir, store) = temp_db_store("gateway-drafts-grant.db").await;
     let store: Arc<dyn Store> = Arc::new(store);
+    // Registration only runs where a deployment is resolvable, so the profile
+    // has to be provisioned or the seam is never reached at all.
+    crate::managed_policy::provision(&*store, "https://gateway.internal.example.com")
+        .await
+        .unwrap();
     let mut state = AppState::new(
         Config::desktop(dir.path()),
         store.clone(),
@@ -451,7 +466,8 @@ async fn a_grant_survives_a_registration_the_gateway_refuses() {
         "https://gateway.internal.example.com",
         &[("gw-issues", "Issues (gateway)", &["listIssues"])],
     ));
-    state.gateway_drafts = Arc::new(UnreachableGateway);
+    let drafts = Arc::new(UnreachableGateway::default());
+    state.gateway_drafts = drafts.clone();
     let bearer = format!("Bearer {}", state.token);
     let router = app(state);
 
@@ -477,8 +493,21 @@ async fn a_grant_survives_a_registration_the_gateway_refuses() {
         .await
         .unwrap();
     assert_eq!(consented.status(), StatusCode::OK);
+
+    // The registration runs off the response, so it is awaited here rather
+    // than assumed to have already happened.
+    let reached = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        while drafts.relayed.load(std::sync::atomic::Ordering::SeqCst) == 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await;
+    assert!(
+        reached.is_ok(),
+        "consenting to a gateway binding must reach the registration seam"
+    );
     assert!(
         store.get_app_grant(app_id).await.unwrap().is_some(),
-        "the grant is durable even though nothing could be registered"
+        "a registration the gateway refused never retracts the grant"
     );
 }

--- a/docs/local-apps.md
+++ b/docs/local-apps.md
@@ -55,6 +55,24 @@ An app revision is an untrusted **bundle** and a trusted **manifest**:
   gateway session, deployment, or draft registration cannot answer gets
   `gateway_unavailable`, with the message naming which.
 
+  A relay needs a shared app at the gateway to relay *to*, and the host
+  establishes that itself rather than asking the author to. Consenting to a
+  manifest that binds a gateway app registers the app at the deployment
+  policy names and relays the author's consent for it; both are best effort
+  after the grant is already durable, because a gateway that is down must
+  never cost the user their consent. The first invoke does the same work if
+  that could not, so a granted app heals into a servable one on its own. The
+  mapping is stored per `(app, deployment)`, so a profile re-paired to a
+  different gateway holds no registration there and registers afresh —
+  exactly as it holds no gateway grant there. Revision sync is lazy: the local
+  revision about to be served is pushed on the next relay, and revisions
+  nobody ever invoked are never pushed, so the gateway's history is what was
+  servable when it was used. The gateway's own `consent_required` refusal is
+  healed once — the consent sheet already displayed exactly the binding set
+  the gateway consent names, and the gateway recomputes that set server-side
+  from the live revision — and a second refusal is reported as the gateway's
+  answer rather than retried.
+
 The containment story is inherited from MCP App views and unchanged: the frame
 is served by the host with its own strict CSP (`default-src 'none'`,
 `connect-src 'none'`), sandboxed `allow-scripts` only, opaque origin. The


### PR DESCRIPTION
Local apps could bind connected apps the model gateway holds, and the invoke
path could relay to them — but nothing ever registered the app at the gateway,
so `GatewayDraftSource` answered "not registered" in every production build and
only a debug env shim (`OPENWAVE_GATEWAY_DRAFT_APPS`) could make a relay work
at all. This builds the registration lifecycle that seam was placed for
(record 7 excluded it deliberately: "its own slice built against this
vocabulary").

## The lifecycle

A new `app_gateway_draft` table maps `(app, gateway deployment)` to the shared
app the gateway minted, the gateway revision it currently serves, and the local
revision that revision was projected from. The deployment is half the key on
purpose: a profile re-paired to a different gateway holds no registration there
and registers afresh, exactly as it holds no gateway grant there. Rows die with
the app via cascade; nothing sweeps.

`GatewayDraftRegistry` owns the ladder:

- **No mapping** — project the current revision and `POST /api/v1/cli/shared-apps`.
  A `slug_taken` is retried exactly once, under a slug carrying the app's own
  identity; a second refusal is reported rather than looped.
- **Mapping, stale revision** — project and `POST .../{id}/revision`, then
  re-point the mapping. Sync is lazy: only the revision about to be served is
  pushed, so revisions nobody invoked never reach the gateway.
- **404 from either route** — a deployment that does not serve shared-app
  registration, which reads as the existing typed `gateway_unavailable` refusal
  rather than as a fault.

Three things keep the mapping and the gateway from disagreeing. The
read-then-register decision is serialized per app, so two concurrent invokes of
an unregistered app cannot both mint a shared app (the loser would retry under
the suffixed slug and succeed, leaving a permanent orphan); the second caller
reads the mapping the first persisted. A soft-deleted app answers as missing, so
an invoke racing a deletion never registers something the library no longer
holds. And the client verifies the connection it resolves is for the deployment
the mapping is keyed to, refusing rather than registering somewhere else when
policy moves mid-call.

The projection is a transcription, not a translation: `title` from the manifest
name, one `{connected_app_id, operation_ids}` per gateway binding, `parameters:
[]`. Folder and local `rest_api` arms are dropped — they name capabilities that
exist only on this machine — and `operation_policies` is never emitted, so the
operations a shared app may call stay exactly the ones its bindings name. A
compile-time assertion holds the local name bound (120 chars) against the
gateway's title bound, because a truncated title would silently rename the app
at the gateway.

## Why the author's consent is relayed automatically

Registration alone leaves a granted app dead-ended on the gateway's own consent
gate — a second, invisible consent surface for a decision the user already made.
So consent is relayed on the host's initiative in two places: after a grant is
recorded, and on a `consent_required` from an invoke, which is healed once and
then retried once. The grant-time relay runs off the request rather than inside
it — the grant is already durable, and a slow gateway must not hold the consent
sheet open while it times out.

That is safe rather than a consent bypass. The dispatcher runs only after the
whole local ladder has passed — manifest pin, grant coverage, fingerprint
currency — so the local sheet has already displayed exactly the binding set the
gateway consent names. The gateway computes the consented bindings server-side
from the live revision and accepts only a revision pin from here, so this cannot
widen what was consented to. When the gateway answers `revision_moved`, the
registration is re-synced from the current local revision and consent is
re-stated against what the gateway now serves. A second refusal is the gateway's
answer and comes back as an `is_error` result in its own words — never a loop.

## Removals

`EnvPinnedDrafts` and `NoRegisteredDrafts` are gone, along with the
`cfg(debug_assertions)` branch that chose between them. The env shim existed
only because registration did not; `GatewayDraftSource` now carries
`ensure_registered` / `relay_consent` and the store-backed registry is its only
implementation. No test referenced either type.

## Schema

`DESKTOP_SCHEMA_EPOCH` 23 → 24. Pre-v1 schema changes edit the baseline in
place and bump the epoch (record 2); there is no dual-reading layer.

## Tests

Seven added, all against behavior that would otherwise fail silently:

- Registration is per deployment — a mapping at gateway A never answers for B.
- A first registration persists, and a taken slug is retried exactly once under
  a slug the app's own identity makes unique; a second relay registers nothing.
- An edited app pushes its current revision — and only that one — before the
  next relay.
- A gateway that cannot hold the app records no mapping, so the next attempt is
  a first attempt again.
- A moved revision pin re-syncs and re-consents, in that order, pinned to what
  the gateway now serves.
- A grant survives a registration the gateway refuses — and the registration
  seam is reached, so the failure is one that was survived rather than a path
  never taken.
- The gateway's consent gate is healed once and never looped (both directions:
  healed then executed, and refused twice then reported).
- Wire decode: `consent_required` and `authorization_required` land on their own
  arms, everything else on `Refused`.

No wire types changed, so `ui/src/generated/` is untouched and there is no UI
change in this PR.

## Follow-up worth deciding

The auto-relayed author consent is a rule two subsystems are now held to, and
the `(app, deployment)` mapping is a new persisted boundary — both arguably
warrant a decision record beside record 7, which explicitly scoped the
registration lifecycle out of itself.
