### PR TITLE
fix(shell-policy): refuse paths the analyzer cannot resolve

### DIFF
--- a/crates/openwave-shell-policy/src/lib.rs
+++ b/crates/openwave-shell-policy/src/lib.rs
@@ -244,17 +244,21 @@ enum Expansion {
 /// `$HOME/.ssh/authorized_keys` and `/et[c]/shadow` both miss every marker
 /// while naming a file the floor exists to protect.
 ///
-/// The shape rules keep it narrow. An expansion only matters in something
-/// already shaped like a path, so `echo $USER` is untouched. A glob matters
-/// when the token is rooted outside the working tree (`/…`, `~…`), climbs
-/// (`..`), or hides a character inside a directory name (`[`, `?` with a
-/// separator) — which leaves the everyday relative globs (`*.py`, `src/*`,
-/// `src/**/*.rs`) exactly as they were, since they can only expand to
-/// non-hidden entries under a directory the grant already covers.
-fn unvettable_path_argument(token: &str) -> bool {
+/// The shape rules keep it narrow. An expansion matters in something already
+/// shaped like a path, or in an operand of a program whose operands *are*
+/// paths — so `cat $F` is caught while `echo $USER` and `make -j$(nproc)` are
+/// untouched. A glob matters when the token is rooted outside the working tree
+/// (`/…`, `~…`), climbs (`..`), hides a character inside a directory name
+/// (`[`, `?` with a separator), or spells a literal with a one-character
+/// bracket group — which leaves the everyday relative globs (`*.py`, `src/*`,
+/// `src/**/*.rs`) and ordinary regex operands exactly as they were.
+fn unvettable_path_argument(token: &str, program_takes_paths: bool) -> bool {
     let expansion = token.contains('$') || token.contains('`');
     let path_shaped = token.contains('/') || token.starts_with('~');
-    if expansion && path_shaped {
+    if expansion && (path_shaped || program_takes_paths) {
+        return true;
+    }
+    if spells_a_literal(token) {
         return true;
     }
     if !token.contains(['*', '?', '[']) {
@@ -264,6 +268,20 @@ fn unvettable_path_argument(token: &str) -> bool {
         || token.starts_with('~')
         || token.contains("..")
         || (path_shaped && token.contains(['[', '?']))
+}
+
+/// A bracket group that can match exactly one character, as in `~/.bashr[c]`.
+///
+/// That is not globbing, it is spelling a literal out of reach of a substring
+/// check: the token names one specific file while matching no marker. Real
+/// patterns quantify over more than one character (`[a-z]`, `[abc]`, `[^x]`),
+/// so this catches the disguise without touching them.
+fn spells_a_literal(token: &str) -> bool {
+    let bytes = token.as_bytes();
+    bytes
+        .iter()
+        .enumerate()
+        .any(|(i, &b)| b == b'[' && bytes.get(i + 2) == Some(&b']'))
 }
 
 /// A redirect target the analyzer cannot resolve to a path.
@@ -276,10 +294,91 @@ fn unvettable_redirect_target(token: &str) -> bool {
     token.contains(['$', '`', '*', '?', '['])
 }
 
+/// Programs whose non-flag operands are filesystem paths.
+///
+/// For these, an operand the shell has yet to resolve is as uncheckable as an
+/// unresolved redirect target: `cat $F` opens whatever `$F` names, and the
+/// literal `$F` matches no sensitive marker. Programs whose operands are
+/// patterns, expressions, or numbers are deliberately absent — `grep`'s first
+/// operand is a regex and `find`'s are predicates, so refusing an unresolved
+/// operand there would cost far more than it buys.
+const PATH_OPERAND_PROGRAMS: &[&str] = &[
+    "cat",
+    "gcat",
+    "tac",
+    "head",
+    "ghead",
+    "tail",
+    "gtail",
+    "nl",
+    "od",
+    "xxd",
+    "hexdump",
+    "strings",
+    "base64",
+    "gbase64",
+    "md5sum",
+    "gmd5sum",
+    "shasum",
+    "sha1sum",
+    "sha256sum",
+    "cksum",
+    "cp",
+    "gcp",
+    "mv",
+    "gmv",
+    "rm",
+    "grm",
+    "rmdir",
+    "ln",
+    "gln",
+    "install",
+    "ginstall",
+    "tee",
+    "gtee",
+    "touch",
+    "gtouch",
+    "truncate",
+    "gtruncate",
+    "shred",
+    "gshred",
+    "dd",
+    "gdd",
+    "chmod",
+    "gchmod",
+    "chown",
+    "gchown",
+    "chgrp",
+    "gchgrp",
+    "stat",
+    "gstat",
+    "file",
+    "readlink",
+    "greadlink",
+    "realpath",
+    "grealpath",
+    "less",
+    "more",
+    "open",
+    "xdg-open",
+    "gzip",
+    "gunzip",
+    "bzip2",
+    "xz",
+    "zstd",
+    "zip",
+    "unzip",
+];
+
+fn takes_path_operands(program: &str) -> bool {
+    PATH_OPERAND_PROGRAMS.contains(&basename(program))
+}
+
 /// The three tiers, applied to whatever leaves were collected.
 fn evaluate(acc: &Collected, ruleset: &ShellRuleSet, expansion: Expansion) -> ShellAnalysis {
     let pending = expansion == Expansion::Pending;
-    let unvettable_argument = |token: &str| pending && unvettable_path_argument(token);
+    let unvettable_argument =
+        |token: &str, takes_paths: bool| pending && unvettable_path_argument(token, takes_paths);
     let unvettable_target = |token: &str| pending && unvettable_redirect_target(token);
     // (1) Deny floor — wins over every allow rule, including `All`.
     for sc in &acc.simples {
@@ -334,6 +433,26 @@ fn evaluate(acc: &Collected, ruleset: &ShellRuleSet, expansion: Expansion) -> Sh
     }
 
     // (2) Escalation — forces `Ask` over any allow match, including `All`.
+    //
+    // An assignment runs nothing, so it is never a leaf and its value is never an argument. But
+    // naming a sensitive path in one is the first half of `F=…; cat $F`, and the value is the only
+    // place that path is ever visible in plain text.
+    for value in &acc.assignment_values {
+        if hits_sensitive(value) {
+            return ShellAnalysis::with_offender(
+                ShellVerdict::Ask,
+                format!("assignment names a sensitive path: {value}"),
+                value,
+            );
+        }
+        if climbs_out(value) {
+            return ShellAnalysis::with_offender(
+                ShellVerdict::Ask,
+                format!("assignment escapes folder: {value}"),
+                value,
+            );
+        }
+    }
     for sc in &acc.simples {
         let args = &sc.argv[1..];
         if is_execution_enabling(&sc.program, args) {
@@ -365,7 +484,7 @@ fn evaluate(acc: &Collected, ruleset: &ShellRuleSet, expansion: Expansion) -> Sh
                     &sc.display(),
                 );
             }
-            if unvettable_argument(token) {
+            if unvettable_argument(token, takes_path_operands(&sc.program)) {
                 return ShellAnalysis::with_offender(
                     ShellVerdict::Ask,
                     format!("unresolved path in arguments: {}", sc.display()),
@@ -485,6 +604,9 @@ struct Collected {
     // Redirects attached to a compound (`{ ...; } > file`) rather than a single command.
     group_write_targets: Vec<String>,
     group_read_targets: Vec<String>,
+    // Every assignment value seen, whether or not a program followed it. A pure assignment runs
+    // nothing, so it is not a leaf — but the path it names is what a later word expands to.
+    assignment_values: Vec<String>,
     // Recursion guard for nested command substitutions (fail closed if exceeded).
     depth: usize,
 }
@@ -648,6 +770,7 @@ fn collect_prefix_or_suffix_item(
             if assignment_is_dangerous(name, &value) {
                 return Err(format!("dangerous environment assignment: {name}={value}"));
             }
+            acc.assignment_values.push(value.clone());
             // `FOO=$(evil) cmd` — a substitution in the value is a sub-command.
             match &assignment.value {
                 ast::AssignmentValue::Scalar(word) => {

--- a/crates/openwave-shell-policy/src/lib.rs
+++ b/crates/openwave-shell-policy/src/lib.rs
@@ -186,7 +186,7 @@ pub fn analyze_shell_command(command: &str, ruleset: &ShellRuleSet) -> ShellAnal
         return ShellAnalysis::new(ShellVerdict::Ask, "no executable command found");
     }
 
-    evaluate(&acc, ruleset)
+    evaluate(&acc, ruleset, Expansion::Pending)
 }
 
 /// Classify one already-parsed `argv` against `ruleset`.
@@ -215,11 +215,72 @@ pub fn analyze_argv(argv: &[String], ruleset: &ShellRuleSet) -> ShellAnalysis {
         }],
         ..Collected::default()
     };
-    evaluate(&acc, ruleset)
+    evaluate(&acc, ruleset, Expansion::Resolved)
+}
+
+/// Whether the collected tokens are still subject to shell expansion.
+///
+/// The analyzer literalizes a word without running it: a parameter expansion
+/// or command substitution contributes its *source text* to the token, and
+/// glob metacharacters survive verbatim. So on the parsed path a token is a
+/// spelling of what will run, not the thing itself, and a path check over it
+/// can be dodged by writing the path in a form the shell resolves later. On
+/// the `argv` path there is no shell between the check and the `execve`, so a
+/// token is exactly the operand the program receives.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Expansion {
+    /// Parsed from a command line: expansions and globs are still unresolved.
+    Pending,
+    /// An already-resolved `argv`: the tokens are what the program will see.
+    Resolved,
+}
+
+/// A token that names a path but still carries something the shell will
+/// resolve after this analysis: a parameter expansion, a command
+/// substitution, or a pathname-expansion metacharacter that could be hiding a
+/// literal.
+///
+/// Such a token cannot be checked against the sensitive-path markers at all —
+/// `$HOME/.ssh/authorized_keys` and `/et[c]/shadow` both miss every marker
+/// while naming a file the floor exists to protect.
+///
+/// The shape rules keep it narrow. An expansion only matters in something
+/// already shaped like a path, so `echo $USER` is untouched. A glob matters
+/// when the token is rooted outside the working tree (`/…`, `~…`), climbs
+/// (`..`), or hides a character inside a directory name (`[`, `?` with a
+/// separator) — which leaves the everyday relative globs (`*.py`, `src/*`,
+/// `src/**/*.rs`) exactly as they were, since they can only expand to
+/// non-hidden entries under a directory the grant already covers.
+fn unvettable_path_argument(token: &str) -> bool {
+    let expansion = token.contains('$') || token.contains('`');
+    let path_shaped = token.contains('/') || token.starts_with('~');
+    if expansion && path_shaped {
+        return true;
+    }
+    if !token.contains(['*', '?', '[']) {
+        return false;
+    }
+    token.starts_with('/')
+        || token.starts_with('~')
+        || token.contains("..")
+        || (path_shaped && token.contains(['[', '?']))
+}
+
+/// A redirect target the analyzer cannot resolve to a path.
+///
+/// Stricter than [`unvettable_path_argument`] because it needs no shape test:
+/// a redirect operand *is* a path, so a bare `$F` names a file just as much as
+/// `$HOME/x` does — and `F=~/.ssh/authorized_keys` followed by `>> $F` is the
+/// whole reason this exists.
+fn unvettable_redirect_target(token: &str) -> bool {
+    token.contains(['$', '`', '*', '?', '['])
 }
 
 /// The three tiers, applied to whatever leaves were collected.
-fn evaluate(acc: &Collected, ruleset: &ShellRuleSet) -> ShellAnalysis {
+fn evaluate(acc: &Collected, ruleset: &ShellRuleSet, expansion: Expansion) -> ShellAnalysis {
+    let pending = expansion == Expansion::Pending;
+    let unvettable_argument = |token: &str| pending && unvettable_path_argument(token);
+    let unvettable_target = |token: &str| pending && unvettable_redirect_target(token);
     // (1) Deny floor — wins over every allow rule, including `All`.
     for sc in &acc.simples {
         if INTERPRETERS.contains(&basename(&sc.program)) {
@@ -234,6 +295,13 @@ fn evaluate(acc: &Collected, ruleset: &ShellRuleSet) -> ShellAnalysis {
                 return ShellAnalysis::with_offender(
                     ShellVerdict::Deny,
                     format!("write to sensitive path: {target}"),
+                    &sc.display(),
+                );
+            }
+            if unvettable_target(target) {
+                return ShellAnalysis::with_offender(
+                    ShellVerdict::Deny,
+                    format!("write to a path that cannot be vetted: {target}"),
                     &sc.display(),
                 );
             }
@@ -253,6 +321,13 @@ fn evaluate(acc: &Collected, ruleset: &ShellRuleSet) -> ShellAnalysis {
             return ShellAnalysis::with_offender(
                 ShellVerdict::Deny,
                 format!("write to sensitive path: {target}"),
+                target,
+            );
+        }
+        if unvettable_target(target) {
+            return ShellAnalysis::with_offender(
+                ShellVerdict::Deny,
+                format!("write to a path that cannot be vetted: {target}"),
                 target,
             );
         }
@@ -290,12 +365,26 @@ fn evaluate(acc: &Collected, ruleset: &ShellRuleSet) -> ShellAnalysis {
                     &sc.display(),
                 );
             }
+            if unvettable_argument(token) {
+                return ShellAnalysis::with_offender(
+                    ShellVerdict::Ask,
+                    format!("unresolved path in arguments: {}", sc.display()),
+                    &sc.display(),
+                );
+            }
         }
         for target in &sc.read_targets {
             if hits_sensitive(target) {
                 return ShellAnalysis::with_offender(
                     ShellVerdict::Ask,
                     format!("read from sensitive path: {target}"),
+                    &sc.display(),
+                );
+            }
+            if unvettable_target(target) {
+                return ShellAnalysis::with_offender(
+                    ShellVerdict::Ask,
+                    format!("read from a path that cannot be vetted: {target}"),
                     &sc.display(),
                 );
             }
@@ -319,6 +408,13 @@ fn evaluate(acc: &Collected, ruleset: &ShellRuleSet) -> ShellAnalysis {
             return ShellAnalysis::with_offender(
                 ShellVerdict::Ask,
                 format!("redirect to sensitive path: {target}"),
+                target,
+            );
+        }
+        if unvettable_target(target) {
+            return ShellAnalysis::with_offender(
+                ShellVerdict::Ask,
+                format!("redirect to a path that cannot be vetted: {target}"),
                 target,
             );
         }

--- a/crates/openwave-shell-policy/src/lib.rs
+++ b/crates/openwave-shell-policy/src/lib.rs
@@ -256,22 +256,14 @@ enum Expansion {
 ///   is visible here — and unlike a variable it needs no cooperating
 ///   environment: `awk '{print}' $(cat p)` is a complete exfiltration written
 ///   in one line. Enumerating the programs it matters for is hopeless, since
-///   any program that opens a file will do. The one exemption is a flag-shaped
-///   token on a program that takes no path operands, which is `make -j$(nproc)`
-///   and its relatives; `sort -o$(cat p)` is a flag too, but `sort` opens paths,
-///   so it stays refused.
+///   any program that opens a file will do. The one exemption is
+///   [`COUNT_FLAGS`], stated over the flag rather than over the program.
 /// - A **parameter expansion** counts in something already shaped like a path,
 ///   or in an operand the program will open — so `cat $F` is caught and
 ///   `echo $USER` is not.
 /// - A **glob** counts in an operand the program will open, when the token is
-///   rooted outside the working tree (`/…`, `~…`), names a hidden directory or
-///   file anywhere along its path, or puts a metacharacter in a segment that
-///   is not the last. The hidden-segment part is where the disguises live: the
-///   marker list is almost entirely dotfiles, so `.en?` names one specific
-///   credential file while matching no marker, and `.git/hook*/pre-commit`
-///   reaches a hook — arbitrary code on the next commit — with every character
-///   of `.git` spelled out. Ordinary patterns do not glob through hidden
-///   directories, so `*.py`, `src/*`, `report[1].pdf` are left alone.
+///   rooted outside the working tree (`/…`, `~…`) or when it
+///   [could expand onto a sensitive marker](could_reach_sensitive).
 ///
 ///   Outside a path operand only the rooted test survives, because everything
 ///   else it could say about a token is something a regex says too: `grep
@@ -282,12 +274,9 @@ enum Expansion {
 /// can reach: a relative glob expands under the working directory, but a `cd`
 /// earlier in the line can move that directory somewhere the grant never
 /// meant to cover. That is a separate gap and not one this predicate closes.
-fn unvettable_path_argument(token: &str, role: OperandRole, program_takes_paths: bool) -> bool {
-    if token.contains("$(") || token.contains('`') {
-        let exempt_flag = token.starts_with('-') && !program_takes_paths;
-        if !exempt_flag {
-            return true;
-        }
+fn unvettable_path_argument(token: &str, role: OperandRole) -> bool {
+    if (token.contains("$(") || token.contains('`')) && !substitution_is_a_count(token) {
+        return true;
     }
     // Program text is never opened as a path: `$1` is a field reference and
     // `s/.*//` is a substitution. Only the substitution rule above applies.
@@ -306,17 +295,155 @@ fn unvettable_path_argument(token: &str, role: OperandRole, program_takes_paths:
     if !opens_path {
         return rooted;
     }
-    let segments: Vec<&str> = token.split('/').collect();
-    let hides_a_segment = segments
-        .iter()
-        .any(|segment| segment.starts_with('.') && *segment != "." && *segment != "..");
-    let globs_a_parent = segments[..segments.len().saturating_sub(1)]
-        .iter()
-        .any(|segment| segment.contains(GLOB_METACHARACTERS));
-    rooted || hides_a_segment || globs_a_parent
+    rooted || could_reach_sensitive(token)
 }
 
 const GLOB_METACHARACTERS: [char; 3] = ['*', '?', '['];
+
+/// Flags whose value is a count, where a substitution is ordinary work.
+///
+/// Stated over the flag rather than over the program: `make -j$(nproc)` and
+/// `cargo build -j$(nproc)` are the same command shape, and a list of programs
+/// that happen not to open files would have to be complete forever to be worth
+/// anything. A flag that names a file — `sort -o$(cat p)`, `jq -f$(cat p)`,
+/// `git -C$(cat p)` — is not on this list and is refused.
+const COUNT_FLAGS: &[&str] = &["-j", "--jobs", "-P", "--parallel", "--max-procs"];
+
+/// Whether a substitution sits in a count-valued flag and nowhere else.
+fn substitution_is_a_count(token: &str) -> bool {
+    let Some(cut) = token.find("$(").into_iter().chain(token.find('`')).min() else {
+        return false;
+    };
+    let flag = token[..cut].trim_end_matches('=');
+    COUNT_FLAGS.contains(&flag)
+}
+
+/// Whether a glob could expand onto something the sensitive-path floor
+/// protects.
+///
+/// Four rounds of this predicate guessed at the *shape* of a disguise — a
+/// bracket in a suspicious position, a leading dot, a metacharacter in a
+/// non-final segment — and each guess was defeated by someone spelling the
+/// same path a different way, because the shapes were invented alongside the
+/// marker list rather than derived from it. This asks the question the deny
+/// floor actually cares about: with its metacharacters read as wildcards,
+/// could this token match a marker? A new marker is covered the day it is
+/// added, and nothing has to be guessed.
+///
+/// The one judgement call is how much of a marker a wildcard may supply. A
+/// wildcard that supplies most of the marker is not a disguise, it is an
+/// ordinary pattern that happens to be able to match a lot: `src/*` can expand
+/// onto `src/etc/passwd` and `*.rs` onto `id_rsa.rs`, and refusing those would
+/// refuse most globs ever written while catching nobody, since anyone who
+/// wanted that file would just write it. So a marker counts as reachable only
+/// when the token **spells more of it than it globs** — `.git/hook*/pre-commit`
+/// pins nine characters of `.git/hooks/` to reach it, `*.pe?` pins `.pe` to
+/// reach `.pem`, and `id_rs?` pins all but one character of `id_rsa`. What that
+/// leaves uncovered is the pattern that matches everything, which is the
+/// working-directory question this predicate cannot answer anyway.
+fn could_reach_sensitive(token: &str) -> bool {
+    let raw = token.to_lowercase();
+    let norm = normpath(token).to_lowercase();
+    let template = ENV_TEMPLATE_SUFFIXES.iter().any(|suf| raw.ends_with(*suf));
+    let spellings = if raw == norm {
+        vec![glob_atoms(&raw)]
+    } else {
+        vec![glob_atoms(&raw), glob_atoms(&norm)]
+    };
+    SENSITIVE_TARGET_MARKERS.iter().any(|marker| {
+        if template && *marker == ".env" {
+            return false;
+        }
+        let marker: Vec<char> = marker.chars().collect();
+        spellings
+            .iter()
+            .any(|atoms| spelled_more_than_globbed(atoms, &marker))
+    })
+}
+
+/// One element of a pathname-expansion pattern.
+enum GlobAtom {
+    /// A character the token spells out.
+    Spelled(char),
+    /// `?`, or a bracket class: exactly one character, unknown here. Treating
+    /// a class as "any character" over-approximates, which is the safe
+    /// direction — and POSIX already refuses to expand `[.]env` onto `.env`,
+    /// so the bracket route to a dotfile is closed by the shell itself.
+    AnyOne,
+    /// `*`: any run of characters, including none.
+    AnyRun,
+}
+
+fn glob_atoms(token: &str) -> Vec<GlobAtom> {
+    let chars: Vec<char> = token.chars().collect();
+    let mut atoms = Vec::with_capacity(chars.len());
+    let mut i = 0;
+    while i < chars.len() {
+        match chars[i] {
+            '*' => atoms.push(GlobAtom::AnyRun),
+            '?' => atoms.push(GlobAtom::AnyOne),
+            '[' => match chars[i + 1..].iter().position(|c| *c == ']') {
+                Some(end) => {
+                    atoms.push(GlobAtom::AnyOne);
+                    i += end + 1;
+                }
+                // An unterminated `[` is a literal bracket, not a class.
+                None => atoms.push(GlobAtom::Spelled('[')),
+            },
+            other => atoms.push(GlobAtom::Spelled(other)),
+        }
+        i += 1;
+    }
+    atoms
+}
+
+/// Whether some expansion of `atoms` contains `marker`, spelling out more of it
+/// than it fills in with wildcards.
+///
+/// The marker has to appear contiguously — that is what `hits_sensitive` looks
+/// for — but it may start and end anywhere in the token, since anything outside
+/// it is text the floor does not care about. Scoring a spelled character `+1`
+/// and a wildcard-supplied one `-1` and asking for a positive total is the
+/// "spells more than it globs" test.
+fn spelled_more_than_globbed(atoms: &[GlobAtom], marker: &[char]) -> bool {
+    // `best[j]`: the highest score with which the first `j` characters of the
+    // marker have been consumed, over every alignment considered so far.
+    // `None` means unreached. A run of the marker may begin at any atom, so
+    // every step re-seeds `best[0]` with a score of zero.
+    let mut best: Vec<Option<i32>> = vec![None; marker.len() + 1];
+    for atom in atoms {
+        best[0] = Some(0);
+        let mut next: Vec<Option<i32>> = vec![None; marker.len() + 1];
+        let relax = |slot: &mut Option<i32>, score: i32| {
+            if slot.is_none_or(|current| score > current) {
+                *slot = Some(score);
+            }
+        };
+        for j in 0..marker.len() {
+            let Some(score) = best[j] else { continue };
+            match atom {
+                GlobAtom::Spelled(c) if *c == marker[j] => relax(&mut next[j + 1], score + 1),
+                GlobAtom::Spelled(_) => {}
+                GlobAtom::AnyOne => relax(&mut next[j + 1], score - 1),
+                GlobAtom::AnyRun => {
+                    for taken in 0..=(marker.len() - j) {
+                        relax(&mut next[j + taken], score - taken as i32);
+                    }
+                }
+            }
+        }
+        // A completed marker stays completed: whatever the rest of the pattern
+        // expands to is text on either side of it.
+        if let Some(score) = best[marker.len()] {
+            relax(&mut next[marker.len()], score);
+        }
+        best = next;
+        if matches!(best[marker.len()], Some(score) if score > 0) {
+            return true;
+        }
+    }
+    matches!(best[marker.len()], Some(score) if score > 0)
+}
 
 /// What a program will do with one of its arguments.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -344,11 +471,12 @@ fn unvettable_redirect_target(token: &str) -> bool {
 ///
 /// For these, an operand the shell has yet to resolve is as uncheckable as an
 /// unresolved redirect target: `cat $F` opens whatever `$F` names, and the
-/// literal `$F` matches no sensitive marker. Programs whose operands are
-/// patterns, expressions, or numbers are deliberately absent — `grep`'s first
-/// operand is a regex and `find`'s are predicates, so refusing an unresolved
-/// operand there would cost far more than it buys. The list only governs bare
-/// parameter expansions; a command substitution is refused whoever runs it.
+/// literal `$F` matches no sensitive marker. Which *positions* are paths is
+/// [`operand_roles`]'s question — `grep` and `rg` are here because their later
+/// operands are files, even though their first is a regex. `find` is absent:
+/// its operands are predicates, and its `-name` pattern is matched against
+/// basenames rather than opened. The list only governs bare parameter
+/// expansions and globs; a command substitution is refused whoever runs it.
 const PATH_OPERAND_PROGRAMS: &[&str] = &[
     "cat",
     "gcat",
@@ -357,6 +485,13 @@ const PATH_OPERAND_PROGRAMS: &[&str] = &[
     "ghead",
     "tail",
     "gtail",
+    "wc",
+    "gwc",
+    "grep",
+    "ggrep",
+    "egrep",
+    "fgrep",
+    "rg",
     "nl",
     "od",
     "xxd",
@@ -431,14 +566,21 @@ const PATH_OPERAND_PROGRAMS: &[&str] = &[
     "unzip",
 ];
 
-/// Programs from [`PATH_OPERAND_PROGRAMS`] whose *first* operand is a script,
-/// not a path.
+/// Programs from [`PATH_OPERAND_PROGRAMS`] whose *first* operand is program
+/// text, not a path.
 ///
 /// `awk '{print $1}' data.txt` is the case that matters: the `$1` is a field
 /// reference in the program text, and treating it as an unresolved path would
 /// refuse one of the most ordinary commands there is. Everything after the
-/// script is still a path.
-const SCRIPT_FIRST_OPERAND_PROGRAMS: &[&str] = &["awk", "gawk", "mawk", "nawk", "sed", "gsed"];
+/// script is still a path — which is the whole reason `grep` and `rg` belong
+/// here rather than being left off the path-operand list entirely. Their first
+/// operand is a regex, but every operand after it is a file, and a program
+/// with no path operands at all is a program every one of these rules can be
+/// walked around by typing its name instead: `grep '' .en?` reads exactly what
+/// `cat .en?` reads.
+const SCRIPT_FIRST_OPERAND_PROGRAMS: &[&str] = &[
+    "awk", "gawk", "mawk", "nawk", "sed", "gsed", "grep", "ggrep", "egrep", "fgrep", "rg",
+];
 
 /// Whether a flag already supplies the script, so no operand slot holds one.
 ///
@@ -452,11 +594,44 @@ const SCRIPT_FIRST_OPERAND_PROGRAMS: &[&str] = &["awk", "gawk", "mawk", "nawk", 
 fn supplies_script(arg: &str) -> bool {
     if let Some(long) = arg.strip_prefix("--") {
         let name = long.split('=').next().unwrap_or(long);
-        return matches!(name, "expression" | "file");
+        return matches!(name, "expression" | "file" | "regexp");
     }
     match arg.strip_prefix('-') {
         Some(cluster) => cluster.contains(['e', 'f']),
         None => false,
+    }
+}
+
+/// Flags that take their value as the *next* argument, per script-taking
+/// program.
+///
+/// Without this the value is read as an operand and every operand after it is
+/// off by one: `awk -F , '{print $1}' data.txt` reads the separator as the
+/// script and the script as a path, and `sed -e 's/.*//' file.txt` reads the
+/// script as a path — the exact regex the rest of this module goes to lengths
+/// not to mistake for a filename.
+///
+/// `sed -i` is deliberately absent. BSD `sed` takes a backup suffix there and
+/// GNU `sed` does not, and guessing wrong in the direction of consuming an
+/// argument would push a real path into the slot that gets skipped. The empty
+/// argument BSD callers pass (`sed -i '' 's/x/y/' f`) occupies no slot on its
+/// own account, so both spellings land correctly without the guess.
+fn separated_value_flags(base: &str) -> &'static [&'static str] {
+    match base {
+        "awk" | "gawk" | "mawk" | "nawk" => &["-F", "-v", "-f", "--field-separator", "--assign"],
+        "sed" | "gsed" => &["-e", "-f", "--expression", "--file"],
+        "grep" | "egrep" | "fgrep" | "rg" => &[
+            "-e",
+            "-f",
+            "-m",
+            "-A",
+            "-B",
+            "-C",
+            "--regexp",
+            "--file",
+            "--max-count",
+        ],
+        _ => &[],
     }
 }
 
@@ -466,31 +641,58 @@ fn operand_roles(program: &str, args: &[String]) -> Vec<OperandRole> {
     let takes_paths = PATH_OPERAND_PROGRAMS.contains(&base);
     let script_first = SCRIPT_FIRST_OPERAND_PROGRAMS.contains(&base)
         && !args.iter().any(|arg| supplies_script(arg));
+    let value_flags = separated_value_flags(base);
+    let bsd_in_place = matches!(base, "sed" | "gsed");
+    let mut roles = Vec::with_capacity(args.len());
     let mut seen_operand = false;
-    args.iter()
-        .map(|arg| {
-            if arg.starts_with('-') {
-                return OperandRole::Other;
-            }
-            let first_operand = !seen_operand;
-            seen_operand = true;
-            if script_first && first_operand {
-                OperandRole::Script
-            } else if takes_paths {
+    let mut flag_value = false;
+    let mut after_in_place = false;
+    for arg in args {
+        // The value of a flag is whatever that flag means — a separator, a
+        // count, a script — and never the program's next positional operand.
+        // A path-valued flag (`-f`) is checked as a path all the same.
+        if std::mem::take(&mut flag_value) {
+            roles.push(if arg.contains('$') || arg.contains('`') {
                 OperandRole::Path
             } else {
                 OperandRole::Other
-            }
-        })
-        .collect()
+            });
+            continue;
+        }
+        // BSD `sed -i ''` passes an empty backup suffix where GNU `sed -i`
+        // passes nothing, so the empty argument there spends no operand slot.
+        // Only there: `grep '' file` is an empty *pattern*, and letting it go
+        // slotless would push the file into the slot a script would occupy and
+        // out of every check.
+        let in_place_suffix = std::mem::take(&mut after_in_place) && arg.is_empty();
+        if in_place_suffix {
+            roles.push(OperandRole::Other);
+            continue;
+        }
+        if arg.starts_with('-') && arg.len() > 1 {
+            flag_value = value_flags.contains(&arg.as_str());
+            after_in_place = bsd_in_place && arg == "-i";
+            roles.push(OperandRole::Other);
+            continue;
+        }
+        let first_operand = !seen_operand;
+        seen_operand = true;
+        roles.push(if script_first && first_operand {
+            OperandRole::Script
+        } else if takes_paths {
+            OperandRole::Path
+        } else {
+            OperandRole::Other
+        });
+    }
+    roles
 }
 
 /// The three tiers, applied to whatever leaves were collected.
 fn evaluate(acc: &Collected, ruleset: &ShellRuleSet, expansion: Expansion) -> ShellAnalysis {
     let pending = expansion == Expansion::Pending;
-    let unvettable_argument = |token: &str, role: OperandRole, takes_paths: bool| {
-        pending && unvettable_path_argument(token, role, takes_paths)
-    };
+    let unvettable_argument =
+        |token: &str, role: OperandRole| pending && unvettable_path_argument(token, role);
     let unvettable_target = |token: &str| pending && unvettable_redirect_target(token);
     // (1) Deny floor — wins over every allow rule, including `All`.
     for sc in &acc.simples {
@@ -573,7 +775,6 @@ fn evaluate(acc: &Collected, ruleset: &ShellRuleSet, expansion: Expansion) -> Sh
             );
         }
         let roles = operand_roles(&sc.program, args);
-        let takes_paths = PATH_OPERAND_PROGRAMS.contains(&basename(&sc.program));
         for (token, role) in args.iter().zip(roles) {
             if hits_sensitive(token) {
                 return ShellAnalysis::with_offender(
@@ -589,7 +790,7 @@ fn evaluate(acc: &Collected, ruleset: &ShellRuleSet, expansion: Expansion) -> Sh
                     &sc.display(),
                 );
             }
-            if unvettable_argument(token, role, takes_paths) {
+            if unvettable_argument(token, role) {
                 return ShellAnalysis::with_offender(
                     ShellVerdict::Ask,
                     format!("unresolved path in arguments: {}", sc.display()),

--- a/crates/openwave-shell-policy/src/lib.rs
+++ b/crates/openwave-shell-policy/src/lib.rs
@@ -244,50 +244,54 @@ enum Expansion {
 /// `$HOME/.ssh/authorized_keys` and `/et[c]/shadow` both miss every marker
 /// while naming a file the floor exists to protect.
 ///
-/// The shape rules keep it narrow. An expansion matters in something already
-/// shaped like a path, or in an operand of a program whose operands *are*
-/// paths — so `cat $F` is caught while `echo $USER` and `make -j$(nproc)` are
-/// untouched. A glob matters when the token is rooted outside the working tree
-/// (`/…`, `~…`), climbs (`..`), hides a character inside a directory name
-/// (`[`, `?` with a separator), or spells a literal with a one-character
-/// bracket group — which leaves the everyday relative globs (`*.py`, `src/*`,
-/// `src/**/*.rs`) and ordinary regex operands exactly as they were.
+/// Three rules, narrowest first:
+///
+/// - A **command substitution** counts in any operand of any program. Its text
+///   is computed by a command that has already run, so nothing about the path
+///   is visible here — and unlike a variable it needs no cooperating
+///   environment: `awk '{print}' $(cat p)` is a complete exfiltration written
+///   in one line. Enumerating the programs it matters for is hopeless, since
+///   any program that opens a file will do.
+/// - A **parameter expansion** counts in something already shaped like a path,
+///   or in an operand of a program whose operands *are* paths — so `cat $F` is
+///   caught and `echo $USER` is not.
+/// - A **glob** counts when the token is rooted outside the working tree
+///   (`/…`, `~…`), climbs (`..`), or puts a metacharacter in a hidden path
+///   segment. That last one is where the disguises live: the marker list is
+///   almost entirely dotfiles and absolute paths, so `.en?` and `.bashr[c]`
+///   name one specific credential file while matching nothing, and no ordinary
+///   pattern spells a hidden name that way. Everything else — `*.py`, `src/*`,
+///   `report[1].pdf`, `grep '[n]ginx'` — is left alone.
+///
+/// The glob rule is about what a *spelling* can hide, not about where a glob
+/// can reach: a relative glob expands under the working directory, but a `cd`
+/// earlier in the line can move that directory somewhere the grant never
+/// meant to cover. That is a separate gap and not one this predicate closes.
 fn unvettable_path_argument(token: &str, program_takes_paths: bool) -> bool {
-    let expansion = token.contains('$') || token.contains('`');
+    if token.contains("$(") || token.contains('`') {
+        return true;
+    }
     let path_shaped = token.contains('/') || token.starts_with('~');
-    if expansion && (path_shaped || program_takes_paths) {
+    if token.contains('$') && (path_shaped || program_takes_paths) {
         return true;
     }
-    if spells_a_literal(token) {
-        return true;
-    }
-    if !token.contains(['*', '?', '[']) {
+    if !token.contains(GLOB_METACHARACTERS) {
         return false;
     }
     token.starts_with('/')
         || token.starts_with('~')
         || token.contains("..")
-        || (path_shaped && token.contains(['[', '?']))
+        || token
+            .split('/')
+            .any(|segment| segment.starts_with('.') && segment.contains(GLOB_METACHARACTERS))
 }
 
-/// A bracket group that can match exactly one character, as in `~/.bashr[c]`.
-///
-/// That is not globbing, it is spelling a literal out of reach of a substring
-/// check: the token names one specific file while matching no marker. Real
-/// patterns quantify over more than one character (`[a-z]`, `[abc]`, `[^x]`),
-/// so this catches the disguise without touching them.
-fn spells_a_literal(token: &str) -> bool {
-    let bytes = token.as_bytes();
-    bytes
-        .iter()
-        .enumerate()
-        .any(|(i, &b)| b == b'[' && bytes.get(i + 2) == Some(&b']'))
-}
+const GLOB_METACHARACTERS: [char; 3] = ['*', '?', '['];
 
 /// A redirect target the analyzer cannot resolve to a path.
 ///
-/// Stricter than [`unvettable_path_argument`] because it needs no shape test:
-/// a redirect operand *is* a path, so a bare `$F` names a file just as much as
+/// Broader than [`unvettable_path_argument`] because it needs no shape test: a
+/// redirect operand *is* a path, so a bare `$F` names a file just as much as
 /// `$HOME/x` does — and `F=~/.ssh/authorized_keys` followed by `>> $F` is the
 /// whole reason this exists.
 fn unvettable_redirect_target(token: &str) -> bool {
@@ -301,7 +305,8 @@ fn unvettable_redirect_target(token: &str) -> bool {
 /// literal `$F` matches no sensitive marker. Programs whose operands are
 /// patterns, expressions, or numbers are deliberately absent — `grep`'s first
 /// operand is a regex and `find`'s are predicates, so refusing an unresolved
-/// operand there would cost far more than it buys.
+/// operand there would cost far more than it buys. The list only governs bare
+/// parameter expansions; a command substitution is refused whoever runs it.
 const PATH_OPERAND_PROGRAMS: &[&str] = &[
     "cat",
     "gcat",
@@ -323,6 +328,20 @@ const PATH_OPERAND_PROGRAMS: &[&str] = &[
     "sha1sum",
     "sha256sum",
     "cksum",
+    "sort",
+    "gsort",
+    "cut",
+    "gcut",
+    "sed",
+    "gsed",
+    "awk",
+    "gawk",
+    "mawk",
+    "nawk",
+    "patch",
+    "tar",
+    "gtar",
+    "bsdtar",
     "cp",
     "gcp",
     "mv",
@@ -370,8 +389,34 @@ const PATH_OPERAND_PROGRAMS: &[&str] = &[
     "unzip",
 ];
 
-fn takes_path_operands(program: &str) -> bool {
-    PATH_OPERAND_PROGRAMS.contains(&basename(program))
+/// Programs from [`PATH_OPERAND_PROGRAMS`] whose *first* operand is a script,
+/// not a path.
+///
+/// `awk '{print $1}' data.txt` is the case that matters: the `$1` is a field
+/// reference in the program text, and treating it as an unresolved path would
+/// refuse one of the most ordinary commands there is. Everything after the
+/// script is still a path.
+const SCRIPT_FIRST_OPERAND_PROGRAMS: &[&str] = &["awk", "gawk", "mawk", "nawk", "sed", "gsed"];
+
+/// Which of `args` are operands this program will open as paths.
+///
+/// Flags are not paths, and a leading script operand is not either — the rest
+/// are, for the programs on the list.
+fn path_operand_flags(program: &str, args: &[String]) -> Vec<bool> {
+    let base = basename(program);
+    let takes_paths = PATH_OPERAND_PROGRAMS.contains(&base);
+    let skip_first = SCRIPT_FIRST_OPERAND_PROGRAMS.contains(&base);
+    let mut seen_operand = false;
+    args.iter()
+        .map(|arg| {
+            if arg.starts_with('-') {
+                return false;
+            }
+            let first_operand = !seen_operand;
+            seen_operand = true;
+            takes_paths && !(skip_first && first_operand)
+        })
+        .collect()
 }
 
 /// The three tiers, applied to whatever leaves were collected.
@@ -397,13 +442,6 @@ fn evaluate(acc: &Collected, ruleset: &ShellRuleSet, expansion: Expansion) -> Sh
                     &sc.display(),
                 );
             }
-            if unvettable_target(target) {
-                return ShellAnalysis::with_offender(
-                    ShellVerdict::Deny,
-                    format!("write to a path that cannot be vetted: {target}"),
-                    &sc.display(),
-                );
-            }
         }
         for rule in &ruleset.deny {
             if rule.matches(&sc.argv) {
@@ -423,13 +461,6 @@ fn evaluate(acc: &Collected, ruleset: &ShellRuleSet, expansion: Expansion) -> Sh
                 target,
             );
         }
-        if unvettable_target(target) {
-            return ShellAnalysis::with_offender(
-                ShellVerdict::Deny,
-                format!("write to a path that cannot be vetted: {target}"),
-                target,
-            );
-        }
     }
 
     // (2) Escalation — forces `Ask` over any allow match, including `All`.
@@ -437,6 +468,11 @@ fn evaluate(acc: &Collected, ruleset: &ShellRuleSet, expansion: Expansion) -> Sh
     // An assignment runs nothing, so it is never a leaf and its value is never an argument. But
     // naming a sensitive path in one is the first half of `F=…; cat $F`, and the value is the only
     // place that path is ever visible in plain text.
+    //
+    // These are the same two checks an argument gets, so `PREFIX=../out make` asks for the same
+    // reason `make ../out` would. `CFLAGS=-I../include make` does not: `climbs_out` normalizes a
+    // path, and `-I../include` is a flag with a path glued to it, not a path. That asymmetry is
+    // deliberate — the value that gets expanded back out as a word later is the one worth checking.
     for value in &acc.assignment_values {
         if hits_sensitive(value) {
             return ShellAnalysis::with_offender(
@@ -469,7 +505,8 @@ fn evaluate(acc: &Collected, ruleset: &ShellRuleSet, expansion: Expansion) -> Sh
                 &sc.display(),
             );
         }
-        for token in args {
+        let path_operands = path_operand_flags(&sc.program, args);
+        for (token, is_path_operand) in args.iter().zip(path_operands) {
             if hits_sensitive(token) {
                 return ShellAnalysis::with_offender(
                     ShellVerdict::Ask,
@@ -484,7 +521,7 @@ fn evaluate(acc: &Collected, ruleset: &ShellRuleSet, expansion: Expansion) -> Sh
                     &sc.display(),
                 );
             }
-            if unvettable_argument(token, takes_path_operands(&sc.program)) {
+            if unvettable_argument(token, is_path_operand) {
                 return ShellAnalysis::with_offender(
                     ShellVerdict::Ask,
                     format!("unresolved path in arguments: {}", sc.display()),
@@ -513,6 +550,16 @@ fn evaluate(acc: &Collected, ruleset: &ShellRuleSet, expansion: Expansion) -> Sh
                 return ShellAnalysis::with_offender(
                     ShellVerdict::Ask,
                     format!("redirect target escapes folder: {target}"),
+                    &sc.display(),
+                );
+            }
+            // "I cannot resolve this" is a weaker signal than "this is a known-sensitive path",
+            // so it earns the tier a human can answer rather than the unappealable one: a
+            // timestamped log file is not `> ~/.ssh/authorized_keys`.
+            if unvettable_target(target) {
+                return ShellAnalysis::with_offender(
+                    ShellVerdict::Ask,
+                    format!("redirect target cannot be vetted: {target}"),
                     &sc.display(),
                 );
             }

--- a/crates/openwave-shell-policy/src/lib.rs
+++ b/crates/openwave-shell-policy/src/lib.rs
@@ -209,6 +209,8 @@ pub fn analyze_argv(argv: &[String], ruleset: &ShellRuleSet) -> ShellAnalysis {
         simples: vec![SimpleCmd {
             program: program.clone(),
             argv: argv.to_vec(),
+            // Nothing stripped anything here: every argument is its own slot.
+            arg_slots: argv[1..].iter().cloned().map(ArgSlot::Word).collect(),
             // An argv carries no redirections; there is no shell to write them.
             write_targets: Vec::new(),
             read_targets: Vec::new(),
@@ -330,17 +332,21 @@ fn substitution_is_a_count(token: &str) -> bool {
 /// could this token match a marker? A new marker is covered the day it is
 /// added, and nothing has to be guessed.
 ///
-/// The one judgement call is how much of a marker a wildcard may supply. A
-/// wildcard that supplies most of the marker is not a disguise, it is an
-/// ordinary pattern that happens to be able to match a lot: `src/*` can expand
-/// onto `src/etc/passwd` and `*.rs` onto `id_rsa.rs`, and refusing those would
-/// refuse most globs ever written while catching nobody, since anyone who
-/// wanted that file would just write it. So a marker counts as reachable only
-/// when the token **spells more of it than it globs** — `.git/hook*/pre-commit`
-/// pins nine characters of `.git/hooks/` to reach it, `*.pe?` pins `.pe` to
-/// reach `.pem`, and `id_rs?` pins all but one character of `id_rsa`. What that
-/// leaves uncovered is the pattern that matches everything, which is the
-/// working-directory question this predicate cannot answer anyway.
+/// The one judgement call is which wildcards count as evidence that the token
+/// is aimed broadly rather than at one file, and only `*` is: it swallows a run
+/// of unknown length, so `src/*` can expand onto `src/etc/passwd` and `*.rs`
+/// onto `id_rsa.rs`. Refusing those would refuse most globs ever written while
+/// catching nobody, since anyone who wanted that file would just write it. A
+/// `?` or a bracket class is the opposite — a precise one-character disguise,
+/// standing in for a character the author already knows. So a marker counts as
+/// reachable when the token spells it out with any number of single-character
+/// wildcards but **more literal characters than `*` covers**: `.e??` and
+/// `.???/id_???` are refused, `*.pe?` is refused for pinning `.pe`, and
+/// `src/*` is not.
+///
+/// What that leaves uncovered is a `*` covering most of a marker, which is the
+/// working-directory question this predicate cannot answer anyway — and the
+/// `cd`-then-glob gap below, which it also cannot.
 fn could_reach_sensitive(token: &str) -> bool {
     let raw = token.to_lowercase();
     let norm = normpath(token).to_lowercase();
@@ -398,13 +404,14 @@ fn glob_atoms(token: &str) -> Vec<GlobAtom> {
 }
 
 /// Whether some expansion of `atoms` contains `marker`, spelling out more of it
-/// than it fills in with wildcards.
+/// than a `*` covers.
 ///
 /// The marker has to appear contiguously — that is what `hits_sensitive` looks
 /// for — but it may start and end anywhere in the token, since anything outside
-/// it is text the floor does not care about. Scoring a spelled character `+1`
-/// and a wildcard-supplied one `-1` and asking for a positive total is the
-/// "spells more than it globs" test.
+/// it is text the floor does not care about. Scoring a spelled character `+1`,
+/// a `*`-supplied one `-1` and a single-character wildcard `0`, then asking for
+/// a positive total, is the test the doc comment on [`could_reach_sensitive`]
+/// describes.
 fn spelled_more_than_globbed(atoms: &[GlobAtom], marker: &[char]) -> bool {
     // `best[j]`: the highest score with which the first `j` characters of the
     // marker have been consumed, over every alignment considered so far.
@@ -424,7 +431,7 @@ fn spelled_more_than_globbed(atoms: &[GlobAtom], marker: &[char]) -> bool {
             match atom {
                 GlobAtom::Spelled(c) if *c == marker[j] => relax(&mut next[j + 1], score + 1),
                 GlobAtom::Spelled(_) => {}
-                GlobAtom::AnyOne => relax(&mut next[j + 1], score - 1),
+                GlobAtom::AnyOne => relax(&mut next[j + 1], score),
                 GlobAtom::AnyRun => {
                     for taken in 0..=(marker.len() - j) {
                         relax(&mut next[j + taken], score - taken as i32);
@@ -612,10 +619,11 @@ fn supplies_script(arg: &str) -> bool {
 /// not to mistake for a filename.
 ///
 /// `sed -i` is deliberately absent. BSD `sed` takes a backup suffix there and
-/// GNU `sed` does not, and guessing wrong in the direction of consuming an
-/// argument would push a real path into the slot that gets skipped. The empty
-/// argument BSD callers pass (`sed -i '' 's/x/y/' f`) occupies no slot on its
-/// own account, so both spellings land correctly without the guess.
+/// GNU `sed` does not, and there is no way to tell which one will run. Both
+/// readings are covered without the guess: the empty argument BSD callers pass
+/// (`sed -i '' 's/x/y/' f`) spends the script slot, which leaves the real
+/// script and the file in path-checked slots on BSD, and on GNU — where that
+/// empty argument *is* the script — leaves the file in one too.
 fn separated_value_flags(base: &str) -> &'static [&'static str] {
     match base {
         "awk" | "gawk" | "mawk" | "nawk" => &["-F", "-v", "-f", "--field-separator", "--assign"],
@@ -635,19 +643,45 @@ fn separated_value_flags(base: &str) -> &'static [&'static str] {
     }
 }
 
-/// What each of `args` is to this program.
-fn operand_roles(program: &str, args: &[String]) -> Vec<OperandRole> {
+/// One post-program word of a simple command.
+///
+/// An assignment is not an argument — the parser strips `k=v` out of `argv`,
+/// and rules match against `argv` — but in a suffix it still occupies a
+/// position the program counts: `grep a=b file` searches for `a=b`, and `awk -v
+/// x=1` spends `-v`. Dropping it from the sequence would shift every operand
+/// after it by one and hand the checks below the wrong word.
+#[derive(Debug, Clone)]
+enum ArgSlot {
+    Word(String),
+    Assignment,
+}
+
+/// What each word slot is to this program. Only [`ArgSlot::Word`] slots get a
+/// role, in order, so the result lines up with `argv[1..]`.
+fn operand_roles(program: &str, slots: &[ArgSlot]) -> Vec<OperandRole> {
     let base = basename(program);
     let takes_paths = PATH_OPERAND_PROGRAMS.contains(&base);
     let script_first = SCRIPT_FIRST_OPERAND_PROGRAMS.contains(&base)
-        && !args.iter().any(|arg| supplies_script(arg));
+        && !slots.iter().any(|slot| match slot {
+            ArgSlot::Word(word) => supplies_script(word),
+            ArgSlot::Assignment => false,
+        });
     let value_flags = separated_value_flags(base);
-    let bsd_in_place = matches!(base, "sed" | "gsed");
-    let mut roles = Vec::with_capacity(args.len());
+    let mut roles = Vec::with_capacity(slots.len());
     let mut seen_operand = false;
     let mut flag_value = false;
-    let mut after_in_place = false;
-    for arg in args {
+    for slot in slots {
+        let arg = match slot {
+            ArgSlot::Word(word) => word,
+            // Spends a flag's value slot or an operand slot, but has no role of
+            // its own: it is not in `argv` and nothing will open it.
+            ArgSlot::Assignment => {
+                if !std::mem::take(&mut flag_value) {
+                    seen_operand = true;
+                }
+                continue;
+            }
+        };
         // The value of a flag is whatever that flag means — a separator, a
         // count, a script — and never the program's next positional operand.
         // A path-valued flag (`-f`) is checked as a path all the same.
@@ -659,19 +693,8 @@ fn operand_roles(program: &str, args: &[String]) -> Vec<OperandRole> {
             });
             continue;
         }
-        // BSD `sed -i ''` passes an empty backup suffix where GNU `sed -i`
-        // passes nothing, so the empty argument there spends no operand slot.
-        // Only there: `grep '' file` is an empty *pattern*, and letting it go
-        // slotless would push the file into the slot a script would occupy and
-        // out of every check.
-        let in_place_suffix = std::mem::take(&mut after_in_place) && arg.is_empty();
-        if in_place_suffix {
-            roles.push(OperandRole::Other);
-            continue;
-        }
         if arg.starts_with('-') && arg.len() > 1 {
             flag_value = value_flags.contains(&arg.as_str());
-            after_in_place = bsd_in_place && arg == "-i";
             roles.push(OperandRole::Other);
             continue;
         }
@@ -774,7 +797,7 @@ fn evaluate(acc: &Collected, ruleset: &ShellRuleSet, expansion: Expansion) -> Sh
                 &sc.display(),
             );
         }
-        let roles = operand_roles(&sc.program, args);
+        let roles = operand_roles(&sc.program, &sc.arg_slots);
         for (token, role) in args.iter().zip(roles) {
             if hits_sensitive(token) {
                 return ShellAnalysis::with_offender(
@@ -901,6 +924,9 @@ fn parse_program(command: &str) -> Result<ast::Program, String> {
 struct SimpleCmd {
     program: String,
     argv: Vec<String>,
+    // Every post-program word in source order, assignments included. `argv`
+    // alone cannot say where an operand sits; see [`ArgSlot`].
+    arg_slots: Vec<ArgSlot>,
     // File targets of output (`>`/`>>`) and input (`<`) redirects.
     write_targets: Vec<String>,
     read_targets: Vec<String>,
@@ -1008,10 +1034,13 @@ fn collect_simple_command(simple: &ast::SimpleCommand, acc: &mut Collected) -> C
     let mut argv: Vec<String> = Vec::new();
     let mut writes: Vec<String> = Vec::new();
     let mut reads: Vec<String> = Vec::new();
+    let mut slots: Vec<ArgSlot> = Vec::new();
 
     if let Some(prefix) = &simple.prefix {
         for item in &prefix.0 {
-            collect_prefix_or_suffix_item(item, acc, &mut argv, &mut writes, &mut reads)?;
+            // A prefix assignment runs before the program and spends no
+            // operand of it, so it is collected but not slotted.
+            collect_prefix_or_suffix_item(item, acc, &mut argv, &mut writes, &mut reads, None)?;
         }
     }
 
@@ -1029,7 +1058,14 @@ fn collect_simple_command(simple: &ast::SimpleCommand, acc: &mut Collected) -> C
 
     if let Some(suffix) = &simple.suffix {
         for item in &suffix.0 {
-            collect_prefix_or_suffix_item(item, acc, &mut argv, &mut writes, &mut reads)?;
+            collect_prefix_or_suffix_item(
+                item,
+                acc,
+                &mut argv,
+                &mut writes,
+                &mut reads,
+                Some(&mut slots),
+            )?;
         }
     }
 
@@ -1047,6 +1083,7 @@ fn collect_simple_command(simple: &ast::SimpleCommand, acc: &mut Collected) -> C
     acc.simples.push(SimpleCmd {
         program,
         argv,
+        arg_slots: slots,
         write_targets: writes,
         read_targets: reads,
     });
@@ -1059,10 +1096,14 @@ fn collect_prefix_or_suffix_item(
     argv: &mut Vec<String>,
     writes: &mut Vec<String>,
     reads: &mut Vec<String>,
+    mut slots: Option<&mut Vec<ArgSlot>>,
 ) -> CollectResult {
     match item {
         ast::CommandPrefixOrSuffixItem::Word(word) => {
             let literal = process_word(word, acc, false)?;
+            if let Some(slots) = slots {
+                slots.push(ArgSlot::Word(literal.clone()));
+            }
             argv.push(literal);
             Ok(())
         }
@@ -1070,6 +1111,9 @@ fn collect_prefix_or_suffix_item(
             collect_redirect(redirect, acc, writes, reads)
         }
         ast::CommandPrefixOrSuffixItem::AssignmentWord(assignment, _word) => {
+            if let Some(slots) = slots.as_mut() {
+                slots.push(ArgSlot::Assignment);
+            }
             let name = match &assignment.name {
                 ast::AssignmentName::VariableName(name) => name.as_str(),
                 ast::AssignmentName::ArrayElementName(name, _index) => name.as_str(),

--- a/crates/openwave-shell-policy/src/lib.rs
+++ b/crates/openwave-shell-policy/src/lib.rs
@@ -244,6 +244,11 @@ enum Expansion {
 /// `$HOME/.ssh/authorized_keys` and `/et[c]/shadow` both miss every marker
 /// while naming a file the floor exists to protect.
 ///
+/// What matters is what the program does with the token, so every rule below
+/// is stated against its [`OperandRole`]. A pattern and a path can be spelled
+/// identically — `.*` is the commonest regex there is and `.e*` names a
+/// credential file — and only the program tells them apart.
+///
 /// Three rules, narrowest first:
 ///
 /// - A **command substitution** counts in any operand of any program. Its text
@@ -251,42 +256,79 @@ enum Expansion {
 ///   is visible here — and unlike a variable it needs no cooperating
 ///   environment: `awk '{print}' $(cat p)` is a complete exfiltration written
 ///   in one line. Enumerating the programs it matters for is hopeless, since
-///   any program that opens a file will do.
+///   any program that opens a file will do. The one exemption is a flag-shaped
+///   token on a program that takes no path operands, which is `make -j$(nproc)`
+///   and its relatives; `sort -o$(cat p)` is a flag too, but `sort` opens paths,
+///   so it stays refused.
 /// - A **parameter expansion** counts in something already shaped like a path,
-///   or in an operand of a program whose operands *are* paths — so `cat $F` is
-///   caught and `echo $USER` is not.
-/// - A **glob** counts when the token is rooted outside the working tree
-///   (`/…`, `~…`), climbs (`..`), or puts a metacharacter in a hidden path
-///   segment. That last one is where the disguises live: the marker list is
-///   almost entirely dotfiles and absolute paths, so `.en?` and `.bashr[c]`
-///   name one specific credential file while matching nothing, and no ordinary
-///   pattern spells a hidden name that way. Everything else — `*.py`, `src/*`,
-///   `report[1].pdf`, `grep '[n]ginx'` — is left alone.
+///   or in an operand the program will open — so `cat $F` is caught and
+///   `echo $USER` is not.
+/// - A **glob** counts in an operand the program will open, when the token is
+///   rooted outside the working tree (`/…`, `~…`), names a hidden directory or
+///   file anywhere along its path, or puts a metacharacter in a segment that
+///   is not the last. The hidden-segment part is where the disguises live: the
+///   marker list is almost entirely dotfiles, so `.en?` names one specific
+///   credential file while matching no marker, and `.git/hook*/pre-commit`
+///   reaches a hook — arbitrary code on the next commit — with every character
+///   of `.git` spelled out. Ordinary patterns do not glob through hidden
+///   directories, so `*.py`, `src/*`, `report[1].pdf` are left alone.
+///
+///   Outside a path operand only the rooted test survives, because everything
+///   else it could say about a token is something a regex says too: `grep
+///   '.*foo'`, `sed -E 's/.*//'` and `awk '/.*x/{print}'` are not paths and
+///   must not be treated as though they were.
 ///
 /// The glob rule is about what a *spelling* can hide, not about where a glob
 /// can reach: a relative glob expands under the working directory, but a `cd`
 /// earlier in the line can move that directory somewhere the grant never
 /// meant to cover. That is a separate gap and not one this predicate closes.
-fn unvettable_path_argument(token: &str, program_takes_paths: bool) -> bool {
+fn unvettable_path_argument(token: &str, role: OperandRole, program_takes_paths: bool) -> bool {
     if token.contains("$(") || token.contains('`') {
-        return true;
+        let exempt_flag = token.starts_with('-') && !program_takes_paths;
+        if !exempt_flag {
+            return true;
+        }
     }
+    // Program text is never opened as a path: `$1` is a field reference and
+    // `s/.*//` is a substitution. Only the substitution rule above applies.
+    if role == OperandRole::Script {
+        return false;
+    }
+    let opens_path = role == OperandRole::Path;
     let path_shaped = token.contains('/') || token.starts_with('~');
-    if token.contains('$') && (path_shaped || program_takes_paths) {
+    if token.contains('$') && (path_shaped || opens_path) {
         return true;
     }
     if !token.contains(GLOB_METACHARACTERS) {
         return false;
     }
-    token.starts_with('/')
-        || token.starts_with('~')
-        || token.contains("..")
-        || token
-            .split('/')
-            .any(|segment| segment.starts_with('.') && segment.contains(GLOB_METACHARACTERS))
+    let rooted = token.starts_with('/') || token.starts_with('~');
+    if !opens_path {
+        return rooted;
+    }
+    let segments: Vec<&str> = token.split('/').collect();
+    let hides_a_segment = segments
+        .iter()
+        .any(|segment| segment.starts_with('.') && *segment != "." && *segment != "..");
+    let globs_a_parent = segments[..segments.len().saturating_sub(1)]
+        .iter()
+        .any(|segment| segment.contains(GLOB_METACHARACTERS));
+    rooted || hides_a_segment || globs_a_parent
 }
 
 const GLOB_METACHARACTERS: [char; 3] = ['*', '?', '['];
+
+/// What a program will do with one of its arguments.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum OperandRole {
+    /// A path the program opens.
+    Path,
+    /// Program text — a `sed` script or an `awk` program.
+    Script,
+    /// A flag, or an operand of a program whose operands are not paths: a
+    /// pattern, a target name, a number.
+    Other,
+}
 
 /// A redirect target the analyzer cannot resolve to a path.
 ///
@@ -398,23 +440,47 @@ const PATH_OPERAND_PROGRAMS: &[&str] = &[
 /// script is still a path.
 const SCRIPT_FIRST_OPERAND_PROGRAMS: &[&str] = &["awk", "gawk", "mawk", "nawk", "sed", "gsed"];
 
-/// Which of `args` are operands this program will open as paths.
+/// Whether a flag already supplies the script, so no operand slot holds one.
 ///
-/// Flags are not paths, and a leading script operand is not either — the rest
-/// are, for the programs on the list.
-fn path_operand_flags(program: &str, args: &[String]) -> Vec<bool> {
+/// `sed -e p f` and `sed -ep f` and `sed --expression=p f` all run the same
+/// program over the same file, but only the first spends an operand on the
+/// script. Miss the other two and the file lands in the slot that gets
+/// skipped, which is the whole operand check gone. Reading a cluster as
+/// script-supplying when it is not only costs an extra path check, so the test
+/// is deliberately generous: any short cluster containing `e` or `f`, and the
+/// long forms in both spellings.
+fn supplies_script(arg: &str) -> bool {
+    if let Some(long) = arg.strip_prefix("--") {
+        let name = long.split('=').next().unwrap_or(long);
+        return matches!(name, "expression" | "file");
+    }
+    match arg.strip_prefix('-') {
+        Some(cluster) => cluster.contains(['e', 'f']),
+        None => false,
+    }
+}
+
+/// What each of `args` is to this program.
+fn operand_roles(program: &str, args: &[String]) -> Vec<OperandRole> {
     let base = basename(program);
     let takes_paths = PATH_OPERAND_PROGRAMS.contains(&base);
-    let skip_first = SCRIPT_FIRST_OPERAND_PROGRAMS.contains(&base);
+    let script_first = SCRIPT_FIRST_OPERAND_PROGRAMS.contains(&base)
+        && !args.iter().any(|arg| supplies_script(arg));
     let mut seen_operand = false;
     args.iter()
         .map(|arg| {
             if arg.starts_with('-') {
-                return false;
+                return OperandRole::Other;
             }
             let first_operand = !seen_operand;
             seen_operand = true;
-            takes_paths && !(skip_first && first_operand)
+            if script_first && first_operand {
+                OperandRole::Script
+            } else if takes_paths {
+                OperandRole::Path
+            } else {
+                OperandRole::Other
+            }
         })
         .collect()
 }
@@ -422,8 +488,9 @@ fn path_operand_flags(program: &str, args: &[String]) -> Vec<bool> {
 /// The three tiers, applied to whatever leaves were collected.
 fn evaluate(acc: &Collected, ruleset: &ShellRuleSet, expansion: Expansion) -> ShellAnalysis {
     let pending = expansion == Expansion::Pending;
-    let unvettable_argument =
-        |token: &str, takes_paths: bool| pending && unvettable_path_argument(token, takes_paths);
+    let unvettable_argument = |token: &str, role: OperandRole, takes_paths: bool| {
+        pending && unvettable_path_argument(token, role, takes_paths)
+    };
     let unvettable_target = |token: &str| pending && unvettable_redirect_target(token);
     // (1) Deny floor — wins over every allow rule, including `All`.
     for sc in &acc.simples {
@@ -505,8 +572,9 @@ fn evaluate(acc: &Collected, ruleset: &ShellRuleSet, expansion: Expansion) -> Sh
                 &sc.display(),
             );
         }
-        let path_operands = path_operand_flags(&sc.program, args);
-        for (token, is_path_operand) in args.iter().zip(path_operands) {
+        let roles = operand_roles(&sc.program, args);
+        let takes_paths = PATH_OPERAND_PROGRAMS.contains(&basename(&sc.program));
+        for (token, role) in args.iter().zip(roles) {
             if hits_sensitive(token) {
                 return ShellAnalysis::with_offender(
                     ShellVerdict::Ask,
@@ -521,7 +589,7 @@ fn evaluate(acc: &Collected, ruleset: &ShellRuleSet, expansion: Expansion) -> Sh
                     &sc.display(),
                 );
             }
-            if unvettable_argument(token, is_path_operand) {
+            if unvettable_argument(token, role, takes_paths) {
                 return ShellAnalysis::with_offender(
                     ShellVerdict::Ask,
                     format!("unresolved path in arguments: {}", sc.display()),

--- a/crates/openwave-shell-policy/src/tests.rs
+++ b/crates/openwave-shell-policy/src/tests.rs
@@ -404,6 +404,14 @@ const NEVER_ALLOW: &[&str] = &[
     "cat ~/.config/gcloud/credentials.db",
     // negated pipeline must not downgrade the interpreter deny floor
     "! bash -c id",
+    // paths the analyzer cannot resolve: the literal it checks is not the path
+    // that will be opened, so the sensitive-path floor has nothing to match on
+    "F=~/.ssh/authorized_keys; echo added >> $F",
+    "echo added >> $HOME_SSH_KEYS",
+    "cp payload ~/.bashr[c]",
+    "cat /et[c]/shadow",
+    "tee .g[i]t/hooks/pre-commit",
+    "cat < $SECRET_FILE",
 ];
 
 #[test]
@@ -555,6 +563,12 @@ fn covered_commands_auto_approve() {
             "GOFLAGS=-mod=vendor go build ./...",
             allow(vec![prefix(&["go", "build"])]),
         ),
+        // A glob that can only expand inside the granted folder is ordinary work
+        // and stays covered, as does an expansion that names no path.
+        ("ls *.rs", allow(vec![prefix(&["ls"])])),
+        ("grep -r foo src/*", readonly()),
+        ("grep -r foo src/**/*.rs", readonly()),
+        ("echo $USER", readonly()),
     ];
     for (command, ruleset) in &cases {
         assert_eq!(
@@ -643,6 +657,10 @@ fn structural_unsafe_returns_deny() {
         "eval rm",
         "echo x > ~/.ssh/authorized_keys",
         "cat secrets > .env",
+        // The redirect operand is a path by definition, so one the analyzer
+        // cannot resolve reaches the same floor as a named sensitive path.
+        "echo added >> $F",
+        "cat report > ~/out.*",
     ] {
         assert_eq!(
             verdict(command, &all),
@@ -809,6 +827,16 @@ fn an_argv_reaches_the_same_floor_as_a_parsed_command() {
     // And an ordinary covered command runs.
     assert_eq!(
         analyze_argv(&argv(&["cargo", "test"]), &allow(vec![prefix(&["cargo"])])).verdict,
+        ShellVerdict::Allow
+    );
+    // An argv operand is already resolved — no shell will expand it — so a
+    // token that would be unvettable in a command line is just a literal here.
+    assert_eq!(
+        analyze_argv(
+            &argv(&["grep", "foo", "/et[c]/shadow"]),
+            &allow(vec![prefix(&["grep"])])
+        )
+        .verdict,
         ShellVerdict::Allow
     );
 }

--- a/crates/openwave-shell-policy/src/tests.rs
+++ b/crates/openwave-shell-policy/src/tests.rs
@@ -412,6 +412,15 @@ const NEVER_ALLOW: &[&str] = &[
     "cat /et[c]/shadow",
     "tee .g[i]t/hooks/pre-commit",
     "cat < $SECRET_FILE",
+    // the same indirection passed as an operand rather than a redirect: the
+    // variable may be assigned on the same line or inherited from the parent
+    "F=~/.ssh/id_rsa; cat $F",
+    "F=~/.ssh/authorized_keys; cp payload $F",
+    "F=~/.bashrc; tee $F",
+    "F=../../outside; cp loot $F",
+    "cat $SECRET_FILE",
+    "cp payload $DEST",
+    "cp payload .bashr[c]",
 ];
 
 #[test]
@@ -564,11 +573,19 @@ fn covered_commands_auto_approve() {
             allow(vec![prefix(&["go", "build"])]),
         ),
         // A glob that can only expand inside the granted folder is ordinary work
-        // and stays covered, as does an expansion that names no path.
+        // and stays covered, as does an expansion that names no path and a
+        // pattern operand that merely looks like one.
         ("ls *.rs", allow(vec![prefix(&["ls"])])),
         ("grep -r foo src/*", readonly()),
         ("grep -r foo src/**/*.rs", readonly()),
         ("echo $USER", readonly()),
+        (
+            "make -j$(nproc)",
+            allow(vec![prefix(&["make"]), prefix(&["nproc"])]),
+        ),
+        ("grep 'a?b' file.txt", readonly()),
+        ("cat README.md", readonly()),
+        ("CFLAGS=-I../include make", allow(vec![prefix(&["make"])])),
     ];
     for (command, ruleset) in &cases {
         assert_eq!(

--- a/crates/openwave-shell-policy/src/tests.rs
+++ b/crates/openwave-shell-policy/src/tests.rs
@@ -421,23 +421,18 @@ const NEVER_ALLOW: &[&str] = &[
     "cat $SECRET_FILE",
     "cp payload $DEST",
     "cp payload .bashr[c]",
-    // a glob standing in for one character of a hidden name: `.en?` names the
-    // credential file `.env` while matching no marker at all
+    // a glob standing in for one character of a name the floor protects. the
+    // marker list is not all dotfiles and not all whole segments, so each of
+    // these reaches a different kind of marker: a hidden file, an extension, a
+    // bare filename, and a directory two segments up from the glob
     "cat .en?",
-    "cat .e?v",
-    "cat .npmr?",
-    "cat .netr?",
-    "cp payload .bashr?",
-    "cp payload .bashr*",
-    "cp .en? /tmp/loot",
-    // spelling the hidden segment out and globbing a later one reaches the same
-    // file: `.git/hook*/pre-commit` is arbitrary code on the next commit
+    "cp certs/server.pe? /tmp/x",
+    "cat id_rs?",
     "cp payload .git/hook*/pre-commit",
-    "tee .git/hook?/pre-commit",
-    "cat .docker/confi*",
-    "cat .kube/confi?",
-    "cat .config/fis?/config.fish",
-    "cp payload .local/bi?/tool",
+    // every one of the above is reachable by typing a different program, so
+    // the operand check has to know which of grep's operands are files
+    "grep '' .en?",
+    "grep '' $SECRET_FILE",
     "ls /et[c]/shadow",
     // a script-supplying flag leaves no operand holding the script, so the
     // first operand is the file — in every spelling of the flag
@@ -631,6 +626,14 @@ fn covered_commands_auto_approve() {
         // `$1` is a field reference in the script, not a path
         ("awk '{print $1}' data.txt", allow(vec![prefix(&["awk"])])),
         ("sed -n '1,5p' file.txt", allow(vec![prefix(&["sed"])])),
+        // a flag that takes its value separately must not shift which operand
+        // is read as the script
+        ("sed -e 's/.*//' file.txt", allow(vec![prefix(&["sed"])])),
+        ("sed -i '' 's/.*//' file.txt", allow(vec![prefix(&["sed"])])),
+        (
+            "awk -F , '{print $1}' data.txt",
+            allow(vec![prefix(&["awk"])]),
+        ),
         // a substitution in a flag of a program that opens no path operands —
         // the substituted command is still a leaf and needs its own coverage
         (

--- a/crates/openwave-shell-policy/src/tests.rs
+++ b/crates/openwave-shell-policy/src/tests.rs
@@ -415,11 +415,8 @@ const NEVER_ALLOW: &[&str] = &[
     // the same indirection passed as an operand rather than a redirect: the
     // variable may be assigned on the same line or inherited from the parent
     "F=~/.ssh/id_rsa; cat $F",
-    "F=~/.ssh/authorized_keys; cp payload $F",
-    "F=~/.bashrc; tee $F",
     "F=../../outside; cp loot $F",
     "cat $SECRET_FILE",
-    "cp payload $DEST",
     "cp payload .bashr[c]",
     // a glob standing in for one character of a name the floor protects. the
     // marker list is not all dotfiles and not all whole segments, so each of
@@ -429,11 +426,23 @@ const NEVER_ALLOW: &[&str] = &[
     "cp certs/server.pe? /tmp/x",
     "cat id_rs?",
     "cp payload .git/hook*/pre-commit",
+    // half a marker spelled and half wildcarded. these are the boundary: only
+    // `*` is evidence that a pattern is aimed broadly, so a token that reaches
+    // a marker on single-character wildcards alone is still a disguise
+    "cat .e??",
+    "cat .???/id_???",
     // every one of the above is reachable by typing a different program, so
     // the operand check has to know which of grep's operands are files
     "grep '' .en?",
     "grep '' $SECRET_FILE",
     "ls /et[c]/shadow",
+    // the parser strips `k=v` out of argv, but the program still counts it: if
+    // it does not spend an operand here, the file lands in grep's pattern slot
+    "grep a=b $F",
+    "awk -v x=1 '{print}' $F",
+    // `sed -i` takes a backup suffix on BSD and nothing on GNU, so on GNU the
+    // empty argument is the script and the operand after it is a file
+    "sed -i '' $F",
     // a script-supplying flag leaves no operand holding the script, so the
     // first operand is the file — in every spelling of the flag
     "sed -ep $SECRET_FILE",
@@ -442,16 +451,10 @@ const NEVER_ALLOW: &[&str] = &[
     // a command substitution needs no cooperating environment: the agent writes
     // the path into a scratch file and reads it back as an operand
     "awk '{print}' $(cat p)",
-    "sort $(cat p)",
-    "sed -n 1,99p $(cat p)",
-    "cut -c1- $(cat p)",
-    "sed -i s/x/y/ $(cat p)",
-    "sort -o $(cat p) data",
+    "cat `cat p`",
     // the flag-shaped exemption that keeps `make -j$(nproc)` must not reach a
     // program whose flags name files
     "sort -o$(cat p) data",
-    "tar -cf out.tar $(cat p)",
-    "cat `cat p`",
 ];
 
 #[test]
@@ -610,7 +613,6 @@ fn covered_commands_auto_approve() {
         ("ls *.rs", allow(vec![prefix(&["ls"])])),
         ("grep -r foo src/*", readonly()),
         ("grep -r foo src/**/*.rs", readonly()),
-        ("ls src/[abc]*.rs", allow(vec![prefix(&["ls"])])),
         ("ls src/[a-z]*.rs", allow(vec![prefix(&["ls"])])),
         ("ls report[1].pdf", allow(vec![prefix(&["ls"])])),
         ("cat file-[1].txt", readonly()),
@@ -670,6 +672,13 @@ fn uncovered_or_restricted_commands_ask() {
             allow(vec![exact(&["pytest", "-q", "tests/"])]),
         ),
         ("timeout 30 npm test", allow(vec![prefix(&["timeout"])])),
+        // a substitution in a filename is an everyday idiom and it prompts,
+        // because nothing here can tell `$(date +%F)` from `$(cat p)`. pinned
+        // so the cost of the rule stays visible rather than being rediscovered
+        (
+            "tar -czf backup-$(date +%F).tgz src",
+            allow(vec![prefix(&["tar"]), prefix(&["date"])]),
+        ),
     ];
     for (command, ruleset) in &cases {
         assert_eq!(

--- a/crates/openwave-shell-policy/src/tests.rs
+++ b/crates/openwave-shell-policy/src/tests.rs
@@ -430,6 +430,20 @@ const NEVER_ALLOW: &[&str] = &[
     "cp payload .bashr?",
     "cp payload .bashr*",
     "cp .en? /tmp/loot",
+    // spelling the hidden segment out and globbing a later one reaches the same
+    // file: `.git/hook*/pre-commit` is arbitrary code on the next commit
+    "cp payload .git/hook*/pre-commit",
+    "tee .git/hook?/pre-commit",
+    "cat .docker/confi*",
+    "cat .kube/confi?",
+    "cat .config/fis?/config.fish",
+    "cp payload .local/bi?/tool",
+    "ls /et[c]/shadow",
+    // a script-supplying flag leaves no operand holding the script, so the
+    // first operand is the file — in every spelling of the flag
+    "sed -ep $SECRET_FILE",
+    "sed --expression=p $SECRET_FILE",
+    "sed -i --expression=s/a/b/ $SECRET_FILE",
     // a command substitution needs no cooperating environment: the agent writes
     // the path into a scratch file and reads it back as an operand
     "awk '{print}' $(cat p)",
@@ -438,6 +452,9 @@ const NEVER_ALLOW: &[&str] = &[
     "cut -c1- $(cat p)",
     "sed -i s/x/y/ $(cat p)",
     "sort -o $(cat p) data",
+    // the flag-shaped exemption that keeps `make -j$(nproc)` must not reach a
+    // program whose flags name files
+    "sort -o$(cat p) data",
     "tar -cf out.tar $(cat p)",
     "cat `cat p`",
 ];
@@ -606,10 +623,20 @@ fn covered_commands_auto_approve() {
         ("grep 'a?b' file.txt", readonly()),
         ("grep -E 'a[b]c' file", readonly()),
         ("grep '[n]ginx' access.log", readonly()),
+        // `.*` is the commonest regex there is, and a regex is not a path
+        ("grep '.*' file.txt", readonly()),
+        ("grep '.*foo' file.txt", readonly()),
+        ("sed 's/.*//' file.txt", allow(vec![prefix(&["sed"])])),
+        ("awk '/.*x/{print}' data.txt", allow(vec![prefix(&["awk"])])),
         // `$1` is a field reference in the script, not a path
         ("awk '{print $1}' data.txt", allow(vec![prefix(&["awk"])])),
         ("sed -n '1,5p' file.txt", allow(vec![prefix(&["sed"])])),
-        ("cat README.md", readonly()),
+        // a substitution in a flag of a program that opens no path operands —
+        // the substituted command is still a leaf and needs its own coverage
+        (
+            "make -j$(nproc)",
+            allow(vec![prefix(&["make"]), prefix(&["nproc"])]),
+        ),
         ("CFLAGS=-I../include make", allow(vec![prefix(&["make"])])),
     ];
     for (command, ruleset) in &cases {

--- a/crates/openwave-shell-policy/src/tests.rs
+++ b/crates/openwave-shell-policy/src/tests.rs
@@ -421,6 +421,25 @@ const NEVER_ALLOW: &[&str] = &[
     "cat $SECRET_FILE",
     "cp payload $DEST",
     "cp payload .bashr[c]",
+    // a glob standing in for one character of a hidden name: `.en?` names the
+    // credential file `.env` while matching no marker at all
+    "cat .en?",
+    "cat .e?v",
+    "cat .npmr?",
+    "cat .netr?",
+    "cp payload .bashr?",
+    "cp payload .bashr*",
+    "cp .en? /tmp/loot",
+    // a command substitution needs no cooperating environment: the agent writes
+    // the path into a scratch file and reads it back as an operand
+    "awk '{print}' $(cat p)",
+    "sort $(cat p)",
+    "sed -n 1,99p $(cat p)",
+    "cut -c1- $(cat p)",
+    "sed -i s/x/y/ $(cat p)",
+    "sort -o $(cat p) data",
+    "tar -cf out.tar $(cat p)",
+    "cat `cat p`",
 ];
 
 #[test]
@@ -573,17 +592,23 @@ fn covered_commands_auto_approve() {
             allow(vec![prefix(&["go", "build"])]),
         ),
         // A glob that can only expand inside the granted folder is ordinary work
-        // and stays covered, as does an expansion that names no path and a
-        // pattern operand that merely looks like one.
+        // and stays covered, as do an expansion that names no path, a pattern
+        // operand that merely looks like a path, and a bracket group in a
+        // perfectly ordinary filename.
         ("ls *.rs", allow(vec![prefix(&["ls"])])),
         ("grep -r foo src/*", readonly()),
         ("grep -r foo src/**/*.rs", readonly()),
+        ("ls src/[abc]*.rs", allow(vec![prefix(&["ls"])])),
+        ("ls src/[a-z]*.rs", allow(vec![prefix(&["ls"])])),
+        ("ls report[1].pdf", allow(vec![prefix(&["ls"])])),
+        ("cat file-[1].txt", readonly()),
         ("echo $USER", readonly()),
-        (
-            "make -j$(nproc)",
-            allow(vec![prefix(&["make"]), prefix(&["nproc"])]),
-        ),
         ("grep 'a?b' file.txt", readonly()),
+        ("grep -E 'a[b]c' file", readonly()),
+        ("grep '[n]ginx' access.log", readonly()),
+        // `$1` is a field reference in the script, not a path
+        ("awk '{print $1}' data.txt", allow(vec![prefix(&["awk"])])),
+        ("sed -n '1,5p' file.txt", allow(vec![prefix(&["sed"])])),
         ("cat README.md", readonly()),
         ("CFLAGS=-I../include make", allow(vec![prefix(&["make"])])),
     ];
@@ -674,15 +699,22 @@ fn structural_unsafe_returns_deny() {
         "eval rm",
         "echo x > ~/.ssh/authorized_keys",
         "cat secrets > .env",
-        // The redirect operand is a path by definition, so one the analyzer
-        // cannot resolve reaches the same floor as a named sensitive path.
-        "echo added >> $F",
-        "cat report > ~/out.*",
     ] {
         assert_eq!(
             verdict(command, &all),
             ShellVerdict::Deny,
             "should deny: {command:?}"
+        );
+    }
+
+    // A path the analyzer cannot resolve is a weaker signal than a named
+    // sensitive path, so it earns the tier a human can answer. `Deny` cannot be
+    // granted around at all, and a timestamped log file is not an SSH key.
+    for command in ["echo done > $LOGFILE", "make > build-$(date +%s).log"] {
+        assert_eq!(
+            verdict(command, &all),
+            ShellVerdict::Ask,
+            "should ask, not deny: {command:?}"
         );
     }
 }


### PR DESCRIPTION
The analyzer literalizes a word without expanding it: a parameter expansion or
command substitution contributes its *source text* to the token, and glob
metacharacters survive verbatim. Every path check downstream — the
sensitive-path deny floor for redirect writes, and the `Ask` tiers for
arguments and read redirects — then substring-matches those literals. So on the
parsed path a token is only a *spelling* of the path that will be opened, and a
spelling the shell resolves later matches none of the sensitive markers.

That is enough to walk past the floor with any grant covering a benign program,
or with a folder-scoped "act without asking" rule, and it reaches every operand
position. `cat .en?` names the credential file that `cat .env` is refused for.
`awk '{print}' $(cat p)` prints whatever path the agent wrote into a scratch
file a moment earlier — no environment variable, no cooperating prior shell,
both halves written by the same author. `F=~/.ssh/id_rsa; cat $F` splits the
path across an assignment that is never checked at all, because a
pure-assignment command executes nothing and so is never recorded as a leaf.

Scope worth stating plainly: `analyze_shell_command` has no production callers
today. The shipped product routes everything through `analyze_argv`, where
operands are already resolved and none of this applies. This hardens the
shell-line path against the day something does call it, which is also why the
false-positive side below is treated as seriously as the bypass side — a policy
that prompts on ordinary work teaches people to click through prompts.

## What now refuses

Three checks, all applied only when the leaves came from a command line.

**A command substitution in any operand, whoever runs it.** Its text is
computed by a command that already ran, so nothing about the resulting path is
visible here. Unlike a variable it needs no cooperating environment, and
enumerating the programs it matters for is hopeless — any program that opens a
file will do. The one exemption is stated over the *flag* rather than over a
program list: `-j`, `-P`, `--jobs`, `--parallel` and `--max-procs` take a
number, so `make -j$(nproc)` runs, while `sort -o$(cat p) data` is refused
because `-o` names a file that gets overwritten. Keying this on the flag rather
than on which program it belongs to is what stops `jq -f$(cat p)` and
`git -C$(cat p)` from riding along.

**A parameter expansion**, when the token is already path-shaped or when the
program's operands are paths.

**A glob in an operand the program opens**, when the token is rooted outside
the working tree (`/…`, `~…`) or could expand onto one of the sensitive markers.

The last one is the substance of this round. Its four previous versions each
guessed at the *shape* of a disguise — a bracket in a suspicious position, a
leading dot, a metacharacter in a non-final segment — and each guess was
defeated by spelling the same path a different way, because the shapes were
invented alongside the marker list instead of derived from it. The markers are
not all dotfiles and not all whole segments: an extension (`.pem`), a bare
filename (`id_rsa`, `authorized_keys`) and a directory two segments above the
glob all slipped past a dotfile-shaped rule.

The check now asks the question the deny floor itself asks. The token's
metacharacters are read as wildcards — `?` matches one character, `*` a run,
`[…]` the class — and each marker is tested for reachability under the same
segment-normalized comparison `hits_sensitive` uses.

The one judgement call is which wildcards count as evidence that the token is
aimed broadly rather than at one file, and only `*` is: it swallows a run of
unknown length, so `src/*` can expand onto `src/etc/passwd` and `*.rs` onto
`id_rsa.rs`. Refusing those would refuse most globs ever written while catching
nobody, since anyone who wanted that file would just write it. A `?` or a
bracket class is the opposite — a precise one-character disguise, standing in
for a character the author already knows. So a marker counts as reached when
the token spells it with any number of single-character wildcards but more
literal characters than `*` covers. `.e??`, `.???/id_???` and `id_rs?` are
refused; `ls *.rs` and `grep -r foo src/*` are not. Specificity is not a ratio,
which is what an earlier scoring rule assumed — it counted `?` against the
token and so let half a marker be wildcarded for free.

What this deliberately leaves uncovered is a `*` covering most of a marker,
which is the working-directory question this predicate cannot answer anyway,
and the `cd`-then-glob gap noted at the end. The gain is that a marker added to
the list later is covered the day it is added, with no second place to update.

Two role fixes the matcher depends on, since a check that never runs on an
operand protects nothing:

- `grep`, `rg` and `wc` open their operands as files and were not on the
  path-operand list, so every rule here could be walked around by typing a
  different program name — `grep '' .en?` reads exactly what `cat .en?` reads.
  They are on it now. `find` stays off deliberately: its operands are
  predicates, and `-name` is matched against basenames.
- `awk`/`sed`/`grep`/`rg` take a script or pattern as their first operand, so
  that slot is skipped — `awk '{print $1}' data.txt` is ordinary work and the
  `$1` is a field reference. Working out *which* operand that is means tracking
  flags that take a separated value (`-e`, `-f`, `-F`, `-v`, `-m`, and the long
  forms). Without that, `sed -e 's/.*//' file.txt` shifted one slot along and
  got the filename skipped and the regex checked as a path. It also means
  counting the words the parser removes: `k=v` is stripped out of `argv`, but
  the program still counts it, so `grep a=b file` and `awk -v x=1 '{print}' f`
  each shifted the real operand out of every check until word positions were
  tracked alongside `argv`.
- `sed -i ''` is not assumed to be BSD. BSD reads that empty argument as a
  backup suffix and GNU reads it as the script, and nothing here can tell which
  will run; letting it spend the script slot is right under both, because it
  leaves the file in a path-checked slot either way.

**Assignment values** now go through the same `hits_sensitive` / `climbs_out`
checks an argument gets, which kills the assign-then-use family at its source.

## What deliberately still runs

Pinned in the positive corpus, so a later widening has to break a test that
says why: `find . -name '*.py'`, `ls *.rs`, `grep -r foo src/*`,
`grep -r foo src/**/*.rs`, `ls src/[a-z]*.rs`,
`ls report[1].pdf`, `cat file-[1].txt`, `grep 'a?b' file.txt`,
`grep -E 'a[b]c' file`, `grep '[n]ginx' access.log`, `grep '.*' file.txt`,
`grep '.*foo' file.txt`, `sed 's/.*//' file.txt`, `sed -e 's/.*//' file.txt`,
`sed -i '' 's/.*//' file.txt`, `awk -F , '{print $1}' data.txt`,
`awk '/.*x/{print}' data.txt`, `awk '{print $1}' data.txt`,
`sed -n '1,5p' file.txt`, `make -j$(nproc)`, `echo $USER`,
`CFLAGS=-I../include make`.

One case still asks and is worth flagging rather than hiding:
`PYTHONPATH=../src pytest`. A search-path assignment pointing outside the
granted folder is a normal monorepo idiom, but it is also exactly what a
folder-scoped grant is about, and the value is the only place that path is
visible in plain text. Distinguishing a search path from an output path by
variable name would exempt the one variable class that can change which code a
vetted program loads, so the prompt stands. Easy to revisit if it proves
annoying in practice.

## What now prompts that did not

A command substitution counts wherever it appears, so a date stamped into a
filename prompts: `tar -czf backup-$(date +%F).tgz src`,
`echo "done at $(date)"`, `git commit -m "$(cat msg)"`. Nothing on this path
can tell `$(date +%F)` from a path the caller wrote into a scratch file a
moment earlier, and narrowing by program name is the maintenance liability
`COUNT_FLAGS` exists to avoid. Likewise a glob rooted outside the working tree:
`ls ~/Downloads/*.pdf`, `cat ~/notes/*.md`, `tail -n 20 /var/log/*.log`.

These follow from the design rather than from a rule that could be tightened,
so they stand — but the first is an everyday idiom, and it is pinned in the
Ask corpus so its cost stays visible instead of being rediscovered.

## Tiers

Unresolvable redirect *writes* `Ask` rather than `Deny`. "I cannot resolve
this" is a weaker signal than "this is a known-sensitive path", and `Deny`
cannot be granted around at all; `echo done > $LOGFILE` is not
`> ~/.ssh/authorized_keys`. Named sensitive writes keep `Deny`. Everything else
this adds lands on `Ask`, matching the tier a named sensitive path in an
argument already gets. After the demotion,
`F=~/.ssh/authorized_keys; echo x >> $F` is refused as
`assignment names a sensitive path` — the assignment check is now the
load-bearing one for that command, with the redirect check behind it for a
value the analyzer never sees.

`PREFIX=../out make` asks, for the same reason `make ../out` would.
`CFLAGS=-I../include make` does not, because `-I../include` is a flag with a
path glued to it rather than a path; the asymmetry is called out in a comment
at the check.

`analyze_argv` is exempt from all of it. Its callers hand over an executable and
an argument vector that go straight to `execve`, so a `*` or a `$` there is a
literal the program receives, not something a shell will resolve afterwards.
Refusing it would reject ordinary operands while protecting nothing. A test
pins this.

## Not fixed here

`cd ~/.ssh && cat *` is allowed both before and after this change: the `.ssh/`
marker requires a trailing slash, so the bare `~/.ssh` operand misses it, and a
relative glob is allowed. That is a pre-existing gap in the marker list plus the
absence of any cwd tracking, and it also means a relative glob's reach is only
bounded by the working directory *until a `cd` moves it*. The doc comment on
the glob rule now says so explicitly rather than claiming a containment the
analyzer does not have.

## Verification

`cargo fmt --all --check`, `cargo check -p openwave-shell-policy --locked`,
`cargo clippy -p openwave-shell-policy --all-targets --locked -- -D warnings`,
`cargo test -p openwave-shell-policy --locked` (16 passed),
`cargo check --workspace --locked`, `cargo test -p openwave-core --locked approval`
(37 passed) and `cargo test -p openwave-server --locked approval` (40 passed)
are all clean.
