### PR TITLE
fix(desktop): accept spawn approvals and preview delegations and writes

### DIFF
--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -605,6 +605,53 @@ describe("pending approval recovery", () => {
     ).toBeNull();
   });
 
+  // A parked spawn approval used to make its chat unreopenable: the kind was
+  // absent from the renderer's approval vocabulary, so the row failed to parse
+  // and one unparseable row fails the whole hydration response.
+  it("recovers a parked background-agent spawn approval", async () => {
+    const spawn = {
+      ...safe,
+      action: "spawn_sandbox_agent",
+      approval: "delegate_may_run_background_agent",
+      preview: {
+        tool: "delegate_agent",
+        task: "summarize the filings",
+        network: {
+          mode: "allowed_hosts",
+          allowed_hosts: ["sec.gov"],
+          package_managers: false,
+        },
+      },
+    };
+    expect(parsePendingToolApproval(spawn)).toMatchObject({
+      action: "spawn_sandbox_agent",
+      approval: "delegate_may_run_background_agent",
+      canApprove: true,
+      canRemember: true,
+      preview: {
+        tool: "delegate_agent",
+        task: "summarize the filings",
+        network: {
+          mode: "allowed_hosts",
+          allowed_hosts: ["sec.gov"],
+          package_managers: false,
+        },
+      },
+    });
+
+    const client = new ApiClient("http://127.0.0.1", "token");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify([spawn]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+    await expect(client.listPendingApprovals("chat-1")).resolves.toHaveLength(1);
+  });
+
   it("fails closed on malformed, duplicate, or cross-turn pages", async () => {
     const client = new ApiClient("http://127.0.0.1", "token");
     for (const body of [
@@ -663,6 +710,56 @@ describe("parseToolActionPreview", () => {
       tool: "search",
       query: "revenue",
     });
+  });
+
+  it("names the file a write lands in", () => {
+    expect(
+      parseToolActionPreview({ tool: "write_file", path: "reports/q1.md" }),
+    ).toEqual({ tool: "write_file", path: "reports/q1.md" });
+    expect(parseToolActionPreview({ tool: "write_file", path: "" })).toBeNull();
+  });
+
+  it("keeps the network policy a delegated run inherits", () => {
+    // The task says what the run does; the policy is the egress being
+    // approved, so a preview missing or misdescribing it is dropped rather
+    // than shown as a narrower run than it is.
+    const delegated = {
+      tool: "delegate_agent",
+      task: "reconcile the ledger",
+      network: {
+        mode: "allowed_hosts",
+        allowed_hosts: ["api.example.com"],
+        package_managers: true,
+      },
+    };
+    expect(parseToolActionPreview(delegated)).toEqual(delegated);
+    expect(
+      parseToolActionPreview({
+        tool: "delegate_agent",
+        task: "reconcile the ledger",
+        network: { mode: "open" },
+      }),
+    ).toEqual({
+      tool: "delegate_agent",
+      task: "reconcile the ledger",
+      network: { mode: "open" },
+    });
+    for (const broken of [
+      { ...delegated, task: "" },
+      { ...delegated, network: undefined },
+      { ...delegated, network: { mode: "everything" } },
+      { ...delegated, network: { mode: "allowed_hosts", allowed_hosts: ["a"] } },
+      {
+        ...delegated,
+        network: {
+          mode: "allowed_hosts",
+          allowed_hosts: "api.example.com",
+          package_managers: true,
+        },
+      },
+    ]) {
+      expect(parseToolActionPreview(broken)).toBeNull();
+    }
   });
 });
 

--- a/crates/openwave-desktop/ui/src/api/parsers.ts
+++ b/crates/openwave-desktop/ui/src/api/parsers.ts
@@ -29,6 +29,7 @@ import {
   type ExecDegradation,
   type InboxItem,
   type InboxItemKind,
+  type NetworkPolicy,
   type PendingChatPrompt,
   type PendingFolderAccessRequest,
   type PendingOutputWritebackRequest,
@@ -909,6 +910,25 @@ export function parseToolActionPreview(
     if (typeof url !== "string" || url.length === 0) return null;
     return { tool: "web_extract", url };
   }
+  if (value.tool === "write_file") {
+    // The path is the whole variant: which file the call will create or
+    // replace. The content deliberately never crosses the boundary.
+    const { path } = value;
+    if (typeof path !== "string" || path.length === 0) return null;
+    return { tool: "write_file", path };
+  }
+  if (value.tool === "delegate_agent") {
+    // The task says what the unattended run will do; the network policy is
+    // what it can do with what it learns, and is the part actually being
+    // consented to. A policy that cannot be read whole drops the preview
+    // rather than describing a run's reach as narrower than it is.
+    const { task } = value;
+    const network = parseNetworkPolicy(value.network);
+    if (typeof task !== "string" || task.length === 0 || network === null) {
+      return null;
+    }
+    return { tool: "delegate_agent", task, network };
+  }
   if (value.tool !== "exec") return null;
   const { command, args, cwd, files } = value;
   // `files` joined the projection after previews were already being stored, so
@@ -927,6 +947,31 @@ export function parseToolActionPreview(
     return null;
   }
   return { tool: "exec", command, args, cwd, files: staged };
+}
+
+/**
+ * The network policy a delegated run inherits, validated mode by mode.
+ *
+ * Every mode carries its own fields, and the named-hosts one names the exact
+ * destinations the run may reach — so a policy is either read whole or not
+ * accepted at all. Half of it would understate the egress being approved.
+ */
+function parseNetworkPolicy(value: unknown): NetworkPolicy | null {
+  if (!isRecord(value)) return null;
+  const { mode } = value;
+  if (mode === "off" || mode === "package_managers" || mode === "open") {
+    return { mode };
+  }
+  if (mode !== "allowed_hosts") return null;
+  const { allowed_hosts, package_managers } = value;
+  if (
+    !Array.isArray(allowed_hosts) ||
+    !allowed_hosts.every((host): host is string => typeof host === "string") ||
+    typeof package_managers !== "boolean"
+  ) {
+    return null;
+  }
+  return { mode, allowed_hosts, package_managers };
 }
 
 /**
@@ -1259,15 +1304,31 @@ export function isRendererToolName(value: unknown): value is RendererToolName {
   );
 }
 
+/**
+ * Every approval kind the renderer will accept, at runtime.
+ *
+ * Typed as a total map over the generated union rather than written out as a
+ * chain of comparisons, so a kind added server-side cannot be left out here: a
+ * missing key fails to compile. The chain this replaces had already drifted —
+ * `delegate_may_run_background_agent` reached the wire without reaching the
+ * list, and because an unparseable row fails the whole hydration response, a
+ * chat with a parked spawn approval could not be reopened at all.
+ */
+const RENDERER_APPROVAL_KINDS = {
+  search_may_share_query_and_excerpts: true,
+  web_search_may_share_query: true,
+  web_extract_may_fetch_url: true,
+  exec_may_run_networked_command: true,
+  external_mcp_may_call_server: true,
+  workspace_may_modify_files: true,
+  delegate_may_run_background_agent: true,
+  unsupported: true,
+} as const satisfies Record<RendererApprovalKind, true>;
+
 function isRendererApprovalKind(value: unknown): value is RendererApprovalKind {
   return (
-    value === "search_may_share_query_and_excerpts" ||
-    value === "web_search_may_share_query" ||
-    value === "web_extract_may_fetch_url" ||
-    value === "exec_may_run_networked_command" ||
-    value === "external_mcp_may_call_server" ||
-    value === "workspace_may_modify_files" ||
-    value === "unsupported"
+    typeof value === "string" &&
+    Object.hasOwn(RENDERER_APPROVAL_KINDS, value)
   );
 }
 

--- a/crates/openwave-desktop/ui/src/api/types.ts
+++ b/crates/openwave-desktop/ui/src/api/types.ts
@@ -747,16 +747,27 @@ export class AppInvokeRefusalError extends Error {
 }
 
 
-/** Approval kinds a human may approve from the renderer. */
+/**
+ * Approval kinds a human may approve from the renderer.
+ *
+ * A total map over the generated union, not a list of the approvable ones: the
+ * server decides this and the renderer cross-checks its answer, so a kind added
+ * server-side has to be classified here deliberately rather than defaulting to
+ * "not approvable" and failing every snapshot that carries it.
+ */
+const APPROVABLE_KINDS = {
+  search_may_share_query_and_excerpts: true,
+  web_search_may_share_query: true,
+  web_extract_may_fetch_url: true,
+  exec_may_run_networked_command: true,
+  external_mcp_may_call_server: true,
+  workspace_may_modify_files: true,
+  delegate_may_run_background_agent: true,
+  unsupported: false,
+} as const satisfies Record<RendererApprovalKind, boolean>;
+
 export function isApprovableKind(kind: RendererApprovalKind): boolean {
-  return (
-    kind === "search_may_share_query_and_excerpts" ||
-    kind === "web_search_may_share_query" ||
-    kind === "web_extract_may_fetch_url" ||
-    kind === "exec_may_run_networked_command" ||
-    kind === "external_mcp_may_call_server" ||
-    kind === "workspace_may_modify_files"
-  );
+  return APPROVABLE_KINDS[kind];
 }
 
 /** Approval kinds whose authority is stable enough to remember by tool name. */


### PR DESCRIPTION
## A chat with a parked spawn approval could not be reopened

`isRendererApprovalKind` in `ui/src/api/parsers.ts` was a hand-written copy of the generated `ToolApprovalKind` union, and it was missing `delegate_may_run_background_agent`. That one omission made `parsePendingToolApproval` return `null` for a pending spawn approval, and because a single unparseable row rejects the entire pending-approval response, `listPendingApprovals` threw and hydration of the chat failed outright — the chat simply would not open.

The same drift was one step further along than it looked: `isApprovableKind` also omitted the kind, and the parser cross-checks the server's `can_approve` against it, so adding the kind to the allowlist alone would still have rejected the row.

Both are now total maps over the generated union (`satisfies Record<RendererApprovalKind, ...>`) rather than chains of string comparisons. A kind added server-side no longer slips through: the allowlist fails to compile until the member is present, and the approvable split fails to compile until the new kind is deliberately classified as approvable or not. That is the property the old form lacked, and it is why the sweep for other missing kinds is not something anyone has to repeat by hand.

I left `listPendingApprovals` throwing on an item it cannot validate. The alternatives are worse for the reader: dropping the row leaves the turn parked with no card and no explanation, and synthesizing a generic approval item would offer consent to an action the renderer cannot describe, which is the one thing this whole boundary exists to prevent. The renderer and the server ship together in the desktop app, so with the exhaustiveness check in place a vocabulary mismatch cannot exist within a build. A browser UI pointed at an older or newer `openwave serve` is the case where a hard failure would still be too blunt, and is the reason to revisit this.

## Spawn and write approvals showed no action

`parseToolActionPreview` handled `search`, `web_search`, `web_extract`, and `exec`, and returned `null` for everything else — so the `delegate_agent` and `write_file` previews the server builds and forwards were discarded before reaching the card, even though `ToolPreview` already knows how to render both.

They now parse:

- **Delegation** shows the task the child is given and the network policy it inherits, including the named hosts when the policy is a host list. The policy is the part actually being consented to: the run is unattended and its own calls never come back to ask, and its workspace carries no folder grants or chat attachments, so egress is what the reader is deciding. A policy that cannot be validated whole drops the preview rather than describing the run's reach as narrower than it is.
- **Write** shows the workspace-relative destination path. The content stays behind the boundary, as it does server-side.

## Tests

Three, each of which fails on the code before this change:

- A pending spawn approval parses, and `listPendingApprovals` resolves rather than throwing — the reproduction of the hydration break.
- A `write_file` preview keeps its path and rejects an empty one.
- A `delegate_agent` preview keeps its network policy, and is dropped when the task is empty or the policy is missing, unknown, or half-formed.

## Verification

From `crates/openwave-desktop/ui`: `pnpm test` (133 files, 905 tests passed), `pnpm exec tsc --noEmit` (clean), `pnpm build` (clean).