### PR TITLE
fix(cli): surface the print-mode failures that left a run parked in silence

### DIFF
--- a/crates/openwave-cli/src/print.rs
+++ b/crates/openwave-cli/src/print.rs
@@ -192,25 +192,13 @@ async fn one_turn(
     // A resumed chat replays its history first; nothing before this turn's own
     // `TurnStarted` is ours to print.
     let mut ours = false;
-    // Watch for the interrupt on its own task: a `ctrl_c()` future created per
-    // loop iteration could miss a signal that lands between two iterations.
-    let (interrupted, mut interrupt) = tokio::sync::oneshot::channel();
-    tokio::spawn(async move {
-        if tokio::signal::ctrl_c().await.is_ok() {
-            let _ = interrupted.send(());
-        }
-    });
+    let mut interrupt = Interrupt::watch();
 
     let outcome = loop {
         let frame = tokio::select! {
             frame = stream.next(client, chat) => frame?,
-            _ = &mut interrupt => {
-                printer.finish();
-                eprintln!("openwave: interrupted; cancelling the turn");
-                // Best effort: the turn may already have finished, which the
-                // server answers with a conflict.
-                let _ = client.cancel_turn(chat, turn_id).await;
-                return Ok(EXIT_INTERRUPTED);
+            () = interrupt.fired() => {
+                break halted(client, chat, turn_id, &interrupted(), &mut printer).await;
             }
         };
 
@@ -232,11 +220,16 @@ async fn one_turn(
                 // is not an `Interaction`, so the driver is never asked and no
                 // decision line can answer it. Whoever is driving gets the same
                 // outcome an unattended run gets.
-                if name == REQUEST_FOLDER_ACCESS_TOOL {
+                let undeclined = if name == REQUEST_FOLDER_ACCESS_TOOL {
                     decline_folder_request(client, executor_token, chat, call_id, &mut printer)
-                        .await;
-                }
+                        .await
+                } else {
+                    None
+                };
                 printer.tool_started(call_id, name);
+                if let Some(halt) = undeclined {
+                    break halted(client, chat, turn_id, &halt, &mut printer).await;
+                }
             }
             ClientEvent::ToolCallCompleted {
                 call_id, status, ..
@@ -258,28 +251,60 @@ async fn one_turn(
                     grant_rungs,
                     preview,
                 };
-                if let Some(halt) = settle(client, chat, &interaction, driver, &mut printer).await {
+                if let Some(halt) = settle(
+                    client,
+                    chat,
+                    &interaction,
+                    driver,
+                    &mut interrupt,
+                    &mut printer,
+                )
+                .await
+                {
                     break halted(client, chat, turn_id, &halt, &mut printer).await;
                 }
             }
             // Neither can be answered from the standing policy, so both reach
             // for the driver first and end the run loudly if there is none.
             ClientEvent::PlanProposed { call_id } => {
-                if let Some(interaction) = pending_plan(client, chat, call_id).await {
-                    if let Some(halt) =
-                        settle(client, chat, &interaction, driver, &mut printer).await
-                    {
-                        break halted(client, chat, turn_id, &halt, &mut printer).await;
+                match pending_plan(client, chat, call_id).await {
+                    Ok(Some(interaction)) => {
+                        if let Some(halt) = settle(
+                            client,
+                            chat,
+                            &interaction,
+                            driver,
+                            &mut interrupt,
+                            &mut printer,
+                        )
+                        .await
+                        {
+                            break halted(client, chat, turn_id, &halt, &mut printer).await;
+                        }
                     }
+                    // Already settled: a decision raced the event.
+                    Ok(None) => {}
+                    Err(halt) => break halted(client, chat, turn_id, &halt, &mut printer).await,
                 }
             }
             ClientEvent::UserQuestionsAsked { call_id } => {
-                if let Some(interaction) = pending_questions(client, chat, call_id).await {
-                    if let Some(halt) =
-                        settle(client, chat, &interaction, driver, &mut printer).await
-                    {
-                        break halted(client, chat, turn_id, &halt, &mut printer).await;
+                match pending_questions(client, chat, call_id).await {
+                    Ok(Some(interaction)) => {
+                        if let Some(halt) = settle(
+                            client,
+                            chat,
+                            &interaction,
+                            driver,
+                            &mut interrupt,
+                            &mut printer,
+                        )
+                        .await
+                        {
+                            break halted(client, chat, turn_id, &halt, &mut printer).await;
+                        }
                     }
+                    Ok(None) => {}
+                    Err(halt) => break halted(client, chat, turn_id, &halt, &mut printer).await,
                 }
             }
             ClientEvent::TurnCompleted { .. } => break 0,
@@ -309,15 +334,27 @@ async fn one_turn(
 
 /// Settle one parked interaction: ask the driver, fall back to the standing
 /// policy, and carry the decision out. `Some(halt)` ends the run.
+///
+/// The interrupt is watched here too. A driven run waiting on a decision line
+/// receives no further frames — the turn is parked on this very answer — so an
+/// interrupt only the frame loop watched would never be seen, and Ctrl-C would
+/// leave killing the process as the only way out.
 async fn settle(
     client: &Client,
     chat: ChatId,
     interaction: &Interaction,
     driver: &mut Driver<tokio::io::BufReader<tokio::io::Stdin>>,
+    interrupt: &mut Interrupt,
     printer: &mut Printer,
 ) -> Option<Halt> {
-    let mut control = |event| printer.control(event);
-    let decision = match driver.decide(interaction, &mut control).await {
+    let answered = {
+        let mut control = |event| printer.control(event);
+        tokio::select! {
+            decision = driver.decide(interaction, &mut control) => decision,
+            () = interrupt.fired() => return Some(interrupted()),
+        }
+    };
+    let decision = match answered {
         Some(decision) => decision,
         None => match interaction.undriven() {
             Undriven::Decide(decision) => {
@@ -331,6 +368,46 @@ async fn settle(
         },
     };
     apply(client, chat, interaction, decision, printer).await
+}
+
+/// SIGINT, observable from every place the run can block.
+///
+/// The signal is watched on its own task — a `ctrl_c()` future created per wait
+/// could miss one that lands between two waits — and the flag it sets stays
+/// set, so whichever wait is current sees the same interrupt.
+struct Interrupt(tokio::sync::watch::Receiver<bool>);
+
+impl Interrupt {
+    fn watch() -> Self {
+        let (fired, seen) = tokio::sync::watch::channel(false);
+        tokio::spawn(async move {
+            if tokio::signal::ctrl_c().await.is_ok() {
+                let _ = fired.send(true);
+            }
+        });
+        Self(seen)
+    }
+
+    /// Resolves once the interrupt has been seen, and immediately thereafter.
+    async fn fired(&mut self) {
+        while !*self.0.borrow_and_update() {
+            if self.0.changed().await.is_err() {
+                // The watcher is gone, so no signal is coming: never resolve,
+                // leaving the other side of the `select!` to finish the run.
+                std::future::pending::<()>().await;
+            }
+        }
+    }
+}
+
+/// The halt an interrupt produces: the turn is cancelled rather than abandoned,
+/// and the run exits 130.
+fn interrupted() -> Halt {
+    Halt {
+        reason: HaltReason::Interrupted,
+        call_id: None,
+        message: "interrupted; cancelling the turn".to_owned(),
+    }
 }
 
 /// Send one decision to the route that owns it.
@@ -415,18 +492,25 @@ async fn halted(
     halt.reason.exit_code()
 }
 
-/// The proposed plan behind a `PlanProposed` event. `None` when it is already
-/// settled — a decision raced the event, and there is nothing left to answer.
+/// The proposed plan behind a `PlanProposed` event.
+///
+/// `Ok(None)` means nothing is pending — a decision raced the event, and there
+/// is nothing left to answer — so the run carries on. A failed lookup is not
+/// that, and must not read as it: the turn is parked on something this run
+/// cannot see, so it halts instead of falling quiet and exiting zero.
 async fn pending_plan(
     client: &Client,
     chat: ChatId,
     call_id: Option<CallId>,
-) -> Option<Interaction> {
-    let pending = client.list_pending_plans(chat).await.ok()?;
-    pending
+) -> std::result::Result<Option<Interaction>, Halt> {
+    let pending = client
+        .list_pending_plans(chat)
+        .await
+        .map_err(|error| lookup_failed("plan", call_id, &error))?;
+    Ok(pending
         .into_iter()
         .find(|plan| call_id.is_none_or(|id| plan.call_id == id))
-        .map(Interaction::from_plan)
+        .map(Interaction::from_plan))
 }
 
 /// The question block behind a `UserQuestionsAsked` event, on the same terms.
@@ -434,12 +518,24 @@ async fn pending_questions(
     client: &Client,
     chat: ChatId,
     call_id: Option<CallId>,
-) -> Option<Interaction> {
-    let pending = client.list_pending_questions(chat).await.ok()?;
-    pending
+) -> std::result::Result<Option<Interaction>, Halt> {
+    let pending = client
+        .list_pending_questions(chat)
+        .await
+        .map_err(|error| lookup_failed("questions", call_id, &error))?;
+    Ok(pending
         .into_iter()
         .find(|block| call_id.is_none_or(|id| block.call_id == id))
-        .map(Interaction::from_questions)
+        .map(Interaction::from_questions))
+}
+
+/// The halt a failed lookup produces, naming what could not be read.
+fn lookup_failed(kind: &str, call_id: Option<CallId>, error: &AgentError) -> Halt {
+    Halt {
+        reason: HaltReason::PendingLookupFailed,
+        call_id,
+        message: format!("the pending {kind} the turn is parked on could not be read: {error}"),
+    }
 }
 
 /// Refuse one parked `request_folder_access` call with the typed declined
@@ -452,16 +548,19 @@ async fn pending_questions(
 /// never consults the driver — folder access is host-machine consent, and
 /// `openwave folder connect` is the only thing that gives it.
 ///
-/// Reporting only, never fatal: a folder request the CLI could not answer is
-/// the server owner's to settle, and cancelling someone else's turn over it
-/// would be worse than saying so.
+/// Reporting only where the answer is somebody else's to give: an attached run
+/// holds no executor credential, and the process that does — a desktop, say —
+/// will settle the call itself. Where this process *is* that surface, an
+/// undeliverable refusal is fatal instead. Nothing else will ever answer the
+/// call, so a run that carried on would sit on a permanently parked turn,
+/// producing no output and no exit at all.
 async fn decline_folder_request(
     client: &Client,
     executor_token: Option<&str>,
     chat: ChatId,
     call_id: CallId,
     printer: &mut Printer,
-) {
+) -> Option<Halt> {
     // Attach mode has no client-executor credential and is not the trusted
     // surface for this server — the process that owns it is, and if that is a
     // desktop it will show the user a picker. Say so and leave the call alone
@@ -471,14 +570,24 @@ async fn decline_folder_request(
             "folder request {call_id} left for the attached server's own client executor; \
              this process holds no executor credential"
         ));
-        return;
+        return None;
     };
     match decline(client, executor_token, chat, call_id).await {
-        Ok(()) => printer.notice(
-            "folder access declined: headless runs connect folders with `openwave folder \
-             connect`, never mid-turn",
-        ),
-        Err(error) => printer.notice(&format!("could not decline the folder request: {error}")),
+        Ok(()) => {
+            printer.notice(
+                "folder access declined: headless runs connect folders with `openwave folder \
+                 connect`, never mid-turn",
+            );
+            None
+        }
+        Err(error) => Some(Halt {
+            reason: HaltReason::DecisionFailed,
+            call_id: Some(call_id),
+            message: format!(
+                "the folder request could not be declined: {error}; the turn is parked on an \
+                 answer this run cannot deliver"
+            ),
+        }),
     }
 }
 
@@ -689,5 +798,31 @@ impl Printer {
             self.dangling_line = false;
         }
         let _ = std::io::stdout().flush();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A poll that fails is not "nothing pending". While the two were the same
+    /// answer, a server the run could not reach read exactly like a plan that
+    /// had already been settled: the run went quiet, left the turn parked, and
+    /// exited zero — the worst shape for a scripted caller, which cannot tell a
+    /// finished turn from a lost one.
+    #[tokio::test]
+    async fn an_unreadable_pending_plan_halts_rather_than_looking_settled() {
+        // A port nothing is listening on, so the poll fails at the transport.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("a free local port");
+        let address = listener.local_addr().expect("the bound address");
+        drop(listener);
+        let client = Client::attach(format!("http://{address}"), "token").expect("a client");
+
+        let halt = pending_plan(&client, ChatId::new(), None)
+            .await
+            .expect_err("an unreachable server must not read as nothing pending");
+
+        assert_eq!(halt.reason, HaltReason::PendingLookupFailed);
+        assert_ne!(halt.reason.exit_code(), 0);
     }
 }

--- a/crates/openwave-cli/src/print.rs
+++ b/crates/openwave-cli/src/print.rs
@@ -33,6 +33,7 @@
 //! are already connected; it has no path to a new grant.
 
 use std::collections::HashMap;
+use std::future::Future as _;
 use std::io::{IsTerminal as _, Write as _};
 
 use futures::StreamExt as _;
@@ -69,11 +70,19 @@ const EXIT_INTERRUPTED: i32 = 130;
 const RECONNECT_ATTEMPTS: usize = 3;
 const RECONNECT_DELAY: std::time::Duration = std::time::Duration::from_millis(200);
 
-/// How long to wait for a folder request to become claimable after its tool
-/// call is announced. The call is checkpointed just after the provider streams
-/// it, so this only covers that gap.
-const FOLDER_REQUEST_SETTLE: std::time::Duration = std::time::Duration::from_secs(10);
+/// How often a folder refusal asks whether its call has become claimable, and
+/// the ceiling that interval backs off to.
+///
+/// There is no deadline. `ToolCallStarted` is announced the moment the provider
+/// begins streaming the call, and what follows is not a short gap: the call
+/// parks only if it survives the client checkpoint, and an isolated client call
+/// is taken last, after every sibling in its step is terminal — which can be
+/// minutes. A call that fails the checkpoint (invalid arguments, a capability
+/// the tool does not offer) is declined by the agent itself and never parks at
+/// all. So the refusal waits for as long as the turn runs and reports nothing
+/// when the call never arrives; the turn ending is what ends the wait.
 const FOLDER_REQUEST_POLL: std::time::Duration = std::time::Duration::from_millis(100);
+const FOLDER_REQUEST_POLL_MAX: std::time::Duration = std::time::Duration::from_secs(2);
 
 /// How the turn is written to stdout.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -183,6 +192,11 @@ async fn one_turn(
     driver: &mut Driver<tokio::io::BufReader<tokio::io::Stdin>>,
 ) -> Result<i32> {
     let turn_id = TurnId::new();
+    // Installed before the turn exists. Until the handler is registered SIGINT
+    // keeps its default disposition, and a signal landing there would kill this
+    // process outright — abandoning the very turn the interrupt is supposed to
+    // cancel.
+    let mut interrupt = Interrupt::watch().await;
     // Subscribe before posting: the turn can start before this returns, and the
     // socket's replay only reaches back to the cursor it was opened at.
     let mut stream = Stream::open(client, chat).await?;
@@ -192,7 +206,7 @@ async fn one_turn(
     // A resumed chat replays its history first; nothing before this turn's own
     // `TurnStarted` is ours to print.
     let mut ours = false;
-    let mut interrupt = Interrupt::watch();
+    let mut declines = FolderDeclines::new();
 
     let outcome = loop {
         let frame = tokio::select! {
@@ -200,6 +214,20 @@ async fn one_turn(
             () = interrupt.fired() => {
                 break halted(client, chat, turn_id, &interrupted(), &mut printer).await;
             }
+            report = declines.reported() => match report {
+                FolderDecline::Noted(message) => {
+                    printer.notice(&message);
+                    continue;
+                }
+                FolderDecline::Unanswerable { call_id, message } => {
+                    let halt = Halt {
+                        reason: HaltReason::DecisionFailed,
+                        call_id: Some(call_id),
+                        message,
+                    };
+                    break halted(client, chat, turn_id, &halt, &mut printer).await;
+                }
+            },
         };
 
         let Some((raw, event)) = frame else {
@@ -219,17 +247,12 @@ async fn one_turn(
                 // Refused here, never routed through `settle`: a folder request
                 // is not an `Interaction`, so the driver is never asked and no
                 // decision line can answer it. Whoever is driving gets the same
-                // outcome an unattended run gets.
-                let undeclined = if name == REQUEST_FOLDER_ACCESS_TOOL {
-                    decline_folder_request(client, executor_token, chat, call_id, &mut printer)
-                        .await
-                } else {
-                    None
-                };
-                printer.tool_started(call_id, name);
-                if let Some(halt) = undeclined {
-                    break halted(client, chat, turn_id, &halt, &mut printer).await;
+                // outcome an unattended run gets. The refusal runs off the loop,
+                // which keeps the turn's own output flowing while it waits.
+                if name == REQUEST_FOLDER_ACCESS_TOOL {
+                    declines.start(client, executor_token, chat, call_id, &mut printer);
                 }
+                printer.tool_started(call_id, name);
             }
             ClientEvent::ToolCallCompleted {
                 call_id, status, ..
@@ -370,7 +393,16 @@ async fn settle(
     apply(client, chat, interaction, decision, printer).await
 }
 
-/// SIGINT, observable from every place the run can block.
+/// SIGINT, observable from both waits that can outlast the user's patience: the
+/// wait for the next journal frame, and a driven run's wait for a decision line.
+///
+/// It is not observable from everything. The HTTP client carries no request
+/// timeout, so a call to an unresponsive `--server` host — applying a decision,
+/// reading a pending request, cancelling the turn — still blocks with the
+/// interrupt unwatched, and because a handler is installed a second Ctrl-C no
+/// longer kills the process either. Bounding those is a matter of giving the
+/// client a request timeout, which is every CLI surface's business and not this
+/// module's to decide.
 ///
 /// The signal is watched on its own task — a `ctrl_c()` future created per wait
 /// could miss one that lands between two waits — and the flag it sets stays
@@ -378,13 +410,29 @@ async fn settle(
 struct Interrupt(tokio::sync::watch::Receiver<bool>);
 
 impl Interrupt {
-    fn watch() -> Self {
+    /// Returns once the handler is registered, so no window is left in which
+    /// SIGINT still takes its default disposition.
+    async fn watch() -> Self {
         let (fired, seen) = tokio::sync::watch::channel(false);
+        let (installed, registered) = tokio::sync::oneshot::channel();
         tokio::spawn(async move {
-            if tokio::signal::ctrl_c().await.is_ok() {
+            let mut signal = std::pin::pin!(tokio::signal::ctrl_c());
+            // Registration happens on the first poll, so report readiness only
+            // after one has been made.
+            let first = std::future::poll_fn(|context| {
+                std::task::Poll::Ready(signal.as_mut().poll(context))
+            })
+            .await;
+            let _ = installed.send(());
+            let interrupted = match first {
+                std::task::Poll::Ready(result) => result.is_ok(),
+                std::task::Poll::Pending => signal.await.is_ok(),
+            };
+            if interrupted {
                 let _ = fired.send(true);
             }
         });
+        let _ = registered.await;
         Self(seen)
     }
 
@@ -538,88 +586,173 @@ fn lookup_failed(kind: &str, call_id: Option<CallId>, error: &AgentError) -> Hal
     }
 }
 
-/// Refuse one parked `request_folder_access` call with the typed declined
-/// result.
+/// The `request_folder_access` refusals this run has in flight.
 ///
-/// The refusal is deliberately the folder contract's existing `Declined`
-/// variant and not a new failure code: to the model, a headless run must be
-/// indistinguishable from a user who closed the picker, so no prompt-shaped
-/// retry looks worthwhile and no path exists that could end in a grant. This
-/// never consults the driver — folder access is host-machine consent, and
-/// `openwave folder connect` is the only thing that gives it.
-///
-/// Reporting only where the answer is somebody else's to give: an attached run
-/// holds no executor credential, and the process that does — a desktop, say —
-/// will settle the call itself. Where this process *is* that surface, an
-/// undeliverable refusal is fatal instead. Nothing else will ever answer the
-/// call, so a run that carried on would sit on a permanently parked turn,
-/// producing no output and no exit at all.
-async fn decline_folder_request(
-    client: &Client,
-    executor_token: Option<&str>,
-    chat: ChatId,
-    call_id: CallId,
-    printer: &mut Printer,
-) -> Option<Halt> {
-    // Attach mode has no client-executor credential and is not the trusted
-    // surface for this server — the process that owns it is, and if that is a
-    // desktop it will show the user a picker. Say so and leave the call alone
-    // rather than pretending to be it.
-    let Some(executor_token) = executor_token else {
-        printer.notice(&format!(
-            "folder request {call_id} left for the attached server's own client executor; \
-             this process holds no executor credential"
-        ));
-        return None;
-    };
-    match decline(client, executor_token, chat, call_id).await {
-        Ok(()) => {
-            printer.notice(
-                "folder access declined: headless runs connect folders with `openwave folder \
-                 connect`, never mid-turn",
-            );
-            None
+/// Each refusal runs on its own task and reports back over one channel, for two
+/// reasons. Waiting inline blocked the event loop, so the assistant text
+/// streaming while a refusal waited was held back and — when the wait ended the
+/// run — never printed at all. And no wait bounded in advance is right: the
+/// call may park immediately, park minutes later behind an isolated sibling, or
+/// never park because the agent declined it at the checkpoint. Off the loop,
+/// the refusal simply waits for as long as the turn does.
+struct FolderDeclines {
+    reports: tokio::sync::mpsc::UnboundedSender<FolderDecline>,
+    inbox: tokio::sync::mpsc::UnboundedReceiver<FolderDecline>,
+    tasks: Vec<tokio::task::JoinHandle<()>>,
+}
+
+/// What a refusal has to say. Only a call seen sitting in the pending set can
+/// produce [`FolderDecline::Unanswerable`]: a call that never parked is the
+/// agent's own business, and ending the run over one would fail a turn the
+/// server is completing perfectly well.
+enum FolderDecline {
+    /// Worth saying, not worth stopping for.
+    Noted(String),
+    /// The call is parked, and the refusal this run owes it cannot be
+    /// delivered. Nothing else will answer it, so the turn would wait forever.
+    Unanswerable { call_id: CallId, message: String },
+}
+
+impl FolderDeclines {
+    fn new() -> Self {
+        let (reports, inbox) = tokio::sync::mpsc::unbounded_channel();
+        Self {
+            reports,
+            inbox,
+            tasks: Vec::new(),
         }
-        Err(error) => Some(Halt {
-            reason: HaltReason::DecisionFailed,
-            call_id: Some(call_id),
-            message: format!(
-                "the folder request could not be declined: {error}; the turn is parked on an \
-                 answer this run cannot deliver"
-            ),
-        }),
+    }
+
+    /// Refuse one announced `request_folder_access` call.
+    ///
+    /// The refusal is deliberately the folder contract's existing `Declined`
+    /// variant and not a new failure code: to the model, a headless run must be
+    /// indistinguishable from a user who closed the picker, so no prompt-shaped
+    /// retry looks worthwhile and no path exists that could end in a grant. This
+    /// never consults the driver — folder access is host-machine consent, and
+    /// `openwave folder connect` is the only thing that gives it.
+    fn start(
+        &mut self,
+        client: &Client,
+        executor_token: Option<&str>,
+        chat: ChatId,
+        call_id: CallId,
+        printer: &mut Printer,
+    ) {
+        // Attach mode has no client-executor credential and is not the trusted
+        // surface for this server — the process that owns it is, and if that is
+        // a desktop it will show the user a picker. Say so and leave the call
+        // alone rather than pretending to be it.
+        let Some(executor_token) = executor_token else {
+            printer.notice(&format!(
+                "folder request {call_id} left for the attached server's own client executor; \
+                 this process holds no executor credential"
+            ));
+            return;
+        };
+        let client = client.clone();
+        let executor_token = executor_token.to_owned();
+        let reports = self.reports.clone();
+        self.tasks.push(tokio::spawn(async move {
+            if let Some(report) = decline(&client, &executor_token, chat, call_id).await {
+                let _ = reports.send(report);
+            }
+        }));
+    }
+
+    /// The next thing a refusal has to report. Pends forever when there is
+    /// nothing to say, which is the common case: this side holds a sender, so
+    /// the channel never closes and never resolves on its own.
+    async fn reported(&mut self) -> FolderDecline {
+        match self.inbox.recv().await {
+            Some(report) => report,
+            None => std::future::pending().await,
+        }
     }
 }
 
-/// Claim the parked call and resolve it declined, or say why not.
+/// Ends every refusal still in flight when the turn is over, however it ended.
+impl Drop for FolderDeclines {
+    fn drop(&mut self) {
+        for task in &self.tasks {
+            task.abort();
+        }
+    }
+}
+
+/// Wait for one folder request to become claimable, then resolve it declined.
+///
+/// `None` means there is nothing to report — including the ordinary case where
+/// the call never parks, because the agent refused it at the checkpoint and is
+/// carrying the turn on without it. Each way this can end is answered on its
+/// own terms rather than as one undifferentiated failure:
+///
+/// - **Never parked, or unreadable.** Not evidence of anything: keep asking. A
+///   poll that fails says nothing about the call, so it is retried too.
+/// - **Parked, and claimed by somebody else.** Never race it — this process has
+///   no way to grant anything. But it is also the only surface that answers for
+///   this server, so a claim it does not hold is a call it cannot settle.
+/// - **Parked, and the claim or the resolve failed.** The refusal is owed and
+///   undeliverable, which is the one shape that must end the run.
+/// - **Parked, but not a folder request.** Impossible by construction — the name
+///   came from the announcement of this same call — and not this run's answer to
+///   give if it happens. Say so and leave it.
 async fn decline(
     client: &Client,
     executor_token: &str,
     chat: ChatId,
     call_id: CallId,
-) -> Result<()> {
-    let deadline = std::time::Instant::now() + FOLDER_REQUEST_SETTLE;
+) -> Option<FolderDecline> {
+    let mut wait = FOLDER_REQUEST_POLL;
     loop {
-        let pending = client
-            .pending_client_executions(executor_token, chat)
-            .await?;
-        match pending.into_iter().find(|call| call.id == call_id) {
-            Some(call) if call.name != REQUEST_FOLDER_ACCESS_TOOL => {
-                return Err(AgentError::msg("the parked call is not a folder request"));
+        if let Ok(pending) = client.pending_client_executions(executor_token, chat).await {
+            match pending.into_iter().find(|call| call.id == call_id) {
+                Some(call) if call.name != REQUEST_FOLDER_ACCESS_TOOL => {
+                    return Some(FolderDecline::Noted(format!(
+                        "folder request {call_id} parked as a {} call and was left alone",
+                        call.name
+                    )));
+                }
+                Some(call) if call.client_executor_id.is_some() => {
+                    return Some(FolderDecline::Unanswerable {
+                        call_id,
+                        message: format!(
+                            "the folder request is claimed by another executor, and this run \
+                             cannot resolve a claim it does not hold: call {call_id} stays parked"
+                        ),
+                    });
+                }
+                Some(_) => break,
+                None => {}
             }
-            Some(call) if call.client_executor_id.is_some() => {
-                // Something else owns the call. Never race it: this process has
-                // no way to grant anything, so leaving it alone is safe.
-                return Err(AgentError::msg("the folder request is already claimed"));
-            }
-            Some(_) => break,
-            None if std::time::Instant::now() >= deadline => {
-                return Err(AgentError::msg("the folder request never parked"));
-            }
-            None => tokio::time::sleep(FOLDER_REQUEST_POLL).await,
         }
+        tokio::time::sleep(wait).await;
+        wait = (wait * 2).min(FOLDER_REQUEST_POLL_MAX);
     }
 
+    match resolve_declined(client, executor_token, chat, call_id).await {
+        Ok(()) => Some(FolderDecline::Noted(
+            "folder access declined: headless runs connect folders with `openwave folder \
+             connect`, never mid-turn"
+                .to_owned(),
+        )),
+        Err(error) => Some(FolderDecline::Unanswerable {
+            call_id,
+            message: format!(
+                "the parked folder request could not be declined: {error}; the turn is waiting \
+                 on an answer this run cannot deliver"
+            ),
+        }),
+    }
+}
+
+/// Claim the parked call and resolve it declined.
+async fn resolve_declined(
+    client: &Client,
+    executor_token: &str,
+    chat: ChatId,
+    call_id: CallId,
+) -> Result<()> {
     let executor_id = uuid::Uuid::new_v4();
     let lease_token = uuid::Uuid::new_v4();
     client

--- a/crates/openwave-cli/src/print.rs
+++ b/crates/openwave-cli/src/print.rs
@@ -192,15 +192,14 @@ async fn one_turn(
     driver: &mut Driver<tokio::io::BufReader<tokio::io::Stdin>>,
 ) -> Result<i32> {
     let turn_id = TurnId::new();
-    // Installed before the turn exists. Until the handler is registered SIGINT
-    // keeps its default disposition, and a signal landing there would kill this
-    // process outright — abandoning the very turn the interrupt is supposed to
-    // cancel.
-    let mut interrupt = Interrupt::watch().await;
     // Subscribe before posting: the turn can start before this returns, and the
     // socket's replay only reaches back to the cursor it was opened at.
     let mut stream = Stream::open(client, chat).await?;
     client.post_message(chat, turn_id, prompt).await?;
+    // Installed once the turn exists, and not before. Installing it earlier
+    // would swallow signals over the handshake and the post — neither of which
+    // watches the interrupt, and neither of which has a turn to cancel yet.
+    let mut interrupt = Interrupt::watch().await;
 
     let mut printer = Printer::new(format);
     // A resumed chat replays its history first; nothing before this turn's own
@@ -215,13 +214,13 @@ async fn one_turn(
                 break halted(client, chat, turn_id, &interrupted(), &mut printer).await;
             }
             report = declines.reported() => match report {
-                FolderDecline::Noted(message) => {
+                FolderDecline::Noted { message, .. } => {
                     printer.notice(&message);
                     continue;
                 }
                 FolderDecline::Unanswerable { call_id, message } => {
                     let halt = Halt {
-                        reason: HaltReason::DecisionFailed,
+                        reason: HaltReason::FolderDeclineFailed,
                         call_id: Some(call_id),
                         message,
                     };
@@ -257,6 +256,9 @@ async fn one_turn(
             ClientEvent::ToolCallCompleted {
                 call_id, status, ..
             } => {
+                // The call is over however it ended, so a refusal still waiting
+                // for it to park has nothing left to wait for.
+                declines.finished(call_id);
                 printer.tool_completed(call_id, status);
             }
             ClientEvent::ApprovalRequired {
@@ -399,10 +401,9 @@ async fn settle(
 /// It is not observable from everything. The HTTP client carries no request
 /// timeout, so a call to an unresponsive `--server` host — applying a decision,
 /// reading a pending request, cancelling the turn — still blocks with the
-/// interrupt unwatched, and because a handler is installed a second Ctrl-C no
-/// longer kills the process either. Bounding those is a matter of giving the
-/// client a request timeout, which is every CLI surface's business and not this
-/// module's to decide.
+/// interrupt unwatched. A second Ctrl-C is the way out of those: the watcher
+/// stays alive after the first one and exits the process on the next, which is
+/// what the default disposition would have done anyway.
 ///
 /// The signal is watched on its own task — a `ctrl_c()` future created per wait
 /// could miss one that lands between two waits — and the flag it sets stays
@@ -428,8 +429,16 @@ impl Interrupt {
                 std::task::Poll::Ready(result) => result.is_ok(),
                 std::task::Poll::Pending => signal.await.is_ok(),
             };
-            if interrupted {
-                let _ = fired.send(true);
+            if !interrupted {
+                return;
+            }
+            let _ = fired.send(true);
+            // The graceful path is now the run's to take. If it cannot — a
+            // cancel to a server that never answers, say — the next Ctrl-C
+            // leaves, because a run nobody can interrupt is worse than a turn
+            // nobody cancelled.
+            if tokio::signal::ctrl_c().await.is_ok() {
+                std::process::exit(EXIT_INTERRUPTED);
             }
         });
         let _ = registered.await;
@@ -598,7 +607,7 @@ fn lookup_failed(kind: &str, call_id: Option<CallId>, error: &AgentError) -> Hal
 struct FolderDeclines {
     reports: tokio::sync::mpsc::UnboundedSender<FolderDecline>,
     inbox: tokio::sync::mpsc::UnboundedReceiver<FolderDecline>,
-    tasks: Vec<tokio::task::JoinHandle<()>>,
+    waiting: HashMap<CallId, tokio::task::JoinHandle<()>>,
 }
 
 /// What a refusal has to say. Only a call seen sitting in the pending set can
@@ -607,10 +616,18 @@ struct FolderDeclines {
 /// server is completing perfectly well.
 enum FolderDecline {
     /// Worth saying, not worth stopping for.
-    Noted(String),
+    Noted { call_id: CallId, message: String },
     /// The call is parked, and the refusal this run owes it cannot be
     /// delivered. Nothing else will answer it, so the turn would wait forever.
     Unanswerable { call_id: CallId, message: String },
+}
+
+impl FolderDecline {
+    fn call_id(&self) -> CallId {
+        match self {
+            Self::Noted { call_id, .. } | Self::Unanswerable { call_id, .. } => *call_id,
+        }
+    }
 }
 
 impl FolderDeclines {
@@ -619,7 +636,7 @@ impl FolderDeclines {
         Self {
             reports,
             inbox,
-            tasks: Vec::new(),
+            waiting: HashMap::new(),
         }
     }
 
@@ -653,28 +670,42 @@ impl FolderDeclines {
         let client = client.clone();
         let executor_token = executor_token.to_owned();
         let reports = self.reports.clone();
-        self.tasks.push(tokio::spawn(async move {
+        let task = tokio::spawn(async move {
             if let Some(report) = decline(&client, &executor_token, chat, call_id).await {
                 let _ = reports.send(report);
             }
-        }));
+        });
+        self.waiting.insert(call_id, task);
+    }
+
+    /// The call is terminal, so stop waiting for it to park. This is the
+    /// ordinary end for a refusal that never had a call to answer: the agent
+    /// declines a request that fails its checkpoint itself, and the only sign of
+    /// that on this side is the completion.
+    fn finished(&mut self, call_id: CallId) {
+        if let Some(task) = self.waiting.remove(&call_id) {
+            task.abort();
+        }
     }
 
     /// The next thing a refusal has to report. Pends forever when there is
     /// nothing to say, which is the common case: this side holds a sender, so
     /// the channel never closes and never resolves on its own.
     async fn reported(&mut self) -> FolderDecline {
-        match self.inbox.recv().await {
+        let report = match self.inbox.recv().await {
             Some(report) => report,
             None => std::future::pending().await,
-        }
+        };
+        // A refusal that has reported is done; its task is spent either way.
+        self.waiting.remove(&report.call_id());
+        report
     }
 }
 
 /// Ends every refusal still in flight when the turn is over, however it ended.
 impl Drop for FolderDeclines {
     fn drop(&mut self) {
-        for task in &self.tasks {
+        for task in self.waiting.values() {
             task.abort();
         }
     }
@@ -682,13 +713,22 @@ impl Drop for FolderDeclines {
 
 /// Wait for one folder request to become claimable, then resolve it declined.
 ///
+/// Only an embedded run gets here — an attached one holds no executor
+/// credential and never starts a refusal — so every call below is to this
+/// process's own server over loopback. That is what makes the asymmetry below
+/// defensible: a poll is retried because the call may simply not have parked
+/// yet, while a claim or a resolve that fails against a local, in-process
+/// server is a real refusal of the operation rather than a network blip, and
+/// retrying it would only postpone the same answer.
+///
 /// `None` means there is nothing to report — including the ordinary case where
 /// the call never parks, because the agent refused it at the checkpoint and is
 /// carrying the turn on without it. Each way this can end is answered on its
 /// own terms rather than as one undifferentiated failure:
 ///
 /// - **Never parked, or unreadable.** Not evidence of anything: keep asking. A
-///   poll that fails says nothing about the call, so it is retried too.
+///   poll that fails says nothing about the call, so it is retried too. The
+///   waiting ends when the call completes or the turn does, not on a clock.
 /// - **Parked, and claimed by somebody else.** Never race it — this process has
 ///   no way to grant anything. But it is also the only surface that answers for
 ///   this server, so a claim it does not hold is a call it cannot settle.
@@ -708,10 +748,13 @@ async fn decline(
         if let Ok(pending) = client.pending_client_executions(executor_token, chat).await {
             match pending.into_iter().find(|call| call.id == call_id) {
                 Some(call) if call.name != REQUEST_FOLDER_ACCESS_TOOL => {
-                    return Some(FolderDecline::Noted(format!(
-                        "folder request {call_id} parked as a {} call and was left alone",
-                        call.name
-                    )));
+                    return Some(FolderDecline::Noted {
+                        call_id,
+                        message: format!(
+                            "folder request {call_id} parked as a {} call and was left alone",
+                            call.name
+                        ),
+                    });
                 }
                 Some(call) if call.client_executor_id.is_some() => {
                     return Some(FolderDecline::Unanswerable {
@@ -731,11 +774,12 @@ async fn decline(
     }
 
     match resolve_declined(client, executor_token, chat, call_id).await {
-        Ok(()) => Some(FolderDecline::Noted(
-            "folder access declined: headless runs connect folders with `openwave folder \
-             connect`, never mid-turn"
+        Ok(()) => Some(FolderDecline::Noted {
+            call_id,
+            message: "folder access declined: headless runs connect folders with `openwave \
+                      folder connect`, never mid-turn"
                 .to_owned(),
-        )),
+        }),
         Err(error) => Some(FolderDecline::Unanswerable {
             call_id,
             message: format!(
@@ -956,6 +1000,5 @@ mod tests {
             .expect_err("an unreachable server must not read as nothing pending");
 
         assert_eq!(halt.reason, HaltReason::PendingLookupFailed);
-        assert_ne!(halt.reason.exit_code(), 0);
     }
 }

--- a/crates/openwave-cli/src/print/protocol.rs
+++ b/crates/openwave-cli/src/print/protocol.rs
@@ -219,6 +219,11 @@ pub enum HaltReason {
     /// The request behind a parked interaction could not be read at all, so the
     /// run cannot tell what it is waiting on.
     PendingLookupFailed,
+    /// A parked `request_folder_access` call could not be refused. Its own
+    /// reason, not `decision_failed`: nothing a driver said produced it, and a
+    /// caller reading exit 4 should be able to tell that a folder request —
+    /// which no decision line can ever answer — is what ended the run.
+    FolderDeclineFailed,
     /// SIGINT reached the run; the turn is cancelled rather than abandoned.
     Interrupted,
 }
@@ -230,19 +235,22 @@ impl HaltReason {
             Self::QuestionsUndriven => "questions_undriven",
             Self::DecisionFailed => "decision_failed",
             Self::PendingLookupFailed => "pending_lookup_failed",
+            Self::FolderDeclineFailed => "folder_decline_failed",
             Self::Interrupted => "interrupted",
         }
     }
 
     /// The process exit status this halt produces. Both undriven reasons share
     /// one code — they are the same fact ("nobody was there to answer") and the
-    /// `reason` field separates them. A failed lookup shares the code of a
-    /// failed decision for the same reason: the run reached an interaction and
-    /// could not carry it through.
+    /// `reason` field separates them. The three failure reasons share one for
+    /// the same reason: the run reached something it had to settle and could
+    /// not carry it through.
     pub fn exit_code(self) -> i32 {
         match self {
             Self::PlanUndriven | Self::QuestionsUndriven => super::EXIT_INTERACTION_UNDRIVEN,
-            Self::DecisionFailed | Self::PendingLookupFailed => super::EXIT_DECISION_FAILED,
+            Self::DecisionFailed | Self::PendingLookupFailed | Self::FolderDeclineFailed => {
+                super::EXIT_DECISION_FAILED
+            }
             Self::Interrupted => super::EXIT_INTERRUPTED,
         }
     }

--- a/crates/openwave-cli/src/print/protocol.rs
+++ b/crates/openwave-cli/src/print/protocol.rs
@@ -216,6 +216,11 @@ pub enum HaltReason {
     PlanUndriven,
     QuestionsUndriven,
     DecisionFailed,
+    /// The request behind a parked interaction could not be read at all, so the
+    /// run cannot tell what it is waiting on.
+    PendingLookupFailed,
+    /// SIGINT reached the run; the turn is cancelled rather than abandoned.
+    Interrupted,
 }
 
 impl HaltReason {
@@ -224,16 +229,21 @@ impl HaltReason {
             Self::PlanUndriven => "plan_undriven",
             Self::QuestionsUndriven => "questions_undriven",
             Self::DecisionFailed => "decision_failed",
+            Self::PendingLookupFailed => "pending_lookup_failed",
+            Self::Interrupted => "interrupted",
         }
     }
 
     /// The process exit status this halt produces. Both undriven reasons share
     /// one code — they are the same fact ("nobody was there to answer") and the
-    /// `reason` field separates them.
+    /// `reason` field separates them. A failed lookup shares the code of a
+    /// failed decision for the same reason: the run reached an interaction and
+    /// could not carry it through.
     pub fn exit_code(self) -> i32 {
         match self {
             Self::PlanUndriven | Self::QuestionsUndriven => super::EXIT_INTERACTION_UNDRIVEN,
-            Self::DecisionFailed => super::EXIT_DECISION_FAILED,
+            Self::DecisionFailed | Self::PendingLookupFailed => super::EXIT_DECISION_FAILED,
+            Self::Interrupted => super::EXIT_INTERRUPTED,
         }
     }
 }

--- a/docs-site/content/docs/headless.mdx
+++ b/docs-site/content/docs/headless.mdx
@@ -181,7 +181,7 @@ under text output, so an undriven run is always machine-diagnosable.
 | `1` | The turn failed, was refused, or was cancelled. |
 | `2` | Usage error — a bad flag or argument. |
 | `3` | The turn parked on a plan or question and no driver answered. `reason` is `plan_undriven` or `questions_undriven`. |
-| `4` | A decision could not be carried through. `reason` is `decision_failed` when one was made and the server refused it, or `pending_lookup_failed` when the parked request itself could not be read. |
+| `4` | Something the run had to settle could not be carried through. `reason` is `decision_failed` when a decision was made and the server refused it, `pending_lookup_failed` when the parked request itself could not be read, or `folder_decline_failed` when a `request_folder_access` call was left parked and the refusal it needs could not be delivered. |
 | `130` | Interrupted (SIGINT). The turn is cancelled, and a `halted` object names the reason `interrupted`. |
 
 #### A dev harness

--- a/docs-site/content/docs/headless.mdx
+++ b/docs-site/content/docs/headless.mdx
@@ -181,8 +181,8 @@ under text output, so an undriven run is always machine-diagnosable.
 | `1` | The turn failed, was refused, or was cancelled. |
 | `2` | Usage error — a bad flag or argument. |
 | `3` | The turn parked on a plan or question and no driver answered. `reason` is `plan_undriven` or `questions_undriven`. |
-| `4` | A decision was made but could not be applied. `reason` is `decision_failed`. |
-| `130` | Interrupted (SIGINT). |
+| `4` | A decision could not be carried through. `reason` is `decision_failed` when one was made and the server refused it, or `pending_lookup_failed` when the parked request itself could not be read. |
+| `130` | Interrupted (SIGINT). The turn is cancelled, and a `halted` object names the reason `interrupted`. |
 
 #### A dev harness
 


### PR DESCRIPTION
Three print-mode failures shared a shape: something went wrong and the run said nothing about it. A caller saw a process that hung, or one that exited as if all was well.

## Ctrl-C during a driven run

Waiting for the next journal frame, and waiting for a driver to write a decision line, were both indefinite waits that did not watch for SIGINT. Pressing Ctrl-C against a driven run left the turn running server-side while the process sat there.

Both waits now race an interrupt watcher. On the first signal the run cancels the turn, emits a `halted` object with reason `interrupted`, and exits 130. The watcher stays alive afterwards: a second Ctrl-C exits the process immediately, which is what the default disposition would have done anyway, so a run that cannot cancel cleanly is still escapable.

The watcher is installed after the turn is posted, not before. Installing it earlier would swallow signals over the WebSocket handshake and the POST — neither of which watches the interrupt, and neither of which has a turn to cancel yet.

The coverage has a limit worth stating: the interrupt covers the frame wait and the driven decision wait. A `--server` host that accepts TCP and then never answers still blocks with the interrupt unwatched, because the CLI's HTTP client sets no request timeout. That is unchanged by this PR and a second Ctrl-C remains the way out of it.

## Pending-plan and pending-question lookups

When the turn parked on a plan or a question, the run fetched the pending request to show the driver what it was answering. That fetch discarded its error, so a failed lookup was indistinguishable from "nothing is pending" — the run continued past the interaction it was parked on, waited for frames that would never come, and eventually exited as though the turn had simply not proposed anything.

The two lookups now return a typed result. A genuine "nothing pending" still continues, since the interaction may have settled before the fetch landed. A transport or server failure produces a `halted` object with reason `pending_lookup_failed`, cancels the parked turn, writes the reason to stderr, and exits 4.

## Declining a folder request

`request_folder_access` cannot be answered by a driving process: the protocol's decision vocabulary is closed at approval, plan, and questions, and standing folder consent comes only from `openwave folder connect`. Print mode printed a notice that it was declining and then did nothing further, so the call stayed parked in the client-execution set and the turn waited on it indefinitely.

The refusal is now actually delivered: the run claims the parked call and resolves it with the declined outcome, the same claim-and-resolve the desktop client performs.

The delivery runs on its own task rather than in the event loop, and reports back over a channel, because the call is not claimable the instant it starts. It polls with backoff and no deadline; a wall-clock budget would have raced a step that parks its client call last. A poller is dropped as soon as the loop sees `ToolCallCompleted` for that call, so a call that ends some other way stops being waited on.

Which outcomes end the run is deliberately narrow. A call that never parks is a routine outcome — the agent can reject it at the client checkpoint and decline it itself, in which case there is nothing to deliver and the turn completes normally. Only a call observed sitting in the pending set that then cannot be refused, because the claim failed, the resolve failed, or another executor already holds it, is fatal; that produces reason `folder_decline_failed` and exit 4. Everything else is reported to stderr and the run carries on.

The exit-code table in the headless docs names the new reasons.

## Tests

One added: an unreadable pending-plan lookup must halt rather than read as "nothing pending". It points the client at a closed local port, which is the failure the old code silently absorbed.
