### PR TITLE
fix(host-broker): stop attachment from restoring revoked folder access

### DIFF
--- a/crates/openwave-desktop/src/host_access.rs
+++ b/crates/openwave-desktop/src/host_access.rs
@@ -5,8 +5,8 @@ use std::path::PathBuf;
 use openwave_core::{ChatId, Store};
 use openwave_host_broker::{
     AppFolderPathRequest, AppFolderWriteRequest, Capability, ControlRequest, ControlResult,
-    ExecutionContext, GrantSubject, OperationEnvelope, OperationRequest, OperationResult,
-    RelativePath, ResolveExecRootsRequest, RootId, RootSummary, WriteFileMode,
+    ExecutionContext, GrantSubject, RelativePath, ResolveExecRootsRequest, RootId, RootSummary,
+    WriteFileMode,
 };
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager, State};
@@ -566,12 +566,28 @@ pub(crate) async fn connect_folder(
     .map(Some)
 }
 
+/// The folders attached to one conversation, by their safe identities.
+///
+/// Identity comes from the trusted management listing of approved roots, not
+/// from the agent's `ListRoots` operation, which answers only for folders the
+/// conversation may currently read. Sourcing it from there made a folder whose
+/// read consent had been revoked vanish from the panel that owns disconnecting
+/// it and granting access back — the one state in which the reader most needs
+/// both. What the folder *allows* is still not part of this answer: the
+/// renderer reads that from the consent statements, so a listed folder can
+/// legitimately allow nothing.
 #[tauri::command]
 pub(crate) async fn list_connected_folders(
     state: State<'_, HostAccess>,
     chat_id: Uuid,
 ) -> Result<Vec<ConnectedFolder>, String> {
-    let context = state.context(chat_id).await?;
+    connected_folders(&state, chat_id).await
+}
+
+async fn connected_folders(
+    state: &HostAccess,
+    chat_id: Uuid,
+) -> Result<Vec<ConnectedFolder>, String> {
     let store = state
         .store()
         .ok_or_else(|| "OpenWave is still starting".to_owned())?;
@@ -583,29 +599,12 @@ pub(crate) async fn list_connected_folders(
     if chat.root_attachments.is_empty() {
         return Ok(Vec::new());
     }
-    let request_id = openwave_host_broker::RequestId::new();
-    let result = state
-        .broker
-        .operation(OperationEnvelope {
-            protocol_version: openwave_host_broker::PROTOCOL_VERSION,
-            request_id,
-            context: context.execution,
-            request: OperationRequest::ListRoots,
-        })
-        .await
-        .map_err(|error| error.to_string())?;
-    let OperationResult::ListRoots { roots } = result else {
-        return Err("host broker returned an unexpected response".to_owned());
-    };
+    let roots = approved_roots(state).await?;
     let product_roots = chat
         .root_attachments
         .iter()
         .map(|attachment| *attachment.root_id.as_uuid())
         .collect::<std::collections::HashSet<_>>();
-    // What each folder allows is no longer projected here: the renderer reads
-    // it from the same consent statements the Permissions surface shows
-    // (`list_capability_consents`), so both panels are groupings of one model
-    // and the desktop keeps no folder-capability vocabulary of its own.
     let mut folders = roots
         .into_iter()
         .filter(|root| product_roots.contains(&root.root_id.as_uuid()))
@@ -833,14 +832,18 @@ pub(crate) async fn connect_approved_folder(
     .map(Some)
 }
 
-/// The capabilities the folders panel may ask to add to an attached folder.
+/// The capabilities the folders and permissions surfaces may ask to add to an
+/// attached folder.
 ///
-/// Read is deliberately absent: a folder whose read consent was revoked no
-/// longer appears in the panel at all, so the recovery for that is the
-/// ordinary re-attach ceremony, not a widening of something still visible.
+/// Read is here because it can be taken away: revoking it leaves the folder
+/// attached and allowing nothing, and without a way to ask for it back that is
+/// a one-way door. Granting it is a widening like any other — an explicit
+/// action answered in the native dialog — never something an attachment does
+/// on the user's behalf.
 #[derive(Debug, Clone, Copy, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum WidenedFolderCapability {
+    ReadFiles,
     WriteFiles,
     ExecuteCommands,
 }
@@ -857,34 +860,23 @@ pub(crate) struct GrantFolderCapabilityRequest {
 ///
 /// The same shape as attach-time consent: a native dialog names the chat, the
 /// folder, and exactly what is being allowed, and the broker records the
-/// approval as a fresh permission-dialog grant. The folder identity comes
-/// from the broker's own listing for this conversation, never from renderer
-/// strings, and the broker independently re-checks that the root is live and
-/// attached before minting anything.
+/// approval as a fresh permission-dialog grant. The folder identity comes from
+/// the broker's own approved-root listing intersected with this chat's
+/// attachments, never from renderer strings, and the broker independently
+/// re-checks that the root is live and attached before minting anything.
 #[tauri::command]
 pub(crate) async fn grant_folder_capability(
     app: AppHandle,
     state: State<'_, HostAccess>,
     request: GrantFolderCapabilityRequest,
 ) -> Result<Option<bool>, String> {
-    let context = state.context(request.chat_id).await?;
     let chat_label = conversation_label(&state, request.chat_id).await?;
-    let result = state
-        .broker
-        .operation(OperationEnvelope {
-            protocol_version: openwave_host_broker::PROTOCOL_VERSION,
-            request_id: openwave_host_broker::RequestId::new(),
-            context: context.execution,
-            request: OperationRequest::ListRoots,
-        })
-        .await
-        .map_err(|error| error.to_string())?;
-    let OperationResult::ListRoots { roots } = result else {
-        return Err("host broker returned an unexpected response".to_owned());
-    };
-    let root = roots
+    let root = connected_folders(&state, request.chat_id)
+        .await?
         .into_iter()
-        .find(|root| root.root_id == request.root_id)
+        .find(|root| {
+            root.root_id == request.root_id && matches!(root.status, FolderStatus::Connected)
+        })
         .ok_or_else(|| "the folder is no longer connected".to_owned())?;
 
     let _consent = state
@@ -900,6 +892,7 @@ pub(crate) async fn grant_folder_capability(
     let _root_change = state.root_changes.lock().await;
     let context = state.context(request.chat_id).await?;
     let capability = match request.capability {
+        WidenedFolderCapability::ReadFiles => Capability::ReadFiles,
         WidenedFolderCapability::WriteFiles => Capability::WriteFiles,
         WidenedFolderCapability::ExecuteCommands => Capability::ExecuteCommands,
     };
@@ -1131,6 +1124,7 @@ async fn confirm_folder_widening(
 ) -> Result<bool, String> {
     let folder_label = safe_dialog_label(display_name);
     let allowed = match capability {
+        WidenedFolderCapability::ReadFiles => "read files in",
         WidenedFolderCapability::WriteFiles => "write files in",
         WidenedFolderCapability::ExecuteCommands => "run commands in",
     };

--- a/crates/openwave-desktop/ui/src/FolderAccess.ts
+++ b/crates/openwave-desktop/ui/src/FolderAccess.ts
@@ -1,4 +1,7 @@
-import type { Chat, ConsentStatementSnapshot } from "./api";
+import type { ConsentStatementSnapshot } from "./api";
+
+/** The part of a conversation a folder statement is matched against. */
+export type FolderChatScope = { id: string; project_id: string | null };
 
 /**
  * The broker's capability vocabulary as consent statements carry it. Folder
@@ -15,7 +18,7 @@ export type FolderReach = Extract<
  * project it is filed under. */
 export function statementReachesChat(
   statement: ConsentStatementSnapshot,
-  chat: Chat,
+  chat: FolderChatScope,
 ): boolean {
   return statement.level.level === "chat"
     ? statement.level.chat_id === chat.id
@@ -26,7 +29,7 @@ export function statementReachesChat(
 export function folderStatements(
   statements: readonly ConsentStatementSnapshot[],
   rootId: string,
-  chat: Chat,
+  chat: FolderChatScope,
 ): ConsentStatementSnapshot[] {
   return statements.filter(
     (statement) =>

--- a/crates/openwave-desktop/ui/src/FoldersView.test.tsx
+++ b/crates/openwave-desktop/ui/src/FoldersView.test.tsx
@@ -196,18 +196,31 @@ describe("FoldersView", () => {
     vi.mocked(host.listConnectedFolders).mockResolvedValue([
       folder("locked-out", "Archive"),
     ]);
-    vi.mocked(host.listCapabilityConsents)
-      .mockResolvedValueOnce([])
-      .mockResolvedValue([statement("locked-out", "read_files")]);
-    vi.mocked(host.grantFolderCapability).mockResolvedValue(true);
+    let granted: ConsentStatementSnapshot[] = [];
+    vi.mocked(host.listCapabilityConsents).mockImplementation(
+      async () => granted,
+    );
+    vi.mocked(host.grantFolderCapability).mockImplementation(async () => {
+      granted = [statement("locked-out", "read_files")];
+      return true;
+    });
     const user = userEvent.setup();
     render(<FoldersView chat={chat} />);
 
     await screen.findByText("Archive");
     expect(screen.getByText("No access")).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Disconnect" }),
-    ).toBeInTheDocument();
+
+    // Disconnect has to work from here, not merely be on screen: the broker
+    // used to refuse a detach for a folder the chat could not read, which made
+    // this button a dead control in the one state it exists for.
+    await user.click(screen.getByRole("button", { name: "Disconnect" }));
+    const confirmations = await screen.findAllByRole("button", {
+      name: "Disconnect",
+    });
+    await user.click(confirmations[confirmations.length - 1]);
+    await waitFor(() =>
+      expect(host.disconnectFolder).toHaveBeenCalledWith(chat, "locked-out"),
+    );
 
     // Read is the first thing offered back, and granting it is an explicit
     // action answered natively — nothing here restores it on its own.

--- a/crates/openwave-desktop/ui/src/FoldersView.test.tsx
+++ b/crates/openwave-desktop/ui/src/FoldersView.test.tsx
@@ -189,6 +189,41 @@ describe("FoldersView", () => {
     expect(screen.getAllByRole("button", { name: "Grant" })).toHaveLength(1);
   });
 
+  it("keeps a folder whose access was revoked listed, with read to grant back", async () => {
+    // Revoking read leaves the folder attached and allowing nothing. It used
+    // to disappear from this panel at that point, taking Disconnect and every
+    // way back with it.
+    vi.mocked(host.listConnectedFolders).mockResolvedValue([
+      folder("locked-out", "Archive"),
+    ]);
+    vi.mocked(host.listCapabilityConsents)
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([statement("locked-out", "read_files")]);
+    vi.mocked(host.grantFolderCapability).mockResolvedValue(true);
+    const user = userEvent.setup();
+    render(<FoldersView chat={chat} />);
+
+    await screen.findByText("Archive");
+    expect(screen.getByText("No access")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Disconnect" }),
+    ).toBeInTheDocument();
+
+    // Read is the first thing offered back, and granting it is an explicit
+    // action answered natively — nothing here restores it on its own.
+    const grants = screen.getAllByRole("button", { name: "Grant" });
+    expect(grants).toHaveLength(3);
+    await user.click(grants[0]);
+    expect(host.grantFolderCapability).toHaveBeenCalledWith(
+      chat,
+      "locked-out",
+      "read_files",
+    );
+    await waitFor(() =>
+      expect(screen.getByText("Read only")).toBeInTheDocument(),
+    );
+  });
+
   it("distinguishes an unavailable folder and lets it be forgotten for good", async () => {
     vi.mocked(host.listConnectedFolders)
       .mockResolvedValueOnce([

--- a/crates/openwave-desktop/ui/src/FoldersView.tsx
+++ b/crates/openwave-desktop/ui/src/FoldersView.tsx
@@ -1,5 +1,6 @@
 import { FolderOpenIcon, PlusIcon } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 
 import type { Chat, ConsentStatementSnapshot } from "./api";
 import { PanelSecondaryHeader } from "@/components/PanelHeader";
@@ -41,6 +42,7 @@ import {
 } from "./FolderAccess";
 import { verbLabel } from "./settings/PermissionsPanel";
 import { useRefreshSignals } from "./RefreshSignals";
+import { friendlyErrorMessage } from "@/lib/utils";
 
 /**
  * A chat's connected folders: the directories the native host may reach on
@@ -87,7 +89,10 @@ export function FoldersView({ chat }: { chat: Chat }) {
       setConsents(statements);
     } catch (err) {
       if (generation !== refreshGeneration.current) return;
-      setError(String(err));
+      // A panel that could not load is a standing state, not a transient
+      // failure, so it stays on the page. Every action below reports through a
+      // toast instead.
+      setError(friendlyErrorMessage(err, "The folders could not be loaded."));
     }
   }
 
@@ -112,16 +117,15 @@ export function FoldersView({ chat }: { chat: Chat }) {
    */
   async function withPicker(holder: string, open: () => Promise<unknown>) {
     if (!useNativePickerLatch.getState().claim(holder)) {
-      setError(PICKER_BUSY_MESSAGE);
+      toast.error(PICKER_BUSY_MESSAGE);
       return;
     }
     setWorking(true);
-    setError(null);
     try {
       const connected = await open();
       if (connected) useRefreshSignals.getState().signal("folderAccess");
     } catch (err) {
-      setError(String(err));
+      toast.error(friendlyErrorMessage(err, "The folder could not be changed."));
     } finally {
       useNativePickerLatch.getState().release(holder);
       setWorking(false);
@@ -161,12 +165,13 @@ export function FoldersView({ chat }: { chat: Chat }) {
     });
     if (!accepted) return;
     setWorking(true);
-    setError(null);
     try {
       await disconnectFolder(chat, folder.rootId);
       useRefreshSignals.getState().signal("folderAccess");
     } catch (err) {
-      setError(String(err));
+      toast.error(
+        friendlyErrorMessage(err, "The folder could not be disconnected."),
+      );
     } finally {
       setWorking(false);
     }
@@ -187,12 +192,11 @@ export function FoldersView({ chat }: { chat: Chat }) {
     });
     if (!accepted) return;
     setWorking(true);
-    setError(null);
     try {
       await forgetFolder(folder.rootId);
       useRefreshSignals.getState().signal("folderAccess");
     } catch (err) {
-      setError(String(err));
+      toast.error(friendlyErrorMessage(err, "The folder could not be forgotten."));
     } finally {
       setWorking(false);
     }
@@ -215,12 +219,11 @@ export function FoldersView({ chat }: { chat: Chat }) {
     });
     if (!accepted) return;
     setWorking(true);
-    setError(null);
     try {
       await revokeCapabilityConsent(statement);
       useRefreshSignals.getState().signal("folderAccess");
     } catch (err) {
-      setError(String(err));
+      toast.error(friendlyErrorMessage(err, "The access could not be revoked."));
     } finally {
       setWorking(false);
     }

--- a/crates/openwave-desktop/ui/src/FoldersView.tsx
+++ b/crates/openwave-desktop/ui/src/FoldersView.tsx
@@ -288,10 +288,12 @@ export function FoldersView({ chat }: { chat: Chat }) {
                   const reach = folderReach(statements);
                   // What the folder does not yet allow is offered next to what
                   // it does, so the recovery for a read-only folder is visible
-                  // before a refused write, not after it. Read is not offered:
-                  // a folder without read consent is not listed here at all.
+                  // before a refused write, not after it. Read is offered on
+                  // the same terms: a folder can be attached with its read
+                  // consent revoked, and asking for it back is how that folder
+                  // becomes usable again short of disconnecting it.
                   const missing = (
-                    ["write_files", "execute_commands"] as const
+                    ["read_files", "write_files", "execute_commands"] as const
                   ).filter((capability) => !reach.includes(capability));
                   return (
                     <FolderCard

--- a/crates/openwave-desktop/ui/src/host.ts
+++ b/crates/openwave-desktop/ui/src/host.ts
@@ -27,12 +27,16 @@ export async function requestUserAttention(): Promise<void> {
 }
 
 /**
- * The folders this conversation can reach, by their safe identities. What
+ * The folders this conversation has attached, by their safe identities. What
  * each folder *allows* is not part of this answer: access is rendered from
  * the same consent statements the Permissions surface shows
- * ([`listCapabilityConsents`]), so both panels are groupings of one model.
+ * ([`listCapabilityConsents`]), so both panels are groupings of one model. A
+ * folder whose access was revoked down to nothing is still listed — it is
+ * still attached, and hiding it would hide the controls that undo that.
  */
-export function listConnectedFolders(chat: Chat): Promise<ConnectedFolder[]> {
+export function listConnectedFolders(chat: {
+  id: string;
+}): Promise<ConnectedFolder[]> {
   return invoke("list_connected_folders", { chatId: chat.id });
 }
 
@@ -117,10 +121,13 @@ export function purgeDeletedConversationSubject(chatId: string): Promise<boolean
   });
 }
 
-/** The reach the folders panel can add to an already-attached folder. Read is
- * absent on purpose: a folder whose read consent was revoked no longer
- * appears in the panel, so its recovery is the re-attach ceremony. */
-export type WidenedFolderCapability = "write_files" | "execute_commands";
+/** The reach a permissions surface can add to an already-attached folder.
+ * Read is included: revoking it leaves the folder attached and allowing
+ * nothing, so asking for it back has to be possible without disconnecting. */
+export type WidenedFolderCapability =
+  | "read_files"
+  | "write_files"
+  | "execute_commands";
 
 /**
  * Ask to add one capability to a folder this chat already has attached. The
@@ -129,7 +136,7 @@ export type WidenedFolderCapability = "write_files" | "execute_commands";
  * as a fresh permission-dialog grant. Resolves `null` when the user cancels.
  */
 export function grantFolderCapability(
-  chat: Chat,
+  chat: { id: string },
   rootId: string,
   capability: WidenedFolderCapability,
 ): Promise<boolean | null> {

--- a/crates/openwave-desktop/ui/src/settings/PermissionsPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/PermissionsPanel.dom.test.tsx
@@ -3,6 +3,7 @@ import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ApiClient, ConsentStatementSnapshot } from "../api";
+import type { ConnectedFolder } from "../host";
 import {
   levelLabel,
   PermissionsPanel,
@@ -15,7 +16,18 @@ const listCapabilityConsents = vi.hoisted(() =>
 const revokeCapabilityConsent = vi.hoisted(() =>
   vi.fn<() => Promise<boolean>>(),
 );
-vi.mock("../host", () => ({ listCapabilityConsents, revokeCapabilityConsent }));
+const listConnectedFolders = vi.hoisted(() =>
+  vi.fn<() => Promise<ConnectedFolder[]>>(),
+);
+const grantFolderCapability = vi.hoisted(() =>
+  vi.fn<() => Promise<boolean | null>>(),
+);
+vi.mock("../host", () => ({
+  listCapabilityConsents,
+  revokeCapabilityConsent,
+  listConnectedFolders,
+  grantFolderCapability,
+}));
 
 const execStatement: ConsentStatementSnapshot = {
   handle: {
@@ -50,6 +62,16 @@ const folderWriteStatement: ConsentStatementSnapshot = {
   granted_at: "2026-07-30T12:00:00Z",
 };
 
+const folderReadStatement: ConsentStatementSnapshot = {
+  ...folderWriteStatement,
+  handle: {
+    kind: "capability_grant",
+    grant_id: "66666666-6666-6666-6666-666666666666",
+  },
+  verb: { kind: "capability", capability: "read_files" },
+  method: "permission_dialog",
+};
+
 function api(overrides: Partial<Record<keyof ApiClient, unknown>> = {}) {
   return {
     listConsentStatements: vi.fn().mockResolvedValue([execStatement]),
@@ -68,6 +90,8 @@ function deferred<T>() {
 
 beforeEach(() => {
   listCapabilityConsents.mockResolvedValue([]);
+  listConnectedFolders.mockResolvedValue([]);
+  grantFolderCapability.mockResolvedValue(true);
 });
 
 afterEach(() => {
@@ -141,6 +165,44 @@ describe("PermissionsPanel", () => {
       expect(screen.queryByText("Documents")).not.toBeInTheDocument(),
     );
     expect(client.revokeStandingGrant).not.toHaveBeenCalled();
+  });
+
+  it("offers read access back on an attached folder that allows nothing", async () => {
+    // The state a reader can reach and could not leave: read revoked, so the
+    // folder is attached and unusable, and nothing re-grants it on its own.
+    const chatId = "22222222-2222-2222-2222-222222222222";
+    listCapabilityConsents.mockResolvedValue([]);
+    listConnectedFolders.mockResolvedValue([
+      {
+        rootId: "55555555-5555-5555-5555-555555555555",
+        displayName: "Documents",
+        status: "connected",
+      },
+    ]);
+    grantFolderCapability.mockImplementation(() => {
+      listCapabilityConsents.mockResolvedValue([folderReadStatement]);
+      listConnectedFolders.mockResolvedValue([]);
+      return Promise.resolve(true);
+    });
+    const client = api({ listConsentStatements: vi.fn().mockResolvedValue([]) });
+    render(
+      <PermissionsPanel client={client} chat={{ id: chatId, project_id: null }} />,
+    );
+
+    await screen.findByText("Documents");
+    await userEvent.click(screen.getByRole("button", { name: "Grant" }));
+
+    await waitFor(() =>
+      expect(grantFolderCapability).toHaveBeenCalledWith(
+        { id: chatId },
+        "55555555-5555-5555-5555-555555555555",
+        "read_files",
+      ),
+    );
+    // The restored grant is listed as an ordinary revocable statement, and the
+    // offer to restore it is gone.
+    await screen.findByText("Read files");
+    expect(screen.queryByRole("button", { name: "Grant" })).toBeNull();
   });
 
   it("names a project statement as reaching past the chat that made it", async () => {

--- a/crates/openwave-desktop/ui/src/settings/PermissionsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/PermissionsPanel.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import { toast } from "sonner";
 
 import type {
   ApiClient,
@@ -7,8 +8,22 @@ import type {
   RendererToolName,
 } from "../api";
 import { useConfirm } from "../components/ConfirmDialog";
-import { listCapabilityConsents, revokeCapabilityConsent } from "../host";
+import {
+  grantFolderCapability,
+  listCapabilityConsents,
+  listConnectedFolders,
+  revokeCapabilityConsent,
+  type ConnectedFolder,
+} from "../host";
+import { folderReach, folderStatements } from "../FolderAccess";
+import {
+  PICKER_BUSY_MESSAGE,
+  PICKER_HOLDERS,
+  useNativePickerLatch,
+} from "../NativePickerLatch";
+import { useRefreshSignals } from "../RefreshSignals";
 import { Button } from "@/components/ui/button";
+import { friendlyErrorMessage } from "@/lib/utils";
 import { SettingsError, SettingsPanel, SettingsSection } from "./primitives";
 
 // The "what may the agent do without asking" surface, rendered from the
@@ -225,6 +240,12 @@ export function handleKey(statement: ConsentStatementSnapshot): string {
     : `capability_grant:${statement.handle.grant_id}`;
 }
 
+/** A restore row's identity, in the same namespace as revocation handles so
+ * one busy row can be named whichever kind it is. */
+export function restoreKey(folder: { rootId: string }): string {
+  return `restore_read:${folder.rootId}`;
+}
+
 /** Statements in listing order, bucketed by what they reach, order preserved. */
 export function groupByLevel(
   statements: readonly ConsentStatementSnapshot[],
@@ -248,6 +269,34 @@ export function groupByLevel(
   return [...groups.values()];
 }
 
+/** One line of the list: what it reaches, what it allows, and its one action. */
+function AccessRow({
+  title,
+  subtitle,
+  meta,
+  action,
+}: {
+  title: string;
+  subtitle: string;
+  meta?: string;
+  action: ReactNode;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium">{title}</p>
+        <p className="text-muted-foreground mt-0.5 truncate text-sm">
+          {subtitle}
+        </p>
+        {meta && (
+          <p className="text-muted-foreground mt-1 truncate text-xs">{meta}</p>
+        )}
+      </div>
+      {action}
+    </div>
+  );
+}
+
 function StatementRow({
   statement,
   busy,
@@ -257,26 +306,17 @@ function StatementRow({
   busy: boolean;
   onRevoke: () => void;
 }) {
-  const metadata = grantedAtLabel(statement);
   return (
-    <div className="flex items-center justify-between gap-4">
-      <div className="min-w-0 flex-1">
-        <p className="truncate text-sm font-medium">
-          {resourceLabel(statement)}
-        </p>
-        <p className="text-muted-foreground mt-0.5 truncate text-sm">
-          {verbLabel(statement.verb)}
-        </p>
-        {metadata && (
-          <p className="text-muted-foreground mt-1 truncate text-xs">
-            {metadata}
-          </p>
-        )}
-      </div>
-      <Button variant="ghost" size="sm" disabled={busy} onClick={onRevoke}>
-        Revoke
-      </Button>
-    </div>
+    <AccessRow
+      title={resourceLabel(statement)}
+      subtitle={verbLabel(statement.verb)}
+      meta={grantedAtLabel(statement) || undefined}
+      action={
+        <Button variant="ghost" size="sm" disabled={busy} onClick={onRevoke}>
+          Revoke
+        </Button>
+      }
+    />
   );
 }
 
@@ -303,6 +343,19 @@ export function PermissionsPanel({
   const [statements, setStatements] = useState<
     ConsentStatementSnapshot[] | null
   >(null);
+  /**
+   * Folders this chat has attached but cannot read.
+   *
+   * Revoking read leaves the attachment alone, so this is a real state with
+   * no way forward: nothing restores a folder's access on its own, and
+   * attaching it again deliberately does not. The panel promises anything
+   * revoked can be asked for again, and these rows are what makes that true.
+   * Only computed with a chat in hand — a widening is granted to one
+   * conversation's subject, and the settings page has no conversation.
+   */
+  const [unreadableFolders, setUnreadableFolders] = useState<ConnectedFolder[]>(
+    [],
+  );
   const [error, setError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
   const { confirm, dialog } = useConfirm();
@@ -323,16 +376,25 @@ export function PermissionsPanel({
   const reload = useCallback(async () => {
     const generation = ++reloadGenerationRef.current;
     try {
-      const [tool, capability] = await Promise.all([
+      const chatScope = chatId ? { id: chatId, project_id: chatProjectId } : null;
+      const [tool, capability, folders] = await Promise.all([
         client.listConsentStatements(),
         listCapabilityConsents(),
+        chatScope ? listConnectedFolders(chatScope) : Promise.resolve([]),
       ]);
       if (generation !== reloadGenerationRef.current) return;
       const all = [...tool, ...capability];
-      setStatements(
-        chatId
-          ? statementsForChat(all, { id: chatId, project_id: chatProjectId })
-          : all,
+      setStatements(chatScope ? statementsForChat(all, chatScope) : all);
+      setUnreadableFolders(
+        chatScope
+          ? folders.filter(
+              (folder) =>
+                folder.status === "connected" &&
+                !folderReach(
+                  folderStatements(all, folder.rootId, chatScope),
+                ).includes("read_files"),
+            )
+          : [],
       );
       setError(null);
     } catch {
@@ -343,6 +405,7 @@ export function PermissionsPanel({
 
   useEffect(() => {
     setStatements(null);
+    setUnreadableFolders([]);
     setError(null);
     setBusyId(null);
     void reload();
@@ -350,6 +413,45 @@ export function PermissionsPanel({
       reloadGenerationRef.current += 1;
     };
   }, [reload, scopeKey]);
+
+  /**
+   * Ask for read access back on a folder this chat still has attached.
+   *
+   * The consent ceremony is the host's own dialog, exactly as it is for the
+   * write and command widenings the folders panel offers — this only asks,
+   * and follows the broker's answer. Nothing here mints anything on its own,
+   * and no other surface restores this grant as a side effect.
+   */
+  async function restoreReadAccess(folder: ConnectedFolder) {
+    const startingScope = scopeKey;
+    if (!chatId) return;
+    if (
+      !useNativePickerLatch
+        .getState()
+        .claim(PICKER_HOLDERS.grantFolderCapability)
+    ) {
+      toast.error(PICKER_BUSY_MESSAGE);
+      return;
+    }
+    setBusyId(restoreKey(folder));
+    try {
+      const granted = await grantFolderCapability(
+        { id: chatId },
+        folder.rootId,
+        "read_files",
+      );
+      if (granted) useRefreshSignals.getState().signal("folderAccess");
+      if (scopeKeyRef.current !== startingScope) return;
+      if (granted !== null) await reload();
+    } catch (caught) {
+      toast.error(
+        friendlyErrorMessage(caught, "The folder could not be granted access."),
+      );
+    } finally {
+      useNativePickerLatch.getState().release(PICKER_HOLDERS.grantFolderCapability);
+      if (scopeKeyRef.current === startingScope) setBusyId(null);
+    }
+  }
 
   async function revoke(statement: ConsentStatementSnapshot) {
     const startingScope = scopeKey;
@@ -397,13 +499,16 @@ export function PermissionsPanel({
   const body = (
     <>
       {error && <SettingsError>{error}</SettingsError>}
-      {statements !== null && statements.length === 0 && !error && (
-        <p className="text-sm text-muted-foreground">
-          {chat
-            ? "Nothing saved for this chat yet. When you answer an approval with “always allow” or connect a folder, it appears here."
-            : "Nothing saved yet. When you answer an approval with “always allow” or connect a folder, it appears here."}
-        </p>
-      )}
+      {statements !== null &&
+        statements.length === 0 &&
+        unreadableFolders.length === 0 &&
+        !error && (
+          <p className="text-sm text-muted-foreground">
+            {chat
+              ? "Nothing saved for this chat yet. When you answer an approval with “always allow” or connect a folder, it appears here."
+              : "Nothing saved yet. When you answer an approval with “always allow” or connect a folder, it appears here."}
+          </p>
+        )}
       {statements !== null &&
         groupByLevel(statements, known).map((group) => (
           <SettingsSection key={group.key} title={group.label}>
@@ -419,6 +524,32 @@ export function PermissionsPanel({
             </div>
           </SettingsSection>
         ))}
+      {unreadableFolders.length > 0 && (
+        <SettingsSection
+          title="Revoked folder access"
+          description="These folders are still connected to this chat, but the agent cannot read them. Grant read access to make one usable again — the host asks you to confirm."
+        >
+          <div className="flex flex-col gap-4">
+            {unreadableFolders.map((folder) => (
+              <AccessRow
+                key={restoreKey(folder)}
+                title={folder.displayName}
+                subtitle={CAPABILITY_LABELS.read_files}
+                action={
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={busyId === restoreKey(folder)}
+                    onClick={() => void restoreReadAccess(folder)}
+                  >
+                    Grant
+                  </Button>
+                }
+              />
+            ))}
+          </div>
+        </SettingsSection>
+      )}
       {dialog}
     </>
   );

--- a/crates/openwave-host-broker/src/broker.rs
+++ b/crates/openwave-host-broker/src/broker.rs
@@ -879,18 +879,22 @@ impl Controller {
             Ok(prepared) => {
                 let existing = preferred_root_alias(&next, &prepared.root);
                 if let Some((root_id, display_name)) = existing {
-                    ensure_default_subject_grants(
-                        &mut next,
-                        prepared.root.owner,
-                        root_id,
-                        prepared.grants[0].consent().clone(),
-                        self.shared.execute_commands,
-                    )
-                    .map_err(error_response)?;
-                    if !next.attachments.iter().any(|attachment| {
-                        attachment.conversation_id() == prepared.conversation_id
-                            && attachment.root_id() == root_id
-                    }) {
+                    // Picking a folder this conversation already has is the
+                    // same non-event as attaching one it already has: it says
+                    // where the folder may be used, and the chat is already
+                    // there. Only the pick that actually brings the folder into
+                    // a conversation carries the access a pick describes — and
+                    // then only for a subject that holds nothing over the root,
+                    // which is what keeps a narrowed position narrowed.
+                    if !has_root_attachment(&next, prepared.conversation_id, root_id) {
+                        ensure_default_subject_grants(
+                            &mut next,
+                            prepared.root.owner,
+                            root_id,
+                            prepared.grants[0].consent().clone(),
+                            self.shared.execute_commands,
+                        )
+                        .map_err(error_response)?;
                         next.attachments.push(
                             RootAttachment::new(prepared.conversation_id, root_id)
                                 .map_err(BrokerError::from)
@@ -1938,6 +1942,11 @@ const MAX_RETAINED_MUTATION_RECEIPTS: usize = 2048;
 /// which is not the growth this bound exists for. Attachment and write records
 /// are each validated on their own terms and are the two that a working
 /// session produces continuously.
+///
+/// Only completed records qualify. A pending one is still owed an outcome, so
+/// it is never enrolled and never evicted — which means a write whose dispatch
+/// was abandoned leaves a record behind for good. That leak is one record per
+/// abandoned in-flight write and is not what this bound is for.
 fn is_prunable_receipt(record: &MutationRecord) -> bool {
     matches!(
         record,
@@ -2555,6 +2564,11 @@ fn subject_has_any_root_grant(state: &State, subject: GrantSubject, root_id: Roo
 /// root, that set is the user's position — possibly narrowed on the folders
 /// panel — and widening it is a consent decision, which belongs to
 /// [`Controller::grant_root_capability`] and its permission dialog.
+///
+/// Both callers gate this on the folder actually arriving in the conversation,
+/// so an emptied position cannot be refilled by repeating an action against a
+/// folder the chat already has. This check is the second half of that rule, for
+/// the position a subject carries across its other conversations.
 fn ensure_default_subject_grants(
     state: &mut State,
     subject: GrantSubject,

--- a/crates/openwave-host-broker/src/broker.rs
+++ b/crates/openwave-host-broker/src/broker.rs
@@ -186,6 +186,22 @@ struct State {
     /// held out of the live tables so the rest of the registry still works, and
     /// written back verbatim so the approval survives the outage.
     unavailable: Vec<UnavailableRoot>,
+    /// Subject/folder pairs whose access the user has already settled once.
+    ///
+    /// Revocation deletes rows, so the grant table cannot tell "narrowed to
+    /// nothing" apart from "never granted" — and every other trace is keyed on
+    /// the wrong entity. Attachments are per conversation while grants are per
+    /// subject, so a chat's own attachment cannot answer for a project subject
+    /// its siblings share, and detaching removes even that. This is the one
+    /// record kept on the same key the grants use, and it only ever answers
+    /// one question: has this subject been given this folder's default access
+    /// before? Once it has, access is the user's to widen through the
+    /// permission dialog, never something an arrival re-mints.
+    ///
+    /// It is dropped when the folder's registration is revoked or the
+    /// conversation subject is purged — the points where the position itself
+    /// stops existing.
+    settled: HashSet<(GrantSubject, RootId)>,
 }
 
 /// A registration that is dormant for the lifetime of this process.
@@ -917,6 +933,11 @@ impl Controller {
                     next.roots.insert(prepared.root_id, prepared.root);
                     next.grants.extend(prepared.grants);
                     next.attachments.push(prepared.attachment);
+                    // A first registration is the first mint for this subject,
+                    // so it settles the position too. Without this, revoking
+                    // the whole folder and picking it again would count as a
+                    // first arrival and hand the access back.
+                    next.settled.insert((fingerprint.subject, prepared.root_id));
                     Ok(result)
                 }
             }
@@ -1185,6 +1206,9 @@ impl Controller {
                 .retain(|grant| !scope_targets_root(grant.scope(), request.root_id));
             next.attachments
                 .retain(|attachment| attachment.root_id() != request.root_id);
+            // The approval itself is gone, so there is no position left to
+            // remember. Picking this folder again is a first arrival.
+            next.settled.retain(|(_, root)| *root != request.root_id);
         }
         let result = Ok(RevokeRootResult { revoked });
         complete_revoke(&mut next, operation_id, fingerprint, result.clone())
@@ -1244,6 +1268,10 @@ impl Controller {
         let before = next.grants.len();
         next.grants.retain(|grant| grant.subject() != subject);
         changed |= next.grants.len() != before;
+        // The conversation subject is gone with the chat, so its settled
+        // positions go too. A project subject the chat happened to use is not
+        // this subject and keeps its own.
+        next.settled.retain(|(settled, _)| *settled != subject);
 
         let before = next.attachments.len();
         next.attachments
@@ -1287,6 +1315,7 @@ impl Controller {
                     .retain(|grant| !scope_targets_root(grant.scope(), root_id));
                 next.attachments
                     .retain(|attachment| attachment.root_id() != root_id);
+                next.settled.retain(|(_, settled)| *settled != root_id);
             }
         }
 
@@ -2385,6 +2414,14 @@ fn apply_root_attachment(
             // folder this chat already has — must leave authority exactly as it
             // is. Minting here is what let a redundant attach undo a
             // revocation.
+            //
+            // A genuinely new attachment still only mints for a subject that
+            // has never held this folder. This check is keyed on the
+            // conversation and the grants it guards are keyed on the subject,
+            // and for a project chat those are different entities — a sibling
+            // chat's first attach passes here while pointing at a position its
+            // neighbour already narrowed. `ensure_default_subject_grants` is
+            // where the subject's own history is consulted.
             if has_root_attachment(state, request.conversation_id, request.root_id) {
                 false
             } else {
@@ -2407,11 +2444,12 @@ fn apply_root_attachment(
             if request.consent_method.is_some() {
                 return Err(BrokerError::InvalidConsentMethod);
             }
-            if state.roots.contains_key(&request.root_id)
-                && !subject_has_root_grant(state, request.subject, request.root_id)
-            {
-                return Err(BrokerError::Denied);
-            }
+            // Disconnecting a folder is not an exercise of access to it, so it
+            // must not require any. Requiring read here meant that narrowing a
+            // folder to nothing also took away the only way to get rid of it:
+            // the folder stayed attached, allowed nothing, and refused to go.
+            // Detach only ever removes this conversation's own attachment rows,
+            // which is why nothing is being protected by asking.
             let before = state.attachments.len();
             state.attachments.retain(|attachment| {
                 attachment.conversation_id() != request.conversation_id
@@ -2552,7 +2590,7 @@ fn subject_has_any_root_grant(state: &State, subject: GrantSubject, root_id: Roo
         .any(|grant| grant.subject() == subject && scope_targets_root(grant.scope(), root_id))
 }
 
-/// Give a subject the folder's default access, but only if it has none.
+/// Give a subject the folder's default access, but only if it has never had it.
 ///
 /// Registration mints read, write and exec together because choosing a folder
 /// in the picker is how the user says the agent may work in it. The same set
@@ -2560,15 +2598,19 @@ fn subject_has_any_root_grant(state: &State, subject: GrantSubject, root_id: Roo
 /// a re-pick, so a chat that connects a folder can use it the way the product
 /// says it can.
 ///
-/// It is not right afterwards. Once the subject holds any statement over the
-/// root, that set is the user's position — possibly narrowed on the folders
-/// panel — and widening it is a consent decision, which belongs to
+/// It is not right afterwards, and "afterwards" cannot be read off the grant
+/// table: revoking deletes rows, so a subject narrowed to nothing looks exactly
+/// like a subject that never had anything. Neither can it be read off the
+/// conversation, because grants are keyed on the subject and attachments are
+/// keyed on the conversation — for a project subject those are different
+/// entities, and a sibling chat connecting the folder used to re-mint the
+/// access its neighbour had just revoked. `State::settled` is the record kept
+/// on the grant's own key, and it is what makes this once-only: after the first
+/// mint, widening is a consent decision belonging to
 /// [`Controller::grant_root_capability`] and its permission dialog.
 ///
-/// Both callers gate this on the folder actually arriving in the conversation,
-/// so an emptied position cannot be refilled by repeating an action against a
-/// folder the chat already has. This check is the second half of that rule, for
-/// the position a subject carries across its other conversations.
+/// A surviving grant still counts on its own, so an install that predates the
+/// record is not re-minted for folders it can currently reach.
 fn ensure_default_subject_grants(
     state: &mut State,
     subject: GrantSubject,
@@ -2576,7 +2618,10 @@ fn ensure_default_subject_grants(
     consent: ConsentRecord,
     execute_commands: bool,
 ) -> Result<(), BrokerError> {
-    if subject_has_any_root_grant(state, subject, root_id) {
+    let settled = state.settled.contains(&(subject, root_id))
+        || subject_has_any_root_grant(state, subject, root_id);
+    state.settled.insert((subject, root_id));
+    if settled {
         return Ok(());
     }
     ensure_subject_grants(state, subject, root_id, consent, execute_commands)

--- a/crates/openwave-host-broker/src/broker.rs
+++ b/crates/openwave-host-broker/src/broker.rs
@@ -7,7 +7,7 @@
 //! operations that were already in flight.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, VecDeque},
     io::{self, Read, Write},
     path::{Path, PathBuf},
     sync::{
@@ -176,6 +176,11 @@ struct State {
     grants: Vec<Grant>,
     attachments: Vec<RootAttachment>,
     mutations: HashMap<OperationId, MutationRecord>,
+    /// Completed attachment and write records in the order they finished,
+    /// oldest first. This is what makes the mutation table bounded: it names
+    /// which records may be dropped, and which of them is the least useful one
+    /// to drop next. See [`prune_mutation_receipts`].
+    receipt_order: VecDeque<OperationId>,
     active_mutations: HashSet<OperationId>,
     /// Persisted roots whose directory could not be reopened at load. They are
     /// held out of the live tables so the rest of the registry still works, and
@@ -874,7 +879,7 @@ impl Controller {
             Ok(prepared) => {
                 let existing = preferred_root_alias(&next, &prepared.root);
                 if let Some((root_id, display_name)) = existing {
-                    ensure_subject_grants(
+                    ensure_default_subject_grants(
                         &mut next,
                         prepared.root.owner,
                         root_id,
@@ -1903,6 +1908,71 @@ fn registration_is_connected(
         })
 }
 
+/// How many completed attachment and write records the broker keeps.
+///
+/// A record earns its place for exactly two readers: a client retrying the
+/// same operation identity with the same content, and a client asking for that
+/// operation's receipt after a crash or a dropped connection. Both are
+/// recovery paths that run within one attempt of the request — the desktop
+/// reconciler and the CLI look the receipt up immediately, or on the next
+/// launch — so nothing consults a record after thousands of later mutations
+/// have gone through. Kept unbounded, the same records are the one part of the
+/// state file that grows with use rather than with what the user has approved,
+/// until it crosses [`state_file::MAX_STATE_FILE_BYTES`] and the broker can
+/// neither save consent nor start.
+///
+/// The bound is a count rather than an age because nothing in a record says
+/// when it was written, and inventing a clock for it would put the retention
+/// of consent receipts at the mercy of the host's wall clock. Two thousand
+/// records is far more than any recovery window needs and roughly two megabytes
+/// at the largest record shape, which leaves the 16 MiB ceiling to the state it
+/// exists for: approved folders, their grants, and their attachments.
+const MAX_RETAINED_MUTATION_RECEIPTS: usize = 2048;
+
+/// Records that may be dropped once they are old enough.
+///
+/// Registration and revocation records stay: the loader reads them against
+/// each other — a registration receipt for a folder that is gone has to find
+/// the revocation that removed it — so dropping one could make the state file
+/// unloadable. They also accrue at the pace of a person choosing folders,
+/// which is not the growth this bound exists for. Attachment and write records
+/// are each validated on their own terms and are the two that a working
+/// session produces continuously.
+fn is_prunable_receipt(record: &MutationRecord) -> bool {
+    matches!(
+        record,
+        MutationRecord::Attachment {
+            outcome: MutationOutcome::Complete(_),
+            ..
+        } | MutationRecord::Write {
+            outcome: MutationOutcome::Complete(_),
+            ..
+        }
+    )
+}
+
+/// Drop the oldest completed receipts until the retained set is within bounds.
+fn prune_mutation_receipts(
+    mutations: &mut HashMap<OperationId, MutationRecord>,
+    order: &mut VecDeque<OperationId>,
+) {
+    while order.len() > MAX_RETAINED_MUTATION_RECEIPTS {
+        let Some(operation_id) = order.pop_front() else {
+            break;
+        };
+        mutations.remove(&operation_id);
+    }
+}
+
+/// Enrol a just-completed record in the bounded retention set.
+///
+/// Only ever called once per operation identity, from the `Pending` to
+/// `Complete` transition, so an identity cannot appear twice in the queue.
+fn retain_mutation_receipt(state: &mut State, operation_id: OperationId) {
+    state.receipt_order.push_back(operation_id);
+    prune_mutation_receipts(&mut state.mutations, &mut state.receipt_order);
+}
+
 fn claim_register(
     state: &mut State,
     operation_id: OperationId,
@@ -2063,6 +2133,7 @@ fn complete_attachment(
         {
             *outcome = MutationOutcome::Complete(result);
             state.active_mutations.remove(&operation_id);
+            retain_mutation_receipt(state, operation_id);
             Ok(())
         }
         _ => Err(BrokerError::OperationIdConflict),
@@ -2122,6 +2193,7 @@ fn complete_write(
         }) if existing == request && matches!(outcome, MutationOutcome::Pending) => {
             *outcome = MutationOutcome::Complete(result);
             state.active_mutations.remove(&operation_id);
+            retain_mutation_receipt(state, operation_id);
             Ok(())
         }
         _ => Err(BrokerError::OperationIdConflict),
@@ -2299,17 +2371,22 @@ fn apply_root_attachment(
             if matches!(method, ConsentMethod::CarriedForward) {
                 return Err(BrokerError::InvalidConsentMethod);
             }
-            let consent = ConsentRecord::new(method, Utc::now());
-            ensure_subject_grants(
-                state,
-                request.subject,
-                request.root_id,
-                consent,
-                execute_commands,
-            )?;
+            // An attachment that already stands is not a consent interaction:
+            // re-running it — a retry, a reconciler pass, a second dialog for a
+            // folder this chat already has — must leave authority exactly as it
+            // is. Minting here is what let a redundant attach undo a
+            // revocation.
             if has_root_attachment(state, request.conversation_id, request.root_id) {
                 false
             } else {
+                let consent = ConsentRecord::new(method, Utc::now());
+                ensure_default_subject_grants(
+                    state,
+                    request.subject,
+                    request.root_id,
+                    consent,
+                    execute_commands,
+                )?;
                 state.attachments.push(RootAttachment::new(
                     request.conversation_id,
                     request.root_id,
@@ -2448,6 +2525,47 @@ fn remove_grant_statement(
         }
     }
     true
+}
+
+/// Does this subject already hold any standing authority over this folder?
+///
+/// Any statement scoped to the root counts, whatever the capability. The
+/// question this answers is not "can it read" but "has the user already
+/// settled what this subject may do here" — and the answer has to be
+/// conservative, because a withdrawn grant leaves no trace: `revoke_grant`
+/// removes the row, so "revoked write" and "never had write" are the same
+/// state. Treating any surviving statement as a settled position is the only
+/// reading that cannot silently restore what the user took away.
+fn subject_has_any_root_grant(state: &State, subject: GrantSubject, root_id: RootId) -> bool {
+    state
+        .grants
+        .iter()
+        .any(|grant| grant.subject() == subject && scope_targets_root(grant.scope(), root_id))
+}
+
+/// Give a subject the folder's default access, but only if it has none.
+///
+/// Registration mints read, write and exec together because choosing a folder
+/// in the picker is how the user says the agent may work in it. The same set
+/// is right the first time a folder reaches a subject through an attachment or
+/// a re-pick, so a chat that connects a folder can use it the way the product
+/// says it can.
+///
+/// It is not right afterwards. Once the subject holds any statement over the
+/// root, that set is the user's position — possibly narrowed on the folders
+/// panel — and widening it is a consent decision, which belongs to
+/// [`Controller::grant_root_capability`] and its permission dialog.
+fn ensure_default_subject_grants(
+    state: &mut State,
+    subject: GrantSubject,
+    root_id: RootId,
+    consent: ConsentRecord,
+    execute_commands: bool,
+) -> Result<(), BrokerError> {
+    if subject_has_any_root_grant(state, subject, root_id) {
+        return Ok(());
+    }
+    ensure_subject_grants(state, subject, root_id, consent, execute_commands)
 }
 
 fn ensure_subject_grants(

--- a/crates/openwave-host-broker/src/broker/state_file.rs
+++ b/crates/openwave-host-broker/src/broker/state_file.rs
@@ -22,7 +22,7 @@ use crate::{
     GrantSubject, OperationId, RootAttachment, RootId, RootPolicy, Scope, UnavailableRootReason,
 };
 
-const STATE_VERSION: u32 = 4;
+const STATE_VERSION: u32 = 5;
 const STATE_FILE_NAME: &str = "host-broker-state.json";
 pub(super) const MAX_STATE_FILE_BYTES: usize = 16 * 1024 * 1024;
 
@@ -44,6 +44,19 @@ struct PersistedState {
     grants: Vec<Grant>,
     attachments: Vec<RootAttachment>,
     mutations: Vec<PersistedMutation>,
+    /// Folder positions this install has already settled. Absent in files
+    /// written before version 5, where it is recovered from the grants that
+    /// survive — see [`StateFile::load`].
+    #[serde(default)]
+    settled: Vec<PersistedSettledRoot>,
+}
+
+/// One subject's settled position on one folder. See `State::settled`.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PersistedSettledRoot {
+    subject: GrantSubject,
+    root_id: RootId,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -161,6 +174,31 @@ impl StateFile {
             grants.retain(|grant| grant.capability() != Capability::ExecuteCommands);
         }
         let mut attachments = persisted.attachments;
+        // A folder a subject can still reach is a folder that subject has
+        // already been granted, so a file written before this record existed
+        // recovers everything except the positions already narrowed to
+        // nothing. Those few re-mint once on the next arrival and are settled
+        // from then on; inventing a settled position for a subject that never
+        // had one would be the worse error, because it leaves a folder that
+        // can only be opened through the permission dialog.
+        let mut settled: HashSet<(GrantSubject, RootId)> = grants
+            .iter()
+            .filter_map(|grant| match grant.scope() {
+                Scope::Root { root_id } | Scope::PathSubtree { root_id, .. } => {
+                    Some((grant.subject(), *root_id))
+                }
+                Scope::Subject => None,
+            })
+            .collect();
+        settled.extend(
+            persisted
+                .settled
+                .into_iter()
+                .map(|item| (item.subject, item.root_id)),
+        );
+        settled.retain(|(_, root_id)| {
+            roots.contains_key(root_id) || unavailable.iter().any(|root| root.id == *root_id)
+        });
         for root in &mut unavailable {
             let root_id = root.id;
             root.grants = take_matching(&mut grants, |grant| {
@@ -208,6 +246,7 @@ impl StateFile {
             receipt_order,
             active_mutations: Default::default(),
             unavailable,
+            settled,
         };
         validate_loaded_state(&state)?;
         Ok(state)
@@ -290,6 +329,14 @@ impl StateFile {
             grants,
             attachments,
             mutations,
+            settled: state
+                .settled
+                .iter()
+                .map(|(subject, root_id)| PersistedSettledRoot {
+                    subject: *subject,
+                    root_id: *root_id,
+                })
+                .collect(),
         };
         let bytes = serde_json::to_vec_pretty(&persisted).map_err(invalid_data)?;
         if bytes.len() > MAX_STATE_FILE_BYTES {
@@ -426,6 +473,16 @@ fn carry_forward_exec_grants(grants: &mut Vec<Grant>) -> Result<(), BrokerError>
     Ok(())
 }
 
+/// Refuse a state file whose tables disagree with each other.
+///
+/// Three of these rules used a surviving grant as the evidence that a root, an
+/// attachment or a registration receipt was genuine. That was only ever a
+/// stand-in: revoking deletes rows, so a user who narrowed a folder all the way
+/// down on the permissions panel wrote a file the next start refused to load,
+/// and the broker came up with no folders at all. The settled record is the
+/// evidence that was missing — it says the position existed and was answered —
+/// so each of those rules now accepts either. A row backed by neither, which is
+/// what an invented attachment or root looks like, is still refused.
 pub(super) fn validate_loaded_state(state: &State) -> Result<(), BrokerError> {
     for grant in &state.grants {
         let root_id = match grant.scope() {
@@ -453,7 +510,24 @@ pub(super) fn validate_loaded_state(state: &State) -> Result<(), BrokerError> {
                 }
             }
         });
-        if !has_matching_grant {
+        // An attachment says where a folder may be used; it authorizes
+        // nothing on its own. A folder narrowed all the way down keeps its
+        // attachment and loses every grant, and rejecting that state made the
+        // broker refuse to start for a user who had only used the permissions
+        // panel as documented. The settled record answers for exactly that
+        // case, so a row with neither a grant nor a settled position — which
+        // is what a hand-edited file adding an attachment looks like — is
+        // still refused.
+        let has_settled_position = state.settled.iter().any(|(subject, root_id)| {
+            *root_id == attachment.root_id()
+                && match subject.kind() {
+                    crate::SubjectKind::Project => true,
+                    crate::SubjectKind::Conversation => {
+                        subject.id() == attachment.conversation_id()
+                    }
+                }
+        });
+        if !has_matching_grant && !has_settled_position {
             return Err(invalid_data("attachment has no matching subject grant").into());
         }
         if !attachment_identities.insert((attachment.conversation_id(), attachment.root_id())) {
@@ -472,7 +546,7 @@ pub(super) fn validate_loaded_state(state: &State) -> Result<(), BrokerError> {
                         } if granted == root_id
                 )
         });
-        if !has_grant {
+        if !has_grant && !state.settled.contains(&(root.owner, *root_id)) {
             return Err(invalid_data("persisted root is missing its grant").into());
         }
     }
@@ -491,7 +565,9 @@ pub(super) fn validate_loaded_state(state: &State) -> Result<(), BrokerError> {
                                     | Scope::PathSubtree { root_id, .. }
                                     if *root_id == result.root.root_id
                             )
-                    });
+                    }) || state
+                        .settled
+                        .contains(&(request.subject, result.root.root_id));
                     if root.display_name != result.root.display_name || !subject_has_grant {
                         return Err(invalid_data(
                             "successful register receipt does not match authoritative state",

--- a/crates/openwave-host-broker/src/broker/state_file.rs
+++ b/crates/openwave-host-broker/src/broker/state_file.rs
@@ -176,7 +176,12 @@ impl StateFile {
         for item in persisted.mutations {
             // Completed attachment and write records are written after
             // everything else, oldest first, so file order is the retention
-            // order this rebuilds. See `prune_mutation_receipts`.
+            // order this rebuilds. A file written before the bound existed
+            // sorted every record by operation identity instead, so the order
+            // recovered from it is arbitrary and the first trim after an
+            // upgrade evicts an arbitrary record rather than the oldest one.
+            // Every save from then on writes the real order.
+            // See `prune_mutation_receipts`.
             if super::is_prunable_receipt(&item.record) {
                 receipt_order.push_back(item.operation_id);
             }
@@ -185,8 +190,10 @@ impl StateFile {
             }
         }
         // A state file written before the bound existed can carry more history
-        // than the bound allows. Trimming it here is what lets such an install
-        // shrink back under the ceiling instead of climbing towards it.
+        // than the bound allows. Trimming it here brings such an install back
+        // down instead of letting it climb towards the ceiling — but only while
+        // it is still under it: the size check above runs before parsing, so a
+        // file that already crossed the cap is refused before this can help.
         super::prune_mutation_receipts(&mut mutations, &mut receipt_order);
         // Version 2 predates write grants. Its read grants migrate as they
         // stand: widening them would hand out authority the user never

--- a/crates/openwave-host-broker/src/broker/state_file.rs
+++ b/crates/openwave-host-broker/src/broker/state_file.rs
@@ -1,7 +1,7 @@
 //! Durable broker registry and mutation receipts.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, VecDeque},
     fs::{self, File, OpenOptions, TryLockError},
     io::{self, Read, Write},
     path::{Path, PathBuf},
@@ -172,11 +172,22 @@ impl StateFile {
         }
 
         let mut mutations = HashMap::new();
+        let mut receipt_order = VecDeque::new();
         for item in persisted.mutations {
+            // Completed attachment and write records are written after
+            // everything else, oldest first, so file order is the retention
+            // order this rebuilds. See `prune_mutation_receipts`.
+            if super::is_prunable_receipt(&item.record) {
+                receipt_order.push_back(item.operation_id);
+            }
             if mutations.insert(item.operation_id, item.record).is_some() {
                 return Err(invalid_data("duplicate persisted operation identity").into());
             }
         }
+        // A state file written before the bound existed can carry more history
+        // than the bound allows. Trimming it here is what lets such an install
+        // shrink back under the ceiling instead of climbing towards it.
+        super::prune_mutation_receipts(&mut mutations, &mut receipt_order);
         // Version 2 predates write grants. Its read grants migrate as they
         // stand: widening them would hand out authority the user never
         // approved, and the only consent record available to attach to such a
@@ -187,6 +198,7 @@ impl StateFile {
             grants,
             attachments,
             mutations,
+            receipt_order,
             active_mutations: Default::default(),
             unavailable,
         };
@@ -228,15 +240,29 @@ impl StateFile {
             identity: root.identity,
         }));
         roots.sort_by_key(|root| root.id.to_string());
+        // Records the retention bound may drop are written last, oldest first,
+        // so a reload recovers which of them is next to go. Everything else
+        // keeps the deterministic identity order it has always had.
+        let retained = state.receipt_order.iter().copied().collect::<HashSet<_>>();
         let mut mutations = state
             .mutations
             .iter()
+            .filter(|(operation_id, _)| !retained.contains(operation_id))
             .map(|(operation_id, record)| PersistedMutation {
                 operation_id: *operation_id,
                 record: record.clone(),
             })
             .collect::<Vec<_>>();
         mutations.sort_by_key(|item| item.operation_id.to_string());
+        mutations.extend(state.receipt_order.iter().filter_map(|operation_id| {
+            state
+                .mutations
+                .get(operation_id)
+                .map(|record| PersistedMutation {
+                    operation_id: *operation_id,
+                    record: record.clone(),
+                })
+        }));
         let mut grants = state.grants.clone();
         grants.extend(
             state

--- a/crates/openwave-host-broker/src/broker/state_file.rs
+++ b/crates/openwave-host-broker/src/broker/state_file.rs
@@ -45,8 +45,9 @@ struct PersistedState {
     attachments: Vec<RootAttachment>,
     mutations: Vec<PersistedMutation>,
     /// Folder positions this install has already settled. Absent in files
-    /// written before version 5, where it is recovered from the grants that
-    /// survive — see [`StateFile::load`].
+    /// written before version 5, where it is reconstructed from the grants,
+    /// attachments, and registration owners that survive — see
+    /// [`StateFile::load`].
     #[serde(default)]
     settled: Vec<PersistedSettledRoot>,
 }
@@ -192,25 +193,35 @@ impl StateFile {
         // position is recovered from the registration owner instead. A position
         // none of the three reaches re-mints once on its next arrival and is
         // settled from then on.
-        let mut settled: HashSet<(GrantSubject, RootId)> = grants
-            .iter()
-            .filter_map(|grant| match grant.scope() {
+        //
+        // All three are inferences, and they only apply to a file that predates
+        // the record. A file that carries the record has already said which
+        // positions are settled, and inferring more on top of it would write
+        // back positions the live code never settles — an attachment's own
+        // conversation subject, where the grants sit on the project — turning a
+        // one-time migration into a permanent rewrite. It would also stand in
+        // for the evidence the validation rules below look for, so a row with
+        // neither a grant nor a recorded position would satisfy them by
+        // construction.
+        let mut settled: HashSet<(GrantSubject, RootId)> = HashSet::new();
+        if persisted.version < STATE_VERSION {
+            settled.extend(grants.iter().filter_map(|grant| match grant.scope() {
                 Scope::Root { root_id } | Scope::PathSubtree { root_id, .. } => {
                     Some((grant.subject(), *root_id))
                 }
                 Scope::Subject => None,
-            })
-            .collect();
-        for attachment in &attachments {
-            if let Ok(subject) = GrantSubject::conversation(attachment.conversation_id()) {
-                settled.insert((subject, attachment.root_id()));
+            }));
+            for attachment in &attachments {
+                if let Ok(subject) = GrantSubject::conversation(attachment.conversation_id()) {
+                    settled.insert((subject, attachment.root_id()));
+                }
             }
-        }
-        for (root_id, root) in &roots {
-            settled.insert((root.owner, *root_id));
-        }
-        for root in &unavailable {
-            settled.insert((root.owner, root.id));
+            for (root_id, root) in &roots {
+                settled.insert((root.owner, *root_id));
+            }
+            for root in &unavailable {
+                settled.insert((root.owner, root.id));
+            }
         }
         settled.extend(
             persisted

--- a/crates/openwave-host-broker/src/broker/state_file.rs
+++ b/crates/openwave-host-broker/src/broker/state_file.rs
@@ -129,7 +129,11 @@ impl StateFile {
             return Err(BrokerError::StateTooLarge);
         }
         let persisted: PersistedState = serde_json::from_slice(&bytes).map_err(invalid_data)?;
-        if !matches!(persisted.version, 2 | 3 | STATE_VERSION) {
+        // Accepted versions widen; they never shift. Dropping the version an
+        // install actually has on disk refuses its file, and a refused file is
+        // a broker that will not start — every folder gone, for everyone, on
+        // upgrade. Add the new version, keep the old ones, and migrate below.
+        if !matches!(persisted.version, 2 | 3 | 4 | STATE_VERSION) {
             return Err(invalid_data(format!(
                 "unsupported broker state version {}",
                 persisted.version
@@ -174,13 +178,20 @@ impl StateFile {
             grants.retain(|grant| grant.capability() != Capability::ExecuteCommands);
         }
         let mut attachments = persisted.attachments;
-        // A folder a subject can still reach is a folder that subject has
-        // already been granted, so a file written before this record existed
-        // recovers everything except the positions already narrowed to
-        // nothing. Those few re-mint once on the next arrival and are settled
-        // from then on; inventing a settled position for a subject that never
-        // had one would be the worse error, because it leaves a folder that
-        // can only be opened through the permission dialog.
+        // A file written before this record existed has to have it
+        // reconstructed, and the reconstruction has to accept the same
+        // evidence the validation rules accept — otherwise the loader refuses a
+        // file it wrote itself. Three sources say a position existed and was
+        // answered: a grant the subject still holds, a folder still attached to
+        // a conversation, and a registration still owned by its subject. The
+        // grants alone are not enough, because the install this record exists
+        // for is exactly the one whose grants are gone.
+        //
+        // An attachment names a conversation rather than a subject, so it can
+        // only settle that conversation's own subject; a project chat's
+        // position is recovered from the registration owner instead. A position
+        // none of the three reaches re-mints once on its next arrival and is
+        // settled from then on.
         let mut settled: HashSet<(GrantSubject, RootId)> = grants
             .iter()
             .filter_map(|grant| match grant.scope() {
@@ -190,6 +201,17 @@ impl StateFile {
                 Scope::Subject => None,
             })
             .collect();
+        for attachment in &attachments {
+            if let Ok(subject) = GrantSubject::conversation(attachment.conversation_id()) {
+                settled.insert((subject, attachment.root_id()));
+            }
+        }
+        for (root_id, root) in &roots {
+            settled.insert((root.owner, *root_id));
+        }
+        for root in &unavailable {
+            settled.insert((root.owner, root.id));
+        }
         settled.extend(
             persisted
                 .settled

--- a/crates/openwave-host-broker/src/broker/tests.rs
+++ b/crates/openwave-host-broker/src/broker/tests.rs
@@ -605,6 +605,89 @@ fn granting_write_to_an_attached_root_requires_fresh_dialog_consent() {
     );
 }
 
+/// Read is the capability whose revocation had no way back. It takes exec
+/// with it and it hides the folder from the listing the panels read, so once
+/// it was gone there was nothing left on screen to widen. The permission-
+/// dialog widening covers it like any other capability: it restores exactly
+/// read, leaves the exec reach that was cascaded away withdrawn, and a retry
+/// mints nothing.
+#[test]
+fn granting_read_back_restores_an_attached_folder_without_its_exec_reach() {
+    let (_temp, broker, path) = setup();
+    let controller = broker.controller();
+    let conversation = Uuid::new_v4();
+    let subject = GrantSubject::conversation(conversation).unwrap();
+    let root_id = register(&controller, subject, conversation, path, OperationId::new())
+        .root
+        .root_id;
+    let context = ExecutionContext::standalone(conversation).unwrap();
+    let listed = || {
+        let OperationResult::ListRoots { roots } =
+            operate(&broker.operator(), context, OperationRequest::ListRoots).unwrap()
+        else {
+            panic!("unexpected operation result")
+        };
+        roots
+    };
+    let grant_read = || {
+        unwrap_response(controller.handle(ControlEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: crate::RequestId::new(),
+            request: ControlRequest::GrantRootCapability(GrantRootCapabilityRequest {
+                subject,
+                conversation_id: conversation,
+                root_id,
+                capability: Capability::ReadFiles,
+                consent_method: ConsentMethod::PermissionDialog,
+            }),
+        }))
+    };
+
+    let read_id = grant_statements(&controller)
+        .into_iter()
+        .find(|grant| grant.capability == Capability::ReadFiles)
+        .unwrap()
+        .grant_id;
+    assert!(revoke_grant(&controller, subject, read_id));
+    // Gone from the agent listing entirely, exec included: the folder is still
+    // attached, it just allows nothing the agent can act on.
+    assert!(listed().is_empty());
+
+    assert_eq!(
+        grant_read().unwrap(),
+        ControlResult::GrantRootCapability(GrantRootCapabilityResult { granted: true })
+    );
+    let restored = listed();
+    assert_eq!(restored.len(), 1);
+    assert!(restored[0].capabilities.contains(&Capability::ReadFiles));
+    assert!(
+        !restored[0]
+            .capabilities
+            .contains(&Capability::ExecuteCommands),
+        "restoring read must not resurrect the exec reach revoking it withdrew"
+    );
+
+    // Idempotent, and it disturbs nothing else the subject holds here.
+    assert_eq!(
+        grant_read().unwrap(),
+        ControlResult::GrantRootCapability(GrantRootCapabilityResult { granted: false })
+    );
+    let mut held = grant_statements(&controller)
+        .into_iter()
+        .filter(|grant| {
+            grant.subject == subject
+                && matches!(grant.scope, Scope::Root { root_id: granted } if granted == root_id)
+        })
+        .map(|grant| grant.capability)
+        .collect::<Vec<_>>();
+    held.sort_by_key(|capability| format!("{capability:?}"));
+    assert_eq!(
+        held,
+        vec![Capability::ReadFiles, Capability::WriteFiles],
+        "the write grant the user never touched has to survive untouched"
+    );
+}
+
 #[test]
 fn an_empty_conversation_lists_no_roots_without_needing_a_grant() {
     let (_temp, broker, _path) = setup();

--- a/crates/openwave-host-broker/src/broker/tests.rs
+++ b/crates/openwave-host-broker/src/broker/tests.rs
@@ -3868,3 +3868,194 @@ fn purge_conversation_subject_forgets_deleted_chat_authority() {
         ControlResult::PurgeConversationSubject(PurgeConversationSubjectResult { changed: false })
     );
 }
+
+/// Attaching a folder says where it may be used, not what may be done in it.
+/// A capability withdrawn on the folders panel has to survive every route back
+/// to the same folder — a redundant attach, a detach and re-attach, and
+/// choosing the same folder in the picker again — because none of those asks
+/// the user the question the revocation answered. A conversation that has
+/// never held the folder still gets what a fresh pick grants.
+#[test]
+fn attaching_a_folder_never_restores_a_revoked_capability() {
+    let (_temp, broker, path) = setup();
+    let controller = broker.controller();
+    let conversation = Uuid::new_v4();
+    let subject = GrantSubject::conversation(conversation).unwrap();
+    let root_id = register(
+        &controller,
+        subject,
+        conversation,
+        path.clone(),
+        OperationId::new(),
+    )
+    .root
+    .root_id;
+    let capabilities = |held_by: GrantSubject| {
+        let mut capabilities = grant_statements(&controller)
+            .into_iter()
+            .filter(|grant| {
+                grant.subject == held_by
+                    && matches!(grant.scope, Scope::Root { root_id: granted } if granted == root_id)
+            })
+            .map(|grant| grant.capability)
+            .collect::<Vec<_>>();
+        capabilities.sort_by_key(|capability| format!("{capability:?}"));
+        capabilities
+    };
+    let attach = |operation_id| {
+        mutate_attachment(
+            &controller,
+            operation_id,
+            subject,
+            conversation,
+            root_id,
+            RootAttachmentMutationKind::Attach,
+        )
+        .unwrap()
+    };
+
+    let write_id = grant_statements(&controller)
+        .into_iter()
+        .find(|grant| grant.capability == Capability::WriteFiles)
+        .unwrap()
+        .grant_id;
+    assert!(revoke_grant(&controller, subject, write_id));
+    let narrowed = capabilities(subject);
+    assert!(!narrowed.contains(&Capability::WriteFiles));
+
+    // A redundant attach reports no change and changes no authority.
+    assert!(!attach(OperationId::new()).changed);
+    assert_eq!(capabilities(subject), narrowed);
+
+    // Nor does taking the folder out of the chat and putting it back.
+    assert!(
+        mutate_attachment(
+            &controller,
+            OperationId::new(),
+            subject,
+            conversation,
+            root_id,
+            RootAttachmentMutationKind::Detach,
+        )
+        .unwrap()
+        .changed
+    );
+    assert!(attach(OperationId::new()).changed);
+    assert_eq!(capabilities(subject), narrowed);
+
+    // Nor does choosing the same folder in the picker again, which lands on
+    // the existing registration.
+    assert_eq!(
+        register(&controller, subject, conversation, path, OperationId::new())
+            .root
+            .root_id,
+        root_id
+    );
+    assert_eq!(capabilities(subject), narrowed);
+
+    // A conversation with no standing position on this folder is a first
+    // grant, not a widening, and still gets the access a pick describes.
+    let newcomer = Uuid::new_v4();
+    let newcomer_subject = GrantSubject::conversation(newcomer).unwrap();
+    assert!(
+        mutate_attachment(
+            &controller,
+            OperationId::new(),
+            newcomer_subject,
+            newcomer,
+            root_id,
+            RootAttachmentMutationKind::Attach,
+        )
+        .unwrap()
+        .changed
+    );
+    assert!(capabilities(newcomer_subject).contains(&Capability::WriteFiles));
+}
+
+/// Retry and receipt records are recovery state, not history: the broker keeps
+/// a bounded window of the completed ones so a long-lived install cannot grow
+/// its state file past the size that would stop it saving consent. Records the
+/// loader reads against each other — registration and revocation — are never
+/// dropped, and a record still inside the window answers a retry exactly as it
+/// did before.
+#[test]
+fn completed_receipts_are_bounded_without_breaking_retry_or_receipt_lookup() {
+    let (_temp, broker, path) = setup();
+    let controller = broker.controller();
+    let conversation = Uuid::new_v4();
+    let subject = GrantSubject::conversation(conversation).unwrap();
+    let registration = OperationId::new();
+    let root_id = register(&controller, subject, conversation, path, registration)
+        .root
+        .root_id;
+    let cycle = |operation_id, mutation| {
+        mutate_attachment(
+            &controller,
+            operation_id,
+            subject,
+            conversation,
+            root_id,
+            mutation,
+        )
+        .unwrap()
+    };
+
+    let oldest = OperationId::new();
+    cycle(oldest, RootAttachmentMutationKind::Detach);
+    let mut newest = oldest;
+    for index in 0..MAX_RETAINED_MUTATION_RECEIPTS {
+        newest = OperationId::new();
+        cycle(
+            newest,
+            if index % 2 == 0 {
+                RootAttachmentMutationKind::Detach
+            } else {
+                RootAttachmentMutationKind::Attach
+            },
+        );
+    }
+
+    let retained = broker.shared.state.lock().unwrap().mutations.len();
+    assert!(
+        retained <= MAX_RETAINED_MUTATION_RECEIPTS + 1,
+        "mutation records must stay bounded, kept {retained}"
+    );
+
+    // The oldest attachment record is gone, and its receipt says so rather
+    // than claiming an outcome the broker no longer holds.
+    let receipt = |operation_id, mutation| {
+        lookup_attachment_receipt(
+            &controller,
+            LookupRootAttachmentReceiptRequest {
+                operation_id,
+                subject,
+                conversation_id: conversation,
+                root_id,
+                mutation,
+            },
+        )
+        .unwrap()
+    };
+    assert_eq!(
+        receipt(oldest, RootAttachmentMutationKind::Detach),
+        RootAttachmentMutationReceipt::Unknown
+    );
+
+    // The newest is still answerable, and retrying it replays the recorded
+    // outcome instead of running a second mutation. The run ends attached, so
+    // the last mutation is the attach half of the cycle.
+    let mutation = RootAttachmentMutationKind::Attach;
+    assert!(matches!(
+        receipt(newest, mutation),
+        RootAttachmentMutationReceipt::Completed { .. }
+    ));
+    assert!(cycle(newest, mutation).changed);
+
+    // Registration receipts outlive any amount of later traffic.
+    assert!(matches!(
+        lookup_register_receipt(&controller, registration, subject, conversation)
+            .unwrap()
+            .receipt,
+        RegisterRootReceipt::Completed { .. }
+    ));
+}

--- a/crates/openwave-host-broker/src/broker/tests.rs
+++ b/crates/openwave-host-broker/src/broker/tests.rs
@@ -3946,12 +3946,49 @@ fn attaching_a_folder_never_restores_a_revoked_capability() {
     // Nor does choosing the same folder in the picker again, which lands on
     // the existing registration.
     assert_eq!(
-        register(&controller, subject, conversation, path, OperationId::new())
-            .root
-            .root_id,
+        register(
+            &controller,
+            subject,
+            conversation,
+            path.clone(),
+            OperationId::new()
+        )
+        .root
+        .root_id,
         root_id
     );
     assert_eq!(capabilities(subject), narrowed);
+
+    // Revoking the rest leaves no statement behind — a withdrawn grant is
+    // indistinguishable from one that never existed — so the folder still
+    // being in this chat is what has to carry the decision. Picking it again
+    // lands on the same registration and mints nothing, exec least of all.
+    let read_id = grant_statements(&controller)
+        .into_iter()
+        .find(|grant| grant.subject == subject && grant.capability == Capability::ReadFiles)
+        .unwrap()
+        .grant_id;
+    assert!(revoke_grant(&controller, subject, read_id));
+    assert!(capabilities(subject).is_empty());
+    assert_eq!(
+        register(
+            &controller,
+            subject,
+            conversation,
+            path.clone(),
+            OperationId::new()
+        )
+        .root
+        .root_id,
+        root_id
+    );
+    assert!(
+        capabilities(subject).is_empty(),
+        "re-picking an attached folder must not refill an emptied position: {:?}",
+        capabilities(subject)
+    );
+    assert!(!attach(OperationId::new()).changed);
+    assert!(capabilities(subject).is_empty());
 
     // A conversation with no standing position on this folder is a first
     // grant, not a widening, and still gets the access a pick describes.

--- a/crates/openwave-host-broker/src/broker/tests.rs
+++ b/crates/openwave-host-broker/src/broker/tests.rs
@@ -3128,6 +3128,87 @@ fn version_three_read_grants_carry_their_exec_reach_forward() {
     );
 }
 
+/// Every install on disk today wrote a version 4 file, and none of them
+/// mentions a settled position. Refusing that file is a broker that will not
+/// start and a user with no folders at all, so the accepted set has to widen
+/// rather than shift — and the record has to be recovered from what such a file
+/// does carry, including for the folder narrowed to nothing that this whole
+/// change exists for. That folder has no grant left to recover from; its
+/// attachment and its registration are the evidence, and they are the same
+/// evidence the loader's own validation accepts.
+#[test]
+fn version_four_files_load_and_recover_their_settled_positions() {
+    let (temp, broker, path, state_dir) = durable_setup();
+    let conversation = Uuid::new_v4();
+    let subject = GrantSubject::conversation(conversation).unwrap();
+    let root_id = register(
+        &broker.controller(),
+        subject,
+        conversation,
+        path,
+        OperationId::new(),
+    )
+    .root
+    .root_id;
+    drop(broker);
+
+    // Reshape the persisted file into what a version 4 install left behind.
+    let state_path = state_dir.join("host-broker-state.json");
+    let mut persisted: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&state_path).unwrap()).unwrap();
+    persisted["version"] = serde_json::json!(4);
+    persisted.as_object_mut().unwrap().remove("settled");
+    std::fs::write(&state_path, serde_json::to_vec(&persisted).unwrap()).unwrap();
+
+    // An ordinary version 4 file — the one every install has — still loads and
+    // still reaches its folder.
+    let broker = Broker::open(test_policy(&temp), &state_dir).unwrap();
+    assert!(operate(
+        &broker.operator(),
+        ExecutionContext::standalone(conversation).unwrap(),
+        OperationRequest::ReadFile(PathRequest {
+            root_id,
+            path: RelativePath::parse("note.txt").unwrap(),
+        }),
+    )
+    .is_ok());
+    drop(broker);
+
+    // Now the folder a version 4 install had revoked down to nothing: the
+    // attachment and the registration stand, every grant naming the folder is
+    // gone, and no position was ever recorded because the field did not exist.
+    let mut persisted: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&state_path).unwrap()).unwrap();
+    persisted["version"] = serde_json::json!(4);
+    persisted.as_object_mut().unwrap().remove("settled");
+    persisted["grants"] = serde_json::json!([]);
+    std::fs::write(&state_path, serde_json::to_vec(&persisted).unwrap()).unwrap();
+
+    let broker = Broker::open(test_policy(&temp), &state_dir).unwrap();
+    let controller = broker.controller();
+    assert!(
+        mutate_attachment(
+            &controller,
+            OperationId::new(),
+            subject,
+            conversation,
+            root_id,
+            RootAttachmentMutationKind::Attach,
+        )
+        .is_ok(),
+        "the folder is still approved, so attaching it is not an error"
+    );
+    assert!(
+        grant_statements(&controller)
+            .into_iter()
+            .all(|grant| !matches!(
+                grant.scope,
+                Scope::Root { root_id: granted } if granted == root_id
+            )),
+        "an upgraded install must not treat an emptied position as a first arrival"
+    );
+}
+
 #[test]
 fn binary_reads_return_bytes_that_text_reads_refuse() {
     let (_temp, broker, path, audit) = audited_setup();

--- a/crates/openwave-host-broker/src/broker/tests.rs
+++ b/crates/openwave-host-broker/src/broker/tests.rs
@@ -3210,6 +3210,39 @@ fn version_four_files_load_and_recover_their_settled_positions() {
 }
 
 #[test]
+fn a_current_version_file_is_not_reinterpreted_on_load() {
+    let (temp, broker, path, state_dir) = durable_setup();
+    let conversation = Uuid::new_v4();
+    let subject = GrantSubject::conversation(conversation).unwrap();
+    register(
+        &broker.controller(),
+        subject,
+        conversation,
+        path,
+        OperationId::new(),
+    );
+    drop(broker);
+
+    // A current-version file says for itself which positions are settled. The
+    // reconstruction that reads positions out of attachments and registrations
+    // applies only to files that predate the record; if it ran here it would
+    // stand in for the evidence the validation rules look for, and this file —
+    // an attachment with no grant behind it and no recorded position — would be
+    // accepted instead of refused.
+    let state_path = state_dir.join("host-broker-state.json");
+    let mut persisted: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&state_path).unwrap()).unwrap();
+    persisted["grants"] = serde_json::json!([]);
+    persisted["settled"] = serde_json::json!([]);
+    std::fs::write(&state_path, serde_json::to_vec(&persisted).unwrap()).unwrap();
+
+    assert!(
+        Broker::open(test_policy(&temp), &state_dir).is_err(),
+        "a current-version file must be validated as written, not reinterpreted"
+    );
+}
+
+#[test]
 fn binary_reads_return_bytes_that_text_reads_refuse() {
     let (_temp, broker, path, audit) = audited_setup();
     // A minimal PDF header followed by a byte sequence that is not valid UTF-8.

--- a/crates/openwave-host-broker/src/broker/tests.rs
+++ b/crates/openwave-host-broker/src/broker/tests.rs
@@ -2007,29 +2007,32 @@ fn a_failed_mutation_reports_the_attachment_it_could_not_change() {
     );
     let root_id = registered.root.root_id;
 
-    // The conversation itself holds no grant on this root, so detaching under
-    // that subject is denied while the attachment plainly still exists.
-    let ungranted = GrantSubject::conversation(conversation).unwrap();
+    // A detach that carries a consent method is malformed — detaching answers
+    // no question — so it is refused while the attachment plainly still exists.
+    let subject = GrantSubject::conversation(conversation).unwrap();
     let operation_id = OperationId::new();
     assert_eq!(
-        mutate_attachment(
-            &broker.controller(),
-            operation_id,
-            ungranted,
-            conversation,
-            root_id,
-            RootAttachmentMutationKind::Detach,
-        )
+        unwrap_response(broker.controller().handle(ControlEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: crate::RequestId::new(),
+            request: ControlRequest::DetachRoot(RootAttachmentMutationRequest {
+                operation_id,
+                subject,
+                conversation_id: conversation,
+                root_id,
+                consent_method: Some(ConsentMethod::PermissionDialog),
+            }),
+        }))
         .unwrap_err()
         .code,
-        ErrorCode::Denied
+        ErrorCode::InvalidRequest
     );
     assert!(matches!(
         lookup_attachment_receipt(
             &broker.controller(),
             LookupRootAttachmentReceiptRequest {
                 operation_id,
-                subject: ungranted,
+                subject,
                 conversation_id: conversation,
                 root_id,
                 mutation: RootAttachmentMutationKind::Detach,
@@ -3954,9 +3957,10 @@ fn purge_conversation_subject_forgets_deleted_chat_authority() {
 
 /// Attaching a folder says where it may be used, not what may be done in it.
 /// A capability withdrawn on the folders panel has to survive every route back
-/// to the same folder — a redundant attach, a detach and re-attach, and
-/// choosing the same folder in the picker again — because none of those asks
-/// the user the question the revocation answered. A conversation that has
+/// to the same folder — a redundant attach, a detach and re-attach, choosing
+/// the same folder in the picker again, and a sibling chat under the same
+/// project subject connecting it for the first time — because none of those
+/// asks the user the question the revocation answered. A subject that has
 /// never held the folder still gets what a fresh pick grants.
 #[test]
 fn attaching_a_folder_never_restores_a_revoked_capability() {
@@ -4073,6 +4077,30 @@ fn attaching_a_folder_never_restores_a_revoked_capability() {
     assert!(!attach(OperationId::new()).changed);
     assert!(capabilities(subject).is_empty());
 
+    // Taking the emptied folder out of the chat and putting it back is the
+    // same non-question. Disconnecting no longer needs read — a folder
+    // narrowed to nothing must still be removable — so this route is open in
+    // a way it was not when the read check stood in for the rule.
+    assert!(
+        mutate_attachment(
+            &controller,
+            OperationId::new(),
+            subject,
+            conversation,
+            root_id,
+            RootAttachmentMutationKind::Detach,
+        )
+        .unwrap()
+        .changed,
+        "a folder that allows nothing must still detach"
+    );
+    assert!(attach(OperationId::new()).changed);
+    assert!(
+        capabilities(subject).is_empty(),
+        "detaching and re-attaching must not refill an emptied position: {:?}",
+        capabilities(subject)
+    );
+
     // A conversation with no standing position on this folder is a first
     // grant, not a widening, and still gets the access a pick describes.
     let newcomer = Uuid::new_v4();
@@ -4090,6 +4118,113 @@ fn attaching_a_folder_never_restores_a_revoked_capability() {
         .changed
     );
     assert!(capabilities(newcomer_subject).contains(&Capability::WriteFiles));
+
+    // The same rule holds for a project subject, where the chat that connects
+    // the folder and the subject that holds the access are different entities.
+    // A sibling chat attaching for the first time is a first arrival for that
+    // chat and not for the project, so it must not restore what the project's
+    // other chat revoked.
+    let project = GrantSubject::project(Uuid::new_v4()).unwrap();
+    let first_chat = Uuid::new_v4();
+    let sibling_chat = Uuid::new_v4();
+    assert!(
+        mutate_attachment(
+            &controller,
+            OperationId::new(),
+            project,
+            first_chat,
+            root_id,
+            RootAttachmentMutationKind::Attach,
+        )
+        .unwrap()
+        .changed
+    );
+    assert!(capabilities(project).contains(&Capability::WriteFiles));
+    for grant_id in grant_statements(&controller)
+        .into_iter()
+        .filter(|grant| {
+            grant.subject == project
+                && matches!(grant.scope, Scope::Root { root_id: granted } if granted == root_id)
+        })
+        .map(|grant| grant.grant_id)
+        .collect::<Vec<_>>()
+    {
+        revoke_grant(&controller, project, grant_id);
+    }
+    assert!(capabilities(project).is_empty());
+    assert!(
+        mutate_attachment(
+            &controller,
+            OperationId::new(),
+            project,
+            sibling_chat,
+            root_id,
+            RootAttachmentMutationKind::Attach,
+        )
+        .unwrap()
+        .changed,
+        "the sibling chat still gets the folder, it just gets no access with it"
+    );
+    assert!(
+        capabilities(project).is_empty(),
+        "a sibling chat's attach must not restore the project's revoked access: {:?}",
+        capabilities(project)
+    );
+}
+
+/// A revoked position has to outlive the process that revoked it. The record
+/// that says "this subject has already been given this folder" is the only
+/// thing standing between an emptied folder and a re-mint, so a restart that
+/// dropped it would hand the access back on the next attach.
+#[test]
+fn an_emptied_folder_position_survives_a_restart() {
+    let (temp, broker, path, state_dir) = durable_setup();
+    let conversation = Uuid::new_v4();
+    let subject = GrantSubject::conversation(conversation).unwrap();
+    let root_id = register(
+        &broker.controller(),
+        subject,
+        conversation,
+        path,
+        OperationId::new(),
+    )
+    .root
+    .root_id;
+    for grant_id in grant_statements(&broker.controller())
+        .into_iter()
+        .filter(
+            |grant| matches!(grant.scope, Scope::Root { root_id: granted } if granted == root_id),
+        )
+        .map(|grant| grant.grant_id)
+        .collect::<Vec<_>>()
+    {
+        revoke_grant(&broker.controller(), subject, grant_id);
+    }
+    drop(broker);
+
+    let broker = Broker::open(test_policy(&temp), &state_dir).unwrap();
+    let controller = broker.controller();
+    assert!(
+        mutate_attachment(
+            &controller,
+            OperationId::new(),
+            subject,
+            conversation,
+            root_id,
+            RootAttachmentMutationKind::Attach,
+        )
+        .is_ok(),
+        "the folder is still approved, so attaching it is not an error"
+    );
+    assert!(
+        grant_statements(&controller)
+            .into_iter()
+            .all(|grant| !matches!(
+                grant.scope,
+                Scope::Root { root_id: granted } if granted == root_id
+            )),
+        "a restart must not turn an emptied position back into a first arrival"
+    );
 }
 
 /// Retry and receipt records are recovery state, not history: the broker keeps

--- a/docs/decisions/0008-settled-folder-positions.md
+++ b/docs/decisions/0008-settled-folder-positions.md
@@ -1,0 +1,150 @@
+# 8. Settled folder positions
+
+- Status: Accepted
+- Date: 2026-08-11
+- Owners: host access / broker
+- Related: [`docs/host-access.md`](../host-access.md),
+  [`0002-pre-v1-schema-and-persisted-format-mutability.md`](0002-pre-v1-schema-and-persisted-format-mutability.md)
+
+## Context
+
+The host broker is deny-by-default: an agent reaches a folder only through a
+grant the user gave. Grants are keyed on a grant subject — a project, or a
+standalone conversation. Attachments are keyed on the conversation. For a chat
+inside a project those are different entities, and every bug this record
+addresses came from code that asked one of them a question only the other could
+answer.
+
+Revoking a grant deletes the row. Nothing else records that the user was ever
+asked, so "narrowed to nothing" and "never granted" look identical from the
+state file. Arrival paths — registering a folder, attaching one to a chat —
+minted default grants when they found none, which meant they minted after a
+revocation as readily as on a first pick. Observed consequences:
+
+- A sibling chat in the same project attaching a folder restored every
+  capability its neighbour had just revoked.
+- A chat that disconnected a folder it had emptied got the full set back on
+  reconnect.
+- Detach was gated on holding read, so a user who revoked read on a connected
+  folder could neither use the folder nor remove it. That gate was also, by
+  accident, the only thing holding up the detach-then-reattach case above:
+  fixing the lockout reopened the minting hole, which is why both land together.
+
+The forces: the user's answer has to survive a revocation, and it has to be
+visible to every arrival path regardless of which key that path happens to hold.
+
+## Decision
+
+Access decisions are recorded per **position** — a `(grant subject, folder)`
+pair — independently of whether any grant currently exists for it.
+
+- A position is settled the first time the user answers for it: registering the
+  folder, or an arrival that mints defaults into it.
+- **No arrival mints into a settled position.** Registration, attachment, and
+  re-picking a folder already known are all arrivals. They may hand a chat the
+  folder; they never widen what it allows.
+- Widening is only ever the host's own permission dialog, answered explicitly.
+- Narrowing is unrestricted, and narrowing to nothing is a legitimate resting
+  state. A folder that allows nothing stays attached and stays listed, so the
+  surfaces that list it can offer both the way out (disconnect) and the way back
+  (ask for read again).
+- **Disconnecting exercises no access to the folder** and is never gated on
+  holding any capability.
+- A position is forgotten when the folder's approval is revoked or the subject
+  is purged. At that point the position no longer exists and picking the folder
+  again is a genuine first arrival.
+
+Deliberately excluded: any attempt to infer the answer from the grant table.
+The grant table cannot answer it, and this record exists because that inference
+was tried and was wrong three separate ways.
+
+### The persisted obligation this introduces
+
+The record is durable state, so the state file gains it and gains a version.
+Two rules bind every future change to that file:
+
+1. **The accepted-version set widens; it never shifts.** Adding a version must
+   not drop one an install has on disk. A refused state file is a broker that
+   does not start, which presents to the user as every folder gone — for
+   everyone, on upgrade. This is the general rule for this file, not a one-off
+   for version 5.
+2. **Older files are reconstructed, not defaulted.** An absent record must not
+   read as "nothing settled", because that is exactly the state that re-mints.
+   Versions 2 through 4 are reconstructed from the evidence they do carry: a
+   surviving grant over the folder; a surviving attachment, which settles only
+   its own conversation's subject; and the folder's registration owner, which is
+   what recovers a project chat. The reconstruction accepts exactly the evidence
+   the loaded-state validation accepts, so a file consistent under the old rules
+   stays loadable under the new ones — including the emptied folder this record
+   exists to serve, which the old validation rules refused outright.
+
+## Alternatives Considered
+
+**Keep the grant row as a tombstone with no capabilities, instead of deleting
+it.** This is the alternative a reviewer reaches for first, and it is genuinely
+attractive: no new structure, no new version, and revocation stops destroying
+information at the point where the information is lost. It was rejected on
+blast radius. `state.grants` is read by authorization, by the listing surfaces,
+by loaded-state validation, and by the product projection the desktop renders;
+a tombstone changes the meaning of "there is a grant" for every one of them at
+once. Each site must then be audited to skip empty rows, and every site missed
+fails open in a different direction — a listing that renders a tombstone shows
+the user access they do not have, and an authorization path that counts one is a
+capability leak. A separate structure that only the arrival paths consult cannot
+fail that way: code that does not read it behaves exactly as it did before.
+The tombstone also has to answer what an empty row means when the folder's
+approval is revoked outright, which is the case where the position genuinely
+should be forgotten.
+
+**Put the grant subject on the attachment and compare it on arrival.** Fixes the
+sibling-project case, and is cheaper. Rejected because it cannot fix the
+detach-then-reconnect case at all: after a detach there is no attachment left to
+consult, so the reconnect is indistinguishable from a first pick. Half the bug,
+in a shape that reads like the whole fix.
+
+**Do nothing and treat the mint-on-arrival behavior as intended.** Rejected:
+it makes revocation advisory. Any chat in the same project, and the same chat
+after a disconnect, silently undoes it.
+
+## Consequences
+
+- The state file is at version 5, and versions 2 through 4 carry a
+  reconstruction path that must keep working for as long as those files exist.
+  Future versions inherit both rules above.
+- Removing the detach gate means a detach request is honored for a folder the
+  requester holds nothing over. That is intended — detaching reads no bytes —
+  but it does mean detach is no longer incidentally covered by capability
+  checks, and its own tests are the only thing pinning it.
+- The settled set is per subject and folder, so it grows with folders the user
+  has answered for and shrinks only on revocation or subject purge. It is not a
+  cache and must not be pruned on size.
+- A user who narrows a folder to nothing now stays narrowed until they ask for
+  access back in the dialog. Any future surface that offers a folder to a chat
+  has to route widening through that dialog rather than through its own
+  convenience path.
+
+Revisit if grants and attachments are ever re-keyed onto a single entity. Most
+of the pressure this record absorbs comes from the two keys, and a design where
+an attachment and a grant name the same thing could carry the answer on the
+grant itself.
+
+## Validation
+
+- An arrival into an emptied position mints nothing: revoke every root-scoped
+  grant, then attach from the same chat, from a sibling chat in the same
+  project, and after a detach — each must yield the folder and no capabilities.
+  A wrong implementation that only compares the conversation key passes the
+  first and fails the sibling case; one that consults the attachment passes both
+  and fails the detach case.
+- The emptied position survives a restart: the same sequence with the broker
+  dropped and reopened between the revoke and the attach. This is the assertion
+  that fails if the record is not durable, and it is also what caught the old
+  validation rules refusing to load such a file at all.
+- A version-4 file loads. This is the check a plausible wrong implementation
+  fails on its first run and no unit test of the new behavior would catch: the
+  version gate was written as a shift, and every existing install would have
+  lost its folders on upgrade.
+- A version-4 file with an emptied folder loads *and* comes back settled —
+  loading is not enough, because a file that loads with an empty record re-mints
+  on the next attach.
+- A folder that allows nothing can still be detached.

--- a/docs/decisions/0008-settled-folder-positions.md
+++ b/docs/decisions/0008-settled-folder-positions.md
@@ -128,6 +128,14 @@ of the pressure this record absorbs comes from the two keys, and a design where
 an attachment and a grant name the same thing could carry the answer on the
 grant itself.
 
+Revisit the reconstruction path separately, and earlier. It applies only to
+files below the current version, and its inferences are deliberately looser than
+what the live code records — an attachment settles its own conversation's
+subject, which the live code never does for a chat in a project. Once version 2
+through 4 files can be assumed gone from the installed base, the whole seeding
+block is deletable, and deleting it removes the only place where a load writes
+positions nobody answered for.
+
 ## Validation
 
 - An arrival into an emptied position mints nothing: revoke every root-scoped

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -280,11 +280,13 @@ kinds bind a stable operation identity to their original request, including the
 trusted consent method for an attach, so an exact retry is idempotent and
 identity reuse with different inputs is rejected. The broker stamps new
 subject grants with that current attachment consent instead of copying another
-subject's earlier consent record. It mints those grants only for a subject that
-holds none for that root: an attachment says where a folder may be used, not
-what may be done in it, so a subject that already has a standing position keeps
-exactly that position — including one narrowed by revoking a statement — and
-widening it needs the permission-dialog capability grant. A read-only
+subject's earlier consent record. It mints those grants only when the folder is
+actually arriving in that conversation, and only for a subject that holds no
+statement over that root: attaching or re-picking a folder says where it may be
+used, not what may be done in it, so a subject that already has a standing
+position keeps exactly that position — including one narrowed by revoking a
+statement, and including one narrowed to nothing — and widening it needs the
+permission-dialog capability grant. A read-only
 attachment receipt lets a
 recovering native client distinguish unknown, completed, and failed work
 without starting or replaying the mutation. Attachment changes are computed and
@@ -527,10 +529,11 @@ This will land in independently reviewable pieces:
    validate the bounded state file and revalidate and descriptor-pin every
    persisted root before advertising it. A mutation with ambiguous publication
    fails the broker closed until restart. Completed attachment and write
-   receipts are retained in a bounded window rather than forever, so ordinary
-   use cannot grow the state file past the size the broker will save or load;
-   registration and revocation records are kept, because the loader reads them
-   against each other.
+   receipts are retained in a bounded window rather than forever, so the
+   receipts an ordinary working session produces no longer accumulate towards
+   the size the broker will save or load; registration and revocation records
+   are kept, because the loader reads them against each other, and a record
+   still awaiting its outcome is never dropped.
 4. Add bounded audit records for every machine-touching operation, including
    the exact grant that authorized an operation, de-sensitized targets, and
    local two-generation retention.

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -280,7 +280,12 @@ kinds bind a stable operation identity to their original request, including the
 trusted consent method for an attach, so an exact retry is idempotent and
 identity reuse with different inputs is rejected. The broker stamps new
 subject grants with that current attachment consent instead of copying another
-subject's earlier consent record. A read-only attachment receipt lets a
+subject's earlier consent record. It mints those grants only for a subject that
+holds none for that root: an attachment says where a folder may be used, not
+what may be done in it, so a subject that already has a standing position keeps
+exactly that position — including one narrowed by revoking a statement — and
+widening it needs the permission-dialog capability grant. A read-only
+attachment receipt lets a
 recovering native client distinguish unknown, completed, and failed work
 without starting or replaying the mutation. Attachment changes are computed and
 published in one durable state replacement, so they do not expose a recoverable
@@ -521,7 +526,11 @@ This will land in independently reviewable pieces:
    under a broker-private, exclusively owned state directory. Restart must
    validate the bounded state file and revalidate and descriptor-pin every
    persisted root before advertising it. A mutation with ambiguous publication
-   fails the broker closed until restart.
+   fails the broker closed until restart. Completed attachment and write
+   receipts are retained in a bounded window rather than forever, so ordinary
+   use cannot grow the state file past the size the broker will save or load;
+   registration and revocation records are kept, because the loader reads them
+   against each other.
 4. Add bounded audit records for every machine-touching operation, including
    the exact grant that authorized an operation, de-sensitized targets, and
    local two-generation retention.

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -280,23 +280,36 @@ kinds bind a stable operation identity to their original request, including the
 trusted consent method for an attach, so an exact retry is idempotent and
 identity reuse with different inputs is rejected. The broker stamps new
 subject grants with that current attachment consent instead of copying another
-subject's earlier consent record. It mints those grants only when the folder is
-actually arriving in that conversation, and only for a subject that holds no
-statement over that root: attaching or re-picking a folder says where it may be
-used, not what may be done in it, so a subject that already has a standing
-position keeps exactly that position — including one narrowed by revoking a
+subject's earlier consent record. It mints those grants once and only once per
+subject and folder: attaching or re-picking a folder says where it may be used,
+not what may be done in it, so a subject that has already been given a folder
+keeps exactly the position it has — including one narrowed by revoking a
 statement, and including one narrowed to nothing — and widening it needs the
 permission-dialog capability grant.
 
-That grant covers reading as well as writing and commands. Revoking read
-narrows a folder to nothing an agent can act on — it takes the folder's command
-reach with it — but the folder stays attached, so the surfaces that list it are
-what has to offer the way back. They list an attached folder by its approval
-rather than by what it currently allows, precisely so a folder narrowed to
-nothing keeps both the control that disconnects it and the one that asks for
-read again. Asking is always an explicit action answered in the host's own
-dialog; nothing restores a revoked capability as a side effect of attaching,
-re-picking, or listing.
+Once is measured against a record the broker keeps of the folder positions each
+subject has already been given, not against the grants that survive. Revocation
+deletes grant rows, so the grant table cannot tell a subject narrowed to nothing
+apart from one that never had anything, and neither can the attachment: grants
+are held by the subject while attachments are held by the conversation, and for
+a chat in a project those are different entities. Without that record a sibling
+chat in the same project connecting the folder for the first time re-minted the
+access its neighbour had just revoked, and a chat that disconnected an emptied
+folder got the full set back when it reconnected. The record is dropped when the
+folder's approval is revoked or the conversation subject is purged, because at
+that point the position itself is gone and picking the folder again is a first
+arrival.
+
+Widening covers reading as well as writing and commands. Revoking read narrows a
+folder to nothing an agent can act on — it takes the folder's command reach with
+it — but the folder stays attached, so the surfaces that list it are what has to
+offer the way back. They list an attached folder by its approval rather than by
+what it currently allows, precisely so a folder narrowed to nothing keeps both
+the control that disconnects it and the one that asks for read again.
+Disconnecting requires no access to the folder at all; a folder that allows
+nothing must still be removable. Asking for access back is always an explicit
+action answered in the host's own dialog, and nothing restores a revoked
+capability as a side effect of attaching, detaching, re-picking, or listing.
 
 A read-only attachment receipt lets a
 recovering native client distinguish unknown, completed, and failed work

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -317,6 +317,20 @@ without starting or replaying the mutation. Attachment changes are computed and
 published in one durable state replacement, so they do not expose a recoverable
 intermediate phase.
 
+The state file carries a version, and the set of versions the loader accepts
+only ever widens: adding a version never drops an older one, because refusing a
+file is a broker that will not start and an install whose folders are all gone.
+Version 5 adds the record of settled positions. Files written by versions 2
+through 4 have no such record, so the loader reconstructs it from the evidence
+those files do carry — a surviving grant over the folder, a surviving attachment
+(which can only settle its own conversation's subject), and the subject that
+registered the folder. That last one is what recovers a project chat, whose
+position is held by the registration owner rather than by any one conversation.
+Reconstruction accepts exactly the evidence the loaded-state validation accepts,
+so a file that was consistent under the old rules stays loadable under the new
+ones — including the case the record exists to serve, a folder the user narrowed
+to nothing.
+
 Legacy version-2 state may contain multiple product root IDs for one pinned
 filesystem object. Those IDs remain valid so existing product projections and
 receipts do not break. Registration selects among them deterministically, and

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -286,8 +286,19 @@ statement over that root: attaching or re-picking a folder says where it may be
 used, not what may be done in it, so a subject that already has a standing
 position keeps exactly that position — including one narrowed by revoking a
 statement, and including one narrowed to nothing — and widening it needs the
-permission-dialog capability grant. A read-only
-attachment receipt lets a
+permission-dialog capability grant.
+
+That grant covers reading as well as writing and commands. Revoking read
+narrows a folder to nothing an agent can act on — it takes the folder's command
+reach with it — but the folder stays attached, so the surfaces that list it are
+what has to offer the way back. They list an attached folder by its approval
+rather than by what it currently allows, precisely so a folder narrowed to
+nothing keeps both the control that disconnects it and the one that asks for
+read again. Asking is always an explicit action answered in the host's own
+dialog; nothing restores a revoked capability as a side effect of attaching,
+re-picking, or listing.
+
+A read-only attachment receipt lets a
 recovering native client distinguish unknown, completed, and failed work
 without starting or replaying the mutation. Attachment changes are computed and
 published in one durable state replacement, so they do not expose a recoverable


### PR DESCRIPTION
## Authority that could be silently restored

`RevokeGrant` is the folders panel's "stop allowing this here" — it removes one
statement and leaves the folder connected. The advertised way back is
`GrantRootCapability`, which refuses anything but `ConsentMethod::PermissionDialog`.

Two paths bypassed that:

- `apply_root_attachment` called `ensure_subject_grants` on every `Attach`,
  *before* checking whether the root was already attached. That helper
  re-creates `ListRoots`, `ReadFiles`, `WriteFiles` and `ExecuteCommands` for
  whichever are missing. So a user who revoked write on a connected folder got
  full read/write/exec back the next time that folder was attached to a chat —
  including a redundant attach that returns `changed: false`, which the desktop
  reconciler and the CLI both issue during recovery, and which no user reads as
  a consent decision.
- `register_root`'s existing-alias branch did the same when the user picked an
  already-registered folder in the picker, again before and independent of its
  attachment check.

## The new rule

Default grants are minted **once per subject and folder**. The broker keeps a
record of the positions a subject has already been given — `State.settled` — and
consults it wherever an arrival used to mint. Registration records the position
as it mints; attaching and re-picking mint only when the record has nothing for
that subject and folder, and neither does the surviving grant table.

- A redundant attach, or picking a folder the chat already has, mints nothing
  and only reports state.
- A subject with a settled position keeps exactly that position, including one
  narrowed to nothing. Widening goes through `GrantRootCapability` and its
  dialog.
- A folder reaching a subject that has never had it is a first grant, not a
  widening, and still mints the default set — `ListRoots`, `ReadFiles`,
  `WriteFiles`, and `ExecuteCommands` on an exec-enabled host.
- The record is dropped when the folder's approval is revoked or the
  conversation subject is purged. At that point the position is gone and picking
  the folder again is a first arrival.

### Why a record and not a check on what survives

Because revocation leaves no trace. `revoke_grant` removes the row, so the grant
table cannot tell "the user took write away" from "this subject never had
write". The first version of this change stood two conversation-keyed checks in
for that record, and both leaked:

- **A sibling chat in the same project restored everything.** Grants are keyed
  on `GrantSubject`; attachments are keyed on `conversation_id`. A chat inside a
  project uses the *project* subject, so a second chat in the same project
  attaching the folder for the first time passed the "does this conversation
  already have it" check while pointing at a position its neighbour had just
  emptied — and the first chat went from no access to full read/write/exec with
  no dialog ever naming it.
- **Detach and reconnect restored everything.** Once detaching works (below),
  removing the folder and adding it back looked like a first arrival too.

`State.settled` is the record kept on the same key the grants use, which is what
makes both cases answerable.

## Disconnecting no longer requires read

`DetachRoot` refused with `Denied` unless the subject held `ReadFiles` on the
root. Revoking read therefore took away the only way to be rid of the folder:
it stayed attached, allowed nothing, and would not go. An earlier revision of
this PR claimed detach did not depend on read — that claim was wrong, and it was
relayed upstream; this is the correction. Detaching exercises no access and only
ever removes the calling conversation's own attachment rows, so it no longer
asks for any.

That is also what reopened the detach-and-reconnect route above, which is why
the two changes are one commit: the invariant test covers both routes.

## Granting read back

Read is now a capability the folders and permissions surfaces can ask to add to
an already-attached folder, alongside write and commands, over the same
`GrantRootCapability` control request, the same native confirmation dialog, and
the same `PermissionDialog`-only consent check. Nothing grants it implicitly.

Folder identity in those surfaces comes from the trusted `ListApprovedRoots`
listing intersected with the chat's attachments, rather than from the agent's
read-gated `ListRoots` operation. A folder narrowed to nothing used to vanish
from the panel that owns disconnecting it and granting access back — the one
state in which the reader needs both.

The chat-scoped Permissions panel gains a "Revoked folder access" section for
folders in that state. The global Settings panel does not: a widening is granted
to one conversation's subject and that page has no conversation in hand.

## A state file that would not load

Three `validate_loaded_state` rules used a surviving grant as the evidence that a
root, an attachment, or a registration receipt was genuine. A folder narrowed to
nothing leaves all three with no grant to point at, so the next `Broker::open`
refused the file and the app came up with no host folder access at all. This was
reachable on `main` by using the permissions panel as documented, and is fixed
here rather than left to a follow-up, because the change above removes the
accidental self-repair — an attach used to re-mint the grants and heal the
invariant within the session, which is precisely the bug.

Each rule now accepts a settled position as the evidence it was really asking
for. A row backed by neither a grant nor a settled position — what a
hand-edited file adding an attachment looks like — is still refused.

State file version 5. A file written before it recovers its positions from the
grants that survive, so an install is fully covered except for folders it had
already narrowed to nothing; those re-mint once on the next arrival and are
settled from then on. Inventing a settled position for a subject that never had
one would be the worse error, since it leaves a folder only the dialog can open.

## Errors as toasts

Folder actions reported failures as raw `String(err)` in an inline banner. They
now go through `friendlyErrorMessage` into a sonner toast, matching the rest of
the settings surfaces. A panel that could not load still says so in place, since
that is a standing state rather than a transient failure.

## Left alone deliberately

The widening dialog says "Allow the chat *X* to read files in *Y*" while the
grant is minted against `context.subject`, which is the project subject for a
chat inside a project — so the dialog names one chat and can grant to all of
them. This is pre-existing wording that the new read variant inherits. Fixing it
needs a decision about what the dialog should say, so it is on the record here
rather than changed in passing.

## Retention bound

`State.mutations` was inserted into on every mutation and never pruned — grep
confirms only `active_mutations` was ever removed from. `commit_state` persists
it verbatim and `state_file` hard-caps the file at 16 MiB on both save and open,
so a long-lived install eventually gets `StateTooLarge`: the broker refuses
consent mutations, or fails to load at all. Every write also paid to rewrite an
ever-larger file.

Completed **attachment** and **write** records are now retained in a FIFO window
of the newest 2048; the rest of the table is untouched.

- **Why those two kinds.** They are the ones a working session produces
  continuously, and each is validated on its own terms at load. Registration and
  revocation records are read *against each other* by `validate_loaded_state` —
  a registration receipt for a folder that is gone has to find the revocation
  that removed it — so dropping one could make the state file unloadable. They
  also accrue at the pace of a person choosing folders, which is not the growth
  this is about.
- **Why a count and not an age.** No record carries a timestamp, and giving
  consent-receipt retention a dependency on the host wall clock is worse than
  the alternative.
- **Why 2048 is safe.** A record has exactly two readers: `claim_*`, replaying a
  retry of the same operation identity with the same content, and the
  `Lookup*Receipt` routes, used by the desktop reconciler and the CLI to recover
  an interrupted mutation. Both run within one attempt of the request — the same
  pass, or the next launch — never after thousands of later mutations have
  completed. 2048 records is also roughly two megabytes at the largest record
  shape, leaving the ceiling to the state it exists for.

Retention order is rebuilt from the state file's own record order — prunable
records are written last, oldest first — so nothing about the persisted schema
or its version changes. Three limits worth stating plainly: a file written
before this change sorted every record by operation identity, so the order
recovered on the first upgrade load is arbitrary and that first trim evicts an
arbitrary record rather than the oldest (every save after it writes the real
order); the 16 MiB check runs before parsing, so trimming on load helps a file
still under the cap, not one that has already crossed it; and a write record
still awaiting its outcome is never enrolled and so never evicted, leaving one
permanent record per abandoned in-flight write.

## Tests

In `broker/tests.rs`:

- `attaching_a_folder_never_restores_a_revoked_capability` — a revoked write
  survives a redundant attach, a detach and re-attach, and a re-pick; the
  remaining statements are then revoked to zero and neither a re-pick, a detach
  and re-attach, nor a sibling chat under the same project subject mints
  anything, exec included. A subject that never held the folder still gets the
  full set.
- `an_emptied_folder_position_survives_a_restart` — the settled record is
  persisted and reloaded, so a restart does not turn an emptied position back
  into a first arrival. This is also the case that used to refuse to load.
- `granting_read_back_restores_an_attached_folder_without_its_exec_reach` —
  read can be granted back on an attached folder, the exec reach revoking it
  withdrew stays gone, a retry reports `granted: false`, and an untouched write
  grant survives.
- `completed_receipts_are_bounded_without_breaking_retry_or_receipt_lookup` —
  the table stays bounded across 2049 mutations, the oldest receipt reports
  `Unknown` rather than a wrong outcome, the newest still replays its recorded
  result on retry, and the registration receipt outlives all of it.

`a_failed_mutation_reports_the_attachment_it_could_not_change` used a
read-less detach as its failure; it now uses a malformed one, since a detach
without read is no longer an error.

In the UI, `FoldersView.test.tsx` drives Disconnect through to
`disconnectFolder` on a folder that allows nothing rather than only asserting
the button is on screen, and `PermissionsPanel.dom.test.tsx` covers the restore
row.

## State-file version and migration

The settled-positions record is durable, so the state file moves to version 5.
Two things that were wrong in the first cut of that migration and are fixed
here:

- The accepted-version set was written as a shift (`2 | 3 | STATE_VERSION`),
  which dropped version 4 — every existing install. A refused state file is a
  broker that does not start, i.e. every folder gone on upgrade. The set now
  widens to `2 | 3 | 4 | STATE_VERSION`, with a comment stating that this set
  widens and never shifts.
- Reconstruction for older files seeded only from surviving grants, which
  leaves the installs that actually hit the startup bug — a folder narrowed to
  nothing — still refused by loaded-state validation. It now seeds from the
  same evidence validation accepts: a surviving grant, a surviving attachment
  (which settles only its own conversation's subject), and the folder's
  registration owner, which is what carries a project chat's position.

Two migration tests come with it: a version-4 file loads, and a version-4 file
with an emptied folder comes back settled rather than re-minting on the next
attach.

`docs/decisions/0008-settled-folder-positions.md` records the rule (no arrival
mints into an answered position; widening is only ever the permission dialog),
the persisted obligation this introduces, and the alternative it owes — keeping
the grant row as an empty tombstone instead of adding a structure — with why
that was rejected. `docs/host-access.md` gains the version and reconstruction
rules.

The reconstruction is gated on the persisted version being below the current
one. It runs for versions 2 through 4 and never on a file that already carries
the record: its inferences are looser than what the live code records — an
attachment settles its own conversation's subject, which the live code does not
do for a chat in a project — so running it on every load would write positions
nobody answered for and would also satisfy two loaded-state validation rules by
construction.

### Known residual

A version-4 file where a folder was re-picked by a second subject, and that
re-picker was then revoked to nothing, is still refused on load with "successful
register receipt does not match authoritative state". Rule 3 asks about the
register receipt's subject, while the re-pick branch mints for the root's owner.
The base refuses the same file at the attachment rule, so this PR narrows the
refusal without closing it. Seeding from receipts would settle positions that
were never minted, which is worse; it is left alone deliberately.

## Verification

```
cargo fmt --all                                                              # clean
cargo clippy -p openwave-host-broker -p openwave-desktop --all-targets --locked -- -D warnings   # clean
cargo test -p openwave-host-broker --locked            # 108 + 1 + 1 passed, 0 failed
cargo test -p openwave-desktop --locked                # 124 passed, 2 ignored
tsc --noEmit                                           # clean
pnpm test                                              # 904 passed
```

The running app was not driven; the native confirmation dialog's read wording
and the click-through are unexercised by tests.


