### PR TITLE
fix(desktop): stop the composer losing messages, plan feedback, and keystrokes

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatQueueMessage.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatQueueMessage.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
+
+import { queueComposerMessage } from "./ChatRoute";
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn() } }));
+
+describe("queueing a message behind a running turn", () => {
+  it("keeps the text and speaks up when the queue refuses it", async () => {
+    // A queued message gets no optimistic bubble, so a refusal used to be
+    // completely silent: the composer emptied and the message was gone.
+    const onQueued = vi.fn();
+    await queueComposerMessage(async () => {
+      throw new Error("chat is not accepting messages");
+    }, onQueued);
+
+    expect(onQueued).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith("chat is not accepting messages");
+  });
+
+  it("clears the composer once the message is on the queue", async () => {
+    const onQueued = vi.fn();
+    await queueComposerMessage(async () => undefined, onQueued);
+    expect(onQueued).toHaveBeenCalled();
+  });
+});

--- a/crates/openwave-desktop/ui/src/ChatQueueMessage.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatQueueMessage.test.ts
@@ -17,10 +17,4 @@ describe("queueing a message behind a running turn", () => {
     expect(onQueued).not.toHaveBeenCalled();
     expect(toast.error).toHaveBeenCalledWith("chat is not accepting messages");
   });
-
-  it("clears the composer once the message is on the queue", async () => {
-    const onQueued = vi.fn();
-    await queueComposerMessage(async () => undefined, onQueued);
-    expect(onQueued).toHaveBeenCalled();
-  });
 });

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -704,7 +704,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
           onVoiceInputAccepted={voice.resetInputUsed}
           nativeDropTarget={
             <DocumentDropTarget
-              chatId={chatId}
+              resolveChatId={async () => chatId}
               onAttached={adoptAttached}
               onError={(error) => setAttachError(friendlyAttachError(error))}
             />

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
+import { toast } from "sonner";
 
 import type {
-  ModelInfo,
   ModelSelectionKey,
   NetworkPolicy,
   PermissionMode,
@@ -44,6 +44,7 @@ import { DocumentDetailRoot } from "./document-detail/DocumentDetailRoot";
 import { warmPresentationConverter } from "./document/officePdf";
 import { FoldersView } from "./FoldersView";
 import { hasNativeHost } from "./host";
+import { friendlyErrorMessage } from "./lib/utils";
 import { attachChatFiles, type AttachedFiles } from "./attachments";
 import { type ImportedDocument, type LibraryImportSuccess } from "./documents";
 import { DocumentDropTarget } from "./DocumentDropTarget";
@@ -54,7 +55,7 @@ import {
   type ImageAttachment,
 } from "./ImageAttachments";
 import { useImageAttachments } from "./useImageAttachments";
-import { modelForSelection } from "./ModelSelection";
+import { modelForSelection, textOnlyModelLabel } from "./ModelSelection";
 import { ContextUsageIndicator } from "./ContextUsageIndicator";
 import { ModelMenu, useModelSettingsNav } from "./ModelMenu";
 import { PermissionModeMenu } from "./PermissionModeMenu";
@@ -365,18 +366,23 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   async function onQueue() {
     const content = draftRef.current.trim();
     if (!chat || !content) return;
-    await client.postMessage(
-      chatId,
-      crypto.randomUUID(),
-      content,
-      readyImageAttachmentIds(images.attachments),
-      files.map((file) => file.documentId),
-      invokedSkills(),
-      voice.inputUsed,
-      true,
+    await queueComposerMessage(
+      () =>
+        client.postMessage(
+          chatId,
+          crypto.randomUUID(),
+          content,
+          readyImageAttachmentIds(images.attachments),
+          files.map((file) => file.documentId),
+          invokedSkills(),
+          voice.inputUsed,
+          true,
+        ),
+      () => {
+        setComposerDraft("");
+        voice.resetInputUsed();
+      },
     );
-    setComposerDraft("");
-    voice.resetInputUsed();
   }
 
   /**
@@ -897,18 +903,26 @@ function withoutConnectionState(status: string): string {
 }
 
 /**
- * The label of the chat's model when it cannot read images, or `null`.
+ * Park the composer's message on the server queue, and empty the composer only
+ * once the server has it.
  *
- * A chat with no model of its own follows the global default, which the
- * renderer does not resolve; the server still refuses such a turn, so the
- * composer stays quiet rather than guessing at a name it would have to print.
+ * A refused queue is the one send that has nothing to show for itself: no
+ * optimistic bubble goes into the transcript and no turn follows, so a
+ * swallowed rejection would take the message away and leave the reader
+ * watching a queue that never grew. The text stays where it was typed and the
+ * failure is said out loud, the same way the queue tray reports its own.
  */
-function textOnlyModelLabel(
-  models: ModelInfo[],
-  selection: string | null,
-): string | null {
-  const model = modelForSelection(models, selection);
-  return model && !model.multimodal ? model.display_name : null;
+export async function queueComposerMessage(
+  post: () => Promise<unknown>,
+  onQueued: () => void,
+): Promise<void> {
+  try {
+    await post();
+  } catch (err) {
+    toast.error(friendlyErrorMessage(err, "Could not queue that message."));
+    return;
+  }
+  onQueued();
 }
 
 function friendlyAttachError(error: unknown): string {

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -24,6 +24,7 @@ import {
   activeSlashQuery,
   availableSlashOptions,
   filterSlashOptions,
+  locateSlashToken,
   nextOptionHighlight,
   replaceSlashToken,
   skillsToInvoke,
@@ -569,14 +570,16 @@ export function Composer({
         }
         // The body arrives whenever the fetch settles, and the reader goes on
         // typing meanwhile. Write into the draft as it stands now rather than
-        // the one this pick started from: the token is replaced only where it
-        // still is, and every keystroke since is kept either way.
+        // the one this pick started from: the token is replaced wherever it
+        // has ended up, and every keystroke since is kept.
         const current = latestDraftRef.current;
-        const tokenIntact =
-          token !== null &&
-          current.slice(token.start, caret) === draft.slice(token.start, caret);
-        if (token && tokenIntact) {
-          applySlashReplacement(current, token.start, caret, body);
+        const typed = token === null ? null : draft.slice(token.start, caret);
+        const start =
+          token === null || typed === null
+            ? -1
+            : locateSlashToken(current, typed, token.start, current.length - draft.length);
+        if (start >= 0 && typed !== null) {
+          applySlashReplacement(current, start, start + typed.length, body);
         } else {
           insertAtSelection(body, current);
         }
@@ -607,7 +610,7 @@ export function Composer({
   }
 
   /** Text put in where the reader last had the caret, without running words together. */
-  function insertAtSelection(text: string, source: string = draft) {
+  function insertAtSelection(text: string, source: string) {
     const remembered = selectionRef.current;
     const start = Math.min(remembered?.start ?? source.length, source.length);
     const end = Math.min(remembered?.end ?? source.length, source.length);
@@ -736,9 +739,12 @@ export function Composer({
 
   function onDrop(event: DragEvent<HTMLFormElement>) {
     endDrag();
-    // The webview, not the host, receives file drops (`dragDropEnabled: false`),
-    // and its own handling of one is to navigate away from the app and display
-    // the file — so a drop must be claimed here whether or not it is taken.
+    // The packaged app runs with `dragDropEnabled: true`, so the host claims
+    // file drops before the webview sees them and `DocumentDropTarget` is the
+    // path that runs there. This handler is what a dev-server webview does
+    // with a drop, and its own handling of one is to navigate away from the
+    // app and display the file — so a drop must be claimed here whether or not
+    // it is taken.
     event.preventDefault();
     acceptTransfer(event.dataTransfer);
   }

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -574,12 +574,17 @@ export function Composer({
         // has ended up, and every keystroke since is kept.
         const current = latestDraftRef.current;
         const typed = token === null ? null : draft.slice(token.start, caret);
-        const start =
-          token === null || typed === null
-            ? -1
-            : locateSlashToken(current, typed, token.start, current.length - draft.length);
-        if (start >= 0 && typed !== null) {
-          applySlashReplacement(current, start, start + typed.length, body);
+        const found =
+          typed === null || token === null
+            ? null
+            : locateSlashToken(
+                current,
+                typed,
+                token.start,
+                current.length - draft.length,
+              );
+        if (found) {
+          applySlashReplacement(current, found.start, found.end, body);
         } else {
           insertAtSelection(body, current);
         }

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -341,6 +341,11 @@ export function Composer({
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const latestResetKeyRef = useRef(resetKey);
   latestResetKeyRef.current = resetKey;
+  // The draft as it stands now, for the paths that write a whole new value
+  // after an await. Rendering reads the prop; anything that resumes later has
+  // to read this, or it overwrites whatever was typed while it was away.
+  const latestDraftRef = useRef(draft);
+  latestDraftRef.current = draft;
   // dragenter and dragleave fire for every descendant the pointer crosses, so a
   // boolean flickers the drop hint on and off while the file is held still.
   const dragDepthRef = useRef(0);
@@ -562,8 +567,19 @@ export function Composer({
           // read leaves the draft exactly as the reader typed it, token and all.
           return;
         }
-        if (token) applySlashReplacement(draft, token.start, caret, body);
-        else insertAtSelection(body);
+        // The body arrives whenever the fetch settles, and the reader goes on
+        // typing meanwhile. Write into the draft as it stands now rather than
+        // the one this pick started from: the token is replaced only where it
+        // still is, and every keystroke since is kept either way.
+        const current = latestDraftRef.current;
+        const tokenIntact =
+          token !== null &&
+          current.slice(token.start, caret) === draft.slice(token.start, caret);
+        if (token && tokenIntact) {
+          applySlashReplacement(current, token.start, caret, body);
+        } else {
+          insertAtSelection(body, current);
+        }
       })();
       return;
     }
@@ -591,14 +607,14 @@ export function Composer({
   }
 
   /** Text put in where the reader last had the caret, without running words together. */
-  function insertAtSelection(text: string) {
+  function insertAtSelection(text: string, source: string = draft) {
     const remembered = selectionRef.current;
-    const start = Math.min(remembered?.start ?? draft.length, draft.length);
-    const end = Math.min(remembered?.end ?? draft.length, draft.length);
-    const before = draft.slice(0, start);
+    const start = Math.min(remembered?.start ?? source.length, source.length);
+    const end = Math.min(remembered?.end ?? source.length, source.length);
+    const before = source.slice(0, start);
     const gap = before && !/\s$/.test(before) ? " " : "";
     moveCaret(
-      `${before}${gap}${text}${draft.slice(end)}`,
+      `${before}${gap}${text}${source.slice(end)}`,
       before.length + gap.length + text.length,
     );
   }

--- a/crates/openwave-desktop/ui/src/ComposerPrompt.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerPrompt.tsx
@@ -45,7 +45,7 @@ export function ComposerPrompt({
   planApprovalRequests: PendingPlanApproval[];
   decidingPlanCalls: Set<string>;
   planApprovalErrors: Record<string, string>;
-  onPlanDecision: (callId: string, decision: PlanDecision) => void;
+  onPlanDecision: (callId: string, decision: PlanDecision) => Promise<boolean>;
   onPlanCancel: (turnId: string) => void;
 }) {
   // A plan card can take the whole pane; the flag lives here because the

--- a/crates/openwave-desktop/ui/src/ComposerSlash.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerSlash.dom.test.tsx
@@ -167,6 +167,44 @@ it("keeps what was typed while the prompt body was still loading", async () => {
   expect(onDraftChange).toHaveBeenLastCalledWith(
     expect.stringContaining("for the team"),
   );
+  // And the token goes, wherever it ended up: leaving it behind would send
+  // "/weekly" to the model as prose.
+  expect(onDraftChange).toHaveBeenLastCalledWith(
+    expect.not.stringContaining("/weekly"),
+  );
+});
+
+it("finds the token again when the typing lands ahead of it", async () => {
+  // Typing before the token moves it, and the body still belongs where the
+  // token is rather than wherever the caret happens to be.
+  const user = userEvent.setup();
+  let release: (body: string) => void = () => {};
+  const loadPromptBody = vi.fn(
+    () => new Promise<string>((resolve) => (release = resolve)),
+  );
+  const onDraftChange = vi.fn();
+  render(
+    <ComposerHarness
+      slash={slash({ loadPromptBody })}
+      onDraftChange={onDraftChange}
+    />,
+  );
+
+  const field = screen.getByRole("textbox", { name: "Message" });
+  await user.click(field);
+  await user.keyboard("draft the /weekly");
+  await user.click(screen.getByRole("option", { name: /Weekly update/ }));
+  await user.type(field, "hey, ", {
+    initialSelectionStart: 0,
+    initialSelectionEnd: 0,
+  });
+  release("Write this week's update covering:");
+
+  await vi.waitFor(() =>
+    expect(onDraftChange).toHaveBeenLastCalledWith(
+      "hey, draft the Write this week's update covering:",
+    ),
+  );
 });
 
 it("invokes a picked skill and shows it as a chip the reader can drop", async () => {

--- a/crates/openwave-desktop/ui/src/ComposerSlash.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerSlash.dom.test.tsx
@@ -136,6 +136,39 @@ it("replaces the token with the prompt body it fetches", async () => {
   expect(menu.onInvoke).not.toHaveBeenCalled();
 });
 
+it("keeps what was typed while the prompt body was still loading", async () => {
+  // Fetching the body is a round trip, and people carry on typing through it.
+  // The insertion used to be built from the draft as it was when the option
+  // was picked, so everything typed in between was overwritten.
+  const user = userEvent.setup();
+  let release: (body: string) => void = () => {};
+  const loadPromptBody = vi.fn(
+    () => new Promise<string>((resolve) => (release = resolve)),
+  );
+  const onDraftChange = vi.fn();
+  render(
+    <ComposerHarness
+      slash={slash({ loadPromptBody })}
+      onDraftChange={onDraftChange}
+    />,
+  );
+
+  await user.click(screen.getByRole("textbox", { name: "Message" }));
+  await user.keyboard("draft the /weekly");
+  await user.click(screen.getByRole("option", { name: /Weekly update/ }));
+  await user.keyboard(" for the team");
+  release("Write this week's update covering:");
+  await vi.waitFor(() =>
+    expect(onDraftChange).toHaveBeenLastCalledWith(
+      expect.stringContaining("Write this week's update covering:"),
+    ),
+  );
+
+  expect(onDraftChange).toHaveBeenLastCalledWith(
+    expect.stringContaining("for the team"),
+  );
+});
+
 it("invokes a picked skill and shows it as a chip the reader can drop", async () => {
   const user = userEvent.setup();
   const onInvoke = vi.fn();

--- a/crates/openwave-desktop/ui/src/ComposerSlash.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerSlash.dom.test.tsx
@@ -207,6 +207,62 @@ it("finds the token again when the typing lands ahead of it", async () => {
   );
 });
 
+it("takes the whole word when the token is still being typed", async () => {
+  // The list narrows before the word is finished, so picking at `/week` and
+  // finishing `ly` while the fetch runs is the ordinary case, not an edge one.
+  const user = userEvent.setup();
+  let release: (body: string) => void = () => {};
+  const loadPromptBody = vi.fn(
+    () => new Promise<string>((resolve) => (release = resolve)),
+  );
+  const onDraftChange = vi.fn();
+  render(
+    <ComposerHarness
+      slash={slash({ loadPromptBody })}
+      onDraftChange={onDraftChange}
+    />,
+  );
+
+  await user.click(screen.getByRole("textbox", { name: "Message" }));
+  await user.keyboard("draft the /week");
+  await user.click(screen.getByRole("option", { name: /Weekly update/ }));
+  await user.keyboard("ly");
+  release("Write this week's update covering:");
+
+  await vi.waitFor(() =>
+    expect(onDraftChange).toHaveBeenLastCalledWith(
+      "draft the Write this week's update covering:",
+    ),
+  );
+});
+
+it("takes the whole word when the token is being deleted", async () => {
+  const user = userEvent.setup();
+  let release: (body: string) => void = () => {};
+  const loadPromptBody = vi.fn(
+    () => new Promise<string>((resolve) => (release = resolve)),
+  );
+  const onDraftChange = vi.fn();
+  render(
+    <ComposerHarness
+      slash={slash({ loadPromptBody })}
+      onDraftChange={onDraftChange}
+    />,
+  );
+
+  await user.click(screen.getByRole("textbox", { name: "Message" }));
+  await user.keyboard("draft the /weekly");
+  await user.click(screen.getByRole("option", { name: /Weekly update/ }));
+  await user.keyboard("{Backspace}{Backspace}");
+  release("Write this week's update covering:");
+
+  await vi.waitFor(() =>
+    expect(onDraftChange).toHaveBeenLastCalledWith(
+      "draft the Write this week's update covering:",
+    ),
+  );
+});
+
 it("invokes a picked skill and shows it as a chip the reader can drop", async () => {
   const user = userEvent.setup();
   const onInvoke = vi.fn();

--- a/crates/openwave-desktop/ui/src/ComposerSlash.ts
+++ b/crates/openwave-desktop/ui/src/ComposerSlash.ts
@@ -110,36 +110,47 @@ export function filterSlashOptions(
 
 /**
  * Where the `/query` token has ended up in a draft that has been typed into
- * since it was read.
+ * since it was read, as the range the body should replace.
  *
  * Fetching a prompt body is a round trip and people carry on typing through
  * it, so by the time the body lands the token may have moved (text typed
- * before it) or merely stayed put (text typed after). The remembered offset
- * and the offset shifted by the length change cover both of those exactly;
- * the scan behind them catches an edit on both sides at once. `-1` when the
- * token is gone — the reader deleted it, and the body belongs at the caret
- * instead.
+ * before it), stayed put (text typed after it), or changed under the reader's
+ * fingers — the likeliest of the three, because the natural continuation of
+ * picking "Weekly update" at `/week` is to finish typing `ly`. So what is
+ * looked for is the whole whitespace-delimited word rather than the token
+ * string as it was read: replacing only the remembered characters would leave
+ * the rest of the word stranded against the body.
  *
- * Nothing here can tell one identical token from another: type a second `/a`
- * ahead of the first while the body loads and the guesses land on whichever
- * `/a` sits at the expected offset, which may be the new one. Distinguishing
- * them needs an identity the textarea does not give us.
+ * A candidate word has to be a prefix of the token or have the token as its
+ * prefix, which is what tells "the same word, still being typed" from an
+ * unrelated `/` word elsewhere in the draft. Between candidates the one
+ * nearest the remembered offset — or that offset shifted by the draft's
+ * length change, which is where an edit ahead of the token puts it — wins.
+ * `null` when the token is gone, and the body belongs at the caret instead.
+ *
+ * Nothing here can tell one such word from another: type a second `/a` ahead
+ * of the first while the body loads and the nearest guess may land on the new
+ * one. Distinguishing them needs an identity the textarea does not give us.
  */
 export function locateSlashToken(
   draft: string,
   token: string,
   start: number,
   shift: number,
-): number {
-  for (const guess of [start, start + shift]) {
-    if (guess >= 0 && draft.startsWith(token, guess)) return guess;
-  }
-  let best = -1;
-  for (let at = draft.indexOf(token); at !== -1; at = draft.indexOf(token, at + 1)) {
-    const before = at === 0 ? "" : draft[at - 1]!;
-    if (before !== "" && !/\s/.test(before)) continue;
-    if (best === -1 || Math.abs(at - (start + shift)) < Math.abs(best - (start + shift))) {
-      best = at;
+): { start: number; end: number } | null {
+  let best: { start: number; end: number } | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (const match of draft.matchAll(/(^|\s)(\/\S*)/g)) {
+    const at = (match.index ?? 0) + match[1]!.length;
+    const word = match[2]!;
+    if (!word.startsWith(token) && !token.startsWith(word)) continue;
+    const distance = Math.min(
+      Math.abs(at - start),
+      Math.abs(at - (start + shift)),
+    );
+    if (distance < bestDistance) {
+      best = { start: at, end: at + word.length };
+      bestDistance = distance;
     }
   }
   return best;

--- a/crates/openwave-desktop/ui/src/ComposerSlash.ts
+++ b/crates/openwave-desktop/ui/src/ComposerSlash.ts
@@ -109,6 +109,43 @@ export function filterSlashOptions(
 }
 
 /**
+ * Where the `/query` token has ended up in a draft that has been typed into
+ * since it was read.
+ *
+ * Fetching a prompt body is a round trip and people carry on typing through
+ * it, so by the time the body lands the token may have moved (text typed
+ * before it) or merely stayed put (text typed after). The remembered offset
+ * and the offset shifted by the length change cover both of those exactly;
+ * the scan behind them catches an edit on both sides at once. `-1` when the
+ * token is gone — the reader deleted it, and the body belongs at the caret
+ * instead.
+ *
+ * Nothing here can tell one identical token from another: type a second `/a`
+ * ahead of the first while the body loads and the guesses land on whichever
+ * `/a` sits at the expected offset, which may be the new one. Distinguishing
+ * them needs an identity the textarea does not give us.
+ */
+export function locateSlashToken(
+  draft: string,
+  token: string,
+  start: number,
+  shift: number,
+): number {
+  for (const guess of [start, start + shift]) {
+    if (guess >= 0 && draft.startsWith(token, guess)) return guess;
+  }
+  let best = -1;
+  for (let at = draft.indexOf(token); at !== -1; at = draft.indexOf(token, at + 1)) {
+    const before = at === 0 ? "" : draft[at - 1]!;
+    if (before !== "" && !/\s/.test(before)) continue;
+    if (best === -1 || Math.abs(at - (start + shift)) < Math.abs(best - (start + shift))) {
+      best = at;
+    }
+  }
+  return best;
+}
+
+/**
  * The draft with the `/query` token taken out and `replacement` put in its
  * place, and where the caret lands after it.
  */

--- a/crates/openwave-desktop/ui/src/DocumentDropTarget.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/DocumentDropTarget.dom.test.tsx
@@ -74,9 +74,10 @@ describe("DocumentDropTarget", () => {
   });
 
   it("cancels its native listener and ignores a stale drop after unmount", async () => {
+    const resolveChatId = vi.fn(async () => "chat-1");
     const view = render(
       <DocumentDropTarget
-        resolveChatId={async () => "chat-1"}
+        resolveChatId={resolveChatId}
         onAttached={vi.fn()}
         onError={vi.fn()}
       />,
@@ -90,6 +91,9 @@ describe("DocumentDropTarget", () => {
         payload: { phase: "dropped", accepted: true, fileCount: 1 },
       });
     });
+    // Resolving the conversation is what creates one on home, so a drop
+    // delivered after teardown must not reach the resolver either.
+    expect(resolveChatId).not.toHaveBeenCalled();
     expect(mocks.attachDropped).not.toHaveBeenCalled();
   });
 

--- a/crates/openwave-desktop/ui/src/DocumentDropTarget.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/DocumentDropTarget.dom.test.tsx
@@ -45,7 +45,7 @@ describe("DocumentDropTarget", () => {
     const onAttached = vi.fn();
     render(
       <DocumentDropTarget
-        chatId="chat-1"
+        resolveChatId={async () => "chat-1"}
         onAttached={onAttached}
         onError={vi.fn()}
       />,
@@ -67,14 +67,16 @@ describe("DocumentDropTarget", () => {
         payload: { phase: "dropped", accepted: true, fileCount: 1 },
       });
     });
-    expect(mocks.attachDropped).toHaveBeenCalledWith("chat-1");
+    // The conversation is resolved on the way through, so the claim lands a
+    // turn later than the drop.
     await waitFor(() => expect(onAttached).toHaveBeenCalledOnce());
+    expect(mocks.attachDropped).toHaveBeenCalledWith("chat-1");
   });
 
   it("cancels its native listener and ignores a stale drop after unmount", async () => {
     const view = render(
       <DocumentDropTarget
-        chatId="chat-1"
+        resolveChatId={async () => "chat-1"}
         onAttached={vi.fn()}
         onError={vi.fn()}
       />,

--- a/crates/openwave-desktop/ui/src/DocumentDropTarget.tsx
+++ b/crates/openwave-desktop/ui/src/DocumentDropTarget.tsx
@@ -57,10 +57,10 @@ export function DocumentDropTarget({
         setState(null);
         if (next.accepted) {
           void (async () => {
-            // Resolving the conversation can create one, so a drop that
-            // arrived after this listener was torn down must stop here rather
-            // than in the callback.
-            if (cancelled) return;
+            // Unmounting during this round trip cannot call the conversation
+            // back: it is already created, and it shows up in the sidebar
+            // unasked. Home writes the id into its draft, so the next send
+            // from home reuses it rather than leaving it stranded.
             const chatId = await resolveRef.current();
             if (cancelled) return;
             const attached = await attachDroppedChatFiles(chatId);

--- a/crates/openwave-desktop/ui/src/DocumentDropTarget.tsx
+++ b/crates/openwave-desktop/ui/src/DocumentDropTarget.tsx
@@ -19,21 +19,28 @@ type DropState = {
  * Native file drops are intercepted by Tauri before the webview sees them.
  * This listener lives inside the composer and sends the claimed paths through
  * the same mixed attachment path as its paperclip button.
+ *
+ * The conversation arrives as a resolver rather than an id because the home
+ * composer has no conversation until something is attached to it. The host
+ * holds a dropped path set briefly, so creating one on the way through is
+ * fine; what is not fine is refusing the drop for want of an id.
  */
 export function DocumentDropTarget({
-  chatId,
+  resolveChatId,
   onAttached,
   onError,
 }: {
-  chatId: string;
+  resolveChatId: () => Promise<string>;
   onAttached: (attached: AttachedFiles) => void;
   onError: (error: unknown) => void;
 }) {
   const [state, setState] = useState<DropState | null>(null);
   const attachedRef = useRef(onAttached);
   const errorRef = useRef(onError);
+  const resolveRef = useRef(resolveChatId);
   attachedRef.current = onAttached;
   errorRef.current = onError;
+  resolveRef.current = resolveChatId;
 
   useEffect(() => {
     if (!hasNativeHost()) return;
@@ -49,13 +56,18 @@ export function DocumentDropTarget({
       if (next.phase === "dropped") {
         setState(null);
         if (next.accepted) {
-          void attachDroppedChatFiles(chatId)
-            .then((attached) => {
-              if (!cancelled && attached) attachedRef.current(attached);
-            })
-            .catch((error) => {
-              if (!cancelled) errorRef.current(error);
-            });
+          void (async () => {
+            // Resolving the conversation can create one, so a drop that
+            // arrived after this listener was torn down must stop here rather
+            // than in the callback.
+            if (cancelled) return;
+            const chatId = await resolveRef.current();
+            if (cancelled) return;
+            const attached = await attachDroppedChatFiles(chatId);
+            if (!cancelled && attached) attachedRef.current(attached);
+          })().catch((error) => {
+            if (!cancelled) errorRef.current(error);
+          });
         }
         return;
       }
@@ -68,7 +80,7 @@ export function DocumentDropTarget({
       cancelled = true;
       unlisten?.();
     };
-  }, [chatId]);
+  }, []);
 
   if (!state) return null;
   return (

--- a/crates/openwave-desktop/ui/src/HomeRoute.test.ts
+++ b/crates/openwave-desktop/ui/src/HomeRoute.test.ts
@@ -7,7 +7,7 @@ const pendingChat = {
   title: null,
   model: null,
   reasoning_effort: null,
-  permission_mode: "allow",
+  permission_mode: "allow" as const,
   network_policy: { mode: "open" as const },
   project_id: null,
   created_at: "2026-08-10T00:00:00Z",
@@ -17,6 +17,8 @@ const pendingChat = {
 
 describe("home attachment settings", () => {
   it("applies attachment → restrict → send settings to the pending server chat", async () => {
+    const patchChatModel = vi.fn(async () => pendingChat);
+    const patchChatReasoningEffort = vi.fn(async () => pendingChat);
     const patchChatPermissionMode = vi.fn(async () => ({
       ...pendingChat,
       permission_mode: "plan" as const,
@@ -29,12 +31,30 @@ describe("home attachment settings", () => {
 
     // Attaching created this chat with the prior, permissive home settings.
     await applyPendingChatSettings(
-      { patchChatPermissionMode, patchChatNetworkPolicy },
+      {
+        patchChatModel,
+        patchChatReasoningEffort,
+        patchChatPermissionMode,
+        patchChatNetworkPolicy,
+      },
       pendingChat.id,
-      // The user restricts both controls before sending their first message.
-      { permissionMode: "plan", networkPolicy: { mode: "off" } },
+      // The user restricts both controls before sending their first message,
+      // and picks a different model to run it on.
+      {
+        model: "anthropic::claude-opus-4",
+        reasoningEffort: "high",
+        permissionMode: "plan",
+        networkPolicy: { mode: "off" },
+      },
     );
 
+    // The model the composer was showing at send is the one the turn runs on:
+    // the chat was created back when the picker still said something else.
+    expect(patchChatModel).toHaveBeenCalledWith(
+      "pending-chat",
+      "anthropic::claude-opus-4",
+    );
+    expect(patchChatReasoningEffort).toHaveBeenCalledWith("pending-chat", "high");
     expect(patchChatPermissionMode).toHaveBeenCalledWith("pending-chat", "plan");
     expect(patchChatNetworkPolicy).toHaveBeenCalledWith("pending-chat", {
       mode: "off",
@@ -43,18 +63,31 @@ describe("home attachment settings", () => {
   });
 
   it("surfaces a rejected pending-chat update to the sender", async () => {
-    const patchChatPermissionMode = vi.fn(async () => {
-      throw new Error("permission update rejected");
+    const patchChatModel = vi.fn(async () => {
+      throw new Error("model update rejected");
     });
+    const patchChatReasoningEffort = vi.fn();
+    const patchChatPermissionMode = vi.fn();
     const patchChatNetworkPolicy = vi.fn();
 
     await expect(
       applyPendingChatSettings(
-        { patchChatPermissionMode, patchChatNetworkPolicy },
+        {
+          patchChatModel,
+          patchChatReasoningEffort,
+          patchChatPermissionMode,
+          patchChatNetworkPolicy,
+        },
         pendingChat.id,
-        { permissionMode: "plan", networkPolicy: { mode: "off" } },
+        {
+          model: null,
+          reasoningEffort: null,
+          permissionMode: "plan",
+          networkPolicy: { mode: "off" },
+        },
       ),
-    ).rejects.toThrow("permission update rejected");
+    ).rejects.toThrow("model update rejected");
+    expect(patchChatPermissionMode).not.toHaveBeenCalled();
     expect(patchChatNetworkPolicy).not.toHaveBeenCalled();
   });
 });

--- a/crates/openwave-desktop/ui/src/HomeRoute.test.ts
+++ b/crates/openwave-desktop/ui/src/HomeRoute.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { applyPendingChatSettings } from "./HomeRoute";
+import { applyPendingChatSettings, singleFlight } from "./HomeRoute";
 
 const pendingChat = {
   id: "pending-chat",
@@ -80,7 +80,7 @@ describe("home attachment settings", () => {
         },
         pendingChat.id,
         {
-          model: null,
+          model: "anthropic::claude-opus-4",
           reasoningEffort: null,
           permissionMode: "plan",
           networkPolicy: { mode: "off" },
@@ -89,5 +89,72 @@ describe("home attachment settings", () => {
     ).rejects.toThrow("model update rejected");
     expect(patchChatPermissionMode).not.toHaveBeenCalled();
     expect(patchChatNetworkPolicy).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Loading the home defaults is allowed to fail quietly, which leaves the
+   * picker showing "default" with nothing resolved behind it. Sending null
+   * would clear the model the server seeded from the sticky default and run
+   * the turn on the global one instead, with nothing on screen to say so.
+   */
+  it("leaves a server-seeded model alone when home resolved none", async () => {
+    const patchChatModel = vi.fn(async () => pendingChat);
+    const patchChatReasoningEffort = vi.fn(async () => pendingChat);
+    const patchChatPermissionMode = vi.fn(async () => pendingChat);
+    const patchChatNetworkPolicy = vi.fn(async () => pendingChat);
+
+    await applyPendingChatSettings(
+      {
+        patchChatModel,
+        patchChatReasoningEffort,
+        patchChatPermissionMode,
+        patchChatNetworkPolicy,
+      },
+      pendingChat.id,
+      {
+        model: null,
+        reasoningEffort: null,
+        permissionMode: "plan",
+        networkPolicy: { mode: "off" },
+      },
+    );
+
+    expect(patchChatModel).not.toHaveBeenCalled();
+    expect(patchChatReasoningEffort).not.toHaveBeenCalled();
+    expect(patchChatPermissionMode).toHaveBeenCalledWith("pending-chat", "plan");
+  });
+});
+
+/**
+ * Home has no conversation until an attachment forces one, and every route in
+ * asks for it independently: each file of a dropped batch, each pasted image,
+ * the paperclip. Creating one per caller leaves empty chats in the sidebar
+ * that the reader never asked for and has to clean up.
+ */
+describe("creating home's pending chat", () => {
+  it("creates one chat for a batch that asks for it all at once", async () => {
+    const create = vi.fn(async () => "chat-1");
+    const ensure = singleFlight<string>();
+
+    const batch = await Promise.all([
+      ensure(create),
+      ensure(create),
+      ensure(create),
+    ]);
+
+    expect(create).toHaveBeenCalledOnce();
+    expect(batch).toEqual(["chat-1", "chat-1", "chat-1"]);
+  });
+
+  it("lets the next attachment try again after a failed creation", async () => {
+    const create = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce("chat-1");
+    const ensure = singleFlight<string>();
+
+    await expect(ensure(create)).rejects.toThrow("offline");
+    await expect(ensure(create)).resolves.toBe("chat-1");
+    expect(create).toHaveBeenCalledTimes(2);
   });
 });

--- a/crates/openwave-desktop/ui/src/HomeRoute.tsx
+++ b/crates/openwave-desktop/ui/src/HomeRoute.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 
 import { useApp } from "./AppContext";
@@ -18,13 +18,8 @@ import {
 import { DocumentDropTarget } from "./DocumentDropTarget";
 import { useFirstMessage } from "./FirstMessage";
 import { hasNativeHost } from "./host";
-import {
-  readyImageAttachment,
-  type ImageAttachment,
-  type PickedImage,
-} from "./ImageAttachments";
 import { ModelMenu, useModelSettingsNav } from "./ModelMenu";
-import { modelForSelection } from "./ModelSelection";
+import { modelForSelection, textOnlyModelLabel } from "./ModelSelection";
 import { effectiveNewChatSettings, useNewChatSettings } from "./NewChatSettings";
 import { PermissionModeMenu } from "./PermissionModeMenu";
 import { pluginsApisFromClient } from "./plugins/pluginsApis";
@@ -34,6 +29,7 @@ import { AppSidebar } from "./sidebar/AppSidebar";
 import { WelcomeState } from "./WelcomeState";
 import type { AttachedFiles } from "./attachments";
 import { MAX_IMAGE_ATTACHMENTS } from "./ImageAttachments";
+import { useImageAttachments } from "./useImageAttachments";
 import { appendTranscript, useVoiceComposer } from "./useVoiceComposer";
 import { useVoiceInputStore, voiceSelectionReady } from "./VoiceInputStore";
 
@@ -45,18 +41,34 @@ const firstMessageActions = useFirstMessage.getState();
  * A file picker creates a chat before there is a first message. Reconcile the
  * home pickers immediately before that first message is held so changes made
  * while the attachment strip was open govern the turn that follows.
+ *
+ * That includes the model and its reasoning level: the chat was created with
+ * whatever was selected when the attachment opened it, and a reader who picks
+ * a different model before sending expects the turn to run on the one they can
+ * see in the composer.
  */
 export async function applyPendingChatSettings(
   client: Pick<
     typeof import("./api").ApiClient.prototype,
-    "patchChatPermissionMode" | "patchChatNetworkPolicy"
+    | "patchChatModel"
+    | "patchChatReasoningEffort"
+    | "patchChatPermissionMode"
+    | "patchChatNetworkPolicy"
   >,
   chatId: string,
   settings: {
+    model: import("./api").ModelSelectionKey | null;
+    reasoningEffort: import("./api").ReasoningEffort | null;
     permissionMode: import("./api").PermissionMode | null;
     networkPolicy: import("./api").NetworkPolicy;
   },
 ): Promise<void> {
+  chatListActions.replaceChat(
+    await client.patchChatModel(chatId, settings.model),
+  );
+  chatListActions.replaceChat(
+    await client.patchChatReasoningEffort(chatId, settings.reasoningEffort),
+  );
   chatListActions.replaceChat(
     await client.patchChatPermissionMode(chatId, settings.permissionMode),
   );
@@ -123,6 +135,13 @@ export function HomeRoute() {
   const pendingSkills = attachments.skills;
   const [attaching, setAttaching] = useState(false);
   const [attachError, setAttachError] = useState<string | null>(null);
+  // One chat creation shared by every route into it — the picker, and each file
+  // of a dropped or pasted batch.
+  const creatingPendingChat = useRef<Promise<string> | null>(null);
+  // The same strip a conversation's composer has. Home's bytes are published
+  // into the chat the attachment silently creates, which is why the target is
+  // resolved per upload rather than being the draft's own key.
+  const images = useImageAttachments(client, HOME_DRAFT_KEY, ensurePendingChat);
 
   const chats = useChatListStore((state) => state.chats);
   const chatsLoaded = useChatListStore((state) => state.chatsLoaded);
@@ -138,14 +157,6 @@ export function HomeRoute() {
     composerDraftActions.setFiles(HOME_DRAFT_KEY, []);
   }, [chatsLoaded, chats, pendingChatId]);
 
-  function setPendingImages(
-    update: (current: readonly ImageAttachment[]) => ImageAttachment[],
-  ) {
-    const current =
-      useComposerDrafts.getState().attachments[HOME_DRAFT_KEY]?.images ?? [];
-    composerDraftActions.setImages(HOME_DRAFT_KEY, update(current));
-  }
-
   function setPendingFiles(
     update: (current: readonly ImportedDocument[]) => ImportedDocument[],
   ) {
@@ -158,6 +169,19 @@ export function HomeRoute() {
     const existing =
       useComposerDrafts.getState().attachments[HOME_DRAFT_KEY]?.pendingChatId;
     if (existing) return existing;
+    // Images arrive in batches — a multi-file drop uploads every file at once,
+    // and each upload asks for the chat to publish into. One in-flight creation
+    // is shared between them so a three-image drop does not leave two orphan
+    // chats behind it.
+    if (!creatingPendingChat.current) {
+      creatingPendingChat.current = createPendingChat().finally(() => {
+        creatingPendingChat.current = null;
+      });
+    }
+    return creatingPendingChat.current;
+  }
+
+  async function createPendingChat(): Promise<string> {
     const created = await client.createChat(newChat.model ?? undefined, null, {
       reasoningEffort: newChat.reasoningEffort,
       permissionMode: newChat.permissionMode,
@@ -209,12 +233,7 @@ export function HomeRoute() {
       Math.max(0, remaining - pickedImages.length),
     );
     if (pickedImages.length > 0) {
-      setPendingImages((current) => [
-        ...current,
-        ...pickedImages.map((image: PickedImage) =>
-          readyImageAttachment(crypto.randomUUID(), image),
-        ),
-      ]);
+      images.adopt(pickedImages);
     }
     if (pickedFiles.length > 0) {
       setPendingFiles((current) => [...current, ...pickedFiles]);
@@ -263,6 +282,8 @@ export function HomeRoute() {
         chatId = created.id;
       } else {
         await applyPendingChatSettings(client, chatId, {
+          model: effective.model,
+          reasoningEffort: effective.reasoningEffort,
           permissionMode: effective.permissionMode,
           networkPolicy: effective.networkPolicy,
         });
@@ -287,18 +308,29 @@ export function HomeRoute() {
     }
   }
 
-  const composerImages: ComposerImages | undefined =
-    pendingImages.length > 0
-      ? {
-          items: pendingImages,
-          error: null,
-          unsupportedModel: null,
-          onAttachFiles: () => {},
-          onRemove: (id) =>
-            setPendingImages((prev) => prev.filter((img) => img.id !== id)),
-          onRetry: () => {},
-        }
-      : undefined;
+  // Offered whether or not anything is attached yet: a drop or a paste is how
+  // the first image usually arrives, and the composer only claims one when a
+  // strip is there to receive it.
+  const composerImages: ComposerImages = {
+    items: pendingImages,
+    error: images.error,
+    unsupportedModel: textOnlyModelLabel(models, effective.model),
+    onAttachFiles: (selected) => {
+      if (
+        pendingImages.length + pendingFiles.length + selected.length >
+        MAX_IMAGE_ATTACHMENTS
+      ) {
+        setAttachError(
+          `A message can carry at most ${MAX_IMAGE_ATTACHMENTS} attachments.`,
+        );
+        return;
+      }
+      setAttachError(null);
+      images.attachFiles(selected);
+    },
+    onRemove: images.remove,
+    onRetry: images.retry,
+  };
 
   // Home is the composer alone. The install-wide libraries that used to open
   // as panels here are routes of their own now, so nothing beside the

--- a/crates/openwave-desktop/ui/src/HomeRoute.tsx
+++ b/crates/openwave-desktop/ui/src/HomeRoute.tsx
@@ -46,6 +46,11 @@ const firstMessageActions = useFirstMessage.getState();
  * whatever was selected when the attachment opened it, and a reader who picks
  * a different model before sending expects the turn to run on the one they can
  * see in the composer.
+ *
+ * A null model is not sent, and the reasoning level rides with it. It means
+ * the home picker never resolved one — loading the defaults is allowed to fail
+ * quietly — and the chat the server seeded from the sticky default is a better
+ * answer than the global default that clearing it would fall back to.
  */
 export async function applyPendingChatSettings(
   client: Pick<
@@ -63,18 +68,42 @@ export async function applyPendingChatSettings(
     networkPolicy: import("./api").NetworkPolicy;
   },
 ): Promise<void> {
-  chatListActions.replaceChat(
-    await client.patchChatModel(chatId, settings.model),
-  );
-  chatListActions.replaceChat(
-    await client.patchChatReasoningEffort(chatId, settings.reasoningEffort),
-  );
+  if (settings.model) {
+    chatListActions.replaceChat(
+      await client.patchChatModel(chatId, settings.model),
+    );
+    chatListActions.replaceChat(
+      await client.patchChatReasoningEffort(chatId, settings.reasoningEffort),
+    );
+  }
   chatListActions.replaceChat(
     await client.patchChatPermissionMode(chatId, settings.permissionMode),
   );
   chatListActions.replaceChat(
     await client.patchChatNetworkPolicy(chatId, settings.networkPolicy),
   );
+}
+
+/**
+ * One in-flight run shared by everyone who asks for it while it is running.
+ *
+ * Home creates its pending chat lazily, and the callers race: a dropped batch
+ * of three images asks for the chat three times in the same tick, and the
+ * paperclip can be mid-flight when a paste lands. Without this each caller
+ * creates its own chat and the reader is left with orphans in the sidebar.
+ * The run is forgotten as soon as it settles, so a failed creation is retried
+ * rather than remembered.
+ */
+export function singleFlight<T>(): (run: () => Promise<T>) => Promise<T> {
+  let inFlight: Promise<T> | null = null;
+  return (run) => {
+    if (!inFlight) {
+      inFlight = run().finally(() => {
+        inFlight = null;
+      });
+    }
+    return inFlight;
+  };
 }
 
 function isImportedDocument(
@@ -137,7 +166,7 @@ export function HomeRoute() {
   const [attachError, setAttachError] = useState<string | null>(null);
   // One chat creation shared by every route into it — the picker, and each file
   // of a dropped or pasted batch.
-  const creatingPendingChat = useRef<Promise<string> | null>(null);
+  const creatingPendingChat = useRef(singleFlight<string>());
   // The same strip a conversation's composer has. Home's bytes are published
   // into the chat the attachment silently creates, which is why the target is
   // resolved per upload rather than being the draft's own key.
@@ -173,12 +202,7 @@ export function HomeRoute() {
     // and each upload asks for the chat to publish into. One in-flight creation
     // is shared between them so a three-image drop does not leave two orphan
     // chats behind it.
-    if (!creatingPendingChat.current) {
-      creatingPendingChat.current = createPendingChat().finally(() => {
-        creatingPendingChat.current = null;
-      });
-    }
-    return creatingPendingChat.current;
+    return creatingPendingChat.current(createPendingChat);
   }
 
   async function createPendingChat(): Promise<string> {
@@ -401,18 +425,16 @@ export function HomeRoute() {
                 ),
             }}
             nativeDropTarget={
-              pendingChatId ? (
-                <DocumentDropTarget
-                  chatId={pendingChatId}
-                  onAttached={adoptAttached}
-                  onError={(caught) =>
-                    setAttachError(
-                      String(caught).replace(/^Error:\s*/, "").trim() ||
-                        "Could not attach that file.",
-                    )
-                  }
-                />
-              ) : undefined
+              <DocumentDropTarget
+                resolveChatId={ensurePendingChat}
+                onAttached={adoptAttached}
+                onError={(caught) =>
+                  setAttachError(
+                    String(caught).replace(/^Error:\s*/, "").trim() ||
+                      "Could not attach that file.",
+                  )
+                }
+              />
             }
             attachError={attachError}
             resetKey="home"

--- a/crates/openwave-desktop/ui/src/ModelSelection.ts
+++ b/crates/openwave-desktop/ui/src/ModelSelection.ts
@@ -36,6 +36,22 @@ export function canonicalModelSelection(
   return modelForSelection(models, value)?.key ?? null;
 }
 
+/**
+ * The label of a selected model when it cannot read images, or `null`.
+ *
+ * A selection the renderer cannot resolve — none made, or one whose provider
+ * is gone — follows the global default, which the renderer does not know; the
+ * server still refuses such a turn, so the composer stays quiet rather than
+ * guessing at a name it would have to print.
+ */
+export function textOnlyModelLabel(
+  models: ModelInfo[],
+  selection: string | null,
+): string | null {
+  const model = modelForSelection(models, selection);
+  return model && !model.multimodal ? model.display_name : null;
+}
+
 /** Provider display label shared by settings and the composer. */
 export function providerLabel(provider: ProviderKind): string {
   switch (provider) {

--- a/crates/openwave-desktop/ui/src/PlanApprovalCard.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/PlanApprovalCard.dom.test.tsx
@@ -22,7 +22,7 @@ const request = {
 describe("PlanApprovalCard", () => {
   it("approves with one click and no feedback payload", async () => {
     const user = userEvent.setup();
-    const onDecide = vi.fn();
+    const onDecide = vi.fn().mockResolvedValue(true);
     render(
       <PlanApprovalCard
         request={request}
@@ -45,7 +45,7 @@ describe("PlanApprovalCard", () => {
    */
   it("sends block comments back as quoted feedback", async () => {
     const user = userEvent.setup();
-    const onDecide = vi.fn();
+    const onDecide = vi.fn().mockResolvedValue(true);
     render(
       <PlanApprovalCard
         request={request}
@@ -71,6 +71,38 @@ describe("PlanApprovalCard", () => {
     });
   });
 
+  /**
+   * A refused send used to take the comments with it: the card cleared them
+   * before it knew whether the decision had landed, and nothing anywhere could
+   * give them back. The reader would have to read the plan and write every
+   * note again.
+   */
+  it("keeps block comments when the decision does not reach the server", async () => {
+    const user = userEvent.setup();
+    const onDecide = vi.fn().mockResolvedValue(false);
+    render(
+      <PlanApprovalCard
+        request={request}
+        working={false}
+        error="Could not send that decision."
+        onDecide={onDecide}
+        onCancel={vi.fn()}
+      />,
+    );
+    const [firstStep] = screen.getAllByRole("button", { name: "Add comment" });
+    await user.click(firstStep!);
+    await user.type(
+      screen.getByLabelText("What should change"),
+      "Split this into its own slice.",
+    );
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    await user.click(screen.getByRole("button", { name: /Update plan/ }));
+
+    expect(onDecide).toHaveBeenCalled();
+    expect(screen.getByText("1 edit added")).toBeInTheDocument();
+    expect(usePlanComments.getState().byCall["call-1"]).toHaveLength(1);
+  });
+
   it("drops pending edits when they are cancelled", async () => {
     const user = userEvent.setup();
     render(
@@ -78,7 +110,7 @@ describe("PlanApprovalCard", () => {
         request={request}
         working={false}
         error={undefined}
-        onDecide={vi.fn()}
+        onDecide={vi.fn().mockResolvedValue(true)}
         onCancel={vi.fn()}
       />,
     );

--- a/crates/openwave-desktop/ui/src/PlanApprovalCard.tsx
+++ b/crates/openwave-desktop/ui/src/PlanApprovalCard.tsx
@@ -199,7 +199,7 @@ export function PlanApprovalCard({
   request: PendingPlanApproval;
   working: boolean;
   error: string | undefined;
-  onDecide: (decision: PlanDecision) => void;
+  onDecide: (decision: PlanDecision) => Promise<boolean>;
   onCancel: () => void;
   onFullscreenChange?: (fullscreen: boolean) => void;
 }) {
@@ -237,17 +237,21 @@ export function PlanApprovalCard({
     [callId, working],
   );
 
-  const accept = () => {
-    clear(callId);
-    onDecide({ decision: "accept" });
+  // The comments are the reader's work, and a refused decision leaves the card
+  // on screen to try again — so they are dropped only once the server has
+  // taken them. Clearing first would erase per-block feedback that nothing can
+  // recover: the row is gone from the store and from localStorage, and the
+  // hydrate effect above does not re-run for a card that never unmounted.
+  const accept = async () => {
+    if (await onDecide({ decision: "accept" })) clear(callId);
   };
 
-  const requestChanges = () => {
+  const requestChanges = async () => {
     const feedback = serializePlanComments(comments ?? []);
-    clear(callId);
-    onDecide(
+    const sent = await onDecide(
       feedback ? { decision: "reject", feedback } : { decision: "reject" },
     );
+    if (sent) clear(callId);
   };
 
   const toggleFullscreen = () => {
@@ -321,7 +325,7 @@ export function PlanApprovalCard({
         >
           Cancel edits
         </Button>
-        <Button type="button" disabled={working} onClick={requestChanges}>
+        <Button type="button" disabled={working} onClick={() => void requestChanges()}>
           {working ? "Sending…" : "Update plan"}
           {!working && <CornerDownLeft aria-hidden="true" />}
         </Button>
@@ -331,7 +335,7 @@ export function PlanApprovalCard({
         <span className="text-muted-foreground grow text-sm">
           Hover over plan to edit
         </span>
-        <Button type="button" disabled={working} onClick={accept}>
+        <Button type="button" disabled={working} onClick={() => void accept()}>
           {working ? "Sending…" : "Execute plan"}
           {!working && <CornerDownLeft aria-hidden="true" />}
         </Button>

--- a/crates/openwave-desktop/ui/src/ShellShortcuts.test.ts
+++ b/crates/openwave-desktop/ui/src/ShellShortcuts.test.ts
@@ -59,18 +59,19 @@ describe("shell shortcut resolution", () => {
     }
   });
 
-  it("provides Alt+Arrow history navigation from editable fields", () => {
-    expect(
-      resolveShellShortcut(
-        keyEvent({
-          key: "ArrowLeft",
-          code: "ArrowLeft",
-          metaKey: false,
-          altKey: true,
-        }),
-        context(),
-      )?.id,
-    ).toBe("history-back");
+  it("leaves Alt+Arrow to the field the reader is typing in", () => {
+    // Option+Arrow jumps a word in every macOS text field. History navigation
+    // takes it only when focus is somewhere the keys mean nothing else.
+    const back = keyEvent({
+      key: "ArrowLeft",
+      code: "ArrowLeft",
+      metaKey: false,
+      altKey: true,
+    });
+    expect(resolveShellShortcut(back, context())).toBeNull();
+    expect(resolveShellShortcut(back, context({ editable: false }))?.id).toBe(
+      "history-back",
+    );
     expect(
       resolveShellShortcut(
         keyEvent({
@@ -79,7 +80,7 @@ describe("shell shortcut resolution", () => {
           metaKey: false,
           altKey: true,
         }),
-        context({ command: false }),
+        context({ editable: false, command: false }),
       )?.id,
     ).toBe("history-forward");
   });

--- a/crates/openwave-desktop/ui/src/ShellShortcuts.ts
+++ b/crates/openwave-desktop/ui/src/ShellShortcuts.ts
@@ -88,7 +88,12 @@ export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
     alt: true,
     description: "Go back",
     group: "Navigation",
-    allowInEditable: true,
+    // Option+Arrow is word-by-word caret movement in every macOS text field,
+    // and Alt+Arrow is the same habit elsewhere. Taking it from the composer
+    // would break typing to provide navigation the reader can reach with the
+    // mouse; unlike the mod-chorded shortcuts below, this one is a key
+    // combination people genuinely press while writing.
+    allowInEditable: false,
   },
   {
     id: "history-forward",
@@ -97,7 +102,7 @@ export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
     alt: true,
     description: "Go forward",
     group: "Navigation",
-    allowInEditable: true,
+    allowInEditable: false,
   },
   {
     id: "new-chat",

--- a/crates/openwave-desktop/ui/src/ShellShortcuts.ts
+++ b/crates/openwave-desktop/ui/src/ShellShortcuts.ts
@@ -86,7 +86,7 @@ export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
     keys: ["arrowleft"],
     mod: false,
     alt: true,
-    description: "Go back",
+    description: "Go back (outside text fields)",
     group: "Navigation",
     // Option+Arrow is word-by-word caret movement in every macOS text field,
     // and Alt+Arrow is the same habit elsewhere. Taking it from the composer
@@ -100,7 +100,7 @@ export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
     keys: ["arrowright"],
     mod: false,
     alt: true,
-    description: "Go forward",
+    description: "Go forward (outside text fields)",
     group: "Navigation",
     allowInEditable: false,
   },

--- a/crates/openwave-desktop/ui/src/useImageAttachments.ts
+++ b/crates/openwave-desktop/ui/src/useImageAttachments.ts
@@ -117,23 +117,33 @@ function setComposerImages(
  * while the reader was looking at another chat. The `File` behind each upload
  * is kept until the attachment leaves the list. That is what makes retry a
  * retry, rather than an invitation to go and find the file again.
+ *
+ * @param draftKey which composer's strip this is — a chat id, or the home
+ *   composer's key.
+ * @param publishTarget the chat the bytes belong to, when that is not the
+ *   draft's own key. Home attaches before its chat exists, so the target is
+ *   resolved at the moment the bytes move rather than at mount, and creating
+ *   the chat is part of resolving it.
  */
 export function useImageAttachments(
   client: ApiClient,
-  chatId: string,
+  draftKey: string,
+  publishTarget?: () => Promise<string>,
 ): ImageAttachmentControls {
   const attachments = useComposerDrafts(
-    (state) => state.attachments[chatId]?.images ?? NO_IMAGES,
+    (state) => state.attachments[draftKey]?.images ?? NO_IMAGES,
   );
   const [error, setError] = useState<string | null>(null);
   const attachmentsRef = useRef<ImageAttachment[]>([]);
+  const publishTargetRef = useRef(publishTarget);
 
   attachmentsRef.current = attachments;
+  publishTargetRef.current = publishTarget;
 
   function update(
     change: (current: readonly ImageAttachment[]) => ImageAttachment[],
   ) {
-    setComposerImages(chatId, change);
+    setComposerImages(draftKey, change);
   }
 
   /**
@@ -146,6 +156,9 @@ export function useImageAttachments(
    * directly is what gives the chip real byte progress.
    */
   async function publish(id: string, file: File, signal: AbortSignal) {
+    const chatId = publishTargetRef.current
+      ? await publishTargetRef.current()
+      : draftKey;
     if (!hasNativeHost()) {
       return uploadImageAttachment(client, chatId, file, {
         onProgress: (uploadedBytes) =>
@@ -163,7 +176,7 @@ export function useImageAttachments(
   }
 
   async function upload(id: string) {
-    const backing = backingFor(chatId);
+    const backing = backingFor(draftKey);
     const file = backing.files.get(id);
     if (!file) return;
     const controller = new AbortController();
@@ -190,7 +203,7 @@ export function useImageAttachments(
       return;
     }
     setError(null);
-    const backing = backingFor(chatId);
+    const backing = backingFor(draftKey);
     const now = new Date();
     const queued = files.map((file) => {
       const id = crypto.randomUUID();
@@ -224,7 +237,7 @@ export function useImageAttachments(
     adopt,
     attachFiles,
     remove: (id) => {
-      forgetBacking(chatId, id);
+      forgetBacking(draftKey, id);
       update((current) => withoutAttachment(current, id));
     },
     retry: (id) => {
@@ -233,7 +246,7 @@ export function useImageAttachments(
     },
     clear: () => {
       for (const attachment of attachmentsRef.current) {
-        forgetBacking(chatId, attachment.id);
+        forgetBacking(draftKey, attachment.id);
       }
       update(() => []);
       setError(null);

--- a/crates/openwave-desktop/ui/src/usePlanApprovals.ts
+++ b/crates/openwave-desktop/ui/src/usePlanApprovals.ts
@@ -7,7 +7,8 @@ export type PlanApprovals = {
   requests: PendingPlanApproval[];
   deciding: Set<string>;
   errors: Record<string, string>;
-  decide: (callId: string, decision: PlanDecision) => void;
+  /** Resolves to whether the server accepted the decision. */
+  decide: (callId: string, decision: PlanDecision) => Promise<boolean>;
   cancel: (turnId: string) => void;
 };
 
@@ -45,7 +46,7 @@ export function usePlanApprovals(
     startedChatId: string,
     request: () => Promise<unknown>,
     failure: (err: unknown) => string,
-  ) {
+  ): Promise<boolean> {
     decidingRef.current.add(callId);
     setDeciding((calls) => new Set(calls).add(callId));
     setErrors((current) => {
@@ -55,10 +56,12 @@ export function usePlanApprovals(
     });
     try {
       await request();
+      return true;
     } catch (err) {
       if (stillOpen(startedChatId)) {
         setErrors((current) => ({ ...current, [callId]: failure(err) }));
       }
+      return false;
     } finally {
       decidingRef.current.delete(callId);
       setDeciding((calls) => {
@@ -70,10 +73,20 @@ export function usePlanApprovals(
     }
   }
 
-  function decide(callId: string, decision: PlanDecision) {
-    if (!client || !chatId || decidingRef.current.has(callId)) return;
+  /**
+   * Send the reader's verdict on a parked plan.
+   *
+   * The card holds the per-block feedback that produced a revision request and
+   * must not throw it away until the server has it, so the outcome is reported
+   * back rather than swallowed: a refused decision leaves the card, its
+   * comments, and the error notice standing together.
+   */
+  function decide(callId: string, decision: PlanDecision): Promise<boolean> {
+    if (!client || !chatId || decidingRef.current.has(callId)) {
+      return Promise.resolve(false);
+    }
     const startedChatId = chatId;
-    void send(
+    return send(
       callId,
       startedChatId,
       () => client.decidePlan(startedChatId, callId, decision),


### PR DESCRIPTION
Six defects in the chat and home composers, each one a case where something the reader had typed or chosen disappeared without a word.

**Queued messages could vanish.** Sending while a turn was running went through `postMessage` with no error handling. A queued message gets no optimistic bubble, so when the call failed the composer emptied, nothing appeared in the transcript, and there was no toast or banner — the message was simply gone. The queue path now reports failures the way `postTurn` does: a toast via `friendlyErrorMessage`, and the draft is left where it was so the reader can retry.

**Plan feedback was destroyed by a failed decision.** `PlanApprovalCard` cleared the per-block comments before calling `onDecide`, and nothing can recover them once cleared — the store row is deleted and the localStorage copy with it. A refused send therefore cost the reader every note they had written on the plan. The decide path now resolves to whether the server accepted the decision, and the card clears only on success.

**Home dropped a model chosen after attaching.** Attaching a file on the home screen creates the chat immediately, with the model and reasoning effort as they stood at that moment. Changing the picker afterwards updated only local state, so the first turn ran on the old model. Both now travel with the permission mode and network policy in the settings applied to the pending chat at send. A null model is not sent: loading the home defaults is allowed to fail quietly, and clearing the model the server seeded from the sticky default would silently run the turn on the global one instead.

**Option+Arrow no longer jumps the caret out of the composer.** The history-navigation shortcuts fired from inside text fields, taking a combination macOS readers press constantly to move a word at a time — and the listener's `preventDefault` meant the binding actively suppressed word-jump. They are now shell shortcuts only when focus is outside an editable field. The existing test asserted the old behaviour and has been rewritten deliberately to assert the new one. Two things to weigh against it: on Windows and Linux, Alt+Left in a text field is not word navigation (Ctrl+Left is), so those platforms give up a working shortcut for a conflict they do not have — low cost while releases are macOS-only, but it is a real loss there. And the shortcuts dialog now says "outside text fields" on both rows rather than listing keys that do nothing while the composer has focus.

**Dropped and pasted images on home were discarded.** The home composer passed empty functions for attaching and retrying images, so a paste was accepted by the composer and then thrown away, and a failed upload's Retry button did nothing. Drops take a different route in the packaged app — `dragDropEnabled` is on, so the host claims them before the webview sees them and `DocumentDropTarget` is the handler that runs — and that target was gated on home already having a conversation, which it does not until something is attached. So both halves are fixed here: the webview handlers are wired to the same upload path the file picker uses, and the native drop target takes a conversation resolver instead of an id so it can create one on the way through. `useImageAttachments` takes the same lazy target, letting home key its drafts locally and only reach the server when an upload needs a conversation, with concurrent attachments sharing one creation so a three-image drop cannot leave orphan chats behind it. One thing the code cannot undo: leaving home while that creation is in flight still produces a conversation, which appears in the sidebar unasked. The id is written into the home draft, so the next send from home reuses it rather than stranding it.

**Slash prompts no longer overwrite typing.** Inserting a prompt body built the new draft from the text as it was when the option was picked, so anything typed during the fetch was overwritten. It now writes into the live draft and replaces the whole word the token sits in, wherever it has ended up — typing before it shifts it, typing after it does not, and typing into the word itself changes it, which is the ordinary case since the list narrows before the word is finished. The body goes in at the caret only when the token is gone.

Tests: reproductions for the queued-message loss, the plan-feedback loss, and the shared chat creation behind home's attachments; slash-insertion cases that type through the fetch before the token, after it, and into it from both ends; the null-model skip; and the Alt+Arrow shortcut test rewritten as described above.

Two things found while in here and deliberately left alone: `onQueue` does not clear the attachment strip on success either, so queueing a message with an image leaves it to ride along with the next one (`postTurn` does clear them) — a separate bug with a separate fix. And attaching on home creates a visible sidebar chat that is orphaned if the reader never sends; that was already reachable through the paperclip, but a paste is a much cheaper gesture, so whether the chat should be created at send instead is worth its own change.