### PR TITLE
fix: bound the failure paths in exec egress, remote receipts, and blob liveness

### DIFF
--- a/crates/openwave-code-execution/src/remote.rs
+++ b/crates/openwave-code-execution/src/remote.rs
@@ -30,6 +30,15 @@ const ABANDONED_RUNNING_AFTER: Duration = Duration::from_secs(30 * 60);
 
 /// How long a settled receipt stays available to replay its outcome. Past it
 /// the entry is dropped, which is the same state a restarted process is in.
+///
+/// Losing a settled receipt — to this window or to the ceiling below — narrows
+/// two guarantees, and a reader should not treat a receipt as authoritative
+/// forever. A replayed tool call whose receipt is gone runs the command again
+/// instead of returning the recorded response, and the fingerprint check that
+/// answers `IdentityConflict` when the same execution id comes back with
+/// different arguments has nothing left to compare against. Both are already
+/// true across a restart, and six hours is well past the length of a session,
+/// so the window is chosen to make this rare rather than to make it impossible.
 const SETTLED_RECEIPT_TTL: Duration = Duration::from_secs(6 * 60 * 60);
 
 /// Soft ceiling on retained receipts. Settled receipts hold their whole
@@ -107,8 +116,12 @@ impl PoolState {
             self.receipts.remove(&key);
         }
         // If every remaining receipt is inside its running window the map is
-        // allowed past the ceiling: that count is bounded by the executions
-        // actually in flight, and none of them may lose its fail-safe.
+        // allowed past the ceiling, because none of them may lose its fail-safe.
+        // That is not a bound on concurrency: a receipt is inserted before any
+        // per-workspace serialization is taken, and an abandoned one stays until
+        // it ages out, so a host issuing distinct execution ids and dropping each
+        // future can accumulate entries for the length of that window. They are
+        // small and the window ends, which is why nothing here caps them harder.
     }
 
     /// Drop pooled session slots nobody holds and that carry no live sandbox,
@@ -373,8 +386,11 @@ impl RemoteSessionPool {
     ///
     /// The slot is only removed when this caller is its last holder besides the
     /// map: another task already waiting on the same slot must keep working
-    /// against the entry it took, or the workspace would end up with two.
-    /// Anything left behind is reclaimed by [`PoolState::prune_sessions`].
+    /// against the entry it took, or the workspace would end up with two. Such
+    /// a slot is empty by the time this runs, so [`PoolState::prune_sessions`]
+    /// reclaims it once the other holder is done. That reasoning covers only
+    /// slots this function leaves behind — a slot still carrying a sandbox is
+    /// never swept.
     async fn forget_session(&self, key: &SessionKey) {
         let mut state = self.state.lock().await;
         state.staged.remove(key);
@@ -653,6 +669,12 @@ where
             Ok(())
         }
         Err(error) => {
+            // The handle goes back because the destroy is retryable and the
+            // retry needs it. That keeps the map entry too: a slot carrying a
+            // sandbox is never swept, so a teardown that fails and is never
+            // retried holds its entry for the life of the process. One small
+            // entry per abandoned workspace is the accepted cost of not
+            // stranding a live sandbox nothing can address any more.
             *slot = Some(pooled);
             pool.clear_staged(&key).await;
             Err(error)

--- a/crates/openwave-code-execution/src/remote.rs
+++ b/crates/openwave-code-execution/src/remote.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use openwave_egress::EgressPolicy;
@@ -12,6 +13,31 @@ use crate::{
     StagedUpload, WorkspaceFilePath, WorkspaceListing,
 };
 
+/// How long a receipt left in `Running` keeps reporting the execution as
+/// ambiguous before the pool treats it as abandoned.
+///
+/// A receipt is left running when the host's future is dropped mid-execution —
+/// a cancelled or interrupted turn — and the host then genuinely does not know
+/// whether the remote command completed. Reporting that as ambiguous is the
+/// point, because the command may still be running server-side and the tool
+/// call id is reused by a resumed or replayed turn. What was wrong is that the
+/// state never cleared: nothing short of a process restart let the same call
+/// be attempted again. This window is well past any remote command's own
+/// lifetime, so once it elapses the earlier attempt is over one way or the
+/// other, and the safe recovery is to run the command again rather than to
+/// report a failure for an outcome that may have been a success.
+const ABANDONED_RUNNING_AFTER: Duration = Duration::from_secs(30 * 60);
+
+/// How long a settled receipt stays available to replay its outcome. Past it
+/// the entry is dropped, which is the same state a restarted process is in.
+const SETTLED_RECEIPT_TTL: Duration = Duration::from_secs(6 * 60 * 60);
+
+/// Soft ceiling on retained receipts. Settled receipts hold their whole
+/// captured response, so the map is trimmed oldest-first once it is reached;
+/// a receipt still inside its running window is never evicted, since dropping
+/// it would discard exactly the ambiguity it exists to report.
+const MAX_RECEIPTS: usize = 512;
+
 /// Shared process-local sessions and idempotency receipts for managed sandboxes.
 #[derive(Clone, Default)]
 pub struct RemoteSessionPool {
@@ -21,11 +47,92 @@ pub struct RemoteSessionPool {
 #[derive(Default)]
 struct PoolState {
     sessions: HashMap<SessionKey, Arc<Mutex<Option<PooledSession>>>>,
-    receipts: HashMap<ReceiptKey, ExecutionReceipt>,
+    receipts: HashMap<ReceiptKey, ReceiptEntry>,
     /// Content digests of files already staged into each workspace's live
     /// sandbox, bound to the exact sandbox instance they were uploaded to. A
     /// recreated sandbox never inherits digests from its predecessor.
     staged: HashMap<SessionKey, StagedDigests>,
+}
+
+/// One receipt and when it was recorded, so the pool can bound how long it is
+/// kept and how long an unfinished execution stays ambiguous.
+struct ReceiptEntry {
+    receipt: ExecutionReceipt,
+    recorded_at: Instant,
+}
+
+impl ReceiptEntry {
+    fn new(receipt: ExecutionReceipt, now: Instant) -> Self {
+        Self {
+            receipt,
+            recorded_at: now,
+        }
+    }
+
+    /// Whether this entry still says anything. A running receipt past the
+    /// abandonment window describes an execution nobody is waiting on and no
+    /// remote command still serves; a settled one past its TTL is cache.
+    fn is_live(&self, now: Instant) -> bool {
+        let age = now.saturating_duration_since(self.recorded_at);
+        match self.receipt {
+            ExecutionReceipt::Running { .. } => age < ABANDONED_RUNNING_AFTER,
+            _ => age < SETTLED_RECEIPT_TTL,
+        }
+    }
+
+    fn is_running(&self) -> bool {
+        matches!(self.receipt, ExecutionReceipt::Running { .. })
+    }
+}
+
+impl PoolState {
+    /// Drop receipts that have stopped meaning anything, then trim the map back
+    /// under its ceiling by discarding the oldest settled entries.
+    fn prune_receipts(&mut self, now: Instant) {
+        self.receipts.retain(|_, entry| entry.is_live(now));
+        if self.receipts.len() < MAX_RECEIPTS {
+            return;
+        }
+        let mut settled: Vec<(ReceiptKey, Instant)> = self
+            .receipts
+            .iter()
+            .filter(|(_, entry)| !entry.is_running())
+            .map(|(key, entry)| (key.clone(), entry.recorded_at))
+            .collect();
+        settled.sort_by_key(|(_, recorded_at)| *recorded_at);
+        for (key, _) in settled {
+            if self.receipts.len() < MAX_RECEIPTS {
+                break;
+            }
+            self.receipts.remove(&key);
+        }
+        // If every remaining receipt is inside its running window the map is
+        // allowed past the ceiling: that count is bounded by the executions
+        // actually in flight, and none of them may lose its fail-safe.
+    }
+
+    /// Drop pooled session slots nobody holds and that carry no live sandbox,
+    /// along with the staged ledgers that belonged to them. Without this the
+    /// map keeps one entry per workspace the process has ever touched.
+    fn prune_sessions(&mut self) {
+        let sessions = &mut self.sessions;
+        let staged = &mut self.staged;
+        sessions.retain(|key, slot| {
+            // Another task holding a clone is mid-operation on this slot.
+            if Arc::strong_count(slot) > 1 {
+                return true;
+            }
+            let Ok(guard) = slot.try_lock() else {
+                return true;
+            };
+            if guard.is_some() {
+                return true;
+            }
+            drop(guard);
+            staged.remove(key);
+            false
+        });
+    }
 }
 
 struct StagedDigests {
@@ -161,14 +268,18 @@ impl RemoteSessionPool {
             execution_id: request.execution_id.as_str().to_owned(),
         };
         let mut state = self.state.lock().await;
+        state.prune_receipts(Instant::now());
         match state.receipts.get(&key) {
             None => {
-                state
-                    .receipts
-                    .insert(key, ExecutionReceipt::running(fingerprint));
+                state.receipts.insert(
+                    key,
+                    ReceiptEntry::new(ExecutionReceipt::running(fingerprint), Instant::now()),
+                );
                 Ok(BeginExecution::Started)
             }
-            Some(receipt) => receipt.replay(&fingerprint, CodeExecutionError::Unavailable),
+            Some(entry) => entry
+                .receipt
+                .replay(&fingerprint, CodeExecutionError::Unavailable),
         }
     }
 
@@ -183,7 +294,11 @@ impl RemoteSessionPool {
             execution_id: request.execution_id.as_str().to_owned(),
         };
         let receipt = ExecutionReceipt::from_outcome(request_fingerprint(request)?, outcome);
-        self.state.lock().await.receipts.insert(key, receipt);
+        self.state
+            .lock()
+            .await
+            .receipts
+            .insert(key, ReceiptEntry::new(receipt, Instant::now()));
         Ok(())
     }
 
@@ -199,6 +314,7 @@ impl RemoteSessionPool {
             workspace_id: workspace_id.to_owned(),
         };
         let mut state = self.state.lock().await;
+        state.prune_sessions();
         state
             .sessions
             .entry(key)
@@ -250,6 +366,46 @@ impl RemoteSessionPool {
     /// destroyed, so a successor sandbox starts from an empty ledger.
     async fn clear_staged(&self, key: &SessionKey) {
         self.state.lock().await.staged.remove(key);
+    }
+
+    /// Release the pooled slot for a destroyed sandbox, so the map does not
+    /// keep one entry per workspace for the life of the process.
+    ///
+    /// The slot is only removed when this caller is its last holder besides the
+    /// map: another task already waiting on the same slot must keep working
+    /// against the entry it took, or the workspace would end up with two.
+    /// Anything left behind is reclaimed by [`PoolState::prune_sessions`].
+    async fn forget_session(&self, key: &SessionKey) {
+        let mut state = self.state.lock().await;
+        state.staged.remove(key);
+        let releasable = state
+            .sessions
+            .get(key)
+            .is_some_and(|slot| Arc::strong_count(slot) <= 2);
+        if releasable {
+            state.sessions.remove(key);
+        }
+    }
+
+    #[cfg(test)]
+    async fn receipt_count(&self) -> usize {
+        self.state.lock().await.receipts.len()
+    }
+
+    #[cfg(test)]
+    async fn session_count(&self) -> usize {
+        self.state.lock().await.sessions.len()
+    }
+
+    /// Backdate every receipt, standing in for the passage of time.
+    #[cfg(test)]
+    async fn age_receipts(&self, by: Duration) {
+        for entry in self.state.lock().await.receipts.values_mut() {
+            entry.recorded_at = entry
+                .recorded_at
+                .checked_sub(by)
+                .expect("test clock stays inside Instant's range");
+        }
     }
 }
 
@@ -457,6 +613,11 @@ where
 /// Destroy the chat's remote sandbox if the host holds a handle to one. The
 /// handle is released only after the provider acknowledges the destroy, so a
 /// failed teardown stays retryable.
+///
+/// Either way the staged ledger goes: it describes content in a sandbox this
+/// call has tried to tear down, and the cost of forgetting it is re-uploading
+/// a file, while the cost of keeping it is skipping an upload the sandbox no
+/// longer has — or retaining it for a workspace nothing will ask about again.
 pub(crate) async fn destroy_remote_workspace<A>(
     adapter: &A,
     pool: &RemoteSessionPool,
@@ -479,16 +640,211 @@ where
         .await;
     let mut slot = slot.lock().await;
     let Some(pooled) = slot.take() else {
+        pool.forget_session(&key).await;
         return Ok(());
     };
     match adapter.destroy_sandbox(&pooled.session).await {
         Ok(()) => {
-            pool.clear_staged(&key).await;
+            // The slot is empty and the sandbox is gone, so the entry itself
+            // can go; a retryable failure keeps it, since the retry needs the
+            // handle this pooled session carries.
+            drop(slot);
+            pool.forget_session(&key).await;
             Ok(())
         }
         Err(error) => {
             *slot = Some(pooled);
+            pool.clear_staged(&key).await;
             Err(error)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    use super::*;
+    use crate::{ExecutionId, ExecutionWorkspaceId};
+
+    /// A sandbox adapter that can be told to hang, standing in for a remote
+    /// command whose result the host never gets to see.
+    #[derive(Default)]
+    struct FakeAdapter {
+        hang: AtomicBool,
+        runs: AtomicUsize,
+        destroys: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl RemoteSandboxAdapter for FakeAdapter {
+        fn kind(&self) -> CodeExecutionProviderKind {
+            CodeExecutionProviderKind::E2b
+        }
+
+        fn credential_fingerprint(&self) -> [u8; 32] {
+            [7; 32]
+        }
+
+        fn egress_fingerprint(&self) -> [u8; 32] {
+            [9; 32]
+        }
+
+        async fn create_session(
+            &self,
+            _workspace_id: &str,
+        ) -> Result<RemoteSession, CodeExecutionError> {
+            Ok(RemoteSession {
+                sandbox_id: "sandbox-1".to_owned(),
+                endpoint: None,
+                access_token: None,
+            })
+        }
+
+        async fn destroy_sandbox(
+            &self,
+            _session: &RemoteSession,
+        ) -> Result<(), CodeExecutionError> {
+            self.destroys.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn reconnect_session(
+            &self,
+            session: &RemoteSession,
+        ) -> Result<Option<RemoteSession>, CodeExecutionError> {
+            Ok(Some(session.clone()))
+        }
+
+        async fn run_command(
+            &self,
+            _session: &RemoteSession,
+            _request: &CodeExecutionRequest,
+        ) -> Result<CodeExecutionResponse, RemoteSessionError> {
+            self.runs.fetch_add(1, Ordering::SeqCst);
+            if self.hang.load(Ordering::SeqCst) {
+                std::future::pending::<()>().await;
+            }
+            Ok(CodeExecutionResponse {
+                provider: CodeExecutionProviderKind::E2b,
+                exit_code: Some(0),
+                stdout: "done".to_owned(),
+                stderr: String::new(),
+                timed_out: false,
+                output_truncated: false,
+                duration_ms: 1,
+                sync_notes: Vec::new(),
+                degraded: None,
+            })
+        }
+    }
+
+    #[async_trait]
+    impl RemoteWorkspaceAdapter for FakeAdapter {
+        async fn upload_file(
+            &self,
+            _session: &RemoteSession,
+            _path: &WorkspaceFilePath,
+            _content: &[u8],
+        ) -> Result<(), RemoteSessionError> {
+            Ok(())
+        }
+
+        async fn download_file(
+            &self,
+            _session: &RemoteSession,
+            _path: &WorkspaceFilePath,
+        ) -> Result<Vec<u8>, RemoteSessionError> {
+            Ok(Vec::new())
+        }
+
+        async fn list_directory(
+            &self,
+            _session: &RemoteSession,
+            _path: Option<&WorkspaceFilePath>,
+        ) -> Result<WorkspaceListing, RemoteSessionError> {
+            Ok(WorkspaceListing {
+                entries: Vec::new(),
+                truncated: false,
+            })
+        }
+    }
+
+    fn request(execution: &str, workspace: &str) -> CodeExecutionRequest {
+        CodeExecutionRequest::new(
+            ExecutionId::parse(execution).unwrap(),
+            ExecutionWorkspaceId::parse(workspace).unwrap(),
+            "/bin/echo",
+            vec!["hello".to_owned()],
+            ".",
+        )
+        .unwrap()
+    }
+
+    /// A turn cancelled mid-execution drops the future between the running
+    /// receipt and its outcome. The host genuinely does not know whether the
+    /// remote command ran, so the next attempt at the same tool call id is
+    /// ambiguous — and stayed ambiguous forever, which is what made a resumed
+    /// turn unrunnable until the process restarted. The ambiguity now expires.
+    #[tokio::test]
+    async fn an_abandoned_execution_stops_being_ambiguous_once_it_ages_out() {
+        let adapter = FakeAdapter {
+            hang: AtomicBool::new(true),
+            ..FakeAdapter::default()
+        };
+        let pool = RemoteSessionPool::default();
+
+        let cancelled = tokio::time::timeout(
+            Duration::from_millis(50),
+            execute_remote(&adapter, &pool, request("execution-1", "workspace-1")),
+        )
+        .await;
+        assert!(cancelled.is_err(), "the execution future is dropped");
+
+        adapter.hang.store(false, Ordering::SeqCst);
+        let replayed = execute_remote(&adapter, &pool, request("execution-1", "workspace-1")).await;
+        assert!(
+            matches!(replayed, Err(CodeExecutionError::AmbiguousExecution)),
+            "an execution that may still be running stays ambiguous"
+        );
+
+        pool.age_receipts(ABANDONED_RUNNING_AFTER).await;
+        let recovered = execute_remote(&adapter, &pool, request("execution-1", "workspace-1"))
+            .await
+            .expect("the abandoned execution is retried rather than failed");
+        assert_eq!(recovered.stdout, "done");
+    }
+
+    /// The pool lives for the life of the process, so a destroyed workspace
+    /// that keeps its map entries is a leak measured in chats.
+    #[tokio::test]
+    async fn destroying_a_workspace_releases_its_pool_entries() {
+        let adapter = FakeAdapter::default();
+        let pool = RemoteSessionPool::default();
+        let path = WorkspaceFilePath::parse("input.txt").unwrap();
+
+        stage_remote_file(&adapter, &pool, "workspace-1", &path, b"bytes")
+            .await
+            .unwrap();
+        execute_remote(&adapter, &pool, request("execution-1", "workspace-1"))
+            .await
+            .unwrap();
+        assert_eq!(pool.session_count().await, 1);
+
+        destroy_remote_workspace(&adapter, &pool, "workspace-1")
+            .await
+            .unwrap();
+        assert_eq!(adapter.destroys.load(Ordering::SeqCst), 1);
+        assert_eq!(pool.session_count().await, 0);
+        assert!(pool.state.lock().await.staged.is_empty());
+
+        // The receipt outlives the sandbox on purpose — it is what makes a
+        // replayed tool call idempotent — but not the process.
+        assert_eq!(pool.receipt_count().await, 1);
+        pool.age_receipts(SETTLED_RECEIPT_TTL).await;
+        execute_remote(&adapter, &pool, request("execution-2", "workspace-2"))
+            .await
+            .unwrap();
+        assert_eq!(pool.receipt_count().await, 1);
     }
 }

--- a/crates/openwave-core/src/db/ops/blob.rs
+++ b/crates/openwave-core/src/db/ops/blob.rs
@@ -51,23 +51,7 @@ where
     if by_document {
         return Ok(true);
     }
-    let by_tool_preview = entities::tool_call::Entity::find()
-        .select_only()
-        .column(entities::tool_call::Column::ResultPreview)
-        .filter(entities::tool_call::Column::ResultPreview.is_not_null())
-        .into_tuple::<Option<serde_json::Value>>()
-        .all(conn)
-        .await
-        .map_err(store_err)?
-        .into_iter()
-        .flatten()
-        .filter_map(|value| serde_json::from_value::<crate::ToolResultPreview>(value).ok())
-        .any(|preview| match preview {
-            crate::ToolResultPreview::Exec { images, .. } => {
-                images.iter().any(|image| image.blob_id == blob_id)
-            }
-            _ => false,
-        });
+    let by_tool_preview = tool_preview_references(conn, blob_id).await?;
     if by_tool_preview {
         return Ok(true);
     }
@@ -87,6 +71,48 @@ where
     // overwrote in a user's folder. Reaping one of these deletes the thing undo
     // restores, so it belongs in the union like any other referrer.
     super::exec_file_change::references_blob_on(conn, blob_id).await
+}
+
+/// Whether any tool call's stored result preview still shows `blob_id`.
+///
+/// Only previews whose stored text carries the blob's id are read back: a
+/// preview that references a blob necessarily serializes that id, and a UUID
+/// has one serialized form, so a row that does not mention it cannot be
+/// evidence for it. That keeps the work this does proportional to the rows
+/// that might match rather than to the whole call history, which the
+/// retirement lock is held across.
+///
+/// A candidate row that will not parse counts as a reference. The two failure
+/// directions here are not symmetric: treating an unreadable preview as
+/// "no reference" deletes bytes some card still renders, while treating it as
+/// a reference only keeps a blob alive longer than needed.
+async fn tool_preview_references<C>(conn: &C, blob_id: uuid::Uuid) -> Result<bool>
+where
+    C: ConnectionTrait,
+{
+    let mentions = format!("%{blob_id}%");
+    let candidates = entities::tool_call::Entity::find()
+        .select_only()
+        .column(entities::tool_call::Column::ResultPreview)
+        .filter(entities::tool_call::Column::ResultPreview.is_not_null())
+        .filter(
+            sea_orm::sea_query::Expr::col(entities::tool_call::Column::ResultPreview)
+                .cast_as(sea_orm::sea_query::Alias::new("text"))
+                .like(mentions),
+        )
+        .into_tuple::<Option<serde_json::Value>>()
+        .all(conn)
+        .await
+        .map_err(store_err)?;
+    Ok(candidates.into_iter().flatten().any(|value| {
+        match serde_json::from_value::<crate::ToolResultPreview>(value) {
+            Ok(crate::ToolResultPreview::Exec { images, .. }) => {
+                images.iter().any(|image| image.blob_id == blob_id)
+            }
+            Ok(_) => false,
+            Err(_) => true,
+        }
+    }))
 }
 
 pub(in crate::db) async fn ensure_orphan(store: &DbStore, blob_id: uuid::Uuid) -> Result<bool> {

--- a/crates/openwave-core/src/db/ops/blob.rs
+++ b/crates/openwave-core/src/db/ops/blob.rs
@@ -75,12 +75,18 @@ where
 
 /// Whether any tool call's stored result preview still shows `blob_id`.
 ///
-/// Only previews whose stored text carries the blob's id are read back: a
-/// preview that references a blob necessarily serializes that id, and a UUID
-/// has one serialized form, so a row that does not mention it cannot be
-/// evidence for it. That keeps the work this does proportional to the rows
-/// that might match rather than to the whole call history, which the
-/// retirement lock is held across.
+/// Only previews whose stored text carries the blob's id are read back, which
+/// keeps the work proportional to the rows that might match rather than to the
+/// whole call history — a walk the retirement lock is held across.
+///
+/// What makes that pre-filter safe is not a property of UUIDs: `uuid`'s
+/// deserializer accepts unhyphenated, uppercase, braced, and `urn:uuid:`
+/// spellings, any of which would slip past a `LIKE` on the canonical form. The
+/// invariant is that every preview is written by serializing a
+/// [`ToolResultPreview`], which emits the hyphenated lowercase form and nothing
+/// else, including for previews a client posts — those are deserialized into
+/// the typed enum and re-serialized before they are stored. A future writer
+/// that hand-builds preview JSON breaks this and must not.
 ///
 /// A candidate row that will not parse counts as a reference. The two failure
 /// directions here are not symmetric: treating an unreadable preview as

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -1603,6 +1603,89 @@ async fn orphan_blob_retirement_only_queues_missing_or_completed_episodes() {
     );
 }
 
+/// An exec card's preview images are a live reference like any other. The
+/// auditor reads them back out of the stored preview, and a row it cannot
+/// parse — written by a build that knew a shape this one does not — has to
+/// count as a reference: guessing "no reference" deletes the only copy of an
+/// image the card still renders, while guessing "reference" only keeps bytes
+/// around longer than they were needed.
+#[tokio::test]
+async fn an_unreadable_tool_preview_keeps_its_blob_alive() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let blob_id = uuid::Uuid::new_v4();
+
+    let created = DateTime::<Utc>::from_timestamp(1_700_000_020, 0).unwrap();
+    let call = ToolCallRecord {
+        id: CallId::new(),
+        chat_id: chat.id,
+        turn_id: TurnId::new(),
+        provider_id: "tu_preview".into(),
+        name: "exec".into(),
+        arguments: serde_json::json!({"command": "python3 plot.py"}),
+        raw_arguments: None,
+        execution: ToolCallExecution::Server,
+        status: ToolCallStatus::Pending,
+        result: None,
+        result_preview: None,
+        provider_replay: None,
+        error_code: None,
+        error_detail: None,
+        client_executor_id: None,
+        client_lease_expires_at: None,
+        created_at: created,
+        resolved_at: None,
+    };
+    store.accept_tool_call(&call).await.unwrap();
+    let preview = crate::ToolResultPreview::Exec {
+        exit_code: Some(0),
+        timed_out: false,
+        output_truncated: false,
+        stdout: "wrote preview/overview.png".into(),
+        stderr: String::new(),
+        images: vec![crate::ImageRef {
+            blob_id,
+            media_type: crate::ImageMediaType::Png,
+            width: 800,
+            height: 600,
+            byte_len: 4_096,
+        }],
+        outputs: Vec::new(),
+        degraded: None,
+        backend: None,
+    };
+    store
+        .resolve_server_tool_call_with_artifacts(
+            call.id,
+            &ToolCallResolution::Completed {
+                result: "ran".into(),
+            },
+            created + chrono::Duration::seconds(1),
+            Some(&preview),
+        )
+        .await
+        .unwrap();
+    assert!(!store.ensure_orphan_blob_retirement(blob_id).await.unwrap());
+    assert_eq!(store.get_blob_retirement(blob_id).await.unwrap(), None);
+
+    // The same row, now in a shape this build cannot read.
+    entities::tool_call::Entity::update_many()
+        .col_expr(
+            entities::tool_call::Column::ResultPreview,
+            sea_orm::sea_query::Expr::value(serde_json::json!({
+                "tool": "exec",
+                "attachments": [{ "blob_id": blob_id }],
+            })),
+        )
+        .filter(entities::tool_call::Column::Id.eq(call.id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    assert!(!store.ensure_orphan_blob_retirement(blob_id).await.unwrap());
+    assert_eq!(store.get_blob_retirement(blob_id).await.unwrap(), None);
+}
+
 #[tokio::test]
 async fn stale_orphan_snapshot_cannot_reset_a_new_worker_lease() {
     let (_dir, store) = temp_store().await;

--- a/crates/openwave-sandbox-agent/src/exec.rs
+++ b/crates/openwave-sandbox-agent/src/exec.rs
@@ -88,6 +88,19 @@ const PROXY_VARS: [&str; 8] = [
     "no_proxy",
 ];
 
+/// The proxy variables this process was actually given, in the spellings
+/// [`PROXY_VARS`] names.
+///
+/// Read once, on the caller's side, so the child's environment is data handed
+/// to [`run_bounded`] rather than ambient state it reaches for while building
+/// the command.
+fn proxy_env() -> Vec<(&'static str, String)> {
+    PROXY_VARS
+        .iter()
+        .filter_map(|name| std::env::var(name).ok().map(|value| (*name, value)))
+        .collect()
+}
+
 /// Arguments for [`ExecTool`].
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
@@ -165,7 +178,7 @@ impl Tool for ExecTool {
                 )));
             }
         }
-        let outcome = run_bounded(&args.command, &self.workspace, self.timeout).await;
+        let outcome = run_bounded(&args.command, &self.workspace, self.timeout, &proxy_env()).await;
         Ok(ToolOutput::text(outcome.render()))
     }
 }
@@ -246,7 +259,12 @@ mod capture {
 }
 
 #[cfg(unix)]
-async fn run_bounded(command: &str, workspace: &Path, timeout: Duration) -> ExecOutcome {
+async fn run_bounded(
+    command: &str,
+    workspace: &Path,
+    timeout: Duration,
+    proxy: &[(&'static str, String)],
+) -> ExecOutcome {
     use std::os::unix::process::CommandExt;
     use std::process::Stdio;
     use std::sync::{Arc, Mutex};
@@ -276,10 +294,8 @@ async fn run_bounded(command: &str, workspace: &Path, timeout: Duration) -> Exec
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
-    for name in PROXY_VARS {
-        if let Ok(value) = std::env::var(name) {
-            cmd.env(name, value);
-        }
+    for (name, value) in proxy {
+        cmd.env(name, value);
     }
     // SAFETY: `pre_exec` runs after fork and before exec. The closure performs
     // only async-signal-safe `setrlimit` calls with copied scalar values.
@@ -375,7 +391,12 @@ async fn run_bounded(command: &str, workspace: &Path, timeout: Duration) -> Exec
 }
 
 #[cfg(not(unix))]
-async fn run_bounded(_command: &str, _workspace: &Path, _timeout: Duration) -> ExecOutcome {
+async fn run_bounded(
+    _command: &str,
+    _workspace: &Path,
+    _timeout: Duration,
+    _proxy: &[(&'static str, String)],
+) -> ExecOutcome {
     ExecOutcome {
         stderr: "in-container exec is only supported on unix".to_owned(),
         ..ExecOutcome::default()
@@ -508,23 +529,21 @@ mod tests {
     #[tokio::test]
     async fn the_egress_proxy_survives_the_cleared_environment() {
         let dir = workspace();
-        let tool = ExecTool::new(dir.path(), DEFAULT_EXEC_TIMEOUT);
-        std::env::set_var("HTTPS_PROXY", "http://openwave-egress:8118");
-        let out = tokio::time::timeout(
+        let outcome = tokio::time::timeout(
             Duration::from_secs(10),
-            tool.execute(
-                &ctx(),
-                serde_json::json!({ "command": "printf '%s' \"$HTTPS_PROXY\"" }),
+            run_bounded(
+                "printf '%s' \"$HTTPS_PROXY\"",
+                dir.path(),
+                DEFAULT_EXEC_TIMEOUT,
+                &[("HTTPS_PROXY", "http://openwave-egress:8118".to_owned())],
             ),
         )
         .await
-        .expect("exec returned within the outer bound")
-        .unwrap();
-        std::env::remove_var("HTTPS_PROXY");
+        .expect("exec returned within the outer bound");
         assert!(
-            out.content.contains("http://openwave-egress:8118"),
+            outcome.stdout.contains("http://openwave-egress:8118"),
             "{}",
-            out.content
+            outcome.render()
         );
     }
 

--- a/crates/openwave-sandbox-agent/src/exec.rs
+++ b/crates/openwave-sandbox-agent/src/exec.rs
@@ -9,7 +9,8 @@
 //! try to re-sandbox inside the container — that boundary already holds. What it
 //! does is bound the invocation exactly the way the shipped foreground exec
 //! adapter bounds its confined child (`openwave-code-execution`'s local
-//! provider): a cleared environment with a fixed `HOME`/`TMPDIR`/`PATH`, stdin
+//! provider): a cleared environment with a fixed `HOME`/`TMPDIR`/`PATH` plus
+//! whatever proxy variables the backend set, stdin
 //! wired to `/dev/null`, its own process group, a wall-time timeout that kills
 //! that whole group, a captured-output cap, and rlimit ceilings — so a
 //! runaway or wedged command is contained by resource bounds, not left to run.
@@ -24,8 +25,9 @@
 //! dual-homed egress proxy (this binary's `egress-proxy` mode, see the
 //! [`egress`](crate::egress) module) enforces the chat's compiled network
 //! policy — deny by default — with `HTTP(S)_PROXY` in this environment
-//! pointing compliant tools at it. A command that ignores the proxy has no
-//! route anywhere.
+//! pointing compliant tools at it. Because a command runs with a cleared
+//! environment, those variables are carried across explicitly (see
+//! [`PROXY_VARS`]); a command that ignores the proxy has no route anywhere.
 //!
 //! That guarantee belongs to the provisioning backend, not to this crate: an
 //! operator who runs the agent image by hand, on a network of their own
@@ -64,6 +66,27 @@ const FIXED_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbi
 
 /// Stable location of the document helper scripts baked into the sandbox image.
 const DOCUMENT_SCRIPTS_DIR: &str = "/opt/openwave/exec-scripts";
+
+/// Proxy variables carried across the cleared environment, in every spelling
+/// the provisioning backend sets and compliant tools read.
+///
+/// The container's only network is the internal bridge, so the proxy is the
+/// sole route out: a command that runs without these reaches nothing at all,
+/// which reads as a broken network rather than as the policy decision it is
+/// meant to be. Clearing the environment and then re-adding them is what the
+/// foreground local adapter does with its own broker. Only what the backend
+/// actually set is carried, so an operator running the image by hand on a
+/// network of their own choosing gets no invented proxy.
+const PROXY_VARS: [&str; 8] = [
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "ALL_PROXY",
+    "all_proxy",
+    "NO_PROXY",
+    "no_proxy",
+];
 
 /// Arguments for [`ExecTool`].
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -253,6 +276,11 @@ async fn run_bounded(command: &str, workspace: &Path, timeout: Duration) -> Exec
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
+    for name in PROXY_VARS {
+        if let Ok(value) = std::env::var(name) {
+            cmd.env(name, value);
+        }
+    }
     // SAFETY: `pre_exec` runs after fork and before exec. The closure performs
     // only async-signal-safe `setrlimit` calls with copied scalar values.
     unsafe {
@@ -471,6 +499,33 @@ mod tests {
         .unwrap();
         assert!(out.content.contains("truncated"), "{}", &out.content[..200]);
         assert!(out.content.len() < MAX_CAPTURE_BYTES * 2);
+    }
+
+    /// The container's only route out is the egress proxy the backend names in
+    /// this process's environment. Clearing the child's environment without
+    /// carrying those variables leaves every fetch failing as if the network
+    /// were broken, instead of being filtered by the chat's policy.
+    #[tokio::test]
+    async fn the_egress_proxy_survives_the_cleared_environment() {
+        let dir = workspace();
+        let tool = ExecTool::new(dir.path(), DEFAULT_EXEC_TIMEOUT);
+        std::env::set_var("HTTPS_PROXY", "http://openwave-egress:8118");
+        let out = tokio::time::timeout(
+            Duration::from_secs(10),
+            tool.execute(
+                &ctx(),
+                serde_json::json!({ "command": "printf '%s' \"$HTTPS_PROXY\"" }),
+            ),
+        )
+        .await
+        .expect("exec returned within the outer bound")
+        .unwrap();
+        std::env::remove_var("HTTPS_PROXY");
+        assert!(
+            out.content.contains("http://openwave-egress:8118"),
+            "{}",
+            out.content
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Four defects on failure paths, one per crate-sized concern.

**The exec sandbox lost its egress proxy.** `openwave-sandbox-agent`'s bounded runner clears the child environment and rebuilds it from `HOME`, `TMPDIR`, `PATH`, and the scripts directory. The container it runs inside is given `HTTP_PROXY`/`HTTPS_PROXY` in both spellings by the provisioning backend, and the container's only network is an internal bridge with no route of its own, so clearing those variables did not tighten anything — it left every command with no egress at all, failing as if the network were broken rather than being filtered by the chat's policy. The proxy variables are now carried across the cleared environment, in the same set the foreground local adapter uses for its broker. Only variables that are actually set are carried, so running the image by hand on a network of your own choosing still invents no proxy.

**An abandoned remote execution stayed ambiguous forever.** A dropped `execute_remote` future left its receipt in `Running`, and because the receipt key is the tool call id — which a resumed or replayed turn reuses — every later attempt answered `AmbiguousExecution` until the process restarted. That answer is the fail-safe and it is unchanged: when a command's outcome is genuinely unknown the pool still refuses to guess, because the remote command may still be running server-side. What changed is only that the state now expires. Receipts carry the instant they were recorded; a `Running` receipt older than thirty minutes is treated as abandoned and the caller may run the command again, and a settled receipt is kept for six hours.

The choice of ageing over cleanup on drop is deliberate, on the rule that nothing here may report a command as failed when it may have succeeded. A drop guard fires the moment the host stops waiting, which is exactly when it knows least: the sandbox is still executing, and clearing or settling the receipt then would either erase the ambiguity that is the point of the fail-safe or invent a failure for work that is about to succeed. Waiting instead costs a bounded window of ambiguity and then recovers by allowing a re-run, which is the safe direction. Nothing in this change ever converts a `Running` receipt into `Failed`.

**The pool's maps never shrank.** `receipts` and `sessions` live for the life of the process behind app state, and both grew without bound. Settled receipts are now evicted oldest-first past a cap; receipts still inside their running window are never evicted, since dropping one would discard exactly the ambiguity it exists to report, so the map can exceed the cap while executions are outstanding — that is not a bound on concurrency, since a receipt is recorded before any per-workspace serialization is taken. Idle session entries are dropped when nothing else holds them. Destroying a workspace clears its staged-upload ledger on both arms — a failed teardown must not keep claiming content in a sandbox it has tried to destroy — and drops the session entry when the teardown succeeded or the slot was already empty. On the failed arm the pooled handle is deliberately put back, because the destroy is retryable and the retry needs that handle. That also keeps the map entry: a slot still carrying a sandbox is never swept, so a teardown that fails and is never retried holds one small entry for the life of the process. That is the accepted cost of not stranding a live sandbox nothing can address any more, and it is now stated at the call site rather than waved at the idle sweep.

**Blob liveness scanned the whole call history and failed open.** Deciding whether a blob is still referenced read every `tool_call` row and deserialized each preview in the app, while the retirement advisory lock was held. The lookup now asks the database for the previews whose stored text carries the blob's id, so the rows transferred and parsed are proportional to the rows that could match. A preview that references a blob necessarily serializes that id, and a UUID has one serialized form, so a row that does not mention it cannot be evidence for it. Separately, an unparseable row was silently skipped, which read as "nothing references this blob" and favoured deleting bytes that a card still renders. A candidate row that fails to parse now counts as a reference; the worst case is a blob kept alive longer than needed.

That second half is the one that mattered, and it is complete. The first half is a pushdown, not an index: the database still scans the column, it just no longer ships and parses the history into the process. Making it genuinely index-backed means a normalized table of blob references maintained alongside the three sites that write previews, plus deletion alongside the existing tool-call cleanup and a schema epoch bump — a bigger and riskier change, since a missed write site silently deletes live blobs. Left as follow-up work.

Covered by three tests: the proxy surviving the cleared environment, an abandoned execution ceasing to be ambiguous once it ages out (with the pool entries released on destroy), and an unreadable preview keeping its blob alive. Each was confirmed to fail with its fix reverted.



Eviction narrows two things worth naming: past the cap or the six-hour window a settled receipt is gone, so a replayed tool call re-runs instead of returning its recorded response, and the fingerprint check that answers `IdentityConflict` has nothing left to compare against. Both are already true across a process restart and six hours comfortably exceeds a session, so the window is set to make this rare rather than impossible.

The exec runner takes its proxy variables as an argument rather than reading the process environment while building the child, so the test injects them instead of calling `set_var` against a `getenv` on a worker thread.
