### PR TITLE
fix(shell-policy): refuse a glob that spells as much of a marker as it hides

### DIFF
--- a/crates/openwave-shell-policy/src/lib.rs
+++ b/crates/openwave-shell-policy/src/lib.rs
@@ -340,13 +340,19 @@ fn substitution_is_a_count(token: &str) -> bool {
 /// `?` or a bracket class is the opposite — a precise one-character disguise,
 /// standing in for a character the author already knows. So a marker counts as
 /// reachable when the token spells it out with any number of single-character
-/// wildcards but **more literal characters than `*` covers**: `.e??` and
-/// `.???/id_???` are refused, `*.pe?` is refused for pinning `.pe`, and
-/// `src/*` is not.
+/// wildcards and **at least as many literal characters as `*` covers**: `.e??`,
+/// `.???/id_???` and `.e*` are refused, `*.pe?` is refused for pinning `.pe`,
+/// and `src/*` is not.
 ///
-/// What that leaves uncovered is a `*` covering most of a marker, which is the
-/// working-directory question this predicate cannot answer anyway — and the
-/// `cd`-then-glob gap below, which it also cannot.
+/// The tie goes to refusing because a `*` that covers no more of a marker than
+/// the token already spells is not a pattern aimed at a directory: `.e*` names
+/// two of the four characters in `.env` and expands onto almost nothing else.
+/// A glob written for ordinary work spells much less of a marker than it
+/// covers, so it stays on the safe side of the tie.
+///
+/// What that leaves uncovered is a `*` covering *most* of a marker, such as
+/// `.*`, which is the working-directory question this predicate cannot answer
+/// anyway — and the `cd`-then-glob gap below, which it also cannot.
 fn could_reach_sensitive(token: &str) -> bool {
     let raw = token.to_lowercase();
     let norm = normpath(token).to_lowercase();
@@ -403,15 +409,15 @@ fn glob_atoms(token: &str) -> Vec<GlobAtom> {
     atoms
 }
 
-/// Whether some expansion of `atoms` contains `marker`, spelling out more of it
-/// than a `*` covers.
+/// Whether some expansion of `atoms` contains `marker`, spelling out at least
+/// as much of it as a `*` covers.
 ///
 /// The marker has to appear contiguously — that is what `hits_sensitive` looks
 /// for — but it may start and end anywhere in the token, since anything outside
 /// it is text the floor does not care about. Scoring a spelled character `+1`,
 /// a `*`-supplied one `-1` and a single-character wildcard `0`, then asking for
-/// a positive total, is the test the doc comment on [`could_reach_sensitive`]
-/// describes.
+/// a non-negative total, is the test the doc comment on
+/// [`could_reach_sensitive`] describes.
 fn spelled_more_than_globbed(atoms: &[GlobAtom], marker: &[char]) -> bool {
     // `best[j]`: the highest score with which the first `j` characters of the
     // marker have been consumed, over every alignment considered so far.
@@ -445,11 +451,11 @@ fn spelled_more_than_globbed(atoms: &[GlobAtom], marker: &[char]) -> bool {
             relax(&mut next[marker.len()], score);
         }
         best = next;
-        if matches!(best[marker.len()], Some(score) if score > 0) {
+        if matches!(best[marker.len()], Some(score) if score >= 0) {
             return true;
         }
     }
-    matches!(best[marker.len()], Some(score) if score > 0)
+    matches!(best[marker.len()], Some(score) if score >= 0)
 }
 
 /// What a program will do with one of its arguments.

--- a/crates/openwave-shell-policy/src/tests.rs
+++ b/crates/openwave-shell-policy/src/tests.rs
@@ -428,9 +428,13 @@ const NEVER_ALLOW: &[&str] = &[
     "cp payload .git/hook*/pre-commit",
     // half a marker spelled and half wildcarded. these are the boundary: only
     // `*` is evidence that a pattern is aimed broadly, so a token that reaches
-    // a marker on single-character wildcards alone is still a disguise
+    // a marker on single-character wildcards alone is still a disguise, and a
+    // `*` that covers no more of the marker than the token already spells is
+    // not aimed at a directory either
     "cat .e??",
     "cat .???/id_???",
+    "cat .e*",
+    "cp .np* /tmp/x",
     // every one of the above is reachable by typing a different program, so
     // the operand check has to know which of grep's operands are files
     "grep '' .en?",


### PR DESCRIPTION
## What was wrong

`could_reach_sensitive` treats a token's metacharacters as wildcards and asks whether it could match one of `SENSITIVE_TARGET_MARKERS`. It scores a spelled character `+1`, a `*`-supplied one `-1`, and a single-character wildcard `0`, then asked for a **positive** total. A tie therefore read as unreachable, so these auto-ran under a folder-wide grant:

- `cat .e*` — spells `.e`, lets `*` supply `nv`
- `cp .np* /tmp/x` — spells `.np`, lets `*` supply `mrc`
- the same shape against `.p*`, `.??*`

## The change

One operator, at both the early-exit and the final check: `score > 0` becomes `score >= 0`.

The reasoning, which is now in the doc comment: a `*` that covers no more of a marker than the token already spells is not a pattern aimed at a directory. `.e*` names two of the four characters in `.env` and expands onto almost nothing else. A glob written for ordinary work spells far less of a marker than it covers, so the tie can go to refusing without catching it.

## What it costs

Nothing measurable. I ran 53 everyday glob commands (`ls *`, `cat *.rs`, `cp *.json dist/`, `rg pat crates/*/src`, `prettier --write 'src/**/*.ts'`, `tar czf out.tgz src/*`, `cat .eslintrc.json`, `ls .github/workflows/*`, and so on) under `allow_all()` with the gate at `> 0` and again at `>= 0`, and diffed the verdicts. **Zero changed.** All 16 existing tests pass unmodified.

## What is still uncovered

A `*` covering *most* of a marker — `.*` reaching `.env` — stays reachable. That is the working-directory question this predicate cannot answer, and the doc comment now names it explicitly rather than describing the old boundary.

## Tests

Two entries added to `NEVER_ALLOW`, the corpus that pins the floor at its widest grant: `cat .e*` and `cp .np* /tmp/x`. They sit with the existing `.e??` / `.???/id_???` boundary cases under a comment that now covers both halves of the rule. No tests removed.

Follow-up to #1942.