### PR TITLE
fix(providers): hide API-only OpenAI models under ChatGPT auth

### DIFF
--- a/crates/openwave-server/src/model_registry.rs
+++ b/crates/openwave-server/src/model_registry.rs
@@ -187,6 +187,19 @@ impl ModelSpec {
         !self.reasoning_efforts.is_empty()
     }
 
+    /// Whether this OpenAI row may run under ChatGPT / Codex subscription auth.
+    ///
+    /// ChatGPT OAuth routes inference through the Codex backend, which rejects
+    /// some API-only model ids (today: `gpt-5.4-nano`) with a 400. Non-OpenAI
+    /// rows return `true` — ChatGPT auth does not apply to them, and callers
+    /// gate on auth mode before consulting this.
+    pub fn supports_chatgpt_auth(&self) -> bool {
+        !matches!(
+            (self.provider, self.id),
+            (ProviderKind::Openai, "gpt-5.4-nano")
+        )
+    }
+
     /// Whether this exact hosted row accepts Chat Completions function tools.
     ///
     /// Native providers and most hosted-compatible rows carry the tool path
@@ -1152,6 +1165,30 @@ mod tests {
         let spec = find_for(ProviderKind::Anthropic, "claude-haiku-4-5-20251001").unwrap();
         assert!(!spec.supports_reasoning);
         assert!(spec.reasoning_efforts.is_empty());
+    }
+
+    #[test]
+    fn openai_chatgpt_auth_excludes_api_only_nano_and_keeps_a_usable_flagship() {
+        let nano = find_for(ProviderKind::Openai, "gpt-5.4-nano").unwrap();
+        assert!(
+            !nano.supports_chatgpt_auth(),
+            "gpt-5.4-nano is API-only; Codex rejects it under a ChatGPT account"
+        );
+        assert!(
+            find_for(ProviderKind::Openai, "gpt-5.6-sol")
+                .unwrap()
+                .supports_chatgpt_auth(),
+            "a ChatGPT-signed-in picker must still have a flagship to offer"
+        );
+        assert!(find_for(ProviderKind::Openai, "gpt-5.4-mini")
+            .unwrap()
+            .supports_chatgpt_auth());
+        // Non-OpenAI rows are not gated by this stance.
+        assert!(
+            find_for(ProviderKind::Anthropic, "claude-haiku-4-5-20251001")
+                .unwrap()
+                .supports_chatgpt_auth()
+        );
     }
 
     #[test]

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -1474,7 +1474,10 @@ pub async fn collect_routes(
                 kind: route_kind(kind),
                 api_key: String::new(),
                 base_url: Some(crate::connectors::CODEX_BASE_URL.to_string()),
+                // Codex rejects API-only ids; keep the route honest with the
+                // same ChatGPT stance the catalog uses for `available`.
                 curated_models: model_registry::models_for(kind)
+                    .filter(|spec| spec.supports_chatgpt_auth())
                     .map(|spec| spec.id.to_string())
                     .collect(),
                 token_source: Some(source),
@@ -1667,7 +1670,22 @@ pub async fn model_is_usable(
     model: &ResolvedModelPolicy,
     policy: &crate::managed_policy::ManagedPolicy,
 ) -> Result<bool> {
-    provider_is_usable(store, secrets, model.provider, policy).await
+    if !provider_is_usable(store, secrets, model.provider, policy).await? {
+        return Ok(false);
+    }
+    // ChatGPT / Codex auth rejects some API-only OpenAI ids. Keep the row in
+    // the catalog (API-key installs still need it) but mark it unusable here.
+    if model.provider == ProviderKind::Openai
+        && matches!(
+            auth_mode_for(secrets, ProviderKind::Openai).await,
+            Some(ProviderAuthMode::Chatgpt)
+        )
+    {
+        let supported = model_registry::find_for(ProviderKind::Openai, &model.id)
+            .is_some_and(model_registry::ModelSpec::supports_chatgpt_auth);
+        return Ok(supported);
+    }
+    Ok(true)
 }
 
 /// Full typed catalog. Unavailable rows remain visible for provider-scoped
@@ -1679,10 +1697,17 @@ pub async fn catalog_models(
 ) -> Result<Vec<CatalogModel>> {
     let mut models = Vec::new();
     for &kind in ProviderKind::ALL {
-        let available = provider_is_usable(store, secrets, kind, policy).await?;
-        models.extend(model_registry::models_for(kind).map(|spec| CatalogModel {
-            policy: ResolvedModelPolicy::curated(spec),
-            available,
+        let provider_usable = provider_is_usable(store, secrets, kind, policy).await?;
+        let chatgpt = matches!(
+            auth_mode_for(secrets, kind).await,
+            Some(ProviderAuthMode::Chatgpt)
+        );
+        models.extend(model_registry::models_for(kind).map(|spec| {
+            let available = provider_usable && (!chatgpt || spec.supports_chatgpt_auth());
+            CatalogModel {
+                policy: ResolvedModelPolicy::curated(spec),
+                available,
+            }
         }));
         // Configured model sets: the compatible endpoint's custom entries,
         // and the managed gateway's entitled snapshot — which is empty on an
@@ -1699,7 +1724,7 @@ pub async fn catalog_models(
                 ProviderKind::ModelGateway => ResolvedModelPolicy::gateway_for(model),
                 _ => ResolvedModelPolicy::custom_for(kind, model),
             },
-            available,
+            available: provider_usable,
         }));
     }
     Ok(models)

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -1325,6 +1325,85 @@ async fn models_catalog_includes_enabled_credentialed_providers() {
     assert!(models
         .iter()
         .any(|m| m["provider"] == "openai" && m["available"] == true));
+    // API-key auth keeps the API-only nano row usable.
+    assert!(models
+        .iter()
+        .any(|m| { m["key"] == "openai::gpt-5.4-nano" && m["available"] == true }));
+}
+
+#[tokio::test]
+async fn chatgpt_auth_marks_api_only_openai_models_unavailable() {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}/test.db?mode=rwc",
+            dir.path().display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let secrets: Arc<dyn SecretProvider> = Arc::new(MemSecrets::default());
+    providers::write_credential(
+        &*secrets,
+        providers::ProviderKind::Openai,
+        &providers::ProviderCredential::Oauth {},
+    )
+    .await
+    .unwrap();
+    secrets
+        .set_secret(
+            crate::connectors::CHATGPT_SECRET_KEY,
+            &serde_json::json!({
+                "access_token": "access",
+                "refresh_token": "refresh",
+                "account_id": "acct-test",
+                "expires_at_unix": 4_102_444_800_u64,
+            })
+            .to_string(),
+        )
+        .await
+        .unwrap();
+    providers::write_config(
+        &*store,
+        providers::ProviderKind::Openai,
+        &providers::ProviderConfig {
+            enabled: true,
+            base_url: None,
+            models: Vec::new(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
+        .await
+        .unwrap();
+    let catalog = providers::catalog_models(&*store, &*secrets, &policy)
+        .await
+        .unwrap();
+    let nano = catalog
+        .iter()
+        .find(|m| m.policy.id == "gpt-5.4-nano")
+        .expect("nano stays in the catalog");
+    assert!(
+        !nano.available,
+        "ChatGPT/Codex cannot run gpt-5.4-nano; available must be false"
+    );
+    let sol = catalog
+        .iter()
+        .find(|m| m.policy.id == "gpt-5.6-sol")
+        .expect("sol stays in the catalog");
+    assert!(sol.available, "a ChatGPT flagship must remain selectable");
+
+    // Selection through model_is_usable must agree with the catalog stance.
+    let nano_policy = providers::ResolvedModelPolicy::curated(
+        crate::model_registry::find_for(providers::ProviderKind::Openai, "gpt-5.4-nano").unwrap(),
+    );
+    assert!(
+        !providers::model_is_usable(&*store, &*secrets, &nano_policy, &policy)
+            .await
+            .unwrap()
+    );
 }
 
 #[tokio::test]

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -92,6 +92,9 @@ Existing machinery that already follows this:
   adapters and the UI always have.
 - Registry flags such as `supports_vendor_web_search` — honest absence beats
   a half-working path.
+- ChatGPT / Codex subscription auth — `ModelSpec::supports_chatgpt_auth`
+  (and the catalog's per-model `available`) hide API-only OpenAI ids such as
+  `gpt-5.4-nano` that Codex rejects, while API-key installs keep them.
 
 ## Checklist for a new provider-coupled feature
 


### PR DESCRIPTION
## Summary
- Mark `gpt-5.4-nano` as unsupported under ChatGPT/Codex auth via `ModelSpec::supports_chatgpt_auth`.
- Per-model `available` in the catalog and ChatGPT route `curated_models` follow that stance; API-key installs keep nano usable.
- Document the honesty rule in `docs/model-providers.md`.

## Test plan
- [x] `cargo test -p openwave-server --lib chatgpt_auth`
- [ ] Confirm ChatGPT-signed-in picker disables nano and still offers a flagship (e.g. gpt-5.6-sol)
- [ ] Confirm API-key OpenAI install still lists nano as available