### PR TITLE
feat(cli): attach to a running desktop or serve via listen.json

### DIFF
--- a/crates/openwave-cli/src/connect.rs
+++ b/crates/openwave-cli/src/connect.rs
@@ -6,7 +6,10 @@
 //! directory, which is the right shape for a script or an agent trying things
 //! out in isolation. With `--server <url>` (or `OPENWAVE_SERVER_URL`) it
 //! **attaches** instead, becoming a pure HTTP+WS client of an already-running
-//! `openwave serve` — the same client the desktop webview is.
+//! `openwave serve` — the same client the desktop webview is. `--attach` is
+//! the same attach, but the URL and token come from `{data_dir}/listen.json`
+//! that the running server published (desktop or `serve`), so the token never
+//! rides argv — see [`docs/decisions/0009-data-dir-listen-endpoint.md`].
 //!
 //! Attaching is what a second process on one data directory must do. A data
 //! directory belongs to exactly one server process (`openwave-server` holds an
@@ -14,10 +17,11 @@
 //! embedding CLI at a directory the desktop or a running daemon already owns is
 //! refused rather than allowed to race the database.
 //!
-//! The token never rides argv. It comes from `OPENWAVE_SERVER_TOKEN`, or from
-//! the variable `--server-token-env <var>` names — a command line is readable
-//! by every process on the machine and lands in shell history, and a per-launch
-//! bearer token is full authority over the profile.
+//! The token never rides argv. It comes from `listen.json` under `--attach`,
+//! from `OPENWAVE_SERVER_TOKEN`, or from the variable `--server-token-env`
+//! names — a command line is readable by every process on the machine and lands
+//! in shell history, and a per-launch bearer token is full authority over the
+//! profile.
 
 use openwave_core::{AgentError, Result};
 
@@ -38,10 +42,38 @@ pub enum Server {
 }
 
 impl Server {
-    /// Resolve the choice from the `--server` / `--server-token-env` flags and
-    /// the environment. The flag wins over `OPENWAVE_SERVER_URL`, so a script
-    /// with the variable exported can still target one invocation elsewhere.
-    pub fn resolve(url_flag: Option<String>, token_env: Option<String>) -> Result<Self> {
+    /// Resolve the choice from `--attach` / `--server` / `--server-token-env`
+    /// and the environment. `--server` wins over `OPENWAVE_SERVER_URL`.
+    /// `--attach` and `--server` together are a mistake.
+    pub fn resolve(
+        url_flag: Option<String>,
+        token_env: Option<String>,
+        attach: bool,
+    ) -> Result<Self> {
+        if attach {
+            if url_flag.is_some()
+                || std::env::var(SERVER_URL_ENV).is_ok_and(|v| !v.trim().is_empty())
+            {
+                return Err(AgentError::config(
+                    "--attach reads {data_dir}/listen.json; do not also pass \
+                     --server or set OPENWAVE_SERVER_URL",
+                ));
+            }
+            if token_env.is_some() {
+                return Err(AgentError::config(
+                    "--attach supplies the token from listen.json; \
+                     --server-token-env is only for --server",
+                ));
+            }
+            let config = crate::profile_config()?;
+            let endpoint =
+                openwave_server::listen_endpoint::ListenEndpoint::read(&config.data_dir)?;
+            let base = base_url(&endpoint.base_url)?;
+            return Ok(Self::Attach {
+                base,
+                token: endpoint.token,
+            });
+        }
         let url = match url_flag {
             Some(url) => Some(url),
             None => std::env::var(SERVER_URL_ENV)
@@ -66,7 +98,7 @@ impl Server {
             .ok_or_else(|| {
                 AgentError::config(format!(
                     "{var} is not set; attaching to {base} needs the bearer token that \
-                     server printed at startup"
+                     server printed at startup (or use --attach to read listen.json)"
                 ))
             })?;
         Ok(Self::Attach { base, token })
@@ -129,8 +161,9 @@ impl Session {
                     client_executor_token: Some(client_executor_token),
                 })
             }
-            // Nothing local is touched in attach mode: no data directory, no
-            // log file, no keychain. This process is only a client.
+            // Nothing local is touched in attach mode beyond the optional
+            // listen.json read that produced this choice: no log file, no
+            // keychain. This process is only a client.
             Server::Attach { base, token } => Ok(Self {
                 client: Client::attach(base.clone(), token)?,
                 serve: None,
@@ -149,9 +182,9 @@ impl Session {
     /// Attaching deliberately gets nothing. That credential is the native-only
     /// boundary: it says "I am the trusted surface for this server", and a
     /// client that merely holds a bearer token is not, no matter which process
-    /// started it. The bearer is all `--server` conveys, and there is no flag
-    /// to hand over the executor token — so an attached run cannot execute a
-    /// client tool call on somebody else's server, which is the point.
+    /// started it. The bearer is all `--server` / `--attach` convey, and there
+    /// is no flag to hand over the executor token — so an attached run cannot
+    /// execute a client tool call on somebody else's server, which is the point.
     pub fn client_executor_token(&self) -> Option<&str> {
         self.client_executor_token.as_deref()
     }
@@ -190,12 +223,23 @@ mod tests {
         assert!(base_url("http://host/?a=1").is_err(), "no query string");
 
         std::env::remove_var(SERVER_URL_ENV);
-        let Err(error) = Server::resolve(None, Some("SOME_VAR".to_owned())) else {
+        let Err(error) = Server::resolve(None, Some("SOME_VAR".to_owned()), false) else {
             panic!("a token variable alone is not enough to attach");
         };
         assert!(
             error.to_string().contains("--server"),
             "error should name the missing flag: {error}"
+        );
+    }
+
+    #[test]
+    fn attach_flag_conflicts_with_server_url() {
+        let Err(error) = Server::resolve(Some("http://127.0.0.1:1".into()), None, true) else {
+            panic!("--attach and --server together must fail");
+        };
+        assert!(
+            error.to_string().contains("--attach"),
+            "error should name the conflict: {error}"
         );
     }
 }

--- a/crates/openwave-cli/src/main.rs
+++ b/crates/openwave-cli/src/main.rs
@@ -58,7 +58,9 @@
 //! Every client command above embeds its own server by default. `--server
 //! <url>` (or `OPENWAVE_SERVER_URL`) makes it a pure client of one that is
 //! already running instead, with the bearer token coming from
-//! `OPENWAVE_SERVER_TOKEN` — see [`connect`]. That is how a second process
+//! `OPENWAVE_SERVER_TOKEN` — see [`connect`]. `--attach` is the same attach
+//! using `{OPENWAVE_DATA_DIR}/listen.json` the running server wrote, so the
+//! token never rides argv (desktop or `serve`). That is how a second process
 //! reaches a data directory a desktop app or daemon already owns; two processes
 //! embedding servers over one data directory is refused.
 
@@ -125,10 +127,12 @@ from the environment variable named by --from-env — never from an argument,
 which every process on the machine can read.
 
 tui, -p, output, attach, and the setup commands also take --server <url>
-[--server-token-env <var>], which talks to a server that is already running
-instead of embedding one. The token comes from OPENWAVE_SERVER_TOKEN, or from the named variable;
-it is never an argument either. The folder commands do not: they provision
-local host consent in this machine's own broker state.";
+[--server-token-env <var>] or --attach, which talks to a server that is already
+running instead of embedding one. --attach reads {OPENWAVE_DATA_DIR}/listen.json
+(written by serve and the desktop). With --server the token comes from
+OPENWAVE_SERVER_TOKEN, or from the named variable; it is never an argument
+either. The folder commands do not: they provision local host consent in this
+machine's own broker state.";
 
 #[tokio::main]
 async fn main() {
@@ -310,16 +314,18 @@ async fn run() -> Result<i32> {
     }
 }
 
-/// The `--server` / `--server-token-env` pair, lifted out of the arguments.
+/// The `--server` / `--server-token-env` / `--attach` choice, lifted out of
+/// the arguments.
 struct ServerFlags {
     url: Option<String>,
     token_env: Option<String>,
+    attach: bool,
 }
 
 impl ServerFlags {
     /// Turn the flags plus the environment into the choice to embed or attach.
     fn resolve(self) -> Result<connect::Server> {
-        connect::Server::resolve(self.url, self.token_env)
+        connect::Server::resolve(self.url, self.token_env, self.attach)
     }
 
     /// Refuse the flags on a command that has no client to point elsewhere.
@@ -328,16 +334,17 @@ impl ServerFlags {
     /// a shell that exports it so its `-p` runs attach must still be able to
     /// start a daemon.
     fn refuse(&self, command: &str) {
-        if self.url.is_some() || self.token_env.is_some() {
+        if self.url.is_some() || self.token_env.is_some() || self.attach {
             usage_error(&format!(
-                "{command} runs a server rather than connecting to one, so it takes no --server"
+                "{command} runs a server rather than connecting to one, so it takes no --server/--attach"
             ));
         }
     }
 }
 
-/// Pull `--server <url>` and `--server-token-env <var>` out of the arguments
-/// wherever they appear, leaving the rest for the per-command parsers.
+/// Pull `--server <url>`, `--server-token-env <var>`, and `--attach` out of
+/// the arguments wherever they appear, leaving the rest for the per-command
+/// parsers.
 ///
 /// A pre-pass rather than an option on each parser: the flags apply to every
 /// client command, and no command takes a value beginning with `--` (each
@@ -346,10 +353,18 @@ fn take_server_flags(args: Vec<OsString>) -> (Vec<OsString>, ServerFlags) {
     let mut flags = ServerFlags {
         url: None,
         token_env: None,
+        attach: false,
     };
     let mut rest = Vec::with_capacity(args.len());
     let mut args = args.into_iter();
     while let Some(arg) = args.next() {
+        if arg == OsStr::new("--attach") {
+            if flags.attach {
+                usage_error("--attach given more than once");
+            }
+            flags.attach = true;
+            continue;
+        }
         let slot = if arg == OsStr::new("--server") {
             &mut flags.url
         } else if arg == OsStr::new("--server-token-env") {
@@ -685,7 +700,7 @@ fn usage_error(message: &str) -> ! {
 ///
 /// Debug builds keep their own keychain service, matching the desktop's
 /// dev/release split: a dev daemon must not mutate release secret state.
-fn profile_config() -> Result<Config> {
+pub(crate) fn profile_config() -> Result<Config> {
     #[cfg_attr(not(debug_assertions), allow(unused_mut))]
     let mut config = Config::from_env()?;
     #[cfg(debug_assertions)]

--- a/crates/openwave-cli/tests/serve.rs
+++ b/crates/openwave-cli/tests/serve.rs
@@ -461,6 +461,43 @@ fn a_setup_command_attaches_to_a_running_server() {
     );
 }
 
+/// `--attach` reads the listen.json the server published into the data
+/// directory — no token on argv, same HTTP client as `--server`.
+#[test]
+fn a_setup_command_attaches_via_listen_json() {
+    let dir = tempfile::tempdir().unwrap();
+    let (_server, _url, _token) = spawn_serve(dir.path());
+
+    let listen = dir.path().join("listen.json");
+    assert!(
+        listen.is_file(),
+        "serve must publish listen.json for --attach"
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_openwave"))
+        .args(["provider", "list", "--output-format", "json", "--attach"])
+        .env("OPENWAVE_DATA_DIR", dir.path())
+        .env_remove("OPENWAVE_SERVER_URL")
+        .env_remove("OPENWAVE_SERVER_TOKEN")
+        .stdin(Stdio::null())
+        .output()
+        .expect("run --attach provider list");
+
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(output.status.success(), "stderr: {stderr}");
+    let listed: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("the route's answer on one line");
+    assert!(
+        listed["providers"]
+            .as_array()
+            .is_some_and(|providers| providers
+                .iter()
+                .any(|provider| provider["kind"] == "anthropic")),
+        "stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
 /// The same rule for the families that read and write a conversation's files.
 /// Their failure mode when `--server` is ignored is not a broken flag but a
 /// silently wrong target: the command reads the local data directory while the

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -45,6 +45,8 @@ mod foreground_prompt;
 mod gateway_drafts;
 mod gateway_runtime;
 pub mod host_folders;
+/// Per-launch `{data_dir}/listen.json` so a CLI can attach without argv tokens.
+pub mod listen_endpoint;
 pub mod logging;
 mod managed_policy;
 mod mcp_config;
@@ -751,6 +753,8 @@ pub struct Server {
     _mcp_supervisor: AbortTask,
     _gateway_model_sync: AbortTask,
     _instance_lock: InstanceLock,
+    /// Removes `{data_dir}/listen.json` when this server drops.
+    _listen_endpoint: listen_endpoint::ListenEndpointGuard,
 }
 
 /// The claim one process makes on a data directory for as long as it serves it.
@@ -786,9 +790,10 @@ impl InstanceLock {
             // first rather than a second server.
             Err(TryLockError::WouldBlock) => Err(AgentError::config(format!(
                 "another OpenWave process is already running on the data directory {}. \
-                 Connect to it instead (the CLI's --server <url>, with that server's token \
-                 in OPENWAVE_SERVER_TOKEN), quit the running one, or point \
-                 OPENWAVE_DATA_DIR somewhere else.",
+                 Attach with the CLI's --attach (reads {}/listen.json), or \
+                 --server <url> with OPENWAVE_SERVER_TOKEN; quit the running one, \
+                 or point OPENWAVE_DATA_DIR somewhere else.",
+                config.data_dir.display(),
                 config.data_dir.display()
             ))),
             Err(TryLockError::Error(error)) => Err(AgentError::config(format!(
@@ -1285,6 +1290,7 @@ async fn bind_inner(
     };
     drop(queued_turn_promoter);
     let server_store = state.store.clone();
+    let data_dir = state.config.data_dir.clone();
     let mcp_runtime = state.mcp.clone();
     let gateway_runtime = state.gateway.clone();
     let router = app(state);
@@ -1295,6 +1301,14 @@ async fn bind_inner(
     let local_addr = listener
         .local_addr()
         .map_err(|e| AgentError::config(format!("no local address: {e}")))?;
+    // Publish before workers start answering so an attach racing boot sees a
+    // file that matches the bound address. Bearer only — never the executor
+    // credential. See docs/decisions/0009-data-dir-listen-endpoint.md.
+    let listen_endpoint = listen_endpoint::ListenEndpointGuard::publish(
+        data_dir,
+        &format!("http://{local_addr}"),
+        token.as_ref(),
+    )?;
 
     let turn_worker = tokio::spawn(turn_worker.run());
     let sandbox_agent_run_worker = tokio::spawn(sandbox_agent_run_worker.run());
@@ -1337,6 +1351,7 @@ async fn bind_inner(
         _mcp_supervisor: AbortTask(mcp_supervisor),
         _gateway_model_sync: AbortTask(gateway_model_sync),
         _instance_lock: instance_lock,
+        _listen_endpoint: listen_endpoint,
     })
 }
 

--- a/crates/openwave-server/src/listen_endpoint.rs
+++ b/crates/openwave-server/src/listen_endpoint.rs
@@ -1,0 +1,159 @@
+//! Per-launch listen endpoint published into the data directory.
+//!
+//! After a successful bind, the server writes `{data_dir}/listen.json` so a
+//! second process can attach without the token riding argv. See
+//! [`docs/decisions/0009-data-dir-listen-endpoint.md`]. The client-executor
+//! credential is deliberately absent — attach stays bearer-only.
+
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+
+use openwave_core::{AgentError, Result};
+use serde::{Deserialize, Serialize};
+
+/// Filename under the profile data directory.
+pub const LISTEN_FILE: &str = "listen.json";
+
+/// What a client needs to reach the process that owns a data directory.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ListenEndpoint {
+    /// Base URL the API is bound on, e.g. `http://127.0.0.1:53421`.
+    pub base_url: String,
+    /// Per-launch bearer token (full LocalOwner authority).
+    pub token: String,
+}
+
+impl ListenEndpoint {
+    /// Path of the listen file under `data_dir`.
+    pub fn path(data_dir: &Path) -> PathBuf {
+        data_dir.join(LISTEN_FILE)
+    }
+
+    /// Read a previously published endpoint, or explain why attach cannot.
+    pub fn read(data_dir: &Path) -> Result<Self> {
+        let path = Self::path(data_dir);
+        let bytes = std::fs::read(&path).map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                AgentError::config(format!(
+                    "no listen endpoint at {} — is an OpenWave server running \
+                     on this data directory? Start the desktop app or \
+                     `openwave serve`, or pass --server <url> with \
+                     OPENWAVE_SERVER_TOKEN",
+                    path.display()
+                ))
+            } else {
+                AgentError::config(format!("failed to read {}: {error}", path.display()))
+            }
+        })?;
+        let endpoint: Self = serde_json::from_slice(&bytes).map_err(|error| {
+            AgentError::config(format!(
+                "{} is not a valid listen endpoint ({error}); remove it or \
+                 restart the server that owns this data directory",
+                path.display()
+            ))
+        })?;
+        if endpoint.base_url.trim().is_empty() || endpoint.token.trim().is_empty() {
+            return Err(AgentError::config(format!(
+                "{} is missing base_url or token",
+                path.display()
+            )));
+        }
+        Ok(endpoint)
+    }
+}
+
+/// Atomically publish the endpoint at `0o600`. Overwrites any prior file.
+pub fn write(data_dir: &Path, base_url: &str, token: &str) -> Result<()> {
+    std::fs::create_dir_all(data_dir)
+        .map_err(|error| AgentError::config(format!("failed to create data dir: {error}")))?;
+    let endpoint = ListenEndpoint {
+        base_url: base_url.trim_end_matches('/').to_owned(),
+        token: token.to_owned(),
+    };
+    let mut bytes = serde_json::to_vec_pretty(&endpoint).map_err(|error| {
+        AgentError::config(format!("failed to encode listen endpoint: {error}"))
+    })?;
+    bytes.push(b'\n');
+    let path = ListenEndpoint::path(data_dir);
+    let temporary = data_dir.join(format!(".{LISTEN_FILE}.{}.tmp", uuid::Uuid::new_v4()));
+    let mut published = false;
+    let result = (|| -> std::io::Result<()> {
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        options.mode(0o600);
+        let mut file = options.open(&temporary)?;
+        file.write_all(&bytes)?;
+        file.sync_all()?;
+        drop(file);
+        std::fs::rename(&temporary, &path)?;
+        published = true;
+        Ok(())
+    })();
+    if result.is_err() && !published {
+        let _ = std::fs::remove_file(&temporary);
+    }
+    result.map_err(|error| {
+        AgentError::config(format!(
+            "failed to publish listen endpoint {}: {error}",
+            path.display()
+        ))
+    })
+}
+
+/// Best-effort removal on clean shutdown.
+pub fn remove(data_dir: &Path) {
+    let _ = std::fs::remove_file(ListenEndpoint::path(data_dir));
+}
+
+/// Holds the published path and removes it when dropped with the server.
+pub struct ListenEndpointGuard {
+    data_dir: PathBuf,
+}
+
+impl ListenEndpointGuard {
+    pub fn publish(data_dir: PathBuf, base_url: &str, token: &str) -> Result<Self> {
+        write(&data_dir, base_url, token)?;
+        Ok(Self { data_dir })
+    }
+}
+
+impl Drop for ListenEndpointGuard {
+    fn drop(&mut self) {
+        remove(&self.data_dir);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_read_roundtrip_and_drop_clears() {
+        let dir = tempfile::tempdir().unwrap();
+        let guard =
+            ListenEndpointGuard::publish(dir.path().to_path_buf(), "http://127.0.0.1:9/", "tok")
+                .unwrap();
+        let read = ListenEndpoint::read(dir.path()).unwrap();
+        assert_eq!(read.base_url, "http://127.0.0.1:9");
+        assert_eq!(read.token, "tok");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(ListenEndpoint::path(dir.path()))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(mode, 0o600);
+        }
+        let json = std::fs::read_to_string(ListenEndpoint::path(dir.path())).unwrap();
+        assert!(!json.contains("executor"));
+        drop(guard);
+        assert!(ListenEndpoint::read(dir.path()).is_err());
+    }
+}

--- a/docs-site/content/docs/headless.mdx
+++ b/docs-site/content/docs/headless.mdx
@@ -52,7 +52,7 @@ openwave mcp-server remove <name>
 A bare `openwave` with no arguments runs `serve`.
 
 `tui`, `-p`, `output`, `attach`, and the setup commands additionally take
-`--server <url>` and `--server-token-env <var>` — see
+`--server <url>` / `--server-token-env <var>`, or `--attach` — see
 [Attaching to a running server](#attaching-to-a-running-server).
 
 ### `serve`
@@ -350,34 +350,52 @@ is honest across a crash: a killed process releases it the moment it dies, and
 the leftover file never has to be cleaned up by hand.
 
 The way in is to *attach* — to be a client of the server that is already there
-rather than a second one:
+rather than a second one. Prefer `--attach`, which reads the
+`listen.json` the running server wrote into the data directory (mode `0600`,
+bearer only — never the native executor credential):
+
+```sh
+# Same data directory the desktop or `serve` owns
+export OPENWAVE_DATA_DIR="$HOME/Library/Application Support/io.brightwave.openwave.dev"
+cargo run -p openwave-cli -- --attach provider list
+cargo run -p openwave-cli -- -p "what changed today?" --attach
+cargo run -p openwave-cli -- tui --attach
+```
+
+On a release desktop build, the directory is `io.brightwave.openwave` (no
+`.dev`). `--attach` and `--server` conflict; pick one.
+
+You can still pass an explicit URL when you already have the pair (for example
+from `serve`'s stdout):
 
 ```sh
 export OPENWAVE_SERVER_TOKEN=<the token that server printed>
 cargo run -p openwave-cli -- --server http://127.0.0.1:53421 provider list
-cargo run -p openwave-cli -- -p "what changed today?" --server http://127.0.0.1:53421
-cargo run -p openwave-cli -- tui --server http://127.0.0.1:53421
 ```
 
-`--server` works on `tui`, `-p`, and every setup command. `OPENWAVE_SERVER_URL`
-sets the same thing for a whole shell, and the flag wins over it. An attached
-command reads no local data directory, writes no log file, and touches no
-keychain — it is only an HTTP+WebSocket client, so `OPENWAVE_DATA_DIR` and the
-rest of the profile environment are ignored.
+`--server` / `--attach` work on `tui`, `-p`, and every setup command.
+`OPENWAVE_SERVER_URL` sets the same thing as `--server` for a whole shell, and
+the flag wins over it. After the endpoint is resolved, an attached command
+writes no log file and touches no keychain — it is only an HTTP+WebSocket
+client. With `--attach`, `OPENWAVE_DATA_DIR` is used solely to find
+`listen.json`; with `--server`, the local data directory is ignored.
 
-`serve`, `mcp`, and `rehome-secrets` reject `--server`: the first two *are*
-servers, and the third rewrites local keychain items. (They ignore
+`serve`, `mcp`, and `rehome-secrets` reject `--server` / `--attach`: the first
+two *are* servers, and the third rewrites local keychain items. (They ignore
 `OPENWAVE_SERVER_URL`, so a shell that exports it can still start a daemon.)
 
 ### Getting a token
 
 The bearer token is per-launch and is full authority over the profile, so it is
 never a command-line argument — every process on the machine can read those, and
-they land in shell history. It comes from `OPENWAVE_SERVER_TOKEN`, or from the
-variable `--server-token-env <var>` names.
+they land in shell history. `--attach` loads it from `listen.json`. With
+`--server` it comes from `OPENWAVE_SERVER_TOKEN`, or from the variable
+`--server-token-env <var>` names.
 
-**From `openwave serve`:** the token is the second line it prints. Capture the
-daemon's stdout directly:
+**From `openwave serve` or the desktop app:** both write
+`{data_dir}/listen.json` on bind. Point `OPENWAVE_DATA_DIR` at that directory
+and use `--attach`. `serve` still prints the URL and token on stdout if you
+prefer to capture them:
 
 ```sh
 cargo run -p openwave-cli -- serve > server.log &
@@ -385,20 +403,13 @@ export OPENWAVE_SERVER_URL=http://$(grep -m1 'listening on http://' server.log |
 export OPENWAVE_SERVER_TOKEN=$(grep -m1 'token ' server.log | sed 's|.*token ||')
 ```
 
-**From the desktop app: not currently possible.** The desktop mints its own
-per-launch token and hands it straight to its webview; nothing displays or
-writes it out, so there is no supported way to attach to a running desktop
-instance today. To drive the desktop's chats from the CLI, quit the app first
-and run `openwave serve` (or the CLI command) against its data directory — while
-the app is running, that directory is claimed.
-
 ## Environment
 
 | Variable | Effect |
 | --- | --- |
-| `OPENWAVE_DATA_DIR` | Where the database, blobs, and logs live. Defaults to `./.openwave` under the current directory. Ignored when attaching to a running server. |
-| `OPENWAVE_SERVER_URL` | Attach to the server at this base URL instead of embedding one. `--server <url>` overrides it, and `serve`/`mcp`/`rehome-secrets` ignore it. |
-| `OPENWAVE_SERVER_TOKEN` | Bearer token for that server, unless `--server-token-env <var>` names a different variable. |
+| `OPENWAVE_DATA_DIR` | Where the database, blobs, logs, and `listen.json` live. Defaults to `./.openwave` under the current directory. With `--attach`, used only to locate `listen.json`; with `--server`, ignored. |
+| `OPENWAVE_SERVER_URL` | Attach to the server at this base URL instead of embedding one. `--server <url>` overrides it; conflicts with `--attach`. `serve`/`mcp`/`rehome-secrets` ignore it. |
+| `OPENWAVE_SERVER_TOKEN` | Bearer token for `--server`, unless `--server-token-env <var>` names a different variable. Not used with `--attach`. |
 | `OPENWAVE_PROFILE` | `desktop` (default, SQLite) or `self_host` (PostgreSQL). |
 | `OPENWAVE_DATABASE_URL` | Required for `self_host`. |
 | `OPENWAVE_AUTH_TOKENS_FILE` | Named bearer tokens for `self_host`. Required there. |
@@ -412,9 +423,10 @@ the app is running, that directory is claimed.
 <Callout>
 `openwave serve` defaults to `./.openwave` in your current directory, which is
 **not** the desktop app's data directory. Point `OPENWAVE_DATA_DIR` at the
-desktop's application data directory if you want the CLI to see the same chats —
-and quit the app first, since a running desktop instance claims that directory
-and the CLI will refuse to start a second server over it. See
+desktop's application data directory (debug:
+`~/Library/Application Support/io.brightwave.openwave.dev`) and use `--attach`
+to drive the same chats while the app is running. Embedding a second server
+over that directory is still refused. See
 [Attaching to a running server](#attaching-to-a-running-server).
 </Callout>
 

--- a/docs/decisions/0009-data-dir-listen-endpoint.md
+++ b/docs/decisions/0009-data-dir-listen-endpoint.md
@@ -1,0 +1,100 @@
+# 9. Data-dir listen endpoint for CLI attach to a running server
+
+- Status: Proposed
+- Date: 2026-08-12
+- Owners: cli, server, desktop
+- Related: [`0005-cli-headless-feature-parity.md`](0005-cli-headless-feature-parity.md)
+  (attach-or-embed; CLI must reach a running desktop),
+  [`docs-site/content/docs/headless.mdx`](../../docs-site/content/docs/headless.mdx)
+- Supersedes: none
+
+## Context
+
+A data directory belongs to exactly one server process. The desktop app and
+`openwave serve` both bind `openwave-server` over that directory and mint a
+per-launch bearer token. Decision 5 already says a second process must
+**attach** as an HTTP+WS client rather than embed again.
+
+Today attach works for `openwave serve` because it prints the URL and token on
+stdout. The desktop publishes the same pair only to the webview via the Tauri
+`server_info` command — nothing on disk, nothing on stdout — so the docs
+honestly say attaching from the desktop is impossible. Agents and scripts that
+want to drive the same profile the window owns are stuck grepping nothing, or
+copying a token by hand (and the token must never ride argv).
+
+The forces: the HTTP+WS API stays the only product surface; the bearer is full
+`LocalOwner` authority and must not land in argv or shell history; the native
+executor credential must stay native-only; discovery has to work for both
+`serve` and the desktop without a second transport.
+
+## Decision
+
+**On every successful bind, the server writes a restricted listen endpoint file
+into its data directory; the CLI may attach by reading that file.**
+
+1. **File.** `{data_dir}/listen.json`, JSON object with exactly:
+   - `base_url` — `http://127.0.0.1:<port>` (or whatever the process bound)
+   - `token` — the per-launch bearer
+
+   Never the client-executor token. Unix mode `0o600`, written atomically
+   (temp file + rename), same pattern as `openwave-schema.json`.
+
+2. **Lifecycle.** Overwrite on each bind. Remove on clean `Server` drop when
+   practical. A stale file after a crash is allowed: the advisory lock still
+   names the live owner, and a stale token simply fails auth.
+
+3. **Writers.** Both `openwave serve` and the desktop (every `bind_*` path)
+   write the file. Log-grepping `serve` stdout remains valid; the file is the
+   attach path that works when nothing is printed.
+
+4. **CLI.** `--attach` resolves the profile data directory
+   (`OPENWAVE_DATA_DIR`, with the same defaults as embed), reads `listen.json`,
+   and becomes `Server::Attach`. It conflicts with `--server` /
+   `OPENWAVE_SERVER_URL`. The token never appears on argv. Explicit
+   `--server` + `OPENWAVE_SERVER_TOKEN` remain for remote or scripted cases
+   that already have the pair.
+
+5. **Desktop attach UX.** Point `OPENWAVE_DATA_DIR` at the desktop profile
+   (debug: `…/io.brightwave.openwave.dev`; release: `…/io.brightwave.openwave`)
+   and run with `--attach`. No new transport, no UI “copy token” requirement.
+
+## Alternatives Considered
+
+- **Do nothing / document “copy from DevTools”.** Leaves decision 5's desktop
+  attach gap open; unusable for agents.
+- **`--server-token` on argv.** Already forbidden: process list and shell
+  history.
+- **Put URL/token in `openwave.lock`.** The lock file is lock-only by design;
+  its contents are irrelevant.
+- **Include the executor token.** Breaks the native-only boundary attach
+  deliberately keeps.
+- **Keychain for the per-launch token.** Heavier than a `0o600` file next to
+  the lock the process already owns; the token dies with the process.
+- **Auto-attach whenever the lock is held (no flag).** Surprising when the
+  user meant a fresh embed under another data dir; prefer explicit `--attach`
+  and a lock-failure hint that names it.
+- **UDS or a second RPC.** Decision 5 keeps HTTP+WS as the product surface.
+
+## Consequences
+
+- Data directories gain a short-lived secret file; installers and backups should
+  treat `listen.json` like a session credential (mode already restricts it).
+- Attach to desktop becomes a supported headless path; headless docs must stop
+  saying it is impossible.
+- Stale `listen.json` after a crash can confuse a naive reader — auth failure
+  plus the lock message are the recovery, not trusting the file blindly.
+
+Revisit if a multi-user shared data directory appears (self-host already uses a
+different auth model), or if OS policy forbids even `0o600` secrets beside the
+DB.
+
+## Validation
+
+- After `bind_*`, `listen.json` exists at `0o600` with matching `base_url` /
+  bearer; after `Server` drop, it is gone (or auth fails if left stale).
+- `openwave --attach provider list` against a directory a `serve` owns returns
+  the same catalog as `--server` + env token, with no token on argv.
+- `--attach` and `--server` together are refused.
+- A second embed on a locked directory still fails, and the error mentions
+  `--attach` (or the listen file) rather than only stdout capture.
+- The file never contains the client-executor token.


### PR DESCRIPTION
## Summary
- On bind, write `{data_dir}/listen.json` (`0600`) with `base_url` and the per-launch bearer (never the executor token); remove it when the server drops.
- Add CLI `--attach` to read that file from `OPENWAVE_DATA_DIR` and talk to the owning process (desktop or `serve`).
- Record the contract in `docs/decisions/0009-data-dir-listen-endpoint.md` and update headless docs.

## Test plan
- [x] `cargo test -p openwave-server --lib listen_endpoint`
- [x] `cargo test -p openwave-cli attach`
- [ ] With `cargo tauri dev` running, `OPENWAVE_DATA_DIR=…/io.brightwave.openwave.dev openwave --attach provider list` succeeds
- [ ] `--attach` and `--server` together are refused