### PR TITLE
feat(cli): let print mode pin the chat model with --model

### DIFF
--- a/crates/openwave-cli/src/main.rs
+++ b/crates/openwave-cli/src/main.rs
@@ -34,9 +34,9 @@
 //! terminal. stdout carries the assistant's text (or, with
 //! `--output-format json`, the turn's event stream as NDJSON), and the exit
 //! status says whether the turn completed. `--permission-mode` sets the chat's
-//! permission mode for the run, and under `--output-format json` a driving
-//! process answers approvals, plans, and questions over stdin — see
-//! [`print::protocol`].
+//! permission mode for the run, `--model` pins the chat's model selection
+//! before the turn, and under `--output-format json` a driving process answers
+//! approvals, plans, and questions over stdin — see [`print::protocol`].
 //!
 //! `openwave provider|model|settings|mcp-server …` configure the profile the
 //! same way the desktop's settings pages do — over the server's own routes.
@@ -90,6 +90,7 @@ usage: openwave serve
        openwave tui [--chat <id> | --new]
        openwave -p <prompt> [--chat <id>] [--output-format text|json]
                   [--permission-mode ask|auto|allow|plan]
+                  [--model <key>]
 
        openwave output list <chat>
        openwave output show <chat> <output> [--revision <id>]
@@ -239,6 +240,7 @@ async fn run() -> Result<i32> {
             let mut chat = None;
             let mut format = OutputFormat::Text;
             let mut permission_mode = None;
+            let mut model = None;
             while let Some(flag) = args.next() {
                 if flag == OsStr::new("--chat") {
                     let Some(id) = args.next() else {
@@ -268,6 +270,17 @@ async fn run() -> Result<i32> {
                         }
                         _ => usage_error("--permission-mode expects ask, auto, allow, or plan"),
                     }
+                } else if flag == OsStr::new("--model") {
+                    let Some(value) = args.next() else {
+                        usage_error("--model requires a catalog key");
+                    };
+                    let Some(value) = value.to_str().map(str::to_owned) else {
+                        usage_error("--model expects a UTF-8 catalog key");
+                    };
+                    if value.is_empty() || value.starts_with("--") {
+                        usage_error("--model requires a catalog key");
+                    }
+                    model = Some(value);
                 } else {
                     usage_error(&format!("unknown print-mode argument {flag:?}"));
                 }
@@ -277,6 +290,7 @@ async fn run() -> Result<i32> {
                 chat,
                 format,
                 permission_mode,
+                model,
                 server_flags.resolve()?,
             )
             .await

--- a/crates/openwave-cli/src/print.rs
+++ b/crates/openwave-cli/src/print.rs
@@ -127,7 +127,14 @@ pub async fn run(
             client.require_chat(chat).await?;
             chat
         }
-        None => client.create_chat().await?,
+        None => {
+            // stderr, never stdout: text mode's stdout is the answer alone, and
+            // json mode's stdout is the journal. A driving agent still needs
+            // the id to continue with `--chat` on the next turn.
+            let chat = client.create_chat().await?;
+            eprintln!("openwave: chat {chat}");
+            chat
+        }
     };
     if let Some(mode) = permission_mode.as_deref() {
         // Fail before the turn starts: a run that asked for `allow` and got

--- a/crates/openwave-cli/src/print.rs
+++ b/crates/openwave-cli/src/print.rs
@@ -110,6 +110,7 @@ pub async fn run(
     chat: Option<ChatId>,
     format: OutputFormat,
     permission_mode: Option<String>,
+    model: Option<String>,
     server: crate::connect::Server,
 ) -> Result<i32> {
     // Either binds the engine in-process (the default) or attaches to one that
@@ -132,6 +133,11 @@ pub async fn run(
         // Fail before the turn starts: a run that asked for `allow` and got
         // `ask` would quietly do something else.
         client.set_chat_permission_mode(chat, Some(mode)).await?;
+    }
+    if let Some(model) = model.as_deref() {
+        // Same fail-before-turn rule as permission mode: a typo or an
+        // unavailable selection must not silently fall back to the default.
+        client.set_chat_model(chat, Some(model)).await?;
     }
 
     // Driving needs somewhere to put the events and something on the other end

--- a/crates/openwave-cli/tests/serve.rs
+++ b/crates/openwave-cli/tests/serve.rs
@@ -584,6 +584,50 @@ fn a_killed_server_leaves_its_data_directory_usable() {
     assert!(url.starts_with("http://127.0.0.1:"), "url: {url}");
 }
 
+/// A fresh `-p` must name the chat it created on stderr so the next invocation
+/// can pass `--chat` — stdout stays the answer / journal alone.
+#[test]
+fn print_mode_prints_a_new_chat_id_on_stderr() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = serde_json::json!([{"text": "ok"}]);
+    let child = Command::new(env!("CARGO_BIN_EXE_openwave"))
+        .args(["-p", "hi", "--permission-mode", "allow"])
+        .env("OPENWAVE_DATA_DIR", dir.path())
+        .env("OPENWAVE_KEYCHAIN_MOCK", "1")
+        .env("OPENWAVE_SCRIPTED_PROVIDER", script.to_string())
+        .env_remove("OPENWAVE_MCP_CONFIG")
+        .env_remove("OPENWAVE_SERVER_URL")
+        .env_remove("OPENWAVE_SERVER_TOKEN")
+        .env_remove("ANTHROPIC_API_KEY")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn openwave -p");
+    let mut child = Reaper(child);
+
+    let output = child.wait_with_output(TURN_EXIT_TIMEOUT);
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout: {stdout}\nstderr: {stderr}"
+    );
+    let chat = stderr
+        .lines()
+        .find_map(|line| line.strip_prefix("openwave: chat "))
+        .unwrap_or_else(|| panic!("new chat id missing from stderr: {stderr}"));
+    assert!(
+        openwave_core::ChatId::from_str(chat).is_ok(),
+        "chat id on stderr: {chat:?}"
+    );
+    assert!(
+        !stdout.contains(chat),
+        "chat id must not leak onto stdout: {stdout}"
+    );
+}
+
 /// `--model` is applied before the turn; a selection the server rejects must
 /// fail the process without writing assistant text to stdout.
 #[test]

--- a/crates/openwave-cli/tests/serve.rs
+++ b/crates/openwave-cli/tests/serve.rs
@@ -583,3 +583,44 @@ fn a_killed_server_leaves_its_data_directory_usable() {
     let (_reclaimed, url, _token) = spawn_serve(dir.path());
     assert!(url.starts_with("http://127.0.0.1:"), "url: {url}");
 }
+
+/// `--model` is applied before the turn; a selection the server rejects must
+/// fail the process without writing assistant text to stdout.
+#[test]
+fn print_mode_rejects_an_unknown_model_before_the_turn() {
+    let dir = tempfile::tempdir().unwrap();
+    let child = Command::new(env!("CARGO_BIN_EXE_openwave"))
+        .args([
+            "-p",
+            "hello",
+            "--model",
+            "openai::definitely-not-a-real-model",
+            "--permission-mode",
+            "allow",
+        ])
+        .env("OPENWAVE_DATA_DIR", dir.path())
+        .env("OPENWAVE_KEYCHAIN_MOCK", "1")
+        .env_remove("OPENWAVE_MCP_CONFIG")
+        .env_remove("OPENWAVE_SERVER_URL")
+        .env_remove("OPENWAVE_SERVER_TOKEN")
+        .env_remove("ANTHROPIC_API_KEY")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn openwave -p --model");
+    let mut child = Reaper(child);
+
+    let output = child.wait_with_output(PROCESS_EXIT_TIMEOUT);
+    assert_ne!(output.status.code(), Some(0));
+    assert!(
+        output.stdout.is_empty(),
+        "stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.to_lowercase().contains("model") || stderr.to_lowercase().contains("provider"),
+        "stderr: {stderr}"
+    );
+}

--- a/docs-site/content/docs/headless.mdx
+++ b/docs-site/content/docs/headless.mdx
@@ -104,10 +104,14 @@ the exit status says how the turn ended.
 cargo run -p openwave-cli -- -p "summarize the CSV in output/"
 cargo run -p openwave-cli -- -p "…" --output-format json
 cargo run -p openwave-cli -- -p "…" --permission-mode allow
+cargo run -p openwave-cli -- -p "…" --model anthropic::claude-haiku-4-5-20251001
 ```
 
 `--output-format json` emits the turn's event stream as NDJSON instead of plain
-text. `--chat <id>` continues an existing conversation.
+text. `--chat <id>` continues an existing conversation. `--model <key>` pins the
+chat's model (a catalog key such as `anthropic::claude-haiku-4-5-20251001`)
+before the turn starts; an unavailable selection fails the process instead of
+falling back silently.
 
 `--permission-mode` sets the chat's permission mode for the run — the same four
 modes the desktop offers, applied before the turn starts:


### PR DESCRIPTION
## Summary
- Add `-p … --model <catalog-key>` so a print-mode turn can pin the chat model without a separate HTTP call.
- Reject unavailable selections before the turn starts (clean stdout).
- When `-p` creates a chat, print `openwave: chat <id>` on stderr so the next `--chat` can continue (stdout stays the answer/journal).
- Document `--model` in the headless guide.

## Test plan
- [x] `cargo test -p openwave-cli print_mode_rejects_an_unknown_model`
- [x] `cargo test -p openwave-cli print_mode_prints_a_new_chat_id`
- [ ] `openwave -p "ping" --model anthropic::claude-haiku-4-5-20251001 --permission-mode allow` completes on a credentialed profile
- [ ] Switching `--model` across turns in one `--chat` works for Anthropic and OpenAI