### PR TITLE
feat(cli): add chat list and chat create setup commands

### DIFF
--- a/crates/openwave-cli/src/main.rs
+++ b/crates/openwave-cli/src/main.rs
@@ -118,6 +118,8 @@ usage: openwave serve
                   [--env-from <var>]… [--cwd <dir>] [--bearer-token-env <var>]
                   [--timeout-ms <ms>] [--disabled]
        openwave mcp-server remove <name>
+       openwave chat list
+       openwave chat create
 
        openwave folder connect <path> --chat <id>
        openwave folder list [--chat <id>]
@@ -303,7 +305,8 @@ async fn run() -> Result<i32> {
             if command == OsStr::new("provider")
                 || command == OsStr::new("model")
                 || command == OsStr::new("settings")
-                || command == OsStr::new("mcp-server") =>
+                || command == OsStr::new("mcp-server")
+                || command == OsStr::new("chat") =>
         {
             let family = command.to_string_lossy().into_owned();
             let (command, format) = parse_setup(&family, text_args(args));
@@ -450,11 +453,13 @@ impl Cursor {
     }
 }
 
-/// Parse one `provider`/`model`/`settings`/`mcp-server` invocation.
+/// Parse one `provider`/`model`/`settings`/`mcp-server`/`chat` invocation.
 fn parse_setup(family: &str, args: Vec<String>) -> (SetupCommand, OutputFormat) {
     let mut cursor = Cursor::new(args);
     let verb = cursor.positional(&format!("a {family} subcommand"));
     let command = match (family, verb.as_str()) {
+        ("chat", "list") => SetupCommand::ChatList,
+        ("chat", "create") => SetupCommand::ChatCreate,
         ("provider", "list") => SetupCommand::ProviderList,
         ("provider", "set-key") => SetupCommand::ProviderSetKey {
             kind: cursor.positional("a provider kind"),

--- a/crates/openwave-cli/src/setup.rs
+++ b/crates/openwave-cli/src/setup.rs
@@ -1,4 +1,4 @@
-//! Scriptable setup: `openwave provider|model|settings|mcp-server`.
+//! Scriptable setup: `openwave provider|model|settings|mcp-server|chat`.
 //!
 //! Every command here is a thin client of a route the server already serves —
 //! the same ones the desktop settings pages call — so configuring OpenWave
@@ -98,6 +98,10 @@ pub enum Command {
     McpAdd { definition: serde_json::Value },
     /// Remove one user-configured MCP server by name.
     McpRemove { name: String },
+    /// Every chat, most recently active first.
+    ChatList,
+    /// A fresh chat (server-side defaults seed the rest).
+    ChatCreate,
 }
 
 /// Run one setup command against the profile's server, and shut down anything
@@ -364,6 +368,39 @@ async fn execute(client: &Client, command: Command, format: OutputFormat) -> Res
             }
             println!("openwave: removed the MCP server {name}");
         }
+        Command::ChatList => {
+            let chats = client.list_chats().await?;
+            if format == OutputFormat::Json {
+                return emit(&serde_json::json!({
+                    "chats": chats.iter().map(|chat| serde_json::json!({
+                        "id": chat.id,
+                        "title": chat.title,
+                        "model": chat.model,
+                        "permission_mode": chat.permission_mode,
+                        "created_at": chat.created_at,
+                    })).collect::<Vec<_>>(),
+                }));
+            }
+            if chats.is_empty() {
+                eprintln!("openwave: no chats");
+                return Ok(());
+            }
+            for chat in chats {
+                let title = chat.title.as_deref().unwrap_or("(untitled)");
+                let model = chat.model.as_deref().unwrap_or("-");
+                println!("{:<36}  {title:<40}  {model}", chat.id);
+            }
+        }
+        Command::ChatCreate => {
+            let chat = client.create_chat().await?;
+            if format == OutputFormat::Json {
+                return emit(&serde_json::json!({ "id": chat }));
+            }
+            // stdout is the id alone so a script can capture it; the label
+            // rides stderr the same way `-p` announces a freshly created chat.
+            println!("{chat}");
+            eprintln!("openwave: chat {chat}");
+        }
     }
     Ok(())
 }
@@ -550,6 +587,33 @@ mod tests {
                 .any(|provider| provider.kind == "anthropic" && provider.has_credential),
             "removing the credential must take it out of the listing"
         );
+
+        serve.abort();
+    }
+
+    /// `chat create` must return an id that `chat list` (and therefore
+    /// `--chat`) can see on the same profile — otherwise scripts that capture
+    /// the id and continue with `-p --chat` fail for no visible reason.
+    #[tokio::test]
+    async fn a_chat_created_through_the_cli_shows_up_in_the_listing() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        openwave_core::KeychainSecretProvider::use_mock();
+        let server = openwave_server::bind_configured(Config::desktop(dir.path()))
+            .await
+            .expect("bind the server");
+        let client = Client::new(server.local_addr(), server.token()).expect("build the client");
+        let serve = tokio::spawn(server.serve());
+
+        assert!(
+            client.list_chats().await.expect("list").is_empty(),
+            "a fresh profile has no chats"
+        );
+
+        execute(&client, Command::ChatCreate, OutputFormat::Text)
+            .await
+            .expect("create a chat");
+        let listed = client.list_chats().await.expect("list after create");
+        assert_eq!(listed.len(), 1, "create must leave exactly one chat visible");
 
         serve.abort();
     }

--- a/crates/openwave-cli/src/setup.rs
+++ b/crates/openwave-cli/src/setup.rs
@@ -613,7 +613,11 @@ mod tests {
             .await
             .expect("create a chat");
         let listed = client.list_chats().await.expect("list after create");
-        assert_eq!(listed.len(), 1, "create must leave exactly one chat visible");
+        assert_eq!(
+            listed.len(),
+            1,
+            "create must leave exactly one chat visible"
+        );
 
         serve.abort();
     }

--- a/docs-site/content/docs/headless.mdx
+++ b/docs-site/content/docs/headless.mdx
@@ -47,6 +47,8 @@ openwave settings exec remove-key <provider>
 openwave mcp-server list
 openwave mcp-server add <name> (--command <cmd> [--arg <a>]… | --url <url>)
 openwave mcp-server remove <name>
+openwave chat list
+openwave chat create
 ```
 
 A bare `openwave` with no arguments runs `serve`.
@@ -219,12 +221,12 @@ cargo run -p openwave-cli -- -p "plan the migration" \
 
 ### Setup commands
 
-`provider`, `model`, `settings`, and `mcp-server` configure a profile without
-the desktop app. Each one boots the same in-process server the other commands
-do, calls the route the desktop's settings pages call, and prints the answer —
-they hold no configuration logic of their own, so both surfaces stay in step.
-All of them accept `--output-format text|json`, and `json` prints the route's
-response object on one line.
+`provider`, `model`, `settings`, `mcp-server`, and `chat` configure a profile
+without the desktop app. Each one boots the same in-process server the other
+commands do, calls the route the desktop's settings pages call, and prints the
+answer — they hold no configuration logic of their own, so both surfaces stay in
+step. All of them accept `--output-format text|json`, and `json` prints the
+route's response object on one line.
 
 ```sh
 # Providers and credentials
@@ -252,6 +254,11 @@ cargo run -p openwave-cli -- mcp-server list
 cargo run -p openwave-cli -- mcp-server add docs \
   --command npx --arg -y --arg @acme/docs-mcp --env-from ACME_TOKEN
 cargo run -p openwave-cli -- mcp-server remove docs
+
+# Chats
+cargo run -p openwave-cli -- chat list
+CHAT=$(cargo run -p openwave-cli -- chat create)
+cargo run -p openwave-cli -- -p "…" --chat "$CHAT"
 ```
 
 **A key is never a command-line argument.** `set-key` reads it from stdin, or


### PR DESCRIPTION
## Summary
- Add `openwave chat list` and `openwave chat create` as setup commands (same session/`--attach` path as `provider`/`model`).
- Text create prints the chat id on stdout (and a stderr label); list shows id, title, and model; both support `--output-format json`.
- Document the commands in the headless docs.

## Test plan
- [x] `cargo test -p openwave-cli a_chat_created_through_the_cli -- --nocapture`
- [x] Against a live desktop with `listen.json`: `OPENWAVE_DATA_DIR=… openwave --attach chat create` then `chat list` / `-p --chat <id>`
- [ ] CI rustfmt/clippy/workspace lanes green