### PR TITLE
feat(cli): inspect agent runs and teach sandbox exec argv form

### DIFF
--- a/crates/openwave-cli/src/api/wire.rs
+++ b/crates/openwave-cli/src/api/wire.rs
@@ -363,7 +363,11 @@ pub struct InboxItem {
 pub struct AgentRunSnapshot {
     pub id: openwave_core::AgentRunId,
     #[serde(default)]
+    pub parent_id: Option<openwave_core::AgentRunId>,
+    #[serde(default)]
     pub tier: Option<String>,
+    #[serde(default)]
+    pub execution_location: Option<String>,
     pub status: String,
     #[serde(default)]
     pub task: Option<String>,
@@ -375,6 +379,9 @@ pub struct AgentRunSnapshot {
     pub last_error_code: Option<String>,
     #[serde(default)]
     pub activity: Option<AgentActivity>,
+    /// Files the run named in its terminal `done` submission.
+    #[serde(default)]
+    pub submitted_outputs: Vec<SubmittedOutput>,
     #[serde(default)]
     pub terminal_text: Option<String>,
     /// The call that spawned this run; lets a transcript attach the run to
@@ -384,6 +391,13 @@ pub struct AgentRunSnapshot {
     pub spawn_call_id: Option<CallId>,
     #[serde(default)]
     pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// One file a background run submitted, as the list route returns it.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SubmittedOutput {
+    pub output_id: openwave_core::OutputId,
+    pub filename: String,
 }
 
 /// The live checkpoint of a background run.
@@ -421,6 +435,20 @@ impl AgentActivityKind {
             Self::Other => "a step",
         }
     }
+
+    /// Stable snake_case name for JSON drivers and text listings.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Exec => "exec",
+            Self::WebSearch => "web_search",
+            Self::ReadDelegatedFile => "read_delegated_file",
+            Self::ListConnectedFolders => "list_connected_folders",
+            Self::ListFolder => "list_folder",
+            Self::ReadConnectedFile => "read_connected_file",
+            Self::ImportConnectedFile => "import_connected_file",
+            Self::Other => "other",
+        }
+    }
 }
 
 /// One history entry in a background run's activity timeline.
@@ -429,6 +457,9 @@ pub struct AgentActivityItem {
     pub kind: AgentActivityKind,
     pub outcome: String,
     pub at: chrono::DateTime<chrono::Utc>,
+    /// Renderer-safe command/query detail when the server supplies it.
+    #[serde(default)]
+    pub detail: Option<serde_json::Value>,
 }
 
 /// One pending approval, from `GET /chats/{id}/approvals`.

--- a/crates/openwave-cli/src/main.rs
+++ b/crates/openwave-cli/src/main.rs
@@ -120,6 +120,8 @@ usage: openwave serve
        openwave mcp-server remove <name>
        openwave chat list
        openwave chat create
+       openwave agent-run list <chat>
+       openwave agent-run show <chat> <run>
 
        openwave folder connect <path> --chat <id>
        openwave folder list [--chat <id>]
@@ -306,7 +308,8 @@ async fn run() -> Result<i32> {
                 || command == OsStr::new("model")
                 || command == OsStr::new("settings")
                 || command == OsStr::new("mcp-server")
-                || command == OsStr::new("chat") =>
+                || command == OsStr::new("chat")
+                || command == OsStr::new("agent-run") =>
         {
             let family = command.to_string_lossy().into_owned();
             let (command, format) = parse_setup(&family, text_args(args));
@@ -453,13 +456,23 @@ impl Cursor {
     }
 }
 
-/// Parse one `provider`/`model`/`settings`/`mcp-server`/`chat` invocation.
+/// Parse one `provider`/`model`/`settings`/`mcp-server`/`chat`/`agent-run`
+/// invocation.
 fn parse_setup(family: &str, args: Vec<String>) -> (SetupCommand, OutputFormat) {
     let mut cursor = Cursor::new(args);
     let verb = cursor.positional(&format!("a {family} subcommand"));
     let command = match (family, verb.as_str()) {
         ("chat", "list") => SetupCommand::ChatList,
         ("chat", "create") => SetupCommand::ChatCreate,
+        ("agent-run", "list") => {
+            let chat = parse_chat_id(&cursor.positional("a chat id"));
+            SetupCommand::AgentRunList { chat }
+        }
+        ("agent-run", "show") => {
+            let chat = parse_chat_id(&cursor.positional("a chat id"));
+            let run = parse_agent_run_id(&cursor.positional("an agent-run id"));
+            SetupCommand::AgentRunShow { chat, run }
+        }
         ("provider", "list") => SetupCommand::ProviderList,
         ("provider", "set-key") => SetupCommand::ProviderSetKey {
             kind: cursor.positional("a provider kind"),
@@ -568,6 +581,15 @@ fn parse_format(value: String) -> OutputFormat {
         Some(format) => format,
         None => usage_error("--output-format expects text or json"),
     }
+}
+
+fn parse_chat_id(value: &str) -> ChatId {
+    ChatId::from_str(value).unwrap_or_else(|_| usage_error("expected a chat UUID"))
+}
+
+fn parse_agent_run_id(value: &str) -> openwave_core::AgentRunId {
+    openwave_core::AgentRunId::from_str(value)
+        .unwrap_or_else(|_| usage_error("expected an agent-run UUID"))
 }
 
 /// Build one MCP server definition from flags, in the shape

--- a/crates/openwave-cli/src/setup.rs
+++ b/crates/openwave-cli/src/setup.rs
@@ -1,4 +1,4 @@
-//! Scriptable setup: `openwave provider|model|settings|mcp-server|chat`.
+//! Scriptable setup: `openwave provider|model|settings|mcp-server|chat|agent-run`.
 //!
 //! Every command here is a thin client of a route the server already serves —
 //! the same ones the desktop settings pages call — so configuring OpenWave
@@ -13,7 +13,7 @@
 
 use std::io::Read as _;
 
-use openwave_core::{AgentError, Result};
+use openwave_core::{AgentError, AgentRunId, ChatId, Result};
 
 use crate::api::client::Client;
 use crate::api::wire::{McpServerInfo, McpServersInfo};
@@ -102,6 +102,10 @@ pub enum Command {
     ChatList,
     /// A fresh chat (server-side defaults seed the rest).
     ChatCreate,
+    /// Background (and foreground) agent runs for one chat.
+    AgentRunList { chat: ChatId },
+    /// One run's status plus its ordered activity timeline.
+    AgentRunShow { chat: ChatId, run: AgentRunId },
 }
 
 /// Run one setup command against the profile's server, and shut down anything
@@ -401,8 +405,187 @@ async fn execute(client: &Client, command: Command, format: OutputFormat) -> Res
             println!("{chat}");
             eprintln!("openwave: chat {chat}");
         }
+        Command::AgentRunList { chat } => {
+            let runs = client.list_agent_runs(chat).await?;
+            if format == OutputFormat::Json {
+                return emit(&serde_json::json!({
+                    "runs": runs.iter().map(agent_run_json).collect::<Vec<_>>(),
+                }));
+            }
+            if runs.is_empty() {
+                eprintln!("openwave: no agent runs in this chat");
+                return Ok(());
+            }
+            for run in runs {
+                let tier = run.tier.as_deref().unwrap_or("-");
+                let task = run
+                    .task
+                    .as_deref()
+                    .map(first_line)
+                    .unwrap_or_else(|| "-".to_owned());
+                let outs: Vec<&str> = run
+                    .submitted_outputs
+                    .iter()
+                    .map(|output| output.filename.as_str())
+                    .collect();
+                let outs = if outs.is_empty() {
+                    "-".to_owned()
+                } else {
+                    outs.join(",")
+                };
+                println!(
+                    "{:<36}  {tier:<10}  {:<12}  outs={outs}  {task}",
+                    run.id, run.status
+                );
+            }
+        }
+        Command::AgentRunShow { chat, run } => {
+            let runs = client.list_agent_runs(chat).await?;
+            let Some(snapshot) = runs.into_iter().find(|entry| entry.id == run) else {
+                return Err(AgentError::msg(format!(
+                    "no agent run {run} in chat {chat}"
+                )));
+            };
+            let activity = client.list_agent_run_activity(chat, run).await?;
+            if format == OutputFormat::Json {
+                return emit(&serde_json::json!({
+                    "run": agent_run_json(&snapshot),
+                    "activity": activity.iter().map(|item| serde_json::json!({
+                        "kind": item.kind.as_str(),
+                        "outcome": item.outcome,
+                        "at": item.at,
+                        "detail": item.detail,
+                    })).collect::<Vec<_>>(),
+                }));
+            }
+            println!("id                  {}", snapshot.id);
+            if let Some(parent) = snapshot.parent_id {
+                println!("parent              {parent}");
+            }
+            println!(
+                "tier                {}",
+                snapshot.tier.as_deref().unwrap_or("-")
+            );
+            println!(
+                "execution_location  {}",
+                snapshot.execution_location.as_deref().unwrap_or("-")
+            );
+            println!("status              {}", snapshot.status);
+            if let Some(error) = &snapshot.last_error_code {
+                println!("last_error_code     {error}");
+            }
+            if let Some(started) = snapshot.started_at {
+                println!("started_at          {started}");
+            }
+            if let Some(finished) = snapshot.finished_at {
+                println!("finished_at         {finished}");
+            }
+            if !snapshot.submitted_outputs.is_empty() {
+                let names: Vec<_> = snapshot
+                    .submitted_outputs
+                    .iter()
+                    .map(|output| output.filename.as_str())
+                    .collect();
+                println!("submitted_outputs   {}", names.join(", "));
+            }
+            if let Some(task) = &snapshot.task {
+                println!("task\n{task}");
+            }
+            if let Some(terminal) = &snapshot.terminal_text {
+                println!("terminal_text\n{terminal}");
+            }
+            if activity.is_empty() {
+                eprintln!("openwave: no activity recorded for this run");
+            } else {
+                println!("activity ({} steps)", activity.len());
+                for item in activity {
+                    let headline = activity_headline(item.detail.as_ref());
+                    println!(
+                        "  {}  {}  {}{}",
+                        item.at,
+                        item.kind.as_str(),
+                        item.outcome,
+                        headline
+                    );
+                }
+            }
+        }
     }
     Ok(())
+}
+
+/// Compact JSON object for one agent-run snapshot — enough for a driver to
+/// branch on status and collect submitted filenames without the full dump.
+fn agent_run_json(run: &crate::api::wire::AgentRunSnapshot) -> serde_json::Value {
+    serde_json::json!({
+        "id": run.id,
+        "parent_id": run.parent_id,
+        "tier": run.tier,
+        "execution_location": run.execution_location,
+        "status": run.status,
+        "task": run.task,
+        "started_at": run.started_at,
+        "finished_at": run.finished_at,
+        "last_error_code": run.last_error_code,
+        "submitted_outputs": run.submitted_outputs.iter().map(|output| serde_json::json!({
+            "output_id": output.output_id,
+            "filename": output.filename,
+        })).collect::<Vec<_>>(),
+        "terminal_text": run.terminal_text,
+        "spawn_call_id": run.spawn_call_id,
+        "created_at": run.created_at,
+    })
+}
+
+/// First line of a multi-line task, truncated for a one-line listing.
+fn first_line(text: &str) -> String {
+    let line = text.lines().next().unwrap_or(text).trim();
+    const LIMIT: usize = 72;
+    if line.chars().count() <= LIMIT {
+        return line.to_owned();
+    }
+    let mut out: String = line.chars().take(LIMIT.saturating_sub(1)).collect();
+    out.push('…');
+    out
+}
+
+/// A short suffix for one activity row: the command or query when present.
+fn activity_headline(detail: Option<&serde_json::Value>) -> String {
+    let Some(detail) = detail else {
+        return String::new();
+    };
+    if let Some(command) = detail.get("command").and_then(|value| value.as_str()) {
+        let args = detail
+            .get("args")
+            .and_then(|value| value.as_array())
+            .map(|entries| {
+                entries
+                    .iter()
+                    .filter_map(|entry| entry.as_str())
+                    .take(4)
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            })
+            .unwrap_or_default();
+        if args.is_empty() {
+            return format!("  {command}");
+        }
+        let clipped = if args.len() > 60 {
+            format!("{}…", &args[..60])
+        } else {
+            args
+        };
+        return format!("  {command} {clipped}");
+    }
+    if let Some(query) = detail.get("query").and_then(|value| value.as_str()) {
+        let clipped = if query.len() > 72 {
+            format!("{}…", &query[..72])
+        } else {
+            query.to_owned()
+        };
+        return format!("  {clipped}");
+    }
+    String::new()
 }
 
 /// Write one JSON object on stdout, matching print mode's one-object-per-line

--- a/crates/openwave-core/src/agent_tools.rs
+++ b/crates/openwave-core/src/agent_tools.rs
@@ -274,17 +274,17 @@ struct SandboxReadDelegatedFileArgs {}
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct SandboxExecArgs {
-    /// Executable name or path.
+    /// Executable name or path (argv[0] only — no spaces or shell syntax).
     #[schemars(
         length(min = 1, max = MAX_SANDBOX_EXEC_COMMAND_BYTES),
-        description = "Executable name or path."
+        description = "Single executable name or path (argv[0]). No spaces; put flags and operands in args."
     )]
     pub command: String,
     /// Arguments passed directly to the executable, with no shell parsing.
     #[serde(default)]
     #[schemars(
         length(max = MAX_SANDBOX_EXEC_ARGUMENTS),
-        description = "Arguments passed directly to the executable."
+        description = "One argv entry per token, with no shell parsing (e.g. [\"-p\", \"output\"] for mkdir)."
     )]
     pub args: Vec<String>,
     /// Workspace-relative working directory.
@@ -589,14 +589,18 @@ pub fn sandbox_exec_tool_spec() -> ToolSpec {
     ToolSpec::for_args::<SandboxExecArgs>(
         SANDBOX_EXEC_TOOL,
         "Run one executable with an argument vector in this background task's own private \
-         workspace. No shell parses the arguments unless you invoke a shell explicitly (for \
-         example command '/bin/sh' with args ['-c', '…']). The workspace starts empty and is \
-         yours alone: it holds nothing but what your own earlier commands wrote, and you cannot \
-         reach the conversation, the user's files, or any connected folder from it. Save every \
-         deliverable under output/ — each file you write there is published to the user as a \
-         durable output named by its own filename, and writing the same filename again publishes \
-         a new version of that same output. Name those files the way you want the user to see \
-         them. Every command returns bounded stdout and stderr.",
+         workspace. command is argv[0] only — a single binary or path with no spaces (python3, \
+         mkdir, /bin/sh). Put every other token in args: mkdir -p output is command mkdir with \
+         args [\"-p\", \"output\"]; a shell one-liner is command /bin/sh with args [\"-c\", \"…\"]. \
+         No shell parses the arguments unless you invoke a shell that way. The workspace starts \
+         empty and is yours alone: it holds nothing but what your own earlier commands wrote, and \
+         you cannot reach the conversation, the user's files, or any connected folder from it. \
+         Write only under the workspace (relative paths such as output/…); absolute paths like \
+         /tmp are not durable here. Save every deliverable under output/ — each file you write \
+         there is published to the user as a durable output named by its own filename, and \
+         writing the same filename again publishes a new version of that same output. Name those \
+         files the way you want the user to see them. Every command returns bounded stdout and \
+         stderr.",
     )
 }
 

--- a/crates/openwave-server/src/sandbox_agent_run_worker/config.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker/config.rs
@@ -22,10 +22,14 @@ use crate::state::SandboxAttemptGuard;
 /// depth-one child run's authority.
 pub(super) const SANDBOX_PROMPT_PREAMBLE: &str = "You are a sandboxed background agent. Work only on the delegated task below. You cannot access the conversation, the user's files, connected folders, or other agents. You do have your own private workspace: use exec to run commands in it, and write every deliverable the task asks for as a file under output/ — each file you write there is published to the user as a durable output named by its own filename, so name those files the way you want the user to see them. Prefer producing a file over describing what a file would contain.";
 pub(super) const SANDBOX_DELEGATED_FILE_PROMPT_PREAMBLE: &str = "You are a sandboxed background agent. Work only on the delegated task below. You cannot access the conversation, the user's files, connected folders, or other agents, except for the one exact file explicitly delegated to this run. You do have your own private workspace: use exec to run commands in it, and write every deliverable the task asks for as a file under output/ — each file you write there is published to the user as a durable output named by its own filename, so name those files the way you want the user to see them. Prefer producing a file over describing what a file would contain.";
+/// How to form exec calls. Stress-tested agents routinely waste steps by
+/// stuffing a whole shell line into `command` (which is argv[0] only) or by
+/// writing under `/tmp`, which this workspace cannot keep or publish.
+pub(super) const SANDBOX_PROMPT_EXEC_CLAUSE: &str = "exec with argv form only — command is a single executable (for example python3, mkdir, /bin/sh), and each shell token is its own args entry (mkdir -p output is command mkdir with args [\"-p\", \"output\"]; a one-liner is command /bin/sh with args [\"-c\", \"…\"]). Never put spaces inside command. Stay inside the workspace: create files under output/ or other relative paths, not under /tmp. Install packages with separate exec calls when needed (python3 -m pip install --user <pkg>==<ver>). There is no skills catalog and no shared conversation context — put any library or path detail you need into the commands themselves";
 pub(super) const SANDBOX_PROMPT_DELEGATED_FILE_CLAUSE: &str =
     "read_delegated_file to read that one delegated file";
 pub(super) const SANDBOX_PROMPT_WEB_SEARCH_CLAUSE: &str =
-    "web_search when current public-web information is necessary";
+    "web_search when current public-web information is necessary (prefer it over curl or other network tools from exec — those often fail in the sandbox)";
 pub(super) const SANDBOX_PROMPT_FOLDER_ACCESS_CLAUSE: &str = "request_folder_access only to propose that your foreground parent decide whether to ask the user — the proposal grants no access and cannot open a picker";
 pub(super) const SANDBOX_PROMPT_TASK_PLAN_CLAUSE: &str = "update_task_plan to keep an ordered checklist when the task takes several steps — send the whole list every time, keep exactly one step in_progress, and update it as steps finish rather than all at the end";
 pub(super) const SANDBOX_PROMPT_CLOSING: &str = "Take as many tool steps as the task genuinely needs, then finish by calling done with the filenames you wrote under output/ and a short summary of what you produced.";
@@ -47,7 +51,10 @@ pub(super) fn sandbox_system_prompt(
     if !tools_supported {
         return SANDBOX_CHAT_ONLY_PROMPT.to_owned();
     }
-    let mut clauses = Vec::with_capacity(4);
+    let mut clauses = Vec::with_capacity(5);
+    // Exec is always on a tool-capable route; name its argv contract first so
+    // the model does not burn early steps on malformed command lines.
+    clauses.push(SANDBOX_PROMPT_EXEC_CLAUSE);
     if delegated_file_available {
         clauses.push(SANDBOX_PROMPT_DELEGATED_FILE_CLAUSE);
     }

--- a/crates/openwave-server/src/sandbox_agent_run_worker/tests.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker/tests.rs
@@ -33,7 +33,8 @@ use openwave_core::{
 };
 
 use super::config::{
-    sandbox_system_prompt, SandboxAgentRunWorkerOutcome, SANDBOX_PROMPT_WEB_SEARCH_CLAUSE,
+    sandbox_system_prompt, SandboxAgentRunWorkerOutcome, SANDBOX_PROMPT_EXEC_CLAUSE,
+    SANDBOX_PROMPT_WEB_SEARCH_CLAUSE,
 };
 use super::model_step::{
     complete_sandbox_task, delegated_file_admission_matches, sandbox_request, SandboxCompletion,
@@ -2654,6 +2655,25 @@ async fn a_vendor_run_on_an_unregistered_model_gets_no_search_at_all() {
         .system
         .as_deref()
         .is_some_and(|system| !system.contains(SANDBOX_PROMPT_WEB_SEARCH_CLAUSE)));
+}
+
+/// Agents that stuff a whole shell line into `command` burn steps and fail
+/// closed; the system prompt must name the argv contract up front.
+#[test]
+fn sandbox_system_prompt_teaches_exec_argv_form() {
+    let prompt = sandbox_system_prompt(false, TurnWebSearch::Host, true);
+    assert!(
+        prompt.contains(SANDBOX_PROMPT_EXEC_CLAUSE),
+        "tool-capable runs must name the exec argv contract: {prompt}"
+    );
+    assert!(
+        prompt.contains("single executable"),
+        "prompt should spell out that command is argv[0] only: {prompt}"
+    );
+    assert!(
+        prompt.contains("output/"),
+        "prompt must still point deliverables at output/: {prompt}"
+    );
 }
 
 fn sandbox_chat() -> Chat {


### PR DESCRIPTION
## Summary

Stress-tested background agents producing real CSV, XLSX, DOCX, PDF, PPTX, chart JSON, and research memos across Sonnet/Haiku/GPT-mini and local/e2b/docker exec (Tavily web search). Agents succeed end-to-end, but children routinely burn steps by stuffing whole shell lines into `exec.command` (argv[0] only) and writing under `/tmp`.

This PR:

- Teaches the sandbox system prompt and `exec` tool description the argv contract, workspace-relative paths, and that there is no skills catalog.
- Adds `openwave agent-run list|show` so headless drivers can inspect run status, submitted outputs, and activity without hand-rolling curl.

## Stress-test notes (not in this PR)

| Matrix | Result |
| --- | --- |
| Sonnet + local, 4-way fanout (csv/xlsx/docx+pdf/md+chart) | All completed; real files published |
| Sonnet + e2b, pptx + csv | PPTX via python-pptx fallback (no node/npm in image); CSV ok |
| Haiku + local + web_search | notes.md + cited model_news.md |
| GPT-5.4-mini + e2b, csv/xlsx/pdf | All three files |
| Sonnet + docker | docker_hello.txt with Linux/OrbStack uname |
| Vague 1–2 sentence spawns (xlsx/pptx/weather md) | All succeeded after 6–8 failed execs each learning argv |

**Prompt / sandbox gaps observed:** no skills catalog on children; `execution_location` stays `in_process` while code-exec provider (e2b/docker/local) still routes commands; folder connect still exclusive of `serve`; only Tavily credential present for web search. Follow-ups welcome.

## Test plan

- [x] `cargo test -p openwave-server sandbox_system_prompt_teaches_exec_argv_form --lib --locked`
- [x] `cargo clippy -p openwave-cli -p openwave-server -p openwave-core --locked -- -D warnings`
- [x] Live: `openwave --attach agent-run list <chat>` and `show` against a chat with completed background runs
- [ ] CI green on the PR