### PR TITLE
feat(cli): add --output-format json to the output family

### DIFF
--- a/crates/openwave-cli/src/main.rs
+++ b/crates/openwave-cli/src/main.rs
@@ -94,10 +94,10 @@ usage: openwave serve
                   [--permission-mode ask|auto|allow|plan]
                   [--model <key>]
 
-       openwave output list <chat>
-       openwave output show <chat> <output> [--revision <id>]
-       openwave output revisions <chat> <output>
-       openwave output export <chat> <output> <path> [--revision <id>]
+       openwave output list <chat> [--output-format text|json]
+       openwave output show <chat> <output> [--revision <id>] [--output-format text|json]
+       openwave output revisions <chat> <output> [--output-format text|json]
+       openwave output export <chat> <output> <path> [--revision <id>] [--output-format text|json]
        openwave attach <chat> <file>
 
        openwave provider list
@@ -125,9 +125,9 @@ usage: openwave serve
        openwave folder list [--chat <id>]
        openwave folder disconnect <path-or-root-id> --chat <id>
 
-The setup commands take --output-format text|json. A key is read from stdin, or
-from the environment variable named by --from-env — never from an argument,
-which every process on the machine can read.
+The setup commands and the output family take --output-format text|json. A key
+is read from stdin, or from the environment variable named by --from-env —
+never from an argument, which every process on the machine can read.
 
 tui, -p, output, attach, and the setup commands also take --server <url>
 [--server-token-env <var>] or --attach, which talks to a server that is already
@@ -630,8 +630,8 @@ fn parse_mcp_definition(cursor: &mut Cursor) -> serde_json::Value {
 /// Parse and run one `openwave output …` subcommand.
 ///
 /// Positional chat and output ids, matching `openwave attach <chat> <file>`;
-/// the only flag is `--revision <id>`, which names an exact version instead of
-/// the current one.
+/// `--revision <id>` names an exact version instead of the current one, and
+/// `--output-format text|json` is the same opt-in the setup family uses.
 async fn output_command(
     args: &mut impl Iterator<Item = OsString>,
     server: connect::Server,
@@ -646,10 +646,8 @@ async fn output_command(
     };
 
     if subcommand == OsStr::new("list") {
-        if args.next().is_some() {
-            usage_error("output list accepts only a chat id");
-        }
-        return outputs::run(outputs::Command::List { chat }, server).await;
+        let (_, format) = parse_output_trailing_flags(args, /*allow_revision=*/ false);
+        return outputs::run(outputs::Command::List { chat }, format, server).await;
     }
 
     let output = match args.next() {
@@ -671,20 +669,8 @@ async fn output_command(
         None
     };
 
-    let mut revision = None;
-    while let Some(flag) = args.next() {
-        if flag == OsStr::new("--revision") {
-            let Some(id) = args.next() else {
-                usage_error("--revision requires a revision id");
-            };
-            match openwave_core::OutputRevisionId::from_str(&id.to_string_lossy()) {
-                Ok(id) => revision = Some(id),
-                Err(_) => usage_error("--revision expects a revision UUID"),
-            }
-        } else {
-            usage_error(&format!("unknown output argument {flag:?}"));
-        }
-    }
+    let allow_revision = subcommand == OsStr::new("show") || subcommand == OsStr::new("export");
+    let (revision, format) = parse_output_trailing_flags(args, allow_revision);
 
     let command = if subcommand == OsStr::new("show") {
         outputs::Command::Show {
@@ -693,9 +679,6 @@ async fn output_command(
             revision,
         }
     } else if subcommand == OsStr::new("revisions") {
-        if revision.is_some() {
-            usage_error("output revisions lists every version and takes no --revision");
-        }
         outputs::Command::Revisions { chat, output }
     } else if subcommand == OsStr::new("export") {
         outputs::Command::Export {
@@ -707,7 +690,42 @@ async fn output_command(
     } else {
         usage_error("output accepts list, show, revisions, or export");
     };
-    outputs::run(command, server).await
+    outputs::run(command, format, server).await
+}
+
+/// Shared flag loop for the output family: optional `--revision` (show/export)
+/// and the trailing `--output-format` every verb accepts.
+fn parse_output_trailing_flags(
+    args: &mut impl Iterator<Item = OsString>,
+    allow_revision: bool,
+) -> (Option<openwave_core::OutputRevisionId>, OutputFormat) {
+    let mut revision = None;
+    let mut format = OutputFormat::Text;
+    while let Some(flag) = args.next() {
+        if flag == OsStr::new("--revision") {
+            if !allow_revision {
+                usage_error(&format!("unknown output argument {flag:?}"));
+            }
+            let Some(id) = args.next() else {
+                usage_error("--revision requires a revision id");
+            };
+            match openwave_core::OutputRevisionId::from_str(&id.to_string_lossy()) {
+                Ok(id) => revision = Some(id),
+                Err(_) => usage_error("--revision expects a revision UUID"),
+            }
+        } else if flag == OsStr::new("--output-format") {
+            let Some(value) = args.next() else {
+                usage_error("--output-format requires text or json");
+            };
+            match OutputFormat::parse(&value.to_string_lossy()) {
+                Some(value) => format = value,
+                None => usage_error("--output-format expects text or json"),
+            }
+        } else {
+            usage_error(&format!("unknown output argument {flag:?}"));
+        }
+    }
+    (revision, format)
 }
 
 fn usage_error(message: &str) -> ! {

--- a/crates/openwave-cli/src/outputs.rs
+++ b/crates/openwave-cli/src/outputs.rs
@@ -13,7 +13,9 @@ use std::path::{Path, PathBuf};
 use openwave_core::{AgentError, ChatId, OutputId, OutputRevisionId, Result};
 
 use crate::api::client::Client;
+use crate::api::wire::{OutputPreview, OutputRevisionRow, OutputSummary};
 use crate::connect::{Server, Session};
+use crate::print::OutputFormat;
 
 /// What `openwave output` was asked to do.
 pub enum Command {
@@ -37,17 +39,27 @@ pub enum Command {
     },
 }
 
-pub async fn run(command: Command, server: Server) -> Result<()> {
+pub async fn run(command: Command, format: OutputFormat, server: Server) -> Result<()> {
     let session = Session::open(&server).await?;
-    execute(session.client(), command).await
+    execute(session.client(), command, format).await
 }
 
 /// Make the calls and render them. Split from [`run`] the way [`crate::setup`]
 /// splits its own, so the work is reachable with a client the caller owns.
-async fn execute(client: &Client, command: Command) -> Result<()> {
+async fn execute(client: &Client, command: Command, format: OutputFormat) -> Result<()> {
     match command {
         Command::List { chat } => {
             let catalog = client.list_outputs(chat).await?;
+            if format == OutputFormat::Json {
+                return emit(&serde_json::json!({
+                    "deliverables": catalog
+                        .deliverables
+                        .iter()
+                        .map(output_summary_json)
+                        .collect::<Vec<_>>(),
+                    "truncated": catalog.truncated,
+                }));
+            }
             if catalog.deliverables.is_empty() {
                 eprintln!("openwave: this conversation has no outputs");
             }
@@ -73,6 +85,12 @@ async fn execute(client: &Client, command: Command) -> Result<()> {
             revision,
         } => {
             let preview = client.read_output(chat, output, revision).await?;
+            if format == OutputFormat::Json {
+                // One object on stdout holds both the preview text and the
+                // metadata text mode splits across stderr and stdout, so a
+                // driver can parse a single value without scraping banners.
+                return emit(&output_preview_json(&preview));
+            }
             if preview.content.is_empty() {
                 return Err(AgentError::msg(format!(
                     "{} is {}, which has no text preview; use `openwave output export`",
@@ -96,6 +114,15 @@ async fn execute(client: &Client, command: Command) -> Result<()> {
         }
         Command::Revisions { chat, output } => {
             let history = client.list_output_revisions(chat, output).await?;
+            if format == OutputFormat::Json {
+                return emit(&serde_json::json!({
+                    "revisions": history
+                        .revisions
+                        .iter()
+                        .map(output_revision_json)
+                        .collect::<Vec<_>>(),
+                }));
+            }
             for revision in &history.revisions {
                 println!(
                     "{}\tv{}\t{} bytes\t{}\t{}{}",
@@ -118,6 +145,12 @@ async fn execute(client: &Client, command: Command) -> Result<()> {
             let bytes = client.read_output_bytes(chat, output, revision).await?;
             let written = bytes.len();
             write_export(&destination, &bytes)?;
+            if format == OutputFormat::Json {
+                return emit(&serde_json::json!({
+                    "path": destination.display().to_string(),
+                    "bytes": written,
+                }));
+            }
             eprintln!(
                 "openwave: wrote {written} bytes to {}",
                 destination.display()
@@ -125,6 +158,45 @@ async fn execute(client: &Client, command: Command) -> Result<()> {
             Ok(())
         }
     }
+}
+
+fn output_summary_json(output: &OutputSummary) -> serde_json::Value {
+    serde_json::json!({
+        "outputId": output.output_id,
+        "filename": output.filename,
+        "mediaType": output.media_type,
+        "sizeBytes": output.size_bytes,
+        "revisionCount": output.revision_count,
+        "updatedAt": output.updated_at,
+    })
+}
+
+fn output_preview_json(preview: &OutputPreview) -> serde_json::Value {
+    serde_json::json!({
+        "filename": preview.filename,
+        "mediaType": preview.media_type,
+        "revisionId": preview.revision_id,
+        "content": preview.content,
+        "truncated": preview.truncated,
+    })
+}
+
+fn output_revision_json(revision: &OutputRevisionRow) -> serde_json::Value {
+    serde_json::json!({
+        "revisionId": revision.revision_id,
+        "ordinal": revision.ordinal,
+        "sizeBytes": revision.size_bytes,
+        "createdAt": revision.created_at,
+        "producedBy": revision.produced_by,
+        "isCurrent": revision.is_current,
+    })
+}
+
+/// Write one JSON object on stdout, matching setup and print mode's shape so
+/// the same consumer can read every CLI surface.
+fn emit(value: &serde_json::Value) -> Result<()> {
+    println!("{value}");
+    Ok(())
 }
 
 /// Write exported bytes, replacing the destination only once the whole file is

--- a/crates/openwave-cli/tests/serve.rs
+++ b/crates/openwave-cli/tests/serve.rs
@@ -552,6 +552,49 @@ fn the_output_and_attach_families_reach_the_attached_server() {
     );
 }
 
+/// `output list --output-format json` writes one object on stdout — the same
+/// single-value shape setup uses — so a driver never has to scrape TSV or the
+/// empty-catalog banner on stderr.
+#[test]
+fn output_list_json_is_one_object_on_stdout() {
+    let dir = tempfile::tempdir().unwrap();
+    let (_server, url, token) = spawn_serve(dir.path());
+    let chat = create_chat(&url, &token);
+
+    let listed = Command::new(env!("CARGO_BIN_EXE_openwave"))
+        .args([
+            "output",
+            "list",
+            &chat,
+            "--output-format",
+            "json",
+            "--server",
+        ])
+        .arg(&url)
+        .env("OPENWAVE_SERVER_TOKEN", &token)
+        .env("OPENWAVE_DATA_DIR", dir.path())
+        .env("OPENWAVE_KEYCHAIN_MOCK", "1")
+        .env_remove("OPENWAVE_SERVER_URL")
+        .stdin(Stdio::null())
+        .output()
+        .expect("run output list --output-format json");
+
+    let stderr = String::from_utf8_lossy(&listed.stderr).into_owned();
+    assert!(listed.status.success(), "stderr: {stderr}");
+    let body: serde_json::Value =
+        serde_json::from_slice(&listed.stdout).expect("one JSON object on stdout");
+    assert_eq!(
+        body,
+        serde_json::json!({ "deliverables": [], "truncated": false }),
+        "stdout: {}",
+        String::from_utf8_lossy(&listed.stdout)
+    );
+    assert!(
+        stderr.is_empty(),
+        "json mode keeps the empty-catalog note off stderr: {stderr}"
+    );
+}
+
 /// Create a chat on the running server and return its id, so a command under
 /// test has something on the *server's* side to name.
 fn create_chat(url: &str, token: &str) -> String {


### PR DESCRIPTION
## Summary

- `openwave output list|show|revisions|export` accept `--output-format text|json`, reusing `print::OutputFormat` the same way setup does.
- Text mode is unchanged (TSV rows, preview body on stdout, banners on stderr).
- JSON mode writes **one object on stdout** per invocation:
  - **list** — `{ deliverables: [...], truncated }` with camelCase fields matching the server catalog (`outputId`, `filename`, `mediaType`, `sizeBytes`, `revisionCount`, `updatedAt`).
  - **revisions** — `{ revisions: [...] }` (`revisionId`, `ordinal`, `sizeBytes`, `createdAt`, `producedBy`, `isCurrent`).
  - **show** — one object with **content + metadata** (`filename`, `mediaType`, `revisionId`, `content`, `truncated`). Text mode keeps splitting metadata onto stderr so stdout stays pure file text; JSON folds both into one parseable value so a driver does not scrape banners. Empty/binary previews still emit the object (with empty `content`) rather than erroring, which is the structured equivalent of “no text preview.”
  - **export** — `{ path, bytes }` after the file is written (success confirmation only; bytes still go to the destination path).

## Test plan

- [x] `cargo test -p openwave-cli --test serve output_list_json_is_one_object_on_stdout`
- [x] `cargo test -p openwave-cli --test serve the_output_and_attach_families_reach_the_attached_server`
- [x] `cargo clippy -p openwave-cli --all-targets -- -D warnings`
- [ ] CI green on the PR lanes