### PR TITLE
fix(core): skip sandbox helper scripts under output/

### DIFF
--- a/crates/openwave-core/src/agent_tools.rs
+++ b/crates/openwave-core/src/agent_tools.rs
@@ -595,12 +595,13 @@ pub fn sandbox_exec_tool_spec() -> ToolSpec {
          No shell parses the arguments unless you invoke a shell that way. The workspace starts \
          empty and is yours alone: it holds nothing but what your own earlier commands wrote, and \
          you cannot reach the conversation, the user's files, or any connected folder from it. \
-         Write only under the workspace (relative paths such as output/…); absolute paths like \
-         /tmp are not durable here. Save every deliverable under output/ — each file you write \
-         there is published to the user as a durable output named by its own filename, and \
-         writing the same filename again publishes a new version of that same output. Name those \
-         files the way you want the user to see them. Every command returns bounded stdout and \
-         stderr.",
+         Write only under the workspace (relative paths); absolute paths like /tmp are not durable \
+         here. Save only final deliverables under output/ (for example .md, .csv, .xlsx, .pdf, \
+         .pptx, .docx, .chart.json) — each file there is published to the user as a durable output \
+         named by its own filename, and writing the same filename again publishes a new version of \
+         that same output. Keep helper scripts and other intermediates in the workspace root (or \
+         any path outside output/); source files under output/ are not published. Name deliverables \
+         the way you want the user to see them. Every command returns bounded stdout and stderr.",
     )
 }
 
@@ -620,11 +621,11 @@ pub fn validate_sandbox_exec_arguments(arguments: &Value) -> bool {
 pub fn sandbox_done_tool_spec() -> ToolSpec {
     ToolSpec::for_args::<SandboxDoneArgs>(
         SANDBOX_DONE_TOOL,
-        "Finish this background task. List the filenames you wrote under output/ that are the \
-         deliverables the task asked for — those files are what the user receives, named exactly \
-         as you named them — and give a short summary of what you produced. Call this only after \
-         the files exist. If the task genuinely produced no file, submit no filenames and say so \
-         in the summary.",
+        "Finish this background task. List the filenames of final deliverables you wrote under \
+         output/ — not helper scripts — that answer the task; those files are what the user \
+         receives, named exactly as you named them. Give a short summary of what you produced. \
+         Call this only after the files exist. If the task genuinely produced no file, submit no \
+         filenames and say so in the summary.",
     )
 }
 

--- a/crates/openwave-core/src/db/tests/output.rs
+++ b/crates/openwave-core/src/db/tests/output.rs
@@ -936,6 +936,54 @@ mod output_scan {
         );
         assert!(!workspace.path().join(&relative).exists());
     }
+
+    /// A background agent that builds a deck often leaves the generator script
+    /// next to the PPTX under output/. The scan must publish the deliverable
+    /// and refuse the script with a note — otherwise junk lands in the catalog
+    /// beside the real file. Foreground turns are out of scope for this skip.
+    #[tokio::test]
+    async fn a_sandbox_run_does_not_publish_helper_scripts_beside_deliverables() {
+        let (_dir, store, chat) = store_with_chat().await;
+        let scratch = tempfile::tempdir().unwrap();
+        let dir = open_scratch(scratch.path());
+
+        // Minimal well-formed empty ZIP = valid PPTX signature for the scan.
+        write_output_file(
+            scratch.path(),
+            "deck.pptx",
+            b"PK\x05\x06\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",
+        );
+        write_output_file(scratch.path(), "build_deck.py", b"print('hi')\n");
+        write_output_file(scratch.path(), "helper.sh", b"#!/bin/sh\n");
+
+        let scan = sync_output_directory(
+            &store,
+            &dir,
+            &dir,
+            chat.id,
+            CallId::new(),
+            RevisionProducer::Run(crate::AgentRunId::new()),
+            at(0),
+        )
+        .await
+        .unwrap();
+
+        let published: Vec<&str> = scan
+            .entries
+            .iter()
+            .map(|entry| entry.filename.as_str())
+            .collect();
+        assert_eq!(published, ["deck.pptx"]);
+        assert!(scan
+            .notes
+            .iter()
+            .any(|note| { note.contains("build_deck.py") && note.contains("workspace root") }));
+        assert!(scan
+            .notes
+            .iter()
+            .any(|note| note.contains("helper.sh") && note.contains("workspace root")));
+        assert_eq!(store.list_outputs(chat.id, 10).await.unwrap().len(), 1);
+    }
 }
 
 #[cfg(feature = "tools")]

--- a/crates/openwave-core/src/output_scan.rs
+++ b/crates/openwave-core/src/output_scan.rs
@@ -17,6 +17,12 @@
 //! creation that lost that race is told which output won and appends to it,
 //! so a name never ends up on two live records.
 //!
+//! Background runs additionally skip obvious source intermediates under
+//! `output/` (`.py`, `.js`, `.ts`, `.sh`): those belong in the workspace root,
+//! not beside the deliverable. The skip is sandbox-only — foreground turns
+//! keep the previous publish-everything rule — and surfaces a note so the
+//! model can move the script rather than silently losing a file.
+//!
 //! The scan is deliberately non-fatal: a file the host cannot accept (too
 //! large, unreadable, over the revision cap) becomes a note for the model
 //! rather than a failed command.
@@ -106,14 +112,19 @@ pub async fn sync_output_directory(
 ) -> Result<OutputDirectorySync> {
     let mut sync = OutputDirectorySync::default();
 
+    // Background sandbox runs are the path that kept dropping helper scripts
+    // next to real deliverables. Foreground turns keep the older, broader rule.
+    let skip_source_intermediates = matches!(producer, RevisionProducer::Run(_));
+
     // Reading is blocking capability I/O; keep it off the async runtime.
     let read_scratch = workspace
         .try_clone()
         .map_err(|error| AgentError::Store(format!("could not open private scratch: {error}")))?;
-    let (candidates, mut read_notes) =
-        tokio::task::spawn_blocking(move || read_output_candidates(&read_scratch))
-            .await
-            .map_err(|error| AgentError::Store(format!("output scan task failed: {error}")))?;
+    let (candidates, mut read_notes) = tokio::task::spawn_blocking(move || {
+        read_output_candidates(&read_scratch, skip_source_intermediates)
+    })
+    .await
+    .map_err(|error| AgentError::Store(format!("output scan task failed: {error}")))?;
     sync.notes.append(&mut read_notes);
     if candidates.is_empty() {
         return Ok(sync);
@@ -307,11 +318,30 @@ async fn publish_revision_bytes(
     .map_err(|error| AgentError::Store(format!("could not publish output revision: {error}")))
 }
 
+/// Whether a filename is an obvious source intermediate a sandbox agent should
+/// keep outside `output/`.
+///
+/// Only the common script extensions that show up as build helpers next to
+/// real deliverables. Curated text and office/binary formats are never matched.
+#[must_use]
+fn is_source_intermediate_filename(name: &str) -> bool {
+    let Some((_, extension)) = name.rsplit_once('.') else {
+        return false;
+    };
+    matches!(
+        extension.to_ascii_lowercase().as_str(),
+        "py" | "js" | "ts" | "sh"
+    )
+}
+
 /// Read and classify the acceptable files directly under `output/`.
 ///
 /// Deterministic (alphabetical) order, bounded at [`MAX_OUTPUT_SCAN_FILES`].
 /// Anything skipped is explained in a note.
-fn read_output_candidates(scratch: &Dir) -> (Vec<ScanCandidate>, Vec<String>) {
+fn read_output_candidates(
+    scratch: &Dir,
+    skip_source_intermediates: bool,
+) -> (Vec<ScanCandidate>, Vec<String>) {
     let mut notes = Vec::new();
 
     // A symlinked `output/` planted by local exec would hand host files from an
@@ -344,6 +374,15 @@ fn read_output_candidates(scratch: &Dir) -> (Vec<ScanCandidate>, Vec<String>) {
         };
         if name.starts_with('.') {
             // Dotfiles are workspace plumbing and never publishable.
+            continue;
+        }
+        if skip_source_intermediates && is_source_intermediate_filename(&name) {
+            // Sandbox-only: helper scripts next to a PPTX/PDF are not
+            // deliverables. Note it so the model moves the script rather than
+            // thinking the file vanished.
+            notes.push(format!(
+                "output/{name} was not published: keep helper scripts in the workspace root, not under output/; only final deliverables belong there"
+            ));
             continue;
         }
         match entry.metadata().map(|metadata| metadata.file_type()) {


### PR DESCRIPTION
## Summary

Background sandbox agents were publishing helper scripts (e.g. `build_deck.py`) as conversation outputs because the `output/` scan accepted every regular file beside real deliverables.

- **Scan (sandbox-only):** when the producer is `RevisionProducer::Run`, skip `.py` / `.js` / `.ts` / `.sh` under `output/` and leave an actionable note telling the model to keep scripts in the workspace root. Foreground turns are unchanged.
- **Tool copy:** `sandbox_exec` / `done` descriptions now say final deliverables go in `output/`, helpers stay outside it.

### Rejected alternatives

- Skip for all producers — junk report is sandbox-specific; keep blast radius narrow.
- Gate on `done` filenames — scan runs after every command, before `done`; junk would already be published.
- Allow-list only curated extensions — too aggressive for valid binary deliverables (parquet, zip, images).
- Silent skip — model would not learn; a note is actionable.

## Test plan

- [x] `cargo test -p openwave-core --features tools --locked output_scan`
- [x] New regression: `a_sandbox_run_does_not_publish_helper_scripts_beside_deliverables`
- [x] `cargo clippy -p openwave-core --features tools --locked --all-targets -- -D warnings`
- [ ] CI lanes on the PR