### PR TITLE
feat(server): surface code-exec backend on agent-run snapshots

### DIFF
--- a/crates/openwave-cli/src/api/wire.rs
+++ b/crates/openwave-cli/src/api/wire.rs
@@ -366,8 +366,14 @@ pub struct AgentRunSnapshot {
     pub parent_id: Option<openwave_core::AgentRunId>,
     #[serde(default)]
     pub tier: Option<String>,
+    /// Where the agent run loop itself executes (`in_process` / `container`).
+    /// Not the code-exec backend — see [`Self::code_execution_provider`].
     #[serde(default)]
     pub execution_location: Option<String>,
+    /// Host code-execution backend for `exec` (`local` / `e2b` / `docker` /
+    /// `daytona` / `off`). Independent of [`Self::execution_location`].
+    #[serde(default)]
+    pub code_execution_provider: Option<String>,
     pub status: String,
     #[serde(default)]
     pub task: Option<String>,

--- a/crates/openwave-cli/src/setup.rs
+++ b/crates/openwave-cli/src/setup.rs
@@ -472,10 +472,7 @@ async fn execute(client: &Client, command: Command, format: OutputFormat) -> Res
             );
             println!(
                 "code_execution_provider  {}",
-                snapshot
-                    .code_execution_provider
-                    .as_deref()
-                    .unwrap_or("-")
+                snapshot.code_execution_provider.as_deref().unwrap_or("-")
             );
             println!("status              {}", snapshot.status);
             if let Some(error) = &snapshot.last_error_code {

--- a/crates/openwave-cli/src/setup.rs
+++ b/crates/openwave-cli/src/setup.rs
@@ -470,6 +470,13 @@ async fn execute(client: &Client, command: Command, format: OutputFormat) -> Res
                 "execution_location  {}",
                 snapshot.execution_location.as_deref().unwrap_or("-")
             );
+            println!(
+                "code_execution_provider  {}",
+                snapshot
+                    .code_execution_provider
+                    .as_deref()
+                    .unwrap_or("-")
+            );
             println!("status              {}", snapshot.status);
             if let Some(error) = &snapshot.last_error_code {
                 println!("last_error_code     {error}");
@@ -522,6 +529,7 @@ fn agent_run_json(run: &crate::api::wire::AgentRunSnapshot) -> serde_json::Value
         "parent_id": run.parent_id,
         "tier": run.tier,
         "execution_location": run.execution_location,
+        "code_execution_provider": run.code_execution_provider,
         "status": run.status,
         "task": run.task,
         "started_at": run.started_at,

--- a/crates/openwave-desktop/ui/src/AgentRunDebugReport.test.ts
+++ b/crates/openwave-desktop/ui/src/AgentRunDebugReport.test.ts
@@ -13,6 +13,7 @@ function run(overrides: Partial<AgentRun> = {}): AgentRun {
     parent_id: null,
     tier: "background",
     execution_location: "container",
+    code_execution_provider: "local",
     status: "failed",
     task: "Summarize the quarterly report",
     started_at: "2026-08-01T10:00:00Z",

--- a/crates/openwave-desktop/ui/src/AgentRunTaskPlan.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/AgentRunTaskPlan.dom.test.tsx
@@ -36,6 +36,7 @@ function run(status: AgentRun["status"]): AgentRun {
     spawn_call_id: "spawn-call",
     tier: "background",
     execution_location: "in_process",
+    code_execution_provider: "local",
     status,
     task: "Prepare the report",
     started_at: "2026-08-07T11:00:00Z",

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.dom.test.tsx
@@ -24,6 +24,7 @@ function run(status: AgentRun["status"]): AgentRun {
     spawn_call_id: "spawn-call",
     tier: "background",
     execution_location: "in_process",
+    code_execution_provider: "local",
     status,
     task: "Prepare the report",
     started_at: "2026-08-05T18:35:00Z",

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.test.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.test.tsx
@@ -21,6 +21,7 @@ function run(
     spawn_call_id: spawnCallId,
     tier: "background",
     execution_location: "in_process",
+    code_execution_provider: "local",
     status,
     task: `Task for ${id}`,
     started_at: null,

--- a/crates/openwave-desktop/ui/src/MessageList.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.test.tsx
@@ -22,6 +22,7 @@ function backgroundRun(
     spawn_call_id: spawnCallId,
     tier: "background",
     execution_location: "in_process",
+    code_execution_provider: "local",
     status,
     task: `Task for ${id}`,
     started_at: null,

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -134,7 +134,14 @@ next_sequence: number, };
  * Worker lease tokens, scheduling budgets, and other executor-facing fields
  * intentionally remain inside the server/store boundary.
  */
-export type AgentRunSnapshot = { id: AgentRunId, parent_id: AgentRunId | null, tier: AgentRunTier, execution_location: AgentRunExecutionLocation, status: AgentRunStatus, 
+export type AgentRunSnapshot = { id: AgentRunId, parent_id: AgentRunId | null, tier: AgentRunTier, execution_location: AgentRunExecutionLocation, 
+/**
+ * Active host code-execution backend for `exec`, not the run-loop seat.
+ *
+ * See [`CodeExecutionProviderSnapshot`]. Read from the current host
+ * setting at list time — the same selection the next `exec` would use.
+ */
+code_execution_provider: CodeExecutionProviderSnapshot, status: AgentRunStatus, 
 /**
  * The exact bounded task delegated by the visible spawn step.
  */
@@ -786,6 +793,17 @@ export type CodeExecutionProviderAvailability = { provider: CodeExecutionProvide
  * A configured code-execution backend.
  */
 export type CodeExecutionProviderKind = "local" | "e2b" | "daytona" | "docker";
+
+/**
+ * Host-selected backend that runs `exec` tool calls.
+ *
+ * Distinct from [`AgentRunExecutionLocation`], which names where the agent
+ * *run loop* itself executes (`in_process` vs `container`). A background run
+ * can be in-process while its shell work still lands on e2b, docker, or
+ * daytona — this field is that backend, or `off` when code execution is
+ * disabled.
+ */
+export type CodeExecutionProviderSnapshot = "local" | "e2b" | "daytona" | "docker" | "off";
 
 /**
  * Why a provider cannot execute anything on this host right now.

--- a/crates/openwave-desktop/ui/src/useAgentRuns.test.ts
+++ b/crates/openwave-desktop/ui/src/useAgentRuns.test.ts
@@ -12,6 +12,7 @@ function run(status: AgentRun["status"] = "running"): AgentRun {
     spawn_call_id: "spawn-1",
     tier: "background",
     execution_location: "in_process",
+    code_execution_provider: "local",
     status,
     task: "Task for run-1",
     started_at: null,

--- a/crates/openwave-server/src/routes/agent_runs.rs
+++ b/crates/openwave-server/src/routes/agent_runs.rs
@@ -5,16 +5,49 @@ use axum::http::StatusCode;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
+use openwave_code_execution::CodeExecutionProviderKind;
 use openwave_core::{
     AgentRun, AgentRunExecutionLocation, AgentRunStatus, AgentRunTier, CallId, ChatId,
     RequestAgentRunCancellationOutcome, SandboxToolCall, SandboxToolCallStatus, ToolCallExecution,
     ToolCallRecord, ToolCallStatus, TurnId,
 };
 
+use crate::code_execution;
 use crate::error::ServerError;
 use crate::extract::{Json, Path, Query};
 use crate::scoped_store::ScopedStore;
 use crate::state::{AppState, SandboxSteerRefusal};
+
+/// Host-selected backend that runs `exec` tool calls.
+///
+/// Distinct from [`AgentRunExecutionLocation`], which names where the agent
+/// *run loop* itself executes (`in_process` vs `container`). A background run
+/// can be in-process while its shell work still lands on e2b, docker, or
+/// daytona — this field is that backend, or `off` when code execution is
+/// disabled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
+#[serde(rename_all = "snake_case")]
+pub enum CodeExecutionProviderSnapshot {
+    Local,
+    E2b,
+    Daytona,
+    Docker,
+    Off,
+}
+
+impl CodeExecutionProviderSnapshot {
+    fn from_config(provider: Option<CodeExecutionProviderKind>) -> Self {
+        match provider {
+            Some(CodeExecutionProviderKind::Local) => Self::Local,
+            Some(CodeExecutionProviderKind::E2b) => Self::E2b,
+            Some(CodeExecutionProviderKind::Daytona) => Self::Daytona,
+            Some(CodeExecutionProviderKind::Docker) => Self::Docker,
+            // `CodeExecutionProviderKind` is non-exhaustive; an unknown future
+            // variant is not something a renderer can name yet.
+            Some(_) | None => Self::Off,
+        }
+    }
+}
 
 /// Renderer-safe state for one agent run.
 ///
@@ -26,6 +59,11 @@ pub struct AgentRunSnapshot {
     pub parent_id: Option<openwave_core::AgentRunId>,
     pub tier: AgentRunTier,
     pub execution_location: AgentRunExecutionLocation,
+    /// Active host code-execution backend for `exec`, not the run-loop seat.
+    ///
+    /// See [`CodeExecutionProviderSnapshot`]. Read from the current host
+    /// setting at list time — the same selection the next `exec` would use.
+    pub code_execution_provider: CodeExecutionProviderSnapshot,
     pub status: AgentRunStatus,
     /// The exact bounded task delegated by the visible spawn step.
     pub task: Option<String>,
@@ -73,6 +111,7 @@ impl AgentRunSnapshot {
         terminal_text: Option<String>,
         submitted_outputs: Vec<SubmittedOutputSnapshot>,
         task_plan: Option<AgentRunTaskPlanProgress>,
+        code_execution_provider: CodeExecutionProviderSnapshot,
     ) -> Self {
         Self {
             id: run.id,
@@ -80,6 +119,7 @@ impl AgentRunSnapshot {
             spawn_call_id: run.spawn_call_id,
             tier: run.tier,
             execution_location: run.execution_location,
+            code_execution_provider,
             status: run.status,
             task: run.input,
             started_at: run.started_at,
@@ -365,11 +405,18 @@ fn foreground_activity(
 
 /// `GET /chats/{id}/agent-runs` — list renderer-safe execution state.
 pub async fn list_agent_runs(
+    State(state): State<AppState>,
     store: ScopedStore,
     Path(id): Path<ChatId>,
 ) -> Result<Json<Vec<AgentRunSnapshot>>, ServerError> {
     store.require_chat(id).await?;
     let runs = store.list_agent_runs(id).await?;
+    // Host code-exec selection is independent of where the run loop sits.
+    // One read covers every snapshot in the response: the next `exec` uses
+    // the same setting, whether the child is foreground or background.
+    let code_execution_provider = CodeExecutionProviderSnapshot::from_config(
+        code_execution::read_config(&*state.store).await?.provider,
+    );
     // This read model needs only live client checkpoints. Loading the complete
     // tool-call transcript here would needlessly deserialize historical model
     // arguments, results, and local diagnostics just to render current work.
@@ -428,6 +475,7 @@ pub async fn list_agent_runs(
             terminal_text,
             submitted_outputs,
             task_plan,
+            code_execution_provider,
         ));
     }
     Ok(Json(snapshots))

--- a/crates/openwave-server/src/tests/sandbox.rs
+++ b/crates/openwave-server/src/tests/sandbox.rs
@@ -76,13 +76,12 @@ async fn create_then_get_and_list() {
     assert!(snapshot.get("chat_id").is_none());
     // Default host selection: local where the sandbox exists, otherwise off.
     // Never confused with execution_location (the run-loop seat).
-    let expected_provider = if openwave_code_execution::LocalExecutionProvider::availability()
-        .is_ok()
-    {
-        "local"
-    } else {
-        "off"
-    };
+    let expected_provider =
+        if openwave_code_execution::LocalExecutionProvider::availability().is_ok() {
+            "local"
+        } else {
+            "off"
+        };
     assert_eq!(
         snapshot.get("code_execution_provider"),
         Some(&serde_json::json!(expected_provider))

--- a/crates/openwave-server/src/tests/sandbox.rs
+++ b/crates/openwave-server/src/tests/sandbox.rs
@@ -74,6 +74,23 @@ async fn create_then_get_and_list() {
     assert!(snapshot.get("lease_expires_at").is_none());
     assert!(snapshot.get("input").is_none());
     assert!(snapshot.get("chat_id").is_none());
+    // Default host selection: local where the sandbox exists, otherwise off.
+    // Never confused with execution_location (the run-loop seat).
+    let expected_provider = if openwave_code_execution::LocalExecutionProvider::availability()
+        .is_ok()
+    {
+        "local"
+    } else {
+        "off"
+    };
+    assert_eq!(
+        snapshot.get("code_execution_provider"),
+        Some(&serde_json::json!(expected_provider))
+    );
+    assert_eq!(
+        snapshot.get("execution_location"),
+        Some(&serde_json::json!("in_process"))
+    );
 
     let listed: Vec<Chat> = {
         let response = router
@@ -90,6 +107,131 @@ async fn create_then_get_and_list() {
         json_body(response).await
     };
     assert_eq!(listed, vec![created]);
+}
+
+/// `code_execution_provider` is the host `exec` backend, not the run-loop seat.
+/// Selecting e2b must surface on every agent-run snapshot while
+/// `execution_location` stays `in_process` for an ordinary in-process child.
+#[tokio::test]
+async fn agent_run_snapshots_surface_active_code_execution_provider() {
+    let (router, token, store, _dir) = test_app_without_turn_worker().await;
+    let bearer = format!("Bearer {token}");
+    let chat: Chat = {
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/chats")
+                    .header(header::AUTHORIZATION, &bearer)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+        json_body(response).await
+    };
+    let run = admit_sandbox_for_test(&store, chat.id, "research").await;
+
+    let select_e2b = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/code-execution")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "provider": "e2b",
+                        "timeout_ms": crate::code_execution::DEFAULT_TIMEOUT_MS,
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(select_e2b.status(), StatusCode::OK);
+
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/chats/{}/agent-runs", chat.id))
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let snapshots: Vec<serde_json::Value> = json_body(response).await;
+    assert!(
+        !snapshots.is_empty(),
+        "chat always has at least the foreground run"
+    );
+    for snapshot in &snapshots {
+        assert_eq!(
+            snapshot.get("code_execution_provider"),
+            Some(&serde_json::json!("e2b")),
+            "snapshot {} should report the active exec backend",
+            snapshot.get("id").unwrap_or(&serde_json::Value::Null)
+        );
+        // The run loop is still in-process; only the exec backend moved.
+        assert_eq!(
+            snapshot.get("execution_location"),
+            Some(&serde_json::json!("in_process"))
+        );
+    }
+    assert!(
+        snapshots
+            .iter()
+            .any(|snapshot| snapshot.get("id") == Some(&serde_json::json!(run.id))),
+        "background run is listed"
+    );
+
+    let disable = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/code-execution")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "provider": null,
+                        "timeout_ms": crate::code_execution::DEFAULT_TIMEOUT_MS,
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(disable.status(), StatusCode::OK);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri(format!("/chats/{}/agent-runs", chat.id))
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let snapshots: Vec<serde_json::Value> = json_body(response).await;
+    for snapshot in &snapshots {
+        assert_eq!(
+            snapshot.get("code_execution_provider"),
+            Some(&serde_json::json!("off"))
+        );
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

`GET /chats/{id}/agent-runs` always reported `execution_location=in_process` even when sandbox `exec` ran on e2b/docker/daytona. That field names where the **agent run loop** sits (`in_process` vs `container`), not which code-execution backend handles shell work.

This adds `code_execution_provider` on every agent-run snapshot: `local | e2b | daytona | docker | off`, read from the current host code-execution setting (same selection the next `exec` would use). `execution_location` is left alone.

- Server: `AgentRunSnapshot.code_execution_provider` + `CodeExecutionProviderSnapshot`
- TS wire regenerated
- CLI wire + `agent-run show` / JSON list display the new field
- Focused route tests cover e2b selection and explicit `off`, and pin that `execution_location` stays `in_process`

## Test plan

- [x] `cargo test -p openwave-server --lib agent_run_snapshots_surface_active_code_execution_provider`
- [x] `cargo test -p openwave-server --lib create_then_get_and_list`
- [x] `cargo test -p openwave-server --lib wire_types::`
- [x] `cargo clippy -p openwave-server -p openwave-cli --all-targets -- -D warnings`
- [ ] CI lanes on the PR