### PR TITLE
feat(server): give sandbox agents a host skills summary

### DIFF
--- a/crates/openwave-server/src/foreground_prompt.rs
+++ b/crates/openwave-server/src/foreground_prompt.rs
@@ -116,7 +116,7 @@ fn render_timeout(timeout_ms: u64) -> String {
 /// description from ever composing into a prompt line, mirroring how folder
 /// paths are JSON-quoted elsewhere; an entry that fails is dropped, not
 /// sanitized.
-fn skill_line(skill: &SkillPackage) -> Option<String> {
+pub(crate) fn skill_line(skill: &SkillPackage) -> Option<String> {
     if !openwave_code_execution::is_valid_skill_name(&skill.name)
         || !openwave_code_execution::is_valid_skill_description(&skill.description)
     {
@@ -135,6 +135,34 @@ fn skill_line(skill: &SkillPackage) -> Option<String> {
     ))
 }
 
+/// One catalog line plus the pinned install pins the skill's manifest names.
+///
+/// Used by tool-capable sandbox prompts so a background agent can pick the
+/// right package and install path without pasting SKILL.md bodies. Dep pins
+/// already passed the skill parser's pin checks when the package was loaded;
+/// foreground composition keeps the leaner [`skill_line`] shape.
+pub(crate) fn skill_summary_line(skill: &SkillPackage) -> Option<String> {
+    let base = skill_line(skill)?;
+    let mut hints = Vec::new();
+    if !skill.python_deps.is_empty() {
+        hints.push(format!(
+            "pip install --user {}",
+            skill.python_deps.join(" ")
+        ));
+    }
+    if !skill.npm_deps.is_empty() {
+        hints.push(format!(
+            "npm install --ignore-scripts {}",
+            skill.npm_deps.join(" ")
+        ));
+    }
+    if hints.is_empty() {
+        Some(base)
+    } else {
+        Some(format!("{base} [{}]", hints.join("; ")))
+    }
+}
+
 /// Render the skill catalog, grouping the skills a plugin bundles under that
 /// plugin's router preamble.
 ///
@@ -147,7 +175,24 @@ fn skill_line(skill: &SkillPackage) -> Option<String> {
 /// skills still render — a bad line never suppresses a real capability. Skills
 /// no plugin claims follow the grouped ones in catalog order, which is where
 /// user-authored skills land.
-fn skill_catalog_lines(skills: &[SkillPackage], plugins: &[PluginPackage]) -> Vec<String> {
+pub(crate) fn skill_catalog_lines(skills: &[SkillPackage], plugins: &[PluginPackage]) -> Vec<String> {
+    skill_catalog_lines_with(skills, plugins, skill_line)
+}
+
+/// Same grouping as [`skill_catalog_lines`], with each skill rendered by
+/// [`skill_summary_line`] so install pins travel with the name.
+pub(crate) fn skill_summary_catalog_lines(
+    skills: &[SkillPackage],
+    plugins: &[PluginPackage],
+) -> Vec<String> {
+    skill_catalog_lines_with(skills, plugins, skill_summary_line)
+}
+
+fn skill_catalog_lines_with(
+    skills: &[SkillPackage],
+    plugins: &[PluginPackage],
+    mut render: impl FnMut(&SkillPackage) -> Option<String>,
+) -> Vec<String> {
     let mut lines = Vec::new();
     let mut grouped: BTreeSet<&str> = BTreeSet::new();
     for plugin in plugins {
@@ -156,7 +201,7 @@ fn skill_catalog_lines(skills: &[SkillPackage], plugins: &[PluginPackage]) -> Ve
             .iter()
             .filter_map(|member| skills.iter().find(|skill| skill.name == *member))
             .collect();
-        let member_lines: Vec<String> = members.iter().copied().filter_map(skill_line).collect();
+        let member_lines: Vec<String> = members.iter().copied().filter_map(&mut render).collect();
         if member_lines.is_empty() {
             continue;
         }
@@ -174,7 +219,7 @@ fn skill_catalog_lines(skills: &[SkillPackage], plugins: &[PluginPackage]) -> Ve
         skills
             .iter()
             .filter(|skill| !grouped.contains(skill.name.as_str()))
-            .filter_map(skill_line),
+            .filter_map(render),
     );
     lines
 }

--- a/crates/openwave-server/src/foreground_prompt.rs
+++ b/crates/openwave-server/src/foreground_prompt.rs
@@ -175,7 +175,10 @@ pub(crate) fn skill_summary_line(skill: &SkillPackage) -> Option<String> {
 /// skills still render — a bad line never suppresses a real capability. Skills
 /// no plugin claims follow the grouped ones in catalog order, which is where
 /// user-authored skills land.
-pub(crate) fn skill_catalog_lines(skills: &[SkillPackage], plugins: &[PluginPackage]) -> Vec<String> {
+pub(crate) fn skill_catalog_lines(
+    skills: &[SkillPackage],
+    plugins: &[PluginPackage],
+) -> Vec<String> {
     skill_catalog_lines_with(skills, plugins, skill_line)
 }
 

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -1230,6 +1230,7 @@ async fn bind_inner(
         state.sandbox_attempts.clone(),
         state.agent_config.clone(),
         Some(state.config.data_dir.join("scratch")),
+        Some(code_execution.clone()),
         sandbox_worker_config,
     );
     let sandbox_web_search_worker =

--- a/crates/openwave-server/src/sandbox_agent_run_worker/config.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker/config.rs
@@ -6,10 +6,13 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
+use openwave_code_execution::{PluginPackage, SkillPackage};
 use openwave_core::{AgentConfig, SecretProvider, Store, TurnWebSearch};
 use tokio::sync::Notify;
 
 use crate::bus::EventBus;
+use crate::code_execution::ConfiguredCodeExecutionProvider;
+use crate::foreground_prompt::skill_summary_catalog_lines;
 use crate::resolver::ProviderResolver;
 use crate::retry::RetrySchedule;
 use crate::state::SandboxAttemptGuard;
@@ -25,7 +28,7 @@ pub(super) const SANDBOX_DELEGATED_FILE_PROMPT_PREAMBLE: &str = "You are a sandb
 /// How to form exec calls. Stress-tested agents routinely waste steps by
 /// stuffing a whole shell line into `command` (which is argv[0] only) or by
 /// writing under `/tmp`, which this workspace cannot keep or publish.
-pub(super) const SANDBOX_PROMPT_EXEC_CLAUSE: &str = "exec with argv form only — command is a single executable (for example python3, mkdir, /bin/sh), and each shell token is its own args entry (mkdir -p output is command mkdir with args [\"-p\", \"output\"]; a one-liner is command /bin/sh with args [\"-c\", \"…\"]). Never put spaces inside command. Stay inside the workspace: create files under output/ or other relative paths, not under /tmp. Install packages with separate exec calls when needed (python3 -m pip install --user <pkg>==<ver>). There is no skills catalog and no shared conversation context — put any library or path detail you need into the commands themselves";
+pub(super) const SANDBOX_PROMPT_EXEC_CLAUSE: &str = "exec with argv form only — command is a single executable (for example python3, mkdir, /bin/sh), and each shell token is its own args entry (mkdir -p output is command mkdir with args [\"-p\", \"output\"]; a one-liner is command /bin/sh with args [\"-c\", \"…\"]). Never put spaces inside command. Stay inside the workspace: create files under output/ or other relative paths, not under /tmp. Install packages with separate exec calls when needed (python3 -m pip install --user <pkg>==<ver>). There is no shared conversation context";
 pub(super) const SANDBOX_PROMPT_DELEGATED_FILE_CLAUSE: &str =
     "read_delegated_file to read that one delegated file";
 pub(super) const SANDBOX_PROMPT_WEB_SEARCH_CLAUSE: &str =
@@ -34,6 +37,9 @@ pub(super) const SANDBOX_PROMPT_FOLDER_ACCESS_CLAUSE: &str = "request_folder_acc
 pub(super) const SANDBOX_PROMPT_TASK_PLAN_CLAUSE: &str = "update_task_plan to keep an ordered checklist when the task takes several steps — send the whole list every time, keep exactly one step in_progress, and update it as steps finish rather than all at the end";
 pub(super) const SANDBOX_PROMPT_CLOSING: &str = "Take as many tool steps as the task genuinely needs, then finish by calling done with the filenames you wrote under output/ and a short summary of what you produced.";
 pub(super) const SANDBOX_CHAT_ONLY_PROMPT: &str = "You are a sandboxed background assistant. Work only on the task below. You cannot access the conversation, files, folders, the public internet, external capabilities, or other agents. Return the best final text result directly from the task and your own knowledge. Do not claim to have inspected, changed, or produced anything outside this reply.";
+/// Introduces the host-derived skill catalog on a tool-capable run. Names,
+/// one-line descriptions, and install pins only — never SKILL.md bodies.
+pub(super) const SANDBOX_PROMPT_SKILLS_INTRO: &str = "Document skills available in this workspace (before producing a listed kind of file, read `.openwave/skills/<name>/SKILL.md` via exec and follow it; install pins are host-validated):";
 
 /// Compose the run's instructions for the surface it actually has.
 ///
@@ -43,10 +49,17 @@ pub(super) const SANDBOX_CHAT_ONLY_PROMPT: &str = "You are a sandboxed backgroun
 /// A vendor-searching run still has `web_search` — the model provider runs it,
 /// but the model names and uses it the same way — so only a run with no search
 /// at all loses the clause, exactly as a foreground turn's prompt does.
+///
+/// `skills` / `plugins` are the same host-derived catalogs a foreground turn
+/// composes from (`ConfiguredCodeExecutionProvider::skill_catalog` /
+/// `plugin_catalog`). An empty catalog omits the skills section rather than
+/// inventing entries or claiming none exist when the host has no surface.
 pub(super) fn sandbox_system_prompt(
     delegated_file_available: bool,
     web_search: TurnWebSearch,
     tools_supported: bool,
+    skills: &[SkillPackage],
+    plugins: &[PluginPackage],
 ) -> String {
     if !tools_supported {
         return SANDBOX_CHAT_ONLY_PROMPT.to_owned();
@@ -81,7 +94,36 @@ pub(super) fn sandbox_system_prompt(
     } else {
         SANDBOX_PROMPT_PREAMBLE
     };
-    format!("{preamble} {tools} {SANDBOX_PROMPT_CLOSING}")
+    let mut prompt = format!("{preamble} {tools} {SANDBOX_PROMPT_CLOSING}");
+    if let Some(summary) = sandbox_skills_summary(skills, plugins) {
+        prompt.push(' ');
+        prompt.push_str(&summary);
+    }
+    prompt
+}
+
+/// Concise skills block for a tool-capable sandbox run: catalog lines with
+/// install pins, grouped the same way the foreground catalog groups them.
+///
+/// Returns `None` when every entry failed validation or the host passed an
+/// empty catalog, so a headless embedding with no skills stays silent.
+pub(super) fn sandbox_skills_summary(
+    skills: &[SkillPackage],
+    plugins: &[PluginPackage],
+) -> Option<String> {
+    let lines = skill_summary_catalog_lines(skills, plugins);
+    if lines.is_empty() {
+        return None;
+    }
+    // Bound how many skill lines a single prompt carries. The host catalog is
+    // already small; this is a hard ceiling against a future oversized load.
+    const MAX_SKILL_LINES: usize = 24;
+    let mut body = String::from(SANDBOX_PROMPT_SKILLS_INTRO);
+    for line in lines.into_iter().take(MAX_SKILL_LINES) {
+        body.push(' ');
+        body.push_str(&line);
+    }
+    Some(body)
 }
 
 /// Progress lines one step may publish for searches the provider ran itself.
@@ -178,5 +220,9 @@ pub(crate) struct SandboxAgentRunWorker {
     /// future sandbox-safe tool adapter must be given an exact per-run handle
     /// rather than a chat or project path.
     pub(crate) private_scratch_root: Option<PathBuf>,
+    /// Same host code-execution surface the foreground turn uses for its skill
+    /// catalog. Absent on a headless embedding with no exec provider — the
+    /// sandbox prompt then carries no skills section.
+    pub(crate) code_execution: Option<Arc<ConfiguredCodeExecutionProvider>>,
     pub(crate) config: SandboxAgentRunWorkerConfig,
 }

--- a/crates/openwave-server/src/sandbox_agent_run_worker/model_step.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker/model_step.rs
@@ -78,6 +78,8 @@ pub(super) async fn sandbox_request(
     calls: &[SandboxToolCall],
     store: &dyn Store,
     delegated_file_available: bool,
+    skills: &[openwave_code_execution::SkillPackage],
+    plugins: &[openwave_code_execution::PluginPackage],
 ) -> Result<ChatRequest> {
     // Steps are the one budget this request rides on: each is one model
     // completion, and the whole chain is replayed on every claim, so the
@@ -148,6 +150,8 @@ pub(super) async fn sandbox_request(
             delegated_file_available,
             config.web_search,
             config.tools_supported,
+            skills,
+            plugins,
         )),
         messages,
         // A checkpoint costs one model completion now and one more to consume

--- a/crates/openwave-server/src/sandbox_agent_run_worker/tests.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker/tests.rs
@@ -2283,7 +2283,13 @@ async fn delegated_file_read_answers_nonempty_arguments_without_parking_work() {
         provider: None,
         model: "m".into(),
         reasoning_model: false,
-        system: Some(sandbox_system_prompt(true, TurnWebSearch::Host, true, &[], &[])),
+        system: Some(sandbox_system_prompt(
+            true,
+            TurnWebSearch::Host,
+            true,
+            &[],
+            &[],
+        )),
         messages: vec![ChatMessage::text(Role::User, "task")],
         tools: vec![sandbox_read_delegated_file_tool_spec()],
         max_tokens: Some(100),
@@ -2745,20 +2751,12 @@ fn tool_capable_sandbox_prompt_includes_host_skills_summary() {
     assert!(summary.contains("pip install --user fpdf2==2.8.3 pypdf==6.15.0"));
     assert!(summary.contains("npm install --ignore-scripts pptxgenjs@4.0.1"));
     assert!(summary.contains("- spreadsheets: Build Excel workbooks with openpyxl."));
-    assert!(summary.contains(
-        "- Pick by the file: pdf-documents for PDF, presentations for decks."
-    ));
+    assert!(summary.contains("- Pick by the file: pdf-documents for PDF, presentations for decks."));
     // Never paste skill bodies.
     assert!(!summary.contains("# PDF documents"));
     assert!(!summary.contains("Produce PDF deliverables"));
 
-    let prompt = sandbox_system_prompt(
-        false,
-        TurnWebSearch::Host,
-        true,
-        &skills,
-        &plugins,
-    );
+    let prompt = sandbox_system_prompt(false, TurnWebSearch::Host, true, &skills, &plugins);
     assert!(
         prompt.contains(SANDBOX_PROMPT_SKILLS_INTRO),
         "tool-capable prompt must include the skills summary: {prompt}"
@@ -2767,13 +2765,7 @@ fn tool_capable_sandbox_prompt_includes_host_skills_summary() {
     assert!(prompt.contains(".openwave/skills/<name>/SKILL.md"));
 
     // Chat-only routes never advertise skills or exec install paths.
-    let chat_only = sandbox_system_prompt(
-        false,
-        TurnWebSearch::Off,
-        false,
-        &skills,
-        &plugins,
-    );
+    let chat_only = sandbox_system_prompt(false, TurnWebSearch::Off, false, &skills, &plugins);
     assert_eq!(chat_only, super::config::SANDBOX_CHAT_ONLY_PROMPT);
     assert!(!chat_only.contains("pdf-documents"));
     assert!(!chat_only.contains(SANDBOX_PROMPT_SKILLS_INTRO));

--- a/crates/openwave-server/src/sandbox_agent_run_worker/tests.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker/tests.rs
@@ -33,8 +33,8 @@ use openwave_core::{
 };
 
 use super::config::{
-    sandbox_system_prompt, SandboxAgentRunWorkerOutcome, SANDBOX_PROMPT_EXEC_CLAUSE,
-    SANDBOX_PROMPT_WEB_SEARCH_CLAUSE,
+    sandbox_skills_summary, sandbox_system_prompt, SandboxAgentRunWorkerOutcome,
+    SANDBOX_PROMPT_EXEC_CLAUSE, SANDBOX_PROMPT_SKILLS_INTRO, SANDBOX_PROMPT_WEB_SEARCH_CLAUSE,
 };
 use super::model_step::{
     complete_sandbox_task, delegated_file_admission_matches, sandbox_request, SandboxCompletion,
@@ -667,7 +667,7 @@ async fn completes_a_claimed_run_with_a_no_tools_private_request() {
     );
     assert_eq!(
         requests[0].system.as_deref(),
-        Some(sandbox_system_prompt(false, TurnWebSearch::Host, true).as_str())
+        Some(sandbox_system_prompt(false, TurnWebSearch::Host, true, &[], &[]).as_str())
     );
 }
 
@@ -1877,6 +1877,7 @@ async fn local_signal_drops_resolver_before_durable_cancellation_ack() {
             ..AgentConfig::default()
         },
         None,
+        None,
         SandboxAgentRunWorkerConfig::default(),
     );
     let entered_wait = entered.notified();
@@ -1927,6 +1928,7 @@ async fn local_signal_drops_provider_stream_before_durable_cancellation_ack() {
             model: "m".into(),
             ..AgentConfig::default()
         },
+        None,
         None,
         SandboxAgentRunWorkerConfig::default(),
     );
@@ -2057,12 +2059,14 @@ async fn sandbox_request_does_not_inherit_foreground_system_or_tools() {
         &[],
         &store,
         false,
+        &[],
+        &[],
     )
     .await
     .unwrap();
     assert_eq!(
         request.system.as_deref(),
-        Some(sandbox_system_prompt(false, TurnWebSearch::Host, true).as_str())
+        Some(sandbox_system_prompt(false, TurnWebSearch::Host, true, &[], &[]).as_str())
     );
     assert_eq!(
         request
@@ -2102,6 +2106,8 @@ async fn sandbox_request_withholds_tools_from_a_chat_only_model() {
         &[],
         &store,
         false,
+        &[],
+        &[],
     )
     .await
     .unwrap();
@@ -2115,7 +2121,9 @@ async fn sandbox_request_withholds_tools_from_a_chat_only_model() {
             TurnWebSearch::Vendor(openwave_core::VendorWebSearch {
                 max_uses: openwave_core::VendorWebSearch::DEFAULT_MAX_USES,
             }),
-            false
+            false,
+            &[],
+            &[],
         )
     );
     for unavailable in [
@@ -2153,6 +2161,8 @@ async fn one_model_step_never_advertises_unconsumable_web_search_work() {
         &[],
         &store,
         false,
+        &[],
+        &[],
     )
     .await
     .unwrap();
@@ -2219,12 +2229,14 @@ async fn desktop_delegation_advertises_one_canonical_file_read() {
         &[],
         &store,
         true,
+        &[],
+        &[],
     )
     .await
     .unwrap();
     assert_eq!(
         request.system.as_deref(),
-        Some(sandbox_system_prompt(true, TurnWebSearch::Host, true).as_str())
+        Some(sandbox_system_prompt(true, TurnWebSearch::Host, true, &[], &[]).as_str())
     );
     assert_eq!(
         request
@@ -2271,7 +2283,7 @@ async fn delegated_file_read_answers_nonempty_arguments_without_parking_work() {
         provider: None,
         model: "m".into(),
         reasoning_model: false,
-        system: Some(sandbox_system_prompt(true, TurnWebSearch::Host, true)),
+        system: Some(sandbox_system_prompt(true, TurnWebSearch::Host, true, &[], &[])),
         messages: vec![ChatMessage::text(Role::User, "task")],
         tools: vec![sandbox_read_delegated_file_tool_spec()],
         max_tokens: Some(100),
@@ -2661,7 +2673,7 @@ async fn a_vendor_run_on_an_unregistered_model_gets_no_search_at_all() {
 /// closed; the system prompt must name the argv contract up front.
 #[test]
 fn sandbox_system_prompt_teaches_exec_argv_form() {
-    let prompt = sandbox_system_prompt(false, TurnWebSearch::Host, true);
+    let prompt = sandbox_system_prompt(false, TurnWebSearch::Host, true, &[], &[]);
     assert!(
         prompt.contains(SANDBOX_PROMPT_EXEC_CLAUSE),
         "tool-capable runs must name the exec argv contract: {prompt}"
@@ -2674,6 +2686,97 @@ fn sandbox_system_prompt_teaches_exec_argv_form() {
         prompt.contains("output/"),
         "prompt must still point deliverables at output/: {prompt}"
     );
+    // Empty catalog: no skills section and no "there is no skills catalog"
+    // denial that would contradict a later host with skills.
+    assert!(!prompt.contains(SANDBOX_PROMPT_SKILLS_INTRO));
+    assert!(!prompt.contains("no skills catalog"));
+}
+
+/// Tool-capable sandbox prompts carry the host skill catalog (names, one-line
+/// descriptions, install pins) so children do not reinvent openpyxl/fpdf after
+/// failed steps. Chat-only runs stay silent, and full SKILL.md bodies never
+/// enter the prompt.
+#[test]
+fn tool_capable_sandbox_prompt_includes_host_skills_summary() {
+    let skills = vec![
+        openwave_code_execution::SkillPackage {
+            name: "pdf-documents".into(),
+            description: "Generate and manipulate PDF documents.".into(),
+            python_deps: vec!["fpdf2==2.8.3".into(), "pypdf==6.15.0".into()],
+            npm_deps: Vec::new(),
+            host_deps: Vec::new(),
+            origin: openwave_code_execution::SkillOrigin::Builtin,
+        },
+        openwave_code_execution::SkillPackage {
+            name: "spreadsheets".into(),
+            description: "Build Excel workbooks with openpyxl.".into(),
+            python_deps: vec!["openpyxl==3.1.5".into()],
+            npm_deps: Vec::new(),
+            host_deps: vec![openwave_code_execution::HostDep::LibreOffice],
+            origin: openwave_code_execution::SkillOrigin::Builtin,
+        },
+        openwave_code_execution::SkillPackage {
+            name: "presentations".into(),
+            description: "Build PowerPoint decks.".into(),
+            python_deps: Vec::new(),
+            npm_deps: vec!["pptxgenjs@4.0.1".into()],
+            host_deps: vec![openwave_code_execution::HostDep::LibreOffice],
+            origin: openwave_code_execution::SkillOrigin::Builtin,
+        },
+    ];
+    let plugins = vec![openwave_code_execution::PluginPackage {
+        name: "documents".into(),
+        display_name: "Documents".into(),
+        description: "Bundle.".into(),
+        category: openwave_code_execution::PluginCategory::Documents,
+        skills: vec!["pdf-documents".into(), "presentations".into()],
+        prompts: Vec::new(),
+        router_preamble: Some(
+            "Pick by the file: pdf-documents for PDF, presentations for decks.".into(),
+        ),
+        mcp_servers: 0,
+        origin: openwave_code_execution::PluginOrigin::Builtin,
+        compatibility: openwave_code_execution::PluginCompatibility::compatible(),
+    }];
+
+    let summary = sandbox_skills_summary(&skills, &plugins).expect("catalog present");
+    assert!(summary.contains(SANDBOX_PROMPT_SKILLS_INTRO));
+    assert!(summary.contains("- pdf-documents: Generate and manipulate PDF documents."));
+    assert!(summary.contains("pip install --user fpdf2==2.8.3 pypdf==6.15.0"));
+    assert!(summary.contains("npm install --ignore-scripts pptxgenjs@4.0.1"));
+    assert!(summary.contains("- spreadsheets: Build Excel workbooks with openpyxl."));
+    assert!(summary.contains(
+        "- Pick by the file: pdf-documents for PDF, presentations for decks."
+    ));
+    // Never paste skill bodies.
+    assert!(!summary.contains("# PDF documents"));
+    assert!(!summary.contains("Produce PDF deliverables"));
+
+    let prompt = sandbox_system_prompt(
+        false,
+        TurnWebSearch::Host,
+        true,
+        &skills,
+        &plugins,
+    );
+    assert!(
+        prompt.contains(SANDBOX_PROMPT_SKILLS_INTRO),
+        "tool-capable prompt must include the skills summary: {prompt}"
+    );
+    assert!(prompt.contains("openpyxl==3.1.5"));
+    assert!(prompt.contains(".openwave/skills/<name>/SKILL.md"));
+
+    // Chat-only routes never advertise skills or exec install paths.
+    let chat_only = sandbox_system_prompt(
+        false,
+        TurnWebSearch::Off,
+        false,
+        &skills,
+        &plugins,
+    );
+    assert_eq!(chat_only, super::config::SANDBOX_CHAT_ONLY_PROMPT);
+    assert!(!chat_only.contains("pdf-documents"));
+    assert!(!chat_only.contains(SANDBOX_PROMPT_SKILLS_INTRO));
 }
 
 fn sandbox_chat() -> Chat {

--- a/crates/openwave-server/src/sandbox_agent_run_worker/worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker/worker.rs
@@ -60,6 +60,7 @@ impl SandboxAgentRunWorker {
             Arc::new(SandboxAttemptGuard::default()),
             agent_config,
             private_scratch_root,
+            None,
             config,
         )
     }
@@ -75,6 +76,7 @@ impl SandboxAgentRunWorker {
         attempts: Arc<SandboxAttemptGuard>,
         agent_config: AgentConfig,
         private_scratch_root: Option<PathBuf>,
+        code_execution: Option<Arc<crate::code_execution::ConfiguredCodeExecutionProvider>>,
         config: SandboxAgentRunWorkerConfig,
     ) -> Self {
         assert!(!config.lease.is_zero());
@@ -95,9 +97,11 @@ impl SandboxAgentRunWorker {
             fail_wait_set_resume_responses: Arc::new(AtomicUsize::new(0)),
             agent_config,
             private_scratch_root,
+            code_execution,
             config,
         }
     }
+
 
     pub(crate) async fn run(self) {
         let mut lanes = tokio::task::JoinSet::new();
@@ -426,12 +430,25 @@ impl SandboxAgentRunWorker {
             supports_vendor_web_search,
         )
         .await?;
+        // Same source the foreground turn freezes into its operating prompt:
+        // the host code-execution provider's enabled skill/plugin catalogs.
+        // Absent a provider (headless without exec), the run gets an empty
+        // catalog and the skills section is omitted — never a fake list.
+        let (skills, plugins) = match self.code_execution.as_ref() {
+            Some(provider) => (
+                provider.skill_catalog().await,
+                provider.plugin_catalog().await,
+            ),
+            None => (Vec::new(), Vec::new()),
+        };
         let request = sandbox_request(
             &agent_config,
             task,
             &previous_calls,
             &*self.store,
             delegated_file_available,
+            &skills,
+            &plugins,
         )
         .await?;
         let Some(provider) = self.resolve_provider(run.id, lease_token, &cancel).await? else {

--- a/crates/openwave-server/src/sandbox_agent_run_worker/worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker/worker.rs
@@ -102,7 +102,6 @@ impl SandboxAgentRunWorker {
         }
     }
 
-
     pub(crate) async fn run(self) {
         let mut lanes = tokio::task::JoinSet::new();
         for _ in 0..self.config.max_concurrency {


### PR DESCRIPTION
## Summary

Sandboxed background agents previously had no skills catalog, so children reinvented openpyxl / python-pptx / fpdf after failed steps. Tool-capable sandbox system prompts now include a concise host-derived skills summary (names, one-line descriptions, key pip/npm install pins), grouped the same way the foreground catalog is.

## Design

**Foreground source (unchanged behavior):**
- `ConfiguredCodeExecutionProvider::skill_catalog()` / `plugin_catalog()` load enabled skills from builtin + user dirs (same path `turn_worker` uses before `compose_for_surface`).
- Catalog lines come from `skill_line` / `skill_catalog_lines` in `foreground_prompt.rs`.

**Shared helpers:**
- Promoted `skill_line` and `skill_catalog_lines` to `pub(crate)`.
- Added `skill_summary_line` (name + description + install pins) and `skill_summary_catalog_lines` (same plugin grouping, richer lines).
- Foreground still uses the lean `skill_line` shape only.

**Sandbox threading:**
- Worker holds `Option<Arc<ConfiguredCodeExecutionProvider>>`, wired at boot from the same provider the turn worker uses.
- On each claim, `process` reads `skill_catalog()` / `plugin_catalog()` and passes them into `sandbox_request` → `sandbox_system_prompt`.
- Empty catalog (no code-execution surface / headless) omits the skills section; chat-only models still get the pure text contract.
- Removed the hard-coded “there is no skills catalog” denial from the exec clause.

## Tests

- `tool_capable_sandbox_prompt_includes_host_skills_summary` — pins, plugin preamble, no SKILL.md body, chat-only silence.
- Existing sandbox + foreground_prompt suites updated for the new signatures.

```
cargo test -p openwave-server --lib --locked sandbox_agent_run_worker
cargo test -p openwave-server --lib --locked skill_catalog
cargo test -p openwave-server --lib --locked foreground_prompt
```

## Notes

- `lib.rs` gains one constructor arg so the worker receives the real catalog (required to avoid empty fakes).
- Skills are still staged into the run workspace on first `exec` by the existing code-execution path; this change only informs the model what is available.