### PR TITLE
fix(cli): allow folder connect while serve owns the data dir

### DIFF
--- a/crates/openwave-cli/Cargo.toml
+++ b/crates/openwave-cli/Cargo.toml
@@ -17,9 +17,11 @@ path = "src/main.rs"
 
 [dependencies]
 # `default-features = false`: the CLI directly needs config/contracts plus the
-# built-in file tools for `openwave mcp`; server persistence features still come
-# through `openwave-server`. This avoids directly enabling unrelated defaults.
-openwave-core = { path = "../openwave-core", default-features = false, features = ["tools"] }
+# built-in file tools for `openwave mcp`. `sqlite` is on so `openwave folder`
+# can open the product store beside a running server without embedding one
+# (and without taking `openwave.lock`). Keychain and blob-fs still come only
+# through `openwave-server`.
+openwave-core = { path = "../openwave-core", default-features = false, features = ["tools", "sqlite"] }
 # `openwave folder …` decides local command reach exactly as the desktop does,
 # so an operator-provisioned folder carries the same grants on the same host.
 openwave-code-execution = { path = "../openwave-code-execution" }

--- a/crates/openwave-cli/src/folder.rs
+++ b/crates/openwave-cli/src/folder.rs
@@ -163,9 +163,7 @@ pub async fn run(command: Command) -> Result<()> {
     match command {
         Command::Connect { chat, path } => connect(&store, &data_dir, chat, path).await,
         Command::List { chat } => list(&store, &data_dir, chat).await,
-        Command::Disconnect { chat, target } => {
-            disconnect(&store, &data_dir, chat, &target).await
-        }
+        Command::Disconnect { chat, target } => disconnect(&store, &data_dir, chat, &target).await,
     }
 }
 
@@ -240,7 +238,8 @@ pub(crate) fn open_broker(data_dir: &Path) -> Result<Broker> {
             AgentError::config(format!("could not initialize the folder policy: {error}"))
         })?;
     let execute_commands = openwave_code_execution::LocalExecutionProvider::availability().is_ok();
-    Broker::open_with_execute_commands(policy, &data_dir, execute_commands).map_err(broker_open_error)
+    Broker::open_with_execute_commands(policy, &data_dir, execute_commands)
+        .map_err(broker_open_error)
 }
 
 /// Map a broker-open failure into an operator-facing configuration error.

--- a/crates/openwave-cli/src/folder.rs
+++ b/crates/openwave-cli/src/folder.rs
@@ -14,25 +14,44 @@
 //! same typed refusal an undecided desktop prompt produces — see
 //! [`crate::print`].
 //!
-//! Both shells hold exclusive locks on the profile data directory (the server's
-//! `openwave.lock` and the broker's `host-broker.lock`), so these commands
-//! refuse rather than write behind a running OpenWave. That is the intended
-//! failure: two owners of one capability store is not a supported arrangement.
+//! ## Locks, and why these commands do not take them
+//!
+//! A running `openwave serve` or desktop holds `openwave.lock` for the life of
+//! the process, and any process that has opened the broker holds
+//! `host-broker.lock` until that handle drops. Provisioning used to embed a
+//! second server and open the broker under those locks, which meant it refused
+//! whenever the profile was already owned — the exact moment an operator needs
+//! to connect a folder for a live daemon.
+//!
+//! The durable authority is not the locks; it is the product store (SQLite WAL)
+//! and the broker's own atomic state file. These commands therefore open the
+//! product store directly and open the broker for the duration of one control
+//! request only, then drop it. They never unlock a lock another process holds,
+//! never claim to be the server, and never half-grant: product projection and
+//! broker registration still converge or the approval is withdrawn.
+//!
+//! A second process that has already opened the broker for a long-lived handle
+//! (the desktop sidecar, or a headless executor mid-operation) will still make
+//! `open_broker` fail closed. The error names that condition; it does not offer
+//! to steal the lock. Server-mediated HTTP provisioning is deliberately not the
+//! path: the server has no broker, and root-attachment routes only move product
+//! state — they cannot mint host grants.
 
 use std::ffi::{OsStr, OsString};
+use std::io;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 
 use chrono::{DateTime, Timelike, Utc};
 use openwave_core::{
-    AgentError, BeginRootAttachmentChange, BeginRootAttachmentChangeOutcome, Chat, ChatId,
-    FinishRootAttachmentChangeOutcome, HostRootId, Result, RootAttachmentChange,
+    AgentError, BeginRootAttachmentChange, BeginRootAttachmentChangeOutcome, Chat, ChatId, Config,
+    DbStore, FinishRootAttachmentChangeOutcome, HostRootId, Profile, Result, RootAttachmentChange,
     RootAttachmentChangeAction, RootAttachmentChangeId, RootAttachmentChangePhase,
     RootAttachmentChangeTerminal, Store, MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
 };
 use openwave_host_broker::{
-    Broker, Capability, ConsentMethod, ControlEnvelope, ControlRequest, ControlResult,
+    Broker, BrokerError, Capability, ConsentMethod, ControlEnvelope, ControlRequest, ControlResult,
     GrantSubject, OperationId, RegisterRootReceipt, RegisterRootRequest, RequestId, Response,
     RevokeRootRequest, RootAttachmentMutationKind, RootAttachmentMutationReceipt,
     RootAttachmentMutationRequest, RootId, RootPolicy, Scope, SubjectKind, PROTOCOL_VERSION,
@@ -133,20 +152,64 @@ pub async fn run(command: Command) -> Result<()> {
     // stdout carries the command's report; logs stay in the profile's log file.
     openwave_server::logging::init_logging_file_only(&config.data_dir);
     let data_dir = config.data_dir.clone();
-    // The engine owns the store, its migrations, and the data-directory lock.
-    // Booting it is what makes the CLI's product writes the same writes the
-    // desktop makes, rather than a second opinion about the schema.
-    let server = openwave_server::bind_configured(config).await?;
-    let store = server.store();
-    let broker = open_broker(&data_dir)?;
+    // Prefer a normal embed: that runs the desktop schema epoch path and is
+    // the only safe first-boot of an idle profile. When serve/desktop already
+    // holds `openwave.lock`, fall back to opening the product store beside it
+    // — WAL allows the concurrent writer, and a live profile has already
+    // passed the epoch gate. Broker handles are opened per control request so
+    // `host-broker.lock` is not held across the whole command.
+    let (store, _embedded) = open_product_store(config).await?;
 
     match command {
-        Command::Connect { chat, path } => connect(&store, &broker, &data_dir, chat, path).await,
-        Command::List { chat } => list(&store, &broker, chat).await,
+        Command::Connect { chat, path } => connect(&store, &data_dir, chat, path).await,
+        Command::List { chat } => list(&store, &data_dir, chat).await,
         Command::Disconnect { chat, target } => {
-            disconnect(&store, &broker, &data_dir, chat, &target).await
+            disconnect(&store, &data_dir, chat, &target).await
         }
     }
+}
+
+/// Open the profile's product store, embedding a server when the data directory
+/// is free and sharing it when it is not.
+///
+/// The embedded [`openwave_server::Server`] is returned so its instance lock and
+/// accept loop stay alive for the command; drop order keeps the store usable.
+/// Self-host has no local broker and no operator folder path: refuse it here
+/// rather than half-open a remote store and fail on the broker later.
+async fn open_product_store(
+    config: Config,
+) -> Result<(Arc<dyn Store>, Option<openwave_server::Server>)> {
+    match config.profile {
+        Profile::Desktop => {}
+        // Self-host has no local broker. Any future profile is refused the
+        // same way until it grows an explicit operator-folder path.
+        _ => {
+            return Err(AgentError::config(
+                "`openwave folder` provisions host consent on this machine's broker; \
+                 it is not available on this profile",
+            ));
+        }
+    }
+    match openwave_server::bind_configured(config.clone()).await {
+        Ok(server) => {
+            let store = server.store();
+            Ok((store, Some(server)))
+        }
+        Err(error) if data_dir_held_by_another_process(&error) => {
+            // The running owner already migrated and marked the schema. Open
+            // the same SQLite file under WAL without taking `openwave.lock`.
+            let store = DbStore::connect(&config.database_url()?).await?;
+            Ok((Arc::new(store), None))
+        }
+        Err(error) => Err(error),
+    }
+}
+
+/// Whether a bind failure is the data-directory instance lock, not a real
+/// configuration problem. Matched on the stable phrase `InstanceLock` writes.
+fn data_dir_held_by_another_process(error: &AgentError) -> bool {
+    let message = error.to_string();
+    message.contains("already running on the data directory")
 }
 
 /// Open the same durable broker state the desktop's sidecar opens.
@@ -157,9 +220,10 @@ pub async fn run(command: Command) -> Result<()> {
 /// probe, so a folder connected here carries the grants it would have carried
 /// had the desktop's picker connected it on this machine.
 ///
-/// Also the handle [`crate::folder_executor`] reads through: one capability
-/// store, opened one way, whether an operator is provisioning a folder or a turn
-/// is reading one.
+/// Also the handle [`crate::folder_executor`] opens through the same path for
+/// each host operation: one capability store, opened one way, whether an
+/// operator is provisioning a folder or a turn is reading one. Callers must
+/// drop the returned handle promptly — it holds `host-broker.lock`.
 pub(crate) fn open_broker(data_dir: &Path) -> Result<Broker> {
     let home = std::env::home_dir()
         .ok_or_else(|| AgentError::config("could not resolve the current user's home directory"))?
@@ -176,12 +240,25 @@ pub(crate) fn open_broker(data_dir: &Path) -> Result<Broker> {
             AgentError::config(format!("could not initialize the folder policy: {error}"))
         })?;
     let execute_commands = openwave_code_execution::LocalExecutionProvider::availability().is_ok();
-    Broker::open_with_execute_commands(policy, &data_dir, execute_commands).map_err(|error| {
-        AgentError::config(format!(
-            "could not open connected-folder state: {error}. Close OpenWave before running \
-             `openwave folder`"
-        ))
-    })
+    Broker::open_with_execute_commands(policy, &data_dir, execute_commands).map_err(broker_open_error)
+}
+
+/// Map a broker-open failure into an operator-facing configuration error.
+///
+/// A lock held by another process is the expected contention case when the
+/// desktop sidecar (or another long-lived broker handle) is already open. The
+/// message names that condition and never suggests unlocking anything.
+pub(crate) fn broker_open_error(error: BrokerError) -> AgentError {
+    match error {
+        BrokerError::Io(ref io_error) if io_error.kind() == io::ErrorKind::WouldBlock => {
+            AgentError::config(
+                "connected-folder state is held by another OpenWave process \
+                 (desktop sidecar or a live folder executor). Retry in a moment; \
+                 do not remove host-broker.lock",
+            )
+        }
+        other => AgentError::config(format!("could not open connected-folder state: {other}")),
+    }
 }
 
 /// The broker subject a chat's host authority belongs to.
@@ -203,7 +280,15 @@ async fn load_chat(store: &Arc<dyn Store>, chat: ChatId) -> Result<Chat> {
         .ok_or_else(|| AgentError::msg(format!("chat {chat} not found")))
 }
 
-fn control(broker: &Broker, request: ControlRequest) -> Result<ControlResult> {
+/// Run one control request against a freshly opened broker handle, then drop
+/// it so `host-broker.lock` is released before the next product-store step.
+///
+/// Opening per request is what lets provisioning share a data directory with a
+/// running `serve`/desktop: the long-lived owner keeps `openwave.lock`, and
+/// this process only briefly contends for the broker lock. Holding the handle
+/// across an await would pin the lock under a concurrent folder executor.
+fn control(data_dir: &Path, request: ControlRequest) -> Result<ControlResult> {
+    let broker = open_broker(data_dir)?;
     let response = broker.controller().handle(ControlEnvelope {
         protocol_version: PROTOCOL_VERSION,
         request_id: RequestId::new(),
@@ -244,7 +329,6 @@ fn canonical_folder(path: &Path) -> Result<PathBuf> {
 
 async fn connect(
     store: &Arc<dyn Store>,
-    broker: &Broker,
     data_dir: &Path,
     chat_id: ChatId,
     path: PathBuf,
@@ -256,7 +340,7 @@ async fn connect(
     // A change left awaiting the broker by an interrupted run blocks the chat.
     // Drive it to a terminal before starting new work rather than reporting a
     // conflict the operator cannot act on.
-    settle_pending_changes(store, broker, &chat, subject, executor_id).await?;
+    settle_pending_changes(store, data_dir, &chat, subject, executor_id).await?;
     // Settling advances the projection's revision, so the CAS fence the attach
     // below carries has to come from a fresh read.
     let chat = load_chat(store, chat_id).await?;
@@ -272,7 +356,7 @@ async fn connect(
     // so this is the only place the CLI can create host reach.
     let operation_id = OperationId::new();
     let root = match control(
-        broker,
+        data_dir,
         ControlRequest::RegisterRoot(RegisterRootRequest {
             operation_id,
             subject,
@@ -287,7 +371,7 @@ async fn connect(
     // Read the durable receipt back rather than trusting the response: it is
     // the same authority the desktop's reconciler consults, and it reports a
     // registration that was revoked between commit and reply.
-    match lookup_registration(broker, operation_id, subject, chat.id.0)? {
+    match lookup_registration(data_dir, operation_id, subject, chat.id.0)? {
         RegisterRootReceipt::Completed { root: recorded } if recorded == root => {}
         _ => {
             return Err(AgentError::msg(
@@ -300,10 +384,10 @@ async fn connect(
     // visible in the desktop's connected-folders panel. If it cannot be
     // committed, withdraw the approval instead of leaving standing host reach
     // no surface can show.
-    let attached = attach_to_chat(store, broker, &chat, subject, root.root_id, executor_id).await;
+    let attached = attach_to_chat(store, data_dir, &chat, subject, root.root_id, executor_id).await;
     if let Err(error) = attached {
         let revoked = control(
-            broker,
+            data_dir,
             ControlRequest::RevokeRoot(RevokeRootRequest {
                 operation_id: OperationId::new(),
                 subject,
@@ -329,13 +413,13 @@ async fn connect(
 }
 
 fn lookup_registration(
-    broker: &Broker,
+    data_dir: &Path,
     operation_id: OperationId,
     subject: GrantSubject,
     conversation_id: Uuid,
 ) -> Result<RegisterRootReceipt> {
     match control(
-        broker,
+        data_dir,
         ControlRequest::LookupRegisterRootReceipt(
             openwave_host_broker::LookupRegisterRootReceiptRequest {
                 operation_id,
@@ -351,12 +435,12 @@ fn lookup_registration(
     }
 }
 
-async fn list(store: &Arc<dyn Store>, broker: &Broker, chat: Option<ChatId>) -> Result<()> {
+async fn list(store: &Arc<dyn Store>, data_dir: &Path, chat: Option<ChatId>) -> Result<()> {
     // `ListGrantStatements` is the same query the desktop's Permissions surface
     // reads (`list_capability_consents`), so the two shells cannot disagree
     // about what is granted or how it was granted.
     let ControlResult::ListGrantStatements { grants } =
-        control(broker, ControlRequest::ListGrantStatements)?
+        control(data_dir, ControlRequest::ListGrantStatements)?
     else {
         return Err(unexpected_broker_response());
     };
@@ -446,7 +530,6 @@ fn consent_label(method: ConsentMethod) -> &'static str {
 
 async fn disconnect(
     store: &Arc<dyn Store>,
-    broker: &Broker,
     data_dir: &Path,
     chat_id: ChatId,
     target: &OsStr,
@@ -454,11 +537,11 @@ async fn disconnect(
     let chat = load_chat(store, chat_id).await?;
     let subject = subject_for(&chat)?;
     let executor_id = executor_identity(data_dir)?;
-    settle_pending_changes(store, broker, &chat, subject, executor_id).await?;
+    settle_pending_changes(store, data_dir, &chat, subject, executor_id).await?;
     let chat = load_chat(store, chat_id).await?;
-    let root_id = resolve_target(broker, &chat, target)?;
+    let root_id = resolve_target(data_dir, &chat, target)?;
 
-    detach_from_chat(store, broker, &chat, subject, root_id, executor_id).await?;
+    detach_from_chat(store, data_dir, &chat, subject, root_id, executor_id).await?;
     println!("openwave: disconnected {root_id} from chat {chat_id}");
 
     // Detaching leaves the host approval standing, which is right when another
@@ -466,9 +549,9 @@ async fn disconnect(
     // would have no way to withdraw it. Withdraw it exactly when this chat's
     // subject is the only one with root-scoped grants on the folder, and say
     // so plainly when it is not.
-    if sole_grant_holder(broker, root_id, subject)? {
+    if sole_grant_holder(data_dir, root_id, subject)? {
         match control(
-            broker,
+            data_dir,
             ControlRequest::RevokeRoot(RevokeRootRequest {
                 operation_id: OperationId::new(),
                 subject,
@@ -491,9 +574,9 @@ async fn disconnect(
 }
 
 /// Whether `subject` is the only holder of root-scoped grants on `root_id`.
-fn sole_grant_holder(broker: &Broker, root_id: RootId, subject: GrantSubject) -> Result<bool> {
+fn sole_grant_holder(data_dir: &Path, root_id: RootId, subject: GrantSubject) -> Result<bool> {
     let ControlResult::ListGrantStatements { grants } =
-        control(broker, ControlRequest::ListGrantStatements)?
+        control(data_dir, ControlRequest::ListGrantStatements)?
     else {
         return Err(unexpected_broker_response());
     };
@@ -512,14 +595,14 @@ fn sole_grant_holder(broker: &Broker, root_id: RootId, subject: GrantSubject) ->
 /// A root id is exact. A path is matched by the leaf name the broker reports,
 /// because the broker deliberately never exposes a root's absolute path — so an
 /// ambiguous name is refused rather than guessed at.
-fn resolve_target(broker: &Broker, chat: &Chat, target: &OsStr) -> Result<RootId> {
+fn resolve_target(data_dir: &Path, chat: &Chat, target: &OsStr) -> Result<RootId> {
     let attached = chat
         .root_attachments
         .iter()
         .map(|attachment| *attachment.root_id.as_uuid())
         .collect::<std::collections::HashSet<_>>();
     let ControlResult::ListApprovedRoots { roots } =
-        control(broker, ControlRequest::ListApprovedRoots)?
+        control(data_dir, ControlRequest::ListApprovedRoots)?
     else {
         return Err(unexpected_broker_response());
     };
@@ -566,7 +649,7 @@ fn resolve_target(broker: &Broker, chat: &Chat, target: &OsStr) -> Result<RootId
 
 async fn attach_to_chat(
     store: &Arc<dyn Store>,
-    broker: &Broker,
+    data_dir: &Path,
     chat: &Chat,
     subject: GrantSubject,
     root_id: RootId,
@@ -574,7 +657,7 @@ async fn attach_to_chat(
 ) -> Result<()> {
     drive_change(
         store,
-        broker,
+        data_dir,
         chat,
         subject,
         root_id,
@@ -586,7 +669,7 @@ async fn attach_to_chat(
 
 async fn detach_from_chat(
     store: &Arc<dyn Store>,
-    broker: &Broker,
+    data_dir: &Path,
     chat: &Chat,
     subject: GrantSubject,
     root_id: RootId,
@@ -603,7 +686,7 @@ async fn detach_from_chat(
     }
     drive_change(
         store,
-        broker,
+        data_dir,
         chat,
         subject,
         root_id,
@@ -622,7 +705,7 @@ async fn detach_from_chat(
 /// the broker, which the next invocation settles.
 async fn drive_change(
     store: &Arc<dyn Store>,
-    broker: &Broker,
+    data_dir: &Path,
     chat: &Chat,
     subject: GrantSubject,
     root_id: RootId,
@@ -657,20 +740,20 @@ async fn drive_change(
             )))
         }
     };
-    settle_change(store, broker, subject, chat.id.0, executor_id, change).await
+    settle_change(store, data_dir, subject, chat.id.0, executor_id, change).await
 }
 
 /// Bring one durable change to a terminal phase and report what it means.
 async fn settle_change(
     store: &Arc<dyn Store>,
-    broker: &Broker,
+    data_dir: &Path,
     subject: GrantSubject,
     conversation_id: Uuid,
     executor_id: Uuid,
     change: RootAttachmentChange,
 ) -> Result<()> {
     let change = if change.phase == RootAttachmentChangePhase::AwaitingBroker {
-        let terminal = converge_broker(broker, subject, conversation_id, &change)?;
+        let terminal = converge_broker(data_dir, subject, conversation_id, &change)?;
         match store
             .finish_root_attachment_change(change.id, executor_id, &terminal, canonical_now())
             .await?
@@ -700,7 +783,7 @@ async fn settle_change(
 
 /// Dispatch (or recover) the broker half of one product change.
 fn converge_broker(
-    broker: &Broker,
+    data_dir: &Path,
     subject: GrantSubject,
     conversation_id: Uuid,
     change: &RootAttachmentChange,
@@ -714,7 +797,7 @@ fn converge_broker(
         RootAttachmentChangeAction::Detach => RootAttachmentMutationKind::Detach,
     };
     let mut receipt = lookup_mutation(
-        broker,
+        data_dir,
         subject,
         conversation_id,
         root_id,
@@ -735,7 +818,7 @@ fn converge_broker(
             },
         };
         let dispatched = control(
-            broker,
+            data_dir,
             match change.action {
                 RootAttachmentChangeAction::Attach => ControlRequest::AttachRoot(request),
                 RootAttachmentChangeAction::Detach => ControlRequest::DetachRoot(request),
@@ -748,7 +831,7 @@ fn converge_broker(
             Ok(_) => return Err(unexpected_broker_response()),
         }
         receipt = lookup_mutation(
-            broker,
+            data_dir,
             subject,
             conversation_id,
             root_id,
@@ -762,7 +845,7 @@ fn converge_broker(
 }
 
 fn lookup_mutation(
-    broker: &Broker,
+    data_dir: &Path,
     subject: GrantSubject,
     conversation_id: Uuid,
     root_id: RootId,
@@ -770,7 +853,7 @@ fn lookup_mutation(
     mutation: RootAttachmentMutationKind,
 ) -> Result<RootAttachmentMutationReceipt> {
     match control(
-        broker,
+        data_dir,
         ControlRequest::LookupRootAttachmentReceipt(
             openwave_host_broker::LookupRootAttachmentReceiptRequest {
                 operation_id,
@@ -867,7 +950,7 @@ fn safe_failure(code: &str, message: &str) -> openwave_core::RootAttachmentChang
 /// command's to finish — and until it is finished, the chat refuses new ones.
 async fn settle_pending_changes(
     store: &Arc<dyn Store>,
-    broker: &Broker,
+    data_dir: &Path,
     chat: &Chat,
     subject: GrantSubject,
     executor_id: Uuid,
@@ -879,7 +962,7 @@ async fn settle_pending_changes(
         if change.chat_id != chat.id {
             continue;
         }
-        settle_change(store, broker, subject, chat.id.0, executor_id, change).await?;
+        settle_change(store, data_dir, subject, chat.id.0, executor_id, change).await?;
     }
     Ok(())
 }

--- a/crates/openwave-cli/src/folder_executor.rs
+++ b/crates/openwave-cli/src/folder_executor.rs
@@ -28,6 +28,9 @@
 //! credential and starts no executor: the call belongs to whichever process owns
 //! that server's host state, and now — if that process is `openwave serve`, an
 //! embedded `openwave -p`, or `openwave tui` — it is actually answered there.
+//! Each host operation opens the broker briefly and drops it, so operator
+//! `openwave folder` provisioning can take `host-broker.lock` between calls
+//! without stopping the daemon.
 //!
 //! ## Recovery
 //!
@@ -69,7 +72,6 @@
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
 use openwave_core::{
     validate_import_connected_file_arguments, validate_list_connected_folders_arguments,
@@ -81,8 +83,8 @@ use openwave_core::{
     READ_CONNECTED_FILE_TOOL, WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL,
 };
 use openwave_host_broker::{
-    Broker, Capability, EntryKind, ExecutionContext, OperationEnvelope, OperationRequest,
-    OperationResult, PathRequest, RelativePath, RequestId, Response, RootId, PROTOCOL_VERSION,
+    Capability, EntryKind, ExecutionContext, OperationEnvelope, OperationRequest, OperationResult,
+    PathRequest, RelativePath, RequestId, Response, RootId, PROTOCOL_VERSION,
 };
 use uuid::Uuid;
 
@@ -137,10 +139,6 @@ pub struct FolderExecutor {
     executor_id: Uuid,
     receipts: ReceiptStore,
     data_dir: PathBuf,
-    /// Opened on first use only. A run that never touches a connected folder
-    /// must not take the broker's exclusive lock, write its state file, or fail
-    /// to boot on a host whose home directory cannot be resolved.
-    broker: tokio::sync::OnceCell<Arc<Broker>>,
 }
 
 impl FolderExecutor {
@@ -164,7 +162,6 @@ impl FolderExecutor {
             executor_id: crate::folder::executor_identity(data_dir)?,
             receipts: ReceiptStore::open(data_dir)?,
             data_dir: data_dir.to_path_buf(),
-            broker: tokio::sync::OnceCell::new(),
         }))
     }
 
@@ -527,23 +524,31 @@ impl FolderExecutor {
     /// authorizes the request against the conversation's live grants, opens the
     /// root through its own pinned descriptor, and re-authorizes after the read
     /// — none of which this process can influence, skip, or cache.
+    ///
+    /// The broker handle is opened for this operation only and dropped before
+    /// return, so `host-broker.lock` is free for `openwave folder` provisioning
+    /// between tool calls. Holding it for the life of `serve` would pin the
+    /// lock under the daemon and make operator connect refuse forever.
     async fn broker_operation(
         &self,
         context: ExecutionContext,
         request: OperationRequest,
     ) -> Result<OperationResult> {
-        let broker = self.broker().await?;
+        let data_dir = self.data_dir.clone();
         let envelope = OperationEnvelope {
             protocol_version: PROTOCOL_VERSION,
             request_id: RequestId::new(),
             context,
             request,
         };
-        // The in-process broker does real, blocking host I/O.
-        let response =
-            tokio::task::spawn_blocking(move || broker.operator().handle(envelope).response)
-                .await
-                .map_err(|_| AgentError::msg("the connected-folder operation did not complete"))?;
+        // The in-process broker does real, blocking host I/O. Open and drop
+        // inside the blocking task so the lock never outlives the operation.
+        let response = tokio::task::spawn_blocking(move || {
+            let broker = crate::folder::open_broker(&data_dir)?;
+            Ok::<_, AgentError>(broker.operator().handle(envelope).response)
+        })
+        .await
+        .map_err(|_| AgentError::msg("the connected-folder operation did not complete"))??;
         match response {
             Response::Ok(result) => Ok(result),
             Response::Error(error) => Err(AgentError::msg(format!(
@@ -551,23 +556,6 @@ impl FolderExecutor {
                 error.code
             ))),
         }
-    }
-
-    /// Open the profile's broker state on first use.
-    async fn broker(&self) -> Result<Arc<Broker>> {
-        let broker = self
-            .broker
-            .get_or_try_init(|| async {
-                let data_dir = self.data_dir.clone();
-                tokio::task::spawn_blocking(move || crate::folder::open_broker(&data_dir))
-                    .await
-                    .map_err(|_| {
-                        AgentError::msg("could not open the connected-folder capability store")
-                    })?
-                    .map(Arc::new)
-            })
-            .await?;
-        Ok(broker.clone())
     }
 
     /// The broker execution context a conversation's folder reads run under.

--- a/crates/openwave-cli/src/main.rs
+++ b/crates/openwave-cli/src/main.rs
@@ -48,8 +48,9 @@
 //! folder, which the broker stamps as operator configuration. It is deliberate
 //! provisioning only — nothing here answers a folder request an agent made
 //! during a turn. See [`folder`]. Unlike the client commands it works on local
-//! broker state and the local data directory, so it embeds and takes no
-//! `--server`.
+//! broker state and the local product store (not via `--server`/`--attach`): it
+//! opens them beside a running `serve`/desktop rather than embedding a second
+//! server, so a live profile can be provisioned without stopping the daemon.
 //!
 //! Once a folder is connected, the tools that read it are executed by whichever
 //! process owns that broker state — `serve`, or the engine `-p` embeds. See
@@ -136,8 +137,9 @@ tui, -p, output, attach, and the setup commands also take --server <url>
 running instead of embedding one. --attach reads {OPENWAVE_DATA_DIR}/listen.json
 (written by serve and the desktop). With --server the token comes from
 OPENWAVE_SERVER_TOKEN, or from the named variable; it is never an argument
-either. The folder commands do not: they provision local host consent in this
-machine's own broker state.";
+either. The folder commands do not take --server/--attach: they provision local
+host consent in this machine's own broker and product store, and they can run
+while serve or the desktop already owns the data directory.";
 
 #[tokio::main]
 async fn main() {

--- a/crates/openwave-cli/tests/folder.rs
+++ b/crates/openwave-cli/tests/folder.rs
@@ -111,9 +111,7 @@ fn start_serve(data_dir: &Path) -> ServeEndpoint {
         .trim()
         .to_owned();
     // Keep draining so a long-lived daemon cannot block on a full stdout pipe.
-    let drain = std::thread::spawn(move || {
-        for _ in lines {}
-    });
+    let drain = std::thread::spawn(move || for _ in lines {});
     ServeEndpoint {
         url,
         token,
@@ -516,9 +514,7 @@ fn a_serve_daemon_executes_folder_calls_for_an_attached_client() {
         .trim_start_matches("openwave: token ")
         .trim()
         .to_owned();
-    let _drain = std::thread::spawn(move || {
-        for _ in lines {}
-    });
+    let _drain = std::thread::spawn(move || for _ in lines {});
 
     let attached = openwave(&data_dir)
         .args([

--- a/crates/openwave-cli/tests/folder.rs
+++ b/crates/openwave-cli/tests/folder.rs
@@ -81,38 +81,72 @@ fn home() -> PathBuf {
         .expect("canonical home")
 }
 
-/// Create one chat through the running server, then stop it: the folder
-/// commands need the data directory's locks for themselves.
-fn create_chat(data_dir: &Path) -> String {
+/// Endpoint of a live `openwave serve` process.
+struct ServeEndpoint {
+    url: String,
+    token: String,
+    /// Keep the daemon alive for the scope of the caller.
+    _daemon: Reaper,
+    /// Drain stdout so a full pipe cannot stall the child.
+    _stdout: std::thread::JoinHandle<()>,
+}
+
+/// Start `openwave serve` and return its base URL and bearer token.
+fn start_serve(data_dir: &Path) -> ServeEndpoint {
     let mut child = openwave(data_dir)
         .arg("serve")
         .stdout(Stdio::piped())
         .spawn()
         .expect("spawn openwave serve");
     let stdout = child.stdout.take().unwrap();
-    let mut reaper = Reaper(child);
     let mut lines = BufReader::new(stdout).lines();
     let addr_line = lines.next().unwrap().unwrap();
     let token_line = lines.next().unwrap().unwrap();
-    let addr = addr_line
-        .rsplit("http://")
-        .next()
-        .unwrap()
-        .trim()
-        .to_owned();
+    let url = format!(
+        "http://{}",
+        addr_line.rsplit("http://").next().unwrap().trim()
+    );
     let token = token_line
         .trim_start_matches("openwave: token ")
         .trim()
         .to_owned();
+    // Keep draining so a long-lived daemon cannot block on a full stdout pipe.
+    let drain = std::thread::spawn(move || {
+        for _ in lines {}
+    });
+    ServeEndpoint {
+        url,
+        token,
+        _daemon: Reaper(child),
+        _stdout: drain,
+    }
+}
 
-    let mut stream = TcpStream::connect(&addr).unwrap();
+/// Create one chat through a short-lived server, then stop it.
+///
+/// Most folder tests still want an idle data directory so they can open the
+/// broker without contending with a daemon. The concurrent case uses
+/// [`start_serve`] and creates the chat while the daemon stays up.
+fn create_chat(data_dir: &Path) -> String {
+    let endpoint = start_serve(data_dir);
+    create_chat_on(&endpoint)
+}
+
+/// Create one chat against a live serve endpoint.
+fn create_chat_on(endpoint: &ServeEndpoint) -> String {
+    let addr = endpoint
+        .url
+        .strip_prefix("http://")
+        .expect("serve url is http");
+    let mut stream = TcpStream::connect(addr).unwrap();
     let body = "{}";
     stream
         .write_all(
             format!(
-                "POST /chats HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer {token}\r\n\
+                "POST /chats HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer {}\r\n\
                  Content-Type: application/json\r\nContent-Length: {}\r\n\
                  Connection: close\r\n\r\n{body}",
+                endpoint.token,
                 body.len()
             )
             .as_bytes(),
@@ -125,11 +159,7 @@ fn create_chat(data_dir: &Path) -> String {
     let start = payload.find('{').expect("chat body");
     let chat: serde_json::Value = serde_json::from_str(&payload[start..])
         .unwrap_or_else(|error| panic!("chat body {payload:?}: {error}"));
-    let id = chat["id"].as_str().expect("chat id").to_owned();
-
-    reaper.0.kill().ok();
-    reaper.0.wait().ok();
-    id
+    chat["id"].as_str().expect("chat id").to_owned()
 }
 
 fn desktop_broker(data_dir: &Path) -> Broker {
@@ -444,6 +474,12 @@ fn an_unattended_turn_reads_a_folder_the_operator_connected() {
 /// turn is a plain `--server` client holding only a bearer token. It cannot
 /// execute a folder call — it has no executor credential and no flag grants it
 /// one — and it does not have to, because the daemon does.
+///
+/// The folder is connected *while a serve holds the data directory*, then the
+/// scripted daemon is started with that root. Concurrent connect is the
+/// operator workflow this change closes; the turn half still proves the daemon
+/// executor. (The scripted provider is process env at serve spawn, so the
+/// scripted engine cannot be the same process that was up during connect.)
 #[test]
 fn a_serve_daemon_executes_folder_calls_for_an_attached_client() {
     let base = tempfile::tempdir_in(home()).unwrap();
@@ -454,9 +490,12 @@ fn a_serve_daemon_executes_folder_calls_for_an_attached_client() {
     std::fs::write(reports.join("q3.md"), "revenue held flat\n").unwrap();
 
     let chat = create_chat(&data_dir);
+    // Prove connect against a live data-dir lock, then hand the root to a
+    // scripted serve for the turn.
+    let lock_holder = start_serve(&data_dir);
     let root = connect_folder(&data_dir, &reports, &chat);
+    drop(lock_holder);
 
-    // The script belongs to the engine, which now lives in the daemon.
     let mut daemon = openwave(&data_dir)
         .arg("serve")
         .env("OPENWAVE_SCRIPTED_PROVIDER", folder_reading_script(&root))
@@ -477,6 +516,9 @@ fn a_serve_daemon_executes_folder_calls_for_an_attached_client() {
         .trim_start_matches("openwave: token ")
         .trim()
         .to_owned();
+    let _drain = std::thread::spawn(move || {
+        for _ in lines {}
+    });
 
     let attached = openwave(&data_dir)
         .args([
@@ -509,4 +551,62 @@ fn a_serve_daemon_executes_folder_calls_for_an_attached_client() {
         "stdout: {stdout}\nstderr: {stderr}"
     );
     assert_folder_tools_completed(&stdout, &stderr);
+}
+
+/// The contract this change exists for: `openwave folder connect|list|
+/// disconnect` must succeed while `openwave serve` holds `openwave.lock`.
+/// Before, provisioning embedded a second server and refused. The daemon's
+/// folder executor opens the broker only per tool call, so a quiet serve leaves
+/// `host-broker.lock` free for these commands.
+#[test]
+fn folder_connect_while_serve_holds_the_data_directory() {
+    let base = tempfile::tempdir_in(home()).unwrap();
+    let data = tempfile::tempdir().unwrap();
+    let data_dir = data.path().join("profile");
+    let reports = base.path().join("reports");
+    std::fs::create_dir_all(&reports).unwrap();
+    std::fs::write(reports.join("q3.md"), "revenue held flat\n").unwrap();
+
+    let endpoint = start_serve(&data_dir);
+    let chat = create_chat_on(&endpoint);
+
+    // The data directory is locked. Connect and list must still work.
+    assert!(
+        data_dir.join("openwave.lock").exists(),
+        "serve should hold openwave.lock"
+    );
+    let root = connect_folder(&data_dir, &reports, &chat);
+    let (ok, listed, stderr) = run(&data_dir, &["folder", "list", "--chat", &chat]);
+    assert!(ok, "list while serve is up failed: {stderr}");
+    // `folder list` reports grant rows (id, subject, capability, display name,
+    // provenance) — not the opaque root id, which only the connect report names.
+    assert!(
+        listed.contains("operator-config")
+            && listed.contains("\tread\treports\t")
+            && !root.is_empty(),
+        "listing: {listed}"
+    );
+
+    // Disconnect while the daemon still owns the profile.
+    let (ok, _, stderr) = run(
+        &data_dir,
+        &[
+            "folder",
+            "disconnect",
+            reports.to_str().unwrap(),
+            "--chat",
+            &chat,
+        ],
+    );
+    assert!(ok, "disconnect while serve is up failed: {stderr}");
+    let statements = desktop_grant_statements(&data_dir);
+    assert!(
+        statements
+            .iter()
+            .all(|grant| !matches!(grant.scope, Scope::Root { .. })),
+        "grants left after disconnect while serve held the lock: {statements:?}"
+    );
+
+    // Keep the endpoint alive until the assertions finish so the lock is real.
+    drop(endpoint);
 }


### PR DESCRIPTION
## Summary

`openwave folder connect|list|disconnect` no longer fails when `openwave serve` or the desktop already holds the profile data directory. Operators can provision host folders for a live daemon without stopping it.

## Design

**Concurrent local product store + short-lived broker handles** (correct partial preferred over dangerous unlock).

1. Prefer a normal embed when the data directory is free (keeps the desktop schema-epoch path for first boot).
2. When `openwave.lock` is held, open the product SQLite store under WAL without taking the instance lock.
3. Open the host broker **per control request / tool call**, then drop it so `host-broker.lock` is not pinned across the command or the daemon's lifetime.
4. Never delete or steal `host-broker.lock` / `openwave.lock`. Contention fails closed with a clear message.

Product begin → broker mutation → finish still converges; a failed product attach still withdraws the host approval. `--server` / `--attach` remain refused on folder commands — they are local host consent, not a client of another machine.

## Rejected alternatives

### Server-mediated path via `--attach` / `listen.json` + root-attachment HTTP routes

**Rejected as insufficient for full connect.** Root-attachment routes only begin/finish *product* projection and require the native client-executor credential. They never call the broker, so they cannot mint `RegisterRoot` / grants. Headless `bind_configured` also leaves `root_attachment_routes_enabled = false` (no restart-stable native executor id). Putting the broker behind ordinary HTTP (absolute paths, host grants) would widen the trust boundary and expand OWN beyond the folder CLI. Product projection still uses the same store APIs those routes wrap; only the transport differs.

### Auto-detect `listen.json` and route all of `folder` through the server

Same gap: bearer-only attach, no executor + broker. Would either half-grant (product without broker) or need new server authority.

### Casually unlock / delete `host-broker.lock`

**Hard reject.** The lock is exclusive ownership of durable broker state; stealing it races the desktop sidecar and can corrupt the state file.

### Keep a process-lifetime broker in `FolderExecutor`; only change the folder CLI

Would leave `serve` pinning `host-broker.lock` after the first folder tool call, so connect-while-serve still fails for any daemon that has already read a folder. Per-op open is required.

### Shared broker in `AppState` + new operator-folder HTTP routes

Reasonable long-term shape if remote/self-host operator consent is needed; not required for local serve/desktop and outside this job's OWN set.

## Changes

- `folder.rs` — bind-or-share product store; per-request broker; clearer lock contention errors
- `folder_executor.rs` — open broker per host operation instead of `OnceCell`
- `tests/folder.rs` — `folder_connect_while_serve_holds_the_data_directory`; connect-under-lock covered in the daemon executor test
- CLI docs/usage text updated

## Test plan

- [x] `cargo test -p openwave-cli --test folder --locked`
- [x] `cargo test -p openwave-cli --bins --locked`
- [x] `cargo clippy -p openwave-cli --all-targets --locked -- -D warnings`
- [ ] CI lanes on the PR