### PR TITLE
feat(cli): add agent-run cancel and chat delete

### DIFF
--- a/crates/openwave-cli/src/main.rs
+++ b/crates/openwave-cli/src/main.rs
@@ -121,8 +121,10 @@ usage: openwave serve
        openwave mcp-server remove <name>
        openwave chat list
        openwave chat create
+       openwave chat delete <chat>
        openwave agent-run list <chat>
        openwave agent-run show <chat> <run>
+       openwave agent-run cancel <chat> <run>
 
        openwave folder connect <path> --chat <id>
        openwave folder list [--chat <id>]
@@ -466,6 +468,10 @@ fn parse_setup(family: &str, args: Vec<String>) -> (SetupCommand, OutputFormat) 
     let command = match (family, verb.as_str()) {
         ("chat", "list") => SetupCommand::ChatList,
         ("chat", "create") => SetupCommand::ChatCreate,
+        ("chat", "delete") => {
+            let chat = parse_chat_id(&cursor.positional("a chat id"));
+            SetupCommand::ChatDelete { chat }
+        }
         ("agent-run", "list") => {
             let chat = parse_chat_id(&cursor.positional("a chat id"));
             SetupCommand::AgentRunList { chat }
@@ -474,6 +480,11 @@ fn parse_setup(family: &str, args: Vec<String>) -> (SetupCommand, OutputFormat) 
             let chat = parse_chat_id(&cursor.positional("a chat id"));
             let run = parse_agent_run_id(&cursor.positional("an agent-run id"));
             SetupCommand::AgentRunShow { chat, run }
+        }
+        ("agent-run", "cancel") => {
+            let chat = parse_chat_id(&cursor.positional("a chat id"));
+            let run = parse_agent_run_id(&cursor.positional("an agent-run id"));
+            SetupCommand::AgentRunCancel { chat, run }
         }
         ("provider", "list") => SetupCommand::ProviderList,
         ("provider", "set-key") => SetupCommand::ProviderSetKey {

--- a/crates/openwave-cli/src/setup.rs
+++ b/crates/openwave-cli/src/setup.rs
@@ -102,10 +102,14 @@ pub enum Command {
     ChatList,
     /// A fresh chat (server-side defaults seed the rest).
     ChatCreate,
+    /// Delete a chat outright.
+    ChatDelete { chat: ChatId },
     /// Background (and foreground) agent runs for one chat.
     AgentRunList { chat: ChatId },
     /// One run's status plus its ordered activity timeline.
     AgentRunShow { chat: ChatId, run: AgentRunId },
+    /// Ask a background run to stop.
+    AgentRunCancel { chat: ChatId, run: AgentRunId },
 }
 
 /// Run one setup command against the profile's server, and shut down anything
@@ -405,6 +409,13 @@ async fn execute(client: &Client, command: Command, format: OutputFormat) -> Res
             println!("{chat}");
             eprintln!("openwave: chat {chat}");
         }
+        Command::ChatDelete { chat } => {
+            client.delete_chat(chat).await?;
+            if format == OutputFormat::Json {
+                return emit(&serde_json::json!({ "id": chat, "deleted": true }));
+            }
+            println!("openwave: deleted chat {chat}");
+        }
         Command::AgentRunList { chat } => {
             let runs = client.list_agent_runs(chat).await?;
             if format == OutputFormat::Json {
@@ -513,6 +524,17 @@ async fn execute(client: &Client, command: Command, format: OutputFormat) -> Res
                     );
                 }
             }
+        }
+        Command::AgentRunCancel { chat, run } => {
+            client.cancel_agent_run(chat, run).await?;
+            if format == OutputFormat::Json {
+                return emit(&serde_json::json!({
+                    "chat": chat,
+                    "run": run,
+                    "cancelled": true,
+                }));
+            }
+            println!("openwave: cancelling agent run {run}");
         }
     }
     Ok(())
@@ -805,6 +827,19 @@ mod tests {
             listed.len(),
             1,
             "create must leave exactly one chat visible"
+        );
+        let chat = listed[0].id;
+
+        execute(&client, Command::ChatDelete { chat }, OutputFormat::Text)
+            .await
+            .expect("delete the chat");
+        assert!(
+            client
+                .list_chats()
+                .await
+                .expect("list after delete")
+                .is_empty(),
+            "delete must take the chat out of the listing"
         );
 
         serve.abort();


### PR DESCRIPTION
## Summary
- Add `openwave agent-run cancel <chat> <run>` (POST cancel via existing `Client::cancel_agent_run`)
- Add `openwave chat delete <chat>` (DELETE via existing `Client::delete_chat`)
- Update USAGE; both support `--output-format text|json` and `--attach`/`--server` like the other setup commands
- Extend the chat create integration test to assert delete removes the chat from the listing

Closes #1970
Closes #1971

## Test plan
- [x] `cargo fmt -p openwave-cli`
- [x] `cargo test -p openwave-cli --locked a_chat_created_through_the_cli`
- [x] Smoke: `openwave chat delete` / `openwave agent-run cancel` parse as known subcommands (demand chat id)
- [ ] CI lanes on this PR