### PR TITLE
fix(cli): stop stacking list-folders grants on reconnect

### DIFF
--- a/crates/openwave-cli/src/folder.rs
+++ b/crates/openwave-cli/src/folder.rs
@@ -53,7 +53,7 @@ use openwave_core::{
 use openwave_host_broker::{
     Broker, BrokerError, Capability, ConsentMethod, ControlEnvelope, ControlRequest, ControlResult,
     GrantStatementSummary, GrantSubject, OperationId, RegisterRootReceipt, RegisterRootRequest,
-    RequestId, Response, RevokeRootRequest, RootAttachmentMutationKind,
+    RequestId, Response, RevokeGrantRequest, RevokeRootRequest, RootAttachmentMutationKind,
     RootAttachmentMutationReceipt, RootAttachmentMutationRequest, RootId, RootPolicy, Scope,
     SubjectKind, PROTOCOL_VERSION,
 };
@@ -726,6 +726,53 @@ async fn disconnect(
             "openwave: the folder approval still reaches other subjects and was left in place; \
              see `openwave folder list`"
         );
+    }
+    // `RevokeRoot` drops only root-scoped grants. `ListRoots` is subject-scoped
+    // and would otherwise survive as a dangling list-folders row; the next
+    // connect then mints a second one. Drop it once this subject holds no
+    // root-scoped reach left to list.
+    revoke_orphan_list_roots(data_dir, subject)?;
+    Ok(())
+}
+
+/// Withdraw subject-scoped `ListRoots` when the subject has no root reach left.
+///
+/// Registration always mints a fresh list-folders grant alongside the folder's
+/// read/write/exec. `RevokeRoot` deliberately leaves subject-scoped grants
+/// alone (they are not properties of one folder), so a sole-holder disconnect
+/// used to leave list-folders standing and the next connect stacked another.
+/// When nothing root-scoped remains for the subject, list-folders has nothing
+/// to name and must go with the rest of the withdrawal.
+fn revoke_orphan_list_roots(data_dir: &Path, subject: GrantSubject) -> Result<()> {
+    let ControlResult::ListGrantStatements { grants } =
+        control(data_dir, ControlRequest::ListGrantStatements)?
+    else {
+        return Err(unexpected_broker_response());
+    };
+    let still_holds_root = grants.iter().any(|grant| {
+        grant.subject == subject
+            && matches!(grant.scope, Scope::Root { .. } | Scope::PathSubtree { .. })
+    });
+    if still_holds_root {
+        return Ok(());
+    }
+    for grant in grants {
+        if grant.subject != subject
+            || grant.capability != Capability::ListRoots
+            || !matches!(grant.scope, Scope::Subject)
+        {
+            continue;
+        }
+        match control(
+            data_dir,
+            ControlRequest::RevokeGrant(RevokeGrantRequest {
+                subject,
+                grant_id: grant.grant_id,
+            }),
+        )? {
+            ControlResult::RevokeGrant(_) => {}
+            _ => return Err(unexpected_broker_response()),
+        }
     }
     Ok(())
 }

--- a/crates/openwave-cli/tests/folder.rs
+++ b/crates/openwave-cli/tests/folder.rs
@@ -272,10 +272,8 @@ fn an_operator_grant_is_one_record_both_shells_read_and_either_side_can_revoke()
     assert!(ok, "disconnect failed: {stderr}");
     let statements = desktop_grant_statements(&data_dir);
     assert!(
-        statements
-            .iter()
-            .all(|grant| !matches!(grant.scope, Scope::Root { .. })),
-        "the withdrawn folder still has grants: {statements:?}"
+        statements.is_empty(),
+        "disconnect must withdraw root reach and the chat's list-folders grant: {statements:?}"
     );
 
     // And the other direction: a grant withdrawn on the desktop's Permissions
@@ -291,7 +289,16 @@ fn an_operator_grant_is_one_record_both_shells_read_and_either_side_can_revoke()
         ],
     );
     assert!(ok, "reconnect failed: {stderr}");
-    let read_grant = desktop_grant_statements(&data_dir)
+    let statements = desktop_grant_statements(&data_dir);
+    let list_folders = statements
+        .iter()
+        .filter(|grant| grant.capability == Capability::ListRoots)
+        .count();
+    assert_eq!(
+        list_folders, 1,
+        "reconnect must not stack list-folders grants: {statements:?}"
+    );
+    let read_grant = statements
         .into_iter()
         .find(|grant| {
             grant.capability == Capability::ReadFiles && matches!(grant.scope, Scope::Root { .. })
@@ -303,6 +310,58 @@ fn an_operator_grant_is_one_record_both_shells_read_and_either_side_can_revoke()
     assert!(
         !listed.contains(&read_grant.grant_id.to_string()),
         "a revoked grant is still listed: {listed}"
+    );
+}
+
+/// #1965: disconnect left the subject-scoped list-folders grant standing;
+/// reconnect then minted a second one. After a sole-holder disconnect+reconnect
+/// the chat must hold exactly one list-folders grant.
+#[test]
+fn disconnect_then_reconnect_keeps_a_single_list_folders_grant() {
+    let base = tempfile::tempdir_in(home()).unwrap();
+    let data = tempfile::tempdir().unwrap();
+    let data_dir = data.path().join("profile");
+    let reports = base.path().join("reports");
+    std::fs::create_dir_all(&reports).unwrap();
+
+    let chat = create_chat(&data_dir);
+    connect_folder(&data_dir, &reports, &chat);
+
+    let (ok, _, stderr) = run(
+        &data_dir,
+        &[
+            "folder",
+            "disconnect",
+            reports.to_str().unwrap(),
+            "--chat",
+            &chat,
+        ],
+    );
+    assert!(ok, "disconnect failed: {stderr}");
+    let after_disconnect = desktop_grant_statements(&data_dir);
+    assert!(
+        after_disconnect
+            .iter()
+            .all(|grant| grant.capability != Capability::ListRoots),
+        "list-folders must not outlive the last root for the chat: {after_disconnect:?}"
+    );
+
+    connect_folder(&data_dir, &reports, &chat);
+    let after_reconnect = desktop_grant_statements(&data_dir);
+    let list_folders: Vec<_> = after_reconnect
+        .iter()
+        .filter(|grant| grant.capability == Capability::ListRoots)
+        .collect();
+    assert_eq!(
+        list_folders.len(),
+        1,
+        "reconnect stacked list-folders grants: {after_reconnect:?}"
+    );
+    assert!(
+        after_reconnect.iter().any(|grant| {
+            grant.capability == Capability::ReadFiles && matches!(grant.scope, Scope::Root { .. })
+        }),
+        "reconnected folder must carry root reach: {after_reconnect:?}"
     );
 }
 
@@ -597,9 +656,7 @@ fn folder_connect_while_serve_holds_the_data_directory() {
     assert!(ok, "disconnect while serve is up failed: {stderr}");
     let statements = desktop_grant_statements(&data_dir);
     assert!(
-        statements
-            .iter()
-            .all(|grant| !matches!(grant.scope, Scope::Root { .. })),
+        statements.is_empty(),
         "grants left after disconnect while serve held the lock: {statements:?}"
     );
 


### PR DESCRIPTION
## Summary

- **Root cause:** `openwave folder disconnect` detaches the root and calls `RevokeRoot` when this subject is the sole holder. `RevokeRoot` removes root-scoped grants (read/write/exec) but deliberately leaves subject-scoped `ListRoots` alone. The next `connect` always mints a fresh `ListRoots` grant via `RegisterRoot`, so disconnect+reconnect stacked two list-folders rows for the same chat.
- **Fix:** After the existing revoke/sole-holder path, drop any subject-scoped `ListRoots` grants for that subject when it no longer holds any root-scoped reach. Shared multi-folder subjects keep list-folders until their last root is gone.
- **Test:** Regression in `crates/openwave-cli/tests/folder.rs` covers disconnect cleanup and single list-folders after reconnect; existing grant lifecycle tests now assert a fully empty grant table after sole-holder disconnect.

## Test plan

- [x] `cargo fmt -p openwave-cli`
- [x] `cargo test -p openwave-cli --test folder --locked -- disconnect_then_reconnect_keeps_a_single_list_folders_grant an_operator_grant_is_one_record folder_connect_while_serve`

Closes #1965