### PR TITLE
fix(cli): settle folder access requests on serve for attach clients

### DIFF
--- a/crates/openwave-cli/src/folder.rs
+++ b/crates/openwave-cli/src/folder.rs
@@ -11,8 +11,8 @@
 //! **These commands never run inside a turn.** They are standalone provisioning
 //! that an operator invokes; there is no flag that answers a folder request the
 //! agent made. A mid-turn `request_folder_access` in a headless run gets the
-//! same typed refusal an undecided desktop prompt produces — see
-//! [`crate::print`].
+//! same typed refusal an undecided desktop prompt produces — settled by
+//! [`crate::folder_executor`] (and by print mode when it embeds the engine).
 //!
 //! ## Locks, and why these commands do not take them
 //!

--- a/crates/openwave-cli/src/folder_executor.rs
+++ b/crates/openwave-cli/src/folder_executor.rs
@@ -18,9 +18,16 @@
 //!
 //! **It never widens a grant.** The tools here read folders that are *already*
 //! connected. `request_folder_access` — the only tool that asks for a new one —
-//! is deliberately not in this module's dispatch table; it keeps the typed
-//! refusal [`crate::print`] gives it, and standing consent still comes only
-//! from `openwave folder connect`. See [`crate::folder`].
+//! is answered here too, but only with the folder contract's typed `Declined`
+//! result: the same answer an undecided desktop prompt and print mode's own
+//! refusal produce. No picker runs, no path is chosen, and no grant is minted.
+//! Standing consent still comes only from `openwave folder connect`. See
+//! [`crate::folder`].
+//!
+//! Declining here is what keeps an attached (`--server` / `--attach`) print run
+//! from hanging: that client holds no executor credential and correctly leaves
+//! the call for this process. Without a headless answer, `openwave serve` would
+//! park `request_folder_access` forever even though it already owns the broker.
 //!
 //! **Only the process that owns the broker runs it.** The executor needs the
 //! server's client-executor credential, which [`crate::connect::Session`] holds
@@ -76,11 +83,12 @@ use std::path::{Path, PathBuf};
 use openwave_core::{
     validate_import_connected_file_arguments, validate_list_connected_folders_arguments,
     validate_list_folder_arguments, validate_read_connected_file_arguments,
-    validate_write_output_to_connected_folder_arguments, AgentError, CallId, ChatId,
-    GrantedFolderCapability, ImportConnectedFileArgs, ImportConnectedFileResult, ListFolderArgs,
-    ReadConnectedFileArgs, Result, ResultEntry, ResultEntryKind, ToolCallExecution, ToolCallRecord,
-    ToolCallStatus, IMPORT_CONNECTED_FILE_TOOL, LIST_CONNECTED_FOLDERS_TOOL, LIST_FOLDER_TOOL,
-    READ_CONNECTED_FILE_TOOL, WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL,
+    validate_request_folder_access_arguments, validate_write_output_to_connected_folder_arguments,
+    AgentError, CallId, ChatId, GrantedFolderCapability, ImportConnectedFileArgs,
+    ImportConnectedFileResult, ListFolderArgs, ReadConnectedFileArgs, RequestFolderAccessResult,
+    Result, ResultEntry, ResultEntryKind, ToolCallExecution, ToolCallRecord, ToolCallStatus,
+    IMPORT_CONNECTED_FILE_TOOL, LIST_CONNECTED_FOLDERS_TOOL, LIST_FOLDER_TOOL,
+    READ_CONNECTED_FILE_TOOL, REQUEST_FOLDER_ACCESS_TOOL, WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL,
 };
 use openwave_host_broker::{
     Capability, EntryKind, ExecutionContext, OperationEnvelope, OperationRequest, OperationResult,
@@ -403,6 +411,14 @@ impl FolderExecutor {
 
     /// Run one claimed call, returning the model-facing terminal outcome.
     async fn run_call(&self, chat: ChatId, call: &ToolCallRecord) -> ClientExecutionOutcome {
+        // New folder consent is operator work (`openwave folder connect`), not
+        // something a headless executor can grant. Resolve the parked call with
+        // the same typed Declined the desktop produces when the picker is
+        // closed, so an attached print client that correctly left the call here
+        // does not hang waiting for a surface that will never appear.
+        if call.name == REQUEST_FOLDER_ACCESS_TOOL {
+            return declined_folder_access();
+        }
         // The one call a headless install cannot honor. It needs the exec
         // write-overlay materializer, which no headless embedding installs, so
         // it fails closed with the desktop's own code for that state rather than
@@ -576,13 +592,14 @@ impl FolderExecutor {
 
 /// Whether this executor answers for a tool.
 ///
-/// `request_folder_access` is deliberately absent: it asks for consent this
-/// process cannot give, and print mode's typed refusal remains the only answer
-/// a headless run has for it.
+/// `request_folder_access` is included only so it can be settled declined: this
+/// process still cannot grant or widen folder access. Standing consent stays
+/// with `openwave folder connect`.
 fn handles(name: &str) -> bool {
     matches!(
         name,
-        LIST_CONNECTED_FOLDERS_TOOL
+        REQUEST_FOLDER_ACCESS_TOOL
+            | LIST_CONNECTED_FOLDERS_TOOL
             | LIST_FOLDER_TOOL
             | READ_CONNECTED_FILE_TOOL
             | IMPORT_CONNECTED_FILE_TOOL
@@ -595,13 +612,13 @@ fn handles(name: &str) -> bool {
 /// A read has no durable host outcome to reconcile against, so an interrupted
 /// one is closed out. An import derives its source identity from the exact
 /// request, so running it again converges on the same single source. A
-/// write-back never reaches the host from here at all, so replaying its
-/// fail-closed answer is free.
+/// write-back and a folder-access refusal never reach the host from here at
+/// all, so replaying their fail-closed answers is free.
 fn recovery_policy(name: &str) -> DispatchRecovery {
     match name {
-        IMPORT_CONNECTED_FILE_TOOL | WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL => {
-            DispatchRecovery::Retry
-        }
+        IMPORT_CONNECTED_FILE_TOOL
+        | WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL
+        | REQUEST_FOLDER_ACCESS_TOOL => DispatchRecovery::Retry,
         _ => DispatchRecovery::Terminalize,
     }
 }
@@ -615,6 +632,7 @@ fn is_canonical_folder_call(call: &ToolCallRecord) -> bool {
         return false;
     }
     match call.name.as_str() {
+        REQUEST_FOLDER_ACCESS_TOOL => validate_request_folder_access_arguments(&call.arguments),
         LIST_CONNECTED_FOLDERS_TOOL => validate_list_connected_folders_arguments(&call.arguments),
         LIST_FOLDER_TOOL => validate_list_folder_arguments(&call.arguments),
         READ_CONNECTED_FILE_TOOL => validate_read_connected_file_arguments(&call.arguments),
@@ -807,6 +825,20 @@ fn read_file_name(path: &str) -> String {
     }
 }
 
+/// The model-facing answer when headless cannot open a consent surface.
+///
+/// Byte-compatible with print mode's own refusal and with the desktop's
+/// closed-picker path: a completed call whose result is `Declined`, never a
+/// failure code that would look like a broken tool.
+fn declined_folder_access() -> ClientExecutionOutcome {
+    let declined = serde_json::to_string(&RequestFolderAccessResult::Declined)
+        .unwrap_or_else(|_| r#"{"status":"declined"}"#.to_owned());
+    ClientExecutionOutcome::Completed {
+        result: declined,
+        rows: None,
+    }
+}
+
 fn unavailable(code: &str, message: &str) -> ClientExecutionOutcome {
     ClientExecutionOutcome::Failed {
         result: serde_json::json!({ "status": "unavailable", "message": message }).to_string(),
@@ -871,20 +903,33 @@ mod tests {
     }
 
     /// The boundary between "a folder this conversation already has" and "ask
-    /// for another one". A headless run answers the first and must never answer
-    /// the second: `request_folder_access` has no route into this executor, so
-    /// print mode's typed refusal stays the only answer to it and no folder
-    /// grant can be created or widened from a parked call.
+    /// for another one". A headless run answers the first for real. It answers
+    /// the second only with `Declined`: the call is claimed so the turn does
+    /// not hang, and no grant can be created or widened from that path.
     #[test]
-    fn the_executor_never_answers_a_request_for_new_folder_access() {
-        assert!(!handles(REQUEST_FOLDER_ACCESS_TOOL));
-        assert!(!is_canonical_folder_call(&call(
+    fn the_executor_declines_a_request_for_new_folder_access_without_granting() {
+        assert!(handles(REQUEST_FOLDER_ACCESS_TOOL));
+        assert!(is_canonical_folder_call(&call(
             REQUEST_FOLDER_ACCESS_TOOL,
             serde_json::json!({
                 "reason": "Read reports",
                 "requested_capabilities": ["read_files"],
             }),
         )));
+        // A malformed request is not canonical, so discovery never claims it
+        // for a host operation or a fabricated decline.
+        assert!(!is_canonical_folder_call(&call(
+            REQUEST_FOLDER_ACCESS_TOOL,
+            serde_json::json!({ "reason": "", "requested_capabilities": ["read_files"] }),
+        )));
+        let ClientExecutionOutcome::Completed { result, rows } = declined_folder_access() else {
+            panic!("a headless folder-access answer completes as Declined");
+        };
+        assert!(rows.is_none());
+        assert_eq!(
+            serde_json::from_str::<RequestFolderAccessResult>(&result).unwrap(),
+            RequestFolderAccessResult::Declined
+        );
         // Nor by any other name: dispatch is a closed match, and a name it does
         // not know produces no broker request at all.
         assert!(broker_request(&call("exec", serde_json::json!({}))).is_err());
@@ -1005,6 +1050,10 @@ mod tests {
         }
         assert_eq!(
             recovery_policy(IMPORT_CONNECTED_FILE_TOOL),
+            DispatchRecovery::Retry
+        );
+        assert_eq!(
+            recovery_policy(REQUEST_FOLDER_ACCESS_TOOL),
             DispatchRecovery::Retry
         );
     }

--- a/crates/openwave-cli/src/print.rs
+++ b/crates/openwave-cli/src/print.rs
@@ -29,8 +29,11 @@
 //! *Using* a folder an operator already connected is a different matter, and it
 //! works: an embedded run starts [`crate::folder_executor`] over the chat it is
 //! driving, which claims the parked folder tool calls and runs them through the
-//! host broker's capability checks. That executor answers only for folders that
-//! are already connected; it has no path to a new grant.
+//! host broker's capability checks. An attached run starts no executor — the
+//! process that owns the server (`openwave serve`, or an embedded peer) does —
+//! and that same executor settles a mid-turn `request_folder_access` as the
+//! typed `Declined` result rather than hanging the turn. Neither path can mint
+//! a new grant; standing consent stays with `openwave folder connect`.
 
 use std::collections::HashMap;
 use std::future::Future as _;
@@ -154,11 +157,13 @@ pub async fn run(
     let mut driver = Driver::from_stdin(driving);
 
     // The folder tools the agent may use on a folder an operator already
-    // connected execute in this process, because this process is the one that
-    // owns the broker state they read. Scoped to this run's chat: a print run
-    // answers for the conversation it drives and no other. An attached run has
-    // no executor credential and starts nothing — it touches no local data
-    // directory either, which is why the profile is only resolved here.
+    // connected execute in this process when this process owns the broker
+    // state they read. Scoped to this run's chat: a print run answers for the
+    // conversation it drives and no other. An attached run has no executor
+    // credential and starts nothing — `openwave serve` (or whichever process
+    // embedded the engine) holds the credential and claims the parked calls,
+    // including declining a mid-turn `request_folder_access`. The profile is
+    // only resolved here for the embedded path that needs a local data dir.
     let folder_executor = match executor_token.as_deref() {
         Some(executor_token) => crate::folder_executor::FolderExecutor::new(
             client.clone(),
@@ -670,9 +675,10 @@ impl FolderDeclines {
         printer: &mut Printer,
     ) {
         // Attach mode has no client-executor credential and is not the trusted
-        // surface for this server — the process that owns it is, and if that is
-        // a desktop it will show the user a picker. Say so and leave the call
-        // alone rather than pretending to be it.
+        // surface for this server — the process that owns it is. Headless
+        // owners (`openwave serve`, an embedded `-p`/`tui`) settle the call
+        // declined without granting; a desktop owner may show a picker. Say so
+        // and leave the call alone rather than pretending to be that surface.
         let Some(executor_token) = executor_token else {
             printer.notice(&format!(
                 "folder request {call_id} left for the attached server's own client executor; \
@@ -742,11 +748,14 @@ impl Drop for FolderDeclines {
 /// - **Never parked, or unreadable.** Not evidence of anything: keep asking. A
 ///   poll that fails says nothing about the call, so it is retried too. The
 ///   waiting ends when the call completes or the turn does, not on a clock.
-/// - **Parked, and claimed by somebody else.** Never race it — this process has
-///   no way to grant anything. But it is also the only surface that answers for
-///   this server, so a claim it does not hold is a call it cannot settle.
-/// - **Parked, and the claim or the resolve failed.** The refusal is owed and
-///   undeliverable, which is the one shape that must end the run.
+/// - **Parked, and claimed by somebody else.** The headless
+///   [`crate::folder_executor`] — this process's own, or `openwave serve`'s —
+///   settles folder-access requests declined. Do not race it and do not halt:
+///   the turn continues when that executor publishes the terminal result.
+/// - **Parked, and this refusal claimed and resolved it.** The ordinary path.
+/// - **Parked, and the claim or the resolve failed while the call is still
+///   unclaimed.** The refusal is owed and undeliverable, which is the one shape
+///   that must end the run.
 /// - **Parked, but not a folder request.** Impossible by construction — the name
 ///   came from the announcement of this same call — and not this run's answer to
 ///   give if it happens. Say so and leave it.
@@ -769,16 +778,17 @@ async fn decline(
                         ),
                     });
                 }
+                // Another executor (this process's folder_executor, or serve's)
+                // already owns the call. Stand down; its terminal result ends
+                // the wait via ToolCallCompleted.
                 Some(call) if call.client_executor_id.is_some() => {
-                    return Some(FolderDecline::Unanswerable {
-                        call_id,
-                        message: format!(
-                            "the folder request is claimed by another executor, and this run \
-                             cannot resolve a claim it does not hold: call {call_id} stays parked"
-                        ),
-                    });
+                    return None;
                 }
                 Some(_) => break,
+                // Gone from the pending set: either never parked, or already
+                // settled (including by folder_executor). Keep polling only for
+                // the never-parked case; ToolCallCompleted aborts this task
+                // when the call is terminal.
                 None => {}
             }
         }
@@ -787,13 +797,16 @@ async fn decline(
     }
 
     match resolve_declined(client, executor_token, chat, call_id).await {
-        Ok(()) => Some(FolderDecline::Noted {
+        ResolveDeclined::Declined => Some(FolderDecline::Noted {
             call_id,
             message: "folder access declined: headless runs connect folders with `openwave \
                       folder connect`, never mid-turn"
                 .to_owned(),
         }),
-        Err(error) => Some(FolderDecline::Unanswerable {
+        // folder_executor won the race after we saw the call unclaimed. The
+        // turn is not stuck; its completion event is what ends the wait.
+        ResolveDeclined::HandledElsewhere => None,
+        ResolveDeclined::Failed(error) => Some(FolderDecline::Unanswerable {
             call_id,
             message: format!(
                 "the parked folder request could not be declined: {error}; the turn is waiting \
@@ -803,21 +816,44 @@ async fn decline(
     }
 }
 
+/// Outcome of trying to claim and decline one folder-access request.
+enum ResolveDeclined {
+    Declined,
+    /// Another executor already claimed or resolved the call.
+    HandledElsewhere,
+    Failed(AgentError),
+}
+
 /// Claim the parked call and resolve it declined.
 async fn resolve_declined(
     client: &Client,
     executor_token: &str,
     chat: ChatId,
     call_id: CallId,
-) -> Result<()> {
+) -> ResolveDeclined {
     let executor_id = uuid::Uuid::new_v4();
     let lease_token = uuid::Uuid::new_v4();
-    client
+    if let Err(error) = client
         .claim_client_execution(executor_token, chat, call_id, executor_id, lease_token)
-        .await?;
-    let declined = serde_json::to_string(&RequestFolderAccessResult::Declined)
-        .map_err(|error| AgentError::msg(format!("could not encode the refusal: {error}")))?;
-    client
+        .await
+    {
+        // A conflict means the call is not claimable by this pair right now —
+        // typically folder_executor already owns it or already finished it.
+        return if error.is_conflict() {
+            ResolveDeclined::HandledElsewhere
+        } else {
+            ResolveDeclined::Failed(error.into())
+        };
+    }
+    let declined = match serde_json::to_string(&RequestFolderAccessResult::Declined) {
+        Ok(declined) => declined,
+        Err(error) => {
+            return ResolveDeclined::Failed(AgentError::msg(format!(
+                "could not encode the refusal: {error}"
+            )));
+        }
+    };
+    match client
         .resolve_client_execution(
             executor_token,
             chat,
@@ -830,8 +866,12 @@ async fn resolve_declined(
                 rows: None,
             },
         )
-        .await?;
-    Ok(())
+        .await
+    {
+        Ok(()) => ResolveDeclined::Declined,
+        Err(error) if error.is_conflict() => ResolveDeclined::HandledElsewhere,
+        Err(error) => ResolveDeclined::Failed(error.into()),
+    }
 }
 
 /// The event socket plus the cursor a reconnect resumes from.

--- a/crates/openwave-cli/tests/folder.rs
+++ b/crates/openwave-cli/tests/folder.rs
@@ -549,6 +549,121 @@ fn a_serve_daemon_executes_folder_calls_for_an_attached_client() {
     assert_folder_tools_completed(&stdout, &stderr);
 }
 
+/// #1967: an attached print client holds no executor credential, so a mid-turn
+/// `request_folder_access` used to park forever — print left the call for
+/// "the attached server's own client executor", and serve's executor did not
+/// handle that tool at all. Serve must settle it declined (no grant) so the
+/// turn completes instead of hanging until killed. The attach client still
+/// cannot claim or grant anything itself.
+#[test]
+fn a_serve_daemon_declines_folder_access_requests_for_an_attached_client() {
+    let data = tempfile::tempdir().unwrap();
+    let data_dir = data.path().join("profile");
+    let chat = create_chat(&data_dir);
+
+    let script = serde_json::json!([
+        {
+            "tool": "request_folder_access",
+            "input": {
+                "reason": "Read the quarterly reports",
+                "requested_capabilities": ["read_files"]
+            }
+        },
+        {"text": "no folder was granted"}
+    ])
+    .to_string();
+    let mut daemon = openwave(&data_dir)
+        .arg("serve")
+        .env("OPENWAVE_SCRIPTED_PROVIDER", script)
+        .env_remove("OPENWAVE_SERVER_URL")
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn openwave serve");
+    let stdout = daemon.stdout.take().unwrap();
+    let _daemon = Reaper(daemon);
+    let mut lines = BufReader::new(stdout).lines();
+    let addr_line = lines.next().unwrap().unwrap();
+    let token_line = lines.next().unwrap().unwrap();
+    let url = format!(
+        "http://{}",
+        addr_line.rsplit("http://").next().unwrap().trim()
+    );
+    let token = token_line
+        .trim_start_matches("openwave: token ")
+        .trim()
+        .to_owned();
+    let _drain = std::thread::spawn(move || for _ in lines {});
+
+    let attached = openwave(&data_dir)
+        .args([
+            "-p",
+            "please connect a folder",
+            "--chat",
+            &chat,
+            "--permission-mode",
+            "allow",
+            "--output-format",
+            "json",
+            "--server",
+        ])
+        .arg(&url)
+        .env("OPENWAVE_SERVER_TOKEN", &token)
+        .env_remove("OPENWAVE_SERVER_URL")
+        .env_remove("OPENWAVE_SCRIPTED_PROVIDER")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn an attached openwave -p");
+    let mut attached = Reaper(attached);
+    let output = attached.wait_with_output(TURN_EXIT_TIMEOUT);
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout: {stdout}\nstderr: {stderr}"
+    );
+    let events = journal_events(&stdout);
+    let call = events
+        .iter()
+        .find(|event| {
+            event["type"] == "tool_call_started" && event["name"] == "request_folder_access"
+        })
+        .unwrap_or_else(|| {
+            panic!("request_folder_access was never called\nstdout: {stdout}\nstderr: {stderr}")
+        });
+    let call_id = call["call_id"].clone();
+    let completed = events
+        .iter()
+        .find(|event| event["type"] == "tool_call_completed" && event["call_id"] == call_id)
+        .unwrap_or_else(|| {
+            panic!(
+                "request_folder_access never completed — it parked\nstdout: {stdout}\nstderr: {stderr}"
+            )
+        });
+    // Settled as completed (the contract's Declined result is a successful
+    // resolution, not a tool failure) — never left pending.
+    assert_eq!(
+        completed["status"], "completed",
+        "request_folder_access did not settle\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        events.iter().any(|event| event["type"] == "turn_completed"),
+        "the turn never completed\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    // Attach still cannot execute; it only observes. The notice names that
+    // hand-off when the tool is announced, and the settled tool is reported.
+    assert!(
+        stderr.contains("left for the attached server's own client executor"),
+        "attach must leave the call for serve's executor: {stderr}"
+    );
+    assert!(
+        stderr.contains("tool: request_folder_access ok"),
+        "serve must settle the request so the attach client sees completion: {stderr}"
+    );
+}
+
 /// The contract this change exists for: `openwave folder connect|list|
 /// disconnect` must succeed while `openwave serve` holds `openwave.lock`.
 /// Before, provisioning embedded a second server and refused. The daemon's


### PR DESCRIPTION
## Summary

- **Who executes folder tools after this fix:** the process that owns the server and holds the native executor credential — `openwave serve`, or an embedded `-p` / `tui`. Attached clients still never receive that credential and never execute host folder work.
- **Connected folders** (`list_connected_folders`, `list_folder`, `read_connected_file`, …): unchanged — serve’s `folder_executor` already claimed and ran them for attach-submitted turns.
- **`request_folder_access`:** serve’s (and any headless) `folder_executor` now claims the parked call and resolves it with the folder contract’s typed `Declined` result — the same answer an undecided desktop picker and embedded print already produced. No grant is minted; standing consent remains `openwave folder connect` only.
- **Print attach path:** still leaves the call for the server’s executor (and says so). Embedded print’s refusal no longer treats “already claimed by folder_executor” as an unanswerable halt, so the two local settlers do not race into exit 4.
- **Security model:** executor credential stays native-only / embed-only; no flag hands it to `--attach` / `--server`.

## Why this design (A over pure fail-closed)

Attach cannot hold the executor credential by design. Serve already owns the broker and already starts `Scope::AllChats` folder_executor — the hang was serve not handling this one tool, not attach waiting incorrectly for connected-folder reads. Settling declined on the trusted surface keeps headless drivers usable without weakening the boundary.

## Test plan

- [x] `cargo test -p openwave-cli --bin openwave folder_executor`
- [x] `cargo test -p openwave-cli --test folder`
- [ ] CI lanes on the PR

Closes #1967