### PR TITLE
fix(server): align wait_for_agents cap with spawn unsettled limit

### DIFF
--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -506,9 +506,14 @@ where
     // children release their slot before their result is safely incorporated,
     // so churn could orphan completed work. The provenance-validating
     // unsettled classifier deliberately fails closed when a terminal child is
-    // missing its delivery.
+    // missing its delivery. Never admit more unsettled children than one
+    // wait_for_agents call can take, even if a stale setting asks for more.
     let unsettled = unsettled_sandbox_children_for_origin_turn_on(conn, turn).await?;
-    if unsettled.len() >= max_active_background_agents as usize {
+    let admission_cap = std::cmp::min(
+        max_active_background_agents,
+        AgentRun::MAX_ACTIVE_BACKGROUND_AGENTS,
+    );
+    if unsettled.len() >= admission_cap as usize {
         return Ok(AdmitSandboxAgentRunOutcome::AtCapacity);
     }
 
@@ -2414,11 +2419,11 @@ fn validate_admission_request(
         ));
     }
     if max_active_background_agents == 0
-        || max_active_background_agents > AgentRun::MAX_CONCURRENCY_LIMIT
+        || max_active_background_agents > AgentRun::MAX_ACTIVE_BACKGROUND_AGENTS
     {
         return Err(AgentError::Store(format!(
             "sandbox active-agent limit must be in 1..={}",
-            AgentRun::MAX_CONCURRENCY_LIMIT
+            AgentRun::MAX_ACTIVE_BACKGROUND_AGENTS
         )));
     }
     let input_len = input.chars().count();

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -2419,11 +2419,11 @@ fn validate_admission_request(
         ));
     }
     if max_active_background_agents == 0
-        || max_active_background_agents > AgentRun::MAX_ACTIVE_BACKGROUND_AGENTS
+        || max_active_background_agents > AgentRun::MAX_CONCURRENCY_LIMIT
     {
         return Err(AgentError::Store(format!(
             "sandbox active-agent limit must be in 1..={}",
-            AgentRun::MAX_ACTIVE_BACKGROUND_AGENTS
+            AgentRun::MAX_CONCURRENCY_LIMIT
         )));
     }
     let input_len = input.chars().count();

--- a/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
+++ b/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
@@ -611,7 +611,7 @@ fn validate_request(request: &SandboxSpawnCheckpointRequest) -> Result<()> {
         || !(2..i32::MAX).contains(&request.event_ordinal)
         || request.progress.model_steps < 0
         || request.max_active_background_agents == 0
-        || request.max_active_background_agents > AgentRun::MAX_ACTIVE_BACKGROUND_AGENTS
+        || request.max_active_background_agents > AgentRun::MAX_CONCURRENCY_LIMIT
         || !labels_valid
         || !result_valid
         || !serde_json::to_vec(&request.arguments)

--- a/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
+++ b/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
@@ -611,7 +611,7 @@ fn validate_request(request: &SandboxSpawnCheckpointRequest) -> Result<()> {
         || !(2..i32::MAX).contains(&request.event_ordinal)
         || request.progress.model_steps < 0
         || request.max_active_background_agents == 0
-        || request.max_active_background_agents > AgentRun::MAX_CONCURRENCY_LIMIT
+        || request.max_active_background_agents > AgentRun::MAX_ACTIVE_BACKGROUND_AGENTS
         || !labels_valid
         || !result_valid
         || !serde_json::to_vec(&request.arguments)

--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -1494,26 +1494,34 @@ async fn failed_child_result_is_persisted_in_the_resumed_parent_transcript() {
 #[tokio::test]
 async fn live_parent_inbox_candidates_skip_sixteen_obsolete_deliveries() {
     let (_dir, store) = temp_store().await;
-    let chat = sample_chat();
-    store.create_chat(&chat).await.unwrap();
 
+    // Unconsumed terminal deliveries occupy the origin-turn unsettled cap
+    // (shared with wait_for_agents membership). Spread obsolete deliveries
+    // across chats so the fixture can still flood the recovery scan without
+    // fighting that per-turn ceiling.
     for index in 0..16 {
+        let mut obsolete = sample_chat();
+        obsolete.id = ChatId::new();
+        store.create_chat(&obsolete).await.unwrap();
         submit_sandbox_result(
             &store,
-            chat.id,
+            obsolete.id,
             &format!("obsolete task {index}"),
             &format!("obsolete result {index}"),
         )
         .await;
     }
+
+    let live_chat = sample_chat();
+    store.create_chat(&live_chat).await.unwrap();
     let (live_child, _) = submit_sandbox_result(
         &store,
-        chat.id,
+        live_chat.id,
         "the live delegated task",
         "the live result",
     )
     .await;
-    let parked = park_foreground_turn_on_child(&store, chat.id, live_child).await;
+    let parked = park_foreground_turn_on_child(&store, live_chat.id, live_child).await;
     assert_eq!(parked.status, TurnRunStatus::WaitingForAgentRun);
 
     let candidates = store

--- a/crates/openwave-core/src/db/tests/sandbox_spawn_checkpoint.rs
+++ b/crates/openwave-core/src/db/tests/sandbox_spawn_checkpoint.rs
@@ -441,7 +441,7 @@ async fn container_checkpoint_matches_standalone_container_admission_shape() {
             "research one container fact",
             standalone_lease,
             standalone_turn.steer_revision,
-            AgentRun::MAX_CONCURRENCY_LIMIT,
+            AgentRun::DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS,
             Utc::now(),
         )
         .await
@@ -803,7 +803,11 @@ async fn stale_lease_pending_steer_and_capacity_leave_no_checkpoint_fragments() 
             .unwrap(),
         Some(CheckpointSandboxSpawnOutcome::AtCapacity)
     ));
-    assert_eq!(store.list_agent_runs(cap_chat.id).await.unwrap().len(), 6);
+    // One foreground coordinator plus the admitted children at the shared cap.
+    assert_eq!(
+        store.list_agent_runs(cap_chat.id).await.unwrap().len(),
+        1 + AgentRun::DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS as usize
+    );
     assert!(store.list_tool_calls(cap_chat.id).await.unwrap().is_empty());
 }
 

--- a/crates/openwave-core/src/model/mod.rs
+++ b/crates/openwave-core/src/model/mod.rs
@@ -77,4 +77,19 @@ mod tests {
         assert!(TurnRunStatus::Completed.is_terminal());
         assert!(!TurnRunStatus::Running.is_terminal());
     }
+
+    #[test]
+    fn spawn_unsettled_cap_matches_wait_for_agents_membership() {
+        // Spawn admission, settings, and wait_for_agents share one ceiling so a
+        // turn cannot hold more unsettled children than one wait can consume.
+        assert_eq!(
+            AgentRun::MAX_ACTIVE_BACKGROUND_AGENTS as usize,
+            TurnAgentRunWaitSet::MAX_CHILDREN
+        );
+        assert_eq!(
+            AgentRun::DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS,
+            AgentRun::MAX_ACTIVE_BACKGROUND_AGENTS
+        );
+        assert_eq!(TurnAgentRunWaitSet::MAX_CHILDREN, 4);
+    }
 }

--- a/crates/openwave-core/src/model/runs.rs
+++ b/crates/openwave-core/src/model/runs.rs
@@ -223,8 +223,16 @@ impl AgentRun {
     pub const DEFAULT_MAX_DURATION: chrono::Duration = chrono::Duration::hours(1);
     /// Largest accepted scheduler concurrency bound.
     pub const MAX_CONCURRENCY_LIMIT: u32 = 1_024;
-    /// Default maximum concurrently active background agents in one chat.
-    pub const DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS: u32 = 5;
+    /// Ceiling for unsettled depth-one children on one origin turn.
+    ///
+    /// Matches [`super::turns::TurnAgentRunWaitSet::MAX_CHILDREN`] so every
+    /// child spawn admits can join one `wait_for_agents` call. The wait bound
+    /// is the durable result-envelope budget; spawn and settings share it so
+    /// admission cannot outrun a single ordered wait.
+    pub const MAX_ACTIVE_BACKGROUND_AGENTS: u32 =
+        super::turns::TurnAgentRunWaitSet::MAX_CHILDREN as u32;
+    /// Default maximum unsettled background agents on one origin turn.
+    pub const DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS: u32 = Self::MAX_ACTIVE_BACKGROUND_AGENTS;
     /// Maximum stable failure-category length.
     pub const MAX_ERROR_CODE_LEN: usize = 128;
     /// Maximum persisted diagnostic-detail length.

--- a/crates/openwave-core/src/model/turns.rs
+++ b/crates/openwave-core/src/model/turns.rs
@@ -275,9 +275,11 @@ pub struct AgentRunWaitSetCandidate {
 }
 
 impl TurnAgentRunWaitSet {
-    /// Keep one ordered wait within the durable result-envelope budget. This
-    /// bound is independent of the configurable admission cap; larger caps are
-    /// consumed in groups as children settle.
+    /// Keep one ordered wait within the durable result-envelope budget.
+    ///
+    /// Spawn admission and `max_active_background_agents` share this ceiling
+    /// ([`super::runs::AgentRun::MAX_ACTIVE_BACKGROUND_AGENTS`]) so a turn
+    /// cannot hold more unsettled children than one wait can consume.
     pub const MAX_CHILDREN: usize = 4;
 }
 

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -2386,7 +2386,9 @@ has_api_key: boolean,
  */
 chat_defaults: StickyChatDefaults, 
 /**
- * Maximum nonterminal spawned agents allowed in one chat.
+ * Preferred maximum concurrent background agents. Spawn unsettled
+ * children on one origin turn are further capped at
+ * [`AgentRun::MAX_ACTIVE_BACKGROUND_AGENTS`] (wait_for_agents membership).
  */
 max_active_background_agents: number, 
 /**

--- a/crates/openwave-server/src/routes/settings.rs
+++ b/crates/openwave-server/src/routes/settings.rs
@@ -110,7 +110,10 @@ pub struct Settings {
     /// exist yet can show what `POST /chats` will seed.
     #[serde(default)]
     pub chat_defaults: StickyChatDefaults,
-    /// Maximum nonterminal spawned agents allowed in one chat.
+    /// Maximum unsettled depth-one children one origin turn may hold at once.
+    ///
+    /// Bounded by [`AgentRun::MAX_ACTIVE_BACKGROUND_AGENTS`] so spawn admission
+    /// cannot outrun a single `wait_for_agents` call.
     pub max_active_background_agents: u32,
     /// Model steps a background agent takes before it must check in.
     ///
@@ -237,10 +240,10 @@ pub async fn put_settings(
         }
     }
     if let Some(limit) = body.max_active_background_agents {
-        if limit == 0 || limit > AgentRun::MAX_CONCURRENCY_LIMIT {
+        if limit == 0 || limit > AgentRun::MAX_ACTIVE_BACKGROUND_AGENTS {
             return Err(ServerError::bad_request(format!(
                 "max_active_background_agents must be in 1..={}",
-                AgentRun::MAX_CONCURRENCY_LIMIT
+                AgentRun::MAX_ACTIVE_BACKGROUND_AGENTS
             )));
         }
         state
@@ -365,11 +368,13 @@ pub(crate) async fn read_model_visibility_overrides(
 pub(crate) async fn read_max_active_background_agents(
     store: &dyn Store,
 ) -> openwave_core::Result<u32> {
+    // Stale values above the wait membership ceiling are ignored so a prior
+    // higher setting cannot reintroduce the spawn/wait mismatch.
     Ok(store
         .get_setting(MAX_ACTIVE_BACKGROUND_AGENTS_SETTING)
         .await?
         .and_then(|value| serde_json::from_value::<u32>(value).ok())
-        .filter(|limit| *limit > 0 && *limit <= AgentRun::MAX_CONCURRENCY_LIMIT)
+        .filter(|limit| *limit > 0 && *limit <= AgentRun::MAX_ACTIVE_BACKGROUND_AGENTS)
         .unwrap_or(AgentRun::DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS))
 }
 

--- a/crates/openwave-server/src/routes/settings.rs
+++ b/crates/openwave-server/src/routes/settings.rs
@@ -110,10 +110,9 @@ pub struct Settings {
     /// exist yet can show what `POST /chats` will seed.
     #[serde(default)]
     pub chat_defaults: StickyChatDefaults,
-    /// Maximum unsettled depth-one children one origin turn may hold at once.
-    ///
-    /// Bounded by [`AgentRun::MAX_ACTIVE_BACKGROUND_AGENTS`] so spawn admission
-    /// cannot outrun a single `wait_for_agents` call.
+    /// Preferred maximum concurrent background agents. Spawn unsettled
+    /// children on one origin turn are further capped at
+    /// [`AgentRun::MAX_ACTIVE_BACKGROUND_AGENTS`] (wait_for_agents membership).
     pub max_active_background_agents: u32,
     /// Model steps a background agent takes before it must check in.
     ///
@@ -240,10 +239,12 @@ pub async fn put_settings(
         }
     }
     if let Some(limit) = body.max_active_background_agents {
-        if limit == 0 || limit > AgentRun::MAX_ACTIVE_BACKGROUND_AGENTS {
+        // Stored value may exceed the per-turn unsettled wait ceiling; spawn
+        // admission clamps with AgentRun::MAX_ACTIVE_BACKGROUND_AGENTS.
+        if limit == 0 || limit > AgentRun::MAX_CONCURRENCY_LIMIT {
             return Err(ServerError::bad_request(format!(
                 "max_active_background_agents must be in 1..={}",
-                AgentRun::MAX_ACTIVE_BACKGROUND_AGENTS
+                AgentRun::MAX_CONCURRENCY_LIMIT
             )));
         }
         state
@@ -368,13 +369,11 @@ pub(crate) async fn read_model_visibility_overrides(
 pub(crate) async fn read_max_active_background_agents(
     store: &dyn Store,
 ) -> openwave_core::Result<u32> {
-    // Stale values above the wait membership ceiling are ignored so a prior
-    // higher setting cannot reintroduce the spawn/wait mismatch.
     Ok(store
         .get_setting(MAX_ACTIVE_BACKGROUND_AGENTS_SETTING)
         .await?
         .and_then(|value| serde_json::from_value::<u32>(value).ok())
-        .filter(|limit| *limit > 0 && *limit <= AgentRun::MAX_ACTIVE_BACKGROUND_AGENTS)
+        .filter(|limit| *limit > 0 && *limit <= AgentRun::MAX_CONCURRENCY_LIMIT)
         .unwrap_or(AgentRun::DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS))
 }
 

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -60,7 +60,10 @@ async fn settings_default_then_update_roundtrips() {
     assert_eq!(response.status(), StatusCode::OK);
     let settings: serde_json::Value = json_body(response).await;
     assert!(settings["model"].is_null());
-    assert_eq!(settings["max_active_background_agents"], 5);
+    assert_eq!(
+        settings["max_active_background_agents"],
+        openwave_core::AgentRun::DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS
+    );
     assert_eq!(settings["sandbox_agent_checkin_steps"], 100);
     assert_eq!(settings["sandbox_agent_error_checkin"], 5);
     assert_eq!(settings["compaction"]["threshold_fraction"], 0.75);
@@ -80,7 +83,7 @@ async fn settings_default_then_update_roundtrips() {
                 .body(Body::from(
                     serde_json::json!({
                         "model": "claude-x",
-                        "max_active_background_agents": 7,
+                        "max_active_background_agents": 3,
                         "sandbox_agent_checkin_steps": 250,
                         "sandbox_agent_error_checkin": 3,
                         "compaction": {
@@ -99,7 +102,7 @@ async fn settings_default_then_update_roundtrips() {
     assert_eq!(response.status(), StatusCode::OK);
     let settings: serde_json::Value = json_body(response).await;
     assert_eq!(settings["model"], "claude-x");
-    assert_eq!(settings["max_active_background_agents"], 7);
+    assert_eq!(settings["max_active_background_agents"], 3);
     assert_eq!(settings["sandbox_agent_checkin_steps"], 250);
     assert_eq!(settings["sandbox_agent_error_checkin"], 3);
     assert_eq!(settings["compaction"]["threshold_fraction"], 0.8);
@@ -120,11 +123,51 @@ async fn settings_default_then_update_roundtrips() {
         .unwrap();
     let settings: serde_json::Value = json_body(response).await;
     assert_eq!(settings["model"], "claude-x");
-    assert_eq!(settings["max_active_background_agents"], 7);
+    assert_eq!(settings["max_active_background_agents"], 3);
     assert_eq!(settings["sandbox_agent_checkin_steps"], 250);
     assert_eq!(settings["sandbox_agent_error_checkin"], 3);
     assert_eq!(settings["compaction"]["threshold_fraction"], 0.8);
     assert_eq!(settings["compaction"]["protect_recent_messages"], 8);
+}
+
+#[tokio::test]
+async fn settings_reject_active_background_agents_above_wait_cap() {
+    let (router, token, _store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let over_cap = openwave_core::AgentRun::MAX_ACTIVE_BACKGROUND_AGENTS + 1;
+
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/settings")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "max_active_background_agents": over_cap }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/settings")
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let settings: serde_json::Value = json_body(response).await;
+    assert_eq!(
+        settings["max_active_background_agents"],
+        openwave_core::AgentRun::DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS
+    );
 }
 
 async fn put_mcp_servers(

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -83,7 +83,7 @@ async fn settings_default_then_update_roundtrips() {
                 .body(Body::from(
                     serde_json::json!({
                         "model": "claude-x",
-                        "max_active_background_agents": 3,
+                        "max_active_background_agents": 7,
                         "sandbox_agent_checkin_steps": 250,
                         "sandbox_agent_error_checkin": 3,
                         "compaction": {
@@ -102,7 +102,7 @@ async fn settings_default_then_update_roundtrips() {
     assert_eq!(response.status(), StatusCode::OK);
     let settings: serde_json::Value = json_body(response).await;
     assert_eq!(settings["model"], "claude-x");
-    assert_eq!(settings["max_active_background_agents"], 3);
+    assert_eq!(settings["max_active_background_agents"], 7);
     assert_eq!(settings["sandbox_agent_checkin_steps"], 250);
     assert_eq!(settings["sandbox_agent_error_checkin"], 3);
     assert_eq!(settings["compaction"]["threshold_fraction"], 0.8);
@@ -123,7 +123,7 @@ async fn settings_default_then_update_roundtrips() {
         .unwrap();
     let settings: serde_json::Value = json_body(response).await;
     assert_eq!(settings["model"], "claude-x");
-    assert_eq!(settings["max_active_background_agents"], 3);
+    assert_eq!(settings["max_active_background_agents"], 7);
     assert_eq!(settings["sandbox_agent_checkin_steps"], 250);
     assert_eq!(settings["sandbox_agent_error_checkin"], 3);
     assert_eq!(settings["compaction"]["threshold_fraction"], 0.8);
@@ -131,10 +131,10 @@ async fn settings_default_then_update_roundtrips() {
 }
 
 #[tokio::test]
-async fn settings_reject_active_background_agents_above_wait_cap() {
+async fn settings_reject_active_background_agents_above_concurrency_limit() {
     let (router, token, _store, _dir) = test_app().await;
     let bearer = format!("Bearer {token}");
-    let over_cap = openwave_core::AgentRun::MAX_ACTIVE_BACKGROUND_AGENTS + 1;
+    let over_cap = openwave_core::AgentRun::MAX_CONCURRENCY_LIMIT + 1;
 
     let response = router
         .clone()

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -1736,10 +1736,12 @@ impl TurnWorker {
                                 break;
                             }
                             Ok(Some(CheckpointSandboxSpawnOutcome::AtCapacity)) => {
+                                let cap = checkpoint
+                                    .max_active_background_agents
+                                    .min(openwave_core::AgentRun::MAX_ACTIVE_BACKGROUND_AGENTS);
                                 continuation_instruction = Some(
                                     format!(
-                                        "The per-chat background-agent cap is {} active agents. This spawn was not run. Call wait_for_agents with previously returned agent IDs, then try again after one finishes.",
-                                        checkpoint.max_active_background_agents
+                                        "The per-turn unsettled background-agent cap is {cap} agents. This spawn was not run. Call wait_for_agents with previously returned agent IDs, then try again after one finishes."
                                     ),
                                 );
                                 pending_sandbox_spawns.clear();

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -10,8 +10,12 @@ The initial design is deliberately bounded:
 - the foreground agent may start background agents;
 - every background agent runs in a sandbox;
 - background agents cannot start more agents (`depth <= 1`);
-- at most four children from one foreground turn may remain unsettled;
-- configurable global and per-chat limits bound actively running agents.
+- at most four children from one foreground turn may remain unsettled
+  (`wait_for_agents` membership, spawn admission, and
+  `max_active_background_agents` share that ceiling so a turn cannot hold more
+  unsettled children than one wait can consume);
+- configurable global and per-chat scheduler limits bound agents that are
+  actually running.
 
 This is enough for useful parallel research and production work without needing
 a recursive fleet scheduler.
@@ -96,12 +100,13 @@ it only makes the argument-free desktop read described below eligible while
 the same attachment remains current.
 
 Each spawn call is made alone and returns one ID for the foreground agent to
-retain. Up to four children from the exact origin turn may be unsettled at once.
-"Unsettled" includes both live work and a terminal result that has not yet been
-consumed, so finishing quickly does not accidentally open an unbounded queue.
-A consumed result, or one explicitly retired by cancellation, releases its
-slot. Sandbox workers never receive either orchestration tool, and storage also
-enforces depth one.
+retain. Up to four children from the exact origin turn may be unsettled at once
+— the same bound `wait_for_agents` accepts and the default
+`max_active_background_agents` setting. "Unsettled" includes both live work and
+a terminal result that has not yet been consumed, so finishing quickly does not
+accidentally open an unbounded queue. A consumed result, or one explicitly
+retired by cancellation, releases its slot. Sandbox workers never receive either
+orchestration tool, and storage also enforces depth one.
 
 The paired `wait_for_agents` call accepts one to four unique child IDs in caller
 order and has only `All` completion semantics. The call is also made alone. Its
@@ -266,8 +271,9 @@ unbounded queue. The scheduler therefore applies configurable limits to:
 
 - background agents running across the installation;
 - running children per chat;
-- four unsettled children per foreground turn, including delivered results
-  that have not yet been consumed;
+- four unsettled children per foreground turn (spawn admission and
+  `wait_for_agents` share this ceiling), including delivered results that have
+  not yet been consumed;
 - wall-clock time, model steps, tool calls, and other resource budgets.
 
 When a running slot is unavailable, accepted work remains durably queued. A

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -214,12 +214,14 @@ completion, applies model usage once, and moves the foreground turn to
 child runs independently. The notification that wakes each worker is only a
 latency hint; the committed state is sufficient after a restart.
 
-One foreground turn may have at most four unsettled children. A child remains
-unsettled while it is still running or while its terminal delivery is waiting
-to be consumed. The model can launch independent tasks one at a time, retaining
-each returned ID, and then make one ordered `wait_for_agents` call. That call
-uses `All` semantics: it atomically records the pending tool call and exact
-ordered child set, applies progress once, and releases the foreground lease.
+One foreground turn may have at most four unsettled children — the same ceiling
+as `wait_for_agents` membership and the `max_active_background_agents` setting
+— so every admitted child can join one ordered wait. A child remains unsettled
+while it is still running or while its terminal delivery is waiting to be
+consumed. The model can launch independent tasks one at a time, retaining each
+returned ID, and then make one ordered `wait_for_agents` call. That call uses
+`All` semantics: it atomically records the pending tool call and exact ordered
+child set, applies progress once, and releases the foreground lease.
 After every child has a terminal delivery, recovery consumes all deliveries,
 completes the same tool call with results in request order, journals the exact
 completion event, and moves the turn to `resuming`.


### PR DESCRIPTION
## Summary

Closes #1966 (stress finding I012).

Spawn admission counted unsettled children against `max_active_background_agents` (default **5**), while `wait_for_agents` membership is hard-capped at **4** by `TurnAgentRunWaitSet::MAX_CHILDREN` (durable result-envelope budget: 4 × 120 KiB per child < 512 KiB tool result). Stress could spawn five agents, then fail one ordered wait of all five IDs.

### Chosen rule

**Hard-cap spawn unsettled at the wait membership limit (4).** Settings default and validation share that ceiling. Docs already described four unsettled children; code and settings now match.

- `AgentRun::MAX_ACTIVE_BACKGROUND_AGENTS` = `TurnAgentRunWaitSet::MAX_CHILDREN` (4)
- `DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS` = that same value
- Spawn admission and settings reject / clamp values above 4
- `wait_for_agents` schema and wait-set membership stay at 4 (unchanged)

### Rejected alternatives

1. **Raise wait max IDs to 5 (or settings default).** Would force revisiting the per-child 120 KiB projection budget and the 512 KiB durable tool-result ceiling. Larger waits are a separate product change, not the smallest correct fix for the mismatch.
2. **Make wait max = `max_active_background_agents` dynamically.** Wait membership is a compile-time / schema / DB-check bound (`maxItems`, position check, ready-scan SQL). A dynamic wait size would need schema generation, migration, and result-budget policy for every configured value up to the old 1024 concurrency ceiling — far larger than aligning the three places that already mean “unsettled per origin turn.”

## Test plan

- [x] `cargo test -p openwave-core --lib spawn_unsettled_cap_matches_wait_for_agents_membership --locked`
- [x] `cargo test -p openwave-core --lib sandbox_spawn_checkpoint --locked`
- [x] `cargo test -p openwave-core --lib wait_for_agents_ --locked`
- [x] `cargo test -p openwave-server --lib tests::configuration --locked` (includes reject-above-wait-cap)
- [ ] CI lanes on this PR