### PR TITLE
fix(cli): revoke orphan list-folders on JSON folder disconnect

### DIFF
--- a/crates/openwave-cli/src/folder.rs
+++ b/crates/openwave-cli/src/folder.rs
@@ -709,6 +709,13 @@ async fn disconnect(
         approval_shared = true;
     }
 
+    // `RevokeRoot` drops only root-scoped grants. `ListRoots` is subject-scoped
+    // and would otherwise survive as a dangling list-folders row; the next
+    // connect then mints a second one. Drop it once this subject holds no
+    // root-scoped reach left to list. Must run before any format-specific
+    // return — JSON used to early-return here and leave the orphan standing.
+    revoke_orphan_list_roots(data_dir, subject)?;
+
     if format == OutputFormat::Json {
         return emit_json(&serde_json::json!({
             "chat": chat_id,
@@ -727,11 +734,6 @@ async fn disconnect(
              see `openwave folder list`"
         );
     }
-    // `RevokeRoot` drops only root-scoped grants. `ListRoots` is subject-scoped
-    // and would otherwise survive as a dangling list-folders row; the next
-    // connect then mints a second one. Drop it once this subject holds no
-    // root-scoped reach left to list.
-    revoke_orphan_list_roots(data_dir, subject)?;
     Ok(())
 }
 

--- a/crates/openwave-cli/tests/folder.rs
+++ b/crates/openwave-cli/tests/folder.rs
@@ -313,9 +313,13 @@ fn an_operator_grant_is_one_record_both_shells_read_and_either_side_can_revoke()
     );
 }
 
-/// #1965: disconnect left the subject-scoped list-folders grant standing;
-/// reconnect then minted a second one. After a sole-holder disconnect+reconnect
-/// the chat must hold exactly one list-folders grant.
+/// #1965 / #1978: disconnect left the subject-scoped list-folders grant
+/// standing; reconnect then minted a second one. After a sole-holder
+/// disconnect+reconnect the chat must hold exactly one list-folders grant.
+///
+/// #1974 only covered the default text path. JSON disconnect returned before
+/// `revoke_orphan_list_roots`, so drivers using `--output-format json` still
+/// stacked grants — exercise that path explicitly.
 #[test]
 fn disconnect_then_reconnect_keeps_a_single_list_folders_grant() {
     let base = tempfile::tempdir_in(home()).unwrap();
@@ -327,7 +331,7 @@ fn disconnect_then_reconnect_keeps_a_single_list_folders_grant() {
     let chat = create_chat(&data_dir);
     connect_folder(&data_dir, &reports, &chat);
 
-    let (ok, _, stderr) = run(
+    let (ok, stdout, stderr) = run(
         &data_dir,
         &[
             "folder",
@@ -335,15 +339,28 @@ fn disconnect_then_reconnect_keeps_a_single_list_folders_grant() {
             reports.to_str().unwrap(),
             "--chat",
             &chat,
+            "--output-format",
+            "json",
         ],
     );
     assert!(ok, "disconnect failed: {stderr}");
+    let body: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("disconnect json body");
+    assert_eq!(body["chat"].as_str(), Some(chat.as_str()));
+    assert!(body["root_id"].as_str().is_some_and(|id| !id.is_empty()));
+    assert_eq!(body["approval_revoked"], true);
+    assert_eq!(body["approval_shared"], false);
+
     let after_disconnect = desktop_grant_statements(&data_dir);
     assert!(
         after_disconnect
             .iter()
             .all(|grant| grant.capability != Capability::ListRoots),
         "list-folders must not outlive the last root for the chat: {after_disconnect:?}"
+    );
+    assert!(
+        after_disconnect.is_empty(),
+        "sole-holder json disconnect must clear every grant: {after_disconnect:?}"
     );
 
     connect_folder(&data_dir, &reports, &chat);


### PR DESCRIPTION
## Summary

Follow-up to #1965 / #1974. That fix added `revoke_orphan_list_roots` on sole-holder disconnect, but only the **text** path reached it.

```rust
if format == OutputFormat::Json {
    return emit_json(...);  // early return
}
// text println ...
revoke_orphan_list_roots(...);  // JSON never got here
```

Drivers using `openwave folder disconnect ... --output-format json` left the subject-scoped `ListRoots` grant standing; reconnect then minted a second `list_roots`.

## Fix

- Call `revoke_orphan_list_roots` **before** any format-specific return so JSON and text both clean up.
- Extend `disconnect_then_reconnect_keeps_a_single_list_folders_grant` to disconnect with `--output-format json`, assert the JSON body fields, assert zero grants (including ListRoots) after disconnect, and a single ListRoots after reconnect.

## Test plan

- [x] `cargo fmt -p openwave-cli`
- [x] `cargo test -p openwave-cli --locked --test folder` (7 passed)

Closes #1978