### PR TITLE
feat(cli): add chat steer for headless drivers

### DIFF
--- a/crates/openwave-cli/src/main.rs
+++ b/crates/openwave-cli/src/main.rs
@@ -71,7 +71,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use openwave_core::{
-    AgentError, ChatId, Config, ListDir, Profile, ReadFile, Result, ToolCtx, ToolRegistry,
+    AgentError, ChatId, Config, ListDir, Profile, ReadFile, Result, ToolCtx, ToolRegistry, TurnId,
 };
 
 mod api;
@@ -122,6 +122,7 @@ usage: openwave serve
        openwave chat list
        openwave chat create
        openwave chat delete <chat>
+       openwave chat steer <chat> <turn> <text...>
        openwave agent-run list <chat>
        openwave agent-run show <chat> <run>
        openwave agent-run cancel <chat> <run>
@@ -473,6 +474,37 @@ fn parse_setup(family: &str, args: Vec<String>) -> (SetupCommand, OutputFormat) 
             let chat = parse_chat_id(&cursor.positional("a chat id"));
             SetupCommand::ChatDelete { chat }
         }
+        ("chat", "steer") => {
+            // `turn` is the durable turn identity from the chat event stream
+            // (not an agent-run id). Remaining positionals are the steer text;
+            // `--output-format` may appear anywhere after the turn id.
+            let chat = parse_chat_id(&cursor.positional("a chat id"));
+            let turn = parse_turn_id(&cursor.positional("a turn id"));
+            let mut content_parts = Vec::new();
+            let mut format = OutputFormat::Text;
+            while let Some(arg) = cursor.next() {
+                match arg.as_str() {
+                    "--output-format" => {
+                        format = parse_format(cursor.value("--output-format"));
+                    }
+                    other if other.starts_with("--") => {
+                        usage_error(&format!("unknown chat steer argument {other:?}"));
+                    }
+                    other => content_parts.push(other.to_owned()),
+                }
+            }
+            if content_parts.is_empty() {
+                usage_error("expected steer text after the turn id");
+            }
+            return (
+                SetupCommand::ChatSteer {
+                    chat,
+                    turn,
+                    content: content_parts.join(" "),
+                },
+                format,
+            );
+        }
         ("agent-run", "list") => {
             let chat = parse_chat_id(&cursor.positional("a chat id"));
             SetupCommand::AgentRunList { chat }
@@ -599,6 +631,10 @@ fn parse_format(value: String) -> OutputFormat {
 
 fn parse_chat_id(value: &str) -> ChatId {
     ChatId::from_str(value).unwrap_or_else(|_| usage_error("expected a chat UUID"))
+}
+
+fn parse_turn_id(value: &str) -> TurnId {
+    TurnId::from_str(value).unwrap_or_else(|_| usage_error("expected a turn UUID"))
 }
 
 fn parse_agent_run_id(value: &str) -> openwave_core::AgentRunId {

--- a/crates/openwave-cli/src/setup.rs
+++ b/crates/openwave-cli/src/setup.rs
@@ -1,5 +1,8 @@
 //! Scriptable setup: `openwave provider|model|settings|mcp-server|chat|agent-run`.
 //!
+//! `chat steer` posts more user text into an active turn (same route the TUI
+//! uses); `turn` is the durable turn identity from the chat event stream.
+//!
 //! Every command here is a thin client of a route the server already serves —
 //! the same ones the desktop settings pages call — so configuring OpenWave
 //! from a script and configuring it from the app converge on one
@@ -13,7 +16,7 @@
 
 use std::io::Read as _;
 
-use openwave_core::{AgentError, AgentRunId, ChatId, Result};
+use openwave_core::{AgentError, AgentRunId, ChatId, Result, TurnId};
 
 use crate::api::client::Client;
 use crate::api::wire::{McpServerInfo, McpServersInfo};
@@ -104,6 +107,15 @@ pub enum Command {
     ChatCreate,
     /// Delete a chat outright.
     ChatDelete { chat: ChatId },
+    /// Steer an active turn with more user text.
+    ///
+    /// `turn` is the durable turn identity from the chat's event stream (not
+    /// an agent-run id). A fresh steer id is minted per call.
+    ChatSteer {
+        chat: ChatId,
+        turn: TurnId,
+        content: String,
+    },
     /// Background (and foreground) agent runs for one chat.
     AgentRunList { chat: ChatId },
     /// One run's status plus its ordered activity timeline.
@@ -415,6 +427,25 @@ async fn execute(client: &Client, command: Command, format: OutputFormat) -> Res
                 return emit(&serde_json::json!({ "id": chat, "deleted": true }));
             }
             println!("openwave: deleted chat {chat}");
+        }
+        Command::ChatSteer {
+            chat,
+            turn,
+            content,
+        } => {
+            // Same client path the TUI uses: mint a steer id, interrupt the
+            // active turn with the new user text.
+            let steer_id = TurnId::new();
+            client.steer(chat, turn, steer_id, &content).await?;
+            if format == OutputFormat::Json {
+                return emit(&serde_json::json!({
+                    "chat": chat,
+                    "turn": turn,
+                    "steer_id": steer_id,
+                    "steered": true,
+                }));
+            }
+            println!("openwave: steered turn {turn}");
         }
         Command::AgentRunList { chat } => {
             let runs = client.list_agent_runs(chat).await?;


### PR DESCRIPTION
## Summary
- Adds `openwave chat steer <chat> <turn> <text…> [--output-format text|json]` to the setup CLI family.
- Uses existing `Client::steer` (same path as the TUI): posts `/chats/{chat}/steer` with a freshly minted `steer_id`, the durable `turn_id`, content, and `interrupt: true`.
- JSON output reports `{chat, turn, steer_id, steered: true}`; text prints a one-line confirmation.

## Notes
- `turn` is the durable turn identity from the chat event stream, **not** an agent-run id.
- `Client::steer` already takes `TurnId` for both `turn_id` and `steer_id` (no type change needed).

Closes #1984

## Test plan
- [x] `cargo check -p openwave-cli --locked`
- [ ] CI: rustfmt / clippy / desktop + workspace lanes as scoped
- [ ] Manual (optional): with an active turn under `--attach`, `openwave chat steer <chat> <turn> please stop` returns 202 and steers