### PR TITLE
fix(server): fence needs_input check-ins as unsettled children

### DIFF
--- a/crates/openwave-core/src/db/ops/agent_run/cancellation.rs
+++ b/crates/openwave-core/src/db/ops/agent_run/cancellation.rs
@@ -411,16 +411,17 @@ where
                             "needs_input sandbox child {child_id} is missing its check-in delivery"
                         ))
                     })?;
-                let result_claim =
-                    entities::agent_run_claim::Entity::find_by_id(inbox.result.lease_token)
-                        .one(conn)
-                        .await
-                        .map_err(store_err)?
-                        .ok_or_else(|| {
-                            AgentError::Store(format!(
-                                "needs_input sandbox child {child_id} check-in is missing claim provenance"
-                            ))
-                        })?;
+                let result_claim = entities::agent_run_claim::Entity::find_by_id(
+                    inbox.result.lease_token,
+                )
+                .one(conn)
+                .await
+                .map_err(store_err)?
+                .ok_or_else(|| {
+                    AgentError::Store(format!(
+                        "needs_input sandbox child {child_id} check-in is missing claim provenance"
+                    ))
+                })?;
                 if inbox.chat_id != ChatId(turn.chat_id)
                     || inbox.result.agent_run_id != child_id
                     || !matches!(inbox.result.payload, AgentRunResultPayload::CheckIn { .. })

--- a/crates/openwave-core/src/db/ops/agent_run/cancellation.rs
+++ b/crates/openwave-core/src/db/ops/agent_run/cancellation.rs
@@ -411,17 +411,16 @@ where
                             "needs_input sandbox child {child_id} is missing its check-in delivery"
                         ))
                     })?;
-                let result_claim = entities::agent_run_claim::Entity::find_by_id(
-                    inbox.result.lease_token,
-                )
-                .one(conn)
-                .await
-                .map_err(store_err)?
-                .ok_or_else(|| {
-                    AgentError::Store(format!(
-                        "needs_input sandbox child {child_id} check-in is missing claim provenance"
-                    ))
-                })?;
+                let result_claim =
+                    entities::agent_run_claim::Entity::find_by_id(inbox.result.lease_token)
+                        .one(conn)
+                        .await
+                        .map_err(store_err)?
+                        .ok_or_else(|| {
+                            AgentError::Store(format!(
+                                "needs_input sandbox child {child_id} check-in is missing claim provenance"
+                            ))
+                        })?;
                 if inbox.chat_id != ChatId(turn.chat_id)
                     || inbox.result.agent_run_id != child_id
                     || !matches!(inbox.result.payload, AgentRunResultPayload::CheckIn { .. })

--- a/crates/openwave-core/src/db/ops/agent_run/cancellation.rs
+++ b/crates/openwave-core/src/db/ops/agent_run/cancellation.rs
@@ -411,17 +411,16 @@ where
                             "needs_input sandbox child {child_id} is missing its check-in delivery"
                         ))
                     })?;
-                let result_claim = entities::agent_run_claim::Entity::find_by_id(
-                    inbox.result.lease_token,
-                )
-                .one(conn)
-                .await
-                .map_err(store_err)?
-                .ok_or_else(|| {
-                    AgentError::Store(format!(
-                        "needs_input sandbox child {child_id} check-in is missing claim provenance"
-                    ))
-                })?;
+                let check_in_lease = inbox.result.lease_token;
+                let result_claim = entities::agent_run_claim::Entity::find_by_id(check_in_lease)
+                    .one(conn)
+                    .await
+                    .map_err(store_err)?
+                    .ok_or_else(|| {
+                        AgentError::Store(format!(
+                            "needs_input sandbox child {child_id} check-in is missing claim provenance",
+                        ))
+                    })?;
                 if inbox.chat_id != ChatId(turn.chat_id)
                     || inbox.result.agent_run_id != child_id
                     || !matches!(inbox.result.payload, AgentRunResultPayload::CheckIn { .. })

--- a/crates/openwave-core/src/db/ops/agent_run/cancellation.rs
+++ b/crates/openwave-core/src/db/ops/agent_run/cancellation.rs
@@ -338,7 +338,13 @@ where
 }
 
 /// Validate every child admitted by one exact foreground turn and return the
-/// ones whose terminal delivery is not yet consumed or explicitly retired.
+/// ones the parent must still account for before completing.
+///
+/// Unsettled covers live work, a terminal delivery not yet consumed or
+/// retired, and a check-in pause in `needs_input` (decision 0005): the pause
+/// rides the same inbox machinery as a terminal result, so a pending or
+/// already-consumed check-in still fences completion until the child is
+/// resumed, cancelled, or otherwise leaves the origin turn.
 ///
 /// The caller holds the scheduler, chat, and turn locks in that order. Stable
 /// admission ordering makes the typed completion fence deterministic across
@@ -392,6 +398,48 @@ where
 
         let status = agent_run_status_from_db(&child.status)?;
         if !status.is_terminal() {
+            // Check-ins deliberately park a nonterminal child with an inbox
+            // delivery the parent's wait can consume. That is not corruption:
+            // validate the check-in receipt and keep the child unsettled so
+            // completion returns ChildrenOutstanding instead of spinning on a
+            // store error.
+            if status == AgentRunStatus::NeedsInput {
+                let inbox = load_agent_run_inbox_by_ids_on(conn, parent_id, child_id)
+                    .await?
+                    .ok_or_else(|| {
+                        AgentError::Store(format!(
+                            "needs_input sandbox child {child_id} is missing its check-in delivery"
+                        ))
+                    })?;
+                let result_claim =
+                    entities::agent_run_claim::Entity::find_by_id(inbox.result.lease_token)
+                        .one(conn)
+                        .await
+                        .map_err(store_err)?
+                        .ok_or_else(|| {
+                            AgentError::Store(format!(
+                                "needs_input sandbox child {child_id} check-in is missing claim provenance"
+                            ))
+                        })?;
+                if inbox.chat_id != ChatId(turn.chat_id)
+                    || inbox.result.agent_run_id != child_id
+                    || !matches!(
+                        inbox.result.payload,
+                        AgentRunResultPayload::CheckIn { .. }
+                    )
+                    || inbox.result.attempt_count != child.attempt_count
+                    || inbox.result.claim_count != child.claim_count
+                    || result_claim.agent_run_id != Some(child.id)
+                    || result_claim.attempt_count != Some(child.attempt_count)
+                    || result_claim.claim_count != Some(child.claim_count)
+                {
+                    return Err(AgentError::Store(format!(
+                        "needs_input sandbox child {child_id} has mismatched check-in provenance"
+                    )));
+                }
+                unsettled.push(child_id);
+                continue;
+            }
             if find_agent_run_inbox_on(conn, parent_id, child_id)
                 .await?
                 .is_some()

--- a/crates/openwave-core/src/db/ops/agent_run/cancellation.rs
+++ b/crates/openwave-core/src/db/ops/agent_run/cancellation.rs
@@ -411,22 +411,20 @@ where
                             "needs_input sandbox child {child_id} is missing its check-in delivery"
                         ))
                     })?;
-                let result_claim =
-                    entities::agent_run_claim::Entity::find_by_id(inbox.result.lease_token)
-                        .one(conn)
-                        .await
-                        .map_err(store_err)?
-                        .ok_or_else(|| {
-                            AgentError::Store(format!(
-                                "needs_input sandbox child {child_id} check-in is missing claim provenance"
-                            ))
-                        })?;
+                let result_claim = entities::agent_run_claim::Entity::find_by_id(
+                    inbox.result.lease_token,
+                )
+                .one(conn)
+                .await
+                .map_err(store_err)?
+                .ok_or_else(|| {
+                    AgentError::Store(format!(
+                        "needs_input sandbox child {child_id} check-in is missing claim provenance"
+                    ))
+                })?;
                 if inbox.chat_id != ChatId(turn.chat_id)
                     || inbox.result.agent_run_id != child_id
-                    || !matches!(
-                        inbox.result.payload,
-                        AgentRunResultPayload::CheckIn { .. }
-                    )
+                    || !matches!(inbox.result.payload, AgentRunResultPayload::CheckIn { .. })
                     || inbox.result.attempt_count != child.attempt_count
                     || inbox.result.claim_count != child.claim_count
                     || result_claim.agent_run_id != Some(child.id)

--- a/crates/openwave-core/src/db/tests/parent_terminal_guard.rs
+++ b/crates/openwave-core/src/db/tests/parent_terminal_guard.rs
@@ -191,12 +191,7 @@ async fn completion_fences_needs_input_checkin_without_store_error() {
         Some(SubmitAgentRunResultOutcome::Completed(_))
     ));
     assert_eq!(
-        store
-            .get_agent_run(child.id)
-            .await
-            .unwrap()
-            .unwrap()
-            .status,
+        store.get_agent_run(child.id).await.unwrap().unwrap().status,
         AgentRunStatus::NeedsInput
     );
     let inbox = store

--- a/crates/openwave-core/src/db/tests/parent_terminal_guard.rs
+++ b/crates/openwave-core/src/db/tests/parent_terminal_guard.rs
@@ -1,8 +1,8 @@
 use super::{sample_chat, temp_store};
 use crate::db::tests::agent_run::{admit_sandbox_call_for_test, live_turn_for_sandbox_test};
 use crate::{
-    AgentRunCancellationReason, AgentRunId, AgentRunInboxStatus, AgentRunStatus, CallId,
-    CompleteTurnRunOutcome, Message, MessageId, RecordTurnFailureOutcome,
+    AgentRunCancellationReason, AgentRunCheckInReason, AgentRunId, AgentRunInboxStatus,
+    AgentRunStatus, CallId, CompleteTurnRunOutcome, Message, MessageId, RecordTurnFailureOutcome,
     RequestAgentRunCancellationOutcome, Role, Store, SubmitAgentRunResultOutcome, TurnFailureRetry,
     TurnRunStatus, Usage,
 };
@@ -157,6 +157,95 @@ async fn completion_fences_children_in_stable_order_without_writing_output() {
             .await
             .unwrap(),
         Some(CompleteTurnRunOutcome::Completed(_))
+    ));
+}
+
+#[tokio::test]
+async fn completion_fences_needs_input_checkin_without_store_error() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (turn, lease) = live_turn_for_sandbox_test(&store, chat.id).await;
+    let child = admit_sandbox_call_for_test(&store, chat.id, CallId::new(), "check in").await;
+    let child_lease = uuid::Uuid::new_v4();
+    assert_eq!(
+        store
+            .claim_agent_run(child_lease, Duration::minutes(5), 1, 1)
+            .await
+            .unwrap()
+            .unwrap()
+            .id,
+        child.id
+    );
+    assert!(matches!(
+        store
+            .submit_agent_run_checkin(
+                child.id,
+                child_lease,
+                AgentRunCheckInReason::ConsecutiveToolErrors,
+                3,
+                "tool errors need direction",
+            )
+            .await
+            .unwrap(),
+        Some(SubmitAgentRunResultOutcome::Completed(_))
+    ));
+    assert_eq!(
+        store
+            .get_agent_run(child.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        AgentRunStatus::NeedsInput
+    );
+    let inbox = store
+        .list_agent_run_inbox(AgentRunId::foreground_for_chat(chat.id))
+        .await
+        .unwrap();
+    assert_eq!(inbox.len(), 1);
+    assert_eq!(inbox[0].child_run_id, child.id);
+    assert_eq!(inbox[0].status, AgentRunInboxStatus::Pending);
+    assert!(matches!(
+        inbox[0].result.payload,
+        crate::AgentRunResultPayload::CheckIn {
+            reason: AgentRunCheckInReason::ConsecutiveToolErrors,
+            ..
+        }
+    ));
+
+    let output = output_for(&turn, chat.id);
+    // The check-in delivery must fence completion as ChildrenOutstanding, not
+    // as a store error the turn worker would retry forever.
+    assert!(matches!(
+        store
+            .complete_turn_run(turn.id, lease, 0, Utc::now(), &output)
+            .await
+            .unwrap(),
+        Some(CompleteTurnRunOutcome::ChildrenOutstanding { child_run_ids, .. })
+            if child_run_ids == vec![child.id]
+    ));
+    assert_eq!(
+        store.get_turn_run(turn.id).await.unwrap().unwrap().status,
+        TurnRunStatus::Running
+    );
+    assert!(!store
+        .list_messages(chat.id)
+        .await
+        .unwrap()
+        .iter()
+        .any(|message| message.id == output.id));
+
+    // Consuming the check-in does not free the child: it is still paused, so
+    // the parent remains fenced until resume or cancellation settles it.
+    consume_child(&store, chat.id, child.id).await;
+    assert!(matches!(
+        store
+            .complete_turn_run(turn.id, lease, 0, Utc::now(), &output)
+            .await
+            .unwrap(),
+        Some(CompleteTurnRunOutcome::ChildrenOutstanding { child_run_ids, .. })
+            if child_run_ids == vec![child.id]
     ));
 }
 


### PR DESCRIPTION
## Summary
- Completion fencing treated a `needs_input` child with a check-in inbox delivery as store corruption (`nonterminal sandbox child … has a terminal inbox delivery`).
- That error is retryable in the turn worker, so parent completion spun while a Daytona (or any) background agent was paused after consecutive tool errors.
- Treat validated check-in deliveries as unsettled so `complete_turn_run` returns `ChildrenOutstanding` and the model is told to `wait_for_agents` once.

## Root cause
Decision 0005 deliberately parks check-ins as nonterminal `NeedsInput` while writing the same inbox/result rows as a terminal result. `unsettled_sandbox_children_for_origin_turn_on` assumed any inbox on a nonterminal child was impossible and failed closed. The worker then looped on that store error.

## Test plan
- [x] `cargo test -p openwave-core --locked parent_terminal_guard`
- [x] New regression: `completion_fences_needs_input_checkin_without_store_error` (pending and consumed check-in both fence without error)

Closes #1983