### PR TITLE
docs: decision record for computer use (screen capture and app control)

### DIFF
--- a/docs/decisions/0010-computer-use-screen-capture-and-app-control.md
+++ b/docs/decisions/0010-computer-use-screen-capture-and-app-control.md
@@ -1,0 +1,211 @@
+# 10. Computer use: screen capture and app control
+
+- Status: Proposed
+- Date: 2026-08-12
+- Owners: desktop / agent core
+- Related: [`docs/deferred.md`](../deferred.md) (browser surface), permission
+  modes and approval classes in `openwave-core/src/approval.rs`, host
+  capability grants in `openwave-host-broker/src/capability.rs`
+
+## Context
+
+OpenWave can read approved folders, run code in sandboxes, and call configured
+tools, but it cannot see the user's screen or operate the applications in
+front of them. That keeps a whole class of "help me with what I'm looking at"
+work out of reach: reading a window the user is describing, working in an app
+the agent cannot reach through files, or checking that something it produced
+actually renders.
+
+Facts that shape the design:
+
+- The desktop app already routes host-native tool calls through a durable
+  claim/heartbeat/resolve loop (`openwave-server/src/routes/client_execution.rs`
+  ↔ `openwave-desktop/src/client_execution/`), so a tool that must run where
+  the display is has an established execution path.
+- Tool outputs already carry images end to end: `ToolOutput::with_images`,
+  blob publication in `agent/dispatch.rs`, and model-facing
+  `ContentBlock::Image` emission gated on the model's `image_input` flag in
+  `agent/transcript.rs`. Screenshots need no new wire types.
+- The `openwave-host-broker` sidecar is the deny-by-default authority for host
+  capabilities (today: folder access). It is the natural home for screen and
+  app-control grants, keeping policy out of the webview and away from the
+  model-reachable surface.
+- macOS mediates both halves behind TCC: Screen Recording for capture,
+  Accessibility for reading UI trees and synthesizing input. TCC binds grants
+  to a binary's code signature and path, so the process holding these
+  permissions must live at a stable, signed location; moving or re-signing it
+  resets the user's grants.
+- Approval machinery exists and is calibrated elsewhere: `ApprovalClass`,
+  `ToolApprovalKind`, standing grants, per-chat permission modes
+  (Plan/Ask/Auto/Allow).
+
+The risk landscape is known. Screen contents are untrusted input (prompt
+injection via whatever is on screen). Input synthesis can trigger
+irreversible, externally visible actions — sending, buying, deleting. And
+over-prompting is its own failure mode: a permission system that interrupts
+for every action trains users to click through, which is worse than asking
+less and meaning it. OpenWave's standing posture is that safety for granted
+capabilities comes from visibility, interruption, and audit, not from a modal
+per action.
+
+## Decision
+
+Build computer use as a first-class, consent-gated capability.
+
+**Scope.** macOS only, desktop app only, foreground chat only. The tools are
+client-executed; sandboxed and background agents can never hold them — they
+run where there is no display. Enablement requires the master setting on, a
+macOS desktop client attached, and a selected model that accepts image input.
+When the model cannot accept images, capture tools refuse with a typed error
+rather than degrading silently.
+
+**Architecture.** Three layers with a strict trust gradient:
+
+1. A small signed Swift helper, bundled at a stable path and spawned per
+   operation over JSON stdio. It talks to ScreenCaptureKit (capture),
+   the Accessibility API (UI trees, element resolution), and CGEvent (input
+   synthesis). It is a dumb executor: no policy, no persistence, bounded
+   output, hard timeout.
+2. `openwave-host-broker` holds all policy: new capabilities `CaptureScreen`,
+   `ReadAppContent`, `ControlApp` scoped per app bundle id (plus a
+   whole-screen capture scope), the app blocklist, the consequential-action
+   classifier, and the append-only audit of every operation. Control intent is
+   recorded durably before input is synthesized; if the audit cannot be made
+   durable the action refuses. Granting `ControlApp` implies the two read
+   capabilities.
+3. The agent surface: named client-executed tools registered in
+   `openwave-core`, claimed and fulfilled by a desktop module that calls the
+   broker, with screenshots entering the transcript through the existing
+   image pipeline.
+
+**Tool surface.** Narrow, named tools rather than one generic controller:
+`computer_list_windows`, `computer_capture_screen`, `computer_read_app_content`,
+`computer_click`, `computer_type_text`, `computer_key_press`,
+`computer_scroll`, `computer_focus_window`, `computer_return_to_openwave`,
+`computer_wait`. Targeting is accessibility-first: elements are addressed by
+tree path plus a content fingerprint that detects drift between look and act,
+and screenshots carry numbered visual marks over interactive elements that
+resolve back to accessibility elements. Raw coordinates are a documented last
+resort for apps with no usable accessibility surface. Element resolution is
+re-checked at act time; a changed element refuses as stale rather than
+clicking whatever is now under the pointer.
+
+**Consent and approval — one surface, calibrated.** The layers a control
+action passes are:
+
+1. OS TCC grants (Screen Recording + Accessibility), requested together on
+   first use with a status checklist in settings.
+2. A per-app grant, asked once per app through the normal in-chat approval
+   card ("Allow OpenWave to control Mail — once / always for this chat /
+   always"). The card decision is written into the broker's grant store; the
+   broker enforces, the card is the only place the question is asked. Grants
+   are listed and revocable in settings. Whole-screen capture gets the same
+   treatment as one standing grant.
+3. An act-time confirmation only for consequential actions: before clicking,
+   the broker re-reads the target element and classifies it; labels that
+   commit an external effect (send, pay, buy, delete, submit, sign,
+   transfer, post) or credential fields force a single non-activating
+   confirmation, honored only if the label still matches at act time. The
+   classifier's word list is deliberately short — navigation-shaped words
+   (cancel, back, close, decline) do not trip it.
+
+Within a granted app, individual clicks, keystrokes, and scrolls do not
+generate approval cards — in any permission mode. Plan mode refuses control
+tools outright and allows reads. Reads (window list, capture, accessibility
+tree) never card once their grant exists. There is no LLM auto-approval judge
+in the loop for control actions.
+
+**Always-on safety, independent of consent state:** a persistent
+"OpenWave is controlling {app}" indicator with a Stop button that halts
+before the next broker round-trip and tells the agent not to retry; an
+auto-yield that aborts any control operation while a security surface
+(login window, authentication prompt) is frontmost, as a non-retryable
+error; and a hard app blocklist — OpenWave itself, terminals, System
+Settings, keychain and security agents — enforced in the broker and
+mirrored defensively in the helper.
+
+**App knowledge lives in plugins, not code.** No per-app drivers. App-specific
+guidance (how an app's UI is laid out, preferred flows, what to avoid) ships
+as instruction-only plugin skills the user can install and invoke. The
+starter set targets Notes and Preview (well-behaved accessibility trees,
+low-stakes content) with Mail as the proving ground for the consequential
+gate. Browsers are deliberately not in the starter set: the everyday browser
+remains the separate deferred surface described in `docs/deferred.md`, and
+computer use does not become a back door to it.
+
+**Deliberately excluded from this decision:** Windows and Linux support,
+scripted per-app automation (AppleScript-style typed intents), controlling
+the user's browser as a substitute for a real browser surface, screenshot
+content redaction, and any auto-approval of control actions.
+
+## Alternatives considered
+
+- **A single generic `computer` tool driven by screenshot coordinates** (the
+  shape some provider-native computer-use tools take). Rejected: coordinate
+  loops are slower (a capture per action), fragile under retina scaling and
+  window movement, and unauditable — a click at (412, 305) cannot be
+  classified or confirmed meaningfully. Accessibility-first targeting gives
+  every action a named target that policy can reason about.
+- **Per-app scripted drivers** (AppleScript/automation APIs per integration).
+  Rejected for v1: each driver is a bespoke, breakable contract, and the
+  accessibility channel already generalizes. Skills carry the per-app
+  knowledge instead. Revisit for apps where accessibility is truly unusable.
+- **Approval card per control action.** Rejected: it makes the capability
+  unusable for any multi-step task and trains click-through. The per-app
+  grant plus the consequential gate covers the same risk with two prompts
+  instead of dozens.
+- **An LLM judge auto-approving control actions in Auto mode.** Deferred: the
+  judge adds a second policy brain whose failure modes are hard to audit, and
+  the calibrated consent layers should make it unnecessary. Revisit if per-app
+  grants prove too coarse in practice.
+- **Routing consent through a separate desktop HUD instead of the in-chat
+  card.** Rejected as the primary surface: two grant systems asking the same
+  question on different surfaces is exactly the over-asking failure. The
+  broker still enforces; the chat card is the single asking surface. The only
+  HUD prompt is the act-time consequential confirmation, which must not steal
+  focus from the target app and so cannot live in the chat window.
+- **Do nothing / wait for the managed browser surface.** Rejected: most of the
+  value (seeing the screen, operating native apps) is orthogonal to the
+  browser plan and blocked on nothing.
+
+## Consequences
+
+- A new signed native binary enters the bundle with strict path/signature
+  stability requirements; CI and release tooling must build and sign it, and
+  its location becomes a compatibility contract with users' TCC grants.
+- The broker grows from a file-capability authority into the general host
+  capability authority. Its grant vocabulary becomes persisted state covered
+  by the pre-1.0 schema mutability rules.
+- The approval system gains a `ToolApprovalKind` for app control whose
+  standing-grant semantics differ from existing kinds (grantable per app, not
+  per tool); the grants UI must render it comprehensibly.
+- Prompt-injection exposure widens: screen contents flow into the transcript
+  as model input. The system prompt must state that screen content is data,
+  not instructions, and the consequential gate is the enforcement backstop.
+- Background agents are permanently second-class for this capability; any
+  future "agent works while you're away" story that wants screen control will
+  need its own decision.
+- Revisit this decision if: TCC attribution for a broker-spawned helper
+  proves unworkable on real hardware (the helper may need to become an app
+  extension or move process ownership); per-app grants prove too coarse or
+  too naggy in field use; a Windows port begins; or the managed browser
+  surface lands and browser-adjacent use of computer use needs re-drawing.
+
+## Validation
+
+- End-to-end: a real turn against a scratch app — capture, read tree, click a
+  named element, type, and read the journal to confirm audit entries precede
+  synthesis and the screenshot blob round-trips into a model image block.
+- The consequential classifier is pure and test-covered: commit-shaped labels
+  and credential fields trip it; navigation labels do not; an implementation
+  that classified nothing would fail these, and one that classified
+  everything fails the navigation cases.
+- Blocklist and auto-yield tests: control ops against blocked bundle ids and
+  while a simulated security surface is frontmost must refuse with
+  non-retryable errors — a plausible wrong implementation retries on these.
+- Stale-element test: mutate the target between look and act; the op must
+  refuse, not click.
+- Image-input gating: with a text-only model selected, capture tools refuse
+  with the typed error; nothing silently drops the image.
+- Grant-store test: a card decision at each scope produces exactly one broker
+  grant, revocation removes it, and no control op proceeds without one.

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -60,9 +60,17 @@ visible foreground control, durable history, cancellation, and a reset path.
 The initial contract must distinguish navigation from entering sensitive text,
 uploading files, downloading files, and submitting an external action. It must
 also keep page-authored content separate from model instructions and from host
-credentials and capabilities. General desktop control, personal-profile access
-by default, CAPTCHA evasion, and password-manager integration are not in this
-plan.
+credentials and capabilities. Personal-profile access by default, CAPTCHA
+evasion, and password-manager integration are not in this plan.
+
+Desktop computer use — screen capture and consent-gated control of native
+apps — is no longer parked; it is specified by
+[decision record 10](decisions/0010-computer-use-screen-capture-and-app-control.md)
+as its own capability with per-app grants. That record deliberately keeps the
+everyday browser out of its starter scope: operating the user's browser
+through the accessibility channel is not a substitute for the managed browser
+surface described here, which stays deferred until its contract above is
+real.
 
 ## More ways to organize and shape work
 


### PR DESCRIPTION
Adds decision record 10 specifying the computer-use capability: macOS screen
capture and consent-gated control of native apps, built on the existing
client-execution path, image pipeline, and host-broker capability store.

The record settles:

- Scope: macOS, desktop, foreground chats only; image-capable model required;
  background/sandboxed agents excluded.
- Architecture: signed Swift helper (dumb executor) → host-broker (all
  policy: per-app grants, blocklist, consequential-action gate, audit) →
  named client-executed tools with accessibility-first targeting.
- Consent calibration: one asking surface (the in-chat approval card writing
  broker grants), per-app standing grants, act-time confirmation only for
  actions that commit external effects, no per-keystroke approvals, no LLM
  auto-judge for control.
- Always-on safety independent of grants: control indicator with Stop,
  auto-yield on security surfaces, hard app blocklist.
- App knowledge ships as plugin skills (starter set: Notes, Preview, Mail),
  not per-app drivers; the everyday browser stays out of scope and the
  managed-browser surface stays deferred.

Also updates `docs/deferred.md` to cross-reference the record and re-draw the
browser-section boundary it previously implied.

Alternatives considered and revisit conditions are in the record. Merging
accepts the record; implementation lands as separate slices.