### PR TITLE
test(server): tolerate heartbeat suite contention

### DIFF
--- a/crates/openwave-server/src/sandbox_container_run/tests.rs
+++ b/crates/openwave-server/src/sandbox_container_run/tests.rs
@@ -1005,7 +1005,11 @@ async fn stops_proxying_inference_at_the_runs_spend_budget() {
 /// move forward before the model call is released.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn heartbeats_the_lease_so_a_long_run_is_not_reaped() {
-    tokio::time::timeout(Duration::from_secs(30), async {
+    // This test runs alongside hundreds of server tests, many with their own
+    // multi-thread runtimes and SQLite stores. Keep a hard bound for genuine
+    // transport hangs, but leave enough headroom for the loopback drive to be
+    // scheduled under full-suite CI contention.
+    tokio::time::timeout(Duration::from_secs(90), async {
         let (_dir, store, chat) = store().await;
         let run_id = admit_container_run(&store, chat.id, "takes a while").await;
 


### PR DESCRIPTION
## Summary

- raise the container lease heartbeat regression test outer timeout from 30 to 90 seconds
- retain a hard bound for genuine loopback transport hangs
- leave production heartbeat behavior and the test assertions unchanged

## Why

The August 12 main CI run failed only because `sandbox_container_run::tests::heartbeats_the_lease_so_a_long_run_is_not_reaped` exhausted its 30-second outer timeout while the 780-test server binary was under full-suite contention. The test produced no product or assertion failure before that deadline. Its focused path completes in under a second, while the suite-level bound needs enough scheduling headroom to avoid treating runner contention as a transport hang.

## Verification

- `cargo test -p openwave-server --lib --locked` (777 passed, 3 ignored)
- `cargo fmt --all -- --check`
- `git diff --check`