### PR TITLE
fix(desktop): show all background agents and quiet empty progress

### DIFF
--- a/crates/openwave-desktop/ui/src/AgentRunProgress.tsx
+++ b/crates/openwave-desktop/ui/src/AgentRunProgress.tsx
@@ -168,27 +168,30 @@ export function AgentRunProgressStream({
   className?: string;
 }) {
   if (state.entries.length === 0) {
-    // Nothing held: an empty stream is the ordinary case for a run that has
-    // not narrated anything yet, so it does not read as a failure.
+    // An empty stream is ordinary: many runs only leave tool activity, not
+    // free-form narration. Stay quiet so the activity timeline below is not
+    // undercut by a "no progress" line while work is clearly underway.
     if (state.loading && !state.loaded) {
       return (
-        <p className="text-xs text-muted-foreground" role="status">
+        <p
+          className={cn("text-xs text-muted-foreground", className)}
+          role="status"
+        >
           Loading progress…
         </p>
       );
     }
     if (state.error) {
       return (
-        <p className="text-xs text-muted-foreground" role="status">
+        <p
+          className={cn("text-xs text-muted-foreground", className)}
+          role="status"
+        >
           Progress is unavailable.
         </p>
       );
     }
-    return (
-      <p className="text-xs text-muted-foreground" role="status">
-        No progress reported yet.
-      </p>
-    );
+    return null;
   }
 
   return (

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
@@ -165,7 +165,7 @@ export function BackgroundAgentList({
           </button>
         </div>
       ) : (
-        <div className="max-h-48 overflow-y-auto" aria-live="polite">
+        <div aria-live="polite">
           {AGENT_RUN_STATUS_GROUPS.map((group) => {
             const groupRuns = matchedRuns.filter((run) => group.statuses.includes(run.status));
             if (groupRuns.length === 0) return null;
@@ -430,9 +430,7 @@ function BackgroundAgentRow({
             <AgentRunTaskPlanChecklist
               state={taskPlan}
               live={live}
-              // Shallow on purpose: this row already sits inside the list's
-              // own 12rem viewport, so a tall checklist here would nest a
-              // second scrollbar and push its siblings out of reach.
+              // Keep an expanded plan from crowding every sibling row.
               className="max-h-24"
             />
           )}


### PR DESCRIPTION
## Summary
- Remove the transcript background-agent list's `max-h-48` scroll clamp so concurrent agents lay out fully in the chat instead of being clipped behind an inner scrollbar.
- Stop rendering "No progress reported yet." in the subagent panel when the progress stream is empty; tool activity is a separate feed, so the empty progress line was misleading while work was underway.

## Test plan
- [ ] Spawn several background agents in one turn and confirm the transcript card shows every row without its own scrollbar.
- [ ] Open a running subagent panel that has tool activity but no free-form progress narration and confirm the empty progress line is gone.
- [ ] Open a subagent that has published progress lines and confirm the Progress section still renders them.
- [ ] Confirm loading and error states for progress still surface when relevant.