### PR TITLE
fix(providers): auto-enable on credential and allow OpenAI auth switch

### DIFF
--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
@@ -331,6 +331,89 @@ describe("ProvidersPanel", () => {
     expect(
       screen.queryByRole("button", { name: "Sign in with ChatGPT" }),
     ).not.toBeInTheDocument();
+    // API key path stays available so the reader can switch modes without
+    // signing out first.
+    expect(
+      screen.getByRole("button", { name: "Switch to API key" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Paste an API key to switch from ChatGPT"),
+    ).toBeInTheDocument();
+  });
+
+  it("lets an API-key install switch to ChatGPT sign-in", () => {
+    renderPanel(
+      <ProvidersPanel
+        providers={[
+          {
+            kind: "openai",
+            enabled: true,
+            has_credential: true,
+            auth_mode: "api_key",
+            models: [],
+          },
+        ]}
+        client={
+          {
+            getOpenaiChatgptStatus: vi
+              .fn()
+              .mockResolvedValue({ signed_in: false }),
+          } as unknown as ApiClient
+        }
+        onChanged={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("API key set")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Switch to ChatGPT sign-in" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save API key" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Clear" })).toBeInTheDocument();
+  });
+
+  it("saves an API key while signed in with ChatGPT to switch modes", async () => {
+    const putProvider = vi.fn().mockResolvedValue({
+      kind: "openai",
+      enabled: true,
+      has_credential: true,
+      auth_mode: "api_key",
+      models: [],
+    });
+    const client = {
+      putProvider,
+      getOpenaiChatgptStatus: vi.fn().mockResolvedValue({ signed_in: true }),
+    } as unknown as ApiClient;
+    const user = userEvent.setup();
+
+    renderPanel(
+      <ProvidersPanel
+        providers={[
+          {
+            kind: "openai",
+            enabled: true,
+            has_credential: true,
+            auth_mode: "chatgpt",
+            models: [],
+          },
+        ]}
+        client={client}
+        onChanged={vi.fn()}
+      />,
+    );
+
+    await user.type(
+      screen.getByPlaceholderText("Paste an API key to switch from ChatGPT"),
+      "sk-switch",
+    );
+    await user.click(screen.getByRole("button", { name: "Switch to API key" }));
+
+    await waitFor(() =>
+      expect(putProvider).toHaveBeenCalledWith("openai", {
+        enabled: true,
+        credential: { type: "api_key", key: "sk-switch" },
+      }),
+    );
   });
 
   it("offers no credential editing on a managed profile", () => {

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -952,35 +952,39 @@ function OpenAiCredentialSection({
     }
   }
 
-  if (signedInWithChatgpt) {
-    return (
-      <div className="flex flex-wrap gap-2">
-        <Button
-          type="button"
-          variant="destructive"
-          disabled={saving}
-          onClick={() => void signOutChatgpt()}
-        >
-          Sign out of ChatGPT
-        </Button>
-      </div>
-    );
-  }
-
+  // Both auth modes stay reachable at once: signing in with ChatGPT replaces
+  // an API key on the server, and saving a key signs ChatGPT out. Hiding one
+  // path behind the other made "switch mode" look impossible.
   return (
     <>
       <p className="text-xs text-muted-foreground">
         Use a ChatGPT subscription (Plus / Pro) or an OpenAI Platform API key.
+        Saving either one turns OpenAI on.
       </p>
-      <div className="flex flex-wrap gap-2">
-        <Button
-          type="button"
-          disabled={saving}
-          onClick={() => void signInWithChatgpt()}
-        >
-          Sign in with ChatGPT
-        </Button>
-      </div>
+      {signedInWithChatgpt ? (
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant="destructive"
+            disabled={saving}
+            onClick={() => void signOutChatgpt()}
+          >
+            Sign out of ChatGPT
+          </Button>
+        </div>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            disabled={saving}
+            onClick={() => void signInWithChatgpt()}
+          >
+            {info.auth_mode === "api_key"
+              ? "Switch to ChatGPT sign-in"
+              : "Sign in with ChatGPT"}
+          </Button>
+        </div>
+      )}
       {pendingUrl && (
         <p className="text-xs text-muted-foreground">
           Waiting for the browser to finish signing in.{" "}
@@ -1003,7 +1007,13 @@ function OpenAiCredentialSection({
       <Input
         ref={apiKeyRef}
         type="password"
-        placeholder="Or paste an API key"
+        placeholder={
+          signedInWithChatgpt
+            ? "Paste an API key to switch from ChatGPT"
+            : info.auth_mode === "api_key"
+              ? "Paste a new API key to replace"
+              : "Or paste an API key"
+        }
         value={apiKey}
         onChange={(e) => setApiKey(e.target.value)}
         autoComplete="off"
@@ -1011,12 +1021,12 @@ function OpenAiCredentialSection({
       <div className="flex flex-wrap gap-2">
         <Button
           type="button"
-          disabled={saving || (!info.has_credential && !apiKey.trim())}
+          disabled={saving || !apiKey.trim()}
           onClick={onSaveApiKey}
         >
-          Save configuration
+          {signedInWithChatgpt ? "Switch to API key" : "Save API key"}
         </Button>
-        {info.has_credential && (
+        {info.has_credential && info.auth_mode === "api_key" && (
           <Button
             type="button"
             variant="destructive"

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -1141,6 +1141,12 @@ pub async fn update_provider(
     }
     if let Some(credential) = update.credential {
         write_credential(secrets, kind, &credential).await?;
+        // Storing a credential is an intent to use the provider — same as
+        // ChatGPT sign-in completion and the Anthropic legacy key route.
+        // An explicit Enabled toggle still turns the provider off afterward
+        // without clearing the credential; only a bare enable/disable write
+        // leaves `enabled` alone.
+        config.enabled = true;
     }
 
     write_config(store, kind, &config).await?;

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -1288,7 +1288,9 @@ async fn writing_a_provider_credential_enables_the_provider() {
                 .uri("/providers/openai")
                 .header(header::AUTHORIZATION, &bearer)
                 .header(header::CONTENT_TYPE, "application/json")
-                .body(Body::from(serde_json::json!({"enabled": false}).to_string()))
+                .body(Body::from(
+                    serde_json::json!({"enabled": false}).to_string(),
+                ))
                 .unwrap(),
         )
         .await
@@ -1328,7 +1330,9 @@ async fn writing_a_provider_credential_enables_the_provider() {
                 .uri("/providers/openai")
                 .header(header::AUTHORIZATION, &bearer)
                 .header(header::CONTENT_TYPE, "application/json")
-                .body(Body::from(serde_json::json!({"enabled": false}).to_string()))
+                .body(Body::from(
+                    serde_json::json!({"enabled": false}).to_string(),
+                ))
                 .unwrap(),
         )
         .await

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -1270,6 +1270,75 @@ async fn providers_list_and_put_roundtrip() {
     assert_eq!(openai["has_credential"], false);
 }
 
+/// Storing a credential is enough to route: the provider turns on even when
+/// the write omits `enabled`, matching ChatGPT sign-in completion and the
+/// CLI's "set-key enables the provider" contract. An explicit later disable
+/// still leaves the credential in place.
+#[tokio::test]
+async fn writing_a_provider_credential_enables_the_provider() {
+    let (router, token, _store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+
+    // Start disabled with no credential.
+    let disable = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/providers/openai")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(serde_json::json!({"enabled": false}).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(disable.status(), StatusCode::OK);
+
+    let put = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/providers/openai")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "credential": {"type": "api_key", "key": "sk-auto-enable"}
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(put.status(), StatusCode::OK);
+    let info: serde_json::Value = json_body(put).await;
+    assert_eq!(info["enabled"], true);
+    assert_eq!(info["has_credential"], true);
+    assert_eq!(info["auth_mode"], "api_key");
+
+    // Disable without touching the credential — still credentialed, just off.
+    let off = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/providers/openai")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(serde_json::json!({"enabled": false}).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(off.status(), StatusCode::OK);
+    let off_info: serde_json::Value = json_body(off).await;
+    assert_eq!(off_info["enabled"], false);
+    assert_eq!(off_info["has_credential"], true);
+}
+
 #[tokio::test]
 async fn openai_compatible_requires_base_url_when_enabled() {
     let (router, token, _store, _dir) = test_app().await;


### PR DESCRIPTION
## Summary
- Writing any provider credential (API key) now forces `enabled = true`, matching ChatGPT OAuth completion and the CLI `provider set-key` contract. An explicit Enabled toggle can still turn the provider off without clearing the credential.
- The OpenAI Providers card keeps ChatGPT sign-in and API-key entry both reachable, so switching modes no longer requires a dead-end sign-out-only state.

This closes the footgun where OpenAI could stay disabled after credentials were present, while Default still labeled GPT-5.6 Sol and turns never started.

## Test plan
- [x] `cargo test -p openwave-server --lib writing_a_provider_credential_enables_the_provider --locked`
- [x] `pnpm test` in `crates/openwave-desktop/ui` (ProvidersPanel coverage + full suite)
- [ ] Desktop: disable OpenAI, paste an API key → provider comes on and models are available
- [ ] Desktop: ChatGPT signed in → paste API key → switches to API key auth and stays enabled
- [ ] Desktop: API key set → Switch to ChatGPT sign-in completes and replaces the key
- [ ] Desktop: Enabled off with credential still present still works as a deliberate pause