### PR TITLE
feat(desktop): show doc-type icons on output pills and file chips

### DIFF
--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -72,7 +72,7 @@ import { Button } from "@/components/ui/button";
 import { useConfirm } from "@/components/ConfirmDialog";
 import { WithTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import { documentIcon } from "@/documentIcon";
+import { DocumentIcon } from "@/components/document-table/DocumentIcon";
 import type { ImportedDocument } from "@/documents";
 import type { PluginInfo } from "./api";
 import { folderAccessLabel, folderReach } from "./FolderAccess";
@@ -1342,11 +1342,10 @@ function FileAttachmentChip({
   file: ImportedDocument;
   onRemove: () => void;
 }) {
-  const Icon = documentIcon(file.mediaType);
   return (
     <li className="relative flex min-w-0 max-w-full items-center gap-2 rounded-lg border border-border bg-muted/50 py-1.5 pl-2 pr-7 text-muted-foreground">
       <span className="inline-flex size-9 shrink-0 items-center justify-center rounded-md bg-background">
-        <Icon size={16} aria-hidden="true" />
+        <DocumentIcon mediaType={file.mediaType} className="size-4" aria-hidden="true" />
       </span>
       <span className="grid min-w-0 gap-px">
         <strong

--- a/crates/openwave-desktop/ui/src/PinnedOutputsStrip.tsx
+++ b/crates/openwave-desktop/ui/src/PinnedOutputsStrip.tsx
@@ -1,8 +1,8 @@
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { create } from "zustand";
 
+import { DocumentIcon } from "./components/document-table/DocumentIcon";
 import type { DeliverableSummary } from "./deliverables";
-import { documentIcon } from "./documentIcon";
 import { cn } from "@/lib/utils";
 
 /** Past this many the rest collapse into a count rather than wrapping on. */
@@ -165,7 +165,6 @@ function OutputChip({
   output: DeliverableSummary;
   onOpen: () => void;
 }) {
-  const Icon = documentIcon(output.mediaType);
   return (
     <button
       type="button"
@@ -176,7 +175,11 @@ function OutputChip({
       onClick={onOpen}
       aria-label={`Open output ${output.filename}`}
     >
-      <Icon className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+      <DocumentIcon
+        mediaType={output.mediaType}
+        className="size-3.5"
+        aria-hidden="true"
+      />
       <span className="min-w-0 truncate">{output.filename}</span>
     </button>
   );

--- a/crates/openwave-desktop/ui/src/ProjectFilesView.tsx
+++ b/crates/openwave-desktop/ui/src/ProjectFilesView.tsx
@@ -4,8 +4,8 @@ import { useEffect, useState } from "react";
 import type { ProjectDocument } from "./api";
 import { useApp } from "./AppContext";
 import { useProjectListStore } from "./ProjectListStore";
-import { documentIcon } from "./documentIcon";
 import { useConfirm } from "@/components/ConfirmDialog";
+import { DocumentIcon } from "@/components/document-table/DocumentIcon";
 import { Button } from "@/components/ui/button";
 import {
   Empty,
@@ -124,14 +124,17 @@ export function ProjectFilesView({ projectId }: { projectId: string }) {
       {documents !== null && documents.length > 0 && (
         <ul className="m-0 flex list-none flex-col gap-2 p-0" aria-label="Project files">
           {documents.map((document) => {
-            const Icon = documentIcon(document.media_type);
             const size = fileSize(document.source_byte_len);
             return (
               <li
                 key={document.document_id}
                 className="flex items-center gap-3 rounded-lg border border-border px-3 py-2"
               >
-                <Icon className="size-4 shrink-0 text-muted-foreground" />
+                <DocumentIcon
+                  mediaType={document.media_type}
+                  className="size-4"
+                  aria-hidden="true"
+                />
                 <span className="min-w-0 flex-1 truncate text-sm">
                   {document.title ?? "Untitled file"}
                 </span>

--- a/crates/openwave-desktop/ui/src/SubmittedOutputPills.tsx
+++ b/crates/openwave-desktop/ui/src/SubmittedOutputPills.tsx
@@ -1,6 +1,6 @@
-import { FileText } from "lucide-react";
-
 import type { AgentRun } from "./api";
+import { DocumentIcon } from "./components/document-table/DocumentIcon";
+import { mediaTypeForFileName } from "./mediaTypeForFileName";
 
 /** Beyond this many, the rest collapse into a count rather than wrapping on. */
 const MAX_VISIBLE_OUTPUTS = 6;
@@ -12,6 +12,10 @@ const MAX_VISIBLE_OUTPUTS = 6;
  * writes files under `output/`, the scan publishes them under their own
  * filenames, and `done` submits that set. So this is the whole result surface —
  * one pill per file, each opening the output it names.
+ *
+ * The wire snapshot carries only the filename, so the glyph is guessed from the
+ * extension — same path the import queue uses when the sniffed type is not in
+ * yet. Brand marks for PDF / Word / Excel / PowerPoint, family glyphs otherwise.
  */
 export function SubmittedOutputPills({
   outputs,
@@ -50,7 +54,11 @@ function SubmittedOutputPill({
 }) {
   const body = (
     <>
-      <FileText className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+      <DocumentIcon
+        mediaType={mediaTypeForFileName(filename)}
+        className="size-3.5"
+        aria-hidden="true"
+      />
       <span className="min-w-0 truncate">{filename}</span>
     </>
   );

--- a/crates/openwave-desktop/ui/src/TranscriptFileAttachments.tsx
+++ b/crates/openwave-desktop/ui/src/TranscriptFileAttachments.tsx
@@ -1,4 +1,4 @@
-import { documentIcon } from "./documentIcon";
+import { DocumentIcon } from "./components/document-table/DocumentIcon";
 import { useSourceNav } from "./panel/SourceNav";
 
 export type TranscriptFileAttachment = {
@@ -18,23 +18,20 @@ export function TranscriptFileAttachments({
       className="m-0 flex list-none flex-wrap gap-2 p-0"
       aria-label="Attached files"
     >
-      {files.map((file) => {
-        const Icon = documentIcon(file.mediaType);
-        return (
-          <li key={file.documentId}>
-            <button
-              type="button"
-              className="flex max-w-64 items-center gap-2 rounded-lg border border-border bg-background/70 px-3 py-2 text-left text-xs text-foreground hover:bg-accent"
-              onClick={() => navigation?.openDocument(file.documentId)}
-            >
-              <Icon className="size-4 shrink-0 text-muted-foreground" />
-              <span className="truncate" title={file.name}>
-                {file.name}
-              </span>
-            </button>
-          </li>
-        );
-      })}
+      {files.map((file) => (
+        <li key={file.documentId}>
+          <button
+            type="button"
+            className="flex max-w-64 items-center gap-2 rounded-lg border border-border bg-background/70 px-3 py-2 text-left text-xs text-foreground hover:bg-accent"
+            onClick={() => navigation?.openDocument(file.documentId)}
+          >
+            <DocumentIcon mediaType={file.mediaType} className="size-4" />
+            <span className="truncate" title={file.name}>
+              {file.name}
+            </span>
+          </button>
+        </li>
+      ))}
     </ul>
   );
 }


### PR DESCRIPTION
## Summary
- Route output pills and file chips through `DocumentIcon` so PDF, Word, Excel, and PowerPoint get brand marks and other types get the existing family glyphs.
- Surfaces updated: submitted-output pills, pinned outputs strip, composer attachment chips, transcript attachment chips, and the project files list.
- Submitted-output snapshots still carry only a filename, so those icons are guessed via `mediaTypeForFileName` (same path as the import queue).

## Test plan
- [x] `pnpm exec vitest run` on `BackgroundAgentList`, `PinnedOutputsStrip`, and `Composer` tests
- [ ] In the app, confirm a background agent that submits `.xlsx` / `.pdf` / `.md` shows distinct icons on the pills
- [ ] Confirm pinned outputs strip and composer attachment chips match for the same file types