### PR TITLE
fix(desktop): make context and usage easier to scan

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatUsageDialog.tsx
+++ b/crates/openwave-desktop/ui/src/ChatUsageDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { toast } from "sonner";
 
 import type { ApiClient, Chat } from "./api";
@@ -9,8 +9,9 @@ import {
   contextTokens,
   contextUsageLevel,
   contextUsagePercent,
+  formatTokenCount,
 } from "./ContextUsage";
-import type { ChatTerminalTurnSnapshot } from "./generated/wire";
+import type { ChatTerminalTurnSnapshot, RendererTurnUsage } from "./generated/wire";
 import { modelForSelection } from "./ModelSelection";
 import {
   Dialog,
@@ -19,7 +20,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Progress } from "@/components/ui/progress";
 import { cn } from "@/lib/utils";
 import { friendlyErrorMessage } from "@/lib/utils";
 
@@ -79,103 +79,398 @@ export function ChatUsageDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md gap-6">
-        <DialogHeader>
-          <DialogTitle>Context and usage</DialogTitle>
-          <DialogDescription>
-            Token counts for this conversation{model ? ` on ${model.display_name}` : ""}.
+      <DialogContent className="max-w-sm gap-5 p-5 sm:rounded-xl">
+        <DialogHeader className="gap-1 pr-6">
+          <DialogTitle className="text-base">Context and usage</DialogTitle>
+          <DialogDescription className="text-xs leading-relaxed">
+            {model
+              ? `Token counts on ${model.display_name}.`
+              : "Token counts for this conversation."}
           </DialogDescription>
         </DialogHeader>
-        <section className="space-y-2">
-          <h3 className="text-2xs font-semibold tracking-[0.08em] text-muted-foreground uppercase">
-            Context window
-          </h3>
-          {lastTurnUsage === null ? (
-            <p className="text-sm text-muted-foreground">
-              No turn has finished in this chat yet.
-            </p>
-          ) : percent === null || contextWindow === undefined ? (
-            <p className="text-sm text-muted-foreground">
-              {contextTokens(lastTurnUsage).toLocaleString()} tokens on the last
-              turn. This model does not publish a context window, so there is
-              nothing honest to meter it against.
-            </p>
-          ) : (
-            <>
-              <Progress
-                value={percent}
-                className={cn(
-                  contextUsageLevel(percent) === "critical" && "bg-destructive/20",
-                )}
-                aria-label="Share of the context window used"
-              />
-              <p className="text-sm tabular-nums">
-                {contextTokens(lastTurnUsage).toLocaleString()} of{" "}
-                {contextWindow.toLocaleString()} tokens ({percent}%)
-              </p>
-            </>
-          )}
-          {lastTurnUsage && (
-            <UsageRows
-              label="Last turn"
-              rows={[
-                ["Input", lastTurnUsage.input_tokens],
-                ["Output", lastTurnUsage.output_tokens],
-                ["Cache read", lastTurnUsage.cache_read_input_tokens],
-                ["Cache write", lastTurnUsage.cache_creation_input_tokens],
-              ]}
-            />
-          )}
-        </section>
-        <section className="space-y-2">
-          <h3 className="text-2xs font-semibold tracking-[0.08em] text-muted-foreground uppercase">
-            This chat
-          </h3>
-          {turns === null ? (
-            <p className="text-sm text-muted-foreground">Reading finished turns…</p>
-          ) : totals.turns === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              Nothing spent yet — no turn has finished.
-            </p>
-          ) : (
-            <UsageRows
-              label={`${totals.turns} ${totals.turns === 1 ? "turn" : "turns"}`}
-              rows={[
-                ["Input", totals.input_tokens],
-                ["Output", totals.output_tokens],
-                ["Cache read", totals.cache_read_input_tokens],
-                ["Cache write", totals.cache_creation_input_tokens],
-                [
-                  "Total",
-                  totals.input_tokens +
-                    totals.output_tokens +
-                    totals.cache_read_input_tokens +
-                    totals.cache_creation_input_tokens,
-                ],
-              ]}
-            />
-          )}
-        </section>
+
+        <ContextWindowPanel
+          lastTurnUsage={lastTurnUsage}
+          contextWindow={contextWindow}
+          percent={percent}
+        />
+
+        <ChatTotalsPanel turns={turns} totals={totals} />
       </DialogContent>
     </Dialog>
   );
 }
 
-function UsageRows({
-  label,
-  rows,
+function ContextWindowPanel({
+  lastTurnUsage,
+  contextWindow,
+  percent,
 }: {
-  label: string;
-  rows: readonly (readonly [string, number])[];
+  lastTurnUsage: RendererTurnUsage | null;
+  contextWindow: number | undefined;
+  percent: number | null;
+}) {
+  if (lastTurnUsage === null) {
+    return (
+      <section className="rounded-lg border bg-muted/30 px-3.5 py-4">
+        <SectionLabel>Last turn</SectionLabel>
+        <p className="mt-2 text-sm text-muted-foreground">
+          No turn has finished in this chat yet.
+        </p>
+      </section>
+    );
+  }
+
+  const used = contextTokens(lastTurnUsage);
+  const metered = percent !== null && contextWindow !== undefined;
+  const level = metered ? contextUsageLevel(percent) : "normal";
+
+  return (
+    <section className="overflow-hidden rounded-lg border">
+      <div
+        className={cn(
+          "px-3.5 pt-3.5 pb-3",
+          level === "critical" && "bg-destructive/10",
+          level === "warning" && "bg-warning-background/60",
+          level === "normal" && "bg-muted/25",
+        )}
+      >
+        <div className="flex items-start justify-between gap-3">
+          <SectionLabel>Last turn</SectionLabel>
+          {metered && level !== "normal" && (
+            <span
+              className={cn(
+                "rounded-full px-2 py-0.5 text-2xs font-semibold tracking-wide uppercase",
+                level === "critical" &&
+                  "bg-destructive/15 text-destructive",
+                level === "warning" &&
+                  "bg-warning-background text-warning-foreground",
+              )}
+            >
+              {level === "critical" ? "Near full" : "Getting full"}
+            </span>
+          )}
+        </div>
+
+        {metered ? (
+          <div className="mt-3 flex items-end gap-3">
+            <p
+              className={cn(
+                "font-mono text-4xl leading-none font-semibold tracking-tight tabular-nums",
+                level === "critical" && "text-destructive",
+                level === "warning" && "text-warning-foreground",
+              )}
+              aria-label={`${percent}% of context window used`}
+            >
+              {percent}
+              <span className="ml-0.5 text-xl font-medium opacity-55">%</span>
+            </p>
+            <div className="min-w-0 flex-1 pb-0.5">
+              <p className="truncate font-mono text-xs tabular-nums text-muted-foreground">
+                {used.toLocaleString()}
+                <span className="mx-1 opacity-40">/</span>
+                {contextWindow.toLocaleString()}
+              </p>
+              <p className="mt-0.5 text-2xs text-muted-foreground">
+                of {formatTokenCount(contextWindow)} context
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="mt-3">
+            <p className="font-mono text-4xl leading-none font-semibold tracking-tight tabular-nums">
+              {formatTokenCount(used)}
+            </p>
+            <p className="mt-1.5 text-xs text-muted-foreground">
+              {used.toLocaleString()} tokens · no published context window
+            </p>
+          </div>
+        )}
+
+        {metered && (
+          <WindowMeter percent={percent} level={level} className="mt-3.5" />
+        )}
+      </div>
+
+      <div className="border-t bg-background px-3.5 py-3">
+        <TokenComposition usage={lastTurnUsage} />
+      </div>
+    </section>
+  );
+}
+
+function ChatTotalsPanel({
+  turns,
+  totals,
+}: {
+  turns: ChatTerminalTurnSnapshot[] | null;
+  totals: ReturnType<typeof chatUsageTotals>;
 }) {
   return (
-    <dl className="grid grid-cols-[1fr_auto] gap-x-6 gap-y-1" aria-label={label}>
-      {rows.map(([name, tokens]) => (
-        <div key={name} className="col-span-2 grid grid-cols-subgrid">
-          <dt className="text-sm text-muted-foreground">{name}</dt>
-          <dd className="text-sm tabular-nums">{tokens.toLocaleString()}</dd>
-        </div>
-      ))}
-    </dl>
+    <section className="space-y-2.5">
+      <div className="flex items-baseline justify-between gap-2">
+        <SectionLabel>This chat</SectionLabel>
+        {turns !== null && totals.turns > 0 && (
+          <span className="text-2xs text-muted-foreground tabular-nums">
+            {totals.turns} {totals.turns === 1 ? "turn" : "turns"}
+          </span>
+        )}
+      </div>
+
+      {turns === null ? (
+        <p className="text-sm text-muted-foreground">Reading finished turns…</p>
+      ) : totals.turns === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          Nothing spent yet — no turn has finished.
+        </p>
+      ) : (
+        <UsageBreakdown
+          usage={totals}
+          totalLabel="Spent so far"
+          emphasizeTotal
+        />
+      )}
+    </section>
+  );
+}
+
+function SectionLabel({ children }: { children: ReactNode }) {
+  return (
+    <h3 className="text-2xs font-semibold tracking-[0.1em] text-muted-foreground uppercase">
+      {children}
+    </h3>
+  );
+}
+
+/**
+ * Filled track for share of the model's context window. Colour follows the
+ * same warning ladder as the header chip so the two surfaces agree.
+ */
+function WindowMeter({
+  percent,
+  level,
+  className,
+}: {
+  percent: number;
+  level: ReturnType<typeof contextUsageLevel>;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "h-1.5 w-full overflow-hidden rounded-full bg-foreground/10",
+        className,
+      )}
+      role="meter"
+      aria-valuenow={percent}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-label="Share of the context window used"
+    >
+      <div
+        className={cn(
+          "h-full rounded-full transition-[width] duration-300 ease-out",
+          level === "critical" && "bg-destructive",
+          level === "warning" && "bg-warning",
+          level === "normal" && "bg-foreground/75",
+        )}
+        style={{ width: `${percent}%` }}
+      />
+    </div>
+  );
+}
+
+type TokenKind = "input" | "output" | "cache_read" | "cache_write";
+
+const TOKEN_KINDS: readonly {
+  key: TokenKind;
+  label: string;
+  short: string;
+  barClass: string;
+  swatchClass: string;
+}[] = [
+  {
+    key: "input",
+    label: "Input",
+    short: "In",
+    barClass: "bg-foreground/80",
+    swatchClass: "bg-foreground/80",
+  },
+  {
+    key: "output",
+    label: "Output",
+    short: "Out",
+    barClass: "bg-info",
+    swatchClass: "bg-info",
+  },
+  {
+    key: "cache_read",
+    label: "Cache read",
+    short: "Cache",
+    barClass: "bg-success",
+    swatchClass: "bg-success",
+  },
+  {
+    key: "cache_write",
+    label: "Cache write",
+    short: "Write",
+    barClass: "bg-muted-foreground/55",
+    swatchClass: "bg-muted-foreground/55",
+  },
+];
+
+function tokensFor(usage: RendererTurnUsage, key: TokenKind): number {
+  switch (key) {
+    case "input":
+      return usage.input_tokens;
+    case "output":
+      return usage.output_tokens;
+    case "cache_read":
+      return usage.cache_read_input_tokens;
+    case "cache_write":
+      return usage.cache_creation_input_tokens;
+  }
+}
+
+/**
+ * Stacked bar of where the tokens went, plus a compact legend. The signature
+ * of this panel: one glance at the strip beats four equal-weight rows.
+ */
+function TokenComposition({ usage }: { usage: RendererTurnUsage }) {
+  const parts = TOKEN_KINDS.map((kind) => ({
+    ...kind,
+    tokens: tokensFor(usage, kind.key),
+  }));
+  const total = parts.reduce((sum, part) => sum + part.tokens, 0);
+  const active = parts.filter((part) => part.tokens > 0);
+
+  return (
+    <div className="space-y-2.5">
+      <div
+        className="flex h-2 w-full overflow-hidden rounded-full bg-muted"
+        role="img"
+        aria-label={
+          total === 0
+            ? "No tokens on this turn"
+            : active
+                .map(
+                  (part) =>
+                    `${part.label} ${part.tokens.toLocaleString()} tokens`,
+                )
+                .join(", ")
+        }
+      >
+        {total > 0 &&
+          active.map((part) => (
+            <span
+              key={part.key}
+              className={cn("h-full min-w-px", part.barClass)}
+              style={{ width: `${(part.tokens / total) * 100}%` }}
+            />
+          ))}
+      </div>
+
+      <ul className="grid grid-cols-2 gap-x-3 gap-y-1.5">
+        {parts.map((part) => {
+          const share = total > 0 ? Math.round((part.tokens / total) * 100) : 0;
+          const idle = part.tokens === 0;
+          return (
+            <li
+              key={part.key}
+              className={cn(
+                "flex min-w-0 items-baseline gap-1.5",
+                idle && "opacity-40",
+              )}
+            >
+              <span
+                aria-hidden="true"
+                className={cn(
+                  "mt-1 size-1.5 shrink-0 rounded-full",
+                  part.swatchClass,
+                )}
+              />
+              <span className="truncate text-2xs text-muted-foreground">
+                {part.short}
+              </span>
+              <span className="ml-auto font-mono text-xs tabular-nums tracking-tight">
+                {formatTokenCount(part.tokens)}
+              </span>
+              {!idle && total > 0 && (
+                <span className="w-7 text-right font-mono text-2xs tabular-nums text-muted-foreground">
+                  {share}%
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+function UsageBreakdown({
+  usage,
+  totalLabel,
+  emphasizeTotal = false,
+}: {
+  usage: RendererTurnUsage;
+  totalLabel: string;
+  emphasizeTotal?: boolean;
+}) {
+  const parts = TOKEN_KINDS.map((kind) => ({
+    ...kind,
+    tokens: tokensFor(usage, kind.key),
+  }));
+  const total = parts.reduce((sum, part) => sum + part.tokens, 0);
+  const max = Math.max(...parts.map((part) => part.tokens), 1);
+
+  return (
+    <div className="overflow-hidden rounded-lg border">
+      <dl className="divide-y divide-border/70">
+        {parts.map((part) => {
+          const idle = part.tokens === 0;
+          const width = idle ? 0 : Math.max(4, (part.tokens / max) * 100);
+          return (
+            <div
+              key={part.key}
+              className={cn(
+                "grid grid-cols-[auto_1fr_auto] items-center gap-2.5 px-3 py-2",
+                idle && "opacity-45",
+              )}
+            >
+              <dt className="flex w-24 items-center gap-2 text-sm text-muted-foreground">
+                <span
+                  aria-hidden="true"
+                  className={cn("size-1.5 shrink-0 rounded-full", part.swatchClass)}
+                />
+                {part.label}
+              </dt>
+              <dd className="min-w-0">
+                <div className="h-1 overflow-hidden rounded-full bg-muted">
+                  <div
+                    className={cn("h-full rounded-full", part.barClass)}
+                    style={{ width: `${width}%` }}
+                  />
+                </div>
+              </dd>
+              <dd className="w-16 text-right font-mono text-sm tabular-nums tracking-tight">
+                {part.tokens.toLocaleString()}
+              </dd>
+            </div>
+          );
+        })}
+      </dl>
+      <div
+        className={cn(
+          "flex items-baseline justify-between gap-3 border-t px-3 py-2.5",
+          emphasizeTotal ? "bg-muted/40" : "bg-muted/20",
+        )}
+      >
+        <span className="text-sm font-medium">{totalLabel}</span>
+        <span className="font-mono text-sm font-semibold tabular-nums tracking-tight">
+          {total.toLocaleString()}
+        </span>
+      </div>
+    </div>
   );
 }

--- a/crates/openwave-desktop/ui/src/ContextUsageIndicator.tsx
+++ b/crates/openwave-desktop/ui/src/ContextUsageIndicator.tsx
@@ -37,29 +37,58 @@ export function ContextUsageIndicator({
 
   const used = contextTokens(usage);
   const level = contextUsageLevel(percent);
-  const cached =
-    usage.cache_read_input_tokens + usage.cache_creation_input_tokens > 0;
+  const parts = [
+    { label: "In", tokens: usage.input_tokens },
+    { label: "Out", tokens: usage.output_tokens },
+    { label: "Cache read", tokens: usage.cache_read_input_tokens },
+    { label: "Cache write", tokens: usage.cache_creation_input_tokens },
+  ].filter((part) => part.tokens > 0);
 
   return (
     <WithTooltip
+      contentClassName="max-w-none px-3.5 py-3"
       label={
-        <div className="space-y-0.5 text-xs">
-          {modelName && <div className="font-medium">{modelName}</div>}
-          <div>
-            {used.toLocaleString()} of {contextWindow.toLocaleString()} tokens (
-            {percent}%)
+        <div className="w-52 space-y-2.5 text-left font-normal">
+          {modelName && (
+            <div className="truncate text-xs font-medium leading-tight">
+              {modelName}
+            </div>
+          )}
+          <div className="flex items-end justify-between gap-3">
+            <div className="font-mono text-2xl leading-none font-semibold tabular-nums tracking-tight">
+              {percent}
+              <span className="ml-0.5 text-sm font-medium opacity-60">%</span>
+            </div>
+            <div className="pb-0.5 text-right font-mono text-[11px] leading-snug tabular-nums opacity-80">
+              <div>
+                {formatTokenCount(used)}
+                <span className="mx-0.5 opacity-50">/</span>
+                {formatTokenCount(contextWindow)}
+              </div>
+              <div className="text-[10px] font-sans opacity-70">context used</div>
+            </div>
           </div>
-          <div className="text-muted-foreground">
-            {usage.input_tokens.toLocaleString()} in ·{" "}
-            {usage.output_tokens.toLocaleString()} out
-            {cached && (
-              <>
-                {" "}
-                · {usage.cache_read_input_tokens.toLocaleString()} cache read ·{" "}
-                {usage.cache_creation_input_tokens.toLocaleString()} cache write
-              </>
-            )}
+          <div
+            className="h-1 w-full overflow-hidden rounded-full bg-primary-foreground/20"
+            aria-hidden="true"
+          >
+            <div
+              className="h-full rounded-full bg-primary-foreground/90"
+              style={{ width: `${percent}%` }}
+            />
           </div>
+          {parts.length > 0 && (
+            <dl className="grid grid-cols-[1fr_auto] gap-x-4 gap-y-0.5 border-t border-primary-foreground/15 pt-2 text-[11px] leading-relaxed">
+              {parts.map((part) => (
+                <div key={part.label} className="col-span-2 grid grid-cols-subgrid">
+                  <dt className="opacity-70">{part.label}</dt>
+                  <dd className="font-mono tabular-nums">
+                    {part.tokens.toLocaleString()}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          )}
         </div>
       }
     >

--- a/crates/openwave-desktop/ui/src/components/ui/tooltip.tsx
+++ b/crates/openwave-desktop/ui/src/components/ui/tooltip.tsx
@@ -37,18 +37,21 @@ export function WithTooltip({
   label,
   side = "top",
   align = "center",
+  contentClassName,
   children,
 }: {
   label: React.ReactNode;
   side?: "top" | "right" | "bottom" | "left";
   align?: "start" | "center" | "end";
+  /** Extra classes on the floating content — use for wider structured tips. */
+  contentClassName?: string;
   children: React.ReactNode;
 }) {
   return (
     <TooltipProvider delayDuration={300} skipDelayDuration={150}>
       <Tooltip>
         <TooltipTrigger asChild>{children}</TooltipTrigger>
-        <TooltipContent side={side} align={align}>
+        <TooltipContent side={side} align={align} className={contentClassName}>
           {label}
         </TooltipContent>
       </Tooltip>


### PR DESCRIPTION
## Summary
- Redesign the Context and usage dialog around a hero reading (percent or token count), a composition strip for last-turn mix, and proportional bars for chat totals.
- Shorten the unmetered-window case to a large count plus one line instead of a prose wall.
- Restructure the header context-chip tooltip to the same hierarchy; allow wider structured tooltip content.

## Test plan
- [x] `pnpm test` in `crates/openwave-desktop/ui` (full suite)
- [x] `tsc --noEmit` clean
- [ ] Open `/usage` after a finished turn with a metered model — confirm % hero, meter, composition strip, and chat totals
- [ ] Open `/usage` on a model without a published window — confirm compact hero and short caption
- [ ] Hover the header context chip — confirm structured tooltip
- [ ] Spot-check warning (≥75%) and critical (≥90%) tinting on the last-turn panel