### PR TITLE
fix(gateway): serve OpenAI-protocol models through the gateway's Responses surface

### DIFF
--- a/crates/openwave-router/src/openai.rs
+++ b/crates/openwave-router/src/openai.rs
@@ -100,6 +100,7 @@ pub struct OpenAiProvider {
     /// `originator` header value when [`Self::chatgpt_account_id`] is set.
     chatgpt_originator: String,
     profile: ResponsesProfile,
+    conversation_attribution: bool,
 }
 
 impl OpenAiProvider {
@@ -113,6 +114,7 @@ impl OpenAiProvider {
             chatgpt_account_id: None,
             chatgpt_originator: DEFAULT_CHATGPT_ORIGINATOR.to_string(),
             profile: ResponsesProfile::OpenAi,
+            conversation_attribution: false,
         }
     }
 
@@ -130,6 +132,7 @@ impl OpenAiProvider {
             chatgpt_account_id: None,
             chatgpt_originator: DEFAULT_CHATGPT_ORIGINATOR.to_string(),
             profile,
+            conversation_attribution: false,
         }
     }
 
@@ -167,6 +170,25 @@ impl OpenAiProvider {
         self.chatgpt_originator = originator.into();
         self
     }
+
+    /// Override the reported provider id and error-message label.
+    #[must_use]
+    pub fn with_provider_label(mut self, label: &'static str) -> Self {
+        self.provider_label = label;
+        self
+    }
+
+    /// Declare each request's conversation to the gateway this provider points
+    /// at, so its usage views can group inference the way the app does.
+    ///
+    /// Only for a model-gateway base URL. OpenAI's own API is not a party to
+    /// how the host organizes conversations, and the header would be sent to
+    /// whatever `base_url` names.
+    #[must_use]
+    pub fn with_conversation_attribution(mut self) -> Self {
+        self.conversation_attribution = true;
+        self
+    }
 }
 
 #[async_trait]
@@ -176,7 +198,12 @@ impl ModelProvider for OpenAiProvider {
     }
 
     async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
-        let mut body = build_request_json_for(&req, self.profile)?;
+        let mut body = build_request_json_for(&req, self.profile).map_err(|error| match error {
+            AgentError::Provider(message) => {
+                AgentError::Provider(format!("{} {message}", self.provider_label))
+            }
+            other => other,
+        })?;
         if self.chatgpt_account_id.is_some() {
             // The ChatGPT Codex backend rejects `max_output_tokens` outright
             // ("Unsupported parameter"); only Platform API requests may carry it.
@@ -204,6 +231,15 @@ impl ModelProvider for OpenAiProvider {
                 .header("ChatGPT-Account-ID", account_id)
                 .header("OpenAI-Beta", CHATGPT_BETA_HEADER)
                 .header("originator", &self.chatgpt_originator);
+        }
+        // A conversation is declared only where one is configured to be read.
+        // The id is a UUID, so it satisfies the gateway's bound on the value
+        // (1-256 ASCII graphic bytes) by construction.
+        if let (true, Some(conversation)) = (self.conversation_attribution, req.conversation) {
+            request = request.header(
+                crate::router::GATEWAY_CONVERSATION_HEADER,
+                conversation.to_string(),
+            );
         }
         let response = request
             .body(body)

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -111,13 +111,6 @@ impl OpenAiCompatProvider {
         self.conversation_attribution = true;
         self
     }
-
-    /// Ask the endpoint to include usage in its streaming response.
-    #[must_use]
-    pub(crate) fn with_streaming_usage(mut self) -> Self {
-        self.streaming_usage = true;
-        self
-    }
 }
 
 #[async_trait]
@@ -1717,16 +1710,24 @@ mod tests {
 
     #[tokio::test]
     async fn compatible_route_in_band_errors_keep_the_public_provider_id() {
-        use axum::http::{header, StatusCode};
+        use axum::http::StatusCode;
         use axum::response::IntoResponse;
         use axum::routing::post;
         use axum::Router;
 
-        async fn error_stream() -> impl IntoResponse {
+        async fn error_stream(uri: axum::http::Uri) -> impl IntoResponse {
+            // The gateway's OpenAI route speaks Responses; its in-band
+            // terminal failure is `response.failed`. Chat-Completions routes
+            // carry the bare `error` frame.
+            let body = if uri.path().ends_with("/responses") {
+                "data: {\"type\":\"response.failed\",\"response\":{\"error\":{\"message\":\"upstream is overloaded\",\"type\":\"server_error\",\"code\":\"server_overloaded\"}}}\n\n"
+            } else {
+                "data: {\"error\":{\"message\":\"upstream is overloaded\",\"type\":\"server_error\",\"code\":\"server_overloaded\"}}\n\n"
+            };
             (
                 StatusCode::OK,
-                [(header::CONTENT_TYPE, "text/event-stream")],
-                "data: {\"error\":{\"message\":\"upstream is overloaded\",\"type\":\"server_error\",\"code\":\"server_overloaded\"}}\n\n",
+                [(axum::http::header::CONTENT_TYPE, "text/event-stream")],
+                body,
             )
         }
 
@@ -1766,7 +1767,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_gateway_request_uses_conversation_credentials_and_requests_streaming_usage() {
+    async fn a_gateway_request_uses_conversation_credentials_on_the_responses_surface() {
         use axum::body::Bytes;
         use axum::extract::State;
         use axum::http::{header, HeaderMap, StatusCode};
@@ -1798,7 +1799,8 @@ mod tests {
             (
                 StatusCode::OK,
                 [(header::CONTENT_TYPE, "text/event-stream")],
-                "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+                "data: {\"type\":\"response.completed\",\"response\":{}}\n\n\
+                 data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
             )
         }
 
@@ -1870,7 +1872,9 @@ mod tests {
         assert_eq!(source.0.lock().unwrap().as_slice(), &[Some(conversation)]);
         let requests = capture_state.0.lock().unwrap();
         assert_eq!(requests.len(), 2);
-        assert_eq!(requests[0].path, "/compat/openai/v1/chat/completions");
+        // The gateway's OpenAI surface is the Responses API; it serves no
+        // northbound Chat Completions route.
+        assert_eq!(requests[0].path, "/compat/openai/v1/responses");
         assert_eq!(
             requests[0].headers.get(header::AUTHORIZATION).unwrap(),
             "Bearer mg_at_rotating"
@@ -1882,10 +1886,9 @@ mod tests {
                 .unwrap(),
             conversation.to_string().as_str()
         );
-        assert_eq!(
-            requests[0].body["stream_options"],
-            json!({ "include_usage": true })
-        );
+        assert_eq!(requests[0].body["stream"], json!(true));
+        assert!(requests[0].body.get("stream_options").is_none());
+        assert_eq!(requests[1].path, "/compat/openai/v1/chat/completions");
         assert_eq!(
             requests[1].headers.get(header::AUTHORIZATION).unwrap(),
             "Bearer direct-key"

--- a/crates/openwave-router/src/router.rs
+++ b/crates/openwave-router/src/router.rs
@@ -79,10 +79,10 @@ pub enum RouteKind {
     /// A model-gateway deployment's Anthropic-compatible surface, authenticated
     /// with short-lived resource-scoped tokens instead of a static key.
     ModelGateway,
-    /// The same model-gateway deployment's OpenAI-compatible Chat Completions
-    /// surface. It shares the public `model_gateway` provider namespace with
-    /// [`ModelGateway`](Self::ModelGateway); the synced model protocol chooses
-    /// which concrete route serves a request.
+    /// The same model-gateway deployment's OpenAI Responses surface
+    /// (`/compat/openai/v1/responses`). It shares the public `model_gateway`
+    /// provider namespace with [`ModelGateway`](Self::ModelGateway); the
+    /// synced model protocol chooses which concrete route serves a request.
     ModelGatewayOpenai,
 }
 
@@ -332,25 +332,27 @@ fn build_adapter(route: &Route) -> Option<Arc<dyn ModelProvider>> {
         #[cfg(not(feature = "anthropic"))]
         RouteKind::ModelGateway => None,
 
-        #[cfg(feature = "openai-compat")]
+        #[cfg(feature = "openai")]
         RouteKind::ModelGatewayOpenai => {
             // Like the Anthropic gateway route, this surface is unusable
             // without a live token source: static credentials cannot follow
-            // the gateway's rotation or conversation attestation context.
+            // the gateway's rotation or conversation attestation context. The
+            // gateway's OpenAI surface is the Responses API — it serves no
+            // northbound Chat Completions route.
             let base = route.base_url.as_deref()?;
             if !(base.starts_with("https://") || base.starts_with("http://")) {
                 return None;
             }
             let source = route.token_source.clone()?;
             Some(Arc::new(
-                OpenAiCompatProvider::compatible(String::new(), base.to_string())
-                    .with_id(route.kind.provider_id())
+                OpenAiProvider::new(String::new())
+                    .with_base_url(base.to_string())
+                    .with_provider_label(route.kind.provider_id())
                     .with_token_source(source)
-                    .with_conversation_attribution()
-                    .with_streaming_usage(),
+                    .with_conversation_attribution(),
             ))
         }
-        #[cfg(not(feature = "openai-compat"))]
+        #[cfg(not(feature = "openai"))]
         RouteKind::ModelGatewayOpenai => None,
 
         #[cfg(feature = "openai")]

--- a/crates/openwave-server/src/connectors/gateway.rs
+++ b/crates/openwave-server/src/connectors/gateway.rs
@@ -153,7 +153,7 @@ pub struct GatewayModel {
     ///
     /// Older gateways exposed only Anthropic Messages and omitted the field,
     /// so absence preserves that route. Newer deployments report their exact
-    /// protocol (`anthropic_messages` or `openai_chat_completions`) so clients
+    /// protocol (`anthropic_messages` or `openai_responses`) so clients
     /// can select the matching compatibility surface.
     #[serde(default = "default_gateway_model_protocol")]
     pub protocol: String,
@@ -595,7 +595,7 @@ impl GatewayAuth {
 
     /// The models the authenticated user may invoke, optionally filtered to
     /// one inference protocol (`anthropic_messages` /
-    /// `openai_chat_completions`).
+    /// `openai_responses`).
     pub async fn models(
         &self,
         access_token: &str,

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -1444,7 +1444,7 @@ mod tests {
                 },
                 {
                     "id": "sample-coder",
-                    "protocol": "openai_chat_completions",
+                    "protocol": "openai_responses",
                     "name": "Sample Coder",
                     "context_window": null,
                     "max_output_tokens": null,
@@ -1634,7 +1634,7 @@ mod tests {
         );
         assert_eq!(
             snapshot.model_protocols.get("sample-coder"),
-            Some(&providers::GatewayModelProtocol::OpenaiChatCompletions)
+            Some(&providers::GatewayModelProtocol::OpenaiResponses)
         );
 
         // The synced snapshot resolves as a model policy under the gateway key.

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -73,8 +73,12 @@ pub(crate) enum GatewayModelProtocol {
     /// Anthropic Messages at `/compat/anthropic/v1/messages`.
     #[default]
     AnthropicMessages,
-    /// OpenAI Chat Completions at `/compat/openai/v1/chat/completions`.
-    OpenaiChatCompletions,
+    /// OpenAI Responses at `/compat/openai/v1/responses` — the only OpenAI
+    /// surface a gateway serves northbound. Snapshots written before the
+    /// route spoke Responses recorded `openai_chat_completions`; accept the
+    /// old spelling rather than dropping the model.
+    #[serde(alias = "openai_chat_completions")]
+    OpenaiResponses,
 }
 
 impl GatewayModelProtocol {
@@ -83,8 +87,8 @@ impl GatewayModelProtocol {
     pub(crate) fn parse(value: &str) -> Option<Self> {
         match value {
             "anthropic" | "anthropic_messages" => Some(Self::AnthropicMessages),
-            "openai" | "openai_compatible" | "openai_chat_completions" => {
-                Some(Self::OpenaiChatCompletions)
+            "openai" | "openai_compatible" | "openai_chat_completions" | "openai_responses" => {
+                Some(Self::OpenaiResponses)
             }
             _ => None,
         }
@@ -1408,7 +1412,7 @@ pub async fn collect_routes(
             for model in models {
                 match model_protocols.get(&model.id).copied().unwrap_or_default() {
                     GatewayModelProtocol::AnthropicMessages => anthropic_models.push(model.id),
-                    GatewayModelProtocol::OpenaiChatCompletions => openai_models.push(model.id),
+                    GatewayModelProtocol::OpenaiResponses => openai_models.push(model.id),
                 }
             }
             let base = base.trim_end_matches('/');
@@ -1934,6 +1938,40 @@ mod tests {
                 .unwrap_or_default(),
             GatewayModelProtocol::AnthropicMessages
         );
+    }
+
+    #[test]
+    fn a_chat_completions_era_snapshot_still_routes_its_openai_models() {
+        // Snapshots written while the gateway's OpenAI route spoke Chat
+        // Completions recorded `openai_chat_completions`; the route now speaks
+        // Responses, the only OpenAI surface a gateway serves.
+        let snapshot: GatewayModelSnapshot = serde_json::from_value(serde_json::json!({
+            "gateway_url": "https://gateway.example/",
+            "models": [{
+                "id": "legacy-coder",
+                "context_window": 32768,
+                "max_output_tokens": 4096
+            }],
+            "model_protocols": {"legacy-coder": "openai_chat_completions"}
+        }))
+        .expect("the persisted chat-completions spelling still loads");
+
+        assert_eq!(
+            snapshot.model_protocols.get("legacy-coder"),
+            Some(&GatewayModelProtocol::OpenaiResponses)
+        );
+        for spelling in [
+            "openai",
+            "openai_compatible",
+            "openai_chat_completions",
+            "openai_responses",
+        ] {
+            assert_eq!(
+                GatewayModelProtocol::parse(spelling),
+                Some(GatewayModelProtocol::OpenaiResponses),
+                "{spelling}"
+            );
+        }
     }
 
     /// An unset display name is represented by the key being absent, in both

--- a/docs/gateway-boundary.md
+++ b/docs/gateway-boundary.md
@@ -127,7 +127,7 @@ The connector speaks a small, versioned HTTP surface on the gateway:
 - `/api/v1/cli/me` — the authenticated user, for the account hint.
 - `/api/v1/cli/models` — the models this user may invoke. OpenWave syncs the
   full list and retains each row's `protocol` (`anthropic_messages` or
-  `openai_chat_completions`) in a local snapshot stamped with the gateway URL
+  `openai_responses`) in a local snapshot stamped with the gateway URL
   after sign-in and on the explicit "Refresh models" affordance; gateways
   predating the field are treated as Anthropic-only. The snapshot is what the
   model picker offers, and sign-out empties it. A stamp that no longer matches
@@ -146,7 +146,8 @@ The connector speaks a small, versioned HTTP surface on the gateway:
   chat content and is meaningless outside the session it is pinned to.
 - Inference itself — invoked with `llm`-audience bearers through the matching
   gateway surface: Anthropic Messages at `/compat/anthropic/v1/messages`, or
-  OpenAI Chat Completions at `/compat/openai/v1/chat/completions`. Both use
+  OpenAI Responses at `/compat/openai/v1/responses` — the only two surfaces
+  a gateway serves northbound; it has no Chat Completions route. Both use
   the same provider machinery as their direct counterparts and fetch the
   rotating bearer per request. A turn also declares which conversation it
   belongs to, as an `x-model-gateway-conversation-id` header carrying the


### PR DESCRIPTION
## Summary

- The model gateway serves exactly two northbound inference surfaces: Anthropic Messages (`/compat/anthropic/v1/messages`) and OpenAI Responses (`/compat/openai/v1/responses`). OpenWave's per-protocol gateway routing sent synced OpenAI-protocol models to `/compat/openai/v1/chat/completions`, which no gateway serves — every turn on such a model (e.g. Fireworks-served deepseek-v4-flash-0731) failed with the transient "connection to the model provider broke" notice.
- `RouteKind::ModelGatewayOpenai` now builds the native Responses adapter (`OpenAiProvider`) pointed at `/compat/openai/v1`, keeping the rotating `llm` bearer, per-conversation token minting, and the `x-model-gateway-conversation-id` attribution header. `OpenAiProvider` gains the same `with_conversation_attribution` opt-in the Anthropic and compat adapters already had, plus a provider-label override so errors keep the public `model_gateway` attribution.
- The synced-protocol vocabulary accepts the gateway's canonical `openai_responses` (previously dropped as an unsupported protocol, which emptied the picker for OpenAI-only deployments) alongside every historical `openai*` spelling; snapshots written in the chat-completions era still load via a serde alias.

## Why

Field report: a paired desktop showed an empty picker until a manual sync, then failed every turn on an OpenAI-protocol model. Root cause chain: the client spoke a protocol the gateway never serves, and the protocol vocabulary drifted (`openai_chat_completions` vs `openai_responses`) so even a corrected client would have dropped those rows. One side had to converge; the gateway's Responses-only northbound surface is deliberate, so the client converges.

## Testing

- `cargo test -p openwave-router --locked` — 158 passed (incl. updated gateway captured-request test asserting `/compat/openai/v1/responses` + bearer + conversation header, and Responses-shaped in-band `response.failed` classification keeping the `model_gateway` label).
- `cargo test -p openwave-server --locked gateway_runtime` — 22 passed; `providers::` — 18 passed; `--test connectors_gateway_flow` — 12 passed.
- New: `a_chat_completions_era_snapshot_still_routes_its_openai_models` pins the serde alias and all four accepted protocol spellings.
- `cargo clippy -p openwave-router -p openwave-server --all-targets --locked -- -D warnings` clean; `cargo fmt --all --check` clean.

Not verified: driving the desktop app against a live gateway (needs a deployment serving the `protocol` field — see the model-gateway models-listing fix that adds it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)