### PR TITLE
feat(desktop): redesign the plugins library as a scannable shelf

### DIFF
--- a/crates/openwave-desktop/ui/src/plugins/PluginDetailView.tsx
+++ b/crates/openwave-desktop/ui/src/plugins/PluginDetailView.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { ChevronLeft, Sparkles } from "lucide-react";
+import { ChevronLeft } from "lucide-react";
 import type { ReactNode } from "react";
 
 import type { PluginSkillInfo } from "@/api";
@@ -7,8 +7,10 @@ import { PanelSecondaryHeader } from "@/components/PanelHeader";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
+import { PluginGlyph, SkillGlyph } from "./PluginGlyph";
 import type { PluginsApis } from "./pluginsApis";
-import { capabilityLabel, categoryIcon, categoryLabel } from "./pluginVocabulary";
+import { capabilityLabel, categoryLabel } from "./pluginVocabulary";
 import { SkillDialog } from "./SkillDialog";
 import type { PluginCatalogState } from "./usePluginCatalog";
 
@@ -39,7 +41,6 @@ export function PluginDetailView({
 }) {
   const { catalog, loading, error, setEnabled } = state;
   const plugin = catalog?.plugins.find((entry) => entry.name === pluginId) ?? null;
-  const Icon = plugin ? categoryIcon(plugin.category) : null;
   const [openSkill, setOpenSkill] = useState<PluginSkillInfo | null>(null);
   // The dialog re-reads its skill from the fresh catalog, so its switch moves
   // with the toggle round trip instead of freezing at the row that opened it.
@@ -76,16 +77,20 @@ export function PluginDetailView({
 
           {plugin && (
             <>
-              <section className="flex flex-col gap-3" aria-label="About">
-                {Icon && (
-                  <div className="grid size-14 place-items-center rounded-xl border bg-muted text-muted-foreground">
-                    <Icon className="size-7" aria-hidden="true" />
-                  </div>
-                )}
+              <section className="flex flex-col gap-4" aria-label="About">
+                <PluginGlyph
+                  pluginName={plugin.name}
+                  category={plugin.category}
+                  size="lg"
+                />
                 <div className="flex items-start justify-between gap-4">
-                  <div className="flex min-w-0 flex-col gap-1">
-                    <h1 className="text-xl font-semibold">{plugin.display_name}</h1>
-                    <p className="text-muted-foreground text-sm">{plugin.description}</p>
+                  <div className="flex min-w-0 flex-col gap-1.5">
+                    <h1 className="text-2xl font-semibold tracking-tight">
+                      {plugin.display_name}
+                    </h1>
+                    <p className="text-muted-foreground text-sm text-pretty">
+                      {plugin.description}
+                    </p>
                   </div>
                   <Switch
                     aria-label={`Enable ${plugin.display_name}`}
@@ -93,14 +98,15 @@ export function PluginDetailView({
                     onCheckedChange={(enabled) =>
                       setEnabled({ plugins: { [plugin.name]: enabled }, skills: {} })
                     }
+                    className="mt-1"
                   />
                 </div>
               </section>
 
               <section className="flex flex-col gap-1" aria-label="Skills">
                 <div className="flex items-baseline gap-2 border-b pb-2">
-                  <h2 className="text-base font-semibold">Skills</h2>
-                  <span className="text-muted-foreground text-sm">
+                  <h2 className="text-sm font-semibold">Skills</h2>
+                  <span className="text-muted-foreground text-xs tabular-nums">
                     {plugin.skills.length}
                   </span>
                 </div>
@@ -110,25 +116,27 @@ export function PluginDetailView({
                     available. Your choices are kept while it is off.
                   </p>
                 )}
-                <ul className="flex flex-col" aria-label="Member skills">
+                <ul className="flex flex-col pt-1" aria-label="Member skills">
                   {plugin.skills.map((skill) => (
                     <li
                       key={skill.name}
-                      className="hover:bg-muted/60 -mx-2 flex items-center gap-3 rounded-md px-2 py-2.5 transition-colors"
+                      className={cn(
+                        "hover:bg-muted/60 -mx-2 flex items-center gap-3 rounded-xl px-2 py-2.5 transition-colors",
+                        !plugin.enabled && "opacity-80",
+                      )}
                     >
                       <button
                         type="button"
                         className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 text-left"
                         onClick={() => setOpenSkill(skill)}
                       >
-                        <span className="grid size-8 shrink-0 place-items-center rounded-lg border bg-muted text-muted-foreground">
-                          <Sparkles className="size-4" aria-hidden="true" />
-                        </span>
+                        <SkillGlyph size="sm" />
                         <span className="flex min-w-0 flex-1 flex-col gap-0.5">
                           <span
-                            className={`truncate text-sm font-medium${
-                              plugin.enabled ? "" : " text-muted-foreground"
-                            }`}
+                            className={cn(
+                              "truncate text-sm font-medium",
+                              !plugin.enabled && "text-muted-foreground",
+                            )}
                           >
                             {skill.name}
                           </span>
@@ -156,7 +164,7 @@ export function PluginDetailView({
               </section>
 
               <section className="flex flex-col gap-1" aria-label="Information">
-                <h2 className="border-b pb-2 text-base font-semibold">Information</h2>
+                <h2 className="border-b pb-2 text-sm font-semibold">Information</h2>
                 <dl className="grid grid-cols-[8rem_1fr] gap-x-4 gap-y-2 pt-2 text-sm">
                   <InfoRow label="Category">{categoryLabel(plugin.category)}</InfoRow>
                   <InfoRow label="Capabilities">

--- a/crates/openwave-desktop/ui/src/plugins/PluginGlyph.tsx
+++ b/crates/openwave-desktop/ui/src/plugins/PluginGlyph.tsx
@@ -1,0 +1,222 @@
+import { BarChart3, FileText, Package, Sparkles, Table2 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+import type { PluginCategory } from "@/api";
+import { cn } from "@/lib/utils";
+
+/**
+ * The library's signature mark: a small instrument tile.
+ *
+ * A plugin is something you pick up and hand to the agent — the glyph has to
+ * read as a tool at a glance, not as a muted list bullet. Known bundles get a
+ * fixed wash and a purpose-built mark; everything else falls back to its
+ * category so a user-written bundle still has a face.
+ */
+
+type GlyphTone = {
+  /** Soft wash behind the mark. */
+  wash: string;
+  /** Ink for the lucide / path mark. */
+  ink: string;
+};
+
+const CATEGORY_TONES: Record<PluginCategory, GlyphTone> = {
+  documents: {
+    wash: "bg-sky-100 dark:bg-sky-400/15",
+    ink: "text-sky-700 dark:text-sky-300",
+  },
+  data: {
+    wash: "bg-emerald-100 dark:bg-emerald-400/15",
+    ink: "text-emerald-700 dark:text-emerald-300",
+  },
+  visualization: {
+    wash: "bg-violet-100 dark:bg-violet-400/15",
+    ink: "text-violet-700 dark:text-violet-300",
+  },
+  other: {
+    wash: "bg-zinc-100 dark:bg-zinc-400/12",
+    ink: "text-zinc-600 dark:text-zinc-300",
+  },
+};
+
+const SKILL_TONE: GlyphTone = {
+  wash: "bg-amber-100 dark:bg-amber-400/15",
+  ink: "text-amber-700 dark:text-amber-300",
+};
+
+const CATEGORY_FALLBACK: Record<PluginCategory, LucideIcon> = {
+  documents: FileText,
+  data: Table2,
+  visualization: BarChart3,
+  other: Package,
+};
+
+/** Known built-in bundles: name wins over category so each keeps its own face. */
+const BUNDLE_TONES: Record<string, GlyphTone> = {
+  documents: CATEGORY_TONES.documents,
+  spreadsheets: CATEGORY_TONES.data,
+  charts: CATEGORY_TONES.visualization,
+};
+
+type GlyphSize = "sm" | "md" | "lg";
+
+const SIZE_CLASS: Record<GlyphSize, string> = {
+  sm: "size-8 rounded-lg [&_svg]:size-4",
+  md: "size-10 rounded-[0.7rem] [&_svg]:size-5",
+  lg: "size-14 rounded-2xl [&_svg]:size-7",
+};
+
+export function PluginGlyph({
+  pluginName,
+  category,
+  size = "md",
+  className,
+}: {
+  /** Bundle slug when known; drives the built-in marks. */
+  pluginName?: string;
+  category: PluginCategory;
+  size?: GlyphSize;
+  className?: string;
+}) {
+  const tone = (pluginName && BUNDLE_TONES[pluginName]) || CATEGORY_TONES[category];
+  const mark = pluginName ? bundleMark(pluginName) : null;
+  const Fallback = CATEGORY_FALLBACK[category];
+
+  return (
+    <span
+      className={cn(
+        "grid shrink-0 place-items-center ring-1 ring-inset ring-black/5 dark:ring-white/8",
+        tone.wash,
+        tone.ink,
+        SIZE_CLASS[size],
+        className,
+      )}
+      aria-hidden="true"
+    >
+      {mark ?? <Fallback strokeWidth={1.75} />}
+    </span>
+  );
+}
+
+/** A standalone skill's tile — warmer than a bundle so the two kinds separate. */
+export function SkillGlyph({
+  size = "md",
+  className,
+}: {
+  size?: GlyphSize;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "grid shrink-0 place-items-center ring-1 ring-inset ring-black/5 dark:ring-white/8",
+        SKILL_TONE.wash,
+        SKILL_TONE.ink,
+        SIZE_CLASS[size],
+        className,
+      )}
+      aria-hidden="true"
+    >
+      <Sparkles strokeWidth={1.75} />
+    </span>
+  );
+}
+
+/**
+ * Purpose-built marks for the three shipped bundles. Drawn as simple geometry
+ * so they stay sharp at 16–28px and never lean on a third-party brand lockup.
+ */
+function bundleMark(name: string): ReactNode | null {
+  switch (name) {
+    case "documents":
+      return <DocumentsMark />;
+    case "spreadsheets":
+      return <SpreadsheetsMark />;
+    case "charts":
+      return <ChartsMark />;
+    default:
+      return null;
+  }
+}
+
+function DocumentsMark() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className="size-[1.15em]">
+      <path
+        d="M7 3.75h7.2L18.5 8v12.25a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V4.75a1 1 0 0 1 1-1Z"
+        fill="currentColor"
+        opacity={0.18}
+      />
+      <path
+        d="M14.1 3.75V7.2a.8.8 0 0 0 .8.8h3.6"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+      />
+      <path
+        d="M7 3.75h7.2L18.5 8v12.25a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V4.75a1 1 0 0 1 1-1Z"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+      />
+      <path
+        d="M9.25 12.25h5.5M9.25 15.25h3.75"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+function SpreadsheetsMark() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className="size-[1.15em]">
+      <rect
+        x={4.5}
+        y={4.5}
+        width={15}
+        height={15}
+        rx={2}
+        fill="currentColor"
+        opacity={0.18}
+      />
+      <rect
+        x={4.5}
+        y={4.5}
+        width={15}
+        height={15}
+        rx={2}
+        stroke="currentColor"
+        strokeWidth={1.5}
+      />
+      <path
+        d="M4.5 9.25h15M4.5 14.75h15M9.25 4.5v15M14.75 4.5v15"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+function ChartsMark() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className="size-[1.15em]">
+      <path
+        d="M5 18.5V14M10 18.5V9.5M15 18.5V12M20 18.5V6.5"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+      />
+      <path
+        d="M4 19.25h16.5"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        opacity={0.45}
+      />
+    </svg>
+  );
+}

--- a/crates/openwave-desktop/ui/src/plugins/PluginsView.tsx
+++ b/crates/openwave-desktop/ui/src/plugins/PluginsView.tsx
@@ -1,9 +1,8 @@
-import { ChevronRight, Puzzle, Sparkles } from "lucide-react";
-import { useState, type ReactNode } from "react";
+import { Puzzle } from "lucide-react";
+import { useMemo, useState, type ReactNode } from "react";
 
 import type { PluginInfo, PluginSkillInfo } from "@/api";
-import { PanelSecondaryHeader } from "@/components/PanelHeader";
-import { Badge } from "@/components/ui/badge";
+import { SearchInput } from "@/components/SearchInput";
 import { Button } from "@/components/ui/button";
 import {
   Empty,
@@ -13,8 +12,9 @@ import {
   EmptyTitle,
 } from "@/components/ui/empty";
 import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
+import { PluginGlyph, SkillGlyph } from "./PluginGlyph";
 import type { PluginsApis } from "./pluginsApis";
-import { capabilityShortLabel, categoryIcon } from "./pluginVocabulary";
 import { SkillDialog } from "./SkillDialog";
 import {
   hostToolProvisioningLabel,
@@ -31,9 +31,10 @@ import type { PluginCatalogState } from "./usePluginCatalog";
  * library. Picking a row opens `plugins.{slug}`: the bundle's description, its
  * badges, and its member skills with their own switches.
  *
- * The origin split is the catalog's own: bundles first, then the skills no
- * bundle claims, with anything the user wrote themselves — bundle or skill —
- * called out as theirs.
+ * Laid out as a scannable instrument shelf: a centered title and search, then
+ * a two-column grid of tiles. The origin split is the catalog's own: bundles
+ * first, then the skills no bundle claims, with anything the user wrote
+ * themselves called out as theirs.
  */
 export function PluginsView({
   state,
@@ -47,15 +48,25 @@ export function PluginsView({
 }) {
   const { catalog, loading, error, reload, setEnabled } = state;
   const provisioning = useHostToolProvisioning();
+  const [query, setQuery] = useState("");
   const [openSkill, setOpenSkill] = useState<PluginSkillInfo | null>(null);
-  const yourPlugins = catalog?.plugins.filter((plugin) => plugin.origin === "user") ?? [];
+
+  const filtered = useMemo(() => filterCatalog(catalog, query), [catalog, query]);
+  const yourPlugins = filtered?.plugins.filter((plugin) => plugin.origin === "user") ?? [];
   const otherPlugins =
-    catalog?.plugins.filter((plugin) => plugin.origin !== "user") ?? [];
-  const yourSkills = catalog?.skills.filter((skill) => skill.origin === "user") ?? [];
+    filtered?.plugins.filter((plugin) => plugin.origin !== "user") ?? [];
+  const yourSkills = filtered?.skills.filter((skill) => skill.origin === "user") ?? [];
   const otherSkills =
-    catalog?.skills.filter((skill) => skill.origin !== "user") ?? [];
+    filtered?.skills.filter((skill) => skill.origin !== "user") ?? [];
   const isEmpty =
     catalog !== null && catalog.plugins.length === 0 && catalog.skills.length === 0;
+  const noMatches =
+    catalog !== null &&
+    !isEmpty &&
+    otherPlugins.length === 0 &&
+    yourPlugins.length === 0 &&
+    yourSkills.length === 0 &&
+    otherSkills.length === 0;
   // The dialog re-reads its skill from the fresh catalog, so its switch moves
   // with the toggle round trip instead of freezing at the row that opened it.
   const shownSkill = openSkill
@@ -64,103 +75,125 @@ export function PluginsView({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <PanelSecondaryHeader showBorder={false} className="pr-1 pl-4">
-        <h1 className="text-lg font-medium">Plugins</h1>
-      </PanelSecondaryHeader>
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-6 pt-10 pb-12">
+          <header className="flex flex-col items-center gap-4 text-center">
+            <div className="flex flex-col gap-1.5">
+              <h1 className="text-2xl font-semibold tracking-tight">Plugins</h1>
+              <p className="text-muted-foreground max-w-md text-sm text-pretty">
+                Skills the agent can use when you turn them on.
+              </p>
+            </div>
+            {catalog && !isEmpty && (
+              <SearchInput
+                value={query}
+                onValueChange={setQuery}
+                placeholder="Search plugins and skills…"
+                aria-label="Search plugins and skills"
+                className="w-full max-w-md rounded-full"
+              />
+            )}
+          </header>
 
-      <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto pt-4 pb-4">
-        {provisioning && (
-          <p className="text-muted-foreground shrink-0 px-4 text-xs" role="status">
-            {hostToolProvisioningLabel(provisioning)}
-          </p>
-        )}
+          {provisioning && (
+            <p className="text-muted-foreground -mt-4 text-center text-xs" role="status">
+              {hostToolProvisioningLabel(provisioning)}
+            </p>
+          )}
 
-        {error && (
-          <div
-            className="mx-4 flex shrink-0 items-center justify-between gap-3 rounded-md bg-critical-background px-3 py-2 text-sm text-critical-foreground-muted"
-            role="alert"
-          >
-            <span>{error}</span>
-            <Button variant="outline" size="xs" className="shrink-0" onClick={reload}>
-              Try again
-            </Button>
-          </div>
-        )}
+          {error && (
+            <div
+              className="flex shrink-0 items-center justify-between gap-3 rounded-lg bg-critical-background px-3 py-2 text-sm text-critical-foreground-muted"
+              role="alert"
+            >
+              <span>{error}</span>
+              <Button variant="outline" size="xs" className="shrink-0" onClick={reload}>
+                Try again
+              </Button>
+            </div>
+          )}
 
-        {loading && !catalog && (
-          <p className="text-muted-foreground px-4 text-sm" role="status">
-            Loading your plugins…
-          </p>
-        )}
+          {loading && !catalog && (
+            <p className="text-muted-foreground text-center text-sm" role="status">
+              Loading your plugins…
+            </p>
+          )}
 
-        {isEmpty && (
-          <Empty>
-            <EmptyHeader>
-              <EmptyMedia variant="icon">
-                <Puzzle />
-              </EmptyMedia>
-              <EmptyTitle>No plugins installed</EmptyTitle>
-              <EmptyDescription>
-                Plugins bundle the skills OpenWave can use in a conversation.
-                This installation has none available — the ones that ship with
-                the app appear here once code execution is set up.
-              </EmptyDescription>
-            </EmptyHeader>
-          </Empty>
-        )}
+          {isEmpty && (
+            <Empty>
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
+                  <Puzzle />
+                </EmptyMedia>
+                <EmptyTitle>No plugins installed</EmptyTitle>
+                <EmptyDescription>
+                  Plugins bundle the skills OpenWave can use in a conversation.
+                  This installation has none available — the ones that ship with
+                  the app appear here once code execution is set up.
+                </EmptyDescription>
+              </EmptyHeader>
+            </Empty>
+          )}
 
-        {otherPlugins.length > 0 && (
-          <Section title="Plugins">
-            <PluginList
-              plugins={otherPlugins}
-              label="Plugins"
-              onOpen={onOpen}
-              setEnabled={setEnabled}
-            />
-          </Section>
-        )}
+          {noMatches && (
+            <p className="text-muted-foreground text-center text-sm" role="status">
+              Nothing matches “{query.trim()}”.
+            </p>
+          )}
 
-        {yourPlugins.length > 0 && (
-          <Section
-            title="Your plugins"
-            description="Plugins you wrote, loaded from your data directory."
-          >
-            <PluginList
-              plugins={yourPlugins}
-              label="Your plugins"
-              onOpen={onOpen}
-              setEnabled={setEnabled}
-            />
-          </Section>
-        )}
+          {otherPlugins.length > 0 && (
+            <Section title="Plugins">
+              <PluginGrid
+                plugins={otherPlugins}
+                label="Plugins"
+                onOpen={onOpen}
+                setEnabled={setEnabled}
+              />
+            </Section>
+          )}
 
-        {yourSkills.length > 0 && (
-          <Section
-            title="Your skills"
-            description="Skills you wrote, loaded from your data directory. They stand on their own rather than belonging to a bundle."
-          >
-            <SkillList
-              skills={yourSkills}
-              setEnabled={setEnabled}
-              label="Your skills"
-              onOpenSkill={setOpenSkill}
-            />
-          </Section>
-        )}
+          {yourPlugins.length > 0 && (
+            <Section
+              title="Your plugins"
+              description="Plugins you wrote, loaded from your data directory."
+            >
+              <PluginGrid
+                plugins={yourPlugins}
+                label="Your plugins"
+                onOpen={onOpen}
+                setEnabled={setEnabled}
+              />
+            </Section>
+          )}
 
-        {otherSkills.length > 0 && (
-          <Section
-            title="Other skills"
-            description="Installed skills that no bundle claims."
-          >
-            <SkillList
-              skills={otherSkills}
-              setEnabled={setEnabled}
-              label="Other skills"
-              onOpenSkill={setOpenSkill}
-            />
-          </Section>
-        )}
+          {yourSkills.length > 0 && (
+            <Section
+              title="Your skills"
+              description="Skills you wrote, loaded from your data directory. They stand on their own rather than belonging to a bundle."
+            >
+              <SkillGrid
+                skills={yourSkills}
+                setEnabled={setEnabled}
+                label="Your skills"
+                onOpenSkill={setOpenSkill}
+              />
+            </Section>
+          )}
+
+          {otherSkills.length > 0 && (
+            <Section
+              title="Other skills"
+              description="Installed skills that no bundle claims."
+            >
+              <SkillGrid
+                skills={otherSkills}
+                setEnabled={setEnabled}
+                label="Other skills"
+                onOpenSkill={setOpenSkill}
+              />
+            </Section>
+          )}
+        </div>
       </div>
 
       <SkillDialog
@@ -188,9 +221,11 @@ function Section({
   children: ReactNode;
 }) {
   return (
-    <section className="mx-3 flex flex-col gap-2" aria-label={title}>
+    <section className="flex flex-col gap-3" aria-label={title}>
       <div className="flex flex-col gap-0.5 px-1">
-        <h2 className="text-sm font-medium">{title}</h2>
+        <h2 className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+          {title}
+        </h2>
         {description && (
           <p className="text-muted-foreground text-xs">{description}</p>
         )}
@@ -200,7 +235,7 @@ function Section({
   );
 }
 
-function PluginList({
+function PluginGrid({
   plugins,
   label,
   onOpen,
@@ -212,7 +247,10 @@ function PluginList({
   setEnabled: PluginCatalogState["setEnabled"];
 }) {
   return (
-    <ul className="flex flex-col gap-1" aria-label={label}>
+    <ul
+      className="grid grid-cols-1 gap-1 sm:grid-cols-2 sm:gap-x-3 sm:gap-y-1"
+      aria-label={label}
+    >
       {plugins.map((plugin) => (
         <li key={plugin.name}>
           <PluginRow
@@ -229,7 +267,7 @@ function PluginList({
 }
 
 /**
- * A bundle's row: the whole row opens the detail, and the switch — which is
+ * A bundle's tile: the whole row opens the detail, and the switch — which is
  * not inside that button — turns the bundle on and off without leaving the
  * list.
  */
@@ -242,35 +280,24 @@ function PluginRow({
   onOpen: () => void;
   onToggle: (enabled: boolean) => void;
 }) {
-  const Icon = categoryIcon(plugin.category);
   return (
-    <div className="hover:bg-muted flex items-center gap-3 rounded-md p-2 transition-colors">
+    <div
+      className={cn(
+        "hover:bg-muted/70 flex items-center gap-3 rounded-xl px-2.5 py-2.5 transition-colors",
+        !plugin.enabled && "opacity-80",
+      )}
+    >
       <button
         type="button"
-        className="flex min-w-0 flex-1 items-start gap-3 text-left"
+        className="flex min-w-0 flex-1 items-center gap-3 text-left"
         onClick={onOpen}
       >
-        <Icon className="text-muted-foreground mt-0.5 size-4 shrink-0" aria-hidden="true" />
-        <span className="flex min-w-0 flex-1 flex-col gap-1">
-          <span className="flex min-w-0 items-center gap-1.5">
-            <span className="truncate text-sm font-medium">{plugin.display_name}</span>
-            <ChevronRight
-              className="text-muted-foreground size-3.5 shrink-0"
-              aria-hidden="true"
-            />
-          </span>
-          <span className="text-muted-foreground line-clamp-2 text-xs">
+        <PluginGlyph pluginName={plugin.name} category={plugin.category} size="md" />
+        <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span className="truncate text-sm font-medium">{plugin.display_name}</span>
+          <span className="text-muted-foreground line-clamp-1 text-xs leading-snug">
             {plugin.description}
           </span>
-          {plugin.capabilities.length > 0 && (
-            <span className="flex flex-wrap gap-1 pt-0.5">
-              {plugin.capabilities.map((capability) => (
-                <Badge key={capability} variant="outline" size="sm">
-                  {capabilityShortLabel(capability)}
-                </Badge>
-              ))}
-            </span>
-          )}
         </span>
       </button>
       <Switch
@@ -282,7 +309,7 @@ function PluginRow({
   );
 }
 
-function SkillList({
+function SkillGrid({
   skills,
   setEnabled,
   label,
@@ -294,23 +321,27 @@ function SkillList({
   onOpenSkill: (skill: PluginSkillInfo) => void;
 }) {
   return (
-    <ul className="flex flex-col gap-1" aria-label={label}>
+    <ul
+      className="grid grid-cols-1 gap-1 sm:grid-cols-2 sm:gap-x-3 sm:gap-y-1"
+      aria-label={label}
+    >
       {skills.map((skill) => (
         <li
           key={skill.name}
-          className="hover:bg-muted flex items-center gap-3 rounded-md p-2 transition-colors"
+          className={cn(
+            "hover:bg-muted/70 flex items-center gap-3 rounded-xl px-2.5 py-2.5 transition-colors",
+            !skill.enabled && "opacity-80",
+          )}
         >
           <button
             type="button"
             className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 text-left"
             onClick={() => onOpenSkill(skill)}
           >
-            <span className="text-muted-foreground grid size-7 shrink-0 place-items-center rounded-md border bg-muted">
-              <Sparkles className="size-3.5" aria-hidden="true" />
-            </span>
+            <SkillGlyph size="md" />
             <span className="flex min-w-0 flex-1 flex-col gap-0.5">
               <span className="truncate text-sm font-medium">{skill.name}</span>
-              <span className="text-muted-foreground line-clamp-2 text-xs">
+              <span className="text-muted-foreground line-clamp-1 text-xs leading-snug">
                 {skill.description}
               </span>
             </span>
@@ -326,4 +357,31 @@ function SkillList({
       ))}
     </ul>
   );
+}
+
+function filterCatalog(
+  catalog: PluginCatalogState["catalog"],
+  query: string,
+): PluginCatalogState["catalog"] {
+  if (!catalog) return null;
+  const needle = query.trim().toLowerCase();
+  if (!needle) return catalog;
+
+  const plugins = catalog.plugins.filter(
+    (plugin) =>
+      plugin.display_name.toLowerCase().includes(needle) ||
+      plugin.name.toLowerCase().includes(needle) ||
+      plugin.description.toLowerCase().includes(needle) ||
+      plugin.skills.some(
+        (skill) =>
+          skill.name.toLowerCase().includes(needle) ||
+          skill.description.toLowerCase().includes(needle),
+      ),
+  );
+  const skills = catalog.skills.filter(
+    (skill) =>
+      skill.name.toLowerCase().includes(needle) ||
+      skill.description.toLowerCase().includes(needle),
+  );
+  return { ...catalog, plugins, skills };
 }


### PR DESCRIPTION
## Summary
- Center the plugins catalog with a short subtitle and pill search.
- Lay bundles and skills out in a two-column tile grid with colored instrument glyphs (purpose-built marks for Documents, Spreadsheets, and Charts; category/skill fallbacks otherwise).
- Match the detail page header and skill rows to the same glyph treatment; keep enable switches and gating behavior unchanged.

## Test plan
- [x] `pnpm exec vitest run src/plugins/Plugins.dom.test.tsx` (6/6)
- [ ] Open `/plugins` in the desktop app (light and dark): confirm search filters, two-column layout, and toggles still round-trip.
- [ ] Open a bundle detail: confirm large glyph, member skill switches stay gated while the bundle is off, and skill dialog still opens from the row.