### PR TITLE
fix(server): stop caching gateway-session keychain misses for the process lifetime

### DIFF
--- a/crates/openwave-core/src/secret_cache.rs
+++ b/crates/openwave-core/src/secret_cache.rs
@@ -16,8 +16,21 @@
 //!
 //! The tradeoff is that edits made outside this process — Keychain Access, the
 //! CLI, another running instance — are not observed until the process restarts.
+//! For most keys that is the right call, but a few are session state with a
+//! lifecycle this process does not fully own: the model-gateway session, say,
+//! can appear in the keychain between a boot-time miss and the read that
+//! would serve it — a read in flight while sign-in completes resolves to the
+//! old `NoEntry` and lands in the cache *after* the write's invalidation, and
+//! a session written by another instance never invalidates this cache at all.
+//! [`with_miss_passthrough`](CachingSecretProvider::with_miss_passthrough)
+//! marks such keys: their hits still memoize, but a miss is never stored, so
+//! the next read re-asks the store. That is cheap for exactly these keys —
+//! reading an *absent* item answers `NoEntry` without raising an ACL prompt;
+//! only an existing item with a stale approval does.
+//!
+//! [`with_miss_passthrough`]: CachingSecretProvider::with_miss_passthrough
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
@@ -28,6 +41,10 @@ use crate::storage::SecretProvider;
 /// Wraps a [`SecretProvider`], serving repeat reads of a key from memory.
 pub struct CachingSecretProvider {
     inner: Arc<dyn SecretProvider>,
+    /// Keys a miss is never memoized for — see the module docs. Hits on these
+    /// keys still cache; only the confirmed-absent entry is skipped, so a
+    /// value that appears after process start is seen on the next read.
+    miss_passthrough: HashSet<String>,
     /// Key → last known value. An entry of `None` records a confirmed miss.
     cache: Mutex<HashMap<String, Option<String>>>,
 }
@@ -38,8 +55,25 @@ impl CachingSecretProvider {
     pub fn new(inner: Arc<dyn SecretProvider>) -> Self {
         Self {
             inner,
+            miss_passthrough: HashSet::new(),
             cache: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Never memoize a miss for `keys`: each absent read re-asks the store.
+    ///
+    /// For keys whose value can appear without this process performing the
+    /// write — a session completed by a flow racing a boot-time read, or
+    /// written by another instance entirely — a cached `None` would hide the
+    /// value until restart. Repeat misses cost one store round-trip each, and
+    /// reading an absent item never raises an ACL prompt, so this is for keys
+    /// that are absent by default and read on slow paths (status surfaces,
+    /// background ticks), not for per-turn resolver probes.
+    #[must_use]
+    pub fn with_miss_passthrough<'a>(mut self, keys: impl IntoIterator<Item = &'a str>) -> Self {
+        self.miss_passthrough
+            .extend(keys.into_iter().map(str::to_string));
+        self
     }
 
     fn cached(&self, key: &str) -> Option<Option<String>> {
@@ -73,7 +107,9 @@ impl SecretProvider for CachingSecretProvider {
             return Ok(hit);
         }
         let value = self.inner.get_secret(key).await?;
-        self.store(key, value.clone());
+        if value.is_some() || !self.miss_passthrough.contains(key) {
+            self.store(key, value.clone());
+        }
         Ok(value)
     }
 
@@ -147,5 +183,41 @@ mod tests {
         secrets.delete_secret(key).await.unwrap();
         assert_eq!(secrets.get_secret(key).await.unwrap(), None);
         assert_eq!(inner.reads.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn a_passthrough_miss_is_reread_so_a_later_write_is_seen() {
+        let inner = Arc::new(CountingSecrets::default());
+        let secrets =
+            CachingSecretProvider::new(inner.clone()).with_miss_passthrough(["some.session_v1"]);
+        let key = "some.session_v1";
+
+        // Every miss re-asks the store — the session key's reason for being
+        // here is that a value can appear without this cache observing the
+        // write (a racing read landing after the write's invalidation, or a
+        // writer outside this process).
+        assert_eq!(secrets.get_secret(key).await.unwrap(), None);
+        assert_eq!(secrets.get_secret(key).await.unwrap(), None);
+        assert_eq!(inner.reads.load(Ordering::SeqCst), 2);
+
+        // A write landing behind the cache's back — straight into the inner
+        // store — is visible on the very next read, with no restart.
+        *inner.value.lock().unwrap() = Some("session-1".to_string());
+        assert_eq!(
+            secrets.get_secret(key).await.unwrap().as_deref(),
+            Some("session-1")
+        );
+
+        // A hit still memoizes: the passthrough costs reads only while absent.
+        assert_eq!(
+            secrets.get_secret(key).await.unwrap().as_deref(),
+            Some("session-1")
+        );
+        assert_eq!(inner.reads.load(Ordering::SeqCst), 3);
+
+        // And a delete through the cache still invalidates the hit.
+        secrets.delete_secret(key).await.unwrap();
+        assert_eq!(secrets.get_secret(key).await.unwrap(), None);
+        assert_eq!(inner.reads.load(Ordering::SeqCst), 4);
     }
 }

--- a/crates/openwave-server/src/connectors/gateway.rs
+++ b/crates/openwave-server/src/connectors/gateway.rs
@@ -29,7 +29,10 @@ pub const RESOURCE_CONTROL: &str = "control";
 pub const RESOURCE_LLM: &str = "llm";
 
 const SCOPE: &str = "openid profile offline_access models:read inference:invoke";
-const SECRET_KEY: &str = "gateway.credentials_v1";
+/// The secret-store key the gateway session lives under. Public so the secret
+/// cache at the server boundary can treat the session key specially (see
+/// `CachingSecretProvider::with_miss_passthrough`).
+pub const SECRET_KEY: &str = "gateway.credentials_v1";
 /// Refresh an access token this close to expiry instead of using it.
 const EXPIRY_LEEWAY_SECONDS: u64 = 60;
 const SIGN_IN_REQUIRED_PREFIX: &str = "gateway sign-in required";

--- a/crates/openwave-server/src/connectors/mod.rs
+++ b/crates/openwave-server/src/connectors/mod.rs
@@ -40,5 +40,5 @@ pub use gateway::{
     GatewayAuthConfig, GatewayConnection, GatewayConsentOutcome, GatewayCredentials,
     GatewayIdentity, GatewayInvokeOutcome, GatewayMeta, GatewayModel, GatewayOperationSummary,
     GatewayPublishOutcome, GatewayRegistrationOutcome, GatewayTeam, PendingSignIn, TokenSet,
-    RESOURCE_CONTROL, RESOURCE_LLM,
+    RESOURCE_CONTROL, RESOURCE_LLM, SECRET_KEY as GATEWAY_SECRET_KEY,
 };

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -576,8 +576,16 @@ impl GatewayRuntime {
                         Ok(()) => {
                             // Best-effort: a failed first sync leaves an
                             // explicit refresh affordance, not a failed
-                            // sign-in.
-                            let _ = runtime.sync_models().await;
+                            // sign-in — but say so in the log, or support
+                            // cannot tell an empty model list from a sync
+                            // that never ran.
+                            if let Err(error) = runtime.sync_models().await {
+                                tracing::warn!(
+                                    "gateway model sync after sign-in failed \
+                                     (the background sync will retry): {}",
+                                    error.message()
+                                );
+                            }
                             // Likewise: mount-by-default must never fail a
                             // sign-in, and the background sync retries it.
                             if let Err(error) = runtime.reconcile_endpoint_mounts(&mcp).await {
@@ -1648,6 +1656,68 @@ mod tests {
             crate::providers::ProviderKind::ModelGateway
         );
         assert_eq!(policy.display_name, "Sample Claude");
+    }
+
+    /// The boot-before-sign-in race: a status or sync read caches the
+    /// keychain's `NoEntry`, and the session then lands without the cache
+    /// observing the write — a read that was in flight while sign-in
+    /// completed stores its stale miss *after* the write's invalidation, and
+    /// a session written by another process never invalidates at all. The
+    /// gateway session key's misses are not memoized
+    /// (`CachingSecretProvider::with_miss_passthrough`), so the next
+    /// background tick sees the session with no restart and no manual sync.
+    #[tokio::test]
+    async fn a_session_written_behind_the_secret_cache_syncs_without_a_restart() {
+        let address = serve(Arc::new(FakeGateway::default())).await;
+        let base = format!("http://{address}");
+        let directory = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                directory.path().join("gateway.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let inner = Arc::new(MockSecrets::default());
+        // The same wrap `secret_provider` in lib.rs applies at boot.
+        let secrets: Arc<dyn SecretProvider> = Arc::new(
+            openwave_core::CachingSecretProvider::new(inner.clone())
+                .with_miss_passthrough([crate::connectors::GATEWAY_SECRET_KEY]),
+        );
+        crate::managed_policy::provision(&*store, &base)
+            .await
+            .unwrap();
+        let runtime = GatewayRuntime::new(
+            store.clone(),
+            secrets,
+            Arc::new(crate::managed_policy::NoOsPolicy),
+        );
+
+        // Boot before sign-in: the tick reads the empty store. Were the miss
+        // memoized, this is the read that would hide the session forever.
+        assert_eq!(runtime.sync_models_if_connected().await.unwrap(), None);
+
+        // The session lands behind the cache's back, straight into the store.
+        let credentials: crate::connectors::GatewayCredentials = serde_json::from_value(json!({
+            "base_url": base,
+            "installation_id": "install-1",
+            "user_id": "user-1",
+            "account_hint": "abaas@example.test",
+            "refresh_token": "mg_rt_seed",
+            "access_tokens": {}
+        }))
+        .unwrap();
+        inner
+            .set_secret(
+                crate::connectors::GATEWAY_SECRET_KEY,
+                &serde_json::to_string(&credentials).unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // The very next tick recovers — no restart, no manual sync click.
+        assert_eq!(runtime.sync_models_if_connected().await.unwrap(), Some(2));
     }
 
     /// A gateway that serves a model under its upstream id is serving that

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -976,12 +976,23 @@ pub async fn bind_configured_with_desktop_executor_and_folder_grants(
 /// process rather than one per turn: [`resolver::ConfiguredResolver`] rebuilds
 /// its route set on every turn, and each candidate route reads its provider's
 /// credential to decide whether it exists.
+///
+/// The gateway session key is the one exception to memoized misses: a session
+/// can land in the keychain without this cache observing the write — a
+/// boot-time status read is in flight while sign-in completes, resolving to
+/// the old `NoEntry` after the write's invalidation already ran — and a
+/// cached `None` would then hide the session from the sync loop until
+/// restart. Its misses re-ask the store instead; an absent item answers
+/// `NoEntry` without an ACL prompt, so the slow-path rereads are cheap.
 fn secret_provider(config: &Config) -> Arc<dyn SecretProvider> {
     let keychain: Arc<dyn SecretProvider> = Arc::new(match &config.keychain_service {
         Some(service) => KeychainSecretProvider::with_service(service),
         None => KeychainSecretProvider::new(),
     });
-    Arc::new(CachingSecretProvider::new(keychain))
+    Arc::new(
+        CachingSecretProvider::new(keychain)
+            .with_miss_passthrough([crate::connectors::GATEWAY_SECRET_KEY]),
+    )
 }
 
 /// Re-home the configured profile's credentials — see [`secret_rehome`].


### PR DESCRIPTION
## Summary

- The model picker could stay empty until the app was restarted: `CachingSecretProvider` memoizes keychain misses (`Ok(None)`) for the process lifetime, and a cached miss on the gateway session key (`gateway.credentials_v1`) survives the session actually landing in the keychain — so `sync_models_if_connected` saw `stored_credentials() == None` on every tick and silently no-oped, and the models' `available` flags stayed false.
- `CachingSecretProvider` gains `with_miss_passthrough(keys)`: hits on those keys still memoize, but a miss is never stored, so the next read re-asks the store. The server's `secret_provider` opts the gateway session key in. A failed post-sign-in `sync_models()` is now logged as a warning (the periodic loop still retries) instead of being dropped silently.

## Why

Writes through the cache already invalidate it, which covers the ordinary in-process sign-in — that's why the manual "Sync with gateway" button usually works. The stuck cases are the ones where the write never reaches this cache:

1. **Read/write race at boot.** A status or sync-tick read is in flight while sign-in completes. `set_secret` invalidates an empty cache entry, then the in-flight read resolves to the old `NoEntry` and stores its stale `None` *after* the invalidation — poisoned until restart.
2. **Out-of-process writes.** A session written by another running instance (or any writer not sharing this cache) is never observed, per the cache's documented tradeoff.

(The manual sync route reads credentials through the same cache, so in the genuinely poisoned state the button fails too; the recovery users saw was the common case where in-process sign-in had invalidated the cache.)

Alternatives considered: an `invalidate(key)` hook called from sign-in — adds nothing, since `set_secret` already invalidates and can't fix case 2 or the race; disabling negative caching wholesale — wrongly re-exposes per-turn resolver probes for never-configured providers to repeated keychain round-trips (the reason the cache exists). Miss passthrough is the smallest change that covers both cases, and it's cheap for exactly this key: reading an *absent* keychain item answers `NoEntry` without an ACL prompt, and while signed out the key is only read on slow paths (status surfaces, the 5-minute sync tick).

## Test plan

- [x] `cargo test -p openwave-core secret_cache --locked` — new test asserts a passthrough miss is re-read (a write landing behind the cache's back is visible without restart), hits still memoize, and deletes still invalidate.
- [x] `cargo test -p openwave-server --lib gateway_runtime --locked` — new test `a_session_written_behind_the_secret_cache_syncs_without_a_restart`: boot tick misses, the session is written straight into the inner store (bypassing the cache), and the next tick syncs without a restart. Verified it fails (returns `None`) when the passthrough is removed.
- [x] `cargo test -p openwave-server --test connectors_gateway_flow --locked` — 12 passed.
- [x] `cargo clippy -p openwave-core -p openwave-server --all-targets --locked -- -D warnings` and `cargo fmt --all` clean.

Note: a sibling change to the same sync stack is in flight in #1999 (`thet/gateway-openai-responses`); this branch doesn't touch it, but a merge-order conflict in `gateway_runtime.rs` is possible and should resolve mechanically.
