### PR TITLE
fix(server): re-home stored credentials at boot so updates keep the gateway session

### DIFF
--- a/crates/openwave-server/src/connectors/gateway.rs
+++ b/crates/openwave-server/src/connectors/gateway.rs
@@ -30,8 +30,8 @@ pub const RESOURCE_LLM: &str = "llm";
 
 const SCOPE: &str = "openid profile offline_access models:read inference:invoke";
 /// The secret-store key the gateway session lives under. Public so the secret
-/// cache at the server boundary can treat the session key specially (see
-/// `CachingSecretProvider::with_miss_passthrough`).
+/// cache can treat it as a miss-passthrough key, and so [`crate::secret_rehome`]
+/// can name every stored credential.
 pub const SECRET_KEY: &str = "gateway.credentials_v1";
 /// Refresh an access token this close to expiry instead of using it.
 const EXPIRY_LEEWAY_SECONDS: u64 = 60;

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -2921,6 +2921,79 @@ mod tests {
         );
     }
 
+    /// A secret store whose reads fail while `fail_reads` is set — the
+    /// transient shape of a keychain read whose ACL no longer matches the
+    /// running binary (denied or pending prompt), as opposed to a confirmed
+    /// absence.
+    #[derive(Default)]
+    struct FlakySecrets {
+        values: MockSecrets,
+        fail_reads: std::sync::atomic::AtomicBool,
+    }
+
+    #[async_trait]
+    impl SecretProvider for FlakySecrets {
+        async fn get_secret(&self, key: &str) -> Result<Option<String>> {
+            if self.fail_reads.load(Ordering::SeqCst) {
+                return Err(AgentError::Secret("keychain read denied".into()));
+            }
+            self.values.get_secret(key).await
+        }
+        async fn set_secret(&self, key: &str, value: &str) -> Result<()> {
+            self.values.set_secret(key, value).await
+        }
+        async fn delete_secret(&self, key: &str) -> Result<()> {
+            self.values.delete_secret(key).await
+        }
+    }
+
+    /// Retire is a one-way door — the session is gone afterwards — so it
+    /// must not open on a transient read error: a keychain read that fails
+    /// (or an unparsable blob, which also errors the load) proves nothing
+    /// about whether the session is superseded. Only a successful read that
+    /// shows a definitive policy mismatch may retire it.
+    #[tokio::test]
+    async fn boot_keeps_the_session_when_the_credential_read_errors() {
+        let directory = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                directory.path().join("gateway.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let secrets = Arc::new(FlakySecrets::default());
+        let credentials: crate::connectors::GatewayCredentials = serde_json::from_value(json!({
+            "base_url": "http://127.0.0.1:1",
+            "installation_id": "install-1",
+            "user_id": "user-1",
+            "refresh_token": "mg_rt_survivor",
+            "access_tokens": {}
+        }))
+        .unwrap();
+        CredentialVault::new(secrets.clone())
+            .save(&credentials)
+            .await
+            .unwrap();
+
+        // Unmanaged policy: a readable session WOULD be retired. With the
+        // read erroring, retire must leave it exactly where it is.
+        let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
+            .await
+            .unwrap();
+        assert!(!policy.managed);
+        secrets.fail_reads.store(true, Ordering::SeqCst);
+        retire_superseded_gateway_session(secrets.clone(), &policy)
+            .await
+            .unwrap();
+        secrets.fail_reads.store(false, Ordering::SeqCst);
+        assert!(
+            crate::connectors::has_stored_credentials(&*secrets).await,
+            "a transient read error must not retire the session"
+        );
+    }
+
     /// The session half of the legacy hard cut: an unmanaged profile with a
     /// session left over from the retired additive mode has no surface that
     /// could ever revoke it, so boot clears it. Without this the refresh

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -1037,6 +1037,17 @@ async fn bind_inner(
     let sandbox_spawn_execution_location = sandbox_container_admission.execution_location;
     let store = connect_store(&config).await?;
     let secrets = secret_provider(&config);
+    // An app update replaces this binary, and macOS pins each keychain
+    // item's access to the creating binary's signature — so the first boot
+    // of a new binary re-homes every stored credential before any consumer
+    // reads one. Inline, not spawned: a concurrent pass could interleave
+    // with token refresh and strand a session (see the function), and the
+    // pass is cheap — one read+rewrite per stored credential, once per
+    // binary, with later boots of the same binary skipping it entirely.
+    // Best-effort: a failure here must not take boot down with it.
+    if let Err(error) = secret_rehome::rehome_once_per_binary(&*store, &*secrets).await {
+        tracing::warn!("could not re-home stored credentials: {error}");
+    }
     // The product boot path is where this platform's OS-managed (MDM) policy
     // reader gets selected; directly assembled AppState stays hermetic. This
     // is the one instance shared by the boot policy read, the legacy-key

--- a/crates/openwave-server/src/mcp_config/types.rs
+++ b/crates/openwave-server/src/mcp_config/types.rs
@@ -665,7 +665,7 @@ pub(super) const fn default_request_timeout_ms() -> u64 {
 /// Derived from the connected-app record id, never from anything in a
 /// request, so this surface can only ever read and write its own secrets.
 /// Mirrors `rest_credential_secret_key` for the REST connected-app kind.
-pub(super) fn env_secret_key(id: ConnectedAppId) -> String {
+pub(crate) fn env_secret_key(id: ConnectedAppId) -> String {
     format!("mcp.{id}.env_v1")
 }
 

--- a/crates/openwave-server/src/secret_rehome.rs
+++ b/crates/openwave-server/src/secret_rehome.rs
@@ -14,12 +14,21 @@
 //! item, then store the value again so the new item belongs to the current
 //! signature. Read the value first and hold it in memory, so a failure to
 //! delete leaves the credential in place.
+//!
+//! Two entry points run that rewrite. Server boot calls
+//! [`rehome_once_per_binary`], which re-homes once per binary (an app update
+//! always replaces the binary, so that is once per update) before any
+//! credential consumer is constructed. And `openwave rehome-secrets` runs
+//! [`rehome_secrets`] on demand — the manual repair for a dev machine whose
+//! signing identity changed without a binary stamp change.
 
 use crate::web_search::WebSearchProviderKind;
 use openwave_code_execution::{DAYTONA_CREDENTIAL_KEY, E2B_CREDENTIAL_KEY};
 use openwave_core::connected_app::ConnectedAppKind;
 use openwave_core::{Result, SecretProvider, Store};
 
+use crate::connectors::{CHATGPT_SECRET_KEY, GATEWAY_SECRET_KEY};
+use crate::mcp_config::env_secret_key;
 use crate::providers::{ProviderKind, LEGACY_ANTHROPIC_API_KEY};
 
 /// Credential keys for the web-search providers. `credential_key` is a `const
@@ -60,17 +69,25 @@ pub enum RehomeOutcome {
 }
 
 /// Every key the application may store a credential under: the fixed
-/// per-feature keys, plus one dynamic `connected_app.{id}.credential` key per
-/// stored `rest_api` record that references a credential.
+/// per-feature keys, plus the dynamic per-record keys — one
+/// `connected_app.{id}.credential` per stored `rest_api` record that
+/// references a credential, and one `mcp.{id}.env_v1` per stored
+/// `mcp_server` record (present or not; a record with no stored values
+/// simply reports [`RehomeOutcome::Absent`]).
 ///
 /// The dynamic keys are why this reads the store: they exist only as records,
 /// so a static list cannot name them, and a re-home pass that skipped them
-/// would silently leave every REST credential owned by the old signature. A
-/// store that cannot be read fails the enumeration rather than shrinking it —
-/// an incomplete key list is exactly the silent loss this exists to prevent.
+/// would silently leave every REST credential and MCP server environment
+/// owned by the old signature. A store that cannot be read fails the
+/// enumeration rather than shrinking it — an incomplete key list is exactly
+/// the silent loss this exists to prevent.
 pub async fn stored_secret_keys(store: &dyn Store) -> Result<Vec<String>> {
     let mut keys = static_secret_keys();
     for record in store.list_connected_apps().await? {
+        if record.kind == ConnectedAppKind::McpServer {
+            keys.push(env_secret_key(record.id));
+            continue;
+        }
         if record.kind != ConnectedAppKind::RestApi {
             continue;
         }
@@ -98,6 +115,12 @@ fn static_secret_keys() -> Vec<String> {
         .map(|kind| kind.credential_key())
         .collect();
     keys.push(LEGACY_ANTHROPIC_API_KEY.to_string());
+    // The OAuth sessions: the model gateway's `gateway.credentials_v1` and
+    // the ChatGPT sign-in. These are the credentials an app update strands
+    // most painfully — an unreadable session reads as "not connected" and
+    // the user re-pairs — so they must not be missed here.
+    keys.push(GATEWAY_SECRET_KEY.to_string());
+    keys.push(CHATGPT_SECRET_KEY.to_string());
     keys.extend(
         WEB_SEARCH_CREDENTIAL_KEYS
             .iter()
@@ -114,6 +137,104 @@ pub async fn rehome_secrets(
     secrets: &dyn SecretProvider,
 ) -> Result<Vec<(String, RehomeOutcome)>> {
     Ok(rehome_keys(secrets, stored_secret_keys(store).await?).await)
+}
+
+/// The settings key recording which binary last completed a re-home pass.
+const REHOME_STAMP_SETTING: &str = "secret_rehome.binary_v1";
+
+/// Identify the running binary for the once-per-binary stamp: the Cargo
+/// version plus the executable's size and modification time. Keychain
+/// ownership is pinned to the code signature, and every app update or dev
+/// rebuild replaces the binary, so the artifact's own metadata is the
+/// stamp that rolls exactly when ownership breaks — the workspace version
+/// stays `0.0.0` outside tagged release builds and cannot serve alone.
+fn binary_stamp() -> String {
+    let exe = std::env::current_exe();
+    let metadata = exe
+        .as_ref()
+        .ok()
+        .and_then(|exe| std::fs::metadata(exe).ok());
+    let (len, mtime) = metadata
+        .and_then(|metadata| {
+            let mtime = metadata.modified().ok()?;
+            let mtime = mtime
+                .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                .ok()?;
+            Some((metadata.len(), mtime.as_secs()))
+        })
+        .unwrap_or((0, 0));
+    format!("{}:{len}:{mtime}", env!("CARGO_PKG_VERSION"))
+}
+
+/// Re-home the stored credentials once per binary, at server boot.
+///
+/// macOS pins a keychain item's access to the code signature of the binary
+/// that created it, so an app update strands every credential the previous
+/// binary wrote — reads prompt or fail, and a gateway session that fails to
+/// read presents as "not connected". Rewriting each value from the new
+/// binary (what [`rehome_secrets`] does) restores ownership. This runs the
+/// pass inline, before boot constructs any credential consumer, for two
+/// reasons: the repair then takes effect in the same launch rather than the
+/// next one, and it cannot interleave with a token refresh — a re-home that
+/// raced a refresh could write back a pre-refresh session, which the
+/// gateway's refresh-token reuse detection would read as a sign-out.
+///
+/// The pass is once per binary (see [`binary_stamp`]) and best-effort: a
+/// failure — the store unreadable, a credential the user declined to
+/// unlock — is logged, never surfaced, and leaves the stamp unwritten so
+/// the next launch retries. A pass where every key resolved (stored or
+/// not) stamps the binary so later boots of the same binary skip the work.
+///
+/// Returns whether the pass ran (`false` when this binary is already
+/// stamped).
+pub(crate) async fn rehome_once_per_binary(
+    store: &dyn Store,
+    secrets: &dyn SecretProvider,
+) -> Result<bool> {
+    let stamp = binary_stamp();
+    if store
+        .get_setting(REHOME_STAMP_SETTING)
+        .await?
+        .as_ref()
+        .and_then(serde_json::Value::as_str)
+        == Some(stamp.as_str())
+    {
+        return Ok(false);
+    }
+    let outcomes = rehome_secrets(store, secrets).await?;
+    let mut rehomed = 0usize;
+    let mut unresolved: Vec<String> = Vec::new();
+    for (key, outcome) in &outcomes {
+        match outcome {
+            RehomeOutcome::Absent => {}
+            RehomeOutcome::Rehomed => rehomed += 1,
+            RehomeOutcome::Skipped(reason) => {
+                unresolved.push(format!("{key} (skipped: {reason})"));
+            }
+            RehomeOutcome::Lost(reason) => {
+                unresolved.push(format!("{key} (LOST: {reason})"));
+            }
+        }
+    }
+    if rehomed > 0 {
+        tracing::info!(
+            "re-homed {rehomed} stored credential(s) so this binary owns their keychain items"
+        );
+    }
+    if unresolved.is_empty() {
+        store
+            .set_setting(REHOME_STAMP_SETTING, &serde_json::Value::String(stamp))
+            .await?;
+    } else {
+        // No stamp: the next launch retries. A skipped credential is usually
+        // a dismissed keychain prompt — exactly the state this exists to
+        // repair — so it gets another chance rather than prompting forever.
+        tracing::warn!(
+            "could not re-home every stored credential (retrying next launch): {}",
+            unresolved.join(", ")
+        );
+    }
+    Ok(true)
 }
 
 async fn rehome_keys(
@@ -270,5 +391,124 @@ mod tests {
             assert!(keys.iter().any(|key| key == expected), "{expected}");
         }
         assert!(keys.iter().any(|key| key == LEGACY_ANTHROPIC_API_KEY));
+    }
+
+    /// The OAuth sessions are the credentials an app update strands most
+    /// painfully — an unreadable session reads as "not connected" — so the
+    /// gateway and ChatGPT session keys must be in the re-home list.
+    #[test]
+    fn connector_session_keys_are_covered() {
+        let keys = static_secret_keys();
+        assert!(keys.iter().any(|key| key == GATEWAY_SECRET_KEY));
+        assert!(keys.iter().any(|key| key == CHATGPT_SECRET_KEY));
+    }
+
+    /// MCP server environment values live under per-record `mcp.{id}.env_v1`
+    /// keys; a re-home pass that skipped them would leave every MCP
+    /// credential owned by the old signature.
+    #[tokio::test]
+    async fn mcp_server_env_keys_are_enumerated() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = openwave_core::DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            directory.path().join("rehome.db").display()
+        ))
+        .await
+        .unwrap();
+        let now = chrono::Utc::now();
+        let record = openwave_core::connected_app::ConnectedApp {
+            id: openwave_core::id::ConnectedAppId::new(),
+            name: "docs".to_string(),
+            kind: ConnectedAppKind::McpServer,
+            definition: serde_json::json!({}),
+            created_at: now,
+            updated_at: now,
+        };
+        let expected = env_secret_key(record.id);
+        store
+            .replace_connected_apps(ConnectedAppKind::McpServer, &[record])
+            .await
+            .unwrap();
+
+        let keys = stored_secret_keys(&store).await.unwrap();
+        assert!(keys.contains(&expected), "{keys:?}");
+    }
+
+    /// Re-homing is idempotent: a second pass over an already re-homed value
+    /// rewrites it again (the implementation cannot tell "already owned"
+    /// apart cheaply, so it rewrites unconditionally) and the value reads
+    /// back unchanged both times.
+    #[tokio::test]
+    async fn rehoming_twice_keeps_the_value_intact() {
+        let key = ProviderKind::Anthropic.credential_key();
+        let secrets = RecordingSecrets::default();
+        secrets.set_secret(&key, "sk-ant-123").await.unwrap();
+
+        for _ in 0..2 {
+            let outcomes = rehome_keys(&secrets, static_secret_keys()).await;
+            assert_eq!(
+                outcomes
+                    .iter()
+                    .find(|(candidate, _)| *candidate == key)
+                    .map(|(_, outcome)| outcome),
+                Some(&RehomeOutcome::Rehomed)
+            );
+            assert_eq!(
+                secrets.get_secret(&key).await.unwrap().as_deref(),
+                Some("sk-ant-123")
+            );
+        }
+    }
+
+    /// Boot runs the pass once per binary: the first call re-homes and
+    /// stamps, and a later call for the same binary is a no-op.
+    #[tokio::test]
+    async fn boot_rehome_runs_once_then_skips() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = openwave_core::DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            directory.path().join("rehome.db").display()
+        ))
+        .await
+        .unwrap();
+        let key = ProviderKind::Anthropic.credential_key();
+        let secrets = RecordingSecrets::default();
+        secrets.set_secret(&key, "sk-ant-123").await.unwrap();
+
+        assert!(rehome_once_per_binary(&store, &secrets).await.unwrap());
+        assert_eq!(
+            secrets.get_secret(&key).await.unwrap().as_deref(),
+            Some("sk-ant-123")
+        );
+
+        secrets.ops.lock().unwrap().clear();
+        assert!(!rehome_once_per_binary(&store, &secrets).await.unwrap());
+        assert!(secrets.ops.lock().unwrap().is_empty());
+    }
+
+    /// A credential that could not be re-homed leaves the binary unstamped,
+    /// so the next launch retries rather than leaving it stranded until the
+    /// next update.
+    #[tokio::test]
+    async fn boot_rehome_retries_after_a_skipped_credential() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = openwave_core::DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            directory.path().join("rehome.db").display()
+        ))
+        .await
+        .unwrap();
+        let key = ProviderKind::Anthropic.credential_key();
+        let secrets = RecordingSecrets {
+            fail_delete: true,
+            ..RecordingSecrets::default()
+        };
+        secrets.set_secret(&key, "sk-ant-123").await.unwrap();
+
+        assert!(rehome_once_per_binary(&store, &secrets).await.unwrap());
+        // Not stamped: the very next boot takes the pass again.
+        secrets.ops.lock().unwrap().clear();
+        assert!(rehome_once_per_binary(&store, &secrets).await.unwrap());
+        assert!(!secrets.ops.lock().unwrap().is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- The re-home key list now covers every persisted credential: added the model-gateway session key (`gateway.credentials_v1`, exported as `GATEWAY_SECRET_KEY`), the ChatGPT OAuth session key (`provider.openai.chatgpt_oauth_v1`), and the per-record MCP server environment keys (`mcp.{id}.env_v1`, enumerated from `mcp_server` connected-app records alongside the existing REST credential enumeration).
- Server boot (`bind_inner`) now runs the re-home pass automatically, once per binary, before any credential consumer is constructed. A per-binary stamp (Cargo version + executable size/mtime — the workspace version is `0.0.0`, and keychain ownership pins to the signature, which rolls with every binary) is recorded in the store; later boots of the same binary skip the pass, and a boot where a credential could not be re-homed leaves the stamp unwritten so the next launch retries.
- The pass is inline, not spawned: it takes effect in the same launch, and it cannot interleave with token refresh — a background re-home racing a refresh could write back a pre-refresh session, which the gateway's refresh-token reuse detection reads as a sign-out. The cost is one read+rewrite per stored credential, once per binary.
- Failures are logged (`tracing::warn!`), never surfaced, and never fail boot. The desktop app and the CLI daemon both reach this through server startup, so no desktop/updater change was needed — an update only ever replaces the binary, and the next boot repairs ownership.
- `retire_superseded_gateway_session` already keeps a session whose keychain read errors transiently (the `Ok(Some(_))` load guard leaves `Err`/`None` alone); a new test pins that contract so it cannot regress.

Idempotency: the current implementation rewrites unconditionally — it cannot cheaply tell "already owned by this signature" apart, so an already-owned item is deleted and written back (value verified read-back unchanged), never a no-op. The per-binary stamp is what bounds that cost to once per binary.

## Why
macOS pins a keychain item's access to the code signature of the binary that created it. Every app update replaced the binary, so reads of `gateway.credentials_v1` prompted or failed, the session read as absent, and users had to re-pair the model gateway after each update. The repair existed (`rehome_configured_secrets`) but neither listed the gateway/ChatGPT session keys nor ran anywhere but the manual `openwave rehome-secrets` CLI command.

## Test plan
- [x] `cargo test -p openwave-server secret_rehome --locked` — 8 passed, incl. new: connector session keys covered, MCP env keys enumerated, re-home idempotent, boot pass runs once then skips, boot pass retries after a skipped credential
- [x] `cargo test -p openwave-server gateway_runtime --locked` — 23 passed, incl. new: boot keeps the session when the credential read errors
- [x] `cargo test -p openwave-server mcp_config --locked` / `connected_apps --locked` / `connectors --locked` — pass
- [x] `cargo test -p openwave-server --lib --locked` — 784 passed (boot-path change is in `bind_inner`)
- [x] `cargo clippy -p openwave-server --all-targets --locked -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [ ] Desktop: install an update over a paired build → gateway session survives without re-pairing (needs a signed release pair to exercise the real ACL)
