### PR TITLE
fix(desktop): align composer controls, restyle queue tray, relocate context meter

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -56,7 +56,6 @@ import {
 } from "./ImageAttachments";
 import { useImageAttachments } from "./useImageAttachments";
 import { modelForSelection, textOnlyModelLabel } from "./ModelSelection";
-import { ContextUsageIndicator } from "./ContextUsageIndicator";
 import { ModelMenu, useModelSettingsNav } from "./ModelMenu";
 import { PermissionModeMenu } from "./PermissionModeMenu";
 import {
@@ -741,6 +740,11 @@ export function ChatRoute({ chatId }: { chatId: string }) {
               onChange={onModelChange}
             />
           }
+          contextUsage={{
+            usage: lastTurnUsage,
+            contextWindow: activeModel?.context_window,
+            modelName: activeModel?.display_name,
+          }}
           composerPermissionMenu={
             <PermissionModeMenu
               scopeKey={chatId}
@@ -850,21 +854,12 @@ export function ChatRoute({ chatId }: { chatId: string }) {
     }
   }
 
-  // Header chrome reads the active model's window so the meter stays honest
-  // when the selection changes, without living in the composer.
-  const headerModel = modelForSelection(models, chat.model);
-
   return (
     <RouteFrame sidebar={<AppSidebar chat={chat} />}>
     <div className="mr-2 flex min-h-0 min-w-0 flex-1 flex-col">
       <header className="mt-2 flex h-9 w-full shrink-0 items-center justify-between gap-2 pl-4 pr-1">
         <ChatHeaderTitle chat={chat} />
         <div className="flex shrink-0 items-center gap-2">
-          <ContextUsageIndicator
-            usage={lastTurnUsage}
-            contextWindow={headerModel?.context_window}
-            modelName={headerModel?.display_name}
-          />
           <ChatStatusChip
             outputCount={deliverables.length}
             folders={folders.items}

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -8,6 +8,7 @@ import {
   type RefObject,
 } from "react";
 import type { ApiClient, Chat } from "./api";
+import type { RendererTurnUsage } from "./generated/wire";
 import {
   followScrollBehavior,
   isNearBottom,
@@ -68,6 +69,12 @@ export type ChatViewProps = {
   draftRef: RefObject<string>;
   composerModelMenu: ReactNode;
   composerPermissionMenu: ReactNode;
+  /** Context-window reading the composer shows beside its own controls. */
+  contextUsage?: {
+    usage: RendererTurnUsage | null;
+    contextWindow: number | undefined;
+    modelName: string | undefined;
+  };
   composerNetwork?: ComposerNetwork;
   composerReasoning?: ComposerReasoning;
   composerImages: ComposerImages;
@@ -108,6 +115,7 @@ export function ChatView({
   draftRef,
   composerModelMenu,
   composerPermissionMenu,
+  contextUsage,
   composerNetwork,
   composerReasoning,
   composerImages,
@@ -678,6 +686,7 @@ export function ChatView({
             history={composerHistory}
             modelMenu={composerModelMenu}
             permissionMenu={composerPermissionMenu}
+            contextUsage={contextUsage}
             network={composerNetwork}
             reasoning={composerReasoning}
             plugins={composerPlugins.plugins}

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -20,6 +20,8 @@ import {
   ListPlus,
 } from "lucide-react";
 import { MAX_STEER_CHARACTERS } from "./ActiveTurnSteer";
+import { ContextUsageIndicator } from "./ContextUsageIndicator";
+import type { RendererTurnUsage } from "./generated/wire";
 import {
   activeSlashQuery,
   availableSlashOptions,
@@ -272,6 +274,12 @@ export type ComposerProps = {
   history?: readonly string[];
   modelMenu?: ReactNode;
   permissionMenu?: ReactNode;
+  /** Context-window reading, shown with the composer's own controls. */
+  contextUsage?: {
+    usage: RendererTurnUsage | null;
+    contextWindow: number | undefined;
+    modelName: string | undefined;
+  };
   network?: ComposerNetwork;
   reasoning?: ComposerReasoning;
   plugins?: ComposerPlugins;
@@ -319,6 +327,7 @@ export function Composer({
   history = [],
   modelMenu,
   permissionMenu,
+  contextUsage,
   network,
   reasoning,
   plugins,
@@ -1055,6 +1064,16 @@ export function Composer({
           {/* The permission mode sits with the send cluster: it is what the
               next turn will be allowed to do, not another way to prepare it. */}
           {permissionMenu}
+          {/* Context usage lives in the composer's action row: the reading
+              answers "how much room is left for what I'm about to send", so
+              it belongs beside the control that sends it. */}
+          {contextUsage && (
+            <ContextUsageIndicator
+              usage={contextUsage.usage}
+              contextWindow={contextUsage.contextWindow}
+              modelName={contextUsage.modelName}
+            />
+          )}
           {/* The mic sits immediately before send: both act on the draft, so
               they belong in the same cluster, apart from the tools and
               model controls that only set the turn up. */}
@@ -1105,8 +1124,8 @@ export function Composer({
                   <Button
                     type="submit"
                     variant="default"
-                    size="sm"
-                    className="min-w-[5rem]"
+                    size="xs"
+                    className="h-8 min-w-[5rem] px-3 text-sm"
                     aria-label={
                       queueAvailable && sendMode === "queue"
                         ? "Queue message for after this response"

--- a/crates/openwave-desktop/ui/src/ContextUsageIndicator.tsx
+++ b/crates/openwave-desktop/ui/src/ContextUsageIndicator.tsx
@@ -19,8 +19,8 @@ import { cn } from "./lib/utils";
  * turn. Switching models mid-chat is a question about what will fit next, so
  * the reading moves the moment the selection does.
  *
- * Lives in the chat header beside the activity chip so the reading stays on
- * screen for the whole conversation, not only while the composer is in view.
+ * Lives in the composer's action row so the reading sits beside the control
+ * that spends the remaining window.
  */
 export function ContextUsageIndicator({
   usage,

--- a/crates/openwave-desktop/ui/src/PermissionModeMenu.tsx
+++ b/crates/openwave-desktop/ui/src/PermissionModeMenu.tsx
@@ -1,10 +1,10 @@
 import {
   Check,
   ChevronDown,
+  Eye,
   Lock,
-  NotebookPen,
   ShieldCheck,
-  Sparkles,
+  ShieldOff,
   Zap,
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
@@ -49,7 +49,7 @@ const PERMISSION_MODE_SCALE: {
     label: "Plan",
     description:
       "Read-only: the agent explores and proposes a plan. Nothing is edited or run until you switch modes.",
-    icon: NotebookPen,
+    icon: Eye,
     elevated: false,
   },
   ASK_PERMISSION_MODE_OPTION,
@@ -58,14 +58,14 @@ const PERMISSION_MODE_SCALE: {
     label: "Auto",
     description:
       "Workspace edits run on their own; anything that leaves the workspace still asks.",
-    icon: Sparkles,
+    icon: Zap,
     elevated: true,
   },
   {
     value: "allow",
     label: "Allow all",
     description: "Everything runs without asking, in this chat only.",
-    icon: Zap,
+    icon: ShieldOff,
     elevated: true,
   },
 ];

--- a/crates/openwave-desktop/ui/src/QueueTray.tsx
+++ b/crates/openwave-desktop/ui/src/QueueTray.tsx
@@ -70,23 +70,45 @@ export function QueueTray({
   return (
     <section
       aria-label="Queued messages"
-      className="mx-auto mb-2 w-full max-w-3xl rounded-xl border border-border bg-card shadow-sm"
+      className="mx-auto mb-2 w-full max-w-3xl overflow-hidden rounded-xl border border-border/60 bg-card/80 shadow-sm"
     >
-      <header className="flex items-center gap-2 border-b border-border px-3 py-1.5">
-        <span className="text-xs font-semibold">
-          Queued <span className="font-normal text-muted-foreground">{queued.length}</span>
-          {paused && (
-            <span className="ml-2 rounded-full border border-warning-border/45 bg-warning-background px-2 py-px text-[11px] font-medium text-warning-foreground">
-              Paused
-            </span>
-          )}
+      <header className="flex h-8 items-center gap-2 border-b border-border/60 pl-3 pr-1.5">
+        <span className="flex min-w-0 items-baseline gap-1.5 text-xs">
+          <span className="font-medium">Queued</span>
+          <span className="tabular-nums text-muted-foreground">
+            {queued.length}
+          </span>
         </span>
-        <div className="ml-auto">
+        {paused && (
+          <span className="rounded-full border border-warning-border/45 bg-warning-background px-1.5 py-px text-[10px] font-medium leading-4 text-warning-foreground">
+            Paused
+          </span>
+        )}
+        <div className="ml-auto flex items-center gap-0.5">
+          {paused && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              className="h-6 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground"
+              disabled={busy}
+              onClick={() =>
+                void act(
+                  () => client.sendQueuedNow(chatId),
+                  "Could not start the queue",
+                )
+              }
+            >
+              <Play className="size-3" />
+              Send now
+            </Button>
+          )}
           <Button
             type="button"
             variant="ghost"
-            size="sm"
-            className="h-6 gap-1 px-2 text-xs text-muted-foreground"
+            size="icon-xs"
+            className="size-6 text-muted-foreground hover:text-foreground"
+            aria-label={paused ? "Resume queue" : "Pause queue"}
             disabled={busy}
             onClick={() =>
               void act(
@@ -96,17 +118,13 @@ export function QueueTray({
             }
           >
             {paused ? <Play className="size-3" /> : <Pause className="size-3" />}
-            {paused ? "Resume" : "Pause"}
           </Button>
         </div>
       </header>
-      <ul className="flex flex-col gap-px p-1.5">
+      <ul className="divide-y divide-border/60 px-3">
         {queued.map((row, index) => (
-          <li
-            key={row.id}
-            className="group flex items-center gap-1.5 rounded-md px-1.5 py-1 hover:bg-accent"
-          >
-            <span className="w-4 shrink-0 text-right text-[11px] tabular-nums text-muted-foreground">
+          <li key={row.id} className="group flex h-8 items-center gap-2">
+            <span className="w-3 shrink-0 text-right text-[11px] tabular-nums text-muted-foreground">
               {index + 1}
             </span>
             {editing === row.id ? (
@@ -137,12 +155,12 @@ export function QueueTray({
                 {row.content}
               </span>
             )}
-            <span className="hidden shrink-0 items-center group-hover:inline-flex">
+            <span className="hidden shrink-0 items-center gap-0.5 group-hover:inline-flex">
               <Button
                 type="button"
                 variant="ghost"
-                size="icon-8"
-                className="size-6"
+                size="icon-xs"
+                className="size-6 text-muted-foreground hover:text-foreground"
                 aria-label="Move up"
                 disabled={busy || index === 0}
                 onClick={() =>
@@ -157,8 +175,8 @@ export function QueueTray({
               <Button
                 type="button"
                 variant="ghost"
-                size="icon-8"
-                className="size-6"
+                size="icon-xs"
+                className="size-6 text-muted-foreground hover:text-foreground"
                 aria-label="Move down"
                 disabled={busy || index === queued.length - 1}
                 onClick={() =>
@@ -173,8 +191,8 @@ export function QueueTray({
               <Button
                 type="button"
                 variant="ghost"
-                size="icon-8"
-                className="size-6"
+                size="icon-xs"
+                className="size-6 text-muted-foreground hover:text-foreground"
                 aria-label="Edit queued message"
                 disabled={busy}
                 onClick={() => {
@@ -187,8 +205,8 @@ export function QueueTray({
               <Button
                 type="button"
                 variant="ghost"
-                size="icon-8"
-                className="size-6 hover:text-destructive"
+                size="icon-xs"
+                className="size-6 text-muted-foreground hover:text-destructive"
                 aria-label="Delete queued message"
                 disabled={busy}
                 onClick={() =>

--- a/crates/openwave-desktop/ui/src/api/client.ts
+++ b/crates/openwave-desktop/ui/src/api/client.ts
@@ -1339,6 +1339,15 @@ export class ApiClient {
     );
   }
 
+  /** Release a paused queue so the oldest message starts on the next sweep. */
+  async sendQueuedNow(chatId: string): Promise<void> {
+    await this.json<unknown>(
+      `/chats/${encodeURIComponent(chatId)}/queued/send-now`,
+      { method: "POST", headers: this.headers() },
+      204,
+    );
+  }
+
   steer(
     chatId: string,
     turnId: string,

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -555,6 +555,10 @@ pub fn app(state: AppState) -> Router {
             axum::routing::put(routes::put_queue_paused),
         )
         .route(
+            "/chats/{chat_id}/queued/send-now",
+            post(routes::post_queue_send_now),
+        )
+        .route(
             "/chats/{chat_id}/agent-runs/{run_id}/steer",
             post(routes::post_agent_run_steer),
         )

--- a/crates/openwave-server/src/routes/turn_control.rs
+++ b/crates/openwave-server/src/routes/turn_control.rs
@@ -530,6 +530,27 @@ pub async fn put_queue_paused(
     Ok(StatusCode::NO_CONTENT)
 }
 
+/// `POST /chats/{chat_id}/queued/send-now` — clear this chat's pause so the
+/// promoter's next sweep starts the oldest queued message.
+///
+/// Promotion stays with the sweep: the idempotent try-and-delete in
+/// [`promote_queued_turns`] owns the exact ordering guarantees, and the sweep
+/// runs on a sub-second cadence, so this route only needs to release the
+/// gate. A chat that was not paused is unaffected, making the call safe to
+/// repeat.
+pub async fn post_queue_send_now(
+    State(state): State<AppState>,
+    store: ScopedStore,
+    Path(id): Path<ChatId>,
+) -> Result<StatusCode, ServerError> {
+    store.require_chat(id).await?;
+    state
+        .store
+        .set_setting(&queue_paused_setting(id), &serde_json::json!(false))
+        .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
 /// Body of `POST /chats/{id}/steer`.
 #[derive(Debug, Deserialize)]
 pub struct SteerBody {

--- a/crates/openwave-server/src/tests/lifecycle.rs
+++ b/crates/openwave-server/src/tests/lifecycle.rs
@@ -3546,3 +3546,123 @@ async fn a_headless_folder_request_resumes_the_turn_with_the_declined_result() {
         "the model was not told the folder request was declined"
     );
 }
+
+/// `POST /chats/{id}/queued/send-now` releases a paused queue: the promoter
+/// runs the oldest message on its next sweep, and the row leaves the queue.
+#[tokio::test]
+async fn send_now_releases_a_paused_queue() {
+    // The first turn parks in the provider, keeping the chat busy so the
+    // follow-ups park as queued rows instead of running immediately.
+    let gate = Arc::new(Notify::new());
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(Arc::new(GatedProvider {
+            gate: gate.clone(),
+        }))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "gated".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let token = state.token.clone();
+    let router = app(state.clone());
+    spawn_turn_worker(&state);
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+
+    assert_eq!(
+        send_message_with_id(&router, &bearer, chat.id, TurnId::new(), "blocking turn").await,
+        StatusCode::ACCEPTED
+    );
+    // Pause promotion. Through the store, not the route: a pause PUT that
+    // lands while the gated turn is still being accepted would race the
+    // promoter claiming that same turn and read as a leak below.
+    store
+        .set_setting(
+            &format!("chats.{}.queue_paused", chat.id),
+            &serde_json::json!(true),
+        )
+        .await
+        .unwrap();
+    for content in ["hold one", "hold two"] {
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/chats/{}/messages", chat.id))
+                    .header(header::AUTHORIZATION, bearer.as_str())
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "turn_id": TurnId::new(),
+                            "content": content,
+                            "queue": true,
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+    }
+    assert_eq!(
+        store.list_queued_turns(chat.id).await.unwrap().len(),
+        2,
+        "the follow-ups did not park as queued rows"
+    );
+
+    // End the blocking turn. A paused promoter must leave both rows alone.
+    gate.notify_one();
+    wait_for_turn(&store, chat.id).await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    assert_eq!(
+        store.list_queued_turns(chat.id).await.unwrap().len(),
+        2,
+        "a paused queue promoted a message"
+    );
+
+    let send_now = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/chats/{}/queued/send-now", chat.id))
+                .header(header::AUTHORIZATION, bearer.as_str())
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+        .status();
+    assert_eq!(send_now, StatusCode::NO_CONTENT);
+
+    // Tests build the router with `app()`, which never spawns the background
+    // promoter task, so drive the sweep directly: the send-now route has
+    // cleared the gate, promotion should now move one row per sweep while
+    // the gate releases one parked turn at a time.
+    for _ in 0..20 {
+        crate::routes::promote_queued_turns(&state).await.unwrap();
+        if store.list_queued_turns(chat.id).await.unwrap().is_empty() {
+            return;
+        }
+        gate.notify_one();
+        // Let the accepted turn reach its provider call before the next
+        // sweep, or the promoter's `ChatBusy` just parks the row again.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("send-now left rows in the queue");
+}


### PR DESCRIPTION
## What

Three composer-area fixes:

- **Button sizing**: the mid-turn Queue/Redirect submit button rendered at h-9 beside h-8 icon buttons. Now h-8, matching the send cluster.
- **Queue tray**: drops the boxed-card look for flat hairline rows and a compact header, and adds a **Send now** action (visible while paused) backed by a new `POST /chats/{id}/queued/send-now` route. The route only clears the pause flag; promotion stays with the background sweep, so ordering guarantees are unchanged.
- **Context usage**: the meter moves from the chat header into the composer's action row, beside the permission menu.
- **Permission icons**: one escalation family (Eye / ShieldCheck / Zap / ShieldOff) instead of the off-note NotebookPen and Sparkles.

## Verification

- UI: 921/921 vitest tests pass; `pnpm build` (tsc + vite) clean.
- Server: new integration test `send_now_releases_a_paused_queue` covers pause-holds, send-now-releases, FIFO drain; clippy and fmt clean.
- Visually verified against the running dev backend: uniform 28px control heights, restyled tray, Send now button, relocated meter.