### PR TITLE
ci: roll macOS caches to v4 and drop the rename-era policy rewrite

### DIFF
--- a/.github/workflows/cache-macos.yml
+++ b/.github/workflows/cache-macos.yml
@@ -88,10 +88,10 @@ jobs:
             target/${{ matrix.target }}/release/tidebreak-host-broker
             target/${{ matrix.target }}/release/libtidebreak_desktop_lib.*
             crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}
-          key: macos-release-target-v3-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ github.sha }}
+          key: macos-release-target-v4-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ github.sha }}
           restore-keys: |
-            macos-release-target-v3-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
-            macos-release-target-v3-${{ matrix.arch }}-
+            macos-release-target-v4-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
+            macos-release-target-v4-${{ matrix.arch }}-
 
       - name: Set up compiler cache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,20 +98,6 @@ jobs:
             exit 1
           fi
           cp "$trusted" "$GITHUB_WORKSPACE/scripts/.trusted-workflow-security.test.mjs"
-          # The assertions remain the base branch's trusted policy; project its
-          # retired product namespace onto the pull request's renamed tree.
-          sed -i \
-            -e 's/OPENWAVE/TIDEBREAK/g' \
-            -e 's/OpenWave/Tidebreak/g' \
-            -e 's/openwave/tidebreak/g' \
-            "$GITHUB_WORKSPACE/scripts/.trusted-workflow-security.test.mjs"
-          # Keep the already-renamed base policy's projected assertion true
-          # for the one PR generation spanning the repository rename.
-          sed -i \
-            -e 's/TIDEBREAK/TIDEBREAK/g' \
-            -e 's/Tidebreak/Tidebreak/g' \
-            -e 's/tidebreak/tidebreak/g' \
-            "$GITHUB_WORKSPACE/scripts/.trusted-workflow-security.test.mjs"
       - name: Test trusted base-branch release policy
         if: ${{ github.event_name == 'pull_request' }}
         run: node --test scripts/.trusted-workflow-security.test.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,12 +290,12 @@ jobs:
             target/${{ matrix.target }}/release/tidebreak-host-broker
             target/${{ matrix.target }}/release/libtidebreak_desktop_lib.*
             crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}
-          key: macos-release-prepared-v3-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
+          key: macos-release-prepared-v4-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
           restore-keys: |
-            macos-release-prepared-v3-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
-            macos-release-target-v3-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}
-            macos-release-target-v3-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
-            macos-release-target-v3-${{ matrix.arch }}-
+            macos-release-prepared-v4-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
+            macos-release-target-v4-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}
+            macos-release-target-v4-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
+            macos-release-target-v4-${{ matrix.arch }}-
 
       - name: Set up compiler cache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
@@ -432,11 +432,11 @@ jobs:
             target/${{ matrix.target }}/release/tidebreak-host-broker
             target/${{ matrix.target }}/release/libtidebreak_desktop_lib.*
             crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}
-          key: macos-release-prepared-v3-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
+          key: macos-release-prepared-v4-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
           restore-keys: |
-            macos-release-prepared-v3-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
-            macos-release-target-v3-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}
-            macos-release-target-v3-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
+            macos-release-prepared-v4-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
+            macos-release-target-v4-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}
+            macos-release-target-v4-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
 
       # A restore extracts the whole archive, including the linked products a
       # cache-warming run left in it. Those are the bytes that get signed, so

--- a/crates/tidebreak-server/src/gateway_runtime.rs
+++ b/crates/tidebreak-server/src/gateway_runtime.rs
@@ -3061,7 +3061,7 @@ mod tests {
         // and the gateway session the policy authorizes.
         let store = DbStore::connect(&format!(
             "sqlite://{}?mode=rwc",
-            data_dir.join("openwave.db").display()
+            data_dir.join("tidebreak.db").display()
         ))
         .await
         .unwrap();
@@ -3099,8 +3099,8 @@ mod tests {
 
         // The epoch reset, as desktop_schema performs it: the database files
         // are deleted; everything else in the data directory stays.
-        std::fs::remove_file(data_dir.join("openwave.db")).unwrap();
-        assert!(!data_dir.join("openwave.db").exists());
+        std::fs::remove_file(data_dir.join("tidebreak.db")).unwrap();
+        assert!(!data_dir.join("tidebreak.db").exists());
 
         // Resolution needs no store at all now: the policy survives, still
         // managed to the same gateway, and the retire step — boot's session

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -245,6 +245,11 @@ test("PR lanes are scope-gated, never label-gated", () => {
     ci,
     /cp "\$trusted" "\$GITHUB_WORKSPACE\/scripts\/\.trusted-workflow-security\.test\.mjs"/,
   );
+  assert.doesNotMatch(
+    ci,
+    /sed -i/,
+    "the trusted policy runs as checked in; do not rewrite it",
+  );
   assert.match(ci, /CANONICAL_REPOSITORY: brightwave-inc\/tidebreak/);
   assert.match(
     ci,
@@ -1006,11 +1011,7 @@ test("release caches restore only credential-free compiler products", () => {
   for (const restoreStep of [releasePrepareCache, warmBuildCache]) {
     assert.match(
       restoreStep,
-<<<<<<< HEAD
       /^\s*macos-release-target-v4-\$\{\{ matrix\.arch \}\}-$/m,
-=======
-      /^\s*macos-release-target-v4-\$\{\{ matrix\.arch \}\}-$/m,
->>>>>>> d4f12ada (ci: roll macOS release build caches to v4)
       "credential-free jobs may fall back to any warmed cache for this arch",
     );
   }

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -990,12 +990,12 @@ test("release caches restore only credential-free compiler products", () => {
   ]) {
     assert.match(
       restoreStep,
-      /macos-release-target-v\d+-\$\{\{ matrix\.arch \}\}-/,
+      /macos-release-target-v4-\$\{\{ matrix\.arch \}\}-/,
       "unsigned product caches should be preferred when available",
     );
     assert.doesNotMatch(
       restoreStep,
-      /macos-release-(?:target|prepared)-v[12]-/,
+      /macos-release-(?:target|prepared)-v[123]-/,
       "older cache generations bake in runner-absolute checkout paths and must not be restored",
     );
   }
@@ -1006,7 +1006,11 @@ test("release caches restore only credential-free compiler products", () => {
   for (const restoreStep of [releasePrepareCache, warmBuildCache]) {
     assert.match(
       restoreStep,
-      /^\s*macos-release-target-v\d+-\$\{\{ matrix\.arch \}\}-$/m,
+<<<<<<< HEAD
+      /^\s*macos-release-target-v4-\$\{\{ matrix\.arch \}\}-$/m,
+=======
+      /^\s*macos-release-target-v4-\$\{\{ matrix\.arch \}\}-$/m,
+>>>>>>> d4f12ada (ci: roll macOS release build caches to v4)
       "credential-free jobs may fall back to any warmed cache for this arch",
     );
   }


### PR DESCRIPTION
The `macOS cache · aarch64` job on main failed after the OpenWave → Tidebreak rename ([run 31646181679](https://github.com/brightwave-inc/tidebreak/actions/runs/31646181679/job/94280278364)).

Tauri's desktop build script looks up plugin permissions at an absolute path baked into the restored unsigned Rust cache:

```
failed to read plugin permissions: failed to read file
'/Users/runner/work/openwave/openwave/target/aarch64-apple-darwin/release/build/tauri-.../out/permissions/app/autogenerated/commands/app_hide.toml'
```

The checkout is now `/Users/runner/work/tidebreak/tidebreak`. The v3 archive was warmed before the rename, and the warming job saves even after a failed compile, so that poison would keep regenerating if we only deleted today's entry.

This PR:

- bumps `macos-release-target` / `macos-release-prepared` to `v4` and drops the v3 restore fallbacks
- deletes the one-generation OpenWave→Tidebreak `sed` rewrite from the release-policy job

Depends on #2022 landing first. Release policy runs **main's** copy of the test, so that PR has to stop requiring the shim and the exact v3 key before this one can go green.

Verified locally with `node --test scripts/workflow-security.test.mjs`.