### PR TITLE
docs: add space above the README mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <p align="center">
+  <br>
   <img src="assets/tidebreak-mark.svg" alt="Tidebreak mark" width="300">
 </p>
 


### PR DESCRIPTION
## Summary

The README mark sat flush under GitHub's tab bar. Add a line break above it so the logo has a little breathing room. GitHub strips CSS on README images, so a `<br>` is the reliable way to get that space.

## Test plan

- [ ] Confirm the README hero on GitHub shows space above the mark