### PR TITLE
ci(deps): bump rust-cache and install-action

### DIFF
--- a/.github/workflows/cache-macos.yml
+++ b/.github/workflows/cache-macos.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Cache Cargo downloads
-        uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
+        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
         with:
           shared-key: macos-release-cargo-registry-v2-${{ hashFiles('Cargo.lock') }}
           add-job-id-key: "false"
@@ -99,7 +99,7 @@ jobs:
           version: v0.16.0
 
       - name: Cache Cargo downloads
-        uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
+        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
         with:
           shared-key: macos-release-cargo-registry-v2-${{ hashFiles('Cargo.lock') }}
           add-job-id-key: "false"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install cargo-deny
-        uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
+        uses: taiki-e/install-action@7f4eb899022d8fe70b20c4f3de697aa85c309026 # v2.85.11
         with:
           tool: cargo-deny@0.20.2
       # Posture and exceptions live in deny.toml. `--all-features` covers
@@ -314,7 +314,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install cargo-machete
-        uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
+        uses: taiki-e/install-action@7f4eb899022d8fe70b20c4f3de697aa85c309026 # v2.85.11
         with:
           tool: cargo-machete@0.9.1
       - name: Check for unused dependencies
@@ -336,7 +336,7 @@ jobs:
       - name: Install toolchain (honors rust-toolchain.toml)
         run: rustup show
       - name: Cache Cargo downloads
-        uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
+        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
         with:
           shared-key: notices-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
           cache-targets: false
@@ -407,7 +407,7 @@ jobs:
             librsvg2-dev \
             mold \
             patchelf
-      - uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
+      - uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
         with:
           shared-key: cargo-registry-v3-${{ hashFiles('Cargo.lock') }}
           add-job-id-key: "false"
@@ -460,7 +460,7 @@ jobs:
             librsvg2-dev \
             mold \
             patchelf
-      - uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
+      - uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
         with:
           shared-key: cargo-registry-v3-${{ hashFiles('Cargo.lock') }}
           add-job-id-key: "false"
@@ -512,7 +512,7 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
-      - uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
+      - uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
         with:
           shared-key: windows-check-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
           add-job-id-key: "false"
@@ -591,7 +591,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends cmake mold
-      - uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
+      - uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
         with:
           shared-key: cargo-registry-v3-${{ hashFiles('Cargo.lock') }}
           add-job-id-key: "false"
@@ -645,7 +645,7 @@ jobs:
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: v0.16.0
-      - uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
+      - uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
         with:
           shared-key: cargo-registry-v3-${{ hashFiles('Cargo.lock') }}
           add-job-id-key: "false"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,7 +303,7 @@ jobs:
           version: v0.16.0
 
       - name: Cache Cargo downloads
-        uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
+        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
         with:
           shared-key: macos-release-cargo-registry-v2-${{ hashFiles('Cargo.lock') }}
           add-job-id-key: "false"
@@ -540,7 +540,7 @@ jobs:
           version: v0.16.0
 
       - name: Cache Cargo downloads
-        uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
+        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
         with:
           shared-key: macos-release-cargo-registry-v2-${{ hashFiles('Cargo.lock') }}
           add-job-id-key: "false"
@@ -803,7 +803,7 @@ jobs:
           version: v0.16.0
 
       - name: Cache Cargo downloads
-        uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
+        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
         with:
           shared-key: windows-release-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
           add-job-id-key: "false"
@@ -975,7 +975,7 @@ jobs:
           version: v0.16.0
 
       - name: Cache Cargo downloads
-        uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
+        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
         with:
           shared-key: windows-release-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
           add-job-id-key: "false"


### PR DESCRIPTION
## Summary

Supersedes #2018 and #2017. Those Dependabot PRs only change GitHub Actions pins, but they were opened against pre-#2022 `main` and failed release-policy (and #2017's test job hit a transient sccache hang).

This reapplies the same bumps on current `main` (after #2021 / #2022):

- `Swatinem/rust-cache` `a45951ff` → `258712b0` (v2; fixes cleanup that returned after the first stale cache entry)
- `taiki-e/install-action` 2.85.10 → 2.85.11

No product code or lockfiles change.

## Test plan

- [x] `node --test scripts/workflow-security.test.mjs scripts/workflow-security-mutations.test.mjs`
- [ ] CI green