### PR TITLE
fix(host-broker): close computer-use consent, audit, and blocklist gaps

### DIFF
--- a/crates/tidebreak-desktop/src/client_execution/computer_use.rs
+++ b/crates/tidebreak-desktop/src/client_execution/computer_use.rs
@@ -1088,6 +1088,7 @@ async fn dispatch_consent(
         capability,
         bundle_id: bundle_id.clone(),
         consent: ConsentMethod::PermissionDialog,
+        single_use: decision == ConsentDecision::Once,
     });
     if let Err(error) = state.broker.control(grant).await {
         return map_control_error(&error);
@@ -1132,10 +1133,10 @@ async fn dispatch_consent(
     resolution
 }
 
-/// A `once` consent wrote a conversation grant so the broker would authorize;
-/// take it back so nothing is remembered. Best-effort: a failed revoke is
-/// reported in the log, not to the model, and the grant remains listed in
-/// Settings where the user can withdraw it.
+/// A `once` consent wrote a session-only grant so the broker would authorize.
+/// The broker also consumes that grant when the authorizing op finishes;
+/// this revoke is the halt / abandoned-hold cleanup so a leftover one-shot
+/// cannot authorize a later op in the same session. Best-effort.
 async fn revoke_once_grant(
     state: &HostAccess,
     decision: ConsentDecision,

--- a/crates/tidebreak-desktop/src/client_execution/computer_use.rs
+++ b/crates/tidebreak-desktop/src/client_execution/computer_use.rs
@@ -74,11 +74,6 @@ const MAX_WINDOW_ROWS: usize = 64;
 const MAX_MARK_TABLES: usize = 64;
 /// Mark numbers are 1-based; mirrors the core contract's bound.
 const MAX_CACHED_MARKS: usize = tidebreak_core::MAX_MARK as usize;
-/// The broker's exact words when auto-yield refuses an op. `ErrorCode::Denied`
-/// covers a grant miss, the blocklist, and a yield; the blocklist is
-/// pre-checked natively, so this message is what tells a security-surface
-/// yield (hard stop, no consent card) apart from a grant miss (consent card).
-const YIELD_MESSAGE: &str = "a system security surface owns the foreground";
 /// Renderer event carrying the full control/consent snapshot on every change.
 const STATE_EVENT: &str = "computer-use-state-changed";
 /// A control op touches the indicator as recently active for this long after
@@ -957,7 +952,7 @@ enum BrokerFailure {
 }
 
 fn map_broker_error(error: &BrokerClientError) -> BrokerFailure {
-    let BrokerClientError::Broker { code, message, .. } = error else {
+    let BrokerClientError::Broker { code, .. } = error else {
         // Transport-layer failures say nothing about authorization and must
         // not surface broker internals to the model.
         return BrokerFailure::Resolution(unavailable(
@@ -966,20 +961,14 @@ fn map_broker_error(error: &BrokerClientError) -> BrokerFailure {
         ));
     };
     match code {
-        ErrorCode::Denied => {
-            // A yield is a hard stop, never a consent prompt. The blocklist was
-            // pre-checked natively, so any other Denied is a grant miss — every
-            // computer-use op names a grantable capability (a display capture
-            // or screen-wide window list asks for the whole-screen scope).
-            if message == YIELD_MESSAGE {
-                BrokerFailure::Resolution(unavailable(
-                    "control_yielded",
-                    "A system security surface owns the foreground, so the action was refused. Do not retry; tell the user what you were trying to do.",
-                ))
-            } else {
-                BrokerFailure::ConsentRequired
-            }
-        }
+        ErrorCode::Yielded => BrokerFailure::Resolution(unavailable(
+            "control_yielded",
+            "A system security surface owns the foreground, so the action was refused. Do not retry; tell the user what you were trying to do.",
+        )),
+        // The blocklist was pre-checked natively, so Denied is a grant miss —
+        // every computer-use op names a grantable capability (a display
+        // capture or screen-wide window list asks for the whole-screen scope).
+        ErrorCode::Denied => BrokerFailure::ConsentRequired,
         ErrorCode::OsPermissionDenied => BrokerFailure::Resolution(unavailable(
             "os_permission_required",
             "macOS has not granted OpenWave Screen Recording and Accessibility. Ask the user to enable them in Settings, then retry.",
@@ -1734,8 +1723,8 @@ mod tests {
     #[test]
     fn a_yield_maps_to_a_hard_refusal_not_a_consent_prompt() {
         let error = BrokerClientError::Broker {
-            code: ErrorCode::Denied,
-            message: YIELD_MESSAGE.to_owned(),
+            code: ErrorCode::Yielded,
+            message: "wording is not the contract".to_owned(),
             retryable: false,
         };
         match map_broker_error(&error) {
@@ -1745,9 +1734,11 @@ mod tests {
             _ => panic!("a yield must never become a consent card"),
         }
 
+        // Denied is a grant miss even if the message still uses the former
+        // yield sentence — the code is the contract, not the English.
         let grant_miss = BrokerClientError::Broker {
             code: ErrorCode::Denied,
-            message: "host operation was denied".to_owned(),
+            message: "a system security surface owns the foreground".to_owned(),
             retryable: false,
         };
         assert!(matches!(

--- a/crates/tidebreak-host-broker/helper/Sources/tidebreak-cu-helper/Control.swift
+++ b/crates/tidebreak-host-broker/helper/Sources/tidebreak-cu-helper/Control.swift
@@ -47,10 +47,35 @@ enum Control {
         // channel-suffixed variant).
         "io.brightwave.tidebreak",
         "io.brightwave.",
-        // Terminals are arbitrary code execution outside the broker's
-        // confinement.
+        // Terminals, IDEs, editors, and command launchers: a ControlApp grant
+        // over any of these reaches unsandboxed local execution (focus the
+        // integrated shell, type a command, press Return) and would bypass the
+        // sandboxed exec path. A bundle-id list cannot enumerate every app that
+        // embeds a shell; this is the common class. See decision record 0010.
         "com.apple.Terminal",
         "com.googlecode.iterm2",
+        "dev.warp.",
+        "net.kovidgoyal.kitty",
+        "org.alacritty",
+        "io.alacritty",
+        "com.github.wez.wezterm",
+        "com.mitchellh.ghostty",
+        "com.microsoft.VSCode",
+        "com.microsoft.VSCodeInsiders",
+        "com.visualstudio.code.oss",
+        // Cursor's stable ToDesktop-issued bundle id (not a com.cursor.* id).
+        "com.todesktop.230313mzl4w4u92",
+        "com.exafunction.windsurf",
+        "com.apple.dt.Xcode",
+        "com.jetbrains.",
+        "com.sublimetext.",
+        "com.panic.Nova",
+        "com.google.android.studio",
+        "dev.zed.Zed",
+        "org.gnu.Emacs",
+        "org.vim.MacVim",
+        "com.runningwithcrayons.Alfred",
+        "com.raycast.macos",
         // Auth / login / credential surfaces — driving these could defeat a
         // human-in-the-loop check.
         "com.apple.loginwindow",

--- a/crates/tidebreak-host-broker/src/audit.rs
+++ b/crates/tidebreak-host-broker/src/audit.rs
@@ -99,7 +99,7 @@ pub enum AuditOperation {
     ProtocolVersionMismatch,
 }
 
-/// Whether the broker performed, refused, or failed an operation.
+/// Whether the broker performed, refused, held, or failed an operation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AuditOutcome {
@@ -110,6 +110,10 @@ pub enum AuditOutcome {
     /// exactly what the trail should say rather than omitting the operation.
     Attempted,
     Allowed,
+    /// A consequential action was parked for confirmation and did not run.
+    /// Distinct from [`Self::Allowed`]: the host was not mutated. Confirming
+    /// later writes its own Attempted/Allowed pair for the act that fired.
+    Held,
     Denied,
     Failed,
 }

--- a/crates/tidebreak-host-broker/src/blocklist.rs
+++ b/crates/tidebreak-host-broker/src/blocklist.rs
@@ -16,9 +16,35 @@ pub const BLOCKED_CONTROL_BUNDLES: &[&str] = &[
     // is being watched through.
     "io.brightwave.tidebreak",
     "io.brightwave.",
-    // Terminals: shell access would bypass the sandboxed exec path entirely.
+    // Terminals, IDEs, editors, and command launchers: a ControlApp grant
+    // over any of these reaches unsandboxed local execution (focus the
+    // integrated shell, type a command, press Return) and would bypass the
+    // sandboxed exec path. A bundle-id list cannot enumerate every app that
+    // embeds a shell; this is the common class. See decision record 0010.
     "com.apple.Terminal",
     "com.googlecode.iterm2",
+    "dev.warp.",
+    "net.kovidgoyal.kitty",
+    "org.alacritty",
+    "io.alacritty",
+    "com.github.wez.wezterm",
+    "com.mitchellh.ghostty",
+    "com.microsoft.VSCode",
+    "com.microsoft.VSCodeInsiders",
+    "com.visualstudio.code.oss",
+    // Cursor's stable ToDesktop-issued bundle id (not a com.cursor.* id).
+    "com.todesktop.230313mzl4w4u92",
+    "com.exafunction.windsurf",
+    "com.apple.dt.Xcode",
+    "com.jetbrains.",
+    "com.sublimetext.",
+    "com.panic.Nova",
+    "com.google.android.studio",
+    "dev.zed.Zed",
+    "org.gnu.Emacs",
+    "org.vim.MacVim",
+    "com.runningwithcrayons.Alfred",
+    "com.raycast.macos",
     // OS security and credential surfaces.
     "com.apple.loginwindow",
     "com.apple.SecurityAgent",
@@ -53,6 +79,28 @@ mod tests {
             "com.apple.Terminal",
             "com.apple.Terminal.helper",
             "com.apple.SecurityAgent",
+            "dev.warp.Warp-Stable",
+            "net.kovidgoyal.kitty",
+            "org.alacritty",
+            "io.alacritty",
+            "com.github.wez.wezterm",
+            "com.mitchellh.ghostty",
+            "com.microsoft.VSCode",
+            "com.microsoft.VSCodeInsiders",
+            "com.visualstudio.code.oss",
+            "com.todesktop.230313mzl4w4u92",
+            "com.exafunction.windsurf",
+            "com.apple.dt.Xcode",
+            "com.jetbrains.intellij",
+            "com.jetbrains.CLion",
+            "com.sublimetext.4",
+            "com.panic.Nova",
+            "com.google.android.studio",
+            "dev.zed.Zed",
+            "org.gnu.Emacs",
+            "org.vim.MacVim",
+            "com.runningwithcrayons.Alfred",
+            "com.raycast.macos",
         ] {
             assert!(is_blocked_control_bundle(blocked), "{blocked}");
         }
@@ -65,6 +113,8 @@ mod tests {
             "com.apple.Terminalized",
             "io.brightwavex.openwave",
             "com.apple.Notes",
+            "com.microsoft.Word",
+            "com.jetbrainsx.intellij",
             "com.example.Mail",
             "",
         ] {

--- a/crates/tidebreak-host-broker/src/broker.rs
+++ b/crates/tidebreak-host-broker/src/broker.rs
@@ -767,17 +767,18 @@ struct OperationAudit {
 
 impl OperationAudit {
     fn from_envelope(envelope: &OperationEnvelope) -> Self {
-        // Input synthesis (click / type / key) is a host mutation: its intent
-        // record must be durable before any event is synthesized, and the op
-        // refuses when the record cannot be made durable. Scroll and focus
-        // are reversible view changes authorized on the read capability, so
-        // like the folder reads they are completion-recorded only.
+        // Input synthesis (click / type / key / scroll / focus) is a host
+        // mutation: its intent record must be durable before any event is
+        // synthesized, and the op refuses when the record cannot be made
+        // durable. Scroll warps the cursor; focus raises a window.
         let mutates = matches!(
             envelope.request,
             OperationRequest::WriteFile(_)
                 | OperationRequest::CuClick { .. }
                 | OperationRequest::CuTypeText { .. }
                 | OperationRequest::CuKeyPress { .. }
+                | OperationRequest::CuScroll { .. }
+                | OperationRequest::CuFocusWindow { .. }
         );
         let (operation, capability, target) = match &envelope.request {
             OperationRequest::ListRoots => (
@@ -2256,7 +2257,7 @@ impl Operator {
             actor: metadata.actor,
             operation,
             target: metadata.target,
-            outcome: audit_outcome(error),
+            outcome: operation_audit_outcome(result),
             capability: Some(metadata.capability),
             grant_id,
             error_code: error.map(|error| error.code),
@@ -3384,6 +3385,15 @@ fn audit_outcome(error: Option<&ErrorResponse>) -> AuditOutcome {
         None => AuditOutcome::Allowed,
         Some(ErrorCode::Denied) => AuditOutcome::Denied,
         Some(_) => AuditOutcome::Failed,
+    }
+}
+
+/// Completion outcome for an operator result. A hold is not an executed
+/// action: [`AuditOutcome::Held`] is distinct from [`AuditOutcome::Allowed`].
+fn operation_audit_outcome(result: &Result<OperationResult, ErrorResponse>) -> AuditOutcome {
+    match result {
+        Ok(OperationResult::CuNeedsConfirmation(_)) => AuditOutcome::Held,
+        _ => audit_outcome(result.as_ref().err()),
     }
 }
 

--- a/crates/tidebreak-host-broker/src/broker.rs
+++ b/crates/tidebreak-host-broker/src/broker.rs
@@ -3327,7 +3327,7 @@ fn error_response(error: BrokerError) -> ErrorResponse {
                 true,
             ),
             BackendErrorKind::Yielded => (
-                ErrorCode::Denied,
+                ErrorCode::Yielded,
                 "a system security surface owns the foreground",
                 false,
             ),

--- a/crates/tidebreak-host-broker/src/broker.rs
+++ b/crates/tidebreak-host-broker/src/broker.rs
@@ -226,9 +226,9 @@ impl Shared {
     }
 
     /// Drop a one-shot grant after the operation it authorized finished.
-    /// Missing or standing grants are no-ops. Persistence failure is
-    /// reported but must not rewrite the operation's own result: the host
-    /// effect already happened.
+    /// Missing or standing grants are no-ops. One-shots are never persisted,
+    /// so this is a memory-only retain — a failed no-op rewrite of the
+    /// standing table must not leave the row live.
     fn consume_single_use_grant(&self, grant_id: Option<GrantId>) -> Result<(), BrokerError> {
         let Some(grant_id) = grant_id else {
             return Ok(());
@@ -240,24 +240,14 @@ impl Shared {
         if self.failed_closed.load(Ordering::SeqCst) {
             return Err(BrokerError::PersistenceAmbiguous);
         }
-        let matches_shot = current
+        if !current
             .grants
             .iter()
-            .any(|grant| grant.id() == grant_id && grant.is_single_use());
-        if !matches_shot {
+            .any(|grant| grant.id() == grant_id && grant.is_single_use())
+        {
             return Ok(());
         }
-        let mut next = current.clone();
-        next.grants.retain(|grant| grant.id() != grant_id);
-        if let Some(state_file) = &self.state_file {
-            if let Err(error) = state_file.save(&next) {
-                if matches!(error, BrokerError::PersistenceAmbiguous) {
-                    self.failed_closed.store(true, Ordering::SeqCst);
-                }
-                return Err(error);
-            }
-        }
-        *current = next;
+        current.grants.retain(|grant| grant.id() != grant_id);
         Ok(())
     }
 }
@@ -968,6 +958,31 @@ impl Broker {
         staging: PathBuf,
     ) -> Self {
         Self::with_components(policy, true, audit, backend, prepare_cu_staging(staging))
+    }
+
+    /// Test hook: durable state plus an injected computer-use backend.
+    #[cfg(test)]
+    pub(crate) fn test_open_with_computer_use(
+        policy: RootPolicy,
+        data_dir: &Path,
+        audit: Arc<dyn AuditSink>,
+        backend: Arc<dyn ComputerUseBackend>,
+        staging: PathBuf,
+    ) -> Result<Self, BrokerError> {
+        let state_file = StateFile::open(data_dir)?;
+        let state = state_file.load(&policy, true)?;
+        Ok(Self {
+            shared: Arc::new(Shared {
+                policy,
+                execute_commands: true,
+                state: Mutex::new(state),
+                state_file: Some(state_file),
+                audit,
+                failed_closed: AtomicBool::new(false),
+                computer_use: backend,
+                cu_staging: prepare_cu_staging(staging),
+            }),
+        })
     }
 
     /// Open durable broker state under the application-private data directory.
@@ -1829,7 +1844,22 @@ impl Controller {
         });
         let revoked = next.grants.len() != before;
         if revoked {
-            self.commit_state(&mut state, next)?;
+            let dropped_only_shots = state
+                .grants
+                .iter()
+                .filter(|grant| {
+                    grant.subject() == request.subject
+                        && grant.capability() == request.capability
+                        && *grant.scope() == scope
+                })
+                .all(Grant::is_single_use);
+            if dropped_only_shots {
+                // One-shots are not on disk. Do not gate forgetting them on a
+                // rewrite of the standing table.
+                *state = next;
+            } else {
+                self.commit_state(&mut state, next)?;
+            }
         }
         Ok(revoked)
     }
@@ -2436,6 +2466,19 @@ impl Operator {
         Ok(grant_id)
     }
 
+    /// A one-shot is spent when the authorizing op fails after the grant
+    /// check. Confirmation holds stay live (they return `Ok`).
+    fn spend_once_on_failure<T>(
+        &self,
+        grant_id: GrantId,
+        result: Result<T, BrokerError>,
+    ) -> Result<T, BrokerError> {
+        if result.is_err() {
+            let _ = self.shared.consume_single_use_grant(Some(grant_id));
+        }
+        result
+    }
+
     /// Every computer-use handler below follows the same spine: validate and
     /// bound the request, hard-refuse a blocked bundle, authorize against the
     /// live grants (deny-by-default, consent-card signal on a miss), and only
@@ -2477,11 +2520,13 @@ impl Operator {
             }
             .ok_or(BrokerError::Denied)?
         };
-        let windows = self
-            .shared
-            .computer_use
-            .list_windows(bundle_id.as_deref())
-            .map_err(BrokerError::ComputerUse)?;
+        let windows = self.spend_once_on_failure(
+            grant_id,
+            self.shared
+                .computer_use
+                .list_windows(bundle_id.as_deref())
+                .map_err(BrokerError::ComputerUse),
+        )?;
         Ok((OperationResult::CuListWindows { windows }, Some(grant_id)))
     }
 
@@ -2540,11 +2585,13 @@ impl Operator {
                 .unwrap_or_default(),
             CaptureTarget::Display { .. } => Vec::new(),
         };
-        let meta = self
-            .shared
-            .computer_use
-            .capture_with_marks(&backend_target, &out_path, &marks)
-            .map_err(BrokerError::ComputerUse)?;
+        let meta = self.spend_once_on_failure(
+            grant_id,
+            self.shared
+                .computer_use
+                .capture_with_marks(&backend_target, &out_path, &marks)
+                .map_err(BrokerError::ComputerUse),
+        )?;
         {
             let mut state = self.lock_state()?;
             state.handoffs.insert(
@@ -2583,15 +2630,17 @@ impl Operator {
             let state = self.lock_state()?;
             authorize_computer_use(&state, context, Capability::ReadAppContent, &bundle_id)?
         };
-        let tree = self
-            .shared
-            .computer_use
-            .read_ax_tree(
-                &bundle_id,
-                Some(max_depth.map_or(MAX_CU_AX_DEPTH, |depth| depth.min(MAX_CU_AX_DEPTH))),
-                Some(max_nodes.map_or(MAX_CU_AX_NODES, |nodes| nodes.min(MAX_CU_AX_NODES))),
-            )
-            .map_err(BrokerError::ComputerUse)?;
+        let tree = self.spend_once_on_failure(
+            grant_id,
+            self.shared
+                .computer_use
+                .read_ax_tree(
+                    &bundle_id,
+                    Some(max_depth.map_or(MAX_CU_AX_DEPTH, |depth| depth.min(MAX_CU_AX_DEPTH))),
+                    Some(max_nodes.map_or(MAX_CU_AX_NODES, |nodes| nodes.min(MAX_CU_AX_NODES))),
+                )
+                .map_err(BrokerError::ComputerUse),
+        )?;
         Ok((OperationResult::CuReadAppContent(tree), Some(grant_id)))
     }
 
@@ -2615,25 +2664,30 @@ impl Operator {
             let state = self.lock_state()?;
             authorize_computer_use(&state, context, Capability::ControlApp, &bundle_id)?
         };
-        if let Some(held) = self.consequential_gate(
-            context,
-            ControlOp::Click,
-            &bundle_id,
-            &target,
-            PendingActionKind::Click {
-                bundle_id: bundle_id.clone(),
-                target: target.clone(),
-                button: button.clone(),
-                click_count,
-            },
+        if let Some(held) = self.spend_once_on_failure(
+            grant_id,
+            self.consequential_gate(
+                context,
+                ControlOp::Click,
+                &bundle_id,
+                &target,
+                PendingActionKind::Click {
+                    bundle_id: bundle_id.clone(),
+                    target: target.clone(),
+                    button: button.clone(),
+                    click_count,
+                },
+            ),
         )? {
             return Ok((held, Some(grant_id)));
         }
-        let meta = self
-            .shared
-            .computer_use
-            .click(&bundle_id, &target, button.as_deref(), click_count)
-            .map_err(BrokerError::ComputerUse)?;
+        let meta = self.spend_once_on_failure(
+            grant_id,
+            self.shared
+                .computer_use
+                .click(&bundle_id, &target, button.as_deref(), click_count)
+                .map_err(BrokerError::ComputerUse),
+        )?;
         Ok((OperationResult::CuClick(meta), Some(grant_id)))
     }
 
@@ -2656,24 +2710,29 @@ impl Operator {
             let state = self.lock_state()?;
             authorize_computer_use(&state, context, Capability::ControlApp, &bundle_id)?
         };
-        if let Some(held) = self.consequential_gate(
-            context,
-            ControlOp::TypeText,
-            &bundle_id,
-            &target,
-            PendingActionKind::TypeText {
-                bundle_id: bundle_id.clone(),
-                text: text.clone(),
-                target: target.clone(),
-            },
+        if let Some(held) = self.spend_once_on_failure(
+            grant_id,
+            self.consequential_gate(
+                context,
+                ControlOp::TypeText,
+                &bundle_id,
+                &target,
+                PendingActionKind::TypeText {
+                    bundle_id: bundle_id.clone(),
+                    text: text.clone(),
+                    target: target.clone(),
+                },
+            ),
         )? {
             return Ok((held, Some(grant_id)));
         }
-        let meta = self
-            .shared
-            .computer_use
-            .type_text(&bundle_id, &text, &target)
-            .map_err(BrokerError::ComputerUse)?;
+        let meta = self.spend_once_on_failure(
+            grant_id,
+            self.shared
+                .computer_use
+                .type_text(&bundle_id, &text, &target)
+                .map_err(BrokerError::ComputerUse),
+        )?;
         Ok((OperationResult::CuTypeText(meta), Some(grant_id)))
     }
 
@@ -2799,30 +2858,35 @@ impl Operator {
                 }
                 _ => key.clone(),
             };
-            if let Some(held) = self.hold_for_confirmation(
-                context,
-                &bundle_id,
-                PendingActionKind::KeyPress {
-                    bundle_id: bundle_id.clone(),
-                    key: key.clone(),
-                    modifiers: modifiers.clone(),
-                },
-                Some(truncate_label(&label)),
-                // A key press has no element, so no fingerprint to bind.
-                None,
-                format!(
-                    "This presses \u{201c}{}\u{201d}, a keyboard shortcut that can commit an action (send, delete, or quit) with no undo.",
-                    truncate_label(&label)
+            if let Some(held) = self.spend_once_on_failure(
+                grant_id,
+                self.hold_for_confirmation(
+                    context,
+                    &bundle_id,
+                    PendingActionKind::KeyPress {
+                        bundle_id: bundle_id.clone(),
+                        key: key.clone(),
+                        modifiers: modifiers.clone(),
+                    },
+                    Some(truncate_label(&label)),
+                    // A key press has no element, so no fingerprint to bind.
+                    None,
+                    format!(
+                        "This presses \u{201c}{}\u{201d}, a keyboard shortcut that can commit an action (send, delete, or quit) with no undo.",
+                        truncate_label(&label)
+                    ),
                 ),
             )? {
                 return Ok((held, Some(grant_id)));
             }
         }
-        let meta = self
-            .shared
-            .computer_use
-            .key_press(&bundle_id, &key, modifiers.as_deref())
-            .map_err(BrokerError::ComputerUse)?;
+        let meta = self.spend_once_on_failure(
+            grant_id,
+            self.shared
+                .computer_use
+                .key_press(&bundle_id, &key, modifiers.as_deref())
+                .map_err(BrokerError::ComputerUse),
+        )?;
         Ok((OperationResult::CuKeyPress(meta), Some(grant_id)))
     }
 
@@ -2851,11 +2915,13 @@ impl Operator {
             let state = self.lock_state()?;
             authorize_computer_use(&state, context, Capability::ControlApp, &bundle_id)?
         };
-        let meta = self
-            .shared
-            .computer_use
-            .scroll(&bundle_id, &target, dx, dy)
-            .map_err(BrokerError::ComputerUse)?;
+        let meta = self.spend_once_on_failure(
+            grant_id,
+            self.shared
+                .computer_use
+                .scroll(&bundle_id, &target, dx, dy)
+                .map_err(BrokerError::ComputerUse),
+        )?;
         Ok((OperationResult::CuScroll(meta), Some(grant_id)))
     }
 
@@ -2873,11 +2939,13 @@ impl Operator {
             let state = self.lock_state()?;
             authorize_computer_use(&state, context, Capability::ControlApp, &bundle_id)?
         };
-        let meta = self
-            .shared
-            .computer_use
-            .focus_window(&bundle_id, window_id)
-            .map_err(BrokerError::ComputerUse)?;
+        let meta = self.spend_once_on_failure(
+            grant_id,
+            self.shared
+                .computer_use
+                .focus_window(&bundle_id, window_id)
+                .map_err(BrokerError::ComputerUse),
+        )?;
         Ok((OperationResult::CuFocusWindow(meta), Some(grant_id)))
     }
 

--- a/crates/tidebreak-host-broker/src/broker.rs
+++ b/crates/tidebreak-host-broker/src/broker.rs
@@ -224,6 +224,42 @@ impl Shared {
             eprintln!("tidebreak host broker could not persist audit event: {error}");
         }
     }
+
+    /// Drop a one-shot grant after the operation it authorized finished.
+    /// Missing or standing grants are no-ops. Persistence failure is
+    /// reported but must not rewrite the operation's own result: the host
+    /// effect already happened.
+    fn consume_single_use_grant(&self, grant_id: Option<GrantId>) -> Result<(), BrokerError> {
+        let Some(grant_id) = grant_id else {
+            return Ok(());
+        };
+        if self.failed_closed.load(Ordering::SeqCst) {
+            return Err(BrokerError::PersistenceAmbiguous);
+        }
+        let mut current = self.state.lock().map_err(|_| BrokerError::StatePoisoned)?;
+        if self.failed_closed.load(Ordering::SeqCst) {
+            return Err(BrokerError::PersistenceAmbiguous);
+        }
+        let matches_shot = current
+            .grants
+            .iter()
+            .any(|grant| grant.id() == grant_id && grant.is_single_use());
+        if !matches_shot {
+            return Ok(());
+        }
+        let mut next = current.clone();
+        next.grants.retain(|grant| grant.id() != grant_id);
+        if let Some(state_file) = &self.state_file {
+            if let Err(error) = state_file.save(&next) {
+                if matches!(error, BrokerError::PersistenceAmbiguous) {
+                    self.failed_closed.store(true, Ordering::SeqCst);
+                }
+                return Err(error);
+            }
+        }
+        *current = next;
+        Ok(())
+    }
 }
 
 #[derive(Clone, Default)]
@@ -1726,11 +1762,32 @@ impl Controller {
         let scope = cu_grant_scope(request.capability, request.bundle_id.as_deref())?;
         let mut state = self.lock_state()?;
         let mut next = state.clone();
-        if let Some(existing) = next.grants.iter().find(|grant| {
+        let same_tuple = |grant: &Grant| {
             grant.subject() == request.subject
                 && grant.capability() == request.capability
                 && *grant.scope() == scope
-        }) {
+        };
+        // A standing grant already covers this tuple. Once is weaker: reuse
+        // the standing row rather than stacking a one-shot beside it.
+        if let Some(existing) = next
+            .grants
+            .iter()
+            .find(|grant| same_tuple(grant) && !grant.is_single_use())
+        {
+            return Ok(CuGrantAppResult {
+                granted: false,
+                grant_id: existing.id(),
+            });
+        }
+        if !request.single_use {
+            // Standing consent replaces any leftover one-shot at this tuple.
+            next.grants
+                .retain(|grant| !(same_tuple(grant) && grant.is_single_use()));
+        } else if let Some(existing) = next
+            .grants
+            .iter()
+            .find(|grant| same_tuple(grant) && grant.is_single_use())
+        {
             return Ok(CuGrantAppResult {
                 granted: false,
                 grant_id: existing.id(),
@@ -1743,6 +1800,11 @@ impl Controller {
             scope,
             ConsentRecord::new(request.consent, Utc::now()),
         )?;
+        let grant = if request.single_use {
+            grant.into_single_use()
+        } else {
+            grant
+        };
         let grant_id = grant.id();
         next.grants.push(grant);
         self.commit_state(&mut state, next)?;
@@ -1883,9 +1945,12 @@ impl Controller {
         let result = self
             .perform_confirmed_action(&pending, bundle_id, target, op)
             .map_err(error_response);
+        if let Ok((_, grant_id)) = &result {
+            let _ = self.shared.consume_single_use_grant(Some(*grant_id));
+        }
         self.shared
             .record_completion(&audit.completion(request_id, result.as_ref().err()));
-        result
+        result.map(|(meta, _)| meta)
     }
 
     /// Re-authorize, re-describe, and finally dispatch a confirmed action.
@@ -1897,14 +1962,14 @@ impl Controller {
         bundle_id: &str,
         target: &ElementTarget,
         op: ControlOp,
-    ) -> Result<ControlMeta, BrokerError> {
+    ) -> Result<(ControlMeta, GrantId), BrokerError> {
         if is_blocked_control_bundle(bundle_id) {
             return Err(BrokerError::BlockedApp);
         }
-        {
+        let grant_id = {
             let state = self.lock_state()?;
-            authorize_computer_use(&state, pending.context, Capability::ControlApp, bundle_id)?;
-        }
+            authorize_computer_use(&state, pending.context, Capability::ControlApp, bundle_id)?
+        };
         // The confirmation is honored only while the element still
         // reports the label the user approved. A UI that shifted under
         // the prompt — or a hijacked page that swapped the button —
@@ -1966,6 +2031,7 @@ impl Controller {
                 .key_press(bundle_id, key, modifiers.as_deref()),
         }
         .map_err(BrokerError::ComputerUse)
+        .map(|meta| (meta, grant_id))
     }
 
     fn hello(&self) -> HelloResult {
@@ -2020,6 +2086,11 @@ impl Operator {
             }
         }
         let (result, grant_id) = self.execute(envelope);
+        // A confirmation hold is not terminal: the one-shot must cover the
+        // confirm that follows. Any other outcome spends it.
+        if !matches!(result, Ok(OperationResult::CuNeedsConfirmation(_))) {
+            let _ = self.shared.consume_single_use_grant(grant_id);
+        }
         let result = result.map_err(error_response);
         self.record_completion(request_id, audit, grant_id, &result);
         response_envelope(request_id, result)
@@ -3079,7 +3150,9 @@ fn list_cu_app_grants(state: &State, subject: GrantSubject) -> Vec<GrantStatemen
         .grants
         .iter()
         .filter(|grant| {
-            grant.subject() == subject && matches!(grant.scope(), Scope::App { .. } | Scope::Screen)
+            !grant.is_single_use()
+                && grant.subject() == subject
+                && matches!(grant.scope(), Scope::App { .. } | Scope::Screen)
         })
         .map(|grant| GrantStatementSummary {
             grant_id: grant.id(),
@@ -4258,6 +4331,7 @@ fn list_grant_statements(state: &State) -> Result<Vec<GrantStatementSummary>, Er
     let live = state
         .grants
         .iter()
+        .filter(|grant| !grant.is_single_use())
         .map(|grant| (grant, None::<&UnavailableRoot>));
     let dormant = state
         .unavailable

--- a/crates/tidebreak-host-broker/src/broker/state_file.rs
+++ b/crates/tidebreak-host-broker/src/broker/state_file.rs
@@ -172,6 +172,10 @@ impl StateFile {
         }
 
         let mut grants = persisted.grants;
+        // One-shot computer-use grants are session-only. A file that somehow
+        // still carries one (an older binary, a crash mid-write) must not
+        // resurrect it as standing consent.
+        grants.retain(|grant| !grant.is_single_use());
         if persisted.version < 4 && execute_commands {
             carry_forward_exec_grants(&mut grants)?;
         }
@@ -351,6 +355,7 @@ impl StateFile {
                 })
         }));
         let mut grants = state.grants.clone();
+        grants.retain(|grant| !grant.is_single_use());
         grants.extend(
             state
                 .unavailable

--- a/crates/tidebreak-host-broker/src/broker/tests.rs
+++ b/crates/tidebreak-host-broker/src/broker/tests.rs
@@ -4456,6 +4456,7 @@ struct StubCuBackend {
     scrolled: Mutex<Vec<String>>,
     focused: Mutex<Vec<String>>,
     capture_png: Vec<u8>,
+    fail_click: Mutex<Option<BackendErrorKind>>,
 }
 
 impl StubCuBackend {
@@ -4578,6 +4579,12 @@ impl ComputerUseBackend for StubCuBackend {
         _button: Option<&str>,
         _click_count: Option<u32>,
     ) -> Result<ControlMeta, BackendError> {
+        if let Some(kind) = *self.fail_click.lock().unwrap() {
+            return Err(BackendError {
+                kind,
+                message: "injected click failure".to_owned(),
+            });
+        }
         self.clicked
             .lock()
             .unwrap()
@@ -5428,6 +5435,86 @@ fn a_once_grant_does_not_survive_broker_reload() {
     assert_eq!(grants.len(), 1);
     assert_eq!(grants[0].id(), standing_id);
     assert!(!grants[0].is_single_use());
+}
+
+fn durable_cu_setup() -> CuFixture {
+    let temp = tempfile::tempdir().unwrap();
+    let backend = StubCuBackend::available();
+    let audit = Arc::new(CollectingAudit::default());
+    let state_dir = temp.path().join("app-data/host-broker");
+    let broker = Broker::test_open_with_computer_use(
+        test_policy(&temp),
+        &state_dir,
+        audit.clone(),
+        backend.clone(),
+        temp.path().join("cu-staging"),
+    )
+    .unwrap();
+    let conversation = Uuid::new_v4();
+    CuFixture {
+        _temp: temp,
+        broker,
+        backend,
+        audit,
+        subject: GrantSubject::conversation(conversation).unwrap(),
+        context: ExecutionContext::standalone(conversation).unwrap(),
+    }
+}
+
+#[test]
+fn a_failed_save_does_not_keep_a_consumed_once_grant() {
+    let fixture = durable_cu_setup();
+    fixture.grant_once(Capability::ControlApp, Some("com.example.app"));
+    fixture
+        .broker
+        .shared
+        .state_file
+        .as_ref()
+        .unwrap()
+        .fail_after_saves(0);
+    fixture.click("com.example.app").unwrap();
+    assert_eq!(fixture.backend.clicks().len(), 1);
+    let error = fixture.click("com.example.app").unwrap_err();
+    assert_eq!(error.code, ErrorCode::Denied);
+}
+
+#[test]
+fn a_failed_save_does_not_block_revoking_an_once_grant() {
+    let fixture = durable_cu_setup();
+    fixture.grant_once(Capability::ControlApp, Some("com.example.app"));
+    fixture
+        .broker
+        .shared
+        .state_file
+        .as_ref()
+        .unwrap()
+        .fail_after_saves(0);
+    let revoked = fixture
+        .control(ControlRequest::CuRevokeApp(CuRevokeAppRequest {
+            subject: fixture.subject,
+            capability: Capability::ControlApp,
+            bundle_id: Some("com.example.app".to_owned()),
+        }))
+        .unwrap();
+    assert!(matches!(
+        revoked,
+        ControlResult::CuRevokeApp { revoked: true }
+    ));
+    let error = fixture.click("com.example.app").unwrap_err();
+    assert_eq!(error.code, ErrorCode::Denied);
+}
+
+#[test]
+fn a_post_authorize_error_spends_an_once_grant() {
+    let fixture = cu_setup();
+    fixture.grant_once(Capability::ControlApp, Some("com.example.app"));
+    *fixture.backend.fail_click.lock().unwrap() = Some(BackendErrorKind::Yielded);
+    let error = fixture.click("com.example.app").unwrap_err();
+    assert_eq!(error.code, ErrorCode::Yielded);
+    *fixture.backend.fail_click.lock().unwrap() = None;
+    let error = fixture.click("com.example.app").unwrap_err();
+    assert_eq!(error.code, ErrorCode::Denied);
+    assert!(fixture.backend.clicks().is_empty());
 }
 
 #[test]

--- a/crates/tidebreak-host-broker/src/broker/tests.rs
+++ b/crates/tidebreak-host-broker/src/broker/tests.rs
@@ -4453,6 +4453,8 @@ struct StubCuBackend {
     clicked: Mutex<Vec<(String, Option<String>)>>,
     typed: Mutex<Vec<String>>,
     keys: Mutex<Vec<String>>,
+    scrolled: Mutex<Vec<String>>,
+    focused: Mutex<Vec<String>>,
     capture_png: Vec<u8>,
 }
 
@@ -4486,6 +4488,14 @@ impl StubCuBackend {
 
     fn keys(&self) -> Vec<String> {
         self.keys.lock().unwrap().clone()
+    }
+
+    fn scrolls(&self) -> Vec<String> {
+        self.scrolled.lock().unwrap().clone()
+    }
+
+    fn focuses(&self) -> Vec<String> {
+        self.focused.lock().unwrap().clone()
     }
 
     /// One interactive button in a tiny AX tree, so Set-of-Marks extraction
@@ -4609,11 +4619,12 @@ impl ComputerUseBackend for StubCuBackend {
 
     fn scroll(
         &self,
-        _bundle_id: &str,
+        bundle_id: &str,
         _target: &ElementTarget,
         _dx: Option<f64>,
         _dy: Option<f64>,
     ) -> Result<ControlMeta, BackendError> {
+        self.scrolled.lock().unwrap().push(bundle_id.to_owned());
         Ok(ControlMeta {
             success: true,
             used_fallback: false,
@@ -4623,9 +4634,10 @@ impl ComputerUseBackend for StubCuBackend {
 
     fn focus_window(
         &self,
-        _bundle_id: &str,
+        bundle_id: &str,
         _window_id: Option<u32>,
     ) -> Result<ControlMeta, BackendError> {
+        self.focused.lock().unwrap().push(bundle_id.to_owned());
         Ok(ControlMeta {
             success: true,
             used_fallback: false,
@@ -5405,4 +5417,144 @@ fn a_once_grant_does_not_survive_broker_reload() {
     assert_eq!(grants.len(), 1);
     assert_eq!(grants[0].id(), standing_id);
     assert!(!grants[0].is_single_use());
+}
+
+#[test]
+fn a_held_click_is_audited_as_held_not_allowed() {
+    let fixture = cu_setup();
+    fixture.grant(Capability::ControlApp, Some("com.example.app"));
+    fixture.backend.set_label("Send");
+
+    let result = fixture.click("com.example.app").unwrap();
+    let OperationResult::CuNeedsConfirmation(held) = result else {
+        panic!("expected a confirmation hold, got {result:?}")
+    };
+    assert!(fixture.backend.clicks().is_empty());
+
+    {
+        let events = fixture.audit.events.lock().unwrap();
+        let click: Vec<_> = events
+            .iter()
+            .filter(|event| event.operation == AuditOperation::CuClick)
+            .map(|event| event.outcome)
+            .collect();
+        assert_eq!(click, [AuditOutcome::Attempted, AuditOutcome::Held]);
+        assert!(!events.iter().any(|event| {
+            event.operation == AuditOperation::CuClick && event.outcome == AuditOutcome::Allowed
+        }));
+    }
+
+    fixture
+        .control(ControlRequest::CuConfirmControlAction(
+            CuConfirmControlActionRequest {
+                confirmation_id: held.confirmation_id,
+            },
+        ))
+        .unwrap();
+    assert_eq!(fixture.backend.clicks().len(), 1);
+
+    let events = fixture.audit.events.lock().unwrap();
+    let click: Vec<_> = events
+        .iter()
+        .filter(|event| event.operation == AuditOperation::CuClick)
+        .map(|event| event.outcome)
+        .collect();
+    assert_eq!(
+        click,
+        [
+            AuditOutcome::Attempted,
+            AuditOutcome::Held,
+            AuditOutcome::Attempted,
+            AuditOutcome::Allowed,
+        ]
+    );
+}
+
+#[test]
+fn scroll_and_focus_record_intent_before_act() {
+    let fixture = cu_setup();
+    fixture.grant(Capability::ControlApp, Some("com.example.app"));
+
+    fixture
+        .operate(OperationRequest::CuScroll {
+            bundle_id: "com.example.app".to_owned(),
+            target: ElementTargetWire::default(),
+            dx: None,
+            dy: Some(40.0),
+        })
+        .unwrap();
+    fixture
+        .operate(OperationRequest::CuFocusWindow {
+            bundle_id: "com.example.app".to_owned(),
+            window_id: Some(7),
+        })
+        .unwrap();
+    assert_eq!(fixture.backend.scrolls(), ["com.example.app"]);
+    assert_eq!(fixture.backend.focuses(), ["com.example.app"]);
+
+    let events = fixture.audit.events.lock().unwrap();
+    for operation in [AuditOperation::CuScroll, AuditOperation::CuFocusWindow] {
+        let intent = events
+            .iter()
+            .position(|event| {
+                event.operation == operation && event.outcome == AuditOutcome::Attempted
+            })
+            .expect("a durable intent record precedes input synthesis");
+        let completion = events
+            .iter()
+            .position(|event| {
+                event.operation == operation && event.outcome == AuditOutcome::Allowed
+            })
+            .expect("the op records its completion");
+        assert!(intent < completion);
+        assert_eq!(events[intent].request_id, events[completion].request_id);
+    }
+}
+
+#[test]
+fn an_unrecordable_scroll_or_focus_never_reaches_the_backend() {
+    let fixture = cu_setup();
+    let broken = Arc::new(BreakableAudit::default());
+    let broker = Broker::test_with_computer_use(
+        test_policy(&fixture._temp),
+        broken.clone(),
+        fixture.backend.clone(),
+        fixture._temp.path().join("cu-staging-broken"),
+    );
+    let conversation = Uuid::new_v4();
+    let subject = GrantSubject::conversation(conversation).unwrap();
+    let context = ExecutionContext::standalone(conversation).unwrap();
+    let granted = unwrap_response(broker.controller().handle(ControlEnvelope {
+        protocol_version: PROTOCOL_VERSION,
+        request_id: crate::RequestId::new(),
+        request: ControlRequest::CuGrantApp(CuGrantAppRequest {
+            subject,
+            capability: Capability::ControlApp,
+            bundle_id: Some("com.example.app".to_owned()),
+            consent: ConsentMethod::PermissionDialog,
+            single_use: false,
+        }),
+    }))
+    .unwrap();
+    assert!(matches!(granted, ControlResult::CuGrantApp(_)));
+
+    broken.broken.store(true, Ordering::SeqCst);
+    for request in [
+        OperationRequest::CuScroll {
+            bundle_id: "com.example.app".to_owned(),
+            target: ElementTargetWire::default(),
+            dx: None,
+            dy: Some(40.0),
+        },
+        OperationRequest::CuFocusWindow {
+            bundle_id: "com.example.app".to_owned(),
+            window_id: Some(7),
+        },
+    ] {
+        let error = operate(&broker.operator(), context, request).unwrap_err();
+        assert_eq!(error.code, ErrorCode::AuditUnavailable);
+        assert!(error.retryable);
+    }
+    assert!(fixture.backend.scrolls().is_empty());
+    assert!(fixture.backend.focuses().is_empty());
 }

--- a/crates/tidebreak-host-broker/src/broker/tests.rs
+++ b/crates/tidebreak-host-broker/src/broker/tests.rs
@@ -4748,6 +4748,17 @@ impl CuFixture {
 }
 
 #[test]
+fn a_yielded_backend_error_surfaces_as_yielded_not_denied() {
+    let response = error_response(BrokerError::ComputerUse(BackendError {
+        kind: BackendErrorKind::Yielded,
+        message: "helper wording is not the contract".to_owned(),
+    }));
+    assert_eq!(response.code, ErrorCode::Yielded);
+    assert_ne!(response.code, ErrorCode::Denied);
+    assert!(!response.retryable);
+}
+
+#[test]
 fn blocked_bundles_refuse_control_ops_and_grants_even_with_a_grant_present() {
     let fixture = cu_setup();
     // The blocklist outranks consent: mint a grant for a blocked bundle by

--- a/crates/tidebreak-host-broker/src/broker/tests.rs
+++ b/crates/tidebreak-host-broker/src/broker/tests.rs
@@ -4693,12 +4693,26 @@ impl CuFixture {
     }
 
     fn grant(&self, capability: Capability, bundle_id: Option<&str>) -> CuGrantAppResult {
+        self.grant_with(capability, bundle_id, false)
+    }
+
+    fn grant_once(&self, capability: Capability, bundle_id: Option<&str>) -> CuGrantAppResult {
+        self.grant_with(capability, bundle_id, true)
+    }
+
+    fn grant_with(
+        &self,
+        capability: Capability,
+        bundle_id: Option<&str>,
+        single_use: bool,
+    ) -> CuGrantAppResult {
         let result = self
             .control(ControlRequest::CuGrantApp(CuGrantAppRequest {
                 subject: self.subject,
                 capability,
                 bundle_id: bundle_id.map(str::to_owned),
                 consent: ConsentMethod::PermissionDialog,
+                single_use,
             }))
             .unwrap();
         let ControlResult::CuGrantApp(result) = result else {
@@ -4756,6 +4770,7 @@ fn blocked_bundles_refuse_control_ops_and_grants_even_with_a_grant_present() {
                 capability: Capability::ControlApp,
                 bundle_id: Some(blocked.to_owned()),
                 consent: ConsentMethod::PermissionDialog,
+                single_use: false,
             }))
             .unwrap_err();
         assert_eq!(grant_error.code, ErrorCode::Denied, "{blocked}");
@@ -4938,6 +4953,7 @@ fn control_grants_cover_reads_but_read_grants_never_cover_control() {
             capability: Capability::ReadAppContent,
             bundle_id: Some("com.example.app".to_owned()),
             consent: ConsentMethod::PermissionDialog,
+            single_use: false,
         }))
         .unwrap();
     assert!(matches!(granted, ControlResult::CuGrantApp(_)));
@@ -4984,6 +5000,7 @@ fn an_unrecordable_control_op_never_reaches_the_backend() {
             capability: Capability::ControlApp,
             bundle_id: Some("com.example.app".to_owned()),
             consent: ConsentMethod::PermissionDialog,
+            single_use: false,
         }),
     }))
     .unwrap();
@@ -5269,4 +5286,123 @@ fn every_computer_use_op_lands_in_the_audit_trail_desensitized() {
     assert!(events.iter().any(|event| {
         event.operation == AuditOperation::CuCaptureScreen && event.outcome == AuditOutcome::Allowed
     }));
+}
+
+#[test]
+fn a_once_grant_authorizes_exactly_one_terminal_op() {
+    let fixture = cu_setup();
+    assert!(
+        fixture
+            .grant_once(Capability::ControlApp, Some("com.example.app"))
+            .granted
+    );
+    // Default stub label is "Cancel" — benign, so the click fires now.
+    fixture.click("com.example.app").unwrap();
+    assert_eq!(fixture.backend.clicks().len(), 1);
+    let error = fixture.click("com.example.app").unwrap_err();
+    assert_eq!(error.code, ErrorCode::Denied);
+    assert!(fixture.backend.clicks().len() == 1);
+}
+
+#[test]
+fn a_once_grant_covers_a_confirmation_hold_then_is_consumed() {
+    let fixture = cu_setup();
+    fixture.grant_once(Capability::ControlApp, Some("com.example.app"));
+    fixture.backend.set_label("Send");
+    fixture.backend.set_fingerprint("fp1");
+
+    let OperationResult::CuNeedsConfirmation(held) = fixture.click("com.example.app").unwrap()
+    else {
+        panic!("expected a confirmation hold")
+    };
+    // One-shots stay out of the management listing even while they still
+    // authorize the held confirm.
+    let listed = fixture
+        .control(ControlRequest::CuListAppGrants(CuListAppGrantsRequest {
+            subject: fixture.subject,
+        }))
+        .unwrap();
+    let ControlResult::CuListAppGrants { grants } = listed else {
+        panic!("unexpected control result")
+    };
+    assert!(grants.is_empty());
+
+    fixture
+        .control(ControlRequest::CuConfirmControlAction(
+            CuConfirmControlActionRequest {
+                confirmation_id: held.confirmation_id,
+            },
+        ))
+        .unwrap();
+    assert_eq!(fixture.backend.clicks().len(), 1);
+
+    let error = fixture.click("com.example.app").unwrap_err();
+    assert_eq!(error.code, ErrorCode::Denied);
+}
+
+#[test]
+fn a_standing_grant_replaces_a_leftover_once_grant() {
+    let fixture = cu_setup();
+    fixture.grant_once(Capability::ControlApp, Some("com.example.app"));
+    let standing = fixture.grant(Capability::ControlApp, Some("com.example.app"));
+    assert!(standing.granted);
+    let listed = fixture
+        .control(ControlRequest::CuListAppGrants(CuListAppGrantsRequest {
+            subject: fixture.subject,
+        }))
+        .unwrap();
+    let ControlResult::CuListAppGrants { grants } = listed else {
+        panic!("unexpected control result")
+    };
+    assert_eq!(grants.len(), 1);
+    assert_eq!(grants[0].grant_id, standing.grant_id);
+    fixture.click("com.example.app").unwrap();
+    fixture.click("com.example.app").unwrap();
+    assert_eq!(fixture.backend.clicks().len(), 2);
+}
+
+#[test]
+fn a_once_grant_does_not_survive_broker_reload() {
+    let (temp, broker, _, state_dir) = durable_setup();
+    let subject = GrantSubject::conversation(Uuid::new_v4()).unwrap();
+    let standing = Grant::from_consent(
+        GrantId::new(),
+        subject,
+        Capability::ControlApp,
+        Scope::App {
+            bundle_id: "com.example.mail".to_owned(),
+        },
+        ConsentRecord::new(ConsentMethod::PermissionDialog, Utc::now()),
+    )
+    .unwrap();
+    let once = Grant::from_consent(
+        GrantId::new(),
+        subject,
+        Capability::ControlApp,
+        Scope::App {
+            bundle_id: "com.example.notes".to_owned(),
+        },
+        ConsentRecord::new(ConsentMethod::PermissionDialog, Utc::now()),
+    )
+    .unwrap()
+    .into_single_use();
+    let standing_id = standing.id();
+    {
+        let mut state = broker.shared.state.lock().unwrap();
+        state.grants.push(standing);
+        state.grants.push(once);
+        broker
+            .shared
+            .state_file
+            .as_ref()
+            .expect("durable broker")
+            .save(&state)
+            .unwrap();
+    }
+    drop(broker);
+    let reloaded = Broker::open(test_policy(&temp), &state_dir).unwrap();
+    let grants = reloaded.shared.state.lock().unwrap().grants.clone();
+    assert_eq!(grants.len(), 1);
+    assert_eq!(grants[0].id(), standing_id);
+    assert!(!grants[0].is_single_use());
 }

--- a/crates/tidebreak-host-broker/src/capability.rs
+++ b/crates/tidebreak-host-broker/src/capability.rs
@@ -147,6 +147,12 @@ pub struct Grant {
     capability: Capability,
     scope: Scope,
     consent: ConsentRecord,
+    /// Session-only one-shot consent. Never written to the durable grant
+    /// table; the broker consumes it when the operation it authorized
+    /// reaches a terminal result (a confirmation hold is not terminal).
+    /// See decision record 0010.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    single_use: bool,
 }
 
 impl Grant {
@@ -164,7 +170,15 @@ impl Grant {
             capability,
             scope,
             consent,
+            single_use: false,
         })
+    }
+
+    /// Mark this grant as a one-shot that must not survive the process or
+    /// outlive the operation it authorizes.
+    pub(crate) fn into_single_use(mut self) -> Self {
+        self.single_use = true;
+        self
     }
 
     /// Stable identity recorded in operation receipts and audit entries.
@@ -191,6 +205,11 @@ impl Grant {
     pub const fn consent(&self) -> &ConsentRecord {
         &self.consent
     }
+
+    /// Whether this grant is a session-only one-shot.
+    pub const fn is_single_use(&self) -> bool {
+        self.single_use
+    }
 }
 
 impl<'de> Deserialize<'de> for Grant {
@@ -205,17 +224,24 @@ impl<'de> Deserialize<'de> for Grant {
             capability: Capability,
             scope: Scope,
             consent: ConsentRecord,
+            #[serde(default)]
+            single_use: bool,
         }
 
         let wire = WireGrant::deserialize(deserializer)?;
-        Self::from_consent(
+        let grant = Self::from_consent(
             wire.id,
             wire.subject,
             wire.capability,
             wire.scope,
             wire.consent,
         )
-        .map_err(D::Error::custom)
+        .map_err(D::Error::custom)?;
+        Ok(if wire.single_use {
+            grant.into_single_use()
+        } else {
+            grant
+        })
     }
 }
 

--- a/crates/tidebreak-host-broker/src/consequential.rs
+++ b/crates/tidebreak-host-broker/src/consequential.rs
@@ -59,6 +59,11 @@ pub enum Consequence {
 /// close, decline, confirm, accept, archive, block, report, approve) are NOT
 /// here. Asking again on those is the over-asking failure mode — see decision
 /// record 0010.
+///
+/// Locale bound: this lexicon is English. That is a deliberate accepted
+/// bound (decision record 0010), not an omission to fill with a translation
+/// dictionary. Navigation words in other languages remaining untripped is
+/// the same over-ask tradeoff as keeping the English list short.
 const RISK_ACTION_WORDS: &[&str] = &[
     "send",
     "resend",
@@ -133,7 +138,7 @@ const MAX_LABEL_IN_REASON: usize = 80;
 /// `label`.
 pub fn classify(op: ControlOp, role: Option<&str>, label: Option<&str>) -> Consequence {
     match op {
-        ControlOp::Click => classify_click(label),
+        ControlOp::Click => classify_click(role, label),
         ControlOp::TypeText => classify_type_text(role, label),
         // A key press has no element label to classify; the broker gates the
         // commit-shaped keys separately via [`key_press_needs_confirmation`].
@@ -158,7 +163,17 @@ pub fn key_press_needs_confirmation(key: &str, has_modifier: bool) -> bool {
     )
 }
 
-fn classify_click(label: Option<&str>) -> Consequence {
+fn classify_click(role: Option<&str>, label: Option<&str>) -> Consequence {
+    // Icon-only activatable controls have no label the lexicon can read, so
+    // they cannot be classified as navigation and must not fail open as
+    // Benign. See decision record 0010.
+    if is_activatable_control_role(role) && label_missing_or_empty(label) {
+        return Consequence::Consequential {
+            reason: "This control has no accessible label, so it cannot be \
+                     classified as navigation."
+                .to_string(),
+        };
+    }
     let Some(label) = label else {
         return Consequence::Benign;
     };
@@ -172,6 +187,22 @@ fn classify_click(label: Option<&str>) -> Consequence {
         };
     }
     Consequence::Benign
+}
+
+/// Buttons, menu items, and links — the activatable roles a click can fire.
+/// Matches the AX names and any role whose lowercase form contains those
+/// tokens, so a future UIA backend's `Button` / `MenuItem` / `Hyperlink`
+/// strings take the same path.
+fn is_activatable_control_role(role: Option<&str>) -> bool {
+    let Some(role) = role else {
+        return false;
+    };
+    let lower = role.to_lowercase();
+    lower.contains("button") || lower.contains("menuitem") || lower.contains("link")
+}
+
+fn label_missing_or_empty(label: Option<&str>) -> bool {
+    label.is_none_or(|label| label.trim().is_empty())
 }
 
 fn classify_type_text(role: Option<&str>, label: Option<&str>) -> Consequence {
@@ -321,11 +352,29 @@ mod tests {
     }
 
     #[test]
-    fn click_with_no_label_is_benign() {
+    fn unlabeled_activatable_click_is_consequential() {
+        for role in ["AXButton", "AXMenuItem", "AXLink", "Button", "menuitem"] {
+            let verdict = classify(ControlOp::Click, Some(role), None);
+            assert!(
+                is_consequential(&verdict),
+                "expected unlabeled {role:?} click to be consequential",
+            );
+        }
+        assert!(is_consequential(&classify(
+            ControlOp::Click,
+            Some("AXButton"),
+            Some(""),
+        )));
+        // A labeled navigation button is still the over-ask we refuse.
         assert_eq!(
-            classify(ControlOp::Click, Some("AXButton"), None),
-            Consequence::Benign
+            classify(ControlOp::Click, Some("AXButton"), Some("Cancel")),
+            Consequence::Benign,
         );
+    }
+
+    #[test]
+    fn unlabeled_click_without_activatable_role_is_benign() {
+        assert_eq!(classify(ControlOp::Click, None, None), Consequence::Benign);
         assert_eq!(
             classify(ControlOp::Click, None, Some("")),
             Consequence::Benign

--- a/crates/tidebreak-host-broker/src/protocol.rs
+++ b/crates/tidebreak-host-broker/src/protocol.rs
@@ -214,6 +214,11 @@ pub struct CuGrantAppRequest {
     /// [`crate::ConsentMethod::PermissionDialog`] is accepted, matching the
     /// per-app approval card.
     pub consent: ConsentMethod,
+    /// One-shot consent: authorize the next matching operation, then forget
+    /// the grant. Session-only — never persisted — so a crash cannot promote
+    /// it into a standing grant. Absent on the wire means standing (`false`).
+    #[serde(default)]
+    pub single_use: bool,
 }
 
 /// Idempotent computer-use grant withdrawal for one exact capability + scope.

--- a/crates/tidebreak-host-broker/src/protocol.rs
+++ b/crates/tidebreak-host-broker/src/protocol.rs
@@ -662,6 +662,10 @@ pub enum ErrorCode {
     /// label changed since it was read. Retryable: re-read the accessibility
     /// tree and re-issue against the fresh element.
     StaleElement,
+    /// A control op backed off because a security surface owns the foreground.
+    /// Distinct from [`ErrorCode::Denied`]: the remedy is to back off, never a
+    /// per-app consent card.
+    Yielded,
 }
 
 /// Safe error payload; it never embeds an absolute path or raw OS error text.

--- a/docs/decisions/0010-computer-use-screen-capture-and-app-control.md
+++ b/docs/decisions/0010-computer-use-screen-capture-and-app-control.md
@@ -96,18 +96,31 @@ action passes are:
 1. OS TCC grants (Screen Recording + Accessibility), requested together on
    first use with a status checklist in settings.
 2. A per-app grant, asked once per app through the normal in-chat approval
-   card ("Allow OpenWave to control Mail — once / always for this chat /
+   card ("Allow Tidebreak to control Mail — once / always for this chat /
    always"). The card decision is written into the broker's grant store; the
    broker enforces, the card is the only place the question is asked. Grants
    are listed and revocable in settings. Whole-screen capture gets the same
-   treatment as one standing grant.
+   treatment as one standing grant. **Once is not a standing grant that the
+   desktop later revokes.** It is a broker-native `single_use` grant:
+   session-only (never written to the durable grant table), hidden from the
+   grants listing, and consumed when the operation it authorized reaches a
+   terminal result. A confirmation hold is not terminal — the same one-shot
+   covers the confirm. A crash or a failed revoke therefore cannot promote
+   once into a durable per-conversation grant. Chat and Always remain
+   persisted standing grants.
 3. An act-time confirmation only for consequential actions: before clicking,
    the broker re-reads the target element and classifies it; labels that
    commit an external effect (send, pay, buy, delete, submit, sign,
    transfer, post) or credential fields force a single non-activating
    confirmation, honored only if the label still matches at act time. The
-   classifier's word list is deliberately short — navigation-shaped words
-   (cancel, back, close, decline) do not trip it.
+   classifier's word list is deliberately short and **English-only** —
+   navigation-shaped words (cancel, back, close, decline) do not trip it.
+   Localized commit verbs ("Envoyer", "Senden") are an accepted miss of the
+   same calibration: a translation dictionary would over-ask in those
+   locales the way a longer English list over-asks here. An activatable
+   control (button / menu item / link) with no accessible label cannot be
+   classified as navigation and is treated as consequential. Icon-only
+   chrome that is not an activatable role stays benign.
 
 Within a granted app, individual clicks, keystrokes, and scrolls do not
 generate approval cards — in any permission mode. Plan mode refuses control
@@ -120,9 +133,14 @@ in the loop for control actions.
 before the next broker round-trip and tells the agent not to retry; an
 auto-yield that aborts any control operation while a security surface
 (login window, authentication prompt) is frontmost, as a non-retryable
-error; and a hard app blocklist — OpenWave itself, terminals, System
-Settings, keychain and security agents — enforced in the broker and
-mirrored defensively in the helper.
+error, carried as a structured `ErrorCode::Yielded` (never a `Denied`
+that the desktop could mistake for a grant miss); and a hard app
+blocklist — Tidebreak itself, terminals, IDEs and editors with an
+integrated shell, command launchers (Alfred, Raycast), System Settings,
+keychain and security agents — enforced in the broker and mirrored
+defensively in the helper. A bundle-id list cannot enumerate every app
+that embeds a shell; the listed class is the known high-traffic set, not
+a proof of completeness.
 
 **App knowledge lives in plugins, not code.** No per-app drivers. App-specific
 guidance (how an app's UI is laid out, preferred flows, what to avoid) ships
@@ -167,6 +185,13 @@ content redaction, and any auto-approval of control actions.
 - **Do nothing / wait for the managed browser surface.** Rejected: most of the
   value (seeing the screen, operating native apps) is orthogonal to the
   browser plan and blocked on nothing.
+- **Persist a once grant and best-effort revoke it after the op.** Rejected:
+  a crash or a failed revoke between write and revoke leaves a standing
+  per-conversation grant the user approved as one-time-only. A broker-native
+  session-only one-shot has no revoke to lose.
+- **Match the security-surface yield by comparing the broker's English error
+  message.** Rejected: any wording edit silently converts a hard-stop yield
+  into a consent prompt. The transport carries `ErrorCode::Yielded`.
 
 ## Consequences
 
@@ -209,3 +234,7 @@ content redaction, and any auto-approval of control actions.
   with the typed error; nothing silently drops the image.
 - Grant-store test: a card decision at each scope produces exactly one broker
   grant, revocation removes it, and no control op proceeds without one.
+- Once-grant test: a `single_use` grant authorizes exactly one terminal
+  operation (including a held confirm), does not appear in the grants
+  listing, and is absent after a broker reload. A standing grant at the
+  same tuple replaces a leftover one-shot.


### PR DESCRIPTION
Closes #2010. Closes #2011. Closes #2012. Closes #2013.

The computer-use landing left four consent and audit holes from the #1995 review. This change closes them together because they share the broker grant, audit, and error contracts.

**Once grants stay one-shot.** A "once" card writes a broker-native `single_use` grant. It is session-only (never written to the durable grant table), hidden from the grants listing, and consumed when the authorizing operation finishes. A confirmation hold is not terminal — the same one-shot covers the confirm. Consuming or revoking a one-shot does not wait on a no-op rewrite of the standing table, so a failed save cannot leave it live. A crash cannot promote once into a standing per-conversation grant.

**Held actions are audited as held.** A consequential gate that parks a click/type records `AuditOutcome::Held`, not `Allowed`. Confirm still writes its own Attempted → Allowed pair. Scroll and focus are mutations: intent is durable before the backend runs, and an unrecordable intent refuses the op.

**Yield is a structured error.** A security-surface yield is `ErrorCode::Yielded`. The desktop hard-stops on that code. `Denied` is always a grant miss. The English message is no longer the contract.

**Blocklist and unlabeled chrome.** Terminals, IDEs/editors with integrated shells, and command launchers (Alfred, Raycast) are blocked. The helper list matches the broker. A click on an unlabeled button/menu item/link is consequential. The classifier stays English-only by design; decision record 0010 records that bound and that a bundle-id list cannot enumerate every app that embeds a shell.

## Tests

`cargo test -p tidebreak-host-broker --locked` (161 lib tests) and `cargo test -p tidebreak-desktop --locked computer_use` (8 tests).

Not verified on a running desktop against a live helper.