### PR TITLE
fix(ci): run staging jobs when the caller is a push

### DIFF
--- a/.github/workflows/staging-publish.yml
+++ b/.github/workflows/staging-publish.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   validate_staging:
     name: validate staging build
-    if: ${{ github.event_name == 'workflow_call' && inputs.channel == 'staging' }}
+    if: ${{ inputs.channel == 'staging' }}
     runs-on: ubuntu-latest
     outputs:
       published_at: ${{ steps.meta.outputs.published_at }}
@@ -64,7 +64,7 @@ jobs:
   prepare_macos_staging:
     name: prepare unsigned staging macOS · ${{ matrix.arch }}
     needs: validate_staging
-    if: ${{ github.event_name == 'workflow_call' && inputs.channel == 'staging' }}
+    if: ${{ inputs.channel == 'staging' }}
     runs-on: macos-latest
     timeout-minutes: 60
     strategy:
@@ -177,7 +177,7 @@ jobs:
   build_macos_staging:
     name: staging macOS · ${{ matrix.arch }}
     needs: [validate_staging, prepare_macos_staging]
-    if: ${{ github.event_name == 'workflow_call' && inputs.channel == 'staging' }}
+    if: ${{ inputs.channel == 'staging' }}
     runs-on: macos-latest
     environment:
       name: desktop-staging

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1292,6 +1292,7 @@ test("staging desktop publishes only under the staging prefix", () => {
   const stagingPublish = workflows["staging-publish.yml"];
   if (stagingPublish) {
     assert.match(stagingPublish, /^on:\n  workflow_call:\n/m);
+    assert.doesNotMatch(stagingPublish, /github\.event_name == 'workflow_call'/);
     assert.doesNotMatch(stagingPublish, /^\s*pull_request(?:_target)?:/m);
     assert.match(stagingPublish, /^permissions:\n  contents: read$/m);
     assert.match(stagingPublish, /group: tidebreak-desktop-staging-build/);


### PR DESCRIPTION
## Why

#2033 made **Publish staging desktop** go green in 24s. Every real job was skipped. In a reusable workflow `github.event_name` is the caller's event (`push`), not `workflow_call`, so the job `if:` never matched.

## What

Run staging jobs when `inputs.channel == 'staging'`. The policy test now rejects the `workflow_call` event-name guard so this cannot go green-and-empty again.