### PR TITLE
feat(desktop): name a project in a dialog and open its first chat

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AppContext.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppContext.tsx
@@ -52,8 +52,11 @@ export type AppContextValue = {
   startRename: (chat: Chat) => void;
   commitRename: (chat: Chat) => void;
   cancelRename: () => void;
-  /** Create a project and drop its rail row straight into its rename field. */
-  newProject: () => void;
+  /**
+   * Create a named project, start a chat inside it, and open that chat.
+   * Resolves `true` when the project exists so the create dialog can close.
+   */
+  newProject: (title: string) => Promise<boolean>;
   /**
    * Confirm, move the project's conversations back to Recents, then delete it.
    * The conversations survive: deleting a folder is not deleting its contents.

--- a/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useChatListStore } from "./ChatListStore";
 import { usePendingPrompts } from "./PendingPrompts";
+import { useProjectListStore } from "./ProjectListStore";
 import { useRefreshSignals } from "./RefreshSignals";
 import { useChatsSectionState } from "./sidebar/ChatsSection";
 import { useUiStore } from "./UiStore";
@@ -38,7 +39,26 @@ const chats = [
 ];
 
 const listChats = vi.fn(async () => chats);
-const createChat = vi.fn(async () => chats[0]);
+const createChat = vi.fn(async (_model?: unknown, projectId?: string | null) =>
+  projectId
+    ? {
+        id: "chat-new",
+        title: null,
+        model: null,
+        reasoning_effort: null,
+        project_id: projectId,
+        created_at: "2026-08-13T12:00:00Z",
+      }
+    : chats[0],
+);
+const listProjects = vi.fn(async () => [] as unknown[]);
+const createProject = vi.fn(async (title: string) => ({
+  id: "project-1",
+  title,
+  attachment_revision: 0,
+  root_attachments: [],
+  created_at: "2026-08-13T12:00:00Z",
+}));
 const listPendingUserQuestions = vi.fn(async () => [] as unknown[]);
 const listPendingFolderAccessRequests = vi.fn(async () => [] as unknown[]);
 const listInbox = vi.fn(async () => [] as unknown[]);
@@ -92,6 +112,8 @@ vi.mock("./api", () => ({
     }));
     listChats = listChats;
     createChat = createChat;
+    listProjects = listProjects;
+    createProject = createProject;
     listPendingUserQuestions = listPendingUserQuestions;
     listPendingFolderAccessRequests = listPendingFolderAccessRequests;
     listInbox = listInbox;
@@ -221,6 +243,9 @@ beforeEach(() => {
   listChats.mockClear();
   listChats.mockResolvedValue(chats);
   createChat.mockClear();
+  listProjects.mockClear();
+  listProjects.mockResolvedValue([]);
+  createProject.mockClear();
   listPendingUserQuestions.mockReset();
   listPendingUserQuestions.mockResolvedValue([]);
   listPendingFolderAccessRequests.mockReset();
@@ -238,6 +263,16 @@ beforeEach(() => {
   // The stores outlive a test file's renders, so a chat list left behind would
   // decide the next test's routing before its own boot ever ran.
   useChatListStore.setState({ chats: [], chatsLoaded: false, chatsError: null });
+  useProjectListStore.setState({
+    projects: [],
+    projectsLoaded: false,
+    creatingProject: false,
+    deletingProjectId: null,
+    renamingProjectId: null,
+    renameProjectDraft: "",
+    savingProjectTitle: false,
+    expandedProjectIds: [],
+  });
   useUiStore.setState({ sidebarCollapsed: false });
   // Module-level chrome state survives a render, so a test that collapsed or
   // filtered the list would otherwise decide the next one's rail.
@@ -581,5 +616,27 @@ describe("app shell", () => {
     await user.click(screen.getByRole("button", { name: "Back to app" }));
 
     await waitFor(() => expect(router.state.location.pathname).toBe("/c/chat-1"));
+  });
+
+  it("creates a project from the dialog and opens a chat inside it", async () => {
+    const user = userEvent.setup();
+    const { router } = await mountApp();
+    await screen.findByText("How can I help?");
+
+    await user.click(screen.getByRole("button", { name: "New project" }));
+    const name = await screen.findByRole("textbox", { name: "Project name" });
+    await user.type(name, "Research");
+    await user.keyboard("{Meta>}{Enter}{/Meta}");
+
+    await waitFor(() =>
+      expect(createProject).toHaveBeenCalledExactlyOnceWith("Research"),
+    );
+    await waitFor(() =>
+      expect(createChat).toHaveBeenCalledWith(undefined, "project-1"),
+    );
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/p/project-1/c/chat-new"),
+    );
+    expect(screen.getByRole("button", { name: "Research" })).toBeInTheDocument();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -263,18 +263,26 @@ export function AppShell() {
     };
   }, [client, info]);
 
-  async function onNewProject() {
-    if (!client || projectMutationRef.current) return;
+  /**
+   * Create a named project and the first chat inside it.
+   *
+   * A project with no conversation is a folder the reader has to fill. The
+   * dialog already collected the name, so this does both writes and opens the
+   * chat rather than leaving an empty row in the rail.
+   */
+  async function onNewProject(title: string): Promise<boolean> {
+    const trimmed = title.trim();
+    if (!client || !trimmed || projectMutationRef.current) return false;
     projectMutationRef.current = true;
     projectListActions.setCreatingProject(true);
     try {
-      const created = await client.createProject("New project");
+      const created = await client.createProject(trimmed);
       projectListActions.prependProject(created);
-      // Named on creation rather than through a dialog: the row drops straight
-      // into its rename field, which is the same edit the menu offers later.
-      projectListActions.beginProjectRename(created);
+      await onNewChatInProject(created.id);
+      return true;
     } catch (err) {
       toast.error(friendlyErrorMessage(err, "Could not create the project."));
+      return false;
     } finally {
       projectMutationRef.current = false;
       projectListActions.setCreatingProject(false);
@@ -614,7 +622,7 @@ export function AppShell() {
           startRename: startChatRename,
           commitRename: (target) => void commitChatRename(target),
           cancelRename: cancelChatRename,
-          newProject: () => void onNewProject(),
+          newProject: (title) => onNewProject(title),
           deleteProject: (target) => void onDeleteProject(target),
           startProjectRename,
           commitProjectRename: (target) => void commitProjectRename(target),

--- a/crates/tidebreak-desktop/ui/src/sidebar/NewProjectDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/NewProjectDialog.dom.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { NewProjectDialog } from "./NewProjectDialog";
+
+afterEach(cleanup);
+
+describe("NewProjectDialog", () => {
+  it("creates on Cmd+Enter with the trimmed name", async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn(async () => true);
+    const onOpenChange = vi.fn();
+    render(
+      <NewProjectDialog
+        open
+        onOpenChange={onOpenChange}
+        onCreate={onCreate}
+        creating={false}
+      />,
+    );
+
+    await user.type(screen.getByRole("textbox", { name: "Project name" }), "  Research  ");
+    await user.keyboard("{Meta>}{Enter}{/Meta}");
+
+    await waitFor(() =>
+      expect(onCreate).toHaveBeenCalledExactlyOnceWith("Research"),
+    );
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+  });
+
+  it("does not create an empty name", async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn(async () => true);
+    render(
+      <NewProjectDialog
+        open
+        onOpenChange={vi.fn()}
+        onCreate={onCreate}
+        creating={false}
+      />,
+    );
+
+    await user.keyboard("{Meta>}{Enter}{/Meta}");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(onCreate).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Create" })).toBeDisabled();
+  });
+
+  it("stays open when create fails so the name is not lost", async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn(async () => false);
+    const onOpenChange = vi.fn();
+    render(
+      <NewProjectDialog
+        open
+        onOpenChange={onOpenChange}
+        onCreate={onCreate}
+        creating={false}
+      />,
+    );
+
+    await user.type(screen.getByRole("textbox", { name: "Project name" }), "Research");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() =>
+      expect(onCreate).toHaveBeenCalledExactlyOnceWith("Research"),
+    );
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/sidebar/NewProjectDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/NewProjectDialog.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useMemo, useState, type FormEvent, type KeyboardEvent } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { usesCommandModifier } from "@/ShellShortcuts";
+
+/** Matches `MAX_PROJECT_TITLE_CHARS` on the project create route. */
+export const MAX_PROJECT_TITLE_CHARS = 120;
+
+/**
+ * Name a project before it exists.
+ *
+ * The rail used to drop a "New project" row straight into rename. That made
+ * the first thing on the list look half-made, and it created the folder
+ * before the reader had said what it was for. This dialog collects the name,
+ * then the shell creates the project and the chat that belongs in it.
+ */
+export function NewProjectDialog({
+  open,
+  onOpenChange,
+  onCreate,
+  creating,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Resolve `true` when the project exists and the dialog should close. */
+  onCreate: (title: string) => Promise<boolean>;
+  creating: boolean;
+}) {
+  const [title, setTitle] = useState("");
+  const command = useMemo(
+    () => usesCommandModifier(navigator.userAgent),
+    [],
+  );
+  const trimmed = title.trim();
+  const canCreate = trimmed.length > 0 && !creating;
+
+  useEffect(() => {
+    if (!open) setTitle("");
+  }, [open]);
+
+  function requestClose(next: boolean) {
+    if (creating) return;
+    onOpenChange(next);
+  }
+
+  async function submit() {
+    if (!canCreate) return;
+    const created = await onCreate(trimmed);
+    if (created) onOpenChange(false);
+  }
+
+  function onSubmit(event: FormEvent) {
+    event.preventDefault();
+    void submit();
+  }
+
+  function onKeyDown(event: KeyboardEvent) {
+    if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+      event.preventDefault();
+      void submit();
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={requestClose}>
+      <DialogContent
+        className="max-w-sm gap-5 p-5 sm:rounded-xl"
+        aria-busy={creating}
+        withCloseButton={!creating}
+        onKeyDown={onKeyDown}
+      >
+        <DialogHeader className="gap-1 pr-6">
+          <DialogTitle className="text-base">New project</DialogTitle>
+          <DialogDescription className="text-xs leading-relaxed">
+            Name it. A chat will open inside it.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form className="flex flex-col gap-5" onSubmit={onSubmit}>
+          <label className="flex flex-col gap-1.5">
+            <span className="text-sm font-medium">Name</span>
+            <Input
+              autoFocus
+              autoComplete="off"
+              aria-label="Project name"
+              placeholder="Research"
+              maxLength={MAX_PROJECT_TITLE_CHARS}
+              value={title}
+              disabled={creating}
+              onChange={(event) => setTitle(event.target.value)}
+            />
+          </label>
+
+          <DialogFooter className="gap-2 sm:justify-end">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={creating}
+              onClick={() => requestClose(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" size="sm" disabled={!canCreate}>
+              {creating ? "Creating…" : "Create"}
+              {!creating && (
+                <span
+                  className="ml-1 inline-flex items-center gap-0.5 text-2xs font-medium opacity-60"
+                  aria-hidden="true"
+                >
+                  <kbd className="font-sans">{command ? "⌘" : "Ctrl"}</kbd>
+                  <kbd className="font-sans">↩</kbd>
+                </span>
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/sidebar/ProjectsSection.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/ProjectsSection.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import {
   ChevronRight,
@@ -25,6 +26,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
+import { NewProjectDialog } from "./NewProjectDialog";
 import { RecentChatRow } from "./RecentChatRow";
 import { useSidebarWidth } from "./primitives";
 
@@ -86,6 +88,7 @@ export function ProjectsSection({ activeChatId }: { activeChatId?: string }) {
     (state) => state.chatIdsWithPendingPrompts,
   );
   const isCompact = useSidebarWidth() === "compact";
+  const [creatingOpen, setCreatingOpen] = useState(false);
 
   // Icons-only leaves no room for a nested tree, the same reason the chat list
   // stands down at this width.
@@ -100,13 +103,20 @@ export function ProjectsSection({ activeChatId }: { activeChatId?: string }) {
         <button
           type="button"
           className="shrink-0 cursor-pointer rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
-          aria-label={creatingProject ? "Creating…" : "New project"}
+          aria-label="New project"
           disabled={creatingProject || deletingProjectId !== null}
-          onClick={newProject}
+          onClick={() => setCreatingOpen(true)}
         >
           <Plus size={15} />
         </button>
       </div>
+
+      <NewProjectDialog
+        open={creatingOpen}
+        onOpenChange={setCreatingOpen}
+        onCreate={newProject}
+        creating={creatingProject}
+      />
 
       <div className="flex flex-col gap-0.5" aria-label="Projects">
         {projects.map((project) => {
@@ -165,9 +175,14 @@ export function ProjectsSection({ activeChatId }: { activeChatId?: string }) {
                     />
                   ))}
                   {held.length === 0 && (
-                    <p className="px-2 py-1 text-xs text-muted-foreground">
-                      No chats
-                    </p>
+                    <button
+                      type="button"
+                      className="cursor-pointer rounded-md px-2 py-1 text-left text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+                      disabled={creatingChat || deletingChatId !== null}
+                      onClick={() => newChatInProject(project.id)}
+                    >
+                      New chat
+                    </button>
                   )}
                 </div>
               )}
@@ -259,6 +274,15 @@ function ProjectRow({
             expanded && "rotate-90",
           )}
         />
+      </button>
+      <button
+        type="button"
+        className="cursor-pointer rounded p-1 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 disabled:pointer-events-none"
+        aria-label={`New chat in ${title}`}
+        disabled={mutating}
+        onClick={onNewChat}
+      >
+        <SquarePen size={15} />
       </button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>


### PR DESCRIPTION
## Summary

Creating a project from the sidebar no longer drops a half-named row into the rail. The `+` opens a dialog, the reader names the project, and ⌘↩ (or Enter, or Create) makes the project and a chat inside it, then opens that chat.

The empty “No chats” label is now a control, and hovering a project offers new chat the same way the overflow menu already did.

## Test plan

- [x] `NewProjectDialog` DOM tests: ⌘↩ submits the trimmed name; empty name does not create; a failed create leaves the dialog open
- [x] App shell test: dialog create calls `createProject` then `createChat` and lands on `/p/{project}/c/{chat}`
- [ ] In the app: click Projects `+`, name something, ⌘↩, land in a new chat under that project
- [ ] Cancel / Escape leaves the list unchanged
- [ ] Hover a project and use the new-chat control; empty project still offers New chat