### PR TITLE
ci: isolate trivy from sandbox image publish credentials

### DIFF
--- a/.github/workflows/publish-sandbox-image.yml
+++ b/.github/workflows/publish-sandbox-image.yml
@@ -40,11 +40,14 @@ run-name: >-
 # whole sandbox under emulation there). Image tags are treated as immutable:
 # a tag that already exists on GHCR fails the run rather than being repointed.
 #
-# Before anything is pushed, both variants pass a trivy vulnerability and
-# secret scan (pinned binary release, checksum-verified — this workflow avoids
-# third-party actions). The full all-severities report lands in the run
-# summary; the publish itself fails only on CRITICAL vulnerabilities with a
-# released fix, or on any detected secret.
+# Per-architecture tags are pushed first. Both variants then pass a trivy
+# vulnerability and secret scan in a separate job that cannot publish
+# (packages: read only; pinned binary release, checksum-verified — this
+# workflow avoids third-party actions). The user-facing version tag is
+# assembled only after that scan passes. The full all-severities report
+# lands in the run summary; the publish itself fails only on CRITICAL
+# vulnerabilities with a released fix, or on any detected secret. A failed
+# scan leaves the per-arch tags in place but never creates $IMAGE_TAG.
 #
 # The final manifest-list digests land in the run summary, and the `pin` job
 # proposes the follow-up PR that records the documents digest as the local
@@ -244,6 +247,47 @@ jobs:
             "$DOCUMENTS_REPOSITORY:$IMAGE_TAG-${{ matrix.arch }}" \
             -e 'require("pptxgenjs")'
 
+      - name: Push per-architecture tags
+        run: |
+          docker push "$SLIM_REPOSITORY:$IMAGE_TAG-${{ matrix.arch }}"
+          docker push "$DOCUMENTS_REPOSITORY:$IMAGE_TAG-${{ matrix.arch }}"
+
+  scan:
+    # Read-only gate: the scanner never holds packages:write. A compromised
+    # trivy can steal this job's token and pull, but cannot push a tag or
+    # assemble the version manifest. No checkout — the job only pulls the
+    # images the build job just pushed.
+    name: scan · ${{ matrix.arch }}
+    needs: [resolve, build]
+    if: needs.resolve.outputs.publish == 'true'
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: read
+    env:
+      IMAGE_TAG: ${{ needs.resolve.outputs.image_tag }}
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      # packages:read is enough to pull a private first-time package; the
+      # token cannot push even if the scanner exfiltrates it.
+      - name: Log in to GHCR
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+        run: printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+
+      - name: Pull both image variants
+        run: |
+          docker pull "$SLIM_REPOSITORY:$IMAGE_TAG-${{ matrix.arch }}"
+          docker pull "$DOCUMENTS_REPOSITORY:$IMAGE_TAG-${{ matrix.arch }}"
+
       # This workflow deliberately uses no third-party actions; the scanner is
       # the trivy release binary, pinned by version and sha256 checksum the
       # same way the base images are pinned by digest.
@@ -273,7 +317,7 @@ jobs:
       # stops only for what is actionable now — a CRITICAL vulnerability with
       # a released fix, or any detected secret — while the full all-severities
       # report lands in the run summary for the record.
-      - name: Scan both variants before push
+      - name: Scan both variants
         run: |
           for repository in "$SLIM_REPOSITORY" "$DOCUMENTS_REPOSITORY"; do
             image="$repository:$IMAGE_TAG-${{ matrix.arch }}"
@@ -294,14 +338,11 @@ jobs:
             trivy image --timeout 15m --scanners secret --exit-code 1 "$image"
           done
 
-      - name: Push per-architecture tags
-        run: |
-          docker push "$SLIM_REPOSITORY:$IMAGE_TAG-${{ matrix.arch }}"
-          docker push "$DOCUMENTS_REPOSITORY:$IMAGE_TAG-${{ matrix.arch }}"
-
   manifest:
+    # Assembles the user-facing version tag only after every arch image has
+    # been pushed and passed the read-only scan job.
     name: assemble multi-arch manifests
-    needs: [resolve, build]
+    needs: [resolve, build, scan]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -764,8 +764,18 @@ test("sandbox image publishing is tag-driven, immutable, and secret-free", () =>
   // The default token with packages:write is the whole credential surface —
   // publishing must not grow a dependency on repository secrets (that set
   // stays isolated to release.yml by the production-secrets test above).
+  // Only the jobs that push (build) or assemble the version tag (manifest)
+  // may hold packages:write; the scanner is packages:read.
   assert.match(publish, /^permissions:\n  contents: read$/m);
-  assert.match(publish, /^    permissions:\n      contents: read\n      packages: write$/m);
+  assert.equal(publish.match(/packages: write/g)?.length, 2);
+  assert.match(
+    workflowJob(publish, "build"),
+    /^    permissions:\n      contents: read\n      packages: write$/m,
+  );
+  assert.match(
+    workflowJob(publish, "manifest"),
+    /^    permissions:\n      contents: read\n      packages: write$/m,
+  );
   assert.doesNotMatch(publish, /secrets\./);
 
   // Version tags are immutable: both the per-arch build job and the manifest
@@ -789,57 +799,41 @@ test("sandbox image publishing is tag-driven, immutable, and secret-free", () =>
   assert.match(publish, /PUBLISHED_IMAGE_DIGEST/);
 });
 
-test("sandbox images are scanned before push and the pin loop never touches main", () => {
+test("sandbox images are scanned in a read-only job before the version tag is published, and the pin loop never touches main", () => {
   const publish = workflows["publish-sandbox-image.yml"];
   const build = workflowJob(publish, "build");
+  const scan = workflowJob(publish, "scan");
+  const manifest = workflowJob(publish, "manifest");
   const pin = workflowJob(publish, "pin");
-  const scanJob = publish.includes("\n  scan:\n")
-    ? workflowJob(publish, "scan")
-    : null;
-  const scanner = scanJob ?? build;
 
   // The scanner is a checksum-pinned binary release, not a third-party
-  // action. It may still live in `build` (scan-before-arch-push) or in a
-  // packages:read `scan` job that gates the version-tag manifest — both
-  // keep trivy off any token that can publish the user-facing tag.
-  assert.match(scanner, /trivy_\$\{TRIVY_VERSION\}_\$\{asset\}\.tar\.gz/);
-  assert.match(scanner, /sha256sum --check/);
+  // action, and it is the only job that runs trivy. It cannot publish:
+  // packages:read, no checkout (so no persisted git credentials), and the
+  // version-tag job waits for it.
+  assert.doesNotMatch(build, /trivy/i);
+  assert.doesNotMatch(manifest, /trivy/i);
+  assert.match(scan, /trivy_\$\{TRIVY_VERSION\}_\$\{asset\}\.tar\.gz/);
+  assert.match(scan, /sha256sum --check/);
   assert.match(publish, /^  TRIVY_VERSION: \d+\.\d+\.\d+$/m);
-  if (scanJob === null) {
-    const scanIndex = build.indexOf("Scan both variants before push");
-    assert.notEqual(scanIndex, -1);
-    assert.ok(
-      build.indexOf("Build both image variants") < scanIndex &&
-        scanIndex < build.indexOf("Push per-architecture tags"),
-      "the scan must gate the per-arch push",
-    );
-  } else {
-    assert.doesNotMatch(build, /trivy/i);
-    assert.match(
-      scanJob,
-      /^    permissions:\n      contents: read\n      packages: read$/m,
-    );
-    assert.doesNotMatch(scanJob, /packages: write/);
-    assert.doesNotMatch(scanJob, /actions\/checkout/);
-    assert.match(
-      workflowJob(publish, "manifest"),
-      /needs: \[resolve, build, scan\]/,
-    );
-  }
+  assert.match(scan, /^    permissions:\n      contents: read\n      packages: read$/m);
+  assert.doesNotMatch(scan, /packages: write/);
+  assert.doesNotMatch(scan, /actions\/checkout/);
+  assert.doesNotMatch(scan, /secrets\./);
+  assert.match(manifest, /needs: \[resolve, build, scan\]/);
 
   // Policy: the run summary carries the full all-severities report, but the
   // publish fails only on fixable CRITICAL vulnerabilities or any secret. A
   // broader gate would drown in LibreOffice CVE noise and be ignored.
   assert.match(
-    scanner,
+    scan,
     /trivy image --timeout 15m --scanners vuln,secret \\\n\s+--format table --output "\$report" "\$image"/,
   );
   assert.match(
-    scanner,
+    scan,
     /trivy image --timeout 15m --scanners vuln \\\n\s+--severity CRITICAL --ignore-unfixed --exit-code 1 "\$image"/,
   );
   assert.match(
-    scanner,
+    scan,
     /trivy image --timeout 15m --scanners secret --exit-code 1 "\$image"/,
   );
 


### PR DESCRIPTION
## Why

LiteLLM's March 2026 PyPI compromise (TeamPCP) came from an unpinned Trivy running in the same CI environment as long-lived publish credentials. Tidebreak already checksum-pins the Trivy binary and does not keep a long-lived registry token, but the scanner still ran in the `build` job that holds `packages: write` and a live `GITHUB_TOKEN`. A compromised scanner on that runner can steal the token the way the March payload actually did and push while the job is still running.

## What

Split `.github/workflows/publish-sandbox-image.yml` so Trivy never holds publish rights:

- **`build`** still builds, smoke-tests, and pushes the per-arch tags. No Trivy.
- **`scan`** is `packages: read` only, with no checkout. It pulls those arch images, checksum-installs Trivy, and scans.
- **`manifest`** waits on `scan` and only then creates the user-facing `$IMAGE_TAG` manifest list.

A failed scan leaves the per-arch tags on GHCR and never creates the version tag the digest pin follows. The workflow-security tests now lock that boundary: Trivy only in `scan`, exactly two `packages: write` jobs, and `manifest` needs `scan`.

## Notes

- Not verified by running the publish workflow (main / tag / schedule / dispatch only).
- Production Apple / Tauri / AWS secrets and `E2B_API_KEY` were already isolated from this workflow and stay that way.