### PR TITLE
fix(ci): do not cancel an in-flight staging notarization

### DIFF
--- a/.github/workflows/staging-publish.yml
+++ b/.github/workflows/staging-publish.yml
@@ -20,10 +20,11 @@ permissions:
   contents: read
 
 concurrency:
-  # Only the newest main tip is worth notarizing. Separate from production
-  # so a staging run cannot block or cancel a desktop release.
+  # Serialize staging publishes so two main tips cannot race latest.json.
+  # Do not cancel: a notarization already in flight should finish. Publish
+  # still refuses to advance latest.json if main has moved on.
   group: tidebreak-desktop-staging-build
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   validate_staging:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -26,10 +26,10 @@ permissions:
   contents: read
 
 concurrency:
-  # Only the newest main tip is worth notarizing. Cancelling this run also
-  # cancels the reusable release.yml jobs it started, so a burst of merges
-  # does not queue a chain of stale staging publishes.
-  group: tidebreak-desktop-staging
+  # Unique per run so a later merge cannot cancel this caller — that would
+  # also cancel the reusable publish it started. The publish workflow
+  # serializes on its own group without dropping an in-flight notarization.
+  group: tidebreak-desktop-staging-${{ github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/docs/decisions/0013-desktop-staging-channel.md
+++ b/docs/decisions/0013-desktop-staging-channel.md
@@ -70,8 +70,9 @@ because the feeds are already isolated by URL and bundle id.
 
 Concurrency:
 
-- The staging workflow's group is `tidebreak-desktop-staging` with
-  `cancel-in-progress: true`. Only the newest `main` tip is worth notarizing.
+- The staging caller uses a per-run group so a later merge cannot cancel it.
+  The publish workflow serializes on `tidebreak-desktop-staging-build` with
+  `cancel-in-progress: false`, so an in-flight notarization finishes.
 - That run invokes a `workflow_call`-only staging publish workflow with
   `channel: staging`. The called run uses its own staging group so it cannot
   share or cancel `tidebreak-desktop-production-release`.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -335,8 +335,10 @@ Tauri updater, and not a production `vMAJOR.MINOR.PATCH` tag.
 
 The caller is **Publish staging desktop**. It derives the version, then
 invokes the `workflow_call`-only **Publish staging desktop build** workflow
-with `channel: staging`. A burst of merges cancels the superseded staging
-run. Production's concurrency group is untouched. Staging artifacts live under
+with `channel: staging`. Staging publishes serialize so an in-flight
+notarization is not cancelled by the next merge; `latest.json` still only
+advances if that commit is still `main`. Production's concurrency group is
+untouched. Staging artifacts live under
 `https://downloads.brightwave.io/tidebreak/staging/`; the publish step
 refuses any other prefix and will not advance `latest.json` if `main` has
 already moved on.

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1296,6 +1296,7 @@ test("staging desktop publishes only under the staging prefix", () => {
     assert.doesNotMatch(stagingPublish, /^\s*pull_request(?:_target)?:/m);
     assert.match(stagingPublish, /^permissions:\n  contents: read$/m);
     assert.match(stagingPublish, /group: tidebreak-desktop-staging-build/);
+    assert.match(stagingPublish, /cancel-in-progress: false/);
     assert.doesNotMatch(stagingPublish, /tidebreak\/latest\.json/);
     assert.doesNotMatch(release, /^  workflow_call:\n/m);
   } else {


### PR DESCRIPTION
## Why

Every real staging build has been cancelled mid-compile. `main` is busy, and `cancel-in-progress: true` on the shared staging group drops the notarization that was already running.

## What

- The caller uses a per-run concurrency group, so a later merge cannot cancel the reusable publish it started. The existing policy substring `group: tidebreak-desktop-staging` still matches.
- The publish workflow stays on `tidebreak-desktop-staging-build` and now has `cancel-in-progress: false`. Staging publishes queue instead of killing each other. `latest.json` still only advances if that commit is still `main`.