### PR TITLE
feat(providers): add Ollama as a local OpenAI-compatible provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ platform differences below first.
 
 Provider credentials go in the OS keychain, not in the database and not in a
 config file you might commit. Tidebreak talks to Anthropic, OpenAI and
-OpenAI-compatible endpoints, Google Gemini, and xAI.
+OpenAI-compatible endpoints, Google Gemini, xAI, and a local Ollama daemon.
 
 The conversation journal is provider-neutral, so a chat can move from Claude to
 Gemini to GPT and back without starting over — useful when a provider is rate
@@ -296,7 +296,7 @@ end-to-end, less technical tour of the runtime and its state machines, see
 | Crate | What it is |
 | --- | --- |
 | [`tidebreak-core`](crates/tidebreak-core) | agent loop, tools, event stream, storage traits |
-| [`tidebreak-router`](crates/tidebreak-router) | Anthropic, OpenAI, Google, and xAI providers + model routing |
+| [`tidebreak-router`](crates/tidebreak-router) | Anthropic, OpenAI, Google, xAI, and OpenAI-compatible providers + model routing |
 | [`tidebreak-host-broker`](crates/tidebreak-host-broker) | consented access to folders on the host |
 | [`tidebreak-code-execution`](crates/tidebreak-code-execution) | provider-neutral command execution + native, Docker, and managed backends |
 | [`tidebreak-egress`](crates/tidebreak-egress) | egress policy decisions for outbound network access |

--- a/crates/tidebreak-desktop/ui/src/ModelSelection.test.ts
+++ b/crates/tidebreak-desktop/ui/src/ModelSelection.test.ts
@@ -77,6 +77,7 @@ describe("typed model selection", () => {
     expect(providerLabel("gemini")).toBe("Google Gemini");
     expect(providerLabel("fireworks")).toBe("Fireworks AI");
     expect(providerLabel("together")).toBe("Together AI");
+    expect(providerLabel("ollama")).toBe("Ollama");
     expect(providerLabel("openai_compatible")).toBe("OpenAI-compatible");
   });
 });

--- a/crates/tidebreak-desktop/ui/src/ModelSelection.ts
+++ b/crates/tidebreak-desktop/ui/src/ModelSelection.ts
@@ -67,6 +67,8 @@ export function providerLabel(provider: ProviderKind): string {
       return "Fireworks AI";
     case "together":
       return "Together AI";
+    case "ollama":
+      return "Ollama";
     case "openai_compatible":
       return "OpenAI-compatible";
     case "model_gateway":

--- a/crates/tidebreak-desktop/ui/src/ProviderIcons.tsx
+++ b/crates/tidebreak-desktop/ui/src/ProviderIcons.tsx
@@ -264,6 +264,7 @@ export function ProviderIcon({
       return <XaiIcon {...rest} />;
     case "gemini":
       return <GeminiIcon {...rest} />;
+    case "ollama":
     case "openai_compatible":
     case "model_gateway":
       return <OpenModelIcon {...rest} />;

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -2017,7 +2017,7 @@ models: Array<CustomModelConfig>, };
  * The known provider kinds. `#[non_exhaustive]` so new kinds can land without
  * breaking wire clients that match on the string form.
  */
-export type ProviderKind = "anthropic" | "openai" | "xai" | "gemini" | "fireworks" | "together" | "openai_compatible" | "model_gateway";
+export type ProviderKind = "anthropic" | "openai" | "xai" | "gemini" | "fireworks" | "together" | "ollama" | "openai_compatible" | "model_gateway";
 
 /**
  * One message accepted while its chat had a live turn, waiting its turn.

--- a/crates/tidebreak-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
@@ -202,6 +202,62 @@ describe("ProvidersPanel", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("saves an Ollama daemon without a credential", async () => {
+    const ollama: ProviderInfo = {
+      kind: "ollama",
+      enabled: false,
+      has_credential: false,
+      base_url: "http://127.0.0.1:11434/v1",
+      models: [],
+    };
+    const putProvider = vi.fn().mockResolvedValue({
+      ...ollama,
+      enabled: true,
+    });
+    const client = { putProvider } as unknown as ApiClient;
+
+    renderPanel(
+      <ProvidersPanel
+        providers={[ollama]}
+        client={client}
+        onChanged={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Ollama")).toBeInTheDocument();
+    expect(
+      screen.getByText("No API key required for a local Ollama"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("API key (optional)"),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Add model" }));
+    fireEvent.change(screen.getByLabelText("Custom model 1 ID"), {
+      target: { value: "qwen3:0.6b" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Save configuration" }),
+    );
+
+    await waitFor(() =>
+      expect(putProvider).toHaveBeenCalledWith("ollama", {
+        enabled: true,
+        base_url: "http://127.0.0.1:11434/v1",
+        models: [
+          {
+            id: "qwen3:0.6b",
+            display_name: undefined,
+            context_window: 32_768,
+            max_output_tokens: 4_096,
+            input_modalities: ["text"],
+            supports_reasoning: false,
+            reasoning_efforts: [],
+          },
+        ],
+      }),
+    );
+  });
+
   it("shows fixed endpoints for direct compatible presets without editing them", () => {
     const fireworks: ProviderInfo = {
       kind: "fireworks",

--- a/crates/tidebreak-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -223,12 +223,18 @@ function ProviderRow({
   const [error, setError] = useState<string | null>(null);
   const { confirm, dialog } = useConfirm();
   const hasConfigurableModels =
-    info.kind === "openai_compatible" || info.kind === "xai";
+    info.kind === "openai_compatible" ||
+    info.kind === "xai" ||
+    info.kind === "ollama";
+  const acceptsBaseUrl =
+    info.kind === "openai_compatible" || info.kind === "ollama";
+  const requiresCredential = info.kind !== "ollama";
   const [visibilitySaving, setVisibilitySaving] = useState(false);
   const [pendingCredentialFocus, setPendingCredentialFocus] = useState(false);
   const cardRef = useRef<HTMLDivElement | null>(null);
   const credentialRef = useRef<HTMLInputElement | null>(null);
-  const connected = info.has_credential && info.enabled;
+  const connected =
+    info.enabled && (info.has_credential || !requiresCredential);
   const visibleCount = useMemo(
     () =>
       catalogModels.filter((model) => isModelVisible(model, overrides)).length,
@@ -324,7 +330,7 @@ function ProviderRow({
         models?: CustomModelConfig[];
       } = { enabled };
       if (hasConfigurableModels) {
-        if (info.kind === "openai_compatible") {
+        if (acceptsBaseUrl) {
           body.base_url = baseUrl.trim() || null;
         }
         body.models = models.map((model) => ({
@@ -455,10 +461,14 @@ function ProviderRow({
           </div>
           {hasConfigurableModels && (
             <>
-              {info.kind === "openai_compatible" && (
+              {acceptsBaseUrl && (
                 <Input
                   type="text"
-                  placeholder="base URL (e.g. http://127.0.0.1:1234/v1)"
+                  placeholder={
+                    info.kind === "ollama"
+                      ? "base URL (default http://127.0.0.1:11434/v1)"
+                      : "base URL (e.g. http://127.0.0.1:1234/v1)"
+                  }
                   value={baseUrl}
                   onChange={(e) => setBaseUrl(e.target.value)}
                 />
@@ -486,7 +496,9 @@ function ProviderRow({
                   <p className="text-xs text-muted-foreground">
                     {info.kind === "xai"
                       ? "Grok 4.5 is ready when you connect xAI. Add any additional account models here, including their limits and supported capabilities."
-                      : "Add each model this endpoint serves. Custom models start with conservative text-only, non-reasoning capabilities."}
+                      : info.kind === "ollama"
+                        ? "Add each model already pulled in Ollama. qwen3:0.6b is a small tool-calling option for a first test."
+                        : "Add each model this endpoint serves. Custom models start with conservative text-only, non-reasoning capabilities."}
                   </p>
                 )}
                 {models.map((model, index) => (
@@ -706,7 +718,9 @@ function ProviderRow({
               <Input
                 ref={credentialRef}
                 type="password"
-                placeholder="API key"
+                placeholder={
+                  info.kind === "ollama" ? "API key (optional)" : "API key"
+                }
                 value={key}
                 onChange={(e) => setKey(e.target.value)}
                 autoComplete="off"
@@ -717,6 +731,7 @@ function ProviderRow({
                   disabled={
                     saving ||
                     (!info.has_credential &&
+                      requiresCredential &&
                       info.kind !== "openai_compatible" &&
                       !key.trim()) ||
                     (hasConfigurableModels &&
@@ -790,7 +805,11 @@ function ProviderRow({
 }
 
 function credentialStatusLabel(info: ProviderInfo): string {
-  if (!info.has_credential) return "No credential";
+  if (!info.has_credential) {
+    return info.kind === "ollama"
+      ? "No API key required for a local Ollama"
+      : "No credential";
+  }
   if (info.kind === "openai" && info.auth_mode === "chatgpt") {
     return "Signed in with ChatGPT";
   }

--- a/crates/tidebreak-router/src/openai_compat.rs
+++ b/crates/tidebreak-router/src/openai_compat.rs
@@ -1,8 +1,8 @@
 //! OpenAI-compatible Chat Completions provider.
 //!
 //! Speaks the widely-supported `/v1/chat/completions` streaming protocol so the
-//! same adapter covers Fireworks, Together, OpenRouter, vLLM, LM Studio, and other
-//! OpenAI-compatible gateways. Point `base_url` at the gateway's
+//! same adapter covers Fireworks, Together, Ollama, OpenRouter, vLLM, LM Studio,
+//! and other OpenAI-compatible gateways. Point `base_url` at the gateway's
 //! `/v1` root (default: `https://api.openai.com/v1`).
 //!
 //! Native OpenAI uses the separate Responses API adapter; this one deliberately

--- a/crates/tidebreak-router/src/router.rs
+++ b/crates/tidebreak-router/src/router.rs
@@ -72,6 +72,8 @@ pub enum RouteKind {
     Fireworks,
     /// Together AI over the shared OpenAI-compatible adapter.
     Together,
+    /// A local Ollama daemon over the shared OpenAI-compatible adapter.
+    Ollama,
     /// Any OpenAI-compatible Chat Completions gateway.
     OpenaiCompatible,
     /// Google Gemini Developer API (native GenerateContent protocol).
@@ -96,6 +98,7 @@ impl RouteKind {
             RouteKind::Xai => "xai",
             RouteKind::Fireworks => "fireworks",
             RouteKind::Together => "together",
+            RouteKind::Ollama => "ollama",
             RouteKind::OpenaiCompatible => "openai_compatible",
             RouteKind::Gemini => "gemini",
             RouteKind::ModelGateway => "model_gateway",
@@ -119,6 +122,7 @@ impl RouteKind {
             "xai" => Some(Self::Xai),
             "fireworks" => Some(Self::Fireworks),
             "together" => Some(Self::Together),
+            "ollama" => Some(Self::Ollama),
             "openai_compatible" => Some(Self::OpenaiCompatible),
             "gemini" => Some(Self::Gemini),
             "model_gateway" => Some(Self::ModelGateway),
@@ -221,6 +225,7 @@ impl Router {
             RouteKind::Gemini,
             RouteKind::Fireworks,
             RouteKind::Together,
+            RouteKind::Ollama,
             RouteKind::ModelGateway,
             RouteKind::ModelGatewayOpenai,
             RouteKind::OpenaiCompatible,
@@ -382,7 +387,10 @@ fn build_adapter(route: &Route) -> Option<Arc<dyn ModelProvider>> {
         // cannot redirect the bearer token around the server's collector.
         RouteKind::Xai => Some(Arc::new(XaiProvider::new(route.api_key.clone()))),
         #[cfg(feature = "openai-compat")]
-        RouteKind::Fireworks | RouteKind::Together | RouteKind::OpenaiCompatible => {
+        RouteKind::Fireworks
+        | RouteKind::Together
+        | RouteKind::Ollama
+        | RouteKind::OpenaiCompatible => {
             let base = route.base_url.as_deref()?;
             // Refuse non-http(s) schemes so a stored base_url can't point the
             // adapter at an arbitrary scheme handler.
@@ -412,7 +420,10 @@ fn build_adapter(route: &Route) -> Option<Arc<dyn ModelProvider>> {
         #[cfg(not(feature = "xai"))]
         RouteKind::Xai => None,
         #[cfg(not(feature = "openai-compat"))]
-        RouteKind::Fireworks | RouteKind::Together | RouteKind::OpenaiCompatible => None,
+        RouteKind::Fireworks
+        | RouteKind::Together
+        | RouteKind::Ollama
+        | RouteKind::OpenaiCompatible => None,
     }
 }
 
@@ -571,6 +582,26 @@ mod tests {
     fn empty_router_selects_nothing() {
         let router = Router::build(vec![]);
         assert_eq!(router.select("claude-opus-4-8"), None);
+    }
+
+    #[test]
+    fn ollama_serves_only_configured_models() {
+        let router = Router::build(vec![route(
+            RouteKind::Ollama,
+            "ollama",
+            &["qwen3:0.6b"],
+            Some("http://127.0.0.1:11434/v1"),
+        )]);
+        assert_eq!(
+            router.select_for(Some(&ProviderId::new("ollama")), "qwen3:0.6b"),
+            Some(RouteKind::Ollama)
+        );
+        assert_eq!(
+            router.select_for(Some(&ProviderId::new("ollama")), "llama3.2:1b"),
+            None
+        );
+        assert_eq!(router.select("qwen3:0.6b"), Some(RouteKind::Ollama));
+        assert_eq!(router.select("llama3.2:1b"), None);
     }
 
     #[test]

--- a/crates/tidebreak-server/src/model_registry.rs
+++ b/crates/tidebreak-server/src/model_registry.rs
@@ -253,9 +253,10 @@ impl ModelSpec {
                     | "nvidia/nemotron-3-ultra-550b-a55b"
                     | "google/gemma-4-31B-it"
             ),
-            ProviderKind::Xai | ProviderKind::OpenaiCompatible | ProviderKind::ModelGateway => {
-                false
-            }
+            ProviderKind::Xai
+            | ProviderKind::Ollama
+            | ProviderKind::OpenaiCompatible
+            | ProviderKind::ModelGateway => false,
         }
     }
 }
@@ -999,7 +1000,7 @@ mod tests {
             ProviderKind::Gemini => true,
             ProviderKind::Fireworks => true,
             ProviderKind::Together => true,
-            ProviderKind::OpenaiCompatible => false,
+            ProviderKind::Ollama | ProviderKind::OpenaiCompatible => false,
             ProviderKind::ModelGateway => true,
         }
     }
@@ -1241,6 +1242,7 @@ mod tests {
                         spec.provider,
                         ProviderKind::Fireworks
                             | ProviderKind::Together
+                            | ProviderKind::Ollama
                             | ProviderKind::OpenaiCompatible
                             | ProviderKind::ModelGateway
                     ),

--- a/crates/tidebreak-server/src/providers.rs
+++ b/crates/tidebreak-server/src/providers.rs
@@ -263,6 +263,8 @@ pub enum ProviderKind {
     Fireworks,
     /// Together AI's hosted OpenAI-compatible Chat Completions API.
     Together,
+    /// A local Ollama daemon over the shared OpenAI-compatible transport.
+    Ollama,
     /// Any OpenAI-compatible Chat Completions gateway (OpenRouter, vLLM, …).
     OpenaiCompatible,
     /// A signed-in model-gateway deployment: entitled models synced from the
@@ -280,6 +282,7 @@ impl ProviderKind {
         ProviderKind::Gemini,
         ProviderKind::Fireworks,
         ProviderKind::Together,
+        ProviderKind::Ollama,
         ProviderKind::OpenaiCompatible,
         ProviderKind::ModelGateway,
     ];
@@ -293,6 +296,7 @@ impl ProviderKind {
             ProviderKind::Gemini => "gemini",
             ProviderKind::Fireworks => "fireworks",
             ProviderKind::Together => "together",
+            ProviderKind::Ollama => "ollama",
             ProviderKind::OpenaiCompatible => "openai_compatible",
             ProviderKind::ModelGateway => "model_gateway",
         }
@@ -307,27 +311,58 @@ impl ProviderKind {
             "gemini" => Some(Self::Gemini),
             "fireworks" => Some(Self::Fireworks),
             "together" => Some(Self::Together),
+            "ollama" => Some(Self::Ollama),
             "openai_compatible" => Some(Self::OpenaiCompatible),
             "model_gateway" => Some(Self::ModelGateway),
             _ => None,
         }
     }
 
-    /// Fixed API root for direct hosted compatible presets.
+    /// Default API root. Hosted presets fix this; Ollama uses it when the
+    /// reader has not pointed the card at another daemon.
     pub const fn default_base_url(self) -> Option<&'static str> {
         match self {
             Self::Fireworks => Some("https://api.fireworks.ai/inference/v1"),
             Self::Together => Some("https://api.together.ai/v1"),
+            Self::Ollama => Some("http://127.0.0.1:11434/v1"),
             _ => None,
         }
+    }
+
+    /// Whether [`default_base_url`] is the only legal endpoint.
+    pub const fn has_fixed_endpoint(self) -> bool {
+        matches!(self, Self::Fireworks | Self::Together)
     }
 
     /// Whether this route speaks the shared OpenAI-compatible transport.
     pub const fn uses_openai_compatible_transport(self) -> bool {
         matches!(
             self,
-            Self::Fireworks | Self::Together | Self::OpenaiCompatible
+            Self::Fireworks | Self::Together | Self::Ollama | Self::OpenaiCompatible
         )
+    }
+
+    /// Whether the reader can register model rows beside the endpoint.
+    pub const fn accepts_configured_models(self) -> bool {
+        matches!(self, Self::OpenaiCompatible | Self::Xai | Self::Ollama)
+    }
+
+    /// Whether a stored or env credential is required before the route is
+    /// usable. Local Ollama accepts unauthenticated requests.
+    pub const fn requires_credential(self) -> bool {
+        !matches!(self, Self::Ollama)
+    }
+
+    /// The URL this kind actually calls: a stored override, else the default,
+    /// with hosted presets ignoring any stored value.
+    pub fn effective_base_url(self, configured: Option<&str>) -> Option<String> {
+        if self.has_fixed_endpoint() {
+            return self.default_base_url().map(str::to_owned);
+        }
+        configured
+            .filter(|url| !url.is_empty())
+            .map(str::to_owned)
+            .or_else(|| self.default_base_url().map(str::to_owned))
     }
 
     /// Store setting key for this kind's non-secret config.
@@ -354,6 +389,7 @@ impl ProviderKind {
                     | ProviderKind::Gemini
                     | ProviderKind::Fireworks
                     | ProviderKind::Together
+                    | ProviderKind::Ollama
                     | ProviderKind::OpenaiCompatible
             ),
             ProviderCredential::Oauth {} => self == ProviderKind::Openai,
@@ -860,8 +896,8 @@ pub struct ProviderUpdate {
     pub base_url: Option<Option<String>>,
     #[serde(default)]
     pub credential: Option<ProviderCredential>,
-    /// Replacement configured-model list. Valid for `openai_compatible` and
-    /// first-party xAI.
+    /// Replacement configured-model list. Valid for `openai_compatible`,
+    /// Ollama, and first-party xAI.
     #[serde(default)]
     pub models: Option<Vec<CustomModelConfig>>,
 }
@@ -1052,10 +1088,7 @@ pub async fn list_providers(
         out.push(ProviderInfo {
             kind,
             enabled: config.enabled,
-            base_url: kind
-                .default_base_url()
-                .map(str::to_owned)
-                .or_else(|| config.base_url.clone()),
+            base_url: kind.effective_base_url(config.base_url.as_deref()),
             has_credential: has_credential(secrets, kind).await,
             auth_mode: auth_mode_for(secrets, kind).await,
             models: config.models,
@@ -1115,7 +1148,7 @@ pub async fn update_provider(
                 "xai uses its fixed first-party API endpoint",
             ));
         }
-        Some(_) if kind.default_base_url().is_some() => {
+        Some(_) if kind.has_fixed_endpoint() => {
             return Err(ServerError::bad_request(format!(
                 "{kind} uses a fixed provider endpoint"
             )));
@@ -1129,10 +1162,10 @@ pub async fn update_provider(
         }
     }
     if let Some(models) = update.models {
-        if !matches!(kind, ProviderKind::OpenaiCompatible | ProviderKind::Xai) {
-            return Err(ServerError::bad_request(
-                "configured models are only supported by openai_compatible and xai",
-            ));
+        if !kind.accepts_configured_models() {
+            return Err(ServerError::bad_request(format!(
+                "configured models are not supported by {kind}"
+            )));
         }
         validate_configured_models(kind, &models)?;
         config.models = models;
@@ -1159,10 +1192,7 @@ pub async fn update_provider(
     Ok(ProviderInfo {
         kind,
         enabled: config.enabled,
-        base_url: kind
-            .default_base_url()
-            .map(str::to_owned)
-            .or_else(|| config.base_url.clone()),
+        base_url: kind.effective_base_url(config.base_url.as_deref()),
         has_credential: has_credential(secrets, kind).await,
         auth_mode: auth_mode_for(secrets, kind).await,
         models: config.models,
@@ -1336,7 +1366,7 @@ fn env_api_key(kind: ProviderKind) -> Option<String> {
         ProviderKind::Together => std::env::var("TOGETHER_API_KEY")
             .ok()
             .filter(|k| !k.is_empty()),
-        ProviderKind::OpenaiCompatible => None,
+        ProviderKind::Ollama | ProviderKind::OpenaiCompatible => None,
         // Gateway tokens rotate; they are supplied per request by the route's
         // token source, never resolved into a static key.
         ProviderKind::ModelGateway => None,
@@ -1358,6 +1388,7 @@ pub fn route_kind(kind: ProviderKind) -> tidebreak_router::RouteKind {
         ProviderKind::Gemini => tidebreak_router::RouteKind::Gemini,
         ProviderKind::Fireworks => tidebreak_router::RouteKind::Fireworks,
         ProviderKind::Together => tidebreak_router::RouteKind::Together,
+        ProviderKind::Ollama => tidebreak_router::RouteKind::Ollama,
         ProviderKind::OpenaiCompatible => tidebreak_router::RouteKind::OpenaiCompatible,
         ProviderKind::ModelGateway => tidebreak_router::RouteKind::ModelGateway,
     }
@@ -1501,13 +1532,15 @@ pub async fn collect_routes(
             Some(_) => None,
             None => env_api_key(kind),
         };
-        let Some(api_key) = api_key else {
-            continue;
+        // Local Ollama accepts unauthenticated requests. The adapter still
+        // sends a bearer token, so an enabled daemon without a stored key
+        // uses a placeholder the endpoint ignores.
+        let api_key = match api_key {
+            Some(key) => key,
+            None if !kind.requires_credential() => "ollama".to_owned(),
+            None => continue,
         };
-        let base_url = kind
-            .default_base_url()
-            .map(str::to_owned)
-            .or_else(|| config.base_url.clone());
+        let base_url = kind.effective_base_url(config.base_url.as_deref());
         if kind == ProviderKind::OpenaiCompatible && base_url.is_none() {
             continue;
         }
@@ -1584,9 +1617,7 @@ pub async fn resolve_model_policy(
             return Ok(Some(ResolvedModelPolicy::curated(spec)));
         }
         let models = match provider {
-            ProviderKind::OpenaiCompatible | ProviderKind::Xai => {
-                read_config(store, provider).await?.models
-            }
+            kind if kind.accepts_configured_models() => read_config(store, provider).await?.models,
             // Resolution is not an offer: usability and routing gate the
             // gateway on policy separately, so the raw snapshot read here
             // only keeps stored selections legible.
@@ -1609,7 +1640,11 @@ pub async fn resolve_model_policy(
         .map(ResolvedModelPolicy::curated)
         .into_iter()
         .collect::<Vec<_>>();
-    for provider in [ProviderKind::Xai, ProviderKind::OpenaiCompatible] {
+    for provider in [
+        ProviderKind::Xai,
+        ProviderKind::Ollama,
+        ProviderKind::OpenaiCompatible,
+    ] {
         let config = read_config(store, provider).await?;
         owners.extend(
             config
@@ -1658,11 +1693,11 @@ pub async fn provider_is_usable(
     if !config.enabled {
         return Ok(false);
     }
-    if !has_credential(secrets, kind).await {
+    if kind.requires_credential() && !has_credential(secrets, kind).await {
         return Ok(false);
     }
     if kind.uses_openai_compatible_transport() {
-        let base_url = kind.default_base_url().or(config.base_url.as_deref());
+        let base_url = kind.effective_base_url(config.base_url.as_deref());
         let Some(base) = base_url else {
             return Ok(false);
         };
@@ -1724,9 +1759,7 @@ pub async fn catalog_models(
         // and the managed gateway's entitled snapshot — which is empty on an
         // unmanaged profile, so no gateway row ever reaches the catalog there.
         let configured = match kind {
-            ProviderKind::OpenaiCompatible | ProviderKind::Xai => {
-                read_config(store, kind).await?.models
-            }
+            kind if kind.accepts_configured_models() => read_config(store, kind).await?.models,
             ProviderKind::ModelGateway => gateway_models(store, policy).await?,
             _ => Vec::new(),
         };
@@ -1921,6 +1954,30 @@ mod tests {
         assert_eq!(
             ProviderKind::Together.default_base_url(),
             Some("https://api.together.ai/v1")
+        );
+        assert_eq!(ProviderKind::parse("ollama"), Some(ProviderKind::Ollama));
+        assert_eq!(
+            ProviderKind::Ollama.default_base_url(),
+            Some("http://127.0.0.1:11434/v1")
+        );
+        assert!(!ProviderKind::Ollama.has_fixed_endpoint());
+        assert!(!ProviderKind::Ollama.requires_credential());
+        assert!(ProviderKind::Ollama.accepts_configured_models());
+        assert_eq!(
+            ProviderKind::Ollama.effective_base_url(None).as_deref(),
+            Some("http://127.0.0.1:11434/v1")
+        );
+        assert_eq!(
+            ProviderKind::Ollama
+                .effective_base_url(Some("http://192.168.1.10:11434/v1"))
+                .as_deref(),
+            Some("http://192.168.1.10:11434/v1")
+        );
+        assert_eq!(
+            ProviderKind::Fireworks
+                .effective_base_url(Some("https://attacker.invalid/v1"))
+                .as_deref(),
+            Some("https://api.fireworks.ai/inference/v1")
         );
     }
 

--- a/crates/tidebreak-server/src/routes/providers_models.rs
+++ b/crates/tidebreak-server/src/routes/providers_models.rs
@@ -91,6 +91,9 @@ fn unknown_model_message(value: &str) -> String {
         Some((ProviderKind::OpenaiCompatible, id)) => {
             format!("model `{id}` is not configured under OpenAI-compatible models")
         }
+        Some((ProviderKind::Ollama, id)) => {
+            format!("model `{id}` is not configured under Ollama models")
+        }
         Some((provider, id)) => {
             format!("model `{id}` is not registered for provider `{provider}`")
         }

--- a/crates/tidebreak-server/src/tests/configuration.rs
+++ b/crates/tidebreak-server/src/tests/configuration.rs
@@ -1183,6 +1183,9 @@ async fn providers_list_and_put_roundtrip() {
     assert!(providers
         .iter()
         .any(|p| p["kind"] == "together" && p["base_url"] == "https://api.together.ai/v1"));
+    assert!(providers
+        .iter()
+        .any(|p| { p["kind"] == "ollama" && p["base_url"] == "http://127.0.0.1:11434/v1" }));
     assert!(providers.iter().any(|p| p["kind"] == "openai_compatible"));
 
     let put = router
@@ -2637,6 +2640,117 @@ async fn direct_compatible_presets_use_fixed_endpoints_and_distinct_routes() {
             "moonshotai/Kimi-K3"
         ),
         Some(tidebreak_router::RouteKind::Together)
+    );
+}
+
+#[tokio::test]
+async fn ollama_is_usable_without_a_credential_and_serves_only_configured_models() {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}/test.db?mode=rwc",
+            dir.path().display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let secrets: Arc<dyn SecretProvider> = Arc::new(MemSecrets::default());
+    let policy = crate::managed_policy::resolve(
+        &*crate::managed_policy::MemoryProvisionedPolicy::new(),
+        &crate::managed_policy::NoOsPolicy,
+    )
+    .unwrap();
+
+    assert!(
+        !providers::provider_is_usable(
+            &*store,
+            &*secrets,
+            providers::ProviderKind::Ollama,
+            &policy
+        )
+        .await
+        .unwrap(),
+        "a disabled Ollama card is not a route"
+    );
+
+    providers::write_config(
+        &*store,
+        providers::ProviderKind::Ollama,
+        &providers::ProviderConfig {
+            enabled: true,
+            base_url: None,
+            models: vec![providers::CustomModelConfig {
+                id: "qwen3:0.6b".into(),
+                display_name: Some("Qwen 3 0.6B".into()),
+                ..providers::CustomModelConfig::default()
+            }],
+        },
+    )
+    .await
+    .unwrap();
+
+    assert!(providers::provider_is_usable(
+        &*store,
+        &*secrets,
+        providers::ProviderKind::Ollama,
+        &policy
+    )
+    .await
+    .unwrap());
+    assert!(
+        !providers::has_credential(&*secrets, providers::ProviderKind::Ollama).await,
+        "usability must not invent a stored credential"
+    );
+
+    let listed = providers::list_providers(&*store, &*secrets, &policy)
+        .await
+        .unwrap();
+    let ollama = listed
+        .iter()
+        .find(|info| info.kind == providers::ProviderKind::Ollama)
+        .expect("Ollama is a first-class provider");
+    assert!(ollama.enabled);
+    assert!(!ollama.has_credential);
+    assert_eq!(
+        ollama.base_url.as_deref(),
+        Some("http://127.0.0.1:11434/v1")
+    );
+
+    let catalog = providers::catalog_models(&*store, &*secrets, &policy)
+        .await
+        .unwrap();
+    let model = catalog
+        .iter()
+        .find(|entry| entry.policy.key == "ollama::qwen3:0.6b")
+        .expect("the configured Ollama model is in the catalog");
+    assert!(model.available);
+    assert_eq!(model.policy.display_name, "Qwen 3 0.6B");
+    assert!(model.policy.supports_tools);
+    assert!(!model.policy.supports_reasoning);
+
+    let routes = providers::collect_routes(&*store, &*secrets, None, None, &policy).await;
+    let route = routes
+        .iter()
+        .find(|route| route.kind == tidebreak_router::RouteKind::Ollama)
+        .expect("an enabled Ollama daemon is a route");
+    assert_eq!(route.api_key, "ollama");
+    assert_eq!(route.base_url.as_deref(), Some("http://127.0.0.1:11434/v1"));
+    assert_eq!(route.curated_models, ["qwen3:0.6b"]);
+
+    let router = tidebreak_router::Router::build(routes);
+    assert_eq!(
+        router.select_for(
+            Some(&tidebreak_core::ProviderId::new("ollama")),
+            "qwen3:0.6b"
+        ),
+        Some(tidebreak_router::RouteKind::Ollama)
+    );
+    assert_eq!(
+        router.select_for(
+            Some(&tidebreak_core::ProviderId::new("ollama")),
+            "llama3.2:1b"
+        ),
+        None
     );
 }
 

--- a/docs-site/content/docs/index.mdx
+++ b/docs-site/content/docs/index.mdx
@@ -29,9 +29,9 @@ formats, and behavior change frequently. Expect rough edges.
 - **Produce files, not just answers.** Anything the agent saves to its
   `output/` directory becomes a versioned output you can preview and export
   with a native save dialog.
-- **Use any model.** Anthropic, OpenAI, Google, xAI, and any
-  OpenAI-compatible endpoint, including a local one. You can switch models
-  mid-conversation without losing the thread.
+- **Use any model.** Anthropic, OpenAI, Google, xAI, a local Ollama daemon,
+  and any OpenAI-compatible endpoint. You can switch models mid-conversation
+  without losing the thread.
 - **Decide how much rope to give it.** Every chat has a permission mode, from
   read-only planning up to full autonomy.
 

--- a/docs-site/content/docs/models-and-providers.mdx
+++ b/docs-site/content/docs/models-and-providers.mdx
@@ -20,6 +20,7 @@ Open **Settings → Providers**. Each provider is its own section: turn on
 | xAI | API key, plus the model IDs you want to use |
 | Fireworks AI | API key; Tidebreak uses `https://api.fireworks.ai/inference/v1` |
 | Together AI | API key; Tidebreak uses `https://api.together.ai/v1` |
+| Ollama | No key for a local daemon. Defaults to `http://127.0.0.1:11434/v1`, plus the model IDs you have already pulled |
 | OpenAI-compatible | Base URL, optional key, plus the model IDs you want to use |
 
 **Google Gemini** is the direct Gemini Developer API path and accepts a Gemini
@@ -67,14 +68,21 @@ been confirmed on that exact provider/model pair.
 
 ## Custom models
 
-**xAI** and **OpenAI-compatible** do not come with a curated list. Add rows
-under the provider's **Models** section: a model ID, an optional display name,
-and context and max-output token counts. For xAI, you also declare whether the
-model takes image input, whether it is a reasoning model, and which
-reasoning-effort levels it accepts.
+**xAI**, **Ollama**, and **OpenAI-compatible** do not come with a curated list.
+Add rows under the provider's **Models** section: a model ID, an optional
+display name, and context and max-output token counts. For xAI, you also
+declare whether the model takes image input, whether it is a reasoning model,
+and which reasoning-effort levels it accepts.
 
-The OpenAI-compatible slot points at any endpoint that speaks the OpenAI
-chat-completions API, including a local one:
+**Ollama** talks to a local daemon over the same OpenAI-compatible
+chat-completions path. Enable it, add a model you have already pulled
+(`ollama pull qwen3:0.6b` is a small tool-calling option for a first test),
+and leave the base URL at `http://127.0.0.1:11434/v1` unless the daemon is
+somewhere else. A key is optional — only remote or locked-down Ollama
+installs need one.
+
+The generic OpenAI-compatible slot still points at any other endpoint that
+speaks the same API, including LM Studio or vLLM:
 
 ```text
 base URL: http://127.0.0.1:1234/v1

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -56,8 +56,8 @@ Major surfaces present today:
 ## `tidebreak-router` — model providers & routing 🟢
 
 Owns the concrete Anthropic, OpenAI Responses, xAI Responses, Gemini, and
-OpenAI-compatible provider adapters (including Fireworks, Together, OpenRouter,
-vLLM, and LM Studio endpoints) plus a composite `Router`.
+OpenAI-compatible provider adapters (including Fireworks, Together, Ollama,
+OpenRouter, vLLM, and LM Studio endpoints) plus a composite `Router`.
 
 The `Router` is itself a `ModelProvider`, so the agent loop holds one provider
 contract and does not depend on a concrete backend. Two things define it:

--- a/docs/how-tidebreak-works.md
+++ b/docs/how-tidebreak-works.md
@@ -303,9 +303,9 @@ independently reauthorizes its live grant. Resolve checks attachment authority
 again, which discards content if a detach won while the read was in flight. A
 crash after possible broker dispatch becomes a safe unavailable result instead
 of another read.
-The model router supports Anthropic, OpenAI, xAI, Gemini, and
-OpenAI-compatible endpoints. It fails closed: if no enabled provider with a
-usable credential can serve the selected model, no model request is sent.
+The model router supports Anthropic, OpenAI, xAI, Gemini, Ollama, and
+OpenAI-compatible endpoints. It fails closed: if no enabled provider that is
+ready to serve the selected model can be used, no model request is sent.
 
 ### Tool calls are small state machines too
 

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -30,12 +30,14 @@ policy, not as unfinished work:
 1. **Tier 1** — one, maybe two providers. Full capability: provider-executed
    tools, images, caching semantics, first-class testing. Design advanced
    features against these and ship when they work here.
-2. **Tier 2** — OpenAI-compatible endpoints and other partial routes. Chat
-   completion, ordinary tool calls, failover. Advanced features are
+2. **Tier 2** — OpenAI-compatible endpoints, Ollama, and other partial routes.
+   Chat completion, ordinary tool calls, failover. Advanced features are
    best-effort or absent, and capability flags say so honestly. Gemini's
    dormant vendor web-search path (`supports_vendor_web_search: false` until
    grounding can coexist with host tools) is the pattern — generalize it
-   rather than lighting every feature everywhere.
+   rather than lighting every feature everywhere. Ollama is a named local
+   runtime on this tier: no key for a default daemon, custom model rows, and
+   the same flatten-on-switch rule as every other compatible route.
 
 Refuse to invent per-provider special cases below the router. If a feature
 cannot be expressed through the existing `ModelProvider` trait plus registry


### PR DESCRIPTION
## Why

A local daemon is a useful way to exercise Tidebreak without a cloud key, but the generic OpenAI-compatible slot still needs a URL and is treated as unusable until a credential exists. That makes a first local test harder than it should be, and it also occupies the one compatible endpoint.

## What

Add Ollama as its own provider kind on the shared Chat Completions transport:

- Default endpoint `http://127.0.0.1:11434/v1`, overridable for a remote daemon
- Usable when enabled, with no API key. A key remains optional
- Custom model rows, same conservative text-only contract as other compatible endpoints
- Settings card, picker label, and docs

`qwen3:0.6b` is a small tool-calling option for a first test. Leave max output at the default 4096 — the model thinks by default, and a tiny cap returns empty content.

## Tests

- Router: Ollama serves only configured models, not the free-form compatible fallback
- Provider: enabled with no credential, default URL, catalog row, collected route
- UI: save an Ollama daemon without a credential
- `UPDATE_WIRE_TYPES=1` regenerated `ProviderKind`

## Notes

- Live check against a local `qwen3:0.6b`: Tidebreak's compatible adapter streamed a reply. Not a CI test.
- Did not drive the running desktop app.