### PR TITLE
fix(desktop): give staging its own updater public key

### DIFF
--- a/crates/tidebreak-desktop/tauri.staging.conf.json
+++ b/crates/tidebreak-desktop/tauri.staging.conf.json
@@ -17,6 +17,7 @@
       }
     },
     "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDlDNEVEMjJDODUwQzhDMTgKUldRWWpBeUZMTkpPbk4xbVpoRENuNkhSL1B1NDVudGY3bWZIMWd5NFp3V24xUEZZaU40ckZJdDgK",
       "endpoints": [
         "https://downloads.brightwave.io/tidebreak/staging/latest.json"
       ]

--- a/docs/decisions/0013-desktop-staging-channel.md
+++ b/docs/decisions/0013-desktop-staging-channel.md
@@ -37,8 +37,9 @@ build of `main`, not a debug build and not a GitHub Release.
 | Staging    | Tidebreak [staging]   | `io.brightwave.tidebreak.staging`   | blue  | `tidebreak.staging` | `tidebreak-staging`  | relevant push to `main`      |
 
 The three channels do not share a single-instance lock, app-data directory,
-keychain service, deep-link scheme, or updater feed. Staging therefore runs
-beside both a debug window and an installed release. A staging binary answers
+keychain service, deep-link scheme, updater feed, or updater signing key.
+Staging therefore runs beside both a debug window and an installed release.
+A staging binary answers
 only `tidebreak-staging://`; it does not register or honor `tidebreak://`, so
 it cannot steal production pairing links the way an early debug build used to.
 
@@ -65,8 +66,11 @@ https://downloads.brightwave.io/tidebreak/staging/releases/v0.0.0-staging.N/
 Production `latest.json` and `tidebreak/releases/` are unreachable from this
 channel. The GitHub environment is `desktop-staging`, with an IAM role scoped
 to `tidebreak/staging/`. Apple signing material may be copied into that
-environment; the updater public key is the same committed key production uses,
-because the feeds are already isolated by URL and bundle id.
+environment. The updater keypair is not shared with production: staging
+commits its own `plugins.updater.pubkey` in `tauri.staging.conf.json`, and
+`desktop-staging` holds a matching `TAURI_SIGNING_PRIVATE_KEY` that must
+never be copied from `desktop-production`. A stolen staging key must not
+verify on production clients.
 
 Concurrency:
 
@@ -127,6 +131,14 @@ perfect, and a yellow `Publish desktop release` run on every merge would make
 the production signal harder to see. A thin caller workflow keeps the
 production trigger list intact.
 
+### Share the production updater signing key
+
+Isolating the feed URL and bundle id was thought to be enough, so staging
+would sign with production's committed public key. Rejected: a leaked
+`desktop-staging` private key would then verify on production clients. The
+feeds being separate does not stop a client from accepting a signature its
+embedded public key trusts.
+
 ### Do nothing
 
 Testers would keep using debug builds or published releases. That leaves `main`
@@ -136,10 +148,14 @@ only way to tell two Tidebreaks apart.
 ## Consequences
 
 Operators must create a `desktop-staging` GitHub environment before the first
-staging publish, copy the Apple and Tauri signing secrets into it, and grant
-its AWS role only `tidebreak/staging/*` plus CloudFront invalidation for those
-paths. A role that can also write `tidebreak/latest.json` would make a
-publish-guard bug a production incident.
+staging publish, copy the Apple signing secrets into it, generate a distinct
+Tauri updater keypair, commit only the public key in
+`tauri.staging.conf.json`, and store that pair's private key and password in
+the staging environment. Copying `TAURI_SIGNING_PRIVATE_KEY` from
+`desktop-production` is forbidden. Grant its AWS role only
+`tidebreak/staging/*` plus CloudFront invalidation for those paths. A role
+that can also write `tidebreak/latest.json` would make a publish-guard bug a
+production incident.
 
 Staging installs are disposable relative to production. They will pick up
 pre-v1 schema epoch resets from `main` and rebuild their local profile. That
@@ -164,6 +180,8 @@ release line (LTS, beta) needs a fourth identity.
   base URL, and refuses a production version under the staging base URL.
 - The staging publish step refuses any S3 key that does not start with
   `tidebreak/staging/`.
+- Staging overlay `plugins.updater.pubkey` exists and is not equal to
+  production's committed updater public key.
 - The staging caller workflow contains `secrets: inherit` and does not contain
   `secrets.`.
 - A newer staging version may replace `latest.json`; an older one may not.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -329,9 +329,10 @@ installed release. The contract is recorded in
 Staging is a release-profile build with a blue icon, product name
 `Tidebreak [staging]`, identifier `io.brightwave.tidebreak.staging`, keychain
 service `tidebreak.staging`, and the `tidebreak-staging://` scheme. It does
-not share a single-instance lock, app-data directory, or updater feed with
-production. Its versions are `0.0.0-staging.{run_number}` — monotonic for the
-Tauri updater, and not a production `vMAJOR.MINOR.PATCH` tag.
+not share a single-instance lock, app-data directory, updater feed, or
+updater signing key with production. Its versions are
+`0.0.0-staging.{run_number}` — monotonic for the Tauri updater, and not a
+production `vMAJOR.MINOR.PATCH` tag.
 
 The caller is **Publish staging desktop**. It derives the version, then
 invokes the `workflow_call`-only **Publish staging desktop build** workflow
@@ -343,8 +344,15 @@ untouched. Staging artifacts live under
 refuses any other prefix and will not advance `latest.json` if `main` has
 already moved on.
 
-Create a GitHub environment named `desktop-staging`. Copy the Apple and Tauri
-signing secrets from `desktop-production`. Point `AWS_RELEASE_ROLE_ARN` at a
+Create a GitHub environment named `desktop-staging`. Copy the Apple signing
+secrets from `desktop-production`. Do **not** copy
+`TAURI_SIGNING_PRIVATE_KEY` or `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`: a
+stolen staging key must not verify on production clients. Staging has its
+own updater keypair. The public half is committed in
+`crates/tidebreak-desktop/tauri.staging.conf.json`. Set the staging
+environment's `TAURI_SIGNING_PRIVATE_KEY` and
+`TAURI_SIGNING_PRIVATE_KEY_PASSWORD` to that pair's private key and
+password. Point `AWS_RELEASE_ROLE_ARN` at a
 role whose GitHub OIDC subject is
 `repo:brightwave-inc/tidebreak:environment:desktop-staging` and whose S3
 write access is only `tidebreak/staging/*`. A role that can also write

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1350,6 +1350,18 @@ test("staging desktop publishes only under the staging prefix", () => {
     ),
   );
   assert.equal(stagingOverlay.identifier, "io.brightwave.tidebreak.staging");
+  const stagingPubkey = stagingOverlay.plugins.updater.pubkey;
+  const productionPubkey = tauriConfig.plugins.updater.pubkey;
+  assert.ok(stagingPubkey, "staging overlay must set plugins.updater.pubkey");
+  assert.notEqual(
+    stagingPubkey,
+    productionPubkey,
+    "staging must not share the production updater public key",
+  );
+  assert.match(
+    Buffer.from(stagingPubkey, "base64").toString("utf8"),
+    /minisign public key/,
+  );
   assert.deepEqual(stagingOverlay.plugins.updater.endpoints, [
     "https://downloads.brightwave.io/tidebreak/staging/latest.json",
   ]);


### PR DESCRIPTION
## Summary

Staging desktop signed updates with production's committed updater public key. `tauri.staging.conf.json` overrode only the feed URL, and operators were told to copy `TAURI_SIGNING_PRIVATE_KEY` from `desktop-production` into `desktop-staging`. A stolen staging key would then verify on production clients.

- Commit a distinct staging updater public key in the staging overlay.
- Update decision 13 (still Proposed) and the staging environment section of `docs/releases.md`: staging must use its own keypair; copying production's private key is forbidden.
- Extend the existing staging policy test so the overlay pubkey exists, decodes as minisign, and is not the production pubkey.

Production's committed updater public key is unchanged.

## Operator action required

A repo admin must set `desktop-staging` environment secrets `TAURI_SIGNING_PRIVATE_KEY` and `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` to the new staging pair. I am not attaching the private key. Until those secrets are installed, staging publishes will fail signature.

Do not copy either secret from `desktop-production`.

## Test plan

- [x] `node --test scripts/workflow-security.test.mjs scripts/desktop-channel.test.mjs`
- [x] `node --test scripts/workflow-security-mutations.test.mjs`
- [ ] Human installs the new staging private key and password in `desktop-staging`; next staging publish signs with that pair.