### PR TITLE
test: accept signing jobs that isolate installers from Apple material

### DIFF
--- a/scripts/workflow-security-mutations.test.mjs
+++ b/scripts/workflow-security-mutations.test.mjs
@@ -50,6 +50,19 @@ function edit(root, path, mutate) {
   writeFileSync(target, after);
 }
 
+function editWorkflowJob(source, name, mutateJob) {
+  const marker = `  ${name}:\n`;
+  const start = source.indexOf(marker);
+  assert.notEqual(start, -1, `missing workflow job: ${name}`);
+  const remainder = source.slice(start + marker.length);
+  const next = remainder.search(/^  [a-zA-Z0-9_-]+:\n/m);
+  const end = next === -1 ? source.length : start + marker.length + next;
+  const job = source.slice(start, end);
+  const mutated = mutateJob(job);
+  assert.notEqual(mutated, job, `mutation did not change job ${name}`);
+  return source.slice(0, start) + mutated + source.slice(end);
+}
+
 function runPolicy(root) {
   const env = {
     ...process.env,
@@ -202,6 +215,39 @@ const mutations = [
     file: "deploy/self-host/Dockerfile.dockerignore",
     expected: "Docker context is allowlisted",
     mutate: (source) => source.replace("**/id_*\n", ""),
+  },
+  {
+    name: "signing job pnpm pin",
+    file: ".github/workflows/release.yml",
+    expected: "signing jobs do not run untrusted installers",
+    mutate: (source) =>
+      editWorkflowJob(source, "build_macos", (job) =>
+        job.replace(/version: 10(?:\.18\.3)?\n/, "version: latest\n"),
+      ),
+  },
+  {
+    name: "signing job lockfile install",
+    file: ".github/workflows/release.yml",
+    expected: "signing jobs do not run untrusted installers",
+    mutate: (source) =>
+      editWorkflowJob(source, "build_macos", (job) =>
+        job.replace(
+          /      - name: Install UI dependencies\n        working-directory: crates\/tidebreak-desktop\/ui\n        run: pnpm install --frozen-lockfile(?: --ignore-scripts)?\n/,
+          "",
+        ),
+      ),
+  },
+  {
+    name: "signing job rust-cache writer",
+    file: ".github/workflows/release.yml",
+    expected: "signing jobs do not run untrusted installers",
+    mutate: (source) =>
+      editWorkflowJob(source, "build_macos", (job) =>
+        job.replace(
+          /save-if: (?:false|\$\{\{ matrix\.arch == 'aarch64' \}\})/,
+          "save-if: true",
+        ),
+      ),
   },
 ];
 

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -71,6 +71,49 @@ function workflowJob(source, name) {
   return source.slice(start, end);
 }
 
+const DESKTOP_SIGNING_JOBS = [
+  {
+    file: "release.yml",
+    name: "build_macos",
+    validate: "Validate production signing configuration",
+  },
+  {
+    file: "staging-publish.yml",
+    name: "build_macos_staging",
+    validate: "Validate staging signing configuration",
+  },
+  {
+    file: "release.yml",
+    name: "build_windows",
+    validate: "Validate updater signing configuration",
+  },
+];
+
+function desktopSigningJobs() {
+  return DESKTOP_SIGNING_JOBS.map((spec) => ({
+    ...spec,
+    job: workflowJob(workflows[spec.file], spec.name),
+  }));
+}
+
+function cargoDownloadCache(job) {
+  return job.match(
+    /- name: Cache Cargo downloads[\s\S]*?(?=\n\s+- (?:name:|uses:))/,
+  )?.[0];
+}
+
+function firstSigningMaterialIndex(job, validate) {
+  const markers = [
+    `- name: ${validate}`,
+    "- name: Prepare App Store Connect key",
+    "- name: Import Developer ID certificate",
+  ];
+  const positions = markers
+    .map((marker) => job.indexOf(marker))
+    .filter((index) => index !== -1);
+  return positions.length === 0 ? -1 : Math.min(...positions);
+}
+
 function stripRustCommentsAndStrings(source) {
   const masked = [...source];
   const erase = (start, end) => {
@@ -1250,6 +1293,83 @@ test("the updater private key is isolated from compilation", () => {
   assert.doesNotMatch(release, /createUpdaterArtifacts/);
   assert.match(release, /tauri signer sign "\$updater_path"/);
   assert.doesNotMatch(release, /cargo tauri signer sign/);
+});
+
+test("signing jobs do not run untrusted installers next to Apple or Tauri material", () => {
+  for (const { file, name, job, validate } of desktopSigningJobs()) {
+    const label = `${name} (${file})`;
+    assert.match(
+      job,
+      /uses: pnpm\/action-setup@[0-9a-f]{40}/,
+      `${label} must set up pnpm`,
+    );
+    // Accept the current floating `10` or the pinned `10.18.3` used by
+    // e2b-cli / docs-site so the implementation PR can land against this test.
+    assert.match(
+      job,
+      /version: 10(?:\.18\.3)?\n/,
+      `${label} must pin pnpm 10 or 10.18.3`,
+    );
+    assert.match(
+      job,
+      /pnpm install --frozen-lockfile(?: --ignore-scripts)?\n/,
+      `${label} must install UI deps from the lockfile`,
+    );
+    assert.match(
+      job,
+      /mozilla-actions\/sccache-action@[0-9a-f]{40}/,
+      `${label} must set up sccache`,
+    );
+    assert.match(
+      job,
+      /Swatinem\/rust-cache@[0-9a-f]{40}/,
+      `${label} must restore the Cargo download cache`,
+    );
+    assert.match(
+      job,
+      /actions\/setup-node@[0-9a-f]{40}/,
+      `${label} must set up Node`,
+    );
+
+    const rustCache = cargoDownloadCache(job);
+    assert.ok(rustCache, `${label} missing Cargo download cache`);
+    if (name === "build_macos") {
+      // Current production writer is aarch64; the follow-up makes this
+      // restore-only. An unconditional save from the signing job is never ok.
+      assert.match(
+        rustCache,
+        /save-if: (?:false|\$\{\{ matrix\.arch == 'aarch64' \}\})/,
+        `${label} rust-cache must not save unconditionally`,
+      );
+    } else {
+      assert.match(
+        rustCache,
+        /save-if: false/,
+        `${label} rust-cache must be restore-only`,
+      );
+    }
+
+    const secretsAt = firstSigningMaterialIndex(job, validate);
+    assert.notEqual(secretsAt, -1, `${label} must still load signing material`);
+
+    const installerIndexes = [
+      job.search(/mozilla-actions\/sccache-action@[0-9a-f]{40}/),
+      job.search(/Swatinem\/rust-cache@[0-9a-f]{40}/),
+      job.search(/pnpm\/action-setup@[0-9a-f]{40}/),
+      job.search(/actions\/setup-node@[0-9a-f]{40}/),
+      job.search(/pnpm install --frozen-lockfile(?: --ignore-scripts)?\n/),
+    ];
+    assert.ok(
+      installerIndexes.every((index) => index !== -1),
+      `${label} is missing an installer step`,
+    );
+    const isolated = installerIndexes.every((index) => index < secretsAt);
+    const legacy = installerIndexes.every((index) => index > secretsAt);
+    assert.ok(
+      isolated || legacy,
+      `${label} must keep installers entirely before or entirely after signing material`,
+    );
+  }
 });
 
 test("macOS disk images are explicitly notarized and stapled", () => {


### PR DESCRIPTION
## Why

CI runs `scripts/workflow-security.test.mjs` from the **base branch** against the PR's workflows, so a pull request cannot weaken a locked invariant and delete the assertion in the same commit. That also blocks a legitimate strengthening: the follow-up moves untrusted installers (floating pnpm, lifecycle scripts, sccache-action, rust-cache) off the desktop signing jobs after Apple/Tauri material is on disk.

## What

Teach the signing-job policy to accept either shape:

- **current:** `pnpm/action-setup` `version: 10`, `pnpm install --frozen-lockfile`, and sccache / rust-cache / UI install after Validate signing
- **next:** pinned `version: 10.18.3`, `--ignore-scripts`, those installer steps before the first Apple/Tauri secret, and `build_macos` rust-cache `save-if: false`

A signing job with no pnpm pin, no lockfile install, or an unconditional rust-cache save still fails. Existing updater-key, scan, and secret-isolation assertions are unchanged.

This is a test-only change. No workflow behavior moves until the implementation PR rebases onto it.