### PR TITLE
ci: publish sandbox images from main only

### DIFF
--- a/.github/workflows/publish-sandbox-image.yml
+++ b/.github/workflows/publish-sandbox-image.yml
@@ -25,6 +25,12 @@ run-name: >-
 #     vulnerability gate flush through even when nothing in-repo changes;
 #   - manual dispatch with an explicit release-style tag.
 #
+# Publication source is the default branch only. Manual dispatch and the
+# weekly schedule must run this workflow from that branch; every publish
+# (including a v* tag) refuses a SHA that is not an ancestor of it. The
+# build checkout does not persist credentials, and the image dockerignore
+# keeps `.git` out of the `COPY . .` context.
+#
 # Release publishes keep human `vX.Y.Z` tags. Scheduled and main-push rebuilds
 # mint `main-<utc date>-<short sha>-r<run number>` instead:
 #
@@ -109,6 +115,45 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+      - name: Validate the publication source
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EVENT_NAME: ${{ github.event_name }}
+          SOURCE_REF: ${{ github.ref }}
+          SOURCE_REF_NAME: ${{ github.ref_name }}
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          [[ -n "$DEFAULT_BRANCH" ]] || {
+            echo "The repository event did not identify a default branch." >&2
+            exit 1
+          }
+          git fetch --no-tags origin \
+            "$DEFAULT_BRANCH:refs/remotes/origin/$DEFAULT_BRANCH"
+          [[ "$(git rev-parse HEAD)" == "$SOURCE_SHA" ]] || {
+            echo "The trusted checkout does not match the workflow revision $SOURCE_SHA." >&2
+            exit 1
+          }
+
+          case "$EVENT_NAME" in
+            workflow_dispatch|schedule)
+              [[ "$SOURCE_REF" == "refs/heads/$DEFAULT_BRANCH" &&
+                "$SOURCE_REF_NAME" == "$DEFAULT_BRANCH" ]] || {
+                echo "Sandbox image publication must run the current $DEFAULT_BRANCH workflow, got $SOURCE_REF ($SOURCE_REF_NAME)" >&2
+                exit 1
+              }
+              ;;
+            push)
+              ;;
+            *)
+              echo "unknown event $EVENT_NAME" >&2
+              exit 1
+              ;;
+          esac
+
+          git merge-base --is-ancestor "$SOURCE_SHA" "origin/$DEFAULT_BRANCH" || {
+            echo "Refusing to publish sandbox images not contained in $DEFAULT_BRANCH: $SOURCE_SHA" >&2
+            exit 1
+          }
       - name: Decide the image tag and whether to publish
         id: decide
         env:
@@ -204,6 +249,8 @@ jobs:
             runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Log in to GHCR
         env:

--- a/crates/tidebreak-sandbox-agent/Dockerfile.dockerignore
+++ b/crates/tidebreak-sandbox-agent/Dockerfile.dockerignore
@@ -1,0 +1,5 @@
+# The sandbox image build context is the workspace root (`COPY . .`).
+# Git metadata is never a build input; excluding it keeps checkout
+# credentials (and the rest of .git) out of the daemon context.
+.git
+.git/**

--- a/scripts/workflow-security-mutations.test.mjs
+++ b/scripts/workflow-security-mutations.test.mjs
@@ -26,6 +26,7 @@ const fixturePaths = [
   "crates/tidebreak-desktop/src/updater.rs",
   "crates/tidebreak-desktop/src/broker.rs",
   "deploy/self-host/Dockerfile.dockerignore",
+  "crates/tidebreak-sandbox-agent/Dockerfile.dockerignore",
   "scripts/stage-self-host-build-context.sh",
   "deny.toml",
   "README.md",
@@ -91,6 +92,16 @@ test("the mirrored workflow-security fixture passes before mutation", () => {
 });
 
 const mutations = [
+  {
+    name: "sandbox image default-branch publication guard",
+    file: ".github/workflows/publish-sandbox-image.yml",
+    expected: "sandbox image publishing",
+    mutate: (source) =>
+      source.replace(
+        /git merge-base --is-ancestor "\$SOURCE_SHA" "origin\/\$DEFAULT_BRANCH" \|\| \{[\s\S]*?\n\s+\}\n/,
+        "",
+      ),
+  },
   {
     name: "default-branch dispatch guard",
     file: ".github/workflows/publish-e2b-template.yml",

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -804,16 +804,6 @@ function sandboxPublishControls(publish) {
   };
 }
 
-function sandboxPublishHasAnyMainOnlyControl(controls) {
-  return (
-    controls.hasDefaultBranchEnv ||
-    controls.hasDefaultBranchRefGate ||
-    controls.hasAncestorGate ||
-    controls.hasPersistCredentialsFalse ||
-    controls.hasDockerIgnore
-  );
-}
-
 function assertSandboxPublishMainOnly(controls) {
   assert.ok(
     controls.hasDefaultBranchEnv,
@@ -857,14 +847,11 @@ test("sandbox image publishing is tag-driven, immutable, and secret-free", () =>
   );
   assert.doesNotMatch(publish, /^\s*pull_request(?:_target)?:/m);
 
-  // Current shape: any v* tag and any-ref dispatch may publish. Next shape:
-  // dispatch/schedule must run the default-branch workflow, and every publish
-  // (tag included) refuses a SHA that is not an ancestor of that branch.
-  // Accept either until the workflow change lands; a partial next shape fails.
-  const controls = sandboxPublishControls(publish);
-  if (sandboxPublishHasAnyMainOnlyControl(controls)) {
-    assertSandboxPublishMainOnly(controls);
-  }
+  // Dispatch/schedule must run the default-branch workflow. Every publish,
+  // tag included, refuses a SHA that is not an ancestor of that branch.
+  // The build checkout must not persist GITHUB_TOKEN, and `.git` stays out
+  // of the Docker context.
+  assertSandboxPublishMainOnly(sandboxPublishControls(publish));
 
   // A main push publishes only when the image inputs changed; the scope lives
   // in the resolve job (an `on.push.paths` filter would also gate the tag


### PR DESCRIPTION
## Why

Sandbox image publish could run from any `v*` tag or any-ref `workflow_dispatch`. Unlike E2B template publish, it had no default-branch workflow gate and no `merge-base --is-ancestor` check, so a tag or dispatch of a non-main SHA could still build and push. The `build` checkout also left `persist-credentials` at its default (`true`) and then `COPY . .` with no dockerignore, so `.git/config` (and the job's `GITHUB_TOKEN`) entered the Docker context.

## What

- `resolve` fetches the default branch and refuses the run unless dispatch/schedule execute that branch's workflow, and unless `$GITHUB_SHA` is an ancestor of it (tags included).
- `build` checkout sets `persist-credentials: false`.
- `crates/tidebreak-sandbox-agent/Dockerfile.dockerignore` excludes `.git` and `.git/**` from the workspace-root build context.
- Policy tests now require that shape. A mutation that deletes the ancestor guard fails closed.

Tag push still runs this workflow from the tag (the `on.push.tags` trigger is unchanged). The ancestor check is the minimum that keeps a non-main SHA from publishing; dispatching the main workflow from a tag, the way `release.yml` does, is left for a follow-up if we want the running YAML itself to come only from main.

## Notes

- Depends on the test-only precursor [#2043](https://github.com/brightwave-inc/tidebreak/pull/2043), which is **not yet on main**. Rebase this PR after #2043 merges so the trusted policy lock matches the new shape.
- Not verified by running the publish workflow (main / tag / schedule / dispatch only).
- Production Apple / Tauri / AWS secrets and `E2B_API_KEY` were already isolated from this workflow and stay that way.

Closes nothing; no issue was filed for this session.