### PR TITLE
fix(plugins): do not auto-start imported plugin MCP servers

### DIFF
--- a/crates/tidebreak-code-execution/src/agent_plugins.rs
+++ b/crates/tidebreak-code-execution/src/agent_plugins.rs
@@ -314,8 +314,8 @@ const MAX_MCP_LIST_ENTRIES: usize = 64;
 /// here starts a process.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct McpStdioServer {
-    /// One executable token: a bare program name resolved by the platform, or
-    /// a `./`-relative path inside the plugin. Never expanded.
+    /// One executable token: a `./`-relative path inside the plugin. Never a
+    /// bare PATH name, and never expanded.
     pub command: String,
     pub args: Vec<String>,
     /// Literal package data, not a secret mechanism — the specification is
@@ -639,10 +639,12 @@ fn is_loopback_host(url: &url::Url) -> bool {
     }
 }
 
-/// Whether `command` is the single executable token the specification allows:
-/// a bare program name the platform resolves, or a `./`-relative path that
-/// stays inside the plugin. No placeholder is expanded in a command, so one
-/// appearing here would be launched literally and is refused instead.
+/// Whether `command` is a `./`-relative path that stays inside the plugin.
+///
+/// Bare PATH names (`python3`, `bash`, `osascript`, `cmd`) are refused: an
+/// imported plugin must not launch a host interpreter by name. No placeholder
+/// is expanded in a command, so one appearing here would be launched literally
+/// and is refused instead.
 fn is_valid_command_token(command: &str) -> bool {
     if command.is_empty()
         || command.len() > MAX_MCP_STRING_BYTES
@@ -653,10 +655,9 @@ fn is_valid_command_token(command: &str) -> bool {
     {
         return false;
     }
-    match command.strip_prefix("./") {
-        Some(relative) => is_contained_relative_path(relative),
-        None => !command.contains('/') && command != "." && command != "..",
-    }
+    command
+        .strip_prefix("./")
+        .is_some_and(is_contained_relative_path)
 }
 
 /// Whether `cwd` names a directory inside one of the two roots it may be
@@ -1087,6 +1088,30 @@ mod tests {
             .config
             .servers
             .is_empty());
+    }
+
+    /// Contract: a plugin stdio command is a `./` path inside the package.
+    /// Bare host interpreters are dropped as a bad entry, not launched.
+    #[test]
+    fn plugin_stdio_commands_must_be_relative_paths_inside_the_plugin() {
+        for banned in ["python3", "bash", "osascript", "cmd", "powershell", "serve"] {
+            let parsed = parse_plugin_mcp_config(&mcp(&format!(
+                "{{\"{banned}\": {{\"type\": \"stdio\", \"command\": \"{banned}\"}}}}"
+            )))
+            .expect("a file whose entries are bad is still a valid file");
+            assert!(
+                parsed.config.servers.is_empty(),
+                "{banned} must not be a plugin MCP command"
+            );
+            assert_eq!(parsed.skipped.len(), 1, "{banned}");
+        }
+
+        let parsed = parse_plugin_mcp_config(&mcp(
+            "{\"local\": {\"type\": \"stdio\", \"command\": \"./bin/serve\"}}",
+        ))
+        .unwrap();
+        assert_eq!(parsed.config.servers.len(), 1);
+        assert!(parsed.skipped.is_empty());
     }
 
     /// Contract: expansion is one pass over the text. Replacement text is

--- a/crates/tidebreak-server/src/code_execution/provider.rs
+++ b/crates/tidebreak-server/src/code_execution/provider.rs
@@ -506,6 +506,20 @@ impl ConfiguredCodeExecutionProvider {
                 "a built-in or installed plugin owns this name or one of its members".to_owned(),
             ));
         }
+        // Public imports start off. Absent still means enabled for built-ins
+        // and hand-authored packages, so this has to be a recorded flag, not
+        // a change to that default. Written before the caller reconciles MCP
+        // so a freshly copied `mcp.json` cannot spawn a host process.
+        let mut flags = crate::plugin_state::read_plugin_enable_state(&*self.store).await;
+        flags.set_plugin(&prepared.package.name, false);
+        if let Err(error) =
+            crate::plugin_state::write_plugin_enable_state(&*self.store, &flags).await
+        {
+            crate::plugin_install::rollback_install(&files);
+            return Err(crate::plugin_install::PluginInstallError::Io(
+                std::io::Error::other(error.to_string()),
+            ));
+        }
         Ok(crate::plugin_install::PluginInstallOutcome {
             plugin: prepared.package.name,
             revision: source.revision,

--- a/crates/tidebreak-server/src/mcp_config/types.rs
+++ b/crates/tidebreak-server/src/mcp_config/types.rs
@@ -344,11 +344,9 @@ impl McpServerDefinition {
                 "MCP server definition has no command to spawn",
             ));
         };
-        // A plugin's `./`-relative command names a file inside the package and
-        // is resolved against the package root before the child is built;
-        // everything else — including a plugin's bare command name — keeps the
-        // platform resolution every other stdio server gets, so the two paths
-        // cannot drift.
+        // A plugin's command must be `./`-relative and is resolved against
+        // the package root before the child is built. User-configured servers
+        // keep the platform resolution they already had; a plugin never does.
         let program = match &self.launch {
             Some(launch) => crate::plugin_mcp::resolve_command(program, &launch.root)
                 .map_err(AgentError::config)?,

--- a/crates/tidebreak-server/src/plugin_mcp.rs
+++ b/crates/tidebreak-server/src/plugin_mcp.rs
@@ -375,17 +375,18 @@ fn resolve_cwd(
 
 /// The program a plugin's stdio server is launched as.
 ///
-/// A `./`-relative command names a file inside the package, so it is resolved
-/// against the plugin root here rather than left for the child to resolve. On
-/// Unix the child would resolve it against its *working directory*, which is
+/// Only a `./`-relative command is accepted: it names a file inside the
+/// package and is resolved against the plugin root. On Unix a relative program
+/// would otherwise resolve against the child's *working directory*, which is
 /// the wrong answer the moment a server configures a `cwd` — and a
 /// `${PLUGIN_DATA}`-anchored one puts it outside the package entirely. On
 /// Windows a relative program resolves against the host process's directory,
-/// which is never right. A bare name is left alone and gets exactly the
-/// platform resolution every other stdio server's command gets.
+/// which is never right. A bare PATH name is refused even if a stale retained
+/// `mcp.json` still carries one, so an imported plugin cannot launch
+/// `python3`, `bash`, or `osascript` on the host.
 pub(crate) fn resolve_command(command: &str, root: &Path) -> Result<PathBuf, &'static str> {
     let Some(relative) = command.strip_prefix("./") else {
-        return Ok(PathBuf::from(command));
+        return Err("plugin MCP server command must be a ./ path inside the plugin");
     };
     let resolved = std::fs::canonicalize(root.join(relative))
         .map_err(|_| "plugin MCP server executable was not found inside the plugin")?;
@@ -625,5 +626,27 @@ mod tests {
         assert!(first
             .bytes()
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-')));
+    }
+
+    /// Contract: launch resolves `./` against the plugin root and refuses a
+    /// bare PATH name, even if a retained `mcp.json` still carries one.
+    #[test]
+    fn plugin_stdio_commands_must_resolve_inside_the_plugin_tree() {
+        let root = tempfile::tempdir().unwrap();
+        let bin = root.path().join("serve");
+        std::fs::write(&bin, b"#!").unwrap();
+
+        assert_eq!(
+            resolve_command("./serve", root.path()).unwrap(),
+            std::fs::canonicalize(&bin).unwrap()
+        );
+
+        for banned in ["python3", "bash", "osascript", "cmd", "powershell", "serve"] {
+            assert!(
+                resolve_command(banned, root.path()).is_err(),
+                "{banned} must not launch from PATH"
+            );
+        }
+        assert!(resolve_command("./missing", root.path()).is_err());
     }
 }

--- a/crates/tidebreak-server/src/plugin_state.rs
+++ b/crates/tidebreak-server/src/plugin_state.rs
@@ -6,12 +6,17 @@
 //! preference uses (the chat model, the background-agent ceiling), because a
 //! handful of booleans does not earn a table of its own.
 //!
-//! Everything defaults to enabled, so only a *disabled* component is
-//! persisted. That keeps the row proportional to what the user actually turned
-//! off, and it gives the plugin gate the behavior the product wants for free:
-//! a plugin's flag is a gate *over* its members' own flags rather than a
-//! rewrite of them, so re-enabling a bundle restores exactly the member
-//! choices that were in place when it was switched off.
+//! Built-in and hand-authored packages default to enabled: only a *disabled*
+//! component is persisted. That keeps the row proportional to what the user
+//! actually turned off, and it gives the plugin gate the behavior the product
+//! wants for free: a plugin's flag is a gate *over* its members' own flags
+//! rather than a rewrite of them, so re-enabling a bundle restores exactly the
+//! member choices that were in place when it was switched off.
+//!
+//! A public import is the exception. The installer records the new plugin as
+//! disabled before anything can start its bundled MCP servers; enabling it is
+//! the consent to launch them. Absent still means enabled, so that recording
+//! has to be a stored `false`, not a change to this default.
 //!
 //! A disabled component must actually bite, which means both consumers read
 //! this: the workspace staging pass never writes it into a sandbox, and the

--- a/crates/tidebreak-server/src/routes/plugins.rs
+++ b/crates/tidebreak-server/src/routes/plugins.rs
@@ -232,8 +232,9 @@ pub async fn post_plugin_install(
                 ServerError::internal("plugin files could not be installed")
             }
         })?;
-    // A freshly installed plugin may ship bundled MCP servers; bring them up
-    // now rather than at the next restart.
+    // The import is recorded disabled, so this reconcile will not start any
+    // bundled MCP servers. It still has to run: an overlapping uninstall, or
+    // a previous enable flag for this name, can change the derived set.
     state.mcp.reconcile_plugin_servers().await;
     Ok((StatusCode::CREATED, Json(installed)))
 }

--- a/crates/tidebreak-server/src/tests/configuration.rs
+++ b/crates/tidebreak-server/src/tests/configuration.rs
@@ -3551,6 +3551,7 @@ async fn installs_a_single_skill_plugin_end_to_end() {
         .find(|plugin| plugin["name"] == "meeting-notes")
         .unwrap();
     assert_eq!(plugin["origin"], "user");
+    assert_eq!(plugin["enabled"], false);
     assert_eq!(plugin["skills"][0]["name"], "meeting-notes");
     assert_eq!(plugin["compatibility"]["status"], "compatible");
 }
@@ -3934,6 +3935,7 @@ async fn retains_validated_mcp_servers_and_derives_the_badge() {
              \"args\": [\"--root\", \"${{PLUGIN_ROOT}}\"]}}, \
            \"remote\": {{\"type\": \"streamable-http\", \
              \"url\": \"https://mcp.example.com/v1\"}}, \
+           \"host-rce\": {{\"type\": \"stdio\", \"command\": \"python3\"}}, \
            \"bogus\": {{\"type\": \"stdio\", \"command\": \"serve\", \"retries\": 3}}}}}}"
     );
     let archive = plugin_archive(&[
@@ -3973,7 +3975,7 @@ async fn retains_validated_mcp_servers_and_derives_the_badge() {
             .iter()
             .map(|entry| entry["path"].as_str().unwrap())
             .collect::<Vec<_>>(),
-        ["mcp.json#bogus"]
+        ["mcp.json#bogus", "mcp.json#host-rce"]
     );
 
     // Only the entries that validated are written back.
@@ -3998,10 +4000,113 @@ async fn retains_validated_mcp_servers_and_derives_the_badge() {
         .iter()
         .find(|plugin| plugin["name"] == "reporting")
         .unwrap();
+    assert_eq!(plugin["enabled"], false);
     assert!(plugin["capabilities"]
         .as_array()
         .unwrap()
         .contains(&serde_json::json!("mcp")));
+}
+
+/// Contract: a public import that ships `mcp.json` is recorded off, so the
+/// install-time reconcile does not start its servers. Enabling the plugin is
+/// what connects them. Reverting either half — default-on at install, or
+/// starting MCP without the enable flag — fails this.
+#[tokio::test]
+async fn imported_plugin_mcp_does_not_start_until_enabled() {
+    let (dir, store) = temp_db_store("plugin-mcp-autostart.db").await;
+    let store: Arc<dyn Store> = Arc::new(store);
+    let manifest = format!(
+        "{{\"$schema\": \"{AGENT_PLUGIN_SCHEMA}\", \"name\": \"toolbox\", \
+          \"description\": \"Bundled tools.\"}}"
+    );
+    let mcp_config = format!(
+        "{{\"$schema\": \"{AGENT_PLUGIN_MCP_SCHEMA}\", \"mcpServers\": {{\
+           \"local\": {{\"type\": \"stdio\", \"command\": \"./serve\"}}}}}}"
+    );
+    let archive = plugin_archive(&[
+        ("pkg/plugin.json", manifest.as_bytes()),
+        ("pkg/mcp.json", mcp_config.as_bytes()),
+        (
+            "pkg/skills/toolbox-notes/SKILL.md",
+            b"---\nname: toolbox-notes\ndescription: Notes.\n---\nBody.\n",
+        ),
+    ]);
+
+    let secrets = Arc::new(MemSecrets::default());
+    let mut state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        secrets.clone(),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let exec = Arc::new(
+        crate::code_execution::ConfiguredCodeExecutionProvider::new(
+            store.clone(),
+            secrets,
+            dir.path().join("scratch"),
+        )
+        .with_user_skills(Some(dir.path().join("skills")))
+        .with_user_plugins(Some(dir.path().join("plugins")))
+        .with_plugin_archive_fetcher(Arc::new(FixedPluginArchiveFetcher {
+            expected_url: "https://example.com/toolbox-1.0.0.zip".to_owned(),
+            archive: Arc::new(archive),
+        })),
+    );
+    state.code_execution = Some(exec.clone());
+    state
+        .mcp
+        .set_plugin_catalog(Arc::new(crate::plugin_mcp::InstalledPluginMcpCatalog::new(
+            exec,
+            store,
+            dir.path().join("plugin-data"),
+        )));
+    let token = state.token.clone();
+    let router = app(state);
+    let bearer = format!("Bearer {token}");
+
+    let response = post_plugin_install(
+        &router,
+        &bearer,
+        serde_json::json!({
+            "source": {
+                "kind": "archive",
+                "url": "https://example.com/toolbox-1.0.0.zip",
+                "revision": "1.0.0"
+            }
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let catalog = get_plugins(&router, &bearer).await;
+    let plugin = catalog["plugins"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|plugin| plugin["name"] == "toolbox")
+        .unwrap();
+    assert_eq!(plugin["enabled"], false);
+    assert!(get_mcp_servers(&router, &bearer).await["servers"]
+        .as_array()
+        .unwrap()
+        .is_empty());
+
+    let response = put_plugins_enabled(
+        &router,
+        &bearer,
+        serde_json::json!({"plugins": {"toolbox": true}}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let listed = get_mcp_servers(&router, &bearer).await;
+    assert_eq!(listed["servers"].as_array().unwrap().len(), 1);
+    assert_eq!(listed["servers"][0]["name"], "toolbox-local");
+    assert_eq!(listed["servers"][0]["plugin"], "toolbox");
 }
 
 /// Contract: a top-level problem in `mcp.json` disables that plugin's MCP

--- a/docs-site/content/docs/skills-and-plugins.mdx
+++ b/docs-site/content/docs/skills-and-plugins.mdx
@@ -19,8 +19,11 @@ asked for a PowerPoint improvises.
 | **Spreadsheets** | Spreadsheets |
 | **Charts** | Charts |
 
-Everything is enabled by default. The agent sees a catalog of the enabled
-skills and reads a skill's full instructions when it decides to use one.
+Built-in plugins and skills you write yourself are enabled by default. A
+plugin installed from a public archive starts off — turn it on in the Plugins
+panel before the agent can use its skills or launch any bundled MCP server.
+The agent sees a catalog of the enabled skills and reads a skill's full
+instructions when it decides to use one.
 
 ## Using one explicitly
 


### PR DESCRIPTION
## Why

A public plugin install treated the new bundle as enabled and immediately reconciled its bundled MCP servers. `mcp.json` could name a bare PATH binary (`python3`, `bash`, `osascript`, `cmd`, `powershell`), and process start was not approval-gated. Installing an untrusted plugin was therefore host RCE.

## What

- Record a public import as disabled before install-time reconcile. Built-in and hand-authored packages still default on.
- Accept only `./` paths inside the retained plugin tree as plugin stdio commands. Reject bare PATH names at parse and again at launch.
- Do not start a plugin MCP server until the user enables the plugin.

## Tests

- Parse rejects `python3` / `bash` / `osascript` / `cmd` / `powershell`.
- Launch refuses those same names even if a stale `mcp.json` still carries one.
- Install leaves the plugin off and mounts no MCP servers; enabling it is what connects them.

These fail if either half is reverted: default-on at install, or a plugin launching a host interpreter by name.