### PR TITLE
ci: do not run untrusted installers next to Apple signing material

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,9 +20,10 @@ updates:
           - minor
           - patch
 
-  # Desktop UI dependencies. These install with lifecycle scripts inside the
-  # release signing job and ship in the notarized app, so they need the same
-  # automated upgrade path as the Cargo graph.
+  # Desktop UI dependencies. These ship in the notarized app, so they need the
+  # same automated upgrade path as the Cargo graph. The signing job installs
+  # them with --ignore-scripts so lifecycle hooks never run next to Apple or
+  # Tauri material.
   - package-ecosystem: npm
     directory: "/crates/tidebreak-desktop/ui"
     schedule:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -454,6 +454,39 @@ jobs:
             "target/$RELEASE_TARGET/release/"libtidebreak_desktop_lib.* \
             "crates/tidebreak-desktop/binaries/tidebreak-host-broker-$RELEASE_TARGET"
 
+      # sccache, rust-cache, and the UI install run before any Apple or Tauri
+      # material is on disk. pnpm is pinned; lifecycle scripts stay off.
+      - name: Set up compiler cache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.16.0
+
+      - name: Cache Cargo downloads
+        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
+        with:
+          shared-key: macos-release-cargo-registry-v2-${{ hashFiles('Cargo.lock') }}
+          add-job-id-key: "false"
+          add-rust-environment-hash-key: "false"
+          cache-bin: false
+          # Signed apps, DMGs, updater archives, and signatures remain outside
+          # both the Cargo download cache and the restore-only build cache.
+          cache-targets: false
+          # prepare_macos and cache-macos.yml are the writers. This job holds
+          # Apple and Tauri material, so it must not publish the cache.
+          save-if: false
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        with:
+          version: 10.18.3
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: crates/tidebreak-desktop/ui/pnpm-lock.yaml
+      - name: Install UI dependencies
+        working-directory: crates/tidebreak-desktop/ui
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
       - name: Validate production signing configuration
         env:
           APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
@@ -533,37 +566,6 @@ jobs:
         run: |
           rustup show
           rustup target add "${{ matrix.target }}"
-
-      - name: Set up compiler cache
-        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
-        with:
-          version: v0.16.0
-
-      - name: Cache Cargo downloads
-        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
-        with:
-          shared-key: macos-release-cargo-registry-v2-${{ hashFiles('Cargo.lock') }}
-          add-job-id-key: "false"
-          add-rust-environment-hash-key: "false"
-          cache-bin: false
-          # Signed apps, DMGs, updater archives, and signatures remain outside
-          # both the Cargo download cache and the restore-only build cache.
-          cache-targets: false
-          # The matrix shares these architecture-independent downloads. Use a
-          # single writer so simultaneous cold builds cannot race the save.
-          save-if: ${{ matrix.arch == 'aarch64' }}
-
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
-        with:
-          version: 10
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version: 22
-          cache: pnpm
-          cache-dependency-path: crates/tidebreak-desktop/ui/pnpm-lock.yaml
-      - name: Install UI dependencies
-        working-directory: crates/tidebreak-desktop/ui
-        run: pnpm install --frozen-lockfile
 
       - name: Write tag-derived Tauri configuration
         env:
@@ -944,6 +946,38 @@ jobs:
             "target/$RELEASE_TARGET/release/"tidebreak_desktop_lib.* \
             "crates/tidebreak-desktop/binaries/tidebreak-host-broker-$RELEASE_TARGET.exe"
 
+      # sccache, rust-cache, and the UI install run before the updater key is
+      # loaded. pnpm is pinned; lifecycle scripts stay off.
+      - name: Set up compiler cache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.16.0
+
+      - name: Cache Cargo downloads
+        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
+        with:
+          shared-key: windows-release-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
+          add-job-id-key: "false"
+          add-rust-environment-hash-key: "false"
+          cache-bin: false
+          # Installers, updater signatures, and signing material remain outside
+          # both the Cargo download cache and the restore-only build cache. The
+          # credential-free prerequisite is the single registry-cache writer.
+          cache-targets: false
+          save-if: false
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        with:
+          version: 10.18.3
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: crates/tidebreak-desktop/ui/pnpm-lock.yaml
+      - name: Install UI dependencies
+        working-directory: crates/tidebreak-desktop/ui
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
       # Authenticode code signing is deliberately absent: v1 Windows releases
       # ship unsigned installers. The Tauri updater key still signs the
       # artifact bytes for latest.json — that is artifact authenticity, not
@@ -968,36 +1002,6 @@ jobs:
         run: |
           rustup show
           rustup target add "${{ matrix.target }}"
-
-      - name: Set up compiler cache
-        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
-        with:
-          version: v0.16.0
-
-      - name: Cache Cargo downloads
-        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
-        with:
-          shared-key: windows-release-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
-          add-job-id-key: "false"
-          add-rust-environment-hash-key: "false"
-          cache-bin: false
-          # Installers, updater signatures, and signing material remain outside
-          # both the Cargo download cache and the restore-only build cache. The
-          # credential-free prerequisite is the single registry-cache writer.
-          cache-targets: false
-          save-if: false
-
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
-        with:
-          version: 10
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version: 22
-          cache: pnpm
-          cache-dependency-path: crates/tidebreak-desktop/ui/pnpm-lock.yaml
-      - name: Install UI dependencies
-        working-directory: crates/tidebreak-desktop/ui
-        run: pnpm install --frozen-lockfile
 
       - name: Write tag-derived Tauri configuration
         env:

--- a/.github/workflows/staging-publish.yml
+++ b/.github/workflows/staging-publish.yml
@@ -236,6 +236,35 @@ jobs:
             "target/$RELEASE_TARGET/release/"libtidebreak_desktop_lib.* \
             "crates/tidebreak-desktop/binaries/tidebreak-host-broker-$RELEASE_TARGET"
 
+      # sccache, rust-cache, and the UI install run before any Apple or Tauri
+      # material is on disk. pnpm is pinned; lifecycle scripts stay off.
+      - name: Set up compiler cache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.16.0
+
+      - name: Cache Cargo downloads
+        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
+        with:
+          shared-key: macos-release-cargo-registry-v2-${{ hashFiles('Cargo.lock') }}
+          add-job-id-key: "false"
+          add-rust-environment-hash-key: "false"
+          cache-bin: false
+          cache-targets: false
+          save-if: false
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        with:
+          version: 10.18.3
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: crates/tidebreak-desktop/ui/pnpm-lock.yaml
+      - name: Install UI dependencies
+        working-directory: crates/tidebreak-desktop/ui
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
       - name: Validate staging signing configuration
         env:
           APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
@@ -315,33 +344,6 @@ jobs:
         run: |
           rustup show
           rustup target add "${{ matrix.target }}"
-
-      - name: Set up compiler cache
-        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
-        with:
-          version: v0.16.0
-
-      - name: Cache Cargo downloads
-        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
-        with:
-          shared-key: macos-release-cargo-registry-v2-${{ hashFiles('Cargo.lock') }}
-          add-job-id-key: "false"
-          add-rust-environment-hash-key: "false"
-          cache-bin: false
-          cache-targets: false
-          save-if: false
-
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
-        with:
-          version: 10
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version: 22
-          cache: pnpm
-          cache-dependency-path: crates/tidebreak-desktop/ui/pnpm-lock.yaml
-      - name: Install UI dependencies
-        working-directory: crates/tidebreak-desktop/ui
-        run: pnpm install --frozen-lockfile
 
       - name: Write staging Tauri configuration
         env:

--- a/scripts/workflow-security-mutations.test.mjs
+++ b/scripts/workflow-security-mutations.test.mjs
@@ -50,6 +50,19 @@ function edit(root, path, mutate) {
   writeFileSync(target, after);
 }
 
+function editWorkflowJob(source, name, mutateJob) {
+  const marker = `  ${name}:\n`;
+  const start = source.indexOf(marker);
+  assert.notEqual(start, -1, `missing workflow job: ${name}`);
+  const remainder = source.slice(start + marker.length);
+  const next = remainder.search(/^  [a-zA-Z0-9_-]+:\n/m);
+  const end = next === -1 ? source.length : start + marker.length + next;
+  const job = source.slice(start, end);
+  const mutated = mutateJob(job);
+  assert.notEqual(mutated, job, `mutation did not change job ${name}`);
+  return source.slice(0, start) + mutated + source.slice(end);
+}
+
 function runPolicy(root) {
   const env = {
     ...process.env,
@@ -202,6 +215,39 @@ const mutations = [
     file: "deploy/self-host/Dockerfile.dockerignore",
     expected: "Docker context is allowlisted",
     mutate: (source) => source.replace("**/id_*\n", ""),
+  },
+  {
+    name: "signing job pnpm pin",
+    file: ".github/workflows/release.yml",
+    expected: "signing jobs do not run untrusted installers",
+    mutate: (source) =>
+      editWorkflowJob(source, "build_macos", (job) =>
+        job.replace(/version: 10(?:\.18\.3)?\n/, "version: latest\n"),
+      ),
+  },
+  {
+    name: "signing job lockfile install",
+    file: ".github/workflows/release.yml",
+    expected: "signing jobs do not run untrusted installers",
+    mutate: (source) =>
+      editWorkflowJob(source, "build_macos", (job) =>
+        job.replace(
+          /      - name: Install UI dependencies\n        working-directory: crates\/tidebreak-desktop\/ui\n        run: pnpm install --frozen-lockfile(?: --ignore-scripts)?\n/,
+          "",
+        ),
+      ),
+  },
+  {
+    name: "signing job rust-cache writer",
+    file: ".github/workflows/release.yml",
+    expected: "signing jobs do not run untrusted installers",
+    mutate: (source) =>
+      editWorkflowJob(source, "build_macos", (job) =>
+        job.replace(
+          /save-if: (?:false|\$\{\{ matrix\.arch == 'aarch64' \}\})/,
+          "save-if: true",
+        ),
+      ),
   },
 ];
 

--- a/scripts/workflow-security-mutations.test.mjs
+++ b/scripts/workflow-security-mutations.test.mjs
@@ -249,6 +249,54 @@ const mutations = [
         ),
       ),
   },
+  {
+    name: "signing job floating pnpm",
+    file: ".github/workflows/release.yml",
+    expected: "signing jobs do not run untrusted installers",
+    mutate: (source) =>
+      editWorkflowJob(source, "build_macos", (job) =>
+        job.replace(/version: 10\.18\.3\n/, "version: 10\n"),
+      ),
+  },
+  {
+    name: "signing job lifecycle scripts",
+    file: ".github/workflows/release.yml",
+    expected: "signing jobs do not run untrusted installers",
+    mutate: (source) =>
+      editWorkflowJob(source, "build_macos", (job) =>
+        job.replace(
+          "pnpm install --frozen-lockfile --ignore-scripts",
+          "pnpm install --frozen-lockfile",
+        ),
+      ),
+  },
+  {
+    name: "signing job installer order",
+    file: ".github/workflows/release.yml",
+    expected: "signing jobs do not run untrusted installers",
+    mutate: (source) =>
+      editWorkflowJob(source, "build_macos", (job) => {
+        const install =
+          "      - name: Install UI dependencies\n        working-directory: crates/tidebreak-desktop/ui\n        run: pnpm install --frozen-lockfile --ignore-scripts\n";
+        assert.ok(job.includes(install));
+        return job.replace(install, "").replace(
+          "      - name: Validate production signing configuration\n",
+          `      - name: Validate production signing configuration\n${install}`,
+        );
+      }),
+  },
+  {
+    name: "production signing rust-cache save-if",
+    file: ".github/workflows/release.yml",
+    expected: "signing jobs do not run untrusted installers",
+    mutate: (source) =>
+      editWorkflowJob(source, "build_macos", (job) =>
+        job.replace(
+          "save-if: false",
+          "save-if: ${{ matrix.arch == 'aarch64' }}",
+        ),
+      ),
+  },
 ];
 
 test("workflow-security controls fail closed under targeted mutations", async (t) => {

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1303,17 +1303,15 @@ test("signing jobs do not run untrusted installers next to Apple or Tauri materi
       /uses: pnpm\/action-setup@[0-9a-f]{40}/,
       `${label} must set up pnpm`,
     );
-    // Accept the current floating `10` or the pinned `10.18.3` used by
-    // e2b-cli / docs-site so the implementation PR can land against this test.
     assert.match(
       job,
-      /version: 10(?:\.18\.3)?\n/,
-      `${label} must pin pnpm 10 or 10.18.3`,
+      /version: 10\.18\.3\n/,
+      `${label} must pin pnpm 10.18.3`,
     );
     assert.match(
       job,
-      /pnpm install --frozen-lockfile(?: --ignore-scripts)?\n/,
-      `${label} must install UI deps from the lockfile`,
+      /pnpm install --frozen-lockfile --ignore-scripts\n/,
+      `${label} must install UI deps without lifecycle scripts`,
     );
     assert.match(
       job,
@@ -1333,21 +1331,11 @@ test("signing jobs do not run untrusted installers next to Apple or Tauri materi
 
     const rustCache = cargoDownloadCache(job);
     assert.ok(rustCache, `${label} missing Cargo download cache`);
-    if (name === "build_macos") {
-      // Current production writer is aarch64; the follow-up makes this
-      // restore-only. An unconditional save from the signing job is never ok.
-      assert.match(
-        rustCache,
-        /save-if: (?:false|\$\{\{ matrix\.arch == 'aarch64' \}\})/,
-        `${label} rust-cache must not save unconditionally`,
-      );
-    } else {
-      assert.match(
-        rustCache,
-        /save-if: false/,
-        `${label} rust-cache must be restore-only`,
-      );
-    }
+    assert.match(
+      rustCache,
+      /save-if: false/,
+      `${label} rust-cache must be restore-only`,
+    );
 
     const secretsAt = firstSigningMaterialIndex(job, validate);
     assert.notEqual(secretsAt, -1, `${label} must still load signing material`);
@@ -1357,17 +1345,15 @@ test("signing jobs do not run untrusted installers next to Apple or Tauri materi
       job.search(/Swatinem\/rust-cache@[0-9a-f]{40}/),
       job.search(/pnpm\/action-setup@[0-9a-f]{40}/),
       job.search(/actions\/setup-node@[0-9a-f]{40}/),
-      job.search(/pnpm install --frozen-lockfile(?: --ignore-scripts)?\n/),
+      job.search(/pnpm install --frozen-lockfile --ignore-scripts\n/),
     ];
     assert.ok(
       installerIndexes.every((index) => index !== -1),
       `${label} is missing an installer step`,
     );
-    const isolated = installerIndexes.every((index) => index < secretsAt);
-    const legacy = installerIndexes.every((index) => index > secretsAt);
     assert.ok(
-      isolated || legacy,
-      `${label} must keep installers entirely before or entirely after signing material`,
+      installerIndexes.every((index) => index < secretsAt),
+      `${label} must finish installers before signing material is loaded`,
     );
   }
 });

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -71,6 +71,49 @@ function workflowJob(source, name) {
   return source.slice(start, end);
 }
 
+const DESKTOP_SIGNING_JOBS = [
+  {
+    file: "release.yml",
+    name: "build_macos",
+    validate: "Validate production signing configuration",
+  },
+  {
+    file: "staging-publish.yml",
+    name: "build_macos_staging",
+    validate: "Validate staging signing configuration",
+  },
+  {
+    file: "release.yml",
+    name: "build_windows",
+    validate: "Validate updater signing configuration",
+  },
+];
+
+function desktopSigningJobs() {
+  return DESKTOP_SIGNING_JOBS.map((spec) => ({
+    ...spec,
+    job: workflowJob(workflows[spec.file], spec.name),
+  }));
+}
+
+function cargoDownloadCache(job) {
+  return job.match(
+    /- name: Cache Cargo downloads[\s\S]*?(?=\n\s+- (?:name:|uses:))/,
+  )?.[0];
+}
+
+function firstSigningMaterialIndex(job, validate) {
+  const markers = [
+    `- name: ${validate}`,
+    "- name: Prepare App Store Connect key",
+    "- name: Import Developer ID certificate",
+  ];
+  const positions = markers
+    .map((marker) => job.indexOf(marker))
+    .filter((index) => index !== -1);
+  return positions.length === 0 ? -1 : Math.min(...positions);
+}
+
 function stripRustCommentsAndStrings(source) {
   const masked = [...source];
   const erase = (start, end) => {
@@ -1250,6 +1293,83 @@ test("the updater private key is isolated from compilation", () => {
   assert.doesNotMatch(release, /createUpdaterArtifacts/);
   assert.match(release, /tauri signer sign "\$updater_path"/);
   assert.doesNotMatch(release, /cargo tauri signer sign/);
+});
+
+test("signing jobs do not run untrusted installers next to Apple or Tauri material", () => {
+  for (const { file, name, job, validate } of desktopSigningJobs()) {
+    const label = `${name} (${file})`;
+    assert.match(
+      job,
+      /uses: pnpm\/action-setup@[0-9a-f]{40}/,
+      `${label} must set up pnpm`,
+    );
+    // Accept the current floating `10` or the pinned `10.18.3` used by
+    // e2b-cli / docs-site so the implementation PR can land against this test.
+    assert.match(
+      job,
+      /version: 10(?:\.18\.3)?\n/,
+      `${label} must pin pnpm 10 or 10.18.3`,
+    );
+    assert.match(
+      job,
+      /pnpm install --frozen-lockfile(?: --ignore-scripts)?\n/,
+      `${label} must install UI deps from the lockfile`,
+    );
+    assert.match(
+      job,
+      /mozilla-actions\/sccache-action@[0-9a-f]{40}/,
+      `${label} must set up sccache`,
+    );
+    assert.match(
+      job,
+      /Swatinem\/rust-cache@[0-9a-f]{40}/,
+      `${label} must restore the Cargo download cache`,
+    );
+    assert.match(
+      job,
+      /actions\/setup-node@[0-9a-f]{40}/,
+      `${label} must set up Node`,
+    );
+
+    const rustCache = cargoDownloadCache(job);
+    assert.ok(rustCache, `${label} missing Cargo download cache`);
+    if (name === "build_macos") {
+      // Current production writer is aarch64; the follow-up makes this
+      // restore-only. An unconditional save from the signing job is never ok.
+      assert.match(
+        rustCache,
+        /save-if: (?:false|\$\{\{ matrix\.arch == 'aarch64' \}\})/,
+        `${label} rust-cache must not save unconditionally`,
+      );
+    } else {
+      assert.match(
+        rustCache,
+        /save-if: false/,
+        `${label} rust-cache must be restore-only`,
+      );
+    }
+
+    const secretsAt = firstSigningMaterialIndex(job, validate);
+    assert.notEqual(secretsAt, -1, `${label} must still load signing material`);
+
+    const installerIndexes = [
+      job.search(/mozilla-actions\/sccache-action@[0-9a-f]{40}/),
+      job.search(/Swatinem\/rust-cache@[0-9a-f]{40}/),
+      job.search(/pnpm\/action-setup@[0-9a-f]{40}/),
+      job.search(/actions\/setup-node@[0-9a-f]{40}/),
+      job.search(/pnpm install --frozen-lockfile(?: --ignore-scripts)?\n/),
+    ];
+    assert.ok(
+      installerIndexes.every((index) => index !== -1),
+      `${label} is missing an installer step`,
+    );
+    const isolated = installerIndexes.every((index) => index < secretsAt);
+    const legacy = installerIndexes.every((index) => index > secretsAt);
+    assert.ok(
+      isolated || legacy,
+      `${label} must keep installers entirely before or entirely after signing material`,
+    );
+  }
 });
 
 test("macOS disk images are explicitly notarized and stapled", () => {


### PR DESCRIPTION
## Why

After Validate signing / Prepare App Store Connect key / Import Developer ID, production `build_macos` and staging `build_macos_staging` ran mozilla-actions/sccache-action (an unchecksummed binary), rust-cache, floating `pnpm/action-setup` `version: 10`, and `pnpm install --frozen-lockfile` without `--ignore-scripts`. Production rust-cache could also save from the aarch64 signing job. Parked `build_windows` would have come back with the same installer-after-secret order.

## What

In `build_macos`, `build_macos_staging`, and parked `build_windows`:

- Pin `pnpm/action-setup` to `version: 10.18.3`
- Install with `pnpm install --frozen-lockfile --ignore-scripts`
- Run pnpm / setup-node / install, sccache-action, and rust-cache **before** the first Apple or Tauri secret
- Set `build_macos` rust-cache `save-if: false` (`prepare_*` and `cache-macos.yml` remain the writers)

`before-tauri-build` stays a named script that Tauri invokes during the build; it is not a pnpm lifecycle hook, so `--ignore-scripts` does not skip it. Dependabot's UI comment no longer claims the signing job runs lifecycle scripts.

The workflow-security tests now require that shape. Depends on the test-only precursor #2044.

## Notes

- Not verified by running `build_macos` / `build_macos_staging` (release and staging only).
- Apple / Tauri secret names are unchanged. Staging still uses the existing updater key.