### PR TITLE
feat(gateway): negotiate the member catalog and render designed denials

### DIFF
--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1024,6 +1024,15 @@ display_name?: string | null,
  */
 upstream_id?: string | null, 
 /**
+ * Alternate gateway ids that also resolve to this model — the
+ * deployment-shaped spellings the member catalog reports, offered to
+ * the curated registry the same way `upstream_id` is.
+ *
+ * Populated only by gateway model sync from a catalog-serving gateway;
+ * a user-entered custom model leaves it empty.
+ */
+aliases?: Array<string>, 
+/**
  * Context limit used by Tidebreak's reducer.
  */
 context_window: number, 
@@ -1188,6 +1197,14 @@ export type FolderAccess = "read" | "read_write";
  */
 export type GatewayAppInfo = { id: string, name: string, app_kind: string, enabled: boolean, mcp_endpoint_slugs: Array<string>, 
 /**
+ * The gateway's readiness for this app when the member catalog reports
+ * one: `ready`, `not_connected`, or `authorization_required`. `None`
+ * against a gateway that predates the catalog — the panel then shows
+ * no readiness rather than guessing. An unfamiliar value renders as
+ * not-ready copy, never an error: the set is the gateway's to grow.
+ */
+connection?: string, 
+/**
  * How many live local-app grants bind this gateway app — the same
  * "Used by N local apps" line the connected-apps page carries per record,
  * so a user can see what a revocation here would break.
@@ -1213,7 +1230,15 @@ supported: boolean, apps: Array<GatewayAppInfo>, };
  * with a usable URL (the retired `configured`/`enabled` bits collapsed into
  * its presence).
  */
-export type GatewayStatus = { base_url?: string, signed_in: boolean, account_hint?: string, installation_id?: string, model_count: number, sign_in: SignInProgress, };
+export type GatewayStatus = { base_url?: string, signed_in: boolean, account_hint?: string, installation_id?: string, model_count: number, 
+/**
+ * The member-catalog contract revision the last model sync read, or
+ * `None` while unsynced or against a gateway that predates
+ * `/api/v1/me/catalog`. The settings panel uses its absence (while
+ * signed in with models) to note that the deployment is older than
+ * this Tidebreak.
+ */
+member_catalog?: string, sign_in: SignInProgress, };
 
 /**
  * How far a standing grant reaches.

--- a/crates/tidebreak-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
@@ -278,4 +278,68 @@ describe("GatewayPanel", () => {
       await screen.findByText(/browser authorization timed out/),
     ).toBeInTheDocument();
   });
+
+  it("soft-warns about a gateway older than this Tidebreak, and stays quiet on a current one", async () => {
+    // A synced snapshot with no member-catalog revision is the older-gateway
+    // shape; the note is informational and nothing is disabled by it.
+    const client = api({
+      getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
+    });
+    render(managedPanel(client));
+    expect(
+      await screen.findByText(/older than this Tidebreak/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Sync with gateway/ }),
+    ).toBeEnabled();
+    cleanup();
+
+    const current = api({
+      getGatewayStatus: vi
+        .fn()
+        .mockResolvedValue({ ...signedIn, member_catalog: "v1" }),
+    });
+    render(managedPanel(current));
+    expect(await screen.findByText("Signed in")).toBeInTheDocument();
+    expect(screen.queryByText(/older than this Tidebreak/)).toBeNull();
+  });
+
+  it("labels an entitled app the gateway reports as not ready", async () => {
+    const client = api({
+      getGatewayStatus: vi
+        .fn()
+        .mockResolvedValue({ ...signedIn, member_catalog: "v1" }),
+      getGatewayApps: vi.fn().mockResolvedValue({
+        supported: true,
+        apps: [
+          {
+            id: "app-1",
+            name: "Tools",
+            app_kind: "mcp_endpoint",
+            enabled: true,
+            mcp_endpoint_slugs: ["tools"],
+            connection: "authorization_required",
+            used_by_app_count: 0,
+          },
+          {
+            id: "app-2",
+            name: "Monitors",
+            app_kind: "rest_api",
+            enabled: true,
+            mcp_endpoint_slugs: [],
+            connection: "ready",
+            used_by_app_count: 0,
+          },
+        ],
+      }),
+    });
+    render(managedPanel(client));
+
+    expect(
+      await screen.findByText(/authorize this app at your gateway/),
+    ).toBeInTheDocument();
+    // A ready app carries no readiness copy at all.
+    expect(screen.queryByText(/not ready at your gateway/)).toBeNull();
+    expect(screen.getByText("Monitors")).toBeInTheDocument();
+  });
 });

--- a/crates/tidebreak-desktop/ui/src/settings/GatewayPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/GatewayPanel.tsx
@@ -15,6 +15,27 @@ import {
 const SIGN_IN_POLL_MS = 2_000;
 
 /**
+ * Readiness copy for one entitled app, from the gateway's member catalog.
+ * `ready` (and an absent value, on gateways that predate the catalog) render
+ * nothing; the named not-ready states get their own copy; anything
+ * unfamiliar renders as generic not-ready copy — the state set is the
+ * gateway's to grow, and an unknown value must degrade, not break.
+ */
+function appReadinessLabel(connection: string | undefined): string | null {
+  switch (connection) {
+    case undefined:
+    case "ready":
+      return null;
+    case "not_connected":
+      return "connect this app at your gateway to use it";
+    case "authorization_required":
+      return "authorize this app at your gateway to use it";
+    default:
+      return "not ready at your gateway";
+  }
+}
+
+/**
  * The Model Gateway section.
  *
  * Policy is the only gateway source: a profile connects through the
@@ -215,6 +236,16 @@ function ManagedGatewayPanel({
                 Installation {status.installation_id}
               </p>
             )}
+            {status.model_count > 0 && !status.member_catalog && (
+              // Soft note, never a block: an older gateway still signs in
+              // and still syncs models; what it cannot do is report app
+              // readiness or serve instant catalog updates.
+              <p className="text-muted-foreground text-xs">
+                This gateway is older than this Tidebreak. Models still sync,
+                but app readiness and instant catalog updates are unavailable
+                until the gateway is upgraded.
+              </p>
+            )}
             <div className="flex flex-wrap gap-2">
               <Button
                 type="button"
@@ -327,6 +358,11 @@ function ManagedGatewayPanel({
                       {!app.enabled && (
                         <span className="text-muted-foreground text-xs">
                           disabled
+                        </span>
+                      )}
+                      {appReadinessLabel(app.connection) && (
+                        <span className="text-muted-foreground text-xs">
+                          {appReadinessLabel(app.connection)}
                         </span>
                       )}
                     </div>

--- a/crates/tidebreak-router/src/anthropic.rs
+++ b/crates/tidebreak-router/src/anthropic.rs
@@ -299,7 +299,17 @@ impl AnthropicProvider {
         let status = response.status();
         if !status.is_success() {
             let retry_after = crate::sse::retry_after_hint(response.headers());
+            // A managed gateway names its designed refusals in a header; a
+            // known code renders as its own copy ("an administrator revoked
+            // this model") instead of a generic provider fault. Unknown
+            // codes fall through to ordinary classification.
+            let gateway_code = crate::sse::gateway_denial_code(response.headers());
             let body = read_bounded_error_body(response.bytes_stream()).await;
+            if let Some(denial) =
+                gateway_code.and_then(|code| crate::sse::classify_gateway_denial(&code, &body))
+            {
+                return Err(denial);
+            }
             return Err(classify_provider_error(
                 self.provider_label,
                 status.as_u16(),

--- a/crates/tidebreak-router/src/openai_compat.rs
+++ b/crates/tidebreak-router/src/openai_compat.rs
@@ -158,7 +158,16 @@ impl ModelProvider for OpenAiCompatProvider {
             // Never forward the raw body — gateways sometimes echo key material
             // or request fragments, and `AgentError` strings reach the client.
             let retry_after = crate::sse::retry_after_hint(response.headers());
+            // A managed gateway names its designed refusals in a header; a
+            // known code renders as its own copy instead of a generic
+            // provider fault, and unknown codes fall through.
+            let gateway_code = crate::sse::gateway_denial_code(response.headers());
             let body = read_bounded_error_body(response.bytes_stream()).await;
+            if let Some(denial) =
+                gateway_code.and_then(|code| crate::sse::classify_gateway_denial(&code, &body))
+            {
+                return Err(denial);
+            }
             return Err(classify_provider_error(
                 &self.provider_id,
                 status.as_u16(),

--- a/crates/tidebreak-router/src/sse.rs
+++ b/crates/tidebreak-router/src/sse.rs
@@ -480,6 +480,93 @@ pub fn parse_retry_after(value: &str) -> Option<Duration> {
     Some(wait.to_std().unwrap_or(Duration::ZERO).min(MAX_RETRY_AFTER))
 }
 
+/// The response header a managed model gateway stamps its designed denial
+/// code on (`x-model-gateway-error`). The body spells the code differently
+/// per compatibility protocol, so the header is the one spelling a client
+/// can read without knowing which protocol the request rode.
+pub const GATEWAY_ERROR_HEADER: &str = "x-model-gateway-error";
+
+/// The gateway denial code on a response, when the origin stamped one.
+#[cfg(any(
+    feature = "anthropic",
+    feature = "openai",
+    feature = "openai-compat",
+    feature = "gemini"
+))]
+#[must_use]
+pub fn gateway_denial_code(headers: &reqwest::header::HeaderMap) -> Option<String> {
+    Some(headers.get(GATEWAY_ERROR_HEADER)?.to_str().ok()?.to_owned())
+}
+
+/// Turn a known gateway denial into its designed, user-facing error, or
+/// `None` for a code this client has not learned — the caller then falls
+/// back to [`classify_provider_error`], so the code set stays open on the
+/// gateway side without a client release riding every addition.
+///
+/// The distinction earns its keep on two codes. `model_not_granted` arrives
+/// as a 404 (so coding harnesses do not read it as a credential problem),
+/// which the generic classifier would render as a provider fault rather
+/// than "an administrator revoked this". The subscription codes arrive as
+/// 403, which the generic classifier would render as *re-authenticate* —
+/// exactly the wrong advice, since the session is fine and the fix lives at
+/// the gateway's account page.
+#[must_use]
+pub fn classify_gateway_denial(
+    code: &str,
+    body: &str,
+) -> Option<tidebreak_core::error::AgentError> {
+    use tidebreak_core::error::AgentError;
+
+    // The gateway's own message is designed to be shown to the user, but the
+    // body is still an untrusted network payload: accept its strings only at
+    // toast-sized lengths, and fall back to this client's own copy.
+    const MAX_DENIAL_MESSAGE_CHARS: usize = 240;
+    const MAX_DENIAL_RESOURCE_CHARS: usize = 100;
+    let parsed = serde_json::from_str::<serde_json::Value>(body).ok();
+    let message = parsed
+        .as_ref()
+        .and_then(provider_error_message)
+        .map(str::trim)
+        .filter(|message| {
+            !message.is_empty() && message.chars().count() <= MAX_DENIAL_MESSAGE_CHARS
+        });
+    // The model the denial is about: top-level on the Anthropic protocol,
+    // inside `error` on the OpenAI protocol.
+    let resource = parsed
+        .as_ref()
+        .and_then(|value| {
+            value
+                .get("resource")
+                .or_else(|| value.get("error")?.get("resource"))
+        })
+        .and_then(serde_json::Value::as_str)
+        .filter(|resource| {
+            !resource.is_empty() && resource.chars().count() <= MAX_DENIAL_RESOURCE_CHARS
+        });
+
+    match code {
+        "model_not_granted" => Some(AgentError::Message(match resource {
+            Some(model) => format!(
+                "You no longer have access to {model} on your gateway — an administrator may have revoked it. Pick another model."
+            ),
+            None => "You no longer have access to this model on your gateway — an administrator may have revoked it. Pick another model.".to_owned(),
+        })),
+        "model_not_found" => Some(AgentError::Message(
+            message.map_or_else(
+                || "Your gateway does not serve this model. Refresh the model list and pick another.".to_owned(),
+                str::to_owned,
+            ),
+        )),
+        "subscription_connection_required" | "subscription_client_incompatible" => {
+            Some(AgentError::Message(message.map_or_else(
+                || "Your gateway needs a provider subscription connected before this model can run. Connect it from the gateway's account page.".to_owned(),
+                str::to_owned,
+            )))
+        }
+        _ => None,
+    }
+}
+
 /// Classify a provider HTTP error, detecting prompt-too-long patterns that the
 /// agent loop can retry with a tighter context budget.
 ///
@@ -908,5 +995,82 @@ mod tests {
             assert!(!in_band.contains(marker));
             assert!(!in_band.contains("provider echoed"));
         }
+    }
+
+    /// The gateway spells `code`/`resource` top-level on the Anthropic
+    /// protocol and inside `error` on the OpenAI protocol; both must name
+    /// the revoked model in the designed copy.
+    #[test]
+    fn a_gateway_revocation_names_the_model_on_both_protocols() {
+        let anthropic = serde_json::json!({
+            "type": "error",
+            "error": {"type": "not_found_error", "message": "You no longer have access to this model."},
+            "code": "model_not_granted",
+            "resource": "claude-opus-5",
+        })
+        .to_string();
+        let error = classify_gateway_denial("model_not_granted", &anthropic)
+            .expect("a known denial classifies");
+        assert!(matches!(
+            error,
+            tidebreak_core::error::AgentError::Message(_)
+        ));
+        assert!(error.to_string().contains("claude-opus-5"));
+        assert!(error.to_string().contains("no longer have access"));
+
+        let openai = serde_json::json!({
+            "error": {
+                "type": "not_found_error",
+                "message": "You no longer have access to this model.",
+                "code": "model_not_granted",
+                "resource": "acme-coder",
+            }
+        })
+        .to_string();
+        let error = classify_gateway_denial("model_not_granted", &openai)
+            .expect("a known denial classifies");
+        assert!(error.to_string().contains("acme-coder"));
+    }
+
+    /// A subscription denial is a 403 the generic classifier would read as
+    /// re-authenticate — the wrong advice, since the fix lives at the
+    /// gateway's account page. The gateway's own message rides through.
+    #[test]
+    fn a_subscription_denial_is_not_an_authentication_error() {
+        let body = serde_json::json!({
+            "error": {
+                "type": "subscription_connection_required",
+                "message": "Connect your provider subscription from the Account page, then retry this model request.",
+                "code": "subscription_connection_required",
+            }
+        })
+        .to_string();
+        let error = classify_gateway_denial("subscription_connection_required", &body)
+            .expect("a known denial classifies");
+        assert!(matches!(
+            error,
+            tidebreak_core::error::AgentError::Message(_)
+        ));
+        assert!(error.to_string().contains("Account page"));
+    }
+
+    /// Unknown codes and oversized payloads fall back rather than break:
+    /// the denial-code set is the gateway's to grow, and the body is an
+    /// untrusted network payload even when the header names a known code.
+    #[test]
+    fn unknown_denial_codes_and_oversized_copy_degrade() {
+        assert!(classify_gateway_denial("model_disabled_next_quarter", "{}").is_none());
+
+        let oversized = serde_json::json!({
+            "error": {"message": "x".repeat(4096), "code": "model_not_found"},
+        })
+        .to_string();
+        let error = classify_gateway_denial("model_not_found", &oversized)
+            .expect("a known denial classifies");
+        assert!(
+            error.to_string().contains("Refresh the model list"),
+            "an oversized message yields this client's own copy"
+        );
+        assert!(!error.to_string().contains("xxxx"));
     }
 }

--- a/crates/tidebreak-server/src/connectors/gateway.rs
+++ b/crates/tidebreak-server/src/connectors/gateway.rs
@@ -136,7 +136,30 @@ pub struct GatewayMeta {
     pub gateway_version: String,
     pub public_url: String,
     pub auth_mode: String,
+    /// The capability surfaces this deployment advertises. Absent on
+    /// gateways that predate the member-catalog contract; every consumer
+    /// must degrade rather than require it.
+    #[serde(default)]
+    pub surfaces: Option<GatewaySurfaces>,
 }
+
+/// The capability document a gateway advertises on `/api/v1/meta` and
+/// `/api/v1/cli/me`, read before choosing a code path. Both fields are open
+/// sets: an unknown catalog revision or denial code is ignored, never an
+/// error, so the gateway may grow the contract without a client release.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+pub struct GatewaySurfaces {
+    /// The member-catalog contract revision, `"v1"` today. Absent means the
+    /// deployment does not serve `/api/v1/me/catalog`.
+    #[serde(default)]
+    pub member_catalog: Option<String>,
+    /// The denial codes this deployment may emit on invoke.
+    #[serde(default)]
+    pub denial_codes: Vec<String>,
+}
+
+/// The member-catalog contract revision this client implements.
+pub const MEMBER_CATALOG_V1: &str = "v1";
 
 /// The authenticated user, from `/api/v1/cli/me`.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
@@ -187,6 +210,70 @@ pub struct GatewayApp {
     pub app_kind: String,
     pub enabled: bool,
     pub mcp_endpoint_slugs: Vec<String>,
+}
+
+/// The member catalog from `/api/v1/me/catalog`: one envelope holding the
+/// entitled models and connected apps together, so the two lists cannot
+/// drift apart between separate fetches. Catalog membership uses the same
+/// entitlement predicate the gateway enforces at invoke.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct GatewayCatalog {
+    pub models: Vec<GatewayCatalogModel>,
+    pub apps: Vec<GatewayCatalogApp>,
+}
+
+/// One entitled model in the member catalog. Unlike the per-protocol rows of
+/// `/api/v1/cli/models`, a dual-protocol model appears once with both
+/// protocols listed.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct GatewayCatalogModel {
+    pub id: String,
+    pub name: String,
+    /// The compatibility protocols this model is served through
+    /// (`anthropic_messages` / `openai_responses`). Open set: unknown values
+    /// are skipped, not fatal.
+    pub protocols: Vec<String>,
+    /// Alternate gateway ids that resolve to this model — deployment-shaped
+    /// spellings such as `us.anthropic.claude-opus-5`. Used to match a
+    /// curated registry row the way `upstream_id` does on the older surface.
+    #[serde(default)]
+    pub aliases: Vec<String>,
+    pub supports_tools: bool,
+    pub supports_vision: bool,
+    pub context_window: Option<i64>,
+    pub max_output_tokens: Option<i64>,
+    pub provider_name: String,
+}
+
+/// One entitled connected app in the member catalog, with its readiness.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct GatewayCatalogApp {
+    pub id: String,
+    pub name: String,
+    pub app_kind: String,
+    pub enabled: bool,
+    pub mcp_endpoint_slugs: Vec<String>,
+    /// `ready`, `not_connected`, or `authorization_required` — whether the
+    /// caller can use the app now or must first connect it at the gateway.
+    /// Open set: an unknown value renders as not-ready, never an error.
+    pub connection: String,
+}
+
+/// What one member-catalog fetch came back as. Three outcomes because the
+/// caller has three different things to do: sync the fresh catalog, keep the
+/// snapshot it already has, or fall back to the older per-surface reads.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GatewayCatalogFetch {
+    /// The gateway predates `/api/v1/me/catalog` (a 404 on the route).
+    Unsupported,
+    /// The catalog has not changed since the `If-None-Match` revision.
+    NotModified,
+    /// A fresh catalog, with the `ETag` to send on the next conditional
+    /// fetch when the gateway returned one.
+    Fresh {
+        catalog: GatewayCatalog,
+        etag: Option<String>,
+    },
 }
 
 /// One operation a gateway connected app declares, from
@@ -598,6 +685,45 @@ impl GatewayAuth {
         }
         let list: AppListResponse = decode_json(response, "app request").await?;
         Ok(Some(list.apps))
+    }
+
+    /// The member catalog from `/api/v1/me/catalog`: models and apps in one
+    /// envelope, from the same entitlement predicate invoke enforces.
+    ///
+    /// `if_none_match` is the `ETag` of the revision already held; a gateway
+    /// that still serves it answers `304` and the caller keeps its snapshot.
+    /// A gateway that predates the route answers `404`, reported as
+    /// [`GatewayCatalogFetch::Unsupported`] so the caller can degrade to the
+    /// older `/api/v1/cli/models` and `/api/v1/cli/apps` reads.
+    pub async fn catalog(
+        &self,
+        access_token: &str,
+        if_none_match: Option<&str>,
+    ) -> Result<GatewayCatalogFetch> {
+        let mut request = self
+            .http
+            .get(self.endpoint("/api/v1/me/catalog")?)
+            .bearer_auth(access_token);
+        if let Some(etag) = if_none_match {
+            request = request.header(reqwest::header::IF_NONE_MATCH, etag);
+        }
+        let response = request
+            .send()
+            .await
+            .map_err(|error| gateway_error("catalog request", error.without_url()))?;
+        match response.status() {
+            reqwest::StatusCode::NOT_FOUND => Ok(GatewayCatalogFetch::Unsupported),
+            reqwest::StatusCode::NOT_MODIFIED => Ok(GatewayCatalogFetch::NotModified),
+            _ => {
+                let etag = response
+                    .headers()
+                    .get(reqwest::header::ETAG)
+                    .and_then(|value| value.to_str().ok())
+                    .map(str::to_owned);
+                let catalog = decode_json(response, "catalog request").await?;
+                Ok(GatewayCatalogFetch::Fresh { catalog, etag })
+            }
+        }
     }
 
     /// The operations one entitled connected app declares, or `None` against a
@@ -1254,6 +1380,13 @@ impl GatewayConnection {
     pub async fn apps(&self) -> Result<Option<Vec<GatewayApp>>> {
         let token = self.access_token(RESOURCE_CONTROL).await?;
         self.auth.apps(&token).await
+    }
+
+    /// The member catalog with a `control` token; `Unsupported` when the
+    /// gateway predates `/api/v1/me/catalog`.
+    pub async fn catalog(&self, if_none_match: Option<&str>) -> Result<GatewayCatalogFetch> {
+        let token = self.access_token(RESOURCE_CONTROL).await?;
+        self.auth.catalog(&token, if_none_match).await
     }
 
     /// One entitled app's declared operations with a `control` token; `None`

--- a/crates/tidebreak-server/src/connectors/mod.rs
+++ b/crates/tidebreak-server/src/connectors/mod.rs
@@ -37,8 +37,9 @@ pub use chatgpt::{
 pub use gateway::{
     has_stored_credentials, has_stored_credentials_for, is_sign_in_required,
     validate_mcp_endpoint_slug, AuthorizedSession, CredentialVault, GatewayApp, GatewayAuth,
-    GatewayAuthConfig, GatewayConnection, GatewayConsentOutcome, GatewayCredentials,
-    GatewayIdentity, GatewayInvokeOutcome, GatewayMeta, GatewayModel, GatewayOperationSummary,
-    GatewayRegistrationOutcome, PendingSignIn, TokenSet, RESOURCE_CONTROL, RESOURCE_LLM,
-    SECRET_KEY as GATEWAY_SECRET_KEY,
+    GatewayAuthConfig, GatewayCatalog, GatewayCatalogApp, GatewayCatalogFetch, GatewayCatalogModel,
+    GatewayConnection, GatewayConsentOutcome, GatewayCredentials, GatewayIdentity,
+    GatewayInvokeOutcome, GatewayMeta, GatewayModel, GatewayOperationSummary,
+    GatewayRegistrationOutcome, GatewaySurfaces, PendingSignIn, TokenSet, MEMBER_CATALOG_V1,
+    RESOURCE_CONTROL, RESOURCE_LLM, SECRET_KEY as GATEWAY_SECRET_KEY,
 };

--- a/crates/tidebreak-server/src/gateway_runtime.rs
+++ b/crates/tidebreak-server/src/gateway_runtime.rs
@@ -14,7 +14,8 @@ use std::time::Duration;
 
 use crate::connectors::{
     is_sign_in_required, CredentialVault, GatewayApp, GatewayAuth, GatewayAuthConfig,
-    GatewayConnection, GatewayOperationSummary, RESOURCE_LLM,
+    GatewayCatalogFetch, GatewayConnection, GatewayOperationSummary, MEMBER_CATALOG_V1,
+    RESOURCE_LLM,
 };
 use async_trait::async_trait;
 use serde::Serialize;
@@ -112,6 +113,14 @@ pub(crate) struct GatewayStatus {
     #[ts(optional)]
     pub(crate) installation_id: Option<String>,
     pub(crate) model_count: usize,
+    /// The member-catalog contract revision the last model sync read, or
+    /// `None` while unsynced or against a gateway that predates
+    /// `/api/v1/me/catalog`. The settings panel uses its absence (while
+    /// signed in with models) to note that the deployment is older than
+    /// this Tidebreak.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub(crate) member_catalog: Option<String>,
     pub(crate) sign_in: SignInProgress,
 }
 
@@ -135,6 +144,14 @@ pub(crate) struct GatewayAppInfo {
     pub(crate) app_kind: String,
     pub(crate) enabled: bool,
     pub(crate) mcp_endpoint_slugs: Vec<String>,
+    /// The gateway's readiness for this app when the member catalog reports
+    /// one: `ready`, `not_connected`, or `authorization_required`. `None`
+    /// against a gateway that predates the catalog — the panel then shows
+    /// no readiness rather than guessing. An unfamiliar value renders as
+    /// not-ready copy, never an error: the set is the gateway's to grow.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub(crate) connection: Option<String>,
     /// How many live local-app grants bind this gateway app — the same
     /// "Used by N local apps" line the connected-apps page carries per record,
     /// so a user can see what a revocation here would break.
@@ -235,6 +252,7 @@ impl GatewayRuntime {
             Some(connection) => connection.stored_credentials().await?,
             None => None,
         };
+        let snapshot = providers::gateway_snapshot_for_policy(&*self.store, &policy).await?;
         Ok(GatewayStatus {
             base_url,
             signed_in: credentials.is_some(),
@@ -244,9 +262,11 @@ impl GatewayRuntime {
             installation_id: credentials
                 .as_ref()
                 .map(|credentials| credentials.installation_id.clone()),
-            model_count: providers::gateway_models(&*self.store, &policy)
-                .await?
-                .len(),
+            model_count: snapshot
+                .as_ref()
+                .map(|snapshot| snapshot.models.len())
+                .unwrap_or_default(),
+            member_catalog: snapshot.and_then(|snapshot| snapshot.member_catalog),
             sign_in: self.sign_in.lock().await.clone(),
         })
     }
@@ -256,11 +276,49 @@ impl GatewayRuntime {
     /// gateway without the JSON apps surface reports `supported: false`.
     pub(crate) async fn apps(&self) -> Result<GatewayApps> {
         let connection = self.managed_connection().await?;
-        let Some(apps) = connection.apps().await? else {
-            return Ok(GatewayApps {
-                supported: false,
-                apps: Vec::new(),
-            });
+        // The member catalog carries per-app readiness the older surface
+        // cannot express; prefer it, and degrade to `/api/v1/cli/apps`
+        // (readiness unknown) against a gateway that predates it. Always an
+        // unconditional fetch: this is the live projection a revoked grant
+        // must fall out of, so a cached revision would be a lie.
+        let apps: Vec<GatewayAppInfo> = match connection.catalog(None).await? {
+            GatewayCatalogFetch::Fresh { catalog, .. } => catalog
+                .apps
+                .into_iter()
+                .map(|app| GatewayAppInfo {
+                    used_by_app_count: 0,
+                    id: app.id,
+                    name: app.name,
+                    app_kind: app.app_kind,
+                    enabled: app.enabled,
+                    mcp_endpoint_slugs: app.mcp_endpoint_slugs,
+                    connection: Some(app.connection),
+                })
+                .collect(),
+            GatewayCatalogFetch::NotModified => {
+                return Err(AgentError::msg(
+                    "gateway answered an unconditional catalog fetch with 304",
+                ));
+            }
+            GatewayCatalogFetch::Unsupported => {
+                let Some(apps) = connection.apps().await? else {
+                    return Ok(GatewayApps {
+                        supported: false,
+                        apps: Vec::new(),
+                    });
+                };
+                apps.into_iter()
+                    .map(|app| GatewayAppInfo {
+                        used_by_app_count: 0,
+                        id: app.id,
+                        name: app.name,
+                        app_kind: app.app_kind,
+                        enabled: app.enabled,
+                        mcp_endpoint_slugs: app.mcp_endpoint_slugs,
+                        connection: None,
+                    })
+                    .collect()
+            }
         };
         // How many local mini-apps currently bind each gateway app: distinct
         // live grants naming the id. The binding grammar forbids a grant
@@ -287,13 +345,9 @@ impl GatewayRuntime {
             supported: true,
             apps: apps
                 .into_iter()
-                .map(|app| GatewayAppInfo {
-                    used_by_app_count: used_by.get(&app.id).copied().unwrap_or_default(),
-                    id: app.id,
-                    name: app.name,
-                    app_kind: app.app_kind,
-                    enabled: app.enabled,
-                    mcp_endpoint_slugs: app.mcp_endpoint_slugs,
+                .map(|mut app| {
+                    app.used_by_app_count = used_by.get(&app.id).copied().unwrap_or_default();
+                    app
                 })
                 .collect(),
         })
@@ -608,6 +662,8 @@ impl GatewayRuntime {
                         gateway_url: base_url,
                         models: Vec::new(),
                         model_protocols: Default::default(),
+                        member_catalog: None,
+                        catalog_etag: None,
                     },
                 )
                 .await?;
@@ -714,38 +770,102 @@ impl GatewayRuntime {
         let policy = crate::managed_policy::resolve(&*self.provisioned_policy, &*self.os_policy)?;
         let base_url = require_managed(&policy)?;
         let connection = self.connection_at(base_url.clone()).await?;
-        // Fetch the full entitled set: each row names the compatibility
-        // protocol the gateway serves it through, and route collection splits
-        // the snapshot across matching adapters. Fetched before the row lock
-        // is taken: the entitlement round-trip must not stall other writers.
+        // The stored snapshot's ETag makes an unchanged catalog a 304: the
+        // background loop runs this every few minutes, and most ticks change
+        // nothing. Read before the row lock — like the fetch itself, the
+        // conditional round-trip must not stall other writers.
+        let held = providers::gateway_snapshot_for_policy(&*self.store, &policy).await?;
+        let held_etag = held
+            .as_ref()
+            .and_then(|snapshot| snapshot.catalog_etag.clone());
+        // Fetch the full entitled set before the row lock is taken. The
+        // member catalog is preferred: one envelope, merged protocols per
+        // model, and the alias list that matches curated rows. A gateway
+        // that predates it degrades to the per-protocol
+        // `/api/v1/cli/models` read.
         let mut model_protocols = std::collections::BTreeMap::new();
-        let models: Vec<CustomModelConfig> = connection
-            .models(None)
-            .await?
-            .into_iter()
-            .filter_map(|model| {
-                let Some(protocol) = providers::GatewayModelProtocol::parse(&model.protocol) else {
-                    tracing::debug!(
-                        "gateway model sync skipped a model with an unsupported inference protocol"
-                    );
-                    return None;
-                };
-                let id = model.id;
-                model_protocols.insert(id.clone(), protocol);
-                Some(CustomModelConfig {
-                    id,
-                    display_name: Some(model.name),
-                    // Carried so a deployment-aliased id can still be matched to
-                    // its curated row; gateways older than the field send none.
-                    upstream_id: model.upstream_id,
-                    context_window: clamp_u32(model.context_window, 32_768),
-                    max_output_tokens: clamp_u32(model.max_output_tokens, 4_096),
-                    input_modalities: vec![crate::model_registry::InputModality::Text],
-                    supports_reasoning: false,
-                    reasoning_efforts: Vec::new(),
+        let mut member_catalog = None;
+        let mut catalog_etag = None;
+        let models: Vec<CustomModelConfig> = match connection.catalog(held_etag.as_deref()).await? {
+            GatewayCatalogFetch::NotModified => {
+                // Nothing moved since the held revision; the snapshot the
+                // policy already honors stays as it is.
+                return Ok(held.map(|snapshot| snapshot.models.len()).unwrap_or_default());
+            }
+            GatewayCatalogFetch::Fresh { catalog, etag } => {
+                member_catalog = Some(MEMBER_CATALOG_V1.to_owned());
+                catalog_etag = etag;
+                catalog
+                    .models
+                    .into_iter()
+                    .filter_map(|model| {
+                        let protocols: Vec<_> = model
+                            .protocols
+                            .iter()
+                            .filter_map(|protocol| {
+                                providers::GatewayModelProtocol::parse(protocol)
+                            })
+                            .collect();
+                        // A dual-protocol model routes through Anthropic
+                        // Messages, the richer adapter; a model with no
+                        // protocol this client speaks is skipped, exactly as
+                        // on the older surface.
+                        let protocol = if protocols
+                            .contains(&providers::GatewayModelProtocol::AnthropicMessages)
+                        {
+                            providers::GatewayModelProtocol::AnthropicMessages
+                        } else {
+                            *protocols.first()?
+                        };
+                        let id = model.id;
+                        model_protocols.insert(id.clone(), protocol);
+                        Some(CustomModelConfig {
+                            id,
+                            display_name: Some(model.name),
+                            // The catalog reports gateway-id aliases instead
+                            // of the provider-side id; both exist to match a
+                            // curated row.
+                            upstream_id: None,
+                            aliases: model.aliases,
+                            context_window: clamp_u32(model.context_window, 32_768),
+                            max_output_tokens: clamp_u32(model.max_output_tokens, 4_096),
+                            input_modalities: vec![crate::model_registry::InputModality::Text],
+                            supports_reasoning: false,
+                            reasoning_efforts: Vec::new(),
+                        })
+                    })
+                    .collect()
+            }
+            GatewayCatalogFetch::Unsupported => connection
+                .models(None)
+                .await?
+                .into_iter()
+                .filter_map(|model| {
+                    let Some(protocol) = providers::GatewayModelProtocol::parse(&model.protocol)
+                    else {
+                        tracing::debug!(
+                            "gateway model sync skipped a model with an unsupported inference protocol"
+                        );
+                        return None;
+                    };
+                    let id = model.id;
+                    model_protocols.insert(id.clone(), protocol);
+                    Some(CustomModelConfig {
+                        id,
+                        display_name: Some(model.name),
+                        // Carried so a deployment-aliased id can still be matched to
+                        // its curated row; gateways older than the field send none.
+                        upstream_id: model.upstream_id,
+                        aliases: Vec::new(),
+                        context_window: clamp_u32(model.context_window, 32_768),
+                        max_output_tokens: clamp_u32(model.max_output_tokens, 4_096),
+                        input_modalities: vec![crate::model_registry::InputModality::Text],
+                        supports_reasoning: false,
+                        reasoning_efforts: Vec::new(),
+                    })
                 })
-            })
-            .collect();
+                .collect(),
+        };
         // The gateway is trusted for entitlements, not for shapes: the synced
         // set is held to the same bounds as user-entered custom models.
         providers::validate_custom_models(&models).map_err(|error| {
@@ -773,6 +893,8 @@ impl GatewayRuntime {
                 gateway_url: base_url,
                 models,
                 model_protocols,
+                member_catalog,
+                catalog_etag,
             },
         )
         .await?;
@@ -1317,6 +1439,39 @@ mod tests {
         minted: std::sync::Mutex<Vec<(String, Option<String>)>>,
         /// `(method, authorization)` per MCP endpoint request, in order.
         mcp_requests: std::sync::Mutex<Vec<(String, String)>>,
+        /// When set, `/api/v1/me/catalog` serves this body under a fixed
+        /// `ETag`; when `None` the route answers 404, the shape of a gateway
+        /// that predates the member catalog.
+        catalog: std::sync::Mutex<Option<Value>>,
+        /// How many catalog fetches arrived with a matching `If-None-Match`
+        /// and were answered 304.
+        catalog_not_modified: AtomicUsize,
+    }
+
+    const CATALOG_ETAG: &str = "W/\"catalog-rev-1\"";
+
+    async fn catalog(State(gateway): State<Arc<FakeGateway>>, headers: HeaderMap) -> Response {
+        let Some(body) = gateway.catalog.lock().unwrap().clone() else {
+            return axum::http::StatusCode::NOT_FOUND.into_response();
+        };
+        let bearer = headers
+            .get("authorization")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default();
+        assert!(bearer.starts_with("Bearer mg_at_control_"), "{bearer}");
+        if headers
+            .get("if-none-match")
+            .and_then(|value| value.to_str().ok())
+            == Some(CATALOG_ETAG)
+        {
+            gateway.catalog_not_modified.fetch_add(1, Ordering::SeqCst);
+            return (
+                axum::http::StatusCode::NOT_MODIFIED,
+                [(axum::http::header::ETAG, CATALOG_ETAG)],
+            )
+                .into_response();
+        }
+        ([(axum::http::header::ETAG, CATALOG_ETAG)], Json(body)).into_response()
     }
 
     /// One entitled connected app aggregating the fixture's `tools` MCP
@@ -1477,6 +1632,7 @@ mod tests {
             .route("/oauth/revoke", post(revoke))
             .route("/api/v1/cli/models", get(models))
             .route("/api/v1/cli/apps", get(apps))
+            .route("/api/v1/me/catalog", get(catalog))
             .route("/mcp/{slug}", post(mcp_endpoint))
             .with_state(gateway);
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -1597,6 +1753,147 @@ mod tests {
             crate::providers::ProviderKind::ModelGateway
         );
         assert_eq!(policy.display_name, "Sample Claude");
+        // Synced through the degraded CLI reads: no catalog revision to stamp.
+        let snapshot = providers::read_gateway_snapshot(&*store).await.unwrap();
+        assert_eq!(snapshot.unwrap().member_catalog, None);
+    }
+
+    fn sample_catalog() -> Value {
+        json!({
+            "models": [
+                {
+                    "id": "sample-claude",
+                    "name": "Sample Claude",
+                    // Dual-protocol: one row, both surfaces, and the sync
+                    // must route it through Anthropic Messages.
+                    "protocols": ["anthropic_messages", "openai_responses"],
+                    "aliases": ["us.anthropic.claude-opus-5"],
+                    "supports_tools": true,
+                    "supports_vision": true,
+                    "context_window": 200000,
+                    "max_output_tokens": 8192,
+                    "provider_name": "Anthropic"
+                },
+                {
+                    "id": "sample-coder",
+                    "name": "Sample Coder",
+                    "protocols": ["openai_responses"],
+                    "supports_tools": true,
+                    "supports_vision": false,
+                    "context_window": null,
+                    "max_output_tokens": null,
+                    "provider_name": "Acme"
+                },
+                {
+                    "id": "sample-exotic",
+                    "name": "Sample Exotic",
+                    // A protocol this client does not speak: skipped, never
+                    // fatal — the set is the gateway's to grow.
+                    "protocols": ["grpc_frames"],
+                    "supports_tools": false,
+                    "supports_vision": false,
+                    "context_window": null,
+                    "max_output_tokens": null,
+                    "provider_name": "Acme"
+                }
+            ],
+            "apps": [{
+                "id": "app-1",
+                "name": "Tools",
+                "app_kind": "mcp_endpoint",
+                "enabled": true,
+                "mcp_endpoint_slugs": ["tools"],
+                "connection": "authorization_required"
+            }]
+        })
+    }
+
+    #[tokio::test]
+    async fn sync_prefers_the_member_catalog_and_stamps_its_revision() {
+        let gateway = Arc::new(FakeGateway::default());
+        *gateway.catalog.lock().unwrap() = Some(sample_catalog());
+        let address = serve(gateway).await;
+        let base = format!("http://{address}");
+        let (runtime, store, _directory) = signed_in_runtime(&base).await;
+
+        // Two models the client can route; the exotic protocol is skipped.
+        assert_eq!(runtime.sync_models().await.unwrap(), 2);
+
+        let snapshot = providers::read_gateway_snapshot(&*store)
+            .await
+            .unwrap()
+            .expect("the sync persisted a snapshot");
+        assert_eq!(snapshot.member_catalog.as_deref(), Some("v1"));
+        assert_eq!(snapshot.catalog_etag.as_deref(), Some(CATALOG_ETAG));
+        assert_eq!(
+            snapshot.model_protocols.get("sample-claude"),
+            Some(&providers::GatewayModelProtocol::AnthropicMessages),
+            "a dual-protocol model routes through Anthropic Messages"
+        );
+        assert_eq!(
+            snapshot.model_protocols.get("sample-coder"),
+            Some(&providers::GatewayModelProtocol::OpenaiResponses)
+        );
+        assert!(!snapshot.model_protocols.contains_key("sample-exotic"));
+
+        // The catalog's alias matches the curated registry row, so the
+        // policy carries curated capabilities under the gateway's own id.
+        let policy =
+            providers::resolve_model_policy(&*store, "model_gateway::sample-claude", false)
+                .await
+                .unwrap()
+                .expect("synced model resolves");
+        assert_eq!(policy.display_name, "Claude Opus 5");
+
+        // The status projection surfaces the catalog revision for the
+        // settings panel's older-gateway note.
+        let status = runtime.status().await.unwrap();
+        assert_eq!(status.member_catalog.as_deref(), Some("v1"));
+    }
+
+    #[tokio::test]
+    async fn an_unchanged_catalog_answers_304_and_the_snapshot_stays() {
+        let gateway = Arc::new(FakeGateway::default());
+        *gateway.catalog.lock().unwrap() = Some(sample_catalog());
+        let address = serve(gateway.clone()).await;
+        let base = format!("http://{address}");
+        let (runtime, store, _directory) = signed_in_runtime(&base).await;
+
+        assert_eq!(runtime.sync_models().await.unwrap(), 2);
+        // The second tick sends the stored ETag and keeps the snapshot.
+        assert_eq!(runtime.sync_models().await.unwrap(), 2);
+        assert_eq!(gateway.catalog_not_modified.load(Ordering::SeqCst), 1);
+        let snapshot = providers::read_gateway_snapshot(&*store).await.unwrap();
+        assert_eq!(snapshot.unwrap().models.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn apps_carry_readiness_from_the_member_catalog() {
+        let gateway = Arc::new(FakeGateway::default());
+        *gateway.catalog.lock().unwrap() = Some(sample_catalog());
+        let address = serve(gateway).await;
+        let base = format!("http://{address}");
+        let (runtime, _store, _directory) = signed_in_runtime(&base).await;
+
+        let apps = runtime.apps().await.unwrap();
+        assert!(apps.supported);
+        assert_eq!(apps.apps.len(), 1);
+        assert_eq!(
+            apps.apps[0].connection.as_deref(),
+            Some("authorization_required")
+        );
+    }
+
+    #[tokio::test]
+    async fn apps_from_a_catalogless_gateway_carry_no_readiness() {
+        let address = serve(Arc::new(FakeGateway::default())).await;
+        let base = format!("http://{address}");
+        let (runtime, _store, _directory) = signed_in_runtime(&base).await;
+
+        let apps = runtime.apps().await.unwrap();
+        assert!(apps.supported);
+        assert_eq!(apps.apps.len(), 1);
+        assert_eq!(apps.apps[0].connection, None);
     }
 
     /// The boot-before-sign-in race: a status or sync read caches the
@@ -1705,6 +2002,8 @@ mod tests {
                     },
                 ],
                 model_protocols: Default::default(),
+                member_catalog: None,
+                catalog_etag: None,
             },
         )
         .await
@@ -3154,6 +3453,7 @@ mod tests {
                     gateway_version: "1".into(),
                     public_url: new_base.clone(),
                     auth_mode: "oauth".into(),
+                    surfaces: None,
                 },
                 identity: crate::connectors::GatewayIdentity {
                     user_id: "user-2".into(),

--- a/crates/tidebreak-server/src/model_roles.rs
+++ b/crates/tidebreak-server/src/model_roles.rs
@@ -510,6 +510,8 @@ mod tests {
                     },
                 ],
                 model_protocols: Default::default(),
+                member_catalog: None,
+                catalog_etag: None,
             },
         )
         .await

--- a/crates/tidebreak-server/src/pairing.rs
+++ b/crates/tidebreak-server/src/pairing.rs
@@ -727,6 +727,8 @@ mod tests {
                     ..Default::default()
                 }],
                 model_protocols: Default::default(),
+                member_catalog: None,
+                catalog_etag: None,
             },
         )
         .await

--- a/crates/tidebreak-server/src/providers.rs
+++ b/crates/tidebreak-server/src/providers.rs
@@ -64,6 +64,16 @@ pub(crate) struct GatewayModelSnapshot {
     /// defaults to that protocol for backward compatibility.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub(crate) model_protocols: BTreeMap<String, GatewayModelProtocol>,
+    /// The member-catalog contract revision the last sync read (`"v1"`),
+    /// or `None` when the deployment predates `/api/v1/me/catalog` and the
+    /// sync degraded to the per-surface CLI reads. Drives the "older
+    /// gateway" note in settings.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) member_catalog: Option<String>,
+    /// The catalog `ETag` of this snapshot, sent as `If-None-Match` on the
+    /// next sync so an unchanged catalog costs a `304` instead of a body.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) catalog_etag: Option<String>,
 }
 
 /// The compatibility protocol a managed gateway uses for one entitled model.
@@ -132,7 +142,7 @@ pub(crate) async fn gateway_models(
         .unwrap_or_default())
 }
 
-async fn gateway_snapshot_for_policy(
+pub(crate) async fn gateway_snapshot_for_policy(
     store: &dyn Store,
     policy: &crate::managed_policy::ManagedPolicy,
 ) -> Result<Option<GatewayModelSnapshot>> {
@@ -227,6 +237,8 @@ pub(crate) async fn retire_legacy_gateway_row(
             gateway_url,
             models: row.models,
             model_protocols: BTreeMap::new(),
+            member_catalog: None,
+            catalog_etag: None,
         },
     )
     .await?;
@@ -523,6 +535,14 @@ pub struct CustomModelConfig {
     /// a deployment-aliased id can still be recognized as a curated model.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub upstream_id: Option<String>,
+    /// Alternate gateway ids that also resolve to this model — the
+    /// deployment-shaped spellings the member catalog reports, offered to
+    /// the curated registry the same way `upstream_id` is.
+    ///
+    /// Populated only by gateway model sync from a catalog-serving gateway;
+    /// a user-entered custom model leaves it empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub aliases: Vec<String>,
     /// Context limit used by Tidebreak's reducer.
     #[serde(default = "default_custom_context_window")]
     pub context_window: u32,
@@ -546,6 +566,7 @@ impl Default for CustomModelConfig {
             id: String::new(),
             display_name: None,
             upstream_id: None,
+            aliases: Vec::new(),
             context_window: default_custom_context_window(),
             max_output_tokens: default_custom_max_output_tokens(),
             input_modalities: default_custom_input_modalities(),
@@ -646,9 +667,15 @@ impl ResolvedModelPolicy {
     fn gateway_for(model: &CustomModelConfig) -> Self {
         let mut policy = Self::custom_for(ProviderKind::ModelGateway, model);
         let Some(spec) = model_registry::find(&model.id).or_else(|| {
-            let upstream = model.upstream_id.as_deref()?;
-            model_registry::find(upstream)
-                .or_else(|| model_registry::find(&curated_id_candidate(upstream)))
+            model
+                .upstream_id
+                .as_deref()
+                .into_iter()
+                .chain(model.aliases.iter().map(String::as_str))
+                .find_map(|candidate| {
+                    model_registry::find(candidate)
+                        .or_else(|| model_registry::find(&curated_id_candidate(candidate)))
+                })
         }) else {
             return policy;
         };
@@ -711,6 +738,7 @@ impl ResolvedModelPolicy {
                 id: id.to_owned(),
                 display_name: None,
                 upstream_id: None,
+                aliases: Vec::new(),
                 context_window: default_custom_context_window(),
                 max_output_tokens: default_custom_max_output_tokens(),
                 input_modalities: default_custom_input_modalities(),
@@ -1265,6 +1293,24 @@ fn validate_configured_models_against(
             return Err(ServerError::bad_request(
                 "configured model display_name must be non-empty, bounded, and contain no control characters",
             ));
+        }
+        const MAX_MODEL_ALIASES: usize = 16;
+        if model.aliases.len() > MAX_MODEL_ALIASES {
+            return Err(ServerError::bad_request(format!(
+                "configured model `{id}` carries more than {MAX_MODEL_ALIASES} aliases"
+            )));
+        }
+        // Aliases are only ever offered to the curated registry, but they are
+        // gateway-supplied, so they are held to the id grammar all the same.
+        if model.aliases.iter().any(|alias| {
+            alias.is_empty()
+                || alias.chars().count() > MAX_MODEL_ID_CHARS
+                || alias.chars().any(char::is_whitespace)
+                || alias.chars().any(char::is_control)
+        }) {
+            return Err(ServerError::bad_request(format!(
+                "configured model `{id}` carries an alias that is empty, oversized, or contains whitespace or control characters"
+            )));
         }
         if !(1_024..=MAX_CONTEXT_WINDOW).contains(&model.context_window) {
             return Err(ServerError::bad_request(format!(

--- a/crates/tidebreak-server/src/tests/configuration.rs
+++ b/crates/tidebreak-server/src/tests/configuration.rs
@@ -2243,6 +2243,8 @@ async fn model_roles_resolve_at_read_time_and_honor_an_explicit_pin() {
                 },
             ],
             model_protocols: Default::default(),
+            member_catalog: None,
+            catalog_etag: None,
         },
     )
     .await

--- a/docs/decisions/0014-gateway-capability-negotiation.md
+++ b/docs/decisions/0014-gateway-capability-negotiation.md
@@ -1,0 +1,70 @@
+# 14. Gateway capability negotiation, not version pinning
+
+- Status: Accepted
+- Date: 2026-08-13
+- Owners: gateway connector / providers
+- Related: 0007 (gateway app bindings), the model gateway's own member-catalog
+  contract (`GET /api/v1/me/catalog`, `surfaces`, denial codes) shipped in
+  model-gateway #635/#636
+
+## Context
+
+One Tidebreak install pairs with many gateways: a work deployment, a
+customer's, a laptop compose stack. They upgrade on their own schedules, and
+Tidebreak ships from its own channel — there is no moment where both sides
+step together, and the `openwave` → `tidebreak` client-name migration already
+demonstrated how expensive an ordered deploy is to coordinate.
+
+The gateway now serves a member catalog (`GET /api/v1/me/catalog`: entitled
+models and apps in one envelope, with per-app readiness and an `ETag`),
+advertises its surfaces on `/api/v1/meta` and `/api/v1/cli/me`
+(`{ member_catalog: "v1", denial_codes: [...] }`), and stamps designed denial
+codes on refused inference (`x-model-gateway-error`, e.g.
+`model_not_granted`). Older gateways serve none of that.
+
+## Decision
+
+Tidebreak negotiates capabilities per gateway and never pins versions.
+
+- **Probe, don't compare versions.** The catalog is fetched directly; a 404
+  means the deployment predates it and the sync degrades to the
+  `/api/v1/cli/models` + `/api/v1/cli/apps` reads. `gateway_version` is for
+  diagnostics only; no code path branches on it.
+- **New Tidebreak, old gateway: degrade.** Everything the old wire cannot
+  express (app readiness, instant catalog updates, designed denial copy) is
+  hidden or generic, never an error. The settings panel may *note* an older
+  gateway; nothing blocks.
+- **Old Tidebreak, new gateway: additive wire only.** Unknown catalog fields,
+  surfaces keys, and denial codes are ignored (no `deny_unknown_fields` on
+  gateway wire types; unknown denial codes fall through to generic
+  classification; unknown app readiness renders as generic not-ready copy).
+- **Neither side waits on the other to ship.** A breaking change gets a new
+  path or surface name, never a silent reinterpretation of an existing field.
+
+The synced snapshot records which contract fed it (`member_catalog`,
+`catalog_etag`), so the picker's provenance survives restarts and the next
+sync can be conditional.
+
+## Alternatives Considered
+
+- **Pin a version matrix** (client ↔ gateway semver ranges): rots the moment
+  either side back-ports, and turns a customer's stale gateway into a client
+  that refuses to open. Rejected.
+- **Ship the client from the gateway image** so versions always match, as the
+  gateway does for `modelctl`: desktop signing/notarization and a second
+  updater fighting the existing channel cost more than a tolerant protocol.
+  Rejected.
+- **Do nothing** (keep scraping `/api/v1/cli/models` only): loses per-app
+  readiness, merged protocols, alias-based curated matching, cheap
+  conditional refresh, and designed denial copy — the picker then can't say
+  *why* a model vanished. Rejected.
+
+## Consequences
+
+Every new gateway surface lands here twice: the preferred path and the
+degraded one, with tests for both. Wire types for gateway payloads must stay
+open (additive, unknown-tolerant), which forgoes strict-parse error catching
+on that boundary. Revisit if gateway deployments ever become centrally
+version-managed (a fleet where the matrix cannot rot), or if a surface
+arrives that genuinely cannot degrade — either would justify a hard minimum
+gateway version at pairing time instead.


### PR DESCRIPTION
## Summary

Client side of the gateway's new member contract (model-gateway #635/#636). Decision record 0014 pins the posture: **negotiate capabilities per gateway, never pin versions** — new Tidebreak degrades against an old gateway, old Tidebreak ignores what a new gateway adds, and neither side waits on the other to ship.

**Catalog-first model sync** (`gateway_runtime::sync_models`)
- Prefers `GET /api/v1/me/catalog`: one envelope of entitled models and apps, from the same predicate the gateway enforces at invoke.
- Conditional on the snapshot's stored `ETag` — an unchanged catalog is a 304 and no rewrite.
- Dual-protocol models route through Anthropic Messages; unknown protocols are skipped, not fatal.
- Catalog `aliases` join `upstream_id` in the curated-registry match, so deployment-shaped ids keep their curated capabilities.
- A 404 on the route degrades to the existing `/api/v1/cli/models` + `/apps` reads, unchanged.

**App readiness** — `GatewayRuntime::apps()` carries the catalog's `connection` state (`ready` / `not_connected` / `authorization_required`); the settings panel labels not-ready apps ("authorize this app at your gateway"). Catalogless gateways show no readiness rather than guessing.

**Designed denial copy** (router) — a known `x-model-gateway-error` code short-circuits generic classification:
- `model_not_granted` → "You no longer have access to {model} on your gateway — an administrator may have revoked it." (instead of a generic 404 provider fault)
- `subscription_connection_required` / `subscription_client_incompatible` → the gateway's own copy (instead of a 403 reading as *re-authenticate*)
- Unknown codes fall through untouched; body strings are accepted only at bounded lengths.

**Soft degrade note** — `GatewayStatus.member_catalog` lets the panel note "this gateway is older than this Tidebreak" while blocking nothing. `GatewayMeta` also parses the `surfaces` capability document.

## Test plan

- [x] `cargo test --workspace` (new: catalog-first sync + revision stamp, 304 keeps snapshot, app readiness both ways, denial classification on both protocols, unknown-code/oversized-copy degrade)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check`
- [x] `pnpm test` (944 passed; new GatewayPanel cases for the older-gateway note and readiness labels) and `pnpm build`
- [x] Wire types regenerated (`UPDATE_WIRE_TYPES=1`); all new fields optional, no UI constructor churn
- [ ] Manual: pair against a current gateway (catalog-synced picker, readiness labels), then against a pre-#635 gateway (legacy sync + older-gateway note)
- [ ] Manual: revoke a grant at the gateway, next turn shows the revocation copy in chat