### PR TITLE
fix(gateway): mount MCP endpoints from the member catalog and retire refused sessions

### DIFF
--- a/crates/tidebreak-server/src/connectors/gateway.rs
+++ b/crates/tidebreak-server/src/connectors/gateway.rs
@@ -1243,7 +1243,7 @@ impl GatewayConnection {
                 return Ok(cached.token.clone());
             }
         }
-        let token = self
+        let token = match self
             .auth
             .refresh(
                 &credentials.refresh_token,
@@ -1251,7 +1251,14 @@ impl GatewayConnection {
                 &credentials.installation_id,
                 None,
             )
-            .await?;
+            .await
+        {
+            Ok(token) => token,
+            Err(error) => {
+                self.retire_refused_session(&error).await;
+                return Err(error);
+            }
+        };
         credentials.refresh_token = token.refresh_token.clone();
         credentials.access_tokens.insert(
             resource.to_string(),
@@ -1349,7 +1356,7 @@ impl GatewayConnection {
         resource: &str,
         context: &str,
     ) -> Result<TokenSet> {
-        let token = self
+        let token = match self
             .auth
             .refresh(
                 &credentials.refresh_token,
@@ -1357,10 +1364,35 @@ impl GatewayConnection {
                 &credentials.installation_id,
                 Some(context),
             )
-            .await?;
+            .await
+        {
+            Ok(token) => token,
+            Err(error) => {
+                self.retire_refused_session(&error).await;
+                return Err(error);
+            }
+        };
         credentials.refresh_token = token.refresh_token.clone();
         self.vault.save(credentials).await?;
         Ok(token)
+    }
+
+    /// Retire the stored session after a refresh the gateway refused as
+    /// sign-in-required (`invalid_grant`): that session can never mint
+    /// again — expired, revoked, or caught by refresh-token reuse
+    /// detection — so leaving it stored would keep the status surface
+    /// reporting a signed-in session whose every call fails. Local clear
+    /// only: revoking a refresh token the gateway already refuses buys
+    /// nothing. Best effort, and never masks the refusal itself — an
+    /// unclearable vault degrades to the old behavior, a stored session
+    /// that keeps failing until the user reconnects.
+    async fn retire_refused_session(&self, error: &AgentError) {
+        if !is_sign_in_required(error) {
+            return;
+        }
+        if let Err(clear_error) = self.vault.clear().await {
+            tracing::warn!("could not clear a gateway session refused at refresh: {clear_error}");
+        }
     }
 
     /// Live identity check with a `control` token.

--- a/crates/tidebreak-server/src/gateway_runtime.rs
+++ b/crates/tidebreak-server/src/gateway_runtime.rs
@@ -276,49 +276,11 @@ impl GatewayRuntime {
     /// gateway without the JSON apps surface reports `supported: false`.
     pub(crate) async fn apps(&self) -> Result<GatewayApps> {
         let connection = self.managed_connection().await?;
-        // The member catalog carries per-app readiness the older surface
-        // cannot express; prefer it, and degrade to `/api/v1/cli/apps`
-        // (readiness unknown) against a gateway that predates it. Always an
-        // unconditional fetch: this is the live projection a revoked grant
-        // must fall out of, so a cached revision would be a lie.
-        let apps: Vec<GatewayAppInfo> = match connection.catalog(None).await? {
-            GatewayCatalogFetch::Fresh { catalog, .. } => catalog
-                .apps
-                .into_iter()
-                .map(|app| GatewayAppInfo {
-                    used_by_app_count: 0,
-                    id: app.id,
-                    name: app.name,
-                    app_kind: app.app_kind,
-                    enabled: app.enabled,
-                    mcp_endpoint_slugs: app.mcp_endpoint_slugs,
-                    connection: Some(app.connection),
-                })
-                .collect(),
-            GatewayCatalogFetch::NotModified => {
-                return Err(AgentError::msg(
-                    "gateway answered an unconditional catalog fetch with 304",
-                ));
-            }
-            GatewayCatalogFetch::Unsupported => {
-                let Some(apps) = connection.apps().await? else {
-                    return Ok(GatewayApps {
-                        supported: false,
-                        apps: Vec::new(),
-                    });
-                };
-                apps.into_iter()
-                    .map(|app| GatewayAppInfo {
-                        used_by_app_count: 0,
-                        id: app.id,
-                        name: app.name,
-                        app_kind: app.app_kind,
-                        enabled: app.enabled,
-                        mcp_endpoint_slugs: app.mcp_endpoint_slugs,
-                        connection: None,
-                    })
-                    .collect()
-            }
+        let Some(apps) = Self::entitled_apps(&connection).await? else {
+            return Ok(GatewayApps {
+                supported: false,
+                apps: Vec::new(),
+            });
         };
         // How many local mini-apps currently bind each gateway app: distinct
         // live grants naming the id. The binding grammar forbids a grant
@@ -353,19 +315,63 @@ impl GatewayRuntime {
         })
     }
 
+    /// The entitled connected apps, or `None` when the gateway serves
+    /// neither apps surface.
+    ///
+    /// The member catalog carries per-app readiness the older surface
+    /// cannot express; prefer it, and degrade to `/api/v1/cli/apps`
+    /// (readiness unknown) against a gateway that predates it. Always an
+    /// unconditional fetch: this is the live projection a revoked grant
+    /// must fall out of, so a cached revision would be a lie.
+    async fn entitled_apps(connection: &GatewayConnection) -> Result<Option<Vec<GatewayAppInfo>>> {
+        match connection.catalog(None).await? {
+            GatewayCatalogFetch::Fresh { catalog, .. } => Ok(Some(
+                catalog
+                    .apps
+                    .into_iter()
+                    .map(|app| GatewayAppInfo {
+                        used_by_app_count: 0,
+                        id: app.id,
+                        name: app.name,
+                        app_kind: app.app_kind,
+                        enabled: app.enabled,
+                        mcp_endpoint_slugs: app.mcp_endpoint_slugs,
+                        connection: Some(app.connection),
+                    })
+                    .collect(),
+            )),
+            GatewayCatalogFetch::NotModified => Err(AgentError::msg(
+                "gateway answered an unconditional catalog fetch with 304",
+            )),
+            GatewayCatalogFetch::Unsupported => Ok(connection.apps().await?.map(|apps| {
+                apps.into_iter()
+                    .map(|app| GatewayAppInfo {
+                        used_by_app_count: 0,
+                        id: app.id,
+                        name: app.name,
+                        app_kind: app.app_kind,
+                        enabled: app.enabled,
+                        mcp_endpoint_slugs: app.mcp_endpoint_slugs,
+                        connection: None,
+                    })
+                    .collect()
+            })),
+        }
+    }
+
     /// Mount newly entitled gateway MCP endpoints into the configured server
     /// set — mount-by-default for a managed profile, where the organization
     /// already curated the entitlements.
     ///
-    /// The entitlement source is the same `/api/v1/cli/apps` read the
-    /// settings panel lists, so server and UI cannot disagree about what is
-    /// entitled. Endpoints the user explicitly unmounted are remembered by
-    /// the MCP runtime and never re-mounted here; a repeat reconcile with no
-    /// new entitlements changes nothing. Every state where a reconcile cannot
-    /// run — unmanaged profile, misconfigured policy, no session for the
-    /// policy's deployment, a gateway predating the apps surface — is
-    /// "nothing to do", not an error, so callers may run this on every
-    /// trigger without gating.
+    /// The entitlement source is [`entitled_apps`](Self::entitled_apps) — the
+    /// same read the settings panel lists, so server and UI cannot disagree
+    /// about what is entitled. Endpoints the user explicitly unmounted are
+    /// remembered by the MCP runtime and never re-mounted here; a repeat
+    /// reconcile with no new entitlements changes nothing. Every state where
+    /// a reconcile cannot run — unmanaged profile, misconfigured policy, no
+    /// session for the policy's deployment, a gateway predating the apps
+    /// surface — is "nothing to do", not an error, so callers may run this on
+    /// every trigger without gating.
     pub(crate) async fn reconcile_endpoint_mounts(
         &self,
         mcp: &crate::mcp_config::McpRuntime,
@@ -377,7 +383,7 @@ impl GatewayRuntime {
         if connection.stored_credentials().await?.is_none() {
             return Ok(());
         }
-        let Some(apps) = connection.apps().await? else {
+        let Some(apps) = Self::entitled_apps(&connection).await? else {
             return Ok(());
         };
         let entitled: Vec<String> = apps

--- a/crates/tidebreak-server/tests/connectors_gateway_flow.rs
+++ b/crates/tidebreak-server/tests/connectors_gateway_flow.rs
@@ -20,8 +20,8 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use tidebreak_core::{Result as CoreResult, SecretProvider};
 use tidebreak_server::connectors::{
-    is_sign_in_required, CredentialVault, GatewayAuth, GatewayAuthConfig, GatewayConnection,
-    GatewayInvokeOutcome, RESOURCE_CONTROL, RESOURCE_LLM,
+    is_sign_in_required, CredentialVault, GatewayAuth, GatewayAuthConfig, GatewayCatalogFetch,
+    GatewayConnection, GatewayInvokeOutcome, RESOURCE_CONTROL, RESOURCE_LLM,
 };
 
 const INSTALLATION: &str = "11111111-2222-3333-4444-555555555555";
@@ -65,6 +65,9 @@ struct FakeGateway {
     corrupt_state: AtomicBool,
     /// Serve 404 for `/api/v1/cli/apps`, like a gateway that predates it.
     apps_unsupported: AtomicBool,
+    /// Serve 404 for `/api/v1/me/catalog`, like a gateway that predates the
+    /// member catalog while still serving the per-surface reads.
+    member_catalog_unsupported: AtomicBool,
     /// Serve 404 for the per-app catalog read, like a gateway that predates
     /// it while still listing entitlements.
     catalogs_unsupported: AtomicBool,
@@ -321,6 +324,52 @@ async fn apps(State(gateway): State<Arc<FakeGateway>>, headers: HeaderMap) -> Re
     .into_response()
 }
 
+const CATALOG_ETAG: &str = "\"catalog-rev-1\"";
+
+async fn member_catalog(State(gateway): State<Arc<FakeGateway>>, headers: HeaderMap) -> Response {
+    if gateway.member_catalog_unsupported.load(Ordering::SeqCst) {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    if bearer_resource(&gateway, &headers).as_deref() != Some("control") {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    if headers
+        .get(axum::http::header::IF_NONE_MATCH)
+        .and_then(|value| value.to_str().ok())
+        == Some(CATALOG_ETAG)
+    {
+        return (
+            StatusCode::NOT_MODIFIED,
+            [(axum::http::header::ETAG, CATALOG_ETAG)],
+        )
+            .into_response();
+    }
+    (
+        [(axum::http::header::ETAG, CATALOG_ETAG)],
+        Json(json!({
+            "models": [{
+                "id": "claude-opus-5",
+                "name": "Claude Opus 5",
+                "protocols": ["anthropic_messages", "openai_responses"],
+                "supports_tools": true,
+                "supports_vision": true,
+                "context_window": 200000,
+                "max_output_tokens": 64000,
+                "provider_name": "Anthropic",
+            }],
+            "apps": [{
+                "id": "app-incident",
+                "name": "Incident API",
+                "app_kind": "rest_api",
+                "enabled": true,
+                "mcp_endpoint_slugs": ["example-security-tools"],
+                "connection": "authorization_required",
+            }],
+        })),
+    )
+        .into_response()
+}
+
 async fn app_operations(
     State(gateway): State<Arc<FakeGateway>>,
     axum::extract::Path(app_id): axum::extract::Path<String>,
@@ -400,6 +449,7 @@ async fn serve_fake_gateway(gateway: Arc<FakeGateway>) -> SocketAddr {
         .route("/api/v1/cli/me", get(me))
         .route("/api/v1/cli/models", get(models))
         .route("/api/v1/cli/apps", get(apps))
+        .route("/api/v1/me/catalog", get(member_catalog))
         .route("/api/v1/cli/apps/{app_id}/operations", get(app_operations))
         .route(
             "/api/apps/shared/{shared_app_id}/invoke",
@@ -511,6 +561,15 @@ async fn a_stale_refresh_token_reads_as_signed_out() {
         .await
         .expect_err("superseded refresh token must fail");
     assert!(is_sign_in_required(&error), "{error}");
+
+    // The refusal retires the stored session: the status surface must read
+    // signed-out and offer reconnect, not report a session whose every call
+    // fails.
+    assert!(stale_connection
+        .stored_credentials()
+        .await
+        .unwrap()
+        .is_none());
 }
 
 #[tokio::test]
@@ -681,6 +740,49 @@ async fn apps_lists_entitlements_and_degrades_when_the_surface_is_missing() {
     // error and not an empty entitlement list.
     gateway.apps_unsupported.store(true, Ordering::SeqCst);
     assert_eq!(connection.apps().await.unwrap(), None);
+}
+
+/// The member catalog is the envelope both the settings panel and the MCP
+/// endpoint mounts read entitlements from, so its wire shape — one fetch
+/// carrying models, apps, per-app readiness, and an `ETag` — is a contract.
+/// It has to degrade to `Unsupported` against a gateway that predates it,
+/// which is what sends callers back to the per-surface reads.
+#[tokio::test]
+async fn member_catalog_reads_one_envelope_and_degrades_when_missing() {
+    let (gateway, connection) = signed_in_connection().await;
+
+    let GatewayCatalogFetch::Fresh { catalog, etag } = connection.catalog(None).await.unwrap()
+    else {
+        panic!("expected a fresh catalog");
+    };
+    assert_eq!(catalog.models.len(), 1);
+    assert_eq!(
+        catalog.models[0].protocols,
+        ["anthropic_messages", "openai_responses"]
+    );
+    assert_eq!(catalog.apps.len(), 1);
+    assert_eq!(
+        catalog.apps[0].mcp_endpoint_slugs,
+        ["example-security-tools"]
+    );
+    assert_eq!(catalog.apps[0].connection, "authorization_required");
+
+    // A conditional refetch with the held revision keeps the snapshot.
+    let etag = etag.expect("catalog carried an ETag");
+    assert_eq!(
+        connection.catalog(Some(&etag)).await.unwrap(),
+        GatewayCatalogFetch::NotModified
+    );
+
+    // A gateway predating the route reads as unsupported, not an error —
+    // that answer is what degrades callers to the per-surface reads.
+    gateway
+        .member_catalog_unsupported
+        .store(true, Ordering::SeqCst);
+    assert_eq!(
+        connection.catalog(None).await.unwrap(),
+        GatewayCatalogFetch::Unsupported
+    );
 }
 
 /// The per-app catalog read is what a gateway binding's fingerprint is taken

--- a/docs/gateway-boundary.md
+++ b/docs/gateway-boundary.md
@@ -119,10 +119,11 @@ cached access tokens — lives in the profile's secret store under
   one.** A committed re-pair revokes at the old gateway (bounded, best
   effort) and clears locally; only then is the new session stored.
 - **`invalid_grant` means sign in again, not retry.** Refresh-token reuse
-  detection or revocation surfaces as a reconnect affordance. Known edge:
-  the credential is not auto-cleared on that failure, so the status surface
-  keeps reporting a signed-in session whose calls fail until the user
-  reconnects or disconnects.
+  detection or revocation surfaces as a reconnect affordance, and the
+  refused session is retired on the spot: the stored credential is cleared
+  (locally — revoking a token the gateway already refuses buys nothing), so
+  the status surface reports signed-out rather than a signed-in session
+  whose every call fails.
 
 ## What crosses the wire
 


### PR DESCRIPTION
## Summary

Two fixes to the gateway-attested MCP call path, toward Tidebreak inheriting
gateway-provided MCP endpoints the way the CLI clients do.

- **MCP auto-mounts now read the member catalog.** The catalog-first fetch the
  settings panel's `apps()` already used is extracted into a shared
  `entitled_apps` helper, and `reconcile_endpoint_mounts` goes through it
  instead of its own legacy `/api/v1/cli/apps` read — the mount path and the
  panel can no longer disagree about what is entitled, which is the drift the
  catalog envelope (decision 0014) exists to prevent. Degradation to the
  per-surface reads against an older gateway is unchanged. Mounts deliberately
  do not filter on app `enabled` or connection readiness: the gateway reports
  disabled apps rather than hiding them, and the slug list it serves already
  contains only enabled endpoints.
- **A refresh refused as `invalid_grant` retires the stored session.** Both
  refresh paths (plain and attested) now clear the vaulted credential when the
  gateway refuses the grant — expired, revoked, or caught by reuse detection —
  so the status surface reports signed-out with a reconnect affordance instead
  of a signed-in session whose every call fails. Local clear only (revoking a
  token the gateway already refuses buys nothing), best-effort, and never masks
  the refusal itself. `docs/gateway-boundary.md` drops this from its known
  edges.

## Tests

- The fake gateway now serves `/api/v1/me/catalog`; one new wire-contract test
  covers the fresh envelope (models, apps, per-app readiness), the
  ETag-conditional 304, and 404 degradation to the per-surface reads.
- The stale-refresh-token test additionally asserts the credential is cleared
  after the refusal.

## Validation

- `cargo test -p tidebreak-server --test connectors_gateway_flow --locked`
- `cargo test -p tidebreak-server --lib --locked gateway`
- `cargo test -p tidebreak-server --lib --locked mcp_config`
- `cargo clippy -p tidebreak-server --all-targets --locked`
- `cargo fmt --check -p tidebreak-server`
- Driven end to end against a locally running model gateway (development
  deployment, member catalog v1, seeded MCP endpoints), with headless
  `tidebreak serve` on a scratch profile: PKCE sign-in, catalog-backed
  `/gateway/status` and `/gateway/apps` (per-app readiness populated),
  auto-mount of all entitled endpoints, and an attested `tools/list`
  (`example-engineering-tools` healthy, 1 tool). Revoking the CLI session at
  the gateway and restarting: the first refused refresh logs "the gateway
  session is no longer valid", subsequent connects see "no gateway session is
  stored", `/gateway/status` reports signed-out, and a fresh sign-in restores
  healthy mounts.

Known pre-existing issue observed while verifying (not addressed here): two
seeded per-user Sentry endpoints degrade with "external server advertised a
provider-incompatible tool name" — endpoint-slug-derived tool names can exceed
the provider tool-name contract.