### PR TITLE
fix(chat): make autotitling resilient

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -542,7 +542,7 @@ export function AppShell() {
     chatListActions.setSavingTitle(true);
     try {
       const updated = await client.patchChatTitle(target.id, trimmed || null);
-      chatListActions.replaceChat(updated);
+      chatListActions.replaceChat(updated, true);
       chatListActions.endRename();
     } catch (err) {
       chatListActions.setChatsError(`Could not rename chat: ${String(err)}`);

--- a/crates/tidebreak-desktop/ui/src/ChatListStore.test.ts
+++ b/crates/tidebreak-desktop/ui/src/ChatListStore.test.ts
@@ -19,7 +19,11 @@ function chat(id: string, title: string | null): Chat {
 }
 
 beforeEach(() => {
-  useChatListStore.setState({ chats: [], derivedTitleChatId: null });
+  useChatListStore.setState({
+    chats: [],
+    derivedTitleChatId: null,
+    streamedTitles: {},
+  });
 });
 
 describe("a title the server derived", () => {
@@ -46,16 +50,72 @@ describe("a title the server derived", () => {
     store.setChats([chat("chat-1", "Q3 revenue reconciliation")]);
     store.applyDerivedTitle("chat-1", "Q3 revenue reconciliation");
 
-    expect(useChatListStore.getState().derivedTitleChatId).toBeNull();
+    const state = useChatListStore.getState();
+    expect(state.derivedTitleChatId).toBeNull();
+    expect(state.streamedTitles).toEqual({
+      "chat-1": "Q3 revenue reconciliation",
+    });
   });
 
-  it("is ignored for a chat this window does not have", () => {
+  it("survives arriving before the initial chat list", () => {
     const store = useChatListStore.getState();
-    store.setChats([chat("chat-1", null)]);
-    store.applyDerivedTitle("chat-elsewhere", "Some other conversation");
+    store.applyDerivedTitle("chat-1", "Q3 revenue reconciliation");
+    store.setChats([chat("chat-1", null), chat("chat-2", null)]);
 
     const state = useChatListStore.getState();
-    expect(state.chats).toEqual([chat("chat-1", null)]);
-    expect(state.derivedTitleChatId).toBeNull();
+    expect(state.chats.map((item) => item.title)).toEqual([
+      "Q3 revenue reconciliation",
+      null,
+    ]);
+    expect(state.derivedTitleChatId).toBe("chat-1");
+  });
+
+  it("is not overwritten when an older list request finishes afterward", () => {
+    const store = useChatListStore.getState();
+    store.setChats([chat("chat-1", null)]);
+    store.applyDerivedTitle("chat-1", "Q3 revenue reconciliation");
+    store.setChats([chat("chat-1", null)]);
+
+    expect(useChatListStore.getState().chats[0].title).toBe(
+      "Q3 revenue reconciliation",
+    );
+  });
+
+  it("does not resurrect a derivation over a later authoritative rename", () => {
+    const store = useChatListStore.getState();
+    store.setChats([chat("chat-1", null)]);
+    store.applyDerivedTitle("chat-1", "Q3 revenue reconciliation");
+    store.replaceChat(chat("chat-1", "Ledger work"), true);
+    store.setChats([chat("chat-1", "Ledger work")]);
+
+    const state = useChatListStore.getState();
+    expect(state.chats[0].title).toBe("Ledger work");
+    expect(state.streamedTitles).toEqual({});
+  });
+
+  it("survives an unrelated mutation response that raced the title write", () => {
+    const store = useChatListStore.getState();
+    store.setChats([chat("chat-1", null)]);
+    store.applyDerivedTitle("chat-1", "Q3 revenue reconciliation");
+    store.replaceChat({
+      ...chat("chat-1", null),
+      permission_mode: "allow",
+    });
+
+    expect(useChatListStore.getState().chats[0].title).toBe(
+      "Q3 revenue reconciliation",
+    );
+  });
+
+  it("honors a deliberate manual clear after a derived title", () => {
+    const store = useChatListStore.getState();
+    store.setChats([chat("chat-1", null)]);
+    store.applyDerivedTitle("chat-1", "Q3 revenue reconciliation");
+    store.replaceChat(chat("chat-1", null), true);
+    store.setChats([chat("chat-1", null)]);
+
+    const state = useChatListStore.getState();
+    expect(state.chats[0].title).toBeNull();
+    expect(state.streamedTitles).toEqual({});
   });
 });

--- a/crates/tidebreak-desktop/ui/src/ChatListStore.ts
+++ b/crates/tidebreak-desktop/ui/src/ChatListStore.ts
@@ -36,6 +36,12 @@ export type ChatListStore = {
    * settled name rather than replaying the animation.
    */
   derivedTitleChatId: string | null;
+  /**
+   * Titles learned from the live chat socket but not yet confirmed by a list
+   * read. This closes two renderer races: the notice can beat the initial list,
+   * and an older list request can finish after the notice with a stale null.
+   */
+  streamedTitles: Record<string, string>;
   setChats: (chats: Chat[]) => void;
   /**
    * Record that fetching the list failed. The load is still settled — the
@@ -44,8 +50,12 @@ export type ChatListStore = {
    * list is in hand stays: a failed refresh is no reason to blank it.
    */
   failChatsLoad: (error: string) => void;
-  /** Replace a chat in the list by id. */
-  replaceChat: (chat: Chat) => void;
+  /**
+   * Replace a chat in the list by id. `titleAuthoritative` is for the rename
+   * endpoint: its nullable title is intentional, while unrelated mutation
+   * responses may race an autotitle write and return an older null.
+   */
+  replaceChat: (chat: Chat, titleAuthoritative?: boolean) => void;
   /** Take a title the server derived, and mark it as newly arrived. */
   applyDerivedTitle: (chatId: string, title: string) => void;
   /** Forget the arrival, so the name is just the name from here on. */
@@ -71,12 +81,46 @@ export function createChatListStore() {
     renameChatDraft: "",
     savingTitle: false,
     derivedTitleChatId: null,
-    setChats: (chats) => set({ chats, chatsLoaded: true }),
+    streamedTitles: {},
+    setChats: (chats) =>
+      set((state) => {
+        const streamedTitles = { ...state.streamedTitles };
+        const merged = chats.map((chat) => {
+          const streamed = streamedTitles[chat.id];
+          if (streamed === undefined) return chat;
+          if (chat.title !== null) {
+            // The list has caught up (or carries a later manual rename), so it
+            // is authoritative from here on.
+            delete streamedTitles[chat.id];
+            return chat;
+          }
+          return { ...chat, title: streamed };
+        });
+        return { chats: merged, chatsLoaded: true, streamedTitles };
+      }),
     failChatsLoad: (error) => set({ chatsLoaded: true, chatsError: error }),
-    replaceChat: (chat) =>
-      set((state) => ({
-        chats: state.chats.map((item) => (item.id === chat.id ? chat : item)),
-      })),
+    replaceChat: (chat, titleAuthoritative = false) =>
+      set((state) => {
+        const streamedTitles = { ...state.streamedTitles };
+        const streamed = streamedTitles[chat.id];
+        let replacement = chat;
+        if (chat.title !== null || titleAuthoritative) {
+          // A stored name, manual rename, or deliberate clear supersedes the
+          // background derivation and prevents it resurfacing on a stale list.
+          delete streamedTitles[chat.id];
+        } else if (streamed !== undefined) {
+          // Model, permission, folder, and other metadata mutations can race
+          // the title write and return an older null. Preserve what the socket
+          // already proved was stored.
+          replacement = { ...chat, title: streamed };
+        }
+        return {
+          chats: state.chats.map((item) =>
+            item.id === chat.id ? replacement : item,
+          ),
+          streamedTitles,
+        };
+      }),
     applyDerivedTitle: (chatId, title) =>
       set((state) => {
         const known = state.chats.find((item) => item.id === chatId);
@@ -84,12 +128,20 @@ export function createChatListStore() {
         // current name on every connect — that is what covers a title stored
         // before the renderer was listening — so without this, reconnecting
         // would replay the animation for a name that has been there all along.
-        if (!known || known.title === title) return {};
+        if (known?.title === title) {
+          // A reconnect restatement still proves this durable title is newer
+          // than any in-flight mutation response that may carry an older null.
+          // Keep that protection without replaying the arrival animation.
+          return {
+            streamedTitles: { ...state.streamedTitles, [chatId]: title },
+          };
+        }
         return {
           chats: state.chats.map((item) =>
             item.id === chatId ? { ...item, title } : item,
           ),
           derivedTitleChatId: chatId,
+          streamedTitles: { ...state.streamedTitles, [chatId]: title },
         };
       }),
     clearDerivedTitle: () => set({ derivedTitleChatId: null }),

--- a/crates/tidebreak-server/src/chat_titling.rs
+++ b/crates/tidebreak-server/src/chat_titling.rs
@@ -22,7 +22,7 @@
 //! greeting: the title outlives the exchange that produced it, so declining is
 //! the better answer while there is nothing to name.
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use futures::StreamExt;
@@ -57,6 +57,16 @@ const MAX_TITLE_SOURCE_MESSAGE_BYTES: usize = 2 * 1024;
 /// Generous for a short JSON object, so a model that reasons before answering
 /// still has room to emit the object it was constrained to.
 const TITLE_MAX_OUTPUT_TOKENS: u32 = 512;
+
+/// Total provider calls one background titling run may make.
+///
+/// Titling is cheap, invisible maintenance, and a transient broken stream
+/// should not leave a useful conversation unnamed until the reader happens to
+/// send another message. Three attempts cover the ordinary one-off transport
+/// and provider failures without turning a background convenience into a retry
+/// loop. If all three fail, the chat stays untitled and the next user turn
+/// starts a fresh run.
+const TITLE_ATTEMPTS: usize = 3;
 
 /// Largest completion accepted before the call is abandoned.
 const MAX_TITLE_COMPLETION_BYTES: usize = 4 * 1024;
@@ -120,12 +130,13 @@ pub(crate) struct ChatTitler {
     store: Arc<dyn Store>,
     resolver: Arc<dyn ProviderResolver>,
     events: Arc<EventBus>,
-    /// Conversations with a titling call in flight.
+    /// Conversations with a titling call in flight, and at most one utility
+    /// model queued by a user turn that arrived while that call was running.
     ///
     /// Every turn on an untitled chat would otherwise start another call: a
     /// conversation that stays untitled — because it is still small talk, or
     /// because the calls keep failing — would pay for one on every message.
-    in_flight: Mutex<HashSet<ChatId>>,
+    in_flight: Mutex<HashMap<ChatId, Option<UtilityModel>>>,
 }
 
 impl ChatTitler {
@@ -140,7 +151,7 @@ impl ChatTitler {
             store,
             resolver,
             events,
-            in_flight: Mutex::new(HashSet::new()),
+            in_flight: Mutex::new(HashMap::new()),
         }
     }
 
@@ -150,28 +161,44 @@ impl ChatTitler {
     /// it does not arrive, which is what lets this be called from the front of a
     /// turn rather than bolted onto each of its completion paths.
     pub(crate) fn spawn(self: &Arc<Self>, chat_id: ChatId, utility: UtilityModel) {
-        let Some(claim) = TitlingClaim::acquire(self, chat_id) else {
+        let Some((mut claim, mut utility)) = TitlingClaim::acquire(self, chat_id, utility) else {
             return;
         };
         let titler = self.clone();
         tokio::spawn(async move {
             // Held for the duration, released on drop, so a call that returns
             // early — or panics — does not lock the chat out of a later attempt.
-            let _claim = claim;
-            // Logged either way. The work is invisible by design — no event, no
-            // turn outcome — so without a line here the only way to tell a
-            // declined title from a broken one is to read the database.
-            match titler.derive_title(chat_id, &utility).await {
-                Ok(Some(title)) => {
-                    eprintln!(
-                        "tidebreak: titled chat {chat_id} on {}: {title}",
-                        utility.model
-                    )
+            loop {
+                // Logged either way. The work is invisible by design — no
+                // event, no turn outcome — so without a line here the only way
+                // to tell a declined title from a broken one is to read the
+                // database.
+                let should_run_pending = match titler.derive_title(chat_id, &utility).await {
+                    Ok(Some(title)) => {
+                        eprintln!(
+                            "tidebreak: titled chat {chat_id} on {}: {title}",
+                            utility.model
+                        );
+                        false
+                    }
+                    Ok(None) => {
+                        eprintln!("tidebreak: left chat {chat_id} untitled");
+                        true
+                    }
+                    Err(error) => {
+                        eprintln!(
+                            "tidebreak: could not derive a title for chat {chat_id}: {error}"
+                        );
+                        true
+                    }
+                };
+                if !should_run_pending {
+                    break;
                 }
-                Ok(None) => eprintln!("tidebreak: left chat {chat_id} untitled"),
-                Err(error) => {
-                    eprintln!("tidebreak: could not derive a title for chat {chat_id}: {error}")
-                }
+                let Some(next_utility) = claim.take_pending_or_release() else {
+                    break;
+                };
+                utility = next_utility;
             }
         });
     }
@@ -199,13 +226,35 @@ impl ChatTitler {
             return Ok(None);
         };
         let provider = self.resolver.resolve().await;
-        let Some(proposed) = request_title(provider.as_ref(), utility, &material).await? else {
-            return Ok(None);
+        let mut attempt = 1;
+        let title = loop {
+            match request_title(provider.as_ref(), utility, &material).await {
+                Ok(None) => break None,
+                Ok(Some(proposed)) => match normalize_derived_title(&proposed) {
+                    Some(title) => break Some(title),
+                    None if attempt < TITLE_ATTEMPTS => {
+                        eprintln!(
+                            "tidebreak: titling attempt {attempt}/{TITLE_ATTEMPTS} returned an unusable title for chat {chat_id}: {proposed:?}"
+                        );
+                        attempt += 1;
+                    }
+                    None => {
+                        return Err(AgentError::msg(format!(
+                            "titling model returned an unusable title: {proposed:?}"
+                        )))
+                    }
+                },
+                Err(error) if attempt < TITLE_ATTEMPTS => {
+                    eprintln!(
+                        "tidebreak: titling attempt {attempt}/{TITLE_ATTEMPTS} failed for chat {chat_id}: {error}"
+                    );
+                    attempt += 1;
+                }
+                Err(error) => return Err(error),
+            }
         };
-        let Some(title) = normalize_derived_title(&proposed) else {
-            return Err(AgentError::msg(format!(
-                "titling model returned an unusable title: {proposed:?}"
-            )));
+        let Some(title) = title else {
+            return Ok(None);
         };
         if !self.store.set_chat_title_if_unset(chat_id, &title).await? {
             return Ok(None);
@@ -226,25 +275,62 @@ impl ChatTitler {
 struct TitlingClaim {
     titler: Arc<ChatTitler>,
     chat_id: ChatId,
+    released: bool,
 }
 
 impl TitlingClaim {
-    /// Claim `chat_id`, or `None` when a titling call already holds it.
-    fn acquire(titler: &Arc<ChatTitler>, chat_id: ChatId) -> Option<Self> {
-        titler
+    /// Claim `chat_id`, or coalesce this trigger behind its running call.
+    fn acquire(
+        titler: &Arc<ChatTitler>,
+        chat_id: ChatId,
+        utility: UtilityModel,
+    ) -> Option<(Self, UtilityModel)> {
+        let mut in_flight = titler
             .in_flight
             .lock()
-            .expect("titling claims are never held across a panic")
-            .insert(chat_id)
-            .then(|| Self {
-                titler: titler.clone(),
-                chat_id,
-            })
+            .expect("titling claims are never held across a panic");
+        match in_flight.entry(chat_id) {
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(None);
+                Some((
+                    Self {
+                        titler: titler.clone(),
+                        chat_id,
+                        released: false,
+                    },
+                    utility,
+                ))
+            }
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                entry.insert(Some(utility));
+                None
+            }
+        }
+    }
+
+    /// Take the one trigger that arrived while this call ran. With none queued,
+    /// release atomically so a concurrent next turn either queues here or starts
+    /// a fresh task; there is no gap in which its trigger can be lost.
+    fn take_pending_or_release(&mut self) -> Option<UtilityModel> {
+        let mut in_flight = self
+            .titler
+            .in_flight
+            .lock()
+            .expect("titling claims are never held across a panic");
+        let pending = in_flight.get_mut(&self.chat_id).and_then(Option::take);
+        if pending.is_none() {
+            in_flight.remove(&self.chat_id);
+            self.released = true;
+        }
+        pending
     }
 }
 
 impl Drop for TitlingClaim {
     fn drop(&mut self) {
+        if self.released {
+            return;
+        }
         if let Ok(mut in_flight) = self.titler.in_flight.lock() {
             in_flight.remove(&self.chat_id);
         }

--- a/crates/tidebreak-server/src/routes/events.rs
+++ b/crates/tidebreak-server/src/routes/events.rs
@@ -45,23 +45,17 @@ pub async fn chat_events(
     headers: axum::http::HeaderMap,
     upgrade: WebSocketUpgrade,
 ) -> Result<Response, ServerError> {
-    let chat = store.require_chat(id).await?;
+    store.require_chat(id).await?;
     let upgrade = if offered_handshake_subprotocol(&headers) {
         upgrade.protocols([WS_HANDSHAKE_SUBPROTOCOL])
     } else {
         upgrade
     };
-    Ok(upgrade.on_upgrade(move |socket| stream_events(socket, state, id, query.after, chat.title)))
+    Ok(upgrade.on_upgrade(move |socket| stream_events(socket, state, id, query.after)))
 }
 
 /// Serve one client's event stream for `chat`: replay from the journal, then live.
-async fn stream_events(
-    mut socket: WebSocket,
-    state: AppState,
-    chat: ChatId,
-    after: i64,
-    title: Option<String>,
-) {
+async fn stream_events(mut socket: WebSocket, state: AppState, chat: ChatId, after: i64) {
     // Subscribe before replaying, so an event emitted during replay is buffered on
     // the live channel rather than lost in the gap between the two.
     let mut live = state.events.subscribe(chat);
@@ -69,11 +63,20 @@ async fn stream_events(
     // and nothing replays it.
     let mut metadata = state.events.subscribe_metadata(chat);
 
-    // The name is state rather than an event, so the socket opens by stating it
-    // and every reconnect restates it. Nothing retains a notice for a client that
-    // was not listening yet, and the common case is exactly that: a new chat's
-    // first turn can name it before the renderer finishes connecting. A client
-    // that already knows this name does nothing with it.
+    // Subscribe before reading the durable name. If titling commits between the
+    // route's existence check and this read, the read sees it; if it commits
+    // after the read, the subscribed metadata channel sees its notice. The two
+    // may both deliver the same title, which clients deliberately deduplicate,
+    // but there is no ordering in which both miss it.
+    //
+    // The name is state rather than an event, so every reconnect restates it.
+    // Nothing retains a notice for a client that was not listening yet, and the
+    // common case is exactly that: a new chat's first turn can name it before
+    // the renderer finishes connecting.
+    let title = match state.store.get_chat(chat).await {
+        Ok(Some(chat)) => chat.title,
+        Ok(None) | Err(_) => return,
+    };
     if let Some(title) = title {
         if send_frame(
             &mut socket,

--- a/crates/tidebreak-server/src/tests/chat_titling.rs
+++ b/crates/tidebreak-server/src/tests/chat_titling.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use std::collections::VecDeque;
+
 use tidebreak_core::UtilityModel;
 
 use crate::chat_titling::ChatTitler;
@@ -21,7 +23,11 @@ const CHAT_MODEL: &str = "gpt-5.6-sol";
 /// credentialed provider and differ only in what they ask for.
 struct TitlingStub {
     requests: Mutex<Vec<serde_json::Value>>,
-    title_answer: String,
+    title_answers: Mutex<VecDeque<String>>,
+    fallback_title_answer: String,
+    pause_next_title: AtomicBool,
+    title_entered: Notify,
+    release_title: Notify,
 }
 
 impl TitlingStub {
@@ -41,8 +47,17 @@ async fn answer_as_stub(
     axum::extract::State(stub): axum::extract::State<Arc<TitlingStub>>,
     axum::Json(request): axum::Json<serde_json::Value>,
 ) -> impl axum::response::IntoResponse {
-    let text = if request.get("text").is_some() {
-        stub.title_answer.clone()
+    let is_title = request.get("text").is_some();
+    if is_title && stub.pause_next_title.swap(false, Ordering::SeqCst) {
+        stub.title_entered.notify_one();
+        stub.release_title.notified().await;
+    }
+    let text = if is_title {
+        stub.title_answers
+            .lock()
+            .unwrap()
+            .pop_front()
+            .unwrap_or_else(|| stub.fallback_title_answer.clone())
     } else {
         ASSISTANT_ANSWER.to_owned()
     };
@@ -73,9 +88,37 @@ async fn titling_app(
     Arc<TitlingStub>,
     tempfile::TempDir,
 ) {
+    titling_app_with_answers(&[title_answer]).await
+}
+
+/// The same app with a sequence of constrained answers, followed by the last
+/// answer forever. This makes transient failures observable without changing
+/// how the conversation's own turn is answered.
+async fn titling_app_with_answers(
+    title_answers: &[&str],
+) -> (
+    Router,
+    String,
+    Arc<dyn Store>,
+    Arc<TitlingStub>,
+    tempfile::TempDir,
+) {
+    let fallback_title_answer = title_answers
+        .last()
+        .expect("a titling stub needs at least one answer")
+        .to_string();
     let stub = Arc::new(TitlingStub {
         requests: Mutex::new(Vec::new()),
-        title_answer: title_answer.to_owned(),
+        title_answers: Mutex::new(
+            title_answers
+                .iter()
+                .map(|answer| answer.to_string())
+                .collect(),
+        ),
+        fallback_title_answer,
+        pause_next_title: AtomicBool::new(false),
+        title_entered: Notify::new(),
+        release_title: Notify::new(),
     });
     let endpoint = axum::Router::new()
         .route("/v1/responses", axum::routing::post(answer_as_stub))
@@ -235,6 +278,87 @@ async fn a_conversation_with_nothing_to_name_stays_untitled() {
         store.get_chat(chat.id).await.unwrap().unwrap().title,
         None,
         "declining is a valid answer, and it leaves the chat named by nobody",
+    );
+}
+
+/// A broken provider stream is background-maintenance noise, not a reason to
+/// leave a real conversation unnamed when the next call would have worked.
+#[tokio::test(flavor = "multi_thread")]
+async fn titling_retries_transient_failures_before_giving_up() {
+    let (router, bearer, store, stub, _dir) = titling_app_with_answers(&[
+        "not json",
+        r#"{"wrong":"shape"}"#,
+        r#"{"title":"Q3 revenue reconciliation"}"#,
+    ])
+    .await;
+    let chat = make_chat(&router, &bearer).await;
+
+    send_message(&router, &bearer, chat.id, "Reconcile Q3 revenue for me").await;
+
+    assert_eq!(
+        wait_for_title(&store, chat.id).await.as_deref(),
+        Some("Q3 revenue reconciliation"),
+    );
+    assert_eq!(
+        wait_for_titling_requests(&stub, 3).await.len(),
+        3,
+        "one background run gets the initial call plus two retries",
+    );
+}
+
+/// Exhausting one run must release the in-flight claim. The next accepted user
+/// message reaches the same front-of-turn hook and starts a fresh set of tries.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_untitled_chat_tries_again_on_the_next_user_message() {
+    let (router, bearer, store, stub, _dir) = titling_app("not json").await;
+    let chat = make_chat(&router, &bearer).await;
+
+    send_message(&router, &bearer, chat.id, "Reconcile Q3 revenue for me").await;
+    wait_for_turn(&store, chat.id).await;
+    assert_eq!(wait_for_titling_requests(&stub, 3).await.len(), 3);
+    assert_eq!(store.get_chat(chat.id).await.unwrap().unwrap().title, None);
+
+    send_message(&router, &bearer, chat.id, "Use the ledger export too").await;
+    assert_eq!(
+        wait_for_titling_requests(&stub, 6).await.len(),
+        6,
+        "the next user submission starts another three-attempt run",
+    );
+    assert_eq!(store.get_chat(chat.id).await.unwrap().unwrap().title, None);
+}
+
+/// The next turn may start after the foreground answer finishes but before the
+/// background titler does. Its trigger must queue behind the in-flight run,
+/// rather than disappearing because the per-chat claim was already held.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_next_message_queued_while_titling_runs_gets_its_own_attempt() {
+    let (router, bearer, store, stub, _dir) = titling_app_with_answers(&[
+        "not json",
+        "not json",
+        "not json",
+        r#"{"title":"Q3 revenue reconciliation"}"#,
+    ])
+    .await;
+    let chat = make_chat(&router, &bearer).await;
+    stub.pause_next_title.store(true, Ordering::SeqCst);
+
+    send_message(&router, &bearer, chat.id, "Reconcile Q3 revenue for me").await;
+    tokio::time::timeout(Duration::from_secs(5), stub.title_entered.notified())
+        .await
+        .expect("the first titling request did not start");
+    wait_for_turn(&store, chat.id).await;
+
+    send_message(&router, &bearer, chat.id, "Use the ledger export too").await;
+    stub.release_title.notify_one();
+
+    assert_eq!(
+        wait_for_title(&store, chat.id).await.as_deref(),
+        Some("Q3 revenue reconciliation"),
+    );
+    assert_eq!(
+        wait_for_titling_requests(&stub, 4).await.len(),
+        4,
+        "the queued user turn runs after the first three-attempt batch fails",
     );
 }
 


### PR DESCRIPTION
## What changed

- retry background chat titling up to three times when provider streams fail, return malformed JSON, or produce unusable titles
- queue one follow-up titling run when another user submission arrives while a title call is still in flight
- leave exhausted chats untitled so the next accepted user message starts another run
- close the WebSocket snapshot/live race by subscribing before rereading the durable title
- preserve streamed titles through initial-list, stale-refresh, and unrelated chat-mutation races in the desktop UI
- keep manual renames and deliberate title clears authoritative

## Why

Autotitling previously depended on one provider call and could lose a next-message trigger while that call was still running. The socket also captured the chat title before upgrade, leaving a narrow ordering where a durable title was neither in the captured snapshot nor delivered as a live notice. On the renderer side, initial or stale list reads and unrelated mutation responses could overwrite a title that had already arrived over the socket.

The result was a chat that could remain “New chat” after a transient failure, or briefly or permanently lose the streamed title until a later reload.

## User impact

Chat names now recover from ordinary transient provider failures, retry again on subsequent user submissions, and reliably appear in the open desktop UI without being overwritten by stale data.

## Validation

- `cargo test -p tidebreak-server chat_titling --locked` — 9 passed
- `pnpm test` — 960 passed
- `pnpm build`
- `pnpm exec vitest run src/ChatListStore.test.ts src/ChatSessionController.test.ts` — 18 passed
- `pnpm exec tsc --noEmit`
- `cargo fmt --all`
- `git diff --check`
