### PR TITLE
feat(ui): warn when model changes may break cache reuse

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ComposerToolsMenu.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ComposerToolsMenu.dom.test.tsx
@@ -1,11 +1,17 @@
 // @vitest-environment jsdom
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
 import { afterEach, expect, it, vi } from "vitest";
 
 import { ComposerToolsMenu } from "./ComposerToolsMenu";
 
-afterEach(cleanup);
+vi.mock("sonner", () => ({ toast: { warning: vi.fn() } }));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
 
 const LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
 
@@ -60,6 +66,28 @@ it("still names an effort level the current model no longer accepts", async () =
   expect(screen.getByRole("menuitem", { name: /Reasoning/ })).toHaveTextContent(
     "Max",
   );
+});
+
+it("warns that changing reasoning effort may prevent cache reuse", async () => {
+  const onChange = vi.fn();
+  render(
+    <ComposerToolsMenu
+      disabled={false}
+      reasoning={{ levels: LEVELS, value: "high", onChange }}
+    />,
+  );
+
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: "Tools" }));
+  const reasoning = screen.getByRole("menuitem", { name: /Reasoning/ });
+  reasoning.focus();
+  await user.keyboard("{ArrowRight}{ArrowDown}{Enter}");
+
+  expect(onChange).toHaveBeenCalledWith("low");
+  expect(toast.warning).toHaveBeenCalledWith("Prompt cache may not be reused", {
+    description:
+      "This change may prevent prompt cache reuse, increasing cost and latency on the next turn.",
+  });
 });
 
 it("opens the network policy in a dialog the menu does not clip", async () => {

--- a/crates/tidebreak-desktop/ui/src/ModelMenu.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ModelMenu.dom.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
+import { afterEach, expect, it, vi } from "vitest";
+
+import { ModelMenu } from "./ModelMenu";
+import type { ModelInfo } from "./api";
+
+vi.mock("sonner", () => ({ toast: { warning: vi.fn() } }));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const MODELS: ModelInfo[] = [
+  {
+    key: "anthropic::claude-sonnet-4",
+    id: "claude-sonnet-4",
+    display_name: "Claude Sonnet 4",
+    provider: "anthropic",
+    vendor: null,
+    verification: "verified",
+    context_window: 200_000,
+    max_output_tokens: 64_000,
+    input_modalities: ["text"],
+    supports_reasoning: true,
+    supports_tools: true,
+    supports_structured_output: true,
+    reasoning_efforts: ["low", "high"],
+    multimodal: false,
+    available: true,
+    recommended: true,
+  },
+  {
+    key: "anthropic::claude-haiku-4",
+    id: "claude-haiku-4",
+    display_name: "Claude Haiku 4",
+    provider: "anthropic",
+    vendor: null,
+    verification: "verified",
+    context_window: 200_000,
+    max_output_tokens: 64_000,
+    input_modalities: ["text"],
+    supports_reasoning: true,
+    supports_tools: true,
+    supports_structured_output: true,
+    reasoning_efforts: ["low", "high"],
+    multimodal: false,
+    available: true,
+    recommended: false,
+  },
+  {
+    key: "openai::gpt-5",
+    id: "gpt-5",
+    display_name: "GPT-5",
+    provider: "openai",
+    vendor: null,
+    verification: "verified",
+    context_window: 128_000,
+    max_output_tokens: 16_384,
+    input_modalities: ["text"],
+    supports_reasoning: true,
+    supports_tools: true,
+    supports_structured_output: true,
+    reasoning_efforts: ["low", "high"],
+    multimodal: false,
+    available: true,
+    recommended: false,
+  },
+];
+
+it("warns only when a model choice switches providers", async () => {
+  const onChange = vi.fn();
+  render(
+    <ModelMenu
+      models={MODELS}
+      value="anthropic::claude-sonnet-4"
+      onSetUpProvider={() => {}}
+      onChange={onChange}
+    />,
+  );
+
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: "Model: Claude Sonnet 4" }));
+  await user.click(screen.getByRole("menuitem", { name: "Claude Haiku 4" }));
+  expect(toast.warning).not.toHaveBeenCalled();
+
+  await user.click(screen.getByRole("button", { name: "Model: Claude Sonnet 4" }));
+  await user.click(screen.getByRole("tab", { name: "OpenAI" }));
+  await user.click(screen.getByRole("menuitem", { name: "GPT-5" }));
+
+  expect(onChange).toHaveBeenLastCalledWith("openai::gpt-5");
+  expect(toast.warning).toHaveBeenCalledWith("Prompt cache may not be reused", {
+    description:
+      "This change may prevent prompt cache reuse, increasing cost and latency on the next turn.",
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/ModelMenu.tsx
+++ b/crates/tidebreak-desktop/ui/src/ModelMenu.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
+import { toast } from "sonner";
 import {
   Atom,
   Check,
@@ -33,6 +34,15 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { WithTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+
+const CACHE_CHANGE_WARNING =
+  "This change may prevent prompt cache reuse, increasing cost and latency on the next turn.";
+
+function warnAboutPromptCacheChange() {
+  toast.warning("Prompt cache may not be reused", {
+    description: CACHE_CHANGE_WARNING,
+  });
+}
 
 /**
  * The order the vendors are listed in, ahead of any the catalog carries that
@@ -473,6 +483,9 @@ export function ModelMenu({
                     // dropped click.
                     onSelect={() => {
                       if (selected || !model.available) return;
+                      if (pillModel && pillModel.provider !== model.provider) {
+                        warnAboutPromptCacheChange();
+                      }
                       void onChange(model.key);
                     }}
                     className="flex items-center gap-2"
@@ -578,6 +591,7 @@ export function ReasoningEffortSubMenu({
           disabled={disabled}
           onSelect={() => {
             if (isDefault) return;
+            warnAboutPromptCacheChange();
             void onChange(null);
           }}
           className="flex items-center gap-2"
@@ -594,6 +608,7 @@ export function ReasoningEffortSubMenu({
               disabled={disabled}
               onSelect={() => {
                 if (selected) return;
+                warnAboutPromptCacheChange();
                 void onChange(option.value);
               }}
               className="flex items-center gap-2"


### PR DESCRIPTION
## Summary

- warn when a model selection switches to a different provider
- warn whenever the reasoning effort changes, including returning to the provider default
- avoid warning for model changes that stay on the same provider or reselect the current value

## Why

Changing providers or reasoning effort can prevent prompt cache reuse. The next turn may therefore cost more and take longer, so the composer now makes that consequence visible at the moment the setting changes.

## Validation

- `pnpm exec vitest run src/ModelMenu.dom.test.tsx src/ComposerToolsMenu.dom.test.tsx src/ModelMenu.test.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `git diff --check`