### PR TITLE
fix(desktop): submit an approval when its choice is clicked

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ApprovalCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/ApprovalCard.tsx
@@ -48,9 +48,11 @@ type ApprovalCardProps = {
  * being decided; the longer sentence about what the action can reach explains
  * rather than asks, so it sits underneath. Below that, the exact action.
  *
- * The choices are selectable buttons followed by an explicit Submit action,
- * ordered narrowest grant first with the decline last. Exploring or selecting
- * a choice never executes the tool or persists a grant by itself.
+ * The choices are action buttons, ordered narrowest grant first with the
+ * decline last. Clicking a choice decides it. Keyboard arrows and number keys
+ * only move the highlight, so browsing the list does not execute the tool or
+ * persist a grant; Enter or Submit confirms the highlighted row. "More options"
+ * expands the hidden rungs without deciding.
  */
 export function ApprovalCard({
   callId,
@@ -113,6 +115,7 @@ export function ApprovalCard({
       return;
     }
     setHighlight(index);
+    onDecide(callId, option.decision, option.grant);
   };
 
   const submitSelected = () => {
@@ -217,7 +220,7 @@ export function ApprovalCard({
       )}
       <div className="flex items-center justify-between gap-2 text-xs">
         <span className="text-muted-foreground">
-          ↑↓ choose · 1–{Math.min(options.length, 9)} jump · Submit confirms
+          ↑↓ choose · 1–{Math.min(options.length, 9)} jump · click or Submit confirms
         </span>
         <Button
           size="sm"

--- a/crates/tidebreak-desktop/ui/src/ChatView.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatView.dom.test.tsx
@@ -293,8 +293,6 @@ describe("ChatView", () => {
       screen.getByRole("group", { name: "Approval choices" }),
     ).getAllByRole("button");
     await userEvent.click(choices[0]!);
-    expect(client.decideApproval).not.toHaveBeenCalled();
-    await userEvent.click(screen.getByRole("button", { name: "Submit" }));
 
     await waitFor(() =>
       expect(client.decideApproval).toHaveBeenCalledWith(

--- a/crates/tidebreak-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/MessageList.dom.test.tsx
@@ -68,7 +68,7 @@ afterEach(() => {
 });
 
 describe("approval card interactions", () => {
-  it("submits only the selected decision with the grant it names", async () => {
+  it("submits the decision named by the row that was clicked", async () => {
     const user = userEvent.setup();
     const onDecide = vi.fn();
     render(card({ onDecide }));
@@ -81,18 +81,12 @@ describe("approval card interactions", () => {
     ]);
 
     await user.click(options[0]!);
-    expect(onDecide).not.toHaveBeenCalled();
-    await user.click(screen.getByRole("button", { name: "Submit" }));
     expect(onDecide).toHaveBeenLastCalledWith("call-1", "approve", null);
 
     await user.click(options[1]!);
-    expect(onDecide).toHaveBeenCalledTimes(1);
-    await user.click(screen.getByRole("button", { name: "Submit" }));
     expect(onDecide).toHaveBeenLastCalledWith("call-1", "approve", "whole_tool");
 
     await user.click(options[2]!);
-    expect(onDecide).toHaveBeenCalledTimes(2);
-    await user.click(screen.getByRole("button", { name: "Submit" }));
     expect(onDecide).toHaveBeenLastCalledWith("call-1", "reject", null);
   });
 
@@ -121,18 +115,18 @@ describe("approval card interactions", () => {
     composer.remove();
   });
 
-  it("selects from the keyboard and waits for explicit submit", async () => {
+  it("selects from the keyboard; Enter or Submit confirms the highlight", async () => {
     const user = userEvent.setup();
     const onDecide = vi.fn();
     render(card({ onDecide }));
 
-    await user.keyboard("{ArrowDown}{Enter}");
+    await user.keyboard("{ArrowDown}");
     expect(onDecide).not.toHaveBeenCalled();
-    await user.click(screen.getByRole("button", { name: "Submit" }));
+    await user.keyboard("{Enter}");
     expect(onDecide).toHaveBeenLastCalledWith("call-1", "approve", "whole_tool");
 
     approvalChoices()[1]?.focus();
-    await user.keyboard("3{Enter}");
+    await user.keyboard("3");
     expect(onDecide).toHaveBeenCalledTimes(1);
     await user.click(screen.getByRole("button", { name: "Submit" }));
     expect(onDecide).toHaveBeenLastCalledWith("call-1", "reject", null);
@@ -144,8 +138,6 @@ describe("approval card interactions", () => {
     render(card({ onDecide }));
 
     await user.keyboard("{ArrowUp}{Enter}");
-    expect(onDecide).not.toHaveBeenCalled();
-    await user.click(screen.getByRole("button", { name: "Submit" }));
     expect(onDecide).toHaveBeenLastCalledWith("call-1", "reject", null);
   });
 
@@ -172,7 +164,6 @@ describe("approval card interactions", () => {
       "Could not send your decision",
     );
     await user.click(approvalChoices()[0]!);
-    await user.click(screen.getByRole("button", { name: "Submit" }));
     expect(onDecide).toHaveBeenCalledWith("call-1", "approve", null);
   });
 
@@ -329,9 +320,8 @@ describe("approval card interactions", () => {
       "aria-pressed",
       "true",
     );
-    await user.keyboard("{Enter}");
     expect(onDecide).not.toHaveBeenCalled();
-    await user.click(screen.getByRole("button", { name: "Submit" }));
+    await user.keyboard("{Enter}");
     expect(onDecide).toHaveBeenCalledWith("call-1", "approve", null);
   });
 
@@ -368,8 +358,6 @@ describe("approval card interactions", () => {
     expect(screen.getByText(/# limited to sec.gov/)).toBeInTheDocument();
 
     await user.click(approvalChoices()[1]!);
-    expect(onDecide).not.toHaveBeenCalled();
-    await user.click(screen.getByRole("button", { name: "Submit" }));
     expect(onDecide).toHaveBeenLastCalledWith(
       "call-1",
       "approve",


### PR DESCRIPTION
## Summary

Clicking **Yes, allow it once** / **No, don't allow this** on a tool-approval card did nothing until you also hit **Submit**. That two-step felt broken: the rows look like actions, not a radio list.

A click on a choice now submits that decision. Arrow keys and number jumps still only move the highlight so you can browse without committing; Enter or Submit still confirm the highlighted row. **More options** still expands without deciding.

## Test plan

- [x] `pnpm test src/MessageList.dom.test.tsx` in `crates/tidebreak-desktop/ui`
- [ ] Click **Yes, allow it once** on a write/exec approval and confirm the tool proceeds without Submit
- [ ] Click **No, don't allow this** and confirm the call is declined
- [ ] Arrow to a wider grant and confirm Enter / Submit still commits only that highlight