### PR TITLE
feat(ui): simplify active-turn message actions

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ChatView.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatView.dom.test.tsx
@@ -363,7 +363,7 @@ describe("ChatView", () => {
     const message = screen.getByLabelText("Message");
     await userEvent.type(message, "go left");
     await userEvent.click(
-      screen.getByRole("button", { name: "Redirect active response" }),
+      screen.getByRole("button", { name: "Steer active response" }),
     );
 
     // Accepting guidance empties the composer. That clearing must not read as
@@ -390,7 +390,7 @@ describe("ChatView", () => {
     const message = screen.getByLabelText("Message");
     await userEvent.type(message, "go left");
     await userEvent.click(
-      screen.getByRole("button", { name: "Redirect active response" }),
+      screen.getByRole("button", { name: "Steer active response" }),
     );
     expect(await screen.findByText(/steer rejected/)).toBeInTheDocument();
 

--- a/crates/tidebreak-desktop/ui/src/ChatView.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatView.tsx
@@ -705,7 +705,12 @@ export function ChatView({
           />
         ) : (
           <>
-            <QueueTray client={client} chatId={chat.id} active={activeTurnId !== null} />
+            <QueueTray
+              client={client}
+              chatId={chat.id}
+              active={activeTurnId !== null}
+              onStop={turnControls.cancel}
+            />
             <Composer
             activeTurnId={activeTurnId}
             busy={busy}

--- a/crates/tidebreak-desktop/ui/src/Composer.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/Composer.test.tsx
@@ -210,13 +210,42 @@ describe("Composer", () => {
       />,
     );
 
-    expect(markup).toContain("Redirect");
+    expect(markup).toContain("Steer");
     expect(markup).toContain('aria-label="Stop response"');
-    expect(markup).toContain('aria-label="Redirect active response"');
+    expect(markup).toContain('aria-label="Steer active response"');
     expect(markup).toContain('aria-label="Stop response"');
     expect(markup).toContain('aria-label="Message"');
     expect(markup).not.toContain('<textarea disabled=""');
     expect(markup).toContain('role="status"');
+  });
+
+  it("shows only the configured Queue action when queueing is available", () => {
+    const markup = renderToStaticMarkup(
+      <Composer
+        activeTurnId="turn-1"
+        busy
+        cancelError={null}
+        cancelPending={false}
+        disabled={false}
+        draft="A later draft"
+        onDraftChange={vi.fn()}
+        onSend={noop}
+        onSteer={noop}
+        onQueue={noop}
+        onStop={noop}
+        resetKey="chat-1"
+        steerError={null}
+        steerPending={false}
+        steerStatus={null}
+      />,
+    );
+
+    expect(markup).toContain(">Queue<");
+    expect(markup).toContain(
+      'aria-label="Queue message for after this response"',
+    );
+    expect(markup).not.toContain('aria-label="Switch send mode"');
+    expect(markup).not.toContain('aria-label="Steer active response"');
   });
 
   it("keeps Stop available for an active turn until the user types", () => {
@@ -267,12 +296,12 @@ describe("Composer", () => {
 
     expect(markup).toContain(">Sending…<");
     expect(markup).toContain('aria-label="Stop response"');
-    expect(markup).toContain('aria-label="Redirect active response"');
+    expect(markup).toContain('aria-label="Steer active response"');
     expect(markup).not.toContain('<textarea disabled=""');
     expect(markup).toContain("Sending guidance…");
   });
 
-  it("keeps Stop available but fences Redirect while cancellation is pending", () => {
+  it("keeps Stop available but fences Steer while cancellation is pending", () => {
     const markup = renderToStaticMarkup(
       <Composer
         activeTurnId="turn-1"
@@ -292,7 +321,7 @@ describe("Composer", () => {
       />,
     );
 
-    expect(markup).toContain(">Redirect<");
+    expect(markup).toContain(">Steer<");
     expect(markup).toContain('aria-label="Stopping response"');
     expect(markup.match(/disabled=""/g)).toHaveLength(2);
   });
@@ -318,7 +347,7 @@ describe("Composer", () => {
     );
 
     expect(markup).toContain("Guidance contains an unsupported character.");
-    expect(markup).toContain('aria-label="Redirect active response"');
+    expect(markup).toContain('aria-label="Steer active response"');
     expect(markup.match(/disabled=""/g)).toHaveLength(1);
   });
 

--- a/crates/tidebreak-desktop/ui/src/Composer.tsx
+++ b/crates/tidebreak-desktop/ui/src/Composer.tsx
@@ -16,8 +16,6 @@ import {
   Square,
   Wand2,
   X,
-  CornerUpRight,
-  ListPlus,
 } from "lucide-react";
 import { MAX_STEER_CHARACTERS } from "./ActiveTurnSteer";
 import { ContextUsageIndicator } from "./ContextUsageIndicator";
@@ -78,6 +76,7 @@ import { DocumentIcon } from "@/components/document-table/DocumentIcon";
 import type { ImportedDocument } from "@/documents";
 import type { PluginInfo } from "./api";
 import { folderAccessLabel, folderReach } from "./FolderAccess";
+import { useUiStore } from "./UiStore";
 import type { ConnectedFolder } from "./host";
 import type { TranscriptFileAttachment } from "./TranscriptFileAttachments";
 import type { ChatFolderAccess } from "./useChatFolderAttachments";
@@ -306,17 +305,6 @@ export type ComposerProps = {
   steerStatus: string | null;
 };
 
-/** The mid-turn Enter behavior, remembered per install. */
-const SEND_MODE_KEY = "tidebreak.composer.sendMode";
-
-function storedSendMode(): "queue" | "steer" {
-  try {
-    return window.localStorage.getItem(SEND_MODE_KEY) === "steer" ? "steer" : "queue";
-  } catch {
-    return "queue";
-  }
-}
-
 export function Composer({
   activeTurnId,
   busy,
@@ -384,16 +372,8 @@ export function Composer({
   const { confirm, dialog: confirmDialog } = useConfirm();
   const inputDisabled = disabled;
   const active = busy && activeTurnId !== null;
-  const [sendMode, setSendMode] = useState<"queue" | "steer">(storedSendMode);
+  const sendMode = useUiStore((state) => state.activeTurnSendMode);
   const queueAvailable = onQueue !== undefined;
-  function pickSendMode(mode: "queue" | "steer") {
-    setSendMode(mode);
-    try {
-      window.localStorage.setItem(SEND_MODE_KEY, mode);
-    } catch {
-      // Preference-only; losing it costs one extra click.
-    }
-  }
   const hasDraft = Boolean(draft.trim());
   const steerHasUnsupportedCharacter = active && draft.includes("\0");
   const steerTooLong =
@@ -1119,51 +1099,24 @@ export function Composer({
           {active ? (
             <>
               {(hasDraft || steerPending) && (
-                <div className="flex items-center gap-1">
-                  <Button
-                    type="submit"
-                    variant="default"
-                    size="xs"
-                    className="h-8 min-w-[5rem] px-3 text-sm"
-                    aria-label={
-                      queueAvailable && sendMode === "queue"
-                        ? "Queue message for after this response"
-                        : "Redirect active response"
-                    }
-                    disabled={!canSubmit}
-                  >
-                    {steerPending
-                      ? "Sending…"
-                      : queueAvailable && sendMode === "queue"
-                        ? "Queue"
-                        : "Redirect"}
-                  </Button>
-                  {queueAvailable && (
-                    <WithTooltip
-                      label={
-                        sendMode === "queue"
-                          ? "Switch to Redirect: interject into the running response"
-                          : "Switch to Queue: run after this response finishes"
-                      }
-                    >
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="icon-8"
-                        aria-label="Switch send mode"
-                        onClick={() =>
-                          pickSendMode(sendMode === "queue" ? "steer" : "queue")
-                        }
-                      >
-                        {sendMode === "queue" ? (
-                          <CornerUpRight size={14} />
-                        ) : (
-                          <ListPlus size={14} />
-                        )}
-                      </Button>
-                    </WithTooltip>
-                  )}
-                </div>
+                <Button
+                  type="submit"
+                  variant="default"
+                  size="xs"
+                  className="h-8 min-w-[5rem] px-3 text-sm"
+                  aria-label={
+                    queueAvailable && sendMode === "queue"
+                      ? "Queue message for after this response"
+                      : "Steer active response"
+                  }
+                  disabled={!canSubmit}
+                >
+                  {steerPending
+                    ? "Sending…"
+                    : queueAvailable && sendMode === "queue"
+                      ? "Queue"
+                      : "Steer"}
+                </Button>
               )}
               <WithTooltip label={cancelPending ? "Stopping…" : "Stop"}>
                 <Button

--- a/crates/tidebreak-desktop/ui/src/QueueTray.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/QueueTray.dom.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ApiClient, QueuedTurn } from "./api";
+import { QueueTray } from "./QueueTray";
+
+afterEach(cleanup);
+
+const first: QueuedTurn = {
+  id: "turn-queued",
+  chat_id: "chat-1",
+  content: "Use the shorter introduction",
+  attachments: [],
+  file_attachments: [],
+  invoked_skills: [],
+  voice_input_used: false,
+  position: 1,
+  created_at: "2026-08-13T12:00:00Z",
+  updated_at: "2026-08-13T12:00:00Z",
+};
+
+describe("QueueTray", () => {
+  it("moves a queued row first, stops the active turn, and releases the queue", async () => {
+    const calls: string[] = [];
+    const client = {
+      listQueuedTurns: vi.fn().mockResolvedValue({ queued: [first], paused: false }),
+      putQueuePaused: vi.fn(async (_chatId: string, paused: boolean) => {
+        calls.push(paused ? "pause" : "resume");
+      }),
+      patchQueuedTurn: vi.fn(async () => {
+        calls.push("move-first");
+        return first;
+      }),
+      sendQueuedNow: vi.fn(async () => {
+        calls.push("release");
+      }),
+    } as unknown as ApiClient;
+    const onStop = vi.fn(async () => {
+      calls.push("stop");
+    });
+
+    render(
+      <QueueTray client={client} chatId="chat-1" active onStop={onStop} />,
+    );
+    await screen.findByText("Use the shorter introduction");
+    await userEvent.click(
+      screen.getByRole("button", { name: "Send queued message 1 now" }),
+    );
+
+    await waitFor(() => expect(calls).toEqual(["pause", "move-first", "stop", "release"]));
+    expect(client.patchQueuedTurn).toHaveBeenCalledWith("chat-1", "turn-queued", {
+      position: 0,
+    });
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/QueueTray.tsx
+++ b/crates/tidebreak-desktop/ui/src/QueueTray.tsx
@@ -1,5 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ChevronDown, ChevronUp, Pause, Pencil, Play, Trash2 } from "lucide-react";
+import {
+  ArrowUpRight,
+  ChevronDown,
+  ChevronUp,
+  Pause,
+  Pencil,
+  Play,
+  Trash2,
+} from "lucide-react";
 import { toast } from "sonner";
 
 import type { ApiClient, QueuedTurn } from "./api";
@@ -20,10 +28,12 @@ export function QueueTray({
   client,
   chatId,
   active,
+  onStop,
 }: {
   client: ApiClient;
   chatId: string;
   active: boolean;
+  onStop: () => Promise<void>;
 }) {
   const [queued, setQueued] = useState<QueuedTurn[]>([]);
   const [paused, setPaused] = useState(false);
@@ -65,6 +75,37 @@ export function QueueTray({
     }
   }
 
+  async function sendNow(row: QueuedTurn) {
+    setBusy(true);
+    let temporarilyPaused = false;
+    try {
+      if (!paused) {
+        await client.putQueuePaused(chatId, true);
+        temporarilyPaused = true;
+      }
+      await client.patchQueuedTurn(chatId, row.id, { position: 0 });
+      if (active) await onStop();
+      await client.sendQueuedNow(chatId);
+      temporarilyPaused = false;
+      await refresh();
+    } catch (error) {
+      toast.error(
+        friendlyErrorMessage(error, "Could not send that message now"),
+      );
+      if (temporarilyPaused) {
+        try {
+          await client.putQueuePaused(chatId, false);
+        } catch {
+          // The original failure is the useful one; polling will show the
+          // actual queue state and the header still offers Resume.
+        }
+      }
+      await refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
   if (queued.length === 0) return null;
 
   return (
@@ -85,24 +126,6 @@ export function QueueTray({
           </span>
         )}
         <div className="ml-auto flex items-center gap-0.5">
-          {paused && (
-            <Button
-              type="button"
-              variant="ghost"
-              size="xs"
-              className="h-6 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground"
-              disabled={busy}
-              onClick={() =>
-                void act(
-                  () => client.sendQueuedNow(chatId),
-                  "Could not start the queue",
-                )
-              }
-            >
-              <Play className="size-3" />
-              Send now
-            </Button>
-          )}
           <Button
             type="button"
             variant="ghost"
@@ -155,7 +178,19 @@ export function QueueTray({
                 {row.content}
               </span>
             )}
-            <span className="hidden shrink-0 items-center gap-0.5 group-hover:inline-flex">
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              className="h-6 shrink-0 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground"
+              aria-label={`Send queued message ${index + 1} now`}
+              disabled={busy}
+              onClick={() => void sendNow(row)}
+            >
+              <ArrowUpRight className="size-3" />
+              Send now
+            </Button>
+            <span className="hidden shrink-0 items-center gap-0.5 group-hover:inline-flex group-focus-within:inline-flex">
               <Button
                 type="button"
                 variant="ghost"

--- a/crates/tidebreak-desktop/ui/src/UiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/UiStore.ts
@@ -2,6 +2,9 @@ import { create } from "zustand";
 
 const SIDEBAR_COLLAPSED_KEY = "tidebreak.sidebar-collapsed";
 const MODEL_MENU_NOT_CONNECTED_KEY = "tidebreak.model-menu-not-connected-collapsed";
+const ACTIVE_TURN_SEND_MODE_KEY = "tidebreak.composer.sendMode";
+
+export type ActiveTurnSendMode = "queue" | "steer";
 
 function readStoredSidebarCollapsed(): boolean {
   try {
@@ -35,6 +38,24 @@ function storeNotConnectedCollapsed(collapsed: boolean): void {
   }
 }
 
+function readStoredActiveTurnSendMode(): ActiveTurnSendMode {
+  try {
+    return window.localStorage.getItem(ACTIVE_TURN_SEND_MODE_KEY) === "steer"
+      ? "steer"
+      : "queue";
+  } catch {
+    return "queue";
+  }
+}
+
+function storeActiveTurnSendMode(mode: ActiveTurnSendMode): void {
+  try {
+    window.localStorage.setItem(ACTIVE_TURN_SEND_MODE_KEY, mode);
+  } catch {
+    // Preference persistence is best-effort.
+  }
+}
+
 /**
  * Chrome state that belongs to no conversation and does not deserve a URL:
  * whether the sidebar is showing.
@@ -52,6 +73,9 @@ export type UiStore = {
    */
   modelMenuNotConnectedCollapsed: boolean;
   toggleModelMenuNotConnected: () => void;
+  /** What Enter and the single composer action do while a response is running. */
+  activeTurnSendMode: ActiveTurnSendMode;
+  setActiveTurnSendMode: (mode: ActiveTurnSendMode) => void;
 };
 
 export function createUiStore() {
@@ -70,6 +94,11 @@ export function createUiStore() {
         storeNotConnectedCollapsed(collapsed);
         return { modelMenuNotConnectedCollapsed: collapsed };
       }),
+    activeTurnSendMode: readStoredActiveTurnSendMode(),
+    setActiveTurnSendMode: (mode) => {
+      storeActiveTurnSendMode(mode);
+      set({ activeTurnSendMode: mode });
+    },
   }));
 }
 

--- a/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.dom.test.tsx
@@ -5,8 +5,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { ApiClient, RuntimeSettings } from "../api";
 import { AgentsPanel } from "./AgentsPanel";
+import { useUiStore } from "../UiStore";
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+  useUiStore.setState({ activeTurnSendMode: "queue" });
+});
 
 describe("AgentsPanel", () => {
   it("loads and saves the agent limits and check-in cadences", async () => {
@@ -44,6 +49,12 @@ describe("AgentsPanel", () => {
 
     render(<AgentsPanel client={client} />);
     await screen.findByText("Active background agents per chat");
+    expect(screen.getByRole("radio", { name: "Queue" })).toBeChecked();
+    fireEvent.click(screen.getByRole("radio", { name: "Steer" }));
+    expect(useUiStore.getState().activeTurnSendMode).toBe("steer");
+    expect(window.localStorage.getItem("tidebreak.composer.sendMode")).toBe(
+      "steer",
+    );
     const [limit, steps, errors] = screen.getAllByRole("spinbutton");
     expect(limit).toHaveValue(5);
     expect(steps).toHaveValue(100);

--- a/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.tsx
@@ -4,6 +4,8 @@ import { toast } from "sonner";
 import type { ApiClient } from "../api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { useUiStore, type ActiveTurnSendMode } from "../UiStore";
 import {
   SettingsError,
   SettingsField,
@@ -19,6 +21,10 @@ const MIN_ERROR_CHECKIN = 1;
 const MAX_ERROR_CHECKIN = 100;
 
 export function AgentsPanel({ client }: { client: ApiClient }) {
+  const activeTurnSendMode = useUiStore((state) => state.activeTurnSendMode);
+  const setActiveTurnSendMode = useUiStore(
+    (state) => state.setActiveTurnSendMode,
+  );
   const [limit, setLimit] = useState("");
   const [checkinSteps, setCheckinSteps] = useState("");
   const [errorCheckin, setErrorCheckin] = useState("");
@@ -103,9 +109,49 @@ export function AgentsPanel({ client }: { client: ApiClient }) {
   return (
     <SettingsPanel
       title="Agents"
-      description="Control how much delegated background work one conversation may run at once, and how often agents report back."
+      description="Choose how messages behave around active work, how much delegated work a conversation may run, and how often agents report back."
       busy={loading}
     >
+      <SettingsSection
+        title="While an agent is responding"
+        description="Choose what the single composer action does when you type during a running response."
+      >
+        <RadioGroup
+          aria-label="Default action while an agent is responding"
+          value={activeTurnSendMode}
+          onValueChange={(value) =>
+            setActiveTurnSendMode(value as ActiveTurnSendMode)
+          }
+          className="gap-3"
+        >
+          <label className="flex cursor-pointer items-start gap-3 rounded-lg border border-border/70 p-3 transition-colors hover:bg-muted/40">
+            <RadioGroupItem
+              value="queue"
+              className="mt-0.5"
+              aria-label="Queue"
+            />
+            <span className="flex flex-col gap-0.5">
+              <span className="text-sm font-medium">Queue</span>
+              <span className="text-sm text-muted-foreground">
+                Run the message as its own turn after the current response.
+              </span>
+            </span>
+          </label>
+          <label className="flex cursor-pointer items-start gap-3 rounded-lg border border-border/70 p-3 transition-colors hover:bg-muted/40">
+            <RadioGroupItem
+              value="steer"
+              className="mt-0.5"
+              aria-label="Steer"
+            />
+            <span className="flex flex-col gap-0.5">
+              <span className="text-sm font-medium">Steer</span>
+              <span className="text-sm text-muted-foreground">
+                Interrupt the current response and use the message as guidance.
+              </span>
+            </span>
+          </label>
+        </RadioGroup>
+      </SettingsSection>
       <SettingsSection>
         <SettingsField
           label="Active background agents per chat"


### PR DESCRIPTION
## What changed

- replace the split Queue/Steer composer control with one primary action while a response is running
- add an Agents setting that chooses whether the active-turn action queues or steers by default
- add a persistent **Send now** action to each queued message
- make **Send now** move the selected row first, stop the active response when needed, and release the queue without dropping attachments or queued metadata
- align the UI vocabulary on **Steer** instead of **Redirect**

## Why

The previous composer showed a primary action plus a separate icon that only switched modes. The relationship between those controls was unclear, and the queue-level send-now action did not identify which queued message would run. This keeps the composer to one clear action and moves immediate delivery to the queued item it affects.

## Validation

- `pnpm exec vitest run src/Composer.test.tsx src/ChatView.dom.test.tsx src/QueueTray.dom.test.tsx src/settings/AgentsPanel.dom.test.tsx` (32 tests)
- `pnpm build`
- `git diff --check`
