### PR TITLE
feat(desktop): lead a background command with the model's own sentence

### DIFF
--- a/crates/tidebreak-core/src/preview.rs
+++ b/crates/tidebreak-core/src/preview.rs
@@ -93,8 +93,8 @@ pub const MAX_ACTIVITY_EXEC_OUTPUT_CHARS: usize = 2_000;
 /// A bounded headline for one background-agent activity step.
 ///
 /// This is deliberately smaller than [`ToolActionPreview`]. The command,
-/// arguments, and query are model-authored text: they are bounded for safe
-/// single-line presentation, but may repeat any information the background
+/// arguments, query, and summary are model-authored text: they are bounded for
+/// safe single-line presentation, but may repeat any information the background
 /// agent already saw and are therefore outside the host-field non-disclosure
 /// guarantee. The projection copies no stored result text except a settled
 /// `exec` receipt's bounded tail — see [`Self::with_exec_result`] — and never
@@ -103,7 +103,9 @@ pub const MAX_ACTIVITY_EXEC_OUTPUT_CHARS: usize = 2_000;
 /// admitted delegated file.
 ///
 /// Command and search fields use the foreground approval-card projection so
-/// both surfaces share the same sanitization.
+/// both surfaces share the same sanitization. The summary is projected the
+/// same way but shown only here and on the result card, never on an approval
+/// card — see `docs/decisions/0015-tool-call-narration.md`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum AgentActivityDetail {
@@ -113,6 +115,13 @@ pub enum AgentActivityDetail {
     Exec {
         command: String,
         args: Vec<String>,
+        /// The model's own sentence about this step, when it wrote one.
+        ///
+        /// Display-only, exactly as on [`ToolActionPreview`]: nothing in the
+        /// background path reads it, and no step's identity depends on it.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        summary: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         #[ts(optional)]
         exit_code: Option<i32>,
@@ -121,8 +130,16 @@ pub enum AgentActivityDetail {
         output: Option<String>,
     },
     /// One public-web query, trimmed and bounded like its approval preview.
+    ///
+    /// No narration: a search step is a single rail row with no body to open,
+    /// so a sentence here would displace the query rather than lead it, and
+    /// the literal action has to stay reachable.
     Search { query: String },
     /// The bounded leaf name of the one canonically admitted delegated file.
+    ///
+    /// No narration: this headline comes from the host's admission record
+    /// rather than from model-authored arguments, so there is nothing the model
+    /// wrote to show.
     File { name: String },
 }
 
@@ -136,9 +153,15 @@ impl AgentActivityDetail {
     #[must_use]
     pub fn build(tool_name: &str, arguments: &Value) -> Option<Self> {
         match ToolActionPreview::build(tool_name, arguments) {
-            Some(ToolActionPreview::Exec { command, args, .. }) => Some(Self::Exec {
+            Some(ToolActionPreview::Exec {
                 command,
                 args,
+                summary,
+                ..
+            }) => Some(Self::Exec {
+                command,
+                args,
+                summary,
                 exit_code: None,
                 output: None,
             }),
@@ -178,7 +201,13 @@ impl AgentActivityDetail {
     /// split mid-codepoint.
     #[must_use]
     pub fn with_exec_result(self, result: &str) -> Self {
-        let Self::Exec { command, args, .. } = self else {
+        let Self::Exec {
+            command,
+            args,
+            summary,
+            ..
+        } = self
+        else {
             return self;
         };
         let exit_code = result
@@ -189,6 +218,7 @@ impl AgentActivityDetail {
         Self::Exec {
             command,
             args,
+            summary,
             exit_code,
             output: receipt_tail(result, MAX_ACTIVITY_EXEC_OUTPUT_CHARS),
         }
@@ -1473,6 +1503,7 @@ mod tests {
                 Some(AgentActivityDetail::Exec {
                     command: "python".into(),
                     args: vec!["safearg".into()],
+                    summary: None,
                     exit_code: None,
                     output: None,
                 }),
@@ -1484,6 +1515,23 @@ mod tests {
                 Some(AgentActivityDetail::Exec {
                     command: "cat".into(),
                     args: vec!["/Users/alice/private.txt".into()],
+                    summary: None,
+                    exit_code: None,
+                    output: None,
+                }),
+            ),
+            (
+                "a background step carries the model's own sentence, bounded",
+                crate::SANDBOX_EXEC_TOOL,
+                json!({
+                    "command": "python3",
+                    "args": ["report.py"],
+                    "summary": "\u{202e}Rebuilding the quarterly report",
+                }),
+                Some(AgentActivityDetail::Exec {
+                    command: "python3".into(),
+                    args: vec!["report.py".into()],
+                    summary: Some("Rebuilding the quarterly report".into()),
                     exit_code: None,
                     output: None,
                 }),
@@ -1503,6 +1551,7 @@ mod tests {
                     args: (0..MAX_ACTION_ARGS)
                         .map(|index| format!("arg-{index}"))
                         .collect(),
+                    summary: None,
                     exit_code: None,
                     output: None,
                 }),
@@ -1538,6 +1587,7 @@ mod tests {
                 Some(AgentActivityDetail::Exec {
                     command: "leftright".into(),
                     args: Vec::new(),
+                    summary: None,
                     exit_code: None,
                     output: None,
                 }),
@@ -1558,9 +1608,14 @@ mod tests {
             })
         );
 
+        // The narration is carried through settling, not re-derived: a receipt
+        // cannot recover a sentence the model wrote at call time, so a
+        // reconstruction that dropped it would blank the headline the moment a
+        // step finished — the state a reader looks at most.
         let base = AgentActivityDetail::Exec {
             command: "python3".into(),
             args: vec!["report.py".into()],
+            summary: Some("Rebuilding the quarterly report".into()),
             exit_code: None,
             output: None,
         };
@@ -1579,6 +1634,7 @@ mod tests {
                 AgentActivityDetail::Exec {
                     command: "python3".into(),
                     args: vec!["report.py".into()],
+                    summary: Some("Rebuilding the quarterly report".into()),
                     exit_code,
                     output: Some(result.into()),
                 },
@@ -1597,6 +1653,7 @@ mod tests {
         let base = AgentActivityDetail::Exec {
             command: "python3".into(),
             args: Vec::new(),
+            summary: None,
             exit_code: None,
             output: None,
         };

--- a/crates/tidebreak-desktop/ui/src/AgentActivityTimeline.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/AgentActivityTimeline.dom.test.tsx
@@ -108,4 +108,38 @@ describe("AgentActivityTimeline", () => {
     );
     expect(screen.getByText("No output captured.")).toBeTruthy();
   });
+
+  it("leads a narrated command with its sentence and keeps the command line in the body", () => {
+    const narrated: AgentActivityState = {
+      ...state,
+      items: state.items.map((item, index) =>
+        index === 1
+          ? {
+              ...item,
+              detail: {
+                kind: "exec",
+                command: "pip",
+                args: ["install", "matplotlib"],
+                exit_code: 1,
+                summary: "Installing the plotting library",
+              },
+            }
+          : item,
+      ),
+    };
+    render(<AgentActivityTimeline state={narrated} active={false} expanded />);
+
+    const commandRow = within(screen.getByRole("list")).getAllByRole(
+      "listitem",
+    )[1]!;
+    const card = within(commandRow).getByRole("button", {
+      name: /Installing the plotting library/,
+    });
+    // The sentence is prose, so it does not wear the command's monospace.
+    expect(card.querySelector(".font-mono")).toBeNull();
+    // The literal action is not lost: the open body still carries it.
+    expect(
+      within(commandRow).getByText("pip install matplotlib"),
+    ).toBeTruthy();
+  });
 });

--- a/crates/tidebreak-desktop/ui/src/AgentActivityTimeline.tsx
+++ b/crates/tidebreak-desktop/ui/src/AgentActivityTimeline.tsx
@@ -215,9 +215,11 @@ export function AgentActivityTimeline({
  * The step's own headline, next to the generic label.
  *
  * "Ran a command" is the same sentence whichever command ran, so the validated
- * detail is what tells the steps apart. Non-exec steps carry it inline; a
- * command gets a full card instead ({@link ExecActivityCard}), so this returns
- * nothing for exec detail.
+ * detail is what tells the steps apart — the query one searched for, the file
+ * one read. These rows have no body to open, so they show the literal action
+ * and nothing else; a command gets a full card instead
+ * ({@link ExecActivityCard}), which is why this returns nothing for exec
+ * detail.
  */
 function activityHeadline(
   detail: AgentActivityHistoryEntry["detail"],
@@ -252,23 +254,33 @@ function ExecActivityCard({
   detail: ExecActivityDetail;
   outcome: AgentActivityHistoryEntry["outcome"];
 }) {
-  const headline = execCommandHeadline(detail.command, detail.args);
+  const command = execCommandHeadline(detail.command, detail.args);
+  // The sentence leads when the step wrote one; the command line stays in the
+  // body either way, so the literal action is never more than a click away.
+  const narrated =
+    detail.summary !== undefined && detail.summary.length > 0
+      ? detail.summary
+      : null;
   const failed = outcome === "failed";
   const settled =
     outcome === "completed" || outcome === "failed" || outcome === "cancelled";
   return (
     <ToolCardShell
       icon={<Terminal className="size-3.5 shrink-0" aria-hidden="true" />}
-      title={headline}
-      titleClassName="font-mono"
+      title={narrated ?? command}
+      titleClassName={narrated === null ? "font-mono" : undefined}
       badge={<ExecActivityBadge outcome={outcome} exitCode={detail.exit_code} />}
       defaultExpanded={failed}
       className={cn(failed && "border-critical/35")}
-      label={failed ? `Failed command: ${headline}` : `Command: ${headline}`}
+      // The assistive label names the command, not the sentence about it: it
+      // stands in for a title the reader can see but a screen reader would
+      // otherwise get only truncated, and the literal action is the part that
+      // cannot be recovered from anywhere else in the row.
+      label={failed ? `Failed command: ${command}` : `Command: ${command}`}
     >
       <div className="flex flex-col gap-1.5 p-2">
         <pre className="bg-muted text-muted-foreground rounded-md p-2 text-xs break-words whitespace-pre-wrap">
-          {headline}
+          {command}
         </pre>
         {detail.output ? (
           <pre className="bg-muted text-muted-foreground rounded-md p-2 text-xs break-words whitespace-pre-wrap">

--- a/crates/tidebreak-desktop/ui/src/ToolPreview.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolPreview.tsx
@@ -125,8 +125,9 @@ export function toolPreviewHeadline(preview: ToolActionPreview): {
  * The one-line form of a command and its argument vector.
  *
  * Shared so a command reads identically wherever it is shown: the foreground
- * approval and result cards, and the background run's activity timeline, which
- * has only this headline and no card to open.
+ * approval and result cards, and the background run's activity timeline, where
+ * it is the card's headline unless the step narrated itself, and its body
+ * either way.
  */
 export function execCommandHeadline(
   command: string,

--- a/crates/tidebreak-desktop/ui/src/api.test.ts
+++ b/crates/tidebreak-desktop/ui/src/api.test.ts
@@ -1142,6 +1142,33 @@ describe("parseAgentActivityHistory", () => {
             output: "\u001b[2Jexit: 0",
           },
         },
+        // The step's own sentence is admitted, and admitting it must not cost
+        // the row: a parser that did not know the key would reject the whole
+        // detail and blank the command, output, and exit status with it.
+        {
+          kind: "exec",
+          outcome: "completed",
+          at: "2026-08-05T18:47:00Z",
+          detail: {
+            kind: "exec",
+            command: "python3",
+            args: ["report.py"],
+            summary: "Rebuilding the quarterly report",
+          },
+        },
+        // An unusable sentence costs only itself; the command still describes
+        // the row.
+        {
+          kind: "exec",
+          outcome: "completed",
+          at: "2026-08-05T18:48:00Z",
+          detail: {
+            kind: "exec",
+            command: "python3",
+            args: [],
+            summary: "x".repeat(201),
+          },
+        },
       ]),
     ).toEqual([
       {
@@ -1187,6 +1214,23 @@ describe("parseAgentActivityHistory", () => {
         outcome: "completed",
         at: "2026-08-05T18:46:00Z",
         detail: { kind: "exec", command: "make", args: [] },
+      },
+      {
+        kind: "exec",
+        outcome: "completed",
+        at: "2026-08-05T18:47:00Z",
+        detail: {
+          kind: "exec",
+          command: "python3",
+          args: ["report.py"],
+          summary: "Rebuilding the quarterly report",
+        },
+      },
+      {
+        kind: "exec",
+        outcome: "completed",
+        at: "2026-08-05T18:48:00Z",
+        detail: { kind: "exec", command: "python3", args: [] },
       },
     ]);
   });

--- a/crates/tidebreak-desktop/ui/src/api/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/api/parsers.ts
@@ -610,6 +610,7 @@ function parseAgentActivityDetail(
         "kind",
         "command",
         "args",
+        "summary",
         "exit_code",
         "output",
       ]) ||
@@ -639,6 +640,7 @@ function parseAgentActivityDetail(
       kind: "exec",
       command: value.command,
       args,
+      ...narration(value),
       ...(exitCode === undefined ? {} : { exit_code: exitCode }),
       ...(output === undefined ? {} : { output }),
     };
@@ -965,14 +967,13 @@ const MAX_SUMMARY_CHARS = 200;
  * Unlike every other field here a bad value costs only itself: narration is
  * decoration over an action the card can already describe, so an unreadable
  * one falls back to the literal form rather than dropping the whole preview.
+ * "Unreadable" is the same standard {@link bounded} applies everywhere else —
+ * prose is not exempt from the check that it cannot redraw the line it is
+ * about to be rendered on.
  */
 function narration(value: Record<string, unknown>): { summary?: string } {
   const { summary } = value;
-  if (
-    typeof summary !== "string" ||
-    summary.length === 0 ||
-    summary.length > MAX_SUMMARY_CHARS
-  ) {
+  if (!bounded(summary, MAX_SUMMARY_CHARS) || summary.length === 0) {
     return {};
   }
   return { summary };

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -12,8 +12,8 @@
  * A bounded headline for one background-agent activity step.
  *
  * This is deliberately smaller than [`ToolActionPreview`]. The command,
- * arguments, and query are model-authored text: they are bounded for safe
- * single-line presentation, but may repeat any information the background
+ * arguments, query, and summary are model-authored text: they are bounded for
+ * safe single-line presentation, but may repeat any information the background
  * agent already saw and are therefore outside the host-field non-disclosure
  * guarantee. The projection copies no stored result text except a settled
  * `exec` receipt's bounded tail — see [`Self::with_exec_result`] — and never
@@ -22,9 +22,18 @@
  * admitted delegated file.
  *
  * Command and search fields use the foreground approval-card projection so
- * both surfaces share the same sanitization.
+ * both surfaces share the same sanitization. The summary is projected the
+ * same way but shown only here and on the result card, never on an approval
+ * card — see `docs/decisions/0015-tool-call-narration.md`.
  */
-export type AgentActivityDetail = { "kind": "exec", command: string, args: Array<string>, exit_code?: number, output?: string, } | { "kind": "search", query: string, } | { "kind": "file", name: string, };
+export type AgentActivityDetail = { "kind": "exec", command: string, args: Array<string>, 
+/**
+ * The model's own sentence about this step, when it wrote one.
+ *
+ * Display-only, exactly as on [`ToolActionPreview`]: nothing in the
+ * background path reads it, and no step's identity depends on it.
+ */
+summary?: string, exit_code?: number, output?: string, } | { "kind": "search", query: string, } | { "kind": "file", name: string, };
 
 /**
  * One renderer-safe entry in a background run's ordered activity history.

--- a/docs/decisions/0015-tool-call-narration.md
+++ b/docs/decisions/0015-tool-call-narration.md
@@ -48,11 +48,19 @@ preview field, and governed by three rules:
    command narrated differently are the same action, and a standing grant covers
    both.
 
-Included: the result card's collapsed headline, and the activity rail row for
-non-`exec` calls. Excluded, deliberately: the approval card, the judge, grant
-identity, `describes_exactly()` (narration is not part of the action, so a
-narrated call remains exactly describable and stays grantable), and the
-background-run activity timeline, which keeps argv this round.
+Included: the result card's collapsed headline, the activity rail row for
+non-`exec` calls, and a background run's `exec` steps, which carry the sentence
+on the smaller `AgentActivityDetail` projection under the same rules — that
+timeline is a record of what already ran, never a consent surface. (This last
+one was written here as excluded "this round", a scope note rather than a
+decision; it was taken on shortly after, and the rules did not change to allow
+it.) Excluded, deliberately: the approval card, the judge, grant identity, and
+`describes_exactly()` (narration is not part of the action, so a narrated call
+remains exactly describable and stays grantable). Two background step kinds
+also stay literal, for the same reason the argv keeps the expanded pane: a
+search row and a delegated-file row have no body to open, so a sentence there
+would displace the literal action rather than lead it — and a delegated file's
+name is the host's own admission record, not something the model wrote.
 
 The argument is **required in each tool's JSON schema** so models reliably write
 one, and **tolerated in code** so a call that omits it still runs and falls back
@@ -123,3 +131,8 @@ would demand a *server*-derived line, not this one.
 - A schema-gate test: a call omitting the narration is not refused, a foreign
   tool's own required `summary` still is, and a narration of the wrong type
   still fails. Relaxing `required` too broadly, or not at all, fails here.
+- Two background-projection tests: `AgentActivityDetail::build` carries the
+  sentence through the same clamp, and `with_exec_result` preserves it when a
+  step settles. The second is the load-bearing one — that reconstruction is the
+  only place the field can be dropped without a compile error, and a receipt
+  cannot recover a sentence the model wrote at call time.


### PR DESCRIPTION
## What

A background run's activity timeline showed only argv, while the foreground result card already led with the sentence the model wrote about the call ([0015](docs/decisions/0015-tool-call-narration.md)). That record excluded the timeline explicitly ("keeps argv this round"); this closes it.

The sentence was already in the database: `SandboxExecArgs` carries it, and `agent_runs.rs` builds the detail from `call.arguments`. It was being discarded at one destructuring site in `AgentActivityDetail::build`.

## Design

`AgentActivityDetail::Exec` gains `summary: Option<String>`, projected from the already-clamped `ToolActionPreview` rather than re-parsed. Same display-only rules as the foreground preview — nothing in the background path reads it, and no step's identity depends on it. `AgentActivityDetail` is not a consent surface at all: it is a record of what already ran, so none of the three approval rules are in tension here.

`ExecActivityCard` leads with the sentence and drops the monospace class when it has one. Two things stay literal on purpose:

- **The card body always carries the command line.** For a narrated card it no longer repeats the headline; the literal action is never more than a click away.
- **The assistive `label` names the command, not the sentence.** That prop exists to give a screen reader the untruncated string behind a `truncate`d title, and the argv is the part that cannot be recovered from anywhere else in the row.

`Search` and `File` steps take no narration. A search row is a single rail line with no body to open, so a sentence would *displace* the query rather than lead it — the same reason the exec card keeps argv in its pane. A delegated file's name comes from the host's admission record, so there is nothing model-authored to show.

## The trap this had to avoid

`parsers.ts` uses `onlyKeys`, which is **strict-reject**: an unrecognized key drops the *entire* detail object. Shipping `summary` server-side without updating the parser would have returned `undefined` for the whole detail, blanking every background step's command, output, and exit code.

While here, `narration()` now runs the summary through `bounded()` like every other field on this path instead of a hand-rolled `typeof`/`length` check. It was the one field skipping the renderer's own formatting-character check — which contradicts that file's stated contract ("the renderer validates what it is about to draw rather than trusting that the sender already did") — and `.length` counts UTF-16 units, so a server-legal 200-scalar summary containing emoji was silently dropped.

## Cost

The activity endpoint returns a run's whole history per response and re-fetches on every update, so each field is multiplied by every step the run ever ran. The narration is bounded at 200 chars by the existing preview clamp — an order of magnitude under `MAX_ACTIVITY_EXEC_OUTPUT_CHARS` (2000). Unlike `output`, which only exists on settled steps, it rides every exec step including running ones; still small.

## Tests

- `preview.rs` — a projection case asserting the sentence is carried and sanitized (the input embeds a bidi override to confirm it goes through the same clamp), and the `with_exec_result` base now carries a summary: settling a receipt must preserve a sentence it cannot re-derive. That reconstruction is the one place the field can be dropped without a compile error.
- `api.test.ts` — a narrated exec survives the strict parser; a 201-char summary costs only itself, not the whole detail.
- `AgentActivityTimeline.dom.test.tsx` — a narrated card leads with the sentence, without monospace, and still carries the command line in its body.

No tests removed.

## Verification

`pnpm test` (970 passed), `pnpm build`, `cargo test -p tidebreak-core --locked --lib` (608 passed), `cargo test -p tidebreak-server --locked --lib` (807 passed), `cargo clippy --workspace --locked --all-targets` — all clean. `wire.ts` is regenerated, not hand-edited. Not driven in the running app.

One unrelated flake seen once and not reproducible: `tests::configuration::api_key_put_configures_it_and_delete_reverts` failed on a full-suite run and passed both isolated and on a clean tree. Not touched by this change.

## Review

Reviewed adversarially before merge. Findings acted on: the assistive label losing the argv, the search row losing the query, `narration()` skipping the formatting-character check and mis-counting astral characters, an inaccurate doc comment on `execCommandHeadline`, and the decision record's Validation section not covering the surface it had just taken on.