### PR TITLE
feat(desktop): refine computer use HUD

### DIFF
--- a/crates/tidebreak-core/src/computer_use.rs
+++ b/crates/tidebreak-core/src/computer_use.rs
@@ -95,9 +95,8 @@ pub fn is_computer_use_control_tool(name: &str) -> bool {
 }
 
 /// Shared guidance folded into the acting tools' descriptions: computer use is
-/// for seeing first and acting second, acting is slower and may need approval,
-/// and the user can stop it at any time.
-const ACTING_NOTE: &str = "\n\nActing is slower than reading and may need the user's approval; prefer reading first and act only when it moves the task. The user can stop control at any time.";
+/// primarily an observation surface, while GUI driving is a disruptive fallback.
+const ACTING_NOTE: &str = "\n\nUse GUI control sparingly. Clicking, typing, scrolling, and moving focus use the user's real interface and are slower, more brittle, and more disruptive than reading app content or using a dedicated tool. Read first, prefer a non-GUI path when one exists, and act only when it is necessary to complete the user's request. The user can stop control at any time.";
 
 /// Shared targeting guidance: prefer a Set-of-Marks number or an element
 /// identity over raw coordinates.
@@ -443,7 +442,7 @@ pub fn validate_computer_wait_arguments(arguments: &Value) -> bool {
 pub fn computer_list_windows_tool_spec() -> ToolSpec {
     ToolSpec::for_args::<ComputerListWindowsArgs>(
         COMPUTER_LIST_WINDOWS_TOOL,
-        "List the on-screen windows, optionally for one app. Use this first to discover what is open and to find an app's bundle id before capturing or reading it.",
+        "List the on-screen windows, optionally for one app. Use this first when you do not know what is open or need an app's bundle id before reading or capturing it. Window ids are ephemeral, so use them promptly.",
     )
 }
 
@@ -452,7 +451,7 @@ pub fn computer_list_windows_tool_spec() -> ToolSpec {
 pub fn computer_capture_screen_tool_spec() -> ToolSpec {
     ToolSpec::for_args::<ComputerCaptureScreenArgs>(
         COMPUTER_CAPTURE_SCREEN_TOOL,
-        "Capture the screen as an image — the whole display, or one app's windows. Annotates interactive elements with numbered marks so you can act on them by number. Use this to see what is on screen before acting.",
+        "Capture the screen as an image — the whole display, or one app's windows. Use this for visual layout, charts, images, or custom-drawn interfaces that the accessibility tree cannot convey. Prefer computer_read_app_content when you only need text or structure. Annotated captures include numbered marks that acting tools can target without guessing coordinates.",
     )
 }
 
@@ -461,7 +460,7 @@ pub fn computer_capture_screen_tool_spec() -> ToolSpec {
 pub fn computer_read_app_content_tool_spec() -> ToolSpec {
     ToolSpec::for_args::<ComputerReadAppContentArgs>(
         COMPUTER_READ_APP_CONTENT_TOOL,
-        "Read an app's accessibility tree: on-screen text, element roles, values, and bounds. This is the primary way to see an app — cheaper and more reliable than a screenshot, and it yields the element ids and fingerprints the acting tools target.",
+        "Read an app's accessibility tree: on-screen text, element roles, values, and bounds. This is the primary way to see an app because structured content is cheaper and more precise than pixels, and it yields the marks, element ids, and fingerprints acting tools target. If the result is truncated, narrow max_depth or max_nodes; use a screenshot only when structure is incomplete or visual layout matters.",
     )
 }
 
@@ -501,7 +500,7 @@ pub fn computer_key_press_tool_spec() -> ToolSpec {
 pub fn computer_scroll_tool_spec() -> ToolSpec {
     ToolSpec::for_args::<ComputerScrollArgs>(
         COMPUTER_SCROLL_TOOL,
-        &format!("Scroll an element or point by a pixel delta. {TARGETING_NOTE}"),
+        &format!("Scroll an element or point by a pixel delta. Use it to reveal content before reading or targeting it. {TARGETING_NOTE}{ACTING_NOTE}"),
     )
 }
 
@@ -510,7 +509,7 @@ pub fn computer_scroll_tool_spec() -> ToolSpec {
 pub fn computer_focus_window_tool_spec() -> ToolSpec {
     ToolSpec::for_args::<ComputerFocusWindowArgs>(
         COMPUTER_FOCUS_WINDOW_TOOL,
-        "Bring an app (or one of its windows) to the front. Use this to return to an app after focus shifted away.",
+        &format!("Bring an app (or one of its windows) to the front. Use this only when focus must move to continue the task, such as before a key press or after another app took focus.{ACTING_NOTE}"),
     )
 }
 
@@ -519,7 +518,7 @@ pub fn computer_focus_window_tool_spec() -> ToolSpec {
 pub fn computer_return_to_tidebreak_tool_spec() -> ToolSpec {
     ToolSpec::for_args::<ComputerReturnToTidebreakArgs>(
         COMPUTER_RETURN_TO_TIDEBREAK_TOOL,
-        "Return focus to the Tidebreak window. Use after acting in another app when you need to read the transcript or report back.",
+        "Return focus to the Tidebreak window. Use after finishing work in another app so the user can see that the task is done and continue the conversation.",
     )
 }
 

--- a/crates/tidebreak-desktop/src/client_execution/computer_use.rs
+++ b/crates/tidebreak-desktop/src/client_execution/computer_use.rs
@@ -43,7 +43,7 @@ use tidebreak_host_broker::{
     extract_marks, is_blocked_control_bundle, Capability, ConsentMethod, ControlRequest,
     ControlResult, CuConfirmControlActionRequest, CuGrantAppRequest, CuResolveHandoffRequest,
     CuRevokeAppRequest, ElementTargetWire, ErrorCode, GrantSubject, Mark, OperationEnvelope,
-    OperationRequest, OperationResult, PROTOCOL_VERSION,
+    OperationRequest, OperationResult, SubjectKind, PROTOCOL_VERSION,
 };
 use tokio::sync::oneshot;
 use uuid::Uuid;
@@ -112,6 +112,15 @@ pub(crate) struct ConsentPromptView {
     bundle_id: String,
     app_name: Option<String>,
     capability: ConsentCapability,
+    grant_scope: ConsentGrantScope,
+}
+
+/// The widest durable scope the consent prompt may offer truthfully.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ConsentGrantScope {
+    Chat,
+    Project,
 }
 
 /// One parked consequential-action confirmation, as the renderer needs it.
@@ -1023,6 +1032,10 @@ async fn dispatch_consent(
             .as_deref()
             .and_then(|bundle_id| cu.app_name(bundle_id)),
         capability,
+        grant_scope: match context.subject.kind() {
+            SubjectKind::Project => ConsentGrantScope::Project,
+            SubjectKind::Conversation => ConsentGrantScope::Chat,
+        },
     };
     let (sender, receiver) = oneshot::channel();
     {

--- a/crates/tidebreak-desktop/ui/src/ComputerUseIndicator.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ComputerUseIndicator.dom.test.tsx
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
       bundleId: string;
       appName: string | null;
       capability: "capture_screen" | "read_app_content" | "control_app";
+      grantScope: "chat" | "project";
     }>,
     pendingConfirmations: [] as Array<{
       callId: string;
@@ -100,26 +101,50 @@ describe("ComputerUseIndicator", () => {
         bundleId: "com.apple.mail",
         appName: "Mail",
         capability: "control_app",
+        grantScope: "project",
       },
     ];
     render(<ComputerUseIndicator />);
 
-    // The consent card names the grant's real principal — the bundle id — with
-    // the app's self-reported name only as a parenthetical, so a spoofed name
-    // cannot mislabel what is being granted.
     expect(
-      screen.getByText(/Allow Tidebreak to control com\.apple\.mail \(Mail\)/),
+      screen.getByText(/Allow Tidebreak to control Mail/),
     ).toBeTruthy();
-    await userEvent.click(screen.getByRole("button", { name: "Once" }));
+    expect(screen.getByText(/com\.apple\.mail/)).toBeTruthy();
+    await userEvent.click(screen.getByRole("button", { name: "Allow once" }));
     expect(mocks.consent).toHaveBeenCalledWith("call-1", "once");
     await userEvent.click(
-      screen.getByRole("button", { name: "Always for this chat" }),
+      screen.getByRole("button", { name: "Allow for this chat" }),
     );
     expect(mocks.consent).toHaveBeenCalledWith("call-1", "chat");
-    await userEvent.click(screen.getByRole("button", { name: "Always" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Always in this project" }),
+    );
     expect(mocks.consent).toHaveBeenCalledWith("call-1", "always");
-    await userEvent.click(screen.getByRole("button", { name: "Decline" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Don't allow" }),
+    );
     expect(mocks.consent).toHaveBeenCalledWith("call-1", "decline");
+  });
+
+  it("uses screen-specific copy and does not offer a duplicate wider scope", () => {
+    mocks.snapshot.pendingConsents = [
+      {
+        callId: "call-screen",
+        chatId: "chat-1",
+        bundleId: "",
+        appName: null,
+        capability: "capture_screen",
+        grantScope: "chat",
+      },
+    ];
+    render(<ComputerUseIndicator />);
+
+    expect(
+      screen.getByText("Allow Tidebreak to capture your entire screen?"),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Always in this project" }),
+    ).toBeNull();
   });
 
   it("ignores a second decision while the first is still in flight", async () => {
@@ -134,18 +159,23 @@ describe("ComputerUseIndicator", () => {
         bundleId: "com.apple.mail",
         appName: "Mail",
         capability: "control_app",
+        grantScope: "project",
       },
     ];
     render(<ComputerUseIndicator />);
 
-    const once = screen.getByRole("button", { name: "Once" });
+    const once = screen.getByRole("button", { name: "Allow once" });
     await userEvent.click(once);
-    await userEvent.click(screen.getByRole("button", { name: "Always" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Always in this project" }),
+    );
     expect(mocks.consent).toHaveBeenCalledOnce();
 
     resolveDecision();
     await waitFor(() => expect(once).not.toBeDisabled());
-    await userEvent.click(screen.getByRole("button", { name: "Always" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Always in this project" }),
+    );
     expect(mocks.consent).toHaveBeenCalledTimes(2);
     expect(mocks.consent).toHaveBeenLastCalledWith("call-1", "always");
   });
@@ -159,19 +189,20 @@ describe("ComputerUseIndicator", () => {
         bundleId: "com.apple.mail",
         appName: "Mail",
         capability: "control_app",
+        grantScope: "chat",
       },
     ];
     render(<ComputerUseIndicator />);
 
-    await userEvent.click(screen.getByRole("button", { name: "Once" }));
+    await userEvent.click(screen.getByRole("button", { name: "Allow once" }));
     expect(
       await screen.findByRole("alert"),
     ).toHaveTextContent(/Could not send your decision/);
     expect(
-      screen.getByRole("button", { name: "Once" }),
+      screen.getByRole("button", { name: "Allow once" }),
     ).not.toBeDisabled();
 
-    await userEvent.click(screen.getByRole("button", { name: "Once" }));
+    await userEvent.click(screen.getByRole("button", { name: "Allow once" }));
     expect(mocks.consent).toHaveBeenCalledTimes(2);
     expect(screen.queryByRole("alert")).toBeNull();
   });
@@ -190,9 +221,9 @@ describe("ComputerUseIndicator", () => {
     render(<ComputerUseIndicator />);
 
     expect(screen.getByText(/“Send”/)).toBeTruthy();
-    await userEvent.click(screen.getByRole("button", { name: "Confirm" }));
+    await userEvent.click(screen.getByRole("button", { name: "Allow action" }));
     expect(mocks.confirmation).toHaveBeenCalledWith("call-9", true);
-    await userEvent.click(screen.getByRole("button", { name: "Deny" }));
+    await userEvent.click(screen.getByRole("button", { name: "Don't allow" }));
     expect(mocks.confirmation).toHaveBeenCalledWith("call-9", false);
   });
 
@@ -210,7 +241,7 @@ describe("ComputerUseIndicator", () => {
     ];
     render(<ComputerUseIndicator />);
 
-    await userEvent.click(screen.getByRole("button", { name: "Deny" }));
+    await userEvent.click(screen.getByRole("button", { name: "Don't allow" }));
     expect(await screen.findByRole("alert")).toHaveTextContent(
       /Could not send your decision/,
     );

--- a/crates/tidebreak-desktop/ui/src/ComputerUseIndicator.tsx
+++ b/crates/tidebreak-desktop/ui/src/ComputerUseIndicator.tsx
@@ -6,18 +6,39 @@ import {
   resumeComputerUseControl,
   stopComputerUseControl,
   useComputerUseState,
-  type ComputerUseCapability,
+  type ComputerUseConsentPrompt,
 } from "./computerUse";
 
-/** How a consent ask reads for each capability. */
-function capabilityAsk(capability: ComputerUseCapability, app: string): string {
-  switch (capability) {
+/** Human copy for one broker capability ask. */
+function consentCopy(
+  prompt: Pick<
+    ComputerUseConsentPrompt,
+    "appName" | "bundleId" | "capability"
+  >,
+): { title: string; detail: string | null } {
+  if (prompt.bundleId === "") {
+    return {
+      title: "Allow Tidebreak to capture your entire screen?",
+      detail: "This lets the agent see everything visible on the current display.",
+    };
+  }
+  const app = appLabel(prompt.appName, prompt.bundleId);
+  switch (prompt.capability) {
     case "control_app":
-      return `Allow Tidebreak to control ${app}? It will be able to click, type, and press keys there.`;
+      return {
+        title: `Allow Tidebreak to control ${app}?`,
+        detail: `It can click, type, and press keys in ${prompt.bundleId}.`,
+      };
     case "capture_screen":
-      return `Allow Tidebreak to capture ${app} on screen?`;
+      return {
+        title: `Allow Tidebreak to capture ${app}?`,
+        detail: `It can take screenshots of ${prompt.bundleId}.`,
+      };
     case "read_app_content":
-      return `Allow Tidebreak to read ${app}'s on-screen content?`;
+      return {
+        title: `Allow Tidebreak to read ${app}?`,
+        detail: `It can read the on-screen content exposed by ${prompt.bundleId}.`,
+      };
   }
 }
 
@@ -28,18 +49,10 @@ function appLabel(appName: string | null, bundleId: string): string {
   return appName && appName.length > 0 ? appName : bundleId;
 }
 
-function consentLabel(appName: string | null, bundleId: string): string {
-  if (bundleId === "") return "the whole screen";
-  // The bundle id is the principal the grant is actually written for; an app's
-  // self-reported name is attacker-influenceable, so the consent question leads
-  // with the bundle id and shows the name only as a parenthetical.
-  return appName && appName.length > 0 ? `${bundleId} (${appName})` : bundleId;
-}
-
 /**
- * The always-on computer-use surface: a banner while Tidebreak is driving an
- * app (with a Stop that halts before the next action), a stopped state with
- * Resume, and the parked consent / confirmation asks the agent is waiting on.
+ * The computer-use HUD: compact permission cards at the top of the window and
+ * a small control indicator at the bottom. Both float over the shell instead
+ * of resizing every route around a short-lived decision.
  *
  * Rendered in the shell so control is visible and stoppable from any screen.
  */
@@ -95,178 +108,206 @@ export function ComputerUseIndicator() {
   }
 
   return (
-    <div className="bg-background flex flex-col gap-2 border-b px-4 py-2">
-      {snapshot.halted ? (
-        <div
-          className="flex items-center justify-between gap-3 text-sm"
-          role="status"
-        >
-          <span>Computer control is stopped.</span>
-          <Button
-            size="sm"
-            variant="outline"
-            disabled={busy.has("control")}
-            onClick={() =>
-              run("control", "Could not resume control", () =>
-                resumeComputerUseControl(),
-              )
-            }
-          >
-            Resume
-          </Button>
+    <>
+      <div className="pointer-events-none fixed inset-x-0 top-5 z-50 flex max-h-[calc(100vh-8rem)] justify-center px-4">
+        <div className="flex w-full max-w-[26rem] flex-col gap-2 overflow-y-auto p-1">
+          {snapshot.pendingConsents.map((prompt) => {
+            const key = `consent:${prompt.callId}`;
+            const deciding = busy.has(key);
+            const copy = consentCopy(prompt);
+            return (
+              <section
+                key={prompt.callId}
+                className="bg-popover text-popover-foreground pointer-events-auto flex flex-col gap-3 rounded-2xl border p-4 shadow-2xl"
+                aria-label="Computer use permission"
+                aria-busy={deciding}
+              >
+                <div>
+                  <p className="text-muted-foreground mb-1 text-[0.6875rem] font-semibold tracking-[0.08em] uppercase">
+                    Computer use
+                  </p>
+                  <h2 className="text-sm font-semibold break-words">
+                    {copy.title}
+                  </h2>
+                  {copy.detail && (
+                    <p className="text-muted-foreground mt-1 text-xs leading-relaxed break-words">
+                      {copy.detail}
+                    </p>
+                  )}
+                </div>
+                <div className="flex flex-wrap justify-end gap-2">
+                  <Button
+                    size="xs"
+                    variant="ghost"
+                    disabled={deciding}
+                    onClick={() =>
+                      run(key, "Could not send your decision", () =>
+                        resolveComputerUseConsent(prompt.callId, "decline"),
+                      )
+                    }
+                  >
+                    Don&apos;t allow
+                  </Button>
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    disabled={deciding}
+                    onClick={() =>
+                      run(key, "Could not send your decision", () =>
+                        resolveComputerUseConsent(prompt.callId, "chat"),
+                      )
+                    }
+                  >
+                    Allow for this chat
+                  </Button>
+                  {prompt.grantScope === "project" && (
+                    <Button
+                      size="xs"
+                      variant="outline"
+                      disabled={deciding}
+                      onClick={() =>
+                        run(key, "Could not send your decision", () =>
+                          resolveComputerUseConsent(prompt.callId, "always"),
+                        )
+                      }
+                    >
+                      Always in this project
+                    </Button>
+                  )}
+                  <Button
+                    size="xs"
+                    disabled={deciding}
+                    onClick={() =>
+                      run(key, "Could not send your decision", () =>
+                        resolveComputerUseConsent(prompt.callId, "once"),
+                      )
+                    }
+                  >
+                    Allow once
+                  </Button>
+                </div>
+                {errors[key] && (
+                  <p className="text-destructive text-xs break-words" role="alert">
+                    {errors[key]}
+                  </p>
+                )}
+              </section>
+            );
+          })}
+          {snapshot.pendingConfirmations.map((prompt) => {
+            const key = `confirmation:${prompt.callId}`;
+            const deciding = busy.has(key);
+            return (
+              <section
+                key={prompt.callId}
+                className="bg-popover text-popover-foreground pointer-events-auto flex flex-col gap-3 rounded-2xl border p-4 shadow-2xl"
+                aria-label="Confirm action"
+                aria-busy={deciding}
+              >
+                <div>
+                  <p className="text-muted-foreground mb-1 text-[0.6875rem] font-semibold tracking-[0.08em] uppercase">
+                    Confirm action
+                  </p>
+                  <h2 className="text-sm font-semibold break-words">
+                    Allow Tidebreak to {prompt.reason}?
+                  </h2>
+                  <p className="text-muted-foreground mt-1 text-xs leading-relaxed break-words">
+                    {prompt.targetLabel ? `“${prompt.targetLabel}” in ` : "In "}
+                    {appLabel(prompt.appName, prompt.bundleId)}
+                  </p>
+                </div>
+                <div className="flex justify-end gap-2">
+                  <Button
+                    size="xs"
+                    variant="ghost"
+                    disabled={deciding}
+                    onClick={() =>
+                      run(key, "Could not send your decision", () =>
+                        resolveComputerUseConfirmation(prompt.callId, false),
+                      )
+                    }
+                  >
+                    Don&apos;t allow
+                  </Button>
+                  <Button
+                    size="xs"
+                    disabled={deciding}
+                    onClick={() =>
+                      run(key, "Could not send your decision", () =>
+                        resolveComputerUseConfirmation(prompt.callId, true),
+                      )
+                    }
+                  >
+                    Allow action
+                  </Button>
+                </div>
+                {errors[key] && (
+                  <p className="text-destructive text-xs break-words" role="alert">
+                    {errors[key]}
+                  </p>
+                )}
+              </section>
+            );
+          })}
         </div>
-      ) : (
-        showActive &&
-        snapshot.active && (
+      </div>
+
+      {(snapshot.halted || (showActive && snapshot.active)) && (
+        <div className="pointer-events-none fixed inset-x-0 bottom-5 z-50 flex justify-center px-4">
           <div
-            className="flex items-center justify-between gap-3 text-sm"
+            className="bg-popover text-popover-foreground pointer-events-auto flex min-w-0 max-w-md items-center gap-3 rounded-2xl border px-3 py-2.5 shadow-2xl"
             role="status"
           >
-            <span>
-              Tidebreak is controlling{" "}
-              {appLabel(snapshot.active.appName, snapshot.active.bundleId)}
-            </span>
+            <span
+              className={`size-2.5 shrink-0 rounded-full ${
+                snapshot.halted
+                  ? "bg-muted-foreground"
+                  : "bg-emerald-400 shadow-[0_0_0_4px_rgba(52,211,153,0.18)]"
+              }`}
+              aria-hidden="true"
+            />
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-xs font-semibold">
+                {snapshot.halted
+                  ? "Computer control is stopped"
+                  : `Tidebreak is controlling ${appLabel(
+                      snapshot.active?.appName ?? null,
+                      snapshot.active?.bundleId ?? "",
+                    )}`}
+              </p>
+              <p className="text-muted-foreground text-[0.6875rem]">
+                {snapshot.halted
+                  ? "Resume only when you want the agent to continue."
+                  : "You can stop before the next action."}
+              </p>
+            </div>
             <Button
-              size="sm"
-              variant="outline"
+              size="xs"
+              variant={snapshot.halted ? "outline" : "destructive"}
               disabled={busy.has("control")}
               onClick={() =>
-                run("control", "Could not stop control", () =>
-                  stopComputerUseControl(),
-                )
+                snapshot.halted
+                  ? run("control", "Could not resume control", () =>
+                      resumeComputerUseControl(),
+                    )
+                  : run("control", "Could not stop control", () =>
+                      stopComputerUseControl(),
+                    )
               }
             >
-              Stop
+              {snapshot.halted ? "Resume" : busy.has("control") ? "Stopping…" : "Stop"}
             </Button>
           </div>
-        )
-      )}
-      {errors.control && (
-        <p className="text-destructive text-xs break-words" role="alert">
-          {errors.control}
-        </p>
-      )}
-      {snapshot.pendingConsents.map((prompt) => {
-        const key = `consent:${prompt.callId}`;
-        const deciding = busy.has(key);
-        return (
-          <section
-            key={prompt.callId}
-            className="flex max-w-prose flex-col gap-2 rounded-lg border p-3"
-            aria-label="Computer use permission"
-            aria-busy={deciding}
-          >
-            <p className="text-sm font-medium break-words">
-              {capabilityAsk(
-                prompt.capability,
-                consentLabel(prompt.appName, prompt.bundleId),
-              )}
+          {errors.control && (
+            <p
+              className="bg-popover text-destructive pointer-events-auto absolute bottom-full mb-2 rounded-lg border px-3 py-2 text-xs shadow-lg"
+              role="alert"
+            >
+              {errors.control}
             </p>
-            <div className="flex flex-wrap gap-2">
-              <Button
-                size="sm"
-                disabled={deciding}
-                onClick={() =>
-                  run(key, "Could not send your decision", () =>
-                    resolveComputerUseConsent(prompt.callId, "once"),
-                  )
-                }
-              >
-                Once
-              </Button>
-              <Button
-                size="sm"
-                variant="outline"
-                disabled={deciding}
-                onClick={() =>
-                  run(key, "Could not send your decision", () =>
-                    resolveComputerUseConsent(prompt.callId, "chat"),
-                  )
-                }
-              >
-                Always for this chat
-              </Button>
-              <Button
-                size="sm"
-                variant="outline"
-                disabled={deciding}
-                onClick={() =>
-                  run(key, "Could not send your decision", () =>
-                    resolveComputerUseConsent(prompt.callId, "always"),
-                  )
-                }
-              >
-                Always
-              </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                disabled={deciding}
-                onClick={() =>
-                  run(key, "Could not send your decision", () =>
-                    resolveComputerUseConsent(prompt.callId, "decline"),
-                  )
-                }
-              >
-                Decline
-              </Button>
-            </div>
-            {errors[key] && (
-              <p className="text-destructive text-xs break-words" role="alert">
-                {errors[key]}
-              </p>
-            )}
-          </section>
-        );
-      })}
-      {snapshot.pendingConfirmations.map((prompt) => {
-        const key = `confirmation:${prompt.callId}`;
-        const deciding = busy.has(key);
-        return (
-          <section
-            key={prompt.callId}
-            className="flex max-w-prose flex-col gap-2 rounded-lg border p-3"
-            aria-label="Confirm action"
-            aria-busy={deciding}
-          >
-            <p className="text-sm font-medium break-words">
-              Tidebreak wants to {prompt.reason}
-              {prompt.targetLabel ? ` — “${prompt.targetLabel}”` : ""} in{" "}
-              {appLabel(prompt.appName, prompt.bundleId)}.
-            </p>
-            <div className="flex flex-wrap gap-2">
-              <Button
-                size="sm"
-                disabled={deciding}
-                onClick={() =>
-                  run(key, "Could not send your decision", () =>
-                    resolveComputerUseConfirmation(prompt.callId, true),
-                  )
-                }
-              >
-                Confirm
-              </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                disabled={deciding}
-                onClick={() =>
-                  run(key, "Could not send your decision", () =>
-                    resolveComputerUseConfirmation(prompt.callId, false),
-                  )
-                }
-              >
-                Deny
-              </Button>
-            </div>
-            {errors[key] && (
-              <p className="text-destructive text-xs break-words" role="alert">
-                {errors[key]}
-              </p>
-            )}
-          </section>
-        );
-      })}
-    </div>
+          )}
+        </div>
+      )}
+    </>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/computerUse.ts
+++ b/crates/tidebreak-desktop/ui/src/computerUse.ts
@@ -18,6 +18,7 @@ export type ComputerUseConsentPrompt = {
   bundleId: string;
   appName: string | null;
   capability: ComputerUseCapability;
+  grantScope: "chat" | "project";
 };
 
 /** A consequential action the host broker is holding for confirmation. */

--- a/crates/tidebreak-server/src/foreground_prompt.rs
+++ b/crates/tidebreak-server/src/foreground_prompt.rs
@@ -490,6 +490,9 @@ pub(crate) fn compose_for_surface(
         );
         if acting {
             lines.push(
+                "- Computer use is primarily for observing the user's apps. GUI control uses their real cursor, keyboard, and focus, so it is slower, more brittle, and more disruptive than reading or a dedicated tool; use it sparingly and only when a non-GUI path will not complete the request.",
+            );
+            lines.push(
                 "- Read before acting: confirm the target with `computer_read_app_content` or `computer_capture_screen` before `computer_click`, `computer_type_text`, or `computer_key_press`, and look again afterward to confirm the effect.",
             );
             lines.push(
@@ -500,6 +503,9 @@ pub(crate) fn compose_for_surface(
             );
             lines.push(
                 "- Acting may ask the user's approval once per app, and the user can stop control at any time; a refusal or a stop is a decision to respect, not an error to retry.",
+            );
+            lines.push(
+                "- When work in another app is finished, use `computer_return_to_tidebreak` so the user can see completion and continue the conversation.",
             );
         }
         push_section(&mut prompt, COMPUTER_USE_HEADING, &lines);


### PR DESCRIPTION
## Summary

- replace the full-width computer-use banner with compact floating permission, confirmation, and control HUDs
- make screen and app consent copy accurately describe the available chat or project grant scope
- strengthen computer-use guidance so models observe first, prefer non-GUI tools, act sparingly, and return focus to Tidebreak when finished

## Why

The existing banner displaced the desktop shell and presented ambiguous permission choices. Computer-use guidance also needed a clearer bias toward reliable observation instead of unnecessary interaction with the user's live interface.

This keeps the change intentionally narrow: the HUD remains inside the Tidebreak window and does not add native always-on-top windows, onboarding flows, or new approval architecture.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p tidebreak-desktop --locked`
- `cargo test -p tidebreak-core computer_use --locked`
- `cargo test -p tidebreak-server foreground_prompt::tests --locked`
- `pnpm test` (142 files, 971 tests)
- `pnpm build`
- `git diff --check`
