### PR TITLE
fix(chat): distinguish provider access failures

### DIFF
--- a/crates/tidebreak-core/src/db/ops/conversation.rs
+++ b/crates/tidebreak-core/src/db/ops/conversation.rs
@@ -1083,6 +1083,7 @@ where
             reasoning: String::new(),
             refusal: None,
             failure_kind: turn.last_error_code,
+            failure_detail: turn.last_error_detail,
             model: turn.model,
             invoked_skills,
             usage,

--- a/crates/tidebreak-core/src/db/tests.rs
+++ b/crates/tidebreak-core/src/db/tests.rs
@@ -6561,6 +6561,7 @@ async fn running_turn_cancellation_holds_the_chat_until_exact_worker_acknowledge
             reasoning: String::new(),
             refusal: None,
             failure_kind: None,
+            failure_detail: None,
             model: "gpt-5".into(),
             invoked_skills: Vec::new(),
             usage,

--- a/crates/tidebreak-core/src/error.rs
+++ b/crates/tidebreak-core/src/error.rs
@@ -113,6 +113,10 @@ pub enum AgentError {
     #[error("provider authentication failed: {0}")]
     Authentication(String),
 
+    /// The provider account or organization is not allowed to make the request.
+    #[error("provider account access denied: {0}")]
+    AccessDenied(String),
+
     /// The provider is rate limiting requests.
     #[error("provider rate limited the request: {0}")]
     RateLimited(ProviderFailure),
@@ -168,6 +172,7 @@ impl AgentError {
             Self::Secret(_) => "secret",
             Self::Provider(_) => "provider",
             Self::Authentication(_) => "authentication",
+            Self::AccessDenied(_) => "access_denied",
             Self::RateLimited(_) => "rate_limited",
             Self::Overloaded(_) => "overloaded",
             Self::InvalidRequest(_) => "invalid_request",
@@ -223,6 +228,7 @@ impl ProviderErrorInfo {
         let message = match error {
             AgentError::Provider(message)
             | AgentError::Authentication(message)
+            | AgentError::AccessDenied(message)
             | AgentError::InvalidRequest(message)
             | AgentError::Refusal(message)
             | AgentError::PromptTooLong(message) => message.clone(),
@@ -253,6 +259,7 @@ impl ProviderErrorInfo {
     pub fn into_agent_error(self) -> AgentError {
         match self.kind.as_str() {
             "authentication" => AgentError::Authentication(self.message),
+            "access_denied" => AgentError::AccessDenied(self.message),
             "rate_limited" => AgentError::RateLimited(self.message.into()),
             "overloaded" => AgentError::Overloaded(self.message.into()),
             "invalid_request" => AgentError::InvalidRequest(self.message),
@@ -306,6 +313,7 @@ mod tests {
         for (error, kind) in [
             (AgentError::Provider("p".into()), "provider"),
             (AgentError::Authentication("a".into()), "authentication"),
+            (AgentError::AccessDenied("d".into()), "access_denied"),
             (AgentError::RateLimited("r".into()), "rate_limited"),
             (AgentError::Overloaded("o".into()), "overloaded"),
             (AgentError::InvalidRequest("i".into()), "invalid_request"),

--- a/crates/tidebreak-core/src/storage/types.rs
+++ b/crates/tidebreak-core/src/storage/types.rs
@@ -92,6 +92,9 @@ pub struct ChatTerminalTurnSnapshot {
     /// Stable internal failure kind. Renderer projections must classify this
     /// before it crosses the server boundary.
     pub failure_kind: Option<String>,
+    /// Bounded terminal diagnostic. Renderer projections must allowlist the
+    /// provider-originated kinds that may cross the server boundary.
+    pub failure_detail: Option<String>,
     /// Provider-qualified model selection captured when the turn was accepted.
     pub model: String,
     /// Skills the user explicitly invoked when the turn was accepted, in

--- a/crates/tidebreak-desktop/ui/src/ChatSessionReducer.ts
+++ b/crates/tidebreak-desktop/ui/src/ChatSessionReducer.ts
@@ -531,6 +531,7 @@ export function reduceChatSessionEvent(
               id: deps.nextId(),
               role: "turn_failure",
               category: event.category,
+              detail: event.detail,
               model: event.model,
             },
           ],

--- a/crates/tidebreak-desktop/ui/src/ChatTranscriptPresentation.ts
+++ b/crates/tidebreak-desktop/ui/src/ChatTranscriptPresentation.ts
@@ -60,6 +60,7 @@ export function presentChatTranscript(
                 id: `failure:${entry.id}`,
                 role: "turn_failure",
                 category: entry.failureCategory ?? "unknown",
+                detail: entry.failureDetail,
                 model: entry.failureModel,
                 invokedSkills:
                   entry.invokedSkills.length > 0

--- a/crates/tidebreak-desktop/ui/src/MessageList.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/MessageList.test.tsx
@@ -579,9 +579,9 @@ describe("retryableTurn", () => {
     { id: "f1", role: "turn_failure", category },
   ];
 
-  // `auth` is the case worth pinning: a retry would present the same credential
-  // the provider just rejected, so offering the button lies about recovery.
-  it("offers a retry for every terminal category except auth", () => {
+  // Account access and authentication failures are stable until the provider
+  // account changes, so replaying the same turn would only repeat the refusal.
+  it("withholds retry for authentication and provider access failures", () => {
     expect(retryableTurn(failed("rate_limited"))).toMatchObject({
       failureId: "f1",
       text: "summarize this",
@@ -589,6 +589,7 @@ describe("retryableTurn", () => {
     expect(retryableTurn(failed("transient"))).not.toBeNull();
     expect(retryableTurn(failed("unknown"))).not.toBeNull();
     expect(retryableTurn(failed("auth"))).toBeNull();
+    expect(retryableTurn(failed("provider_access"))).toBeNull();
   });
 
   it("offers nothing once the failure is no longer the newest message", () => {

--- a/crates/tidebreak-desktop/ui/src/MessageList.tsx
+++ b/crates/tidebreak-desktop/ui/src/MessageList.tsx
@@ -131,6 +131,7 @@ export type ChatMessage =
       id: string;
       role: "turn_failure";
       category: TurnFailureCategory;
+      detail?: string;
       model?: { id: string; provider: ModelInfo["provider"] };
       invokedSkills?: readonly string[];
       voiceInputUsed?: boolean;
@@ -1267,6 +1268,7 @@ function MessageBubbleImpl({
     return (
       <TurnFailureNotice
         category={message.category}
+        detail={message.detail}
         model={message.model}
         onRetry={onRetry}
       />

--- a/crates/tidebreak-desktop/ui/src/TranscriptHistory.ts
+++ b/crates/tidebreak-desktop/ui/src/TranscriptHistory.ts
@@ -56,6 +56,7 @@ export type HydratedTranscriptEntry =
       text: string;
       reasoning?: string;
       failureCategory?: NonNullable<ChatTerminalTurn["failure_category"]>;
+      failureDetail?: NonNullable<ChatTerminalTurn["failure_detail"]>;
       failureModel?: NonNullable<ChatTerminalTurn["failure_model"]>;
       invokedSkills: readonly string[];
       voiceInputUsed: boolean;
@@ -169,6 +170,7 @@ export function hydrateTranscriptHistory(
         text: turn.partial_content,
         reasoning: turn.reasoning,
         failureCategory: turn.failure_category,
+        failureDetail: turn.failure_detail,
         failureModel: turn.failure_model,
         invokedSkills: turn.invoked_skills ?? [],
         voiceInputUsed: turn.voice_input_used ?? false,

--- a/crates/tidebreak-desktop/ui/src/TurnFailureNotice.test.ts
+++ b/crates/tidebreak-desktop/ui/src/TurnFailureNotice.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  turnFailureCopy,
+  turnFailureOffersRetry,
+} from "./TurnFailureNotice";
+
+describe("TurnFailureNotice copy", () => {
+  it("attributes a bare provider access denial without inventing one cause", () => {
+    const copy = turnFailureCopy("provider_access", "xAI");
+
+    expect(copy.title).toBe("xAI denied access to this request");
+    expect(copy.body).toContain("not Tidebreak");
+    expect(copy.body).toContain("exhausted credits or quota");
+    expect(copy.body).toContain("billing or organization restrictions");
+    expect(turnFailureOffersRetry("provider_access")).toBe(false);
+  });
+
+  it("keeps invalid credentials separate from provider account access", () => {
+    const copy = turnFailureCopy("auth", "xAI");
+
+    expect(copy.title).toContain("authenticate");
+    expect(copy.body).toContain("API key");
+    expect(copy.body).not.toContain("credits");
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/TurnFailureNotice.tsx
+++ b/crates/tidebreak-desktop/ui/src/TurnFailureNotice.tsx
@@ -1,4 +1,4 @@
-import { RefreshCw, Settings } from "lucide-react";
+import { AlertCircle, RefreshCw, Settings } from "lucide-react";
 import { useNavigate } from "@tanstack/react-router";
 
 import { Button } from "@/components/ui/button";
@@ -17,7 +17,7 @@ import { providerLabel } from "./ModelSelection";
  * rejection. That case points at settings instead.
  */
 export function turnFailureOffersRetry(category: TurnFailureCategory): boolean {
-  return category !== "auth";
+  return category !== "auth" && category !== "provider_access";
 }
 
 /**
@@ -28,16 +28,36 @@ export function turnFailureOffersRetry(category: TurnFailureCategory): boolean {
  * those retries were already spent — copy that asks the reader to be patient
  * would be describing something that has already finished happening.
  */
-export function turnFailureCopy(category: TurnFailureCategory): string {
+export function turnFailureCopy(
+  category: TurnFailureCategory,
+  provider = "The model provider",
+): { title: string; body: string } {
   switch (category) {
     case "rate_limited":
-      return "The model provider rate-limited this turn, and the automatic retries behind it are already spent. Sending it again may work once demand eases.";
+      return {
+        title: `${provider} is rate-limiting requests`,
+        body: "Automatic retries are already spent. Retry after demand or your provider quota resets.",
+      };
     case "auth":
-      return "The model provider rejected the credentials for this model. Sending the turn again would be rejected the same way — check the provider's API key in Settings.";
+      return {
+        title: `${provider} could not authenticate this request`,
+        body: "Check that the API key is present, active, and belongs to the account or organization you intended to use.",
+      };
+    case "provider_access":
+      return {
+        title: `${provider} denied access to this request`,
+        body: `This came from ${provider}, not Tidebreak. Common causes include exhausted credits or quota, billing or organization restrictions, missing model access, and key permissions.`,
+      };
     case "transient":
-      return "The connection to the model provider broke before the turn finished. Sending it again should pick up where this left off.";
+      return {
+        title: `The connection to ${provider} failed`,
+        body: "The turn ended before the provider finished responding. Retrying may succeed.",
+      };
     case "unknown":
-      return "The turn could not be completed, and the provider gave no reason we can act on. Sending it again may not help; if it keeps failing, check the provider's API key in Settings.";
+      return {
+        title: "This turn could not be completed",
+        body: "Tidebreak does not have a specific recovery for this failure. Retry once; if it repeats, use the detail below when troubleshooting.",
+      };
   }
 }
 
@@ -50,10 +70,12 @@ export function turnFailureCopy(category: TurnFailureCategory): string {
  */
 export function TurnFailureNotice({
   category,
+  detail,
   model,
   onRetry,
 }: {
   category: TurnFailureCategory;
+  detail?: string;
   model?: { id: string; provider: ProviderKind };
   onRetry?: () => void;
 }) {
@@ -61,16 +83,21 @@ export function TurnFailureNotice({
   // Settings sections are registered from a runtime table, so TanStack's
   // generated route union contains `/settings` but not each literal child.
   const providerSettingsPath: string = "/settings/providers";
+  const provider = model ? providerLabel(model.provider) : "The model provider";
+  const copy = turnFailureCopy(category, provider);
 
   return (
-    <div className="message-notice is-error message-turn-failure" role="alert">
+    <aside className="message-turn-failure" role="alert">
+      <AlertCircle className="message-turn-failure-icon" aria-hidden="true" />
       <div className="message-turn-failure-text">
+        <p className="message-turn-failure-title">{copy.title}</p>
+        <p className="message-turn-failure-body">{copy.body}</p>
+        {detail && <code className="message-turn-failure-detail">{detail}</code>}
         {model && (
-          <p className="text-muted-foreground mb-1 text-xs font-medium">
-            {model.id} · {providerLabel(model.provider)}
+          <p className="message-turn-failure-model">
+            {model.id} · {provider}
           </p>
         )}
-        <p>{turnFailureCopy(category)}</p>
       </div>
       {turnFailureOffersRetry(category) ? (
         onRetry && (
@@ -78,7 +105,7 @@ export function TurnFailureNotice({
             type="button"
             variant="outline"
             size="sm"
-            className="shrink-0"
+            className="message-turn-failure-action"
             onClick={onRetry}
           >
             <RefreshCw aria-hidden="true" />
@@ -90,13 +117,13 @@ export function TurnFailureNotice({
           type="button"
           variant="outline"
           size="sm"
-          className="shrink-0"
+          className="message-turn-failure-action"
           onClick={() => void navigate({ to: providerSettingsPath })}
         >
           <Settings aria-hidden="true" />
           Open provider settings
         </Button>
       )}
-    </div>
+    </aside>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -2156,7 +2156,8 @@ action?: ToolActionPreview,
 result?: ToolResultPreview, } | { "type": "turn_completed", usage: RendererTurnUsage, } | { "type": "turn_refused", refusal: RendererRefusal, usage: RendererTurnUsage, } | { "type": "turn_failed", 
 /**
  * Why the turn failed, at the only resolution a client can act on.
- * The failure's `kind` and `message` stay internal.
+ * The internal `kind` stays behind the server; allowlisted provider
+ * diagnostics may cross separately as `detail`.
  */
 category: TurnFailureCategory, 
 /**

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -605,7 +605,7 @@ origin: RootAttachmentOrigin, };
  * message-less failed and cancelled turns remain first-class transcript entries
  * carrying the partial prose and reasoning the reader already saw live.
  */
-export type ChatTerminalTurnSnapshot = { turn_id: TurnId, message_id?: MessageId, status: ChatTerminalTurnStatus, partial_content: string, reasoning?: string, refusal?: RendererRefusal, failure_category?: TurnFailureCategory, failure_model?: RendererModelIdentity, file_changes: Array<ExecFileChangeSummary>, 
+export type ChatTerminalTurnSnapshot = { turn_id: TurnId, message_id?: MessageId, status: ChatTerminalTurnStatus, partial_content: string, reasoning?: string, refusal?: RendererRefusal, failure_category?: TurnFailureCategory, failure_detail?: string, failure_model?: RendererModelIdentity, file_changes: Array<ExecFileChangeSummary>, 
 /**
  * Skills the user explicitly invoked for this turn, in submitted order.
  * Absent for the ordinary turn that invoked none.
@@ -2158,7 +2158,11 @@ result?: ToolResultPreview, } | { "type": "turn_completed", usage: RendererTurnU
  * Why the turn failed, at the only resolution a client can act on.
  * The failure's `kind` and `message` stay internal.
  */
-category: TurnFailureCategory, model?: RendererModelIdentity, } | { "type": "turn_cancelled", usage: RendererTurnUsage, } | { "type": "user_steered", message_id: MessageId, text: string, } | { "type": "context_truncated", 
+category: TurnFailureCategory, 
+/**
+ * Bounded provider diagnostic, when the failure originated upstream.
+ */
+detail?: string, model?: RendererModelIdentity, } | { "type": "turn_cancelled", usage: RendererTurnUsage, } | { "type": "user_steered", message_id: MessageId, text: string, } | { "type": "context_truncated", 
 /**
  * Estimated transcript tokens before the reduction.
  */
@@ -2807,7 +2811,7 @@ export type TranscriptRole = "user" | "assistant" | "system" | "compaction";
  * whether a failed turn is rescheduled — so the category a client sees and the
  * category the scheduler acted on cannot drift apart.
  */
-export type TurnFailureCategory = "rate_limited" | "auth" | "transient" | "unknown";
+export type TurnFailureCategory = "rate_limited" | "auth" | "provider_access" | "transient" | "unknown";
 
 /**
  * Identifies one turn: a single user input through to the final answer.

--- a/crates/tidebreak-desktop/ui/src/styles.css
+++ b/crates/tidebreak-desktop/ui/src/styles.css
@@ -897,20 +897,80 @@ body {
   text-align: left;
 }
 
-/* A failure carries its recovery, so the notice becomes a row: explanation on
-   the left, the one action it offers pinned to the right. */
 .message-turn-failure {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+  align-self: stretch;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: start;
   gap: 0.75rem;
-  flex-wrap: wrap;
-  padding: 0.5rem 0.5rem 0.5rem 0.7rem;
+  padding: 0.875rem;
+  border: 1px solid color-mix(in srgb, var(--destructive) 24%, var(--line));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--critical-background) 48%, var(--background));
+  color: var(--foreground);
+  text-align: left;
+}
+
+.message-turn-failure-icon {
+  width: 1rem;
+  height: 1rem;
+  margin-top: 0.15rem;
+  color: var(--destructive);
 }
 
 .message-turn-failure-text {
   min-width: 0;
-  flex: 1 1 16rem;
+  max-width: 44rem;
+}
+
+.message-turn-failure-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.message-turn-failure-body {
+  margin-top: 0.25rem;
+  color: var(--muted-foreground);
+  font-size: 0.8rem;
+  line-height: 1.5;
+  text-wrap: pretty;
+}
+
+.message-turn-failure-detail {
+  display: block;
+  width: fit-content;
+  max-width: 100%;
+  margin-top: 0.55rem;
+  padding: 0.2rem 0.4rem;
+  overflow-wrap: anywhere;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--muted) 76%, transparent);
+  color: var(--foreground);
+  font-size: 0.72rem;
+  line-height: 1.45;
+}
+
+.message-turn-failure-model {
+  margin-top: 0.5rem;
+  color: var(--muted-foreground);
+  font-size: 0.7rem;
+}
+
+.message-turn-failure-action {
+  align-self: center;
+  flex-shrink: 0;
+}
+
+@media (max-width: 640px) {
+  .message-turn-failure {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .message-turn-failure-action {
+    grid-column: 2;
+    justify-self: start;
+  }
 }
 
 .message-notice.is-refusal {

--- a/crates/tidebreak-router/src/gemini.rs
+++ b/crates/tidebreak-router/src/gemini.rs
@@ -2218,7 +2218,7 @@ mod tests {
         };
         server.abort();
 
-        assert!(matches!(error, AgentError::Authentication(_)));
+        assert!(matches!(error, AgentError::AccessDenied(_)));
         let visible = error.to_string();
         assert!(visible.contains("gemini returned 403"), "{visible}");
         assert!(visible.contains("permission_denied"), "{visible}");
@@ -2352,7 +2352,7 @@ mod tests {
             events,
             vec![ProviderEvent::Failed {
                 error: ProviderErrorInfo {
-                    kind: "authentication".into(),
+                    kind: "access_denied".into(),
                     message: "gemini returned 403 (permission_denied): The caller does not have permission"
                         .into(),
                 },

--- a/crates/tidebreak-router/src/sse.rs
+++ b/crates/tidebreak-router/src/sse.rs
@@ -597,8 +597,11 @@ pub fn classify_provider_error(
     {
         return AgentError::PromptTooLong(safe());
     }
-    if matches!(status, 401 | 403) || matches!(code, "authentication_error" | "invalid_api_key") {
+    if status == 401 || matches!(code, "authentication_error" | "invalid_api_key") {
         return AgentError::Authentication(safe());
+    }
+    if status == 403 {
+        return AgentError::AccessDenied(safe());
     }
     if status == 429 || code == "rate_limit_error" {
         return AgentError::RateLimited(ProviderFailure::new(safe(), retry_after));
@@ -923,6 +926,33 @@ mod tests {
                 r#"{"error":"invalid_request","error_description":"The requested model is unavailable"}"#,
             ),
             "openai returned 400 (invalid_request): The requested model is unavailable"
+        );
+    }
+
+    #[test]
+    fn bare_403_is_account_access_not_invalid_credentials() {
+        let error = classify_provider_error("xai", 403, "", None);
+        assert!(
+            matches!(error, tidebreak_core::error::AgentError::AccessDenied(_)),
+            "{error:?}"
+        );
+        assert_eq!(
+            error.to_string(),
+            "provider account access denied: xai returned 403"
+        );
+
+        let explicit_bad_key = classify_provider_error(
+            "xai",
+            403,
+            r#"{"error":{"code":"invalid_api_key","message":"Incorrect API key"}}"#,
+            None,
+        );
+        assert!(
+            matches!(
+                explicit_bad_key,
+                tidebreak_core::error::AgentError::Authentication(_)
+            ),
+            "{explicit_bad_key:?}"
         );
     }
 

--- a/crates/tidebreak-server/src/event_projection.rs
+++ b/crates/tidebreak-server/src/event_projection.rs
@@ -250,8 +250,13 @@ pub(crate) enum RendererAgentEvent {
     },
     TurnFailed {
         /// Why the turn failed, at the only resolution a client can act on.
-        /// The failure's `kind` and `message` stay internal.
+        /// The internal `kind` stays behind the server; allowlisted provider
+        /// diagnostics may cross separately as `detail`.
         category: TurnFailureCategory,
+        /// Bounded provider diagnostic, when the failure originated upstream.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        detail: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         #[ts(optional)]
         model: Option<RendererModelIdentity>,
@@ -306,6 +311,10 @@ pub(crate) enum TurnFailureCategory {
     /// The provider rejected our credentials. Retrying replays the same
     /// rejection; only fixing the key changes the outcome.
     Auth,
+    /// The provider account or organization denied access. This includes bare
+    /// 403 responses that may represent credits, billing, policy, entitlement,
+    /// or key-permission failures.
+    ProviderAccess,
     /// A transient fault below the turn — an upstream error, a storage or
     /// secret-store failure. Retrying is reasonable.
     Transient,
@@ -324,6 +333,7 @@ impl TurnFailureCategory {
         match kind {
             "rate_limited" | "overloaded" => Self::RateLimited,
             "authentication" | "missing_credential" => Self::Auth,
+            "access_denied" => Self::ProviderAccess,
             "provider" | "store" | "secret" | "empty_model_response" => Self::Transient,
             _ => Self::Unknown,
         }
@@ -333,6 +343,25 @@ impl TurnFailureCategory {
     pub(crate) const fn retries_may_succeed(self) -> bool {
         matches!(self, Self::RateLimited | Self::Transient)
     }
+}
+
+/// Only provider-originated diagnostics cross to the renderer. These strings
+/// have already passed the router's bounded message extraction and credential
+/// redaction; internal failures can carry host paths and stay server-side.
+pub(crate) fn renderer_provider_failure_detail(kind: &str, detail: &str) -> Option<String> {
+    matches!(
+        kind,
+        "authentication"
+            | "access_denied"
+            | "rate_limited"
+            | "overloaded"
+            | "invalid_request"
+            | "refusal"
+            | "prompt_too_long"
+            | "provider"
+    )
+    .then(|| detail.trim().to_owned())
+    .filter(|detail| !detail.is_empty())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
@@ -422,10 +451,14 @@ impl From<&SequencedEvent> for RendererSequencedEvent {
                 refusal: refusal.into(),
                 usage: (*usage).into(),
             },
-            AgentEvent::TurnFailed { error } => RendererAgentEvent::TurnFailed {
-                category: TurnFailureCategory::from_kind(&error.kind),
-                model: None,
-            },
+            AgentEvent::TurnFailed { error } => {
+                let category = TurnFailureCategory::from_kind(&error.kind);
+                RendererAgentEvent::TurnFailed {
+                    category,
+                    detail: renderer_provider_failure_detail(&error.kind, &error.message),
+                    model: None,
+                }
+            }
             AgentEvent::TurnCancelled { usage } => RendererAgentEvent::TurnCancelled {
                 usage: (*usage).into(),
             },
@@ -673,34 +706,44 @@ mod tests {
         );
     }
 
-    /// A failure carries only the category and, when attached later from the
-    /// turn receipt, its safe model identity. Provider diagnostics stay behind.
+    /// A failure carries its category and a bounded provider diagnostic. Host
+    /// and internal failures still keep their detail behind the server.
     #[test]
-    fn failure_projection_carries_a_category_and_nothing_else() {
+    fn failure_projection_carries_category_and_provider_detail_only() {
         let cases = [
             (
                 AgentError::RateLimited("upstream said 429 for key sk-live".into()),
                 TurnFailureCategory::RateLimited,
+                true,
             ),
             (
                 AgentError::Authentication("invalid x-api-key sk-live".into()),
                 TurnFailureCategory::Auth,
+                true,
+            ),
+            (
+                AgentError::AccessDenied("xai returned 403".into()),
+                TurnFailureCategory::ProviderAccess,
+                true,
             ),
             (
                 AgentError::MissingCredential("no model provider is configured".into()),
                 TurnFailureCategory::Auth,
+                false,
             ),
             (
                 AgentError::Provider("upstream 503 from api.example".into()),
                 TurnFailureCategory::Transient,
+                true,
             ),
             (
                 AgentError::msg("max steps per turn were consumed"),
                 TurnFailureCategory::Unknown,
+                false,
             ),
         ];
 
-        for (error, expected) in cases {
+        for (error, expected, exposes_detail) in cases {
             let projected = RendererSequencedEvent::from(&SequencedEvent {
                 seq: 1,
                 event: AgentEvent::TurnFailed {
@@ -711,12 +754,17 @@ mod tests {
                 projected.event,
                 RendererAgentEvent::TurnFailed {
                     category: expected,
+                    detail: exposes_detail.then(|| error.to_string()),
                     model: None,
                 },
                 "{error}"
             );
             let encoded = serde_json::to_value(&projected).unwrap();
-            assert_eq!(encoded["event"].as_object().unwrap().len(), 2, "{encoded}");
+            assert_eq!(
+                encoded["event"].get("detail").is_some(),
+                exposes_detail,
+                "{encoded}"
+            );
         }
     }
 

--- a/crates/tidebreak-server/src/routes/projects_chats.rs
+++ b/crates/tidebreak-server/src/routes/projects_chats.rs
@@ -521,6 +521,9 @@ pub struct ChatTerminalTurnSnapshot {
     pub failure_category: Option<crate::event_projection::TurnFailureCategory>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
+    pub failure_detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
     pub failure_model: Option<crate::event_projection::RendererModelIdentity>,
     pub file_changes: Vec<ExecFileChangeSummary>,
     /// Skills the user explicitly invoked for this turn, in submitted order.
@@ -557,6 +560,12 @@ impl From<tidebreak_core::ChatTerminalTurnSnapshot> for ChatTerminalTurnSnapshot
         });
         let failure_model =
             failure_category.and_then(|_| crate::event_projection::model_identity(&snapshot.model));
+        let failure_detail = snapshot.failure_kind.as_deref().and_then(|kind| {
+            crate::event_projection::renderer_provider_failure_detail(
+                kind,
+                snapshot.failure_detail.as_deref().unwrap_or_default(),
+            )
+        });
         Self {
             turn_id: snapshot.turn_id,
             message_id: snapshot.message_id,
@@ -565,6 +574,7 @@ impl From<tidebreak_core::ChatTerminalTurnSnapshot> for ChatTerminalTurnSnapshot
             reasoning: (!snapshot.reasoning.trim().is_empty()).then_some(snapshot.reasoning),
             refusal: snapshot.refusal.as_ref().map(Into::into),
             failure_category,
+            failure_detail,
             failure_model,
             file_changes: Vec::new(),
             invoked_skills: (!snapshot.invoked_skills.is_empty())

--- a/docs/decisions/0016-provider-failures-preserve-account-access-detail.md
+++ b/docs/decisions/0016-provider-failures-preserve-account-access-detail.md
@@ -1,0 +1,70 @@
+# 16. Provider failures preserve account-access detail
+
+- Status: Proposed
+- Date: 2026-08-14
+- Owners: provider routing and desktop chat
+- Related: `crates/tidebreak-router/src/sse.rs`, `crates/tidebreak-server/src/event_projection.rs`
+- Supersedes: none
+
+## Context
+
+Tidebreak currently classifies every provider HTTP 401 and 403 as an
+authentication failure. The desktop then turns that category into a definitive
+claim that the API key is invalid. Providers also use 403 for exhausted credits,
+organization billing restrictions, missing model access, and key permissions.
+The current message therefore sends users to rotate a valid key and obscures
+whether Tidebreak, the provider, or the user's provider account rejected the
+request.
+
+Turn failures already retain a bounded error detail. The renderer projection
+discards it even when it was produced by the provider-error sanitizer, leaving
+the UI with only a coarse category.
+
+## Decision
+
+Treat a bare provider 403 as a distinct, terminal `provider_access` failure.
+Reserve `auth` for a 401, an explicit provider authentication code, or a locally
+missing credential. Provider access failures do not retry automatically because
+the same account state will ordinarily reject the same request again.
+
+The renderer contract carries an optional bounded detail for provider-originated
+failures. The desktop shows that detail directly and explains which system made
+the decision. It may name likely account causes such as credits, billing,
+organization policy, model access, or key permissions, but must not assert one
+without a provider code or message that establishes it. Existing credential
+redaction remains as defense against a provider echoing secret material.
+
+Internal storage, filesystem, and invariant details remain excluded from the
+renderer contract.
+
+## Alternatives Considered
+
+- Keep the wire unchanged and soften the `auth` sentence. Rejected because it
+  still cannot distinguish an invalid key from provider-account access and
+  continues to hide useful provider diagnostics.
+- Treat every 403 as quota exhaustion. Rejected because 403 is also used for
+  organization policy, model entitlements, billing, and permissions.
+- Expose every terminal error verbatim. Rejected because non-provider failures
+  can include host paths and internal diagnostics that are irrelevant to the
+  user-facing recovery path.
+
+## Consequences
+
+The event and transcript wire types gain an optional failure detail and a new
+failure category. Clients must handle `provider_access` explicitly. Users get a
+stable explanation after both live failure and transcript hydration, and can
+see the provider's bounded response without opening a debug bundle.
+
+Revisit this decision if providers converge on a reliable structured taxonomy
+for credits, billing, entitlements, and organization policy; those states could
+then become separate actionable categories.
+
+## Validation
+
+- A bare xAI 403 projects as `provider_access`, not `auth`, and does not offer a
+  retry.
+- A 401 and explicit `invalid_api_key` still project as `auth`.
+- A bounded provider message survives live projection and transcript hydration.
+- A store or invariant failure does not expose its detail to the renderer.
+- The desktop identifies the provider as the rejecting system and presents
+  credits/quota as a possibility rather than a fact when only a bare 403 exists.


### PR DESCRIPTION
## Summary

- distinguish provider account/access denials from invalid credentials instead of treating every HTTP 403 as an authentication failure
- preserve bounded provider diagnostics through live events and transcript hydration
- replace the oversized destructive chat banner with a compact, responsive error panel that names the rejecting provider and gives actionable account-level causes
- document the renderer contract in decision record 0016

## Root cause

The provider classifier mapped every HTTP 401 and 403 to `authentication`. The desktop then converted that coarse category into a definitive “credentials rejected” message. Providers also use 403 for exhausted credits or quota, billing and organization restrictions, missing model entitlements, and key permissions, so the UI could incorrectly tell users to rotate a valid key and obscure whether Tidebreak or the upstream provider rejected the request.

## User impact

A bare xAI 403 now reads as an xAI access denial and explains that the response came from xAI, not Tidebreak. The notice lists credits/quota, billing or organization restrictions, model access, and key permissions as possibilities without claiming a cause the provider did not establish. Explicit 401, `invalid_api_key`, and `authentication_error` responses still use the credential-specific recovery path.

## Validation

- `cargo check --workspace --locked`
- `UPDATE_WIRE_TYPES=1 cargo test -p tidebreak-server wire_types::tests --locked`
- focused router, event-projection, and core error round-trip tests
- `pnpm test` — 143 files, 972 tests passed
- `pnpm build`