### PR TITLE
feat(desktop): add collapsible chat activity panel

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
@@ -305,8 +305,8 @@ describe("app shell", () => {
   });
 
   it("marks a parked conversation other than the one that is open", async () => {
-    listInbox.mockResolvedValue([parked("chat-2", "call-parked")]);
     const user = userEvent.setup();
+    listInbox.mockResolvedValue([parked("chat-2", "call-parked")]);
     await mountApp({ at: "/c/chat-1" });
 
     // The row itself carries the marker while the list is showing…
@@ -401,8 +401,8 @@ describe("app shell", () => {
     const { router } = await mountApp({ at: "/c/chat-1" });
     await screen.findByTestId("transcript");
 
-    // Chat-scoped places open from the chat's own chip, not the rail.
-    await user.click(screen.getByRole("button", { name: /^Chat activity/ }));
+    // Chat-scoped places are open by default while the conversation owns the
+    // canvas, rather than being hidden in the rail.
     await user.click(await screen.findByRole("button", { name: /Folders/ }));
 
     expect(await screen.findByTestId("folders")).toBeInTheDocument();
@@ -494,20 +494,17 @@ describe("app shell", () => {
     expect(await screen.findByText("No chat title contains that.")).toBeInTheDocument();
   });
 
-  it("keeps chat-scoped places behind the chat's own chip", async () => {
+  it("keeps chat-scoped places with the conversation", async () => {
     await mountApp();
     await screen.findByText("How can I help?");
     // Not disabled — absent. Home has no conversation for the chip to
     // describe, and the rail itself carries nothing chat-scoped anymore.
-    expect(
-      screen.queryByRole("button", { name: /^Chat activity/ }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Chat activity")).not.toBeInTheDocument();
     cleanup();
 
-    const user = userEvent.setup();
     await mountApp({ at: "/c/chat-1" });
     await screen.findByTestId("transcript");
-    await user.click(screen.getByRole("button", { name: /^Chat activity/ }));
+    expect(screen.getByLabelText("Chat activity")).toBeInTheDocument();
     expect(await screen.findByRole("button", { name: /Outputs/ })).toBeEnabled();
     expect(screen.getByRole("button", { name: /Folders/ })).toBeEnabled();
   });

--- a/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
@@ -854,39 +854,40 @@ export function ChatRoute({ chatId }: { chatId: string }) {
 
   return (
     <RouteFrame sidebar={<AppSidebar chat={chat} />}>
-    <div className="mr-2 flex min-h-0 min-w-0 flex-1 flex-col">
-      <header className="mt-2 flex h-9 w-full shrink-0 items-center justify-between gap-2 pl-4 pr-1">
-        <ChatHeaderTitle chat={chat} />
-        <div className="flex shrink-0 items-center gap-2">
-          <ChatStatusChip
-            outputCount={deliverables.length}
-            folders={folders.items}
-            runs={chatAgentRuns}
-            onOpenOutputs={() => openPanel({ type: "outputs" })}
-            onOpenFolders={() => openPanel({ type: "folders" })}
-            onOpenPermissions={() => openPanel({ type: "permissions" })}
-            onOpenAgents={() => openPanel({ type: "agents" })}
-          />
-        </div>
-      </header>
-      <PinnedOutputsStrip
-        chatId={chatId}
-        outputs={deliverables}
-        panelOpen={layout.tabs.length > 0}
-        onOpenOutput={(outputId) => openPanel({ type: "outputs", outputId })}
-        onOpenOutputs={() => openPanel({ type: "outputs" })}
-      />
-      {/* Citations live in the transcript but open into the panel beside it,
-          so the way there is provided above both slots. */}
-      <SourceNavProvider value={sourceNav}>
-        <PanelLayout
-          layout={layout}
-          tabLabel={tabLabel}
-          renderChat={renderChat}
-          renderPanel={renderPanel}
+      <div className="relative mr-2 flex min-h-0 min-w-0 flex-1 flex-col">
+        <header className="mt-2 flex h-9 w-full shrink-0 items-center justify-between gap-2 pl-4 pr-1">
+          <ChatHeaderTitle chat={chat} />
+          <div className="relative z-20 flex shrink-0 items-center gap-2 self-start">
+            <ChatStatusChip
+              compact={layout.tabs.length > 0}
+              outputCount={deliverables.length}
+              folders={folders.items}
+              runs={chatAgentRuns}
+              onOpenOutputs={() => openPanel({ type: "outputs" })}
+              onOpenFolders={() => openPanel({ type: "folders" })}
+              onOpenPermissions={() => openPanel({ type: "permissions" })}
+              onOpenAgents={() => openPanel({ type: "agents" })}
+            />
+          </div>
+        </header>
+        <PinnedOutputsStrip
+          chatId={chatId}
+          outputs={deliverables}
+          panelOpen={layout.tabs.length > 0}
+          onOpenOutput={(outputId) => openPanel({ type: "outputs", outputId })}
+          onOpenOutputs={() => openPanel({ type: "outputs" })}
         />
-      </SourceNavProvider>
-    </div>
+        {/* Citations live in the transcript but open into the panel beside it,
+            so the way there is provided above both slots. */}
+        <SourceNavProvider value={sourceNav}>
+          <PanelLayout
+            layout={layout}
+            tabLabel={tabLabel}
+            renderChat={renderChat}
+            renderPanel={renderPanel}
+          />
+        </SourceNavProvider>
+      </div>
     </RouteFrame>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/ChatStatusChip.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatStatusChip.dom.test.tsx
@@ -27,6 +27,7 @@ function run(id: string, status: AgentRun["status"]): AgentRun {
 function renderChip({
   outputCount = 0,
   runs = [] as AgentRun[],
+  compact = false,
 } = {}) {
   const onOpenOutputs = vi.fn();
   const onOpenFolders = vi.fn();
@@ -34,6 +35,7 @@ function renderChip({
   const onOpenPermissions = vi.fn();
   render(
     <ChatStatusChip
+      compact={compact}
       outputCount={outputCount}
       folders={[folder]}
       runs={runs}
@@ -54,21 +56,27 @@ afterEach(() => {
 it("summarizes activity on its face and opens the chat-scoped places", async () => {
   const { onOpenOutputs, onOpenFolders, onOpenPermissions } = renderChip({ outputCount: 2 });
 
-  // No live work, so the face falls back to what the chat has produced.
-  const chip = screen.getByRole("button", { name: "Chat activity: 2 outputs" });
-
-  await userEvent.click(chip);
-  // The label span sits inside the row button, so the click lands on it.
+  // With the whole canvas available, the useful places are visible without a
+  // disclosure click and the summary falls back to what the chat produced.
+  expect(screen.getByLabelText("Chat activity")).toHaveTextContent("2 outputs");
   await userEvent.click(await screen.findByText("Outputs"));
   expect(onOpenOutputs).toHaveBeenCalled();
 
-  await userEvent.click(chip);
-  await userEvent.click(await screen.findByText("Folders"));
+  await userEvent.click(screen.getByText("Folders"));
   expect(onOpenFolders).toHaveBeenCalled();
 
-  await userEvent.click(chip);
-  await userEvent.click(await screen.findByText("Permissions"));
+  await userEvent.click(screen.getByText("Permissions"));
   expect(onOpenPermissions).toHaveBeenCalled();
+});
+
+it("folds the open card down to an icon and restores it", async () => {
+  renderChip({ outputCount: 2 });
+
+  await userEvent.click(screen.getByRole("button", { name: "Collapse chat activity" }));
+  expect(screen.queryByLabelText("Chat activity")).not.toBeInTheDocument();
+
+  await userEvent.click(screen.getByRole("button", { name: "Expand chat activity" }));
+  expect(screen.getByLabelText("Chat activity")).toHaveTextContent("2 outputs");
 });
 
 /**
@@ -78,6 +86,7 @@ it("summarizes activity on its face and opens the chat-scoped places", async () 
 it("counts live background runs and opens the agents table", async () => {
   const { onOpenAgents } = renderChip({
     runs: [run("run-1", "running"), run("run-2", "retry_wait"), run("run-3", "completed")],
+    compact: true,
   });
 
   const chip = screen.getByRole("button", { name: "Chat activity: 2 running" });

--- a/crates/tidebreak-desktop/ui/src/ChatStatusChip.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatStatusChip.tsx
@@ -1,5 +1,13 @@
 import { useState } from "react";
-import { Bot, ChevronDown, FolderOpen, Shapes, Shield } from "lucide-react";
+import {
+  Activity as ActivityIcon,
+  Bot,
+  ChevronDown,
+  ChevronUp,
+  FolderOpen,
+  Shapes,
+  Shield,
+} from "lucide-react";
 
 import type { AgentRun } from "./api";
 import { RUNNING_AGENT_STATUSES } from "./AgentRunDisplay";
@@ -28,6 +36,8 @@ function liveRunDotClass(status: AgentRun["status"]): string {
 }
 
 export type ChatStatusChipProps = {
+  /** Collapse the persistent card while a side panel is using the canvas. */
+  compact?: boolean;
   /** How many outputs the conversation has produced. */
   outputCount: number;
   folders: readonly ChatFolderAccess[];
@@ -56,6 +66,7 @@ export type ChatStatusChipProps = {
  * those controls.
  */
 export function ChatStatusChip({
+  compact = false,
   outputCount,
   folders,
   runs,
@@ -66,6 +77,7 @@ export function ChatStatusChip({
   permissionCount,
 }: ChatStatusChipProps) {
   const [open, setOpen] = useState(false);
+  const [collapsed, setCollapsed] = useState(false);
 
   const liveRuns = runs.filter((run) => RUNNING_AGENT_STATUSES.has(run.status));
   const overflowRuns = Math.max(0, liveRuns.length - MAX_STATUS_DOTS);
@@ -113,6 +125,55 @@ export function ChatStatusChip({
           ? "1 saved"
           : `${permissionCount} saved`;
 
+  const details = (
+    <ActivityDetails
+      outputsSummary={outputsSummary}
+      folderSummary={folderSummary}
+      permissionsSummary={permissionsSummary}
+      agentsSummary={agentsSummary}
+      onOpenOutputs={onOpenOutputs}
+      onOpenFolders={onOpenFolders}
+      onOpenPermissions={onOpenPermissions}
+      onOpenAgents={onOpenAgents}
+      onChoose={() => setOpen(false)}
+    />
+  );
+
+  if (!compact) {
+    if (collapsed) {
+      return (
+        <button
+          type="button"
+          className="activity-card-collapsed"
+          aria-label="Expand chat activity"
+          onClick={() => setCollapsed(false)}
+        >
+          <ActivityIcon className="size-4" aria-hidden="true" />
+        </button>
+      );
+    }
+
+    return (
+      <aside className="activity-card" aria-label="Chat activity">
+        <div className="activity-card-heading">
+          <div>
+            <p className="activity-card-kicker">Activity</p>
+            <p className="activity-card-summary">{faceLabel}</p>
+          </div>
+          <button
+            type="button"
+            className="activity-card-collapse-button"
+            aria-label="Collapse chat activity"
+            onClick={() => setCollapsed(true)}
+          >
+            <ChevronUp className="size-4" aria-hidden="true" />
+          </button>
+        </div>
+        <div className="activity-card-rows">{details}</div>
+      </aside>
+    );
+  }
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
@@ -140,45 +201,66 @@ export function ChatStatusChip({
           <ChevronDown className="size-3.5 opacity-50" />
         </button>
       </PopoverTrigger>
-      <PopoverContent align="end" className="w-80 p-1">
-        <DetailRow
-          icon={<Shapes className="size-3.5" aria-hidden="true" />}
-          label="Outputs"
-          value={outputsSummary}
-          onClick={() => {
-            setOpen(false);
-            onOpenOutputs();
-          }}
-        />
-        <DetailRow
-          icon={<FolderOpen className="size-3.5" aria-hidden="true" />}
-          label="Folders"
-          value={folderSummary}
-          onClick={() => {
-            setOpen(false);
-            onOpenFolders();
-          }}
-        />
-        <DetailRow
-          icon={<Shield className="size-3.5" aria-hidden="true" />}
-          label="Permissions"
-          value={permissionsSummary}
-          onClick={() => {
-            setOpen(false);
-            onOpenPermissions();
-          }}
-        />
-        <DetailRow
-          icon={<Bot className="size-3.5" aria-hidden="true" />}
-          label="Agents"
-          value={agentsSummary}
-          onClick={() => {
-            setOpen(false);
-            onOpenAgents();
-          }}
-        />
+      <PopoverContent align="end" className="w-80 p-1.5">
+        {details}
       </PopoverContent>
     </Popover>
+  );
+}
+
+function ActivityDetails({
+  outputsSummary,
+  folderSummary,
+  permissionsSummary,
+  agentsSummary,
+  onOpenOutputs,
+  onOpenFolders,
+  onOpenPermissions,
+  onOpenAgents,
+  onChoose,
+}: {
+  outputsSummary: string;
+  folderSummary: string;
+  permissionsSummary: string;
+  agentsSummary: string;
+  onOpenOutputs: () => void;
+  onOpenFolders: () => void;
+  onOpenPermissions: () => void;
+  onOpenAgents: () => void;
+  onChoose: () => void;
+}) {
+  const choose = (action: () => void) => {
+    onChoose();
+    action();
+  };
+
+  return (
+    <>
+      <DetailRow
+        icon={<Shapes className="size-4" aria-hidden="true" />}
+        label="Outputs"
+        value={outputsSummary}
+        onClick={() => choose(onOpenOutputs)}
+      />
+      <DetailRow
+        icon={<FolderOpen className="size-4" aria-hidden="true" />}
+        label="Folders"
+        value={folderSummary}
+        onClick={() => choose(onOpenFolders)}
+      />
+      <DetailRow
+        icon={<Shield className="size-4" aria-hidden="true" />}
+        label="Permissions"
+        value={permissionsSummary}
+        onClick={() => choose(onOpenPermissions)}
+      />
+      <DetailRow
+        icon={<Bot className="size-4" aria-hidden="true" />}
+        label="Agents"
+        value={agentsSummary}
+        onClick={() => choose(onOpenAgents)}
+      />
+    </>
   );
 }
 
@@ -194,16 +276,12 @@ function DetailRow({
   onClick: () => void;
 }) {
   return (
-    <button
-      type="button"
-      className="flex w-full cursor-pointer items-center justify-between gap-2 rounded-md px-2 py-2 text-left transition-colors hover:bg-accent"
-      onClick={onClick}
-    >
-      <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+    <button type="button" className="activity-card-row" onClick={onClick}>
+      <span className="activity-card-row-label">
         {icon}
         {label}
       </span>
-      <span className="min-w-0 truncate text-xs">{value}</span>
+      <span className="activity-card-row-value">{value}</span>
     </button>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/Titlebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/Titlebar.tsx
@@ -1,6 +1,4 @@
-import { getName } from "@tauri-apps/api/app";
 import { ChevronLeft, ChevronRight } from "lucide-react";
-import { useEffect, useState } from "react";
 
 import { WithTooltip } from "@/components/ui/tooltip";
 import type { DesktopNavigation } from "./DesktopNavigation";
@@ -10,9 +8,9 @@ import { cn } from "@/lib/utils";
  * The desktop titlebar: navigation stays available even where the native
  * window decorations do not provide browser-style history controls.
  *
- * It carries navigation and the app's name and nothing else. The rail's own
- * collapse control stays in the rail — it acts on the rail, and putting a
- * second copy up here left two buttons for one job on adjacent rows.
+ * It carries only native navigation. Product identity lives in the sidebar,
+ * so the window chrome can recede into the shell instead of reading as a
+ * second application header above it.
  */
 export function Titlebar({
   macOverlay,
@@ -21,21 +19,6 @@ export function Titlebar({
   macOverlay: boolean;
   navigation: DesktopNavigation;
 }) {
-  // The host owns the display name: debug reports "Tidebreak [dev]" and
-  // staging reports "Tidebreak [staging]" so those windows are
-  // distinguishable from an installed release. The titlebar only renders
-  // inside the native host, where `getName` is always available.
-  const [appName, setAppName] = useState("Tidebreak");
-  useEffect(() => {
-    let cancelled = false;
-    getName().then((name) => {
-      if (!cancelled) setAppName(name);
-    }, () => {});
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
   return (
     <div
       className={cn("titlebar", macOverlay && "is-mac-overlay")}
@@ -65,9 +48,6 @@ export function Titlebar({
           </button>
         </WithTooltip>
       </div>
-      <span className="titlebar-title" data-tauri-drag-region>
-        {appName}
-      </span>
     </div>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/sidebar/SidebarFrame.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/SidebarFrame.tsx
@@ -1,4 +1,5 @@
-import type { ReactNode } from "react";
+import { getName } from "@tauri-apps/api/app";
+import { useEffect, useState, type ReactNode } from "react";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 import {
   Monitor,
@@ -12,6 +13,7 @@ import {
 
 import { useApp } from "@/AppContext";
 import { WithTooltip } from "@/components/ui/tooltip";
+import { hasNativeHost } from "@/host";
 import { Logomark } from "@/Logomark";
 import {
   Sidebar as SidebarRail,
@@ -39,6 +41,20 @@ export function SidebarFrame({ children }: { children: ReactNode }) {
   const toggleSidebar = useUiStore((state) => state.toggleSidebar);
   const isCompact = useSidebarWidth() === "compact";
   const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const [appName, setAppName] = useState("Tidebreak");
+
+  // Keep dev and staging windows distinguishable, but put that identity in
+  // the rail where it belongs instead of restoring a duplicate top header.
+  useEffect(() => {
+    if (!hasNativeHost()) return;
+    let cancelled = false;
+    getName().then((name) => {
+      if (!cancelled) setAppName(name);
+    }, () => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const updateReady = updateState.status === "ready";
 
@@ -61,7 +77,7 @@ export function SidebarFrame({ children }: { children: ReactNode }) {
           />
           {!isCompact && (
             <span className="truncate font-mono text-sm font-medium leading-none">
-              Tidebreak
+              {appName}
             </span>
           )}
         </button>

--- a/crates/tidebreak-desktop/ui/src/styles.css
+++ b/crates/tidebreak-desktop/ui/src/styles.css
@@ -1460,6 +1460,146 @@ body {
 
 /* ---------- Window chrome ---------- */
 
+.activity-card {
+  width: min(21rem, calc(100vw - 5rem));
+  overflow: hidden;
+  border: 1px solid color-mix(in oklch, var(--color-border) 82%, transparent);
+  border-radius: calc(var(--radius) + 0.65rem);
+  background: color-mix(in oklch, var(--color-popover) 94%, var(--page-background));
+  padding: 0.65rem;
+  box-shadow:
+    0 18px 46px oklch(0 0 0 / 0.16),
+    inset 0 1px 0 color-mix(in oklch, var(--foreground) 7%, transparent);
+  backdrop-filter: blur(18px);
+}
+
+.activity-card-collapsed,
+.activity-card-collapse-button {
+  display: inline-grid;
+  place-items: center;
+  color: var(--muted-foreground);
+  transition:
+    color 160ms ease,
+    background-color 160ms ease,
+    transform 160ms ease;
+}
+
+.activity-card-collapsed {
+  width: 2.25rem;
+  height: 2.25rem;
+  border: 1px solid color-mix(in oklch, var(--color-border) 82%, transparent);
+  border-radius: calc(var(--radius) + 0.2rem);
+  background: color-mix(in oklch, var(--color-popover) 94%, var(--page-background));
+  box-shadow:
+    0 10px 28px oklch(0 0 0 / 0.13),
+    inset 0 1px 0 color-mix(in oklch, var(--foreground) 7%, transparent);
+  backdrop-filter: blur(18px);
+}
+
+.activity-card-collapse-button {
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: calc(var(--radius) - 0.1rem);
+}
+
+.activity-card-collapsed:hover,
+.activity-card-collapse-button:hover {
+  color: var(--foreground);
+  background: var(--color-accent);
+}
+
+.activity-card-collapsed:active,
+.activity-card-collapse-button:active {
+  transform: translateY(1px);
+}
+
+.activity-card-collapsed:focus-visible,
+.activity-card-collapse-button:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.activity-card-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.45rem 0.55rem 0.6rem;
+}
+
+.activity-card-kicker {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.035em;
+}
+
+.activity-card-summary {
+  margin: 0.1rem 0 0;
+  font-size: 0.95rem;
+  font-weight: 550;
+}
+
+.activity-card-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.activity-card-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, auto);
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  min-height: 2.45rem;
+  border-radius: calc(var(--radius) - 0.05rem);
+  padding: 0.5rem 0.55rem;
+  text-align: left;
+  transition:
+    background-color 160ms ease,
+    transform 160ms ease;
+}
+
+.activity-card-row:hover {
+  background: color-mix(in oklch, var(--color-accent) 82%, transparent);
+}
+
+.activity-card-row:active {
+  transform: translateY(1px);
+}
+
+.activity-card-row:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 1px;
+}
+
+.activity-card-row-label {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 0.65rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.activity-card-row-label svg {
+  flex: 0 0 auto;
+  color: var(--muted-foreground);
+}
+
+.activity-card-row-value {
+  min-width: 0;
+  max-width: 10.5rem;
+  overflow: hidden;
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .app-shell {
   position: relative;
   height: 100%;
@@ -1468,8 +1608,8 @@ body {
 }
 
 
-/* Desktop titlebar: one strip carries back/forward, the app name, and a drag
-   region. macOS reserves additional room for the overlay traffic lights. */
+/* Desktop titlebar: a quiet drag region with back/forward controls. Product
+   identity stays in the sidebar below; macOS reserves room for traffic lights. */
 .app-shell.with-titlebar {
   flex-direction: column;
 }
@@ -1481,7 +1621,7 @@ body {
   gap: 0.5rem;
   padding-left: 1rem;
   padding-right: 1rem;
-  border-bottom: 1px solid var(--color-border);
+  background: var(--page-background);
 }
 
 .titlebar.is-mac-overlay {
@@ -1494,19 +1634,8 @@ body {
   gap: 0.1rem;
 }
 
-.titlebar-title {
-  min-width: 0;
-  color: var(--muted-foreground);
-  font-size: 0.875rem;
-  font-weight: 600;
-  line-height: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-/* The strip already provides top breathing room; keep the sidebar header
-   tight beneath it. */
+/* The strip is window chrome rather than a second product header. Keep the
+   sidebar identity close enough that both rows read as one integrated rail. */
 .app-shell.with-titlebar .sidebar {
   padding-top: 0;
 }


### PR DESCRIPTION
## Summary

- replace the understated chat activity pill with a persistent activity card when the right pane is closed
- let the card collapse manually to a single icon and restore on click
- automatically use the compact activity trigger while a right-side tab is open
- integrate native window navigation into quieter chrome and move environment-aware app identity into the sidebar
- update shell and activity interaction coverage for the new states

## Why

The previous activity control was easy to miss and the separate titlebar duplicated product identity. This gives chat-scoped resources a clearer default presence while preserving canvas space whenever the user opens a side panel or manually collapses the card.

## Validation

- `pnpm test` — 143 files, 973 tests passed
- focused activity/shell tests after the final collapse interaction — 2 files, 22 tests passed
- `pnpm build`
- `git diff --check`

## Compatibility and risk

This is a desktop UI-only change. It reuses the existing outputs, folders, permissions, and agents actions without changing their data or command contracts. The main risk is layout behavior at narrow widths; the compact mode remains tied to right-pane occupancy and is covered by DOM tests.