### PR TITLE
feat: preview source-code outputs

### DIFF
--- a/crates/tidebreak-core/src/agent_tools.rs
+++ b/crates/tidebreak-core/src/agent_tools.rs
@@ -1112,12 +1112,13 @@ pub fn sandbox_exec_tool_spec() -> ToolSpec {
          empty and is yours alone: it holds nothing but what your own earlier commands wrote, and \
          you cannot reach the conversation, the user's files, or any connected folder from it. \
          Write only under the workspace (relative paths); absolute paths like /tmp are not durable \
-         here. Save only final deliverables under output/ (for example .md, .csv, .xlsx, .pdf, \
-         .pptx, .docx, .chart.json) — each file there is published to the user as a durable output \
+         here. Save only final deliverables under output/ (for example .md, .csv, .py, .tsx, \
+         .xlsx, .pdf, .pptx, .docx, .chart.json) — each file there is published to the user as a durable output \
          named by its own filename, and writing the same filename again publishes a new version of \
          that same output. Keep helper scripts and other intermediates in the workspace root (or \
-         any path outside output/); source files under output/ are not published. Name deliverables \
-         the way you want the user to see them. Every command returns bounded stdout and stderr.",
+         any path outside output/). Source files are valid final deliverables when the task asks for \
+         code. Name deliverables the way you want the user to see them. Every command returns bounded \
+         stdout and stderr.",
     )
 }
 

--- a/crates/tidebreak-core/src/db/tests/output.rs
+++ b/crates/tidebreak-core/src/db/tests/output.rs
@@ -937,24 +937,16 @@ mod output_scan {
         assert!(!workspace.path().join(&relative).exists());
     }
 
-    /// A background agent that builds a deck often leaves the generator script
-    /// next to the PPTX under output/. The scan must publish the deliverable
-    /// and refuse the script with a note — otherwise junk lands in the catalog
-    /// beside the real file. Foreground turns are out of scope for this skip.
+    /// Directory placement is the deliverable declaration. A background run
+    /// can therefore return source code itself, using the same text-output path
+    /// and media type as a foreground turn.
     #[tokio::test]
-    async fn a_sandbox_run_does_not_publish_helper_scripts_beside_deliverables() {
+    async fn a_sandbox_run_publishes_source_code_outputs() {
         let (_dir, store, chat) = store_with_chat().await;
         let scratch = tempfile::tempdir().unwrap();
         let dir = open_scratch(scratch.path());
 
-        // Minimal well-formed empty ZIP = valid PPTX signature for the scan.
-        write_output_file(
-            scratch.path(),
-            "deck.pptx",
-            b"PK\x05\x06\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",
-        );
-        write_output_file(scratch.path(), "build_deck.py", b"print('hi')\n");
-        write_output_file(scratch.path(), "helper.sh", b"#!/bin/sh\n");
+        write_output_file(scratch.path(), "solution.py", b"print('hi')\n");
 
         let scan = sync_output_directory(
             &store,
@@ -973,15 +965,10 @@ mod output_scan {
             .iter()
             .map(|entry| entry.filename.as_str())
             .collect();
-        assert_eq!(published, ["deck.pptx"]);
-        assert!(scan
-            .notes
-            .iter()
-            .any(|note| { note.contains("build_deck.py") && note.contains("workspace root") }));
-        assert!(scan
-            .notes
-            .iter()
-            .any(|note| note.contains("helper.sh") && note.contains("workspace root")));
+        assert_eq!(published, ["solution.py"]);
+        assert!(scan.notes.is_empty());
+        let outputs = store.list_outputs(chat.id, 10).await.unwrap();
+        assert_eq!(outputs[0].media_type, "text/plain");
         assert_eq!(store.list_outputs(chat.id, 10).await.unwrap().len(), 1);
     }
 }

--- a/crates/tidebreak-core/src/deliverable.rs
+++ b/crates/tidebreak-core/src/deliverable.rs
@@ -166,10 +166,11 @@ impl RevisionProducer {
 ///
 /// Editing publishes a new user-authored revision through the same append-only
 /// path everything else uses, so the only question is whether a plain text box
-/// can faithfully represent the bytes. Markdown and plain text qualify; the
-/// structured text types (CSV, JSON, chart figures, HTML) and every binary
-/// artifact do not, because a free-text edit of those is as likely to break the
-/// document as to fix it.
+/// can faithfully represent the bytes. Markdown and plain text qualify,
+/// including source-code filenames classified as plain text; the structured
+/// document types (CSV, JSON, chart figures, HTML) and every binary artifact do
+/// not, because a free-text edit of those is as likely to break the document as
+/// to fix it.
 #[must_use]
 pub fn media_type_is_editable_text(media_type: &str) -> bool {
     matches!(media_type, "text/markdown" | "text/plain")
@@ -264,7 +265,7 @@ pub struct CreateOutput {
 pub fn validate_deliverable_name(name: &str) -> Result<(), &'static str> {
     validate_portable_filename(name)?;
     if deliverable_media_type(name).is_none() {
-        return Err("filename must end in .md, .txt, .csv, .json, or .html");
+        return Err("filename must use a supported text or source-code name");
     }
     Ok(())
 }
@@ -378,12 +379,21 @@ pub fn deliverable_media_type(name: &str) -> Option<&'static str> {
     if lowercased.ends_with(CHART_FILENAME_SUFFIX) {
         return Some(CHART_MEDIA_TYPE);
     }
+    if matches!(lowercased.as_str(), "dockerfile" | "makefile" | "justfile") {
+        return Some("text/plain");
+    }
     match lowercased.rsplit_once('.')?.1 {
         "md" => Some("text/markdown"),
         "txt" => Some("text/plain"),
         "csv" => Some("text/csv"),
         "json" => Some("application/json"),
         "html" => Some("text/html"),
+        "py" | "pyw" | "js" | "jsx" | "mjs" | "cjs" | "ts" | "tsx" | "mts" | "cts" | "rs"
+        | "go" | "java" | "c" | "h" | "cc" | "cpp" | "cxx" | "hpp" | "hxx" | "cs" | "rb"
+        | "php" | "swift" | "kt" | "kts" | "scala" | "sh" | "bash" | "zsh" | "fish" | "sql"
+        | "css" | "scss" | "sass" | "less" | "vue" | "svelte" | "toml" | "yaml" | "yml" | "xml"
+        | "graphql" | "gql" | "proto" | "dart" | "lua" | "r" | "ex" | "exs" | "erl" | "hrl"
+        | "fs" | "fsx" | "clj" | "cljs" | "cljc" | "hs" | "pl" | "pm" | "ps1" => Some("text/plain"),
         _ => None,
     }
 }
@@ -428,6 +438,10 @@ mod tests {
             "forecast.csv",
             "data.json",
             "report.html",
+            "example.py",
+            "component.tsx",
+            "Cargo.toml",
+            "Dockerfile",
         ] {
             assert!(validate_deliverable_name(valid).is_ok(), "{valid}");
         }
@@ -478,6 +492,10 @@ mod tests {
     fn media_types_are_derived_only_from_supported_extensions() {
         assert_eq!(deliverable_media_type("brief.MD"), Some("text/markdown"));
         assert_eq!(deliverable_media_type("table.csv"), Some("text/csv"));
+        assert_eq!(deliverable_media_type("example.PY"), Some("text/plain"));
+        assert_eq!(deliverable_media_type("component.tsx"), Some("text/plain"));
+        assert_eq!(deliverable_media_type("Cargo.toml"), Some("text/plain"));
+        assert_eq!(deliverable_media_type("Dockerfile"), Some("text/plain"));
         assert_eq!(deliverable_media_type("archive.zip"), None);
         // The chart suffix is compound, and only the full suffix qualifies.
         assert_eq!(

--- a/crates/tidebreak-core/src/output_scan.rs
+++ b/crates/tidebreak-core/src/output_scan.rs
@@ -17,12 +17,6 @@
 //! creation that lost that race is told which output won and appends to it,
 //! so a name never ends up on two live records.
 //!
-//! Background runs additionally skip obvious source intermediates under
-//! `output/` (`.py`, `.js`, `.ts`, `.sh`): those belong in the workspace root,
-//! not beside the deliverable. The skip is sandbox-only — foreground turns
-//! keep the previous publish-everything rule — and surfaces a note so the
-//! model can move the script rather than silently losing a file.
-//!
 //! The scan is deliberately non-fatal: a file the host cannot accept (too
 //! large, unreadable, over the revision cap) becomes a note for the model
 //! rather than a failed command.
@@ -112,19 +106,14 @@ pub async fn sync_output_directory(
 ) -> Result<OutputDirectorySync> {
     let mut sync = OutputDirectorySync::default();
 
-    // Background sandbox runs are the path that kept dropping helper scripts
-    // next to real deliverables. Foreground turns keep the older, broader rule.
-    let skip_source_intermediates = matches!(producer, RevisionProducer::Run(_));
-
     // Reading is blocking capability I/O; keep it off the async runtime.
     let read_scratch = workspace
         .try_clone()
         .map_err(|error| AgentError::Store(format!("could not open private scratch: {error}")))?;
-    let (candidates, mut read_notes) = tokio::task::spawn_blocking(move || {
-        read_output_candidates(&read_scratch, skip_source_intermediates)
-    })
-    .await
-    .map_err(|error| AgentError::Store(format!("output scan task failed: {error}")))?;
+    let (candidates, mut read_notes) =
+        tokio::task::spawn_blocking(move || read_output_candidates(&read_scratch))
+            .await
+            .map_err(|error| AgentError::Store(format!("output scan task failed: {error}")))?;
     sync.notes.append(&mut read_notes);
     if candidates.is_empty() {
         return Ok(sync);
@@ -318,30 +307,11 @@ async fn publish_revision_bytes(
     .map_err(|error| AgentError::Store(format!("could not publish output revision: {error}")))
 }
 
-/// Whether a filename is an obvious source intermediate a sandbox agent should
-/// keep outside `output/`.
-///
-/// Only the common script extensions that show up as build helpers next to
-/// real deliverables. Curated text and office/binary formats are never matched.
-#[must_use]
-fn is_source_intermediate_filename(name: &str) -> bool {
-    let Some((_, extension)) = name.rsplit_once('.') else {
-        return false;
-    };
-    matches!(
-        extension.to_ascii_lowercase().as_str(),
-        "py" | "js" | "ts" | "sh"
-    )
-}
-
 /// Read and classify the acceptable files directly under `output/`.
 ///
 /// Deterministic (alphabetical) order, bounded at [`MAX_OUTPUT_SCAN_FILES`].
 /// Anything skipped is explained in a note.
-fn read_output_candidates(
-    scratch: &Dir,
-    skip_source_intermediates: bool,
-) -> (Vec<ScanCandidate>, Vec<String>) {
+fn read_output_candidates(scratch: &Dir) -> (Vec<ScanCandidate>, Vec<String>) {
     let mut notes = Vec::new();
 
     // A symlinked `output/` planted by local exec would hand host files from an
@@ -374,15 +344,6 @@ fn read_output_candidates(
         };
         if name.starts_with('.') {
             // Dotfiles are workspace plumbing and never publishable.
-            continue;
-        }
-        if skip_source_intermediates && is_source_intermediate_filename(&name) {
-            // Sandbox-only: helper scripts next to a PPTX/PDF are not
-            // deliverables. Note it so the model moves the script rather than
-            // thinking the file vanished.
-            notes.push(format!(
-                "output/{name} was not published: keep helper scripts in the workspace root, not under output/; only final deliverables belong there"
-            ));
             continue;
         }
         match entry.metadata().map(|metadata| metadata.file_type()) {

--- a/crates/tidebreak-desktop/ui/src/deliverables.ts
+++ b/crates/tidebreak-desktop/ui/src/deliverables.ts
@@ -142,9 +142,10 @@ export function isTextDeliverableMediaType(
  * Whether an output's content can be edited in place, mirroring the native
  * `media_type_is_editable_text`.
  *
- * Prose formats only. A plain text box is a faithful editor for Markdown and
- * plain text and a hazard for the structured types, where a free-hand edit is
- * as likely to break the document as to fix it.
+ * A plain text box is a faithful editor for Markdown and plain text, including
+ * source-code filenames classified as plain text. It is a hazard for the
+ * structured document types, where a free-hand edit is as likely to break the
+ * document as to fix it.
  */
 export function isEditableTextMediaType(value: string): boolean {
   return value === "text/markdown" || value === "text/plain";

--- a/crates/tidebreak-desktop/ui/src/outputs/CodeViewer.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/outputs/CodeViewer.test.tsx
@@ -3,13 +3,26 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { CodeViewer, codeLanguageForMediaType } from "./CodeViewer";
+import {
+  CodeViewer,
+  codeLanguageForFilename,
+  codeLanguageForMediaType,
+} from "./CodeViewer";
 
 describe("CodeViewer", () => {
   it("maps curated media types to highlight languages", () => {
     expect(codeLanguageForMediaType("application/json")).toBe("json");
     expect(codeLanguageForMediaType("text/html")).toBe("xml");
     expect(codeLanguageForMediaType("text/plain")).toBe("plaintext");
+  });
+
+  it("maps source filenames to highlight languages", () => {
+    expect(codeLanguageForFilename("solution.py")).toBe("python");
+    expect(codeLanguageForFilename("Component.TSX")).toBe("typescript");
+    expect(codeLanguageForFilename("Cargo.toml")).toBe("ini");
+    expect(codeLanguageForFilename("Dockerfile")).toBe("bash");
+    expect(codeLanguageForFilename("worker.exs")).toBeNull();
+    expect(codeLanguageForFilename("notes.txt")).toBeNull();
   });
 
   it("highlights JSON without treating it as markdown prose", () => {
@@ -30,5 +43,17 @@ describe("CodeViewer", () => {
     expect(screen.getByText(/still source/)).toBeVisible();
     expect(screen.getByText(/before/)).toBeVisible();
     expect(screen.getByText(/after/)).toBeVisible();
+  });
+
+  it("uses the filename to highlight a plain-text source output", () => {
+    render(
+      <CodeViewer
+        filename="solution.py"
+        mediaType="text/plain"
+        content={'def greet():\n    return "hello"'}
+      />,
+    );
+    expect(document.querySelector(".language-python")).not.toBeNull();
+    expect(document.querySelector(".hljs-keyword")).not.toBeNull();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/outputs/CodeViewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/outputs/CodeViewer.tsx
@@ -2,6 +2,59 @@ import { useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
 
+// `rehype-highlight` bundles lowlight's common grammars. Keep this mapping to
+// that exact set: recognized source extensions outside it still use the source
+// viewer, with the media-type fallback selecting plain text.
+const LANGUAGE_BY_EXTENSION: Readonly<Record<string, string>> = {
+  py: "python",
+  pyw: "python",
+  js: "javascript",
+  jsx: "javascript",
+  mjs: "javascript",
+  cjs: "javascript",
+  ts: "typescript",
+  tsx: "typescript",
+  mts: "typescript",
+  cts: "typescript",
+  rs: "rust",
+  go: "go",
+  java: "java",
+  c: "c",
+  h: "c",
+  cc: "cpp",
+  cpp: "cpp",
+  cxx: "cpp",
+  hpp: "cpp",
+  hxx: "cpp",
+  cs: "csharp",
+  rb: "ruby",
+  php: "php",
+  swift: "swift",
+  kt: "kotlin",
+  kts: "kotlin",
+  sh: "bash",
+  bash: "bash",
+  zsh: "bash",
+  fish: "bash",
+  sql: "sql",
+  css: "css",
+  scss: "scss",
+  sass: "scss",
+  less: "less",
+  vue: "xml",
+  svelte: "xml",
+  toml: "ini",
+  yaml: "yaml",
+  yml: "yaml",
+  xml: "xml",
+  graphql: "graphql",
+  gql: "graphql",
+  lua: "lua",
+  r: "r",
+  pl: "perl",
+  pm: "perl",
+};
+
 /**
  * Fence long enough that no run of backticks inside `content` can close it.
  * Markdown fences match the longest opening run, so stretching past the
@@ -26,6 +79,16 @@ export function codeLanguageForMediaType(mediaType: string): string {
   }
 }
 
+/** Highlight language for a source filename, when the extension identifies one. */
+export function codeLanguageForFilename(filename: string): string | null {
+  const lower = filename.toLowerCase();
+  if (["dockerfile", "makefile", "justfile"].includes(lower)) {
+    return lower === "dockerfile" ? "bash" : "makefile";
+  }
+  const extension = lower.includes(".") ? lower.split(".").pop()! : "";
+  return LANGUAGE_BY_EXTENSION[extension] ?? null;
+}
+
 /**
  * Syntax-highlighted source view for curated text outputs that are not
  * markdown (JSON, HTML-as-source, plain text).
@@ -36,11 +99,15 @@ export function codeLanguageForMediaType(mediaType: string): string {
 export function CodeViewer({
   content,
   mediaType,
+  filename,
 }: {
   content: string;
   mediaType: string;
+  filename?: string;
 }) {
-  const language = codeLanguageForMediaType(mediaType);
+  const language =
+    (filename && codeLanguageForFilename(filename)) ??
+    codeLanguageForMediaType(mediaType);
   const markdown = useMemo(
     () => fence(language, content),
     [language, content],

--- a/crates/tidebreak-desktop/ui/src/outputs/OutputContent.tsx
+++ b/crates/tidebreak-desktop/ui/src/outputs/OutputContent.tsx
@@ -93,7 +93,11 @@ export function OutputContent({
         {type === "text/markdown" ? (
           <MessageMarkdown>{preview.content}</MessageMarkdown>
         ) : (
-          <CodeViewer content={preview.content} mediaType={type} />
+          <CodeViewer
+            content={preview.content}
+            mediaType={type}
+            filename={preview.filename}
+          />
         )}
         {preview.truncated && (
           <p className="mt-6 text-xs text-muted-foreground">

--- a/crates/tidebreak-desktop/ui/src/outputs/OutputDetailRoot.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/outputs/OutputDetailRoot.dom.test.tsx
@@ -269,6 +269,24 @@ describe("OutputDetailRoot", () => {
     ).toBeVisible();
   });
 
+  it("draws a source-code output in the syntax-highlighted viewer", async () => {
+    const apis = detailApis({
+      read: vi.fn().mockResolvedValue(
+        preview({
+          filename: "solution.py",
+          mediaType: "text/plain",
+          content: "def greet():\n    return 'hello'",
+        }),
+      ),
+    });
+    await openOutput(apis);
+
+    await waitFor(() =>
+      expect(document.querySelector(".language-python")).not.toBeNull(),
+    );
+    expect(screen.queryByText(/No preview for this file type/)).toBeNull();
+  });
+
   // Formats with no viewer still arrive with empty content; the panel offers
   // export rather than an inline rendering it cannot produce.
   it("offers export instead of a preview for an unsupported binary artifact", async () => {

--- a/crates/tidebreak-server/src/tests/outputs.rs
+++ b/crates/tidebreak-server/src/tests/outputs.rs
@@ -51,8 +51,8 @@ async fn a_published_output_is_listed_read_revised_restored_and_exported_over_ht
         .join(workspace.as_str())
         .join(tidebreak_core::EXEC_OUTPUT_DIRECTORY);
     std::fs::create_dir_all(&output_dir).unwrap();
-    let published = b"# Q3 revenue\n\nUp.";
-    std::fs::write(output_dir.join("summary.md"), published).unwrap();
+    let published = b"def revenue():\n    return 'up'\n";
+    std::fs::write(output_dir.join("analysis.py"), published).unwrap();
     let provider = crate::code_execution::ConfiguredCodeExecutionProvider::new(
         store.clone(),
         Arc::new(MemSecrets::default()),
@@ -70,8 +70,8 @@ async fn a_published_output_is_listed_read_revised_restored_and_exported_over_ht
         json_body(get(&router, &bearer, &format!("/chats/{}/outputs", chat.id)).await).await;
     assert_eq!(catalog["truncated"], false);
     let summary = &catalog["deliverables"][0];
-    assert_eq!(summary["filename"], "summary.md");
-    assert_eq!(summary["mediaType"], "text/markdown");
+    assert_eq!(summary["filename"], "analysis.py");
+    assert_eq!(summary["mediaType"], "text/plain");
     assert_eq!(summary["revisionCount"], 1);
     assert_eq!(summary["producingRunId"], run_id.to_string());
     assert_eq!(summary["sizeBytes"], published.len());
@@ -98,7 +98,7 @@ async fn a_published_output_is_listed_read_revised_restored_and_exported_over_ht
             &format!("{outputs}/revisions"),
             serde_json::json!({
                 "expectedRevisionId": first_revision,
-                "content": "# Q3 revenue\n\nUp, and to the right.",
+                "content": "def revenue():\n    return 'up and to the right'\n",
             }),
         )
         .await,
@@ -172,7 +172,7 @@ async fn a_published_output_is_listed_read_revised_restored_and_exported_over_ht
             .await
         )
         .await,
-        b"# Q3 revenue\n\nUp, and to the right."
+        b"def revenue():\n    return 'up and to the right'\n"
     );
     // …and the current bytes are the restored ones.
     assert_eq!(

--- a/docs/decisions/0019-source-code-files-are-text-outputs.md
+++ b/docs/decisions/0019-source-code-files-are-text-outputs.md
@@ -1,0 +1,83 @@
+# 19. Source-code files are text outputs
+
+- Status: Proposed
+- Date: 2026-08-14
+- Owners: Outputs
+- Related: `docs/deliverables.md`
+- Supersedes: none
+
+## Context
+
+Files written directly under an execution workspace's `output/` directory are
+the agent's explicit user-visible deliverables. The output scanner currently
+classifies only Markdown, plain text, CSV, JSON, HTML, and chart JSON as text.
+A source file such as `example.py` therefore becomes an opaque binary output in
+a foreground turn, while a background run refuses a small hard-coded set of
+source extensions as presumed helper scripts.
+
+The desktop already has a safe syntax-highlighted source viewer for text
+outputs. The missing classification prevents source-code deliverables from
+reaching it and makes foreground and background execution disagree about the
+same file.
+
+## Decision
+
+Recognized source-code and text-configuration filenames under `output/` publish
+as bounded UTF-8 text outputs with media type `text/plain`. This includes common
+language, shell, stylesheet, data-definition, and configuration extensions, as
+well as conventional extensionless build files such as `Dockerfile`, `Makefile`,
+and `Justfile`.
+
+The desktop selects syntax highlighting from the filename, falling back to the
+media type and then plain text. Source is displayed, never executed.
+
+Background runs no longer reject source extensions. The location remains the
+intent boundary: a file directly under `output/` is a proposed deliverable;
+helper scripts belong elsewhere because the model-facing tool contract says so,
+not because the host guesses intent from an extension.
+
+The existing 512 KiB, valid-UTF-8, non-empty, no-NUL text-output contract still
+applies. Unknown extensions retain the existing binary-artifact behavior.
+
+## Alternatives Considered
+
+- **Keep source files export-only.** This preserves the current classifier but
+  wastes the existing safe source viewer and makes a common requested output
+  impossible to inspect before export.
+- **Add one distinct media type per programming language.** This would encode
+  more information in the persisted record, but would multiply mirrored
+  allowlists across Rust, HTTP, and TypeScript. The filename already survives
+  end to end and is the conventional language signal.
+- **Continue suppressing source files only for background runs.** This avoids
+  accidental helper outputs, but it also makes delegated code-generation tasks
+  unable to submit their actual result. Directory placement is the clearer and
+  provider-neutral intent signal.
+- **Treat every valid UTF-8 unknown extension as text.** This is simpler but
+  changes opaque-file behavior too broadly and risks misclassifying formats
+  whose first bytes happen to decode. A curated filename set keeps the boundary
+  reviewable.
+
+## Consequences
+
+Source-code outputs gain bounded previews, syntax highlighting, version history,
+editing, and export through the existing text-output path. A background agent
+that incorrectly places a helper script under `output/` can now expose it in the
+catalog, so prompts and skill instructions must continue to keep intermediates
+outside that directory.
+
+Existing source files previously recorded as `application/octet-stream` keep
+their stored media type and remain export-only; output media types are fixed per
+record. Tidebreak is pre-1.0 and does not migrate those rare records.
+
+Revisit this decision if output submission gains a staged manifest that can
+distinguish final files from intermediates before publication, or if language
+services require a persisted language identity rather than filename inference.
+
+## Validation
+
+- Core tests prove representative source filenames map to `text/plain`, obey
+  the text ceiling, and publish from both foreground and background scans.
+- Desktop tests prove the filename selects the expected highlight language and
+  that a source output reaches the source viewer rather than the export-only
+  fallback.
+- Existing tests continue to prove unknown extensions remain binary artifacts.

--- a/docs/deliverables.md
+++ b/docs/deliverables.md
@@ -8,7 +8,8 @@ destination through the native **Save As…** dialog.
 
 ## Product flow
 
-1. The user asks for a report, plan, table, data file, or simple web page.
+1. The user asks for a report, plan, table, data file, source-code file, or
+   simple web page.
 2. The foreground agent produces the file with code execution, saving it under
    the workspace's `output/` directory.
 3. After each command, Tidebreak scans `output/` and publishes what it finds as
@@ -26,9 +27,10 @@ symlinks rather than following them.
 
 ## Closed first-slice contract
 
-- Curated text formats — Markdown, plain text, CSV, JSON, and HTML — publish as
-  text outputs; any other extension publishes as a binary artifact with a
-  media type derived from its extension, bounded at 16 MiB.
+- Curated text formats — Markdown, plain text, CSV, JSON, HTML, and recognized
+  source-code or text-configuration filenames — publish as text outputs; any
+  other extension publishes as a binary artifact with a media type derived from
+  its extension, bounded at 16 MiB.
 - Filenames are one portable ASCII component, at most 120 characters.
 - Content is valid UTF-8, non-empty, and at most 512 KiB.
 - The catalog returns the newest 100 valid output files.
@@ -39,9 +41,10 @@ symlinks rather than following them.
   reuse the same engines as source documents.
 - Markdown previews use the same safe renderer as assistant messages: raw HTML,
   local-file links, executable URL schemes, and remote image loads are not
-  rendered. Plain text, JSON, and HTML outputs use a syntax-highlighted source
-  view (HTML is never executed). Unsupported binary types (for example ZIP)
-  remain export-only.
+  rendered. Plain text, source code, JSON, and HTML outputs use a
+  syntax-highlighted source view selected from the filename where possible
+  (HTML and source are never executed). Unsupported binary types (for example
+  ZIP) remain export-only.
 
 The output directory is a capability-confined child of private per-chat
 scratch. Native reads reject symlinks and non-regular or oversized files.
@@ -163,9 +166,10 @@ is a durable, append-only version history the user can always walk back:
   turn or background run published a newer version while the editor was open,
   nothing is written and the reader is offered the version that won. Content
   obeys the same bounds as an agent-written text output — non-empty, UTF-8, no
-  NUL, at most 512 KiB — and the structured text types (CSV, JSON, charts,
-  HTML) and binary artifacts are not editable, because a free-text edit of
-  those is as likely to break the document as to fix it.
+  NUL, at most 512 KiB. Source-code filenames use the plain-text path and are
+  editable; the structured document types (CSV, JSON, charts, HTML) and binary
+  artifacts are not, because a free-text edit of those is as likely to break
+  the document as to fix it.
 - **Delete is explicit and soft.** Deleting an output hides it from the catalog
   while retaining every revision; the catalog offers an inline Undo that
   restores it exactly.


### PR DESCRIPTION
## Summary

- classify common source-code and text-configuration filenames as bounded UTF-8 text outputs
- render code outputs through the existing safe source viewer with filename-based syntax highlighting
- allow background agents to publish source files when they deliberately place them under `output/`
- document the output-intent boundary and compatibility behavior in decision record 0019

## Why

The desktop already had a safe syntax-highlighted viewer for text outputs, but normal source filenames were classified as opaque binary artifacts. Foreground source outputs were therefore export-only, while background runs rejected several source extensions entirely. This makes the output contract consistent: placement under `output/` declares a deliverable, and recognized source filenames use the existing text path.

## Implementation

- source and configuration extensions map to `text/plain`, preserving the existing 512 KiB UTF-8/no-NUL contract
- conventional extensionless files such as `Dockerfile`, `Makefile`, and `Justfile` are supported
- the viewer selects only grammars bundled with `rehype-highlight`; other supported source formats fall back to plain text
- unknown extensions retain the existing binary-artifact behavior
- existing outputs already stored as `application/octet-stream` are unchanged because output media types are immutable

## Safety and compatibility

Source content is displayed as escaped text and is never executed. Existing export, version history, editing, chat isolation, filename portability, and revision limits remain unchanged. The change is additive for newly published source files; previously stored opaque source outputs remain export-only.

## Validation

- `cargo test -p tidebreak-core deliverable::tests --locked`
- `cargo test -p tidebreak-core a_sandbox_run_publishes_source_code_outputs --locked`
- `cargo test -p tidebreak-server a_published_output_is_listed_read_revised_restored_and_exported_over_http --locked`
- `pnpm exec vitest run src/outputs/CodeViewer.test.tsx src/outputs/OutputDetailRoot.dom.test.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `cargo fmt --all -- --check`
- `git diff --check`
