### PR TITLE
feat(desktop): add high-fidelity spreadsheet previews

### DIFF
--- a/crates/tidebreak-desktop/native-only-commands.txt
+++ b/crates/tidebreak-desktop/native-only-commands.txt
@@ -51,7 +51,7 @@ stop_computer_use_control: sets the native halt latch that short-circuits contro
 resume_computer_use_control: clears that latch on an explicit user gesture.
 
 # Office converter and Node runtime installers
-convert_presentation_to_pdf: drives the user's locally installed LibreOffice.
+convert_office_to_pdf: drives the user's locally installed LibreOffice inside the desktop sandbox.
 install_presentation_converter: installs the local office converter onto this machine.
 cancel_presentation_converter_install: cancels that local installation.
 warm_presentation_converter: warms the locally installed converter process.

--- a/crates/tidebreak-desktop/src/lib.rs
+++ b/crates/tidebreak-desktop/src/lib.rs
@@ -308,7 +308,7 @@ pub fn run() {
             deliverables::export_deliverable,
             chat_debug::copy_chat_debug_bundle,
             chat_debug::save_chat_debug_bundle,
-            office_pdf::convert_presentation_to_pdf,
+            office_pdf::convert_office_to_pdf,
             office_install::install_presentation_converter,
             office_install::cancel_presentation_converter_install,
             office_install::warm_presentation_converter,

--- a/crates/tidebreak-desktop/src/office_pdf.rs
+++ b/crates/tidebreak-desktop/src/office_pdf.rs
@@ -1,8 +1,7 @@
-//! Presentation-to-PDF conversion for the inline preview.
+//! Office-document-to-PDF conversion for inline previews.
 //!
-//! There is no presentation engine in the renderer, so slides are shown the
-//! way most tools outside PowerPoint show them: converted to PDF and drawn by
-//! the PDF viewer. Conversion prefers the app's own managed LibreOffice
+//! Presentations and the high-fidelity spreadsheet view are converted to PDF
+//! and drawn by the PDF viewer. Conversion prefers the app's own managed LibreOffice
 //! (downloaded and digest-verified by [`crate::office_install`] the first
 //! time a preview needs it, on macOS), then falls back to one the user
 //! installed. Its absence is a first-class state the renderer turns into a
@@ -38,12 +37,12 @@ use tidebreak_core::MAX_BINARY_DELIVERABLE_BYTES;
 use tokio::process::Command;
 
 /// LibreOffice loads the whole document before exporting; 90 seconds is
-/// generous for any deck the 16 MB input cap admits, and bounds a hang on a
+/// generous for any document the 16 MB input cap admits, and bounds a hang on a
 /// crafted file.
 const CONVERT_TIMEOUT: Duration = Duration::from_secs(90);
 
 /// A PDF export larger than this is not a preview any more. Four times the
-/// binary-output ceiling covers decks whose images recompress badly.
+/// binary-output ceiling covers documents whose images recompress badly.
 const MAX_PDF_BYTES: u64 = 4 * MAX_BINARY_DELIVERABLE_BYTES as u64;
 
 /// Disk budget for cached conversions. Oldest files are pruned past this;
@@ -62,8 +61,8 @@ const CONVERTER_CONFINED: bool = cfg!(target_os = "macos");
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub(crate) struct PresentationPdfRequest {
-    /// The presentation's bytes, base64 like every other bulk IPC payload.
+pub(crate) struct OfficePdfRequest {
+    /// The office document's bytes, base64 like every other bulk IPC payload.
     content_base64: String,
     /// Stored media type of the source; picks the input filename extension
     /// LibreOffice keys its import filter on.
@@ -83,7 +82,7 @@ pub(crate) struct PresentationPdfRequest {
     rename_all_fields = "camelCase",
     tag = "status"
 )]
-pub(crate) enum PresentationPdfResult {
+pub(crate) enum OfficePdfResult {
     Converted {
         pdf_base64: String,
     },
@@ -103,26 +102,26 @@ pub(crate) enum PresentationPdfResult {
     },
 }
 
-fn converter_missing() -> PresentationPdfResult {
-    PresentationPdfResult::ConverterMissing {
+fn converter_missing() -> OfficePdfResult {
+    OfficePdfResult::ConverterMissing {
         installable: crate::office_install::supported(),
         install_failure: crate::office_install::last_failure(),
     }
 }
 
-/// Convert one presentation's bytes to PDF with the user's LibreOffice.
+/// Convert one supported office document's bytes to PDF with LibreOffice.
 ///
 /// Bytes travel in and out rather than a document identity so the one command
 /// serves both transports the viewers already use — HTTP-fetched source
 /// documents and IPC-read output revisions — without duplicating either
 /// resolution path here.
 #[tauri::command]
-pub(crate) async fn convert_presentation_to_pdf(
+pub(crate) async fn convert_office_to_pdf(
     app: AppHandle,
-    request: PresentationPdfRequest,
-) -> Result<PresentationPdfResult, String> {
+    request: OfficePdfRequest,
+) -> Result<OfficePdfResult, String> {
     let extension = input_extension(&request.media_type)
-        .ok_or_else(|| "That file type has no presentation preview".to_owned())?;
+        .ok_or_else(|| "That file type has no office preview".to_owned())?;
     let bytes = BASE64
         .decode(request.content_base64.as_bytes())
         .map_err(|_| "Could not read that file".to_owned())?;
@@ -135,16 +134,16 @@ pub(crate) async fn convert_presentation_to_pdf(
 
     let data_dir = crate::data_dir(&app)?;
     let cache_dir = data_dir.join(CACHE_DIRECTORY);
-    let cache_path = cache_dir.join(format!("{}.pdf", content_key(&bytes)));
+    let cache_path = cache_dir.join(format!("{}.pdf", content_key(&bytes, extension)));
     if let Ok(cached) = tokio::fs::read(&cache_path).await {
         if !cached.is_empty() {
-            return Ok(PresentationPdfResult::Converted {
+            return Ok(OfficePdfResult::Converted {
                 pdf_base64: BASE64.encode(cached),
             });
         }
     }
 
-    // One conversion at a time. Duplicate requests for the same deck arrive
+    // One conversion at a time. Duplicate requests for the same document arrive
     // routinely (two panels, or a fetch retried around an aborted render) and
     // used to race two cold LibreOffice launches — flaky in exactly the
     // hard-to-reproduce way, and their `.partial` cache staging collided.
@@ -153,7 +152,7 @@ pub(crate) async fn convert_presentation_to_pdf(
     let _serialized = conversion_lock().lock().await;
     if let Ok(cached) = tokio::fs::read(&cache_path).await {
         if !cached.is_empty() {
-            return Ok(PresentationPdfResult::Converted {
+            return Ok(OfficePdfResult::Converted {
                 pdf_base64: BASE64.encode(cached),
             });
         }
@@ -170,13 +169,13 @@ pub(crate) async fn convert_presentation_to_pdf(
         // LibreOffice at all: the install hint is the actionable message.
         Err(ConversionError::Spawn) => return Ok(converter_missing()),
         Err(ConversionError::Sandbox(reason)) => {
-            return Ok(PresentationPdfResult::Failed {
+            return Ok(OfficePdfResult::Failed {
                 message: "Could not sandbox LibreOffice".to_owned(),
                 details: sanitize_diagnostic(&reason),
             })
         }
         Err(ConversionError::Failed(failure)) => {
-            return Ok(PresentationPdfResult::Failed {
+            return Ok(OfficePdfResult::Failed {
                 message: failure.message,
                 details: sanitize_diagnostic(&failure.details),
             })
@@ -187,7 +186,7 @@ pub(crate) async fn convert_presentation_to_pdf(
     // still a preview.
     let _ = store_cached_pdf(&cache_dir, &cache_path, &pdf).await;
 
-    Ok(PresentationPdfResult::Converted {
+    Ok(OfficePdfResult::Converted {
         pdf_base64: BASE64.encode(pdf),
     })
 }
@@ -204,14 +203,21 @@ fn input_extension(media_type: &str) -> Option<&'static str> {
         "application/vnd.openxmlformats-officedocument.presentationml.presentation" => Some("pptx"),
         "application/vnd.ms-powerpoint" => Some("ppt"),
         "application/vnd.oasis.opendocument.presentation" => Some("odp"),
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" => Some("xlsx"),
+        "application/vnd.ms-excel" => Some("xls"),
+        "application/vnd.oasis.opendocument.spreadsheet" => Some("ods"),
         _ => None,
     }
 }
 
-/// Cache key: the SHA-256 of the source bytes. Content-addressed like blob
-/// ids, so the same deck imported twice converts once.
-fn content_key(bytes: &[u8]) -> String {
+/// Cache key: the conversion profile plus the SHA-256 of the source bytes.
+/// The profile is part of the identity because Calc's one-page-per-sheet
+/// export is intentionally different from LibreOffice's default print export.
+fn content_key(bytes: &[u8], extension: &str) -> String {
     let mut hasher = Sha256::new();
+    hasher.update(b"office-pdf-v2\0");
+    hasher.update(extension.as_bytes());
+    hasher.update(b"\0");
     hasher.update(bytes);
     let digest = hasher.finalize();
     let mut key = String::with_capacity(64);
@@ -419,7 +425,7 @@ async fn run_conversion(
         .map_err(|error| {
             ConversionError::Failed(ConversionFailure::message(format!("workspace: {error}")))
         })?;
-    let input = workdir.path().join(format!("slides.{extension}"));
+    let input = workdir.path().join(format!("document.{extension}"));
     let out_dir = workdir.path().join("out");
     let profile = workdir.path().join("profile");
     let profile_uri = file_uri(&profile).map_err(|error| {
@@ -433,6 +439,8 @@ async fn run_conversion(
     })?;
 
     let mut command = converter_command(soffice, workdir.path())?;
+    let export_filter = pdf_export_filter(extension);
+
     command
         .arg("--headless")
         .arg("--nologo")
@@ -441,7 +449,7 @@ async fn run_conversion(
         .arg("--nofirststartwizard")
         .arg(format!("-env:UserInstallation={profile_uri}"))
         .arg("--convert-to")
-        .arg("pdf")
+        .arg(export_filter)
         .arg("--outdir")
         .arg(&out_dir)
         .arg(&input)
@@ -474,7 +482,7 @@ async fn run_conversion(
         .await
         .map_err(|_| {
             ConversionError::Failed(ConversionFailure::message(
-                "Converting the presentation timed out",
+                "Converting the document timed out",
             ))
         })?
         .map_err(|error| {
@@ -483,7 +491,7 @@ async fn run_conversion(
 
     // LibreOffice can exit zero without writing anything, so the produced
     // file — present and non-empty — is the success signal, not the code.
-    let produced = out_dir.join("slides.pdf");
+    let produced = out_dir.join("document.pdf");
     let metadata = tokio::fs::metadata(&produced).await;
     let produced_len = metadata.as_ref().map(|m| m.len()).unwrap_or(0);
     if !output.status.success() || produced_len == 0 {
@@ -542,6 +550,18 @@ async fn run_conversion(
     })
 }
 
+fn pdf_export_filter(extension: &str) -> &'static str {
+    match extension {
+        // Preserve a spreadsheet as one complete canvas per sheet instead of
+        // chopping dashboards into ordinary printer pages.
+        "xlsx" | "xls" | "ods" => concat!(
+            "pdf:calc_pdf_Export:",
+            r#"{"SinglePageSheets":{"type":"boolean","value":"true"}}"#
+        ),
+        _ => "pdf",
+    }
+}
+
 fn first_line(detail: &str) -> &str {
     detail.lines().next().unwrap_or(detail)
 }
@@ -565,7 +585,7 @@ fn sanitize_diagnostic(detail: &str) -> String {
 ///
 /// Temp roots can contain spaces, `#`, or other URI-reserved characters.
 /// Passing the display path verbatim makes LibreOffice reject the value with
-/// "The string contains invalid characters" before it opens the deck.
+/// "The string contains invalid characters" before it opens the document.
 fn file_uri(path: &Path) -> Result<String, &'static str> {
     url::Url::from_file_path(path)
         .map(|uri| uri.into())
@@ -644,7 +664,7 @@ impl tidebreak_code_execution::HostOfficeConverter for ExecOfficeConverter {
             ));
         }
         let cache_dir = self.data_dir.join(CACHE_DIRECTORY);
-        let cache_path = cache_dir.join(format!("{}.pdf", content_key(bytes)));
+        let cache_path = cache_dir.join(format!("{}.pdf", content_key(bytes, extension)));
         if let Ok(cached) = tokio::fs::read(&cache_path).await {
             if !cached.is_empty() {
                 return Ok(cached);
@@ -664,7 +684,7 @@ impl tidebreak_code_execution::HostOfficeConverter for ExecOfficeConverter {
         match run_conversion(&soffice, bytes, extension).await {
             Ok(pdf) => {
                 // Cache best-effort, shared with the preview panel: the same
-                // deck previewed and QA-rendered converts once.
+                // document previewed and QA-rendered converts once.
                 let _ = store_cached_pdf(&cache_dir, &cache_path, &pdf).await;
                 Ok(pdf)
             }
@@ -689,7 +709,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn presentation_media_types_map_to_import_extensions() {
+    fn office_media_types_map_to_import_extensions() {
         assert_eq!(
             input_extension(
                 "application/vnd.openxmlformats-officedocument.presentationml.presentation"
@@ -704,7 +724,19 @@ mod tests {
             input_extension("application/vnd.oasis.opendocument.presentation"),
             Some("odp")
         );
+        assert_eq!(
+            input_extension("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
+            Some("xlsx")
+        );
+        assert_eq!(input_extension("application/vnd.ms-excel"), Some("xls"));
         assert_eq!(input_extension("application/pdf"), None);
+    }
+
+    #[test]
+    fn spreadsheet_export_keeps_each_sheet_on_one_pdf_page() {
+        assert!(pdf_export_filter("xlsx").contains("calc_pdf_Export"));
+        assert!(pdf_export_filter("xlsx").contains("SinglePageSheets"));
+        assert_eq!(pdf_export_filter("pptx"), "pdf");
     }
 
     /// A verified managed install answers resolution outright; the system is
@@ -757,10 +789,10 @@ mod tests {
     /// The IPC wire contract for the preview. The renderer reads these keys
     /// by name, and an enum-level `rename_all` renames only the variants —
     /// leaving `pdf_base64` on the wire, which the renderer read as
-    /// `undefined` and handed to `atob`, failing every presentation preview.
+    /// `undefined` and handed to `atob`, failing every office preview.
     #[test]
     fn conversion_result_serializes_camel_case_variants_and_fields() {
-        let converted = serde_json::to_value(PresentationPdfResult::Converted {
+        let converted = serde_json::to_value(OfficePdfResult::Converted {
             pdf_base64: "JVBERi0=".to_owned(),
         })
         .unwrap();
@@ -769,7 +801,7 @@ mod tests {
             serde_json::json!({ "status": "converted", "pdfBase64": "JVBERi0=" })
         );
 
-        let missing = serde_json::to_value(PresentationPdfResult::ConverterMissing {
+        let missing = serde_json::to_value(OfficePdfResult::ConverterMissing {
             installable: true,
             install_failure: Some("Download cancelled".to_owned()),
         })
@@ -783,7 +815,7 @@ mod tests {
             })
         );
 
-        let failed = serde_json::to_value(PresentationPdfResult::Failed {
+        let failed = serde_json::to_value(OfficePdfResult::Failed {
             message: "LibreOffice failed".to_owned(),
             details: "Exit status: exit status: 1".to_owned(),
         })

--- a/crates/tidebreak-desktop/ui/src/document/DocumentViewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/DocumentViewer.tsx
@@ -25,6 +25,11 @@ const PdfViewer = lazy(() =>
 const UniverSpreadsheetViewer = lazy(
   () => import("@/document/UniverSpreadsheetViewer"),
 );
+const SpreadsheetViewer = lazy(() =>
+  import("@/document/SpreadsheetViewer").then((m) => ({
+    default: m.SpreadsheetViewer,
+  })),
+);
 const DocxViewer = lazy(() => import("@/document/DocxViewer"));
 // Presentations render as converted PDFs; the viewer carries the conversion
 // states (preparing, converter missing) on top of the lazy PDF engine.
@@ -137,14 +142,28 @@ export function DocumentViewer({
     );
   }
 
-  if (SPREADSHEET_MEDIA_TYPES.has(type) || DELIMITED_TEXT_MEDIA_TYPES.has(type)) {
+  if (SPREADSHEET_MEDIA_TYPES.has(type)) {
+    return (
+      <ViewerBoundary>
+        <SpreadsheetViewer
+          key={source.id}
+          source={source}
+          mediaType={type}
+          highlightRange={citationCellRange}
+          className={className}
+        />
+      </ViewerBoundary>
+    );
+  }
+
+  if (DELIMITED_TEXT_MEDIA_TYPES.has(type)) {
     return (
       <ViewerBoundary>
         <UniverSpreadsheetViewer
           key={source.id}
           source={source}
           highlightRange={citationCellRange}
-          isCsv={DELIMITED_TEXT_MEDIA_TYPES.has(type)}
+          isCsv
           className={className}
         />
       </ViewerBoundary>

--- a/crates/tidebreak-desktop/ui/src/document/PresentationViewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/PresentationViewer.tsx
@@ -11,7 +11,11 @@
  * install-it-yourself hint, and a failed conversion gets its own card so a
  * corrupt file never reads as a broken app.
  */
-import { Loader2Icon, PresentationIcon } from "lucide-react";
+import {
+  FileSpreadsheetIcon,
+  Loader2Icon,
+  PresentationIcon,
+} from "lucide-react";
 import { lazy, useEffect, useMemo, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -20,8 +24,8 @@ import {
   cancelPresentationConverterInstall,
   ConverterMissingError,
   installPresentationConverter,
-  PresentationConversionError,
-  presentationPdfSource,
+  OfficeConversionError,
+  officePdfSource,
   type ConverterInstallProgress,
 } from "@/document/officePdf";
 import {
@@ -43,11 +47,31 @@ interface Props {
 }
 
 export function PresentationViewer({ source, mediaType, className }: Props) {
+  return (
+    <ConvertedOfficeViewer
+      source={source}
+      mediaType={mediaType}
+      kind="presentation"
+      className={className}
+    />
+  );
+}
+
+interface ConvertedOfficeViewerProps extends Props {
+  kind: "presentation" | "spreadsheet";
+}
+
+export function ConvertedOfficeViewer({
+  source,
+  mediaType,
+  kind,
+  className,
+}: ConvertedOfficeViewerProps) {
   // Bumped when the managed install completes, so the conversion that found
   // no converter is retried under a fresh cache key.
   const [attempt, setAttempt] = useState(0);
   const pdfSource = useMemo(() => {
-    const converted = presentationPdfSource(source, mediaType);
+    const converted = officePdfSource(source, mediaType);
     return attempt === 0
       ? converted
       : { ...converted, cacheKey: `${converted.cacheKey}#${attempt}` };
@@ -73,29 +97,30 @@ export function PresentationViewer({ source, mediaType, className }: Props) {
       return (
         <ConverterInstall
           key={attempt}
+          kind={kind}
           initialFailure={error.installFailure}
           onReady={() => setAttempt((current) => current + 1)}
         />
       );
     }
     return (
-      <PresentationNotice>
-        Install LibreOffice to preview presentations. The file itself is fine —
+      <OfficeNotice kind={kind}>
+        Install LibreOffice to preview this {kind}. The file itself is fine —
         Save as… exports it unchanged.
-      </PresentationNotice>
+      </OfficeNotice>
     );
   }
 
   if (error !== null || data === null) {
     return (
-      <PresentationNotice>
+      <OfficeNotice kind={kind}>
         <span className="block">
-          This presentation could not be converted for preview.
+          This {kind} could not be converted for preview.
         </span>
         {error?.message ? (
           <span className="mt-1 block">{error.message}</span>
         ) : null}
-        {error instanceof PresentationConversionError ? (
+        {error instanceof OfficeConversionError ? (
           <details className="mt-3 w-full text-left">
             <summary className="cursor-pointer text-xs font-medium text-foreground">
               Troubleshooting details
@@ -106,7 +131,7 @@ export function PresentationViewer({ source, mediaType, className }: Props) {
           </details>
         ) : null}
         <span className="mt-1 block">Save as… exports the original file.</span>
-      </PresentationNotice>
+      </OfficeNotice>
     );
   }
 
@@ -127,9 +152,11 @@ export function PresentationViewer({ source, mediaType, className }: Props) {
  * with the reason; only the explicit retry starts another download.
  */
 function ConverterInstall({
+  kind,
   initialFailure,
   onReady,
 }: {
+  kind: "presentation" | "spreadsheet";
   initialFailure: string | null;
   onReady: () => void;
 }) {
@@ -168,9 +195,9 @@ function ConverterInstall({
 
   if (!running) {
     return (
-      <PresentationNotice>
+      <OfficeNotice kind={kind}>
         <span className="block">
-          Couldn’t set up the presentation preview
+          Couldn’t set up the {kind} preview
           {failure ? `: ${failure}` : "."}
         </span>
         <span className="mt-1 block">
@@ -188,7 +215,7 @@ function ConverterInstall({
         >
           Try again
         </Button>
-      </PresentationNotice>
+      </OfficeNotice>
     );
   }
 
@@ -201,10 +228,10 @@ function ConverterInstall({
   return (
     <div className="flex grow items-center justify-center p-6">
       <div className="flex w-full max-w-sm flex-col items-center gap-3 text-center">
-        <PresentationIcon className="size-6 text-muted-foreground" />
+        <OfficeIcon kind={kind} />
         <p className="text-sm text-muted-foreground" role="status">
           {downloading
-            ? "Preparing presentation preview — downloading LibreOffice (~300 MB)…"
+            ? `Preparing ${kind} preview — downloading LibreOffice (~300 MB)…`
             : "Setting up LibreOffice…"}
         </p>
         <Progress value={percent ?? undefined} className="w-56" />
@@ -232,11 +259,22 @@ function formatMegabytes(bytes: number): string {
   return Math.round(bytes / (1024 * 1024)).toString();
 }
 
-function PresentationNotice({ children }: { children: React.ReactNode }) {
+function OfficeIcon({ kind }: { kind: "presentation" | "spreadsheet" }) {
+  const Icon = kind === "presentation" ? PresentationIcon : FileSpreadsheetIcon;
+  return <Icon className="size-6 text-muted-foreground" />;
+}
+
+function OfficeNotice({
+  kind,
+  children,
+}: {
+  kind: "presentation" | "spreadsheet";
+  children: React.ReactNode;
+}) {
   return (
     <div className="flex grow items-center justify-center p-6">
       <div className="flex w-full max-w-xl flex-col items-center gap-3 text-center">
-        <PresentationIcon className="size-6 text-muted-foreground" />
+        <OfficeIcon kind={kind} />
         <p className="text-sm text-muted-foreground" role="status">
           {children}
         </p>

--- a/crates/tidebreak-desktop/ui/src/document/SpreadsheetViewer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/SpreadsheetViewer.dom.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/document/PresentationViewer", () => ({
+  ConvertedOfficeViewer: () => <div>high fidelity preview</div>,
+}));
+
+vi.mock("@/document/UniverSpreadsheetViewer", () => ({
+  default: () => <div>interactive cell inspector</div>,
+}));
+
+import { SpreadsheetViewer } from "./SpreadsheetViewer";
+import type { FileBytesSource } from "./useFileDownload";
+
+const source: FileBytesSource = {
+  id: "book-1",
+  cacheKey: "output/book-1",
+  fetch: vi.fn(),
+};
+
+describe("SpreadsheetViewer", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(cleanup);
+
+  it("opens on the rendered preview and lets the reader inspect cells", async () => {
+    const user = userEvent.setup();
+    render(
+      <SpreadsheetViewer
+        source={source}
+        mediaType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+      />,
+    );
+
+    expect(screen.getByText("high fidelity preview")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Inspect cells" }));
+
+    expect(screen.getByText("interactive cell inspector")).toBeInTheDocument();
+  });
+
+  it("uses the cell inspector when a citation names a workbook range", () => {
+    render(
+      <SpreadsheetViewer
+        source={source}
+        mediaType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        highlightRange={{
+          startCell: "B7",
+          endCell: "D9",
+          sheetName: "Revenue",
+          sheetIndex: null,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("interactive cell inspector")).toBeInTheDocument();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/document/SpreadsheetViewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/SpreadsheetViewer.tsx
@@ -1,0 +1,92 @@
+import { EyeIcon, TablePropertiesIcon } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { ConvertedOfficeViewer } from "@/document/PresentationViewer";
+import UniverSpreadsheetViewer, {
+  type SheetHighlightRange,
+} from "@/document/UniverSpreadsheetViewer";
+import type { FileBytesSource } from "@/document/useFileDownload";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  source: FileBytesSource;
+  mediaType: string;
+  highlightRange?: SheetHighlightRange;
+  className?: string;
+}
+
+type SpreadsheetView = "preview" | "inspect";
+
+/**
+ * Two deliberately different readings of a workbook:
+ *
+ * - Preview renders LibreOffice's complete-sheet PDF, preserving the authored
+ *   visual document including charts and drawings.
+ * - Inspect keeps the interactive Univer grid for formulas, selection,
+ *   keyboard navigation, and cell-range citations.
+ */
+export function SpreadsheetViewer({
+  source,
+  mediaType,
+  highlightRange,
+  className,
+}: Props) {
+  const [view, setView] = useState<SpreadsheetView>(() =>
+    highlightRange?.startCell ? "inspect" : "preview",
+  );
+
+  // A citation names cells, not a position on a rendered PDF. Move to the
+  // representation that can select and center that exact range.
+  useEffect(() => {
+    if (highlightRange?.startCell) setView("inspect");
+  }, [highlightRange]);
+
+  return (
+    <div className={cn("flex min-h-0 flex-col", className)}>
+      <div className="flex h-10 shrink-0 items-center gap-1 border-b px-3">
+        <Button
+          variant={view === "preview" ? "secondary" : "ghost"}
+          size="sm"
+          aria-pressed={view === "preview"}
+          onClick={() => setView("preview")}
+        >
+          <EyeIcon />
+          Preview
+        </Button>
+        <Button
+          variant={view === "inspect" ? "secondary" : "ghost"}
+          size="sm"
+          aria-pressed={view === "inspect"}
+          onClick={() => setView("inspect")}
+        >
+          <TablePropertiesIcon />
+          Inspect cells
+        </Button>
+        <span className="ml-2 text-xs text-muted-foreground">
+          {view === "preview"
+            ? "Rendered for visual fidelity"
+            : "Read-only formulas and cell navigation"}
+        </span>
+      </div>
+
+      <div className="min-h-0 grow">
+        {view === "preview" ? (
+          <ConvertedOfficeViewer
+            source={source}
+            mediaType={mediaType}
+            kind="spreadsheet"
+            className="h-full"
+          />
+        ) : (
+          <UniverSpreadsheetViewer
+            key={source.id}
+            source={source}
+            highlightRange={highlightRange}
+            className="h-full"
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/document/officePdf.test.ts
+++ b/crates/tidebreak-desktop/ui/src/document/officePdf.test.ts
@@ -7,10 +7,10 @@ vi.mock("@tauri-apps/api/event", () => ({ listen: listenMock }));
 
 import {
   ConverterMissingError,
-  convertPresentationToPdf,
+  convertOfficeToPdf,
   installPresentationConverter,
-  presentationPdfSource,
-  PresentationConversionError,
+  officePdfSource,
+  OfficeConversionError,
   resetConverterInstallStateForTest,
   warmPresentationConverter,
 } from "./officePdf";
@@ -25,20 +25,20 @@ beforeEach(() => {
   resetConverterInstallStateForTest();
 });
 
-describe("presentation-to-PDF conversion", () => {
+describe("office-to-PDF conversion", () => {
   it("round-trips bytes through the host command as base64", async () => {
     invokeMock.mockResolvedValue({
       status: "converted",
       pdfBase64: btoa("%PDF-1.7 fake"),
     });
 
-    const pdf = await convertPresentationToPdf(
+    const pdf = await convertOfficeToPdf(
       new Uint8Array([0x50, 0x4b, 0x03, 0x04]),
       PPTX,
     );
 
     expect(new TextDecoder().decode(pdf)).toBe("%PDF-1.7 fake");
-    expect(invokeMock).toHaveBeenCalledWith("convert_presentation_to_pdf", {
+    expect(invokeMock).toHaveBeenCalledWith("convert_office_to_pdf", {
       request: { contentBase64: btoa("PK\x03\x04"), mediaType: PPTX },
     });
   });
@@ -50,7 +50,7 @@ describe("presentation-to-PDF conversion", () => {
       installFailure: "Download cancelled",
     });
 
-    const error = await convertPresentationToPdf(
+    const error = await convertOfficeToPdf(
       new Uint8Array([1]),
       PPTX,
     ).then(
@@ -72,7 +72,7 @@ describe("presentation-to-PDF conversion", () => {
         "Exit status: exit status: 1\n\nStandard error:\nfirst line\nsecond line",
     });
 
-    const error = await convertPresentationToPdf(
+    const error = await convertOfficeToPdf(
       new Uint8Array([1]),
       PPTX,
     ).then(
@@ -80,7 +80,7 @@ describe("presentation-to-PDF conversion", () => {
       (thrown: unknown) => thrown,
     );
 
-    expect(error).toBeInstanceOf(PresentationConversionError);
+    expect(error).toBeInstanceOf(OfficeConversionError);
     expect(error).toMatchObject({
       message: "LibreOffice failed: source file could not be loaded",
       details:
@@ -186,7 +186,7 @@ describe("presentation-to-PDF conversion", () => {
       }),
     };
 
-    const converted = presentationPdfSource(original, PPTX);
+    const converted = officePdfSource(original, PPTX);
     expect(converted.cacheKey).toBe("document/chat/doc-1/converted-pdf");
 
     const fetched = await converted.fetch(new AbortController().signal);

--- a/crates/tidebreak-desktop/ui/src/document/officePdf.ts
+++ b/crates/tidebreak-desktop/ui/src/document/officePdf.ts
@@ -1,11 +1,10 @@
 /**
- * Presentations preview as converted PDFs.
+ * Office documents preview as converted PDFs.
  *
- * No engine here draws slides natively, so a presentation is converted to PDF
- * by a LibreOffice the user already has installed and rendered with the PDF
- * viewer. The conversion command takes the original bytes and returns PDF
- * bytes, which keeps it transport-agnostic: HTTP-fetched source documents and
- * IPC-read output revisions wrap into the same converted source.
+ * LibreOffice converts presentations and spreadsheets to PDF for the existing
+ * PDF viewer. The command takes original bytes and returns PDF bytes, which
+ * keeps it transport-agnostic: HTTP-fetched source documents and IPC-read
+ * output revisions wrap into the same converted source.
  *
  * A machine without LibreOffice is a designed-for state, not an error path:
  * the converter's absence surfaces as {@link ConverterMissingError} and the
@@ -22,6 +21,12 @@ export const PRESENTATION_MEDIA_TYPES = new Set([
   "application/vnd.oasis.opendocument.presentation",
 ]);
 
+export const SPREADSHEET_MEDIA_TYPES = new Set([
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/vnd.ms-excel",
+  "application/vnd.oasis.opendocument.spreadsheet",
+]);
+
 /**
  * LibreOffice is not installed (or its remains cannot start).
  *
@@ -35,14 +40,14 @@ export class ConverterMissingError extends Error {
   readonly installFailure: string | null;
 
   constructor(installable = false, installFailure: string | null = null) {
-    super("No presentation converter is installed");
+    super("No office document converter is installed");
     this.name = "ConverterMissingError";
     this.installable = installable;
     this.installFailure = installFailure;
   }
 }
 
-type PresentationPdfResponse =
+type OfficePdfResponse =
   | { status: "converted"; pdfBase64: string }
   | {
       status: "converterMissing";
@@ -51,29 +56,29 @@ type PresentationPdfResponse =
     }
   | { status: "failed"; message: string; details: string };
 
-export class PresentationConversionError extends Error {
+export class OfficeConversionError extends Error {
   readonly details: string;
 
   constructor(message: string, details: string) {
     super(message);
-    this.name = "PresentationConversionError";
+    this.name = "OfficeConversionError";
     this.details = details;
   }
 }
 
 /**
- * Convert one presentation's bytes to PDF on the host.
+ * Convert one supported office document's bytes to PDF on the host.
  *
  * Throws {@link ConverterMissingError} when there is no LibreOffice to run;
  * every other failure propagates as an ordinary error with the host's message.
  */
-export async function convertPresentationToPdf(
+export async function convertOfficeToPdf(
   bytes: Uint8Array,
   mediaType: string,
 ): Promise<Uint8Array> {
-  const response = (await invoke("convert_presentation_to_pdf", {
+  const response = (await invoke("convert_office_to_pdf", {
     request: { contentBase64: encodeBase64(bytes), mediaType },
-  })) as PresentationPdfResponse;
+  })) as OfficePdfResponse;
   if (response.status === "converterMissing") {
     throw new ConverterMissingError(
       response.installable,
@@ -81,10 +86,10 @@ export async function convertPresentationToPdf(
     );
   }
   if (response.status === "failed") {
-    throw new PresentationConversionError(response.message, response.details);
+    throw new OfficeConversionError(response.message, response.details);
   }
   if (typeof response.pdfBase64 !== "string" || response.pdfBase64 === "") {
-    throw new Error("Invalid presentation preview response");
+    throw new Error("Invalid office preview response");
   }
   return decodeBase64(response.pdfBase64);
 }
@@ -198,14 +203,14 @@ export function resetConverterInstallStateForTest(): void {
 }
 
 /**
- * The converted-PDF bytes of a presentation source.
+ * The converted-PDF bytes of an office-document source.
  *
  * Wraps the original source rather than a new identity: the cache key extends
  * the original's (which already names immutable content), so the in-session
  * byte cache holds the converted PDF and a re-open never reconverts. The host
  * keeps its own on-disk cache keyed by content hash for cross-session hits.
  */
-export function presentationPdfSource(
+export function officePdfSource(
   original: FileBytesSource,
   mediaType: string,
 ): FileBytesSource {
@@ -214,7 +219,7 @@ export function presentationPdfSource(
     cacheKey: `${original.cacheKey}/converted-pdf`,
     fetch: async (signal, onProgress) => {
       const source = await original.fetch(signal, onProgress);
-      const pdf = await convertPresentationToPdf(source.bytes, mediaType);
+      const pdf = await convertOfficeToPdf(source.bytes, mediaType);
       if (signal.aborted) {
         throw new DOMException("The operation was aborted.", "AbortError");
       }
@@ -222,6 +227,9 @@ export function presentationPdfSource(
     },
   };
 }
+
+export const presentationPdfSource = officePdfSource;
+export const spreadsheetPdfSource = officePdfSource;
 
 function encodeBase64(bytes: Uint8Array): string {
   let binary = "";
@@ -238,8 +246,8 @@ function decodeBase64(value: string): Uint8Array {
     binary = atob(value);
   } catch {
     // `atob` rejects malformed input with "The string contains invalid
-    // characters", which says nothing about presentations to whoever reads it.
-    throw new Error("Invalid presentation preview response");
+    // characters", which says nothing about the preview to whoever reads it.
+    throw new Error("Invalid office preview response");
   }
   const bytes = new Uint8Array(binary.length);
   for (let index = 0; index < binary.length; index += 1) {


### PR DESCRIPTION
## What changed

- route XLS and XLSX documents through a new read-only spreadsheet viewer
- make a LibreOffice-rendered PDF the default `Preview` mode for visual fidelity
- retain the existing Univer renderer as an `Inspect cells` mode for formulas, selection, keyboard navigation, and cell citations
- automatically open `Inspect cells` when a citation targets a workbook range
- generalize the existing sandboxed presentation-to-PDF command and cache for supported office documents
- export Calc workbooks with `SinglePageSheets`, producing one complete PDF page per worksheet

## Why

The existing SheetJS-to-Univer reconstruction loses authored workbook layout, charts, drawing placement, and portions of Excel formatting. The same limitation exists in Alpha's viewer. LibreOffice already provides much better read-only fidelity, and Tidebreak already owns a sandboxed, cached, managed LibreOffice conversion path for presentations.

The hybrid keeps the two useful representations separate: PDF for faithful reading and Univer for structured cell inspection. Editing remains out of scope.

## Compatibility and safety

- presentation previews continue through the same converter, now under a generalized command name
- CSV and TSV files continue opening directly in Univer
- original workbook bytes are never modified; `Save as…` still exports the source file
- conversion remains sandboxed and serialized, with the existing managed LibreOffice install and missing-converter states
- cache keys include the source extension and a new conversion-profile version so prior presentation cache entries cannot collide with Calc's export profile

## Validation

- `pnpm exec tsc --noEmit`
- focused Vitest suite: 10 tests passed across office conversion, spreadsheet mode switching/citations, and the existing Univer viewer
- `pnpm build`
- `cargo check -p tidebreak-desktop --locked`
- `cargo test -p tidebreak-desktop office_pdf --locked` (8 tests passed)
- `cargo fmt --all`
- `git diff --check`
- real LibreOffice smoke test: a generated two-sheet XLSX exported as a two-page PDF
- representative eight-sheet launch command-center workbook rendered successfully with charts, dashboard formatting, conditional formatting, and one page per sheet

## Risk

LibreOffice output follows workbook print/layout semantics. Extremely wide sheets are fitted to a single page and may require PDF zoom for comfortable reading. The existing `Inspect cells` mode remains available when users need cell-level navigation instead of visual fidelity.
