### PR TITLE
fix: harden soft-launch security boundaries

### DIFF
--- a/.github/vercel-cli/package.json
+++ b/.github/vercel-cli/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "tidebreak-vercel-cli",
+  "version": "0.0.0",
+  "private": true,
+  "packageManager": "pnpm@10.18.3",
+  "dependencies": {
+    "vercel": "59.0.0"
+  }
+}

--- a/.github/vercel-cli/pnpm-lock.yaml
+++ b/.github/vercel-cli/pnpm-lock.yaml
@@ -1,0 +1,3037 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      vercel:
+        specifier: 59.0.0
+        version: 59.0.0(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+
+packages:
+
+  '@bytecodealliance/preview2-shim@0.17.6':
+    resolution: {integrity: sha512-n3cM88gTen5980UOBAD6xDcNNL3ocTK8keab21bpx1ONdA+ARj7uD1qoFxOWCyKlkpSi195FH+GeAut7Oc6zZw==}
+
+  '@edge-runtime/format@2.2.1':
+    resolution: {integrity: sha512-JQTRVuiusQLNNLe2W9tnzBlV/GvSVcozLl4XZHk5swnRZ/v6jp8TqR8P7sqmJsQqblDZ3EztcWmLDbhRje/+8g==}
+    engines: {node: '>=16'}
+
+  '@edge-runtime/node-utils@2.3.0':
+    resolution: {integrity: sha512-uUtx8BFoO1hNxtHjp3eqVPC/mWImGb2exOfGjMLUoipuWgjej+f4o/VP4bUI8U40gu7Teogd5VTeZUkGvJSPOQ==}
+    engines: {node: '>=16'}
+
+  '@edge-runtime/ponyfill@2.4.2':
+    resolution: {integrity: sha512-oN17GjFr69chu6sDLvXxdhg0Qe8EZviGSuqzR9qOiKh4MhFYGdBBcqRNzdmYeAdeRzOW2mM9yil4RftUQ7sUOA==}
+    engines: {node: '>=16'}
+
+  '@edge-runtime/primitives@4.1.0':
+    resolution: {integrity: sha512-Vw0lbJ2lvRUqc7/soqygUX216Xb8T3WBZ987oywz6aJqRxcwSVWwr9e+Nqo2m9bxobA9mdbWNNoRY6S9eko1EQ==}
+    engines: {node: '>=16'}
+
+  '@edge-runtime/vm@3.2.0':
+    resolution: {integrity: sha512-0dEVyRLM/lG4gp1R/Ik5bfPl/1wX00xFwd5KcNH602tzBa09oF7pbTKETEhR1GjZ75K6OJnYFu8II2dyMhONMw==}
+    engines: {node: '>=16'}
+
+  '@emnapi/core@1.11.3':
+    resolution: {integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==}
+
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
+
+  '@emnapi/wasi-threads@1.2.3':
+    resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
+
+  '@esbuild/aix-ppc64@0.27.0':
+    resolution: {integrity: sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.0':
+    resolution: {integrity: sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.0':
+    resolution: {integrity: sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.0':
+    resolution: {integrity: sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.0':
+    resolution: {integrity: sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.0':
+    resolution: {integrity: sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.0':
+    resolution: {integrity: sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.0':
+    resolution: {integrity: sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.0':
+    resolution: {integrity: sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.0':
+    resolution: {integrity: sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.0':
+    resolution: {integrity: sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.0':
+    resolution: {integrity: sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.0':
+    resolution: {integrity: sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.0':
+    resolution: {integrity: sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.0':
+    resolution: {integrity: sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.0':
+    resolution: {integrity: sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.0':
+    resolution: {integrity: sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.0':
+    resolution: {integrity: sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.0':
+    resolution: {integrity: sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.0':
+    resolution: {integrity: sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.0':
+    resolution: {integrity: sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.0':
+    resolution: {integrity: sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.0':
+    resolution: {integrity: sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.0':
+    resolution: {integrity: sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.0':
+    resolution: {integrity: sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.0':
+    resolution: {integrity: sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
+
+  '@isaacs/balanced-match@4.0.1':
+    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/brace-expansion@5.0.1':
+    resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
+  '@mapbox/node-pre-gyp@2.0.3':
+    resolution: {integrity: sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@napi-rs/keyring-darwin-arm64@1.2.0':
+    resolution: {integrity: sha512-CA83rDeyONDADO25JLZsh3eHY8yTEtm/RS6ecPsY+1v+dSawzT9GywBMu2r6uOp1IEhQs/xAfxgybGAFr17lSA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/keyring-darwin-x64@1.2.0':
+    resolution: {integrity: sha512-dBHjtKRCj4ByfnfqIKIJLo3wueQNJhLRyuxtX/rR4K/XtcS7VLlRD01XXizjpre54vpmObj63w+ZpHG+mGM8uA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/keyring-freebsd-x64@1.2.0':
+    resolution: {integrity: sha512-DPZFr11pNJSnaoh0dzSUNF+T6ORhy3CkzUT3uGixbA71cAOPJ24iG8e8QrLOkuC/StWrAku3gBnth2XMWOcR3Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.2.0':
+    resolution: {integrity: sha512-8xv6DyEMlvRdqJzp4F39RLUmmTQsLcGYYv/3eIfZNZN1O5257tHxTrFYqAsny659rJJK2EKeSa7PhrSibQqRWQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.2.0':
+    resolution: {integrity: sha512-Pu2V6Py+PBt7inryEecirl+t+ti8bhZphjP+W68iVaXHUxLdWmkgL9KI1VkbRHbx5k8K5Tew9OP218YfmVguIA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-arm64-musl@1.2.0':
+    resolution: {integrity: sha512-8TDymrpC4P1a9iDEaegT7RnrkmrJN5eNZh3Im3UEV5PPYGtrb82CRxsuFohthCWQW81O483u1bu+25+XA4nKUw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.2.0':
+    resolution: {integrity: sha512-awsB5XI1MYL7fwfjMDGmKOWvNgJEO7mM7iVEMS0fO39f0kVJnOSjlu7RHcXAF0LOx+0VfF3oxbWqJmZbvRCRHw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-x64-gnu@1.2.0':
+    resolution: {integrity: sha512-8E+7z4tbxSJXxIBqA+vfB1CGajpCDRyTyqXkBig5NtASrv4YXcntSo96Iah2QDR5zD3dSTsmbqJudcj9rKKuHQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-x64-musl@1.2.0':
+    resolution: {integrity: sha512-8RZ8yVEnmWr/3BxKgBSzmgntI7lNEsY7xouNfOsQkuVAiCNmxzJwETspzK3PQ2FHtDxgz5vHQDEBVGMyM4hUHA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.2.0':
+    resolution: {integrity: sha512-AoqaDZpQ6KPE19VBLpxyORcp+yWmHI9Xs9Oo0PJ4mfHma4nFSLVdhAubJCxdlNptHe5va7ghGCHj3L9Akiv4cQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.2.0':
+    resolution: {integrity: sha512-EYL+EEI6bCsYi3LfwcQdnX3P/R76ENKNn+3PmpGheBsUFLuh0gQuP7aMVHM4rTw6UVe+L3vCLZSptq/oeacz0A==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-x64-msvc@1.2.0':
+    resolution: {integrity: sha512-xFlx/TsmqmCwNU9v+AVnEJgoEAlBYgzFF5Ihz1rMpPAt4qQWWkMd4sCyM1gMJ1A/GnRqRegDiQpwaxGUHFtFbA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/keyring@1.2.0':
+    resolution: {integrity: sha512-d0d4Oyxm+v980PEq1ZH2PmS6cvpMIRc17eYpiU47KgW+lzxklMu6+HOEOPmxrpnF/XQZ0+Q78I2mgMhbIIo/dg==}
+    engines: {node: '>= 10'}
+
+  '@napi-rs/wasm-runtime@1.2.3':
+    resolution: {integrity: sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.4
+      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.4
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@oxc-project/types@0.110.0':
+    resolution: {integrity: sha512-6Ct21OIlrEnFEJk5LT4e63pk3btsI6/TusD/GStLi7wYlGJNOl1GI9qvXAnRAxQU9zqA2Oz+UwhfTOU2rPZVow==}
+
+  '@oxc-transform/binding-android-arm-eabi@0.111.0':
+    resolution: {integrity: sha512-NdFLicvorfHYu0g2ftjVJaH7+Dz27AQUNJOq8t/ofRUoWmczOodgUCHx8C1M1htCN4ZmhS/FzfSy6yd/UngJGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-transform/binding-android-arm64@0.111.0':
+    resolution: {integrity: sha512-J2v9ajarD2FYlhHtjbgZUFsS2Kvi27pPxDWLGCy7i8tO60xBoozX9/ktSgbiE/QsxKaUhfv4zVKppKWUo71PmQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-transform/binding-darwin-arm64@0.111.0':
+    resolution: {integrity: sha512-2UYmExxpXzmiHTldhNlosWqG9Nc4US51K0GB9RLcGlTE23WO33vVo1NVAKwxPE+KYuhffwDnRYTovTMUjzwvZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-transform/binding-darwin-x64@0.111.0':
+    resolution: {integrity: sha512-c4YRwfLV8Pj/ToiTCbndZaHxM2BD4W3bltr/fjXZcGypEK+U2RZFDL7tIZYT/tyneAC9hCORZKDaKhLLNuzPtA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-transform/binding-freebsd-x64@0.111.0':
+    resolution: {integrity: sha512-prvf32IcEuLnLZbNVomFosBu0CaZpyj3YsZ6epbOgJy8iJjfLsXBb+PrkO/NBKzjuJoJa2+u7jFKRE0KT7gSOw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.111.0':
+    resolution: {integrity: sha512-+se3579Wp7VOk8TnTZCpT+obTAyzOw2b/UuoM0+51LtbzCSfjKxd4A+o7zRl7GyPrPZvx57KdbMOC9rWB1xNrw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-arm-musleabihf@0.111.0':
+    resolution: {integrity: sha512-8faC99pStqaSDPK/vBgaagAHUeL0LcIzfeSjSiDTtvPGc3AwZIeqC1tx3CP15a6tWXjdgS/IUw4IjfD5HweBlg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-arm64-gnu@0.111.0':
+    resolution: {integrity: sha512-HtfQv8j796gzI5WR/RaP6IMwFpiL0vYeDrUA1hYhlPzTHKYan/B+NlhJkKOI1v24yAl/yEnFmb0pxIxLNqBqBA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-arm64-musl@0.111.0':
+    resolution: {integrity: sha512-ARyfcMCIxVLDgLf6FQ8Oo1/TFySpnquV+vuSb4SFQZfYDqgMklzwv0NYXxWD0aB6enElyMDs6pQJBzusEKCkOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-ppc64-gnu@0.111.0':
+    resolution: {integrity: sha512-PKpVRrSvBNK3tv9vwxn7Fay+QWZmprPGlEqJcseBJllQc5mFMD4Q/w44chu5iR9ZLsDeSHzmNWrgMLo4J0sP2A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-riscv64-gnu@0.111.0':
+    resolution: {integrity: sha512-9bUml6rMgk+8GF5rvNMweFspkzSiCjqpV6HduwiUyexqfGKrmjq9IZOxxvnzkE2RGdQzP507NNDoVNYIoGQYuA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-riscv64-musl@0.111.0':
+    resolution: {integrity: sha512-tzGCohGxaeH6KRJjfYZd4mHCoGjCai6N+zZi1Oj+tSDMAAdyvs1dRzYb8PNUGnybCg3Te4M0jLPzWZaSmnKraQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-s390x-gnu@0.111.0':
+    resolution: {integrity: sha512-sRG1KIfZ0ML9ToEygm5aM/5GJeBA05uHlgW3M0Rx/DNWMJhuahLmqWuB02aWSmijndLfEKXLLXIWhvWupRG8lg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-x64-gnu@0.111.0':
+    resolution: {integrity: sha512-T0Kmvk+OdlUdABdXlDIf3MQReMzFfC75NEI9x8jxy5pKooACEFg0k0V8gyR3gq4DzbDCfucqFQDWNvSgIopAbQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-x64-musl@0.111.0':
+    resolution: {integrity: sha512-EgoutsP3YfqzN8a9vpc9+XLr0bmBl0dA3uOMiP77+exATCPxJBkJErGmQkqk6RtTp5XqX6q6mB45qWQyKk6+pA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-transform/binding-openharmony-arm64@0.111.0':
+    resolution: {integrity: sha512-d8J+ejc0j5WODbVwR/QxFaI65YMwvG0W53vcVCHwa6ja1QI5lpe7sislrefG2EFYgnY47voMRzlXab5d4gEcDw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-transform/binding-wasm32-wasi@0.111.0':
+    resolution: {integrity: sha512-HtyIZO8IwuZgXkyb56rysLz1OLbfLhEu8A3BeuyJXzUseAj96yuxgGt3cu3QYX9AXb9pfRfA3c/fvlhsDugyTQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-transform/binding-win32-arm64-msvc@0.111.0':
+    resolution: {integrity: sha512-YeP80Riptc0MkVVBnzbmoFuHVLUq278+MbwNo9sTLALmzTIJxJqN029xRZbG+Bun7aLsoZhmRnm3J5JZ1NcP5w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-transform/binding-win32-ia32-msvc@0.111.0':
+    resolution: {integrity: sha512-A6ztCXpoSHt6PbvGAFqB0MLOcGG7ZJrrPXY1iB0zfOB1atLgI8oNePGxPl03XSbwpiTsFJ1oo8rj9DXcBzgT9g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-transform/binding-win32-x64-msvc@0.111.0':
+    resolution: {integrity: sha512-QddKW4kBH0Wof6Y65eYCNHM4iOGmCTWLLcNYY1FGswhzmTYOUVXajNROR+iCXAOFnOF0ldtsR79SyqgyHH1Bgg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@renovatebot/pep440@4.2.1':
+    resolution: {integrity: sha512-2FK1hF93Fuf1laSdfiEmJvSJPVIDHEUTz68D3Fi9s0IZrrpaEcj6pTFBTbYvsgC5du4ogrtf5re7yMMvrKNgkw==}
+    engines: {node: ^20.9.0 || ^22.11.0 || ^24, pnpm: ^10.0.0}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.1':
+    resolution: {integrity: sha512-He6ZoCfv5D7dlRbrhNBkuMVIHd0GDnjJwbICE1OWpG7G3S2gmJ+eXkcNLJjzjNDpeI2aRy56ou39AJM9AD8YFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.1':
+    resolution: {integrity: sha512-YzJdn08kSOXnj85ghHauH2iHpOJ6eSmstdRTLyaziDcUxe9SyQJgGyx/5jDIhDvtOcNvMm2Ju7m19+S/Rm1jFg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.1':
+    resolution: {integrity: sha512-cIvAbqM+ZVV6lBSKSBtlNqH5iCiW933t1q8j0H66B3sjbe8AxIRetVqfGgcHcJtMzBIkIALlL9fcDrElWLJQcQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.1':
+    resolution: {integrity: sha512-rVt+B1B/qmKwCl1XD02wKfgh3vQPXRXdB/TicV2w6g7RVAM1+cZcpigwhLarqiVCxDObFZ7UgXCxPC7tpDoRog==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.1':
+    resolution: {integrity: sha512-69YKwJJBOFprQa1GktPgbuBOfnn+EGxu8sBJ1TjPER+zhSpYeaU4N07uqmyBiksOLGXsMegymuecLobfz03h8Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.1':
+    resolution: {integrity: sha512-9JDhHUf3WcLfnViFWm+TyorqUtnSAHaCzlSNmMOq824prVuuzDOK91K0Hl8DUcEb9M5x2O+d2/jmBMsetRIn3g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.1':
+    resolution: {integrity: sha512-UvApLEGholmxw/HIwmUnLq3CwdydbhaHHllvWiCTNbyGom7wTwOtz5OAQbAKZYyiEOeIXZNPkM7nA4Dtng7CLw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.1':
+    resolution: {integrity: sha512-uVctNgZHiGnJx5Fij7wHLhgw4uyZBVi6mykeWKOqE7bVy9Hcxn0fM/IuqdMwk6hXlaf9fFShDTFz2+YejP+x0A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.1':
+    resolution: {integrity: sha512-T6Eg0xWwcxd/MzBcuv4Z37YVbUbJxy5cMNnbIt/Yr99wFwli30O4BPlY8hKeGyn6lWNtU0QioBS46lVzDN38bg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.1':
+    resolution: {integrity: sha512-PuGZVS2xNJyLADeh2F04b+Cz4NwvpglbtWACgrDOa5YDTEHKwmiTDjoD5eZ9/ptXtcpeFrMqD2H4Zn33KAh1Eg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.1':
+    resolution: {integrity: sha512-2mOxY562ihHlz9lEXuaGEIDCZ1vI+zyFdtsoa3M62xsEunDXQE+DVPO4S4x5MPK9tKulG/aFcA/IH5eVN257Cw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.1':
+    resolution: {integrity: sha512-oQVOP5cfAWZwRD0Q3nGn/cA9FW3KhMMuQ0NIndALAe6obqjLhqYVYDiGGRGrxvnjJsVbpLwR14gIUYnpIcHR1g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.1':
+    resolution: {integrity: sha512-Ydsxxx++FNOuov3wCBPaYjZrEvKOOGq3k+BF4BPridhg2pENfitSRD2TEuQ8i33bp5VptuNdC9IzxRKU031z5A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.1':
+    resolution: {integrity: sha512-UTBjtTxVOhodhzFVp/ayITaTETRHPUPYZPXQe0WU0wOgxghMojXxYjOiPOauKIYNWJAWS2fd7gJgGQK8GU8vDA==}
+
+  '@rollup/pluginutils@5.4.0':
+    resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@sinclair/typebox@0.25.24':
+    resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
+
+  '@tootallnate/once@2.0.0':
+    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
+    engines: {node: '>= 10'}
+
+  '@ts-morph/common@0.11.1':
+    resolution: {integrity: sha512-7hWZS0NRpEsNV8vWJzg7FEz6V8MaLNeJOmwmghqUXTpzk16V1LLZhdo+4QvE/+zv4cVci0OviuJFnqhEfoV3+g==}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@20.11.0':
+    resolution: {integrity: sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==}
+
+  '@vercel/backends@0.8.37':
+    resolution: {integrity: sha512-o7KadmQ5lHKx4yvBuYwVmNWSwqWYtA5eF3JREE7avdFvIusu5a8h4DWQv9p69urMcX7pTH69bVCq9vGea7X61A==}
+
+  '@vercel/blob@2.8.0':
+    resolution: {integrity: sha512-Nu+HWKpkgovCh/ezlG7wCVwF7RErTzLzZMbGKFBdGBCbTKyK+s5VXPLl+0+TpNEQPH8AVaGzOpIsXUOtkqylCQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@vercel/build-utils@14.1.0':
+    resolution: {integrity: sha512-Bxwkv5phTRgU1QZ3NHzxjC6mLWJYqtYExkm/OS6Si2t3EhLFN+wls8U0oMmCrg2nXANkB1S+eXrbeu8hCcXV0A==}
+
+  '@vercel/cervel@0.1.45':
+    resolution: {integrity: sha512-H2i5T/26rw/bLcoROTU3XRyBrizPEsUjMPaZSWd97Qy9lhHzpjfxftSPZmfOFI2z9dUkr+IYgRSgZIkhDSde7g==}
+    hasBin: true
+
+  '@vercel/cli-auth@0.3.4':
+    resolution: {integrity: sha512-RQf67uc5HPtlhok3H2fChFW17ZB0gQxw0eeFkboMkHuclejfZ1cHy+04dRdnetX8/J8L6YUErNW2kO1tmeoKzw==}
+
+  '@vercel/cli-config@0.2.3':
+    resolution: {integrity: sha512-Ggh0Wmi92TUkUexmSUPkkDtvJmbjUr7IvF5T3FkSsWrXXs3GFzOujfxFpECdJZpux1JG4SWDv9BT4w++TDgD6A==}
+
+  '@vercel/cli-exec@1.0.1':
+    resolution: {integrity: sha512-g9XerViJ/paZujufXYcu5XYI2vU2rtB4sgdpjUHde5RnOkdmpu0ngH46LCFGHoPXO/C+qDPSczIHIRN+8Q2YKQ==}
+    engines: {node: '>= 18'}
+
+  '@vercel/container@0.2.0':
+    resolution: {integrity: sha512-l4prOR48EFu3CGNgwN64DCNwfqw8ZJty70HrY0X0+i5AMxi4GiIttZsSYBmttUAM+OSIg3BqMg767dlzjlzQyQ==}
+
+  '@vercel/detect-agent@1.2.5':
+    resolution: {integrity: sha512-0krENrjuitlW8s6TJu0MlqCevyCU7K7JK63jZAf7xZ6n17tx+vUEwzHT3sTxawtwZxaW21hu+oFUpoOrm49FsQ==}
+    engines: {node: '>=14'}
+
+  '@vercel/elysia@0.1.114':
+    resolution: {integrity: sha512-bgCicgRSjYdXrejDGWN68HkobQ5tOcIXuT1q+uBjHIAtqSdH4xll8tyIreR39MsRQgTURAa5LtHg8uDHXidI3Q==}
+
+  '@vercel/error-utils@2.2.1':
+    resolution: {integrity: sha512-9DhP8jP7raLML4hGsBemxX5fXuQnu5xxMV+HjGygGbzEmVK/+KyJ3QP2Cw7PdF0uXdb9N0Qa4c3tRGH34ZX6vw==}
+
+  '@vercel/express@0.1.128':
+    resolution: {integrity: sha512-c10sYn5r/3wfTPmwN4PRosvt2JgQ68PDfBmI7MVYyKTM5zN4ky1eL6V0oJ8LNvsFVvoQX/OH+3qg3yTEZNeDEQ==}
+
+  '@vercel/fastify@0.1.117':
+    resolution: {integrity: sha512-YoNAqo8xrL0GQwPTnkJ4LhsUJiPu2XlntwwQQvG2m2OYOJDCojq80nVWQvqfyqYCUBoYEfrYawFfTtvivl63Ew==}
+
+  '@vercel/fun@1.3.0':
+    resolution: {integrity: sha512-8erw9uPe0dFg45THkNxmjtvMX143SkZebmjgSVbcM3XCkXu3RIiBaJMcMNG8aaS+rnTuw8+d4De9HVT0M/r3wg==}
+    engines: {node: '>= 18'}
+
+  '@vercel/gatsby-plugin-vercel-analytics@1.0.12':
+    resolution: {integrity: sha512-Ejlhwxr7EBYJxtwYnlh6Vm6A2dPsUSPxMdYrfv0koZkgAzVwo7cG4aDQiy7iASMaGzwuI/PAnwlY2sJBF5b4OA==}
+
+  '@vercel/gatsby-plugin-vercel-builder@2.2.40':
+    resolution: {integrity: sha512-6QyQEJRNljTXZ1Yfcw58g3Css9wBeS0aXHechX3Oy5trzCtvMP82M74pcHAp3Wngb2s1byvEPb0Cm0FlFGFkhg==}
+
+  '@vercel/go@3.11.0':
+    resolution: {integrity: sha512-aeeWnefoRHuH7eYekQLq/vAsTbg6RQi7mKP49pLfxY/nfTsBnLtat9KCD7WF3Nunu41uN5uq3LVvoqRJ09S/fA==}
+
+  '@vercel/h3@0.1.123':
+    resolution: {integrity: sha512-oMGcBAJQIOQALnO+xu4di4ON8ElFyJry1Gn5YpFjkHITHMA+ZbhJbOzh+w7EKw6GACtdWrTZ16AONPFyxVx0gw==}
+
+  '@vercel/hono@0.2.117':
+    resolution: {integrity: sha512-R1bBZ38jPo980NrC4w9pLcipeQZv5ArF0V/0vGQWZ7437ZA/zKJSzhO90Cb+GVdjSCwHA2HyG6f8ODtBSSsGPg==}
+
+  '@vercel/hydrogen@1.4.1':
+    resolution: {integrity: sha512-fD3DAjMcWkGPZwcWCbF4ekZpDY4cMz+QZWR5F3Qss3hkQx6Vuu0kTpKX0xGgQ/CYTtKknZJTwIfM/ZvByAsrKA==}
+
+  '@vercel/koa@0.1.97':
+    resolution: {integrity: sha512-E/dwq5SgqIav7+nYGE/c3UOjGai+OlTmCkuegoFDxmajrFhINAlwwIbmLjFvT2ZmDEneu329VboPpeeuT/58Gg==}
+
+  '@vercel/nestjs@0.2.118':
+    resolution: {integrity: sha512-jmRFYtehiYY4DQfrkIv1ZN+iGhjXWmvylYzntuhverj1BwoIO2ancN+B6BpkcPDX/zky00RH2kN/nPb7NxDtdQ==}
+
+  '@vercel/next@4.21.4':
+    resolution: {integrity: sha512-JZkpxczlFkyQsgpraISTfXPvPu5A+be0ubYM8T3k1RACsBsv5UzkXp5EVDfNa8JB/6Q+p5Zh1FQTqbjH/EW2kg==}
+
+  '@vercel/nft@1.10.0':
+    resolution: {integrity: sha512-iLOW4fcsgkipfOh2Bw3wB38YDfxTlxr7+j4uFeui2OswkNT28jIitS/aMce7tS0mef1YPQ8zLIDYr3a0aahNrA==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  '@vercel/node@5.10.0':
+    resolution: {integrity: sha512-VhpH6g8kpM8wvi15/BST3ggXLaVRYQ7KCmDDsxkHaOfkwWICWBrgAratveMaU6sCIyETKS0gCU+Z7Dksv/i0UA==}
+
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
+  '@vercel/oidc@3.8.4':
+    resolution: {integrity: sha512-FGNvVZ5pgX9FaBqkPt6VkYFZ6bWAMDzYi7nxW+1Xt+Z4fn5PuTULVwsxjKc+0uKhysyWBQmvsmM50Oh6C2/oMA==}
+    engines: {node: '>= 20'}
+
+  '@vercel/prepare-flags-definitions@0.3.0':
+    resolution: {integrity: sha512-/0nuDFwYje0nqZnVKSd2VfJy2wOPQwbkas1qO1JQgtb0sLl+EeSCW4O9hrvq55pN50PNlAZ/APSeWHIAT9ZGHg==}
+
+  '@vercel/python-analysis@0.13.2':
+    resolution: {integrity: sha512-IEr5K2gvX143NBoQc1W4BWrdDWjZwxnIT6UrL5Y1dnyH7Cqc4AV00FIAddB1YpnIZBJwT4ZhE8QbgqBeO6C9Zw==}
+
+  '@vercel/python@6.56.2':
+    resolution: {integrity: sha512-TUQnflCTuK1AFSRka38wn6qqMwI0N70YG2uk5jKVrVXl3w+gZ+yA1DLn5OMMDUdYR21dJMDcMbn0NTaUGxLWaQ==}
+
+  '@vercel/redwood@2.5.1':
+    resolution: {integrity: sha512-oldy4mZmhFzHKkXluyPNHiIyZHxVW1Zpznn0qBag2hzmn2HpqkL9fZfZvlWGIvuAdQz/Sa4AErbreMEPOzCv0w==}
+
+  '@vercel/remix-builder@5.9.4':
+    resolution: {integrity: sha512-QKtQ4JUgjoU2gKkJJbhQcjMxvwMG3uvloAT4yz0m+0deyAPNMaHQJ0KKPtiOZH8+ILf4KqbebjjoC4UEzkiTWA==}
+
+  '@vercel/ruby@2.5.1':
+    resolution: {integrity: sha512-e23M7pfORQyyxSUmeQ8PqEnyLJ4swhtNrnyctU5E02UCaUYFm5YAdNfdPYRP4It874H4Wyvm+LV8u7CPBrfcPA==}
+
+  '@vercel/rust@1.4.2':
+    resolution: {integrity: sha512-vWVSMhj+3cMjQxj03jZTCNa94M0o+roVBA5wwfadxNMP8rCqdvZ0aamT/8zGCtjZ13PJc9v2W2nq0dlaaOZf4Q==}
+
+  '@vercel/sandbox@2.4.0':
+    resolution: {integrity: sha512-pifnr8hex/rgQ3EPyLYHYwHyf0Kwmc4Vbya9kHGk4aERFVGj44P+742S8/SDdt2guMxBriXBOMkMLq1Kaiyyeg==}
+
+  '@vercel/static-build@2.12.6':
+    resolution: {integrity: sha512-3WwhXA8HZyezQB8waCTO5KopceecS0+hvCHVaTk2kwWlUVnWUVsCHj7aaLPVUtBCF+tAiuv0gkloBhN2SXNvHw==}
+
+  '@vercel/static-config@3.4.1':
+    resolution: {integrity: sha512-kJKTyOg25JDRgDkHEkc+vWlvURxmSQkVKyRPO4EEGD/8HpJT+4u9Z/VGxwnCZ6zZBxYPpma283qBsHwY0gXjfw==}
+
+  '@vercel/vc-native-darwin-arm64@59.0.0':
+    resolution: {integrity: sha512-FloDB7nfXGnCjb9aVYiV99QQjK1UBcxQ3L/g3T9ekEWnjwHfpwSwcjWQFEEjfrSG4L042Lk3vQMDCOdPpGh6Ow==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@vercel/vc-native-darwin-x64@59.0.0':
+    resolution: {integrity: sha512-onrrc/1Jq/yfNncKmQdaXkR1p7R0NvU9ob7DhLHdAeJOwZzPBo+2DzV2mByk4rrkhQBjCGFiYEN9n/Gtzu8MrQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@vercel/vc-native-linux-arm64@59.0.0':
+    resolution: {integrity: sha512-+0wpedwJx/Vd5gaBvxWhNMw8aSCLvbirYDR5ndscWxG97yhlLDeGnDpuFxTg4YA4VC6SWXv9rhl+1/pTu9P13Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@vercel/vc-native-linux-x64@59.0.0':
+    resolution: {integrity: sha512-gRfWyhgzNnzPA7jrR83Ji84m9t41aUKB4sG6RX7MWnqXx3+Q3QaOFEQA9zJpadoRosSG2mEywKEA3b0h+pWxMA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@workflow/serde@4.1.0-beta.2':
+    resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
+
+  abbrev@3.0.1:
+    resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
+
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ajv@8.6.3:
+    resolution: {integrity: sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  arg@4.1.0:
+    resolution: {integrity: sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  async-listen@1.2.0:
+    resolution: {integrity: sha512-CcEtRh/oc9Jc4uWeUwdpG/+Mb2YUHKmdaTf0gUr7Wa+bfp4xx70HOb3RuSTJMvqKNB1TkdTfjLdrcz2X4rkkZA==}
+
+  async-listen@3.0.0:
+    resolution: {integrity: sha512-V+SsTpDqkrWTimiotsyl33ePSjA5/KrithwupuvJ6ztsqPvGv6ge4OredFhPffVXiLN/QUWvE0XcqJaYgt6fOg==}
+    engines: {node: '>= 14'}
+
+  async-listen@3.0.1:
+    resolution: {integrity: sha512-cWMaNwUJnf37C/S5TfCkk/15MwbPRwVYALA2jtjkbHjCmAPiDXyNJy2q3p1KAZzDLHAWyarUWSujUoHR4pEgrA==}
+    engines: {node: '>= 14'}
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
+
+  async-sema@3.1.1:
+    resolution: {integrity: sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==}
+
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  bare-events@2.9.1:
+    resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  bytes@3.1.0:
+    resolution: {integrity: sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==}
+    engines: {node: '>= 0.8'}
+
+  chokidar@4.0.0:
+    resolution: {integrity: sha512-mxIojEAQcuEvT/lyXq+jf/3cO/KoA6z4CeNDGGevTybECPOMFCnQy3OPahluUkbqgPNGw5Bi78UC7Po6Lhy+NA==}
+    engines: {node: '>= 14.16.0'}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
+
+  cjs-module-lexer@1.2.3:
+    resolution: {integrity: sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==}
+
+  code-block-writer@10.1.1:
+    resolution: {integrity: sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  content-type@1.0.4:
+    resolution: {integrity: sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==}
+    engines: {node: '>= 0.6'}
+
+  convert-hrtime@3.0.0:
+    resolution: {integrity: sha512-7V+KqSvMiHp8yWDuwfww06XleMWVVB9b9tURBx+G7UTADuo5hYPuowKloz4OzOqbPezxgo+fdQ1522WzPG4OeA==}
+    engines: {node: '>=8'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  define-lazy-prop@2.0.0:
+    resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
+    engines: {node: '>=8'}
+
+  depd@1.1.2:
+    resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
+    engines: {node: '>= 0.6'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  edge-runtime@2.5.9:
+    resolution: {integrity: sha512-pk+k0oK0PVXdlT4oRp4lwh+unuKB7Ng4iZ2HB+EZ7QCEQizX360Rp/F4aRpgpRgdP2ufB35N+1KppHmYjqIGSg==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  end-of-stream@1.1.0:
+    resolution: {integrity: sha512-EoulkdKF/1xa92q25PbjuDcgJ9RDHYU2Rs3SCIvs2/dSQ3BpmxneNHmA/M7fe60M3PrV7nNGTTNbkK62l6vXiQ==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  es-module-lexer@1.4.1:
+    resolution: {integrity: sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==}
+
+  es-module-lexer@1.5.0:
+    resolution: {integrity: sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw==}
+
+  esbuild@0.27.0:
+    resolution: {integrity: sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  events-intercept@2.0.0:
+    resolution: {integrity: sha512-blk1va0zol9QOrdZt0rFXo5KMkNPVSp92Eju/Qz8THwKWKRKeE0T8Br/1aW6+Edkyq9xHYgYxn2QtOnUKPUp+Q==}
+
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
+  execa@3.2.0:
+    resolution: {integrity: sha512-kJJfVbI/lZE1PZYDI5VPxp8zXPO9rtxOkhpZ0jMKha56AI9y2gGVC6bkukStQf0ka5Rh15BA5m7cCCH4jmHqkw==}
+    engines: {node: ^8.12.0 || >=9.7.0}
+
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
+
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  fs-extra@11.1.0:
+    resolution: {integrity: sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==}
+    engines: {node: '>=14.14'}
+
+  fs-extra@11.1.1:
+    resolution: {integrity: sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==}
+    engines: {node: '>=14.14'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  generic-pool@3.4.2:
+    resolution: {integrity: sha512-H7cUpwCQSiJmAHM4c/aFu6fUfrhWXW1ncyh8ftxEPMu6AiYkHw9K8br720TGPZJbk5eOH2bynjZD1yPvdDAmag==}
+    engines: {node: '>= 4'}
+
+  get-port@5.1.1:
+    resolution: {integrity: sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==}
+    engines: {node: '>=8'}
+
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
+  get-tsconfig@4.14.2:
+    resolution: {integrity: sha512-XpwZALwwl/BaKTAyC6+c5T8y6kCg2jk+XGqOVrKIQmW49pNypYLMRjCUXqa28tQgJlhS2RlzP7sc+Rx7W6qsfw==}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  http-errors@1.7.3:
+    resolution: {integrity: sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==}
+    engines: {node: '>= 0.6'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  human-signals@1.1.1:
+    resolution: {integrity: sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==}
+    engines: {node: '>=8.12.0'}
+
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
+
+  is-docker@2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
+  is-wsl@2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jose@5.9.6:
+    resolution: {integrity: sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==}
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  json-schema-to-ts@1.6.4:
+    resolution: {integrity: sha512-pR4yQ9DHz6itqswtHCm26mw45FSNfQ9rEQjosaZErhn5J3J2sIViQiz8rDaezjKAhFGpmsoczYVBgGHzFw/stA==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
+  jsonlines@0.1.1:
+    resolution: {integrity: sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==}
+
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micro@9.3.5-canary.3:
+    resolution: {integrity: sha512-viYIo9PefV+w9dvoIBh1gI44Mvx1BOk67B4BpC2QK77qdY0xZF0Q+vWLt/BII6cLkIc8rLmSIcJaB/OrXXKe1g==}
+    engines: {node: '>= 8.0.0'}
+    hasBin: true
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
+  minimatch@10.1.1:
+    resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
+    engines: {node: 20 || >=22}
+
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
+  ms@2.1.1:
+    resolution: {integrity: sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==}
+
+  ms@2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  node-fetch@2.6.7:
+    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-fetch@2.6.9:
+    resolution: {integrity: sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
+
+  nopt@8.1.0:
+    resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
+  once@1.3.3:
+    resolution: {integrity: sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
+  open@8.4.0:
+    resolution: {integrity: sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==}
+    engines: {node: '>=12'}
+
+  os-paths@4.4.0:
+    resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
+    engines: {node: '>= 6.0'}
+
+  oxc-transform@0.111.0:
+    resolution: {integrity: sha512-oa5KKSDNLHZGaiqIGAbCWXeN9IJUAz9MElWcQX90epDxdKc9Hrt/BsLj3K4gDqfAYa5dwdH+ZCFJG9hR74fiGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  p-finally@2.0.1:
+    resolution: {integrity: sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==}
+    engines: {node: '>=8'}
+
+  parse-ms@2.1.0:
+    resolution: {integrity: sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==}
+    engines: {node: '>=6'}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
+  path-to-regexp@6.1.0:
+    resolution: {integrity: sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  path-to-regexp@8.2.0:
+    resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
+    engines: {node: '>=16'}
+
+  path-to-regexp@8.3.0:
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
+  picocolors@1.0.0:
+    resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  pretty-ms@7.0.1:
+    resolution: {integrity: sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==}
+    engines: {node: '>=10'}
+
+  promisepipe@3.0.0:
+    resolution: {integrity: sha512-V6TbZDJ/ZswevgkDNpGt/YqNCiZP9ASfgU+p83uJE6NrGtvSGoOcHLiDCqkMs2+yg7F5qHdLV8d0aS8O26G/KA==}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  raw-body@2.4.1:
+    resolution: {integrity: sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==}
+    engines: {node: '>= 0.8'}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve.exports@2.0.3:
+    resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
+    engines: {node: '>=10'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rolldown@1.0.0-rc.1:
+    resolution: {integrity: sha512-M3AeZjYE6UclblEf531Hch0WfVC/NOL43Cc+WdF3J50kk5/fvouHhDumSGTh0oRjbZ8C4faaVr5r6Nx1xMqDGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sandbox@3.4.0:
+    resolution: {integrity: sha512-JPdADikobt6zFuuCRhl6whNrCJlLPxpUmT/hNxLij70mkpeejHKDN+HeVlrdHI8snDTzRIiF3Ye8KyMIyVWA+A==}
+    hasBin: true
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.5.4:
+    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  setprototypeof@1.1.1:
+    resolution: {integrity: sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  signal-exit@4.0.2:
+    resolution: {integrity: sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==}
+    engines: {node: '>=14'}
+
+  smol-toml@1.5.2:
+    resolution: {integrity: sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ==}
+    engines: {node: '>= 18'}
+
+  srvx@0.11.16:
+    resolution: {integrity: sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
+
+  stat-mode@0.3.0:
+    resolution: {integrity: sha512-QjMLR0A3WwFY2aZdV0okfFEJB5TRjkggXZjxP3A1RsWsNHNu3YPv8btmtc6iCFZ0Rul3FE93OYogvhOUClU+ng==}
+
+  statuses@1.5.0:
+    resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
+    engines: {node: '>= 0.6'}
+
+  stream-to-array@2.3.0:
+    resolution: {integrity: sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA==}
+
+  stream-to-promise@2.2.0:
+    resolution: {integrity: sha512-HAGUASw8NT0k8JvIVutB2Y/9iBk7gpgEyAudXwNJmZERdMITGdajOa4VJfD/kNiA3TppQpTP4J+CtcHwdzKBAw==}
+    deprecated: Deprecated. Use node:stream/promises and node:stream/consumers instead.
+
+  streamx@2.28.0:
+    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
+
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+
+  tar-stream@3.1.7:
+    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
+    engines: {node: '>=18'}
+
+  tar@7.5.7:
+    resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
+    engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
+
+  time-span@4.0.0:
+    resolution: {integrity: sha512-MyqZCTGLDZ77u4k+jqg4UlrzPTPZ49NDlaekU6uuFaJLzPIN1woaRXCbGeqOfxwc3Y37ZROGAJ614Rdv7Olt+g==}
+    engines: {node: '>=10'}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  toidentifier@1.0.0:
+    resolution: {integrity: sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==}
+    engines: {node: '>=0.6'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-morph@12.0.0:
+    resolution: {integrity: sha512-VHC8XgU2fFW7yO1f/b3mxKDje1vmyzFXHWzOYmKEkCEwcLjDtbdLgBQviqj4ZwP4MJkQtRo6Ha2I29lq/B+VxA==}
+
+  ts-toolbelt@6.15.5:
+    resolution: {integrity: sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  uid-promise@1.0.0:
+    resolution: {integrity: sha512-R8375j0qwXyIu/7R0tjdF06/sElHqbmdmWC9M2qQHpEVbvE4I5+38KJI7LUUmQMp7NVq4tKHiBMkT0NFM453Ig==}
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  undici@5.28.4:
+    resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
+    engines: {node: '>=14.0'}
+
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
+    engines: {node: '>=14.0'}
+
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
+    engines: {node: '>=18.17'}
+
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
+
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
+    hasBin: true
+
+  vercel@59.0.0:
+    resolution: {integrity: sha512-9q4NEUYiiwC45ZVoShZhY0lYZPKwbK7In3Cw8SbNK7gwfeTv84bDhPqjos6UZk91lbzgaqclDPdPfLmH1kz7jA==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
+  web-vitals@0.2.4:
+    resolution: {integrity: sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg==}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xdg-app-paths@5.1.0:
+    resolution: {integrity: sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA==}
+    engines: {node: '>=6'}
+
+  xdg-app-paths@5.5.1:
+    resolution: {integrity: sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==}
+    engines: {node: '>= 6.0'}
+
+  xdg-portable@7.3.0:
+    resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
+    engines: {node: '>= 6.0'}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
+
+  yauzl-clone@1.0.4:
+    resolution: {integrity: sha512-igM2RRCf3k8TvZoxR2oguuw4z1xasOnA31joCqHIyLkeWrvAc2Jgay5ISQ2ZplinkoGaJ6orCz56Ey456c5ESA==}
+    engines: {node: '>=6'}
+
+  yauzl-promise@2.1.3:
+    resolution: {integrity: sha512-A1pf6fzh6eYkK0L4Qp7g9jzJSDrM6nN0bOn5T0IbY4Yo3w+YkWlHFkJP7mzknMXjqusHFHlKsK2N+4OLsK2MRA==}
+    engines: {node: '>=6'}
+
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+
+  zod@3.22.4:
+    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
+
+snapshots:
+
+  '@bytecodealliance/preview2-shim@0.17.6': {}
+
+  '@edge-runtime/format@2.2.1': {}
+
+  '@edge-runtime/node-utils@2.3.0': {}
+
+  '@edge-runtime/ponyfill@2.4.2': {}
+
+  '@edge-runtime/primitives@4.1.0': {}
+
+  '@edge-runtime/vm@3.2.0':
+    dependencies:
+      '@edge-runtime/primitives': 4.1.0
+
+  '@emnapi/core@1.11.3':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.3
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/android-arm@0.27.0':
+    optional: true
+
+  '@esbuild/android-x64@0.27.0':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.0':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.0':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.0':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.0':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.0':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.0':
+    optional: true
+
+  '@fastify/busboy@2.1.1': {}
+
+  '@isaacs/balanced-match@4.0.1': {}
+
+  '@isaacs/brace-expansion@5.0.1':
+    dependencies:
+      '@isaacs/balanced-match': 4.0.1
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
+
+  '@mapbox/node-pre-gyp@2.0.3':
+    dependencies:
+      consola: 3.4.2
+      detect-libc: 2.1.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 2.7.0
+      nopt: 8.1.0
+      semver: 7.8.5
+      tar: 7.5.22
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@napi-rs/keyring-darwin-arm64@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-darwin-x64@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-freebsd-x64@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-musl@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-gnu@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-musl@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-x64-msvc@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring@1.2.0':
+    optionalDependencies:
+      '@napi-rs/keyring-darwin-arm64': 1.2.0
+      '@napi-rs/keyring-darwin-x64': 1.2.0
+      '@napi-rs/keyring-freebsd-x64': 1.2.0
+      '@napi-rs/keyring-linux-arm-gnueabihf': 1.2.0
+      '@napi-rs/keyring-linux-arm64-gnu': 1.2.0
+      '@napi-rs/keyring-linux-arm64-musl': 1.2.0
+      '@napi-rs/keyring-linux-riscv64-gnu': 1.2.0
+      '@napi-rs/keyring-linux-x64-gnu': 1.2.0
+      '@napi-rs/keyring-linux-x64-musl': 1.2.0
+      '@napi-rs/keyring-win32-arm64-msvc': 1.2.0
+      '@napi-rs/keyring-win32-ia32-msvc': 1.2.0
+      '@napi-rs/keyring-win32-x64-msvc': 1.2.0
+
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
+    dependencies:
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
+  '@oxc-project/types@0.110.0': {}
+
+  '@oxc-transform/binding-android-arm-eabi@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-android-arm64@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-darwin-arm64@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-darwin-x64@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-freebsd-x64@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm-musleabihf@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm64-gnu@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm64-musl@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-ppc64-gnu@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-riscv64-gnu@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-riscv64-musl@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-s390x-gnu@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-x64-gnu@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-x64-musl@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-openharmony-arm64@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-wasm32-wasi@0.111.0(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  '@oxc-transform/binding-win32-arm64-msvc@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-win32-ia32-msvc@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-win32-x64-msvc@0.111.0':
+    optional: true
+
+  '@renovatebot/pep440@4.2.1': {}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.1': {}
+
+  '@rollup/pluginutils@5.4.0':
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-walker: 2.0.2
+      picomatch: 4.0.5
+
+  '@sinclair/typebox@0.25.24': {}
+
+  '@tootallnate/once@2.0.0': {}
+
+  '@ts-morph/common@0.11.1':
+    dependencies:
+      fast-glob: 3.3.3
+      minimatch: 3.1.5
+      mkdirp: 1.0.4
+      path-browserify: 1.0.1
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/estree@1.0.9': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/node@20.11.0':
+    dependencies:
+      undici-types: 5.26.5
+
+  '@vercel/backends@0.8.37(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
+    dependencies:
+      '@vercel/build-utils': 14.1.0
+      '@vercel/nft': 1.10.0
+      '@vercel/static-config': 3.4.1
+      execa: 3.2.0
+      fs-extra: 11.1.0
+      get-port: 5.1.1
+      oxc-transform: 0.111.0(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+      path-to-regexp: 8.3.0
+      resolve.exports: 2.0.3
+      rolldown: 1.0.0-rc.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+      srvx: 0.11.16
+      ts-morph: 12.0.0
+      tsx: 4.21.0
+      zod: 3.22.4
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/blob@2.8.0':
+    dependencies:
+      '@vercel/oidc': 3.8.4
+      async-retry: 1.3.3
+      is-buffer: 2.0.5
+      is-node-process: 1.2.0
+      throttleit: 2.1.0
+      undici: 6.28.0
+
+  '@vercel/build-utils@14.1.0':
+    dependencies:
+      '@vercel/python-analysis': 0.13.2
+      cjs-module-lexer: 1.2.3
+      es-module-lexer: 1.5.0
+
+  '@vercel/cervel@0.1.45(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
+    dependencies:
+      '@vercel/backends': 0.8.37(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/cli-auth@0.3.4':
+    dependencies:
+      '@napi-rs/keyring': 1.2.0
+      '@vercel/cli-config': 0.2.3
+      async-listen: 3.0.0
+      open: 8.4.0
+      zod: 4.1.11
+
+  '@vercel/cli-config@0.2.3':
+    dependencies:
+      xdg-app-paths: 5.5.1
+      zod: 4.1.11
+
+  '@vercel/cli-exec@1.0.1':
+    dependencies:
+      execa: 5.1.1
+
+  '@vercel/container@0.2.0': {}
+
+  '@vercel/detect-agent@1.2.5': {}
+
+  '@vercel/elysia@0.1.114':
+    dependencies:
+      '@vercel/node': 5.10.0
+      '@vercel/static-config': 3.4.1
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/error-utils@2.2.1': {}
+
+  '@vercel/express@0.1.128(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
+    dependencies:
+      '@vercel/cervel': 0.1.45(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+      '@vercel/nft': 1.10.0
+      '@vercel/node': 5.10.0
+      '@vercel/static-config': 3.4.1
+      fs-extra: 11.1.0
+      path-to-regexp: 8.3.0
+      ts-morph: 12.0.0
+      zod: 3.22.4
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/fastify@0.1.117':
+    dependencies:
+      '@vercel/node': 5.10.0
+      '@vercel/static-config': 3.4.1
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/fun@1.3.0':
+    dependencies:
+      '@tootallnate/once': 2.0.0
+      async-listen: 1.2.0
+      debug: 4.3.4
+      generic-pool: 3.4.2
+      micro: 9.3.5-canary.3
+      ms: 2.1.1
+      node-fetch: 2.6.7
+      path-to-regexp: 8.2.0
+      promisepipe: 3.0.0
+      semver: 7.5.4
+      stat-mode: 0.3.0
+      stream-to-promise: 2.2.0
+      tar: 7.5.7
+      tinyexec: 0.3.2
+      tree-kill: 1.2.2
+      uid-promise: 1.0.0
+      xdg-app-paths: 5.1.0
+      yauzl-promise: 2.1.3
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@vercel/gatsby-plugin-vercel-analytics@1.0.12':
+    dependencies:
+      web-vitals: 0.2.4
+
+  '@vercel/gatsby-plugin-vercel-builder@2.2.40':
+    dependencies:
+      '@sinclair/typebox': 0.25.24
+      '@vercel/build-utils': 14.1.0
+      esbuild: 0.27.0
+      etag: 1.8.1
+      fs-extra: 11.1.0
+
+  '@vercel/go@3.11.0': {}
+
+  '@vercel/h3@0.1.123':
+    dependencies:
+      '@vercel/node': 5.10.0
+      '@vercel/static-config': 3.4.1
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/hono@0.2.117':
+    dependencies:
+      '@vercel/nft': 1.10.0
+      '@vercel/node': 5.10.0
+      '@vercel/static-config': 3.4.1
+      fs-extra: 11.1.0
+      path-to-regexp: 8.3.0
+      ts-morph: 12.0.0
+      zod: 3.22.4
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/hydrogen@1.4.1':
+    dependencies:
+      '@vercel/static-config': 3.4.1
+      ts-morph: 12.0.0
+
+  '@vercel/koa@0.1.97':
+    dependencies:
+      '@vercel/node': 5.10.0
+      '@vercel/static-config': 3.4.1
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/nestjs@0.2.118':
+    dependencies:
+      '@vercel/node': 5.10.0
+      '@vercel/static-config': 3.4.1
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/next@4.21.4':
+    dependencies:
+      '@vercel/nft': 1.10.0
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/nft@1.10.0':
+    dependencies:
+      '@mapbox/node-pre-gyp': 2.0.3
+      '@rollup/pluginutils': 5.4.0
+      acorn: 8.18.0
+      acorn-import-attributes: 1.9.5(acorn@8.18.0)
+      async-sema: 3.1.1
+      bindings: 1.5.0
+      estree-walker: 2.0.2
+      glob: 13.0.6
+      graceful-fs: 4.2.11
+      node-gyp-build: 4.8.4
+      picomatch: 4.0.5
+      resolve-from: 5.0.0
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/node@5.10.0':
+    dependencies:
+      '@edge-runtime/node-utils': 2.3.0
+      '@edge-runtime/primitives': 4.1.0
+      '@edge-runtime/vm': 3.2.0
+      '@types/node': 20.11.0
+      '@vercel/build-utils': 14.1.0
+      '@vercel/error-utils': 2.2.1
+      '@vercel/nft': 1.10.0
+      '@vercel/static-config': 3.4.1
+      async-listen: 3.0.0
+      cjs-module-lexer: 1.2.3
+      edge-runtime: 2.5.9
+      es-module-lexer: 1.4.1
+      esbuild: 0.27.0
+      etag: 1.8.1
+      mime-types: 2.1.35
+      node-fetch: 2.6.9
+      path-to-regexp: 6.1.0
+      path-to-regexp-updated: path-to-regexp@6.3.0
+      ts-morph: 12.0.0
+      tsx: 4.21.0
+      typescript: 5.9.3
+      undici: 5.28.4
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/oidc@3.2.0': {}
+
+  '@vercel/oidc@3.8.4':
+    dependencies:
+      '@vercel/cli-config': 0.2.3
+      '@vercel/cli-exec': 1.0.1
+      jose: 5.9.6
+
+  '@vercel/prepare-flags-definitions@0.3.0': {}
+
+  '@vercel/python-analysis@0.13.2':
+    dependencies:
+      '@bytecodealliance/preview2-shim': 0.17.6
+      '@renovatebot/pep440': 4.2.1
+      fs-extra: 11.1.1
+      js-yaml: 4.1.1
+      minimatch: 10.1.1
+      smol-toml: 1.5.2
+      zod: 3.22.4
+
+  '@vercel/python@6.56.2':
+    dependencies:
+      '@vercel/python-analysis': 0.13.2
+
+  '@vercel/redwood@2.5.1':
+    dependencies:
+      '@vercel/nft': 1.10.0
+      '@vercel/static-config': 3.4.1
+      semver: 6.3.1
+      ts-morph: 12.0.0
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/remix-builder@5.9.4':
+    dependencies:
+      '@vercel/error-utils': 2.2.1
+      '@vercel/nft': 1.10.0
+      '@vercel/static-config': 3.4.1
+      path-to-regexp: 6.1.0
+      path-to-regexp-updated: path-to-regexp@6.3.0
+      ts-morph: 12.0.0
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/ruby@2.5.1': {}
+
+  '@vercel/rust@1.4.2':
+    dependencies:
+      execa: 5.1.1
+      get-port: 5.1.1
+      smol-toml: 1.5.2
+
+  '@vercel/sandbox@2.4.0':
+    dependencies:
+      '@vercel/oidc': 3.2.0
+      '@workflow/serde': 4.1.0-beta.2
+      async-retry: 1.3.3
+      jose: 6.2.3
+      jsonlines: 0.1.1
+      ms: 2.1.3
+      picocolors: 1.1.1
+      tar-stream: 3.1.7
+      undici: 7.29.0
+      xdg-app-paths: 5.1.0
+      zod: 4.1.11
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  '@vercel/static-build@2.12.6':
+    dependencies:
+      '@vercel/gatsby-plugin-vercel-analytics': 1.0.12
+      '@vercel/gatsby-plugin-vercel-builder': 2.2.40
+      '@vercel/static-config': 3.4.1
+      ts-morph: 12.0.0
+
+  '@vercel/static-config@3.4.1':
+    dependencies:
+      ajv: 8.6.3
+      json-schema-to-ts: 1.6.4
+      ts-morph: 12.0.0
+
+  '@vercel/vc-native-darwin-arm64@59.0.0':
+    optional: true
+
+  '@vercel/vc-native-darwin-x64@59.0.0':
+    optional: true
+
+  '@vercel/vc-native-linux-arm64@59.0.0':
+    optional: true
+
+  '@vercel/vc-native-linux-x64@59.0.0':
+    optional: true
+
+  '@workflow/serde@4.1.0-beta.2': {}
+
+  abbrev@3.0.1: {}
+
+  acorn-import-attributes@1.9.5(acorn@8.18.0):
+    dependencies:
+      acorn: 8.18.0
+
+  acorn@8.18.0: {}
+
+  agent-base@7.1.4: {}
+
+  ajv@8.6.3:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js: 4.4.1
+
+  any-promise@1.3.0: {}
+
+  arg@4.1.0: {}
+
+  argparse@2.0.1: {}
+
+  async-listen@1.2.0: {}
+
+  async-listen@3.0.0: {}
+
+  async-listen@3.0.1: {}
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
+
+  async-sema@3.1.1: {}
+
+  b4a@1.8.1: {}
+
+  balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
+
+  bare-events@2.9.1: {}
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  brace-expansion@1.1.18:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@5.0.9:
+    dependencies:
+      balanced-match: 4.0.4
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  buffer-crc32@0.2.13: {}
+
+  bytes@3.1.0: {}
+
+  chokidar@4.0.0:
+    dependencies:
+      readdirp: 4.1.2
+
+  chownr@3.0.0: {}
+
+  cjs-module-lexer@1.2.3: {}
+
+  code-block-writer@10.1.1: {}
+
+  concat-map@0.0.1: {}
+
+  consola@3.4.2: {}
+
+  content-type@1.0.4: {}
+
+  convert-hrtime@3.0.0: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.3.4:
+    dependencies:
+      ms: 2.1.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  define-lazy-prop@2.0.0: {}
+
+  depd@1.1.2: {}
+
+  detect-libc@2.1.2: {}
+
+  edge-runtime@2.5.9:
+    dependencies:
+      '@edge-runtime/format': 2.2.1
+      '@edge-runtime/ponyfill': 2.4.2
+      '@edge-runtime/vm': 3.2.0
+      async-listen: 3.0.1
+      mri: 1.2.0
+      picocolors: 1.0.0
+      pretty-ms: 7.0.1
+      signal-exit: 4.0.2
+      time-span: 4.0.0
+
+  end-of-stream@1.1.0:
+    dependencies:
+      once: 1.3.3
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
+  es-module-lexer@1.4.1: {}
+
+  es-module-lexer@1.5.0: {}
+
+  esbuild@0.27.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.0
+      '@esbuild/android-arm': 0.27.0
+      '@esbuild/android-arm64': 0.27.0
+      '@esbuild/android-x64': 0.27.0
+      '@esbuild/darwin-arm64': 0.27.0
+      '@esbuild/darwin-x64': 0.27.0
+      '@esbuild/freebsd-arm64': 0.27.0
+      '@esbuild/freebsd-x64': 0.27.0
+      '@esbuild/linux-arm': 0.27.0
+      '@esbuild/linux-arm64': 0.27.0
+      '@esbuild/linux-ia32': 0.27.0
+      '@esbuild/linux-loong64': 0.27.0
+      '@esbuild/linux-mips64el': 0.27.0
+      '@esbuild/linux-ppc64': 0.27.0
+      '@esbuild/linux-riscv64': 0.27.0
+      '@esbuild/linux-s390x': 0.27.0
+      '@esbuild/linux-x64': 0.27.0
+      '@esbuild/netbsd-arm64': 0.27.0
+      '@esbuild/netbsd-x64': 0.27.0
+      '@esbuild/openbsd-arm64': 0.27.0
+      '@esbuild/openbsd-x64': 0.27.0
+      '@esbuild/openharmony-arm64': 0.27.0
+      '@esbuild/sunos-x64': 0.27.0
+      '@esbuild/win32-arm64': 0.27.0
+      '@esbuild/win32-ia32': 0.27.0
+      '@esbuild/win32-x64': 0.27.0
+
+  estree-walker@2.0.2: {}
+
+  etag@1.8.1: {}
+
+  events-intercept@2.0.0: {}
+
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+
+  execa@3.2.0:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 5.2.0
+      human-signals: 1.1.1
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      p-finally: 2.0.1
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-fifo@1.3.2: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
+
+  file-uri-to-path@1.0.0: {}
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  fs-extra@11.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
+  fs-extra@11.1.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  generic-pool@3.4.2: {}
+
+  get-port@5.1.1: {}
+
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
+
+  get-stream@6.0.1: {}
+
+  get-tsconfig@4.14.2:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.6
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
+  graceful-fs@4.2.11: {}
+
+  http-errors@1.7.3:
+    dependencies:
+      depd: 1.1.2
+      inherits: 2.0.4
+      setprototypeof: 1.1.1
+      statuses: 1.5.0
+      toidentifier: 1.0.0
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  human-signals@1.1.1: {}
+
+  human-signals@2.1.0: {}
+
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  inherits@2.0.4: {}
+
+  is-buffer@2.0.5: {}
+
+  is-docker@2.2.1: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-node-process@1.2.0: {}
+
+  is-number@7.0.0: {}
+
+  is-stream@2.0.1: {}
+
+  is-wsl@2.2.0:
+    dependencies:
+      is-docker: 2.2.1
+
+  isexe@2.0.0: {}
+
+  jose@5.9.6: {}
+
+  jose@6.2.3: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  json-schema-to-ts@1.6.4:
+    dependencies:
+      '@types/json-schema': 7.0.15
+      ts-toolbelt: 6.15.5
+
+  json-schema-traverse@1.0.0: {}
+
+  jsonc-parser@3.3.1: {}
+
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  jsonlines@0.1.1: {}
+
+  lru-cache@11.5.2: {}
+
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
+
+  luxon@3.7.2: {}
+
+  merge-stream@2.0.0: {}
+
+  merge2@1.4.1: {}
+
+  micro@9.3.5-canary.3:
+    dependencies:
+      arg: 4.1.0
+      content-type: 1.0.4
+      raw-body: 2.4.1
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mimic-fn@2.1.0: {}
+
+  minimatch@10.1.1:
+    dependencies:
+      '@isaacs/brace-expansion': 5.0.1
+
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.9
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.18
+
+  minipass@7.1.3: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
+  mkdirp@1.0.4: {}
+
+  mri@1.2.0: {}
+
+  ms@2.1.1: {}
+
+  ms@2.1.2: {}
+
+  ms@2.1.3: {}
+
+  node-fetch@2.6.7:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-fetch@2.6.9:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-gyp-build@4.8.4: {}
+
+  nopt@8.1.0:
+    dependencies:
+      abbrev: 3.0.1
+
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
+  once@1.3.3:
+    dependencies:
+      wrappy: 1.0.2
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
+  open@8.4.0:
+    dependencies:
+      define-lazy-prop: 2.0.0
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
+
+  os-paths@4.4.0: {}
+
+  oxc-transform@0.111.0(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3):
+    optionalDependencies:
+      '@oxc-transform/binding-android-arm-eabi': 0.111.0
+      '@oxc-transform/binding-android-arm64': 0.111.0
+      '@oxc-transform/binding-darwin-arm64': 0.111.0
+      '@oxc-transform/binding-darwin-x64': 0.111.0
+      '@oxc-transform/binding-freebsd-x64': 0.111.0
+      '@oxc-transform/binding-linux-arm-gnueabihf': 0.111.0
+      '@oxc-transform/binding-linux-arm-musleabihf': 0.111.0
+      '@oxc-transform/binding-linux-arm64-gnu': 0.111.0
+      '@oxc-transform/binding-linux-arm64-musl': 0.111.0
+      '@oxc-transform/binding-linux-ppc64-gnu': 0.111.0
+      '@oxc-transform/binding-linux-riscv64-gnu': 0.111.0
+      '@oxc-transform/binding-linux-riscv64-musl': 0.111.0
+      '@oxc-transform/binding-linux-s390x-gnu': 0.111.0
+      '@oxc-transform/binding-linux-x64-gnu': 0.111.0
+      '@oxc-transform/binding-linux-x64-musl': 0.111.0
+      '@oxc-transform/binding-openharmony-arm64': 0.111.0
+      '@oxc-transform/binding-wasm32-wasi': 0.111.0(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+      '@oxc-transform/binding-win32-arm64-msvc': 0.111.0
+      '@oxc-transform/binding-win32-ia32-msvc': 0.111.0
+      '@oxc-transform/binding-win32-x64-msvc': 0.111.0
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  p-finally@2.0.1: {}
+
+  parse-ms@2.1.0: {}
+
+  path-browserify@1.0.1: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.2
+      minipass: 7.1.3
+
+  path-to-regexp@6.1.0: {}
+
+  path-to-regexp@6.3.0: {}
+
+  path-to-regexp@8.2.0: {}
+
+  path-to-regexp@8.3.0: {}
+
+  pend@1.2.0: {}
+
+  picocolors@1.0.0: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
+
+  picomatch@4.0.5: {}
+
+  pretty-ms@7.0.1:
+    dependencies:
+      parse-ms: 2.1.0
+
+  promisepipe@3.0.0: {}
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
+  punycode@2.3.1: {}
+
+  queue-microtask@1.2.3: {}
+
+  raw-body@2.4.1:
+    dependencies:
+      bytes: 3.1.0
+      http-errors: 1.7.3
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  readdirp@4.1.2: {}
+
+  require-from-string@2.0.2: {}
+
+  resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  resolve.exports@2.0.3: {}
+
+  retry@0.13.1: {}
+
+  reusify@1.1.0: {}
+
+  rolldown@1.0.0-rc.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3):
+    dependencies:
+      '@oxc-project/types': 0.110.0
+      '@rolldown/pluginutils': 1.0.0-rc.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.1
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.1
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.1
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.1
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.1
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.1
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.1
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.1
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.1
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.1
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.1
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.1
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  safer-buffer@2.1.2: {}
+
+  sandbox@3.4.0:
+    dependencies:
+      '@vercel/sandbox': 2.4.0
+      async-retry: 1.3.3
+      debug: 4.4.3
+      ws: 8.21.3
+      zod: 4.1.11
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
+
+  semver@6.3.1: {}
+
+  semver@7.5.4:
+    dependencies:
+      lru-cache: 6.0.0
+
+  semver@7.8.5: {}
+
+  setprototypeof@1.1.1: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  signal-exit@3.0.7: {}
+
+  signal-exit@4.0.2: {}
+
+  smol-toml@1.5.2: {}
+
+  srvx@0.11.16: {}
+
+  stat-mode@0.3.0: {}
+
+  statuses@1.5.0: {}
+
+  stream-to-array@2.3.0:
+    dependencies:
+      any-promise: 1.3.0
+
+  stream-to-promise@2.2.0:
+    dependencies:
+      any-promise: 1.3.0
+      end-of-stream: 1.1.0
+      stream-to-array: 2.3.0
+
+  streamx@2.28.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  strip-final-newline@2.0.0: {}
+
+  tar-stream@3.1.7:
+    dependencies:
+      b4a: 1.8.1
+      fast-fifo: 1.3.2
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  tar@7.5.22:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
+  tar@7.5.7:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  throttleit@2.1.0: {}
+
+  time-span@4.0.0:
+    dependencies:
+      convert-hrtime: 3.0.0
+
+  tinyexec@0.3.2: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  toidentifier@1.0.0: {}
+
+  tr46@0.0.3: {}
+
+  tree-kill@1.2.2: {}
+
+  ts-morph@12.0.0:
+    dependencies:
+      '@ts-morph/common': 0.11.1
+      code-block-writer: 10.1.1
+
+  ts-toolbelt@6.15.5: {}
+
+  tslib@2.8.1:
+    optional: true
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.0
+      get-tsconfig: 4.14.2
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  uid-promise@1.0.0: {}
+
+  undici-types@5.26.5: {}
+
+  undici@5.28.4:
+    dependencies:
+      '@fastify/busboy': 2.1.1
+
+  undici@5.29.0:
+    dependencies:
+      '@fastify/busboy': 2.1.1
+
+  undici@6.28.0: {}
+
+  undici@7.29.0: {}
+
+  universalify@2.0.1: {}
+
+  unpipe@1.0.0: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  uuid@14.0.1: {}
+
+  vercel@59.0.0(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3):
+    dependencies:
+      '@vercel/backends': 0.8.37(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+      '@vercel/blob': 2.8.0
+      '@vercel/build-utils': 14.1.0
+      '@vercel/cli-auth': 0.3.4
+      '@vercel/cli-config': 0.2.3
+      '@vercel/container': 0.2.0
+      '@vercel/detect-agent': 1.2.5
+      '@vercel/elysia': 0.1.114
+      '@vercel/express': 0.1.128(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+      '@vercel/fastify': 0.1.117
+      '@vercel/fun': 1.3.0
+      '@vercel/go': 3.11.0
+      '@vercel/h3': 0.1.123
+      '@vercel/hono': 0.2.117
+      '@vercel/hydrogen': 1.4.1
+      '@vercel/koa': 0.1.97
+      '@vercel/nestjs': 0.2.118
+      '@vercel/next': 4.21.4
+      '@vercel/node': 5.10.0
+      '@vercel/prepare-flags-definitions': 0.3.0
+      '@vercel/python': 6.56.2
+      '@vercel/redwood': 2.5.1
+      '@vercel/remix-builder': 5.9.4
+      '@vercel/ruby': 2.5.1
+      '@vercel/rust': 1.4.2
+      '@vercel/static-build': 2.12.6
+      chokidar: 4.0.0
+      esbuild: 0.27.0
+      jose: 5.9.6
+      jsonc-parser: 3.3.1
+      luxon: 3.7.2
+      sandbox: 3.4.0
+      smol-toml: 1.5.2
+      undici: 5.29.0
+      uuid: 14.0.1
+      zod: 4.1.11
+    optionalDependencies:
+      '@vercel/vc-native-darwin-arm64': 59.0.0
+      '@vercel/vc-native-darwin-x64': 59.0.0
+      '@vercel/vc-native-linux-arm64': 59.0.0
+      '@vercel/vc-native-linux-x64': 59.0.0
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - bare-abort-controller
+      - bufferutil
+      - encoding
+      - react-native-b4a
+      - rollup
+      - supports-color
+      - utf-8-validate
+
+  web-vitals@0.2.4: {}
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  wrappy@1.0.2: {}
+
+  ws@8.21.3: {}
+
+  xdg-app-paths@5.1.0:
+    dependencies:
+      xdg-portable: 7.3.0
+
+  xdg-app-paths@5.5.1:
+    dependencies:
+      os-paths: 4.4.0
+      xdg-portable: 7.3.0
+
+  xdg-portable@7.3.0:
+    dependencies:
+      os-paths: 4.4.0
+
+  yallist@4.0.0: {}
+
+  yallist@5.0.0: {}
+
+  yauzl-clone@1.0.4:
+    dependencies:
+      events-intercept: 2.0.0
+
+  yauzl-promise@2.1.3:
+    dependencies:
+      yauzl: 2.10.0
+      yauzl-clone: 1.0.4
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
+
+  zod@3.22.4: {}
+
+  zod@4.1.11: {}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,7 +281,7 @@ jobs:
           request /docs/search-index.json "$RUNNER_TEMP/docs-search-index.json"
           request /docs/sitemap.xml "$RUNNER_TEMP/docs-sitemap.xml"
 
-          grep -Fq 'https://tidebreak.sh/docs/' "$RUNNER_TEMP/docs-index.html"
+          grep -Fq 'https://www.tidebreak.sh/docs/' "$RUNNER_TEMP/docs-index.html"
           grep -Fq '/docs/_next/' "$RUNNER_TEMP/docs-index.html"
           asset_path="$(grep -oE '/docs/_next/[^" ]+' \
             "$RUNNER_TEMP/docs-index.html" | head -n 1)"
@@ -328,7 +328,7 @@ jobs:
               https://tidebreak-docs.vercel.app/docs/ \
               --dump-header "$RUNNER_TEMP/docs-production-headers" \
               --output "$RUNNER_TEMP/docs-production.html" \
-              && grep -Fq 'https://tidebreak.sh/docs/' \
+              && grep -Fq 'https://www.tidebreak.sh/docs/' \
                 "$RUNNER_TEMP/docs-production.html" \
               && grep -Fqi 'content-security-policy:' \
                 "$RUNNER_TEMP/docs-production-headers" \
@@ -1343,6 +1343,9 @@ jobs:
           ref: ${{ needs.validate.outputs.sha }}
           path: release-source
           persist-credentials: false
+
+      - name: Create the source SBOM output directory
+        run: mkdir -p source-sbom
 
       - name: Generate the source-scoped release SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,8 +242,9 @@ jobs:
             --scope "$VERCEL_SCOPE" \
             --token "$VERCEL_TOKEN" \
             --json)"
-          deployment_url="$(jq -er .url <<<"$deployment_json")"
-          deployment_id="$(jq -er .deployment.id <<<"$deployment_json")"
+          deployment="$(jq -ce '.deployment // .' <<<"$deployment_json")"
+          deployment_url="$(jq -er .url <<<"$deployment")"
+          deployment_id="$(jq -er .id <<<"$deployment")"
           echo "url=$deployment_url" >> "$GITHUB_OUTPUT"
           echo "id=$deployment_id" >> "$GITHUB_OUTPUT"
       - name: Smoke-test the staged deployment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1103,9 +1103,51 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  source_sbom:
+    name: generate source SBOM
+    needs: [validate, inspect_hosted]
+    if: ${{ needs.inspect_hosted.outputs.exists != 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out the released source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.validate.outputs.sha }}
+          path: release-source
+          persist-credentials: false
+
+      - name: Generate the source-scoped release SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: release-source
+          format: spdx-json
+          output-file: source-sbom/Tidebreak_${{ needs.validate.outputs.version }}_source.spdx.json
+          syft-version: v1.51.0
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Checksum the source-scoped release SBOM
+        env:
+          TIDEBREAK_VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          sbom="source-sbom/Tidebreak_${TIDEBREAK_VERSION}_source.spdx.json"
+          sbom_name="${sbom#source-sbom/}"
+          sbom_digest="$(sha256sum "$sbom" | cut -d ' ' -f 1)"
+          printf '%s  %s\n' "$sbom_digest" "$sbom_name" > "$sbom.sha256"
+
+      - name: Upload the checksummed source SBOM
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: tidebreak-source-sbom-${{ needs.validate.outputs.version }}
+          path: source-sbom/
+          if-no-files-found: error
+          retention-days: 7
+
   publish:
     name: publish downloads.brightwave.io
-    needs: [validate, inspect_hosted, build_macos, build_windows]
+    needs: [validate, inspect_hosted, build_macos, build_windows, source_sbom]
     # `build_windows` is parked (see docs/deferred.md), so a skipped result is
     # the expected steady state; only an outright failure may block publishing.
     if: >-
@@ -1119,6 +1161,7 @@ jobs:
             needs.build_macos.result == 'success'
             && needs.build_windows.result != 'failure'
             && needs.build_windows.result != 'cancelled'
+            && needs.source_sbom.result == 'success'
           )
         )
       }}
@@ -1129,6 +1172,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      attestations: write
     env:
       TIDEBREAK_VERSION: ${{ needs.validate.outputs.version }}
       RELEASE_TAG: ${{ needs.validate.outputs.tag }}
@@ -1192,6 +1236,44 @@ jobs:
           --sha "$RELEASE_SHA"
           --published-at "$RELEASE_PUBLISHED_AT"
           --base-url "$RELEASE_BASE_URL"
+
+      - name: Download the checksummed source SBOM
+        if: ${{ needs.inspect_hosted.outputs.exists != 'true' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: tidebreak-source-sbom-${{ needs.validate.outputs.version }}
+          path: dist
+
+      - name: Prepare provenance attestation subjects
+        if: ${{ needs.inspect_hosted.outputs.exists != 'true' }}
+        run: |
+          sbom="dist/Tidebreak_${TIDEBREAK_VERSION}_source.spdx.json"
+          (cd dist && sha256sum --check --strict "${sbom#dist/}.sha256")
+          find dist -type f ! -name latest.json -print0 \
+            | sort -z \
+            | xargs -0 sha256sum \
+            > "$RUNNER_TEMP/immutable-release-files.sha256"
+
+      # GitHub artifact attestations are available to every public repository,
+      # but private repositories require Enterprise Cloud. The release remains
+      # usable while this repository is private; public releases fail closed if
+      # its independently signed provenance cannot be recorded.
+      - name: Attest immutable release provenance
+        if: >-
+          ${{
+            needs.inspect_hosted.outputs.exists != 'true'
+            && github.event.repository.visibility == 'public'
+          }}
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-checksums: ${{ runner.temp }}/immutable-release-files.sha256
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
+        with:
+          role-to-assume: ${{ env.AWS_RELEASE_ROLE_ARN }}
+          role-session-name: tidebreak-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Resume from the hosted immutable release
         if: ${{ needs.inspect_hosted.outputs.exists == 'true' }}
@@ -1320,6 +1402,13 @@ jobs:
             [[ -n "$url" ]] || continue
             curl --fail --silent --show-error --head "$url" >/dev/null
           done
+          sbom="Tidebreak_${TIDEBREAK_VERSION}_source.spdx.json"
+          if [[ -f "dist/$sbom" ]]; then
+            curl --fail --silent --show-error --head \
+              "$RELEASE_BASE_URL/releases/v$TIDEBREAK_VERSION/$sbom" >/dev/null
+            curl --fail --silent --show-error --head \
+              "$RELEASE_BASE_URL/releases/v$TIDEBREAK_VERSION/$sbom.sha256" >/dev/null
+          fi
 
   attach_downloads:
     name: attach GitHub release downloads
@@ -1388,6 +1477,16 @@ jobs:
           cp "$universal_dmg" "$compatibility_dmg"
           (cd downloads && sha256sum "$(basename "$compatibility_dmg")" \
             > "$(basename "$compatibility_dmg").sha256")
+
+          sbom="Tidebreak_${TIDEBREAK_VERSION}_source.spdx.json"
+          sbom_url="$RELEASE_BASE_URL/releases/v$TIDEBREAK_VERSION/$sbom"
+          if curl --fail --silent --show-error --head "$sbom_url" >/dev/null; then
+            curl --fail --silent --show-error "$sbom_url" \
+              --output "downloads/$sbom"
+            curl --fail --silent --show-error "$sbom_url.sha256" \
+              --output "downloads/$sbom.sha256"
+            (cd downloads && sha256sum --check --strict "$sbom.sha256")
+          fi
 
       # Version-free asset names give the README permanent one-click download
       # links through GitHub's /releases/latest/download/ redirect.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,14 +195,21 @@ jobs:
       VERCEL_PROJECT_ID: prj_XixuEje56Ofw70MmAqOfj7BUFQw9
       VERCEL_SCOPE: brightwave-inc
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.validate.outputs.sha }}
+          sparse-checkout: .github/vercel-cli
+          sparse-checkout-cone-mode: false
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 10.18.3
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
-      - name: Install the pinned deployment client
-        run: pnpm add --global vercel@59.0.0 --ignore-scripts
+          cache: pnpm
+          cache-dependency-path: .github/vercel-cli/pnpm-lock.yaml
+      - name: Install the locked deployment client
+        run: pnpm --dir .github/vercel-cli install --frozen-lockfile --ignore-scripts
       - name: Download the inert prebuilt documentation
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -225,7 +232,7 @@ jobs:
             echo "The docs-production environment must provide VERCEL_TOKEN." >&2
             exit 1
           }
-          deployment_json="$(vercel deploy \
+          deployment_json="$(./.github/vercel-cli/node_modules/.bin/vercel deploy \
             --prebuilt \
             --prod \
             --skip-domain \
@@ -247,7 +254,7 @@ jobs:
           request() {
             local path="$1"
             local output="$2"
-            vercel curl "$path" \
+            ./.github/vercel-cli/node_modules/.bin/vercel curl "$path" \
               --deployment "$DEPLOYMENT_URL" \
               --scope "$VERCEL_SCOPE" \
               --token "$VERCEL_TOKEN" \
@@ -259,7 +266,7 @@ jobs:
           }
 
           request /docs/ "$RUNNER_TEMP/docs-index.html"
-          vercel curl /docs/ \
+          ./.github/vercel-cli/node_modules/.bin/vercel curl /docs/ \
             --deployment "$DEPLOYMENT_URL" \
             --scope "$VERCEL_SCOPE" \
             --token "$VERCEL_TOKEN" \
@@ -295,7 +302,7 @@ jobs:
           DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: >-
-          vercel promote "$DEPLOYMENT_URL"
+          ./.github/vercel-cli/node_modules/.bin/vercel promote "$DEPLOYMENT_URL"
           --yes
           --scope "$VERCEL_SCOPE"
           --token "$VERCEL_TOKEN"
@@ -305,7 +312,7 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
           for _ in {1..12}; do
-            production_json="$(vercel inspect \
+            production_json="$(./.github/vercel-cli/node_modules/.bin/vercel inspect \
               https://tidebreak-docs.vercel.app \
               --scope "$VERCEL_SCOPE" \
               --token "$VERCEL_TOKEN" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,6 @@ jobs:
       VERCEL_ORG_ID: team_akhCRtYAsxrr6iIL6g6YGuKY
       VERCEL_PROJECT_ID: prj_XixuEje56Ofw70MmAqOfj7BUFQw9
       VERCEL_SCOPE: brightwave-inc
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -140,10 +139,6 @@ jobs:
         run: |
           test "$(git rev-parse HEAD)" = "$RELEASE_SHA" || {
             echo "Documentation checkout does not match the validated release." >&2
-            exit 1
-          }
-          [[ -n "$VERCEL_TOKEN" ]] || {
-            echo "The docs-production environment must provide VERCEL_TOKEN." >&2
             exit 1
           }
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
@@ -156,13 +151,6 @@ jobs:
           cache-dependency-path: docs-site/pnpm-lock.yaml
       - name: Install locked documentation dependencies
         run: pnpm --dir docs-site install --frozen-lockfile
-      - name: Link the dedicated production project
-        run: >-
-          ./docs-site/node_modules/.bin/vercel pull
-          --yes
-          --environment=production
-          --scope "$VERCEL_SCOPE"
-          --token "$VERCEL_TOKEN"
       - name: Build and validate the static release documentation
         run: |
           pnpm --dir docs-site build
@@ -180,9 +168,21 @@ jobs:
           test -f .vercel/output/static/docs/quickstart/index.html
           test -f .vercel/output/static/docs/search-index.json
           test -f .vercel/output/static/docs/sitemap.xml
+          mkdir -p .vercel
+          jq -n \
+            --arg orgId "$VERCEL_ORG_ID" \
+            --arg projectId "$VERCEL_PROJECT_ID" \
+            '{orgId: $orgId, projectId: $projectId}' \
+            > .vercel/project.json
       - name: Create an unaliased production deployment
         id: deploy
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
+          [[ -n "$VERCEL_TOKEN" ]] || {
+            echo "The docs-production environment must provide VERCEL_TOKEN." >&2
+            exit 1
+          }
           deployment_json="$(./docs-site/node_modules/.bin/vercel deploy \
             --prebuilt \
             --prod \
@@ -194,10 +194,13 @@ jobs:
             --token "$VERCEL_TOKEN" \
             --json)"
           deployment_url="$(jq -er .url <<<"$deployment_json")"
+          deployment_id="$(jq -er .deployment.id <<<"$deployment_json")"
           echo "url=$deployment_url" >> "$GITHUB_OUTPUT"
+          echo "id=$deployment_id" >> "$GITHUB_OUTPUT"
       - name: Smoke-test the staged deployment
         env:
           DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
           request() {
             local path="$1"
@@ -220,21 +223,40 @@ jobs:
 
           grep -Fq 'https://tidebreak.sh/docs/' "$RUNNER_TEMP/docs-index.html"
           grep -Fq '/docs/_next/' "$RUNNER_TEMP/docs-index.html"
+          asset_path="$(grep -oE '/docs/_next/[^" ]+' \
+            "$RUNNER_TEMP/docs-index.html" | head -n 1)"
+          case "$asset_path" in
+            /docs/_next/*) ;;
+            *) echo "Documentation did not reference a safe Next asset." >&2; exit 1 ;;
+          esac
+          request "$asset_path" "$RUNNER_TEMP/docs-asset"
           jq -e 'type == "array" and length > 0' \
             "$RUNNER_TEMP/docs-search-index.json" >/dev/null
           grep -Fq '<urlset' "$RUNNER_TEMP/docs-sitemap.xml"
       - name: Promote the verified deployment
         env:
           DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: >-
           ./docs-site/node_modules/.bin/vercel promote "$DEPLOYMENT_URL"
           --yes
           --scope "$VERCEL_SCOPE"
           --token "$VERCEL_TOKEN"
       - name: Verify the production alias
+        env:
+          DEPLOYMENT_ID: ${{ steps.deploy.outputs.id }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
           for _ in {1..12}; do
-            if curl \
+            production_json="$(./docs-site/node_modules/.bin/vercel inspect \
+              https://tidebreak-docs.vercel.app \
+              --scope "$VERCEL_SCOPE" \
+              --token "$VERCEL_TOKEN" \
+              --json 2>/dev/null || true)"
+            if jq -e --arg id "$DEPLOYMENT_ID" \
+              '.id == $id and .readyState == "READY"' \
+              <<<"$production_json" >/dev/null \
+              && curl \
               --fail \
               --silent \
               --show-error \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,23 +114,17 @@ jobs:
             exit 1
           }
 
-  publish_docs:
-    name: publish release documentation
+  build_docs:
+    name: build release documentation
     needs: validate
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    environment:
-      name: docs-production
-      url: https://tidebreak-docs.vercel.app/docs/
     permissions:
       contents: read
     env:
       BASE_PATH: /docs
       RELEASE_SHA: ${{ needs.validate.outputs.sha }}
       RELEASE_TAG: ${{ needs.validate.outputs.tag }}
-      VERCEL_ORG_ID: team_akhCRtYAsxrr6iIL6g6YGuKY
-      VERCEL_PROJECT_ID: prj_XixuEje56Ofw70MmAqOfj7BUFQw9
-      VERCEL_SCOPE: brightwave-inc
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -168,6 +162,54 @@ jobs:
           test -f .vercel/output/static/docs/quickstart/index.html
           test -f .vercel/output/static/docs/search-index.json
           test -f .vercel/output/static/docs/sitemap.xml
+      - name: Transfer inert prebuilt documentation
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: tidebreak-docs-${{ needs.validate.outputs.tag }}-prebuilt
+          path: .vercel/output
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 1
+      - name: Retain the static-content digest manifest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: tidebreak-docs-${{ needs.validate.outputs.tag }}-manifest
+          path: ${{ runner.temp }}/tidebreak-docs-${{ needs.validate.outputs.tag }}.sha256
+          if-no-files-found: error
+          retention-days: 90
+
+  publish_docs:
+    name: publish release documentation
+    needs: [validate, build_docs]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: docs-production
+      url: https://tidebreak-docs.vercel.app/docs/
+    permissions:
+      contents: read
+    env:
+      RELEASE_SHA: ${{ needs.validate.outputs.sha }}
+      RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+      VERCEL_ORG_ID: team_akhCRtYAsxrr6iIL6g6YGuKY
+      VERCEL_PROJECT_ID: prj_XixuEje56Ofw70MmAqOfj7BUFQw9
+      VERCEL_SCOPE: brightwave-inc
+    steps:
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        with:
+          version: 10.18.3
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+      - name: Install the pinned deployment client
+        run: pnpm add --global vercel@59.0.0 --ignore-scripts
+      - name: Download the inert prebuilt documentation
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: tidebreak-docs-${{ needs.validate.outputs.tag }}-prebuilt
+          path: .vercel/output
+      - name: Link the fixed documentation project
+        run: |
           mkdir -p .vercel
           jq -n \
             --arg orgId "$VERCEL_ORG_ID" \
@@ -183,7 +225,7 @@ jobs:
             echo "The docs-production environment must provide VERCEL_TOKEN." >&2
             exit 1
           }
-          deployment_json="$(./docs-site/node_modules/.bin/vercel deploy \
+          deployment_json="$(vercel deploy \
             --prebuilt \
             --prod \
             --skip-domain \
@@ -205,7 +247,7 @@ jobs:
           request() {
             local path="$1"
             local output="$2"
-            ./docs-site/node_modules/.bin/vercel curl "$path" \
+            vercel curl "$path" \
               --deployment "$DEPLOYMENT_URL" \
               --scope "$VERCEL_SCOPE" \
               --token "$VERCEL_TOKEN" \
@@ -217,6 +259,16 @@ jobs:
           }
 
           request /docs/ "$RUNNER_TEMP/docs-index.html"
+          vercel curl /docs/ \
+            --deployment "$DEPLOYMENT_URL" \
+            --scope "$VERCEL_SCOPE" \
+            --token "$VERCEL_TOKEN" \
+            -- \
+            --fail \
+            --silent \
+            --show-error \
+            --dump-header "$RUNNER_TEMP/docs-headers" \
+            --output /dev/null
           request /docs/quickstart/ "$RUNNER_TEMP/docs-quickstart.html"
           request /docs/search-index.json "$RUNNER_TEMP/docs-search-index.json"
           request /docs/sitemap.xml "$RUNNER_TEMP/docs-sitemap.xml"
@@ -230,6 +282,11 @@ jobs:
             *) echo "Documentation did not reference a safe Next asset." >&2; exit 1 ;;
           esac
           request "$asset_path" "$RUNNER_TEMP/docs-asset"
+          grep -Fqi 'content-security-policy:' "$RUNNER_TEMP/docs-headers"
+          grep -Fqi 'cross-origin-opener-policy: same-origin' "$RUNNER_TEMP/docs-headers"
+          grep -Fqi 'cross-origin-resource-policy: same-origin' "$RUNNER_TEMP/docs-headers"
+          grep -Fqi 'x-content-type-options: nosniff' "$RUNNER_TEMP/docs-headers"
+          grep -Fqi 'x-frame-options: DENY' "$RUNNER_TEMP/docs-headers"
           jq -e 'type == "array" and length > 0' \
             "$RUNNER_TEMP/docs-search-index.json" >/dev/null
           grep -Fq '<urlset' "$RUNNER_TEMP/docs-sitemap.xml"
@@ -238,7 +295,7 @@ jobs:
           DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: >-
-          ./docs-site/node_modules/.bin/vercel promote "$DEPLOYMENT_URL"
+          vercel promote "$DEPLOYMENT_URL"
           --yes
           --scope "$VERCEL_SCOPE"
           --token "$VERCEL_TOKEN"
@@ -248,7 +305,7 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
           for _ in {1..12}; do
-            production_json="$(./docs-site/node_modules/.bin/vercel inspect \
+            production_json="$(vercel inspect \
               https://tidebreak-docs.vercel.app \
               --scope "$VERCEL_SCOPE" \
               --token "$VERCEL_TOKEN" \
@@ -261,23 +318,20 @@ jobs:
               --silent \
               --show-error \
               https://tidebreak-docs.vercel.app/docs/ \
+              --dump-header "$RUNNER_TEMP/docs-production-headers" \
               --output "$RUNNER_TEMP/docs-production.html" \
               && grep -Fq 'https://tidebreak.sh/docs/' \
-                "$RUNNER_TEMP/docs-production.html"; then
+                "$RUNNER_TEMP/docs-production.html" \
+              && grep -Fqi 'content-security-policy:' \
+                "$RUNNER_TEMP/docs-production-headers" \
+              && grep -Fqi 'x-frame-options: DENY' \
+                "$RUNNER_TEMP/docs-production-headers"; then
               exit 0
             fi
             sleep 5
           done
           echo "The promoted docs deployment did not become healthy." >&2
           exit 1
-      - name: Retain the static-content digest manifest
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: tidebreak-docs-${{ needs.validate.outputs.tag }}-manifest
-          path: ${{ runner.temp }}/tidebreak-docs-${{ needs.validate.outputs.tag }}.sha256
-          if-no-files-found: error
-          retention-days: 90
-
   inspect_hosted:
     name: inspect hosted release
     needs: validate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1430,13 +1430,6 @@ jobs:
             exit 1
           fi
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
-        with:
-          role-to-assume: ${{ env.AWS_RELEASE_ROLE_ARN }}
-          role-session-name: tidebreak-${{ github.run_id }}
-          aws-region: ${{ env.AWS_REGION }}
-
       - name: Download universal macOS artifacts
         if: ${{ needs.inspect_hosted.outputs.exists != 'true' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ needs.validate.outputs.sha }}
+          persist-credentials: false
       - name: Require the validated release source
         run: |
           test "$(git rev-parse HEAD)" = "$RELEASE_SHA" || {
@@ -150,18 +151,22 @@ jobs:
           pnpm --dir docs-site build
           pnpm --dir docs-site lint
           pnpm --dir docs-site types:check
+          pnpm --dir docs-site test:vercel-output
           test -f docs-site/out/index.html
           test -f docs-site/out/search-index.json
           test -f docs-site/out/sitemap.xml
-          find docs-site/out -type f -print0 \
-            | sort -z \
-            | xargs -0 sha256sum \
-            > "$RUNNER_TEMP/tidebreak-docs-$RELEASE_TAG.sha256"
           pnpm --dir docs-site package:vercel
           test -f .vercel/output/static/docs/index.html
           test -f .vercel/output/static/docs/quickstart/index.html
           test -f .vercel/output/static/docs/search-index.json
           test -f .vercel/output/static/docs/sitemap.xml
+          (
+            cd .vercel/output
+            find . -type f -print0 \
+              | sort -z \
+              | xargs -0 sha256sum \
+              > "$RUNNER_TEMP/tidebreak-docs-$RELEASE_TAG.sha256"
+          )
       - name: Transfer inert prebuilt documentation
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -198,6 +203,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ needs.validate.outputs.sha }}
+          persist-credentials: false
           sparse-checkout: .github/vercel-cli
           sparse-checkout-cone-mode: false
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
@@ -215,6 +221,18 @@ jobs:
         with:
           name: tidebreak-docs-${{ needs.validate.outputs.tag }}-prebuilt
           path: .vercel/output
+      - name: Download the documentation digest manifest
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: tidebreak-docs-${{ needs.validate.outputs.tag }}-manifest
+          path: ${{ runner.temp }}/docs-manifest
+      - name: Verify the transferred documentation
+        run: |
+          (
+            cd .vercel/output
+            sha256sum --check --strict \
+              "$RUNNER_TEMP/docs-manifest/tidebreak-docs-$RELEASE_TAG.sha256"
+          )
       - name: Link the fixed documentation project
         run: |
           mkdir -p .vercel
@@ -240,7 +258,6 @@ jobs:
             --meta "releaseTag=$RELEASE_TAG" \
             --meta "releaseSha=$RELEASE_SHA" \
             --scope "$VERCEL_SCOPE" \
-            --token "$VERCEL_TOKEN" \
             --json)"
           deployment="$(jq -ce '.deployment // .' <<<"$deployment_json")"
           deployment_url="$(jq -er .url <<<"$deployment")"
@@ -258,7 +275,6 @@ jobs:
             ./.github/vercel-cli/node_modules/.bin/vercel curl "$path" \
               --deployment "$DEPLOYMENT_URL" \
               --scope "$VERCEL_SCOPE" \
-              --token "$VERCEL_TOKEN" \
               -- \
               --fail \
               --silent \
@@ -270,7 +286,6 @@ jobs:
           ./.github/vercel-cli/node_modules/.bin/vercel curl /docs/ \
             --deployment "$DEPLOYMENT_URL" \
             --scope "$VERCEL_SCOPE" \
-            --token "$VERCEL_TOKEN" \
             -- \
             --fail \
             --silent \
@@ -290,7 +305,9 @@ jobs:
             *) echo "Documentation did not reference a safe Next asset." >&2; exit 1 ;;
           esac
           request "$asset_path" "$RUNNER_TEMP/docs-asset"
-          grep -Fqi 'content-security-policy:' "$RUNNER_TEMP/docs-headers"
+          grep -Eqi "content-security-policy:.*default-src 'self'" "$RUNNER_TEMP/docs-headers"
+          grep -Eqi "content-security-policy:.*object-src 'none'" "$RUNNER_TEMP/docs-headers"
+          grep -Eqi "content-security-policy:.*frame-ancestors 'none'" "$RUNNER_TEMP/docs-headers"
           grep -Fqi 'cross-origin-opener-policy: same-origin' "$RUNNER_TEMP/docs-headers"
           grep -Fqi 'cross-origin-resource-policy: same-origin' "$RUNNER_TEMP/docs-headers"
           grep -Fqi 'x-content-type-options: nosniff' "$RUNNER_TEMP/docs-headers"
@@ -306,7 +323,6 @@ jobs:
           ./.github/vercel-cli/node_modules/.bin/vercel promote "$DEPLOYMENT_URL"
           --yes
           --scope "$VERCEL_SCOPE"
-          --token "$VERCEL_TOKEN"
       - name: Verify the production alias
         env:
           DEPLOYMENT_ID: ${{ steps.deploy.outputs.id }}
@@ -316,7 +332,6 @@ jobs:
             production_json="$(./.github/vercel-cli/node_modules/.bin/vercel inspect \
               https://tidebreak-docs.vercel.app \
               --scope "$VERCEL_SCOPE" \
-              --token "$VERCEL_TOKEN" \
               --json 2>/dev/null || true)"
             if jq -e --arg id "$DEPLOYMENT_ID" \
               '.id == $id and .readyState == "READY"' \
@@ -330,7 +345,11 @@ jobs:
               --output "$RUNNER_TEMP/docs-production.html" \
               && grep -Fq 'https://www.tidebreak.sh/docs/' \
                 "$RUNNER_TEMP/docs-production.html" \
-              && grep -Fqi 'content-security-policy:' \
+              && grep -Eqi "content-security-policy:.*default-src 'self'" \
+                "$RUNNER_TEMP/docs-production-headers" \
+              && grep -Eqi "content-security-policy:.*object-src 'none'" \
+                "$RUNNER_TEMP/docs-production-headers" \
+              && grep -Eqi "content-security-policy:.*frame-ancestors 'none'" \
                 "$RUNNER_TEMP/docs-production-headers" \
               && grep -Fqi 'x-frame-options: DENY' \
                 "$RUNNER_TEMP/docs-production-headers"; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,148 @@ jobs:
             exit 1
           }
 
+  publish_docs:
+    name: publish release documentation
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: docs-production
+      url: https://tidebreak-docs.vercel.app/docs/
+    permissions:
+      contents: read
+    env:
+      BASE_PATH: /docs
+      RELEASE_SHA: ${{ needs.validate.outputs.sha }}
+      RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+      VERCEL_ORG_ID: team_akhCRtYAsxrr6iIL6g6YGuKY
+      VERCEL_PROJECT_ID: prj_XixuEje56Ofw70MmAqOfj7BUFQw9
+      VERCEL_SCOPE: brightwave-inc
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.validate.outputs.sha }}
+      - name: Require the validated release source
+        run: |
+          test "$(git rev-parse HEAD)" = "$RELEASE_SHA" || {
+            echo "Documentation checkout does not match the validated release." >&2
+            exit 1
+          }
+          [[ -n "$VERCEL_TOKEN" ]] || {
+            echo "The docs-production environment must provide VERCEL_TOKEN." >&2
+            exit 1
+          }
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        with:
+          version: 10.18.3
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: docs-site/pnpm-lock.yaml
+      - name: Install locked documentation dependencies
+        run: pnpm --dir docs-site install --frozen-lockfile
+      - name: Link the dedicated production project
+        run: >-
+          ./docs-site/node_modules/.bin/vercel pull
+          --yes
+          --environment=production
+          --scope "$VERCEL_SCOPE"
+          --token "$VERCEL_TOKEN"
+      - name: Build and validate the static release documentation
+        run: |
+          pnpm --dir docs-site build
+          pnpm --dir docs-site lint
+          pnpm --dir docs-site types:check
+          test -f docs-site/out/index.html
+          test -f docs-site/out/search-index.json
+          test -f docs-site/out/sitemap.xml
+          find docs-site/out -type f -print0 \
+            | sort -z \
+            | xargs -0 sha256sum \
+            > "$RUNNER_TEMP/tidebreak-docs-$RELEASE_TAG.sha256"
+          pnpm --dir docs-site package:vercel
+          test -f .vercel/output/static/docs/index.html
+          test -f .vercel/output/static/docs/quickstart/index.html
+          test -f .vercel/output/static/docs/search-index.json
+          test -f .vercel/output/static/docs/sitemap.xml
+      - name: Create an unaliased production deployment
+        id: deploy
+        run: |
+          deployment_json="$(./docs-site/node_modules/.bin/vercel deploy \
+            --prebuilt \
+            --prod \
+            --skip-domain \
+            --yes \
+            --meta "releaseTag=$RELEASE_TAG" \
+            --meta "releaseSha=$RELEASE_SHA" \
+            --scope "$VERCEL_SCOPE" \
+            --token "$VERCEL_TOKEN" \
+            --json)"
+          deployment_url="$(jq -er .url <<<"$deployment_json")"
+          echo "url=$deployment_url" >> "$GITHUB_OUTPUT"
+      - name: Smoke-test the staged deployment
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
+        run: |
+          request() {
+            local path="$1"
+            local output="$2"
+            ./docs-site/node_modules/.bin/vercel curl "$path" \
+              --deployment "$DEPLOYMENT_URL" \
+              --scope "$VERCEL_SCOPE" \
+              --token "$VERCEL_TOKEN" \
+              -- \
+              --fail \
+              --silent \
+              --show-error \
+              --output "$output"
+          }
+
+          request /docs/ "$RUNNER_TEMP/docs-index.html"
+          request /docs/quickstart/ "$RUNNER_TEMP/docs-quickstart.html"
+          request /docs/search-index.json "$RUNNER_TEMP/docs-search-index.json"
+          request /docs/sitemap.xml "$RUNNER_TEMP/docs-sitemap.xml"
+
+          grep -Fq 'https://tidebreak.sh/docs/' "$RUNNER_TEMP/docs-index.html"
+          grep -Fq '/docs/_next/' "$RUNNER_TEMP/docs-index.html"
+          jq -e 'type == "array" and length > 0' \
+            "$RUNNER_TEMP/docs-search-index.json" >/dev/null
+          grep -Fq '<urlset' "$RUNNER_TEMP/docs-sitemap.xml"
+      - name: Promote the verified deployment
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
+        run: >-
+          ./docs-site/node_modules/.bin/vercel promote "$DEPLOYMENT_URL"
+          --yes
+          --scope "$VERCEL_SCOPE"
+          --token "$VERCEL_TOKEN"
+      - name: Verify the production alias
+        run: |
+          for _ in {1..12}; do
+            if curl \
+              --fail \
+              --silent \
+              --show-error \
+              https://tidebreak-docs.vercel.app/docs/ \
+              --output "$RUNNER_TEMP/docs-production.html" \
+              && grep -Fq 'https://tidebreak.sh/docs/' \
+                "$RUNNER_TEMP/docs-production.html"; then
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "The promoted docs deployment did not become healthy." >&2
+          exit 1
+      - name: Retain the static-content digest manifest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: tidebreak-docs-${{ needs.validate.outputs.tag }}-manifest
+          path: ${{ runner.temp }}/tidebreak-docs-${{ needs.validate.outputs.tag }}.sha256
+          if-no-files-found: error
+          retention-days: 90
+
   inspect_hosted:
     name: inspect hosted release
     needs: validate

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ credentials.json
 node_modules/
 dist/
 .vite/
+.vercel/
 
 # Python helper bytecode
 __pycache__/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7737,6 +7737,7 @@ dependencies = [
  "serde_json",
  "tidebreak-core",
  "tokio",
+ "url",
  "uuid",
 ]
 

--- a/crates/tidebreak-core/src/db/entities.rs
+++ b/crates/tidebreak-core/src/db/entities.rs
@@ -1465,6 +1465,7 @@ pub mod app {
     pub struct Model {
         #[sea_orm(primary_key, auto_increment = false)]
         pub id: Uuid,
+        pub owner: String,
         pub name: String,
         pub current_revision_id: Uuid,
         pub revision_count: i32,

--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -1,11 +1,10 @@
 //! The database schema.
 //!
-//! Pre-v1 the schema is a single [`Baseline`] migration rather than a chain:
-//! there are no deployed databases to carry forward, so a schema change edits
-//! the baseline in place and bumps `DESKTOP_SCHEMA_EPOCH` in
-//! `tidebreak-server`, which discards any database written by an older one.
-//! Once the schema stabilizes for v1 this becomes an ordinary migration
-//! chain, with the baseline as its first entry.
+//! Fresh pre-v1 databases are still described by [`Baseline`], and desktop
+//! SQLite changes bump `DESKTOP_SCHEMA_EPOCH` so disposable local data is
+//! rebuilt. Self-host databases are durable, however, so any schema change
+//! that must reach an already-recorded baseline also gets an ordered upgrade
+//! migration in this module.
 
 mod baseline;
 mod idens;
@@ -18,7 +17,74 @@ pub struct Migrator;
 #[async_trait::async_trait]
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
-        vec![Box::new(Baseline)]
+        vec![Box::new(Baseline), Box::new(AddAppOwner)]
+    }
+}
+
+/// Upgrade databases that recorded the original pre-launch baseline before
+/// apps became principal-owned. Fresh databases already receive this shape
+/// from [`Baseline`], so the migration is deliberately idempotent.
+struct AddAppOwner;
+
+impl MigrationName for AddAppOwner {
+    fn name(&self) -> &str {
+        "m20260814_000002_add_app_owner"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for AddAppOwner {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if !manager.has_column("app", "owner").await? {
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(idens::App::Table)
+                        .add_column(
+                            ColumnDef::new(idens::App::Owner)
+                                .text()
+                                .not_null()
+                                .default("local"),
+                        )
+                        .to_owned(),
+                )
+                .await?;
+        }
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .name("idx_app_owner_updated")
+                    .table(idens::App::Table)
+                    .col(idens::App::Owner)
+                    .col(idens::App::UpdatedAt)
+                    .col(idens::App::Id)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.has_column("app", "owner").await? {
+            manager
+                .drop_index(
+                    Index::drop()
+                        .if_exists()
+                        .name("idx_app_owner_updated")
+                        .table(idens::App::Table)
+                        .to_owned(),
+                )
+                .await?;
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(idens::App::Table)
+                        .drop_column(idens::App::Owner)
+                        .to_owned(),
+                )
+                .await?;
+        }
+        Ok(())
     }
 }
 
@@ -59,5 +125,47 @@ impl MigrationTrait for Baseline {
                 .await?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{ConnectionTrait, Database, DbBackend, Statement};
+    use sea_orm_migration::MigratorTrait;
+
+    use super::Migrator;
+
+    #[tokio::test]
+    async fn an_existing_baseline_app_is_backfilled_to_the_local_owner() {
+        let db = Database::connect("sqlite::memory:").await.unwrap();
+        Migrator::up(&db, Some(1)).await.unwrap();
+        db.execute_unprepared("DROP INDEX idx_app_owner_updated")
+            .await
+            .unwrap();
+        db.execute_unprepared("ALTER TABLE app DROP COLUMN owner")
+            .await
+            .unwrap();
+        db.execute_unprepared(
+            concat!(
+                "INSERT INTO app (id, name, current_revision_id, revision_count, created_at, updated_at, deleted_at) ",
+                "VALUES ('00000000-0000-0000-0000-000000000001', 'legacy', ",
+                "'00000000-0000-0000-0000-000000000002', 1, ",
+                "'2026-08-14 00:00:00+00:00', '2026-08-14 00:00:00+00:00', NULL)"
+            ),
+        )
+        .await
+        .unwrap();
+
+        Migrator::up(&db, None).await.unwrap();
+
+        let row = db
+            .query_one_raw(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT owner FROM app WHERE name = 'legacy'".to_owned(),
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.try_get::<String>("", "owner").unwrap(), "local");
     }
 }

--- a/crates/tidebreak-core/src/db/migration/baseline/content.rs
+++ b/crates/tidebreak-core/src/db/migration/baseline/content.rs
@@ -599,15 +599,22 @@ pub(super) fn message_document_attachment_indexes() -> Vec<IndexCreateStatement>
     ]
 }
 
-/// The profile-scoped local-app record: one row per app.
+/// The principal-owned local-app record: one row per app.
 ///
 /// Follows `output`/`output_revision` with one deliberate difference: there is
-/// no chat foreign key anywhere. The profile owns the app, so an app and its
-/// history survive deletion of the conversation that authored them.
+/// no chat foreign key anywhere. The immutable owner on the app row keeps its
+/// history alive after the authoring conversation is deleted while still
+/// partitioning a shared database by principal.
 pub(super) fn app_table() -> TableCreateStatement {
     Table::create()
         .table(App::Table)
         .col(ColumnDef::new(App::Id).uuid().not_null().primary_key())
+        .col(
+            ColumnDef::new(App::Owner)
+                .text()
+                .not_null()
+                .default("local"),
+        )
         .col(ColumnDef::new(App::Name).text().not_null())
         .col(ColumnDef::new(App::CurrentRevisionId).uuid().not_null())
         .col(ColumnDef::new(App::RevisionCount).integer().not_null())
@@ -627,12 +634,21 @@ pub(super) fn app_table() -> TableCreateStatement {
 }
 
 pub(super) fn app_indexes() -> Vec<IndexCreateStatement> {
-    vec![Index::create()
-        .name("idx_app_updated")
-        .table(App::Table)
-        .col(App::UpdatedAt)
-        .col(App::Id)
-        .to_owned()]
+    vec![
+        Index::create()
+            .name("idx_app_updated")
+            .table(App::Table)
+            .col(App::UpdatedAt)
+            .col(App::Id)
+            .to_owned(),
+        Index::create()
+            .name("idx_app_owner_updated")
+            .table(App::Table)
+            .col(App::Owner)
+            .col(App::UpdatedAt)
+            .col(App::Id)
+            .to_owned(),
+    ]
 }
 
 /// Insert-only app revisions, each pairing a bounded manifest with the length

--- a/crates/tidebreak-core/src/db/migration/baseline/mod.rs
+++ b/crates/tidebreak-core/src/db/migration/baseline/mod.rs
@@ -1,11 +1,11 @@
 //! The schema baseline: every table, index, and seed row a fresh database
 //! starts with.
 //!
-//! Pre-v1 databases are disposable — [`crate::db::migration::Migrator`] runs
-//! this one migration, and `tidebreak-server`'s schema-epoch guard discards any
-//! database written by an older baseline. So the baseline is edited in place
-//! rather than extended by an upgrade step: change the table definition here
-//! and bump the epoch.
+//! Pre-v1 desktop databases are disposable: `tidebreak-server`'s schema-epoch
+//! guard discards a database written by an older baseline. The self-host
+//! PostgreSQL store is durable, so a baseline edit that changes an existing
+//! table must also have an ordered upgrade migration in
+//! [`crate::db::migration`].
 
 use sea_orm_migration::prelude::*;
 

--- a/crates/tidebreak-core/src/db/migration/idens.rs
+++ b/crates/tidebreak-core/src/db/migration/idens.rs
@@ -71,6 +71,7 @@ pub(crate) enum OutputRevision {
 pub(crate) enum App {
     Table,
     Id,
+    Owner,
     Name,
     CurrentRevisionId,
     RevisionCount,

--- a/crates/tidebreak-core/src/db/mod.rs
+++ b/crates/tidebreak-core/src/db/mod.rs
@@ -845,7 +845,15 @@ impl Store for DbStore {
     }
 
     async fn create_app(&self, request: &CreateApp) -> Result<AppRecord> {
-        ops::app::create_app(self, request).await
+        ops::app::create_app(self, None, None, request).await
+    }
+
+    async fn create_app_for_chat(&self, chat_id: ChatId, request: &CreateApp) -> Result<AppRecord> {
+        ops::app::create_app(self, None, Some(chat_id), request).await
+    }
+
+    async fn create_app_scoped(&self, owner: &OwnerId, request: &CreateApp) -> Result<AppRecord> {
+        ops::app::create_app(self, Some(owner), None, request).await
     }
 
     async fn append_app_revision(
@@ -853,43 +861,135 @@ impl Store for DbStore {
         app_id: AppId,
         revision: &NewAppRevision,
     ) -> Result<AppRecord> {
-        ops::app::append_app_revision(self, app_id, revision).await
+        ops::app::append_app_revision(self, None, None, app_id, revision).await
+    }
+
+    async fn append_app_revision_for_chat(
+        &self,
+        chat_id: ChatId,
+        app_id: AppId,
+        revision: &NewAppRevision,
+    ) -> Result<AppRecord> {
+        ops::app::append_app_revision(self, None, Some(chat_id), app_id, revision).await
+    }
+
+    async fn append_app_revision_scoped(
+        &self,
+        owner: &OwnerId,
+        app_id: AppId,
+        revision: &NewAppRevision,
+    ) -> Result<AppRecord> {
+        ops::app::append_app_revision(self, Some(owner), None, app_id, revision).await
     }
 
     async fn get_app(&self, id: AppId) -> Result<Option<AppRecord>> {
-        ops::app::get_app(self, id).await
+        ops::app::get_app(self, None, id).await
+    }
+
+    async fn get_app_scoped(&self, owner: &OwnerId, id: AppId) -> Result<Option<AppRecord>> {
+        ops::app::get_app(self, Some(owner), id).await
+    }
+
+    async fn get_app_for_chat(&self, chat_id: ChatId, id: AppId) -> Result<Option<AppRecord>> {
+        ops::app::get_app_for_chat(self, chat_id, id).await
     }
 
     async fn list_apps(&self, limit: u64) -> Result<Vec<AppRecord>> {
-        ops::app::list_apps(self, limit).await
+        ops::app::list_apps(self, None, limit).await
+    }
+
+    async fn list_apps_scoped(&self, owner: &OwnerId, limit: u64) -> Result<Vec<AppRecord>> {
+        ops::app::list_apps(self, Some(owner), limit).await
     }
 
     async fn list_app_revisions(&self, app_id: AppId) -> Result<Vec<AppRevision>> {
-        ops::app::list_app_revisions(self, app_id).await
+        ops::app::list_app_revisions(self, None, app_id).await
+    }
+
+    async fn list_app_revisions_scoped(
+        &self,
+        owner: &OwnerId,
+        app_id: AppId,
+    ) -> Result<Vec<AppRevision>> {
+        ops::app::list_app_revisions(self, Some(owner), app_id).await
     }
 
     async fn get_app_revision(&self, id: AppRevisionId) -> Result<Option<AppRevision>> {
-        ops::app::get_app_revision(self, id).await
+        ops::app::get_app_revision(self, None, id).await
+    }
+
+    async fn get_app_revision_scoped(
+        &self,
+        owner: &OwnerId,
+        id: AppRevisionId,
+    ) -> Result<Option<AppRevision>> {
+        ops::app::get_app_revision(self, Some(owner), id).await
+    }
+
+    async fn get_app_revision_for_chat(
+        &self,
+        chat_id: ChatId,
+        id: AppRevisionId,
+    ) -> Result<Option<AppRevision>> {
+        ops::app::get_app_revision_for_chat(self, chat_id, id).await
     }
 
     async fn delete_app(&self, id: AppId, deleted_at: chrono::DateTime<Utc>) -> Result<bool> {
-        ops::app::delete_app(self, id, deleted_at).await
+        ops::app::delete_app(self, None, id, deleted_at).await
+    }
+
+    async fn delete_app_scoped(
+        &self,
+        owner: &OwnerId,
+        id: AppId,
+        deleted_at: chrono::DateTime<Utc>,
+    ) -> Result<bool> {
+        ops::app::delete_app(self, Some(owner), id, deleted_at).await
     }
 
     async fn restore_app(&self, id: AppId, restored_at: chrono::DateTime<Utc>) -> Result<bool> {
-        ops::app::restore_app(self, id, restored_at).await
+        ops::app::restore_app(self, None, id, restored_at).await
+    }
+
+    async fn restore_app_scoped(
+        &self,
+        owner: &OwnerId,
+        id: AppId,
+        restored_at: chrono::DateTime<Utc>,
+    ) -> Result<bool> {
+        ops::app::restore_app(self, Some(owner), id, restored_at).await
     }
 
     async fn put_app_grant(&self, grant: &AppGrant) -> Result<()> {
-        ops::app::put_app_grant(self, grant).await
+        ops::app::put_app_grant(self, None, grant).await
+    }
+
+    async fn put_app_grant_scoped(&self, owner: &OwnerId, grant: &AppGrant) -> Result<()> {
+        ops::app::put_app_grant(self, Some(owner), grant).await
     }
 
     async fn get_app_grant(&self, app_id: AppId) -> Result<Option<AppGrant>> {
-        ops::app::get_app_grant(self, app_id).await
+        ops::app::get_app_grant(self, None, app_id).await
+    }
+
+    async fn get_app_grant_scoped(
+        &self,
+        owner: &OwnerId,
+        app_id: AppId,
+    ) -> Result<Option<AppGrant>> {
+        ops::app::get_app_grant(self, Some(owner), app_id).await
     }
 
     async fn put_app_gateway_draft(&self, draft: &AppGatewayDraft) -> Result<()> {
-        ops::app::put_app_gateway_draft(self, draft).await
+        ops::app::put_app_gateway_draft(self, None, draft).await
+    }
+
+    async fn put_app_gateway_draft_scoped(
+        &self,
+        owner: &OwnerId,
+        draft: &AppGatewayDraft,
+    ) -> Result<()> {
+        ops::app::put_app_gateway_draft(self, Some(owner), draft).await
     }
 
     async fn get_app_gateway_draft(
@@ -897,15 +997,32 @@ impl Store for DbStore {
         app_id: AppId,
         gateway_base_url: &str,
     ) -> Result<Option<AppGatewayDraft>> {
-        ops::app::get_app_gateway_draft(self, app_id, gateway_base_url).await
+        ops::app::get_app_gateway_draft(self, None, app_id, gateway_base_url).await
+    }
+
+    async fn get_app_gateway_draft_scoped(
+        &self,
+        owner: &OwnerId,
+        app_id: AppId,
+        gateway_base_url: &str,
+    ) -> Result<Option<AppGatewayDraft>> {
+        ops::app::get_app_gateway_draft(self, Some(owner), app_id, gateway_base_url).await
     }
 
     async fn delete_app_grant(&self, app_id: AppId) -> Result<bool> {
-        ops::app::delete_app_grant(self, app_id).await
+        ops::app::delete_app_grant(self, None, app_id).await
+    }
+
+    async fn delete_app_grant_scoped(&self, owner: &OwnerId, app_id: AppId) -> Result<bool> {
+        ops::app::delete_app_grant(self, Some(owner), app_id).await
     }
 
     async fn list_live_app_grants(&self) -> Result<Vec<AppGrant>> {
-        ops::app::list_live_app_grants(self).await
+        ops::app::list_live_app_grants(self, None).await
+    }
+
+    async fn list_live_app_grants_scoped(&self, owner: &OwnerId) -> Result<Vec<AppGrant>> {
+        ops::app::list_live_app_grants(self, Some(owner)).await
     }
 
     async fn list_connected_apps(&self) -> Result<Vec<ConnectedApp>> {

--- a/crates/tidebreak-core/src/db/ops/app.rs
+++ b/crates/tidebreak-core/src/db/ops/app.rs
@@ -14,24 +14,32 @@ use sea_orm::{
 };
 
 use crate::error::{AgentError, Result};
-use crate::id::{AppId, AppRevisionId};
+use crate::id::{AppId, AppRevisionId, ChatId};
 use crate::local_app::{
     validate_app_gateway_draft, validate_app_grant, validate_app_manifest, AppGatewayDraft,
     AppGrant, AppGrantBinding, AppManifest, AppRecord, AppRevision, CreateApp, NewAppRevision,
     MAX_APP_BUNDLE_BYTES, MAX_APP_REVISIONS,
 };
+use crate::OwnerId;
 
 use super::super::{entities, store_err, DbStore};
 use super::turn::canonical_db_timestamp;
 
-pub(in crate::db) async fn create_app(store: &DbStore, request: &CreateApp) -> Result<AppRecord> {
+pub(in crate::db) async fn create_app(
+    store: &DbStore,
+    owner: Option<&OwnerId>,
+    chat_id: Option<ChatId>,
+    request: &CreateApp,
+) -> Result<AppRecord> {
     let manifest_json = validate_revision(&request.revision)?;
     let created_at = canonical_db_timestamp(request.revision.created_at)?;
     let transaction = store.conn.begin().await.map_err(store_err)?;
+    let owner = resolve_owner_on(&transaction, owner, chat_id).await?;
     if let Some(existing) = find_app_on(&transaction, request.id).await? {
         // An exact retry must return the original record rather than fail. A
         // reused id that describes different content is a caller bug.
-        let exact = exact_app_on(&transaction, &existing, request, created_at).await?;
+        let exact = existing.owner == owner
+            && exact_app_on(&transaction, &existing, request, created_at).await?;
         transaction.rollback().await.map_err(store_err)?;
         return if exact {
             Ok(existing)
@@ -44,6 +52,7 @@ pub(in crate::db) async fn create_app(store: &DbStore, request: &CreateApp) -> R
     }
     entities::app::ActiveModel {
         id: Set(request.id.0),
+        owner: Set(owner.as_str().to_owned()),
         name: Set(request.revision.manifest.name.clone()),
         current_revision_id: Set(request.revision.id.0),
         revision_count: Set(1),
@@ -70,20 +79,23 @@ pub(in crate::db) async fn create_app(store: &DbStore, request: &CreateApp) -> R
 
 pub(in crate::db) async fn append_app_revision(
     store: &DbStore,
+    owner: Option<&OwnerId>,
+    chat_id: Option<ChatId>,
     app_id: AppId,
     revision: &NewAppRevision,
 ) -> Result<AppRecord> {
     let manifest_json = validate_revision(revision)?;
     let created_at = canonical_db_timestamp(revision.created_at)?;
     let transaction = store.conn.begin().await.map_err(store_err)?;
+    let owner = resolve_owner_on(&transaction, owner, chat_id).await?;
     // Take the app row's write lock so two concurrent revisions cannot both
     // read the same ordinal and race to publish a current revision. There is
     // no owning chat to lock: the app row itself is the serialization point.
-    if !acquire_app_write_lock(&transaction, app_id).await? {
+    if !acquire_app_write_lock(&transaction, &owner, app_id).await? {
         transaction.rollback().await.map_err(store_err)?;
         return Err(AgentError::Store(format!("app {app_id} not found")));
     }
-    let existing = require_app_on(&transaction, app_id).await?;
+    let existing = require_app_scoped_on(&transaction, &owner, app_id).await?;
     if existing.deleted_at.is_some() {
         transaction.rollback().await.map_err(store_err)?;
         return Err(AgentError::Store(format!("app {app_id} is deleted")));
@@ -136,12 +148,30 @@ pub(in crate::db) async fn append_app_revision(
     Ok(record)
 }
 
-pub(in crate::db) async fn get_app(store: &DbStore, id: AppId) -> Result<Option<AppRecord>> {
-    find_app_on(&store.conn, id).await
+pub(in crate::db) async fn get_app(
+    store: &DbStore,
+    owner: Option<&OwnerId>,
+    id: AppId,
+) -> Result<Option<AppRecord>> {
+    find_app_scoped_on(&store.conn, effective_owner(owner), id).await
 }
 
-pub(in crate::db) async fn list_apps(store: &DbStore, limit: u64) -> Result<Vec<AppRecord>> {
+pub(in crate::db) async fn get_app_for_chat(
+    store: &DbStore,
+    chat_id: ChatId,
+    id: AppId,
+) -> Result<Option<AppRecord>> {
+    let owner = resolve_owner_on(&store.conn, None, Some(chat_id)).await?;
+    find_app_scoped_on(&store.conn, &owner, id).await
+}
+
+pub(in crate::db) async fn list_apps(
+    store: &DbStore,
+    owner: Option<&OwnerId>,
+    limit: u64,
+) -> Result<Vec<AppRecord>> {
     entities::app::Entity::find()
+        .filter(entities::app::Column::Owner.eq(effective_owner(owner).as_str()))
         .filter(entities::app::Column::DeletedAt.is_null())
         .order_by_desc(entities::app::Column::UpdatedAt)
         .order_by_desc(entities::app::Column::Id)
@@ -156,8 +186,15 @@ pub(in crate::db) async fn list_apps(store: &DbStore, limit: u64) -> Result<Vec<
 
 pub(in crate::db) async fn list_app_revisions(
     store: &DbStore,
+    owner: Option<&OwnerId>,
     app_id: AppId,
 ) -> Result<Vec<AppRevision>> {
+    if find_app_scoped_on(&store.conn, effective_owner(owner), app_id)
+        .await?
+        .is_none()
+    {
+        return Ok(Vec::new());
+    }
     entities::app_revision::Entity::find()
         .filter(entities::app_revision::Column::AppId.eq(app_id.0))
         .order_by_desc(entities::app_revision::Column::Ordinal)
@@ -171,19 +208,43 @@ pub(in crate::db) async fn list_app_revisions(
 
 pub(in crate::db) async fn get_app_revision(
     store: &DbStore,
+    owner: Option<&OwnerId>,
     id: AppRevisionId,
 ) -> Result<Option<AppRevision>> {
-    find_revision_on(&store.conn, id).await
+    let Some(revision) = find_revision_on(&store.conn, id).await? else {
+        return Ok(None);
+    };
+    Ok(
+        find_app_scoped_on(&store.conn, effective_owner(owner), revision.app_id)
+            .await?
+            .map(|_| revision),
+    )
+}
+
+pub(in crate::db) async fn get_app_revision_for_chat(
+    store: &DbStore,
+    chat_id: ChatId,
+    id: AppRevisionId,
+) -> Result<Option<AppRevision>> {
+    let owner = resolve_owner_on(&store.conn, None, Some(chat_id)).await?;
+    let Some(revision) = find_revision_on(&store.conn, id).await? else {
+        return Ok(None);
+    };
+    Ok(find_app_scoped_on(&store.conn, &owner, revision.app_id)
+        .await?
+        .map(|_| revision))
 }
 
 pub(in crate::db) async fn delete_app(
     store: &DbStore,
+    owner: Option<&OwnerId>,
     id: AppId,
     deleted_at: chrono::DateTime<chrono::Utc>,
 ) -> Result<bool> {
     let deleted_at = canonical_db_timestamp(deleted_at)?;
     let transaction = store.conn.begin().await.map_err(store_err)?;
-    let Some(existing) = find_app_on(&transaction, id).await? else {
+    let owner = effective_owner(owner);
+    let Some(existing) = find_app_scoped_on(&transaction, owner, id).await? else {
         transaction.rollback().await.map_err(store_err)?;
         return Ok(false);
     };
@@ -206,12 +267,14 @@ pub(in crate::db) async fn delete_app(
 
 pub(in crate::db) async fn restore_app(
     store: &DbStore,
+    owner: Option<&OwnerId>,
     id: AppId,
     restored_at: chrono::DateTime<chrono::Utc>,
 ) -> Result<bool> {
     let restored_at = canonical_db_timestamp(restored_at)?;
     let transaction = store.conn.begin().await.map_err(store_err)?;
-    let Some(existing) = find_app_on(&transaction, id).await? else {
+    let owner = effective_owner(owner);
+    let Some(existing) = find_app_scoped_on(&transaction, owner, id).await? else {
         transaction.rollback().await.map_err(store_err)?;
         return Ok(false);
     };
@@ -236,18 +299,23 @@ pub(in crate::db) async fn restore_app(
     Ok(true)
 }
 
-pub(in crate::db) async fn put_app_grant(store: &DbStore, grant: &AppGrant) -> Result<()> {
+pub(in crate::db) async fn put_app_grant(
+    store: &DbStore,
+    owner: Option<&OwnerId>,
+    grant: &AppGrant,
+) -> Result<()> {
     let bindings_json = validate_app_grant(grant)
         .map_err(|message| AgentError::Store(format!("invalid app grant: {message}")))?;
     let created_at = canonical_db_timestamp(grant.created_at)?;
     let transaction = store.conn.begin().await.map_err(store_err)?;
+    let owner = effective_owner(owner);
     // The app row's write lock serializes replacement of the single grant row
     // the same way it serializes revision appends.
-    if !acquire_app_write_lock(&transaction, grant.app_id).await? {
+    if !acquire_app_write_lock(&transaction, owner, grant.app_id).await? {
         transaction.rollback().await.map_err(store_err)?;
         return Err(AgentError::Store(format!("app {} not found", grant.app_id)));
     }
-    let existing = require_app_on(&transaction, grant.app_id).await?;
+    let existing = require_app_scoped_on(&transaction, owner, grant.app_id).await?;
     if existing.deleted_at.is_some() {
         transaction.rollback().await.map_err(store_err)?;
         return Err(AgentError::Store(format!(
@@ -275,9 +343,16 @@ pub(in crate::db) async fn put_app_grant(store: &DbStore, grant: &AppGrant) -> R
 
 pub(in crate::db) async fn get_app_grant(
     store: &DbStore,
+    owner: Option<&OwnerId>,
     app_id: AppId,
 ) -> Result<Option<AppGrant>> {
-    entities::app_grant::Entity::find_by_id(app_id.0)
+    entities::app_grant::Entity::find()
+        .filter(entities::app_grant::Column::AppId.eq(app_id.0))
+        .join(
+            sea_orm::JoinType::InnerJoin,
+            entities::app_grant::Relation::App.def(),
+        )
+        .filter(entities::app::Column::Owner.eq(effective_owner(owner).as_str()))
         .one(&store.conn)
         .await
         .map_err(store_err)?
@@ -285,21 +360,36 @@ pub(in crate::db) async fn get_app_grant(
         .transpose()
 }
 
-pub(in crate::db) async fn delete_app_grant(store: &DbStore, app_id: AppId) -> Result<bool> {
+pub(in crate::db) async fn delete_app_grant(
+    store: &DbStore,
+    owner: Option<&OwnerId>,
+    app_id: AppId,
+) -> Result<bool> {
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    let owner = effective_owner(owner);
+    if !acquire_app_write_lock(&transaction, owner, app_id).await? {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(false);
+    }
     let deleted = entities::app_grant::Entity::delete_many()
         .filter(entities::app_grant::Column::AppId.eq(app_id.0))
-        .exec(&store.conn)
+        .exec(&transaction)
         .await
         .map_err(store_err)?;
+    transaction.commit().await.map_err(store_err)?;
     Ok(deleted.rows_affected > 0)
 }
 
-pub(in crate::db) async fn list_live_app_grants(store: &DbStore) -> Result<Vec<AppGrant>> {
+pub(in crate::db) async fn list_live_app_grants(
+    store: &DbStore,
+    owner: Option<&OwnerId>,
+) -> Result<Vec<AppGrant>> {
     entities::app_grant::Entity::find()
         .join(
             sea_orm::JoinType::InnerJoin,
             entities::app_grant::Relation::App.def(),
         )
+        .filter(entities::app::Column::Owner.eq(effective_owner(owner).as_str()))
         .filter(entities::app::Column::DeletedAt.is_null())
         .all(&store.conn)
         .await
@@ -311,20 +401,22 @@ pub(in crate::db) async fn list_live_app_grants(store: &DbStore) -> Result<Vec<A
 
 pub(in crate::db) async fn put_app_gateway_draft(
     store: &DbStore,
+    owner: Option<&OwnerId>,
     draft: &AppGatewayDraft,
 ) -> Result<()> {
     validate_app_gateway_draft(draft)
         .map_err(|message| AgentError::Store(format!("invalid gateway registration: {message}")))?;
     let updated_at = canonical_db_timestamp(draft.updated_at)?;
     let transaction = store.conn.begin().await.map_err(store_err)?;
+    let owner = effective_owner(owner);
     // The app row's write lock serializes replacement of the registration the
     // same way it serializes revision appends: two invokes racing a first
     // registration must not both insert.
-    if !acquire_app_write_lock(&transaction, draft.app_id).await? {
+    if !acquire_app_write_lock(&transaction, owner, draft.app_id).await? {
         transaction.rollback().await.map_err(store_err)?;
         return Err(AgentError::Store(format!("app {} not found", draft.app_id)));
     }
-    let existing = require_app_on(&transaction, draft.app_id).await?;
+    let existing = require_app_scoped_on(&transaction, owner, draft.app_id).await?;
     if existing.deleted_at.is_some() {
         transaction.rollback().await.map_err(store_err)?;
         return Err(AgentError::Store(format!(
@@ -357,9 +449,16 @@ pub(in crate::db) async fn put_app_gateway_draft(
 
 pub(in crate::db) async fn get_app_gateway_draft(
     store: &DbStore,
+    owner: Option<&OwnerId>,
     app_id: AppId,
     gateway_base_url: &str,
 ) -> Result<Option<AppGatewayDraft>> {
+    if find_app_scoped_on(&store.conn, effective_owner(owner), app_id)
+        .await?
+        .is_none()
+    {
+        return Ok(None);
+    }
     Ok(
         entities::app_gateway_draft::Entity::find_by_id((app_id.0, gateway_base_url.to_owned()))
             .one(&store.conn)
@@ -391,7 +490,7 @@ fn grant_from_model(model: entities::app_grant::Model) -> Result<AppGrant> {
 /// Same shape as the chat/project locks: a self-assigning update serializes
 /// read-then-write decisions (ordinal allocation, current-revision publication)
 /// across server processes.
-async fn acquire_app_write_lock<C>(conn: &C, app_id: AppId) -> Result<bool>
+async fn acquire_app_write_lock<C>(conn: &C, owner: &OwnerId, app_id: AppId) -> Result<bool>
 where
     C: ConnectionTrait,
 {
@@ -401,6 +500,7 @@ where
             sea_orm::sea_query::Expr::col(entities::app::Column::Name),
         )
         .filter(entities::app::Column::Id.eq(app_id.0))
+        .filter(entities::app::Column::Owner.eq(owner.as_str()))
         .exec(conn)
         .await
         .map_err(store_err)?;
@@ -516,6 +616,19 @@ where
         .transpose()
 }
 
+async fn find_app_scoped_on<C>(conn: &C, owner: &OwnerId, id: AppId) -> Result<Option<AppRecord>>
+where
+    C: ConnectionTrait,
+{
+    entities::app::Entity::find_by_id(id.0)
+        .filter(entities::app::Column::Owner.eq(owner.as_str()))
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .map(app_from_model)
+        .transpose()
+}
+
 async fn require_app_on<C>(conn: &C, id: AppId) -> Result<AppRecord>
 where
     C: ConnectionTrait,
@@ -523,6 +636,45 @@ where
     find_app_on(conn, id)
         .await?
         .ok_or_else(|| AgentError::Store(format!("app {id} not found")))
+}
+
+async fn require_app_scoped_on<C>(conn: &C, owner: &OwnerId, id: AppId) -> Result<AppRecord>
+where
+    C: ConnectionTrait,
+{
+    find_app_scoped_on(conn, owner, id)
+        .await?
+        .ok_or_else(|| AgentError::Store(format!("app {id} not found")))
+}
+
+fn effective_owner(owner: Option<&OwnerId>) -> &OwnerId {
+    static LOCAL: std::sync::LazyLock<OwnerId> = std::sync::LazyLock::new(OwnerId::local);
+    owner.unwrap_or(&LOCAL)
+}
+
+async fn resolve_owner_on<C>(
+    conn: &C,
+    owner: Option<&OwnerId>,
+    chat_id: Option<ChatId>,
+) -> Result<OwnerId>
+where
+    C: ConnectionTrait,
+{
+    match (owner, chat_id) {
+        (Some(owner), None) => Ok(owner.clone()),
+        (None, Some(chat_id)) => {
+            let chat = entities::chat::Entity::find_by_id(chat_id.0)
+                .one(conn)
+                .await
+                .map_err(store_err)?
+                .ok_or_else(|| AgentError::Store(format!("chat {chat_id} not found")))?;
+            OwnerId::new(&chat.owner)
+        }
+        (None, None) => Ok(OwnerId::local()),
+        (Some(_), Some(_)) => Err(AgentError::Store(
+            "app ownership must come from either a principal or a chat, not both".into(),
+        )),
+    }
 }
 
 async fn find_revision_on<C>(conn: &C, id: AppRevisionId) -> Result<Option<AppRevision>>
@@ -540,6 +692,7 @@ where
 fn app_from_model(model: entities::app::Model) -> Result<AppRecord> {
     Ok(AppRecord {
         id: AppId(model.id),
+        owner: OwnerId::new(&model.owner)?,
         name: model.name,
         current_revision: AppRevisionId(model.current_revision_id),
         revision_count: u32::try_from(model.revision_count)

--- a/crates/tidebreak-core/src/db/tests/app.rs
+++ b/crates/tidebreak-core/src/db/tests/app.rs
@@ -1,9 +1,10 @@
 use super::*;
 use crate::id::{AgentRunId, AppId, AppRevisionId, ConnectedAppId};
 use crate::local_app::{
-    AppBinding, AppManifest, AppOperationsBinding, CreateApp, NewAppRevision, MAX_APP_BUNDLE_BYTES,
-    MAX_APP_REVISIONS,
+    AppBinding, AppGatewayDraft, AppGrant, AppManifest, AppOperationsBinding, CreateApp,
+    NewAppRevision, MAX_APP_BUNDLE_BYTES, MAX_APP_REVISIONS,
 };
+use crate::OwnerId;
 
 fn at(second: i64) -> DateTime<Utc> {
     DateTime::<Utc>::from_timestamp(1_710_000_000 + second, 0).unwrap()
@@ -247,4 +248,124 @@ async fn deleting_an_app_hides_it_and_refuses_revisions_until_restored() {
         !store.restore_app(AppId::new(), at(60)).await.unwrap(),
         "an unknown app reports no restore"
     );
+}
+
+/// The app row is the authority root: every child path resolves through its
+/// immutable owner, and another principal sees the same absence as for an
+/// unknown id even when it guesses the exact app or revision id.
+#[tokio::test]
+async fn two_principals_cannot_cross_app_ownership() {
+    let (_dir, store) = temp_store().await;
+    let alice = OwnerId::new("user:alice").unwrap();
+    let bob = OwnerId::new("user:bob").unwrap();
+    let request = create_request(1);
+    let created = store.create_app_scoped(&alice, &request).await.unwrap();
+    assert_eq!(created.owner, alice);
+
+    assert_eq!(store.get_app_scoped(&bob, created.id).await.unwrap(), None);
+    assert!(store.list_apps_scoped(&bob, 10).await.unwrap().is_empty());
+    assert_eq!(
+        store
+            .get_app_revision_scoped(&bob, created.current_revision)
+            .await
+            .unwrap(),
+        None
+    );
+    assert!(store
+        .list_app_revisions_scoped(&bob, created.id)
+        .await
+        .unwrap()
+        .is_empty());
+    assert!(store
+        .append_app_revision_scoped(&bob, created.id, &revision(2, 30))
+        .await
+        .is_err());
+    assert!(!store
+        .delete_app_scoped(&bob, created.id, at(60))
+        .await
+        .unwrap());
+
+    let grant = AppGrant {
+        app_id: created.id,
+        bindings: Vec::new(),
+        created_at: at(30),
+    };
+    assert!(store.put_app_grant_scoped(&bob, &grant).await.is_err());
+    store.put_app_grant_scoped(&alice, &grant).await.unwrap();
+    assert_eq!(
+        store.get_app_grant_scoped(&bob, created.id).await.unwrap(),
+        None
+    );
+    assert!(!store
+        .delete_app_grant_scoped(&bob, created.id)
+        .await
+        .unwrap());
+    assert!(store
+        .get_app_grant_scoped(&alice, created.id)
+        .await
+        .unwrap()
+        .is_some());
+
+    let draft = AppGatewayDraft {
+        app_id: created.id,
+        gateway_base_url: "https://gateway.example/".into(),
+        shared_app_id: "shared-1".into(),
+        gateway_revision_id: "revision-1".into(),
+        synced_revision_id: created.current_revision,
+        updated_at: at(45),
+    };
+    assert!(store
+        .put_app_gateway_draft_scoped(&bob, &draft)
+        .await
+        .is_err());
+    store
+        .put_app_gateway_draft_scoped(&alice, &draft)
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .get_app_gateway_draft_scoped(&bob, created.id, &draft.gateway_base_url)
+            .await
+            .unwrap(),
+        None
+    );
+
+    assert!(store.create_app_scoped(&bob, &request).await.is_err());
+    assert_eq!(
+        store
+            .get_app_scoped(&alice, created.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .owner,
+        alice,
+        "an id retry cannot transfer ownership"
+    );
+}
+
+/// Tool-facing writes derive ownership from the durable authoring chat and
+/// cannot append a second principal's app.
+#[tokio::test]
+async fn chat_derived_app_ownership_is_stamped_and_enforced_transactionally() {
+    let (_dir, store) = temp_store().await;
+    let alice = OwnerId::new("user:alice").unwrap();
+    let bob = OwnerId::new("user:bob").unwrap();
+    let alice_chat = sample_chat();
+    let bob_chat = sample_chat();
+    store.create_chat_scoped(&alice, &alice_chat).await.unwrap();
+    store.create_chat_scoped(&bob, &bob_chat).await.unwrap();
+
+    let created = store
+        .create_app_for_chat(alice_chat.id, &create_request(1))
+        .await
+        .unwrap();
+    assert_eq!(created.owner, alice);
+    assert!(store
+        .append_app_revision_for_chat(bob_chat.id, created.id, &revision(2, 30))
+        .await
+        .is_err());
+    assert!(store
+        .append_app_revision_for_chat(alice_chat.id, created.id, &revision(2, 60))
+        .await
+        .is_ok());
 }

--- a/crates/tidebreak-core/src/local_app.rs
+++ b/crates/tidebreak-core/src/local_app.rs
@@ -109,11 +109,13 @@ pub async fn publish_app_bundle(
     .map_err(|error| AgentError::Store(format!("could not publish app bundle: {error}")))
 }
 
-/// One profile-owned app and its current revision.
+/// One principal-owned app and its current revision.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AppRecord {
     /// Durable opaque identity, stable across every revision.
     pub id: AppId,
+    /// Principal that owns the app. Stamped once at creation and immutable.
+    pub owner: crate::OwnerId,
     /// Display name, following the current revision's manifest. Not identity.
     pub name: String,
     /// Revision currently presented as the app's content.

--- a/crates/tidebreak-core/src/storage/store.rs
+++ b/crates/tidebreak-core/src/storage/store.rs
@@ -763,7 +763,7 @@ pub trait Store: Send + Sync {
         output_storage_unavailable()
     }
 
-    /// Create a profile-scoped local app together with its first revision.
+    /// Create a local app together with its first revision.
     ///
     /// The caller has already published the bundle bytes under the profile
     /// data directory at [`crate::local_app::app_revision_relative_path`] and
@@ -772,6 +772,20 @@ pub trait Store: Send + Sync {
     /// identical content returns the original record so an ambiguous store
     /// response can be retried; reusing it with different content is rejected.
     async fn create_app(&self, _request: &CreateApp) -> Result<AppRecord> {
+        app_storage_unavailable()
+    }
+
+    /// Create an app owned by the same principal as `chat_id`.
+    async fn create_app_for_chat(
+        &self,
+        _chat_id: ChatId,
+        _request: &CreateApp,
+    ) -> Result<AppRecord> {
+        app_storage_unavailable()
+    }
+
+    /// Create an app owned by `owner`.
+    async fn create_app_scoped(&self, _owner: &OwnerId, _request: &CreateApp) -> Result<AppRecord> {
         app_storage_unavailable()
     }
 
@@ -789,13 +803,48 @@ pub trait Store: Send + Sync {
         app_storage_unavailable()
     }
 
+    /// Append only when the app belongs to the same principal as `chat_id`.
+    async fn append_app_revision_for_chat(
+        &self,
+        _chat_id: ChatId,
+        _app_id: AppId,
+        _revision: &NewAppRevision,
+    ) -> Result<AppRecord> {
+        app_storage_unavailable()
+    }
+
+    /// Append a revision only to `owner`'s app.
+    async fn append_app_revision_scoped(
+        &self,
+        _owner: &OwnerId,
+        _app_id: AppId,
+        _revision: &NewAppRevision,
+    ) -> Result<AppRecord> {
+        app_storage_unavailable()
+    }
+
     /// Fetch one app by opaque id, including a soft-deleted one.
     async fn get_app(&self, _id: AppId) -> Result<Option<AppRecord>> {
         app_storage_unavailable()
     }
 
-    /// List the profile's live apps, most recently updated first.
+    /// Fetch one app only when it belongs to `owner`.
+    async fn get_app_scoped(&self, _owner: &OwnerId, _id: AppId) -> Result<Option<AppRecord>> {
+        app_storage_unavailable()
+    }
+
+    /// Fetch one app only when it belongs to the same principal as `chat_id`.
+    async fn get_app_for_chat(&self, _chat_id: ChatId, _id: AppId) -> Result<Option<AppRecord>> {
+        app_storage_unavailable()
+    }
+
+    /// List the local profile's live apps, most recently updated first.
     async fn list_apps(&self, _limit: u64) -> Result<Vec<AppRecord>> {
+        app_storage_unavailable()
+    }
+
+    /// List `owner`'s live apps, most recently updated first.
+    async fn list_apps_scoped(&self, _owner: &OwnerId, _limit: u64) -> Result<Vec<AppRecord>> {
         app_storage_unavailable()
     }
 
@@ -804,8 +853,35 @@ pub trait Store: Send + Sync {
         app_storage_unavailable()
     }
 
+    /// List revisions only when the parent app belongs to `owner`.
+    async fn list_app_revisions_scoped(
+        &self,
+        _owner: &OwnerId,
+        _app_id: AppId,
+    ) -> Result<Vec<AppRevision>> {
+        app_storage_unavailable()
+    }
+
     /// Fetch one app revision by opaque id.
     async fn get_app_revision(&self, _id: AppRevisionId) -> Result<Option<AppRevision>> {
+        app_storage_unavailable()
+    }
+
+    /// Fetch a revision only through an app `owner` owns.
+    async fn get_app_revision_scoped(
+        &self,
+        _owner: &OwnerId,
+        _id: AppRevisionId,
+    ) -> Result<Option<AppRevision>> {
+        app_storage_unavailable()
+    }
+
+    /// Fetch a revision only through an app owned by `chat_id`'s principal.
+    async fn get_app_revision_for_chat(
+        &self,
+        _chat_id: ChatId,
+        _id: AppRevisionId,
+    ) -> Result<Option<AppRevision>> {
         app_storage_unavailable()
     }
 
@@ -814,6 +890,16 @@ pub trait Store: Send + Sync {
     /// an already-deleted app is the same durable outcome, not a conflict.
     async fn delete_app(
         &self,
+        _id: AppId,
+        _deleted_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<bool> {
+        app_storage_unavailable()
+    }
+
+    /// Soft-delete only `owner`'s app.
+    async fn delete_app_scoped(
+        &self,
+        _owner: &OwnerId,
         _id: AppId,
         _deleted_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<bool> {
@@ -832,6 +918,16 @@ pub trait Store: Send + Sync {
         app_storage_unavailable()
     }
 
+    /// Restore only `owner`'s app.
+    async fn restore_app_scoped(
+        &self,
+        _owner: &OwnerId,
+        _id: AppId,
+        _restored_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<bool> {
+        app_storage_unavailable()
+    }
+
     /// Record explicit user consent for one app, replacing any previous grant.
     ///
     /// The grant is host-computed from the app's current manifest and the
@@ -842,14 +938,33 @@ pub trait Store: Send + Sync {
         app_storage_unavailable()
     }
 
+    /// Record consent only for an app `owner` owns.
+    async fn put_app_grant_scoped(&self, _owner: &OwnerId, _grant: &AppGrant) -> Result<()> {
+        app_storage_unavailable()
+    }
+
     /// Fetch one app's grant, when the user has consented and not revoked.
     async fn get_app_grant(&self, _app_id: AppId) -> Result<Option<AppGrant>> {
+        app_storage_unavailable()
+    }
+
+    /// Fetch a grant only through an app `owner` owns.
+    async fn get_app_grant_scoped(
+        &self,
+        _owner: &OwnerId,
+        _app_id: AppId,
+    ) -> Result<Option<AppGrant>> {
         app_storage_unavailable()
     }
 
     /// Revoke one app's grant. Returns `false` when no grant existed;
     /// revoking twice is the same durable outcome, not a conflict.
     async fn delete_app_grant(&self, _app_id: AppId) -> Result<bool> {
+        app_storage_unavailable()
+    }
+
+    /// Revoke only a grant belonging to `owner`.
+    async fn delete_app_grant_scoped(&self, _owner: &OwnerId, _app_id: AppId) -> Result<bool> {
         app_storage_unavailable()
     }
 
@@ -865,6 +980,11 @@ pub trait Store: Send + Sync {
         app_storage_unavailable()
     }
 
+    /// Every live app grant held by `owner`.
+    async fn list_live_app_grants_scoped(&self, _owner: &OwnerId) -> Result<Vec<AppGrant>> {
+        app_storage_unavailable()
+    }
+
     /// Record the gateway-side registration one app holds at one deployment,
     /// replacing any registration it already held there.
     ///
@@ -877,11 +997,30 @@ pub trait Store: Send + Sync {
         app_storage_unavailable()
     }
 
+    /// Record gateway state only for an app `owner` owns.
+    async fn put_app_gateway_draft_scoped(
+        &self,
+        _owner: &OwnerId,
+        _draft: &AppGatewayDraft,
+    ) -> Result<()> {
+        app_storage_unavailable()
+    }
+
     /// Fetch one app's gateway registration at `gateway_base_url`, when it
     /// holds one there. A registration made against a different deployment is
     /// simply absent, never a near match.
     async fn get_app_gateway_draft(
         &self,
+        _app_id: AppId,
+        _gateway_base_url: &str,
+    ) -> Result<Option<AppGatewayDraft>> {
+        app_storage_unavailable()
+    }
+
+    /// Fetch gateway state only through an app `owner` owns.
+    async fn get_app_gateway_draft_scoped(
+        &self,
+        _owner: &OwnerId,
         _app_id: AppId,
         _gateway_base_url: &str,
     ) -> Result<Option<AppGatewayDraft>> {

--- a/crates/tidebreak-core/src/tools/create_app.rs
+++ b/crates/tidebreak-core/src/tools/create_app.rs
@@ -386,7 +386,7 @@ impl Tool for CreateAppTool {
         // Appending must address an app that exists before any bytes are
         // published under its id; the store re-checks inside the transaction.
         if args.app_id.is_some() {
-            match self.store.get_app(app_id).await {
+            match self.store.get_app_for_chat(ctx.chat_id, app_id).await {
                 Ok(Some(app)) if app.deleted_at.is_none() => {}
                 Ok(Some(_)) => {
                     return Ok(ToolOutput::error(
@@ -407,7 +407,11 @@ impl Tool for CreateAppTool {
         // Recognize an exact retry before writing anything: the same call
         // republishing the same content reports the record it already made,
         // while a call id reused for different content is refused.
-        match self.store.get_app_revision(revision_id).await {
+        match self
+            .store
+            .get_app_revision_for_chat(ctx.chat_id, revision_id)
+            .await
+        {
             Ok(Some(recorded)) => {
                 let exact = recorded.app_id == app_id
                     && recorded.byte_len == byte_len
@@ -418,12 +422,14 @@ impl Tool for CreateAppTool {
                         "this call already published a different app revision",
                     ));
                 }
-                return Ok(match self.store.get_app(app_id).await {
-                    Ok(Some(record)) => {
-                        Self::success(&record, recorded.ordinal, recorded.ordinal == 1)
-                    }
-                    _ => ToolOutput::error("could not read back the app record"),
-                });
+                return Ok(
+                    match self.store.get_app_for_chat(ctx.chat_id, app_id).await {
+                        Ok(Some(record)) => {
+                            Self::success(&record, recorded.ordinal, recorded.ordinal == 1)
+                        }
+                        _ => ToolOutput::error("could not read back the app record"),
+                    },
+                );
             }
             Ok(None) => {}
             Err(_) => return Ok(ToolOutput::error("could not check for an earlier attempt")),
@@ -460,13 +466,18 @@ impl Tool for CreateAppTool {
             created_at: Utc::now(),
         };
         let recorded = if args.app_id.is_some() {
-            self.store.append_app_revision(app_id, &revision).await
+            self.store
+                .append_app_revision_for_chat(ctx.chat_id, app_id, &revision)
+                .await
         } else {
             self.store
-                .create_app(&CreateApp {
-                    id: app_id,
-                    revision,
-                })
+                .create_app_for_chat(
+                    ctx.chat_id,
+                    &CreateApp {
+                        id: app_id,
+                        revision,
+                    },
+                )
                 .await
         };
         Ok(match recorded {

--- a/crates/tidebreak-desktop/native-only-commands.txt
+++ b/crates/tidebreak-desktop/native-only-commands.txt
@@ -42,11 +42,10 @@ grant_folder_capability: widens a folder's capability only after the native perm
 # Host-side execution of client-executed tool calls
 resolve_folder_access_request: carries the user's in-turn folder decision into the native picker and the host broker that owns the grant.
 resolve_output_writeback_request: executes the approved write into a connected host folder, which only the desktop-side broker can reach.
-resolve_computer_use_consent: carries the user's per-app control/capture consent into the host broker's grant store, which only the desktop-side broker client can reach.
-resolve_computer_use_confirmation: confirms one broker-held consequential control action; the confirmation identity is broker-side and single-use, reachable only from the desktop.
+put_native_mcp_servers: shows the OS-native local-command warning and uses the host-only executor credential to save an approved configuration.
 
 # Computer-use control indicator and Stop
-computer_use_state: reads the native control/consent state (active app, halt latch, parked prompts) that lives only in this process.
+computer_use_state: reads the native control state (active app and halt latch) that lives only in this process.
 stop_computer_use_control: sets the native halt latch that short-circuits control ops before their next broker round-trip.
 resume_computer_use_control: clears that latch on an explicit user gesture.
 

--- a/crates/tidebreak-desktop/src/client_execution/computer_use.rs
+++ b/crates/tidebreak-desktop/src/client_execution/computer_use.rs
@@ -190,6 +190,11 @@ pub(crate) struct ComputerUseState {
     /// cleared only by the user (resume, or a fresh consent approval — both
     /// are explicit opt-ins).
     halt: tokio::sync::watch::Sender<bool>,
+    /// Linearizes Stop with redemption of a broker-held consequential action.
+    /// The gate stays held until the broker accepts or rejects the one-shot
+    /// confirmation so Stop either lands before dispatch (and prevents it) or
+    /// after that dispatch has already become authoritative.
+    consequential_dispatch: tokio::sync::Mutex<()>,
 }
 
 impl Default for ComputerUseState {
@@ -199,6 +204,7 @@ impl Default for ComputerUseState {
             app_names: StdMutex::new(HashMap::new()),
             indicator: StdMutex::new(IndicatorState::default()),
             halt: tokio::sync::watch::channel(false).0,
+            consequential_dispatch: tokio::sync::Mutex::new(()),
         }
     }
 }
@@ -267,10 +273,23 @@ impl ComputerUseState {
         }
     }
 
-    fn halt(&self) {
+    async fn halt(&self) {
+        let _dispatch = self.consequential_dispatch.lock().await;
         // send_replace, not send: the latch must hold even when no prompt is
         // currently parked on it (send drops the value with zero receivers).
         self.halt.send_replace(true);
+    }
+
+    async fn redeem_consequential<T, F, Fut>(&self, dispatch: F) -> Result<T, StoredResolution>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = T>,
+    {
+        let _dispatch = self.consequential_dispatch.lock().await;
+        if self.is_halted() {
+            return Err(stopped_resolution());
+        }
+        Ok(dispatch().await)
     }
 
     fn resume(&self) {
@@ -459,9 +478,13 @@ pub(crate) fn computer_use_state(state: State<'_, HostAccess>) -> ComputerUseSna
 /// wanted. In-memory only — a restart re-arms, and every agent whose op was
 /// short-circuited was already told not to retry.
 #[tauri::command]
-pub(crate) fn stop_computer_use_control(app: AppHandle, state: State<'_, HostAccess>) {
-    state.computer_use.halt();
+pub(crate) async fn stop_computer_use_control(
+    app: AppHandle,
+    state: State<'_, HostAccess>,
+) -> Result<(), String> {
+    state.computer_use.halt().await;
     emit_state(&app, &state.computer_use);
+    Ok(())
 }
 
 /// Re-arm control after a Stop. A renderer request may open the native prompt,
@@ -1281,7 +1304,14 @@ async fn dispatch_confirmation(
         confirmation_id: held.confirmation_id,
     });
     let deadline = tokio::time::Instant::now() + crate::broker::MUTATION_DISPATCH_WINDOW;
-    match state.broker.control_without_retry(confirm, deadline).await {
+    let result = match cu
+        .redeem_consequential(|| state.broker.control_without_retry(confirm, deadline))
+        .await
+    {
+        Ok(result) => result,
+        Err(resolution) => return resolution,
+    };
+    match result {
         Ok(ControlResult::CuConfirmControlAction(meta)) => completed(control_meta_json(&meta)),
         Ok(_) => unavailable(
             "operation_failed",
@@ -1672,11 +1702,11 @@ mod tests {
         assert_eq!(wire.element_fingerprint.as_deref(), Some("abc"));
     }
 
-    #[test]
-    fn the_halt_latch_short_circuits_before_any_broker_round_trip() {
+    #[tokio::test]
+    async fn the_halt_latch_short_circuits_before_any_broker_round_trip() {
         let cu = ComputerUseState::default();
         assert!(!cu.is_halted());
-        cu.halt();
+        cu.halt().await;
         assert!(cu.is_halted());
         // The gate the dispatcher runs immediately before dispatch: halted
         // control ops get the non-retryable stop error without a broker call.
@@ -1696,6 +1726,49 @@ mod tests {
 
         cu.resume();
         assert!(!cu.is_halted());
+    }
+
+    #[tokio::test]
+    async fn stop_after_native_approval_prevents_confirmation_redemption() {
+        let cu = std::sync::Arc::new(ComputerUseState::default());
+        let (approved, native_approval) = oneshot::channel::<()>();
+        let (continue_after_approval, continue_redemption) = oneshot::channel::<()>();
+        let (broker_request, mut broker_requests) = tokio::sync::mpsc::unbounded_channel();
+
+        let redemption_cu = std::sync::Arc::clone(&cu);
+        let redemption = tokio::spawn(async move {
+            native_approval.await.expect("native approval arrives");
+            continue_redemption
+                .await
+                .expect("the approved action may continue");
+            redemption_cu
+                .redeem_consequential(|| async move {
+                    broker_request
+                        .send(ControlRequest::CuConfirmControlAction(
+                            CuConfirmControlActionRequest {
+                                confirmation_id: Uuid::new_v4(),
+                            },
+                        ))
+                        .expect("the broker observer remains open");
+                })
+                .await
+        });
+
+        approved.send(()).expect("approve the native prompt");
+        cu.halt().await;
+        continue_after_approval
+            .send(())
+            .expect("release the approved action after Stop");
+
+        let resolution = redemption
+            .await
+            .expect("the redemption task completes")
+            .expect_err("Stop must prevent the confirmation request");
+        let StoredResolution::Failed { error_code, .. } = resolution else {
+            panic!("a stopped confirmation fails the call");
+        };
+        assert_eq!(error_code, "stopped_by_user");
+        assert!(broker_requests.try_recv().is_err());
     }
 
     #[test]

--- a/crates/tidebreak-desktop/src/client_execution/computer_use.rs
+++ b/crates/tidebreak-desktop/src/client_execution/computer_use.rs
@@ -190,11 +190,11 @@ pub(crate) struct ComputerUseState {
     /// cleared only by the user (resume, or a fresh consent approval — both
     /// are explicit opt-ins).
     halt: tokio::sync::watch::Sender<bool>,
-    /// Linearizes Stop with redemption of a broker-held consequential action.
-    /// The gate stays held until the broker accepts or rejects the one-shot
-    /// confirmation so Stop either lands before dispatch (and prevents it) or
-    /// after that dispatch has already become authoritative.
-    consequential_dispatch: tokio::sync::Mutex<()>,
+    /// Linearizes Stop with every broker dispatch that can act on the host.
+    /// The gate stays held through the broker round-trip so Stop either lands
+    /// before dispatch (and prevents it) or after that dispatch has already
+    /// completed. Read-only operations do not take this gate.
+    acting_dispatch: tokio::sync::Mutex<()>,
 }
 
 impl Default for ComputerUseState {
@@ -204,7 +204,7 @@ impl Default for ComputerUseState {
             app_names: StdMutex::new(HashMap::new()),
             indicator: StdMutex::new(IndicatorState::default()),
             halt: tokio::sync::watch::channel(false).0,
-            consequential_dispatch: tokio::sync::Mutex::new(()),
+            acting_dispatch: tokio::sync::Mutex::new(()),
         }
     }
 }
@@ -274,18 +274,18 @@ impl ComputerUseState {
     }
 
     async fn halt(&self) {
-        let _dispatch = self.consequential_dispatch.lock().await;
+        let _dispatch = self.acting_dispatch.lock().await;
         // send_replace, not send: the latch must hold even when no prompt is
         // currently parked on it (send drops the value with zero receivers).
         self.halt.send_replace(true);
     }
 
-    async fn redeem_consequential<T, F, Fut>(&self, dispatch: F) -> Result<T, StoredResolution>
+    async fn dispatch_acting<T, F, Fut>(&self, dispatch: F) -> Result<T, StoredResolution>
     where
         F: FnOnce() -> Fut,
         Fut: std::future::Future<Output = T>,
     {
-        let _dispatch = self.consequential_dispatch.lock().await;
+        let _dispatch = self.acting_dispatch.lock().await;
         if self.is_halted() {
             return Err(stopped_resolution());
         }
@@ -1019,9 +1019,9 @@ async fn dispatch_broker(
     let acting = acts_on_host(&call.name);
     let bundle_id = request_bundle_id(&request).map(str::to_owned);
 
-    // The halt latch is checked immediately before the round-trip so Stop
-    // always lands first; the broker's blocklist is mirrored here so a blocked
-    // app fails closed without surfacing a consent card for it.
+    // The broker's blocklist is mirrored here so a blocked app fails closed
+    // without surfacing a consent card for it. Acting dispatches take the Stop
+    // gate below; that gate owns the authoritative final halt check.
     if acting && cu.is_halted() {
         return stopped_resolution();
     }
@@ -1040,15 +1040,23 @@ async fn dispatch_broker(
         }
     }
 
-    let result = state
-        .broker
-        .operation(OperationEnvelope {
-            protocol_version: PROTOCOL_VERSION,
-            request_id: tidebreak_host_broker::RequestId::new(),
-            context: context.execution,
-            request: request.clone(),
-        })
-        .await;
+    let envelope = OperationEnvelope {
+        protocol_version: PROTOCOL_VERSION,
+        request_id: tidebreak_host_broker::RequestId::new(),
+        context: context.execution,
+        request: request.clone(),
+    };
+    let result = if acting {
+        match cu
+            .dispatch_acting(|| state.broker.operation(envelope))
+            .await
+        {
+            Ok(result) => result,
+            Err(resolution) => return resolution,
+        }
+    } else {
+        state.broker.operation(envelope).await
+    };
     match result {
         Ok(OperationResult::CuNeedsConfirmation(held)) => {
             if cu.is_halted() {
@@ -1199,19 +1207,27 @@ async fn dispatch_consent(
     // did not cover the op (a broker-side surprise, not another ask). A held
     // consequential action re-authorizes at confirm time, so the one-time
     // grant must outlive the whole continuation — revoke happens after it.
-    if cu.is_halted() {
-        revoke_once_grant(state, decision, capability, bundle_id.as_deref(), call).await;
-        return stopped_resolution();
-    }
-    let result = state
-        .broker
-        .operation(OperationEnvelope {
-            protocol_version: PROTOCOL_VERSION,
-            request_id: tidebreak_host_broker::RequestId::new(),
-            context: context.execution,
-            request,
-        })
-        .await;
+    let envelope = OperationEnvelope {
+        protocol_version: PROTOCOL_VERSION,
+        request_id: tidebreak_host_broker::RequestId::new(),
+        context: context.execution,
+        request,
+    };
+    let acting = acts_on_host(&call.name);
+    let result = if acting {
+        match cu
+            .dispatch_acting(|| state.broker.operation(envelope))
+            .await
+        {
+            Ok(result) => result,
+            Err(resolution) => {
+                revoke_once_grant(state, decision, capability, bundle_id.as_deref(), call).await;
+                return resolution;
+            }
+        }
+    } else {
+        state.broker.operation(envelope).await
+    };
     let resolution = match result {
         Ok(OperationResult::CuNeedsConfirmation(held)) => {
             if cu.is_halted() {
@@ -1305,7 +1321,7 @@ async fn dispatch_confirmation(
     });
     let deadline = tokio::time::Instant::now() + crate::broker::MUTATION_DISPATCH_WINDOW;
     let result = match cu
-        .redeem_consequential(|| state.broker.control_without_retry(confirm, deadline))
+        .dispatch_acting(|| state.broker.control_without_retry(confirm, deadline))
         .await
     {
         Ok(result) => result,
@@ -1729,6 +1745,92 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stop_prevents_an_ordinary_acting_request_from_starting_after_it_completes() {
+        let cu = std::sync::Arc::new(ComputerUseState::default());
+        let (ready_to_dispatch, dispatch_ready) = oneshot::channel::<()>();
+        let (continue_dispatch, dispatch_continues) = oneshot::channel::<()>();
+        let (broker_request, mut broker_requests) = tokio::sync::mpsc::unbounded_channel();
+
+        let dispatch_cu = std::sync::Arc::clone(&cu);
+        let dispatch = tokio::spawn(async move {
+            ready_to_dispatch
+                .send(())
+                .expect("the test observes the acting request before dispatch");
+            dispatch_continues
+                .await
+                .expect("the acting request may continue");
+            dispatch_cu
+                .dispatch_acting(|| async move {
+                    broker_request
+                        .send("ordinary_acting_request")
+                        .expect("the broker observer remains open");
+                })
+                .await
+        });
+
+        dispatch_ready
+            .await
+            .expect("the acting request reaches the pre-dispatch pause");
+        cu.halt().await;
+        continue_dispatch
+            .send(())
+            .expect("release the acting request after Stop completes");
+
+        let resolution = dispatch
+            .await
+            .expect("the acting dispatch task completes")
+            .expect_err("Stop must prevent the ordinary acting broker request");
+        let StoredResolution::Failed { error_code, .. } = resolution else {
+            panic!("a stopped acting request fails the call");
+        };
+        assert_eq!(error_code, "stopped_by_user");
+        assert!(broker_requests.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn stop_prevents_a_post_consent_reissue_from_starting_after_it_completes() {
+        let cu = std::sync::Arc::new(ComputerUseState::default());
+        let (consent_committed, consent_is_committed) = oneshot::channel::<()>();
+        let (continue_reissue, reissue_continues) = oneshot::channel::<()>();
+        let (broker_request, mut broker_requests) = tokio::sync::mpsc::unbounded_channel();
+
+        let reissue_cu = std::sync::Arc::clone(&cu);
+        let reissue = tokio::spawn(async move {
+            consent_committed
+                .send(())
+                .expect("the test observes consent before the reissue");
+            reissue_continues
+                .await
+                .expect("the authorized reissue may continue");
+            reissue_cu
+                .dispatch_acting(|| async move {
+                    broker_request
+                        .send("post_consent_reissue")
+                        .expect("the broker observer remains open");
+                })
+                .await
+        });
+
+        consent_is_committed
+            .await
+            .expect("consent reaches the pre-reissue pause");
+        cu.halt().await;
+        continue_reissue
+            .send(())
+            .expect("release the authorized reissue after Stop completes");
+
+        let resolution = reissue
+            .await
+            .expect("the post-consent reissue task completes")
+            .expect_err("Stop must prevent the post-consent broker request");
+        let StoredResolution::Failed { error_code, .. } = resolution else {
+            panic!("a stopped post-consent reissue fails the call");
+        };
+        assert_eq!(error_code, "stopped_by_user");
+        assert!(broker_requests.try_recv().is_err());
+    }
+
+    #[tokio::test]
     async fn stop_after_native_approval_prevents_confirmation_redemption() {
         let cu = std::sync::Arc::new(ComputerUseState::default());
         let (approved, native_approval) = oneshot::channel::<()>();
@@ -1742,7 +1844,7 @@ mod tests {
                 .await
                 .expect("the approved action may continue");
             redemption_cu
-                .redeem_consequential(|| async move {
+                .dispatch_acting(|| async move {
                     broker_request
                         .send(ControlRequest::CuConfirmControlAction(
                             CuConfirmControlActionRequest {

--- a/crates/tidebreak-desktop/src/client_execution/computer_use.rs
+++ b/crates/tidebreak-desktop/src/client_execution/computer_use.rs
@@ -25,6 +25,9 @@ use std::sync::{Mutex as StdMutex, MutexGuard as StdMutexGuard};
 
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, Manager, State};
+use tauri_plugin_dialog::{
+    DialogExt, MessageDialogButtons, MessageDialogKind, MessageDialogResult,
+};
 use tidebreak_core::{
     validate_computer_capture_screen_arguments, validate_computer_click_arguments,
     validate_computer_focus_window_arguments, validate_computer_key_press_arguments,
@@ -103,7 +106,8 @@ enum ConsentDecision {
     Decline,
 }
 
-/// One parked consent ask, as the renderer needs it.
+/// One native consent ask. This stays host-side: the renderer never receives
+/// the call id or an authority that can resolve the decision.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ConsentPromptView {
@@ -123,7 +127,7 @@ pub(crate) enum ConsentGrantScope {
     Project,
 }
 
-/// One parked consequential-action confirmation, as the renderer needs it.
+/// One native consequential-action confirmation.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ConfirmationPromptView {
@@ -153,20 +157,6 @@ pub(crate) struct ActiveControlView {
 pub(crate) struct ComputerUseSnapshot {
     pub(crate) active: Option<ActiveControlView>,
     pub(crate) halted: bool,
-    pub(crate) pending_consents: Vec<ConsentPromptView>,
-    pub(crate) pending_confirmations: Vec<ConfirmationPromptView>,
-}
-
-/// What a parked prompt is waiting on, with the channel that resolves it.
-enum PendingPrompt {
-    Consent {
-        view: ConsentPromptView,
-        decision: oneshot::Sender<ConsentDecision>,
-    },
-    Confirmation {
-        view: ConfirmationPromptView,
-        decision: oneshot::Sender<bool>,
-    },
 }
 
 /// Indicator bookkeeping, kept separate so the lock is never held across an
@@ -200,7 +190,6 @@ pub(crate) struct ComputerUseState {
     /// cleared only by the user (resume, or a fresh consent approval — both
     /// are explicit opt-ins).
     halt: tokio::sync::watch::Sender<bool>,
-    prompts: StdMutex<HashMap<CallId, PendingPrompt>>,
 }
 
 impl Default for ComputerUseState {
@@ -210,7 +199,6 @@ impl Default for ComputerUseState {
             app_names: StdMutex::new(HashMap::new()),
             indicator: StdMutex::new(IndicatorState::default()),
             halt: tokio::sync::watch::channel(false).0,
-            prompts: StdMutex::new(HashMap::new()),
         }
     }
 }
@@ -290,24 +278,9 @@ impl ComputerUseState {
     }
 
     fn snapshot(&self) -> ComputerUseSnapshot {
-        let prompts = lock(&self.prompts);
         ComputerUseSnapshot {
             active: lock(&self.indicator).active.clone(),
             halted: self.is_halted(),
-            pending_consents: prompts
-                .values()
-                .filter_map(|prompt| match prompt {
-                    PendingPrompt::Consent { view, .. } => Some(view.clone()),
-                    PendingPrompt::Confirmation { .. } => None,
-                })
-                .collect(),
-            pending_confirmations: prompts
-                .values()
-                .filter_map(|prompt| match prompt {
-                    PendingPrompt::Confirmation { view, .. } => Some(view.clone()),
-                    PendingPrompt::Consent { .. } => None,
-                })
-                .collect(),
         }
     }
 }
@@ -316,6 +289,160 @@ fn emit_state(app: &AppHandle, cu: &ComputerUseState) {
     if let Err(error) = app.emit(STATE_EVENT, cu.snapshot()) {
         eprintln!("tidebreak-desktop: could not emit computer-use state: {error}");
     }
+}
+
+async fn native_binary_choice(
+    app: &AppHandle,
+    title: &str,
+    message: &str,
+    allow_label: &str,
+) -> Result<bool, String> {
+    let (sender, receiver) = oneshot::channel();
+    let mut dialog = app
+        .dialog()
+        .message(message)
+        .title(title)
+        .kind(MessageDialogKind::Warning)
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            allow_label.to_owned(),
+            "Cancel".to_owned(),
+        ));
+    if let Some(window) = app.get_webview_window("main") {
+        dialog = dialog.parent(&window);
+    }
+    dialog.show(move |approved| {
+        let _ = sender.send(approved);
+    });
+    receiver
+        .await
+        .map_err(|_| "the native computer-use prompt closed unexpectedly".to_owned())
+}
+
+async fn native_three_way_choice(
+    app: &AppHandle,
+    title: &str,
+    message: &str,
+    first: &str,
+    second: &str,
+    cancel: &str,
+) -> Result<MessageDialogResult, String> {
+    let (sender, receiver) = oneshot::channel();
+    let mut dialog = app
+        .dialog()
+        .message(message)
+        .title(title)
+        .kind(MessageDialogKind::Warning)
+        .buttons(MessageDialogButtons::YesNoCancelCustom(
+            first.to_owned(),
+            second.to_owned(),
+            cancel.to_owned(),
+        ));
+    if let Some(window) = app.get_webview_window("main") {
+        dialog = dialog.parent(&window);
+    }
+    dialog.show_with_result(move |answer| {
+        let _ = sender.send(answer);
+    });
+    receiver
+        .await
+        .map_err(|_| "the native computer-use prompt closed unexpectedly".to_owned())
+}
+
+async fn native_consent_choice(
+    app: &AppHandle,
+    view: &ConsentPromptView,
+) -> Result<ConsentDecision, String> {
+    let app_label = if view.bundle_id.is_empty() {
+        "your entire screen".to_owned()
+    } else {
+        crate::native_security_label(view.app_name.as_deref().unwrap_or(&view.bundle_id))
+    };
+    let action = match view.capability {
+        ConsentCapability::CaptureScreen => "capture",
+        ConsentCapability::ReadAppContent => "read on-screen content from",
+        ConsentCapability::ControlApp => "control",
+    };
+    let first = native_three_way_choice(
+        app,
+        "Allow computer use?",
+        &format!(
+            "Allow Tidebreak to {action} {app_label}? This permission is enforced by the native host, outside the conversation renderer."
+        ),
+        "Allow once",
+        "Remember permission…",
+        "Don't allow",
+    )
+    .await?;
+    match first {
+        MessageDialogResult::Yes => Ok(ConsentDecision::Once),
+        MessageDialogResult::Custom(ref value) if value == "Allow once" => {
+            Ok(ConsentDecision::Once)
+        }
+        MessageDialogResult::No => {
+            if view.grant_scope == ConsentGrantScope::Chat {
+                return Ok(ConsentDecision::Chat);
+            }
+            let scope = native_three_way_choice(
+                app,
+                "Remember computer-use permission?",
+                "Choose how widely Tidebreak may remember this native permission.",
+                "This chat",
+                "This project",
+                "Cancel",
+            )
+            .await?;
+            remembered_scope(scope)
+        }
+        MessageDialogResult::Custom(ref value) if value == "Remember permission…" => {
+            if view.grant_scope == ConsentGrantScope::Chat {
+                return Ok(ConsentDecision::Chat);
+            }
+            let scope = native_three_way_choice(
+                app,
+                "Remember computer-use permission?",
+                "Choose how widely Tidebreak may remember this native permission.",
+                "This chat",
+                "This project",
+                "Cancel",
+            )
+            .await?;
+            remembered_scope(scope)
+        }
+        _ => Ok(ConsentDecision::Decline),
+    }
+}
+
+fn remembered_scope(answer: MessageDialogResult) -> Result<ConsentDecision, String> {
+    match answer {
+        MessageDialogResult::Yes => Ok(ConsentDecision::Chat),
+        MessageDialogResult::No => Ok(ConsentDecision::Always),
+        MessageDialogResult::Custom(value) if value == "This chat" => Ok(ConsentDecision::Chat),
+        MessageDialogResult::Custom(value) if value == "This project" => {
+            Ok(ConsentDecision::Always)
+        }
+        _ => Ok(ConsentDecision::Decline),
+    }
+}
+
+async fn native_confirmation_choice(
+    app: &AppHandle,
+    view: &ConfirmationPromptView,
+) -> Result<bool, String> {
+    let app_label =
+        crate::native_security_label(view.app_name.as_deref().unwrap_or(&view.bundle_id));
+    let target = view
+        .target_label
+        .as_deref()
+        .map(crate::native_security_label)
+        .unwrap_or_else(|| "an unlabeled control".to_owned());
+    let reason = crate::native_security_label(&view.reason);
+    native_binary_choice(
+        app,
+        "Confirm consequential action",
+        &format!("Allow Tidebreak to {reason}?\n\nTarget: {target}\nApplication: {app_label}"),
+        "Allow action",
+    )
+    .await
 }
 
 // MARK: - Tauri surface
@@ -337,61 +464,24 @@ pub(crate) fn stop_computer_use_control(app: AppHandle, state: State<'_, HostAcc
     emit_state(&app, &state.computer_use);
 }
 
-/// Re-arm control after a Stop. Explicit and user-driven only.
+/// Re-arm control after a Stop. A renderer request may open the native prompt,
+/// but cannot silently authorize the state transition.
 #[tauri::command]
-pub(crate) fn resume_computer_use_control(app: AppHandle, state: State<'_, HostAccess>) {
-    state.computer_use.resume();
-    emit_state(&app, &state.computer_use);
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub(crate) struct ResolveConsentRequest {
-    call_id: Uuid,
-    decision: ConsentDecision,
-}
-
-/// Commit the user's per-app consent decision for a parked computer-use call.
-#[tauri::command]
-pub(crate) fn resolve_computer_use_consent(
+pub(crate) async fn resume_computer_use_control(
     app: AppHandle,
     state: State<'_, HostAccess>,
-    request: ResolveConsentRequest,
 ) -> Result<(), String> {
-    let prompt = lock(&state.computer_use.prompts).remove(&CallId::from(request.call_id));
-    let Some(PendingPrompt::Consent { decision, .. }) = prompt else {
-        return Err("that computer-use consent request is no longer pending".to_owned());
-    };
-    // A grant the user just approved is an explicit opt-in, which is also what
-    // re-arms control after a Stop.
-    if request.decision != ConsentDecision::Decline {
+    if native_binary_choice(
+        &app,
+        "Resume computer control?",
+        "Resume only if you want Tidebreak to continue controlling applications on this Mac.",
+        "Resume control",
+    )
+    .await?
+    {
         state.computer_use.resume();
+        emit_state(&app, &state.computer_use);
     }
-    let _ = decision.send(request.decision);
-    emit_state(&app, &state.computer_use);
-    Ok(())
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub(crate) struct ResolveConfirmationRequest {
-    call_id: Uuid,
-    confirmed: bool,
-}
-
-/// Commit the user's decision on one consequential action the broker held.
-#[tauri::command]
-pub(crate) fn resolve_computer_use_confirmation(
-    app: AppHandle,
-    state: State<'_, HostAccess>,
-    request: ResolveConfirmationRequest,
-) -> Result<(), String> {
-    let prompt = lock(&state.computer_use.prompts).remove(&CallId::from(request.call_id));
-    let Some(PendingPrompt::Confirmation { decision, .. }) = prompt else {
-        return Err("that computer-use confirmation is no longer pending".to_owned());
-    };
-    let _ = decision.send(request.confirmed);
-    emit_state(&app, &state.computer_use);
     Ok(())
 }
 
@@ -1012,8 +1102,8 @@ fn stopped_resolution() -> StoredResolution {
     )
 }
 
-/// The per-app consent park: surface the card, wait for the decision, write
-/// the grant the decision implies, then re-issue the operation once.
+/// The per-app consent park: surface a native prompt, wait for the decision,
+/// write the grant the decision implies, then re-issue the operation once.
 async fn dispatch_consent(
     app: &AppHandle,
     state: &HostAccess,
@@ -1037,24 +1127,10 @@ async fn dispatch_consent(
             SubjectKind::Conversation => ConsentGrantScope::Chat,
         },
     };
-    let (sender, receiver) = oneshot::channel();
-    {
-        let mut prompts = lock(&cu.prompts);
-        prompts.insert(
-            call.id,
-            PendingPrompt::Consent {
-                view,
-                decision: sender,
-            },
-        );
-    }
-    emit_state(app, cu);
     let decision = tokio::select! {
-        decision = receiver => decision.unwrap_or(ConsentDecision::Decline),
+        decision = native_consent_choice(app, &view) => decision.unwrap_or(ConsentDecision::Decline),
         () = cu.wait_for_halt() => ConsentDecision::Decline,
     };
-    lock(&cu.prompts).remove(&call.id);
-    emit_state(app, cu);
 
     if cu.is_halted() {
         return stopped_resolution();
@@ -1163,7 +1239,8 @@ async fn revoke_once_grant(
 }
 
 /// The act-time consequential confirmation: the broker is holding the action
-/// and honors the confirmation only while the target's label still matches.
+/// and honors the native confirmation only while the target's label still
+/// matches.
 async fn dispatch_confirmation(
     app: &AppHandle,
     state: &HostAccess,
@@ -1179,24 +1256,10 @@ async fn dispatch_confirmation(
         target_label: held.target_label.clone(),
         reason: held.reason.clone(),
     };
-    let (sender, receiver) = oneshot::channel();
-    {
-        let mut prompts = lock(&cu.prompts);
-        prompts.insert(
-            call.id,
-            PendingPrompt::Confirmation {
-                view,
-                decision: sender,
-            },
-        );
-    }
-    emit_state(app, cu);
     let confirmed = tokio::select! {
-        confirmed = receiver => confirmed.unwrap_or(false),
+        confirmed = native_confirmation_choice(app, &view) => confirmed.unwrap_or(false),
         () = cu.wait_for_halt() => false,
     };
-    lock(&cu.prompts).remove(&call.id);
-    emit_state(app, cu);
 
     if !confirmed {
         return unavailable(

--- a/crates/tidebreak-desktop/src/client_execution/computer_use.rs
+++ b/crates/tidebreak-desktop/src/client_execution/computer_use.rs
@@ -274,10 +274,12 @@ impl ComputerUseState {
     }
 
     async fn halt(&self) {
-        let _dispatch = self.acting_dispatch.lock().await;
         // send_replace, not send: the latch must hold even when no prompt is
         // currently parked on it (send drops the value with zero receivers).
         self.halt.send_replace(true);
+        // Make Stop visible immediately, then wait for any action that was
+        // already in flight to drain before reporting the stop complete.
+        let _dispatch = self.acting_dispatch.lock().await;
     }
 
     async fn dispatch_acting<T, F, Fut>(&self, dispatch: F) -> Result<T, StoredResolution>
@@ -1203,6 +1205,11 @@ async fn dispatch_consent(
         return map_control_error(&error);
     }
 
+    if cu.is_halted() {
+        revoke_once_grant(state, decision, capability, bundle_id.as_deref(), call).await;
+        return stopped_resolution();
+    }
+
     // Re-issued exactly once, now authorized. A second Denied means the grant
     // did not cover the op (a broker-side surprise, not another ask). A held
     // consequential action re-authorizes at confirm time, so the one-time
@@ -1742,6 +1749,50 @@ mod tests {
 
         cu.resume();
         assert!(!cu.is_halted());
+    }
+
+    #[tokio::test]
+    async fn stop_sets_the_latch_before_waiting_for_an_in_flight_action() {
+        let cu = std::sync::Arc::new(ComputerUseState::default());
+        let (dispatch_started_tx, dispatch_started_rx) = oneshot::channel::<()>();
+        let (release_dispatch_tx, release_dispatch_rx) = oneshot::channel::<()>();
+
+        let dispatch_cu = std::sync::Arc::clone(&cu);
+        let dispatch = tokio::spawn(async move {
+            dispatch_cu
+                .dispatch_acting(|| async move {
+                    dispatch_started_tx
+                        .send(())
+                        .expect("the test observes the in-flight action");
+                    release_dispatch_rx
+                        .await
+                        .expect("the test releases the in-flight action");
+                })
+                .await
+        });
+        dispatch_started_rx
+            .await
+            .expect("the acting request holds the dispatch gate");
+
+        let halt_cu = std::sync::Arc::clone(&cu);
+        let halt = tokio::spawn(async move { halt_cu.halt().await });
+        tokio::time::timeout(std::time::Duration::from_millis(100), async {
+            while !cu.is_halted() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("Stop must publish its latch without waiting for the broker");
+        assert!(
+            !halt.is_finished(),
+            "Stop still drains the in-flight action"
+        );
+
+        release_dispatch_tx
+            .send(())
+            .expect("release the in-flight action");
+        dispatch.await.expect("the acting task completes").unwrap();
+        halt.await.expect("the Stop task completes after the drain");
     }
 
     #[tokio::test]

--- a/crates/tidebreak-desktop/src/lib.rs
+++ b/crates/tidebreak-desktop/src/lib.rs
@@ -9,8 +9,11 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use serde::Serialize;
+use serde_json::Value;
 use tauri::Manager;
+use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 use tokio::sync::watch;
+use unicode_general_category::{get_general_category, GeneralCategory};
 
 use tidebreak_core::Config;
 
@@ -77,6 +80,151 @@ struct AppState {
 #[tauri::command]
 async fn server_info(state: tauri::State<'_, Arc<AppState>>) -> Result<ServerInfo, String> {
     Ok(wait_server_info(state.inner()).await?.renderer_info())
+}
+
+/// Save MCP configuration through the native-only server surface. Command
+/// transports receive an OS-native confirmation before the host credential is
+/// attached; renderer JavaScript can request the prompt but cannot approve it.
+#[tauri::command]
+async fn put_native_mcp_servers(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, Arc<AppState>>,
+    config: Value,
+) -> Result<Value, String> {
+    let commands = native_command_previews(&config)?;
+    if !commands.is_empty() {
+        let preview = commands.join("\n");
+        let (sender, receiver) = tokio::sync::oneshot::channel();
+        let mut dialog = app
+            .dialog()
+            .message(format!(
+                "Allow these MCP servers to run local programs as your macOS user?\n\n{preview}"
+            ))
+            .title("Allow local MCP commands?")
+            .kind(MessageDialogKind::Warning)
+            .buttons(MessageDialogButtons::OkCancelCustom(
+                "Allow and save".to_owned(),
+                "Cancel".to_owned(),
+            ));
+        if let Some(window) = app.get_webview_window("main") {
+            dialog = dialog.parent(&window);
+        }
+        dialog.show(move |approved| {
+            let _ = sender.send(approved);
+        });
+        if !receiver.await.unwrap_or(false) {
+            return Err("local MCP command configuration was not approved".to_owned());
+        }
+    }
+
+    let info = wait_server_info(state.inner()).await?;
+    let response = documents::native_auth(
+        documents::local_client()
+            .put(format!("{}/native/mcp/servers", info.base_url))
+            .json(&config),
+        &info,
+    )
+    .send()
+    .await
+    .map_err(|error| format!("save MCP servers: {error}"))?;
+    let status = response.status();
+    let body = response
+        .bytes()
+        .await
+        .map_err(|error| format!("read MCP server response: {error}"))?;
+    if !status.is_success() {
+        let message = serde_json::from_slice::<Value>(&body)
+            .ok()
+            .and_then(|body| {
+                body.get("message")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned)
+            })
+            .unwrap_or_else(|| format!("MCP server returned {status}"));
+        return Err(message);
+    }
+    serde_json::from_slice(&body).map_err(|error| format!("decode MCP server response: {error}"))
+}
+
+fn native_command_previews(config: &Value) -> Result<Vec<String>, String> {
+    let servers = config
+        .get("servers")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "MCP configuration must contain a servers array".to_owned())?;
+    let mut previews = Vec::new();
+    for server in servers {
+        if !server
+            .get("enabled")
+            .and_then(Value::as_bool)
+            .unwrap_or(true)
+        {
+            continue;
+        }
+        let Some(command) = server.get("command").and_then(Value::as_str) else {
+            continue;
+        };
+        let name = server
+            .get("name")
+            .and_then(Value::as_str)
+            .unwrap_or("unnamed");
+        let mut argv = vec![native_command_token(command)?];
+        if let Some(args) = server.get("args") {
+            let args = args
+                .as_array()
+                .ok_or_else(|| "MCP command args must be an array".to_owned())?;
+            for argument in args {
+                let argument = argument
+                    .as_str()
+                    .ok_or_else(|| "every MCP command argument must be a string".to_owned())?;
+                argv.push(native_command_token(argument)?);
+            }
+        }
+        let argv = serde_json::to_string(&argv).expect("string vectors serialize");
+        previews.push(format!("{}: {argv}", native_security_label(name)));
+    }
+    Ok(previews)
+}
+
+fn native_command_token(value: &str) -> Result<String, String> {
+    if value.chars().count() > 240 {
+        return Err("MCP command or argument is too long to display safely".to_owned());
+    }
+    Ok(value
+        .chars()
+        .map(|character| {
+            if matches!(
+                get_general_category(character),
+                GeneralCategory::Control
+                    | GeneralCategory::Format
+                    | GeneralCategory::LineSeparator
+                    | GeneralCategory::ParagraphSeparator
+            ) {
+                '\u{fffd}'
+            } else {
+                character
+            }
+        })
+        .collect())
+}
+
+pub(crate) fn native_security_label(value: &str) -> String {
+    value
+        .chars()
+        .take(160)
+        .map(|character| {
+            if matches!(
+                get_general_category(character),
+                GeneralCategory::Control
+                    | GeneralCategory::Format
+                    | GeneralCategory::LineSeparator
+                    | GeneralCategory::ParagraphSeparator
+            ) {
+                '\u{fffd}'
+            } else {
+                character
+            }
+        })
+        .collect()
 }
 
 /// Best-effort attention hint for a newly parked user question.
@@ -300,6 +448,7 @@ pub fn run() {
         .manage(updater::UpdateManager::default())
         .invoke_handler(tauri::generate_handler![
             server_info,
+            put_native_mcp_servers,
             request_user_attention,
             attachments::attach_chat_files,
             attachments::attach_dropped_chat_files,
@@ -318,8 +467,6 @@ pub fn run() {
             client_execution::computer_use::computer_use_state,
             client_execution::computer_use::stop_computer_use_control,
             client_execution::computer_use::resume_computer_use_control,
-            client_execution::computer_use::resolve_computer_use_consent,
-            client_execution::computer_use::resolve_computer_use_confirmation,
             host_access::connect_folder,
             host_access::connect_approved_folder,
             host_access::list_approved_folders,
@@ -610,5 +757,63 @@ mod server_info_tests {
         assert!(serialized.contains("renderer-bearer"));
         assert!(!serialized.contains("native-credential-sentinel"));
         assert!(!serialized.contains("executor"));
+    }
+
+    #[test]
+    fn native_security_labels_strip_format_controls_and_are_bounded() {
+        let label = native_security_label(&format!("trusted\u{202e}\u{200b}{}", "x".repeat(200)));
+        assert!(!label.contains('\u{202e}'));
+        assert!(!label.contains('\u{200b}'));
+        assert_eq!(label.chars().count(), 160);
+        assert!(label.starts_with("trusted\u{fffd}\u{fffd}"));
+    }
+
+    #[test]
+    fn only_enabled_local_commands_require_a_native_preview() {
+        let config = serde_json::json!({
+            "servers": [
+                {"name": "draft", "command": "/bin/echo", "enabled": false},
+                {"name": "remote", "url": "https://example.test/mcp", "enabled": true},
+                {"name": "live", "command": "/bin/sh", "args": ["-c", "echo safe"], "enabled": true}
+            ]
+        });
+        assert_eq!(
+            native_command_previews(&config).unwrap(),
+            vec![r#"live: ["/bin/sh","-c","echo safe"]"#]
+        );
+    }
+
+    #[test]
+    fn native_command_preview_refuses_arguments_it_cannot_show_completely() {
+        let config = serde_json::json!({
+            "servers": [{
+                "name": "hidden suffix",
+                "command": "/bin/sh",
+                "args": ["-c", "x".repeat(241)],
+                "enabled": true
+            }]
+        });
+        assert!(native_command_previews(&config).is_err());
+    }
+
+    #[test]
+    fn omitted_enabled_defaults_to_an_approved_command_and_every_command_is_shown() {
+        let servers = (0..9)
+            .map(|index| serde_json::json!({"name": format!("server-{index}"), "command": "/bin/true"}))
+            .collect::<Vec<_>>();
+        let previews = native_command_previews(&serde_json::json!({"servers": servers})).unwrap();
+        assert_eq!(previews.len(), 9);
+        assert!(previews[8].starts_with("server-8:"));
+    }
+
+    #[test]
+    fn command_arguments_are_not_truncated_inside_the_displayable_bound() {
+        let suffix = "DANGEROUS_SUFFIX";
+        let argument = format!("{}{}", "x".repeat(180), suffix);
+        let config = serde_json::json!({
+            "servers": [{"name": "long", "command": "/bin/sh", "args": ["-c", argument]}]
+        });
+        let previews = native_command_previews(&config).unwrap();
+        assert!(previews[0].contains(suffix));
     }
 }

--- a/crates/tidebreak-desktop/src/lib.rs
+++ b/crates/tidebreak-desktop/src/lib.rs
@@ -205,7 +205,13 @@ fn native_command_previews(config: &Value) -> Result<Vec<String>, String> {
             .get("name")
             .and_then(Value::as_str)
             .unwrap_or("unnamed");
-        let mut argv = vec![native_command_token(command)?];
+        let command = native_command_token(command)?;
+        if !std::path::Path::new(&command).is_absolute() {
+            return Err(
+                "enabled MCP local commands must use an absolute executable path".to_owned(),
+            );
+        }
+        let mut argv = vec![command];
         if let Some(args) = server.get("args") {
             let args = args
                 .as_array()
@@ -915,7 +921,7 @@ mod server_info_tests {
     fn only_enabled_local_commands_require_a_native_preview() {
         let config = serde_json::json!({
             "servers": [
-                {"name": "draft", "command": "/bin/echo", "enabled": false},
+                {"name": "draft", "command": "editable-bare-command", "enabled": false},
                 {"name": "remote", "url": "https://example.test/mcp", "enabled": true},
                 {"name": "live", "command": "/bin/sh", "args": ["-c", "echo safe"], "enabled": true}
             ]
@@ -931,6 +937,36 @@ mod server_info_tests {
             "desktop_process_current_directory"
         );
         assert_eq!(approval["environment"]["ambient_environment"], "cleared");
+    }
+
+    #[test]
+    fn enabled_native_commands_require_an_absolute_executable_path() {
+        for command in ["node", "./node", "tools/node"] {
+            let config = serde_json::json!({
+                "servers": [{"name": "ambiguous", "command": command, "enabled": true}]
+            });
+            assert_eq!(
+                native_command_previews(&config).unwrap_err(),
+                "enabled MCP local commands must use an absolute executable path"
+            );
+        }
+    }
+
+    #[test]
+    fn native_approval_displays_the_exact_absolute_executable_path() {
+        let config = serde_json::json!({
+            "servers": [{
+                "name": "pinned executable",
+                "command": "/opt/tidebreak/bin/docs-mcp",
+                "args": ["serve"],
+                "enabled": true
+            }]
+        });
+        let approval = single_native_approval(config);
+        assert_eq!(
+            approval["argv"],
+            serde_json::json!(["/opt/tidebreak/bin/docs-mcp", "serve"])
+        );
     }
 
     #[test]
@@ -973,7 +1009,7 @@ mod server_info_tests {
         let base = serde_json::json!({
             "servers": [{
                 "name": "workspace",
-                "command": "node",
+                "command": "/usr/bin/node",
                 "args": ["server.mjs"],
                 "cwd": "/srv/first",
                 "env_from": ["HOME"]
@@ -982,7 +1018,7 @@ mod server_info_tests {
         let changed = serde_json::json!({
             "servers": [{
                 "name": "workspace",
-                "command": "node",
+                "command": "/usr/bin/node",
                 "args": ["server.mjs"],
                 "cwd": "/srv/second",
                 "env_from": ["HOME", "PATH"]

--- a/crates/tidebreak-desktop/src/lib.rs
+++ b/crates/tidebreak-desktop/src/lib.rs
@@ -146,6 +146,44 @@ async fn put_native_mcp_servers(
     serde_json::from_slice(&body).map_err(|error| format!("decode MCP server response: {error}"))
 }
 
+const MAX_NATIVE_APPROVAL_FIELD_CHARS: usize = 240;
+const MAX_NATIVE_APPROVAL_MANIFEST_CHARS: usize = 16_384;
+
+#[derive(Serialize)]
+struct NativeCommandApproval<'a> {
+    server: &'a str,
+    argv: Vec<String>,
+    cwd: NativeCommandCwd,
+    environment: NativeCommandEnvironment,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case", tag = "source", content = "path")]
+enum NativeCommandCwd {
+    DesktopProcessCurrentDirectory,
+    Configured(String),
+}
+
+#[derive(Serialize)]
+struct NativeCommandEnvironment {
+    ambient_environment: &'static str,
+    inherited_from_desktop_process: Vec<String>,
+    stored_secrets: Vec<NativeStoredSecret>,
+}
+
+#[derive(Serialize)]
+struct NativeStoredSecret {
+    name: String,
+    effect: NativeStoredSecretEffect,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+enum NativeStoredSecretEffect {
+    SetFromThisSave,
+    PreserveExistingStoredValue,
+}
+
 fn native_command_previews(config: &Value) -> Result<Vec<String>, String> {
     let servers = config
         .get("servers")
@@ -179,32 +217,131 @@ fn native_command_previews(config: &Value) -> Result<Vec<String>, String> {
                 argv.push(native_command_token(argument)?);
             }
         }
-        let argv = serde_json::to_string(&argv).expect("string vectors serialize");
-        previews.push(format!("{}: {argv}", native_security_label(name)));
+
+        let cwd = match server.get("cwd") {
+            None | Some(Value::Null) => NativeCommandCwd::DesktopProcessCurrentDirectory,
+            Some(Value::String(path)) => NativeCommandCwd::Configured(native_command_token(path)?),
+            Some(_) => return Err("MCP command cwd must be a string or null".to_owned()),
+        };
+        let mut inherited_from_desktop_process =
+            native_string_array(server, "env_from", "MCP env_from must be an array")?;
+        inherited_from_desktop_process.sort_unstable();
+        reject_duplicates(
+            &inherited_from_desktop_process,
+            "MCP env_from contains a duplicate name",
+        )?;
+
+        let mut stored_names = native_string_array(server, "env", "MCP env must be an array")?;
+        stored_names.sort_unstable();
+        reject_duplicates(&stored_names, "MCP env contains a duplicate name")?;
+        if stored_names
+            .iter()
+            .any(|name| inherited_from_desktop_process.binary_search(name).is_ok())
+        {
+            return Err("an MCP environment name cannot be both stored and inherited".to_owned());
+        }
+
+        let env_values = match server.get("env_values") {
+            None => None,
+            Some(Value::Object(values)) => Some(values),
+            Some(_) => return Err("MCP env_values must be an object".to_owned()),
+        };
+        if let Some(values) = env_values {
+            for (name, value) in values {
+                native_command_token(name)?;
+                if !value.is_string() {
+                    return Err("every MCP environment value must be a string".to_owned());
+                }
+                if stored_names.binary_search(name).is_err() {
+                    return Err(
+                        "every MCP env_values entry must name a stored environment variable"
+                            .to_owned(),
+                    );
+                }
+            }
+        }
+        let stored_secrets = stored_names
+            .into_iter()
+            .map(|name| NativeStoredSecret {
+                effect: if env_values.is_some_and(|values| values.contains_key(&name)) {
+                    NativeStoredSecretEffect::SetFromThisSave
+                } else {
+                    NativeStoredSecretEffect::PreserveExistingStoredValue
+                },
+                name,
+            })
+            .collect();
+        let safe_name = native_command_token(name)?;
+        let manifest = serde_json::to_string_pretty(&NativeCommandApproval {
+            server: &safe_name,
+            argv,
+            cwd,
+            environment: NativeCommandEnvironment {
+                ambient_environment: "cleared",
+                inherited_from_desktop_process,
+                stored_secrets,
+            },
+        })
+        .expect("native command approval manifests serialize infallibly");
+        if manifest.chars().count() > MAX_NATIVE_APPROVAL_MANIFEST_CHARS {
+            return Err("MCP command approval manifest is too long to display safely".to_owned());
+        }
+        previews.push(manifest);
+    }
+    let manifest_chars = previews
+        .iter()
+        .map(|preview| preview.chars().count())
+        .sum::<usize>()
+        .saturating_add(previews.len().saturating_sub(1));
+    if manifest_chars > MAX_NATIVE_APPROVAL_MANIFEST_CHARS {
+        return Err("MCP command approval manifest is too long to display safely".to_owned());
     }
     Ok(previews)
 }
 
-fn native_command_token(value: &str) -> Result<String, String> {
-    if value.chars().count() > 240 {
-        return Err("MCP command or argument is too long to display safely".to_owned());
-    }
-    Ok(value
-        .chars()
-        .map(|character| {
-            if matches!(
-                get_general_category(character),
-                GeneralCategory::Control
-                    | GeneralCategory::Format
-                    | GeneralCategory::LineSeparator
-                    | GeneralCategory::ParagraphSeparator
-            ) {
-                '\u{fffd}'
-            } else {
-                character
-            }
+fn native_string_array(
+    server: &Value,
+    field: &str,
+    type_error: &str,
+) -> Result<Vec<String>, String> {
+    let Some(value) = server.get(field) else {
+        return Ok(Vec::new());
+    };
+    let values = value.as_array().ok_or_else(|| type_error.to_owned())?;
+    values
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .ok_or_else(|| format!("every MCP {field} entry must be a string"))
+                .and_then(native_command_token)
         })
-        .collect())
+        .collect()
+}
+
+fn reject_duplicates(values: &[String], error: &str) -> Result<(), String> {
+    if values.windows(2).any(|pair| pair[0] == pair[1]) {
+        return Err(error.to_owned());
+    }
+    Ok(())
+}
+
+fn native_command_token(value: &str) -> Result<String, String> {
+    if value.chars().count() > MAX_NATIVE_APPROVAL_FIELD_CHARS {
+        return Err("MCP command approval field is too long to display safely".to_owned());
+    }
+    if value.chars().any(|character| {
+        matches!(
+            get_general_category(character),
+            GeneralCategory::Control
+                | GeneralCategory::Format
+                | GeneralCategory::LineSeparator
+                | GeneralCategory::ParagraphSeparator
+        )
+    }) {
+        return Err("MCP command approval field contains unsafe formatting characters".to_owned());
+    }
+    Ok(value.to_owned())
 }
 
 pub(crate) fn native_security_label(value: &str) -> String {
@@ -733,6 +870,12 @@ mod bundle_tests {
 mod server_info_tests {
     use super::*;
 
+    fn single_native_approval(config: Value) -> Value {
+        let previews = native_command_previews(&config).expect("valid native command preview");
+        assert_eq!(previews.len(), 1);
+        serde_json::from_str(&previews[0]).expect("approval is a canonical JSON manifest")
+    }
+
     #[tokio::test]
     async fn wait_server_info_returns_the_published_boot_error() {
         let (tx, rx) = watch::channel(None);
@@ -777,10 +920,17 @@ mod server_info_tests {
                 {"name": "live", "command": "/bin/sh", "args": ["-c", "echo safe"], "enabled": true}
             ]
         });
+        let approval = single_native_approval(config);
+        assert_eq!(approval["server"], "live");
         assert_eq!(
-            native_command_previews(&config).unwrap(),
-            vec![r#"live: ["/bin/sh","-c","echo safe"]"#]
+            approval["argv"],
+            serde_json::json!(["/bin/sh", "-c", "echo safe"])
         );
+        assert_eq!(
+            approval["cwd"]["source"],
+            "desktop_process_current_directory"
+        );
+        assert_eq!(approval["environment"]["ambient_environment"], "cleared");
     }
 
     #[test]
@@ -803,7 +953,8 @@ mod server_info_tests {
             .collect::<Vec<_>>();
         let previews = native_command_previews(&serde_json::json!({"servers": servers})).unwrap();
         assert_eq!(previews.len(), 9);
-        assert!(previews[8].starts_with("server-8:"));
+        let ninth: Value = serde_json::from_str(&previews[8]).unwrap();
+        assert_eq!(ninth["server"], "server-8");
     }
 
     #[test]
@@ -815,5 +966,114 @@ mod server_info_tests {
         });
         let previews = native_command_previews(&config).unwrap();
         assert!(previews[0].contains(suffix));
+    }
+
+    #[test]
+    fn cwd_and_inherited_path_changes_are_explicit_in_native_approval() {
+        let base = serde_json::json!({
+            "servers": [{
+                "name": "workspace",
+                "command": "node",
+                "args": ["server.mjs"],
+                "cwd": "/srv/first",
+                "env_from": ["HOME"]
+            }]
+        });
+        let changed = serde_json::json!({
+            "servers": [{
+                "name": "workspace",
+                "command": "node",
+                "args": ["server.mjs"],
+                "cwd": "/srv/second",
+                "env_from": ["HOME", "PATH"]
+            }]
+        });
+        let first = single_native_approval(base);
+        let second = single_native_approval(changed);
+        assert_ne!(first, second);
+        assert_eq!(first["cwd"]["path"], "/srv/first");
+        assert_eq!(second["cwd"]["path"], "/srv/second");
+        assert_eq!(
+            second["environment"]["inherited_from_desktop_process"],
+            serde_json::json!(["HOME", "PATH"])
+        );
+    }
+
+    #[test]
+    fn stored_secret_sources_and_preservation_are_visible_without_values() {
+        let preserved = serde_json::json!({
+            "servers": [{
+                "name": "private docs",
+                "command": "/usr/bin/docs-mcp",
+                "env": ["DOCS_TOKEN", "LOG_LEVEL"]
+            }]
+        });
+        let replaced = serde_json::json!({
+            "servers": [{
+                "name": "private docs",
+                "command": "/usr/bin/docs-mcp",
+                "env": ["DOCS_TOKEN", "LOG_LEVEL"],
+                "env_values": {"DOCS_TOKEN": "secret-sentinel-value"}
+            }]
+        });
+        let preserved = single_native_approval(preserved);
+        let replaced = single_native_approval(replaced);
+        assert_ne!(preserved, replaced);
+        assert_eq!(
+            replaced["environment"]["stored_secrets"],
+            serde_json::json!([
+                {"name": "DOCS_TOKEN", "effect": "set_from_this_save"},
+                {"name": "LOG_LEVEL", "effect": "preserve_existing_stored_value"}
+            ])
+        );
+        let encoded = replaced.to_string();
+        assert!(!encoded.contains("secret-sentinel-value"));
+    }
+
+    #[test]
+    fn environment_source_changes_alter_approval_and_never_show_parent_values() {
+        let inherited = serde_json::json!({
+            "servers": [{
+                "name": "docs",
+                "command": "/usr/bin/docs-mcp",
+                "env_from": ["PRIVATE_DOCS_TOKEN"]
+            }]
+        });
+        let stored = serde_json::json!({
+            "servers": [{
+                "name": "docs",
+                "command": "/usr/bin/docs-mcp",
+                "env": ["PRIVATE_DOCS_TOKEN"]
+            }]
+        });
+        let inherited = single_native_approval(inherited);
+        let stored = single_native_approval(stored);
+        assert_ne!(inherited, stored);
+        assert_eq!(
+            inherited["environment"]["inherited_from_desktop_process"],
+            serde_json::json!(["PRIVATE_DOCS_TOKEN"])
+        );
+        assert_eq!(
+            stored["environment"]["stored_secrets"],
+            serde_json::json!([{
+                "name": "PRIVATE_DOCS_TOKEN",
+                "effect": "preserve_existing_stored_value"
+            }])
+        );
+        if let Ok(parent_value) = std::env::var("PRIVATE_DOCS_TOKEN") {
+            assert!(!inherited.to_string().contains(&parent_value));
+        }
+    }
+
+    #[test]
+    fn native_approval_refuses_unrepresentable_environment_manifest() {
+        let config = serde_json::json!({
+            "servers": [{
+                "name": "oversized",
+                "command": "/bin/true",
+                "env_from": ["X".repeat(MAX_NATIVE_APPROVAL_FIELD_CHARS + 1)]
+            }]
+        });
+        assert!(native_command_previews(&config).is_err());
     }
 }

--- a/crates/tidebreak-desktop/ui/src/ComputerUseIndicator.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ComputerUseIndicator.dom.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -12,37 +12,15 @@ const mocks = vi.hoisted(() => ({
       visibleUntilMillis: number;
     },
     halted: false,
-    pendingConsents: [] as Array<{
-      callId: string;
-      chatId: string;
-      bundleId: string;
-      appName: string | null;
-      capability: "capture_screen" | "read_app_content" | "control_app";
-      grantScope: "chat" | "project";
-    }>,
-    pendingConfirmations: [] as Array<{
-      callId: string;
-      chatId: string;
-      bundleId: string;
-      appName: string | null;
-      targetLabel: string | null;
-      reason: string;
-    }>,
   },
   stop: vi.fn(() => Promise.resolve()),
   resume: vi.fn(() => Promise.resolve()),
-  consent: vi.fn((_callId: string, _decision: string) => Promise.resolve()),
-  confirmation: vi.fn((_callId: string, _confirmed: boolean) =>
-    Promise.resolve(),
-  ),
 }));
 
 vi.mock("./computerUse", () => ({
   useComputerUseState: () => mocks.snapshot,
   stopComputerUseControl: mocks.stop,
   resumeComputerUseControl: mocks.resume,
-  resolveComputerUseConsent: mocks.consent,
-  resolveComputerUseConfirmation: mocks.confirmation,
 }));
 
 import { ComputerUseIndicator } from "./ComputerUseIndicator";
@@ -54,8 +32,6 @@ describe("ComputerUseIndicator", () => {
     mocks.snapshot = {
       active: null,
       halted: false,
-      pendingConsents: [],
-      pendingConfirmations: [],
     };
     vi.clearAllMocks();
   });
@@ -93,157 +69,4 @@ describe("ComputerUseIndicator", () => {
     expect(mocks.resume).toHaveBeenCalledOnce();
   });
 
-  it("commits a per-app consent decision for the parked call", async () => {
-    mocks.snapshot.pendingConsents = [
-      {
-        callId: "call-1",
-        chatId: "chat-1",
-        bundleId: "com.apple.mail",
-        appName: "Mail",
-        capability: "control_app",
-        grantScope: "project",
-      },
-    ];
-    render(<ComputerUseIndicator />);
-
-    expect(
-      screen.getByText(/Allow Tidebreak to control Mail/),
-    ).toBeTruthy();
-    expect(screen.getByText(/com\.apple\.mail/)).toBeTruthy();
-    await userEvent.click(screen.getByRole("button", { name: "Allow once" }));
-    expect(mocks.consent).toHaveBeenCalledWith("call-1", "once");
-    await userEvent.click(
-      screen.getByRole("button", { name: "Allow for this chat" }),
-    );
-    expect(mocks.consent).toHaveBeenCalledWith("call-1", "chat");
-    await userEvent.click(
-      screen.getByRole("button", { name: "Always in this project" }),
-    );
-    expect(mocks.consent).toHaveBeenCalledWith("call-1", "always");
-    await userEvent.click(
-      screen.getByRole("button", { name: "Don't allow" }),
-    );
-    expect(mocks.consent).toHaveBeenCalledWith("call-1", "decline");
-  });
-
-  it("uses screen-specific copy and does not offer a duplicate wider scope", () => {
-    mocks.snapshot.pendingConsents = [
-      {
-        callId: "call-screen",
-        chatId: "chat-1",
-        bundleId: "",
-        appName: null,
-        capability: "capture_screen",
-        grantScope: "chat",
-      },
-    ];
-    render(<ComputerUseIndicator />);
-
-    expect(
-      screen.getByText("Allow Tidebreak to capture your entire screen?"),
-    ).toBeTruthy();
-    expect(
-      screen.queryByRole("button", { name: "Always in this project" }),
-    ).toBeNull();
-  });
-
-  it("ignores a second decision while the first is still in flight", async () => {
-    let resolveDecision: () => void = () => {};
-    mocks.consent.mockImplementationOnce(
-      () => new Promise<void>((resolve) => (resolveDecision = resolve)),
-    );
-    mocks.snapshot.pendingConsents = [
-      {
-        callId: "call-1",
-        chatId: "chat-1",
-        bundleId: "com.apple.mail",
-        appName: "Mail",
-        capability: "control_app",
-        grantScope: "project",
-      },
-    ];
-    render(<ComputerUseIndicator />);
-
-    const once = screen.getByRole("button", { name: "Allow once" });
-    await userEvent.click(once);
-    await userEvent.click(
-      screen.getByRole("button", { name: "Always in this project" }),
-    );
-    expect(mocks.consent).toHaveBeenCalledOnce();
-
-    resolveDecision();
-    await waitFor(() => expect(once).not.toBeDisabled());
-    await userEvent.click(
-      screen.getByRole("button", { name: "Always in this project" }),
-    );
-    expect(mocks.consent).toHaveBeenCalledTimes(2);
-    expect(mocks.consent).toHaveBeenLastCalledWith("call-1", "always");
-  });
-
-  it("surfaces a failed decision on the card and lets it be retried", async () => {
-    mocks.consent.mockRejectedValueOnce(new Error("broker went away"));
-    mocks.snapshot.pendingConsents = [
-      {
-        callId: "call-1",
-        chatId: "chat-1",
-        bundleId: "com.apple.mail",
-        appName: "Mail",
-        capability: "control_app",
-        grantScope: "chat",
-      },
-    ];
-    render(<ComputerUseIndicator />);
-
-    await userEvent.click(screen.getByRole("button", { name: "Allow once" }));
-    expect(
-      await screen.findByRole("alert"),
-    ).toHaveTextContent(/Could not send your decision/);
-    expect(
-      screen.getByRole("button", { name: "Allow once" }),
-    ).not.toBeDisabled();
-
-    await userEvent.click(screen.getByRole("button", { name: "Allow once" }));
-    expect(mocks.consent).toHaveBeenCalledTimes(2);
-    expect(screen.queryByRole("alert")).toBeNull();
-  });
-
-  it("confirms a broker-held consequential action", async () => {
-    mocks.snapshot.pendingConfirmations = [
-      {
-        callId: "call-9",
-        chatId: "chat-1",
-        bundleId: "com.apple.mail",
-        appName: "Mail",
-        targetLabel: "Send",
-        reason: "send a message",
-      },
-    ];
-    render(<ComputerUseIndicator />);
-
-    expect(screen.getByText(/“Send”/)).toBeTruthy();
-    await userEvent.click(screen.getByRole("button", { name: "Allow action" }));
-    expect(mocks.confirmation).toHaveBeenCalledWith("call-9", true);
-    await userEvent.click(screen.getByRole("button", { name: "Don't allow" }));
-    expect(mocks.confirmation).toHaveBeenCalledWith("call-9", false);
-  });
-
-  it("surfaces a failed confirmation on the card", async () => {
-    mocks.confirmation.mockRejectedValueOnce(new Error("broker went away"));
-    mocks.snapshot.pendingConfirmations = [
-      {
-        callId: "call-9",
-        chatId: "chat-1",
-        bundleId: "com.apple.mail",
-        appName: "Mail",
-        targetLabel: "Send",
-        reason: "send a message",
-      },
-    ];
-    render(<ComputerUseIndicator />);
-
-    await userEvent.click(screen.getByRole("button", { name: "Don't allow" }));
-    expect(await screen.findByRole("alert")).toHaveTextContent(
-      /Could not send your decision/,
-    );
-  });
 });

--- a/crates/tidebreak-desktop/ui/src/ComputerUseIndicator.tsx
+++ b/crates/tidebreak-desktop/ui/src/ComputerUseIndicator.tsx
@@ -1,46 +1,10 @@
 import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
-  resolveComputerUseConfirmation,
-  resolveComputerUseConsent,
   resumeComputerUseControl,
   stopComputerUseControl,
   useComputerUseState,
-  type ComputerUseConsentPrompt,
 } from "./computerUse";
-
-/** Human copy for one broker capability ask. */
-function consentCopy(
-  prompt: Pick<
-    ComputerUseConsentPrompt,
-    "appName" | "bundleId" | "capability"
-  >,
-): { title: string; detail: string | null } {
-  if (prompt.bundleId === "") {
-    return {
-      title: "Allow Tidebreak to capture your entire screen?",
-      detail: "This lets the agent see everything visible on the current display.",
-    };
-  }
-  const app = appLabel(prompt.appName, prompt.bundleId);
-  switch (prompt.capability) {
-    case "control_app":
-      return {
-        title: `Allow Tidebreak to control ${app}?`,
-        detail: `It can click, type, and press keys in ${prompt.bundleId}.`,
-      };
-    case "capture_screen":
-      return {
-        title: `Allow Tidebreak to capture ${app}?`,
-        detail: `It can take screenshots of ${prompt.bundleId}.`,
-      };
-    case "read_app_content":
-      return {
-        title: `Allow Tidebreak to read ${app}?`,
-        detail: `It can read the on-screen content exposed by ${prompt.bundleId}.`,
-      };
-  }
-}
 
 function appLabel(appName: string | null, bundleId: string): string {
   // A screen-scoped ask (whole-display capture, screen-wide window list)
@@ -50,9 +14,8 @@ function appLabel(appName: string | null, bundleId: string): string {
 }
 
 /**
- * The computer-use HUD: compact permission cards at the top of the window and
- * a small control indicator at the bottom. Both float over the shell instead
- * of resizing every route around a short-lived decision.
+ * The computer-use HUD is only an indicator and emergency stop. Consent and
+ * consequential confirmation are native dialogs, outside renderer authority.
  *
  * Rendered in the shell so control is visible and stoppable from any screen.
  */
@@ -98,160 +61,12 @@ export function ComputerUseIndicator() {
 
   const showActive =
     snapshot.active !== null && now < snapshot.active.visibleUntilMillis;
-  if (
-    !snapshot.halted &&
-    !showActive &&
-    snapshot.pendingConsents.length === 0 &&
-    snapshot.pendingConfirmations.length === 0
-  ) {
+  if (!snapshot.halted && !showActive) {
     return null;
   }
 
   return (
     <>
-      <div className="pointer-events-none fixed inset-x-0 top-5 z-50 flex max-h-[calc(100vh-8rem)] justify-center px-4">
-        <div className="flex w-full max-w-[26rem] flex-col gap-2 overflow-y-auto p-1">
-          {snapshot.pendingConsents.map((prompt) => {
-            const key = `consent:${prompt.callId}`;
-            const deciding = busy.has(key);
-            const copy = consentCopy(prompt);
-            return (
-              <section
-                key={prompt.callId}
-                className="bg-popover text-popover-foreground pointer-events-auto flex flex-col gap-3 rounded-2xl border p-4 shadow-2xl"
-                aria-label="Computer use permission"
-                aria-busy={deciding}
-              >
-                <div>
-                  <p className="text-muted-foreground mb-1 text-[0.6875rem] font-semibold tracking-[0.08em] uppercase">
-                    Computer use
-                  </p>
-                  <h2 className="text-sm font-semibold break-words">
-                    {copy.title}
-                  </h2>
-                  {copy.detail && (
-                    <p className="text-muted-foreground mt-1 text-xs leading-relaxed break-words">
-                      {copy.detail}
-                    </p>
-                  )}
-                </div>
-                <div className="flex flex-wrap justify-end gap-2">
-                  <Button
-                    size="xs"
-                    variant="ghost"
-                    disabled={deciding}
-                    onClick={() =>
-                      run(key, "Could not send your decision", () =>
-                        resolveComputerUseConsent(prompt.callId, "decline"),
-                      )
-                    }
-                  >
-                    Don&apos;t allow
-                  </Button>
-                  <Button
-                    size="xs"
-                    variant="outline"
-                    disabled={deciding}
-                    onClick={() =>
-                      run(key, "Could not send your decision", () =>
-                        resolveComputerUseConsent(prompt.callId, "chat"),
-                      )
-                    }
-                  >
-                    Allow for this chat
-                  </Button>
-                  {prompt.grantScope === "project" && (
-                    <Button
-                      size="xs"
-                      variant="outline"
-                      disabled={deciding}
-                      onClick={() =>
-                        run(key, "Could not send your decision", () =>
-                          resolveComputerUseConsent(prompt.callId, "always"),
-                        )
-                      }
-                    >
-                      Always in this project
-                    </Button>
-                  )}
-                  <Button
-                    size="xs"
-                    disabled={deciding}
-                    onClick={() =>
-                      run(key, "Could not send your decision", () =>
-                        resolveComputerUseConsent(prompt.callId, "once"),
-                      )
-                    }
-                  >
-                    Allow once
-                  </Button>
-                </div>
-                {errors[key] && (
-                  <p className="text-destructive text-xs break-words" role="alert">
-                    {errors[key]}
-                  </p>
-                )}
-              </section>
-            );
-          })}
-          {snapshot.pendingConfirmations.map((prompt) => {
-            const key = `confirmation:${prompt.callId}`;
-            const deciding = busy.has(key);
-            return (
-              <section
-                key={prompt.callId}
-                className="bg-popover text-popover-foreground pointer-events-auto flex flex-col gap-3 rounded-2xl border p-4 shadow-2xl"
-                aria-label="Confirm action"
-                aria-busy={deciding}
-              >
-                <div>
-                  <p className="text-muted-foreground mb-1 text-[0.6875rem] font-semibold tracking-[0.08em] uppercase">
-                    Confirm action
-                  </p>
-                  <h2 className="text-sm font-semibold break-words">
-                    Allow Tidebreak to {prompt.reason}?
-                  </h2>
-                  <p className="text-muted-foreground mt-1 text-xs leading-relaxed break-words">
-                    {prompt.targetLabel ? `“${prompt.targetLabel}” in ` : "In "}
-                    {appLabel(prompt.appName, prompt.bundleId)}
-                  </p>
-                </div>
-                <div className="flex justify-end gap-2">
-                  <Button
-                    size="xs"
-                    variant="ghost"
-                    disabled={deciding}
-                    onClick={() =>
-                      run(key, "Could not send your decision", () =>
-                        resolveComputerUseConfirmation(prompt.callId, false),
-                      )
-                    }
-                  >
-                    Don&apos;t allow
-                  </Button>
-                  <Button
-                    size="xs"
-                    disabled={deciding}
-                    onClick={() =>
-                      run(key, "Could not send your decision", () =>
-                        resolveComputerUseConfirmation(prompt.callId, true),
-                      )
-                    }
-                  >
-                    Allow action
-                  </Button>
-                </div>
-                {errors[key] && (
-                  <p className="text-destructive text-xs break-words" role="alert">
-                    {errors[key]}
-                  </p>
-                )}
-              </section>
-            );
-          })}
-        </div>
-      </div>
-
       {(snapshot.halted || (showActive && snapshot.active)) && (
         <div className="pointer-events-none fixed inset-x-0 bottom-5 z-50 flex justify-center px-4">
           <div

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -1,3 +1,5 @@
+import { invoke, isTauri } from "@tauri-apps/api/core";
+
 import {
   APP_INVOKE_REFUSAL_KINDS,
   AppInvokeRefusalError,
@@ -471,6 +473,11 @@ export class ApiClient {
   }
 
   putMcpServers(servers: McpServerDefinition[]): Promise<McpServersInfo> {
+    if (isTauri()) {
+      return invoke<McpServersInfo>("put_native_mcp_servers", {
+        config: { servers },
+      });
+    }
     return this.json("/mcp/servers", {
       method: "PUT",
       headers: this.headers(true),

--- a/crates/tidebreak-desktop/ui/src/computerUse.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/computerUse.dom.test.tsx
@@ -6,8 +6,6 @@ import type { ComputerUseSnapshot } from "./computerUse";
 const EMPTY_SNAPSHOT: ComputerUseSnapshot = {
   active: null,
   halted: false,
-  pendingConsents: [],
-  pendingConfirmations: [],
 };
 
 const mocks = vi.hoisted(() => ({

--- a/crates/tidebreak-desktop/ui/src/computerUse.ts
+++ b/crates/tidebreak-desktop/ui/src/computerUse.ts
@@ -2,35 +2,6 @@ import { invoke, isTauri } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { useEffect, useState } from "react";
 
-/** The capability a parked computer-use consent ask is for. */
-export type ComputerUseCapability =
-  | "capture_screen"
-  | "read_app_content"
-  | "control_app";
-
-/** What the user can do with a per-app consent card. */
-export type ComputerUseConsentDecision = "once" | "chat" | "always" | "decline";
-
-/** A parked per-app consent ask, as the native executor reports it. */
-export type ComputerUseConsentPrompt = {
-  callId: string;
-  chatId: string;
-  bundleId: string;
-  appName: string | null;
-  capability: ComputerUseCapability;
-  grantScope: "chat" | "project";
-};
-
-/** A consequential action the host broker is holding for confirmation. */
-export type ComputerUseConfirmationPrompt = {
-  callId: string;
-  chatId: string;
-  bundleId: string;
-  appName: string | null;
-  targetLabel: string | null;
-  reason: string;
-};
-
 /** The app most recently under control, with its idle re-arm window. */
 export type ComputerUseActiveControl = {
   bundleId: string;
@@ -43,8 +14,6 @@ export type ComputerUseActiveControl = {
 export type ComputerUseSnapshot = {
   active: ComputerUseActiveControl | null;
   halted: boolean;
-  pendingConsents: ComputerUseConsentPrompt[];
-  pendingConfirmations: ComputerUseConfirmationPrompt[];
 };
 
 const STATE_EVENT = "computer-use-state-changed";
@@ -52,8 +21,6 @@ const STATE_EVENT = "computer-use-state-changed";
 const EMPTY: ComputerUseSnapshot = {
   active: null,
   halted: false,
-  pendingConsents: [],
-  pendingConfirmations: [],
 };
 
 /**
@@ -103,22 +70,4 @@ export function stopComputerUseControl(): Promise<void> {
 /** Re-arm control after a Stop. */
 export function resumeComputerUseControl(): Promise<void> {
   return invoke("resume_computer_use_control");
-}
-
-export function resolveComputerUseConsent(
-  callId: string,
-  decision: ComputerUseConsentDecision,
-): Promise<void> {
-  return invoke("resolve_computer_use_consent", {
-    request: { callId, decision },
-  });
-}
-
-export function resolveComputerUseConfirmation(
-  callId: string,
-  confirmed: boolean,
-): Promise<void> {
-  return invoke("resolve_computer_use_confirmation", {
-    request: { callId, confirmed },
-  });
 }

--- a/crates/tidebreak-desktop/ui/src/document/DocxViewer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/DocxViewer.dom.test.tsx
@@ -27,6 +27,11 @@ function source(id = "doc-1"): FileBytesSource {
 }
 
 function renderPage(bodyContainer: HTMLElement, label = "document") {
+  const hostileStyle = document.createElement("style");
+  hostileStyle.textContent =
+    "body { display: none !important; } </style><script>alert(1)</script><style>";
+  bodyContainer.append(hostileStyle);
+
   const page = document.createElement("section");
   page.className = "docx";
   page.dataset.label = label;
@@ -76,7 +81,7 @@ beforeEach(() => {
 });
 afterEach(cleanup);
 
-it("renders one secured read-only document without remounting on parent rerenders", async () => {
+it("confines generated document styles to an opaque-origin sandbox", async () => {
   const { container, rerender } = render(<DocxViewer source={source()} />);
 
   await waitFor(() => expect(docxMocks.renderAsync).toHaveBeenCalledTimes(1));
@@ -87,15 +92,37 @@ it("renders one secured read-only document without remounting on parent rerender
     DOCX_RENDER_OPTIONS,
   );
 
-  const links = Array.from(container.querySelectorAll("a"));
-  expect(links[0]).toHaveAttribute("href", "https://example.com/report");
-  expect(links[0]).toHaveAttribute("target", "_blank");
-  expect(links[0]).toHaveAttribute("rel", "noopener noreferrer");
-  expect(links[1]).not.toHaveAttribute("href");
-  expect(links[2]).toHaveAttribute("href", "#section-2");
+  const frame = await waitFor(() => {
+    const candidate = container.querySelector("iframe");
+    expect(candidate).not.toBeNull();
+    return candidate as HTMLIFrameElement;
+  });
+  expect(frame).toHaveAttribute("sandbox", "allow-popups");
+  expect(frame).not.toHaveAttribute(
+    "sandbox",
+    expect.stringContaining("allow-scripts"),
+  );
+  expect(frame).not.toHaveAttribute(
+    "sandbox",
+    expect.stringContaining("allow-same-origin"),
+  );
+  expect(frame).toHaveAttribute("referrerpolicy", "no-referrer");
+  expect(frame.srcdoc).toContain("default-src 'none'; img-src data: blob:");
+  expect(frame.srcdoc).toContain("script-src 'none'");
+  expect(frame.srcdoc).toContain("connect-src 'none'");
+  expect(frame.srcdoc).toContain("form-action 'none'");
 
-  const page = container.querySelector<HTMLElement>("section.docx");
-  expect(page).toHaveStyle({ height: "auto", minHeight: "1056px" });
+  // docx-preview generated a document-global rule, but neither it nor the
+  // rendered page ever entered Tidebreak's live document.
+  expect(container.querySelector("section.docx")).toBeNull();
+  expect(document.body.textContent).not.toContain(
+    "body { display: none !important; }",
+  );
+  expect(frame.srcdoc).toContain("body { display: none !important; }");
+  expect(frame.srcdoc).not.toContain("</style><script>alert(1)</script>");
+  expect(frame.srcdoc).toContain('href="https://example.com/report"');
+  expect(frame.srcdoc).toContain('target="_blank"');
+  expect(frame.srcdoc).not.toContain("http://example.com/plain");
 
   rerender(<DocxViewer source={source()} />);
   expect(docxMocks.renderAsync).toHaveBeenCalledTimes(1);
@@ -130,16 +157,18 @@ it("does not let a superseded parse overwrite the current document", async () =>
   await waitFor(() => expect(docxMocks.renderAsync).toHaveBeenCalledTimes(1));
 
   rerender(<DocxViewer source={source("new")} />);
-  await waitFor(() =>
-    expect(container.querySelector("section.docx")).toHaveAttribute(
-      "data-label",
-      "new",
-    ),
-  );
+  await waitFor(() => expect(docxMocks.renderAsync).toHaveBeenCalledTimes(2));
+  await waitFor(() => {
+    expect(container.querySelector("iframe")?.getAttribute("srcdoc")).toContain(
+      'data-label="new"',
+    );
+  });
 
   await act(async () => firstRender.resolve());
-  expect(container.querySelector("section.docx")).toHaveAttribute(
-    "data-label",
-    "new",
+  expect(container.querySelector("iframe")?.getAttribute("srcdoc")).toContain(
+    'data-label="new"',
   );
+  expect(
+    container.querySelector("iframe")?.getAttribute("srcdoc"),
+  ).not.toContain('data-label="old"');
 });

--- a/crates/tidebreak-desktop/ui/src/document/DocxViewer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/DocxViewer.dom.test.tsx
@@ -97,7 +97,7 @@ it("confines generated document styles to an opaque-origin sandbox", async () =>
     expect(candidate).not.toBeNull();
     return candidate as HTMLIFrameElement;
   });
-  expect(frame).toHaveAttribute("sandbox", "allow-popups");
+  expect(frame).toHaveAttribute("sandbox", "");
   expect(frame).not.toHaveAttribute(
     "sandbox",
     expect.stringContaining("allow-scripts"),
@@ -120,8 +120,14 @@ it("confines generated document styles to an opaque-origin sandbox", async () =>
   );
   expect(frame.srcdoc).toContain("body { display: none !important; }");
   expect(frame.srcdoc).not.toContain("</style><script>alert(1)</script>");
-  expect(frame.srcdoc).toContain('href="https://example.com/report"');
-  expect(frame.srcdoc).toContain('target="_blank"');
+  expect(frame.srcdoc).not.toContain('href="https://example.com/report"');
+  expect(frame.srcdoc).not.toContain('target="_blank"');
+  expect(frame.srcdoc).toContain(
+    "safe (https://example.com/report)",
+  );
+  expect(frame.srcdoc).toContain(
+    "External link (copy this address): https://example.com/report",
+  );
   expect(frame.srcdoc).not.toContain("http://example.com/plain");
 
   rerender(<DocxViewer source={source()} />);

--- a/crates/tidebreak-desktop/ui/src/document/DocxViewer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/DocxViewer.dom.test.tsx
@@ -49,6 +49,14 @@ function renderPage(bodyContainer: HTMLElement, label = "document") {
   unsafe.textContent = "unsafe";
   page.append(unsafe);
 
+  const spoofed = document.createElement("a");
+  spoofed.setAttribute(
+    "data-tidebreak-external-href",
+    "javascript:alert('spoofed')",
+  );
+  spoofed.textContent = "spoofed";
+  page.append(spoofed);
+
   const bookmark = document.createElement("a");
   bookmark.href = "#section-2";
   bookmark.textContent = "bookmark";
@@ -129,9 +137,28 @@ it("confines generated document styles to an opaque-origin sandbox", async () =>
     "External link (copy this address): https://example.com/report",
   );
   expect(frame.srcdoc).not.toContain("http://example.com/plain");
+  expect(frame.srcdoc).not.toContain("data-tidebreak-external-href");
+  expect(frame.srcdoc).not.toContain("javascript:alert");
 
   rerender(<DocxViewer source={source()} />);
   expect(docxMocks.renderAsync).toHaveBeenCalledTimes(1);
+});
+
+it("finishes rendering when animation frames are suspended", async () => {
+  const requestAnimationFrame = vi
+    .spyOn(window, "requestAnimationFrame")
+    .mockImplementation(() => 1);
+
+  try {
+    const { container } = render(<DocxViewer source={source()} />);
+
+    await waitFor(
+      () => expect(container.querySelector("iframe")).not.toBeNull(),
+      { timeout: 500 },
+    );
+  } finally {
+    requestAnimationFrame.mockRestore();
+  }
 });
 
 it("does not let a superseded parse overwrite the current document", async () => {

--- a/crates/tidebreak-desktop/ui/src/document/DocxViewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/DocxViewer.tsx
@@ -1,19 +1,17 @@
 import { renderAsync } from "docx-preview";
 import { Loader2Icon } from "lucide-react";
 import type { HTMLAttributes } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { FileDownloadProgressIndicator } from "@/components/document/FileDownloadProgress";
-import { openExternal } from "@/host";
 import { cn } from "@/lib/utils";
 import { useFileDownload, type FileBytesSource } from "./useFileDownload";
 
-const PAGE_GUTTER_PX = 48;
-
 /**
- * docx-preview intentionally renders the Word package into ordinary HTML. Its
- * embedded resources therefore stay local to the document, and disabling
- * altChunk prevents an untrusted DOCX from injecting an HTML iframe.
+ * docx-preview intentionally renders the Word package into ordinary HTML.
+ * altChunk stays disabled so a DOCX cannot add arbitrary HTML to that output.
+ * The generated HTML and CSS are additionally confined to an opaque-origin,
+ * scriptless iframe below.
  */
 export const DOCX_RENDER_OPTIONS = {
   breakPages: true,
@@ -28,25 +26,45 @@ export const DOCX_RENDER_OPTIONS = {
   useBase64URL: true,
 } as const;
 
-const DOCX_VIEWER_STYLES = `
-.tidebreak-docx-viewer .docx-wrapper {
-  min-height: 100%;
-  padding: 24px !important;
-  background: color-mix(in srgb, var(--muted) 45%, transparent) !important;
-}
+const DOCX_FRAME_PREFIX = `<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data: blob:; font-src data: blob:; style-src 'unsafe-inline'; script-src 'none'; connect-src 'none'; form-action 'none'; base-uri 'none'; frame-src 'none'; object-src 'none'">
+  <meta name="referrer" content="no-referrer">
+  <style>
+    :root { color-scheme: light; }
+    * { box-sizing: border-box; }
+    html, body { min-height: 100%; margin: 0; }
+    body {
+      min-width: 0;
+      overflow: auto;
+      background: rgb(241 245 249);
+      font-family: system-ui, sans-serif;
+    }
+    #document-root { min-height: 100%; }
+    #document-root .docx-wrapper {
+      min-height: 100%;
+      padding: 24px !important;
+      background: rgb(241 245 249) !important;
+    }
+    #document-root section.docx {
+      height: auto !important;
+      min-height: var(--tidebreak-docx-page-height);
+      margin: 0 auto 24px !important;
+      overflow: visible !important;
+      color: #111827;
+      box-shadow: 0 1px 2px rgb(15 23 42 / 0.12), 0 8px 28px rgb(15 23 42 / 0.10) !important;
+    }
+    #document-root section.docx:last-child { margin-bottom: 0 !important; }
+  </style>
+</head>
+<body>
+  <div id="document-root">`;
 
-.tidebreak-docx-viewer section.docx {
-  margin: 0 auto 24px !important;
-  color: #111827;
-  box-shadow:
-    0 1px 2px rgb(15 23 42 / 0.12),
-    0 8px 28px rgb(15 23 42 / 0.10) !important;
-}
-
-.tidebreak-docx-viewer section.docx:last-child {
-  margin-bottom: 0 !important;
-}
-`;
+const DOCX_FRAME_SUFFIX = `</div>
+</body>
+</html>`;
 
 interface Props extends HTMLAttributes<HTMLDivElement> {
   source: FileBytesSource;
@@ -58,37 +76,31 @@ export default function DocxViewer({
   className,
   ...restProps
 }: Props) {
-  const containerRef = useRef<HTMLDivElement>(null);
+  const [frameDocument, setFrameDocument] = useState<string | null>(null);
   const [errorType, setErrorType] = useState<"parse" | "load" | null>(null);
   const [isReady, setIsReady] = useState(false);
 
   const fileDownload = useFileDownload(source, { parseAs: "arrayBuffer" });
 
   useEffect(() => {
-    const container = containerRef.current;
-    if (!fileDownload.data || !container) return;
+    if (!fileDownload.data) return;
 
     let cancelled = false;
-    let resizeObserver: ResizeObserver | null = null;
     const staging = document.createElement("div");
+    setFrameDocument(null);
     setIsReady(false);
     setErrorType(null);
-    container.replaceChildren();
 
-    // docx-preview cannot cancel a parse. Render into a detached node so a
-    // superseded document can finish without overwriting the current one.
+    // docx-preview cannot cancel a parse. Render into a detached node so its
+    // generated styles never enter Tidebreak's main document. The sanitized
+    // serialization is then loaded into a scriptless sandboxed frame.
     void renderAsync(fileDownload.data, staging, staging, DOCX_RENDER_OPTIONS)
       .then(() => {
         if (cancelled) return;
-
-        container.replaceChildren(...staging.childNodes);
-        secureDocumentLinks(container);
-        const pages = preparePages(container);
-        const fitPages = () => fitPagesToWidth(container, pages);
-        fitPages();
-        resizeObserver = new ResizeObserver(fitPages);
-        resizeObserver.observe(container);
-        setIsReady(true);
+        sanitizeRenderedDocument(staging);
+        setFrameDocument(
+          `${DOCX_FRAME_PREFIX}${staging.innerHTML}${DOCX_FRAME_SUFFIX}`,
+        );
       })
       .catch(() => {
         if (!cancelled) setErrorType("parse");
@@ -96,44 +108,12 @@ export default function DocxViewer({
 
     return () => {
       cancelled = true;
-      resizeObserver?.disconnect();
-      container.replaceChildren();
     };
   }, [fileDownload.data]);
 
   useEffect(() => {
     if (fileDownload.error) setErrorType("load");
   }, [fileDownload.error]);
-
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
-
-    const handleClick = (event: MouseEvent) => {
-      const target = event.target as HTMLElement | null;
-      const anchor = target?.closest?.("a") as HTMLAnchorElement | null;
-      if (!anchor || !container.contains(anchor)) return;
-
-      const href = anchor.getAttribute("href");
-      if (!href || href.startsWith("#")) return;
-
-      event.preventDefault();
-      event.stopPropagation();
-      const safeHref = safeExternalHref(href);
-      if (!safeHref) return;
-
-      void openExternal(safeHref)
-        .catch(() => false)
-        .then((opened) => {
-          if (!opened) {
-            window.open(safeHref, "_blank", "noopener,noreferrer");
-          }
-        });
-    };
-
-    container.addEventListener("click", handleClick, true);
-    return () => container.removeEventListener("click", handleClick, true);
-  }, []);
 
   if (errorType) {
     return (
@@ -153,13 +133,9 @@ export default function DocxViewer({
 
   return (
     <div
-      className={cn(
-        "tidebreak-docx-viewer relative min-h-0 overflow-auto",
-        className,
-      )}
+      className={cn("relative min-h-0 overflow-hidden", className)}
       {...restProps}
     >
-      <style dangerouslySetInnerHTML={{ __html: DOCX_VIEWER_STYLES }} />
       {isLoading && (
         <div className="bg-background/80 absolute inset-0 z-10 flex items-center justify-center">
           {fileDownload.progress ? (
@@ -176,67 +152,98 @@ export default function DocxViewer({
           )}
         </div>
       )}
-      <div ref={containerRef} className="min-h-full min-w-0" />
+      {frameDocument && (
+        <iframe
+          title="Document preview"
+          sandbox="allow-popups"
+          referrerPolicy="no-referrer"
+          srcDoc={frameDocument}
+          className="h-full min-h-64 w-full border-0"
+          onLoad={() => setIsReady(true)}
+        />
+      )}
     </div>
   );
 }
 
-type PreparedPage = { element: HTMLElement; width: number };
-
 /**
- * Keep Word's page as the minimum height, but let content grow rather than be
- * clipped when a producer did not persist Word's last-rendered page breaks.
+ * Defense in depth for any unexpected element emitted by docx-preview. Styles
+ * remain intentionally intact, but are serialized safely and can only affect
+ * the sandboxed document.
  */
-function preparePages(container: HTMLElement): PreparedPage[] {
-  return Array.from(container.querySelectorAll<HTMLElement>("section.docx")).map(
-    (page) => {
-      const width = page.offsetWidth;
-      const height = page.style.height;
-      if (height) page.style.minHeight = height;
-      page.style.height = "auto";
-      page.style.overflow = "visible";
-      return { element: page, width };
-    },
-  );
-}
+function sanitizeRenderedDocument(container: HTMLElement): void {
+  container
+    .querySelectorAll(
+      "script, iframe, frame, frameset, object, embed, meta, base, link, form, input, button, textarea, select, option, title, noscript, template, xmp, noembed, plaintext",
+    )
+    .forEach((element) => element.remove());
 
-/** Fit pages down to a narrow panel without ever enlarging or reflowing them. */
-function fitPagesToWidth(container: HTMLElement, pages: PreparedPage[]): void {
-  const availableWidth = Math.max(0, container.clientWidth - PAGE_GUTTER_PX);
-  if (availableWidth === 0) return;
-  for (const page of pages) {
-    const scale = page.width > 0 ? Math.min(1, availableWidth / page.width) : 1;
-    page.element.style.zoom = String(scale);
+  for (const element of container.querySelectorAll<HTMLElement>("*")) {
+    for (const attribute of Array.from(element.attributes)) {
+      const name = attribute.name.toLowerCase();
+      if (
+        name.startsWith("on") ||
+        name === "srcdoc" ||
+        name === "srcset" ||
+        name === "action" ||
+        name === "formaction" ||
+        name === "ping"
+      ) {
+        element.removeAttribute(attribute.name);
+      }
+    }
+
+    if (element.hasAttribute("src")) {
+      const src = element.getAttribute("src") ?? "";
+      if (!src.startsWith("data:") && !src.startsWith("blob:")) {
+        element.removeAttribute("src");
+      }
+    }
+
+    for (const name of ["href", "xlink:href"]) {
+      if (!element.hasAttribute(name)) continue;
+      const href = element.getAttribute(name) ?? "";
+      if (href.startsWith("#")) continue;
+      const safeHref = safeExternalHref(href);
+      if (safeHref) {
+        element.setAttribute(name, safeHref);
+      } else {
+        element.removeAttribute(name);
+      }
+    }
   }
-}
 
-/** Leave internal bookmarks intact; only HTTPS links may leave the document. */
-function secureDocumentLinks(container: HTMLElement): void {
   for (const anchor of container.querySelectorAll<HTMLAnchorElement>("a")) {
     const href = anchor.getAttribute("href");
-    if (!href || href.startsWith("#")) continue;
-
-    const safeHref = safeExternalHref(href);
-
-    if (safeHref === null) {
-      anchor.removeAttribute("href");
+    if (!href || href.startsWith("#")) {
       anchor.removeAttribute("target");
       anchor.removeAttribute("rel");
       continue;
     }
-
-    anchor.href = safeHref;
     anchor.target = "_blank";
     anchor.rel = "noopener noreferrer";
+  }
+
+  for (const page of container.querySelectorAll<HTMLElement>("section.docx")) {
+    if (page.style.height) {
+      page.style.setProperty("--tidebreak-docx-page-height", page.style.height);
+    }
+  }
+
+  // <style> is an HTML raw-text element. Neutralize a DOCX-controlled closing
+  // tag before innerHTML is embedded in srcdoc so it cannot become frame HTML.
+  for (const style of container.querySelectorAll<HTMLStyleElement>("style")) {
+    style.textContent = style.textContent?.replace(/<\/style/giu, "<\\/style") ?? "";
   }
 }
 
 function safeExternalHref(href: string): string | null {
   try {
     const parsed = new URL(href);
-    return parsed.protocol === "https:" ? parsed.href : null;
+    return parsed.protocol === "https:" && !parsed.username && !parsed.password
+      ? parsed.href
+      : null;
   } catch {
-    // Relative links have no safe meaning outside the DOCX package.
     return null;
   }
 }

--- a/crates/tidebreak-desktop/ui/src/document/DocxViewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/DocxViewer.tsx
@@ -104,7 +104,7 @@ export default function DocxViewer({
     // is then loaded into a scriptless sandboxed frame.
     void renderAsync(fileDownload.data, staging, staging, DOCX_RENDER_OPTIONS)
       .then(async () => {
-        await nextAnimationFrame();
+        await waitForLayoutPass();
         if (cancelled) return;
         sanitizeRenderedDocument(staging);
         setFrameDocument(
@@ -185,6 +185,8 @@ export default function DocxViewer({
  * the sandboxed document.
  */
 function sanitizeRenderedDocument(container: HTMLElement): void {
+  const externalHrefs = new WeakMap<Element, string>();
+
   container
     .querySelectorAll(
       "script, iframe, frame, frameset, object, embed, meta, base, link, form, input, button, textarea, select, option, title, noscript, template, xmp, noembed, plaintext",
@@ -196,6 +198,7 @@ function sanitizeRenderedDocument(container: HTMLElement): void {
       const name = attribute.name.toLowerCase();
       if (
         name.startsWith("on") ||
+        name === "data-tidebreak-external-href" ||
         name === "srcdoc" ||
         name === "srcset" ||
         name === "action" ||
@@ -223,15 +226,14 @@ function sanitizeRenderedDocument(container: HTMLElement): void {
         name === "href" &&
         element.tagName.toLowerCase() === "a"
       ) {
-        element.setAttribute("data-tidebreak-external-href", safeHref);
+        externalHrefs.set(element, safeHref);
       }
       element.removeAttribute(name);
     }
   }
 
   for (const anchor of container.querySelectorAll<HTMLAnchorElement>("a")) {
-    const externalHref = anchor.getAttribute("data-tidebreak-external-href");
-    anchor.removeAttribute("data-tidebreak-external-href");
+    const externalHref = externalHrefs.get(anchor);
     anchor.removeAttribute("target");
     anchor.removeAttribute("rel");
     if (externalHref) {
@@ -259,6 +261,13 @@ function nextAnimationFrame(): Promise<void> {
   return new Promise((resolve) => {
     window.requestAnimationFrame(() => resolve());
   });
+}
+
+function waitForLayoutPass(): Promise<void> {
+  return Promise.race([
+    nextAnimationFrame(),
+    new Promise<void>((resolve) => window.setTimeout(resolve, 100)),
+  ]);
 }
 
 function safeExternalHref(href: string): string | null {

--- a/crates/tidebreak-desktop/ui/src/document/DocxViewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/DocxViewer.tsx
@@ -15,7 +15,9 @@ import { useFileDownload, type FileBytesSource } from "./useFileDownload";
  */
 export const DOCX_RENDER_OPTIONS = {
   breakPages: true,
-  experimental: true,
+  // The experimental tab-stop pass runs on a fixed delayed timer after
+  // renderAsync resolves. Keep it off so serialization never races it.
+  experimental: false,
   ignoreLastRenderedPageBreak: false,
   renderAltChunks: false,
   renderComments: false,
@@ -86,16 +88,23 @@ export default function DocxViewer({
     if (!fileDownload.data) return;
 
     let cancelled = false;
+    const stagingHost = document.createElement("div");
     const staging = document.createElement("div");
+    stagingHost.style.cssText =
+      "position:fixed;left:-100000px;top:0;width:1200px;opacity:0;pointer-events:none;";
+    stagingHost.attachShadow({ mode: "closed" }).append(staging);
+    document.body.append(stagingHost);
     setFrameDocument(null);
     setIsReady(false);
     setErrorType(null);
 
-    // docx-preview cannot cancel a parse. Render into a detached node so its
-    // generated styles never enter Tidebreak's main document. The sanitized
-    // serialization is then loaded into a scriptless sandboxed frame.
+    // docx-preview cannot cancel a parse. Render inside an offscreen closed
+    // shadow root so layout-dependent SVG sizing can finish without generated
+    // styles entering Tidebreak's main document. The sanitized serialization
+    // is then loaded into a scriptless sandboxed frame.
     void renderAsync(fileDownload.data, staging, staging, DOCX_RENDER_OPTIONS)
-      .then(() => {
+      .then(async () => {
+        await nextAnimationFrame();
         if (cancelled) return;
         sanitizeRenderedDocument(staging);
         setFrameDocument(
@@ -104,10 +113,14 @@ export default function DocxViewer({
       })
       .catch(() => {
         if (!cancelled) setErrorType("parse");
+      })
+      .finally(() => {
+        stagingHost.remove();
       });
 
     return () => {
       cancelled = true;
+      stagingHost.remove();
     };
   }, [fileDownload.data]);
 
@@ -155,7 +168,7 @@ export default function DocxViewer({
       {frameDocument && (
         <iframe
           title="Document preview"
-          sandbox="allow-popups"
+          sandbox=""
           referrerPolicy="no-referrer"
           srcDoc={frameDocument}
           className="h-full min-h-64 w-full border-0"
@@ -205,23 +218,28 @@ function sanitizeRenderedDocument(container: HTMLElement): void {
       const href = element.getAttribute(name) ?? "";
       if (href.startsWith("#")) continue;
       const safeHref = safeExternalHref(href);
-      if (safeHref) {
-        element.setAttribute(name, safeHref);
-      } else {
-        element.removeAttribute(name);
+      if (
+        safeHref &&
+        name === "href" &&
+        element.tagName.toLowerCase() === "a"
+      ) {
+        element.setAttribute("data-tidebreak-external-href", safeHref);
       }
+      element.removeAttribute(name);
     }
   }
 
   for (const anchor of container.querySelectorAll<HTMLAnchorElement>("a")) {
-    const href = anchor.getAttribute("href");
-    if (!href || href.startsWith("#")) {
-      anchor.removeAttribute("target");
-      anchor.removeAttribute("rel");
-      continue;
+    const externalHref = anchor.getAttribute("data-tidebreak-external-href");
+    anchor.removeAttribute("data-tidebreak-external-href");
+    anchor.removeAttribute("target");
+    anchor.removeAttribute("rel");
+    if (externalHref) {
+      anchor.title = `External link (copy this address): ${externalHref}`;
+      if (!anchor.textContent?.includes(externalHref)) {
+        anchor.append(document.createTextNode(` (${externalHref})`));
+      }
     }
-    anchor.target = "_blank";
-    anchor.rel = "noopener noreferrer";
   }
 
   for (const page of container.querySelectorAll<HTMLElement>("section.docx")) {
@@ -235,6 +253,12 @@ function sanitizeRenderedDocument(container: HTMLElement): void {
   for (const style of container.querySelectorAll<HTMLStyleElement>("style")) {
     style.textContent = style.textContent?.replace(/<\/style/giu, "<\\/style") ?? "";
   }
+}
+
+function nextAnimationFrame(): Promise<void> {
+  return new Promise((resolve) => {
+    window.requestAnimationFrame(() => resolve());
+  });
 }
 
 function safeExternalHref(href: string): string | null {

--- a/crates/tidebreak-router/Cargo.toml
+++ b/crates/tidebreak-router/Cargo.toml
@@ -38,6 +38,7 @@ serde_json = { workspace = true }
 reqwest = { workspace = true, optional = true }
 async-stream = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["time"], optional = true }
+url = { workspace = true }
 uuid = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/tidebreak-router/src/router.rs
+++ b/crates/tidebreak-router/src/router.rs
@@ -608,7 +608,7 @@ fn build_adapter(route: &Route) -> Option<Arc<dyn ModelProvider>> {
 }
 
 fn base_url_is_allowed(base: &str, allow_credentialless_loopback_http: bool) -> bool {
-    let Ok(url) = reqwest::Url::parse(base) else {
+    let Ok(url) = url::Url::parse(base) else {
         return false;
     };
     if !url.username().is_empty() || url.password().is_some() || url.fragment().is_some() {

--- a/crates/tidebreak-router/src/router.rs
+++ b/crates/tidebreak-router/src/router.rs
@@ -473,7 +473,9 @@ impl ModelProvider for Router {
 }
 
 fn build_adapter(route: &Route) -> Option<Arc<dyn ModelProvider>> {
-    if route.api_key.is_empty() && route.token_source.is_none() {
+    let credentialless_ollama =
+        route.kind == RouteKind::Ollama && route.api_key.is_empty() && route.token_source.is_none();
+    if route.api_key.is_empty() && route.token_source.is_none() && !credentialless_ollama {
         return None;
     }
     match route.kind {
@@ -564,9 +566,14 @@ fn build_adapter(route: &Route) -> Option<Arc<dyn ModelProvider>> {
         | RouteKind::Ollama
         | RouteKind::OpenaiCompatible => {
             let base = route.base_url.as_deref()?;
-            // Refuse non-http(s) schemes so a stored base_url can't point the
-            // adapter at an arbitrary scheme handler.
-            if !(base.starts_with("https://") || base.starts_with("http://")) {
+            let configurable_transport =
+                matches!(route.kind, RouteKind::Ollama | RouteKind::OpenaiCompatible);
+            if configurable_transport && !base_url_is_allowed(base, credentialless_ollama) {
+                return None;
+            }
+            if !configurable_transport
+                && !(base.starts_with("https://") || base.starts_with("http://"))
+            {
                 return None;
             }
             Some(Arc::new(
@@ -597,6 +604,27 @@ fn build_adapter(route: &Route) -> Option<Arc<dyn ModelProvider>> {
         | RouteKind::Openrouter
         | RouteKind::Ollama
         | RouteKind::OpenaiCompatible => None,
+    }
+}
+
+fn base_url_is_allowed(base: &str, allow_credentialless_loopback_http: bool) -> bool {
+    let Ok(url) = reqwest::Url::parse(base) else {
+        return false;
+    };
+    if !url.username().is_empty() || url.password().is_some() || url.fragment().is_some() {
+        return false;
+    }
+    match url.scheme() {
+        "https" => true,
+        "http" if allow_credentialless_loopback_http => url.host_str().is_some_and(|host| {
+            host.eq_ignore_ascii_case("localhost")
+                || host
+                    .trim_start_matches('[')
+                    .trim_end_matches(']')
+                    .parse::<std::net::IpAddr>()
+                    .is_ok_and(|address| address.is_loopback())
+        }),
+        _ => false,
     }
 }
 
@@ -683,7 +711,7 @@ mod tests {
                 RouteKind::OpenaiCompatible,
                 "sk-c",
                 &[],
-                Some("http://127.0.0.1:1234/v1"),
+                Some("https://compat.example/v1"),
             ),
         ]);
         assert_eq!(router.select("claude-opus-4-8"), Some(RouteKind::Anthropic));
@@ -774,7 +802,7 @@ mod tests {
     fn ollama_serves_only_configured_models() {
         let router = Router::build(vec![route(
             RouteKind::Ollama,
-            "ollama",
+            "",
             &["qwen3:0.6b"],
             Some("http://127.0.0.1:11434/v1"),
         )]);
@@ -825,6 +853,36 @@ mod tests {
             Some("file:///etc/passwd"),
         )]);
         assert_eq!(router.select("anything"), None);
+    }
+
+    #[test]
+    fn credentialed_routes_reject_cleartext_http() {
+        let router = Router::build(vec![route(
+            RouteKind::OpenaiCompatible,
+            "sk-c",
+            &[],
+            Some("http://127.0.0.1:1234/v1"),
+        )]);
+        assert_eq!(router.select("anything"), None);
+    }
+
+    #[test]
+    fn credentialless_ollama_allows_only_loopback_cleartext() {
+        let loopback = Router::build(vec![route(
+            RouteKind::Ollama,
+            "",
+            &["local"],
+            Some("http://[::1]:11434/v1"),
+        )]);
+        assert_eq!(loopback.select("local"), Some(RouteKind::Ollama));
+
+        let lan = Router::build(vec![route(
+            RouteKind::Ollama,
+            "",
+            &["remote"],
+            Some("http://192.168.1.10:11434/v1"),
+        )]);
+        assert_eq!(lan.select("remote"), None);
     }
 
     struct StaticSource(&'static str);

--- a/crates/tidebreak-server/src/connected_apps.rs
+++ b/crates/tidebreak-server/src/connected_apps.rs
@@ -553,6 +553,7 @@ pub(crate) trait GatewayInvokeDispatcher: Send + Sync {
     /// already checked the pin, the grant, and the fingerprint currency of.
     async fn dispatch(
         &self,
+        owner: &tidebreak_core::OwnerId,
         app: tidebreak_core::id::AppId,
         request: &GatewayOperationRequest,
     ) -> Result<crate::connectors::GatewayInvokeOutcome, GatewayDispatchError>;
@@ -575,6 +576,7 @@ pub(crate) trait GatewayDraftSource: Send + Sync {
     /// appending as needed.
     async fn ensure_registered(
         &self,
+        owner: &tidebreak_core::OwnerId,
         app: tidebreak_core::id::AppId,
         gateway_base_url: &str,
     ) -> tidebreak_core::Result<GatewayRegistration>;
@@ -588,6 +590,7 @@ pub(crate) trait GatewayDraftSource: Send + Sync {
     /// from the live revision, accepting only a revision pin from here.
     async fn relay_consent(
         &self,
+        owner: &tidebreak_core::OwnerId,
         app: tidebreak_core::id::AppId,
         gateway_base_url: &str,
     ) -> tidebreak_core::Result<GatewayConsentRelay>;

--- a/crates/tidebreak-server/src/desktop_schema.rs
+++ b/crates/tidebreak-server/src/desktop_schema.rs
@@ -33,7 +33,7 @@ const VECTOR_DIRECTORY: &str = "vectors";
 const MAX_MARKER_BYTES: u64 = 1_024;
 
 /// Bump this whenever the pre-v1 schema baseline changes incompatibly.
-const DESKTOP_SCHEMA_EPOCH: u32 = 25;
+const DESKTOP_SCHEMA_EPOCH: u32 = 26;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/tidebreak-server/src/gateway_drafts.rs
+++ b/crates/tidebreak-server/src/gateway_drafts.rs
@@ -33,7 +33,7 @@ use tidebreak_core::local_app::{
     app_revision_relative_path, AppBinding, AppGatewayDraft, AppManifest, AppRecord, AppRevision,
     MAX_APP_NAME_CHARS,
 };
-use tidebreak_core::{AgentError, Result, Store};
+use tidebreak_core::{AgentError, OwnerId, Result, Store};
 
 use crate::connected_apps::{
     GatewayConsentRelay, GatewayDispatchError, GatewayDraftSource, GatewayRegistration,
@@ -257,6 +257,7 @@ impl GatewayDraftRegistry {
     /// that keeps saying no is worse than an honest refusal.
     async fn register(
         &self,
+        owner: &OwnerId,
         record: &AppRecord,
         revision: &AppRevision,
         base_url: &str,
@@ -278,8 +279,15 @@ impl GatewayDraftRegistry {
                 shared_app_id,
                 revision_id,
             }) => {
-                self.persist(record, revision, base_url, &shared_app_id, &revision_id)
-                    .await?;
+                self.persist(
+                    owner,
+                    record,
+                    revision,
+                    base_url,
+                    &shared_app_id,
+                    &revision_id,
+                )
+                .await?;
                 Ok(GatewayRegistration::Registered {
                     shared_app_id,
                     revision_id,
@@ -302,6 +310,7 @@ impl GatewayDraftRegistry {
     /// mapping at what the gateway now serves.
     async fn append(
         &self,
+        owner: &OwnerId,
         draft: &AppGatewayDraft,
         record: &AppRecord,
         revision: &AppRevision,
@@ -316,6 +325,7 @@ impl GatewayDraftRegistry {
             None => Ok(GatewayRegistration::NotRegistered),
             Some(GatewayRegistrationOutcome::Registered { revision_id, .. }) => {
                 self.persist(
+                    owner,
                     record,
                     revision,
                     base_url,
@@ -343,6 +353,7 @@ impl GatewayDraftRegistry {
     /// Record what the gateway now holds for this app at this deployment.
     async fn persist(
         &self,
+        owner: &OwnerId,
         record: &AppRecord,
         revision: &AppRevision,
         base_url: &str,
@@ -350,14 +361,17 @@ impl GatewayDraftRegistry {
         gateway_revision_id: &str,
     ) -> Result<()> {
         self.store
-            .put_app_gateway_draft(&AppGatewayDraft {
-                app_id: record.id,
-                gateway_base_url: base_url.to_owned(),
-                shared_app_id: shared_app_id.to_owned(),
-                gateway_revision_id: gateway_revision_id.to_owned(),
-                synced_revision_id: revision.id,
-                updated_at: chrono::Utc::now(),
-            })
+            .put_app_gateway_draft_scoped(
+                owner,
+                &AppGatewayDraft {
+                    app_id: record.id,
+                    gateway_base_url: base_url.to_owned(),
+                    shared_app_id: shared_app_id.to_owned(),
+                    gateway_revision_id: gateway_revision_id.to_owned(),
+                    synced_revision_id: revision.id,
+                    updated_at: chrono::Utc::now(),
+                },
+            )
             .await
     }
 
@@ -368,15 +382,19 @@ impl GatewayDraftRegistry {
     /// a shared app at the gateway for something the library no longer holds:
     /// the store refuses the mapping write for the same reason, and refusing
     /// here means the network call never happens in the first place.
-    async fn current(&self, app: AppId) -> Result<(AppRecord, AppRevision)> {
+    async fn current(&self, owner: &OwnerId, app: AppId) -> Result<(AppRecord, AppRevision)> {
         let missing = || AgentError::Store(format!("app {app} not found"));
-        let record = self.store.get_app(app).await?.ok_or_else(missing)?;
+        let record = self
+            .store
+            .get_app_scoped(owner, app)
+            .await?
+            .ok_or_else(missing)?;
         if record.deleted_at.is_some() {
             return Err(missing());
         }
         let revision = self
             .store
-            .get_app_revision(record.current_revision)
+            .get_app_revision_scoped(owner, record.current_revision)
             .await?
             .ok_or_else(missing)?;
         Ok((record, revision))
@@ -406,6 +424,7 @@ impl GatewayDraftRegistry {
 impl GatewayDraftSource for GatewayDraftRegistry {
     async fn ensure_registered(
         &self,
+        owner: &OwnerId,
         app: AppId,
         gateway_base_url: &str,
     ) -> Result<GatewayRegistration> {
@@ -413,8 +432,12 @@ impl GatewayDraftSource for GatewayDraftRegistry {
         // Serialize the read-then-register decision per app; see `app_locks`.
         let lock = self.app_lock(app).await;
         let _guard = lock.lock().await;
-        let (record, revision) = self.current(app).await?;
-        match self.store.get_app_gateway_draft(app, &base_url).await? {
+        let (record, revision) = self.current(owner, app).await?;
+        match self
+            .store
+            .get_app_gateway_draft_scoped(owner, app, &base_url)
+            .await?
+        {
             // The gateway is already serving this exact local revision.
             Some(draft) if draft.synced_revision_id == revision.id => {
                 Ok(GatewayRegistration::Registered {
@@ -425,18 +448,25 @@ impl GatewayDraftSource for GatewayDraftRegistry {
             // Registered, but the app has moved on locally. The sync is lazy
             // by design: revisions nobody ever invoked are never pushed, so
             // the gateway's history is what was servable when it was used.
-            Some(draft) => self.append(&draft, &record, &revision, &base_url).await,
-            None => self.register(&record, &revision, &base_url).await,
+            Some(draft) => {
+                self.append(owner, &draft, &record, &revision, &base_url)
+                    .await
+            }
+            None => self.register(owner, &record, &revision, &base_url).await,
         }
     }
 
     async fn relay_consent(
         &self,
+        owner: &OwnerId,
         app: AppId,
         gateway_base_url: &str,
     ) -> Result<GatewayConsentRelay> {
         let base_url = normalized_gateway_base_url(gateway_base_url);
-        let (shared_app_id, revision_id) = match self.ensure_registered(app, &base_url).await? {
+        let (shared_app_id, revision_id) = match self
+            .ensure_registered(owner, app, &base_url)
+            .await?
+        {
             GatewayRegistration::Registered {
                 shared_app_id,
                 revision_id,
@@ -460,12 +490,18 @@ impl GatewayDraftSource for GatewayDraftRegistry {
             // else appended one. Re-establish the pin from the current local
             // revision and consent to that, once.
             Some(GatewayConsentOutcome::RevisionMoved) => {
-                let (record, revision) = self.current(app).await?;
-                let draft = self.store.get_app_gateway_draft(app, &base_url).await?;
+                let (record, revision) = self.current(owner, app).await?;
+                let draft = self
+                    .store
+                    .get_app_gateway_draft_scoped(owner, app, &base_url)
+                    .await?;
                 let Some(draft) = draft else {
                     return Ok(GatewayConsentRelay::NotRegistered);
                 };
-                let revision_id = match self.append(&draft, &record, &revision, &base_url).await? {
+                let revision_id = match self
+                    .append(owner, &draft, &record, &revision, &base_url)
+                    .await?
+                {
                     GatewayRegistration::Registered { revision_id, .. } => revision_id,
                     GatewayRegistration::NotRegistered => {
                         return Ok(GatewayConsentRelay::NotRegistered)
@@ -516,6 +552,7 @@ impl GatewayDraftSource for GatewayDraftRegistry {
 /// has decided no.
 pub(crate) async fn relay_with_consent_self_heal<F, Fut>(
     drafts: &dyn GatewayDraftSource,
+    owner: &OwnerId,
     app: AppId,
     gateway_base_url: &str,
     relay: F,
@@ -530,7 +567,7 @@ where
     if !matches!(outcome, GatewayInvokeOutcome::ConsentRequired { .. }) {
         return Ok(outcome);
     }
-    match drafts.relay_consent(app, gateway_base_url).await {
+    match drafts.relay_consent(owner, app, gateway_base_url).await {
         Ok(GatewayConsentRelay::Consented) => {}
         Ok(refused) => {
             tracing::info!("this app's gateway consent could not be relayed: {refused:?}");
@@ -652,13 +689,19 @@ mod tests {
     impl GatewayDraftSource for ScriptedDrafts {
         async fn ensure_registered(
             &self,
+            _owner: &OwnerId,
             _app: AppId,
             _base_url: &str,
         ) -> Result<GatewayRegistration> {
             unreachable!("the relay resolves registration before the self-heal runs")
         }
 
-        async fn relay_consent(&self, _app: AppId, _base_url: &str) -> Result<GatewayConsentRelay> {
+        async fn relay_consent(
+            &self,
+            _owner: &OwnerId,
+            _app: AppId,
+            _base_url: &str,
+        ) -> Result<GatewayConsentRelay> {
             self.relayed.fetch_add(1, Ordering::SeqCst);
             Ok(GatewayConsentRelay::Consented)
         }
@@ -678,8 +721,12 @@ mod tests {
             relayed: AtomicUsize::new(0),
         };
         let attempts = AtomicUsize::new(0);
-        let outcome =
-            relay_with_consent_self_heal(&drafts, AppId::new(), "https://gw.example/", || {
+        let outcome = relay_with_consent_self_heal(
+            &drafts,
+            &OwnerId::local(),
+            AppId::new(),
+            "https://gw.example/",
+            || {
                 let attempt = attempts.fetch_add(1, Ordering::SeqCst);
                 async move {
                     Ok(if attempt == 0 {
@@ -694,9 +741,10 @@ mod tests {
                         }
                     })
                 }
-            })
-            .await
-            .unwrap();
+            },
+        )
+        .await
+        .unwrap();
         assert!(matches!(outcome, GatewayInvokeOutcome::Executed { .. }));
         assert_eq!(attempts.load(Ordering::SeqCst), 2);
         assert_eq!(drafts.relayed.load(Ordering::SeqCst), 1);
@@ -705,13 +753,18 @@ mod tests {
             relayed: AtomicUsize::new(0),
         };
         let attempts = AtomicUsize::new(0);
-        let outcome =
-            relay_with_consent_self_heal(&drafts, AppId::new(), "https://gw.example/", || {
+        let outcome = relay_with_consent_self_heal(
+            &drafts,
+            &OwnerId::local(),
+            AppId::new(),
+            "https://gw.example/",
+            || {
                 attempts.fetch_add(1, Ordering::SeqCst);
                 async { Ok(refusal()) }
-            })
-            .await
-            .unwrap();
+            },
+        )
+        .await
+        .unwrap();
         assert!(
             matches!(outcome, GatewayInvokeOutcome::ConsentRequired { .. }),
             "a second refusal is the gateway's answer, carried back as one"

--- a/crates/tidebreak-server/src/gateway_runtime.rs
+++ b/crates/tidebreak-server/src/gateway_runtime.rs
@@ -1297,6 +1297,7 @@ impl GatewayRelayDispatcher {
 impl crate::connected_apps::GatewayInvokeDispatcher for GatewayRelayDispatcher {
     async fn dispatch(
         &self,
+        owner: &tidebreak_core::OwnerId,
         app: tidebreak_core::id::AppId,
         request: &crate::connected_apps::GatewayOperationRequest,
     ) -> std::result::Result<
@@ -1341,7 +1342,7 @@ impl crate::connected_apps::GatewayInvokeDispatcher for GatewayRelayDispatcher {
         }
         let shared_app_id = match self
             .drafts
-            .ensure_registered(app, &base_url)
+            .ensure_registered(owner, app, &base_url)
             .await
             .map_err(unreachable("register this app at the gateway"))?
         {
@@ -1356,9 +1357,13 @@ impl crate::connected_apps::GatewayInvokeDispatcher for GatewayRelayDispatcher {
             }
         };
         let body = shared_app_invoke_body(request);
-        crate::gateway_drafts::relay_with_consent_self_heal(&*self.drafts, app, &base_url, || {
-            self.relay(&connection, &shared_app_id, &body)
-        })
+        crate::gateway_drafts::relay_with_consent_self_heal(
+            &*self.drafts,
+            owner,
+            app,
+            &base_url,
+            || self.relay(&connection, &shared_app_id, &body),
+        )
         .await
     }
 }

--- a/crates/tidebreak-server/src/gateway_runtime.rs
+++ b/crates/tidebreak-server/src/gateway_runtime.rs
@@ -295,7 +295,7 @@ impl GatewayRuntime {
     /// The entitled connected apps, fetched live from the gateway with the
     /// stored session. Managed-only, like the whole sign-in surface; a
     /// gateway without the JSON apps surface reports `supported: false`.
-    pub(crate) async fn apps(&self) -> Result<GatewayApps> {
+    pub(crate) async fn apps(&self, owner: &tidebreak_core::OwnerId) -> Result<GatewayApps> {
         let connection = self.managed_connection().await?;
         let Some(apps) = Self::entitled_apps(&connection).await? else {
             return Ok(GatewayApps {
@@ -310,7 +310,7 @@ impl GatewayRuntime {
         // grant table leaves the counts at zero rather than failing the list.
         let mut used_by: std::collections::BTreeMap<String, usize> =
             std::collections::BTreeMap::new();
-        match self.store.list_live_app_grants().await {
+        match self.store.list_live_app_grants_scoped(owner).await {
             Ok(grants) => {
                 for grant in grants {
                     for binding in &grant.bindings {
@@ -1639,13 +1639,22 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use axum::extract::{Form, State};
-    use axum::http::HeaderMap;
+    use axum::http::{HeaderMap, Request};
     use axum::response::{IntoResponse, Json, Response};
     use axum::routing::{get, post};
-    use axum::Router as AxumRouter;
+    use axum::{Extension, Router as AxumRouter};
     use futures::StreamExt;
     use serde_json::{json, Value};
-    use tidebreak_core::{ChatMessage, ChatRequest, DbStore, ModelProvider, ProviderId, Role};
+    use tidebreak_core::id::{AppId, AppRevisionId};
+    use tidebreak_core::local_app::{
+        AppGatewayOperationsGrantBinding, AppGrant, AppGrantBinding, AppManifest, CreateApp,
+        NewAppRevision,
+    };
+    use tidebreak_core::{
+        AgentConfig, ChatMessage, ChatRequest, Config, DbStore, ModelProvider, OwnerId, ProviderId,
+        Role, ToolRegistry,
+    };
+    use tower::ServiceExt;
 
     use super::*;
 
@@ -2812,7 +2821,10 @@ mod tests {
         let base = format!("http://{address}");
         let (runtime, _store, _directory) = signed_in_runtime(&base).await;
 
-        let apps = runtime.apps().await.unwrap();
+        let apps = runtime
+            .apps(&tidebreak_core::OwnerId::local())
+            .await
+            .unwrap();
         assert!(apps.supported);
         assert_eq!(apps.apps.len(), 1);
         assert_eq!(
@@ -2822,12 +2834,141 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn gateway_apps_route_scopes_used_by_count_to_the_authenticated_principal() {
+        let gateway = Arc::new(FakeGateway::default());
+        *gateway.catalog.lock().unwrap() = Some(sample_catalog());
+        let address = serve(gateway).await;
+        let base = format!("http://{address}");
+        let (runtime, store, directory) = signed_in_runtime(&base).await;
+        let alice = OwnerId::new("user:alice").unwrap();
+        let app_id = AppId::new();
+        store
+            .create_app_scoped(
+                &alice,
+                &CreateApp {
+                    id: app_id,
+                    revision: NewAppRevision {
+                        id: AppRevisionId::new(),
+                        manifest: AppManifest {
+                            name: "Alice gateway app".into(),
+                            bindings: Vec::new(),
+                        },
+                        byte_len: 1,
+                        sha256: [0; 32],
+                        turn_id: None,
+                        producing_run_id: None,
+                        chat_id: None,
+                        created_at: chrono::Utc::now(),
+                    },
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .put_app_grant_scoped(
+                &alice,
+                &AppGrant {
+                    app_id,
+                    bindings: vec![AppGrantBinding::GatewayOperations(
+                        AppGatewayOperationsGrantBinding {
+                            gateway_app: "app-1".into(),
+                            operation_ids: vec!["list".into()],
+                            fingerprint: [1; 32],
+                        },
+                    )],
+                    created_at: chrono::Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        struct RouteTestResolver;
+
+        #[async_trait]
+        impl crate::resolver::ProviderResolver for RouteTestResolver {
+            async fn resolve(&self) -> Arc<dyn ModelProvider> {
+                Arc::new(crate::provider::UnconfiguredProvider)
+            }
+        }
+
+        let secrets: Arc<dyn SecretProvider> = Arc::new(MockSecrets::default());
+        let chatgpt = Arc::new(
+            crate::chatgpt_runtime::ChatGptRuntime::new(store.clone(), secrets.clone()).unwrap(),
+        );
+        let state = crate::state::AppState::with_gateway_runtime(
+            Config::desktop(directory.path()),
+            store,
+            Arc::new(RouteTestResolver),
+            secrets,
+            Arc::new(ToolRegistry::new()),
+            AgentConfig::default(),
+            uuid::Uuid::new_v4(),
+            runtime,
+            chatgpt,
+            crate::managed_policy::MemoryProvisionedPolicy::new(),
+            Arc::new(crate::managed_policy::NoOsPolicy),
+        )
+        .unwrap();
+
+        async fn count_for(
+            state: crate::state::AppState,
+            principal: crate::principal::Principal,
+        ) -> usize {
+            let response = AxumRouter::new()
+                .route("/gateway/apps", get(crate::routes::get_gateway_apps))
+                .with_state(state)
+                .layer(Extension(crate::principal::AuthContext {
+                    principal,
+                    client_executor: false,
+                }))
+                .oneshot(
+                    Request::builder()
+                        .uri("/gateway/apps")
+                        .body(axum::body::Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), axum::http::StatusCode::OK);
+            let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            serde_json::from_slice::<Value>(&body).unwrap()["apps"][0]["used_by_app_count"]
+                .as_u64()
+                .unwrap() as usize
+        }
+
+        let alice_count = count_for(
+            state.clone(),
+            crate::principal::Principal::User {
+                id: crate::principal::UserId::new("alice").unwrap(),
+                role: crate::principal::Role::Member,
+            },
+        )
+        .await;
+        let bob_count = count_for(
+            state,
+            crate::principal::Principal::User {
+                id: crate::principal::UserId::new("bob").unwrap(),
+                role: crate::principal::Role::Member,
+            },
+        )
+        .await;
+
+        assert_eq!(alice_count, 1);
+        assert_eq!(bob_count, 0);
+    }
+
+    #[tokio::test]
     async fn apps_from_a_catalogless_gateway_carry_no_readiness() {
         let address = serve(Arc::new(FakeGateway::default())).await;
         let base = format!("http://{address}");
         let (runtime, _store, _directory) = signed_in_runtime(&base).await;
 
-        let apps = runtime.apps().await.unwrap();
+        let apps = runtime
+            .apps(&tidebreak_core::OwnerId::local())
+            .await
+            .unwrap();
         assert!(apps.supported);
         assert_eq!(apps.apps.len(), 1);
         assert_eq!(apps.apps[0].connection, None);
@@ -3954,7 +4095,10 @@ mod tests {
             "{error}"
         );
         assert!(runtime.sync_models().await.is_err());
-        assert!(runtime.apps().await.is_err());
+        assert!(runtime
+            .apps(&tidebreak_core::OwnerId::local())
+            .await
+            .is_err());
         assert!(runtime.sign_out().await.is_err());
     }
 

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -235,6 +235,11 @@ pub fn app(state: AppState) -> Router {
 
     let client_executor_api = Router::new()
         .route(
+            "/native/mcp/servers",
+            axum::routing::put(routes::put_mcp_servers)
+                .layer(DefaultBodyLimit::max(mcp_config::MAX_CONFIG_BODY_BYTES)),
+        )
+        .route(
             "/sandbox-file-reads/pending",
             get(routes::list_pending_delegated_file_reads),
         )

--- a/crates/tidebreak-server/src/providers.rs
+++ b/crates/tidebreak-server/src/providers.rs
@@ -383,18 +383,6 @@ impl ProviderKind {
         matches!(self, Self::Fireworks | Self::Together | Self::Openrouter)
     }
 
-    /// Whether this route speaks the shared OpenAI-compatible transport.
-    pub const fn uses_openai_compatible_transport(self) -> bool {
-        matches!(
-            self,
-            Self::Fireworks
-                | Self::Together
-                | Self::Openrouter
-                | Self::Ollama
-                | Self::OpenaiCompatible
-        )
-    }
-
     /// Whether the reader can register model rows beside the endpoint.
     pub const fn accepts_configured_models(self) -> bool {
         matches!(
@@ -452,6 +440,88 @@ impl ProviderKind {
             ProviderCredential::Oauth {} => self == ProviderKind::Openai,
         }
     }
+}
+
+fn base_url_is_allowed(base: &str, allow_credentialless_loopback_http: bool) -> bool {
+    let Ok(url) = url::Url::parse(base) else {
+        return false;
+    };
+    if !url.username().is_empty() || url.password().is_some() || url.fragment().is_some() {
+        return false;
+    }
+    let allowed = match url.scheme() {
+        "https" => true,
+        "http" if allow_credentialless_loopback_http => match url.host() {
+            Some(url::Host::Domain(host)) => host.eq_ignore_ascii_case("localhost"),
+            Some(url::Host::Ipv4(address)) => address.is_loopback(),
+            Some(url::Host::Ipv6(address)) => address.is_loopback(),
+            None => false,
+        },
+        _ => false,
+    };
+    if allowed {
+        return true;
+    }
+
+    #[cfg(test)]
+    return test_loopback_provider_urls()
+        .lock()
+        .unwrap()
+        .contains(url.as_str());
+
+    #[cfg(not(test))]
+    false
+}
+
+#[cfg(test)]
+fn test_loopback_provider_urls() -> &'static std::sync::Mutex<std::collections::HashSet<String>> {
+    static URLS: std::sync::OnceLock<std::sync::Mutex<std::collections::HashSet<String>>> =
+        std::sync::OnceLock::new();
+    URLS.get_or_init(Default::default)
+}
+
+/// Admit one exact loopback HTTP endpoint used by an in-process provider stub.
+///
+/// This exists only in crate tests. Production builds cannot register an
+/// exception, and provider-update tests exercise the production validator
+/// unless they explicitly opt a URL into this narrow seam first.
+#[cfg(test)]
+pub(crate) fn allow_test_loopback_provider_base_url(base: &str) {
+    let url = url::Url::parse(base).expect("test provider base URL must parse");
+    assert_eq!(url.scheme(), "http", "test seam is only for cleartext HTTP");
+    assert!(
+        match url.host() {
+            Some(url::Host::Domain(host)) => host.eq_ignore_ascii_case("localhost"),
+            Some(url::Host::Ipv4(address)) => address.is_loopback(),
+            Some(url::Host::Ipv6(address)) => address.is_loopback(),
+            None => false,
+        },
+        "test seam is only for loopback endpoints"
+    );
+    assert!(url.username().is_empty() && url.password().is_none() && url.fragment().is_none());
+    test_loopback_provider_urls()
+        .lock()
+        .unwrap()
+        .insert(url.to_string());
+}
+
+fn validate_base_url_transport(
+    kind: ProviderKind,
+    base: &str,
+    has_reusable_credential: bool,
+) -> std::result::Result<(), ServerError> {
+    let allow_credentialless_loopback_http =
+        !kind.requires_credential() && !has_reusable_credential;
+    if base_url_is_allowed(base, allow_credentialless_loopback_http) {
+        return Ok(());
+    }
+    Err(ServerError::bad_request(
+        if allow_credentialless_loopback_http {
+            "base_url must use HTTPS, or HTTP on a loopback address for a credentialless provider"
+        } else {
+            "base_url must use HTTPS when provider credentials are present or required"
+        },
+    ))
 }
 
 impl std::fmt::Display for ProviderKind {
@@ -1437,6 +1507,17 @@ pub async fn update_provider(
         )));
     }
 
+    let base_url_changed = update.base_url.is_some();
+    let credential_changed = update.credential.is_some();
+    if let Some(credential) = update.credential.as_ref() {
+        credential.validate()?;
+        if !kind.accepts_credential(credential) {
+            return Err(ServerError::bad_request(format!(
+                "{kind} does not support this credential type"
+            )));
+        }
+    }
+
     let mut config = read_config(store, kind).await?;
 
     if let Some(enabled) = update.enabled {
@@ -1477,6 +1558,16 @@ pub async fn update_provider(
         return Err(ServerError::bad_request(
             "openai_compatible requires a base_url when enabled",
         ));
+    }
+    if config.enabled || base_url_changed || credential_changed {
+        if let Some(base) = kind
+            .effective_base_url(config.base_url.as_deref())
+            .as_deref()
+        {
+            let has_reusable_credential =
+                update.credential.is_some() || has_credential(secrets, kind).await;
+            validate_base_url_transport(kind, base, has_reusable_credential)?;
+        }
     }
     if let Some(credential) = update.credential {
         write_credential(secrets, kind, &credential).await?;
@@ -1870,22 +1961,23 @@ pub async fn collect_routes(
             Some(_) => None,
             None => env_api_key(kind),
         };
-        // Local Ollama accepts unauthenticated requests. The adapter still
-        // sends a bearer token, so an enabled daemon without a stored key
-        // uses a placeholder the endpoint ignores.
+        // Local Ollama accepts unauthenticated requests. Keep its route key
+        // empty so the router can distinguish this narrow trust class from a
+        // reusable bearer credential when validating cleartext loopback URLs.
         let api_key = match api_key {
             Some(key) => key,
-            None if !kind.requires_credential() => "ollama".to_owned(),
+            None if !kind.requires_credential() => String::new(),
             None => continue,
         };
         let base_url = kind.effective_base_url(config.base_url.as_deref());
         if kind == ProviderKind::OpenaiCompatible && base_url.is_none() {
             continue;
         }
-        if kind.uses_openai_compatible_transport() {
-            let base = base_url.as_deref().unwrap_or("");
-            if !(base.starts_with("https://") || base.starts_with("http://")) {
-                continue;
+        if !matches!(kind, ProviderKind::Gemini | ProviderKind::Xai) {
+            if let Some(base) = base_url.as_deref() {
+                if !base_url_is_allowed(base, kind == ProviderKind::Ollama && api_key.is_empty()) {
+                    continue;
+                }
             }
         }
         routes.push(tidebreak_router::Route {
@@ -2033,13 +2125,15 @@ pub async fn provider_is_usable(
     if kind.requires_credential() && !has_credential(secrets, kind).await {
         return Ok(false);
     }
-    if kind.uses_openai_compatible_transport() {
-        let base_url = kind.effective_base_url(config.base_url.as_deref());
-        let Some(base) = base_url else {
-            return Ok(false);
-        };
-        if !(base.starts_with("https://") || base.starts_with("http://")) {
-            return Ok(false);
+    if !matches!(kind, ProviderKind::Gemini | ProviderKind::Xai) {
+        if let Some(base) = kind.effective_base_url(config.base_url.as_deref()) {
+            let has_reusable_credential = has_credential(secrets, kind).await;
+            if !base_url_is_allowed(
+                &base,
+                kind == ProviderKind::Ollama && !has_reusable_credential,
+            ) {
+                return Ok(false);
+            }
         }
     }
     Ok(true)
@@ -2195,6 +2289,89 @@ mod tests {
         .await
         .unwrap();
         (store, directory, policy)
+    }
+
+    async fn provider_test_store() -> (DbStore, tempfile::TempDir) {
+        let directory = tempfile::tempdir().unwrap();
+        let store = DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            directory.path().join("provider-transport.db").display()
+        ))
+        .await
+        .unwrap();
+        (store, directory)
+    }
+
+    #[tokio::test]
+    async fn provider_updates_reject_credentials_on_cleartext_endpoints() {
+        let (store, _directory) = provider_test_store().await;
+        let secrets = TestSecrets::default();
+        let provisioned = crate::managed_policy::MemoryProvisionedPolicy::new();
+
+        let error = update_provider(
+            &store,
+            &secrets,
+            ProviderKind::OpenaiCompatible,
+            ProviderUpdate {
+                enabled: Some(true),
+                base_url: Some(Some("http://127.0.0.1:1234/v1".into())),
+                credential: Some(ProviderCredential::api_key("secret")),
+                models: None,
+            },
+            &*provisioned,
+            &crate::managed_policy::NoOsPolicy,
+        )
+        .await
+        .expect_err("a reusable credential must not be sent over cleartext HTTP");
+        assert!(error.message().contains("must use HTTPS"));
+        assert_eq!(
+            read_credential(&secrets, ProviderKind::OpenaiCompatible)
+                .await
+                .unwrap(),
+            None,
+            "validation must happen before secret storage"
+        );
+    }
+
+    #[tokio::test]
+    async fn credentialless_ollama_keeps_loopback_http_support() {
+        let (store, _directory) = provider_test_store().await;
+        let secrets = TestSecrets::default();
+        let provisioned = crate::managed_policy::MemoryProvisionedPolicy::new();
+
+        let info = update_provider(
+            &store,
+            &secrets,
+            ProviderKind::Ollama,
+            ProviderUpdate {
+                enabled: Some(true),
+                base_url: Some(Some("http://localhost:11434/v1".into())),
+                credential: None,
+                models: None,
+            },
+            &*provisioned,
+            &crate::managed_policy::NoOsPolicy,
+        )
+        .await
+        .expect("credentialless loopback HTTP remains supported");
+        assert_eq!(info.base_url.as_deref(), Some("http://localhost:11434/v1"));
+
+        let error = update_provider(
+            &store,
+            &secrets,
+            ProviderKind::Ollama,
+            ProviderUpdate {
+                enabled: None,
+                base_url: Some(Some("http://192.168.1.10:11434/v1".into())),
+                credential: None,
+                models: None,
+            },
+            &*provisioned,
+            &crate::managed_policy::NoOsPolicy,
+        )
+        .await
+        .expect_err("credentialless cleartext is loopback-only");
+        assert!(error.message().contains("loopback"));
     }
 
     fn gateway_test_snapshot(

--- a/crates/tidebreak-server/src/routes/app_gateway_page.rs
+++ b/crates/tidebreak-server/src/routes/app_gateway_page.rs
@@ -29,6 +29,7 @@ use tidebreak_core::id::AppId;
 use crate::connected_apps::GatewayRegistration;
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
+use crate::scoped_store::ScopedStore;
 use crate::state::AppState;
 
 /// What asking for an app's gateway page came back as.
@@ -110,9 +111,10 @@ fn shared_app_page_url(base_url: &str, shared_app_id: &str) -> Option<String> {
 /// actually serve.
 pub async fn post_app_gateway_page(
     State(state): State<AppState>,
+    store: ScopedStore,
     Path(app_id): Path<AppId>,
 ) -> Result<Json<AppGatewayPageResult>, ServerError> {
-    let (app, revision) = super::app_grant::current_live_app(&state, app_id).await?;
+    let (app, revision) = super::app_grant::current_live_app(&store, app_id).await?;
     // An app that binds nothing at the gateway has nothing there to be. It
     // would register as an empty shared app, so it is refused here rather than
     // sending the author to a page for a shell they cannot share.
@@ -134,7 +136,7 @@ pub async fn post_app_gateway_page(
     };
     let registered = state
         .gateway_drafts
-        .ensure_registered(app.id, &base_url)
+        .ensure_registered(&store.owner_id(), app.id, &base_url)
         .await;
     Ok(Json(match registered {
         Ok(GatewayRegistration::Registered { shared_app_id, .. }) => {

--- a/crates/tidebreak-server/src/routes/app_grant.rs
+++ b/crates/tidebreak-server/src/routes/app_grant.rs
@@ -27,6 +27,7 @@ use crate::connected_apps::{current_fingerprints, current_rest_definitions, Curr
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
 use crate::host_folders::folder_fingerprint;
+use crate::scoped_store::ScopedStore;
 use crate::state::AppState;
 
 /// Renderer-safe grant state for one app: the consent sheet's whole input.
@@ -94,10 +95,11 @@ pub struct AppGrantBindingState {
 /// `GET /apps/{id}/grant` — the app's current grant state.
 pub async fn get_app_grant_state(
     State(state): State<AppState>,
+    store: ScopedStore,
     Path(app_id): Path<AppId>,
 ) -> Result<Json<AppGrantState>, ServerError> {
-    let (app, revision) = current_live_app(&state, app_id).await?;
-    let grant = state.store.get_app_grant(app.id).await?;
+    let (app, revision) = current_live_app(&store, app_id).await?;
+    let grant = store.get_app_grant(app.id).await?;
     let current = current_fingerprints(
         &state,
         &crate::connected_apps::gateway_apps_bound_by(&revision.manifest.bindings),
@@ -118,9 +120,10 @@ pub async fn get_app_grant_state(
 /// folders, then replaces any previous grant wholesale.
 pub async fn post_app_grant(
     State(state): State<AppState>,
+    store: ScopedStore,
     Path(app_id): Path<AppId>,
 ) -> Result<Json<AppGrantState>, ServerError> {
-    let (app, revision) = current_live_app(&state, app_id).await?;
+    let (app, revision) = current_live_app(&store, app_id).await?;
     let current = current_fingerprints(
         &state,
         &crate::connected_apps::gateway_apps_bound_by(&revision.manifest.bindings),
@@ -242,8 +245,8 @@ pub async fn post_app_grant(
         bindings,
         created_at: Utc::now(),
     };
-    state.store.put_app_grant(&grant).await?;
-    register_at_the_gateway(&state, app.id, &revision.manifest);
+    store.put_app_grant(&grant).await?;
+    register_at_the_gateway(&state, store.owner_id(), app.id, &revision.manifest);
     Ok(Json(grant_state(
         &revision.manifest,
         Some(&grant),
@@ -257,13 +260,13 @@ pub async fn post_app_grant(
 /// revocation is fail-safe and must never be blocked by library state. The
 /// next invoke refuses with `consent_required`.
 pub async fn delete_app_grant(
-    State(state): State<AppState>,
+    store: ScopedStore,
     Path(app_id): Path<AppId>,
 ) -> Result<StatusCode, ServerError> {
-    if state.store.get_app(app_id).await?.is_none() {
+    if store.get_app(app_id).await?.is_none() {
         return Err(ServerError::not_found(format!("no app {app_id}")));
     }
-    state.store.delete_app_grant(app_id).await?;
+    store.delete_app_grant(app_id).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -282,7 +285,12 @@ pub async fn delete_app_grant(
 ///
 /// Nothing is attempted for a manifest that binds no gateway app: there is
 /// nothing at the gateway for it to be.
-fn register_at_the_gateway(state: &AppState, app_id: AppId, manifest: &AppManifest) {
+fn register_at_the_gateway(
+    state: &AppState,
+    owner: tidebreak_core::OwnerId,
+    app_id: AppId,
+    manifest: &AppManifest,
+) {
     if crate::connected_apps::gateway_apps_bound_by(&manifest.bindings).is_empty() {
         return;
     }
@@ -292,7 +300,11 @@ fn register_at_the_gateway(state: &AppState, app_id: AppId, manifest: &AppManife
         else {
             return;
         };
-        match state.gateway_drafts.relay_consent(app_id, &base_url).await {
+        match state
+            .gateway_drafts
+            .relay_consent(&owner, app_id, &base_url)
+            .await
+        {
             Ok(crate::connected_apps::GatewayConsentRelay::Consented) => {}
             Ok(outcome) => tracing::info!(
                 %app_id,
@@ -311,16 +323,15 @@ fn register_at_the_gateway(state: &AppState, app_id: AppId, manifest: &AppManife
 /// A soft-deleted app answers as missing on the consent surface, exactly as
 /// it does on invoke.
 pub(crate) async fn current_live_app(
-    state: &AppState,
+    store: &ScopedStore,
     app_id: AppId,
 ) -> Result<(AppRecord, AppRevision), ServerError> {
     let absent = || ServerError::not_found(format!("no app {app_id}"));
-    let app = state.store.get_app(app_id).await?.ok_or_else(absent)?;
+    let app = store.get_app(app_id).await?.ok_or_else(absent)?;
     if app.deleted_at.is_some() {
         return Err(absent());
     }
-    let revision = state
-        .store
+    let revision = store
         .get_app_revision(app.current_revision)
         .await?
         .ok_or_else(absent)?;

--- a/crates/tidebreak-server/src/routes/app_invoke.rs
+++ b/crates/tidebreak-server/src/routes/app_invoke.rs
@@ -38,6 +38,7 @@ use crate::connectors::GatewayInvokeOutcome;
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
 use crate::rest_executor::{RestExecuteError, RestOperationRequest};
+use crate::scoped_store::ScopedStore;
 use crate::state::AppState;
 
 /// Body bound for an invoke request: a capability name plus its opaque
@@ -349,16 +350,18 @@ fn requested_surface(request: AppInvokeRequest) -> Result<InvokeSurface, AppInvo
 /// widen what a call reaches.
 pub async fn post_app_invoke(
     State(state): State<AppState>,
+    store: ScopedStore,
     Path(app_id): Path<AppId>,
     Json(request): Json<AppInvokeRequest>,
 ) -> Result<Response, AppInvokeError> {
     let surface = requested_surface(request)?;
-    let (app, revision) = current_app_revision(&state, app_id).await?;
+    let (app, revision) = current_app_revision(&store, app_id).await?;
     match surface {
         InvokeSurface::Operation(request) => {
             require_pinned_operation(&revision, &request.operation_id)?;
             require_app_grant(
                 &state,
+                &store,
                 &app,
                 &revision,
                 &Pinned::Operation(&request.operation_id),
@@ -376,6 +379,7 @@ pub async fn post_app_invoke(
             )?;
             let current = require_app_grant(
                 &state,
+                &store,
                 &app,
                 &revision,
                 &Pinned::GatewayOperation {
@@ -392,7 +396,7 @@ pub async fn post_app_invoke(
                 .get(&request.gateway_app)
                 .map_or(request.gateway_app.as_str(), |app| app.name.as_str())
                 .to_owned();
-            dispatch_gateway_operation(&state, app_id, &request, &display_name)
+            dispatch_gateway_operation(&state, &store.owner_id(), app_id, &request, &display_name)
                 .await
                 .map(|result| Json(result).into_response())
         }
@@ -400,6 +404,7 @@ pub async fn post_app_invoke(
             require_pinned_folder(&revision, folder, op.writes())?;
             require_app_grant(
                 &state,
+                &store,
                 &app,
                 &revision,
                 &Pinned::Folder {
@@ -420,7 +425,7 @@ pub async fn post_app_invoke(
 /// A deleted app refuses identically to a missing one: soft-deletion removes
 /// the app from every renderer surface, so it must remove it from this one.
 async fn current_app_revision(
-    state: &AppState,
+    store: &ScopedStore,
     app_id: AppId,
 ) -> Result<(AppRecord, AppRevision), AppInvokeError> {
     let absent = || {
@@ -429,14 +434,13 @@ async fn current_app_revision(
             format!("no app {app_id}"),
         )
     };
-    let app = state.store.get_app(app_id).await?.ok_or_else(absent)?;
+    let app = store.get_app(app_id).await?.ok_or_else(absent)?;
     if app.deleted_at.is_some() {
         return Err(absent());
     }
     // A live app always points at a stored revision; if the record is ever
     // inconsistent, fail closed as absent rather than dispatch unpinned.
-    let revision = state
-        .store
+    let revision = store
         .get_app_revision(app.current_revision)
         .await?
         .ok_or_else(absent)?;
@@ -598,13 +602,14 @@ impl Pinned<'_> {
 /// gateway currently calls an app, without a second live read.
 async fn require_app_grant(
     state: &AppState,
+    store: &ScopedStore,
     app: &AppRecord,
     revision: &AppRevision,
     pinned: &Pinned<'_>,
 ) -> Result<crate::connected_apps::CurrentFingerprints, AppInvokeError> {
     let consent_required =
         |message: String| AppInvokeError::refused(AppInvokeRefusalKind::ConsentRequired, message);
-    let Some(grant) = state.store.get_app_grant(app.id).await? else {
+    let Some(grant) = store.get_app_grant(app.id).await? else {
         return Err(consent_required(format!(
             "no live app grant covers {}",
             pinned.description()
@@ -790,6 +795,7 @@ async fn dispatch_rest_operation(
 /// `gateway_unavailable`, whose message says which of the two reasons it was.
 async fn dispatch_gateway_operation(
     state: &AppState,
+    owner: &tidebreak_core::OwnerId,
     app_id: AppId,
     request: &GatewayOperationRequest,
     display_name: &str,
@@ -801,7 +807,11 @@ async fn dispatch_gateway_operation(
         is_error: true,
         error: Some(error),
     };
-    match state.gateway_dispatch.dispatch(app_id, request).await {
+    match state
+        .gateway_dispatch
+        .dispatch(owner, app_id, request)
+        .await
+    {
         Ok(GatewayInvokeOutcome::Executed {
             status,
             content_type,

--- a/crates/tidebreak-server/src/routes/app_library.rs
+++ b/crates/tidebreak-server/src/routes/app_library.rs
@@ -15,6 +15,7 @@ use tidebreak_core::id::{AppId, AppRevisionId};
 
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
+use crate::scoped_store::ScopedStore;
 use crate::state::AppState;
 
 /// How many library rows one listing returns. The library is a personal
@@ -72,8 +73,9 @@ pub struct AppRevisionSummary {
 /// `GET /apps` — the library listing.
 pub async fn get_app_library(
     State(state): State<AppState>,
+    store: ScopedStore,
 ) -> Result<Json<AppLibrary>, ServerError> {
-    let records = state.store.list_apps(MAX_LISTED_APPS).await?;
+    let records = store.list_apps(MAX_LISTED_APPS).await?;
     // The current revisions first, so the fingerprint read knows which gateway
     // apps the listing actually needs — each one is a live catalog read, and
     // the listing must not fetch the whole entitled set to badge apps that
@@ -81,12 +83,7 @@ pub async fn get_app_library(
     // closed below: it lists, but never as granted.
     let mut revisions = Vec::with_capacity(records.len());
     for record in &records {
-        revisions.push(
-            state
-                .store
-                .get_app_revision(record.current_revision)
-                .await?,
-        );
+        revisions.push(store.get_app_revision(record.current_revision).await?);
     }
     let needed = crate::connected_apps::gateway_apps_bound_by(
         revisions
@@ -101,7 +98,7 @@ pub async fn get_app_library(
         // the invoke gate's verdict rather than a cached approximation.
         let granted = match revision {
             Some(revision) => {
-                let grant = state.store.get_app_grant(record.id).await?;
+                let grant = store.get_app_grant(record.id).await?;
                 super::grant_state(&revision.manifest, grant.as_ref(), &current).granted
             }
             None => false,
@@ -120,16 +117,15 @@ pub async fn get_app_library(
 /// `GET /apps/{id}` — one live app's detail. A soft-deleted app answers as
 /// missing, exactly as it does on every other renderer surface.
 pub async fn get_app_detail(
-    State(state): State<AppState>,
+    store: ScopedStore,
     Path(id): Path<AppId>,
 ) -> Result<Json<AppDetail>, ServerError> {
     let absent = || ServerError::not_found(format!("no app {id}"));
-    let app = state.store.get_app(id).await?.ok_or_else(absent)?;
+    let app = store.get_app(id).await?.ok_or_else(absent)?;
     if app.deleted_at.is_some() {
         return Err(absent());
     }
-    let revisions = state
-        .store
+    let revisions = store
         .list_app_revisions(id)
         .await?
         .into_iter()
@@ -155,10 +151,10 @@ pub async fn get_app_detail(
 /// what deletion removes is every open affordance — the library row, frame
 /// minting, and invoke all refuse a deleted app server-side.
 pub async fn delete_app(
-    State(state): State<AppState>,
+    store: ScopedStore,
     Path(id): Path<AppId>,
 ) -> Result<StatusCode, ServerError> {
-    if !state.store.delete_app(id, Utc::now()).await? {
+    if !store.delete_app(id, Utc::now()).await? {
         return Err(ServerError::not_found(format!("no app {id}")));
     }
     Ok(StatusCode::NO_CONTENT)

--- a/crates/tidebreak-server/src/routes/connected_apps.rs
+++ b/crates/tidebreak-server/src/routes/connected_apps.rs
@@ -26,6 +26,7 @@ use crate::mcp_curated::McpCuration;
 use crate::openapi_catalog::{
     enumerate_openapi_operations, ingest_openapi_document, sha256_hex, MAX_OPENAPI_DOCUMENT_BYTES,
 };
+use crate::principal::AuthContext;
 use crate::providers::managed_profile_refusal;
 use crate::rest_executor::{
     admit_base_url, fetch_spec_document, CredentialPlacement, RestCredential,
@@ -184,8 +185,11 @@ pub struct RestCredentialSet {
 /// `GET /connected-apps` — every configured connected app, both kinds.
 pub async fn get_connected_apps(
     State(state): State<AppState>,
+    auth: AuthContext,
 ) -> Result<Json<ConnectedAppsInfo>, ServerError> {
-    Ok(Json(connected_apps_info(&state).await?))
+    Ok(Json(
+        connected_apps_info(&state, &auth.principal.owner_id()).await?,
+    ))
 }
 
 /// `PUT /connected-apps/rest/{id}` — create or replace one `rest_api`
@@ -198,6 +202,7 @@ pub async fn get_connected_apps(
 /// BYOK provider keys. An unreadable policy refuses too — fail closed.
 pub async fn put_rest_connected_app(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(id): Path<ConnectedAppId>,
     Json(body): Json<RestConnectedAppUpsert>,
 ) -> Result<Json<ConnectedAppsInfo>, ServerError> {
@@ -356,7 +361,9 @@ pub async fn put_rest_connected_app(
             .await;
     }
 
-    Ok(Json(connected_apps_info(&state).await?))
+    Ok(Json(
+        connected_apps_info(&state, &auth.principal.owner_id()).await?,
+    ))
 }
 
 /// `DELETE /connected-apps/rest/{id}` — remove one `rest_api` connected app
@@ -492,7 +499,10 @@ async fn rest_records(state: &AppState) -> Result<Vec<ConnectedApp>, ServerError
 }
 
 /// The combined listing behind `GET /connected-apps` and the upsert response.
-async fn connected_apps_info(state: &AppState) -> Result<ConnectedAppsInfo, ServerError> {
+async fn connected_apps_info(
+    state: &AppState,
+    owner: &tidebreak_core::OwnerId,
+) -> Result<ConnectedAppsInfo, ServerError> {
     // `mcp_server` entries reuse the runtime's health projection, joined to
     // their record ids by namespace. A definition without a record id has
     // nothing bindings could name, so it is not listed here (the MCP page
@@ -511,7 +521,7 @@ async fn connected_apps_info(state: &AppState) -> Result<ConnectedAppsInfo, Serv
     // connected app twice, so grants and apps count one-to-one.
     let mut used_by: std::collections::BTreeMap<ConnectedAppId, usize> =
         std::collections::BTreeMap::new();
-    for grant in state.store.list_live_app_grants().await? {
+    for grant in state.store.list_live_app_grants_scoped(owner).await? {
         for binding in &grant.bindings {
             // Folder grant bindings name broker roots and gateway grant
             // bindings name apps the gateway holds; neither is a record on
@@ -532,7 +542,7 @@ async fn connected_apps_info(state: &AppState) -> Result<ConnectedAppsInfo, Serv
         .iter()
         .any(|server| server.definition.gateway_endpoint.is_some())
     {
-        if let Ok(gateway_apps) = state.gateway.apps().await {
+        if let Ok(gateway_apps) = state.gateway.apps(owner).await {
             for app in gateway_apps.apps.into_iter().filter(|app| app.enabled) {
                 for slug in &app.mcp_endpoint_slugs {
                     gateway_app_names

--- a/crates/tidebreak-server/src/routes/mcp_gateway.rs
+++ b/crates/tidebreak-server/src/routes/mcp_gateway.rs
@@ -12,6 +12,7 @@ use tidebreak_core::{AgentError, CallId, ChatId, SequencedEvent};
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
 use crate::mcp_config::{McpServersConfig, McpServersInfo};
+use crate::principal::AuthContext;
 use crate::providers::{self};
 use crate::scoped_store::ScopedStore;
 use crate::state::AppState;
@@ -46,8 +47,21 @@ pub async fn get_mcp_servers(
 /// servers, leaving local stdio servers to the user.
 pub async fn put_mcp_servers(
     State(state): State<AppState>,
+    auth: AuthContext,
     Json(body): Json<McpServersConfig>,
 ) -> Result<Json<McpServersInfo>, ServerError> {
+    if state.config.profile == tidebreak_core::Profile::Desktop
+        && !auth.client_executor
+        && body
+            .servers
+            .iter()
+            .any(|server| server.command.is_some() && server.enabled)
+    {
+        return Err(ServerError::bad_request_kind(
+            "native_confirmation_required",
+            "local command MCP servers must be saved through Tidebreak's native confirmation",
+        ));
+    }
     if let Some(server) = body.servers.iter().find(|server| server.plugin.is_some()) {
         return Err(ServerError::bad_request_kind(
             "mcp_plugin_server_read_only",
@@ -352,19 +366,18 @@ fn view_frame_response(body: impl Into<axum::body::Body>) -> Response {
 /// the open affordance, not just the library row.
 pub async fn post_app_view_session(
     State(state): State<AppState>,
+    store: ScopedStore,
     Path(id): Path<AppId>,
     Json(body): Json<AppViewSessionRequest>,
 ) -> Result<Json<AppViewSession>, ServerError> {
-    let app = state
-        .store
+    let app = store
         .get_app(id)
         .await?
         .filter(|app| app.deleted_at.is_none())
         .ok_or_else(|| ServerError::not_found(format!("app {id} not found")))?;
     let revision_id = match body.revision {
         Some(revision_id) => {
-            state
-                .store
+            store
                 .get_app_revision(revision_id)
                 .await?
                 .filter(|revision| revision.app_id == id)

--- a/crates/tidebreak-server/src/routes/mcp_gateway.rs
+++ b/crates/tidebreak-server/src/routes/mcp_gateway.rs
@@ -238,8 +238,9 @@ pub async fn post_gateway_sign_out(
 /// session is stored; the renderer only asks while signed in.
 pub async fn get_gateway_apps(
     State(state): State<AppState>,
+    auth: AuthContext,
 ) -> Result<Json<crate::gateway_runtime::GatewayApps>, ServerError> {
-    Ok(Json(state.gateway.apps().await?))
+    Ok(Json(state.gateway.apps(&auth.principal.owner_id()).await?))
 }
 
 /// `POST /gateway/models/sync` — the settings page's explicit "sync with the

--- a/crates/tidebreak-server/src/routes/projects_chats.rs
+++ b/crates/tidebreak-server/src/routes/projects_chats.rs
@@ -18,13 +18,14 @@ use tidebreak_core::{
 use crate::error::ServerError;
 use crate::exec_write_snapshot::{list_file_change_summaries, ExecFileChangeSummary};
 use crate::extract::{Json, Path};
+use crate::principal::AuthContext;
 use crate::scoped_store::ScopedStore;
 use crate::state::AppState;
 
 use super::providers_models::{refuse_permission_mode_over_ceiling, validate_model_selection};
 use super::settings::{
-    double_option, read_sticky_default, sticky_default_value, write_sticky_default,
-    STICKY_MODEL_KEY, STICKY_NETWORK_POLICY_KEY, STICKY_PERMISSION_MODE_KEY,
+    double_option, read_sticky_default, sticky_default_key, sticky_default_value,
+    write_sticky_default, STICKY_MODEL_KEY, STICKY_NETWORK_POLICY_KEY, STICKY_PERMISSION_MODE_KEY,
     STICKY_REASONING_EFFORT_KEY,
 };
 
@@ -193,9 +194,11 @@ pub struct CreateChat {
 /// defaults (`ask`, open network, configured model).
 pub async fn create_chat(
     State(state): State<AppState>,
+    auth: AuthContext,
     store: ScopedStore,
     Json(mut body): Json<CreateChat>,
 ) -> Result<impl IntoResponse, ServerError> {
+    let owner = auth.principal.owner_id();
     // Return a product-facing 400 for an unknown project. The Store and schema
     // independently enforce the same membership invariant inside insertion.
     if let Some(project_id) = body.project_id {
@@ -217,7 +220,8 @@ pub async fn create_chat(
         // sticky value is durable user intent: copy it unchanged so turn
         // admission can resolve a unique gateway equivalent or refuse an
         // ambiguous/unmatched selection honestly.
-        None => match read_sticky_default::<String>(&*state.store, STICKY_MODEL_KEY).await? {
+        None => match read_sticky_default::<String>(&*state.store, &owner, STICKY_MODEL_KEY).await?
+        {
             Some(sticky) => match validate_model_selection(&state, &sticky, false).await {
                 Ok(model) => Some(model),
                 Err(_) if managed.managed => Some(sticky),
@@ -228,14 +232,15 @@ pub async fn create_chat(
     };
     let reasoning_effort = match body.reasoning_effort.as_ref() {
         Some(effort) => Some(*effort),
-        None => read_sticky_default(&*state.store, STICKY_REASONING_EFFORT_KEY).await?,
+        None => read_sticky_default(&*state.store, &owner, STICKY_REASONING_EFFORT_KEY).await?,
     };
     let permission_mode = match body.permission_mode.as_ref() {
         Some(mode) => Some(*mode),
         // The managed ceiling clamps a sticky mode recorded before the policy
         // arrived: a remembered `allow` under an `ask` ceiling seeds `ask`,
         // mirroring how the turn gate treats stored over-ceiling modes.
-        None => match read_sticky_default(&*state.store, STICKY_PERMISSION_MODE_KEY).await? {
+        None => match read_sticky_default(&*state.store, &owner, STICKY_PERMISSION_MODE_KEY).await?
+        {
             Some(sticky) => {
                 crate::managed_policy::resolve(&*state.provisioned_policy, &*state.os_policy)?
                     .clamp_permission_mode(Some(sticky))
@@ -246,7 +251,7 @@ pub async fn create_chat(
     let network_policy = match body.network_policy.as_ref() {
         Some(policy) => policy.clone(),
         None => {
-            let mut sticky = read_sticky_default(&*state.store, STICKY_NETWORK_POLICY_KEY)
+            let mut sticky = read_sticky_default(&*state.store, &owner, STICKY_NETWORK_POLICY_KEY)
                 .await?
                 .unwrap_or_default();
             // Stored values were normalized at write; a stale one that no
@@ -266,25 +271,25 @@ pub async fn create_chat(
     let mut sticky_default_updates = Vec::with_capacity(4);
     if let Some(model) = &body.model {
         sticky_default_updates.push((
-            STICKY_MODEL_KEY.to_owned(),
+            sticky_default_key(&owner, STICKY_MODEL_KEY),
             sticky_default_value(Some(model))?,
         ));
     }
     if let Some(effort) = &body.reasoning_effort {
         sticky_default_updates.push((
-            STICKY_REASONING_EFFORT_KEY.to_owned(),
+            sticky_default_key(&owner, STICKY_REASONING_EFFORT_KEY),
             sticky_default_value(Some(effort))?,
         ));
     }
     if let Some(mode) = &body.permission_mode {
         sticky_default_updates.push((
-            STICKY_PERMISSION_MODE_KEY.to_owned(),
+            sticky_default_key(&owner, STICKY_PERMISSION_MODE_KEY),
             sticky_default_value(Some(mode))?,
         ));
     }
     if let Some(policy) = &body.network_policy {
         sticky_default_updates.push((
-            STICKY_NETWORK_POLICY_KEY.to_owned(),
+            sticky_default_key(&owner, STICKY_NETWORK_POLICY_KEY),
             sticky_default_value(Some(policy))?,
         ));
     }
@@ -339,10 +344,12 @@ pub struct ChatUpdate {
 /// `PATCH /chats/{id}` — update the human-facing title and/or model selection.
 pub async fn patch_chat(
     State(state): State<AppState>,
+    auth: AuthContext,
     store: ScopedStore,
     Path(id): Path<ChatId>,
     Json(mut body): Json<ChatUpdate>,
 ) -> Result<Json<Chat>, ServerError> {
+    let owner = auth.principal.owner_id();
     // Validate every supplied field before touching durable state. This keeps a
     // mixed request all-or-nothing from the user's point of view.
     if let Some(Some(model)) = body.model.as_mut() {
@@ -405,16 +412,34 @@ pub async fn patch_chat(
     // from; an explicit clear (`null`) clears the sticky default the same way,
     // back to the hard default. Recorded server-side so every client benefits.
     if let Some(model) = &body.model {
-        write_sticky_default(&*state.store, STICKY_MODEL_KEY, model.as_ref()).await?;
+        write_sticky_default(&*state.store, &owner, STICKY_MODEL_KEY, model.as_ref()).await?;
     }
     if let Some(effort) = &body.reasoning_effort {
-        write_sticky_default(&*state.store, STICKY_REASONING_EFFORT_KEY, effort.as_ref()).await?;
+        write_sticky_default(
+            &*state.store,
+            &owner,
+            STICKY_REASONING_EFFORT_KEY,
+            effort.as_ref(),
+        )
+        .await?;
     }
     if let Some(mode) = &body.permission_mode {
-        write_sticky_default(&*state.store, STICKY_PERMISSION_MODE_KEY, mode.as_ref()).await?;
+        write_sticky_default(
+            &*state.store,
+            &owner,
+            STICKY_PERMISSION_MODE_KEY,
+            mode.as_ref(),
+        )
+        .await?;
     }
     if let Some(policy) = &body.network_policy {
-        write_sticky_default(&*state.store, STICKY_NETWORK_POLICY_KEY, Some(policy)).await?;
+        write_sticky_default(
+            &*state.store,
+            &owner,
+            STICKY_NETWORK_POLICY_KEY,
+            Some(policy),
+        )
+        .await?;
     }
     if let Some(title) = title {
         chat.title = title;

--- a/crates/tidebreak-server/src/routes/settings.rs
+++ b/crates/tidebreak-server/src/routes/settings.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 use tidebreak_core::{
-    AgentRun, ChatId, CompactionPolicy, PermissionMode, ReasoningEffort, Store, TurnId,
+    AgentRun, ChatId, CompactionPolicy, OwnerId, PermissionMode, ReasoningEffort, Store, TurnId,
     DEFAULT_COMPACTION_MIN_THRESHOLD_TOKENS, DEFAULT_COMPACTION_PROTECT_RECENT_MESSAGES,
     DEFAULT_COMPACTION_TARGET_FRACTION, DEFAULT_COMPACTION_THRESHOLD_FRACTION,
 };
@@ -24,6 +24,7 @@ use crate::exec_write_snapshot::{
 };
 use crate::extract::{Json, Path};
 use crate::model_roles::{self, ModelRole};
+use crate::principal::AuthContext;
 use crate::scoped_store::ScopedStore;
 use crate::state::AppState;
 use crate::web_search::{
@@ -218,14 +219,20 @@ where
 }
 
 /// `GET /settings` — the current runtime settings.
-pub async fn get_settings(State(state): State<AppState>) -> Result<Json<Settings>, ServerError> {
-    Ok(Json(read_settings(&state).await?))
+pub async fn get_settings(
+    State(state): State<AppState>,
+    auth: AuthContext,
+) -> Result<Json<Settings>, ServerError> {
+    Ok(Json(
+        read_settings(&state, &auth.principal.owner_id()).await?,
+    ))
 }
 
 /// `PUT /settings` — update runtime settings, returning the new state. Only the
 /// fields present in the body are touched.
 pub async fn put_settings(
     State(state): State<AppState>,
+    auth: AuthContext,
     Json(mut body): Json<SettingsUpdate>,
 ) -> Result<Json<Settings>, ServerError> {
     if let Some(Some(model)) = body.model.as_mut() {
@@ -327,16 +334,18 @@ pub async fn put_settings(
             )
             .await?;
     }
-    Ok(Json(read_settings(&state).await?))
+    Ok(Json(
+        read_settings(&state, &auth.principal.owner_id()).await?,
+    ))
 }
 
 /// The settings both handlers return, read back from the store so a response
 /// always reflects what was persisted rather than what was requested.
-async fn read_settings(state: &AppState) -> Result<Settings, ServerError> {
+async fn read_settings(state: &AppState, owner: &OwnerId) -> Result<Settings, ServerError> {
     Ok(Settings {
         model: read_model(&*state.store).await?,
         has_api_key: has_api_key(&*state.secrets).await,
-        chat_defaults: read_sticky_chat_defaults(state).await?,
+        chat_defaults: read_sticky_chat_defaults(state, owner).await?,
         max_active_background_agents: read_max_active_background_agents(&*state.store).await?,
         sandbox_agent_checkin_steps: read_sandbox_agent_checkin_steps(&*state.store).await?,
         sandbox_agent_error_checkin: read_sandbox_agent_error_checkin(&*state.store).await?,
@@ -849,8 +858,8 @@ pub async fn delete_web_search_credential(
 /// Settings keys holding the sticky new-chat defaults: the reader's last
 /// explicit per-chat choice at these routes, replayed into the next chat.
 ///
-/// Deployment-scoped like every other setting. `model` deliberately gets its
-/// own key rather than reusing the global `model` selection: seeding is a
+/// Owner-scoped within the deployment. `model` deliberately gets its own key
+/// rather than reusing the global `model` selection: seeding is a
 /// creation-time copy into the new chat, so picking a model in one chat never
 /// retargets existing chats that ride the configured default.
 pub(super) const STICKY_MODEL_KEY: &str = "chat_default.model";
@@ -858,14 +867,27 @@ pub(super) const STICKY_REASONING_EFFORT_KEY: &str = "chat_default.reasoning_eff
 pub(super) const STICKY_PERMISSION_MODE_KEY: &str = "chat_default.permission_mode";
 pub(super) const STICKY_NETWORK_POLICY_KEY: &str = "chat_default.network_policy";
 
+/// Resolve a sticky setting's durable key for one principal. The local profile
+/// keeps the historical key so existing desktop defaults survive upgrade;
+/// named self-host users receive disjoint keys.
+pub(super) fn sticky_default_key(owner: &OwnerId, key: &str) -> String {
+    if owner.is_local() {
+        key.to_owned()
+    } else {
+        format!("{key}.owner.{}", owner.as_str())
+    }
+}
+
 /// Read one sticky new-chat default. A stored value this build no longer
 /// recognizes reads as unset rather than failing the create.
 pub(super) async fn read_sticky_default<T: serde::de::DeserializeOwned>(
     store: &dyn Store,
+    owner: &OwnerId,
     key: &str,
 ) -> tidebreak_core::Result<Option<T>> {
+    let key = sticky_default_key(owner, key);
     Ok(store
-        .get_setting(key)
+        .get_setting(&key)
         .await?
         .and_then(|value| serde_json::from_value(value).ok()))
 }
@@ -884,11 +906,14 @@ pub(super) fn sticky_default_value<T: Serialize>(
 /// Record (or clear, with `None`) one sticky new-chat default.
 pub(super) async fn write_sticky_default<T: Serialize>(
     store: &dyn Store,
+    owner: &OwnerId,
     key: &str,
     value: Option<&T>,
 ) -> Result<(), ServerError> {
     let value = sticky_default_value(value)?;
-    Ok(store.set_setting(key, &value).await?)
+    Ok(store
+        .set_setting(&sticky_default_key(owner, key), &value)
+        .await?)
 }
 
 /// Read every sticky new-chat default, the permission mode clamped to any
@@ -896,23 +921,25 @@ pub(super) async fn write_sticky_default<T: Serialize>(
 /// composer should display before the chat exists.
 pub(super) async fn read_sticky_chat_defaults(
     state: &AppState,
+    owner: &OwnerId,
 ) -> Result<StickyChatDefaults, ServerError> {
     let store = &*state.store;
-    let permission_mode = match read_sticky_default(store, STICKY_PERMISSION_MODE_KEY).await? {
-        // The managed ceiling clamps a sticky mode recorded before the
-        // policy arrived: a remembered `allow` under an `ask` ceiling seeds
-        // (and reads back) `ask`, mirroring the turn gate's treatment of
-        // stored over-ceiling modes.
-        Some(mode) => {
-            crate::managed_policy::resolve(&*state.provisioned_policy, &*state.os_policy)?
-                .clamp_permission_mode(Some(mode))
-        }
-        None => None,
-    };
+    let permission_mode =
+        match read_sticky_default(store, owner, STICKY_PERMISSION_MODE_KEY).await? {
+            // The managed ceiling clamps a sticky mode recorded before the
+            // policy arrived: a remembered `allow` under an `ask` ceiling seeds
+            // (and reads back) `ask`, mirroring the turn gate's treatment of
+            // stored over-ceiling modes.
+            Some(mode) => {
+                crate::managed_policy::resolve(&*state.provisioned_policy, &*state.os_policy)?
+                    .clamp_permission_mode(Some(mode))
+            }
+            None => None,
+        };
     Ok(StickyChatDefaults {
-        model: read_sticky_default(store, STICKY_MODEL_KEY).await?,
-        reasoning_effort: read_sticky_default(store, STICKY_REASONING_EFFORT_KEY).await?,
+        model: read_sticky_default(store, owner, STICKY_MODEL_KEY).await?,
+        reasoning_effort: read_sticky_default(store, owner, STICKY_REASONING_EFFORT_KEY).await?,
         permission_mode,
-        network_policy: read_sticky_default(store, STICKY_NETWORK_POLICY_KEY).await?,
+        network_policy: read_sticky_default(store, owner, STICKY_NETWORK_POLICY_KEY).await?,
     })
 }

--- a/crates/tidebreak-server/src/scoped_store.rs
+++ b/crates/tidebreak-server/src/scoped_store.rs
@@ -26,6 +26,8 @@ use axum::http::request::Parts;
 use axum::http::StatusCode;
 use serde_json::Value;
 
+use tidebreak_core::id::{AppId, AppRevisionId};
+use tidebreak_core::local_app::{AppGrant, AppRecord, AppRevision};
 use tidebreak_core::storage::DecidePlanOutcome;
 use tidebreak_core::{
     AcceptTurnSteerOutcome, AgentRun, AgentRunId, AgentRunResult, AnswerUserQuestionsOutcome,
@@ -62,6 +64,12 @@ impl ScopedStore {
             store: state.store.clone(),
             owner: auth.principal.owner_id(),
         }
+    }
+
+    /// Durable owner key carried into owner-aware background seams after the
+    /// request has authorized an app through this view.
+    pub(crate) fn owner_id(&self) -> OwnerId {
+        self.owner.clone()
     }
 
     // ------------------------------------------------------------------
@@ -212,6 +220,52 @@ impl ScopedStore {
     ) -> Result<DocumentRecord> {
         self.store
             .accept_document_source_scoped(&self.owner, document)
+            .await
+    }
+
+    /// Fetch the principal's app by id.
+    pub async fn get_app(&self, id: AppId) -> Result<Option<AppRecord>> {
+        self.store.get_app_scoped(&self.owner, id).await
+    }
+
+    /// List the principal's live apps.
+    pub async fn list_apps(&self, limit: u64) -> Result<Vec<AppRecord>> {
+        self.store.list_apps_scoped(&self.owner, limit).await
+    }
+
+    /// List revisions only when the parent app belongs to the principal.
+    pub async fn list_app_revisions(&self, app_id: AppId) -> Result<Vec<AppRevision>> {
+        self.store
+            .list_app_revisions_scoped(&self.owner, app_id)
+            .await
+    }
+
+    /// Fetch a revision only through an app the principal owns.
+    pub async fn get_app_revision(&self, id: AppRevisionId) -> Result<Option<AppRevision>> {
+        self.store.get_app_revision_scoped(&self.owner, id).await
+    }
+
+    pub async fn delete_app(
+        &self,
+        id: AppId,
+        deleted_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<bool> {
+        self.store
+            .delete_app_scoped(&self.owner, id, deleted_at)
+            .await
+    }
+
+    pub async fn get_app_grant(&self, app_id: AppId) -> Result<Option<AppGrant>> {
+        self.store.get_app_grant_scoped(&self.owner, app_id).await
+    }
+
+    pub async fn put_app_grant(&self, grant: &AppGrant) -> Result<()> {
+        self.store.put_app_grant_scoped(&self.owner, grant).await
+    }
+
+    pub async fn delete_app_grant(&self, app_id: AppId) -> Result<bool> {
+        self.store
+            .delete_app_grant_scoped(&self.owner, app_id)
             .await
     }
 

--- a/crates/tidebreak-server/src/tests/app_gateway_page.rs
+++ b/crates/tidebreak-server/src/tests/app_gateway_page.rs
@@ -31,6 +31,7 @@ impl ScriptedDrafts {
 impl GatewayDraftSource for ScriptedDrafts {
     async fn ensure_registered(
         &self,
+        _owner: &tidebreak_core::OwnerId,
         _app: AppId,
         _gateway_base_url: &str,
     ) -> tidebreak_core::Result<GatewayRegistration> {
@@ -40,6 +41,7 @@ impl GatewayDraftSource for ScriptedDrafts {
 
     async fn relay_consent(
         &self,
+        _owner: &tidebreak_core::OwnerId,
         _app: AppId,
         _gateway_base_url: &str,
     ) -> tidebreak_core::Result<GatewayConsentRelay> {

--- a/crates/tidebreak-server/src/tests/app_invoke.rs
+++ b/crates/tidebreak-server/src/tests/app_invoke.rs
@@ -584,6 +584,7 @@ impl FakeGatewayDispatch {
 impl GatewayInvokeDispatcher for FakeGatewayDispatch {
     async fn dispatch(
         &self,
+        _owner: &tidebreak_core::OwnerId,
         app: AppId,
         request: &GatewayOperationRequest,
     ) -> Result<GatewayInvokeOutcome, GatewayDispatchError> {

--- a/crates/tidebreak-server/src/tests/app_library.rs
+++ b/crates/tidebreak-server/src/tests/app_library.rs
@@ -8,6 +8,20 @@ use tidebreak_core::local_app::{
     AppBinding, AppManifest, AppOperationsBinding, CreateApp, NewAppRevision,
 };
 
+fn app_state_for_owner_test(dir: &std::path::Path, store: Arc<dyn Store>) -> AppState {
+    AppState::new(
+        Config::desktop(dir),
+        store,
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    )
+}
+
 /// The library lifecycle in one pass: the listing carries renderer-safe rows
 /// whose `granted` badge is the grant surface's own verdict, the detail lists
 /// revision history, and deletion removes the app from every one of those
@@ -130,6 +144,134 @@ async fn library_lists_grant_verdicts_and_deletion_removes_the_row() {
         .await
         .unwrap();
     assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+}
+
+/// The authenticated principal is carried through every app route before an
+/// app id reaches revisions, grants, invocation, or gateway publication.
+#[tokio::test]
+async fn another_principal_cannot_reach_an_app_through_any_app_route() {
+    use crate::principal::{AuthContext, Principal, Role, UserId};
+
+    let (dir, db) = temp_db_store("app-route-owner.db").await;
+    let store: Arc<dyn Store> = Arc::new(db);
+    let alice = tidebreak_core::OwnerId::new("user:alice").unwrap();
+    let app_id = AppId::new();
+    store
+        .create_app_scoped(
+            &alice,
+            &CreateApp {
+                id: app_id,
+                revision: NewAppRevision {
+                    id: AppRevisionId::new(),
+                    manifest: AppManifest {
+                        name: "Alice only".into(),
+                        bindings: Vec::new(),
+                    },
+                    byte_len: 1,
+                    sha256: [0; 32],
+                    turn_id: None,
+                    producing_run_id: None,
+                    chat_id: None,
+                    created_at: chrono::Utc::now(),
+                },
+            },
+        )
+        .await
+        .unwrap();
+
+    let router = Router::new()
+        .route("/apps", axum::routing::get(crate::routes::get_app_library))
+        .route(
+            "/apps/{id}",
+            axum::routing::get(crate::routes::get_app_detail).delete(crate::routes::delete_app),
+        )
+        .route(
+            "/apps/{id}/grant",
+            axum::routing::get(crate::routes::get_app_grant_state)
+                .post(crate::routes::post_app_grant)
+                .delete(crate::routes::delete_app_grant),
+        )
+        .route(
+            "/apps/{id}/invoke",
+            axum::routing::post(crate::routes::post_app_invoke),
+        )
+        .route(
+            "/apps/{id}/gateway-page",
+            axum::routing::post(crate::routes::post_app_gateway_page),
+        )
+        .route(
+            "/apps/{id}/view-session",
+            axum::routing::post(crate::routes::post_app_view_session),
+        )
+        .with_state(app_state_for_owner_test(dir.path(), store))
+        .layer(axum::middleware::from_fn(
+            |mut request: Request<Body>, next: axum::middleware::Next| async move {
+                let id = request
+                    .headers()
+                    .get("x-test-user")
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or("bob")
+                    .to_owned();
+                request.extensions_mut().insert(AuthContext {
+                    principal: Principal::User {
+                        id: UserId::new(&id).unwrap(),
+                        role: Role::Member,
+                    },
+                    client_executor: false,
+                });
+                next.run(request).await
+            },
+        ));
+
+    let request = |method: &str, uri: String, body: Body| {
+        router.clone().oneshot(
+            Request::builder()
+                .method(method)
+                .uri(uri)
+                .header("x-test-user", "bob")
+                .header("content-type", "application/json")
+                .body(body)
+                .unwrap(),
+        )
+    };
+
+    let listed = request("GET", "/apps".into(), Body::empty()).await.unwrap();
+    assert_eq!(listed.status(), StatusCode::OK);
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&body_string(listed).await).unwrap()["apps"],
+        json!([])
+    );
+    for (method, suffix) in [
+        ("GET", ""),
+        ("DELETE", ""),
+        ("GET", "/grant"),
+        ("POST", "/grant"),
+        ("DELETE", "/grant"),
+        ("POST", "/gateway-page"),
+        ("POST", "/view-session"),
+    ] {
+        let body = if suffix == "/view-session" {
+            Body::from("{}")
+        } else {
+            Body::empty()
+        };
+        let response = request(method, format!("/apps/{app_id}{suffix}"), body)
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::NOT_FOUND,
+            "{method} {suffix}"
+        );
+    }
+    let invoked = request(
+        "POST",
+        format!("/apps/{app_id}/invoke"),
+        Body::from(r#"{"operation_id":"listIssues"}"#),
+    )
+    .await
+    .unwrap();
+    assert_eq!(invoked.status(), StatusCode::NOT_FOUND);
 }
 
 async fn body_string(response: axum::response::Response) -> String {

--- a/crates/tidebreak-server/src/tests/chat_titling.rs
+++ b/crates/tidebreak-server/src/tests/chat_titling.rs
@@ -130,6 +130,8 @@ async fn titling_app_with_answers(
     tokio::spawn(async move {
         let _ = axum::serve(listener, endpoint).await;
     });
+    let provider_base_url = format!("http://{address}/v1");
+    providers::allow_test_loopback_provider_base_url(&provider_base_url);
 
     let dir = tempfile::tempdir().unwrap();
     let store: Arc<dyn Store> = Arc::new(
@@ -146,7 +148,7 @@ async fn titling_app_with_answers(
         providers::ProviderKind::Openai,
         &providers::ProviderConfig {
             enabled: true,
-            base_url: Some(format!("http://{address}/v1")),
+            base_url: Some(provider_base_url),
             models: Vec::new(),
         },
     )

--- a/crates/tidebreak-server/src/tests/configuration.rs
+++ b/crates/tidebreak-server/src/tests/configuration.rs
@@ -213,6 +213,30 @@ async fn put_mcp_servers(
         .unwrap()
 }
 
+async fn put_native_mcp_servers(
+    router: &Router,
+    bearer: &str,
+    body: serde_json::Value,
+) -> axum::response::Response {
+    router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/native/mcp/servers")
+                .header(header::AUTHORIZATION, bearer)
+                .header(
+                    crate::auth::CLIENT_EXECUTOR_HEADER,
+                    crate::state::TEST_CLIENT_EXECUTOR_TOKEN,
+                )
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
 async fn get_mcp_servers(router: &Router, bearer: &str) -> serde_json::Value {
     let response = router
         .clone()
@@ -290,6 +314,29 @@ async fn mcp_settings_roundtrip_disabled_typed_definitions_without_credentials()
 }
 
 #[tokio::test]
+async fn enabled_local_mcp_commands_require_the_native_executor_surface() {
+    let (router, token, _store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let body = serde_json::json!({
+        "servers": [{
+            "name": "local_command",
+            "command": "/not/started",
+            "enabled": true
+        }]
+    });
+
+    let renderer = put_mcp_servers(&router, &bearer, body.clone()).await;
+    assert_eq!(renderer.status(), StatusCode::BAD_REQUEST);
+    let error: AgentErrorInfo = json_body(renderer).await;
+    assert_eq!(error.kind, "native_confirmation_required");
+
+    let native = put_native_mcp_servers(&router, &bearer, body).await;
+    assert_ne!(native.status(), StatusCode::UNAUTHORIZED);
+    let error: AgentErrorInfo = json_body(native).await;
+    assert_ne!(error.kind, "native_confirmation_required");
+}
+
+#[tokio::test]
 async fn failed_mcp_candidate_does_not_replace_the_active_configuration() {
     const MISSING: &str = "TIDEBREAK_TEST_MCP_ROUTE_MISSING_ENV_65B7A2";
     assert!(std::env::var_os(MISSING).is_none());
@@ -309,7 +356,7 @@ async fn failed_mcp_candidate_does_not_replace_the_active_configuration() {
     .await;
     assert_eq!(initial.status(), StatusCode::OK);
 
-    let failed = put_mcp_servers(
+    let failed = put_native_mcp_servers(
         &router,
         &bearer,
         serde_json::json!({
@@ -1910,7 +1957,7 @@ async fn configured_router_canonicalizes_typed_models_and_rejects_wrong_or_unava
                 .body(Body::from(
                     serde_json::json!({
                         "enabled": true,
-                        "base_url": "http://127.0.0.1:1234/v1",
+                        "base_url": "https://compat.example/v1",
                         "credential": {"type": "api_key", "key": "sk-local"},
                         "models": [{
                             "id": "gpt-5.6-sol",
@@ -2505,7 +2552,7 @@ async fn custom_models_live_under_openai_compatible_with_conservative_capabiliti
                 .body(Body::from(
                     serde_json::json!({
                         "enabled": true,
-                        "base_url": "http://127.0.0.1:1234/v1",
+                        "base_url": "https://compat.example/v1",
                         "credential": {"type": "api_key", "key": "sk-local"},
                         "models": [{
                             "id": "vendor/model",
@@ -2732,7 +2779,7 @@ async fn openai_compatible_route_is_free_form_fallback() {
         providers::ProviderKind::OpenaiCompatible,
         &providers::ProviderConfig {
             enabled: true,
-            base_url: Some("http://127.0.0.1:1234/v1".into()),
+            base_url: Some("https://compat.example/v1".into()),
             models: Vec::new(),
         },
     )
@@ -2926,7 +2973,7 @@ async fn ollama_is_usable_without_a_credential_and_serves_only_configured_models
         .iter()
         .find(|route| route.kind == tidebreak_router::RouteKind::Ollama)
         .expect("an enabled Ollama daemon is a route");
-    assert_eq!(route.api_key, "ollama");
+    assert!(route.api_key.is_empty());
     assert_eq!(route.base_url.as_deref(), Some("http://127.0.0.1:11434/v1"));
     assert_eq!(route.curated_models, ["qwen3:0.6b"]);
 
@@ -3526,7 +3573,8 @@ async fn a_managed_profile_refuses_manual_mcp_servers_and_accepts_gateway_mounts
                             "enabled": true}]),
     ] {
         let refused =
-            put_mcp_servers(&router, &bearer, serde_json::json!({"servers": candidate})).await;
+            put_native_mcp_servers(&router, &bearer, serde_json::json!({"servers": candidate}))
+                .await;
         assert_eq!(refused.status(), StatusCode::CONFLICT, "{candidate}");
         let error: AgentErrorInfo = json_body(refused).await;
         assert_eq!(error.kind, "managed_profile");

--- a/crates/tidebreak-server/src/tests/conformance.rs
+++ b/crates/tidebreak-server/src/tests/conformance.rs
@@ -68,6 +68,77 @@ async fn request(
     router.clone().oneshot(request).await.unwrap()
 }
 
+#[tokio::test]
+async fn sticky_chat_defaults_are_isolated_between_self_host_users() {
+    let (router, _state, _store, _dir) = self_host_app().await;
+    let alice = format!("Bearer {ALICE_TOKEN}");
+    let bob = format!("Bearer {BOB_TOKEN}");
+
+    let alice_chat = make_chat(&router, &alice).await;
+    let patched = patch_chat(
+        &router,
+        &alice,
+        alice_chat.id,
+        serde_json::json!({
+            "permission_mode": "allow",
+            "network_policy": {"mode": "off"},
+        }),
+    )
+    .await;
+    assert_eq!(patched.status(), StatusCode::OK);
+
+    let bob_chat = make_chat(&router, &bob).await;
+    assert_eq!(bob_chat.permission_mode, None);
+    assert_eq!(
+        bob_chat.network_policy,
+        tidebreak_core::NetworkPolicy::default()
+    );
+
+    let bob_explicit: Chat = json_body(
+        request(
+            &router,
+            "POST",
+            "/chats",
+            &bob,
+            Some(serde_json::json!({
+                "permission_mode": "plan",
+                "network_policy": {"mode": "package_managers"},
+            })),
+        )
+        .await,
+    )
+    .await;
+    assert_eq!(
+        bob_explicit.permission_mode,
+        Some(tidebreak_core::PermissionMode::Plan)
+    );
+
+    let alice_next = make_chat(&router, &alice).await;
+    assert_eq!(
+        alice_next.permission_mode,
+        Some(tidebreak_core::PermissionMode::Allow)
+    );
+    assert_eq!(
+        alice_next.network_policy,
+        tidebreak_core::NetworkPolicy::Off
+    );
+
+    let alice_settings: serde_json::Value =
+        json_body(request(&router, "GET", "/settings", &alice, None).await).await;
+    let bob_settings: serde_json::Value =
+        json_body(request(&router, "GET", "/settings", &bob, None).await).await;
+    assert_eq!(alice_settings["chat_defaults"]["permission_mode"], "allow");
+    assert_eq!(
+        alice_settings["chat_defaults"]["network_policy"]["mode"],
+        "off"
+    );
+    assert_eq!(bob_settings["chat_defaults"]["permission_mode"], "plan");
+    assert_eq!(
+        bob_settings["chat_defaults"]["network_policy"]["mode"],
+        "package_managers"
+    );
+}
+
 async fn ingest_document(router: &Router, bearer: &str, uri: &str) -> String {
     let accepted: serde_json::Value = json_body(
         post_raw(

--- a/crates/tidebreak-server/src/tests/gateway_drafts.rs
+++ b/crates/tidebreak-server/src/tests/gateway_drafts.rs
@@ -241,7 +241,7 @@ async fn a_first_registration_persists_and_retries_a_taken_slug_once() {
     let registry = fixture.registry(gateway.clone());
 
     let registration = registry
-        .ensure_registered(fixture.app_id, GATEWAY_A)
+        .ensure_registered(&tidebreak_core::OwnerId::local(), fixture.app_id, GATEWAY_A)
         .await
         .unwrap();
     assert_eq!(shared_app_id(&registration), "shared-1");
@@ -271,7 +271,7 @@ async fn a_first_registration_persists_and_retries_a_taken_slug_once() {
 
     // A second relay reads the mapping rather than registering again.
     registry
-        .ensure_registered(fixture.app_id, GATEWAY_A)
+        .ensure_registered(&tidebreak_core::OwnerId::local(), fixture.app_id, GATEWAY_A)
         .await
         .unwrap();
     assert_eq!(
@@ -294,11 +294,11 @@ async fn a_registration_at_one_gateway_never_answers_for_another() {
     let registry = fixture.registry(gateway.clone());
 
     let first = registry
-        .ensure_registered(fixture.app_id, GATEWAY_A)
+        .ensure_registered(&tidebreak_core::OwnerId::local(), fixture.app_id, GATEWAY_A)
         .await
         .unwrap();
     let second = registry
-        .ensure_registered(fixture.app_id, GATEWAY_B)
+        .ensure_registered(&tidebreak_core::OwnerId::local(), fixture.app_id, GATEWAY_B)
         .await
         .unwrap();
 
@@ -319,7 +319,7 @@ async fn an_edited_app_pushes_its_current_revision_before_the_next_relay() {
     let gateway = Arc::new(FakeGateway::default());
     let registry = fixture.registry(gateway.clone());
     registry
-        .ensure_registered(fixture.app_id, GATEWAY_A)
+        .ensure_registered(&tidebreak_core::OwnerId::local(), fixture.app_id, GATEWAY_A)
         .await
         .unwrap();
 
@@ -327,7 +327,7 @@ async fn an_edited_app_pushes_its_current_revision_before_the_next_relay() {
     fixture.revise(b"<html>two</html>").await;
     let current = fixture.revise(b"<html>three</html>").await;
     let registration = registry
-        .ensure_registered(fixture.app_id, GATEWAY_A)
+        .ensure_registered(&tidebreak_core::OwnerId::local(), fixture.app_id, GATEWAY_A)
         .await
         .unwrap();
 
@@ -362,7 +362,7 @@ async fn a_gateway_that_cannot_hold_the_app_records_no_mapping() {
     let registry = fixture.registry(gateway.clone());
 
     let registration = registry
-        .ensure_registered(fixture.app_id, GATEWAY_A)
+        .ensure_registered(&tidebreak_core::OwnerId::local(), fixture.app_id, GATEWAY_A)
         .await
         .unwrap();
     assert_eq!(registration, GatewayRegistration::NotRegistered);
@@ -386,7 +386,7 @@ async fn a_moved_revision_pin_is_re_synced_before_consent_is_relayed_again() {
     let registry = fixture.registry(gateway.clone());
 
     let relayed = registry
-        .relay_consent(fixture.app_id, GATEWAY_A)
+        .relay_consent(&tidebreak_core::OwnerId::local(), fixture.app_id, GATEWAY_A)
         .await
         .unwrap();
 
@@ -423,6 +423,7 @@ async fn a_grant_survives_a_registration_the_gateway_refuses() {
     impl GatewayDraftSource for UnreachableGateway {
         async fn ensure_registered(
             &self,
+            _owner: &tidebreak_core::OwnerId,
             _app: AppId,
             _gateway_base_url: &str,
         ) -> tidebreak_core::Result<GatewayRegistration> {
@@ -433,6 +434,7 @@ async fn a_grant_survives_a_registration_the_gateway_refuses() {
 
         async fn relay_consent(
             &self,
+            _owner: &tidebreak_core::OwnerId,
             _app: AppId,
             _gateway_base_url: &str,
         ) -> tidebreak_core::Result<GatewayConsentRelay> {

--- a/crates/tidebreak-server/src/tests/image_attachment.rs
+++ b/crates/tidebreak-server/src/tests/image_attachment.rs
@@ -1010,7 +1010,7 @@ async fn a_turn_carrying_images_against_a_text_only_model_is_refused() {
         providers::ProviderKind::OpenaiCompatible,
         &providers::ProviderConfig {
             enabled: true,
-            base_url: Some("http://127.0.0.1:1234/v1".into()),
+            base_url: Some("https://compat.example/v1".into()),
             models: vec![providers::CustomModelConfig {
                 id: "vendor/model".into(),
                 upstream_id: None,
@@ -1114,6 +1114,8 @@ async fn a_curated_openai_model_answers_after_receiving_png_and_jpeg_attachments
     tokio::spawn(async move {
         let _ = axum::serve(listener, provider).await;
     });
+    let provider_base_url = format!("http://{address}/v1");
+    providers::allow_test_loopback_provider_base_url(&provider_base_url);
 
     let dir = tempfile::tempdir().unwrap();
     let store: Arc<dyn Store> = Arc::new(
@@ -1130,7 +1132,7 @@ async fn a_curated_openai_model_answers_after_receiving_png_and_jpeg_attachments
         providers::ProviderKind::Openai,
         &providers::ProviderConfig {
             enabled: true,
-            base_url: Some(format!("http://{address}/v1")),
+            base_url: Some(provider_base_url),
             models: Vec::new(),
         },
     )

--- a/deploy/self-host/Dockerfile
+++ b/deploy/self-host/Dockerfile
@@ -48,8 +48,21 @@ FROM debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639
 # the lockfile), but parts of the graph resolve platform roots, so the system
 # trust store must exist for outbound model-provider calls.
 # curl: the container healthcheck below, and nothing else.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates curl \
+#
+# Debian snapshots are immutable, so the digest-pinned base plus this dated
+# repository set resolve the same transitive packages on every rebuild. Bump
+# the snapshot and direct package versions together as a deliberate dependency
+# update; Debian Release signatures still authenticate the snapshot metadata.
+RUN rm -f /etc/apt/sources.list.d/debian.sources \
+    && printf '%s\n' \
+       'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20260810T000000Z bookworm main' \
+       'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20260810T000000Z bookworm-updates main' \
+       'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/20260810T000000Z bookworm-security main' \
+       > /etc/apt/sources.list \
+    && apt-get -o Acquire::Check-Valid-Until=false update \
+    && apt-get install -y --no-install-recommends \
+       ca-certificates=20250419~deb12u1 \
+       curl=7.88.1-10+deb12u15 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /src/target/release/tidebreak /usr/local/bin/tidebreak

--- a/docs-site/.gitignore
+++ b/docs-site/.gitignore
@@ -7,6 +7,7 @@
 # build output
 /.next/
 /out/
+/.vercel/
 *.tsbuildinfo
 
 # misc

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -56,11 +56,11 @@ BASE_PATH=/docs pnpm build
 rewrites asset URLs, `next/link` hrefs, and the search-index fetch. Leave it
 unset for local development. See `.env.example`.
 
-Nothing here is wired to a host yet. `metadataBase` in `src/app/layout.tsx` is
-set to the intended public URL, but the indexing decision is still open —
-either a canonical URL pointing at the public path, or `noindex` on the raw
-deployment origin, so the deployment origin and the public URL are not indexed
-as separate sites.
+The release workflow deploys this export to the dedicated documentation
+project, then the marketing project serves it under
+`https://www.tidebreak.sh/docs/`. Canonical metadata and the sitemap point at
+that public path so the raw deployment origin is not indexed as a separate
+site.
 
 ## Design tokens
 

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -8,6 +8,7 @@
     "dev": "next dev",
     "prebuild": "node scripts/generate-search-index.mjs",
     "build": "next build",
+    "package:vercel": "node scripts/package-vercel-output.mjs",
     "start": "serve out",
     "types:check": "next typegen && tsc --noEmit",
     "lint": "eslint"
@@ -42,6 +43,7 @@
     "postcss": "8.5.26",
     "serve": "14.2.6",
     "tailwindcss": "4.3.3",
-    "typescript": "6.0.3"
+    "typescript": "6.0.3",
+    "vercel": "59.0.0"
   }
 }

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -9,6 +9,7 @@
     "prebuild": "node scripts/generate-search-index.mjs",
     "build": "next build",
     "package:vercel": "node scripts/package-vercel-output.mjs",
+    "test:vercel-output": "node --test scripts/vercel-output-config.test.mjs",
     "start": "serve out",
     "types:check": "next typegen && tsc --noEmit",
     "lint": "eslint"

--- a/docs-site/pnpm-lock.yaml
+++ b/docs-site/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
+      vercel:
+        specifier: 59.0.0
+        version: 59.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)
 
 packages:
 
@@ -167,6 +170,29 @@ packages:
     resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
 
+  '@bytecodealliance/preview2-shim@0.17.6':
+    resolution: {integrity: sha512-n3cM88gTen5980UOBAD6xDcNNL3ocTK8keab21bpx1ONdA+ARj7uD1qoFxOWCyKlkpSi195FH+GeAut7Oc6zZw==}
+
+  '@edge-runtime/format@2.2.1':
+    resolution: {integrity: sha512-JQTRVuiusQLNNLe2W9tnzBlV/GvSVcozLl4XZHk5swnRZ/v6jp8TqR8P7sqmJsQqblDZ3EztcWmLDbhRje/+8g==}
+    engines: {node: '>=16'}
+
+  '@edge-runtime/node-utils@2.3.0':
+    resolution: {integrity: sha512-uUtx8BFoO1hNxtHjp3eqVPC/mWImGb2exOfGjMLUoipuWgjej+f4o/VP4bUI8U40gu7Teogd5VTeZUkGvJSPOQ==}
+    engines: {node: '>=16'}
+
+  '@edge-runtime/ponyfill@2.4.2':
+    resolution: {integrity: sha512-oN17GjFr69chu6sDLvXxdhg0Qe8EZviGSuqzR9qOiKh4MhFYGdBBcqRNzdmYeAdeRzOW2mM9yil4RftUQ7sUOA==}
+    engines: {node: '>=16'}
+
+  '@edge-runtime/primitives@4.1.0':
+    resolution: {integrity: sha512-Vw0lbJ2lvRUqc7/soqygUX216Xb8T3WBZ987oywz6aJqRxcwSVWwr9e+Nqo2m9bxobA9mdbWNNoRY6S9eko1EQ==}
+    engines: {node: '>=16'}
+
+  '@edge-runtime/vm@3.2.0':
+    resolution: {integrity: sha512-0dEVyRLM/lG4gp1R/Ik5bfPl/1wX00xFwd5KcNH602tzBa09oF7pbTKETEhR1GjZ75K6OJnYFu8II2dyMhONMw==}
+    engines: {node: '>=16'}
+
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
@@ -178,6 +204,162 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@esbuild/aix-ppc64@0.27.0':
+    resolution: {integrity: sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.0':
+    resolution: {integrity: sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.0':
+    resolution: {integrity: sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.0':
+    resolution: {integrity: sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.0':
+    resolution: {integrity: sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.0':
+    resolution: {integrity: sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.0':
+    resolution: {integrity: sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.0':
+    resolution: {integrity: sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.0':
+    resolution: {integrity: sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.0':
+    resolution: {integrity: sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.0':
+    resolution: {integrity: sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.0':
+    resolution: {integrity: sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.0':
+    resolution: {integrity: sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.0':
+    resolution: {integrity: sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.0':
+    resolution: {integrity: sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.0':
+    resolution: {integrity: sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.0':
+    resolution: {integrity: sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.0':
+    resolution: {integrity: sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.0':
+    resolution: {integrity: sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.0':
+    resolution: {integrity: sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.0':
+    resolution: {integrity: sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.0':
+    resolution: {integrity: sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.0':
+    resolution: {integrity: sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.0':
+    resolution: {integrity: sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.0':
+    resolution: {integrity: sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.0':
+    resolution: {integrity: sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.10.1':
     resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
@@ -222,6 +404,10 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -389,6 +575,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/balanced-match@4.0.1':
+    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/brace-expansion@5.0.1':
+    resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -405,6 +603,11 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@mapbox/node-pre-gyp@2.0.3':
+    resolution: {integrity: sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
@@ -413,6 +616,82 @@ packages:
     peerDependencies:
       '@types/react': '>=16'
       react: '>=16'
+
+  '@napi-rs/keyring-darwin-arm64@1.2.0':
+    resolution: {integrity: sha512-CA83rDeyONDADO25JLZsh3eHY8yTEtm/RS6ecPsY+1v+dSawzT9GywBMu2r6uOp1IEhQs/xAfxgybGAFr17lSA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/keyring-darwin-x64@1.2.0':
+    resolution: {integrity: sha512-dBHjtKRCj4ByfnfqIKIJLo3wueQNJhLRyuxtX/rR4K/XtcS7VLlRD01XXizjpre54vpmObj63w+ZpHG+mGM8uA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/keyring-freebsd-x64@1.2.0':
+    resolution: {integrity: sha512-DPZFr11pNJSnaoh0dzSUNF+T6ORhy3CkzUT3uGixbA71cAOPJ24iG8e8QrLOkuC/StWrAku3gBnth2XMWOcR3Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.2.0':
+    resolution: {integrity: sha512-8xv6DyEMlvRdqJzp4F39RLUmmTQsLcGYYv/3eIfZNZN1O5257tHxTrFYqAsny659rJJK2EKeSa7PhrSibQqRWQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.2.0':
+    resolution: {integrity: sha512-Pu2V6Py+PBt7inryEecirl+t+ti8bhZphjP+W68iVaXHUxLdWmkgL9KI1VkbRHbx5k8K5Tew9OP218YfmVguIA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-arm64-musl@1.2.0':
+    resolution: {integrity: sha512-8TDymrpC4P1a9iDEaegT7RnrkmrJN5eNZh3Im3UEV5PPYGtrb82CRxsuFohthCWQW81O483u1bu+25+XA4nKUw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.2.0':
+    resolution: {integrity: sha512-awsB5XI1MYL7fwfjMDGmKOWvNgJEO7mM7iVEMS0fO39f0kVJnOSjlu7RHcXAF0LOx+0VfF3oxbWqJmZbvRCRHw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-x64-gnu@1.2.0':
+    resolution: {integrity: sha512-8E+7z4tbxSJXxIBqA+vfB1CGajpCDRyTyqXkBig5NtASrv4YXcntSo96Iah2QDR5zD3dSTsmbqJudcj9rKKuHQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-x64-musl@1.2.0':
+    resolution: {integrity: sha512-8RZ8yVEnmWr/3BxKgBSzmgntI7lNEsY7xouNfOsQkuVAiCNmxzJwETspzK3PQ2FHtDxgz5vHQDEBVGMyM4hUHA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.2.0':
+    resolution: {integrity: sha512-AoqaDZpQ6KPE19VBLpxyORcp+yWmHI9Xs9Oo0PJ4mfHma4nFSLVdhAubJCxdlNptHe5va7ghGCHj3L9Akiv4cQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.2.0':
+    resolution: {integrity: sha512-EYL+EEI6bCsYi3LfwcQdnX3P/R76ENKNn+3PmpGheBsUFLuh0gQuP7aMVHM4rTw6UVe+L3vCLZSptq/oeacz0A==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-x64-msvc@1.2.0':
+    resolution: {integrity: sha512-xFlx/TsmqmCwNU9v+AVnEJgoEAlBYgzFF5Ihz1rMpPAt4qQWWkMd4sCyM1gMJ1A/GnRqRegDiQpwaxGUHFtFbA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/keyring@1.2.0':
+    resolution: {integrity: sha512-d0d4Oyxm+v980PEq1ZH2PmS6cvpMIRc17eYpiU47KgW+lzxklMu6+HOEOPmxrpnF/XQZ0+Q78I2mgMhbIIo/dg==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@1.2.2':
     resolution: {integrity: sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==}
@@ -494,6 +773,128 @@ packages:
   '@orama/orama@3.1.18':
     resolution: {integrity: sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA==}
     engines: {node: '>= 20.0.0'}
+
+  '@oxc-project/types@0.110.0':
+    resolution: {integrity: sha512-6Ct21OIlrEnFEJk5LT4e63pk3btsI6/TusD/GStLi7wYlGJNOl1GI9qvXAnRAxQU9zqA2Oz+UwhfTOU2rPZVow==}
+
+  '@oxc-transform/binding-android-arm-eabi@0.111.0':
+    resolution: {integrity: sha512-NdFLicvorfHYu0g2ftjVJaH7+Dz27AQUNJOq8t/ofRUoWmczOodgUCHx8C1M1htCN4ZmhS/FzfSy6yd/UngJGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-transform/binding-android-arm64@0.111.0':
+    resolution: {integrity: sha512-J2v9ajarD2FYlhHtjbgZUFsS2Kvi27pPxDWLGCy7i8tO60xBoozX9/ktSgbiE/QsxKaUhfv4zVKppKWUo71PmQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-transform/binding-darwin-arm64@0.111.0':
+    resolution: {integrity: sha512-2UYmExxpXzmiHTldhNlosWqG9Nc4US51K0GB9RLcGlTE23WO33vVo1NVAKwxPE+KYuhffwDnRYTovTMUjzwvZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-transform/binding-darwin-x64@0.111.0':
+    resolution: {integrity: sha512-c4YRwfLV8Pj/ToiTCbndZaHxM2BD4W3bltr/fjXZcGypEK+U2RZFDL7tIZYT/tyneAC9hCORZKDaKhLLNuzPtA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-transform/binding-freebsd-x64@0.111.0':
+    resolution: {integrity: sha512-prvf32IcEuLnLZbNVomFosBu0CaZpyj3YsZ6epbOgJy8iJjfLsXBb+PrkO/NBKzjuJoJa2+u7jFKRE0KT7gSOw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.111.0':
+    resolution: {integrity: sha512-+se3579Wp7VOk8TnTZCpT+obTAyzOw2b/UuoM0+51LtbzCSfjKxd4A+o7zRl7GyPrPZvx57KdbMOC9rWB1xNrw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-arm-musleabihf@0.111.0':
+    resolution: {integrity: sha512-8faC99pStqaSDPK/vBgaagAHUeL0LcIzfeSjSiDTtvPGc3AwZIeqC1tx3CP15a6tWXjdgS/IUw4IjfD5HweBlg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-arm64-gnu@0.111.0':
+    resolution: {integrity: sha512-HtfQv8j796gzI5WR/RaP6IMwFpiL0vYeDrUA1hYhlPzTHKYan/B+NlhJkKOI1v24yAl/yEnFmb0pxIxLNqBqBA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-arm64-musl@0.111.0':
+    resolution: {integrity: sha512-ARyfcMCIxVLDgLf6FQ8Oo1/TFySpnquV+vuSb4SFQZfYDqgMklzwv0NYXxWD0aB6enElyMDs6pQJBzusEKCkOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-ppc64-gnu@0.111.0':
+    resolution: {integrity: sha512-PKpVRrSvBNK3tv9vwxn7Fay+QWZmprPGlEqJcseBJllQc5mFMD4Q/w44chu5iR9ZLsDeSHzmNWrgMLo4J0sP2A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-riscv64-gnu@0.111.0':
+    resolution: {integrity: sha512-9bUml6rMgk+8GF5rvNMweFspkzSiCjqpV6HduwiUyexqfGKrmjq9IZOxxvnzkE2RGdQzP507NNDoVNYIoGQYuA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-riscv64-musl@0.111.0':
+    resolution: {integrity: sha512-tzGCohGxaeH6KRJjfYZd4mHCoGjCai6N+zZi1Oj+tSDMAAdyvs1dRzYb8PNUGnybCg3Te4M0jLPzWZaSmnKraQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-s390x-gnu@0.111.0':
+    resolution: {integrity: sha512-sRG1KIfZ0ML9ToEygm5aM/5GJeBA05uHlgW3M0Rx/DNWMJhuahLmqWuB02aWSmijndLfEKXLLXIWhvWupRG8lg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-x64-gnu@0.111.0':
+    resolution: {integrity: sha512-T0Kmvk+OdlUdABdXlDIf3MQReMzFfC75NEI9x8jxy5pKooACEFg0k0V8gyR3gq4DzbDCfucqFQDWNvSgIopAbQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-x64-musl@0.111.0':
+    resolution: {integrity: sha512-EgoutsP3YfqzN8a9vpc9+XLr0bmBl0dA3uOMiP77+exATCPxJBkJErGmQkqk6RtTp5XqX6q6mB45qWQyKk6+pA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-transform/binding-openharmony-arm64@0.111.0':
+    resolution: {integrity: sha512-d8J+ejc0j5WODbVwR/QxFaI65YMwvG0W53vcVCHwa6ja1QI5lpe7sislrefG2EFYgnY47voMRzlXab5d4gEcDw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-transform/binding-wasm32-wasi@0.111.0':
+    resolution: {integrity: sha512-HtyIZO8IwuZgXkyb56rysLz1OLbfLhEu8A3BeuyJXzUseAj96yuxgGt3cu3QYX9AXb9pfRfA3c/fvlhsDugyTQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-transform/binding-win32-arm64-msvc@0.111.0':
+    resolution: {integrity: sha512-YeP80Riptc0MkVVBnzbmoFuHVLUq278+MbwNo9sTLALmzTIJxJqN029xRZbG+Bun7aLsoZhmRnm3J5JZ1NcP5w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-transform/binding-win32-ia32-msvc@0.111.0':
+    resolution: {integrity: sha512-A6ztCXpoSHt6PbvGAFqB0MLOcGG7ZJrrPXY1iB0zfOB1atLgI8oNePGxPl03XSbwpiTsFJ1oo8rj9DXcBzgT9g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-transform/binding-win32-x64-msvc@0.111.0':
+    resolution: {integrity: sha512-QddKW4kBH0Wof6Y65eYCNHM4iOGmCTWLLcNYY1FGswhzmTYOUVXajNROR+iCXAOFnOF0ldtsR79SyqgyHH1Bgg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@radix-ui/primitive@1.1.7':
     resolution: {integrity: sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==}
@@ -670,8 +1071,104 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@renovatebot/pep440@4.2.1':
+    resolution: {integrity: sha512-2FK1hF93Fuf1laSdfiEmJvSJPVIDHEUTz68D3Fi9s0IZrrpaEcj6pTFBTbYvsgC5du4ogrtf5re7yMMvrKNgkw==}
+    engines: {node: ^20.9.0 || ^22.11.0 || ^24, pnpm: ^10.0.0}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.1':
+    resolution: {integrity: sha512-He6ZoCfv5D7dlRbrhNBkuMVIHd0GDnjJwbICE1OWpG7G3S2gmJ+eXkcNLJjzjNDpeI2aRy56ou39AJM9AD8YFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.1':
+    resolution: {integrity: sha512-YzJdn08kSOXnj85ghHauH2iHpOJ6eSmstdRTLyaziDcUxe9SyQJgGyx/5jDIhDvtOcNvMm2Ju7m19+S/Rm1jFg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.1':
+    resolution: {integrity: sha512-cIvAbqM+ZVV6lBSKSBtlNqH5iCiW933t1q8j0H66B3sjbe8AxIRetVqfGgcHcJtMzBIkIALlL9fcDrElWLJQcQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.1':
+    resolution: {integrity: sha512-rVt+B1B/qmKwCl1XD02wKfgh3vQPXRXdB/TicV2w6g7RVAM1+cZcpigwhLarqiVCxDObFZ7UgXCxPC7tpDoRog==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.1':
+    resolution: {integrity: sha512-69YKwJJBOFprQa1GktPgbuBOfnn+EGxu8sBJ1TjPER+zhSpYeaU4N07uqmyBiksOLGXsMegymuecLobfz03h8Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.1':
+    resolution: {integrity: sha512-9JDhHUf3WcLfnViFWm+TyorqUtnSAHaCzlSNmMOq824prVuuzDOK91K0Hl8DUcEb9M5x2O+d2/jmBMsetRIn3g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.1':
+    resolution: {integrity: sha512-UvApLEGholmxw/HIwmUnLq3CwdydbhaHHllvWiCTNbyGom7wTwOtz5OAQbAKZYyiEOeIXZNPkM7nA4Dtng7CLw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.1':
+    resolution: {integrity: sha512-uVctNgZHiGnJx5Fij7wHLhgw4uyZBVi6mykeWKOqE7bVy9Hcxn0fM/IuqdMwk6hXlaf9fFShDTFz2+YejP+x0A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.1':
+    resolution: {integrity: sha512-T6Eg0xWwcxd/MzBcuv4Z37YVbUbJxy5cMNnbIt/Yr99wFwli30O4BPlY8hKeGyn6lWNtU0QioBS46lVzDN38bg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.1':
+    resolution: {integrity: sha512-PuGZVS2xNJyLADeh2F04b+Cz4NwvpglbtWACgrDOa5YDTEHKwmiTDjoD5eZ9/ptXtcpeFrMqD2H4Zn33KAh1Eg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.1':
+    resolution: {integrity: sha512-2mOxY562ihHlz9lEXuaGEIDCZ1vI+zyFdtsoa3M62xsEunDXQE+DVPO4S4x5MPK9tKulG/aFcA/IH5eVN257Cw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.1':
+    resolution: {integrity: sha512-oQVOP5cfAWZwRD0Q3nGn/cA9FW3KhMMuQ0NIndALAe6obqjLhqYVYDiGGRGrxvnjJsVbpLwR14gIUYnpIcHR1g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.1':
+    resolution: {integrity: sha512-Ydsxxx++FNOuov3wCBPaYjZrEvKOOGq3k+BF4BPridhg2pENfitSRD2TEuQ8i33bp5VptuNdC9IzxRKU031z5A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.1':
+    resolution: {integrity: sha512-UTBjtTxVOhodhzFVp/ayITaTETRHPUPYZPXQe0WU0wOgxghMojXxYjOiPOauKIYNWJAWS2fd7gJgGQK8GU8vDA==}
+
+  '@rollup/pluginutils@5.4.0':
+    resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@sinclair/typebox@0.25.24':
+    resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -769,6 +1266,13 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.0.0 || >=4.0.0 || insiders'
 
+  '@tootallnate/once@2.0.0':
+    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
+    engines: {node: '>= 10'}
+
+  '@ts-morph/common@0.11.1':
+    resolution: {integrity: sha512-7hWZS0NRpEsNV8vWJzg7FEz6V8MaLNeJOmwmghqUXTpzk16V1LLZhdo+4QvE/+zv4cVci0OviuJFnqhEfoV3+g==}
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
@@ -798,6 +1302,9 @@ packages:
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/node@20.11.0':
+    resolution: {integrity: sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==}
 
   '@types/node@26.2.0':
     resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
@@ -988,8 +1495,160 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vercel/backends@0.8.37':
+    resolution: {integrity: sha512-o7KadmQ5lHKx4yvBuYwVmNWSwqWYtA5eF3JREE7avdFvIusu5a8h4DWQv9p69urMcX7pTH69bVCq9vGea7X61A==}
+
+  '@vercel/blob@2.8.0':
+    resolution: {integrity: sha512-Nu+HWKpkgovCh/ezlG7wCVwF7RErTzLzZMbGKFBdGBCbTKyK+s5VXPLl+0+TpNEQPH8AVaGzOpIsXUOtkqylCQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@vercel/build-utils@14.1.0':
+    resolution: {integrity: sha512-Bxwkv5phTRgU1QZ3NHzxjC6mLWJYqtYExkm/OS6Si2t3EhLFN+wls8U0oMmCrg2nXANkB1S+eXrbeu8hCcXV0A==}
+
+  '@vercel/cervel@0.1.45':
+    resolution: {integrity: sha512-H2i5T/26rw/bLcoROTU3XRyBrizPEsUjMPaZSWd97Qy9lhHzpjfxftSPZmfOFI2z9dUkr+IYgRSgZIkhDSde7g==}
+    hasBin: true
+
+  '@vercel/cli-auth@0.3.4':
+    resolution: {integrity: sha512-RQf67uc5HPtlhok3H2fChFW17ZB0gQxw0eeFkboMkHuclejfZ1cHy+04dRdnetX8/J8L6YUErNW2kO1tmeoKzw==}
+
+  '@vercel/cli-config@0.2.3':
+    resolution: {integrity: sha512-Ggh0Wmi92TUkUexmSUPkkDtvJmbjUr7IvF5T3FkSsWrXXs3GFzOujfxFpECdJZpux1JG4SWDv9BT4w++TDgD6A==}
+
+  '@vercel/cli-exec@1.0.1':
+    resolution: {integrity: sha512-g9XerViJ/paZujufXYcu5XYI2vU2rtB4sgdpjUHde5RnOkdmpu0ngH46LCFGHoPXO/C+qDPSczIHIRN+8Q2YKQ==}
+    engines: {node: '>= 18'}
+
+  '@vercel/container@0.2.0':
+    resolution: {integrity: sha512-l4prOR48EFu3CGNgwN64DCNwfqw8ZJty70HrY0X0+i5AMxi4GiIttZsSYBmttUAM+OSIg3BqMg767dlzjlzQyQ==}
+
+  '@vercel/detect-agent@1.2.5':
+    resolution: {integrity: sha512-0krENrjuitlW8s6TJu0MlqCevyCU7K7JK63jZAf7xZ6n17tx+vUEwzHT3sTxawtwZxaW21hu+oFUpoOrm49FsQ==}
+    engines: {node: '>=14'}
+
+  '@vercel/elysia@0.1.114':
+    resolution: {integrity: sha512-bgCicgRSjYdXrejDGWN68HkobQ5tOcIXuT1q+uBjHIAtqSdH4xll8tyIreR39MsRQgTURAa5LtHg8uDHXidI3Q==}
+
+  '@vercel/error-utils@2.2.1':
+    resolution: {integrity: sha512-9DhP8jP7raLML4hGsBemxX5fXuQnu5xxMV+HjGygGbzEmVK/+KyJ3QP2Cw7PdF0uXdb9N0Qa4c3tRGH34ZX6vw==}
+
+  '@vercel/express@0.1.128':
+    resolution: {integrity: sha512-c10sYn5r/3wfTPmwN4PRosvt2JgQ68PDfBmI7MVYyKTM5zN4ky1eL6V0oJ8LNvsFVvoQX/OH+3qg3yTEZNeDEQ==}
+
+  '@vercel/fastify@0.1.117':
+    resolution: {integrity: sha512-YoNAqo8xrL0GQwPTnkJ4LhsUJiPu2XlntwwQQvG2m2OYOJDCojq80nVWQvqfyqYCUBoYEfrYawFfTtvivl63Ew==}
+
+  '@vercel/fun@1.3.0':
+    resolution: {integrity: sha512-8erw9uPe0dFg45THkNxmjtvMX143SkZebmjgSVbcM3XCkXu3RIiBaJMcMNG8aaS+rnTuw8+d4De9HVT0M/r3wg==}
+    engines: {node: '>= 18'}
+
+  '@vercel/gatsby-plugin-vercel-analytics@1.0.12':
+    resolution: {integrity: sha512-Ejlhwxr7EBYJxtwYnlh6Vm6A2dPsUSPxMdYrfv0koZkgAzVwo7cG4aDQiy7iASMaGzwuI/PAnwlY2sJBF5b4OA==}
+
+  '@vercel/gatsby-plugin-vercel-builder@2.2.40':
+    resolution: {integrity: sha512-6QyQEJRNljTXZ1Yfcw58g3Css9wBeS0aXHechX3Oy5trzCtvMP82M74pcHAp3Wngb2s1byvEPb0Cm0FlFGFkhg==}
+
+  '@vercel/go@3.11.0':
+    resolution: {integrity: sha512-aeeWnefoRHuH7eYekQLq/vAsTbg6RQi7mKP49pLfxY/nfTsBnLtat9KCD7WF3Nunu41uN5uq3LVvoqRJ09S/fA==}
+
+  '@vercel/h3@0.1.123':
+    resolution: {integrity: sha512-oMGcBAJQIOQALnO+xu4di4ON8ElFyJry1Gn5YpFjkHITHMA+ZbhJbOzh+w7EKw6GACtdWrTZ16AONPFyxVx0gw==}
+
+  '@vercel/hono@0.2.117':
+    resolution: {integrity: sha512-R1bBZ38jPo980NrC4w9pLcipeQZv5ArF0V/0vGQWZ7437ZA/zKJSzhO90Cb+GVdjSCwHA2HyG6f8ODtBSSsGPg==}
+
+  '@vercel/hydrogen@1.4.1':
+    resolution: {integrity: sha512-fD3DAjMcWkGPZwcWCbF4ekZpDY4cMz+QZWR5F3Qss3hkQx6Vuu0kTpKX0xGgQ/CYTtKknZJTwIfM/ZvByAsrKA==}
+
+  '@vercel/koa@0.1.97':
+    resolution: {integrity: sha512-E/dwq5SgqIav7+nYGE/c3UOjGai+OlTmCkuegoFDxmajrFhINAlwwIbmLjFvT2ZmDEneu329VboPpeeuT/58Gg==}
+
+  '@vercel/nestjs@0.2.118':
+    resolution: {integrity: sha512-jmRFYtehiYY4DQfrkIv1ZN+iGhjXWmvylYzntuhverj1BwoIO2ancN+B6BpkcPDX/zky00RH2kN/nPb7NxDtdQ==}
+
+  '@vercel/next@4.21.4':
+    resolution: {integrity: sha512-JZkpxczlFkyQsgpraISTfXPvPu5A+be0ubYM8T3k1RACsBsv5UzkXp5EVDfNa8JB/6Q+p5Zh1FQTqbjH/EW2kg==}
+
+  '@vercel/nft@1.10.0':
+    resolution: {integrity: sha512-iLOW4fcsgkipfOh2Bw3wB38YDfxTlxr7+j4uFeui2OswkNT28jIitS/aMce7tS0mef1YPQ8zLIDYr3a0aahNrA==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  '@vercel/node@5.10.0':
+    resolution: {integrity: sha512-VhpH6g8kpM8wvi15/BST3ggXLaVRYQ7KCmDDsxkHaOfkwWICWBrgAratveMaU6sCIyETKS0gCU+Z7Dksv/i0UA==}
+
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
+  '@vercel/oidc@3.8.4':
+    resolution: {integrity: sha512-FGNvVZ5pgX9FaBqkPt6VkYFZ6bWAMDzYi7nxW+1Xt+Z4fn5PuTULVwsxjKc+0uKhysyWBQmvsmM50Oh6C2/oMA==}
+    engines: {node: '>= 20'}
+
+  '@vercel/prepare-flags-definitions@0.3.0':
+    resolution: {integrity: sha512-/0nuDFwYje0nqZnVKSd2VfJy2wOPQwbkas1qO1JQgtb0sLl+EeSCW4O9hrvq55pN50PNlAZ/APSeWHIAT9ZGHg==}
+
+  '@vercel/python-analysis@0.13.2':
+    resolution: {integrity: sha512-IEr5K2gvX143NBoQc1W4BWrdDWjZwxnIT6UrL5Y1dnyH7Cqc4AV00FIAddB1YpnIZBJwT4ZhE8QbgqBeO6C9Zw==}
+
+  '@vercel/python@6.56.2':
+    resolution: {integrity: sha512-TUQnflCTuK1AFSRka38wn6qqMwI0N70YG2uk5jKVrVXl3w+gZ+yA1DLn5OMMDUdYR21dJMDcMbn0NTaUGxLWaQ==}
+
+  '@vercel/redwood@2.5.1':
+    resolution: {integrity: sha512-oldy4mZmhFzHKkXluyPNHiIyZHxVW1Zpznn0qBag2hzmn2HpqkL9fZfZvlWGIvuAdQz/Sa4AErbreMEPOzCv0w==}
+
+  '@vercel/remix-builder@5.9.4':
+    resolution: {integrity: sha512-QKtQ4JUgjoU2gKkJJbhQcjMxvwMG3uvloAT4yz0m+0deyAPNMaHQJ0KKPtiOZH8+ILf4KqbebjjoC4UEzkiTWA==}
+
+  '@vercel/ruby@2.5.1':
+    resolution: {integrity: sha512-e23M7pfORQyyxSUmeQ8PqEnyLJ4swhtNrnyctU5E02UCaUYFm5YAdNfdPYRP4It874H4Wyvm+LV8u7CPBrfcPA==}
+
+  '@vercel/rust@1.4.2':
+    resolution: {integrity: sha512-vWVSMhj+3cMjQxj03jZTCNa94M0o+roVBA5wwfadxNMP8rCqdvZ0aamT/8zGCtjZ13PJc9v2W2nq0dlaaOZf4Q==}
+
+  '@vercel/sandbox@2.4.0':
+    resolution: {integrity: sha512-pifnr8hex/rgQ3EPyLYHYwHyf0Kwmc4Vbya9kHGk4aERFVGj44P+742S8/SDdt2guMxBriXBOMkMLq1Kaiyyeg==}
+
+  '@vercel/static-build@2.12.6':
+    resolution: {integrity: sha512-3WwhXA8HZyezQB8waCTO5KopceecS0+hvCHVaTk2kwWlUVnWUVsCHj7aaLPVUtBCF+tAiuv0gkloBhN2SXNvHw==}
+
+  '@vercel/static-config@3.4.1':
+    resolution: {integrity: sha512-kJKTyOg25JDRgDkHEkc+vWlvURxmSQkVKyRPO4EEGD/8HpJT+4u9Z/VGxwnCZ6zZBxYPpma283qBsHwY0gXjfw==}
+
+  '@vercel/vc-native-darwin-arm64@59.0.0':
+    resolution: {integrity: sha512-FloDB7nfXGnCjb9aVYiV99QQjK1UBcxQ3L/g3T9ekEWnjwHfpwSwcjWQFEEjfrSG4L042Lk3vQMDCOdPpGh6Ow==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@vercel/vc-native-darwin-x64@59.0.0':
+    resolution: {integrity: sha512-onrrc/1Jq/yfNncKmQdaXkR1p7R0NvU9ob7DhLHdAeJOwZzPBo+2DzV2mByk4rrkhQBjCGFiYEN9n/Gtzu8MrQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@vercel/vc-native-linux-arm64@59.0.0':
+    resolution: {integrity: sha512-+0wpedwJx/Vd5gaBvxWhNMw8aSCLvbirYDR5ndscWxG97yhlLDeGnDpuFxTg4YA4VC6SWXv9rhl+1/pTu9P13Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@vercel/vc-native-linux-x64@59.0.0':
+    resolution: {integrity: sha512-gRfWyhgzNnzPA7jrR83Ji84m9t41aUKB4sG6RX7MWnqXx3+Q3QaOFEQA9zJpadoRosSG2mEywKEA3b0h+pWxMA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@workflow/serde@4.1.0-beta.2':
+    resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
+
   '@zeit/schemas@2.36.0':
     resolution: {integrity: sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==}
+
+  abbrev@3.0.1:
+    resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1001,11 +1660,18 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  ajv@8.6.3:
+    resolution: {integrity: sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==}
 
   ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
@@ -1026,8 +1692,14 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
   arch@2.2.0:
     resolution: {integrity: sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==}
+
+  arg@4.1.0:
+    resolution: {integrity: sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==}
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
@@ -1089,6 +1761,23 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  async-listen@1.2.0:
+    resolution: {integrity: sha512-CcEtRh/oc9Jc4uWeUwdpG/+Mb2YUHKmdaTf0gUr7Wa+bfp4xx70HOb3RuSTJMvqKNB1TkdTfjLdrcz2X4rkkZA==}
+
+  async-listen@3.0.0:
+    resolution: {integrity: sha512-V+SsTpDqkrWTimiotsyl33ePSjA5/KrithwupuvJ6ztsqPvGv6ge4OredFhPffVXiLN/QUWvE0XcqJaYgt6fOg==}
+    engines: {node: '>= 14'}
+
+  async-listen@3.0.1:
+    resolution: {integrity: sha512-cWMaNwUJnf37C/S5TfCkk/15MwbPRwVYALA2jtjkbHjCmAPiDXyNJy2q3p1KAZzDLHAWyarUWSujUoHR4pEgrA==}
+    engines: {node: '>= 14'}
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
+
+  async-sema@3.1.1:
+    resolution: {integrity: sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -1101,6 +1790,14 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
@@ -1111,10 +1808,21 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  bare-events@2.9.1:
+    resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
   baseline-browser-mapping@2.11.13:
     resolution: {integrity: sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
   boxen@7.0.0:
     resolution: {integrity: sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==}
@@ -1136,8 +1844,15 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
   bytes@3.0.0:
     resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
+    engines: {node: '>= 0.8'}
+
+  bytes@3.1.0:
+    resolution: {integrity: sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==}
     engines: {node: '>= 0.8'}
 
   bytes@3.1.2:
@@ -1194,6 +1909,17 @@ packages:
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
+  chokidar@4.0.0:
+    resolution: {integrity: sha512-mxIojEAQcuEvT/lyXq+jf/3cO/KoA6z4CeNDGGevTybECPOMFCnQy3OPahluUkbqgPNGw5Bi78UC7Po6Lhy+NA==}
+    engines: {node: '>= 14.16.0'}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
+
+  cjs-module-lexer@1.2.3:
+    resolution: {integrity: sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==}
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
@@ -1211,6 +1937,9 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  code-block-writer@10.1.1:
+    resolution: {integrity: sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw==}
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -1236,9 +1965,21 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
   content-disposition@0.5.2:
     resolution: {integrity: sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==}
     engines: {node: '>= 0.6'}
+
+  content-type@1.0.4:
+    resolution: {integrity: sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==}
+    engines: {node: '>= 0.6'}
+
+  convert-hrtime@3.0.0:
+    resolution: {integrity: sha512-7V+KqSvMiHp8yWDuwfww06XleMWVVB9b9tURBx+G7UTADuo5hYPuowKloz4OzOqbPezxgo+fdQ1522WzPG4OeA==}
+    engines: {node: '>=8'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1286,6 +2027,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1309,9 +2059,17 @@ packages:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
 
+  define-lazy-prop@2.0.0:
+    resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
+    engines: {node: '>=8'}
+
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  depd@1.1.2:
+    resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
+    engines: {node: '>= 0.6'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -1338,6 +2096,11 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  edge-runtime@2.5.9:
+    resolution: {integrity: sha512-pk+k0oK0PVXdlT4oRp4lwh+unuKB7Ng4iZ2HB+EZ7QCEQizX360Rp/F4aRpgpRgdP2ufB35N+1KppHmYjqIGSg==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   electron-to-chromium@1.5.403:
     resolution: {integrity: sha512-MQsYmdaLzvaCX5j+ZZBr5Fm6uCCnPQcRtlvmvRlWqrXy+BH2O4ffXIAScF+JQznQWB9brWp4lSD9Z4yNmaf2BA==}
 
@@ -1346,6 +2109,12 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  end-of-stream@1.1.0:
+    resolution: {integrity: sha512-EoulkdKF/1xa92q25PbjuDcgJ9RDHYU2Rs3SCIvs2/dSQ3BpmxneNHmA/M7fe60M3PrV7nNGTTNbkK62l6vXiQ==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enhanced-resolve@5.24.5:
     resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
@@ -1371,6 +2140,12 @@ packages:
     resolution: {integrity: sha512-c/A0P0oxkACDc+cKWw8evLXK83oBKgn0qPOqCYT4x9uolpCIJAcYvJC9QYKNDRPsTeGyCrQ326jrvgZWdCdK5Q==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.4.1:
+    resolution: {integrity: sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==}
+
+  es-module-lexer@1.5.0:
+    resolution: {integrity: sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw==}
+
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
@@ -1392,6 +2167,11 @@ packages:
 
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
+
+  esbuild@0.27.0:
+    resolution: {integrity: sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1544,12 +2324,29 @@ packages:
   estree-util-visit@2.0.0:
     resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
 
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  events-intercept@2.0.0:
+    resolution: {integrity: sha512-blk1va0zol9QOrdZt0rFXo5KMkNPVSp92Eju/Qz8THwKWKRKeE0T8Br/1aW6+Edkyq9xHYgYxn2QtOnUKPUp+Q==}
+
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
+  execa@3.2.0:
+    resolution: {integrity: sha512-kJJfVbI/lZE1PZYDI5VPxp8zXPO9rtxOkhpZ0jMKha56AI9y2gGVC6bkukStQf0ka5Rh15BA5m7cCCH4jmHqkw==}
+    engines: {node: ^8.12.0 || >=9.7.0}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -1564,6 +2361,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
@@ -1581,6 +2381,9 @@ packages:
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1593,6 +2396,9 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -1613,6 +2419,19 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  fs-extra@11.1.0:
+    resolution: {integrity: sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==}
+    engines: {node: '>=14.14'}
+
+  fs-extra@11.1.1:
+    resolution: {integrity: sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==}
+    engines: {node: '>=14.14'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
@@ -1627,6 +2446,10 @@ packages:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
 
+  generic-pool@3.4.2:
+    resolution: {integrity: sha512-H7cUpwCQSiJmAHM4c/aFu6fUfrhWXW1ncyh8ftxEPMu6AiYkHw9K8br720TGPZJbk5eOH2bynjZD1yPvdDAmag==}
+    engines: {node: '>= 4'}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -1639,9 +2462,17 @@ packages:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
 
+  get-port@5.1.1:
+    resolution: {integrity: sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==}
+    engines: {node: '>=8'}
+
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
 
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
@@ -1661,6 +2492,10 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -1727,9 +2562,25 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  http-errors@1.7.3:
+    resolution: {integrity: sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==}
+    engines: {node: '>= 0.6'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  human-signals@1.1.1:
+    resolution: {integrity: sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==}
+    engines: {node: '>=8.12.0'}
+
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1746,6 +2597,9 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
@@ -1778,6 +2632,10 @@ packages:
   is-boolean-object@1.2.2:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
+
+  is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
 
   is-bun-module@2.0.0:
     resolution: {integrity: sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==}
@@ -1844,6 +2702,9 @@ packages:
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
@@ -1919,11 +2780,21 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  jose@5.9.6:
+    resolution: {integrity: sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==}
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-yaml@3.15.1:
     resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
+    hasBin: true
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
   js-yaml@4.3.1:
@@ -1937,6 +2808,9 @@ packages:
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-to-ts@1.6.4:
+    resolution: {integrity: sha512-pR4yQ9DHz6itqswtHCm26mw45FSNfQ9rEQjosaZErhn5J3J2sIViQiz8rDaezjKAhFGpmsoczYVBgGHzFw/stA==}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -1955,6 +2829,15 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
+  jsonlines@0.1.1:
+    resolution: {integrity: sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==}
 
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
@@ -2062,13 +2945,25 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
 
   lucide-react@1.31.0:
     resolution: {integrity: sha512-G8u2eEtoHUnUa9f8lbvqDhCiORMnYLdUEo06EEG9MQvHQrInKcX3Pa2TH39MM5qyzRcWETxB0+aOwAPI1g1kEg==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2138,6 +3033,11 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  micro@9.3.5-canary.3:
+    resolution: {integrity: sha512-viYIo9PefV+w9dvoIBh1gI44Mvx1BOk67B4BpC2QK77qdY0xZF0Q+vWLt/BII6cLkIc8rLmSIcJaB/OrXXKe1g==}
+    engines: {node: '>= 8.0.0'}
+    hasBin: true
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -2252,6 +3152,10 @@ packages:
     resolution: {integrity: sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
@@ -2260,9 +3164,17 @@ packages:
     resolution: {integrity: sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==}
     engines: {node: '>= 0.6'}
 
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
+
+  minimatch@10.1.1:
+    resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
+    engines: {node: 20 || >=22}
 
   minimatch@10.2.6:
     resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
@@ -2274,8 +3186,31 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
+  ms@2.1.1:
+    resolution: {integrity: sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==}
+
+  ms@2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -2334,9 +3269,45 @@ packages:
     resolution: {integrity: sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==}
     engines: {node: '>= 0.4'}
 
+  node-fetch@2.6.7:
+    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-fetch@2.6.9:
+    resolution: {integrity: sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
+
   node-releases@2.0.53:
     resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
     engines: {node: '>=18'}
+
+  nopt@8.1.0:
+    resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
 
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
@@ -2378,17 +3349,39 @@ packages:
     resolution: {integrity: sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==}
     engines: {node: '>= 0.8'}
 
+  once@1.3.3:
+    resolution: {integrity: sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
+
+  open@8.4.0:
+    resolution: {integrity: sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==}
+    engines: {node: '>=12'}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  os-paths@4.4.0:
+    resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
+    engines: {node: '>= 6.0'}
+
   own-keys@1.0.2:
     resolution: {integrity: sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==}
     engines: {node: '>= 0.4'}
+
+  oxc-transform@0.111.0:
+    resolution: {integrity: sha512-oa5KKSDNLHZGaiqIGAbCWXeN9IJUAz9MElWcQX90epDxdKc9Hrt/BsLj3K4gDqfAYa5dwdH+ZCFJG9hR74fiGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  p-finally@2.0.1:
+    resolution: {integrity: sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==}
+    engines: {node: '>=8'}
 
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
@@ -2405,6 +3398,13 @@ packages:
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
+  parse-ms@2.1.0:
+    resolution: {integrity: sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==}
+    engines: {node: '>=6'}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2419,8 +3419,31 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
   path-to-regexp@3.3.0:
     resolution: {integrity: sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==}
+
+  path-to-regexp@6.1.0:
+    resolution: {integrity: sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  path-to-regexp@8.2.0:
+    resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
+    engines: {node: '>=16'}
+
+  path-to-regexp@8.3.0:
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
+  picocolors@1.0.0:
+    resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2453,11 +3476,21 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  pretty-ms@7.0.1:
+    resolution: {integrity: sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==}
+    engines: {node: '>=10'}
+
+  promisepipe@3.0.0:
+    resolution: {integrity: sha512-V6TbZDJ/ZswevgkDNpGt/YqNCiZP9ASfgU+p83uJE6NrGtvSGoOcHLiDCqkMs2+yg7F5qHdLV8d0aS8O26G/KA==}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2469,6 +3502,10 @@ packages:
   range-parser@1.2.0:
     resolution: {integrity: sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==}
     engines: {node: '>= 0.6'}
+
+  raw-body@2.4.1:
+    resolution: {integrity: sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==}
+    engines: {node: '>= 0.8'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -2515,6 +3552,10 @@ packages:
   react@19.2.8:
     resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
 
   recma-build-jsx@1.0.0:
     resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
@@ -2571,17 +3612,34 @@ packages:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve.exports@2.0.3:
+    resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
+    engines: {node: '>=10'}
 
   resolve@2.0.0-next.7:
     resolution: {integrity: sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==}
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rolldown@1.0.0-rc.1:
+    resolution: {integrity: sha512-M3AeZjYE6UclblEf531Hch0WfVC/NOL43Cc+WdF3J50kk5/fvouHhDumSGTh0oRjbZ8C4faaVr5r6Nx1xMqDGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -2601,6 +3659,13 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sandbox@3.4.0:
+    resolution: {integrity: sha512-JPdADikobt6zFuuCRhl6whNrCJlLPxpUmT/hNxLij70mkpeejHKDN+HeVlrdHI8snDTzRIiF3Ye8KyMIyVWA+A==}
+    hasBin: true
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -2610,6 +3675,11 @@ packages:
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.5.4:
+    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
+    engines: {node: '>=10'}
     hasBin: true
 
   semver@7.8.5:
@@ -2636,6 +3706,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setprototypeof@1.1.1:
+    resolution: {integrity: sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==}
 
   sharp@0.35.3:
     resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
@@ -2673,6 +3746,14 @@ packages:
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
+  signal-exit@4.0.2:
+    resolution: {integrity: sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==}
+    engines: {node: '>=14'}
+
+  smol-toml@1.5.2:
+    resolution: {integrity: sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ==}
+    engines: {node: '>= 18'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2687,12 +3768,34 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  srvx@0.11.16:
+    resolution: {integrity: sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
+
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  stat-mode@0.3.0:
+    resolution: {integrity: sha512-QjMLR0A3WwFY2aZdV0okfFEJB5TRjkggXZjxP3A1RsWsNHNu3YPv8btmtc6iCFZ0Rul3FE93OYogvhOUClU+ng==}
+
+  statuses@1.5.0:
+    resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
+    engines: {node: '>= 0.6'}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  stream-to-array@2.3.0:
+    resolution: {integrity: sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA==}
+
+  stream-to-promise@2.2.0:
+    resolution: {integrity: sha512-HAGUASw8NT0k8JvIVutB2Y/9iBk7gpgEyAudXwNJmZERdMITGdajOa4VJfD/kNiA3TppQpTP4J+CtcHwdzKBAw==}
+    deprecated: Deprecated. Use node:stream/promises and node:stream/consumers instead.
+
+  streamx@2.28.0:
+    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -2798,6 +3901,32 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tar-stream@3.1.7:
+    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
+    engines: {node: '>=18'}
+
+  tar@7.5.7:
+    resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
+    engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
+
+  time-span@4.0.0:
+    resolution: {integrity: sha512-MyqZCTGLDZ77u4k+jqg4UlrzPTPZ49NDlaekU6uuFaJLzPIN1woaRXCbGeqOfxwc3Y37ZROGAJ614Rdv7Olt+g==}
+    engines: {node: '>=10'}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -2805,6 +3934,17 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  toidentifier@1.0.0:
+    resolution: {integrity: sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==}
+    engines: {node: '>=0.6'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -2818,11 +3958,22 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-morph@12.0.0:
+    resolution: {integrity: sha512-VHC8XgU2fFW7yO1f/b3mxKDje1vmyzFXHWzOYmKEkCEwcLjDtbdLgBQviqj4ZwP4MJkQtRo6Ha2I29lq/B+VxA==}
+
+  ts-toolbelt@6.15.5:
+    resolution: {integrity: sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==}
+
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2855,17 +4006,44 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uid-promise@1.0.0:
+    resolution: {integrity: sha512-R8375j0qwXyIu/7R0tjdF06/sElHqbmdmWC9M2qQHpEVbvE4I5+38KJI7LUUmQMp7NVq4tKHiBMkT0NFM453Ig==}
+
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  undici@5.28.4:
+    resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
+    engines: {node: '>=14.0'}
+
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
+    engines: {node: '>=14.0'}
+
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
+    engines: {node: '>=18.17'}
+
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -2890,6 +4068,14 @@ packages:
 
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
 
   unrs-resolver@1.12.2:
     resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
@@ -2929,9 +4115,18 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
+    hasBin: true
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vercel@59.0.0:
+    resolution: {integrity: sha512-9q4NEUYiiwC45ZVoShZhY0lYZPKwbK7In3Cw8SbNK7gwfeTv84bDhPqjos6UZk91lbzgaqclDPdPfLmH1kz7jA==}
+    engines: {node: '>= 18'}
+    hasBin: true
 
   vfile-matter@5.0.1:
     resolution: {integrity: sha512-o6roP82AiX0XfkyTHyRCMXgHfltUNlXSEqCIS80f+mbAyiQBE2fxtDVMtseyytGx75sihiJFo/zR6r/4LTs2Cw==}
@@ -2941,6 +4136,15 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  web-vitals@0.2.4:
+    resolution: {integrity: sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg==}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -2975,13 +4179,58 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xdg-app-paths@5.1.0:
+    resolution: {integrity: sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA==}
+    engines: {node: '>=6'}
+
+  xdg-app-paths@5.5.1:
+    resolution: {integrity: sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==}
+    engines: {node: '>= 6.0'}
+
+  xdg-portable@7.3.0:
+    resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
+    engines: {node: '>= 6.0'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yauzl-clone@1.0.4:
+    resolution: {integrity: sha512-igM2RRCf3k8TvZoxR2oguuw4z1xasOnA31joCqHIyLkeWrvAc2Jgay5ISQ2ZplinkoGaJ6orCz56Ey456c5ESA==}
+    engines: {node: '>=6'}
+
+  yauzl-promise@2.1.3:
+    resolution: {integrity: sha512-A1pf6fzh6eYkK0L4Qp7g9jzJSDrM6nN0bOn5T0IbY4Yo3w+YkWlHFkJP7mzknMXjqusHFHlKsK2N+4OLsK2MRA==}
+    engines: {node: '>=6'}
+
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -2992,6 +4241,12 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
+
+  zod@3.22.4:
+    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -3103,6 +4358,20 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
+  '@bytecodealliance/preview2-shim@0.17.6': {}
+
+  '@edge-runtime/format@2.2.1': {}
+
+  '@edge-runtime/node-utils@2.3.0': {}
+
+  '@edge-runtime/ponyfill@2.4.2': {}
+
+  '@edge-runtime/primitives@4.1.0': {}
+
+  '@edge-runtime/vm@3.2.0':
+    dependencies:
+      '@edge-runtime/primitives': 4.1.0
+
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -3122,6 +4391,84 @@ snapshots:
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/android-arm@0.27.0':
+    optional: true
+
+  '@esbuild/android-x64@0.27.0':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.0':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.0':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.0':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.0':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.0':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.10.1(eslint@9.39.5(jiti@2.7.0))':
@@ -3174,6 +4521,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@fastify/busboy@2.1.1': {}
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -3298,6 +4647,16 @@ snapshots:
   '@img/sharp-win32-x64@0.35.3':
     optional: true
 
+  '@isaacs/balanced-match@4.0.1': {}
+
+  '@isaacs/brace-expansion@5.0.1':
+    dependencies:
+      '@isaacs/balanced-match': 4.0.1
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3316,6 +4675,19 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@mapbox/node-pre-gyp@2.0.3':
+    dependencies:
+      consola: 3.4.2
+      detect-libc: 2.1.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 2.7.0
+      nopt: 8.1.0
+      semver: 7.8.5
+      tar: 7.5.22
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   '@mdx-js/mdx@3.1.1':
     dependencies:
@@ -3353,10 +4725,68 @@ snapshots:
       '@types/react': 19.2.18
       react: 19.2.8
 
+  '@napi-rs/keyring-darwin-arm64@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-darwin-x64@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-freebsd-x64@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-musl@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-gnu@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-musl@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-x64-msvc@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring@1.2.0':
+    optionalDependencies:
+      '@napi-rs/keyring-darwin-arm64': 1.2.0
+      '@napi-rs/keyring-darwin-x64': 1.2.0
+      '@napi-rs/keyring-freebsd-x64': 1.2.0
+      '@napi-rs/keyring-linux-arm-gnueabihf': 1.2.0
+      '@napi-rs/keyring-linux-arm64-gnu': 1.2.0
+      '@napi-rs/keyring-linux-arm64-musl': 1.2.0
+      '@napi-rs/keyring-linux-riscv64-gnu': 1.2.0
+      '@napi-rs/keyring-linux-x64-gnu': 1.2.0
+      '@napi-rs/keyring-linux-x64-musl': 1.2.0
+      '@napi-rs/keyring-win32-arm64-msvc': 1.2.0
+      '@napi-rs/keyring-win32-ia32-msvc': 1.2.0
+      '@napi-rs/keyring-win32-x64-msvc': 1.2.0
+
   '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -3408,6 +4838,73 @@ snapshots:
   '@nolyfill/is-core-module@1.0.39': {}
 
   '@orama/orama@3.1.18': {}
+
+  '@oxc-project/types@0.110.0': {}
+
+  '@oxc-transform/binding-android-arm-eabi@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-android-arm64@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-darwin-arm64@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-darwin-x64@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-freebsd-x64@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm-musleabihf@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm64-gnu@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm64-musl@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-ppc64-gnu@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-riscv64-gnu@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-riscv64-musl@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-s390x-gnu@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-x64-gnu@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-x64-musl@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-openharmony-arm64@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-wasm32-wasi@0.111.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  '@oxc-transform/binding-win32-arm64-msvc@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-win32-ia32-msvc@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-win32-x64-msvc@0.111.0':
+    optional: true
 
   '@radix-ui/primitive@1.1.7': {}
 
@@ -3555,7 +5052,63 @@ snapshots:
       '@types/react': 19.2.18
       '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
+  '@renovatebot/pep440@4.2.1': {}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.1': {}
+
+  '@rollup/pluginutils@5.4.0':
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-walker: 2.0.2
+      picomatch: 4.0.5
+
   '@rtsao/scc@1.1.0': {}
+
+  '@sinclair/typebox@0.25.24': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -3635,6 +5188,15 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.3.3
 
+  '@tootallnate/once@2.0.0': {}
+
+  '@ts-morph/common@0.11.1':
+    dependencies:
+      fast-glob: 3.3.1
+      minimatch: 3.1.5
+      mkdirp: 1.0.4
+      path-browserify: 1.0.1
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -3665,6 +5227,10 @@ snapshots:
   '@types/mdx@2.0.14': {}
 
   '@types/ms@2.1.0': {}
+
+  '@types/node@20.11.0':
+    dependencies:
+      undici-types: 5.26.5
 
   '@types/node@26.2.0':
     dependencies:
@@ -3845,13 +5411,367 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
+  '@vercel/backends@0.8.37(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)':
+    dependencies:
+      '@vercel/build-utils': 14.1.0
+      '@vercel/nft': 1.10.0
+      '@vercel/static-config': 3.4.1
+      execa: 3.2.0
+      fs-extra: 11.1.0
+      get-port: 5.1.1
+      oxc-transform: 0.111.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)
+      path-to-regexp: 8.3.0
+      resolve.exports: 2.0.3
+      rolldown: 1.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)
+      srvx: 0.11.16
+      ts-morph: 12.0.0
+      tsx: 4.21.0
+      zod: 3.22.4
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/blob@2.8.0':
+    dependencies:
+      '@vercel/oidc': 3.8.4
+      async-retry: 1.3.3
+      is-buffer: 2.0.5
+      is-node-process: 1.2.0
+      throttleit: 2.1.0
+      undici: 6.28.0
+
+  '@vercel/build-utils@14.1.0':
+    dependencies:
+      '@vercel/python-analysis': 0.13.2
+      cjs-module-lexer: 1.2.3
+      es-module-lexer: 1.5.0
+
+  '@vercel/cervel@0.1.45(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)':
+    dependencies:
+      '@vercel/backends': 0.8.37(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/cli-auth@0.3.4':
+    dependencies:
+      '@napi-rs/keyring': 1.2.0
+      '@vercel/cli-config': 0.2.3
+      async-listen: 3.0.0
+      open: 8.4.0
+      zod: 4.1.11
+
+  '@vercel/cli-config@0.2.3':
+    dependencies:
+      xdg-app-paths: 5.5.1
+      zod: 4.1.11
+
+  '@vercel/cli-exec@1.0.1':
+    dependencies:
+      execa: 5.1.1
+
+  '@vercel/container@0.2.0': {}
+
+  '@vercel/detect-agent@1.2.5': {}
+
+  '@vercel/elysia@0.1.114':
+    dependencies:
+      '@vercel/node': 5.10.0
+      '@vercel/static-config': 3.4.1
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/error-utils@2.2.1': {}
+
+  '@vercel/express@0.1.128(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)':
+    dependencies:
+      '@vercel/cervel': 0.1.45(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)
+      '@vercel/nft': 1.10.0
+      '@vercel/node': 5.10.0
+      '@vercel/static-config': 3.4.1
+      fs-extra: 11.1.0
+      path-to-regexp: 8.3.0
+      ts-morph: 12.0.0
+      zod: 3.22.4
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/fastify@0.1.117':
+    dependencies:
+      '@vercel/node': 5.10.0
+      '@vercel/static-config': 3.4.1
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/fun@1.3.0':
+    dependencies:
+      '@tootallnate/once': 2.0.0
+      async-listen: 1.2.0
+      debug: 4.3.4
+      generic-pool: 3.4.2
+      micro: 9.3.5-canary.3
+      ms: 2.1.1
+      node-fetch: 2.6.7
+      path-to-regexp: 8.2.0
+      promisepipe: 3.0.0
+      semver: 7.5.4
+      stat-mode: 0.3.0
+      stream-to-promise: 2.2.0
+      tar: 7.5.7
+      tinyexec: 0.3.2
+      tree-kill: 1.2.2
+      uid-promise: 1.0.0
+      xdg-app-paths: 5.1.0
+      yauzl-promise: 2.1.3
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@vercel/gatsby-plugin-vercel-analytics@1.0.12':
+    dependencies:
+      web-vitals: 0.2.4
+
+  '@vercel/gatsby-plugin-vercel-builder@2.2.40':
+    dependencies:
+      '@sinclair/typebox': 0.25.24
+      '@vercel/build-utils': 14.1.0
+      esbuild: 0.27.0
+      etag: 1.8.1
+      fs-extra: 11.1.0
+
+  '@vercel/go@3.11.0': {}
+
+  '@vercel/h3@0.1.123':
+    dependencies:
+      '@vercel/node': 5.10.0
+      '@vercel/static-config': 3.4.1
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/hono@0.2.117':
+    dependencies:
+      '@vercel/nft': 1.10.0
+      '@vercel/node': 5.10.0
+      '@vercel/static-config': 3.4.1
+      fs-extra: 11.1.0
+      path-to-regexp: 8.3.0
+      ts-morph: 12.0.0
+      zod: 3.22.4
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/hydrogen@1.4.1':
+    dependencies:
+      '@vercel/static-config': 3.4.1
+      ts-morph: 12.0.0
+
+  '@vercel/koa@0.1.97':
+    dependencies:
+      '@vercel/node': 5.10.0
+      '@vercel/static-config': 3.4.1
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/nestjs@0.2.118':
+    dependencies:
+      '@vercel/node': 5.10.0
+      '@vercel/static-config': 3.4.1
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/next@4.21.4':
+    dependencies:
+      '@vercel/nft': 1.10.0
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/nft@1.10.0':
+    dependencies:
+      '@mapbox/node-pre-gyp': 2.0.3
+      '@rollup/pluginutils': 5.4.0
+      acorn: 8.18.0
+      acorn-import-attributes: 1.9.5(acorn@8.18.0)
+      async-sema: 3.1.1
+      bindings: 1.5.0
+      estree-walker: 2.0.2
+      glob: 13.0.6
+      graceful-fs: 4.2.11
+      node-gyp-build: 4.8.4
+      picomatch: 4.0.5
+      resolve-from: 5.0.0
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/node@5.10.0':
+    dependencies:
+      '@edge-runtime/node-utils': 2.3.0
+      '@edge-runtime/primitives': 4.1.0
+      '@edge-runtime/vm': 3.2.0
+      '@types/node': 20.11.0
+      '@vercel/build-utils': 14.1.0
+      '@vercel/error-utils': 2.2.1
+      '@vercel/nft': 1.10.0
+      '@vercel/static-config': 3.4.1
+      async-listen: 3.0.0
+      cjs-module-lexer: 1.2.3
+      edge-runtime: 2.5.9
+      es-module-lexer: 1.4.1
+      esbuild: 0.27.0
+      etag: 1.8.1
+      mime-types: 2.1.35
+      node-fetch: 2.6.9
+      path-to-regexp: 6.1.0
+      path-to-regexp-updated: path-to-regexp@6.3.0
+      ts-morph: 12.0.0
+      tsx: 4.21.0
+      typescript: 5.9.3
+      undici: 5.28.4
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/oidc@3.2.0': {}
+
+  '@vercel/oidc@3.8.4':
+    dependencies:
+      '@vercel/cli-config': 0.2.3
+      '@vercel/cli-exec': 1.0.1
+      jose: 5.9.6
+
+  '@vercel/prepare-flags-definitions@0.3.0': {}
+
+  '@vercel/python-analysis@0.13.2':
+    dependencies:
+      '@bytecodealliance/preview2-shim': 0.17.6
+      '@renovatebot/pep440': 4.2.1
+      fs-extra: 11.1.1
+      js-yaml: 4.1.1
+      minimatch: 10.1.1
+      smol-toml: 1.5.2
+      zod: 3.22.4
+
+  '@vercel/python@6.56.2':
+    dependencies:
+      '@vercel/python-analysis': 0.13.2
+
+  '@vercel/redwood@2.5.1':
+    dependencies:
+      '@vercel/nft': 1.10.0
+      '@vercel/static-config': 3.4.1
+      semver: 6.3.1
+      ts-morph: 12.0.0
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/remix-builder@5.9.4':
+    dependencies:
+      '@vercel/error-utils': 2.2.1
+      '@vercel/nft': 1.10.0
+      '@vercel/static-config': 3.4.1
+      path-to-regexp: 6.1.0
+      path-to-regexp-updated: path-to-regexp@6.3.0
+      ts-morph: 12.0.0
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/ruby@2.5.1': {}
+
+  '@vercel/rust@1.4.2':
+    dependencies:
+      execa: 5.1.1
+      get-port: 5.1.1
+      smol-toml: 1.5.2
+
+  '@vercel/sandbox@2.4.0':
+    dependencies:
+      '@vercel/oidc': 3.2.0
+      '@workflow/serde': 4.1.0-beta.2
+      async-retry: 1.3.3
+      jose: 6.2.3
+      jsonlines: 0.1.1
+      ms: 2.1.3
+      picocolors: 1.1.1
+      tar-stream: 3.1.7
+      undici: 7.29.0
+      xdg-app-paths: 5.1.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  '@vercel/static-build@2.12.6':
+    dependencies:
+      '@vercel/gatsby-plugin-vercel-analytics': 1.0.12
+      '@vercel/gatsby-plugin-vercel-builder': 2.2.40
+      '@vercel/static-config': 3.4.1
+      ts-morph: 12.0.0
+
+  '@vercel/static-config@3.4.1':
+    dependencies:
+      ajv: 8.6.3
+      json-schema-to-ts: 1.6.4
+      ts-morph: 12.0.0
+
+  '@vercel/vc-native-darwin-arm64@59.0.0':
+    optional: true
+
+  '@vercel/vc-native-darwin-x64@59.0.0':
+    optional: true
+
+  '@vercel/vc-native-linux-arm64@59.0.0':
+    optional: true
+
+  '@vercel/vc-native-linux-x64@59.0.0':
+    optional: true
+
+  '@workflow/serde@4.1.0-beta.2': {}
+
   '@zeit/schemas@2.36.0': {}
+
+  abbrev@3.0.1: {}
+
+  acorn-import-attributes@1.9.5(acorn@8.18.0):
+    dependencies:
+      acorn: 8.18.0
 
   acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:
       acorn: 8.18.0
 
   acorn@8.18.0: {}
+
+  agent-base@7.1.4: {}
 
   ajv@6.15.0:
     dependencies:
@@ -3867,6 +5787,13 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  ajv@8.6.3:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js: 4.4.1
+
   ansi-align@3.0.1:
     dependencies:
       string-width: 4.2.3
@@ -3881,7 +5808,11 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  any-promise@1.3.0: {}
+
   arch@2.2.0: {}
+
+  arg@4.1.0: {}
 
   arg@5.0.2: {}
 
@@ -3970,6 +5901,18 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  async-listen@1.2.0: {}
+
+  async-listen@3.0.0: {}
+
+  async-listen@3.0.1: {}
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
+
+  async-sema@3.1.1: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -3978,13 +5921,21 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  b4a@1.8.1: {}
+
   bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
 
+  bare-events@2.9.1: {}
+
   baseline-browser-mapping@2.11.13: {}
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
 
   boxen@7.0.0:
     dependencies:
@@ -4018,7 +5969,11 @@ snapshots:
       node-releases: 2.0.53
       update-browserslist-db: 1.3.1(browserslist@4.28.8)
 
+  buffer-crc32@0.2.13: {}
+
   bytes@3.0.0: {}
+
+  bytes@3.1.0: {}
 
   bytes@3.1.2: {}
 
@@ -4066,6 +6021,14 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
+  chokidar@4.0.0:
+    dependencies:
+      readdirp: 4.1.2
+
+  chownr@3.0.0: {}
+
+  cjs-module-lexer@1.2.3: {}
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
@@ -4081,6 +6044,8 @@ snapshots:
       is-wsl: 2.2.0
 
   clsx@2.1.1: {}
+
+  code-block-writer@10.1.1: {}
 
   collapse-white-space@2.1.0: {}
 
@@ -4110,7 +6075,13 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  consola@3.4.2: {}
+
   content-disposition@0.5.2: {}
+
+  content-type@1.0.4: {}
+
+  convert-hrtime@3.0.0: {}
 
   convert-source-map@2.0.0: {}
 
@@ -4152,6 +6123,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.3.4:
+    dependencies:
+      ms: 2.1.2
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -4170,11 +6145,15 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  define-lazy-prop@2.0.0: {}
+
   define-properties@1.2.1:
     dependencies:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  depd@1.1.2: {}
 
   dequal@2.0.3: {}
 
@@ -4198,11 +6177,31 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
+  edge-runtime@2.5.9:
+    dependencies:
+      '@edge-runtime/format': 2.2.1
+      '@edge-runtime/ponyfill': 2.4.2
+      '@edge-runtime/vm': 3.2.0
+      async-listen: 3.0.1
+      mri: 1.2.0
+      picocolors: 1.0.0
+      pretty-ms: 7.0.1
+      signal-exit: 4.0.2
+      time-span: 4.0.0
+
   electron-to-chromium@1.5.403: {}
 
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  end-of-stream@1.1.0:
+    dependencies:
+      once: 1.3.3
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enhanced-resolve@5.24.5:
     dependencies:
@@ -4296,6 +6295,10 @@ snapshots:
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
 
+  es-module-lexer@1.4.1: {}
+
+  es-module-lexer@1.5.0: {}
+
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
@@ -4333,6 +6336,35 @@ snapshots:
       acorn: 8.18.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
+
+  esbuild@0.27.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.0
+      '@esbuild/android-arm': 0.27.0
+      '@esbuild/android-arm64': 0.27.0
+      '@esbuild/android-x64': 0.27.0
+      '@esbuild/darwin-arm64': 0.27.0
+      '@esbuild/darwin-x64': 0.27.0
+      '@esbuild/freebsd-arm64': 0.27.0
+      '@esbuild/freebsd-x64': 0.27.0
+      '@esbuild/linux-arm': 0.27.0
+      '@esbuild/linux-arm64': 0.27.0
+      '@esbuild/linux-ia32': 0.27.0
+      '@esbuild/linux-loong64': 0.27.0
+      '@esbuild/linux-mips64el': 0.27.0
+      '@esbuild/linux-ppc64': 0.27.0
+      '@esbuild/linux-riscv64': 0.27.0
+      '@esbuild/linux-s390x': 0.27.0
+      '@esbuild/linux-x64': 0.27.0
+      '@esbuild/netbsd-arm64': 0.27.0
+      '@esbuild/netbsd-x64': 0.27.0
+      '@esbuild/openbsd-arm64': 0.27.0
+      '@esbuild/openbsd-x64': 0.27.0
+      '@esbuild/openharmony-arm64': 0.27.0
+      '@esbuild/sunos-x64': 0.27.0
+      '@esbuild/win32-arm64': 0.27.0
+      '@esbuild/win32-ia32': 0.27.0
+      '@esbuild/win32-x64': 0.27.0
 
   escalade@3.2.0: {}
 
@@ -4574,11 +6606,36 @@ snapshots:
       '@types/estree-jsx': 1.0.5
       '@types/unist': 3.0.3
 
+  estree-walker@2.0.2: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
+
+  etag@1.8.1: {}
+
+  events-intercept@2.0.0: {}
+
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+
+  execa@3.2.0:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 5.2.0
+      human-signals: 1.1.1
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      p-finally: 2.0.1
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
 
   execa@5.1.1:
     dependencies:
@@ -4600,6 +6657,8 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-fifo@1.3.2: {}
+
   fast-glob@3.3.1:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -4618,6 +6677,10 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
+
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
@@ -4625,6 +6688,8 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  file-uri-to-path@1.0.0: {}
 
   fill-range@7.1.1:
     dependencies:
@@ -4646,6 +6711,21 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  fs-extra@11.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
+  fs-extra@11.1.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
+  fsevents@2.3.3:
+    optional: true
+
   function-bind@1.1.2: {}
 
   function.prototype.name@1.2.0:
@@ -4664,6 +6744,8 @@ snapshots:
 
   generator-function@2.0.1: {}
 
+  generic-pool@3.4.2: {}
+
   gensync@1.0.0-beta.2: {}
 
   get-intrinsic@1.3.0:
@@ -4681,10 +6763,16 @@ snapshots:
 
   get-nonce@1.0.1: {}
 
+  get-port@5.1.1: {}
+
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.2
+
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
 
   get-stream@6.0.1: {}
 
@@ -4705,6 +6793,12 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.6
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   globals@14.0.0: {}
 
@@ -4799,7 +6893,28 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  http-errors@1.7.3:
+    dependencies:
+      depd: 1.1.2
+      inherits: 2.0.4
+      setprototypeof: 1.1.1
+      statuses: 1.5.0
+      toidentifier: 1.0.0
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  human-signals@1.1.1: {}
+
   human-signals@2.1.0: {}
+
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
 
@@ -4811,6 +6926,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  inherits@2.0.4: {}
 
   ini@1.3.8: {}
 
@@ -4851,6 +6968,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+
+  is-buffer@2.0.5: {}
 
   is-bun-module@2.0.0:
     dependencies:
@@ -4908,6 +7027,8 @@ snapshots:
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
+
+  is-node-process@1.2.0: {}
 
   is-number-object@1.1.1:
     dependencies:
@@ -4980,12 +7101,20 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  jose@5.9.6: {}
+
+  jose@6.2.3: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
 
   js-yaml@4.3.1:
     dependencies:
@@ -4994,6 +7123,11 @@ snapshots:
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
+
+  json-schema-to-ts@1.6.4:
+    dependencies:
+      '@types/json-schema': 7.0.15
+      ts-toolbelt: 6.15.5
 
   json-schema-traverse@0.4.1: {}
 
@@ -5006,6 +7140,16 @@ snapshots:
       minimist: 1.2.8
 
   json5@2.2.3: {}
+
+  jsonc-parser@3.3.1: {}
+
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  jsonlines@0.1.1: {}
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -5092,13 +7236,21 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lru-cache@11.5.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
 
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
+
   lucide-react@1.31.0(react@19.2.8):
     dependencies:
       react: 19.2.8
+
+  luxon@3.7.2: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -5276,6 +7428,12 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  micro@9.3.5-canary.3:
+    dependencies:
+      arg: 4.1.0
+      content-type: 1.0.4
+      raw-body: 2.4.1
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -5548,13 +7706,23 @@ snapshots:
 
   mime-db@1.33.0: {}
 
+  mime-db@1.52.0: {}
+
   mime-db@1.54.0: {}
 
   mime-types@2.1.18:
     dependencies:
       mime-db: 1.33.0
 
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
   mimic-fn@2.1.0: {}
+
+  minimatch@10.1.1:
+    dependencies:
+      '@isaacs/brace-expansion': 5.0.1
 
   minimatch@10.2.6:
     dependencies:
@@ -5566,7 +7734,21 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass@7.1.3: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
+  mkdirp@1.0.4: {}
+
+  mri@1.2.0: {}
+
   ms@2.0.0: {}
+
+  ms@2.1.1: {}
+
+  ms@2.1.2: {}
 
   ms@2.1.3: {}
 
@@ -5629,7 +7811,25 @@ snapshots:
       object.entries: 1.1.9
       semver: 6.3.1
 
+  node-fetch@2.6.7:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-fetch@2.6.9:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-gyp-build@4.8.4: {}
+
   node-releases@2.0.53: {}
+
+  nopt@8.1.0:
+    dependencies:
+      abbrev: 3.0.1
 
   npm-run-path@4.0.1:
     dependencies:
@@ -5679,9 +7879,23 @@ snapshots:
 
   on-headers@1.1.0: {}
 
+  once@1.3.3:
+    dependencies:
+      wrappy: 1.0.2
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+
+  open@8.4.0:
+    dependencies:
+      define-lazy-prop: 2.0.0
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
 
   optionator@0.9.4:
     dependencies:
@@ -5692,12 +7906,42 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  os-paths@4.4.0: {}
+
   own-keys@1.0.2:
     dependencies:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
+
+  oxc-transform@0.111.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3):
+    optionalDependencies:
+      '@oxc-transform/binding-android-arm-eabi': 0.111.0
+      '@oxc-transform/binding-android-arm64': 0.111.0
+      '@oxc-transform/binding-darwin-arm64': 0.111.0
+      '@oxc-transform/binding-darwin-x64': 0.111.0
+      '@oxc-transform/binding-freebsd-x64': 0.111.0
+      '@oxc-transform/binding-linux-arm-gnueabihf': 0.111.0
+      '@oxc-transform/binding-linux-arm-musleabihf': 0.111.0
+      '@oxc-transform/binding-linux-arm64-gnu': 0.111.0
+      '@oxc-transform/binding-linux-arm64-musl': 0.111.0
+      '@oxc-transform/binding-linux-ppc64-gnu': 0.111.0
+      '@oxc-transform/binding-linux-riscv64-gnu': 0.111.0
+      '@oxc-transform/binding-linux-riscv64-musl': 0.111.0
+      '@oxc-transform/binding-linux-s390x-gnu': 0.111.0
+      '@oxc-transform/binding-linux-x64-gnu': 0.111.0
+      '@oxc-transform/binding-linux-x64-musl': 0.111.0
+      '@oxc-transform/binding-openharmony-arm64': 0.111.0
+      '@oxc-transform/binding-wasm32-wasi': 0.111.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)
+      '@oxc-transform/binding-win32-arm64-msvc': 0.111.0
+      '@oxc-transform/binding-win32-ia32-msvc': 0.111.0
+      '@oxc-transform/binding-win32-x64-msvc': 0.111.0
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  p-finally@2.0.1: {}
 
   p-limit@3.1.0:
     dependencies:
@@ -5721,6 +7965,10 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  parse-ms@2.1.0: {}
+
+  path-browserify@1.0.1: {}
+
   path-exists@4.0.0: {}
 
   path-is-inside@1.0.2: {}
@@ -5729,7 +7977,24 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.2
+      minipass: 7.1.3
+
   path-to-regexp@3.3.0: {}
+
+  path-to-regexp@6.1.0: {}
+
+  path-to-regexp@6.3.0: {}
+
+  path-to-regexp@8.2.0: {}
+
+  path-to-regexp@8.3.0: {}
+
+  pend@1.2.0: {}
+
+  picocolors@1.0.0: {}
 
   picocolors@1.1.1: {}
 
@@ -5758,6 +8023,12 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  pretty-ms@7.0.1:
+    dependencies:
+      parse-ms: 2.1.0
+
+  promisepipe@3.0.0: {}
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -5766,11 +8037,23 @@ snapshots:
 
   property-information@7.2.0: {}
 
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
 
   range-parser@1.2.0: {}
+
+  raw-body@2.4.1:
+    dependencies:
+      bytes: 3.1.0
+      http-errors: 1.7.3
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
 
   rc@1.2.8:
     dependencies:
@@ -5814,6 +8097,8 @@ snapshots:
       '@types/react': 19.2.18
 
   react@19.2.8: {}
+
+  readdirp@4.1.2: {}
 
   recma-build-jsx@1.0.0:
     dependencies:
@@ -5926,7 +8211,11 @@ snapshots:
 
   resolve-from@4.0.0: {}
 
+  resolve-from@5.0.0: {}
+
   resolve-pkg-maps@1.0.0: {}
+
+  resolve.exports@2.0.3: {}
 
   resolve@2.0.0-next.7:
     dependencies:
@@ -5937,7 +8226,31 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  retry@0.13.1: {}
+
   reusify@1.1.0: {}
+
+  rolldown@1.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3):
+    dependencies:
+      '@oxc-project/types': 0.110.0
+      '@rolldown/pluginutils': 1.0.0-rc.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.1
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.1
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.1
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.1
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.1
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.1
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.1
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.1
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.1
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.1
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.1
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.1
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
   run-parallel@1.2.0:
     dependencies:
@@ -5964,6 +8277,22 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  safer-buffer@2.1.2: {}
+
+  sandbox@3.4.0:
+    dependencies:
+      '@vercel/sandbox': 2.4.0
+      async-retry: 1.3.3
+      debug: 4.4.3
+      ws: 8.21.3
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
+
   scheduler@0.27.0: {}
 
   section-matter@1.0.0:
@@ -5972,6 +8301,10 @@ snapshots:
       kind-of: 6.0.3
 
   semver@6.3.1: {}
+
+  semver@7.5.4:
+    dependencies:
+      lru-cache: 6.0.0
 
   semver@7.8.5: {}
 
@@ -6022,6 +8355,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.2
+
+  setprototypeof@1.1.1: {}
 
   sharp@0.35.3(@types/node@26.2.0):
     dependencies:
@@ -6093,6 +8428,10 @@ snapshots:
 
   signal-exit@3.0.7: {}
 
+  signal-exit@4.0.2: {}
+
+  smol-toml@1.5.2: {}
+
   source-map-js@1.2.1: {}
 
   source-map@0.7.6: {}
@@ -6101,12 +8440,37 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  srvx@0.11.16: {}
+
   stable-hash@0.0.5: {}
+
+  stat-mode@0.3.0: {}
+
+  statuses@1.5.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  stream-to-array@2.3.0:
+    dependencies:
+      any-promise: 1.3.0
+
+  stream-to-promise@2.2.0:
+    dependencies:
+      any-promise: 1.3.0
+      end-of-stream: 1.1.0
+      stream-to-array: 2.3.0
+
+  streamx@2.28.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
 
   string-width@4.2.3:
     dependencies:
@@ -6225,6 +8589,45 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tar-stream@3.1.7:
+    dependencies:
+      b4a: 1.8.1
+      fast-fifo: 1.3.2
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  tar@7.5.22:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
+  tar@7.5.7:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  throttleit@2.1.0: {}
+
+  time-span@4.0.0:
+    dependencies:
+      convert-hrtime: 3.0.0
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
@@ -6234,6 +8637,12 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.0: {}
+
+  tr46@0.0.3: {}
+
+  tree-kill@1.2.2: {}
+
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
@@ -6241,6 +8650,13 @@ snapshots:
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
+
+  ts-morph@12.0.0:
+    dependencies:
+      '@ts-morph/common': 0.11.1
+      code-block-writer: 10.1.1
+
+  ts-toolbelt@6.15.5: {}
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -6250,6 +8666,13 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.0
+      get-tsconfig: 4.14.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-check@0.4.0:
     dependencies:
@@ -6301,7 +8724,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  typescript@5.9.3: {}
+
   typescript@6.0.3: {}
+
+  uid-promise@1.0.0: {}
 
   unbox-primitive@1.1.0:
     dependencies:
@@ -6310,7 +8737,21 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
+  undici-types@5.26.5: {}
+
   undici-types@8.3.0: {}
+
+  undici@5.28.4:
+    dependencies:
+      '@fastify/busboy': 2.1.1
+
+  undici@5.29.0:
+    dependencies:
+      '@fastify/busboy': 2.1.1
+
+  undici@6.28.0: {}
+
+  undici@7.29.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -6354,6 +8795,10 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
+
+  universalify@2.0.1: {}
+
+  unpipe@1.0.0: {}
 
   unrs-resolver@1.12.2:
     dependencies:
@@ -6414,7 +8859,63 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  uuid@14.0.1: {}
+
   vary@1.1.2: {}
+
+  vercel@59.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3):
+    dependencies:
+      '@vercel/backends': 0.8.37(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)
+      '@vercel/blob': 2.8.0
+      '@vercel/build-utils': 14.1.0
+      '@vercel/cli-auth': 0.3.4
+      '@vercel/cli-config': 0.2.3
+      '@vercel/container': 0.2.0
+      '@vercel/detect-agent': 1.2.5
+      '@vercel/elysia': 0.1.114
+      '@vercel/express': 0.1.128(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)
+      '@vercel/fastify': 0.1.117
+      '@vercel/fun': 1.3.0
+      '@vercel/go': 3.11.0
+      '@vercel/h3': 0.1.123
+      '@vercel/hono': 0.2.117
+      '@vercel/hydrogen': 1.4.1
+      '@vercel/koa': 0.1.97
+      '@vercel/nestjs': 0.2.118
+      '@vercel/next': 4.21.4
+      '@vercel/node': 5.10.0
+      '@vercel/prepare-flags-definitions': 0.3.0
+      '@vercel/python': 6.56.2
+      '@vercel/redwood': 2.5.1
+      '@vercel/remix-builder': 5.9.4
+      '@vercel/ruby': 2.5.1
+      '@vercel/rust': 1.4.2
+      '@vercel/static-build': 2.12.6
+      chokidar: 4.0.0
+      esbuild: 0.27.0
+      jose: 5.9.6
+      jsonc-parser: 3.3.1
+      luxon: 3.7.2
+      sandbox: 3.4.0
+      smol-toml: 1.5.2
+      undici: 5.29.0
+      uuid: 14.0.1
+      zod: 4.1.11
+    optionalDependencies:
+      '@vercel/vc-native-darwin-arm64': 59.0.0
+      '@vercel/vc-native-darwin-x64': 59.0.0
+      '@vercel/vc-native-linux-arm64': 59.0.0
+      '@vercel/vc-native-linux-x64': 59.0.0
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - bare-abort-controller
+      - bufferutil
+      - encoding
+      - react-native-b4a
+      - rollup
+      - supports-color
+      - utf-8-validate
 
   vfile-matter@5.0.1:
     dependencies:
@@ -6430,6 +8931,15 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
+  web-vitals@0.2.4: {}
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -6488,15 +8998,54 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.2.0
 
+  wrappy@1.0.2: {}
+
+  ws@8.21.3: {}
+
+  xdg-app-paths@5.1.0:
+    dependencies:
+      xdg-portable: 7.3.0
+
+  xdg-app-paths@5.5.1:
+    dependencies:
+      os-paths: 4.4.0
+      xdg-portable: 7.3.0
+
+  xdg-portable@7.3.0:
+    dependencies:
+      os-paths: 4.4.0
+
   yallist@3.1.1: {}
 
+  yallist@4.0.0: {}
+
+  yallist@5.0.0: {}
+
   yaml@2.9.0: {}
+
+  yauzl-clone@1.0.4:
+    dependencies:
+      events-intercept: 2.0.0
+
+  yauzl-promise@2.1.3:
+    dependencies:
+      yauzl: 2.10.0
+      yauzl-clone: 1.0.4
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
 
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
+
+  zod@3.22.4: {}
+
+  zod@4.1.11: {}
 
   zod@4.4.3: {}
 

--- a/docs-site/scripts/package-vercel-output.mjs
+++ b/docs-site/scripts/package-vercel-output.mjs
@@ -2,6 +2,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { VERCEL_OUTPUT_CONFIG } from './vercel-output-config.mjs';
+
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const docsDirectory = path.resolve(scriptDirectory, '..');
 const repositoryDirectory = path.resolve(docsDirectory, '..');
@@ -25,46 +27,9 @@ fs.rmSync(outputDirectory, { recursive: true, force: true });
 fs.mkdirSync(staticDirectory, { recursive: true });
 fs.cpSync(exportDirectory, staticDirectory, { recursive: true });
 
-const config = {
-  version: 3,
-  routes: [
-    {
-      src: '^/docs(?:/.*)?$',
-      headers: {
-        'Content-Security-Policy': "default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self'; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data:; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; upgrade-insecure-requests",
-        'Cross-Origin-Opener-Policy': 'same-origin',
-        'Cross-Origin-Resource-Policy': 'same-origin',
-        'Permissions-Policy': 'camera=(), geolocation=(), microphone=(), payment=(), usb=()',
-        'Referrer-Policy': 'strict-origin-when-cross-origin',
-        'X-Content-Type-Options': 'nosniff',
-        'X-Frame-Options': 'DENY',
-      },
-      continue: true,
-    },
-    {
-      src: '^/$',
-      headers: { Location: '/docs/' },
-      status: 308,
-    },
-    {
-      src: '^/docs$',
-      headers: { Location: '/docs/' },
-      status: 308,
-    },
-    {
-      src: '/docs/_next/static/.+',
-      headers: {
-        'cache-control': 'public,max-age=31536000,immutable',
-      },
-      continue: true,
-    },
-    { handle: 'filesystem' },
-  ],
-};
-
 fs.writeFileSync(
   path.join(outputDirectory, 'config.json'),
-  `${JSON.stringify(config, null, 2)}\n`,
+  `${JSON.stringify(VERCEL_OUTPUT_CONFIG, null, 2)}\n`,
 );
 
 console.log(`Vercel static output: ${staticDirectory}`);

--- a/docs-site/scripts/package-vercel-output.mjs
+++ b/docs-site/scripts/package-vercel-output.mjs
@@ -29,6 +29,19 @@ const config = {
   version: 3,
   routes: [
     {
+      src: '^/docs(?:/.*)?$',
+      headers: {
+        'Content-Security-Policy': "default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self'; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data:; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; upgrade-insecure-requests",
+        'Cross-Origin-Opener-Policy': 'same-origin',
+        'Cross-Origin-Resource-Policy': 'same-origin',
+        'Permissions-Policy': 'camera=(), geolocation=(), microphone=(), payment=(), usb=()',
+        'Referrer-Policy': 'strict-origin-when-cross-origin',
+        'X-Content-Type-Options': 'nosniff',
+        'X-Frame-Options': 'DENY',
+      },
+      continue: true,
+    },
+    {
       src: '^/$',
       headers: { Location: '/docs/' },
       status: 308,

--- a/docs-site/scripts/package-vercel-output.mjs
+++ b/docs-site/scripts/package-vercel-output.mjs
@@ -1,0 +1,57 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const docsDirectory = path.resolve(scriptDirectory, '..');
+const repositoryDirectory = path.resolve(docsDirectory, '..');
+const exportDirectory = path.join(docsDirectory, 'out');
+const outputDirectory = path.join(repositoryDirectory, '.vercel', 'output');
+const staticDirectory = path.join(outputDirectory, 'static', 'docs');
+
+for (const requiredFile of [
+  'index.html',
+  'quickstart/index.html',
+  'search-index.json',
+  'sitemap.xml',
+]) {
+  const requiredPath = path.join(exportDirectory, requiredFile);
+  if (!fs.existsSync(requiredPath)) {
+    throw new Error(`Static documentation is missing ${requiredPath}`);
+  }
+}
+
+fs.rmSync(outputDirectory, { recursive: true, force: true });
+fs.mkdirSync(staticDirectory, { recursive: true });
+fs.cpSync(exportDirectory, staticDirectory, { recursive: true });
+
+const config = {
+  version: 3,
+  routes: [
+    {
+      src: '^/$',
+      headers: { Location: '/docs/' },
+      status: 308,
+    },
+    {
+      src: '^/docs$',
+      headers: { Location: '/docs/' },
+      status: 308,
+    },
+    {
+      src: '/docs/_next/static/.+',
+      headers: {
+        'cache-control': 'public,max-age=31536000,immutable',
+      },
+      continue: true,
+    },
+    { handle: 'filesystem' },
+  ],
+};
+
+fs.writeFileSync(
+  path.join(outputDirectory, 'config.json'),
+  `${JSON.stringify(config, null, 2)}\n`,
+);
+
+console.log(`Vercel static output: ${staticDirectory}`);

--- a/docs-site/scripts/vercel-output-config.mjs
+++ b/docs-site/scripts/vercel-output-config.mjs
@@ -1,0 +1,36 @@
+export const VERCEL_OUTPUT_CONFIG = {
+  version: 3,
+  routes: [
+    {
+      src: '^/docs(?:/.*)?$',
+      headers: {
+        'Content-Security-Policy': "default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self'; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; img-src 'self' data:; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; upgrade-insecure-requests",
+        'Cross-Origin-Opener-Policy': 'same-origin',
+        'Cross-Origin-Resource-Policy': 'same-origin',
+        'Permissions-Policy': 'camera=(), geolocation=(), microphone=(), payment=(), usb=()',
+        'Referrer-Policy': 'strict-origin-when-cross-origin',
+        'X-Content-Type-Options': 'nosniff',
+        'X-Frame-Options': 'DENY',
+      },
+      continue: true,
+    },
+    {
+      src: '^/$',
+      headers: { Location: '/docs/' },
+      status: 308,
+    },
+    {
+      src: '^/docs$',
+      headers: { Location: '/docs/' },
+      status: 308,
+    },
+    {
+      src: '/docs/_next/static/.+',
+      headers: {
+        'cache-control': 'public,max-age=31536000,immutable',
+      },
+      continue: true,
+    },
+    { handle: 'filesystem' },
+  ],
+};

--- a/docs-site/scripts/vercel-output-config.test.mjs
+++ b/docs-site/scripts/vercel-output-config.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { VERCEL_OUTPUT_CONFIG } from './vercel-output-config.mjs';
+
+test('the docs route carries the release security headers', () => {
+  const docsRoute = VERCEL_OUTPUT_CONFIG.routes.find(
+    (route) => route.src === '^/docs(?:/.*)?$',
+  );
+  assert.ok(docsRoute);
+
+  const csp = docsRoute.headers['Content-Security-Policy'];
+  assert.match(csp, /(?:^|; )default-src 'self'(?:;|$)/);
+  assert.match(csp, /(?:^|; )object-src 'none'(?:;|$)/);
+  assert.match(csp, /(?:^|; )frame-ancestors 'none'(?:;|$)/);
+  assert.equal(docsRoute.headers['Cross-Origin-Opener-Policy'], 'same-origin');
+  assert.equal(docsRoute.headers['Cross-Origin-Resource-Policy'], 'same-origin');
+  assert.equal(docsRoute.headers['X-Content-Type-Options'], 'nosniff');
+  assert.equal(docsRoute.headers['X-Frame-Options'], 'DENY');
+});
+
+test('the output redirects only the root docs entry points', () => {
+  assert.deepEqual(
+    VERCEL_OUTPUT_CONFIG.routes
+      .filter((route) => route.status === 308)
+      .map(({ src, headers }) => [src, headers.Location]),
+    [
+      ['^/$', '/docs/'],
+      ['^/docs$', '/docs/'],
+    ],
+  );
+  assert.deepEqual(
+    VERCEL_OUTPUT_CONFIG.routes.at(-1),
+    { handle: 'filesystem' },
+  );
+});

--- a/docs-site/src/app/(docs)/[[...slug]]/page.tsx
+++ b/docs-site/src/app/(docs)/[[...slug]]/page.tsx
@@ -96,12 +96,20 @@ export async function generateMetadata(
     return {
       title: { absolute: 'Tidebreak Docs' },
       description: 'Documentation for Tidebreak.',
+      alternates: { canonical: 'https://tidebreak.sh/docs/' },
     };
   }
+
+  const publicPath = page.slugs.length > 0
+    ? `${page.slugs.join('/')}/`
+    : '';
 
   return {
     title: page.title,
     description: page.description,
+    alternates: {
+      canonical: `https://tidebreak.sh/docs/${publicPath}`,
+    },
     openGraph: {
       images: getPageImage(page).url,
     },

--- a/docs-site/src/app/(docs)/[[...slug]]/page.tsx
+++ b/docs-site/src/app/(docs)/[[...slug]]/page.tsx
@@ -96,7 +96,7 @@ export async function generateMetadata(
     return {
       title: { absolute: 'Tidebreak Docs' },
       description: 'Documentation for Tidebreak.',
-      alternates: { canonical: 'https://tidebreak.sh/docs/' },
+      alternates: { canonical: 'https://www.tidebreak.sh/docs/' },
     };
   }
 
@@ -108,7 +108,7 @@ export async function generateMetadata(
     title: page.title,
     description: page.description,
     alternates: {
-      canonical: `https://tidebreak.sh/docs/${publicPath}`,
+      canonical: `https://www.tidebreak.sh/docs/${publicPath}`,
     },
     openGraph: {
       images: getPageImage(page).url,

--- a/docs-site/src/app/layout.tsx
+++ b/docs-site/src/app/layout.tsx
@@ -12,7 +12,7 @@ const homePage = getPage([]);
 const homeImage = homePage ? getPageImage(homePage).url : '/og/image.png';
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://tidebreak.dev'),
+  metadataBase: new URL('https://tidebreak.sh'),
   title: {
     default: 'Tidebreak Docs',
     template: '%s — Tidebreak Docs',

--- a/docs-site/src/app/layout.tsx
+++ b/docs-site/src/app/layout.tsx
@@ -12,7 +12,7 @@ const homePage = getPage([]);
 const homeImage = homePage ? getPageImage(homePage).url : '/og/image.png';
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://tidebreak.sh'),
+  metadataBase: new URL('https://www.tidebreak.sh'),
   title: {
     default: 'Tidebreak Docs',
     template: '%s — Tidebreak Docs',

--- a/docs-site/src/app/sitemap.ts
+++ b/docs-site/src/app/sitemap.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from 'next';
+import { getAllPages } from '@/lib/content';
+
+const PUBLIC_DOCS_URL = 'https://tidebreak.sh/docs/';
+
+export const dynamic = 'force-static';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return getAllPages().map((page) => ({
+    url: new URL(
+      page.slugs.length > 0 ? `${page.slugs.join('/')}/` : '',
+      PUBLIC_DOCS_URL,
+    ).toString(),
+  }));
+}

--- a/docs-site/src/app/sitemap.ts
+++ b/docs-site/src/app/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from 'next';
 import { getAllPages } from '@/lib/content';
 
-const PUBLIC_DOCS_URL = 'https://tidebreak.sh/docs/';
+const PUBLIC_DOCS_URL = 'https://www.tidebreak.sh/docs/';
 
 export const dynamic = 'force-static';
 

--- a/docs-site/src/components/header.tsx
+++ b/docs-site/src/components/header.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Menu, X } from 'lucide-react';
 import { useState } from 'react';
 
-const PRODUCT_URL = 'https://tidebreak.io';
+const PRODUCT_URL = 'https://tidebreak.sh';
 const REPO_URL = 'https://github.com/brightwave-inc/tidebreak';
 
 const navLinks = [{ text: 'Product', href: PRODUCT_URL }];

--- a/docs-site/src/components/header.tsx
+++ b/docs-site/src/components/header.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Menu, X } from 'lucide-react';
 import { useState } from 'react';
 
-const PRODUCT_URL = 'https://tidebreak.sh';
+const PRODUCT_URL = 'https://www.tidebreak.sh';
 const REPO_URL = 'https://github.com/brightwave-inc/tidebreak';
 
 const navLinks = [{ text: 'Product', href: PRODUCT_URL }];

--- a/docs-site/src/lib/content.ts
+++ b/docs-site/src/lib/content.ts
@@ -180,7 +180,7 @@ export function getPageImage(page: PageData) {
   const segments = [...page.slugs, 'image.png'];
   return {
     segments,
-    url: `/og/${segments.join('/')}`,
+    url: `/docs/og/${segments.join('/')}`,
   };
 }
 

--- a/docs/decisions/0010-computer-use-screen-capture-and-app-control.md
+++ b/docs/decisions/0010-computer-use-screen-capture-and-app-control.md
@@ -95,12 +95,14 @@ action passes are:
 
 1. OS TCC grants (Screen Recording + Accessibility), requested together on
    first use with a status checklist in settings.
-2. A per-app grant, asked once per app through the normal in-chat approval
-   card ("Allow Tidebreak to control Mail — once / always for this chat /
-   always"). The card decision is written into the broker's grant store; the
-   broker enforces, the card is the only place the question is asked. Grants
-   are listed and revocable in settings. Whole-screen capture gets the same
-   treatment as one standing grant. **Once is not a standing grant that the
+2. A per-app grant, asked once per app through an OS-native dialog owned by the
+   Tauri host ("Allow Tidebreak to control Mail — once / always for this chat /
+   always"). The renderer may show that computer use is waiting, but it never
+   receives the pending call identifier and exposes no command that can resolve
+   the decision. The native answer is written into the broker's grant store;
+   the broker enforces. Grants are listed and revocable in settings.
+   Whole-screen capture gets the same treatment as one standing grant.
+   **Once is not a standing grant that the
    desktop later revokes.** It is a broker-native `single_use` grant:
    session-only (never written to the durable grant table), hidden from the
    grants listing, and consumed when the operation it authorized reaches a
@@ -108,11 +110,13 @@ action passes are:
    covers the confirm. A crash or a failed revoke therefore cannot promote
    once into a durable per-conversation grant. Chat and Always remain
    persisted standing grants.
-3. An act-time confirmation only for consequential actions: before clicking,
-   the broker re-reads the target element and classifies it; labels that
+3. An act-time OS-native confirmation only for consequential actions: before
+   clicking, the broker re-reads the target element and classifies it; labels that
    commit an external effect (send, pay, buy, delete, submit, sign,
    transfer, post) or credential fields force a single non-activating
    confirmation, honored only if the label still matches at act time. The
+   renderer receives neither the confirmation identity nor an API that can
+   redeem it. The
    classifier's word list is deliberately short and **English-only** —
    navigation-shaped words (cancel, back, close, decline) do not trip it.
    Localized commit verbs ("Envoyer", "Senden") are an accepted miss of the
@@ -176,12 +180,11 @@ content redaction, and any auto-approval of control actions.
   judge adds a second policy brain whose failure modes are hard to audit, and
   the calibrated consent layers should make it unnecessary. Revisit if per-app
   grants prove too coarse in practice.
-- **Routing consent through a separate desktop HUD instead of the in-chat
-  card.** Rejected as the primary surface: two grant systems asking the same
-  question on different surfaces is exactly the over-asking failure. The
-  broker still enforces; the chat card is the single asking surface. The only
-  HUD prompt is the act-time consequential confirmation, which must not steal
-  focus from the target app and so cannot live in the chat window.
+- **Renderer-hosted consent and confirmation cards.** Rejected: a renderer
+  compromise could enumerate pending call identifiers and resolve its own
+  approval. The native host owns the only asking surface. There is still one
+  grant system and one prompt per decision; moving it outside the renderer does
+  not add a second policy brain.
 - **Do nothing / wait for the managed browser surface.** Rejected: most of the
   value (seeing the screen, operating native apps) is orthogonal to the
   browser plan and blocked on nothing.
@@ -233,7 +236,9 @@ content redaction, and any auto-approval of control actions.
 - Image-input gating: with a text-only model selected, capture tools refuse
   with the typed error; nothing silently drops the image.
 - Grant-store test: a card decision at each scope produces exactly one broker
-  grant, revocation removes it, and no control op proceeds without one.
+  grant, revocation removes it, and no control op proceeds without one. The
+  renderer snapshot contains no pending call identifiers, and command-parity
+  coverage proves no renderer command can resolve consent or confirmation.
 - Once-grant test: a `single_use` grant authorizes exactly one terminal
   operation (including a held confirm), does not appear in the grants
   listing, and is absent after a broker reload. A standing grant at the

--- a/docs/decisions/0020-native-authorization-for-local-mcp-commands.md
+++ b/docs/decisions/0020-native-authorization-for-local-mcp-commands.md
@@ -1,0 +1,74 @@
+# 20. Native authorization for local MCP commands
+
+- Status: Proposed
+- Date: 2026-08-14
+- Owners: desktop / MCP configuration
+- Related: [`0004-self-host-deployment-plane-authorization.md`](0004-self-host-deployment-plane-authorization.md), [`../host-access.md`](../host-access.md)
+
+## Context
+
+The desktop renderer authenticates to the loopback API as the single local
+owner. That is sufficient identity for conversations and ordinary deployment
+configuration, but an enabled stdio MCP definition crosses a second boundary:
+its `command` and arguments become a process running as the desktop user.
+
+Treating the renderer bearer as sufficient for that transition means any
+renderer compromise can silently turn into native process execution. CSP and
+content isolation reduce the chance of such a compromise; they are not an
+authorization boundary for the host process.
+
+The desktop already has a separate client-executor credential that is withheld
+from the renderer and attached only by native Rust code.
+
+## Decision
+
+An unmanaged web or self-host administrator may continue to configure MCP
+servers through the authenticated deployment API. In the desktop profile, an
+enabled `command` transport additionally requires the native client-executor
+surface.
+
+The renderer sends the candidate configuration to a Tauri command. When the
+candidate contains enabled local commands, the native host displays an
+OS-native warning naming the server and executable. Only an affirmative native
+answer causes the host to forward the configuration with the client-executor
+credential. The ordinary renderer API refuses enabled command definitions with
+the stable `native_confirmation_required` error.
+
+Disabled command definitions may be edited without confirmation because they
+cannot start a process. Enabling them later crosses the native confirmation.
+Remote HTTP and gateway transports remain on their existing authorization
+paths; this record does not turn every settings write into a native prompt.
+
+## Alternatives Considered
+
+- **Trust the renderer bearer because desktop is single-user.** Rejected: it
+  conflates user identity with host-process authority and removes a useful
+  containment boundary after renderer compromise.
+- **Disable stdio MCP servers.** Rejected: local MCP is a supported developer
+  workflow, and a native confirmation preserves it without silent execution.
+- **Return a reusable approval token to the renderer.** Rejected: renderer code
+  could retain or replay it. The native host performs the privileged request
+  itself and never reveals the client-executor credential.
+- **Prompt for every MCP edit.** Rejected: URL-only and disabled definitions do
+  not start host code. Prompting for them trains users to approve warnings that
+  carry no matching risk.
+
+## Consequences
+
+Desktop saves use a Tauri command rather than a direct `PUT /mcp/servers`.
+Headless and self-host clients retain the existing administrator API. Native
+dialog availability becomes necessary to enable local commands in the desktop
+app, and tests must cover both the renderer refusal and native acceptance.
+
+Revisit this decision if the renderer is moved into a process sandbox that can
+hold a narrowly scoped, non-replayable host capability, or if local MCP process
+ownership moves to a separately authenticated broker.
+
+## Validation
+
+- A desktop bearer alone cannot save an enabled command server.
+- The same candidate on the client-executor route passes the native-authority
+  check.
+- Disabled command and remote definitions retain their existing behavior.
+- The Tauri command shows a native warning before forwarding an enabled command
+  and never serializes the executor credential to the renderer.

--- a/docs/decisions/0021-apps-have-immutable-principal-ownership.md
+++ b/docs/decisions/0021-apps-have-immutable-principal-ownership.md
@@ -1,0 +1,72 @@
+# 21. Apps Have Immutable Principal Ownership
+
+- Status: Proposed
+- Date: 2026-08-14
+- Owners: app runtime and storage
+- Related: 0004-self-host-deployment-plane-authorization.md, principal-scoped storage
+- Supersedes: none
+
+## Context
+
+Local apps were introduced as profile-scoped records. That was exact for the
+single-user desktop profile, but a shared self-host database now serves named
+principals. An app id addresses revisions, grants, invocation, view sessions,
+and gateway publication; filtering only the library route would leave the same
+record reachable through those secondary surfaces.
+
+Creation happens inside a recorded tool call. The durable conversation already
+has an owner, while request routes carry the authenticated principal's
+`OwnerId`. Both are trusted server-side sources; renderer and tool arguments
+are not.
+
+## Decision
+
+The app row is the ownership root. It stores one non-null `owner` value stamped
+at creation and never updated. Existing pre-v1 rows use the `local` default.
+Revisions, grants, and gateway drafts inherit authority through their foreign
+key to the app rather than duplicating an independently mutable owner column.
+
+Every request-facing app operation uses owner-scoped store methods. A row owned
+by another principal is indistinguishable from a missing row. Mutations lock
+and test the app row for the same owner in the transaction that appends a
+revision, deletes or restores the app, replaces or revokes a grant, or replaces
+a gateway draft. Tool-created apps derive the owner from the recorded call's
+conversation in the creation transaction; later revisions require the
+authoring conversation and target app to have the same owner.
+
+Gateway registration carries the already-authenticated owner through its
+background and network lifecycle. Single-use frame redemption remains
+capability-based, but only an owner-authorized request may mint the token.
+
+## Alternatives Considered
+
+- Keep apps deployment-wide and authorize only the library. Rejected because
+  guessed app ids would still reach detail, grants, invocation, frames, or
+  gateway publication.
+- Copy `owner` onto every app child table. Rejected because duplicated policy
+  can drift; the app foreign key is the one immutable authority root.
+- Infer ownership from the latest revision's `chat_id`. Rejected because that
+  field is nullable provenance, may dangle after chat deletion, and would make
+  ownership change when a different conversation publishes a revision.
+- Trust an owner supplied by `create_app` arguments. Rejected because model and
+  renderer input is not an authentication boundary.
+
+## Consequences
+
+The schema baseline changes and the disposable desktop schema epoch advances.
+All app-specific store APIs gain scoped variants, and gateway draft helpers
+carry an `OwnerId`. Cross-owner attempts intentionally read as absence, which
+prevents ids from becoming an ownership oracle.
+
+This decision should be revisited only if apps become explicitly shareable or
+transferable. That would require a separate membership/delegation model and an
+audited transfer operation; changing the owner column in place is not such a
+model.
+
+## Validation
+
+Database tests create two principals and prove that the second cannot list,
+read, revise, delete, grant, revoke, or read/write gateway draft state for the
+first principal's app. Route tests prove that an authenticated second principal
+receives the same not-found/refusal behavior as for an unknown app, while the
+owner retains normal access.

--- a/docs/decisions/0022-release-tags-publish-static-documentation.md
+++ b/docs/decisions/0022-release-tags-publish-static-documentation.md
@@ -1,0 +1,90 @@
+# 22. Release Tags Publish Static Documentation
+
+- Status: Proposed
+- Date: 2026-08-14
+- Owners: release engineering and documentation
+- Related: `docs/releases.md`, `docs-site/README.md`
+- Supersedes: none
+
+## Context
+
+Tidebreak's documentation describes a released desktop product and is built
+from source in this repository. Building it from a mutable branch can publish
+behavior that users cannot install yet. Building it inside the marketing-site
+deployment instead couples two repositories, requires cross-repository source
+access during an unrelated build, and makes a marketing rollback also a docs
+build operation.
+
+The documentation application already exports static files and supports the
+`/docs` base path. The marketing site can expose a fixed separately deployed
+origin through an edge rewrite without running an application proxy.
+
+## Decision
+
+Publishing a non-prerelease GitHub Release is the documentation publication
+boundary. The trusted release workflow validates the tag, resolves its exact
+commit on `main`, checks out that commit, and builds `docs-site/` with
+`BASE_PATH=/docs`.
+
+The static export is packaged beneath `/docs` in Vercel's prebuilt output,
+rather than relying on framework-generated routes that store the exported
+files at the deployment root. The deployment therefore serves `/docs` as a
+real static path at its own origin as well as through the marketing rewrite.
+
+The build is deployed first as an unaliased production-target deployment in
+the dedicated `tidebreak-docs` project. The workflow smoke-tests the staged
+deployment through Vercel's authenticated deployment client, then promotes
+that immutable deployment to the project's production aliases. Deployment
+metadata records the release tag and commit SHA, and the workflow retains a
+digest manifest for the generated static files.
+
+The marketing site remains static. It rewrites `/docs` and `/docs/*` to the
+fixed docs production alias. It does not clone this repository, rebuild the
+documentation, or proxy requests through an Astro server route.
+
+Only the publication job receives the Vercel credential, through the
+`docs-production` GitHub environment. Documentation build dependencies and
+the Vercel CLI are exact-version lockfile inputs. No repository setting is
+changed by this decision or its implementation; the environment secret must
+be configured separately before the first release publication.
+
+## Alternatives Considered
+
+- Deploy documentation on every merge to `main`. Rejected because public docs
+  could describe unreleased behavior and would not identify the product
+  version they accompany.
+- Clone and build Tidebreak from the marketing-site deployment. Rejected
+  because it is a fail-open cross-repository build dependency and does not
+  prove which release the documentation represents.
+- Run a marketing-site application proxy in front of a docs deployment.
+  Rejected because the edge platform can perform the fixed rewrite without a
+  server runtime, response-header relay, or additional availability boundary.
+- Commit generated docs into the marketing repository. Rejected because large
+  generated diffs obscure review, duplicate source of truth, and require a
+  cross-repository writer token.
+
+## Consequences
+
+Documentation updates intentionally wait for a published release. A docs-only
+correction therefore requires a patch release unless a future policy creates a
+separately versioned documentation channel.
+
+The release workflow gains a dependency on the Vercel API and one scoped
+deployment credential. A failed docs deployment fails the release workflow but
+does not replace the current production docs deployment, because promotion
+happens only after staged smoke tests pass. The previous deployment remains
+available for rollback through Vercel.
+
+Revisit this decision if documentation becomes independently versioned, if
+multiple maintained product versions require parallel docs, or if the docs
+host changes to a content-addressed object store with equivalent staged
+promotion and rollback behavior.
+
+## Validation
+
+Workflow policy tests must prove that the job checks out the validated release
+SHA, builds with `/docs`, scopes credentials to the publication job, deploys
+without immediately assigning production aliases, smoke-tests the staged
+deployment, and only then promotes it. A release rehearsal must verify the
+root page, a nested page, static Next assets, search index, sitemap, and
+canonical metadata through both the staged URL and the public `/docs` path.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -137,12 +137,22 @@ automatic.
    published release, checks out that exact tag, rejects malformed tags,
    prereleases, drafts, or commits outside `main`, and pins all later jobs to
    the resolved commit SHA.
-5. The dispatched workflow first checks whether that exact tag, commit, and
+5. In parallel with the desktop release, the documentation publisher checks
+   out that validated SHA and builds `docs-site/` as a static export under
+   `/docs`. It creates an unaliased production-target deployment in the
+   dedicated Vercel project, smoke-tests the staged root page, nested content,
+   search index, sitemap, assets, and canonical metadata, and only then
+   promotes that immutable deployment to `tidebreak-docs.vercel.app`. The
+   `docs-production` environment supplies the only required secret,
+   `VERCEL_TOKEN`; its project and organization identifiers are non-secret
+   workflow constants. A failed build or smoke test leaves the previous docs
+   deployment serving production.
+6. The dispatched workflow first checks whether that exact tag, commit, and
    publication date already have a complete immutable release on S3.
    Credential-free prerequisites — one per platform — otherwise compile the tag
    with its product version and save unsigned Cargo outputs before any signing
    or notarization can fail.
-6. The production jobs reuse those prepared compiler outputs — every cache key
+7. The production jobs reuse those prepared compiler outputs — every cache key
    they can restore names the release commit or, at minimum, the `Cargo.lock`
    and toolchain hashes, and they delete the linked binaries the archive
    carries so the products they package are always linked from the tag's own
@@ -152,7 +162,7 @@ automatic.
    behind a literal `false` and never runs — see
    [What comes after v1](deferred.md) — so a release currently produces macOS
    artifacts only.
-7. For a release that is not already hosted, a separate least-privilege job
+8. For a release that is not already hosted, a separate least-privilege job
    generates an SPDX JSON SBOM from the exact released source and checksums it
    independently of the package builds. That job has no production environment,
    deployment variables, OIDC permission, or AWS role; it transfers the two
@@ -168,7 +178,7 @@ automatic.
    complete immutable prefix, a new dispatch validates and reuses those bytes,
    skips the desktop build, and resumes only mutable metadata publication,
    CDN invalidation, and smoke testing.
-8. A final job downloads every installer the immutable manifest lists back from
+9. A final job downloads every installer the immutable manifest lists back from
    the CDN, checks them against its digests, and attaches them to the GitHub
    Release with `.sha256` sidecars — today that is the notarized disk image as
    `Tidebreak-macos-universal.dmg`, plus the byte-identical legacy

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -152,9 +152,19 @@ automatic.
    behind a literal `false` and never runs — see
    [What comes after v1](deferred.md) — so a release currently produces macOS
    artifacts only.
-7. Only after the build passes does the publisher upload immutable versioned
-   files, advance the public manifests, invalidate their CDN paths, and
-   smoke-test the hosted release. If a prior attempt already uploaded the
+7. For a release that is not already hosted, a separate least-privilege job
+   generates an SPDX JSON SBOM from the exact released source and checksums it
+   independently of the package builds. That job has no production environment,
+   deployment variables, OIDC permission, or AWS role; it transfers the two
+   files to the publisher through a pinned GitHub artifact action. Publication
+   waits for both the package build and source SBOM. For public repositories,
+   the publisher also records
+   Sigstore-backed SLSA-style build provenance for every immutable release file
+   (including `manifest.json`). The source-tree SBOM is deliberately published
+   as source-scoped metadata, not attested as a description of the packaged
+   installers. The publisher then uploads immutable versioned files, advances
+   the public manifests, invalidates their CDN paths, and smoke-tests the hosted
+   release. If a prior attempt already uploaded the
    complete immutable prefix, a new dispatch validates and reuses those bytes,
    skips the desktop build, and resumes only mutable metadata publication,
    CDN invalidation, and smoke testing.
@@ -163,7 +173,8 @@ automatic.
    Release with `.sha256` sidecars — today that is the notarized disk image as
    `Tidebreak-macos-universal.dmg`, plus the byte-identical legacy
    `Tidebreak-macos-apple-silicon.dmg` alias that keeps the existing README URL
-   live through the transition. It would again include
+   live through the transition. It also attaches the release SBOM and its
+   checksum when that release carries one. It would again include
    `Tidebreak-windows-x86_64-setup.exe` if the Windows lane were unparked. It
    holds no signing or AWS credentials. The names omit the version so that
    `https://github.com/brightwave-inc/tidebreak/releases/latest/download/<name>`
@@ -249,9 +260,28 @@ Each macOS architecture directory contains a notarized DMG, a zip of the
 notarized app, a signed `.app.tar.gz` updater archive, its signature, and
 SHA-256 files. A Windows architecture directory, when the lane produces one,
 contains an unsigned NSIS installer, its Tauri updater signature, and SHA-256
-files. The root `manifest.json` and Tauri-compatible `latest.json` are the only
-mutable objects. The workflow refuses to overwrite a versioned object with
-different bytes or move `latest.json` to an older version.
+files. The immutable release root also contains
+`Tidebreak_VERSION_source.spdx.json` and its checksum. The root `manifest.json`
+inside each versioned prefix is immutable; only the unversioned
+Tauri-compatible `manifest.json` and `latest.json` pointers are mutable. The
+workflow refuses to overwrite a versioned object with different bytes or move
+`latest.json` to an older version.
+
+After the repository is public, verify the independently signed provenance for
+any downloaded artifact with GitHub CLI:
+
+```sh
+gh attestation verify Tidebreak-macos-apple-silicon.dmg \
+  --repo brightwave-inc/tidebreak
+```
+
+GitHub artifact attestations require a public repository unless the owner uses
+GitHub Enterprise Cloud. While this repository remains private on another
+plan, the workflow still publishes the checksummed, source-scoped SBOM but
+skips provenance attestation rather than making private release retries fail.
+The SBOM inventories the released source checkout; it must not be interpreted
+as an inventory of files or dependencies embedded in the DMG, app bundle, or
+updater archive.
 
 Packaged macOS apps check `latest.json` 15 seconds after launch and every five
 minutes. When a newer signed version is available, the Tauri updater downloads

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -219,6 +219,13 @@ docker compose up -d --build
 docker image prune -f     # optional
 ```
 
+The runtime image pins both Debian base images by digest and installs its small
+runtime package set from a dated Debian snapshot with exact direct versions.
+That keeps a rebuild of one commit from silently picking up different `curl`,
+CA-certificate, or transitive package bytes. Updating the snapshot date and
+package pins is therefore an explicit dependency-maintenance change rather
+than an incidental effect of rebuilding.
+
 The server applies its own schema migrations on boot. Take a database backup
 before an upgrade: Tidebreak is pre-1.0 and persisted formats may change
 between versions (see

--- a/scripts/workflow-security-mutations.test.mjs
+++ b/scripts/workflow-security-mutations.test.mjs
@@ -316,6 +316,51 @@ const mutations = [
       ),
   },
   {
+    name: "docs output config test execution",
+    file: ".github/workflows/release.yml",
+    expected: "release documentation is built from the validated tag",
+    mutate: (source) =>
+      editWorkflowJob(source, "build_docs", (job) =>
+        job.replace("          pnpm --dir docs-site test:vercel-output\n", ""),
+      ),
+  },
+  {
+    name: "docs manifest verification before deployment",
+    file: ".github/workflows/release.yml",
+    expected: "release documentation is built from the validated tag",
+    mutate: (source) =>
+      editWorkflowJob(source, "publish_docs", (job) =>
+        job.replace(
+          /      - name: Verify the transferred documentation[\s\S]*?(?=\n      - name: Link the fixed documentation project)/,
+          "",
+        ),
+      ),
+  },
+  {
+    name: "docs deployment token stays out of argv",
+    file: ".github/workflows/release.yml",
+    expected: "release documentation is built from the validated tag",
+    mutate: (source) =>
+      editWorkflowJob(source, "publish_docs", (job) =>
+        job.replace(
+          '            --scope "$VERCEL_SCOPE" \\\n            --json)',
+          '            --scope "$VERCEL_SCOPE" \\\n            --token "$VERCEL_TOKEN" \\\n            --json)',
+        ),
+      ),
+  },
+  {
+    name: "docs deployed CSP directive checks",
+    file: ".github/workflows/release.yml",
+    expected: "release documentation is built from the validated tag",
+    mutate: (source) =>
+      editWorkflowJob(source, "publish_docs", (job) =>
+        job.replace(
+          '          grep -Eqi "content-security-policy:.*object-src \'none\'" "$RUNNER_TEMP/docs-headers"\n',
+          "",
+        ),
+      ),
+  },
+  {
     name: "docs unaliased staging deployment",
     file: ".github/workflows/release.yml",
     expected: "release documentation is built from the validated tag",
@@ -457,6 +502,16 @@ const mutations = [
           "save-if: false",
           "save-if: ${{ matrix.arch == 'aarch64' }}",
         ),
+      ),
+  },
+  {
+    name: "README macOS download matches an uploaded asset",
+    file: "README.md",
+    expected: "GitHub release downloads are copied from the hosted release",
+    mutate: (source) =>
+      source.replace(
+        /Tidebreak-macos-[\w-]+\.dmg/,
+        "Tidebreak-macos-legacy.dmg",
       ),
   },
 ];

--- a/scripts/workflow-security-mutations.test.mjs
+++ b/scripts/workflow-security-mutations.test.mjs
@@ -19,6 +19,8 @@ const fixturePaths = [
   ".github/workflows",
   ".github/release-drafter.yml",
   ".github/e2b-cli/package.json",
+  ".github/vercel-cli/package.json",
+  ".github/vercel-cli/pnpm-lock.yaml",
   "docs-site/package.json",
   "crates/tidebreak-desktop/tauri.conf.json",
   "crates/tidebreak-desktop/tauri.staging.conf.json",

--- a/scripts/workflow-security-mutations.test.mjs
+++ b/scripts/workflow-security-mutations.test.mjs
@@ -26,6 +26,7 @@ const fixturePaths = [
   "crates/tidebreak-desktop/src/updater.rs",
   "crates/tidebreak-desktop/src/broker.rs",
   "crates/tidebreak-desktop/scripts/prepare-sidecar.mjs",
+  "deploy/self-host/Dockerfile",
   "deploy/self-host/Dockerfile.dockerignore",
   "crates/tidebreak-sandbox-agent/Dockerfile.dockerignore",
   "scripts/stage-self-host-build-context.sh",
@@ -93,6 +94,19 @@ test("the mirrored workflow-security fixture passes before mutation", () => {
 });
 
 const mutations = [
+  {
+    name: "self-host mutable runtime packages",
+    file: "deploy/self-host/Dockerfile",
+    expected: "self-host runtime installs packages from an immutable Debian snapshot",
+    mutate: (source) =>
+      source
+        .replace(
+          /RUN rm -f \/etc\/apt\/sources\.list\.d\/debian\.sources[\s\S]*?&& apt-get -o Acquire::Check-Valid-Until=false update \\\n/,
+          "RUN apt-get update \\\n",
+        )
+        .replace(/ca-certificates=[^\s\\]+/, "ca-certificates")
+        .replace(/curl=[^\s\\]+/, "curl"),
+  },
   {
     name: "sandbox image default-branch publication guard",
     file: ".github/workflows/publish-sandbox-image.yml",
@@ -237,6 +251,90 @@ const mutations = [
     file: "deploy/self-host/Dockerfile.dockerignore",
     expected: "Docker context is allowlisted",
     mutate: (source) => source.replace("**/id_*\n", ""),
+  },
+  {
+    name: "source SBOM OIDC isolation",
+    file: ".github/workflows/release.yml",
+    expected: "source SBOM generation is isolated from production credentials",
+    mutate: (source) =>
+      editWorkflowJob(source, "source_sbom", (job) =>
+        job.replace(
+          "    permissions:\n      contents: read\n",
+          "    permissions:\n      contents: read\n      id-token: write\n",
+        ),
+      ),
+  },
+  {
+    name: "source SBOM production-environment isolation",
+    file: ".github/workflows/release.yml",
+    expected: "source SBOM generation is isolated from production credentials",
+    mutate: (source) =>
+      editWorkflowJob(source, "source_sbom", (job) =>
+        job.replace(
+          "    runs-on: ubuntu-latest\n",
+          "    runs-on: ubuntu-latest\n    environment: desktop-production\n",
+        ),
+      ),
+  },
+  {
+    name: "source SBOM deployment-variable isolation",
+    file: ".github/workflows/release.yml",
+    expected: "source SBOM generation is isolated from production credentials",
+    mutate: (source) =>
+      editWorkflowJob(source, "source_sbom", (job) =>
+        job.replace(
+          "    steps:\n",
+          "    env:\n      AWS_RELEASE_ROLE_ARN: ${{ vars.AWS_RELEASE_ROLE_ARN }}\n    steps:\n",
+        ),
+      ),
+  },
+  {
+    name: "source SBOM exact release checkout",
+    file: ".github/workflows/release.yml",
+    expected: "source SBOM generation is isolated from production credentials",
+    mutate: (source) =>
+      editWorkflowJob(source, "source_sbom", (job) =>
+        job.replace(
+          "          ref: ${{ needs.validate.outputs.sha }}\n",
+          "          ref: ${{ github.sha }}\n",
+        ),
+      ),
+  },
+  {
+    name: "source SBOM pinned artifact transfer",
+    file: ".github/workflows/release.yml",
+    expected: "source SBOM generation is isolated from production credentials",
+    mutate: (source) =>
+      editWorkflowJob(source, "source_sbom", (job) =>
+        job.replace(
+          /uses: actions\/upload-artifact@[0-9a-f]{40} # v7/,
+          "uses: actions/upload-artifact@v7",
+        ),
+      ),
+  },
+  {
+    name: "source SBOM pinned artifact download",
+    file: ".github/workflows/release.yml",
+    expected: "source SBOM generation is isolated from production credentials",
+    mutate: (source) =>
+      editWorkflowJob(source, "publish", (job) =>
+        job.replace(
+          /uses: actions\/download-artifact@[0-9a-f]{40} # v8\n        with:\n          name: tidebreak-source-sbom-/,
+          "uses: actions/download-artifact@v8\n        with:\n          name: tidebreak-source-sbom-",
+        ),
+      ),
+  },
+  {
+    name: "source SBOM is not an installer attestation",
+    file: ".github/workflows/release.yml",
+    expected: "public releases attest provenance without treating the source SBOM as an installer SBOM",
+    mutate: (source) =>
+      editWorkflowJob(source, "publish", (job) =>
+        job.replace(
+          "          subject-checksums: ${{ runner.temp }}/immutable-release-files.sha256\n",
+          "          subject-checksums: ${{ runner.temp }}/immutable-release-files.sha256\n          sbom-path: dist/Tidebreak_${{ needs.validate.outputs.version }}_source.spdx.json\n",
+        ),
+      ),
   },
   {
     name: "signing job pnpm pin",

--- a/scripts/workflow-security-mutations.test.mjs
+++ b/scripts/workflow-security-mutations.test.mjs
@@ -306,7 +306,7 @@ const mutations = [
     file: ".github/workflows/release.yml",
     expected: "release documentation is built from the validated tag",
     mutate: (source) =>
-      editWorkflowJob(source, "publish_docs", (job) =>
+      editWorkflowJob(source, "build_docs", (job) =>
         job.replace(
           "          ref: ${{ needs.validate.outputs.sha }}\n",
           "          ref: main\n",

--- a/scripts/workflow-security-mutations.test.mjs
+++ b/scripts/workflow-security-mutations.test.mjs
@@ -19,6 +19,7 @@ const fixturePaths = [
   ".github/workflows",
   ".github/release-drafter.yml",
   ".github/e2b-cli/package.json",
+  "docs-site/package.json",
   "crates/tidebreak-desktop/tauri.conf.json",
   "crates/tidebreak-desktop/tauri.staging.conf.json",
   "crates/tidebreak-desktop/Cargo.toml",
@@ -299,6 +300,45 @@ const mutations = [
           "          ref: ${{ github.sha }}\n",
         ),
       ),
+  },
+  {
+    name: "docs exact release checkout",
+    file: ".github/workflows/release.yml",
+    expected: "release documentation is built from the validated tag",
+    mutate: (source) =>
+      editWorkflowJob(source, "publish_docs", (job) =>
+        job.replace(
+          "          ref: ${{ needs.validate.outputs.sha }}\n",
+          "          ref: main\n",
+        ),
+      ),
+  },
+  {
+    name: "docs unaliased staging deployment",
+    file: ".github/workflows/release.yml",
+    expected: "release documentation is built from the validated tag",
+    mutate: (source) =>
+      editWorkflowJob(source, "publish_docs", (job) =>
+        job.replace("            --skip-domain \\\n", ""),
+      ),
+  },
+  {
+    name: "docs promotion follows staged checks",
+    file: ".github/workflows/release.yml",
+    expected: "release documentation is built from the validated tag",
+    mutate: (source) =>
+      editWorkflowJob(source, "publish_docs", (job) => {
+        const promote = job.match(
+          /      - name: Promote the verified deployment[\s\S]*?(?=\n      - name: Verify the production alias)/,
+        )?.[0];
+        assert.ok(promote);
+        return job
+          .replace(promote, "")
+          .replace(
+            "      - name: Smoke-test the staged deployment\n",
+            `${promote}\n      - name: Smoke-test the staged deployment\n`,
+          );
+      }),
   },
   {
     name: "source SBOM pinned artifact transfer",

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1496,6 +1496,15 @@ test("source SBOM generation is isolated from production credentials", () => {
   assert.doesNotMatch(sbomJob, /\n    environment:/);
   assert.doesNotMatch(sbomJob, /AWS_|DOWNLOADS_|RELEASE_BASE_URL|vars\.|secrets\./);
   assert.match(sbomJob, /ref: \$\{\{ needs\.validate\.outputs\.sha \}\}/);
+  const outputDirectoryIndex = sbomJob.indexOf(
+    "- name: Create the source SBOM output directory",
+  );
+  const generatorIndex = sbomJob.indexOf(
+    "- name: Generate the source-scoped release SBOM",
+  );
+  assert.ok(outputDirectoryIndex !== -1 && generatorIndex !== -1);
+  assert.ok(outputDirectoryIndex < generatorIndex);
+  assert.match(sbomJob, /run: mkdir -p source-sbom/);
   assert.match(
     sbomJob,
     /uses: anchore\/sbom-action@[0-9a-f]{40} # v0\.24\.0/,

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1057,22 +1057,40 @@ test("release documentation is built from the validated tag and promoted only af
   assert.match(docsPackage.devDependencies.vercel, /^\d+\.\d+\.\d+$/);
   assert.match(build, /pnpm --dir docs-site install --frozen-lockfile/);
   assert.match(build, /ref: \$\{\{ needs\.validate\.outputs\.sha \}\}/);
+  assert.match(build, /persist-credentials: false/);
   assert.match(build, /test "\$\(git rev-parse HEAD\)" = "\$RELEASE_SHA"/);
   assert.match(build, /pnpm --dir docs-site build/);
+  assert.match(build, /pnpm --dir docs-site test:vercel-output/);
   assert.match(build, /pnpm --dir docs-site package:vercel/);
   assert.match(build, /\.vercel\/output\/static\/docs\/index\.html/);
+  assert.match(build, /cd \.vercel\/output/);
+  assert.match(build, /find \. -type f -print0/);
+  assert.match(build, /tidebreak-docs-\$RELEASE_TAG\.sha256/);
   assert.match(build, /name: tidebreak-docs-\$\{\{ needs\.validate\.outputs\.tag \}\}-prebuilt/);
   assert.doesNotMatch(publish, /docs-site install|docs-site build/);
   assert.equal(vercelCliPackage.dependencies.vercel, "59.0.0");
   assert.match(publish, /sparse-checkout: \.github\/vercel-cli/);
+  assert.match(publish, /persist-credentials: false/);
   assert.match(
     publish,
     /pnpm --dir \.github\/vercel-cli install --frozen-lockfile --ignore-scripts/,
   );
   assert.doesNotMatch(publish, /pnpm (?:add --global|dlx)|npx/);
   assert.match(publish, /actions\/download-artifact@[0-9a-f]{40} # v8/);
+  assert.match(publish, /name: tidebreak-docs-\$\{\{ needs\.validate\.outputs\.tag \}\}-manifest/);
+  assert.match(publish, /sha256sum --check --strict/);
   assert.match(publish, /asset_path=.*\/docs\/_next\//);
-  assert.match(publish, /content-security-policy:/);
+  for (const directive of [
+    "default-src 'self'",
+    "object-src 'none'",
+    "frame-ancestors 'none'",
+  ]) {
+    assert.equal(
+      publish.split(`content-security-policy:.*${directive}`).length - 1,
+      2,
+      `staged and promoted docs must both verify ${directive}`,
+    );
+  }
   assert.match(publish, /x-frame-options: DENY/);
   assert.match(publish, /\.id == \$id and \.readyState == "READY"/);
   assert.match(publish, /--prebuilt/);
@@ -1084,18 +1102,31 @@ test("release documentation is built from the validated tag and promoted only af
   assert.match(publish, /deployment_url=.*jq -er \.url/);
   assert.match(publish, /deployment_id=.*jq -er \.id/);
   assert.match(publish, /\.github\/vercel-cli\/node_modules\/\.bin\/vercel curl/);
+  assert.doesNotMatch(publish, /--token/);
   assert.match(publish, /\/docs\/quickstart\//);
   assert.match(publish, /\/docs\/search-index\.json/);
   assert.match(publish, /\/docs\/sitemap\.xml/);
   assert.match(publish, /\.github\/vercel-cli\/node_modules\/\.bin\/vercel promote/);
 
   const deploy = publish.indexOf("Create an unaliased production deployment");
+  const verify = publish.indexOf("Verify the transferred documentation");
   const smoke = publish.indexOf("Smoke-test the staged deployment");
   const promote = publish.indexOf("Promote the verified deployment");
   const production = publish.indexOf("Verify the production alias");
   assert.ok(
-    deploy !== -1 && deploy < smoke && smoke < promote && promote < production,
-    "docs must be staged, checked, promoted, and then verified in that order",
+    verify !== -1 &&
+      verify < deploy &&
+      deploy < smoke &&
+      smoke < promote &&
+      promote < production,
+    "docs must be verified, staged, checked, promoted, and then verified in that order",
+  );
+
+  const packageOutput = build.indexOf("pnpm --dir docs-site package:vercel");
+  const digestOutput = build.indexOf("find . -type f -print0");
+  assert.ok(
+    packageOutput !== -1 && packageOutput < digestOutput,
+    "the digest must cover the packaged Vercel output, including config.json",
   );
 });
 
@@ -1565,17 +1596,19 @@ test("GitHub release downloads are copied from the hosted release", () => {
   // manifest, rather than a second copy built alongside the hosted release.
   assert.match(attachJob, /releases\/v\$TIDEBREAK_VERSION\/manifest\.json/);
   assert.match(attachJob, /sha256sum --check --strict/);
-  if (/Tidebreak-macos-universal\.dmg/.test(attachJob)) {
-    assert.match(attachJob, /Tidebreak-macos-universal\.dmg/);
-  }
+  assert.match(attachJob, /Tidebreak-macos-universal\.dmg/);
   assert.match(attachJob, /Tidebreak-macos-apple-silicon\.dmg/);
   assert.match(attachJob, /Tidebreak-windows-x86_64-setup\.exe/);
   assert.match(attachJob, /gh release upload "\$RELEASE_TAG"/);
 
-  assert.match(
-    readFileSync(repositoryFile("README.md"), "utf8"),
-    /releases\/latest\/download\/Tidebreak-macos-universal\.dmg/,
-    "the README download link must match the published asset name",
+  const macDownloadLink = readFileSync(repositoryFile("README.md"), "utf8")
+    .match(
+      /releases\/latest\/download\/(Tidebreak-macos-[\w-]+\.dmg)/,
+    )?.[1];
+  assert.ok(macDownloadLink, "the README must publish a macOS download link");
+  assert.ok(
+    attachJob.includes(`downloads/${macDownloadLink}`),
+    `attach_downloads must upload ${macDownloadLink}`,
   );
 });
 

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -63,6 +63,9 @@ const denyConfig = readFileSync(repositoryFile("deny.toml"), "utf8");
 const e2bPackage = JSON.parse(
   readFileSync(repositoryFile(".github", "e2b-cli", "package.json"), "utf8"),
 );
+const docsPackage = JSON.parse(
+  readFileSync(repositoryFile("docs-site", "package.json"), "utf8"),
+);
 
 function workflowJob(source, name) {
   const marker = `  ${name}:\n`;
@@ -1027,6 +1030,48 @@ test("release builds use the trusted shared main cache scope", () => {
     /repos\/\$GITHUB_REPOSITORY\/releases\/tags\/\$RELEASE_TAG/,
   );
   assert.match(release, /ref: \$\{\{ needs\.validate\.outputs\.sha \}\}/);
+});
+
+test("release documentation is built from the validated tag and promoted only after staged checks", () => {
+  const job = workflowJob(workflows["release.yml"], "publish_docs");
+
+  assert.match(job, /^    needs: validate$/m);
+  assert.match(job, /^    environment:\n      name: docs-production$/m);
+  assert.match(job, /^    permissions:\n      contents: read$/m);
+  assert.doesNotMatch(job, /id-token: write|contents: write/);
+  assert.match(job, /BASE_PATH: \/docs/);
+  assert.match(job, /RELEASE_SHA: \$\{\{ needs\.validate\.outputs\.sha \}\}/);
+  assert.match(job, /VERCEL_TOKEN: \$\{\{ secrets\.VERCEL_TOKEN \}\}/);
+  assert.equal(
+    Object.values(docsPackage.dependencies ?? {}).includes("vercel"),
+    false,
+  );
+  assert.match(docsPackage.devDependencies.vercel, /^\d+\.\d+\.\d+$/);
+  assert.match(job, /pnpm --dir docs-site install --frozen-lockfile/);
+  assert.match(job, /ref: \$\{\{ needs\.validate\.outputs\.sha \}\}/);
+  assert.match(job, /test "\$\(git rev-parse HEAD\)" = "\$RELEASE_SHA"/);
+  assert.match(job, /pnpm --dir docs-site build/);
+  assert.match(job, /pnpm --dir docs-site package:vercel/);
+  assert.match(job, /\.vercel\/output\/static\/docs\/index\.html/);
+  assert.match(job, /--prebuilt/);
+  assert.match(job, /--prod/);
+  assert.match(job, /--skip-domain/);
+  assert.match(job, /--meta "releaseTag=\$RELEASE_TAG"/);
+  assert.match(job, /--meta "releaseSha=\$RELEASE_SHA"/);
+  assert.match(job, /\.\/docs-site\/node_modules\/\.bin\/vercel curl/);
+  assert.match(job, /\/docs\/quickstart\//);
+  assert.match(job, /\/docs\/search-index\.json/);
+  assert.match(job, /\/docs\/sitemap\.xml/);
+  assert.match(job, /\.\/docs-site\/node_modules\/\.bin\/vercel promote/);
+
+  const deploy = job.indexOf("Create an unaliased production deployment");
+  const smoke = job.indexOf("Smoke-test the staged deployment");
+  const promote = job.indexOf("Promote the verified deployment");
+  const production = job.indexOf("Verify the production alias");
+  assert.ok(
+    deploy !== -1 && deploy < smoke && smoke < promote && promote < production,
+    "docs must be staged, checked, promoted, and then verified in that order",
+  );
 });
 
 test("cache warming cannot access production credentials or publish", () => {

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1041,6 +1041,8 @@ test("release documentation is built from the validated tag and promoted only af
   assert.doesNotMatch(job, /id-token: write|contents: write/);
   assert.match(job, /BASE_PATH: \/docs/);
   assert.match(job, /RELEASE_SHA: \$\{\{ needs\.validate\.outputs\.sha \}\}/);
+  const jobEnvironment = job.match(/^    env:[\s\S]*?(?=^    steps:)/m)?.[0] ?? '';
+  assert.doesNotMatch(jobEnvironment, /VERCEL_TOKEN/);
   assert.match(job, /VERCEL_TOKEN: \$\{\{ secrets\.VERCEL_TOKEN \}\}/);
   assert.equal(
     Object.values(docsPackage.dependencies ?? {}).includes("vercel"),
@@ -1053,6 +1055,8 @@ test("release documentation is built from the validated tag and promoted only af
   assert.match(job, /pnpm --dir docs-site build/);
   assert.match(job, /pnpm --dir docs-site package:vercel/);
   assert.match(job, /\.vercel\/output\/static\/docs\/index\.html/);
+  assert.match(job, /asset_path=.*\/docs\/_next\//);
+  assert.match(job, /\.id == \$id and \.readyState == "READY"/);
   assert.match(job, /--prebuilt/);
   assert.match(job, /--prod/);
   assert.match(job, /--skip-domain/);

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -55,6 +55,10 @@ const dockerIgnore = readFileSync(
   repositoryFile("deploy", "self-host", "Dockerfile.dockerignore"),
   "utf8",
 );
+const selfHostDockerfile = readFileSync(
+  repositoryFile("deploy", "self-host", "Dockerfile"),
+  "utf8",
+);
 const denyConfig = readFileSync(repositoryFile("deny.toml"), "utf8");
 const e2bPackage = JSON.parse(
   readFileSync(repositoryFile(".github", "e2b-cli", "package.json"), "utf8"),
@@ -668,6 +672,23 @@ test("the self-host Docker context is allowlisted and denies hidden credentials"
   assert.match(
     readFileSync(repositoryFile("scripts", "stage-self-host-build-context.sh"), "utf8"),
     /git -C "\$root" archive --format=tar "\$revision" \| tar -x -C "\$destination"/,
+  );
+});
+
+test("the self-host runtime installs packages from an immutable Debian snapshot", () => {
+  assert.match(
+    selfHostDockerfile,
+    /snapshot\.debian\.org\/archive\/debian\/[0-9]{8}T[0-9]{6}Z/,
+  );
+  assert.match(
+    selfHostDockerfile,
+    /snapshot\.debian\.org\/archive\/debian-security\/[0-9]{8}T[0-9]{6}Z/,
+  );
+  assert.match(selfHostDockerfile, /ca-certificates=[^\s\\]+/);
+  assert.match(selfHostDockerfile, /curl=[^\s\\]+/);
+  assert.doesNotMatch(
+    selfHostDockerfile,
+    /apt-get install -y --no-install-recommends ca-certificates curl/,
   );
 });
 
@@ -1390,6 +1411,65 @@ test("an existing immutable release resumes without rebuilding or overwriting", 
     immutableUpload,
     /if: \$\{\{ needs\.inspect_hosted\.outputs\.exists != 'true' \}\}/,
   );
+});
+
+test("source SBOM generation is isolated from production credentials", () => {
+  const release = workflows["release.yml"];
+  const sbomJob = workflowJob(release, "source_sbom");
+  const publishJob = workflowJob(workflows["release.yml"], "publish");
+
+  assert.match(sbomJob, /needs: \[validate, inspect_hosted\]/);
+  assert.match(sbomJob, /permissions:\n      contents: read/);
+  assert.doesNotMatch(sbomJob, /id-token:/);
+  assert.doesNotMatch(sbomJob, /attestations:/);
+  assert.doesNotMatch(sbomJob, /artifact-metadata:/);
+  assert.doesNotMatch(sbomJob, /\n    environment:/);
+  assert.doesNotMatch(sbomJob, /AWS_|DOWNLOADS_|RELEASE_BASE_URL|vars\.|secrets\./);
+  assert.match(sbomJob, /ref: \$\{\{ needs\.validate\.outputs\.sha \}\}/);
+  assert.match(
+    sbomJob,
+    /uses: anchore\/sbom-action@[0-9a-f]{40} # v0\.24\.0/,
+  );
+  assert.match(sbomJob, /syft-version: v1\.51\.0/);
+  assert.match(sbomJob, /format: spdx-json/);
+  assert.match(sbomJob, /upload-artifact: false/);
+  assert.match(sbomJob, /upload-release-assets: false/);
+  assert.match(
+    sbomJob,
+    /uses: actions\/upload-artifact@[0-9a-f]{40} # v7/,
+  );
+  assert.match(sbomJob, /name: tidebreak-source-sbom-\$\{\{ needs\.validate\.outputs\.version \}\}/);
+  assert.doesNotMatch(publishJob, /anchore\/sbom-action/);
+
+  assert.match(publishJob, /needs: \[validate, inspect_hosted, build_macos, build_windows, source_sbom\]/);
+  assert.match(publishJob, /needs\.source_sbom\.result == 'success'/);
+  assert.match(
+    publishJob,
+    /uses: actions\/download-artifact@[0-9a-f]{40} # v8/,
+  );
+  assert.match(publishJob, /name: tidebreak-source-sbom-\$\{\{ needs\.validate\.outputs\.version \}\}/);
+  assert.match(publishJob, /sha256sum --check --strict/);
+});
+
+test("public releases attest provenance without treating the source SBOM as an installer SBOM", () => {
+  const publishJob = workflowJob(workflows["release.yml"], "publish");
+
+  assert.match(publishJob, /attestations: write/);
+  assert.match(publishJob, /id-token: write/);
+  assert.match(publishJob, /github\.event\.repository\.visibility == 'public'/);
+
+  const attestations = publishJob.match(
+    /uses: actions\/attest@[0-9a-f]{40} # v4\.2\.2/g,
+  );
+  assert.equal(attestations?.length, 1);
+  assert.match(publishJob, /subject-checksums: \$\{\{ runner\.temp \}\}\/immutable-release-files\.sha256/);
+  assert.doesNotMatch(publishJob, /sbom-path:/);
+  assert.doesNotMatch(publishJob, /release-artifacts\.sha256/);
+
+  const provenanceIndex = publishJob.indexOf("- name: Attest immutable release provenance");
+  const awsIndex = publishJob.indexOf("- name: Configure AWS credentials");
+  assert.ok(provenanceIndex !== -1 && awsIndex !== -1);
+  assert.ok(provenanceIndex < awsIndex);
 });
 
 test("GitHub release downloads are copied from the hosted release", () => {

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1080,6 +1080,9 @@ test("release documentation is built from the validated tag and promoted only af
   assert.match(publish, /--skip-domain/);
   assert.match(publish, /--meta "releaseTag=\$RELEASE_TAG"/);
   assert.match(publish, /--meta "releaseSha=\$RELEASE_SHA"/);
+  assert.match(publish, /jq -ce '\.deployment \/\/ \.'/);
+  assert.match(publish, /deployment_url=.*jq -er \.url/);
+  assert.match(publish, /deployment_id=.*jq -er \.id/);
   assert.match(publish, /\.github\/vercel-cli\/node_modules\/\.bin\/vercel curl/);
   assert.match(publish, /\/docs\/quickstart\//);
   assert.match(publish, /\/docs\/search-index\.json/);

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -66,6 +66,9 @@ const e2bPackage = JSON.parse(
 const docsPackage = JSON.parse(
   readFileSync(repositoryFile("docs-site", "package.json"), "utf8"),
 );
+const vercelCliPackage = JSON.parse(
+  readFileSync(repositoryFile(".github", "vercel-cli", "package.json"), "utf8"),
+);
 
 function workflowJob(source, name) {
   const marker = `  ${name}:\n`;
@@ -1059,8 +1062,14 @@ test("release documentation is built from the validated tag and promoted only af
   assert.match(build, /pnpm --dir docs-site package:vercel/);
   assert.match(build, /\.vercel\/output\/static\/docs\/index\.html/);
   assert.match(build, /name: tidebreak-docs-\$\{\{ needs\.validate\.outputs\.tag \}\}-prebuilt/);
-  assert.doesNotMatch(publish, /actions\/checkout|docs-site install|docs-site build/);
-  assert.match(publish, /pnpm add --global vercel@59\.0\.0 --ignore-scripts/);
+  assert.doesNotMatch(publish, /docs-site install|docs-site build/);
+  assert.equal(vercelCliPackage.dependencies.vercel, "59.0.0");
+  assert.match(publish, /sparse-checkout: \.github\/vercel-cli/);
+  assert.match(
+    publish,
+    /pnpm --dir \.github\/vercel-cli install --frozen-lockfile --ignore-scripts/,
+  );
+  assert.doesNotMatch(publish, /pnpm (?:add --global|dlx)|npx/);
   assert.match(publish, /actions\/download-artifact@[0-9a-f]{40} # v8/);
   assert.match(publish, /asset_path=.*\/docs\/_next\//);
   assert.match(publish, /content-security-policy:/);
@@ -1071,11 +1080,11 @@ test("release documentation is built from the validated tag and promoted only af
   assert.match(publish, /--skip-domain/);
   assert.match(publish, /--meta "releaseTag=\$RELEASE_TAG"/);
   assert.match(publish, /--meta "releaseSha=\$RELEASE_SHA"/);
-  assert.match(publish, /vercel curl/);
+  assert.match(publish, /\.github\/vercel-cli\/node_modules\/\.bin\/vercel curl/);
   assert.match(publish, /\/docs\/quickstart\//);
   assert.match(publish, /\/docs\/search-index\.json/);
   assert.match(publish, /\/docs\/sitemap\.xml/);
-  assert.match(publish, /vercel promote/);
+  assert.match(publish, /\.github\/vercel-cli\/node_modules\/\.bin\/vercel promote/);
 
   const deploy = publish.indexOf("Create an unaliased production deployment");
   const smoke = publish.indexOf("Smoke-test the staged deployment");

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1033,45 +1033,54 @@ test("release builds use the trusted shared main cache scope", () => {
 });
 
 test("release documentation is built from the validated tag and promoted only after staged checks", () => {
-  const job = workflowJob(workflows["release.yml"], "publish_docs");
+  const build = workflowJob(workflows["release.yml"], "build_docs");
+  const publish = workflowJob(workflows["release.yml"], "publish_docs");
 
-  assert.match(job, /^    needs: validate$/m);
-  assert.match(job, /^    environment:\n      name: docs-production$/m);
-  assert.match(job, /^    permissions:\n      contents: read$/m);
-  assert.doesNotMatch(job, /id-token: write|contents: write/);
-  assert.match(job, /BASE_PATH: \/docs/);
-  assert.match(job, /RELEASE_SHA: \$\{\{ needs\.validate\.outputs\.sha \}\}/);
-  const jobEnvironment = job.match(/^    env:[\s\S]*?(?=^    steps:)/m)?.[0] ?? '';
-  assert.doesNotMatch(jobEnvironment, /VERCEL_TOKEN/);
-  assert.match(job, /VERCEL_TOKEN: \$\{\{ secrets\.VERCEL_TOKEN \}\}/);
+  assert.match(build, /^    needs: validate$/m);
+  assert.doesNotMatch(build, /^    environment:/m);
+  assert.match(publish, /^    needs: \[validate, build_docs\]$/m);
+  assert.match(publish, /^    environment:\n      name: docs-production$/m);
+  assert.match(build, /^    permissions:\n      contents: read$/m);
+  assert.match(publish, /^    permissions:\n      contents: read$/m);
+  assert.doesNotMatch(`${build}\n${publish}`, /id-token: write|contents: write/);
+  assert.match(build, /BASE_PATH: \/docs/);
+  assert.match(build, /RELEASE_SHA: \$\{\{ needs\.validate\.outputs\.sha \}\}/);
+  assert.doesNotMatch(build, /VERCEL_TOKEN|docs-production/);
+  assert.match(publish, /VERCEL_TOKEN: \$\{\{ secrets\.VERCEL_TOKEN \}\}/);
   assert.equal(
     Object.values(docsPackage.dependencies ?? {}).includes("vercel"),
     false,
   );
   assert.match(docsPackage.devDependencies.vercel, /^\d+\.\d+\.\d+$/);
-  assert.match(job, /pnpm --dir docs-site install --frozen-lockfile/);
-  assert.match(job, /ref: \$\{\{ needs\.validate\.outputs\.sha \}\}/);
-  assert.match(job, /test "\$\(git rev-parse HEAD\)" = "\$RELEASE_SHA"/);
-  assert.match(job, /pnpm --dir docs-site build/);
-  assert.match(job, /pnpm --dir docs-site package:vercel/);
-  assert.match(job, /\.vercel\/output\/static\/docs\/index\.html/);
-  assert.match(job, /asset_path=.*\/docs\/_next\//);
-  assert.match(job, /\.id == \$id and \.readyState == "READY"/);
-  assert.match(job, /--prebuilt/);
-  assert.match(job, /--prod/);
-  assert.match(job, /--skip-domain/);
-  assert.match(job, /--meta "releaseTag=\$RELEASE_TAG"/);
-  assert.match(job, /--meta "releaseSha=\$RELEASE_SHA"/);
-  assert.match(job, /\.\/docs-site\/node_modules\/\.bin\/vercel curl/);
-  assert.match(job, /\/docs\/quickstart\//);
-  assert.match(job, /\/docs\/search-index\.json/);
-  assert.match(job, /\/docs\/sitemap\.xml/);
-  assert.match(job, /\.\/docs-site\/node_modules\/\.bin\/vercel promote/);
+  assert.match(build, /pnpm --dir docs-site install --frozen-lockfile/);
+  assert.match(build, /ref: \$\{\{ needs\.validate\.outputs\.sha \}\}/);
+  assert.match(build, /test "\$\(git rev-parse HEAD\)" = "\$RELEASE_SHA"/);
+  assert.match(build, /pnpm --dir docs-site build/);
+  assert.match(build, /pnpm --dir docs-site package:vercel/);
+  assert.match(build, /\.vercel\/output\/static\/docs\/index\.html/);
+  assert.match(build, /name: tidebreak-docs-\$\{\{ needs\.validate\.outputs\.tag \}\}-prebuilt/);
+  assert.doesNotMatch(publish, /actions\/checkout|docs-site install|docs-site build/);
+  assert.match(publish, /pnpm add --global vercel@59\.0\.0 --ignore-scripts/);
+  assert.match(publish, /actions\/download-artifact@[0-9a-f]{40} # v8/);
+  assert.match(publish, /asset_path=.*\/docs\/_next\//);
+  assert.match(publish, /content-security-policy:/);
+  assert.match(publish, /x-frame-options: DENY/);
+  assert.match(publish, /\.id == \$id and \.readyState == "READY"/);
+  assert.match(publish, /--prebuilt/);
+  assert.match(publish, /--prod/);
+  assert.match(publish, /--skip-domain/);
+  assert.match(publish, /--meta "releaseTag=\$RELEASE_TAG"/);
+  assert.match(publish, /--meta "releaseSha=\$RELEASE_SHA"/);
+  assert.match(publish, /vercel curl/);
+  assert.match(publish, /\/docs\/quickstart\//);
+  assert.match(publish, /\/docs\/search-index\.json/);
+  assert.match(publish, /\/docs\/sitemap\.xml/);
+  assert.match(publish, /vercel promote/);
 
-  const deploy = job.indexOf("Create an unaliased production deployment");
-  const smoke = job.indexOf("Smoke-test the staged deployment");
-  const promote = job.indexOf("Promote the verified deployment");
-  const production = job.indexOf("Verify the production alias");
+  const deploy = publish.indexOf("Create an unaliased production deployment");
+  const smoke = publish.indexOf("Smoke-test the staged deployment");
+  const promote = publish.indexOf("Promote the verified deployment");
+  const production = publish.indexOf("Verify the production alias");
   assert.ok(
     deploy !== -1 && deploy < smoke && smoke < promote && promote < production,
     "docs must be staged, checked, promoted, and then verified in that order",


### PR DESCRIPTION
## Summary

- Move computer-use consent, consequential confirmation, resume, and local-command MCP authorization behind OS-native trust boundaries.
- Isolate DOCX rendering in a sanitized, scriptless opaque-origin iframe.
- Enforce immutable principal ownership for local apps, grants, invocation, gateway drafts, view sessions, and connected-app usage counts.
- Scope sticky chat defaults per self-host principal and reject unsafe credential-bearing provider transports.
- Harden release provenance, source-scoped SBOM generation, Docker reproducibility, workflow credential isolation, and release-built static documentation.

## Documentation publication

Decision record 0022 establishes published GitHub Releases as the docs publication boundary. A credential-free runner builds `docs-site/` from the validated release SHA with `BASE_PATH=/docs` and transfers only inert Build Output. A fresh deployment runner sparsely checks out a dedicated Vercel client package, installs its exact frozen dependency graph with lifecycle scripts disabled, deploys without assigning the stable alias, verifies pages, assets, search, sitemap, metadata, security headers, and deployment identity, then promotes.

## Compatibility

- Desktop SQLite advances its pre-v1 schema epoch.
- Existing self-host databases receive an ordered migration that adds and backfills `app.owner`; legacy rows use the non-user `local` owner.
- Credential-bearing configurable provider endpoints require HTTPS. Credentialless Ollama retains loopback HTTP support.
- Enabled local MCP commands now require an absolute executable path; disabled drafts remain editable.
- The published SBOM is explicitly source-scoped and is not represented as installer-content metadata.
- Docs source remains in `docs-site/`; `docs/` remains ordinary Markdown and decision/release documentation.

## Safety and risk

- Stop is linearized with every acting broker dispatch, including initial operations, post-consent reissues, and consequential redemption.
- Native MCP approval displays the complete bounded execution context and exact absolute executable without disclosing secret values.
- Connected-app and gateway usage counts are scoped to the authenticated owner.
- Documentation build code never shares a runner filesystem with the Vercel production credential.
- The credentialed deployment client is installed from a dedicated exact lockfile with scripts disabled.
- A failed docs build or staged smoke test cannot replace the current production deployment.
- Repository settings were not changed.

## Validation

- 11 focused computer-use tests
- 13 native server-info and approval-manifest tests
- Two-principal authenticated gateway-app route regression
- Provider transport regression tests
- Docs build, lint, typecheck, and static Build Output packaging
- Real unpromoted Vercel deployment: pages, assets, search, sitemap, canonical/OG URLs, and security headers
- 70 workflow policy and mutation tests
- `actionlint`

## Review status

All prior P1/P2 findings have been fixed. A fresh final convergence review is running against commit `99ab7125`.