### PR TITLE
fix(desktop): clarify gateway models in picker

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ModelMenu.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ModelMenu.dom.test.tsx
@@ -97,3 +97,56 @@ it("warns only when a model choice switches providers", async () => {
       "This change may prevent prompt cache reuse, increasing cost and latency on the next turn.",
   });
 });
+
+it("searches every visible provider when typing with the picker open", async () => {
+  const onChange = vi.fn();
+  render(
+    <ModelMenu
+      models={MODELS}
+      value="anthropic::claude-sonnet-4"
+      onSetUpProvider={() => {}}
+      onChange={onChange}
+    />,
+  );
+
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: "Model: Claude Sonnet 4" }));
+  await user.keyboard("gpt");
+
+  expect(screen.getByRole("searchbox", { name: "Search models" })).toHaveValue(
+    "gpt",
+  );
+  await user.click(screen.getByRole("menuitem", { name: /GPT-5/ }));
+  expect(onChange).toHaveBeenCalledWith("openai::gpt-5");
+});
+
+it("uses the generic gateway mark for a mixed gateway rail", async () => {
+  const gatewayModels: ModelInfo[] = [
+    {
+      ...MODELS[0],
+      key: "model_gateway::claude-sonnet-4",
+      provider: "model_gateway",
+      vendor: "anthropic",
+    },
+    {
+      ...MODELS[2],
+      key: "model_gateway::gpt-5",
+      provider: "model_gateway",
+      vendor: "openai",
+    },
+  ];
+  render(
+    <ModelMenu
+      models={gatewayModels}
+      value={gatewayModels[0].key}
+      onSetUpProvider={() => {}}
+      onChange={() => {}}
+    />,
+  );
+
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: "Model: Claude Sonnet 4" }));
+  const gatewayTab = screen.getByRole("tab", { name: "Model Gateway" });
+  expect(gatewayTab.querySelector(".lucide-network")).not.toBeNull();
+  expect(gatewayTab.querySelector("svg[fill='#D97757']")).toBeNull();
+});

--- a/crates/tidebreak-desktop/ui/src/ModelMenu.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ModelMenu.test.tsx
@@ -2,6 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import {
   firstAvailableModel,
+  matchingModels,
   ModelMenu,
   ModelToolCapabilityChip,
   notConnectedProviders,
@@ -174,6 +175,9 @@ describe("visibleModelGroups", () => {
       "openai::gpt-4o",
     );
     expect(groups.map((group) => group.provider)).toEqual(["openai", "anthropic"]);
+    expect(groups[0].models.map((model) => model.key)).toEqual([
+      "openai::gpt-4o",
+    ]);
   });
 
   it("keeps a partially available provider intact", () => {
@@ -197,6 +201,28 @@ describe("visibleModelGroups", () => {
     expect(anthropic?.models.map((model) => model.key)).toEqual([
       MODELS[0].key,
       HAIKU.key,
+    ]);
+  });
+});
+
+describe("matchingModels", () => {
+  const gatewayClaude: ModelInfo = {
+    ...MODELS[0],
+    key: "model_gateway::claude-sonnet-4",
+    provider: "model_gateway",
+    vendor: "anthropic",
+  };
+
+  it("matches model, serving-provider, and vendor text across groups", () => {
+    const groups = visibleModelGroups([MODELS[1], gatewayClaude], null);
+    expect(matchingModels(groups, "gpt").map((model) => model.key)).toEqual([
+      "openai::gpt-4o",
+    ]);
+    expect(matchingModels(groups, "gateway").map((model) => model.key)).toEqual([
+      gatewayClaude.key,
+    ]);
+    expect(matchingModels(groups, "anthropic").map((model) => model.key)).toEqual([
+      gatewayClaude.key,
     ]);
   });
 });
@@ -359,6 +385,14 @@ describe("ProviderIcon", () => {
     );
     expect(throughGateway).toBe(throughCompatible);
     expect(throughGateway).not.toBe(unbranded);
+  });
+
+  it("uses a route-neutral mark for an unmatched gateway model", () => {
+    const gateway = renderToStaticMarkup(
+      <ProviderIcon provider="model_gateway" />,
+    );
+    expect(gateway).toContain("lucide-network");
+    expect(gateway).not.toContain("lucide-lock-open");
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/ModelMenu.tsx
+++ b/crates/tidebreak-desktop/ui/src/ModelMenu.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { toast } from "sonner";
 import {
@@ -6,6 +6,7 @@ import {
   Check,
   ChevronDown,
   Gauge,
+  Search,
 } from "lucide-react";
 import type {
   ModelInfo,
@@ -187,11 +188,36 @@ export function visibleModelGroups(
   models: readonly ModelInfo[],
   selectedKey: string | null,
 ): { provider: ProviderKind; models: ModelInfo[] }[] {
-  return groupByProvider(models).filter(
-    (group) =>
-      group.models.some((model) => model.available) ||
-      (selectedKey !== null &&
-        group.models.some((model) => model.key === selectedKey)),
+  return groupByProvider(models).flatMap((group) => {
+    if (group.models.some((model) => model.available)) return [group];
+    if (selectedKey === null) return [];
+
+    // Keep an unavailable explicit selection visible so the picker explains
+    // what the chat still names, but do not resurrect that provider's entire
+    // disabled catalog. This is especially noisy after a gateway becomes the
+    // usable route for the same upstream models.
+    const selected = group.models.find((model) => model.key === selectedKey);
+    return selected ? [{ ...group, models: [selected] }] : [];
+  });
+}
+
+/** Models visible in cross-provider search, in the same order as browsing. */
+export function matchingModels(
+  groups: readonly { provider: ProviderKind; models: readonly ModelInfo[] }[],
+  query: string,
+): ModelInfo[] {
+  const needle = query.trim().toLocaleLowerCase();
+  if (!needle) return [];
+  return groups.flatMap((group) =>
+    group.models.filter((model) => {
+      const vendor = model.vendor ? providerLabel(model.vendor) : "";
+      return [
+        model.display_name,
+        model.id,
+        providerLabel(model.provider),
+        vendor,
+      ].some((value) => value.toLocaleLowerCase().includes(needle));
+    }),
   );
 }
 
@@ -323,6 +349,8 @@ export function ModelMenu({
   const pillModel = known ?? (isDefault ? usableDefault : null);
 
   const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const searchInput = useRef<HTMLInputElement>(null);
   const [activeProvider, setActiveProvider] = useState<ProviderKind | null>(
     () => pickerProviderForSelection(rail, known ?? usableDefault),
   );
@@ -331,14 +359,57 @@ export function ModelMenu({
   const activeGroup =
     groups.find((group) => group.provider === activeRail?.provider) ?? null;
   const showProviderRail = rail.length > 0;
+  const searchResults = matchingModels(groups, query);
+  const searching = query.length > 0;
 
   function openMenu(next: boolean) {
     if (next) {
+      setQuery("");
       setActiveProvider(
         pickerProviderForSelection(rail, known ?? usableDefault),
       );
     }
     setOpen(next);
+  }
+
+  function chooseModel(model: ModelInfo, selected: boolean) {
+    if (selected || !model.available) return;
+    if (pillModel && pillModel.provider !== model.provider) {
+      warnAboutPromptCacheChange();
+    }
+    void onChange(model.key);
+  }
+
+  function modelRow(model: ModelInfo, showProvider: boolean = false) {
+    const selected = isDefault
+      ? usableDefault?.key === model.key
+      : canonical === model.key;
+    return (
+      <DropdownMenuItem
+        key={model.key}
+        disabled={disabled || !model.available}
+        // Picking a model is the whole point of opening this, so the menu
+        // closes on it. Re-selecting the current row still closes naturally.
+        onSelect={() => chooseModel(model, selected)}
+        className="flex items-center gap-2"
+      >
+        <ProviderIcon
+          provider={model.vendor ?? model.provider}
+          modelId={model.id}
+          className="size-4 shrink-0"
+        />
+        <span className="min-w-0 flex-1 truncate text-sm">
+          {model.display_name}
+        </span>
+        {showProvider && (
+          <span className="text-muted-foreground shrink-0 text-[0.65rem]">
+            {providerLabel(model.provider)}
+          </span>
+        )}
+        <ModelToolCapabilityChip model={model} />
+        {selected && <Check className="ml-auto size-4" />}
+      </DropdownMenuItem>
+    );
   }
 
   return (
@@ -369,6 +440,14 @@ export function ModelMenu({
         side="top"
         collisionPadding={12}
         className="model-menu-content w-80 p-0"
+        onKeyDownCapture={(event) => {
+          if (event.target === searchInput.current) return;
+          if (event.metaKey || event.ctrlKey || event.altKey) return;
+          if (event.key.length !== 1) return;
+          event.preventDefault();
+          setQuery((current) => current + event.key);
+          requestAnimationFrame(() => searchInput.current?.focus());
+        }}
       >
         {showProviderRail && (
           <div
@@ -378,8 +457,6 @@ export function ModelMenu({
           >
             {rail.map((entry) => {
               const selected = activeRail?.provider === entry.provider;
-              const mark = groups.find((group) => group.provider === entry.provider)
-                ?.models[0];
               return (
                 <WithTooltip
                   key={entry.provider}
@@ -407,8 +484,11 @@ export function ModelMenu({
                     onClick={() => setActiveProvider(entry.provider)}
                   >
                     <ProviderIcon
-                      provider={mark?.vendor ?? entry.provider}
-                      modelId={mark?.id}
+                      // A rail tab represents the route serving the group,
+                      // not whichever upstream vendor happened to be first.
+                      // Gateway catalogs are mixed, so their tab must stay the
+                      // generic gateway mark while rows retain vendor marks.
+                      provider={entry.provider}
                       className="size-4"
                     />
                     {selected && (
@@ -425,6 +505,21 @@ export function ModelMenu({
         )}
 
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+          <div className="border-border border-b p-1.5">
+            <label className="bg-muted/40 focus-within:ring-ring flex h-8 items-center gap-2 rounded-md px-2 focus-within:ring-2">
+              <Search className="text-muted-foreground size-3.5 shrink-0" />
+              <input
+                ref={searchInput}
+                type="search"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                onKeyDown={(event) => event.stopPropagation()}
+                placeholder="Search models"
+                aria-label="Search models"
+                className="placeholder:text-muted-foreground min-w-0 flex-1 bg-transparent text-sm outline-none"
+              />
+            </label>
+          </div>
           <div className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto p-1">
           {!anyAvailable && (
             <p className="text-muted-foreground px-2 py-2 text-sm">
@@ -434,7 +529,7 @@ export function ModelMenu({
             </p>
           )}
 
-          {activeRail && !activeRail.connected && (
+          {!searching && activeRail && !activeRail.connected && (
             <div>
               <div className="flex flex-col items-start gap-3 px-2 py-3">
                 <ProviderIcon
@@ -466,45 +561,25 @@ export function ModelMenu({
             </div>
           )}
 
-          {activeGroup && (
+          {!searching && activeGroup && (
             <div>
-              {activeGroup.models.map((model) => {
-                const selected = isDefault
-                  ? usableDefault?.key === model.key
-                  : canonical === model.key;
-                return (
-                  <DropdownMenuItem
-                    key={model.key}
-                    disabled={disabled || !model.available}
-                    // Picking a model is the whole point of opening this, so
-                    // the menu closes on it. Re-selecting what is already
-                    // chosen still closes: the reader asked for this model and
-                    // has it, and holding the menu open would read as a
-                    // dropped click.
-                    onSelect={() => {
-                      if (selected || !model.available) return;
-                      if (pillModel && pillModel.provider !== model.provider) {
-                        warnAboutPromptCacheChange();
-                      }
-                      void onChange(model.key);
-                    }}
-                    className="flex items-center gap-2"
-                  >
-                    <ProviderIcon
-                      provider={model.vendor ?? model.provider}
-                      modelId={model.id}
-                      className="size-4 shrink-0"
-                    />
-                    <span className="text-sm">{model.display_name}</span>
-                    <ModelToolCapabilityChip model={model} />
-                    {selected && <Check className="ml-auto size-4" />}
-                  </DropdownMenuItem>
-                );
-              })}
+              {activeGroup.models.map((model) => modelRow(model))}
             </div>
           )}
 
-          {!isDefault && !known && (
+          {searching && (
+            <div>
+              {searchResults.length > 0 ? (
+                searchResults.map((model) => modelRow(model, true))
+              ) : (
+                <p className="text-muted-foreground px-2 py-3 text-sm">
+                  No models match “{query}”.
+                </p>
+              )}
+            </div>
+          )}
+
+          {!searching && !isDefault && !known && (
             <div>
               <DropdownMenuSeparator />
               <DropdownMenuItem disabled className="flex items-center gap-2">

--- a/crates/tidebreak-desktop/ui/src/ProviderIcons.tsx
+++ b/crates/tidebreak-desktop/ui/src/ProviderIcons.tsx
@@ -1,4 +1,4 @@
-import { LockOpenIcon } from "lucide-react";
+import { LockOpenIcon, NetworkIcon } from "lucide-react";
 import type { ComponentProps } from "react";
 import type { ProviderKind } from "./api";
 
@@ -259,6 +259,11 @@ export function OpenModelIcon(props: IconProps) {
   return <LockOpenIcon {...props} />;
 }
 
+/** The serving route for a mixed catalog supplied by an organization. */
+export function ModelGatewayIcon(props: IconProps) {
+  return <NetworkIcon {...props} />;
+}
+
 /**
  * The mark for a catalog row.
  *
@@ -292,8 +297,9 @@ export function ProviderIcon({
     case "ollama":
       return <OllamaIcon {...rest} />;
     case "openai_compatible":
-    case "model_gateway":
       return <OpenModelIcon {...rest} />;
+    case "model_gateway":
+      return <ModelGatewayIcon {...rest} />;
     case "fireworks":
       return <FireworksIcon {...rest} />;
     case "together":


### PR DESCRIPTION
## What changed

- keep model-gateway catalogs in one route-level group with a neutral gateway icon
- preserve vendor-specific icons on individual model rows
- show only the stale selected row when a previously selected direct provider is no longer available, instead of reviving its entire disabled catalog
- add type-to-search across visible provider groups, matching model names, IDs, serving providers, and inferred vendors
- label search results with the serving provider so direct and gateway routes remain distinguishable

## Why

The provider rail was deriving its icon from the first model in each group. A mixed model-gateway catalog whose first row happened to be Anthropic therefore appeared as a second Anthropic group. When a chat still selected a now-unavailable direct model, the picker also displayed that provider's full disabled catalog, amplifying the duplicate-group effect.

The rail now represents the route serving the group, while model rows retain useful upstream branding. Cross-provider search removes the need to browse provider tabs for large catalogs.

## User impact

After connecting a model gateway, readers see one clearly identified Model Gateway group rather than a misleading duplicate vendor group. Existing stale selections remain honestly visible but no longer flood the menu with unrelated disabled rows. Opening the picker and typing immediately searches all visible providers.

## Validation

- `pnpm test` — 144 files, 983 tests passed
- `pnpm build`
- `git diff --check`
