### PR TITLE
feat(desktop): package universal macOS builds

### DIFF
--- a/.github/workflows/cache-macos.yml
+++ b/.github/workflows/cache-macos.yml
@@ -39,29 +39,22 @@ jobs:
           cache-targets: false
 
       - name: Fetch Cargo dependency downloads
-        run: cargo fetch --locked --target aarch64-apple-darwin
+        run: |
+          cargo fetch --locked --target aarch64-apple-darwin
+          cargo fetch --locked --target x86_64-apple-darwin
 
   warm:
-    name: macOS cache · ${{ matrix.arch }}
+    name: macOS cache · universal
     needs: cargo-downloads
     runs-on: macos-latest
     timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        # Apple Silicon only while the product is in active development; see
-        # docs/releases.md. Restoring Intel means adding its row back here, to
-        # the two macOS release matrices, and to RELEASE_PLATFORMS.
-        include:
-          - arch: aarch64
-            target: aarch64-apple-darwin
     env:
       CARGO_INCREMENTAL: 0
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
       # GitHub throttles sccache's many small writes. Retain its existing
       # object cache as a read-only fallback and persist build outputs below
-      # with one cache archive per architecture.
+      # with one cache archive containing both universal slices.
       SCCACHE_GHA_RW_MODE: READ_ONLY
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -69,7 +62,7 @@ jobs:
       - name: Install Rust target
         run: |
           rustup show
-          rustup target add "${{ matrix.target }}"
+          rustup target add aarch64-apple-darwin x86_64-apple-darwin
 
       - name: Restore unsigned Rust build cache
         id: rust-build-cache
@@ -80,18 +73,27 @@ jobs:
             target/release/.fingerprint
             target/release/build
             target/release/deps
-            target/${{ matrix.target }}/release/.cargo-lock
-            target/${{ matrix.target }}/release/.fingerprint
-            target/${{ matrix.target }}/release/build
-            target/${{ matrix.target }}/release/deps
-            target/${{ matrix.target }}/release/tidebreak-desktop
-            target/${{ matrix.target }}/release/tidebreak-host-broker
-            target/${{ matrix.target }}/release/libtidebreak_desktop_lib.*
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}
-          key: macos-release-target-v4-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ github.sha }}
+            target/aarch64-apple-darwin/release/.cargo-lock
+            target/aarch64-apple-darwin/release/.fingerprint
+            target/aarch64-apple-darwin/release/build
+            target/aarch64-apple-darwin/release/deps
+            target/aarch64-apple-darwin/release/tidebreak-desktop
+            target/aarch64-apple-darwin/release/tidebreak-host-broker
+            target/aarch64-apple-darwin/release/libtidebreak_desktop_lib.*
+            target/x86_64-apple-darwin/release/.cargo-lock
+            target/x86_64-apple-darwin/release/.fingerprint
+            target/x86_64-apple-darwin/release/build
+            target/x86_64-apple-darwin/release/deps
+            target/x86_64-apple-darwin/release/tidebreak-desktop
+            target/x86_64-apple-darwin/release/tidebreak-host-broker
+            target/x86_64-apple-darwin/release/libtidebreak_desktop_lib.*
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-aarch64-apple-darwin
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-x86_64-apple-darwin
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-universal-apple-darwin
+          key: macos-release-target-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ github.sha }}
           restore-keys: |
-            macos-release-target-v4-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
-            macos-release-target-v4-${{ matrix.arch }}-
+            macos-release-target-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
+            macos-release-target-v5-universal-
 
       - name: Set up compiler cache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
@@ -126,18 +128,19 @@ jobs:
         uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1
         with:
           projectPath: crates/tidebreak-desktop
-          args: --target ${{ matrix.target }} --no-bundle --ci
+          args: --target universal-apple-darwin --no-bundle --ci
 
       - name: Report unsigned Rust build cache size
         if: ${{ !cancelled() }}
         run: |
           du -ch \
             target/release/{.cargo-lock,.fingerprint,build,deps} \
-            target/${{ matrix.target }}/release/{.cargo-lock,.fingerprint,build,deps} \
-            target/${{ matrix.target }}/release/tidebreak-desktop \
-            target/${{ matrix.target }}/release/tidebreak-host-broker \
-            target/${{ matrix.target }}/release/libtidebreak_desktop_lib.* \
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }} \
+            target/{aarch64-apple-darwin,x86_64-apple-darwin}/release/{.cargo-lock,.fingerprint,build,deps} \
+            target/{aarch64-apple-darwin,x86_64-apple-darwin}/release/tidebreak-desktop \
+            target/{aarch64-apple-darwin,x86_64-apple-darwin}/release/tidebreak-host-broker \
+            target/{aarch64-apple-darwin,x86_64-apple-darwin}/release/libtidebreak_desktop_lib.* \
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-{aarch64-apple-darwin,x86_64-apple-darwin} \
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-universal-apple-darwin \
             2>/dev/null | tail -1 || true
 
       - name: Save unsigned Rust build cache
@@ -149,14 +152,23 @@ jobs:
             target/release/.fingerprint
             target/release/build
             target/release/deps
-            target/${{ matrix.target }}/release/.cargo-lock
-            target/${{ matrix.target }}/release/.fingerprint
-            target/${{ matrix.target }}/release/build
-            target/${{ matrix.target }}/release/deps
-            target/${{ matrix.target }}/release/tidebreak-desktop
-            target/${{ matrix.target }}/release/tidebreak-host-broker
-            target/${{ matrix.target }}/release/libtidebreak_desktop_lib.*
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}
+            target/aarch64-apple-darwin/release/.cargo-lock
+            target/aarch64-apple-darwin/release/.fingerprint
+            target/aarch64-apple-darwin/release/build
+            target/aarch64-apple-darwin/release/deps
+            target/aarch64-apple-darwin/release/tidebreak-desktop
+            target/aarch64-apple-darwin/release/tidebreak-host-broker
+            target/aarch64-apple-darwin/release/libtidebreak_desktop_lib.*
+            target/x86_64-apple-darwin/release/.cargo-lock
+            target/x86_64-apple-darwin/release/.fingerprint
+            target/x86_64-apple-darwin/release/build
+            target/x86_64-apple-darwin/release/deps
+            target/x86_64-apple-darwin/release/tidebreak-desktop
+            target/x86_64-apple-darwin/release/tidebreak-host-broker
+            target/x86_64-apple-darwin/release/libtidebreak_desktop_lib.*
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-aarch64-apple-darwin
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-x86_64-apple-darwin
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-universal-apple-darwin
           key: ${{ steps.rust-build-cache.outputs.cache-primary-key }}
 
       - name: Require a successful cache-warm compilation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,19 +244,11 @@ jobs:
           echo "exists=true" >> "$GITHUB_OUTPUT"
 
   prepare_macos:
-    name: prepare unsigned macOS · ${{ matrix.arch }}
+    name: prepare unsigned macOS · universal
     needs: [validate, inspect_hosted]
     if: ${{ needs.inspect_hosted.outputs.exists != 'true' }}
     runs-on: macos-latest
     timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        # Apple Silicon only while the product is in active development; see
-        # docs/releases.md.
-        include:
-          - arch: aarch64
-            target: aarch64-apple-darwin
     env:
       CARGO_INCREMENTAL: 0
       RUSTC_WRAPPER: sccache
@@ -271,7 +263,7 @@ jobs:
       - name: Install Rust target
         run: |
           rustup show
-          rustup target add "${{ matrix.target }}"
+          rustup target add aarch64-apple-darwin x86_64-apple-darwin
 
       - name: Restore unsigned Rust build cache
         id: rust-build-cache
@@ -282,20 +274,29 @@ jobs:
             target/release/.fingerprint
             target/release/build
             target/release/deps
-            target/${{ matrix.target }}/release/.cargo-lock
-            target/${{ matrix.target }}/release/.fingerprint
-            target/${{ matrix.target }}/release/build
-            target/${{ matrix.target }}/release/deps
-            target/${{ matrix.target }}/release/tidebreak-desktop
-            target/${{ matrix.target }}/release/tidebreak-host-broker
-            target/${{ matrix.target }}/release/libtidebreak_desktop_lib.*
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}
-          key: macos-release-prepared-v4-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
+            target/aarch64-apple-darwin/release/.cargo-lock
+            target/aarch64-apple-darwin/release/.fingerprint
+            target/aarch64-apple-darwin/release/build
+            target/aarch64-apple-darwin/release/deps
+            target/aarch64-apple-darwin/release/tidebreak-desktop
+            target/aarch64-apple-darwin/release/tidebreak-host-broker
+            target/aarch64-apple-darwin/release/libtidebreak_desktop_lib.*
+            target/x86_64-apple-darwin/release/.cargo-lock
+            target/x86_64-apple-darwin/release/.fingerprint
+            target/x86_64-apple-darwin/release/build
+            target/x86_64-apple-darwin/release/deps
+            target/x86_64-apple-darwin/release/tidebreak-desktop
+            target/x86_64-apple-darwin/release/tidebreak-host-broker
+            target/x86_64-apple-darwin/release/libtidebreak_desktop_lib.*
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-aarch64-apple-darwin
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-x86_64-apple-darwin
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-universal-apple-darwin
+          key: macos-release-prepared-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
           restore-keys: |
-            macos-release-prepared-v4-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
-            macos-release-target-v4-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}
-            macos-release-target-v4-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
-            macos-release-target-v4-${{ matrix.arch }}-
+            macos-release-prepared-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
+            macos-release-target-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}
+            macos-release-target-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
+            macos-release-target-v5-universal-
 
       - name: Set up compiler cache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
@@ -337,7 +338,7 @@ jobs:
         uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1
         with:
           projectPath: crates/tidebreak-desktop
-          args: --target ${{ matrix.target }} --no-bundle --ci
+          args: --target universal-apple-darwin --no-bundle --ci
 
       - name: Save release-specific unsigned Rust build cache
         if: ${{ !cancelled() && steps.rust-build-cache.outputs.cache-hit != 'true' }}
@@ -348,14 +349,23 @@ jobs:
             target/release/.fingerprint
             target/release/build
             target/release/deps
-            target/${{ matrix.target }}/release/.cargo-lock
-            target/${{ matrix.target }}/release/.fingerprint
-            target/${{ matrix.target }}/release/build
-            target/${{ matrix.target }}/release/deps
-            target/${{ matrix.target }}/release/tidebreak-desktop
-            target/${{ matrix.target }}/release/tidebreak-host-broker
-            target/${{ matrix.target }}/release/libtidebreak_desktop_lib.*
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}
+            target/aarch64-apple-darwin/release/.cargo-lock
+            target/aarch64-apple-darwin/release/.fingerprint
+            target/aarch64-apple-darwin/release/build
+            target/aarch64-apple-darwin/release/deps
+            target/aarch64-apple-darwin/release/tidebreak-desktop
+            target/aarch64-apple-darwin/release/tidebreak-host-broker
+            target/aarch64-apple-darwin/release/libtidebreak_desktop_lib.*
+            target/x86_64-apple-darwin/release/.cargo-lock
+            target/x86_64-apple-darwin/release/.fingerprint
+            target/x86_64-apple-darwin/release/build
+            target/x86_64-apple-darwin/release/deps
+            target/x86_64-apple-darwin/release/tidebreak-desktop
+            target/x86_64-apple-darwin/release/tidebreak-host-broker
+            target/x86_64-apple-darwin/release/libtidebreak_desktop_lib.*
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-aarch64-apple-darwin
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-x86_64-apple-darwin
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-universal-apple-darwin
           key: ${{ steps.rust-build-cache.outputs.cache-primary-key }}
 
       - name: Require a successful unsigned compilation
@@ -363,7 +373,7 @@ jobs:
         run: exit 1
 
   build_macos:
-    name: macOS · ${{ matrix.arch }}
+    name: macOS · universal
     needs: [validate, inspect_hosted, prepare_macos]
     if: >-
       ${{
@@ -377,14 +387,6 @@ jobs:
     environment:
       name: desktop-production
       url: https://downloads.brightwave.io/tidebreak/manifest.json
-    strategy:
-      fail-fast: false
-      matrix:
-        # Apple Silicon only while the product is in active development; see
-        # docs/releases.md.
-        include:
-          - arch: aarch64
-            target: aarch64-apple-darwin
     env:
       # Reuse compiler outputs across trusted release runs without caching the
       # signed bundles or any signing material.
@@ -424,19 +426,28 @@ jobs:
             target/release/.fingerprint
             target/release/build
             target/release/deps
-            target/${{ matrix.target }}/release/.cargo-lock
-            target/${{ matrix.target }}/release/.fingerprint
-            target/${{ matrix.target }}/release/build
-            target/${{ matrix.target }}/release/deps
-            target/${{ matrix.target }}/release/tidebreak-desktop
-            target/${{ matrix.target }}/release/tidebreak-host-broker
-            target/${{ matrix.target }}/release/libtidebreak_desktop_lib.*
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}
-          key: macos-release-prepared-v4-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
+            target/aarch64-apple-darwin/release/.cargo-lock
+            target/aarch64-apple-darwin/release/.fingerprint
+            target/aarch64-apple-darwin/release/build
+            target/aarch64-apple-darwin/release/deps
+            target/aarch64-apple-darwin/release/tidebreak-desktop
+            target/aarch64-apple-darwin/release/tidebreak-host-broker
+            target/aarch64-apple-darwin/release/libtidebreak_desktop_lib.*
+            target/x86_64-apple-darwin/release/.cargo-lock
+            target/x86_64-apple-darwin/release/.fingerprint
+            target/x86_64-apple-darwin/release/build
+            target/x86_64-apple-darwin/release/deps
+            target/x86_64-apple-darwin/release/tidebreak-desktop
+            target/x86_64-apple-darwin/release/tidebreak-host-broker
+            target/x86_64-apple-darwin/release/libtidebreak_desktop_lib.*
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-aarch64-apple-darwin
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-x86_64-apple-darwin
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-universal-apple-darwin
+          key: macos-release-prepared-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
           restore-keys: |
-            macos-release-prepared-v4-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
-            macos-release-target-v4-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}
-            macos-release-target-v4-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
+            macos-release-prepared-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
+            macos-release-target-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}
+            macos-release-target-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
 
       # A restore extracts the whole archive, including the linked products a
       # cache-warming run left in it. Those are the bytes that get signed, so
@@ -445,14 +456,13 @@ jobs:
       # stay. The sidecar matters most: Tauri copies it into the signed
       # product verbatim, with no Cargo fingerprint governing it.
       - name: Discard restored product binaries
-        env:
-          RELEASE_TARGET: ${{ matrix.target }}
         run: |
           rm -rf \
-            "target/$RELEASE_TARGET/release/tidebreak-desktop" \
-            "target/$RELEASE_TARGET/release/tidebreak-host-broker" \
-            "target/$RELEASE_TARGET/release/"libtidebreak_desktop_lib.* \
-            "crates/tidebreak-desktop/binaries/tidebreak-host-broker-$RELEASE_TARGET"
+            target/{aarch64-apple-darwin,x86_64-apple-darwin,universal-apple-darwin}/release/tidebreak-desktop \
+            target/{aarch64-apple-darwin,x86_64-apple-darwin}/release/tidebreak-host-broker \
+            target/{aarch64-apple-darwin,x86_64-apple-darwin}/release/libtidebreak_desktop_lib.* \
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-{aarch64-apple-darwin,x86_64-apple-darwin} \
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-universal-apple-darwin
 
       # sccache, rust-cache, and the UI install run before any Apple or Tauri
       # material is on disk. pnpm is pinned; lifecycle scripts stay off.
@@ -565,7 +575,7 @@ jobs:
       - name: Install Rust target
         run: |
           rustup show
-          rustup target add "${{ matrix.target }}"
+          rustup target add aarch64-apple-darwin x86_64-apple-darwin
 
       - name: Write tag-derived Tauri configuration
         env:
@@ -595,13 +605,13 @@ jobs:
         with:
           projectPath: crates/tidebreak-desktop
           args: >-
-            --target ${{ matrix.target }}
+            --target universal-apple-darwin
             --config ${{ runner.temp }}/tidebreak-release.json
             --bundles app,dmg
 
       - name: Notarize and staple the DMG
         env:
-          RELEASE_TARGET: ${{ matrix.target }}
+          RELEASE_TARGET: universal-apple-darwin
         run: |
           target_dir="$(cargo metadata --format-version 1 --no-deps | jq -r .target_directory)"
           dmg_paths=("$target_dir/$RELEASE_TARGET/release/bundle/dmg/"*.dmg)
@@ -636,8 +646,8 @@ jobs:
 
       - name: Verify and collect signed artifacts
         env:
-          RELEASE_ARCH: ${{ matrix.arch }}
-          RELEASE_TARGET: ${{ matrix.target }}
+          RELEASE_ARCH: universal
+          RELEASE_TARGET: universal-apple-darwin
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
@@ -693,11 +703,21 @@ jobs:
           executable="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$app_path/Contents/Info.plist")"
           binary_arches="$(lipo -archs "$app_path/Contents/MacOS/$executable")"
           case "$RELEASE_ARCH" in
-            aarch64) [[ "$binary_arches" = *arm64* && "$binary_arches" != *x86_64* ]] ;;
-            x86_64) [[ "$binary_arches" = *x86_64* && "$binary_arches" != *arm64* ]] ;;
+            universal) [[ "$binary_arches" = *arm64* && "$binary_arches" = *x86_64* ]] ;;
             *) echo "Unsupported release architecture: $RELEASE_ARCH" >&2; exit 1 ;;
           esac || {
             echo "Expected $RELEASE_ARCH app, found Mach-O architectures: $binary_arches" >&2
+            exit 1
+          }
+
+          sidecar="$app_path/Contents/MacOS/tidebreak-host-broker"
+          [[ -x "$sidecar" ]] || {
+            echo "Universal app is missing its executable host broker: $sidecar" >&2
+            exit 1
+          }
+          sidecar_arches="$(lipo -archs "$sidecar")"
+          [[ "$sidecar_arches" = *arm64* && "$sidecar_arches" = *x86_64* ]] || {
+            echo "Expected universal host broker, found Mach-O architectures: $sidecar_arches" >&2
             exit 1
           }
 
@@ -725,8 +745,8 @@ jobs:
       - name: Upload verified macOS artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: tidebreak-macos-${{ matrix.arch }}-${{ needs.validate.outputs.version }}
-          path: dist/macos/${{ matrix.arch }}/
+          name: tidebreak-macos-universal-${{ needs.validate.outputs.version }}
+          path: dist/macos/universal/
           if-no-files-found: error
           retention-days: 7
 
@@ -1146,12 +1166,12 @@ jobs:
           role-session-name: tidebreak-${{ github.run_id }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Download Apple Silicon artifacts
+      - name: Download universal macOS artifacts
         if: ${{ needs.inspect_hosted.outputs.exists != 'true' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: tidebreak-macos-aarch64-${{ needs.validate.outputs.version }}
-          path: dist/macos/aarch64
+          name: tidebreak-macos-universal-${{ needs.validate.outputs.version }}
+          path: dist/macos/universal
 
       # Parked with the Windows build; see docs/deferred.md.
       - name: Download Windows artifacts
@@ -1334,7 +1354,7 @@ jobs:
 
           while IFS=$'\t' read -r platform arch url digest; do
             case "$platform/$arch" in
-              macos/aarch64) name="Tidebreak-macos-apple-silicon.dmg" ;;
+              macos/universal) name="Tidebreak-macos-universal.dmg" ;;
               windows/x86_64) name="Tidebreak-windows-x86_64-setup.exe" ;;
               *) echo "Unsupported release platform: $platform/$arch" >&2; exit 1 ;;
             esac
@@ -1354,6 +1374,19 @@ jobs:
             echo "Expected one macOS disk image, found $dmg_count." >&2
             exit 1
           }
+
+          # Keep the existing permanent README URL live across the transition
+          # to universal packages. Both names carry the same CDN-verified bytes;
+          # the universal name is canonical for new links.
+          universal_dmg="downloads/Tidebreak-macos-universal.dmg"
+          compatibility_dmg="downloads/Tidebreak-macos-apple-silicon.dmg"
+          [[ -f "$universal_dmg" ]] || {
+            echo "The universal macOS disk image was not downloaded." >&2
+            exit 1
+          }
+          cp "$universal_dmg" "$compatibility_dmg"
+          (cd downloads && sha256sum "$(basename "$compatibility_dmg")" \
+            > "$(basename "$compatibility_dmg").sha256")
 
       # Version-free asset names give the README permanent one-click download
       # links through GitHub's /releases/latest/download/ redirect.

--- a/.github/workflows/staging-publish.yml
+++ b/.github/workflows/staging-publish.yml
@@ -63,17 +63,11 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   prepare_macos_staging:
-    name: prepare unsigned staging macOS · ${{ matrix.arch }}
+    name: prepare unsigned staging macOS · universal
     needs: validate_staging
     if: ${{ inputs.channel == 'staging' }}
     runs-on: macos-latest
     timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: aarch64
-            target: aarch64-apple-darwin
     env:
       CARGO_INCREMENTAL: 0
       RUSTC_WRAPPER: sccache
@@ -89,7 +83,7 @@ jobs:
       - name: Install Rust target
         run: |
           rustup show
-          rustup target add "${{ matrix.target }}"
+          rustup target add aarch64-apple-darwin x86_64-apple-darwin
 
       - name: Restore unsigned Rust build cache
         id: rust-build-cache
@@ -100,19 +94,28 @@ jobs:
             target/release/.fingerprint
             target/release/build
             target/release/deps
-            target/${{ matrix.target }}/release/.cargo-lock
-            target/${{ matrix.target }}/release/.fingerprint
-            target/${{ matrix.target }}/release/build
-            target/${{ matrix.target }}/release/deps
-            target/${{ matrix.target }}/release/tidebreak-desktop
-            target/${{ matrix.target }}/release/tidebreak-host-broker
-            target/${{ matrix.target }}/release/libtidebreak_desktop_lib.*
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}
-          key: macos-staging-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate_staging.outputs.sha }}-${{ needs.validate_staging.outputs.version }}
+            target/aarch64-apple-darwin/release/.cargo-lock
+            target/aarch64-apple-darwin/release/.fingerprint
+            target/aarch64-apple-darwin/release/build
+            target/aarch64-apple-darwin/release/deps
+            target/aarch64-apple-darwin/release/tidebreak-desktop
+            target/aarch64-apple-darwin/release/tidebreak-host-broker
+            target/aarch64-apple-darwin/release/libtidebreak_desktop_lib.*
+            target/x86_64-apple-darwin/release/.cargo-lock
+            target/x86_64-apple-darwin/release/.fingerprint
+            target/x86_64-apple-darwin/release/build
+            target/x86_64-apple-darwin/release/deps
+            target/x86_64-apple-darwin/release/tidebreak-desktop
+            target/x86_64-apple-darwin/release/tidebreak-host-broker
+            target/x86_64-apple-darwin/release/libtidebreak_desktop_lib.*
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-aarch64-apple-darwin
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-x86_64-apple-darwin
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-universal-apple-darwin
+          key: macos-staging-prepared-v2-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate_staging.outputs.sha }}-${{ needs.validate_staging.outputs.version }}
           restore-keys: |
-            macos-staging-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate_staging.outputs.sha }}-
-            macos-release-target-v4-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate_staging.outputs.sha }}
-            macos-release-target-v4-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
+            macos-staging-prepared-v2-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate_staging.outputs.sha }}-
+            macos-release-target-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate_staging.outputs.sha }}
+            macos-release-target-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
 
       - name: Set up compiler cache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
@@ -150,7 +153,7 @@ jobs:
         uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1
         with:
           projectPath: crates/tidebreak-desktop
-          args: --target ${{ matrix.target }} --no-bundle --ci
+          args: --target universal-apple-darwin --no-bundle --ci
 
       - name: Save staging-specific unsigned Rust build cache
         if: ${{ !cancelled() && steps.rust-build-cache.outputs.cache-hit != 'true' }}
@@ -161,14 +164,23 @@ jobs:
             target/release/.fingerprint
             target/release/build
             target/release/deps
-            target/${{ matrix.target }}/release/.cargo-lock
-            target/${{ matrix.target }}/release/.fingerprint
-            target/${{ matrix.target }}/release/build
-            target/${{ matrix.target }}/release/deps
-            target/${{ matrix.target }}/release/tidebreak-desktop
-            target/${{ matrix.target }}/release/tidebreak-host-broker
-            target/${{ matrix.target }}/release/libtidebreak_desktop_lib.*
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}
+            target/aarch64-apple-darwin/release/.cargo-lock
+            target/aarch64-apple-darwin/release/.fingerprint
+            target/aarch64-apple-darwin/release/build
+            target/aarch64-apple-darwin/release/deps
+            target/aarch64-apple-darwin/release/tidebreak-desktop
+            target/aarch64-apple-darwin/release/tidebreak-host-broker
+            target/aarch64-apple-darwin/release/libtidebreak_desktop_lib.*
+            target/x86_64-apple-darwin/release/.cargo-lock
+            target/x86_64-apple-darwin/release/.fingerprint
+            target/x86_64-apple-darwin/release/build
+            target/x86_64-apple-darwin/release/deps
+            target/x86_64-apple-darwin/release/tidebreak-desktop
+            target/x86_64-apple-darwin/release/tidebreak-host-broker
+            target/x86_64-apple-darwin/release/libtidebreak_desktop_lib.*
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-aarch64-apple-darwin
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-x86_64-apple-darwin
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-universal-apple-darwin
           key: ${{ steps.rust-build-cache.outputs.cache-primary-key }}
 
       - name: Require a successful unsigned compilation
@@ -176,19 +188,13 @@ jobs:
         run: exit 1
 
   build_macos_staging:
-    name: staging macOS · ${{ matrix.arch }}
+    name: staging macOS · universal
     needs: [validate_staging, prepare_macos_staging]
     if: ${{ inputs.channel == 'staging' }}
     runs-on: macos-latest
     environment:
       name: desktop-staging
       url: https://downloads.brightwave.io/tidebreak/staging/manifest.json
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: aarch64
-            target: aarch64-apple-darwin
     env:
       CARGO_INCREMENTAL: 0
       RUSTC_WRAPPER: sccache
@@ -212,29 +218,37 @@ jobs:
             target/release/.fingerprint
             target/release/build
             target/release/deps
-            target/${{ matrix.target }}/release/.cargo-lock
-            target/${{ matrix.target }}/release/.fingerprint
-            target/${{ matrix.target }}/release/build
-            target/${{ matrix.target }}/release/deps
-            target/${{ matrix.target }}/release/tidebreak-desktop
-            target/${{ matrix.target }}/release/tidebreak-host-broker
-            target/${{ matrix.target }}/release/libtidebreak_desktop_lib.*
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}
-          key: macos-staging-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate_staging.outputs.sha }}-${{ needs.validate_staging.outputs.version }}
+            target/aarch64-apple-darwin/release/.cargo-lock
+            target/aarch64-apple-darwin/release/.fingerprint
+            target/aarch64-apple-darwin/release/build
+            target/aarch64-apple-darwin/release/deps
+            target/aarch64-apple-darwin/release/tidebreak-desktop
+            target/aarch64-apple-darwin/release/tidebreak-host-broker
+            target/aarch64-apple-darwin/release/libtidebreak_desktop_lib.*
+            target/x86_64-apple-darwin/release/.cargo-lock
+            target/x86_64-apple-darwin/release/.fingerprint
+            target/x86_64-apple-darwin/release/build
+            target/x86_64-apple-darwin/release/deps
+            target/x86_64-apple-darwin/release/tidebreak-desktop
+            target/x86_64-apple-darwin/release/tidebreak-host-broker
+            target/x86_64-apple-darwin/release/libtidebreak_desktop_lib.*
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-aarch64-apple-darwin
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-x86_64-apple-darwin
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-universal-apple-darwin
+          key: macos-staging-prepared-v2-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate_staging.outputs.sha }}-${{ needs.validate_staging.outputs.version }}
           restore-keys: |
-            macos-staging-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate_staging.outputs.sha }}-
-            macos-release-target-v4-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate_staging.outputs.sha }}
-            macos-release-target-v4-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
+            macos-staging-prepared-v2-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate_staging.outputs.sha }}-
+            macos-release-target-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate_staging.outputs.sha }}
+            macos-release-target-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
 
       - name: Discard restored product binaries
-        env:
-          RELEASE_TARGET: ${{ matrix.target }}
         run: |
           rm -rf \
-            "target/$RELEASE_TARGET/release/tidebreak-desktop" \
-            "target/$RELEASE_TARGET/release/tidebreak-host-broker" \
-            "target/$RELEASE_TARGET/release/"libtidebreak_desktop_lib.* \
-            "crates/tidebreak-desktop/binaries/tidebreak-host-broker-$RELEASE_TARGET"
+            target/{aarch64-apple-darwin,x86_64-apple-darwin,universal-apple-darwin}/release/tidebreak-desktop \
+            target/{aarch64-apple-darwin,x86_64-apple-darwin}/release/tidebreak-host-broker \
+            target/{aarch64-apple-darwin,x86_64-apple-darwin}/release/libtidebreak_desktop_lib.* \
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-{aarch64-apple-darwin,x86_64-apple-darwin} \
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-universal-apple-darwin
 
       # sccache, rust-cache, and the UI install run before any Apple or Tauri
       # material is on disk. pnpm is pinned; lifecycle scripts stay off.
@@ -343,7 +357,7 @@ jobs:
       - name: Install Rust target
         run: |
           rustup show
-          rustup target add "${{ matrix.target }}"
+          rustup target add aarch64-apple-darwin x86_64-apple-darwin
 
       - name: Write staging Tauri configuration
         env:
@@ -374,13 +388,13 @@ jobs:
         with:
           projectPath: crates/tidebreak-desktop
           args: >-
-            --target ${{ matrix.target }}
+            --target universal-apple-darwin
             --config ${{ runner.temp }}/tidebreak-staging.json
             --bundles app,dmg
 
       - name: Notarize and staple the DMG
         env:
-          RELEASE_TARGET: ${{ matrix.target }}
+          RELEASE_TARGET: universal-apple-darwin
         run: |
           target_dir="$(cargo metadata --format-version 1 --no-deps | jq -r .target_directory)"
           dmg_paths=("$target_dir/$RELEASE_TARGET/release/bundle/dmg/"*.dmg)
@@ -415,8 +429,8 @@ jobs:
 
       - name: Verify and collect signed artifacts
         env:
-          RELEASE_ARCH: ${{ matrix.arch }}
-          RELEASE_TARGET: ${{ matrix.target }}
+          RELEASE_ARCH: universal
+          RELEASE_TARGET: universal-apple-darwin
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
@@ -465,10 +479,21 @@ jobs:
           executable="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$app_path/Contents/Info.plist")"
           binary_arches="$(lipo -archs "$app_path/Contents/MacOS/$executable")"
           case "$RELEASE_ARCH" in
-            aarch64) [[ "$binary_arches" = *arm64* && "$binary_arches" != *x86_64* ]] ;;
+            universal) [[ "$binary_arches" = *arm64* && "$binary_arches" = *x86_64* ]] ;;
             *) echo "Unsupported staging architecture: $RELEASE_ARCH" >&2; exit 1 ;;
           esac || {
             echo "Expected $RELEASE_ARCH app, found Mach-O architectures: $binary_arches" >&2
+            exit 1
+          }
+
+          sidecar="$app_path/Contents/MacOS/tidebreak-host-broker"
+          [[ -x "$sidecar" ]] || {
+            echo "Universal staging app is missing its executable host broker: $sidecar" >&2
+            exit 1
+          }
+          sidecar_arches="$(lipo -archs "$sidecar")"
+          [[ "$sidecar_arches" = *arm64* && "$sidecar_arches" = *x86_64* ]] || {
+            echo "Expected universal staging host broker, found Mach-O architectures: $sidecar_arches" >&2
             exit 1
           }
 
@@ -494,8 +519,8 @@ jobs:
       - name: Upload verified macOS artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: tidebreak-staging-macos-${{ matrix.arch }}-${{ needs.validate_staging.outputs.version }}
-          path: dist/macos/${{ matrix.arch }}/
+          name: tidebreak-staging-macos-universal-${{ needs.validate_staging.outputs.version }}
+          path: dist/macos/universal/
           if-no-files-found: error
           retention-days: 7
 
@@ -567,11 +592,11 @@ jobs:
           role-session-name: tidebreak-staging-${{ github.run_id }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Download Apple Silicon artifacts
+      - name: Download universal macOS artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: tidebreak-staging-macos-aarch64-${{ needs.validate_staging.outputs.version }}
-          path: dist/macos/aarch64
+          name: tidebreak-staging-macos-universal-${{ needs.validate_staging.outputs.version }}
+          path: dist/macos/universal
 
       - name: Create staging manifests and checksums
         run: >-

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-macos-apple-silicon.dmg"><img src="https://img.shields.io/badge/Download%20for%20macOS-Apple%20Silicon-000000.svg?logo=apple&logoColor=white" alt="Download for macOS, Apple Silicon"></a>
+  <a href="https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-macos-apple-silicon.dmg"><img src="https://img.shields.io/badge/Download%20for%20macOS-000000.svg?logo=apple&logoColor=white" alt="Download the latest macOS release"></a>
 </p>
 
 ---
@@ -83,10 +83,9 @@ PDFs under [`skills/`](skills) and [`plugins/`](plugins).
 
 ## Download
 
-Tidebreak ships as a signed and notarized macOS app for **Apple Silicon**. Intel
-is paused while the product is in active development, and the release pipeline
-publishes one `aarch64` build ([`docs/releases.md`](docs/releases.md)). The
-button above always resolves to the newest release; the
+Tidebreak ships as one signed and notarized **universal macOS app** for Apple
+Silicon and Intel ([`docs/releases.md`](docs/releases.md)). The button above
+always resolves to the newest release; the
 [releases page](https://github.com/brightwave-inc/tidebreak/releases) has the
 notes and earlier versions.
 
@@ -168,7 +167,7 @@ place.
 
 Worth knowing before you install:
 
-- **Packaged builds are macOS on Apple Silicon only.** See
+- **Packaged builds are macOS only, for Apple Silicon and Intel.** See
   [Download](#download).
 - **The native execution sandbox is macOS-only.** On Linux or Windows there is
   no native confinement primitive; the choices are the opt-in local Docker

--- a/crates/tidebreak-desktop/README.md
+++ b/crates/tidebreak-desktop/README.md
@@ -70,6 +70,15 @@ broker and the default Tauri configuration includes it automatically:
 cargo tauri build
 ```
 
+For the release-shaped universal macOS bundle, install both Rust targets and
+select Tauri's synthetic universal target. The hook stages one broker per slice
+and combines those brokers with `lipo`; Tauri combines the app executable:
+
+```sh
+rustup target add aarch64-apple-darwin x86_64-apple-darwin
+cargo tauri build --target universal-apple-darwin
+```
+
 ## Run locally (browser UI against `tidebreak serve`)
 
 Useful when iterating on the React UI without rebuilding the native shell.

--- a/crates/tidebreak-desktop/scripts/prepare-sidecar.mjs
+++ b/crates/tidebreak-desktop/scripts/prepare-sidecar.mjs
@@ -18,35 +18,61 @@ const triple =
 if (!triple) {
   throw new Error("rustc did not report a host target triple");
 }
-const extension = triple.includes("windows") ? ".exe" : "";
-
-const cargoArgs = [
-  "build",
-  "-p",
-  "tidebreak-host-broker",
-  "--bin",
-  "tidebreak-host-broker",
-  "--locked",
-];
-if (release) cargoArgs.push("--release");
-if (configuredTarget) cargoArgs.push("--target", configuredTarget);
-execFileSync("cargo", cargoArgs, { cwd: workspaceDir, stdio: "inherit" });
-
 const targetRoot = process.env.CARGO_TARGET_DIR
   ? resolve(workspaceDir, process.env.CARGO_TARGET_DIR)
   : join(workspaceDir, "target");
-const source = join(
-  targetRoot,
-  ...(configuredTarget ? [configuredTarget] : []),
-  profile,
-  `tidebreak-host-broker${extension}`,
-);
 const destinationDir = join(desktopDir, "binaries");
-const destination = join(
-  destinationDir,
-  `tidebreak-host-broker-${triple}${extension}`,
-);
-
 mkdirSync(destinationDir, { recursive: true });
-copyFileSync(source, destination);
-if (process.platform !== "win32") chmodSync(destination, 0o755);
+
+// Tauri's synthetic universal target builds the app once per real Rust target
+// and lipo-combines the app executable. Its bundler expects an already-combined
+// external binary under the synthetic target name, while the per-target Cargo
+// builds still need their own target-suffixed sidecars.
+const targets =
+  triple === "universal-apple-darwin"
+    ? ["aarch64-apple-darwin", "x86_64-apple-darwin"]
+    : [triple];
+const stagedSidecars = [];
+
+for (const target of targets) {
+  const extension = target.includes("windows") ? ".exe" : "";
+  const cargoArgs = [
+    "build",
+    "-p",
+    "tidebreak-host-broker",
+    "--bin",
+    "tidebreak-host-broker",
+    "--locked",
+  ];
+  if (release) cargoArgs.push("--release");
+  if (configuredTarget) cargoArgs.push("--target", target);
+  execFileSync("cargo", cargoArgs, { cwd: workspaceDir, stdio: "inherit" });
+
+  const source = join(
+    targetRoot,
+    ...(configuredTarget ? [target] : []),
+    profile,
+    `tidebreak-host-broker${extension}`,
+  );
+  const destination = join(
+    destinationDir,
+    `tidebreak-host-broker-${target}${extension}`,
+  );
+
+  copyFileSync(source, destination);
+  if (process.platform !== "win32") chmodSync(destination, 0o755);
+  stagedSidecars.push(destination);
+}
+
+if (triple === "universal-apple-darwin") {
+  const destination = join(
+    destinationDir,
+    "tidebreak-host-broker-universal-apple-darwin",
+  );
+  execFileSync(
+    "lipo",
+    ["-create", ...stagedSidecars, "-output", destination],
+    { stdio: "inherit" },
+  );
+  chmodSync(destination, 0o755);
+}

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -161,7 +161,9 @@ automatic.
 8. A final job downloads every installer the immutable manifest lists back from
    the CDN, checks them against its digests, and attaches them to the GitHub
    Release with `.sha256` sidecars — today that is the notarized disk image as
-   `Tidebreak-macos-apple-silicon.dmg`, and it would again include
+   `Tidebreak-macos-universal.dmg`, plus the byte-identical legacy
+   `Tidebreak-macos-apple-silicon.dmg` alias that keeps the existing README URL
+   live through the transition. It would again include
    `Tidebreak-windows-x86_64-setup.exe` if the Windows lane were unparked. It
    holds no signing or AWS credentials. The names omit the version so that
    `https://github.com/brightwave-inc/tidebreak/releases/latest/download/<name>`
@@ -176,27 +178,26 @@ not the shipping signal.
 
 ## Public desktop delivery
 
-### Apple Silicon only, for now
+### One universal macOS application
 
-A release ships one `aarch64` build. Intel is paused while the product is in
-active development. Cross-compiling `x86_64` on GitHub's arm64 macOS runners
-takes roughly two and a half times as long as the native build for the
-identical crate set — about 18 minutes against 7 on a recent release — so the
-Intel job, not the one anybody installs, set the length of every release and
-cache-warm run. No one on the team or in early testing uses an Intel Mac.
+A release ships one universal app, DMG, zip, and signed updater archive. Tauri
+builds the desktop for both `aarch64-apple-darwin` and
+`x86_64-apple-darwin` and combines the app executable. The before-build hook
+builds the host broker for both targets and combines those slices with `lipo`
+before bundling. Release verification rejects the bundle unless both the main
+executable and the host broker contain both slices.
 
 `RELEASE_PLATFORMS` in `scripts/create-release-manifests.mjs` is the single
 source of truth for what a release contains: it drives the manifest, the
-`latest.json` platform keys, and the immutable prefix below. Restoring Intel
-means adding `x86_64` to the macOS entry there and adding its row back to the
-two macOS `release.yml` build matrices and the `cache-macos.yml` warm matrix.
+`latest.json` platform keys, and the immutable prefix below. The immutable
+manifest contains one `macos/universal` artifact set; `latest.json` advertises
+that same signed updater archive under both `darwin-aarch64` and
+`darwin-x86_64`, so either native updater downloads identical universal bytes.
 
-Two consequences worth knowing. `latest.json` advertises only the platforms in
-that table, so an unsupported install finds no update rather than a broken
-one. And the preflight that resumes an already-hosted release validates it
-against the current platform set, so a release published before a platform
-change cannot be re-dispatched; it fails on the artifact count instead of
-silently republishing.
+The preflight that resumes an already-hosted release validates it against the
+current platform set. A release published before this platform change cannot
+be re-dispatched: it fails on the artifact paths and updater keys instead of
+silently republishing a different release shape.
 
 ### Windows: parked, unsigned x86_64 when it returns
 

--- a/scripts/create-release-manifests.mjs
+++ b/scripts/create-release-manifests.mjs
@@ -17,8 +17,8 @@ import { parseStagingVersion, stagingTag } from "./staging-version.mjs";
 // The platforms, architectures, and artifact formats a release ships. This is
 // the single source of truth for what a release contains: it drives the
 // manifest, the `latest.json` platform keys, and the immutable hosting prefix.
-// macOS is Apple Silicon only while the product is in active development; see
-// docs/releases.md.
+// macOS ships one universal artifact whose signed updater archive is advertised
+// to both native architectures; see docs/releases.md.
 //
 // Windows packaging is paused (see docs/deferred.md), so no release currently
 // carries a Windows artifact. The descriptor is retained rather than deleted:
@@ -37,7 +37,8 @@ export const RELEASE_PLATFORMS = [
   {
     platform: "macos",
     updaterPlatform: "darwin",
-    architectures: ["aarch64"],
+    architectures: ["universal"],
+    updaterArchitectures: ["aarch64", "x86_64"],
     formats: [
       { extension: ".dmg", format: "dmg" },
       { extension: ".app.zip", format: "app.zip" },
@@ -102,10 +103,9 @@ export function createLatestDocument({ version, publishedAt, artifacts }) {
           `invalid ${descriptor.platform} updater artifact in release manifest`,
         );
       }
-      updaterArtifacts.set(
-        `${descriptor.updaterPlatform}-${artifact.arch}`,
-        artifact,
-      );
+      for (const arch of descriptor.updaterArchitectures ?? [artifact.arch]) {
+        updaterArtifacts.set(`${descriptor.updaterPlatform}-${arch}`, artifact);
+      }
     }
   }
 
@@ -114,16 +114,18 @@ export function createLatestDocument({ version, publishedAt, artifacts }) {
     pub_date: publishedAt,
     platforms: Object.fromEntries(
       RELEASE_PLATFORMS.flatMap((descriptor) =>
-        descriptor.architectures.map((arch) => {
-          const key = `${descriptor.updaterPlatform}-${arch}`;
-          const artifact = updaterArtifacts.get(key);
-          if (!artifact) {
-            throw new Error(
-              `missing ${key} updater artifact in release manifest`,
-            );
-          }
-          return [key, { signature: artifact.signature, url: artifact.url }];
-        }),
+        (descriptor.updaterArchitectures ?? descriptor.architectures).map(
+          (arch) => {
+            const key = `${descriptor.updaterPlatform}-${arch}`;
+            const artifact = updaterArtifacts.get(key);
+            if (!artifact) {
+              throw new Error(
+                `missing ${key} updater artifact in release manifest`,
+              );
+            }
+            return [key, { signature: artifact.signature, url: artifact.url }];
+          },
+        ),
       ),
     ),
   };

--- a/scripts/create-release-manifests.test.mjs
+++ b/scripts/create-release-manifests.test.mjs
@@ -52,14 +52,21 @@ test("creates a complete manifest and Tauri updater document", () => {
   const { manifest, latest } = createReleaseManifests({ dist, ...RELEASE });
 
   assert.equal(manifest.artifacts.length, EXPECTED_ARTIFACT_COUNT);
-  assert.deepEqual(Object.keys(latest.platforms), ["darwin-aarch64"]);
+  assert.deepEqual(Object.keys(latest.platforms), [
+    "darwin-aarch64",
+    "darwin-x86_64",
+  ]);
   assert.match(
     latest.platforms["darwin-aarch64"].url,
-    /releases\/v0\.4\.2\/macos\/aarch64\/Tidebreak_0\.4\.2_aarch64\.app\.tar\.gz$/,
+    /releases\/v0\.4\.2\/macos\/universal\/Tidebreak_0\.4\.2_universal\.app\.tar\.gz$/,
   );
   assert.equal(
     latest.platforms["darwin-aarch64"].signature,
-    "signature-macos-aarch64",
+    "signature-macos-universal",
+  );
+  assert.deepEqual(
+    latest.platforms["darwin-x86_64"],
+    latest.platforms["darwin-aarch64"],
   );
 
   const diskManifest = JSON.parse(
@@ -81,8 +88,8 @@ test("fails closed when an architecture is incomplete", () => {
   const missing = path.join(
     dist,
     "macos",
-    "aarch64",
-    "Tidebreak_0.4.2_aarch64.app.tar.gz.sig",
+    "universal",
+    "Tidebreak_0.4.2_universal.app.tar.gz.sig",
   );
   writeFileSync(missing, "");
 

--- a/scripts/workflow-security-mutations.test.mjs
+++ b/scripts/workflow-security-mutations.test.mjs
@@ -25,6 +25,7 @@ const fixturePaths = [
   "crates/tidebreak-desktop/src/lib.rs",
   "crates/tidebreak-desktop/src/updater.rs",
   "crates/tidebreak-desktop/src/broker.rs",
+  "crates/tidebreak-desktop/scripts/prepare-sidecar.mjs",
   "deploy/self-host/Dockerfile.dockerignore",
   "crates/tidebreak-sandbox-agent/Dockerfile.dockerignore",
   "scripts/stage-self-host-build-context.sh",


### PR DESCRIPTION
## Summary

- build production, staging, and cache-warm macOS jobs with Tauri’s universal-apple-darwin target
- compile the host broker for arm64 and x86_64, combine it with lipo, and verify both slices in the signed app bundle
- publish one macos/universal artifact set while advertising its signed updater archive under both darwin-aarch64 and darwin-x86_64
- preserve the existing Apple Silicon GitHub download filename as a byte-identical compatibility alias while introducing Tidebreak-macos-universal.dmg
- update release documentation and workflow policy coverage for the new packaging contract

## Compatibility

Existing Apple Silicon installations continue to receive updates through darwin-aarch64. Intel installations use darwin-x86_64; both keys resolve to the same universal updater archive. The existing permanent README download URL remains valid through the compatibility asset alias.

Previously published arm64-only immutable releases cannot be resumed under the new platform descriptor, and fail closed during hosted-release validation rather than being republished with a different artifact shape.

## Safety and risk

The signing jobs still restore only credential-free compiler outputs and discard all restored linked products before rebuilding with signing material. Release and staging verification now reject the bundle unless both the main executable and host-broker sidecar contain arm64 and x86_64 slices.

The main operational risk is increased macOS compilation time because both Rust targets are built sequentially. The release and cache jobs retain their existing 60-minute timeouts and use a single cache archive containing both slices.

## Validation

- cargo tauri build --target universal-apple-darwin --no-bundle --ci
- cargo tauri build --target universal-apple-darwin --bundles app --no-sign --ci
- verified the bundled app executable reports x86_64 arm64 with lipo -archs
- verified the bundled host broker reports x86_64 arm64 with lipo -archs
- actionlint on all changed workflows
- manifest and workflow-security test suites: 62 tests passed
- Node syntax checks for the sidecar and manifest scripts
- git diff --check