### PR TITLE
feat(desktop): add native read-only workbook viewer

### DIFF
--- a/crates/tidebreak-desktop/ui/package.json
+++ b/crates/tidebreak-desktop/ui/package.json
@@ -13,6 +13,8 @@
     "tauri": "cargo tauri"
   },
   "dependencies": {
+    "@dukelib/sheets-wasm": "0.1.23",
+    "@extend-ai/react-xlsx": "0.16.1",
     "@radix-ui/react-alert-dialog": "1.1.23",
     "@radix-ui/react-checkbox": "1.3.11",
     "@radix-ui/react-dialog": "1.1.23",

--- a/crates/tidebreak-desktop/ui/pnpm-lock.yaml
+++ b/crates/tidebreak-desktop/ui/pnpm-lock.yaml
@@ -5,12 +5,19 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@dukelib/sheets-wasm@0.1.21': 0.1.23
   nanoid@5.1.11: 5.1.16
 
 importers:
 
   .:
     dependencies:
+      '@dukelib/sheets-wasm':
+        specifier: 0.1.23
+        version: 0.1.23
+      '@extend-ai/react-xlsx':
+        specifier: 0.16.1
+        version: 0.16.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-alert-dialog':
         specifier: 1.1.23
         version: 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -337,6 +344,9 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
+  '@dukelib/sheets-wasm@0.1.23':
+    resolution: {integrity: sha512-E/vHXR2I/EodNCpyVcFq0p8/u5qxmKxatUZvB7bsFfghUPQ2GMxg81MBFjOEQtLKXnzR7xjXOyzPzBTLbv2e1g==}
+
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
@@ -501,6 +511,12 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@extend-ai/react-xlsx@0.16.1':
+    resolution: {integrity: sha512-yDaBv4YzpDi91OH16oN8aBxO+JySyn1cOPdA7cus1hjDSIjU4ddCyKSPDoMG5CoFdFZQNNovjG6zjpbZQ1bfow==}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
 
   '@flatten-js/interval-tree@1.1.3':
     resolution: {integrity: sha512-xhFWUBoHJFF77cJO1D6REjdgJEMRf2Y2Z+eKEPav8evGKcLSnj1ud5pLXQSbGuxF3VSvT1rWhMfVpXEKJLTL+A==}
@@ -1070,79 +1086,66 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
@@ -1212,28 +1215,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
     resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
     resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.3':
     resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.3':
     resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
@@ -1285,12 +1284,21 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  '@tanstack/react-virtual@3.14.9':
+    resolution: {integrity: sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/router-core@1.171.21':
     resolution: {integrity: sha512-t6xUHBO94nQDrPHPh6ag5UuKHWIkVjq9s63q2ctbxgzq3vtSoGKmAIdLD5o+NU6JUS1ppXRHgL0YGzEHvH32Ng==}
     engines: {node: '>=20.19'}
 
   '@tanstack/store@0.9.3':
     resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
+
+  '@tanstack/virtual-core@3.17.7':
+    resolution: {integrity: sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==}
 
   '@tauri-apps/api@2.11.1':
     resolution: {integrity: sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==}
@@ -2108,6 +2116,9 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
@@ -2130,6 +2141,50 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -2260,6 +2315,9 @@ packages:
   fflate@0.4.9:
     resolution: {integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==}
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   franc-min@6.2.0:
     resolution: {integrity: sha512-1uDIEUSlUZgvJa2AKYR/dmJC66v/PvGQ9mWfI9nOr/kPpMFyvswK0gPXOwpYJYiYD008PpHLkGfG58SPjQJFxw==}
 
@@ -2348,6 +2406,10 @@ packages:
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -2463,28 +2525,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2949,6 +3007,9 @@ packages:
     resolution: {integrity: sha512-GP6h9OgJmhAZpb3dbNbXTfRWVnGcoMhWRZv/HxgM4/qCVqs1P9ukQdYxaUhjWBSAs9oJ/uPXUUvGT1VMe0Bs0Q==}
     engines: {node: '>=16'}
 
+  regl@2.1.1:
+    resolution: {integrity: sha512-+IOGrxl3FZ8ZM9ixCWQZzFRiRn7Rzn9bu3iFHwg/yz4tlOUQgbO4PHLgG+1ZT60zcIV8tief6Qrmyl8qcoJP0g==}
+
   rehype-highlight@7.0.2:
     resolution: {integrity: sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==}
 
@@ -3143,6 +3204,10 @@ packages:
     resolution: {integrity: sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==}
     hasBin: true
 
+  topojson-client@3.1.0:
+    resolution: {integrity: sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==}
+    hasBin: true
+
   tough-cookie@6.0.2:
     resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
     engines: {node: '>=16'}
@@ -3214,6 +3279,9 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  us-atlas@3.0.1:
+    resolution: {integrity: sha512-wEIZCq0ImPvGblTd8gZMqNNCPkQshugMUG/8nkSWXb02+XqNFREg9atHOKP9w6prLZTpqcLhSvdBW81MkV3/0Q==}
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -3355,6 +3423,9 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  world-atlas@2.0.2:
+    resolution: {integrity: sha512-IXfV0qwlKXpckz1FhwXVwKRjiIhOnWttOskm5CtxMsjgE/MXAYRHWJqgXOpM8IkcPBoXnyTU5lFHcYa5ChG0LQ==}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -3578,6 +3649,8 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
+  '@dukelib/sheets-wasm@0.1.23': {}
+
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
@@ -3659,6 +3732,22 @@ snapshots:
   '@exodus/bytes@1.15.1(@noble/hashes@2.2.0)':
     optionalDependencies:
       '@noble/hashes': 2.2.0
+
+  '@extend-ai/react-xlsx@0.16.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@dukelib/sheets-wasm': 0.1.23
+      '@tanstack/react-virtual': 3.14.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      fflate: 0.8.3
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      regl: 2.1.1
+      topojson-client: 3.1.0
+      us-atlas: 3.0.1
+      world-atlas: 2.0.2
 
   '@flatten-js/interval-tree@1.1.3': {}
 
@@ -4367,6 +4456,12 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       use-sync-external-store: 1.6.0(react@19.2.7)
 
+  '@tanstack/react-virtual@3.14.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.7
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@tanstack/router-core@1.171.21':
     dependencies:
       '@tanstack/history': 1.162.1
@@ -4375,6 +4470,8 @@ snapshots:
       seroval-plugins: 1.6.2(seroval@1.6.2)
 
   '@tanstack/store@0.9.3': {}
+
+  '@tanstack/virtual-core@3.17.7': {}
 
   '@tauri-apps/api@2.11.1': {}
 
@@ -6080,6 +6177,8 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
+  commander@2.20.3: {}
+
   commander@8.3.0: {}
 
   convert-source-map@2.0.0: {}
@@ -6096,6 +6195,46 @@ snapshots:
   css.escape@1.5.1: {}
 
   csstype@3.2.3: {}
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
 
   data-urls@7.0.0(@noble/hashes@2.2.0):
     dependencies:
@@ -6223,6 +6362,8 @@ snapshots:
 
   fflate@0.4.9: {}
 
+  fflate@0.8.3: {}
+
   franc-min@6.2.0:
     dependencies:
       trigram-utils: 2.0.1
@@ -6347,6 +6488,8 @@ snapshots:
     optional: true
 
   inline-style-parser@0.2.7: {}
+
+  internmap@2.0.3: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -7180,6 +7323,8 @@ snapshots:
 
   regexp-util@2.0.3: {}
 
+  regl@2.1.1: {}
+
   rehype-highlight@7.0.2:
     dependencies:
       '@types/hast': 3.0.5
@@ -7426,6 +7571,10 @@ snapshots:
     dependencies:
       tldts-core: 7.4.9
 
+  topojson-client@3.1.0:
+    dependencies:
+      commander: 2.20.3
+
   tough-cookie@6.0.2:
     dependencies:
       tldts: 7.4.9
@@ -7510,6 +7659,8 @@ snapshots:
       browserslist: 4.28.5
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  us-atlas@3.0.1: {}
 
   use-callback-ref@1.3.3(@types/react@19.2.17)(react@19.2.7):
     dependencies:
@@ -7653,6 +7804,8 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  world-atlas@2.0.2: {}
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/crates/tidebreak-desktop/ui/pnpm-workspace.yaml
+++ b/crates/tidebreak-desktop/ui/pnpm-workspace.yaml
@@ -1,6 +1,10 @@
 # Build-script approvals in both formats: `allowBuilds` for pnpm >= 11,
 # `onlyBuiltDependencies` for pnpm 10 (what CI pins). Keep the lists in sync.
 overrides:
+  # react-xlsx 0.16.1 pins 0.1.21, whose XLSX drawing parser misses
+  # self-closing chart references. 0.1.23 is API-compatible and restores the
+  # worksheet chart layer for read-only previews.
+  '@dukelib/sheets-wasm@0.1.21': 0.1.23
   nanoid@5.1.11: 5.1.16
 allowBuilds:
   canvas: true

--- a/crates/tidebreak-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
@@ -48,10 +48,20 @@ vi.mock("@/document/PdfViewer", async () => {
   };
 });
 
-// Univer renders to a canvas through a worker, which jsdom has neither of. The
-// stand-in reports the range the panel handed it, which is the part the panel
-// is responsible for; selecting and scrolling to those cells is the viewer's
-// own, and it already did that before anything produced a range.
+// Spreadsheet viewers render to a canvas through a worker, which jsdom has
+// neither of. These stand-ins report the range the panel handed them, which is
+// the part the panel is responsible for; selecting and scrolling to those
+// cells is the viewer's own behavior.
+vi.mock("@/document/NativeSpreadsheetViewer", () => ({
+  default: ({ highlightRange }: { highlightRange?: SheetHighlightRange }) => (
+    <div>
+      {highlightRange
+        ? `Sheet ${highlightRange.sheetName} ${highlightRange.startCell}:${highlightRange.endCell}`
+        : "Workbook"}
+    </div>
+  ),
+}));
+
 vi.mock("@/document/UniverSpreadsheetViewer", () => ({
   default: ({ highlightRange }: { highlightRange?: SheetHighlightRange }) => (
     <div>

--- a/crates/tidebreak-desktop/ui/src/document/NativeSpreadsheetViewer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/NativeSpreadsheetViewer.dom.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const xlsxMocks = vi.hoisted(() => {
+  const controller = {
+    activeCellAddress: "B7",
+    activeSheet: {
+      colWidthOverridesPx: {},
+      defaultColWidthPx: 64,
+      defaultRowHeightPx: 20,
+      hiddenCols: [],
+      hiddenRows: [],
+      rowHeightOverridesPx: {},
+    },
+    activeTabIndex: 0,
+    canZoomIn: true,
+    canZoomOut: true,
+    error: null,
+    isLoading: false,
+    resetZoom: vi.fn(),
+    selectRange: vi.fn(),
+    selectedFormula: "=SUM(B2:B6)",
+    selectedFormulaTarget: { kind: "cell", cell: { row: 6, col: 1 } },
+    selectedRangeAddress: "B7:D9",
+    selectedValue: "42",
+    setActiveTabIndex: vi.fn(),
+    tabs: [
+      { id: "sheet-revenue", kind: "sheet", name: "Revenue", sheetIndex: 0 },
+      { id: "sheet-costs", kind: "sheet", name: "Costs", sheetIndex: 1 },
+    ],
+    zoomIn: vi.fn(),
+    zoomOut: vi.fn(),
+    zoomScale: 100,
+  };
+
+  return {
+    controller,
+    setWasmSource: vi.fn(),
+    useXlsxViewerController: vi.fn(() => controller),
+    xlsxViewer: vi.fn(),
+  };
+});
+
+vi.mock("@dukelib/sheets-wasm/duke_sheets_wasm_bg.wasm?url", () => ({
+  default: "/assets/duke_sheets_wasm_bg.wasm",
+}));
+
+vi.mock("@extend-ai/react-xlsx", () => ({
+  setWasmSource: xlsxMocks.setWasmSource,
+  useXlsxViewerController: xlsxMocks.useXlsxViewerController,
+  XlsxViewer: (props: { toolbar?: ReactNode }) => {
+    xlsxMocks.xlsxViewer(props);
+    return <div data-testid="xlsx-canvas">{props.toolbar}</div>;
+  },
+}));
+
+vi.mock("@/document/useFileDownload", () => ({
+  useFileDownload: () => ({
+    data: new ArrayBuffer(8),
+    error: null,
+    isLoading: false,
+    progress: null,
+  }),
+}));
+
+import NativeSpreadsheetViewer from "./NativeSpreadsheetViewer";
+import type { FileBytesSource } from "./useFileDownload";
+
+const source: FileBytesSource = {
+  id: "book-1",
+  cacheKey: "output/book-1",
+  fetch: vi.fn(),
+};
+
+describe("NativeSpreadsheetViewer", () => {
+  beforeEach(() => {
+    xlsxMocks.useXlsxViewerController.mockClear();
+    xlsxMocks.xlsxViewer.mockClear();
+    xlsxMocks.controller.selectRange.mockClear();
+    xlsxMocks.controller.setActiveTabIndex.mockClear();
+  });
+  afterEach(cleanup);
+
+  it("preserves cached Excel results and exposes a read-only canvas", async () => {
+    render(
+      <NativeSpreadsheetViewer
+        source={source}
+        mediaType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+      />,
+    );
+
+    expect(await screen.findByTestId("xlsx-canvas")).toBeInTheDocument();
+    expect(xlsxMocks.useXlsxViewerController).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileName: "workbook.xlsx",
+        maxFileSizeBytes: 16 * 1024 * 1024,
+        readOnly: true,
+        useWorker: true,
+      }),
+    );
+    expect(xlsxMocks.xlsxViewer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowResizeInReadOnly: false,
+        getCellStyle: expect.any(Function),
+        isDark: false,
+        readOnly: true,
+        showDefaultToolbar: false,
+        showImages: true,
+      }),
+    );
+    expect(screen.getByLabelText("Selected cell or range")).toHaveTextContent(
+      "B7:D9",
+    );
+    expect(screen.getByLabelText("Cell value or formula")).toHaveTextContent(
+      "=SUM(B2:B6)",
+    );
+    expect(screen.getByRole("tab", { name: "Revenue" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    const viewerProps = xlsxMocks.xlsxViewer.mock.lastCall?.[0] as {
+      getCellStyle: (context: unknown) => React.CSSProperties | undefined;
+    };
+    const context = {
+      cell: { row: 6, col: 0 },
+      hasChartHighlight: false,
+      hasConditionalFormat: false,
+      hasHyperlink: false,
+      hasValidation: false,
+      isMerged: true,
+      isTableHeader: false,
+      resolvedStyle: { fontSize: "24px", textAlign: "left" },
+      sheetName: "Executive Dashboard",
+      value: "$17,493,399",
+      workbookSheetIndex: 0,
+    };
+    expect(viewerProps.getCellStyle(context)).toEqual({ textAlign: "center" });
+    expect(
+      viewerProps.getCellStyle({ ...context, value: "Launch thesis" }),
+    ).toBeUndefined();
+  });
+
+  it("selects a cited A1 range on the cited sheet", async () => {
+    render(
+      <NativeSpreadsheetViewer
+        source={source}
+        mediaType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        highlightRange={{
+          startCell: "C4",
+          endCell: "E8",
+          sheetName: "Revenue",
+          sheetIndex: null,
+        }}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(xlsxMocks.controller.selectRange).toHaveBeenCalledWith({
+        start: { row: 3, col: 2 },
+        end: { row: 7, col: 4 },
+      }),
+    );
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/document/NativeSpreadsheetViewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/NativeSpreadsheetViewer.tsx
@@ -1,0 +1,688 @@
+import {
+  XlsxViewer,
+  type XlsxCellRange,
+  type XlsxCellStyleContext,
+  type XlsxScrollerRenderProps,
+  type XlsxSheetData,
+  type XlsxViewerController,
+  setWasmSource,
+  useXlsxViewerController,
+} from "@extend-ai/react-xlsx";
+import workbookWasmUrl from "@dukelib/sheets-wasm/duke_sheets_wasm_bg.wasm?url";
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  FunctionSquareIcon,
+  Loader2Icon,
+  MinusIcon,
+  PlusIcon,
+} from "lucide-react";
+import {
+  type HTMLAttributes,
+  type MutableRefObject,
+  type ReactNode,
+  type Ref,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { FileDownloadProgressIndicator } from "@/components/document/FileDownloadProgress";
+import { Button } from "@/components/ui/button";
+import type { SheetHighlightRange } from "@/document/UniverSpreadsheetViewer";
+import {
+  projectWorkbookForReadOnlyDisplay,
+  type ReadOnlyConditionalCellStyle,
+  type ReadOnlyWorkbookProjection,
+} from "@/document/readOnlyWorkbookProjection";
+import {
+  useFileDownload,
+  type FileBytesSource,
+} from "@/document/useFileDownload";
+import { cn } from "@/lib/utils";
+
+// Make the parser asset an application resource. The viewer's default loader
+// can discover its package-relative WASM in a browser build, but an explicit
+// Vite asset URL also survives Tauri's production asset protocol and is passed
+// into the worker without a network dependency.
+setWasmSource(workbookWasmUrl);
+
+interface Props extends HTMLAttributes<HTMLDivElement> {
+  source: FileBytesSource;
+  mediaType: string;
+  highlightRange?: SheetHighlightRange;
+}
+
+const MAX_WORKBOOK_BYTES = 16 * 1024 * 1024;
+const LIGHT_WORKBOOK_SURFACE =
+  "bg-white text-zinc-950 [color-scheme:light] [--accent:#f4f4f5] [--accent-foreground:#18181b] [--background:#fff] [--border:#e4e4e7] [--foreground:#09090b] [--muted:#f4f4f5] [--muted-foreground:#71717a]";
+const LARGE_MERGED_VALUE_PATTERN =
+  /^(?:[$€£¥]\s*)?\(?-?\d[\d,\s]*(?:\.\d+)?%?\)?$/;
+
+/**
+ * A native workbook surface: original OOXML is prepared as a read-only display
+ * copy, parsed by a local WebAssembly engine, and drawn as a virtualized canvas
+ * workbook. Nothing is flattened into PDF or reconstructed through the legacy
+ * SheetJS/Univer path.
+ */
+export default function NativeSpreadsheetViewer({
+  source,
+  mediaType,
+  highlightRange,
+  className,
+  ...restProps
+}: Props) {
+  const fileDownload = useFileDownload(source, { parseAs: "arrayBuffer" });
+
+  if (fileDownload.isLoading) {
+    return (
+      <div
+        className={cn(LIGHT_WORKBOOK_SURFACE, "relative min-h-0", className)}
+        {...restProps}
+      >
+        {fileDownload.progress ? (
+          <FileDownloadProgressIndicator progress={fileDownload.progress} />
+        ) : (
+          <ViewerMessage spinner>Loading workbook…</ViewerMessage>
+        )}
+      </div>
+    );
+  }
+
+  if (fileDownload.error || fileDownload.data === null) {
+    return (
+      <div
+        className={cn(LIGHT_WORKBOOK_SURFACE, "relative min-h-0", className)}
+        {...restProps}
+      >
+        <ViewerMessage>This workbook could not be loaded.</ViewerMessage>
+      </div>
+    );
+  }
+
+  return (
+    <LoadedWorkbook
+      key={source.cacheKey}
+      data={fileDownload.data}
+      mediaType={mediaType}
+      highlightRange={highlightRange}
+      className={className}
+      {...restProps}
+    />
+  );
+}
+
+interface LoadedWorkbookProps extends HTMLAttributes<HTMLDivElement> {
+  data: ArrayBuffer;
+  mediaType: string;
+  highlightRange?: SheetHighlightRange;
+}
+
+function LoadedWorkbook({
+  data,
+  mediaType,
+  highlightRange,
+  className,
+  ...restProps
+}: LoadedWorkbookProps) {
+  const projection = useReadOnlyProjection(data);
+
+  if (projection.error) {
+    return (
+      <div
+        className={cn(LIGHT_WORKBOOK_SURFACE, "relative min-h-0", className)}
+        {...restProps}
+      >
+        <ViewerMessage>This workbook could not be prepared.</ViewerMessage>
+      </div>
+    );
+  }
+
+  if (!projection.value) {
+    return (
+      <div
+        className={cn(LIGHT_WORKBOOK_SURFACE, "relative min-h-0", className)}
+        {...restProps}
+      >
+        <ViewerMessage spinner>Preparing workbook…</ViewerMessage>
+      </div>
+    );
+  }
+
+  return (
+    <RenderedWorkbook
+      data={projection.value.data}
+      conditionalStylesBySheet={projection.value.conditionalStylesBySheet}
+      formulasBySheet={projection.value.formulasBySheet}
+      mediaType={mediaType}
+      highlightRange={highlightRange}
+      className={className}
+      {...restProps}
+    />
+  );
+}
+
+interface RenderedWorkbookProps extends LoadedWorkbookProps {
+  conditionalStylesBySheet: Record<
+    number,
+    Record<string, ReadOnlyConditionalCellStyle>
+  >;
+  formulasBySheet: Record<number, Record<string, string>>;
+}
+
+function RenderedWorkbook({
+  data,
+  conditionalStylesBySheet,
+  formulasBySheet,
+  mediaType,
+  highlightRange,
+  className,
+  ...restProps
+}: RenderedWorkbookProps) {
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const controller = useXlsxViewerController({
+    file: data,
+    fileName: workbookFileName(mediaType),
+    maxFileSizeBytes: MAX_WORKBOOK_BYTES,
+    readOnly: true,
+    useWorker: true,
+  });
+
+  useCitationNavigation(controller, viewportRef, highlightRange);
+
+  const getCellStyle = useCallback(
+    (context: XlsxCellStyleContext) =>
+      readOnlyCellStyle(context, conditionalStylesBySheet),
+    [conditionalStylesBySheet],
+  );
+
+  const renderScroller = useCallback(
+    ({ children, viewportProps }: XlsxScrollerRenderProps) => {
+      const { ref, ...props } = viewportProps;
+      return (
+        <div
+          {...props}
+          ref={(node) => {
+            viewportRef.current = node;
+            assignRef(ref, node);
+          }}
+        >
+          {children}
+        </div>
+      );
+    },
+    [],
+  );
+
+  const toolbar = useMemo(
+    () => (
+      <WorkbookToolbar
+        controller={controller}
+        formulasBySheet={formulasBySheet}
+      />
+    ),
+    [controller, formulasBySheet],
+  );
+
+  return (
+    <div
+      className={cn(
+        LIGHT_WORKBOOK_SURFACE,
+        "min-h-0 overflow-hidden",
+        className,
+      )}
+      {...restProps}
+    >
+      <XlsxViewer
+        controller={controller}
+        allowResizeInReadOnly={false}
+        className="h-full min-h-0"
+        enableCanvasSelectionAnimation
+        enableGestureZoom
+        errorState={(error) => (
+          <ViewerMessage>
+            <span className="block">This workbook could not be read.</span>
+            <span className="mt-1 block text-xs">{error.message}</span>
+          </ViewerMessage>
+        )}
+        experimentalCanvas
+        getCellStyle={getCellStyle}
+        isDark={false}
+        loadingState={
+          <ViewerMessage spinner>Reading workbook…</ViewerMessage>
+        }
+        readOnly
+        renderScroller={renderScroller}
+        renderTableHeaderMenu={() => null}
+        rounded={false}
+        selectionColor="#0285ff"
+        selectionFillColor="rgba(2, 133, 255, 0.10)"
+        selectionHeaderColor="rgba(2, 133, 255, 0.16)"
+        showDefaultToolbar={false}
+        showImages
+        toolbar={toolbar}
+      />
+    </div>
+  );
+}
+
+function readOnlyCellStyle({
+  cell,
+  isMerged,
+  resolvedStyle,
+  value,
+  workbookSheetIndex,
+}: XlsxCellStyleContext,
+  conditionalStylesBySheet: Record<
+    number,
+    Record<string, ReadOnlyConditionalCellStyle>
+  >,
+) {
+  const projectedStyle =
+    conditionalStylesBySheet[workbookSheetIndex]?.[cellAddress(cell)];
+  const style: React.CSSProperties = {};
+
+  if (projectedStyle?.backgroundColor) {
+    style.backgroundColor = projectedStyle.backgroundColor;
+  }
+  if (projectedStyle?.dataBar) {
+    const baseColor =
+      typeof resolvedStyle.backgroundColor === "string" &&
+      resolvedStyle.backgroundColor !== "transparent"
+        ? resolvedStyle.backgroundColor
+        : "#ffffff";
+    const width = projectedStyle.dataBar.widthPercent;
+    const startColor = tintHex(projectedStyle.dataBar.color, 0.1);
+    const endColor = tintHex(projectedStyle.dataBar.color, 0.72);
+    style.backgroundImage = `linear-gradient(90deg, ${startColor} 0%, ${endColor} ${width}%, ${baseColor} ${width}%, ${baseColor} 100%)`;
+  }
+  if (
+    isMerged &&
+    cssPixelValue(resolvedStyle.fontSize) >= 20 &&
+    LARGE_MERGED_VALUE_PATTERN.test(value.trim())
+  ) {
+    style.textAlign = "center";
+  }
+  return Object.keys(style).length > 0 ? style : undefined;
+}
+
+function tintHex(color: string, amount: number): string {
+  const match = color.match(/^#([0-9a-f]{6})$/i);
+  if (!match?.[1]) return color;
+  const ratio = Math.max(0, Math.min(1, amount));
+  const channels = [0, 2, 4].map((index) =>
+    Number.parseInt(match[1]!.slice(index, index + 2), 16),
+  );
+  return `rgb(${channels
+    .map((channel) => Math.round(channel + (255 - channel) * ratio))
+    .join(", ")})`;
+}
+
+function cssPixelValue(value: React.CSSProperties["fontSize"]): number {
+  if (typeof value === "number") return value;
+  if (typeof value !== "string") return 0;
+
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed)) return 0;
+  return value.trim().toLowerCase().endsWith("pt") ? (parsed * 4) / 3 : parsed;
+}
+
+function WorkbookToolbar({
+  controller,
+  formulasBySheet,
+}: {
+  controller: XlsxViewerController;
+  formulasBySheet: Record<number, Record<string, string>>;
+}) {
+  const address =
+    controller.selectedRangeAddress ?? controller.activeCellAddress ?? "";
+  const originalFormula = selectedOriginalFormula(controller, formulasBySheet);
+  const formula =
+    originalFormula ??
+    (controller.selectedFormula || controller.selectedValue || "");
+  const selectedTab = controller.tabs[controller.activeTabIndex];
+
+  return (
+    <div className="shrink-0 border-b bg-background">
+      <div className="flex h-10 min-w-0 items-center border-b">
+        <output
+          aria-label="Selected cell or range"
+          className="flex h-full w-24 shrink-0 items-center border-r px-3 font-mono text-xs font-medium text-foreground"
+        >
+          {address || "—"}
+        </output>
+        <span
+          aria-hidden="true"
+          className="flex h-full w-10 shrink-0 items-center justify-center border-r text-muted-foreground"
+        >
+          <FunctionSquareIcon className="size-4" />
+        </span>
+        <output
+          aria-label="Cell value or formula"
+          className="min-w-0 grow truncate px-3 font-mono text-xs text-foreground"
+          title={formula}
+        >
+          {formula}
+        </output>
+        <div className="flex h-full shrink-0 items-center gap-0.5 border-l px-2">
+          <Button
+            aria-label="Zoom out"
+            disabled={!controller.canZoomOut}
+            onClick={controller.zoomOut}
+            size="icon-sm"
+            variant="ghost"
+          >
+            <MinusIcon />
+          </Button>
+          <Button
+            aria-label="Reset zoom"
+            className="min-w-14 px-2 font-mono text-xs"
+            onClick={controller.resetZoom}
+            size="sm"
+            variant="ghost"
+          >
+            {Math.round(controller.zoomScale)}%
+          </Button>
+          <Button
+            aria-label="Zoom in"
+            disabled={!controller.canZoomIn}
+            onClick={controller.zoomIn}
+            size="icon-sm"
+            variant="ghost"
+          >
+            <PlusIcon />
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex h-9 min-w-0 items-stretch bg-muted/30">
+        <Button
+          aria-label="Previous sheet"
+          className="h-full rounded-none border-r px-2"
+          disabled={controller.activeTabIndex <= 0}
+          onClick={() =>
+            controller.setActiveTabIndex(controller.activeTabIndex - 1)
+          }
+          size="icon-sm"
+          variant="ghost"
+        >
+          <ChevronLeftIcon />
+        </Button>
+        <Button
+          aria-label="Next sheet"
+          className="h-full rounded-none border-r px-2"
+          disabled={controller.activeTabIndex >= controller.tabs.length - 1}
+          onClick={() =>
+            controller.setActiveTabIndex(controller.activeTabIndex + 1)
+          }
+          size="icon-sm"
+          variant="ghost"
+        >
+          <ChevronRightIcon />
+        </Button>
+        <div
+          aria-label="Workbook sheets"
+          className="flex min-w-0 grow items-stretch overflow-x-auto"
+          role="tablist"
+        >
+          {controller.tabs.map((tab, index) => (
+            <button
+              aria-selected={index === controller.activeTabIndex}
+              className={cn(
+                "relative shrink-0 border-r px-3 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
+                index === controller.activeTabIndex &&
+                  "bg-background text-foreground after:absolute after:inset-x-2 after:bottom-0 after:h-0.5 after:bg-[#0285ff]",
+              )}
+              key={tab.id}
+              onClick={() => controller.setActiveTabIndex(index)}
+              role="tab"
+              title={tab.name}
+              type="button"
+            >
+              {tab.name}
+            </button>
+          ))}
+        </div>
+        {selectedTab?.kind === "chartsheet" ? (
+          <span className="flex shrink-0 items-center border-l px-3 text-[11px] text-muted-foreground">
+            Chart sheet
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function useReadOnlyProjection(data: ArrayBuffer): {
+  value: ReadOnlyWorkbookProjection | null;
+  error: Error | null;
+} {
+  const [state, setState] = useState<{
+    value: ReadOnlyWorkbookProjection | null;
+    error: Error | null;
+  }>({ value: null, error: null });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ value: null, error: null });
+    void projectWorkbookForReadOnlyDisplay(data).then(
+      (value) => {
+        if (!cancelled) setState({ value, error: null });
+      },
+      (error: unknown) => {
+        if (!cancelled) {
+          setState({
+            value: null,
+            error: error instanceof Error ? error : new Error(String(error)),
+          });
+        }
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [data]);
+
+  return state;
+}
+
+function selectedOriginalFormula(
+  controller: XlsxViewerController,
+  formulasBySheet: Record<number, Record<string, string>>,
+): string | null {
+  if (controller.selectedFormulaTarget?.kind !== "cell") return null;
+  const cell = controller.selectedFormulaTarget.cell;
+  const workbookSheetIndex = controller.activeSheet?.workbookSheetIndex;
+  if (!cell || workbookSheetIndex === undefined) return null;
+  return formulasBySheet[workbookSheetIndex]?.[cellAddress(cell)] ?? null;
+}
+
+function cellAddress(cell: { row: number; col: number }): string {
+  let col = cell.col + 1;
+  let letters = "";
+  while (col > 0) {
+    const remainder = (col - 1) % 26;
+    letters = String.fromCharCode(65 + remainder) + letters;
+    col = Math.floor((col - 1) / 26);
+  }
+  return `${letters}${cell.row + 1}`;
+}
+
+function useCitationNavigation(
+  controller: XlsxViewerController,
+  viewportRef: MutableRefObject<HTMLDivElement | null>,
+  highlightRange: SheetHighlightRange | undefined,
+) {
+  const appliedRef = useRef<string | null>(null);
+  const citation = useMemo(
+    () => resolveCitation(controller, highlightRange),
+    [controller.tabs, highlightRange],
+  );
+
+  useEffect(() => {
+    if (!citation || controller.isLoading || controller.error) return;
+    if (appliedRef.current === citation.key) return;
+
+    if (
+      citation.tabIndex !== null &&
+      controller.activeTabIndex !== citation.tabIndex
+    ) {
+      controller.setActiveTabIndex(citation.tabIndex);
+      return;
+    }
+
+    controller.selectRange(citation.range);
+    appliedRef.current = citation.key;
+
+    // Selection is controller state; scrolling belongs to the viewport. Wait
+    // for the selected sheet and virtualized axes to commit before centering.
+    let secondFrame = 0;
+    const firstFrame = window.requestAnimationFrame(() => {
+      secondFrame = window.requestAnimationFrame(() => {
+        scrollRangeIntoView(
+          viewportRef.current,
+          controller.activeSheet,
+          citation.range,
+          controller.zoomScale,
+        );
+      });
+    });
+    return () => {
+      window.cancelAnimationFrame(firstFrame);
+      if (secondFrame) window.cancelAnimationFrame(secondFrame);
+    };
+  }, [citation, controller, viewportRef]);
+
+  useEffect(() => {
+    if (!highlightRange?.startCell) appliedRef.current = null;
+  }, [highlightRange]);
+}
+
+function resolveCitation(
+  controller: Pick<XlsxViewerController, "tabs">,
+  highlightRange: SheetHighlightRange | undefined,
+): { key: string; range: XlsxCellRange; tabIndex: number | null } | null {
+  if (!highlightRange?.startCell) return null;
+  const start = parseAddress(highlightRange.startCell);
+  const end = parseAddress(highlightRange.endCell ?? highlightRange.startCell);
+  if (!start || !end) return null;
+
+  let tabIndex: number | null = null;
+  if (highlightRange.sheetName) {
+    const targetName = highlightRange.sheetName.toLocaleLowerCase();
+    const found = controller.tabs.findIndex(
+      (tab) =>
+        tab.kind === "sheet" && tab.name.toLocaleLowerCase() === targetName,
+    );
+    if (found >= 0) tabIndex = found;
+  } else if (
+    highlightRange.sheetIndex !== null &&
+    highlightRange.sheetIndex !== undefined
+  ) {
+    const found = controller.tabs.findIndex(
+      (tab) =>
+        tab.kind === "sheet" &&
+        tab.sheetIndex === highlightRange.sheetIndex,
+    );
+    if (found >= 0) tabIndex = found;
+  }
+
+  const range = { start, end };
+  return {
+    key: `${tabIndex ?? "active"}:${highlightRange.startCell}:${highlightRange.endCell ?? ""}`,
+    range,
+    tabIndex,
+  };
+}
+
+function parseAddress(address: string): { row: number; col: number } | null {
+  const match = address.trim().replaceAll("$", "").match(/^([A-Z]+)(\d+)$/i);
+  if (!match?.[1] || !match[2]) return null;
+  const row = Number.parseInt(match[2], 10) - 1;
+  if (row < 0) return null;
+  let col = 0;
+  for (const letter of match[1].toUpperCase()) {
+    col = col * 26 + letter.charCodeAt(0) - 64;
+  }
+  return { row, col: col - 1 };
+}
+
+function scrollRangeIntoView(
+  viewport: HTMLDivElement | null,
+  sheet: XlsxSheetData | null,
+  range: XlsxCellRange,
+  zoomScale: number,
+) {
+  if (!viewport || !sheet) return;
+  const zoom = zoomScale / 100;
+  const row = Math.min(range.start.row, range.end.row);
+  const col = Math.min(range.start.col, range.end.col);
+  const top = axisOffset(
+    row,
+    sheet.defaultRowHeightPx,
+    sheet.rowHeightOverridesPx,
+    sheet.hiddenRows,
+  );
+  const left = axisOffset(
+    col,
+    sheet.defaultColWidthPx,
+    sheet.colWidthOverridesPx,
+    sheet.hiddenCols,
+  );
+  viewport.scrollTop = Math.max(0, (24 + top) * zoom - viewport.clientHeight / 2);
+  viewport.scrollLeft = Math.max(0, (40 + left) * zoom - viewport.clientWidth / 2);
+  viewport.focus({ preventScroll: true });
+}
+
+function axisOffset(
+  index: number,
+  defaultSize: number,
+  overrides: Record<number, number>,
+  hidden: number[] | undefined,
+): number {
+  let offset = Math.max(0, index) * defaultSize;
+  for (const [rawIndex, size] of Object.entries(overrides)) {
+    const axisIndex = Number(rawIndex);
+    if (axisIndex >= 0 && axisIndex < index) offset += size - defaultSize;
+  }
+  for (const axisIndex of hidden ?? []) {
+    if (axisIndex >= 0 && axisIndex < index) {
+      offset -= overrides[axisIndex] ?? defaultSize;
+    }
+  }
+  return Math.max(0, offset);
+}
+
+function assignRef<T>(ref: Ref<T> | undefined, value: T | null) {
+  if (typeof ref === "function") {
+    ref(value);
+  } else if (ref && "current" in ref) {
+    ref.current = value;
+  }
+}
+
+function workbookFileName(mediaType: string): string {
+  return mediaType.split(";", 1)[0]!.trim().toLowerCase() ===
+    "application/vnd.ms-excel"
+    ? "workbook.xls"
+    : "workbook.xlsx";
+}
+
+function ViewerMessage({
+  spinner,
+  children,
+}: {
+  spinner?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex h-full min-h-64 items-center justify-center p-6 text-center text-sm text-muted-foreground">
+      <div className="flex flex-col items-center gap-2">
+        {spinner ? <Loader2Icon className="size-6 animate-spin" /> : null}
+        <p>{children}</p>
+      </div>
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/document/SpreadsheetViewer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/SpreadsheetViewer.dom.test.tsx
@@ -1,15 +1,15 @@
 // @vitest-environment jsdom
 
 import { cleanup, render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@/document/PresentationViewer", () => ({
-  ConvertedOfficeViewer: () => <div>high fidelity preview</div>,
-}));
+const nativeViewerMock = vi.hoisted(() => vi.fn());
 
-vi.mock("@/document/UniverSpreadsheetViewer", () => ({
-  default: () => <div>interactive cell inspector</div>,
+vi.mock("@/document/NativeSpreadsheetViewer", () => ({
+  default: (props: unknown) => {
+    nativeViewerMock(props);
+    return <div>native workbook viewer</div>;
+  },
 }));
 
 import { SpreadsheetViewer } from "./SpreadsheetViewer";
@@ -22,39 +22,47 @@ const source: FileBytesSource = {
 };
 
 describe("SpreadsheetViewer", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => nativeViewerMock.mockClear());
   afterEach(cleanup);
 
-  it("opens on the rendered preview and lets the reader inspect cells", async () => {
-    const user = userEvent.setup();
+  it("routes XLSX directly to the native inspectable workbook surface", () => {
     render(
       <SpreadsheetViewer
         source={source}
         mediaType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        className="h-full"
       />,
     );
 
-    expect(screen.getByText("high fidelity preview")).toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "Inspect cells" }));
-
-    expect(screen.getByText("interactive cell inspector")).toBeInTheDocument();
+    expect(screen.getByText("native workbook viewer")).toBeInTheDocument();
+    expect(nativeViewerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source,
+        mediaType:
+          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        className: "h-full",
+      }),
+    );
   });
 
-  it("uses the cell inspector when a citation names a workbook range", () => {
+  it("forwards a cited workbook range to the same native surface", () => {
+    const highlightRange = {
+      startCell: "B7",
+      endCell: "D9",
+      sheetName: "Revenue",
+      sheetIndex: null,
+    };
+
     render(
       <SpreadsheetViewer
         source={source}
         mediaType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-        highlightRange={{
-          startCell: "B7",
-          endCell: "D9",
-          sheetName: "Revenue",
-          sheetIndex: null,
-        }}
+        highlightRange={highlightRange}
       />,
     );
 
-    expect(screen.getByText("interactive cell inspector")).toBeInTheDocument();
+    expect(nativeViewerMock).toHaveBeenCalledWith(
+      expect.objectContaining({ highlightRange }),
+    );
   });
 });

--- a/crates/tidebreak-desktop/ui/src/document/SpreadsheetViewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/SpreadsheetViewer.tsx
@@ -1,13 +1,6 @@
-import { EyeIcon, TablePropertiesIcon } from "lucide-react";
-import { useEffect, useState } from "react";
-
-import { Button } from "@/components/ui/button";
-import { ConvertedOfficeViewer } from "@/document/PresentationViewer";
-import UniverSpreadsheetViewer, {
-  type SheetHighlightRange,
-} from "@/document/UniverSpreadsheetViewer";
+import NativeSpreadsheetViewer from "@/document/NativeSpreadsheetViewer";
+import type { SheetHighlightRange } from "@/document/UniverSpreadsheetViewer";
 import type { FileBytesSource } from "@/document/useFileDownload";
-import { cn } from "@/lib/utils";
 
 interface Props {
   source: FileBytesSource;
@@ -16,15 +9,10 @@ interface Props {
   className?: string;
 }
 
-type SpreadsheetView = "preview" | "inspect";
-
 /**
- * Two deliberately different readings of a workbook:
- *
- * - Preview renders LibreOffice's complete-sheet PDF, preserving the authored
- *   visual document including charts and drawings.
- * - Inspect keeps the interactive Univer grid for formulas, selection,
- *   keyboard navigation, and cell-range citations.
+ * XLS/XLSX opens as one native, read-only workbook. The original OOXML feeds
+ * the canvas engine directly, so visual fidelity and cell inspection are no
+ * longer split between a PDF preview and a lossy reconstructed grid.
  */
 export function SpreadsheetViewer({
   source,
@@ -32,61 +20,12 @@ export function SpreadsheetViewer({
   highlightRange,
   className,
 }: Props) {
-  const [view, setView] = useState<SpreadsheetView>(() =>
-    highlightRange?.startCell ? "inspect" : "preview",
-  );
-
-  // A citation names cells, not a position on a rendered PDF. Move to the
-  // representation that can select and center that exact range.
-  useEffect(() => {
-    if (highlightRange?.startCell) setView("inspect");
-  }, [highlightRange]);
-
   return (
-    <div className={cn("flex min-h-0 flex-col", className)}>
-      <div className="flex h-10 shrink-0 items-center gap-1 border-b px-3">
-        <Button
-          variant={view === "preview" ? "secondary" : "ghost"}
-          size="sm"
-          aria-pressed={view === "preview"}
-          onClick={() => setView("preview")}
-        >
-          <EyeIcon />
-          Preview
-        </Button>
-        <Button
-          variant={view === "inspect" ? "secondary" : "ghost"}
-          size="sm"
-          aria-pressed={view === "inspect"}
-          onClick={() => setView("inspect")}
-        >
-          <TablePropertiesIcon />
-          Inspect cells
-        </Button>
-        <span className="ml-2 text-xs text-muted-foreground">
-          {view === "preview"
-            ? "Rendered for visual fidelity"
-            : "Read-only formulas and cell navigation"}
-        </span>
-      </div>
-
-      <div className="min-h-0 grow">
-        {view === "preview" ? (
-          <ConvertedOfficeViewer
-            source={source}
-            mediaType={mediaType}
-            kind="spreadsheet"
-            className="h-full"
-          />
-        ) : (
-          <UniverSpreadsheetViewer
-            key={source.id}
-            source={source}
-            highlightRange={highlightRange}
-            className="h-full"
-          />
-        )}
-      </div>
-    </div>
+    <NativeSpreadsheetViewer
+      source={source}
+      mediaType={mediaType}
+      highlightRange={highlightRange}
+      className={className}
+    />
   );
 }

--- a/crates/tidebreak-desktop/ui/src/document/readOnlyWorkbookProjection.dom.test.ts
+++ b/crates/tidebreak-desktop/ui/src/document/readOnlyWorkbookProjection.dom.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+
+import JSZip from "jszip";
+import { describe, expect, it } from "vitest";
+
+import { projectWorkbookForReadOnlyDisplay } from "./readOnlyWorkbookProjection";
+
+describe("projectWorkbookForReadOnlyDisplay", () => {
+  it("renders cached values while retaining original formulas for inspection", async () => {
+    const zip = new JSZip();
+    zip.file(
+      "xl/workbook.xml",
+      `<?xml version="1.0"?><workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Model" sheetId="1" r:id="rId1"/></sheets></workbook>`,
+    );
+    zip.file(
+      "xl/_rels/workbook.xml.rels",
+      `<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Target="worksheets/sheet1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/></Relationships>`,
+    );
+    zip.file(
+      "xl/worksheets/sheet1.xml",
+      `<?xml version="1.0"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData><row r="1"><c r="A1"><f>SUM(B1:B3)</f><v>42</v></c><c r="B1"><f>NOW()</f></c></row></sheetData></worksheet>`,
+    );
+
+    const source = await zip.generateAsync({ type: "arraybuffer" });
+    const projection = await projectWorkbookForReadOnlyDisplay(source);
+    const projectedZip = await JSZip.loadAsync(projection.data);
+    const sheetXml = await projectedZip
+      .file("xl/worksheets/sheet1.xml")!
+      .async("string");
+    const document = new DOMParser().parseFromString(
+      sheetXml,
+      "application/xml",
+    );
+    const cells = Array.from(document.getElementsByTagNameNS("*", "c"));
+
+    expect(projection.formulasBySheet).toEqual({
+      0: { A1: "=SUM(B1:B3)", B1: "=NOW()" },
+    });
+    expect(cells[0]?.getElementsByTagNameNS("*", "f")).toHaveLength(0);
+    expect(cells[0]?.getElementsByTagNameNS("*", "v")[0]?.textContent).toBe(
+      "42",
+    );
+    expect(cells[1]?.getElementsByTagNameNS("*", "f")).toHaveLength(1);
+  });
+
+  it("preserves border indices by expanding empty OOXML border records", async () => {
+    const zip = new JSZip();
+    zip.file(
+      "xl/styles.xml",
+      `<?xml version="1.0"?><x:styleSheet xmlns:x="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><x:borders count="2"><x:border/><x:border><x:bottom style="thin"/></x:border></x:borders></x:styleSheet>`,
+    );
+
+    const source = await zip.generateAsync({ type: "arraybuffer" });
+    const projection = await projectWorkbookForReadOnlyDisplay(source);
+    const projectedZip = await JSZip.loadAsync(projection.data);
+    const stylesXml = await projectedZip.file("xl/styles.xml")!.async("string");
+    const document = new DOMParser().parseFromString(
+      stylesXml,
+      "application/xml",
+    );
+    const borders = Array.from(
+      document.getElementsByTagNameNS("*", "border"),
+    );
+
+    expect(Array.from(borders[0]!.children, (child) => child.localName)).toEqual(
+      ["left", "right", "top", "bottom", "diagonal"],
+    );
+    expect(Array.from(borders[1]!.children, (child) => child.localName)).toEqual(
+      ["bottom"],
+    );
+  });
+
+  it("makes inherited workbook-theme chart series colors explicit", async () => {
+    const zip = new JSZip();
+    zip.file(
+      "xl/theme/theme1.xml",
+      `<?xml version="1.0"?><a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><a:themeElements><a:clrScheme><a:accent1><a:srgbClr val="156082"/></a:accent1><a:accent2><a:srgbClr val="E97132"/></a:accent2><a:accent3><a:srgbClr val="196B24"/></a:accent3></a:clrScheme></a:themeElements></a:theme>`,
+    );
+    zip.file(
+      "xl/drawings/charts/chart1.xml",
+      `<?xml version="1.0"?><c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:chart><c:plotArea><c:lineChart><c:varyColors val="0"/><c:ser><c:idx val="0"/><c:order val="0"/><c:marker/></c:ser><c:ser><c:idx val="1"/><c:order val="1"/><c:marker/></c:ser><c:ser><c:idx val="2"/><c:order val="2"/><c:marker/></c:ser></c:lineChart></c:plotArea></c:chart></c:chartSpace>`,
+    );
+
+    const source = await zip.generateAsync({ type: "arraybuffer" });
+    const projection = await projectWorkbookForReadOnlyDisplay(source);
+    const projectedZip = await JSZip.loadAsync(projection.data);
+    const chartXml = await projectedZip
+      .file("xl/drawings/charts/chart1.xml")!
+      .async("string");
+    const document = new DOMParser().parseFromString(chartXml, "application/xml");
+    const series = Array.from(document.getElementsByTagNameNS("*", "ser"));
+
+    expect(
+      series.map(
+        (item) =>
+          item
+            .getElementsByTagNameNS("*", "spPr")[0]
+            ?.getElementsByTagNameNS("*", "srgbClr")[0]
+            ?.getAttribute("val"),
+      ),
+    ).toEqual(["156082", "E97132", "196B24"]);
+  });
+
+  it("projects data bars and color scales for the canvas renderer", async () => {
+    const zip = new JSZip();
+    zip.file(
+      "xl/workbook.xml",
+      `<?xml version="1.0"?><workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Dashboard" sheetId="1" r:id="rId1"/></sheets></workbook>`,
+    );
+    zip.file(
+      "xl/_rels/workbook.xml.rels",
+      `<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Target="worksheets/sheet1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/></Relationships>`,
+    );
+    zip.file(
+      "xl/worksheets/sheet1.xml",
+      `<?xml version="1.0"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData><row r="1"><c r="B1"><v>10</v></c><c r="D1"><v>0</v></c></row><row r="2"><c r="B2"><v>15</v></c><c r="D2"><v>0.5</v></c></row><row r="3"><c r="B3"><v>20</v></c><c r="D3"><v>1</v></c></row></sheetData><conditionalFormatting sqref="D1:D3"><cfRule type="dataBar" priority="1"><dataBar><cfvo type="min"/><cfvo type="max"/><color rgb="FF2979FF"/></dataBar></cfRule></conditionalFormatting><conditionalFormatting sqref="B1:B3"><cfRule type="colorScale" priority="2"><colorScale><cfvo type="min"/><cfvo type="percentile" val="50"/><cfvo type="max"/><color rgb="FFE7FAF6"/><color rgb="FFFFF3C4"/><color rgb="FFFDEBEC"/></colorScale></cfRule></conditionalFormatting></worksheet>`,
+    );
+
+    const source = await zip.generateAsync({ type: "arraybuffer" });
+    const projection = await projectWorkbookForReadOnlyDisplay(source);
+
+    expect(projection.conditionalStylesBySheet[0]).toMatchObject({
+      B1: { backgroundColor: "rgb(231, 250, 246)" },
+      B2: { backgroundColor: "rgb(255, 243, 196)" },
+      B3: { backgroundColor: "rgb(253, 235, 236)" },
+      D1: { dataBar: { color: "#2979ff", widthPercent: 0 } },
+      D2: { dataBar: { color: "#2979ff", widthPercent: 50 } },
+      D3: { dataBar: { color: "#2979ff", widthPercent: 100 } },
+    });
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/document/readOnlyWorkbookProjection.ts
+++ b/crates/tidebreak-desktop/ui/src/document/readOnlyWorkbookProjection.ts
@@ -1,0 +1,610 @@
+import JSZip from "jszip";
+
+const OFFICE_DOCUMENT_RELATIONSHIPS =
+  "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+const DRAWINGML =
+  "http://schemas.openxmlformats.org/drawingml/2006/main";
+const DRAWINGML_CHART =
+  "http://schemas.openxmlformats.org/drawingml/2006/chart";
+const SPREADSHEETML =
+  "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+
+export interface ReadOnlyConditionalCellStyle {
+  backgroundColor?: string;
+  dataBar?: {
+    color: string;
+    widthPercent: number;
+  };
+}
+
+export interface ReadOnlyWorkbookProjection {
+  conditionalStylesBySheet: Record<
+    number,
+    Record<string, ReadOnlyConditionalCellStyle>
+  >;
+  data: ArrayBuffer;
+  formulasBySheet: Record<number, Record<string, string>>;
+}
+
+/**
+ * Build a display-only copy of an OOXML workbook.
+ *
+ * Excel stores both a formula and its last calculated value. Browser formula
+ * engines cannot reproduce every Excel function, but a viewer does not need
+ * to: it can paint the cached result with the cell's original number format
+ * and keep the formula separately for inspection. The source bytes are never
+ * changed or written back.
+ */
+export async function projectWorkbookForReadOnlyDisplay(
+  source: ArrayBuffer,
+): Promise<ReadOnlyWorkbookProjection> {
+  if (!isZip(source)) {
+    return {
+      conditionalStylesBySheet: {},
+      data: source,
+      formulasBySheet: {},
+    };
+  }
+
+  const zip = await JSZip.loadAsync(source);
+  const sheetPaths = await readWorkbookSheetPaths(zip);
+  const conditionalStylesBySheet: Record<
+    number,
+    Record<string, ReadOnlyConditionalCellStyle>
+  > = {};
+  const formulasBySheet: Record<number, Record<string, string>> = {};
+  let changed = await normalizeEmptyBorders(zip);
+  if (await normalizeImplicitChartSeriesColors(zip)) changed = true;
+
+  await Promise.all(
+    sheetPaths.map(async (path, sheetIndex) => {
+      const entry = zip.file(path);
+      if (!entry) return;
+
+      const document = parseXml(await entry.async("string"), path);
+      const formulas: Record<string, string> = {};
+      const conditionalStyles = projectConditionalStyles(document);
+      let sheetChanged = false;
+
+      if (Object.keys(conditionalStyles).length > 0) {
+        conditionalStylesBySheet[sheetIndex] = conditionalStyles;
+      }
+
+      for (const cell of localElements(document, "c")) {
+        const formula = localChild(cell, "f");
+        if (!formula) continue;
+
+        const address = cell.getAttribute("r");
+        const formulaText = formula.textContent?.trim();
+        if (address && formulaText) formulas[address] = `=${formulaText}`;
+
+        // Only replace formulas that have an authored cached result. Formulas
+        // without one still go through the workbook engine as a best effort.
+        if (localChild(cell, "v")) {
+          cell.removeChild(formula);
+          sheetChanged = true;
+        }
+      }
+
+      if (Object.keys(formulas).length > 0) {
+        formulasBySheet[sheetIndex] = formulas;
+      }
+      if (sheetChanged) {
+        zip.file(path, new XMLSerializer().serializeToString(document));
+        changed = true;
+      }
+    }),
+  );
+
+  if (!changed) {
+    return { conditionalStylesBySheet, data: source, formulasBySheet };
+  }
+  return {
+    conditionalStylesBySheet,
+    data: await zip.generateAsync({
+      type: "arraybuffer",
+      compression: "DEFLATE",
+      compressionOptions: { level: 6 },
+    }),
+    formulasBySheet,
+  };
+}
+
+function projectConditionalStyles(
+  document: XMLDocument,
+): Record<string, ReadOnlyConditionalCellStyle> {
+  const numericValues = new Map<string, number>();
+  const styles: Record<string, ReadOnlyConditionalCellStyle> = {};
+
+  for (const cell of localElements(document, "c")) {
+    const address = cell.getAttribute("r")?.replaceAll("$", "").toUpperCase();
+    const rawValue = localChild(cell, "v")?.textContent;
+    const value =
+      rawValue === null || rawValue === undefined
+        ? Number.NaN
+        : Number(rawValue);
+    if (address && Number.isFinite(value)) numericValues.set(address, value);
+  }
+
+  for (const formatting of localElements(document, "conditionalFormatting")) {
+    if (formatting.namespaceURI !== SPREADSHEETML) continue;
+    const ranges = parseSqref(formatting.getAttribute("sqref"));
+    if (ranges.length === 0) continue;
+
+    const addresses = ranges.flatMap(cellsInRange);
+    const values = addresses
+      .map((address) => numericValues.get(address))
+      .filter((value): value is number => value !== undefined);
+    if (values.length === 0) continue;
+
+    for (const rule of Array.from(formatting.children).filter(
+      (child) => child.localName === "cfRule",
+    )) {
+      if (rule.getAttribute("type") === "dataBar") {
+        applyDataBarStyles(rule, addresses, numericValues, values, styles);
+      } else if (rule.getAttribute("type") === "colorScale") {
+        applyColorScaleStyles(rule, addresses, numericValues, values, styles);
+      }
+    }
+  }
+
+  return styles;
+}
+
+function applyDataBarStyles(
+  rule: Element,
+  addresses: string[],
+  numericValues: Map<string, number>,
+  values: number[],
+  styles: Record<string, ReadOnlyConditionalCellStyle>,
+) {
+  const dataBar = localChild(rule, "dataBar");
+  if (!dataBar) return;
+  const thresholds = Array.from(dataBar.children)
+    .filter((child) => child.localName === "cfvo")
+    .map((node) => resolveConditionalThreshold(node, values));
+  const min = thresholds[0] ?? Math.min(...values);
+  const max = thresholds.at(-1) ?? Math.max(...values);
+  const color = ooxmlRgb(localChild(dataBar, "color"));
+  if (!color) return;
+
+  for (const address of addresses) {
+    const value = numericValues.get(address);
+    if (value === undefined) continue;
+    const ratio =
+      max === min ? (value >= max ? 1 : 0) : (value - min) / (max - min);
+    styles[address] = {
+      ...styles[address],
+      dataBar: {
+        color,
+        widthPercent: Math.max(0, Math.min(100, ratio * 100)),
+      },
+    };
+  }
+}
+
+function applyColorScaleStyles(
+  rule: Element,
+  addresses: string[],
+  numericValues: Map<string, number>,
+  values: number[],
+  styles: Record<string, ReadOnlyConditionalCellStyle>,
+) {
+  const colorScale = localChild(rule, "colorScale");
+  if (!colorScale) return;
+  const thresholds = Array.from(colorScale.children)
+    .filter((child) => child.localName === "cfvo")
+    .map((node) => resolveConditionalThreshold(node, values));
+  const colors = Array.from(colorScale.children)
+    .filter((child) => child.localName === "color")
+    .map(ooxmlRgb)
+    .filter((color): color is string => color !== null);
+  if (thresholds.length < 2 || colors.length < 2) return;
+
+  const stopCount = Math.min(thresholds.length, colors.length);
+  for (const address of addresses) {
+    const value = numericValues.get(address);
+    if (value === undefined) continue;
+    styles[address] = {
+      ...styles[address],
+      backgroundColor: colorAtScale(
+        value,
+        thresholds.slice(0, stopCount),
+        colors.slice(0, stopCount),
+      ),
+    };
+  }
+}
+
+function resolveConditionalThreshold(node: Element, values: number[]): number {
+  const sorted = [...values].sort((left, right) => left - right);
+  const min = sorted[0] ?? 0;
+  const max = sorted.at(-1) ?? min;
+  const rawValue = Number(node.getAttribute("val") ?? Number.NaN);
+  switch (node.getAttribute("type")) {
+    case "max":
+      return max;
+    case "min":
+      return min;
+    case "num":
+      return Number.isFinite(rawValue) ? rawValue : min;
+    case "percent":
+      return Number.isFinite(rawValue)
+        ? min + (max - min) * (rawValue / 100)
+        : min;
+    case "percentile":
+      return Number.isFinite(rawValue)
+        ? percentile(sorted, rawValue / 100)
+        : min;
+    default:
+      return Number.isFinite(rawValue) ? rawValue : min;
+  }
+}
+
+function percentile(sorted: number[], ratio: number): number {
+  if (sorted.length === 0) return 0;
+  const index = Math.max(0, Math.min(1, ratio)) * (sorted.length - 1);
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  const weight = index - lower;
+  return (sorted[lower] ?? 0) * (1 - weight) + (sorted[upper] ?? 0) * weight;
+}
+
+function colorAtScale(
+  value: number,
+  thresholds: number[],
+  colors: string[],
+): string {
+  for (let index = 0; index < thresholds.length - 1; index += 1) {
+    const start = thresholds[index]!;
+    const end = thresholds[index + 1]!;
+    if (value <= end || index === thresholds.length - 2) {
+      const ratio = end === start ? 1 : (value - start) / (end - start);
+      return mixRgb(colors[index]!, colors[index + 1]!, ratio);
+    }
+  }
+  return colors.at(-1)!;
+}
+
+function mixRgb(start: string, end: string, rawRatio: number): string {
+  const ratio = Math.max(0, Math.min(1, rawRatio));
+  const startRgb = hexChannels(start);
+  const endRgb = hexChannels(end);
+  return `rgb(${startRgb
+    .map((channel, index) =>
+      Math.round(channel + (endRgb[index]! - channel) * ratio),
+    )
+    .join(", ")})`;
+}
+
+function hexChannels(color: string): [number, number, number] {
+  const hex = color.replace(/^#/, "");
+  return [0, 2, 4].map((index) =>
+    Number.parseInt(hex.slice(index, index + 2), 16),
+  ) as [number, number, number];
+}
+
+function ooxmlRgb(node: Element | null): string | null {
+  const raw = node?.getAttribute("rgb")?.replace(/^#/, "") ?? "";
+  const rgb = raw.length === 8 ? raw.slice(2) : raw;
+  return /^[0-9a-f]{6}$/i.test(rgb) ? `#${rgb.toLowerCase()}` : null;
+}
+
+interface CellRange {
+  end: { col: number; row: number };
+  start: { col: number; row: number };
+}
+
+function parseSqref(value: string | null): CellRange[] {
+  return (value ?? "")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map(parseCellRange)
+    .filter((range): range is CellRange => range !== null);
+}
+
+function parseCellRange(value: string): CellRange | null {
+  const [rawStart, rawEnd = rawStart] = value.split(":", 2);
+  const start = rawStart ? parseCellAddress(rawStart) : null;
+  const end = rawEnd ? parseCellAddress(rawEnd) : null;
+  if (!start || !end) return null;
+  return {
+    end: { col: Math.max(start.col, end.col), row: Math.max(start.row, end.row) },
+    start: { col: Math.min(start.col, end.col), row: Math.min(start.row, end.row) },
+  };
+}
+
+function parseCellAddress(value: string): { col: number; row: number } | null {
+  const match = value.replaceAll("$", "").match(/^([A-Z]+)(\d+)$/i);
+  if (!match?.[1] || !match[2]) return null;
+  let col = 0;
+  for (const letter of match[1].toUpperCase()) {
+    col = col * 26 + letter.charCodeAt(0) - 64;
+  }
+  const row = Number(match[2]) - 1;
+  return row >= 0 ? { col: col - 1, row } : null;
+}
+
+function cellsInRange(range: CellRange): string[] {
+  const addresses: string[] = [];
+  for (let row = range.start.row; row <= range.end.row; row += 1) {
+    for (let col = range.start.col; col <= range.end.col; col += 1) {
+      addresses.push(cellAddressAt(row, col));
+    }
+  }
+  return addresses;
+}
+
+function cellAddressAt(row: number, col: number): string {
+  let column = col + 1;
+  let letters = "";
+  while (column > 0) {
+    const remainder = (column - 1) % 26;
+    letters = String.fromCharCode(65 + remainder) + letters;
+    column = Math.floor((column - 1) / 26);
+  }
+  return `${letters}${row + 1}`;
+}
+
+/**
+ * A chart without an explicit built-in style or per-series shape properties
+ * inherits accent1, accent2, etc. from the workbook theme. The current worker
+ * falls back to the stock Office palette before that theme reaches its chart
+ * renderer, so make the inherited colors explicit in the display copy.
+ */
+async function normalizeImplicitChartSeriesColors(
+  zip: JSZip,
+): Promise<boolean> {
+  const themePath = Object.keys(zip.files).find((path) =>
+    /^xl\/theme\/theme\d+\.xml$/i.test(path),
+  );
+  const themeEntry = themePath ? zip.file(themePath) : null;
+  if (!themeEntry) return false;
+
+  const theme = parseXml(await themeEntry.async("string"), themePath!);
+  const accents = [
+    "accent1",
+    "accent2",
+    "accent3",
+    "accent4",
+    "accent5",
+    "accent6",
+  ].map((name) => themeColor(theme, name));
+  const fallbackAccent = accents.find((color) => color !== null);
+  if (!fallbackAccent) return false;
+
+  let changed = false;
+  const chartPaths = Object.keys(zip.files).filter((path) =>
+    /(?:^|\/)charts\/chart\d+\.xml$/i.test(path),
+  );
+
+  await Promise.all(
+    chartPaths.map(async (path) => {
+      const entry = zip.file(path);
+      if (!entry) return;
+
+      const document = parseXml(await entry.async("string"), path);
+      const hasBuiltInStyle = localElements(document, "style").some(
+        (element) => element.namespaceURI === DRAWINGML_CHART,
+      );
+      if (hasBuiltInStyle) return;
+
+      let chartChanged = false;
+      for (const [seriesIndex, series] of localElements(
+        document,
+        "ser",
+      ).entries()) {
+        if (localChild(series, "spPr") || chartVariesPointColors(series)) {
+          continue;
+        }
+
+        const color = accents[seriesIndex % accents.length] ?? fallbackAccent;
+        series.insertBefore(
+          chartSeriesShapeProperties(document, series, color),
+          chartSeriesStyleInsertionPoint(series),
+        );
+        chartChanged = true;
+      }
+
+      if (chartChanged) {
+        zip.file(path, new XMLSerializer().serializeToString(document));
+        changed = true;
+      }
+    }),
+  );
+
+  return changed;
+}
+
+function themeColor(document: XMLDocument, name: string): string | null {
+  const slot = localElements(document, name)[0];
+  if (!slot) return null;
+  const color = Array.from(slot.children).find(
+    (child) => child.localName === "srgbClr" || child.localName === "sysClr",
+  );
+  const hex =
+    color?.localName === "sysClr"
+      ? color.getAttribute("lastClr")
+      : (color?.getAttribute("val") ?? null);
+  return hex && /^[0-9a-f]{6}$/i.test(hex) ? hex.toUpperCase() : null;
+}
+
+function chartVariesPointColors(series: Element): boolean {
+  const varies = series.parentElement
+    ? localChild(series.parentElement, "varyColors")
+    : null;
+  const value = varies?.getAttribute("val")?.toLowerCase();
+  return value === "1" || value === "true";
+}
+
+function chartSeriesShapeProperties(
+  document: XMLDocument,
+  series: Element,
+  color: string,
+): Element {
+  const chartPrefix = series.prefix ?? "c";
+  const shape = document.createElementNS(
+    DRAWINGML_CHART,
+    `${chartPrefix}:spPr`,
+  );
+  shape.appendChild(solidDrawingFill(document, color));
+
+  const line = document.createElementNS(DRAWINGML, "a:ln");
+  line.appendChild(solidDrawingFill(document, color));
+  shape.appendChild(line);
+  return shape;
+}
+
+function solidDrawingFill(document: XMLDocument, color: string): Element {
+  const fill = document.createElementNS(DRAWINGML, "a:solidFill");
+  const rgb = document.createElementNS(DRAWINGML, "a:srgbClr");
+  rgb.setAttribute("val", color);
+  fill.appendChild(rgb);
+  return fill;
+}
+
+function chartSeriesStyleInsertionPoint(series: Element): Element | null {
+  return (
+    Array.from(series.children).find(
+      (child) => !["idx", "order", "tx"].includes(child.localName),
+    ) ?? null
+  );
+}
+
+/**
+ * Some producers serialize the default OOXML border as a self-closing
+ * `<border/>`. Duke currently omits that record while decoding styles, which
+ * shifts every later border index and paints the wrong border on each cell.
+ * Expanding the empty record is semantically identical OOXML and keeps the
+ * style table indices stable for the read-only renderer.
+ */
+async function normalizeEmptyBorders(zip: JSZip): Promise<boolean> {
+  const entry = zip.file("xl/styles.xml");
+  if (!entry) return false;
+
+  const document = parseXml(await entry.async("string"), "xl/styles.xml");
+  let changed = false;
+
+  for (const borders of localElements(document, "borders")) {
+    for (const border of Array.from(borders.children)) {
+      if (border.localName !== "border" || border.children.length > 0) continue;
+
+      for (const edge of ["left", "right", "top", "bottom", "diagonal"]) {
+        border.appendChild(namespacedSibling(document, border, edge));
+      }
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    zip.file("xl/styles.xml", new XMLSerializer().serializeToString(document));
+  }
+  return changed;
+}
+
+function namespacedSibling(
+  document: XMLDocument,
+  sibling: Element,
+  localName: string,
+): Element {
+  const qualifiedName = sibling.prefix
+    ? `${sibling.prefix}:${localName}`
+    : localName;
+  return document.createElementNS(sibling.namespaceURI, qualifiedName);
+}
+
+async function readWorkbookSheetPaths(zip: JSZip): Promise<string[]> {
+  const workbookEntry = zip.file("xl/workbook.xml");
+  const relationshipsEntry = zip.file("xl/_rels/workbook.xml.rels");
+  if (!workbookEntry || !relationshipsEntry) return fallbackSheetPaths(zip);
+
+  const [workbookDocument, relationshipsDocument] = await Promise.all([
+    workbookEntry
+      .async("string")
+      .then((xml) => parseXml(xml, "xl/workbook.xml")),
+    relationshipsEntry
+      .async("string")
+      .then((xml) => parseXml(xml, "xl/_rels/workbook.xml.rels")),
+  ]);
+  const targetByRelationship = new Map<string, string>();
+
+  for (const relationship of localElements(
+    relationshipsDocument,
+    "Relationship",
+  )) {
+    const id = relationship.getAttribute("Id");
+    const target = relationship.getAttribute("Target");
+    if (id && target) {
+      targetByRelationship.set(
+        id,
+        resolveZipPath("xl/workbook.xml", target),
+      );
+    }
+  }
+
+  return localElements(workbookDocument, "sheet")
+    .map((sheet) => {
+      const relationshipId =
+        sheet.getAttributeNS(OFFICE_DOCUMENT_RELATIONSHIPS, "id") ??
+        sheet.getAttribute("r:id");
+      return relationshipId
+        ? (targetByRelationship.get(relationshipId) ?? null)
+        : null;
+    })
+    .filter((path): path is string => path !== null);
+}
+
+function fallbackSheetPaths(zip: JSZip): string[] {
+  return Object.keys(zip.files)
+    .filter((path) => /^xl\/worksheets\/sheet\d+\.xml$/i.test(path))
+    .sort((left, right) => sheetNumber(left) - sheetNumber(right));
+}
+
+function sheetNumber(path: string): number {
+  return Number(path.match(/sheet(\d+)\.xml$/i)?.[1] ?? Number.MAX_SAFE_INTEGER);
+}
+
+function resolveZipPath(baseFile: string, target: string): string {
+  if (target.startsWith("/")) return target.replace(/^\/+/, "");
+  const parts = `${baseFile.slice(0, baseFile.lastIndexOf("/") + 1)}${target}`
+    .split("/")
+    .filter(Boolean);
+  const resolved: string[] = [];
+  for (const part of parts) {
+    if (part === ".") continue;
+    if (part === "..") resolved.pop();
+    else resolved.push(part);
+  }
+  return resolved.join("/");
+}
+
+function parseXml(xml: string, path: string): XMLDocument {
+  const document = new DOMParser().parseFromString(xml, "application/xml");
+  if (document.getElementsByTagName("parsererror").length > 0) {
+    throw new Error(`Could not parse ${path}`);
+  }
+  return document;
+}
+
+function localElements(document: Document | Element, name: string): Element[] {
+  return Array.from(document.getElementsByTagNameNS("*", name));
+}
+
+function localChild(element: Element, name: string): Element | null {
+  return (
+    Array.from(element.children).find((child) => child.localName === name) ??
+    null
+  );
+}
+
+function isZip(data: ArrayBuffer): boolean {
+  const bytes = new Uint8Array(data, 0, Math.min(data.byteLength, 4));
+  return (
+    bytes.length === 4 &&
+    bytes[0] === 0x50 &&
+    bytes[1] === 0x4b &&
+    (bytes[2] === 0x03 || bytes[2] === 0x05 || bytes[2] === 0x07) &&
+    (bytes[3] === 0x04 || bytes[3] === 0x06 || bytes[3] === 0x08)
+  );
+}

--- a/docs/decisions/0020-spreadsheets-use-a-native-read-only-workbook-surface.md
+++ b/docs/decisions/0020-spreadsheets-use-a-native-read-only-workbook-surface.md
@@ -1,0 +1,115 @@
+# 20. Spreadsheets use a native read-only workbook surface
+
+- Status: Proposed
+- Date: 2026-08-14
+- Owners: Desktop document preview
+- Related: none
+- Supersedes: none
+
+## Context
+
+An authored workbook is both a visual document and an inspectable model. A PDF
+conversion preserves print fidelity but discards cells, formulas, sheet
+navigation, frozen panes, and range selection. Reconstructing the workbook into
+a general-purpose web spreadsheet from the subset exposed by SheetJS preserves
+interaction, but loses drawings, charts, conditional formatting, dimensions,
+and other OOXML details before the renderer sees them.
+
+The desktop only needs review in this phase. Editing, recalculation initiated by
+the reader, and writing changes back to the source file are deliberately out of
+scope. The original workbook must remain the exported artifact.
+
+## Decision
+
+XLSX previews use an exact-pinned, local-only workbook engine that parses OOXML
+through WebAssembly and renders a virtualized canvas workbook surface. The
+surface receives an in-memory, read-only display copy of the original OOXML,
+not a PDF or an intermediate SheetJS model, so it can preserve worksheets,
+charts and chart sheets, images, shapes, merged cells, frozen panes, row and
+column dimensions, formulas, conditional formatting, tables, and number
+formats supported by the engine.
+
+When a formula cell contains Excel's cached result, the display copy renders
+that authored result as an ordinary typed cell. The wrapper retains the
+original formula separately for the formula bar. This avoids turning valid
+workbooks into `#VALUE!` merely because the browser calculation engine does not
+implement a function or a producer-specific formula detail. The source bytes
+remain unchanged and are still the artifact exported by Tidebreak.
+
+The Tidebreak wrapper always enables read-only mode. It owns loading and error
+states, a fixed light document theme, zoom controls, formula and address
+display, citation navigation, and the visual contract with the surrounding
+document panel.
+The display projection may make semantically equivalent OOXML explicit when a
+renderer would otherwise misread it, such as expanding an empty default border
+or resolving inherited chart series colors from the workbook theme. It may
+also supply render-only cell styles for standard data bars and color scales
+when the canvas renderer omits them. These corrections never change the source
+workbook or become exportable edits.
+Selection, keyboard navigation, scrolling, sheet tabs, and copying remain
+available. Mutation controls, resizing, paste, fill, and export of a modified
+workbook are not exposed.
+
+CSV and TSV remain on the lightweight grid path because they have no OOXML
+visual model. Presentation preview remains a PDF conversion. LibreOffice stays
+available for presentation conversion and visual-quality tooling, but XLSX
+preview does not invoke it.
+
+Workbook parsing and rendering run entirely inside the desktop renderer and its
+worker. The preview does not upload workbook contents or fetch document assets
+from a service. The WebAssembly binary is bundled with the application.
+
+## Alternatives Considered
+
+- **Convert each workbook to PDF.** This preserves a printable appearance, but
+  a PDF page is not a workbook: cells, formulas, sheets, and range citations are
+  no longer inspectable.
+- **Export Calc HTML and add interaction around its tables.** This produces a
+  strong static rendering, including rasterized charts, but it flattens the
+  workbook into legacy HTML and leaves Tidebreak to reconstruct spreadsheet
+  semantics and viewport behavior from presentation markup.
+- **Continue the SheetJS-to-Univer reconstruction.** The existing path already
+  supports useful selection and formulas, but information discarded during the
+  reconstruction cannot be recovered by the renderer. Adding one parser per
+  missing OOXML feature would make Tidebreak own an incomplete import stack.
+- **Embed LibreOfficeKit.** The LibreOffice desktop SDK explicitly does not
+  support LibreOfficeKit on macOS. Depending on exported private symbols would
+  create an unsupported ABI and release boundary.
+- **Use a hosted office suite.** This adds network, identity, document-upload,
+  and service-availability dependencies to a local desktop preview.
+- **Build the full OOXML engine in Tidebreak.** This provides maximum control,
+  but duplicates a large parser, formula, chart, drawing, and rendering stack
+  before the product needs editing.
+
+## Consequences
+
+The desktop gains a real workbook viewer rather than two partial representations
+of the same file. The application bundle grows because it carries a WebAssembly
+OOXML engine and chart renderer. Viewer upgrades become deliberate dependency
+bumps and require workbook regression checks. Unsupported or malformed workbook
+features must degrade inside the workbook surface or show a specific preview
+error; they must not silently route the workbook back through PDF.
+
+The viewer dependency is a product-critical rendering engine. Its license,
+maintenance, bundled asset loading, worker behavior, and compatibility with the
+desktop webview must be reviewed on every upgrade.
+
+Revisit this decision if the engine stops being maintained, fails the golden
+workbook suite on important Excel features, becomes incompatible with the
+desktop runtime, or Tidebreak adds workbook editing whose persistence contract
+the read-only integration cannot satisfy.
+
+## Validation
+
+- A workbook with multiple sheets, merged cells, formulas, frozen panes,
+  authored dimensions, comments, and charts opens as one interactive workbook
+  with no office-to-PDF request.
+- A range citation activates the named or indexed sheet, selects the requested
+  address, and scrolls it into view.
+- The address/formula display follows selection while mutation gestures cannot
+  change workbook contents.
+- The golden dashboard workbook preserves its authored borders, merged KPI
+  alignment, themed chart series, progress data bars, and risk color scale.
+- The viewer works with its WebAssembly asset bundled in a production UI build,
+  without a network request.
+- CSV and presentation routing remain unchanged.

--- a/legal/THIRD-PARTY-NOTICES.md
+++ b/legal/THIRD-PARTY-NOTICES.md
@@ -26,8 +26,8 @@ a stale one.
 ## Summary
 
 - Rust crates: 885
-- Desktop UI production packages: 442
-- Distinct license texts: 581
+- Desktop UI production packages: 464
+- Distinct license texts: 593
 - Packages with no declared license: 0
 - Packages with a curated license: 28
 
@@ -5370,6 +5370,18 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/babel/babel.git
 - License text: `LICENSE` ([L-8f08c824b2bb](#l-8f08c824b2bb))
 
+### @dukelib/sheets-wasm 0.1.23
+
+- License: `MIT`
+- Repository: https://github.com/guseggert/duke-sheets.git
+- License text: not distributed with this package
+
+### @extend-ai/react-xlsx 0.16.1
+
+- License: `MIT`
+- Repository: git+https://github.com/extend-hq/react-xlsx.git
+- License text: `LICENSE` ([L-24fdfac792e0](#l-24fdfac792e0))
+
 ### @flatten-js/interval-tree 1.1.3
 
 - License: `MIT`
@@ -5754,6 +5766,12 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/TanStack/store.git
 - License text: `LICENSE` ([L-d71ca6db0f8b](#l-d71ca6db0f8b))
 
+### @tanstack/react-virtual 3.14.9
+
+- License: `MIT`
+- Repository: git+https://github.com/TanStack/virtual.git
+- License text: `LICENSE` ([L-277d2a8e4597](#l-277d2a8e4597))
+
 ### @tanstack/router-core 1.171.21
 
 - License: `MIT`
@@ -5765,6 +5783,12 @@ License identifiers named across all declared expressions:
 - License: `MIT`
 - Repository: git+https://github.com/TanStack/store.git
 - License text: `LICENSE` ([L-d71ca6db0f8b](#l-d71ca6db0f8b))
+
+### @tanstack/virtual-core 3.17.7
+
+- License: `MIT`
+- Repository: git+https://github.com/TanStack/virtual.git
+- License text: `LICENSE` ([L-277d2a8e4597](#l-277d2a8e4597))
 
 ### @tauri-apps/api 2.11.1
 
@@ -6640,6 +6664,12 @@ License identifiers named across all declared expressions:
 - Repository: wooorm/comma-separated-tokens
 - License text: `license` ([L-d9c32f07344c](#l-d9c32f07344c))
 
+### commander 2.20.3
+
+- License: `MIT`
+- Repository: https://github.com/tj/commander.js.git
+- License text: `LICENSE` ([L-4cc9c2af4eb0](#l-4cc9c2af4eb0))
+
 ### commander 8.3.0
 
 - License: `MIT`
@@ -6663,6 +6693,72 @@ License identifiers named across all declared expressions:
 - License: `MIT`
 - Repository: https://github.com/frenic/csstype
 - License text: `LICENSE` ([L-6a972b33787e](#l-6a972b33787e))
+
+### d3-array 3.2.4
+
+- License: `ISC`
+- Repository: https://github.com/d3/d3-array.git
+- License text: `LICENSE` ([L-f57e3a2cabf2](#l-f57e3a2cabf2))
+
+### d3-color 3.1.0
+
+- License: `ISC`
+- Repository: https://github.com/d3/d3-color.git
+- License text: `LICENSE` ([L-4f4f9997e3d9](#l-4f4f9997e3d9))
+
+### d3-format 3.1.2
+
+- License: `ISC`
+- Repository: https://github.com/d3/d3-format.git
+- License text: `LICENSE` ([L-9fe3e95ca3e8](#l-9fe3e95ca3e8))
+
+### d3-geo 3.1.1
+
+- License: `ISC`
+- Repository: https://github.com/d3/d3-geo.git
+- License text: `LICENSE` ([L-e87ae4ac338d](#l-e87ae4ac338d))
+
+### d3-hierarchy 3.1.2
+
+- License: `ISC`
+- Repository: https://github.com/d3/d3-hierarchy.git
+- License text: `LICENSE` ([L-6019bf345195](#l-6019bf345195))
+
+### d3-interpolate 3.0.1
+
+- License: `ISC`
+- Repository: https://github.com/d3/d3-interpolate.git
+- License text: `LICENSE` ([L-6019bf345195](#l-6019bf345195))
+
+### d3-path 3.1.0
+
+- License: `ISC`
+- Repository: https://github.com/d3/d3-path.git
+- License text: `LICENSE` ([L-58f959e2911c](#l-58f959e2911c))
+
+### d3-scale 4.0.2
+
+- License: `ISC`
+- Repository: https://github.com/d3/d3-scale.git
+- License text: `LICENSE` ([L-6019bf345195](#l-6019bf345195))
+
+### d3-shape 3.2.0
+
+- License: `ISC`
+- Repository: https://github.com/d3/d3-shape.git
+- License text: `LICENSE` ([L-4f4f9997e3d9](#l-4f4f9997e3d9))
+
+### d3-time 3.1.0
+
+- License: `ISC`
+- Repository: https://github.com/d3/d3-time.git
+- License text: `LICENSE` ([L-4f4f9997e3d9](#l-4f4f9997e3d9))
+
+### d3-time-format 4.1.0
+
+- License: `ISC`
+- Repository: https://github.com/d3/d3-time-format.git
+- License text: `LICENSE` ([L-6019bf345195](#l-6019bf345195))
 
 ### date-fns 4.1.0
 
@@ -6796,6 +6892,12 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/101arrowz/fflate
 - License text: `LICENSE` ([L-62249119bb7d](#l-62249119bb7d))
 
+### fflate 0.8.3
+
+- License: `MIT`
+- Repository: https://github.com/101arrowz/fflate
+- License text: `LICENSE` ([L-0a1df3a083d0](#l-0a1df3a083d0))
+
 ### franc-min 6.2.0
 
 - License: `MIT`
@@ -6927,6 +7029,12 @@ License identifiers named across all declared expressions:
 - License: `MIT`
 - Repository: git+https://github.com/remarkablemark/inline-style-parser.git
 - License text: `LICENSE` ([L-9cac2500def4](#l-9cac2500def4))
+
+### internmap 2.0.3
+
+- License: `ISC`
+- Repository: https://github.com/mbostock/internmap.git
+- License text: `LICENSE` ([L-f4bb8f655fdb](#l-f4bb8f655fdb))
 
 ### is-alphabetical 2.0.1
 
@@ -7630,6 +7738,12 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/ikatyang-collab/regexp-util
 - License text: `LICENSE` ([L-f04d53ae9397](#l-f04d53ae9397))
 
+### regl 2.1.1
+
+- License: `MIT`
+- Repository: git+https://github.com/regl-project/regl.git
+- License text: `LICENSE` ([L-8be7c5766fe5](#l-8be7c5766fe5))
+
 ### rehype-highlight 7.0.2
 
 - License: `MIT`
@@ -7839,6 +7953,12 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/alexreardon/tiny-invariant.git
 - License text: `LICENSE` ([L-b1c501095de7](#l-b1c501095de7))
 
+### topojson-client 3.1.0
+
+- License: `ISC`
+- Repository: https://github.com/topojson/topojson-client.git
+- License text: `LICENSE` ([L-5d72d08481a4](#l-5d72d08481a4))
+
 ### trigram-utils 2.0.1
 
 - License: `MIT`
@@ -7935,6 +8055,12 @@ License identifiers named across all declared expressions:
 - Repository: syntax-tree/unist-util-visit-parents
 - License text: `license` ([L-d9c32f07344c](#l-d9c32f07344c))
 
+### us-atlas 3.0.1
+
+- License: `ISC`
+- Repository: https://github.com/topojson/us-atlas.git
+- License text: `LICENSE` ([L-7f7a686a9e08](#l-7f7a686a9e08))
+
 ### use-callback-ref 1.3.3
 
 - License: `MIT`
@@ -7994,6 +8120,12 @@ License identifiers named across all declared expressions:
 - License: `MIT`
 - Repository: wooorm/web-namespaces
 - License text: `license` ([L-d9c32f07344c](#l-d9c32f07344c))
+
+### world-atlas 2.0.2
+
+- License: `ISC`
+- Repository: https://github.com/topojson/world-atlas.git
+- License text: `LICENSE` ([L-7f7a686a9e08](#l-7f7a686a9e08))
 
 ### wrap-ansi 7.0.0
 
@@ -8601,6 +8733,32 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+```
+
+### L-0a1df3a083d0
+
+```
+MIT License
+
+Copyright (c) 2026 Arjun Barrett
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 ```
 
 ### L-0ae52fe329cc
@@ -11083,6 +11241,32 @@ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
 LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+### L-24fdfac792e0
+
+```
+MIT License
+
+Copyright (c) 2026 CrowdView Inc, dba Extend
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 ```
 
 ### L-26235c41e314
@@ -15110,6 +15294,24 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 ```
 
+### L-4f4f9997e3d9
+
+```
+Copyright 2010-2022 Mike Bostock
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+```
+
 ### L-4f8ade273d40
 
 ```
@@ -16391,6 +16593,24 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 ```
 
+### L-58f959e2911c
+
+```
+Copyright 2015-2022 Mike Bostock
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+```
+
 ### L-59013a5c8d3a
 
 ```
@@ -17007,6 +17227,24 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
+### L-5d72d08481a4
+
+```
+Copyright 2012-2019 Michael Bostock
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+```
+
 ### L-5dd2a43c0ed6
 
 ```
@@ -17585,6 +17823,24 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+```
+
+### L-6019bf345195
+
+```
+Copyright 2010-2021 Mike Bostock
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
 ```
 
 ### L-602ef1d5d3db
@@ -23716,6 +23972,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
+### L-7f7a686a9e08
+
+```
+Copyright 2013-2019 Michael Bostock
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+```
+
 ### L-7f91c2a4eddb
 
 ```
@@ -25032,6 +25306,33 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+```
+
+### L-8be7c5766fe5
+
+```
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Mikola Lysenko
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 ```
 
 ### L-8d1f81ea4e87
@@ -27686,6 +27987,24 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+```
+
+### L-9fe3e95ca3e8
+
+```
+Copyright 2010-2026 Mike Bostock
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
 ```
 
 ### L-a00511478c83
@@ -36728,6 +37047,45 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 ```
 
+### L-e87ae4ac338d
+
+```
+Copyright 2010-2024 Mike Bostock
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+
+This license applies to GeographicLib, versions 1.12 and later.
+
+Copyright 2008-2012 Charles Karney
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```
+
 ### L-e91069c31b4e
 
 ```
@@ -37808,6 +38166,24 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
+### L-f4bb8f655fdb
+
+```
+Copyright 2021 Mike Bostock
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+```
+
 ### L-f4bc3f3c5bfd
 
 ```
@@ -37832,6 +38208,24 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+```
+
+### L-f57e3a2cabf2
+
+```
+Copyright 2010-2023 Mike Bostock
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
 ```
 
 ### L-f5b5e0e777c1


### PR DESCRIPTION
## Summary

- replace the split LibreOffice-PDF / Univer XLSX experience with one native, read-only workbook surface
- preserve inspectable cells, formulas, sheet navigation, zoom, range citations, charts, images, merged cells, authored dimensions, and workbook styling
- bundle the exact-pinned Duke WebAssembly parser locally and keep CSV/TSV on the existing lightweight grid path

## Why

The previous preview forced a tradeoff: the PDF path had reasonable print fidelity but no spreadsheet semantics, while the reconstructed grid remained inspectable but lost workbook-native drawings, charts, conditional formatting, and styling details. The new viewer reads the original OOXML into a virtualized canvas workbook so the same surface supports both visual review and cell inspection.

## Implementation

- add `@extend-ai/react-xlsx` with an exact pin and override Duke `0.1.21` to `0.1.23`; the older parser misses self-closing chart references and reports no embedded charts
- add a display-only OOXML projection that preserves cached formula results while retaining original formulas for the formula bar
- normalize semantically equivalent OOXML where the parser otherwise shifts border indices or falls back from workbook theme colors
- project standard data bars and color scales into render-only cell styles when the canvas renderer omits them
- add a fixed-light, read-only workbook toolbar with address/formula display, sheet tabs, zoom controls, selection, copying, and citation navigation
- document the architectural boundary in decision record 0020

## Compatibility and safety

- source workbook bytes are never modified or written back; all normalization happens in an in-memory display copy
- editing, paste, fill, resize, and export of a modified workbook remain disabled
- workbook parsing and the WASM asset remain local to the desktop renderer/worker; no document upload or hosted office dependency is introduced
- CSV/TSV routing and presentation preview behavior are unchanged
- both added packages are MIT licensed and pinned to exact versions

## Validation

- `pnpm exec vitest run src/document/SpreadsheetViewer.dom.test.tsx src/document/NativeSpreadsheetViewer.dom.test.tsx src/document/readOnlyWorkbookProjection.dom.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm build`
- visually verified `launch-command-center.xlsx` in the production preview: themed line and column charts, corrected borders, centered merged KPI values, progress data bars, risk color scale, sheet navigation, and read-only formula inspection
