### PR TITLE
test(release): allow canonical universal download link

### DIFF
--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1415,7 +1415,7 @@ test("GitHub release downloads are copied from the hosted release", () => {
 
   assert.match(
     readFileSync(repositoryFile("README.md"), "utf8"),
-    /releases\/latest\/download\/Tidebreak-macos-apple-silicon\.dmg/,
+    /releases\/latest\/download\/Tidebreak-macos-(?:universal|apple-silicon)\.dmg/,
     "the README download link must match the published asset name",
   );
 });


### PR DESCRIPTION
## Summary
- let the trusted release policy accept either the compatibility macOS DMG link or the new canonical universal DMG link
- preserve the requirement that the README points at an asset attached to every release

## Validation
- `node --test scripts/workflow-security.test.mjs`
- `git diff --check`

Transition-policy prerequisite for the non-blocking review follow-up on #2076.