### PR TITLE
fix(desktop): group the composer mic beside send

### DIFF
--- a/crates/tidebreak-desktop/ui/src/Composer.tsx
+++ b/crates/tidebreak-desktop/ui/src/Composer.tsx
@@ -1044,6 +1044,16 @@ export function Composer({
           {/* The permission mode sits with the send cluster: it is what the
               next turn will be allowed to do, not another way to prepare it. */}
           {permissionMenu}
+          {/* The ring reads as status, so it sits ahead of the two controls
+              that act on the draft: it answers how much room is left for the
+              next turn before you reach for the mic or send. */}
+          {contextUsage && (
+            <ContextUsageIndicator
+              usage={contextUsage.usage}
+              contextWindow={contextUsage.contextWindow}
+              modelName={contextUsage.modelName}
+            />
+          )}
           {/* The mic sits immediately before send: both act on the draft, so
               they belong in the same cluster, apart from the tools and
               model controls that only set the turn up. */}
@@ -1086,15 +1096,6 @@ export function Composer({
                 <Mic size={15} />
               </Button>
             </WithTooltip>
-          )}
-          {/* The ring sits beside send: it answers how much room is left for
-              the next turn, so it belongs with the control that spends it. */}
-          {contextUsage && (
-            <ContextUsageIndicator
-              usage={contextUsage.usage}
-              contextWindow={contextUsage.contextWindow}
-              modelName={contextUsage.modelName}
-            />
           )}
           {active ? (
             <>


### PR DESCRIPTION
The context-usage ring sat between the mic and the send/stop button, so the
two controls that act on the draft were split by a status readout. Reorder the
right-hand composer cluster to permission menu → context ring → mic →
send/stop: the ring reads as "how much room is left for this turn" and belongs
ahead of the controls, and the mic now sits directly beside send.

Comment-only change beyond the reorder — no props, handlers, or sizes touched.

Note on sizing: the mic, stop, and send buttons already share `size="icon-8"`
(32×32), the same token as the tools/model buttons on the left, and nothing
overrides it. They can read as different sizes because the stop/send button
uses the filled `default` variant against the outline mic, which is visual
weight rather than geometry. Left alone here since changing it is a design
choice, not a fix.

Not verified locally: `node_modules` isn't installed in this worktree, so the
UI lanes on this PR are the first run of `pnpm test` / `pnpm build`.