### PR TITLE
chore(release): finalize universal macOS packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -384,6 +384,7 @@ jobs:
         && needs.prepare_macos.result == 'success'
       }}
     runs-on: macos-latest
+    timeout-minutes: 90
     environment:
       name: desktop-production
       url: https://downloads.brightwave.io/tidebreak/manifest.json

--- a/.github/workflows/staging-publish.yml
+++ b/.github/workflows/staging-publish.yml
@@ -192,6 +192,7 @@ jobs:
     needs: [validate_staging, prepare_macos_staging]
     if: ${{ inputs.channel == 'staging' }}
     runs-on: macos-latest
+    timeout-minutes: 90
     environment:
       name: desktop-staging
       url: https://downloads.brightwave.io/tidebreak/staging/manifest.json

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-macos-apple-silicon.dmg"><img src="https://img.shields.io/badge/Download%20for%20macOS-000000.svg?logo=apple&logoColor=white" alt="Download the latest macOS release"></a>
+  <a href="https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-macos-universal.dmg"><img src="https://img.shields.io/badge/Download%20for%20macOS-000000.svg?logo=apple&logoColor=white" alt="Download the latest macOS release"></a>
 </p>
 
 ---

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1415,7 +1415,7 @@ test("GitHub release downloads are copied from the hosted release", () => {
 
   assert.match(
     readFileSync(repositoryFile("README.md"), "utf8"),
-    /releases\/latest\/download\/Tidebreak-macos-(?:universal|apple-silicon)\.dmg/,
+    /releases\/latest\/download\/Tidebreak-macos-universal\.dmg/,
     "the README download link must match the published asset name",
   );
 });
@@ -1547,6 +1547,7 @@ test("universal macOS release and staging packages contain both slices", () => {
   }
 
   for (const job of [releaseBuild, stagingBuild]) {
+    assert.match(job, /timeout-minutes: 90/);
     assert.match(job, /lipo -archs "\$app_path\/Contents\/MacOS\/\$executable"/);
     assert.match(job, /\$binary_arches" = \*arm64\*/);
     assert.match(job, /\$binary_arches" = \*x86_64\*/);


### PR DESCRIPTION
## Summary
- point the README download button at the canonical universal macOS DMG while retaining the Apple Silicon compatibility asset
- cap production and staging macOS signing jobs at 90 minutes
- make both review follow-ups part of the trusted release policy

## Validation
- `node --test scripts/workflow-security.test.mjs scripts/workflow-security-mutations.test.mjs scripts/create-release-manifests.test.mjs` (62 passed)
- `git diff --check`

Addresses the two non-blocking review findings from #2076.