### PR TITLE
feat(desktop): add first-task walkthrough

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
@@ -290,7 +290,7 @@ describe("app shell", () => {
   it("opens on home rather than on a conversation", { timeout: 15000 }, async () => {
     const { router } = await mountApp();
 
-    expect(await screen.findByText("How can I help?")).toBeInTheDocument();
+    expect(await screen.findByText("Welcome to Tidebreak")).toBeInTheDocument();
     expect(router.state.location.pathname).toBe("/");
     // Home used to create a chat on every cold start, leaving an empty one
     // behind whenever the reader did not use it.
@@ -335,7 +335,7 @@ describe("app shell", () => {
     // fine, so the shell stands and the failure is reported where the list
     // would be. The settled load also frees the deep link to redirect home
     // rather than wait on a fetch that already failed.
-    expect(await screen.findByText("How can I help?")).toBeInTheDocument();
+    expect(await screen.findByText("Welcome to Tidebreak")).toBeInTheDocument();
     await waitFor(() => expect(router.state.location.pathname).toBe("/"));
     expect(
       await screen.findByText(/Could not load chats/),
@@ -353,7 +353,7 @@ describe("app shell", () => {
   it("starts a conversation from the home composer and sends what was written", async () => {
     const user = userEvent.setup();
     const { router } = await mountApp();
-    await screen.findByText("How can I help?");
+    await screen.findByText("Welcome to Tidebreak");
 
     await user.type(
       screen.getByRole("textbox", { name: "Message" }),
@@ -384,7 +384,7 @@ describe("app shell", () => {
   it("opens a conversation from the sidebar", async () => {
     const user = userEvent.setup();
     const { router } = await mountApp();
-    await screen.findByText("How can I help?");
+    await screen.findByText("Welcome to Tidebreak");
 
     const chatList = screen.getByLabelText("Chats");
     const [row] = screen
@@ -496,7 +496,7 @@ describe("app shell", () => {
 
   it("keeps chat-scoped places with the conversation", async () => {
     await mountApp();
-    await screen.findByText("How can I help?");
+    await screen.findByText("Welcome to Tidebreak");
     // Not disabled — absent. Home has no conversation for the chip to
     // describe, and the rail itself carries nothing chat-scoped anymore.
     expect(screen.queryByLabelText("Chat activity")).not.toBeInTheDocument();
@@ -529,7 +529,7 @@ describe("app shell", () => {
   it("remembers the collapsed rail across a restart", async () => {
     const user = userEvent.setup();
     await mountApp();
-    await screen.findByText("How can I help?");
+    await screen.findByText("Welcome to Tidebreak");
 
     await user.click(screen.getByRole("button", { name: "Collapse sidebar" }));
 
@@ -618,7 +618,7 @@ describe("app shell", () => {
   it("creates a project from the dialog and opens a chat inside it", async () => {
     const user = userEvent.setup();
     const { router } = await mountApp();
-    await screen.findByText("How can I help?");
+    await screen.findByText("Welcome to Tidebreak");
 
     await user.click(screen.getByRole("button", { name: "New project" }));
     const name = await screen.findByRole("textbox", { name: "Project name" });

--- a/crates/tidebreak-desktop/ui/src/ComposerToolsMenu.tsx
+++ b/crates/tidebreak-desktop/ui/src/ComposerToolsMenu.tsx
@@ -97,6 +97,7 @@ export function ComposerToolsMenu({
               variant="ghost"
               size="icon-8"
               aria-label="Tools"
+              data-first-task-target="tools"
               disabled={disabled}
             >
               <Plus size={16} />

--- a/crates/tidebreak-desktop/ui/src/FirstTaskWalkthrough.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/FirstTaskWalkthrough.dom.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -20,18 +22,33 @@ function Targets() {
   );
 }
 
+function WalkthroughHarness({
+  onClose,
+}: {
+  onClose: (outcome: "completed" | "skipped") => void;
+}) {
+  const [open, setOpen] = useState(true);
+  return (
+    <>
+      <Targets />
+      <FirstTaskWalkthrough
+        open={open}
+        onClose={(outcome) => {
+          onClose(outcome);
+          setOpen(false);
+        }}
+      />
+    </>
+  );
+}
+
 beforeEach(() => window.localStorage.clear());
 afterEach(cleanup);
 
 describe("FirstTaskWalkthrough", () => {
   it("walks the four setup controls, remembers completion, and returns focus", async () => {
     const onClose = vi.fn();
-    render(
-      <>
-        <Targets />
-        <FirstTaskWalkthrough open onClose={onClose} />
-      </>,
-    );
+    render(<WalkthroughHarness onClose={onClose} />);
 
     expect(
       screen.getByRole("heading", { name: "Choose a model" }),
@@ -60,20 +77,36 @@ describe("FirstTaskWalkthrough", () => {
     );
   });
 
-  it("treats Escape as an intentional skip", () => {
+  it("treats Escape as an intentional skip", async () => {
+    const user = userEvent.setup();
     const onClose = vi.fn();
-    render(
-      <>
-        <Targets />
-        <FirstTaskWalkthrough open onClose={onClose} />
-      </>,
-    );
+    render(<WalkthroughHarness onClose={onClose} />);
 
-    fireEvent.keyDown(window, { key: "Escape" });
+    await user.keyboard("{Escape}");
 
     expect(onClose).toHaveBeenCalledWith("skipped");
     expect(window.localStorage.getItem(FIRST_TASK_WALKTHROUGH_KEY)).toBe(
       "skipped",
+    );
+  });
+
+  it("keeps keyboard focus inside the walkthrough through layout changes", async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <Targets />
+        <FirstTaskWalkthrough open onClose={vi.fn()} />
+      </>,
+    );
+
+    const next = screen.getByRole("button", { name: "Next" });
+    next.focus();
+    fireEvent(window, new Event("resize"));
+    expect(next).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByRole("dialog")).toContainElement(
+      document.activeElement as HTMLElement | null,
     );
   });
 });

--- a/crates/tidebreak-desktop/ui/src/FirstTaskWalkthrough.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/FirstTaskWalkthrough.dom.test.tsx
@@ -109,4 +109,25 @@ describe("FirstTaskWalkthrough", () => {
       document.activeElement as HTMLElement | null,
     );
   });
+
+  it("does not turn a click on the highlighted control into a permanent skip", async () => {
+    const onClose = vi.fn();
+    render(<WalkthroughHarness onClose={onClose} />);
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+
+    const target = screen.getByText("Model");
+    fireEvent.pointerDown(target);
+    fireEvent.mouseDown(target);
+    fireEvent.pointerUp(target);
+    fireEvent.mouseUp(target);
+    fireEvent.click(target);
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem(FIRST_TASK_WALKTHROUGH_KEY)).toBeNull();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("1 of 4").parentElement?.parentElement).toHaveAttribute(
+      "aria-live",
+      "polite",
+    );
+  });
 });

--- a/crates/tidebreak-desktop/ui/src/FirstTaskWalkthrough.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/FirstTaskWalkthrough.dom.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  FIRST_TASK_WALKTHROUGH_KEY,
+  FirstTaskWalkthrough,
+  shouldOfferFirstTaskWalkthrough,
+} from "./FirstTaskWalkthrough";
+
+function Targets() {
+  return (
+    <>
+      <button data-first-task-target="model">Model</button>
+      <button data-first-task-target="tools">Tools</button>
+      <button data-first-task-target="permissions">Ask</button>
+      <textarea data-composer-input aria-label="Message" />
+    </>
+  );
+}
+
+beforeEach(() => window.localStorage.clear());
+afterEach(cleanup);
+
+describe("FirstTaskWalkthrough", () => {
+  it("walks the four setup controls, remembers completion, and returns focus", async () => {
+    const onClose = vi.fn();
+    render(
+      <>
+        <Targets />
+        <FirstTaskWalkthrough open onClose={onClose} />
+      </>,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Choose a model" }),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(
+      screen.getByRole("heading", { name: "Set internet access" }),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(
+      screen.getByRole("heading", { name: "Choose a permission level" }),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(
+      screen.getByRole("heading", { name: "Add attachments" }),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+
+    expect(onClose).toHaveBeenCalledWith("completed");
+    expect(window.localStorage.getItem(FIRST_TASK_WALKTHROUGH_KEY)).toBe(
+      "completed",
+    );
+    expect(shouldOfferFirstTaskWalkthrough()).toBe(false);
+    await waitFor(() =>
+      expect(screen.getByRole("textbox", { name: "Message" })).toHaveFocus(),
+    );
+  });
+
+  it("treats Escape as an intentional skip", () => {
+    const onClose = vi.fn();
+    render(
+      <>
+        <Targets />
+        <FirstTaskWalkthrough open onClose={onClose} />
+      </>,
+    );
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(onClose).toHaveBeenCalledWith("skipped");
+    expect(window.localStorage.getItem(FIRST_TASK_WALKTHROUGH_KEY)).toBe(
+      "skipped",
+    );
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/FirstTaskWalkthrough.tsx
+++ b/crates/tidebreak-desktop/ui/src/FirstTaskWalkthrough.tsx
@@ -1,0 +1,263 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { Button } from "@/components/ui/button";
+
+export const FIRST_TASK_WALKTHROUGH_KEY =
+  "tidebreak.first-task-walkthrough.v1";
+
+export type FirstTaskWalkthroughOutcome = "completed" | "skipped";
+
+type WalkthroughStep = {
+  id: string;
+  target: string;
+  title: string;
+  body: string;
+};
+
+const STEPS: readonly WalkthroughStep[] = [
+  {
+    id: "model",
+    target: "model",
+    title: "Choose a model",
+    body: "Models differ in speed, reasoning, and the inputs they understand. The current default is a good place to start.",
+  },
+  {
+    id: "internet",
+    target: "tools",
+    title: "Set internet access",
+    body: "Open Tools and choose Network when the task needs websites or current information. Leave it off when Tidebreak should use only your message and attachments.",
+  },
+  {
+    id: "permissions",
+    target: "permissions",
+    title: "Choose a permission level",
+    body: "Ask confirms actions, Auto handles routine workspace work, and Allow all runs without asking in this chat. Ask is a safe place to start.",
+  },
+  {
+    id: "attachments",
+    target: "tools",
+    title: "Add attachments",
+    body: "Open Tools to attach files for this task or connect a folder when the agent should work across a collection of files.",
+  },
+] as const;
+
+type ElementRect = {
+  top: number;
+  left: number;
+  right: number;
+  bottom: number;
+  width: number;
+  height: number;
+};
+
+export function shouldOfferFirstTaskWalkthrough(): boolean {
+  try {
+    const value = window.localStorage.getItem(FIRST_TASK_WALKTHROUGH_KEY);
+    return value !== "completed" && value !== "skipped";
+  } catch {
+    return true;
+  }
+}
+
+function storeOutcome(outcome: FirstTaskWalkthroughOutcome): void {
+  try {
+    window.localStorage.setItem(FIRST_TASK_WALKTHROUGH_KEY, outcome);
+  } catch {
+    // The walkthrough still closes when preference persistence is unavailable.
+  }
+}
+
+function targetSelector(target: string): string {
+  return `[data-first-task-target="${CSS.escape(target)}"]`;
+}
+
+function focusComposer(): void {
+  window.requestAnimationFrame(() => {
+    document
+      .querySelector<HTMLTextAreaElement>("[data-composer-input]")
+      ?.focus();
+  });
+}
+
+export function FirstTaskWalkthrough({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: (outcome: FirstTaskWalkthroughOutcome) => void;
+}) {
+  const [stepIndex, setStepIndex] = useState(0);
+  const [rect, setRect] = useState<ElementRect | null>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const step = STEPS[stepIndex];
+
+  useEffect(() => {
+    if (!open) {
+      setStepIndex(0);
+      setRect(null);
+      return;
+    }
+
+    const target = document.querySelector<HTMLElement>(
+      targetSelector(step.target),
+    );
+    if (!target) {
+      setRect(null);
+      return;
+    }
+
+    target.scrollIntoView({ block: "nearest", inline: "nearest" });
+    const update = () => {
+      const next = target.getBoundingClientRect();
+      setRect({
+        top: next.top,
+        left: next.left,
+        right: next.right,
+        bottom: next.bottom,
+        width: next.width,
+        height: next.height,
+      });
+    };
+    update();
+
+    const observer = new ResizeObserver(update);
+    observer.observe(target);
+    window.addEventListener("resize", update);
+    window.addEventListener("scroll", update, true);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", update, true);
+    };
+  }, [open, step.target]);
+
+  useEffect(() => {
+    if (!open) return;
+    dialogRef.current?.focus();
+  }, [open, stepIndex, rect]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      finish("skipped");
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  });
+
+  function finish(outcome: FirstTaskWalkthroughOutcome) {
+    storeOutcome(outcome);
+    onClose(outcome);
+    focusComposer();
+  }
+
+  if (!open || typeof document === "undefined") return null;
+
+  const dialogWidth = Math.min(320, window.innerWidth - 24);
+  const above = rect !== null && rect.top >= 220;
+  const dialogLeft = rect
+    ? Math.max(
+        12,
+        Math.min(
+          rect.left + rect.width / 2 - dialogWidth / 2,
+          window.innerWidth - dialogWidth - 12,
+        ),
+      )
+    : Math.max(12, (window.innerWidth - dialogWidth) / 2);
+  const dialogTop = rect
+    ? above
+      ? rect.top - 12
+      : rect.bottom + 12
+    : window.innerHeight / 2;
+
+  return createPortal(
+    <div className="fixed inset-0 z-[100]" aria-live="polite">
+      <div className="absolute inset-0 bg-black/45" aria-hidden="true" />
+      {rect && (
+        <div
+          className="pointer-events-none fixed z-[101] rounded-[10px] ring-2 ring-[var(--brightwave)] ring-offset-2 ring-offset-transparent"
+          aria-hidden="true"
+          style={{
+            top: rect.top - 4,
+            left: rect.left - 4,
+            width: rect.width + 8,
+            height: rect.height + 8,
+            boxShadow: "0 0 0 9999px rgb(0 0 0 / 0.01)",
+          }}
+        />
+      )}
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={`first-task-walkthrough-${step.id}`}
+        tabIndex={-1}
+        className="fixed z-[102] rounded-xl border border-border bg-popover p-4 text-popover-foreground shadow-xl outline-none"
+        style={{
+          top: dialogTop,
+          left: dialogLeft,
+          width: dialogWidth,
+          transform: rect
+            ? above
+              ? "translateY(-100%)"
+              : undefined
+            : "translateY(-50%)",
+        }}
+      >
+        <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+          <span>Set up your first task</span>
+          <span>
+            {stepIndex + 1} of {STEPS.length}
+          </span>
+        </div>
+        <h2
+          id={`first-task-walkthrough-${step.id}`}
+          className="mt-3 text-base font-semibold tracking-[-0.01em]"
+        >
+          {step.title}
+        </h2>
+        <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+          {step.body}
+        </p>
+        <div className="mt-4 flex items-center gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="mr-auto text-muted-foreground"
+            onClick={() => finish("skipped")}
+          >
+            Skip setup
+          </Button>
+          {stepIndex > 0 && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setStepIndex((current) => current - 1)}
+            >
+              Back
+            </Button>
+          )}
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => {
+              if (stepIndex === STEPS.length - 1) {
+                finish("completed");
+              } else {
+                setStepIndex((current) => current + 1);
+              }
+            }}
+          >
+            {stepIndex === STEPS.length - 1 ? "Done" : "Next"}
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/FirstTaskWalkthrough.tsx
+++ b/crates/tidebreak-desktop/ui/src/FirstTaskWalkthrough.tsx
@@ -1,7 +1,13 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
 
 export const FIRST_TASK_WALKTHROUGH_KEY =
   "tidebreak.first-task-walkthrough.v1";
@@ -32,13 +38,13 @@ const STEPS: readonly WalkthroughStep[] = [
     id: "permissions",
     target: "permissions",
     title: "Choose a permission level",
-    body: "Ask confirms actions, Auto handles routine workspace work, and Allow all runs without asking in this chat. Ask is a safe place to start.",
+    body: "Plan stays read-only, Ask confirms actions, Auto handles routine workspace work, and Allow all runs without asking in this chat. Ask is a balanced place to start.",
   },
   {
     id: "attachments",
     target: "tools",
     title: "Add attachments",
-    body: "Open Tools to attach files for this task or connect a folder when the agent should work across a collection of files.",
+    body: "Open Tools to attach files from your computer. This option appears in the desktop app when local file access is available.",
   },
 ] as const;
 
@@ -89,7 +95,6 @@ export function FirstTaskWalkthrough({
 }) {
   const [stepIndex, setStepIndex] = useState(0);
   const [rect, setRect] = useState<ElementRect | null>(null);
-  const dialogRef = useRef<HTMLDivElement>(null);
   const step = STEPS[stepIndex];
 
   useEffect(() => {
@@ -132,22 +137,6 @@ export function FirstTaskWalkthrough({
     };
   }, [open, step.target]);
 
-  useEffect(() => {
-    if (!open) return;
-    dialogRef.current?.focus();
-  }, [open, stepIndex, rect]);
-
-  useEffect(() => {
-    if (!open) return;
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== "Escape") return;
-      event.preventDefault();
-      finish("skipped");
-    };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  });
-
   function finish(outcome: FirstTaskWalkthroughOutcome) {
     storeOutcome(outcome);
     onClose(outcome);
@@ -173,10 +162,14 @@ export function FirstTaskWalkthrough({
       : rect.bottom + 12
     : window.innerHeight / 2;
 
-  return createPortal(
-    <div className="fixed inset-0 z-[100]" aria-live="polite">
-      <div className="absolute inset-0 bg-black/45" aria-hidden="true" />
-      {rect && (
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) finish("skipped");
+      }}
+    >
+      {rect && createPortal(
         <div
           className="pointer-events-none fixed z-[101] rounded-[10px] ring-2 ring-[var(--brightwave)] ring-offset-2 ring-offset-transparent"
           aria-hidden="true"
@@ -187,15 +180,13 @@ export function FirstTaskWalkthrough({
             height: rect.height + 8,
             boxShadow: "0 0 0 9999px rgb(0 0 0 / 0.01)",
           }}
-        />
+        />,
+        document.body,
       )}
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={`first-task-walkthrough-${step.id}`}
-        tabIndex={-1}
-        className="fixed z-[102] rounded-xl border border-border bg-popover p-4 text-popover-foreground shadow-xl outline-none"
+      <DialogContent
+        withCloseButton={false}
+        overlayClassName="z-[100] bg-black/45"
+        className="z-[102] block max-w-none translate-x-0 translate-y-0 gap-0 rounded-xl border-border bg-popover p-4 text-popover-foreground shadow-xl duration-0 data-[state=closed]:animate-none data-[state=open]:animate-none"
         style={{
           top: dialogTop,
           left: dialogLeft,
@@ -213,15 +204,12 @@ export function FirstTaskWalkthrough({
             {stepIndex + 1} of {STEPS.length}
           </span>
         </div>
-        <h2
-          id={`first-task-walkthrough-${step.id}`}
-          className="mt-3 text-base font-semibold tracking-[-0.01em]"
-        >
+        <DialogTitle className="mt-3 text-base tracking-[-0.01em]">
           {step.title}
-        </h2>
-        <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+        </DialogTitle>
+        <DialogDescription className="mt-1.5 leading-relaxed">
           {step.body}
-        </p>
+        </DialogDescription>
         <div className="mt-4 flex items-center gap-2">
           <Button
             type="button"
@@ -256,8 +244,7 @@ export function FirstTaskWalkthrough({
             {stepIndex === STEPS.length - 1 ? "Done" : "Next"}
           </Button>
         </div>
-      </div>
-    </div>,
-    document.body,
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/FirstTaskWalkthrough.tsx
+++ b/crates/tidebreak-desktop/ui/src/FirstTaskWalkthrough.tsx
@@ -185,6 +185,7 @@ export function FirstTaskWalkthrough({
       )}
       <DialogContent
         withCloseButton={false}
+        onInteractOutside={(event) => event.preventDefault()}
         overlayClassName="z-[100] bg-black/45"
         className="z-[102] block max-w-none translate-x-0 translate-y-0 gap-0 rounded-xl border-border bg-popover p-4 text-popover-foreground shadow-xl duration-0 data-[state=closed]:animate-none data-[state=open]:animate-none"
         style={{
@@ -198,18 +199,20 @@ export function FirstTaskWalkthrough({
             : "translateY(-50%)",
         }}
       >
-        <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
-          <span>Set up your first task</span>
-          <span>
-            {stepIndex + 1} of {STEPS.length}
-          </span>
+        <div aria-live="polite" aria-atomic="true">
+          <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+            <span>Set up your first task</span>
+            <span>
+              {stepIndex + 1} of {STEPS.length}
+            </span>
+          </div>
+          <DialogTitle className="mt-3 text-base tracking-[-0.01em]">
+            {step.title}
+          </DialogTitle>
+          <DialogDescription className="mt-1.5 leading-relaxed">
+            {step.body}
+          </DialogDescription>
         </div>
-        <DialogTitle className="mt-3 text-base tracking-[-0.01em]">
-          {step.title}
-        </DialogTitle>
-        <DialogDescription className="mt-1.5 leading-relaxed">
-          {step.body}
-        </DialogDescription>
         <div className="mt-4 flex items-center gap-2">
           <Button
             type="button"

--- a/crates/tidebreak-desktop/ui/src/HomeRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/HomeRoute.tsx
@@ -32,6 +32,10 @@ import { MAX_IMAGE_ATTACHMENTS } from "./ImageAttachments";
 import { useImageAttachments } from "./useImageAttachments";
 import { appendTranscript, useVoiceComposer } from "./useVoiceComposer";
 import { useVoiceInputStore, voiceSelectionReady } from "./VoiceInputStore";
+import {
+  FirstTaskWalkthrough,
+  shouldOfferFirstTaskWalkthrough,
+} from "./FirstTaskWalkthrough";
 
 const chatListActions = useChatListStore.getState();
 const composerDraftActions = useComposerDrafts.getState();
@@ -139,6 +143,10 @@ export function HomeRoute() {
     },
   );
   const [error, setError] = useState<string | null>(null);
+  const [walkthroughAvailable, setWalkthroughAvailable] = useState(
+    shouldOfferFirstTaskWalkthrough,
+  );
+  const [walkthroughOpen, setWalkthroughOpen] = useState(false);
   const newChat = useNewChatSettings();
   // What the pickers show and the created chat will get: this visit's picks
   // over the server's sticky defaults. Only the explicit picks are sent; the
@@ -379,6 +387,13 @@ export function HomeRoute() {
             }}
             executionConfigClient={client}
             promptLibrary={promptLibrary}
+            heading="Welcome to Tidebreak"
+            description="Choose how the agent works, add what it needs, and start with a real task."
+            onStartWalkthrough={
+              walkthroughAvailable
+                ? () => setWalkthroughOpen(true)
+                : undefined
+            }
           />
         </div>
 
@@ -482,6 +497,13 @@ export function HomeRoute() {
         </div>
         </div>
       </div>
+      <FirstTaskWalkthrough
+        open={walkthroughOpen}
+        onClose={() => {
+          setWalkthroughOpen(false);
+          setWalkthroughAvailable(false);
+        }}
+      />
     </RouteFrame>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/HomeRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/HomeRoute.tsx
@@ -387,8 +387,12 @@ export function HomeRoute() {
             }}
             executionConfigClient={client}
             promptLibrary={promptLibrary}
-            heading="Welcome to Tidebreak"
-            description="Choose how the agent works, add what it needs, and start with a real task."
+            heading={walkthroughAvailable ? "Welcome to Tidebreak" : undefined}
+            description={
+              walkthroughAvailable
+                ? "Choose how the agent works, add what it needs, and start with a real task."
+                : undefined
+            }
             onStartWalkthrough={
               walkthroughAvailable
                 ? () => setWalkthroughOpen(true)

--- a/crates/tidebreak-desktop/ui/src/ModelMenu.tsx
+++ b/crates/tidebreak-desktop/ui/src/ModelMenu.tsx
@@ -420,6 +420,7 @@ export function ModelMenu({
           className="h-8 max-w-56 gap-2"
           disabled={disabled}
           aria-label={triggerLabel}
+          data-first-task-target="model"
           title={triggerLabel}
         >
           {pillModel ? (

--- a/crates/tidebreak-desktop/ui/src/PermissionModeMenu.tsx
+++ b/crates/tidebreak-desktop/ui/src/PermissionModeMenu.tsx
@@ -170,6 +170,7 @@ export function PermissionModeMenu({
           disabled={controlsDisabled}
           aria-label={`Permissions: ${current.label}`}
           aria-busy={saving}
+          data-first-task-target="permissions"
         >
           <CurrentIcon className="size-4 text-foreground" />
           {current.label}

--- a/crates/tidebreak-desktop/ui/src/WelcomeState.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/WelcomeState.test.tsx
@@ -55,6 +55,25 @@ describe("WelcomeState", () => {
     );
   });
 
+  it("offers the first-task walkthrough when home provides it", () => {
+    const onStartWalkthrough = vi.fn();
+    render(
+      <WelcomeState
+        heading="Welcome to Tidebreak"
+        description="Set up the agent before the first task."
+        onStartWalkthrough={onStartWalkthrough}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Welcome to Tidebreak" }),
+    ).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Set up your first task" }),
+    );
+    expect(onStartWalkthrough).toHaveBeenCalledOnce();
+  });
+
   it("omits the starter prompts when no handler is provided", () => {
     const { container } = render(<WelcomeState />);
 

--- a/crates/tidebreak-desktop/ui/src/WelcomeState.tsx
+++ b/crates/tidebreak-desktop/ui/src/WelcomeState.tsx
@@ -17,6 +17,7 @@ import {
 } from "./CodeExecutionDisclosure";
 import { Logomark } from "./Logomark";
 import type { PluginsApis } from "./plugins/pluginsApis";
+import { Button } from "@/components/ui/button";
 
 /**
  * What the welcome screen calls on the prompt library.
@@ -89,9 +90,15 @@ export function WelcomeState({
   onSelectPrompt,
   executionConfigClient,
   promptLibrary,
+  heading = "How can I help?",
+  description = "Ask a question, work through your files, or start a task.",
+  onStartWalkthrough,
 }: {
   onSelectPrompt?: (prompt: string) => void;
   executionConfigClient?: Pick<ApiClient, "getCodeExecutionConfig">;
+  heading?: string;
+  description?: string;
+  onStartWalkthrough?: () => void;
   /**
    * The installed prompt library, when this surface offers it. Absent — or
    * empty, or still loading — the hardcoded starters stand, so an install with
@@ -172,12 +179,15 @@ export function WelcomeState({
         <Logomark />
       </span>
       <div className="welcome-copy">
-        <h2>How can I help?</h2>
-        <p>
-          Ask a question, work through your files, or start a task.
-        </p>
+        <h2>{heading}</h2>
+        <p>{description}</p>
         {managedExecutionOnly && <p>{MANAGED_EXECUTION_DISCLOSURE}</p>}
       </div>
+      {onStartWalkthrough && (
+        <Button type="button" size="sm" onClick={onStartWalkthrough}>
+          Set up your first task
+        </Button>
+      )}
       {onSelectPrompt && libraryPrompts.length > 0 && (
         <div className="welcome-prompts">
           {libraryPrompts.map((prompt) => (


### PR DESCRIPTION
## Summary

- welcome new users from the home screen with a lightweight first-task setup entry point
- walk through model choice, internet access, permission level, and attachments using the existing composer controls
- remember completion or skip locally so the setup prompt stays out of the way afterward
- keep the existing empty-chat welcome state and avoid adding a help agent, backend contract, or new dependency

## Validation

- `pnpm test` (147 files, 992 tests)
- `pnpm build`
- `git diff --check`

## Compatibility and risk

This is a desktop UI-only change. It adds semantic targeting attributes to existing controls and a localStorage preference; it does not change provider, model, permission, attachment, or wire behavior.
