### PR TITLE
feat(desktop): add app reload

### DIFF
--- a/crates/tidebreak-desktop/src/lib.rs
+++ b/crates/tidebreak-desktop/src/lib.rs
@@ -636,7 +636,7 @@ pub fn run() {
             let handle = app.handle().clone();
             deep_link::install(&handle);
             #[cfg(target_os = "macos")]
-            updater::install_update_menu(app)?;
+            updater::install_app_menu(app)?;
             updater::spawn_update_loop(handle.clone());
             let data = data_dir(&handle)?;
             // Before anything that can warn: the embedded server's tracing

--- a/crates/tidebreak-desktop/src/updater.rs
+++ b/crates/tidebreak-desktop/src/updater.rs
@@ -34,6 +34,7 @@ const UPDATE_STATE_EVENT: &str = "desktop-update-state";
 /// there so the outcome (up to date, or an update staged) is visible.
 const UPDATE_CHECK_REQUESTED_EVENT: &str = "desktop-update-check-requested";
 const MENU_CHECK_FOR_UPDATES_ID: &str = "check-for-updates";
+const MENU_RELOAD_ID: &str = "reload-app";
 const UPDATE_CHECK_STARTUP_DELAY: Duration = Duration::from_secs(15);
 const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(5 * 60);
 const UPDATE_CHECK_ERROR: &str = "Could not check for updates. Try again later.";
@@ -284,21 +285,19 @@ async fn run_update_check(app: AppHandle) -> DesktopUpdateState {
     current_update_state(&app)
 }
 
-/// Install the app's native menu with a "Check for Updates…" item in the
-/// standard macOS placement: the application submenu, directly under "About".
-/// The rest of the default menu is kept intact. Other platforms keep the
-/// stock menu untouched.
+/// Install the app's native menu additions on macOS.
+///
+/// "Check for Updates…" sits in the application submenu directly under
+/// "About", while "Reload" leads the View menu with the browser-standard
+/// Cmd+R accelerator. The rest of Tauri's default menu stays intact.
 #[cfg(target_os = "macos")]
-pub(crate) fn install_update_menu(app: &tauri::App) -> tauri::Result<()> {
-    use tauri::menu::{Menu, MenuItem};
+pub(crate) fn install_app_menu(app: &tauri::App) -> tauri::Result<()> {
+    use tauri::menu::{Menu, MenuItem, PredefinedMenuItem};
 
     let handle = app.handle();
     let menu = Menu::default(handle)?;
-    if let Some(app_submenu) = menu
-        .items()?
-        .first()
-        .and_then(|item| item.as_submenu().cloned())
-    {
+    let items = menu.items()?;
+    if let Some(app_submenu) = items.first().and_then(|item| item.as_submenu().cloned()) {
         let check = MenuItem::with_id(
             handle,
             MENU_CHECK_FOR_UPDATES_ID,
@@ -308,15 +307,35 @@ pub(crate) fn install_update_menu(app: &tauri::App) -> tauri::Result<()> {
         )?;
         app_submenu.insert(&check, 1)?;
     }
+    if let Some(view_submenu) = items.iter().find_map(|item| {
+        let submenu = item.as_submenu()?;
+        matches!(submenu.text().as_deref(), Ok("View")).then(|| submenu.clone())
+    }) {
+        let reload =
+            MenuItem::with_id(handle, MENU_RELOAD_ID, "Reload", true, Some("CmdOrCtrl+R"))?;
+        let separator = PredefinedMenuItem::separator(handle)?;
+        view_submenu.prepend(&separator)?;
+        view_submenu.prepend(&reload)?;
+    }
     app.set_menu(menu)?;
     Ok(())
 }
 
 pub(crate) fn handle_menu_event(app: &AppHandle, event: tauri::menu::MenuEvent) {
-    if event.id().as_ref() == MENU_CHECK_FOR_UPDATES_ID {
-        if let Err(error) = app.emit(UPDATE_CHECK_REQUESTED_EVENT, ()) {
-            eprintln!("tidebreak-desktop: could not raise the update-check request: {error}");
+    match event.id().as_ref() {
+        MENU_CHECK_FOR_UPDATES_ID => {
+            if let Err(error) = app.emit(UPDATE_CHECK_REQUESTED_EVENT, ()) {
+                eprintln!("tidebreak-desktop: could not raise the update-check request: {error}");
+            }
         }
+        MENU_RELOAD_ID => {
+            if let Some(window) = app.get_webview_window("main") {
+                if let Err(error) = window.reload() {
+                    eprintln!("tidebreak-desktop: could not reload the app: {error}");
+                }
+            }
+        }
+        _ => {}
     }
 }
 

--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -156,6 +156,7 @@ export function AppShell() {
     "zoom-in": zoom.zoomIn,
     "zoom-out": zoom.zoomOut,
     "zoom-reset": zoom.resetZoom,
+    "reload-app": () => window.location.reload(),
     "show-shortcuts": () => setShortcutsOpen(true),
   };
 

--- a/crates/tidebreak-desktop/ui/src/ShellShortcuts.test.ts
+++ b/crates/tidebreak-desktop/ui/src/ShellShortcuts.test.ts
@@ -52,6 +52,7 @@ describe("shell shortcut resolution", () => {
       [{ key: "k", code: "KeyK" }, "focus-composer"],
       [{ key: "/", code: "Slash" }, "show-shortcuts"],
       [{ key: "0", code: "Digit0" }, "zoom-reset"],
+      [{ key: "r", code: "KeyR" }, "reload-app"],
     ];
     for (const [event, id] of cases) {
       const resolved = resolveShellShortcut(keyEvent(event), context());

--- a/crates/tidebreak-desktop/ui/src/ShellShortcuts.ts
+++ b/crates/tidebreak-desktop/ui/src/ShellShortcuts.ts
@@ -17,6 +17,7 @@ export type ShellShortcutAction =
   | "zoom-in"
   | "zoom-out"
   | "zoom-reset"
+  | "reload-app"
   | "show-shortcuts";
 
 /** The heading a shortcut sits under in the help dialog. */
@@ -151,6 +152,14 @@ export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
     codes: ["Digit0", "Numpad0"],
     mod: true,
     description: "Reset the interface size",
+    group: "View",
+    allowInEditable: true,
+  },
+  {
+    id: "reload-app",
+    codes: ["KeyR"],
+    mod: true,
+    description: "Reload the app",
     group: "View",
     allowInEditable: true,
   },


### PR DESCRIPTION
## Summary

- add Cmd/Ctrl+R as a shell-level shortcut that reloads the app
- expose the shortcut in the keyboard shortcuts help
- add a native macOS View → Reload menu item so reload remains available when the renderer is unavailable

## User impact

Users can refresh Tidebreak with the standard reload shortcut or the macOS View menu, including as a recovery path for a stuck renderer.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p tidebreak-desktop --locked`
- `pnpm exec vitest run src/ShellShortcuts.test.ts`
- `pnpm build`
- full UI suite before rebase: 989 tests passed