### PR TITLE
docs: polish soft-launch documentation and metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,65 @@
+name: Bug report
+description: Report reproducible behavior that is broken or misleading.
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Tidebreak. Please search existing issues first.
+        For security vulnerabilities, use private vulnerability reporting instead of this form.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: Tell us what you expected and what happened instead.
+      placeholder: Include the exact error text when there is one.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open …
+        2. Configure …
+        3. Run …
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Tidebreak version
+      description: Find this in the app's About panel or release name.
+      placeholder: v0.43.0
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - macOS (Apple Silicon)
+        - macOS (Intel, built from source)
+        - Windows (built from source or legacy package)
+        - Linux (built from source)
+        - Headless / server
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics
+      description: Paste relevant logs or attach a debug bundle after checking it for sensitive data.
+      render: shell
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues for the same problem.
+          required: true
+        - label: I removed API keys, tokens, private document contents, and other sensitive data.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/brightwave-inc/tidebreak/security/advisories/new
+    about: Please report vulnerabilities privately, not in a public issue.
+  - name: Read the documentation
+    url: https://www.tidebreak.sh/docs/
+    about: Installation, quickstart, permissions, providers, and troubleshooting.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,35 @@
+name: Feature request
+description: Propose a focused improvement to Tidebreak.
+title: "feat: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the work you are trying to complete, not only the interface you want.
+        Large implementation proposals should be discussed here before a pull request is opened.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do?
+      description: Explain the workflow, constraint, or missing capability.
+    validations:
+      required: true
+  - type: textarea
+    id: current
+    attributes:
+      label: What happens today?
+      description: Include workarounds and why they are insufficient.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would a good outcome look like?
+      description: A product outcome is more useful than a prescriptive implementation.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links, examples, screenshots, or constraints that would help evaluate the request.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## What changed
+
+<!-- Describe the user-visible or maintainer-visible change and why it is needed. -->
+
+## Validation
+
+<!-- List the checks you ran. Say explicitly when something could not be verified locally. -->
+
+## Compatibility and risk
+
+<!-- Note persisted/wire-format changes, platform differences, security boundaries, or "None". -->
+
+## Tracking
+
+<!-- Use "Closes #123" when this PR completes an issue. Remove this section when there is no issue. -->

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ Thumbs.db
 # Default `tidebreak serve` data dir when TIDEBREAK_DATA_DIR is unset (SQLite +
 # vector index); created wherever the server is launched from.
 .tidebreak/
+.vercel/
+.env.local
+.env.*.local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,8 @@ React/TypeScript under `crates/tidebreak-desktop/ui`.
 
 ## Workflow
 
-- **Do not use the `bw` CLI in Tidebreak.** It is tooling for the separate Alpha
-  repository, not this one; use this repository's documented Cargo, pnpm, and
-  GitHub commands instead.
+- **Do not use the `bw` CLI in Tidebreak.** It is not part of this repository;
+  use this repository's documented Cargo, pnpm, and GitHub commands instead.
 - **Branch off `main`; PR back into `main`.** Never commit straight to `main`.
 - **Issues are for active or cross-agent work, not for narrating the current
   task or keeping a someday backlog.** Use an issue when work needs a concrete

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing to Tidebreak
 
-Thanks for your interest in Tidebreak! It's early — the fastest way to help right
-now is to try the walking skeleton as it lands, file sharp issues, and discuss
-design before large changes.
+Thanks for your interest in Tidebreak! It's early — the fastest way to help is
+to try the latest build, file focused issues, and discuss design before large
+changes.
 
 ## Ground rules
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.0.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/brightwave-inc/tidebreak"
-homepage = "https://github.com/brightwave-inc/tidebreak"
+homepage = "https://www.tidebreak.sh"
 authors = ["Brightwave, Inc."]
 
 [workspace.lints.clippy]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,13 @@
 <p align="center">
   <strong>A private AI coworker that runs on your machine.</strong><br>
   Point it at your files and tools, and it produces finished, versioned work —
-  and reusable local apps — without your data leaving your computer.
+  and reusable local apps — while keeping its workspace and history local.
+</p>
+
+<p align="center">
+  <a href="https://www.tidebreak.sh">Website</a> ·
+  <a href="https://www.tidebreak.sh/docs/">Documentation</a> ·
+  <a href="https://github.com/brightwave-inc/tidebreak/releases">Releases</a>
 </p>
 
 <p align="center">

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ coordinate disclosure once a fix is available.
 
 ## Scope
 
-Tidebreak is pre-alpha and under active development. Security fixes land on the
+Tidebreak is pre-1.0 and under active development. Security fixes land on the
 default branch; there are no supported release branches yet. Before `1.0.0`,
 maintainers must replace this statement with explicit supported release lines
 and an end-of-support policy as required by the

--- a/crates/tidebreak-cli/src/connect.rs
+++ b/crates/tidebreak-cli/src/connect.rs
@@ -9,7 +9,7 @@
 //! `tidebreak serve` — the same client the desktop webview is. `--attach` is
 //! the same attach, but the URL and token come from `{data_dir}/listen.json`
 //! that the running server published (desktop or `serve`), so the token never
-//! rides argv — see [`docs/decisions/0009-data-dir-listen-endpoint.md`].
+//! rides argv — see [`docs/decisions/0012-data-dir-listen-endpoint.md`].
 //!
 //! Attaching is what a second process on one data directory must do. A data
 //! directory belongs to exactly one server process (`tidebreak-server` holds an

--- a/crates/tidebreak-cli/src/outputs.rs
+++ b/crates/tidebreak-cli/src/outputs.rs
@@ -1,7 +1,7 @@
 //! `tidebreak output …` and `tidebreak attach …` — conversation outputs and file
 //! attachment without a desktop.
 //!
-//! Both are thin clients of the server's HTTP surface (decision record 5): the
+//! Both are thin clients of the server's HTTP surface (decision record 7): the
 //! catalog, previews, version history, and revision bytes come from the output
 //! routes, and an attachment goes through the same document-ingest and image
 //! routes the desktop's picker feeds. The one thing that happens here rather

--- a/crates/tidebreak-cli/src/tui/app.rs
+++ b/crates/tidebreak-cli/src/tui/app.rs
@@ -821,9 +821,6 @@ impl App {
         }
     }
 
-    /// The slash-command table, Claude Code style: `/name args` in the
-    /// composer. Each entry is the canonical name plus a one-line blurb the
-    /// help overlay and the autocomplete list share.
     /// Run a slash command. Returns true when the input was a command (so the
     /// composer resets and nothing is sent to the model). The command table
     /// lives in `overlays::SLASH_COMMANDS`, shared with the help overlay.

--- a/crates/tidebreak-cli/src/tui/overlays.rs
+++ b/crates/tidebreak-cli/src/tui/overlays.rs
@@ -41,7 +41,7 @@ pub fn panel(
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
 }
 
-/// The slash-command table, Claude Code style: `/name args` in the composer.
+/// The slash-command table: `/name args` in the composer.
 /// Each entry is the canonical name plus a one-line blurb the help overlay and
 /// the autocomplete list share.
 pub(crate) const SLASH_COMMANDS: &[(&str, &str)] = &[

--- a/crates/tidebreak-cli/src/tui/theme.rs
+++ b/crates/tidebreak-cli/src/tui/theme.rs
@@ -11,7 +11,7 @@
 use ratatui::style::{Color, Modifier, Style};
 
 /// The one brand accent: the wordmark, ❯ input markers, the working spinner,
-/// the approval card's gutter and approve action. From `--brightwave`
+/// the approval card's gutter and approve action. From `--brand-accent`
 /// (oklch 0.87 0.2 102).
 pub const ACCENT: Color = Color::Rgb(240, 215, 0);
 

--- a/crates/tidebreak-cli/tests/serve.rs
+++ b/crates/tidebreak-cli/tests/serve.rs
@@ -319,7 +319,7 @@ fn print_mode_fails_with_clean_stdout_when_no_model_provider_is_configured() {
     );
 }
 
-/// The headless run record 5 exists for: one unattended `-p` turn, in `allow`
+/// The headless run record 7 exists for: one unattended `-p` turn, in `allow`
 /// mode, on a data directory that has never been used, that calls a tool for
 /// real and finishes. The model is scripted (`TIDEBREAK_SCRIPTED_PROVIDER`, see
 /// `tidebreak-server`'s `scripted_provider` module) so the turn is deterministic

--- a/crates/tidebreak-core/src/agent/registry.rs
+++ b/crates/tidebreak-core/src/agent/registry.rs
@@ -108,7 +108,7 @@ impl RegisteredSpec {
 /// `summary` is advertised as required so models reliably write one, but a call
 /// that omits it is still a valid call — the narration is display-only and no
 /// execution path reads it (see
-/// `docs/decisions/0015-tool-call-narration.md`). Refusing such a call would
+/// `docs/decisions/0018-tool-call-narration.md`). Refusing such a call would
 /// spend a model round trip correcting a field that changes nothing but a card
 /// headline. The relaxation is keyed on our own argument description so a
 /// mounted MCP server whose tool genuinely requires a `summary` keeps its

--- a/crates/tidebreak-core/src/agent/types.rs
+++ b/crates/tidebreak-core/src/agent/types.rs
@@ -70,7 +70,7 @@ Include only facts explicit in the conversation above. Preserve opaque source, c
 /// Compaction is deliberately not one of these: it runs on the conversation's
 /// own model and route so it can read the conversation's prompt cache instead
 /// of paying full price for a second copy of the transcript. See
-/// `docs/decisions/0015-compaction-rides-the-conversation-cache.md`.
+/// `docs/decisions/0019-compaction-rides-the-conversation-cache.md`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UtilityModel {
     /// Explicit provider route for this model.

--- a/crates/tidebreak-core/src/approval.rs
+++ b/crates/tidebreak-core/src/approval.rs
@@ -626,7 +626,7 @@ impl GrantScope {
             // Compared without narration on both sides: the model's sentence
             // about a call is display-only, so the same action described in
             // different words is the same action and a standing grant covers
-            // it. See `docs/decisions/0015-tool-call-narration.md`.
+            // it. See `docs/decisions/0018-tool-call-narration.md`.
             Self::ExactAction(granted) => granted.without_summary() == action.without_summary(),
             // Only a command has an executable or a token run to name.
             Self::AnyArgsFor { .. } | Self::CommandPrefix { .. } => false,

--- a/crates/tidebreak-core/src/context.rs
+++ b/crates/tidebreak-core/src/context.rs
@@ -165,7 +165,7 @@ pub const TOOL_RESULT_IMAGE_MESSAGE_WINDOW: usize = 10;
 ///
 /// The standing rule this follows — a boundary never slides through
 /// already-sent bytes — is recorded in
-/// `docs/decisions/0015-compaction-rides-the-conversation-cache.md`.
+/// `docs/decisions/0019-compaction-rides-the-conversation-cache.md`.
 pub fn evict_old_tool_result_images(messages: &mut [ChatMessage], keep_messages: usize) {
     // Quantizing down can only shrink the cutoff, so the newest
     // `keep_messages` are never touched; in the worst case the pixels of up to
@@ -218,7 +218,7 @@ pub fn evict_old_tool_result_images(messages: &mut [ChatMessage], keep_messages:
 ///
 /// The standing rule this follows — a boundary never slides through
 /// already-sent bytes — is recorded in
-/// `docs/decisions/0015-compaction-rides-the-conversation-cache.md`.
+/// `docs/decisions/0019-compaction-rides-the-conversation-cache.md`.
 pub fn evict_images_beyond(messages: &mut [ChatMessage], keep_last_n: usize) {
     let total = messages
         .iter()

--- a/crates/tidebreak-core/src/db/ops/agent_run/cancellation.rs
+++ b/crates/tidebreak-core/src/db/ops/agent_run/cancellation.rs
@@ -444,7 +444,7 @@ where
 /// ones the parent must still account for before completing.
 ///
 /// Unsettled covers live work, a terminal delivery not yet consumed or
-/// retired, and a check-in pause in `needs_input` (decision 0005): the pause
+/// retired, and a check-in pause in `needs_input` (decision 0008): the pause
 /// rides the same inbox machinery as a terminal result, so a pending or
 /// already-consumed check-in still fences completion until the child is
 /// resumed, cancelled, or otherwise leaves the origin turn.

--- a/crates/tidebreak-core/src/lib.rs
+++ b/crates/tidebreak-core/src/lib.rs
@@ -8,10 +8,9 @@
 //! This crate must never depend on a specific client, and is independently
 //! publishable on crates.io.
 //!
-//! Built incrementally with the M0 walking skeleton. Present so far: [`id`]
-//! (typed identifiers), [`error`], [`model`] (the persisted chat/message
-//! model), [`tool`] (the tool contract), and [`provider`] (the model-provider
-//! contract).
+//! The main surfaces are [`id`] (typed identifiers), [`error`], [`model`] (the
+//! persisted chat/message model), [`tool`] (the tool contract), and [`provider`]
+//! (the model-provider contract).
 
 /// Version of the Tidebreak product containing this crate.
 ///

--- a/crates/tidebreak-core/src/preview.rs
+++ b/crates/tidebreak-core/src/preview.rs
@@ -105,7 +105,7 @@ pub const MAX_ACTIVITY_EXEC_OUTPUT_CHARS: usize = 2_000;
 /// Command and search fields use the foreground approval-card projection so
 /// both surfaces share the same sanitization. The summary is projected the
 /// same way but shown only here and on the result card, never on an approval
-/// card — see `docs/decisions/0015-tool-call-narration.md`.
+/// card — see `docs/decisions/0018-tool-call-narration.md`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum AgentActivityDetail {
@@ -249,7 +249,7 @@ fn receipt_tail(result: &str, max_chars: usize) -> Option<String> {
 /// Most variants also carry a `summary`: one sentence the model wrote about
 /// what its own call is doing. It is **display-only**, and it is the one field
 /// here that is prose rather than a projection of the action. See
-/// `docs/decisions/0015-tool-call-narration.md` — it never reaches an approval
+/// `docs/decisions/0018-tool-call-narration.md` — it never reaches an approval
 /// card, never reaches the auto-approval judge, and is never part of a grant's
 /// identity ([`Self::without_summary`]), because a call that could describe
 /// itself to a consent decision could describe itself favourably.

--- a/crates/tidebreak-desktop/native-only-commands.txt
+++ b/crates/tidebreak-desktop/native-only-commands.txt
@@ -1,6 +1,6 @@
 # Native-only Tauri commands.
 #
-# Decision record 5 (docs/decisions/0005-cli-headless-feature-parity.md) makes
+# Decision record 7 (docs/decisions/0007-cli-headless-feature-parity.md) makes
 # the server HTTP/WS API the canonical product surface: a feature has
 # CLI/headless parity when it is reachable through `tidebreak-server` routes.
 # A `#[tauri::command]` is reserved for what genuinely needs the native shell —
@@ -16,7 +16,7 @@
 #
 # Adding a line is a conscious amendment, not a formality: if the command is not
 # native-only, it belongs behind a server route instead. Lines marked
-# `TODO(record 5)` are commands that already existed when the gate landed and do
+# `TODO(record 7)` are commands that already existed when the gate landed and do
 # not fit the closed native-only set — they are recorded debt to migrate, not
 # precedent for new ones.
 #
@@ -61,14 +61,14 @@ desktop_update_state: reports the native auto-updater's state.
 check_for_update: asks the native auto-updater to check.
 restart_for_update: relaunches the app to apply a staged native update.
 
-# TODO(record 5): commands that predate the gate and do not fit the native-only
+# TODO(record 7): commands that predate the gate and do not fit the native-only
 # set. Each should become a server route with a CLI client; until then they are
 # listed so the gate stays honest about what is already owed.
-publish_chat_image: TODO(record 5) — publishes pasted image bytes from the renderer; no native shell involvement, belongs on the ingest routes.
-list_connected_folders: TODO(record 5) — broker read with no native UI; headless consumers need the same listing.
-list_approved_folders: TODO(record 5) — broker read with no native UI.
-list_capability_consents: TODO(record 5) — broker read with no native UI; the consent projection should be a route.
-revoke_capability_consent: TODO(record 5) — broker mutation with no native dialog; revocation must be reachable headlessly.
-disconnect_folder: TODO(record 5) — broker mutation with no native dialog; record 5 item 4 gives folders a CLI path.
-forget_folder: TODO(record 5) — broker mutation with no native dialog.
-purge_deleted_conversation_subject: TODO(record 5) — broker cleanup with no native dialog.
+publish_chat_image: TODO(record 7) — publishes pasted image bytes from the renderer; no native shell involvement, belongs on the ingest routes.
+list_connected_folders: TODO(record 7) — broker read with no native UI; headless consumers need the same listing.
+list_approved_folders: TODO(record 7) — broker read with no native UI.
+list_capability_consents: TODO(record 7) — broker read with no native UI; the consent projection should be a route.
+revoke_capability_consent: TODO(record 7) — broker mutation with no native dialog; revocation must be reachable headlessly.
+disconnect_folder: TODO(record 7) — broker mutation with no native dialog; record 7 item 4 gives folders a CLI path.
+forget_folder: TODO(record 7) — broker mutation with no native dialog.
+purge_deleted_conversation_subject: TODO(record 7) — broker cleanup with no native dialog.

--- a/crates/tidebreak-desktop/src/channel.rs
+++ b/crates/tidebreak-desktop/src/channel.rs
@@ -3,7 +3,7 @@
 //! The three identities must not share a bundle id, product name, keychain
 //! service, or deep-link scheme. Debug is selected by the build profile;
 //! staging is selected by `TIDEBREAK_CHANNEL=staging` on a release build.
-//! See [`docs/decisions/0013-desktop-staging-channel.md`].
+//! See [`docs/decisions/0016-desktop-staging-channel.md`].
 
 pub const PRODUCTION_IDENTIFIER: &str = "io.brightwave.tidebreak";
 pub const DEV_IDENTIFIER: &str = "io.brightwave.tidebreak.dev";

--- a/crates/tidebreak-desktop/src/command_parity.rs
+++ b/crates/tidebreak-desktop/src/command_parity.rs
@@ -1,6 +1,6 @@
 //! Parity gate for the desktop's Tauri IPC surface.
 //!
-//! Decision record 5 makes the server HTTP/WS API the canonical product
+//! Decision record 7 makes the server HTTP/WS API the canonical product
 //! surface and closes the set of features that may legitimately be native-only.
 //! Nothing enforces that in review reliably, so this scans the crate's own
 //! sources for `#[tauri::command]` and holds the result against
@@ -10,7 +10,7 @@
 /// Where the allowlist lives, relative to the crate root — named in the failure
 /// messages so the fix path needs no searching.
 const ALLOWLIST_FILE: &str = "crates/tidebreak-desktop/native-only-commands.txt";
-const RECORD: &str = "docs/decisions/0005-cli-headless-feature-parity.md";
+const RECORD: &str = "docs/decisions/0007-cli-headless-feature-parity.md";
 
 const ALLOWLIST: &str = include_str!("../native-only-commands.txt");
 
@@ -109,7 +109,7 @@ fn allowlist_covers_every_tauri_command() {
     assert!(
         unlisted.is_empty(),
         "these #[tauri::command] handlers are not in {ALLOWLIST_FILE}:\n{}\n\n\
-         Decision record 5 ({RECORD}) makes the server HTTP/WS API the product \
+         Decision record 7 ({RECORD}) makes the server HTTP/WS API the product \
          surface and closes the set of native-only features. Give the feature \
          `tidebreak-server` routes and call them from the UI, or — if it \
          genuinely needs the native shell — add it to {ALLOWLIST_FILE} with a \
@@ -125,7 +125,7 @@ fn allowlist_covers_every_tauri_command() {
         stale.is_empty(),
         "{ALLOWLIST_FILE} lists commands that no longer exist: {stale:?}\n\n\
          A stale entry silently pre-approves a name a later change could reuse. \
-         Remove these lines — see decision record 5 ({RECORD})."
+         Remove these lines — see decision record 7 ({RECORD})."
     );
 
     let mut seen = allowlisted.clone();

--- a/crates/tidebreak-desktop/src/deliverables.rs
+++ b/crates/tidebreak-desktop/src/deliverables.rs
@@ -2,7 +2,7 @@
 //!
 //! Everything a conversation output *is* — its catalog, previews, revision
 //! history, restores, edits, and its bytes — now lives on the server's HTTP
-//! surface, where a headless client reaches it too (decision record 5). What
+//! surface, where a headless client reaches it too (decision record 7). What
 //! is left here is the one thing that genuinely needs the native shell: the
 //! save dialog, and the write to the path a reader chooses. The bytes come
 //! from `GET /chats/{chat}/outputs/{output}/content` like any other client's

--- a/crates/tidebreak-desktop/ui/src/McpAppBridge.ts
+++ b/crates/tidebreak-desktop/ui/src/McpAppBridge.ts
@@ -47,8 +47,8 @@ export type AppOperationInvoker = (
  * same `operations/call` method, routed by the presence of
  * `connected_app_id` in the call's params.
  *
- * That field is the gateway shell's own invoke vocabulary (its ADR 0036), and
- * naming it the same here is the whole point: a bundle written against this
+ * That field is the gateway shell's own invoke vocabulary, and naming it the
+ * same here is the whole point: a bundle written against this
  * bridge runs unmodified in the gateway's shell, and one written there runs
  * unmodified here. The two hosts differ in where a binding resolves, not in
  * what the bundle speaks.

--- a/crates/tidebreak-desktop/ui/src/ToolPreview.test.ts
+++ b/crates/tidebreak-desktop/ui/src/ToolPreview.test.ts
@@ -73,7 +73,7 @@ describe("how a call narrates itself", () => {
   it("keeps the narration out of the text an approval is given against", () => {
     // The approval card renders `detail`, and consent is given to a command
     // rather than to a sentence about one — see
-    // docs/decisions/0015-tool-call-narration.md.
+    // docs/decisions/0018-tool-call-narration.md.
     const literal = toolPreviewPresentation(narrated);
     expect(literal.headline).toBe("rm -rf /tmp/build");
     expect(literal.detail).not.toContain("Clearing");

--- a/crates/tidebreak-desktop/ui/src/ToolPreview.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolPreview.tsx
@@ -11,7 +11,7 @@ import { networkPolicyLabel } from "./NetworkPolicyDialog";
  * Deliberately literal, both fields: the action as the tool stated it, never
  * the call's own `summary`. The approval card renders `detail`, and consent is
  * given to a command rather than to a sentence about one — see
- * `docs/decisions/0015-tool-call-narration.md`. Prose belongs to
+ * `docs/decisions/0018-tool-call-narration.md`. Prose belongs to
  * {@link toolPreviewHeadline}, which only result cards call.
  */
 export type ToolPreviewPresentation = {

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -635,7 +635,7 @@ export class ApiClient {
    *
    * Publishing itself happens on that page, not here: it mutates entitlement
    * state the gateway owns, and every other mutation of that state is already
-   * done at the gateway (decision record 11).
+   * done at the gateway (decision record 14).
    *
    * Every way the gateway can decline is an outcome in the response rather
    * than a thrown error: the author asked a legitimate question and the

--- a/crates/tidebreak-desktop/ui/src/apps/AppDetailView.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/apps/AppDetailView.dom.test.tsx
@@ -627,7 +627,7 @@ describe("AppDetailView", () => {
   };
 
   it("opens the app's page at the gateway rather than publishing here", async () => {
-    // Decision record 11: publishing mutates entitlement state the gateway
+    // Decision record 14: publishing mutates entitlement state the gateway
     // owns, so this host resolves the address and hands the author over. What
     // it must never do is publish, and there is no longer anything here that
     // could.

--- a/crates/tidebreak-desktop/ui/src/apps/AppDetailView.tsx
+++ b/crates/tidebreak-desktop/ui/src/apps/AppDetailView.tsx
@@ -243,7 +243,7 @@ export function AppDetailView({
   }
 
   // Publishing happens at the gateway, on the app's own page there, next to
-  // the publish state and team grants it changes — decision record 11. This
+  // the publish state and team grants it changes — decision record 14. This
   // host's part is the address, and getting it registers the app there if it
   // never has been, so the page exists by the time the browser arrives.
   async function onPublishAtGateway() {

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -24,7 +24,7 @@
  * Command and search fields use the foreground approval-card projection so
  * both surfaces share the same sanitization. The summary is projected the
  * same way but shown only here and on the result card, never on an approval
- * card — see `docs/decisions/0015-tool-call-narration.md`.
+ * card — see `docs/decisions/0018-tool-call-narration.md`.
  */
 export type AgentActivityDetail = { "kind": "exec", command: string, args: Array<string>, 
 /**
@@ -1731,7 +1731,7 @@ export type OutputWriteMode = "create" | "replace";
  * preview of the action under review does. That preview may carry the call's
  * own `summary`, which the approval card does not render — consent is given to
  * an action, not to a sentence about one. See
- * `docs/decisions/0015-tool-call-narration.md`.
+ * `docs/decisions/0018-tool-call-narration.md`.
  */
 export type PendingApprovalSnapshot = { call_id: CallId, turn_id: TurnId, action: RendererToolName, approval: ToolApprovalKind, class: ApprovalClass, 
 /**
@@ -2601,7 +2601,7 @@ export type TaskPlanStepStatus = "pending" | "in_progress" | "completed";
  * Most variants also carry a `summary`: one sentence the model wrote about
  * what its own call is doing. It is **display-only**, and it is the one field
  * here that is prose rather than a projection of the action. See
- * `docs/decisions/0015-tool-call-narration.md` — it never reaches an approval
+ * `docs/decisions/0018-tool-call-narration.md` — it never reaches an approval
  * card, never reaches the auto-approval judge, and is never part of a grant's
  * identity ([`Self::without_summary`]), because a call that could describe
  * itself to a consent decision could describe itself favourably.

--- a/crates/tidebreak-desktop/ui/src/outputs/OutputDetailRoot.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/outputs/OutputDetailRoot.dom.test.tsx
@@ -161,8 +161,8 @@ describe("OutputDetailRoot", () => {
     expect(screen.queryByRole("heading", { name: "not a heading,2" })).toBeNull();
   });
 
-  // Alpha parity: the history affordance is invisible until an output actually
-  // has history, so a first version can never offer a restore.
+  // The history affordance stays hidden until an output actually has history,
+  // so a first version can never offer a restore.
   it("hides version history when the output has a single version", async () => {
     const apis = detailApis();
     await openOutput(apis);

--- a/crates/tidebreak-desktop/ui/src/styles.css
+++ b/crates/tidebreak-desktop/ui/src/styles.css
@@ -58,8 +58,8 @@
   --info-background: oklch(0.951 0.026 236.824);
   --info-border: oklch(0.391 0.09 240.876);
 
-  /* Brand highlight — the band a cited phrase carries and the chip beside it. */
-  --brightwave: oklch(0.87 0.2 102);
+  /* Brand highlight — the band a source phrase carries and the chip beside it. */
+  --brand-accent: oklch(0.87 0.2 102);
   --citation-mark: var(--color-neutral-300);
   --citation-mark-active-ink: var(--foreground);
 
@@ -101,9 +101,8 @@
 
 .dark {
   /* --- Tidebreak palette (oklch, dark mode) --- */
-  /* Deliberate divergence from Brightwave: cool near-neutral grays (hue ~262,
-     chroma <= 0.01) instead of the warm hue-85 ramp, which read brown at low
-     lightness. Elevation is carried by the lightness ramp alone:
+  /* Cool near-neutral grays (hue ~262, chroma <= 0.01) keep low-lightness
+     surfaces from reading brown. Elevation is carried by the lightness ramp:
      page chrome 0.12 < popover 0.14 < card 0.16 < content surface 0.21. */
   color-scheme: dark;
 
@@ -160,7 +159,7 @@
 
   /* The band keeps its brand chroma on a dark page; only the chip and the glyph
      it sits on have to swap so the mark stays legible either way. */
-  --brightwave: oklch(0.87 0.2 102);
+  --brand-accent: oklch(0.87 0.2 102);
   --citation-mark: var(--color-neutral-700);
   --citation-mark-active-ink: var(--background);
 
@@ -227,7 +226,7 @@
   --color-info-background: var(--info-background);
   --color-info-border: var(--info-border);
 
-  --color-brightwave: var(--brightwave);
+  --color-brand-accent: var(--brand-accent);
 
   --font-sans: var(--sans);
   --font-mono: var(--mono);
@@ -813,7 +812,7 @@ body {
    from nothing to the full phrase — an underline's thickness is animatable, its
    length is not. */
 .inline-citation-phrase {
-  background-image: linear-gradient(var(--brightwave), var(--brightwave));
+  background-image: linear-gradient(var(--brand-accent), var(--brand-accent));
   background-position: left bottom;
   background-repeat: no-repeat;
   background-size: 0% 35%;
@@ -838,7 +837,7 @@ body {
 .inline-citation:hover .inline-citation-mark,
 .inline-citation:focus-visible .inline-citation-mark,
 .inline-citation[data-state="open"] .inline-citation-mark {
-  background: var(--brightwave);
+  background: var(--brand-accent);
 }
 
 /* Mirrored to read as a closing quote, and filled rather than stroked because a

--- a/crates/tidebreak-host-broker/helper/Sources/tidebreak-cu-helper/Control.swift
+++ b/crates/tidebreak-host-broker/helper/Sources/tidebreak-cu-helper/Control.swift
@@ -51,7 +51,7 @@ enum Control {
         // over any of these reaches unsandboxed local execution (focus the
         // integrated shell, type a command, press Return) and would bypass the
         // sandboxed exec path. A bundle-id list cannot enumerate every app that
-        // embeds a shell; this is the common class. See decision record 0010.
+        // embeds a shell; this is the common class. See decision record 0013.
         "com.apple.Terminal",
         "com.googlecode.iterm2",
         "dev.warp.",

--- a/crates/tidebreak-host-broker/src/blocklist.rs
+++ b/crates/tidebreak-host-broker/src/blocklist.rs
@@ -20,7 +20,7 @@ pub const BLOCKED_CONTROL_BUNDLES: &[&str] = &[
     // over any of these reaches unsandboxed local execution (focus the
     // integrated shell, type a command, press Return) and would bypass the
     // sandboxed exec path. A bundle-id list cannot enumerate every app that
-    // embeds a shell; this is the common class. See decision record 0010.
+    // embeds a shell; this is the common class. See decision record 0013.
     "com.apple.Terminal",
     "com.googlecode.iterm2",
     "dev.warp.",

--- a/crates/tidebreak-host-broker/src/capability.rs
+++ b/crates/tidebreak-host-broker/src/capability.rs
@@ -150,7 +150,7 @@ pub struct Grant {
     /// Session-only one-shot consent. Never written to the durable grant
     /// table; the broker consumes it when the operation it authorized
     /// reaches a terminal result (a confirmation hold is not terminal).
-    /// See decision record 0010.
+    /// See decision record 0013.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     single_use: bool,
 }

--- a/crates/tidebreak-host-broker/src/consequential.rs
+++ b/crates/tidebreak-host-broker/src/consequential.rs
@@ -19,7 +19,7 @@
 //! prompts instead of a card per action; over-asking on navigation-shaped words
 //! (cancel, back, close, decline) trains click-through and makes the capability
 //! unusable. So commit-shaped words trip the gate and navigation-shaped words
-//! do not. This is a deliberate tradeoff recorded in decision record 0010: we
+//! do not. This is a deliberate tradeoff recorded in decision record 0013: we
 //! accept a slightly narrower tripwire in exchange for a consent flow the user
 //! will actually read.
 
@@ -58,10 +58,10 @@ pub enum Consequence {
 /// Deliberately narrow: navigation- and dismissal-shaped words (cancel, back,
 /// close, decline, confirm, accept, archive, block, report, approve) are NOT
 /// here. Asking again on those is the over-asking failure mode — see decision
-/// record 0010.
+/// record 0013.
 ///
 /// Locale bound: this lexicon is English. That is a deliberate accepted
-/// bound (decision record 0010), not an omission to fill with a translation
+/// bound (decision record 0013), not an omission to fill with a translation
 /// dictionary. Navigation words in other languages remaining untripped is
 /// the same over-ask tradeoff as keeping the English list short.
 const RISK_ACTION_WORDS: &[&str] = &[
@@ -166,7 +166,7 @@ pub fn key_press_needs_confirmation(key: &str, has_modifier: bool) -> bool {
 fn classify_click(role: Option<&str>, label: Option<&str>) -> Consequence {
     // Icon-only activatable controls have no label the lexicon can read, so
     // they cannot be classified as navigation and must not fail open as
-    // Benign. See decision record 0010.
+    // Benign. See decision record 0013.
     if is_activatable_control_role(role) && label_missing_or_empty(label) {
         return Consequence::Consequential {
             reason: "This control has no accessible label, so it cannot be \

--- a/crates/tidebreak-server/src/approval_judge.rs
+++ b/crates/tidebreak-server/src/approval_judge.rs
@@ -174,7 +174,7 @@ Be conservative: when in any doubt, set `safe` or `confident` to false and the p
 /// Every variant is destructured field by field, and each one's `summary` is
 /// discarded explicitly rather than by a wildcard: it is a sentence the call
 /// wrote about itself, so letting it reach the judge would let a call argue
-/// for its own approval. See `docs/decisions/0015-tool-call-narration.md`.
+/// for its own approval. See `docs/decisions/0018-tool-call-narration.md`.
 fn action_description(preview: &ToolActionPreview) -> Option<String> {
     match preview {
         ToolActionPreview::Search { query, summary: _ } => Some(format!(

--- a/crates/tidebreak-server/src/auth.rs
+++ b/crates/tidebreak-server/src/auth.rs
@@ -31,7 +31,7 @@
 //! them a member. A user's lines must agree about the role, and a file naming
 //! no admin at all fails to load — a deployment nobody can configure must not
 //! start, for the same reason an empty file must not. See
-//! `docs/decisions/0004-self-host-deployment-plane-authorization.md`.
+//! `docs/decisions/0006-self-host-deployment-plane-authorization.md`.
 //!
 //! ```text
 //! # user-id  token                                              role

--- a/crates/tidebreak-server/src/connected_apps.rs
+++ b/crates/tidebreak-server/src/connected_apps.rs
@@ -504,8 +504,8 @@ pub(crate) fn governed_rest_dispatcher(
 
 /// One shared-app operation call, as the invoke route assembled it.
 ///
-/// The field names are the gateway's own invoke vocabulary (ADR 0036) rather
-/// than a second spelling of it: `gateway_app` is what crosses the wire as
+/// The field names are the gateway's own invoke vocabulary rather than a
+/// second spelling of it: `gateway_app` is what crosses the wire as
 /// `connected_app_id`, and the three passthrough halves are opaque JSON the
 /// server never interprets — a bundle authored against a harness frame speaks
 /// exactly this shape to the gateway shell.

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -334,7 +334,7 @@ pub fn app(state: AppState) -> Router {
     // what the deployment can do stay on the member plane below, including the
     // `GET` halves of paths whose `PUT` lives here.
     //
-    // See `docs/decisions/0004-self-host-deployment-plane-authorization.md`.
+    // See `docs/decisions/0006-self-host-deployment-plane-authorization.md`.
     let deployment_api = Router::new()
         .route("/settings", axum::routing::put(routes::put_settings))
         .route(

--- a/crates/tidebreak-server/src/listen_endpoint.rs
+++ b/crates/tidebreak-server/src/listen_endpoint.rs
@@ -2,8 +2,8 @@
 //!
 //! After a successful bind, the server writes `{data_dir}/listen.json` so a
 //! second process can attach without the token riding argv. See
-//! [`docs/decisions/0009-data-dir-listen-endpoint.md`] and
-//! [`docs/decisions/0016-scoped-local-import-capability.md`]. The
+//! [`docs/decisions/0012-data-dir-listen-endpoint.md`] and
+//! [`docs/decisions/0022-scoped-local-import-capability.md`]. The
 //! client-executor credential is deliberately absent. A separate scoped token
 //! permits only publication of bytes the attached process already holds.
 

--- a/crates/tidebreak-server/src/model_roles.rs
+++ b/crates/tidebreak-server/src/model_roles.rs
@@ -6,7 +6,7 @@
 //! [`ModelRole::Utility`] is for work the user did not ask for: naming a chat
 //! and judging an approval today, and other maintenance later. Compacting a
 //! transcript is deliberately not one of them — it runs on the conversation's
-//! own model so it can read that conversation's prompt cache (decision 0015).
+//! own model so it can read that conversation's prompt cache (decision 0019).
 //! Two roles is deliberate; adding a third is an entry in the tables below
 //! rather than a refactor.
 //!

--- a/crates/tidebreak-server/src/principal.rs
+++ b/crates/tidebreak-server/src/principal.rs
@@ -20,7 +20,7 @@
 //! (owner-scoped data and capability discovery) and the deployment plane
 //! (what the deployment *is*, and its shared secrets) is enforced by
 //! [`crate::auth::require_admin`] over the role resolved here — see
-//! `docs/decisions/0004-self-host-deployment-plane-authorization.md`.
+//! `docs/decisions/0006-self-host-deployment-plane-authorization.md`.
 
 use std::fmt;
 use std::sync::Arc;

--- a/crates/tidebreak-server/src/routes/app_gateway_page.rs
+++ b/crates/tidebreak-server/src/routes/app_gateway_page.rs
@@ -3,7 +3,7 @@
 //! Publishing a shared app — and re-publishing a later revision — is a
 //! governance action, done on the gateway's own web surface alongside the
 //! publish state, the team grants, and the revocation that belong with it.
-//! Decision record 11 states why: publishing mutates gateway-owned entitlement
+//! Decision record 14 states why: publishing mutates gateway-owned entitlement
 //! state, every other mutation of that state is already done at the gateway,
 //! and a second interface of record in each harness that authors apps can only
 //! drift from the first. So this host offers the way *there* and nothing else.

--- a/crates/tidebreak-server/src/routes/approvals.rs
+++ b/crates/tidebreak-server/src/routes/approvals.rs
@@ -79,7 +79,7 @@ fn default_pending_approvals_limit() -> u64 {
 /// preview of the action under review does. That preview may carry the call's
 /// own `summary`, which the approval card does not render — consent is given to
 /// an action, not to a sentence about one. See
-/// `docs/decisions/0015-tool-call-narration.md`.
+/// `docs/decisions/0018-tool-call-narration.md`.
 #[derive(Debug, Serialize, ts_rs::TS)]
 pub(crate) struct PendingApprovalSnapshot {
     pub call_id: CallId,

--- a/crates/tidebreak-server/src/routes/compaction.rs
+++ b/crates/tidebreak-server/src/routes/compaction.rs
@@ -101,7 +101,7 @@ pub async fn post_compact(
         // request shape, and a turn's request advertises the turn's tools. An
         // on-demand compaction therefore starts cold more often than the
         // in-turn pass does — see
-        // `docs/decisions/0015-compaction-rides-the-conversation-cache.md`.
+        // `docs/decisions/0019-compaction-rides-the-conversation-cache.md`.
         std::sync::Arc::new(ToolRegistry::new()),
         state.store.clone(),
         config,

--- a/crates/tidebreak-server/src/routes/outputs.rs
+++ b/crates/tidebreak-server/src/routes/outputs.rs
@@ -5,7 +5,7 @@
 //! restore, user edits, and soft delete with its undo. They were Tauri commands
 //! reading `tidebreak-core`'s `Store` directly, which made every one of them
 //! unreachable without the desktop shell; moving them here is what makes an
-//! output readable and exportable headlessly (decision record 5).
+//! output readable and exportable headlessly (decision record 7).
 //!
 //! Two things deliberately did not move. **Export-to-path stays client-side**:
 //! the route serves bytes and the caller decides where they land, which is the

--- a/crates/tidebreak-server/tests/connectors_gateway_flow.rs
+++ b/crates/tidebreak-server/tests/connectors_gateway_flow.rs
@@ -395,8 +395,8 @@ async fn app_operations(
     .into_response()
 }
 
-/// The shared-app invoke route (ADR 0036): the SPA-tier data plane, reached
-/// here on a harness's `control`-audience PKCE session.
+/// The shared-app invoke route: the SPA-tier data plane, reached here on a
+/// harness's `control`-audience PKCE session.
 async fn shared_app_invoke(
     State(gateway): State<Arc<FakeGateway>>,
     axum::extract::Path(shared_app_id): axum::extract::Path<String>,

--- a/deploy/self-host/Dockerfile
+++ b/deploy/self-host/Dockerfile
@@ -14,7 +14,7 @@
 #   docker build -f "$context/deploy/self-host/Dockerfile" -t tidebreak-self-host "$context"
 #   rm -rf "$context"
 #
-# The deployment posture this image assumes is decision record 4: the server
+# The deployment posture this image assumes is decision record 6: the server
 # and its PostgreSQL database run inside the operator's own network, and TLS
 # termination plus network exposure belong to the operator's fronting
 # infrastructure. Nothing here terminates TLS. See docs/self-hosting.md.

--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -2,8 +2,8 @@
 #
 # THIS STACK BINDS TO LOCALHOST BY DESIGN. The published port below is
 # `127.0.0.1:8080`, and the API it serves is plain HTTP with bearer-token
-# authentication. Decision record 4 (docs/decisions/
-# 0004-self-host-deployment-plane-authorization.md) states the supported
+# authentication. Decision record 6 (docs/decisions/
+# 0006-self-host-deployment-plane-authorization.md) states the supported
 # posture: the server and PostgreSQL run inside the operator's own network,
 # and TLS termination plus network exposure belong to the operator's fronting
 # infrastructure. Do not change the port binding to `0.0.0.0` to "make it

--- a/docs-site/content/docs/documents.mdx
+++ b/docs-site/content/docs/documents.mdx
@@ -1,0 +1,64 @@
+---
+title: Documents and sources
+description: Attach source files, see what the agent can read, and reopen sources from its responses.
+---
+
+Documents are source material for a chat. They are different from
+[outputs](/outputs): a document is something the agent reads, while an output
+is a versioned file the agent produces.
+
+## Attach files to a chat
+
+Use the composer's **Tools** menu and choose **Attach files**, or type `@` in
+the message box to search for a file. Attached documents appear above the
+composer and remain available to later turns in that chat.
+
+Tidebreak copies the selected bytes into its private application data. Moving
+or deleting the original file later does not remove the chat's copy. To work
+against files that continue changing on disk, connect their folder instead;
+see [Connected folders](/connected-folders).
+
+## What the agent reads
+
+At import, Tidebreak keeps the original bytes and extracts canonical text when
+the format supports it. The agent can list the chat's sources and read bounded
+ranges from them. There is no vector database or hidden semantic index: the
+agent reads the source directly and decides which ranges it needs.
+
+PDFs, Word documents, spreadsheets, CSV files, text, and common image formats
+can be opened in the document panel. A file can still be retained when text
+extraction is unavailable; in that case the app reports that it is not ready
+for text reading instead of inventing content.
+
+## Source pills in responses
+
+When a response carries source references, Tidebreak shows a compact
+**Sources** row below it. The numbered pills summarize how many sources the
+response used. Expand the row to see the available locator for each one, such
+as a page, line range, sheet, or cell range.
+
+Select a source to open its document beside the conversation, at the recorded
+location when the format provides one. These are source shortcuts attached to
+the response, not a separate bibliography.
+
+Source pills point into the copy attached to that chat. They are not web links,
+and they do not grant the agent access to neighboring files on your machine.
+
+## Privacy and deletion
+
+Documents and extracted text stay in the local Tidebreak profile. They are
+sent only to the model provider used for a turn when the agent reads them, and
+to another configured service only when an approved tool call requires it.
+
+Removing a document makes it unavailable to future turns in that chat. Before
+deleting a chat or resetting a pre-1.0 profile, export any source or output you
+need to keep.
+
+<Cards>
+  <Card title="Connected folders" href="/connected-folders">
+    Work against a directory without attaching every file up front.
+  </Card>
+  <Card title="Outputs" href="/outputs">
+    Preview, version, restore, and export files the agent creates.
+  </Card>
+</Cards>

--- a/docs-site/content/docs/how-the-agent-works.mdx
+++ b/docs-site/content/docs/how-the-agent-works.mdx
@@ -1,0 +1,79 @@
+---
+title: How the agent works
+description: What happens during a turn, how plans and questions pause it, and how to redirect work in progress.
+---
+
+A Tidebreak turn is a durable loop: the selected model proposes the next step,
+Tidebreak applies the chat's permission rules, a tool runs when allowed, and
+the result goes back to the model. The loop continues until the model answers,
+the turn is stopped, or it needs you.
+
+## A turn, step by step
+
+1. Your message and current chat settings are saved.
+2. A worker claims the turn and calls the selected model with the conversation,
+   available tools, attached sources, and relevant instructions.
+3. If the model calls a tool, Tidebreak validates its arguments and checks the
+   chat's [permission mode](/permission-modes) and standing grants.
+4. The tool result is recorded and the model receives it for the next step.
+5. Text, reasoning status, tool activity, and waiting states stream into the
+   transcript as they are recorded.
+6. The final answer and any source references become part of the durable chat
+   history.
+
+The journal is the source of truth. Closing the window does not turn an
+accepted approval, question, or running background job into an unrecorded
+side effect; the app reconstructs the state when you return.
+
+## Plans
+
+In **Plan** mode, mutating tools are refused rather than queued for approval.
+The agent can inspect available information and propose a plan. A plan review
+card lets you comment, request a revision, or execute it. Executing the plan
+switches the chat out of Plan so the work can proceed under the selected
+permission boundary.
+
+During ordinary work, the agent may also maintain a visible task plan. It is a
+progress aid, not a source of authority: listing a step does not approve the
+tools needed to perform it.
+
+## Questions and approvals
+
+When the agent needs a small choice, it can ask up to three structured
+questions and pause. The question remains in the transcript and the **Inbox**
+until you answer it. Approval cards work the same way: the turn waits on a
+durable decision rather than treating a closed window as consent or refusal.
+
+## Redirecting a running turn
+
+If you send another message while a turn is active, Tidebreak can either queue
+it as the next turn or use it to steer the current one, depending on the send
+mode you selected. Steering is applied at a safe model boundary; it does not
+interrupt a tool halfway through and pretend the tool never ran.
+
+Use steering for corrections that matter to the current result. Queue a
+message when it is a separate follow-up you want handled after the current
+turn settles.
+
+## Background work
+
+The foreground agent can delegate independent jobs to background agents. Each
+job has its own isolated workspace and visible status, cannot create more
+agents, and returns its result to the parent turn. Closing and reopening the
+app does not erase an admitted job.
+
+Background work does not bypass consent. The foreground turn must be allowed
+to delegate, and any host resource passed to a child is named and checked
+explicitly.
+
+<Cards>
+  <Card title="Chats" href="/chats">
+    Learn what belongs to a chat and what survives a restart.
+  </Card>
+  <Card title="Permission modes" href="/permission-modes">
+    Understand which calls run, ask, or are refused.
+  </Card>
+  <Card title="Code execution" href="/code-execution">
+    See where commands run and how network policy is enforced.
+  </Card>
+</Cards>

--- a/docs-site/content/docs/index.mdx
+++ b/docs-site/content/docs/index.mdx
@@ -15,7 +15,7 @@ requests you configure: your model provider, your search provider, and
 whatever the agent explicitly fetches.
 
 <Callout type="warn">
-Tidebreak is pre-alpha and under active development. Interfaces, storage
+Tidebreak is pre-1.0 and under active development. Interfaces, storage
 formats, and behavior change frequently. Expect rough edges.
 </Callout>
 

--- a/docs-site/content/docs/meta.json
+++ b/docs-site/content/docs/meta.json
@@ -7,6 +7,8 @@
     "quickstart",
     "---Using Tidebreak---",
     "chats",
+    "documents",
+    "how-the-agent-works",
     "models-and-providers",
     "connected-folders",
     "code-execution",

--- a/docs-site/content/docs/roadmap.mdx
+++ b/docs-site/content/docs/roadmap.mdx
@@ -42,7 +42,7 @@ must be limited to exact, canonicalized destinations.
 
 Browser automation is valuable, but Tidebreak will not take over your everyday
 browser profile or silently become general desktop control. A future browser
-capability needs an Tidebreak-managed profile with explicit rules for cookies,
+capability needs a Tidebreak-managed profile with explicit rules for cookies,
 logins, reset, uploads, downloads, cancellation, and a visible foreground
 control surface.
 

--- a/docs-site/content/docs/web-search.mdx
+++ b/docs-site/content/docs/web-search.mdx
@@ -7,8 +7,9 @@ The agent has two tools that reach the public web: `web_search`, which
 searches, and `web_extract`, which fetches a specific page. Both are sensitive
 calls, so they ask for approval in Ask and Auto.
 
-Pages the agent fetches are added to the conversation as sources, so it can
-cite them and you can read what it read.
+Pages the agent fetches are added to the conversation as sources. When a
+response includes them, they appear in the expandable **Sources** row below
+the answer so you can open what the agent read.
 
 ## Two ways to search
 

--- a/docs/agent-operating-prompt.md
+++ b/docs/agent-operating-prompt.md
@@ -4,7 +4,7 @@ Tidebreak gives every normal foreground turn a small host-owned operating
 prompt. Tool schemas still define how individual calls work; the operating
 prompt defines product-level behavior that otherwise varies between model
 providers, such as when to proceed, when to ask, how to handle untrusted
-content, and how to use citations and delegation.
+content, and how to use sources and delegation.
 
 The prompt is conversation-first. It does not assume that a conversation
 belongs to a project, organization, or shared workspace.
@@ -33,7 +33,7 @@ registered:
 
 - structured user clarification;
 - private scratch;
-- conversation sources and opaque citation references;
+- conversation sources and opaque source references;
 - public web research;
 - public web page reading;
 - connected folders;

--- a/docs/code-execution.md
+++ b/docs/code-execution.md
@@ -450,6 +450,6 @@ tool arguments, logs, or renderer responses. Remote API endpoints are fixed by
 the build; Daytona toolbox URLs returned by the control plane are restricted to
 HTTPS Daytona origins. By default both managed providers allow internet access
 inside the sandbox, unlike the local native provider; a configured
-[egress policy](#egress-policy) restricts that access at sandbox creation. E2B's
+[network policy](#per-chat-network-policy) restricts that access at sandbox creation. E2B's
 enforcement is confirmed but applied-with-gaps; Daytona's per-sandbox policy is a
 strict, live-confirmed boundary conditional on org tier 3+.

--- a/docs/connected-apps.md
+++ b/docs/connected-apps.md
@@ -54,9 +54,9 @@ app on behalf of a caller. Its guarantees, all server-side and fail-closed:
 - Response bounds are sized for interactive UIs, not model context
   windows — deliberately larger than tool-result clamps.
 
-This is a scoped local analog of the gateway's governed REST tools
-(its ADR 0008), minus multi-user governance — which is exactly why managed
-profiles do not get it (below).
+This is the local form of the gateway's governed REST-tool contract, without
+multi-user governance — which is exactly why managed profiles do not get it
+(below).
 
 ## Bindings key off the app
 
@@ -81,7 +81,7 @@ placement. Rotating the credential value behind the same reference does not
 invalidate consent; repointing the reference does.
 
 A manifest may also bind `{ gateway_app, operation_ids[] }` — an app the
-model gateway holds, named by the gateway's own id (record 7). It is not a
+model gateway holds, named by the gateway's own id (record 10). It is not a
 connected-app record and nothing about it resolves locally, so it keys off
 its own namespace and carries its own canonical fingerprint form: the gateway
 origin, the app id, and a hash of the operation catalog the gateway declared.

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -26,9 +26,9 @@ libraries.
 
 ## `tidebreak-core` — the open-core seam 🟢
 
-The foundation every client (and, later, the Brightwave Connect control plane)
-sits on. It's independently publishable on crates.io and **never depends on a
-specific client**.
+The foundation every client, including a future managed control plane, sits on.
+It's independently publishable on crates.io and **never depends on a specific
+client**.
 
 It holds the agent loop, the tool registry, the `AgentEvent` stream that every
 client renders from, and the trait **contracts** — `Tool`, `ModelProvider`,

--- a/docs/decisions/0001-project-files-and-attachment-vocabulary.md
+++ b/docs/decisions/0001-project-files-and-attachment-vocabulary.md
@@ -3,7 +3,7 @@
 - Status: Accepted
 - Date: 2026-08-07
 - Owners: desktop
-- Related: [How OpenWave works](../how-openwave-works.md) (document model),
+- Related: [How Tidebreak works](../how-tidebreak-works.md) (document model),
   [Tool architecture](../tools.md) (the document-reading tool pair),
   [Host access and connected folders](../host-access.md) (the grant subject a
   conversation carries, and the creation-time root snapshot this record

--- a/docs/decisions/0002-pre-v1-schema-and-persisted-format-mutability.md
+++ b/docs/decisions/0002-pre-v1-schema-and-persisted-format-mutability.md
@@ -3,11 +3,11 @@
 - Status: Accepted
 - Date: 2026-08-07
 - Owners: core
-- Related: [`crates/openwave-core/src/db/migration.rs`](../../crates/openwave-core/src/db/migration.rs)
+- Related: [`crates/tidebreak-core/src/db/migration.rs`](../../crates/tidebreak-core/src/db/migration.rs)
   (the single-baseline migrator),
-  [`crates/openwave-server/src/desktop_schema.rs`](../../crates/openwave-server/src/desktop_schema.rs)
+  [`crates/tidebreak-server/src/desktop_schema.rs`](../../crates/tidebreak-server/src/desktop_schema.rs)
   (`DESKTOP_SCHEMA_EPOCH` and the reset it drives),
-  [`crates/openwave-core/src/event.rs`](../../crates/openwave-core/src/event.rs)
+  [`crates/tidebreak-core/src/event.rs`](../../crates/tidebreak-core/src/event.rs)
   (the journal payload and its shape fixture)
 
 ## Context

--- a/docs/decisions/0003-curated-model-visibility.md
+++ b/docs/decisions/0003-curated-model-visibility.md
@@ -3,9 +3,9 @@
 - Status: Accepted
 - Date: 2026-08-10
 - Owners: core, desktop
-- Related: [`crates/openwave-server/src/model_registry.rs`](../../crates/openwave-server/src/model_registry.rs)
+- Related: [`crates/tidebreak-server/src/model_registry.rs`](../../crates/tidebreak-server/src/model_registry.rs)
   (the static catalog and its honesty invariants),
-  [`crates/openwave-server/src/providers.rs`](../../crates/openwave-server/src/providers.rs)
+  [`crates/tidebreak-server/src/providers.rs`](../../crates/tidebreak-server/src/providers.rs)
   (`ProviderKind` and credential-backed provider status)
 - Supersedes: none
 

--- a/docs/decisions/0005-background-agents-checkin-supervision.md
+++ b/docs/decisions/0005-background-agents-checkin-supervision.md
@@ -1,4 +1,4 @@
-# 4. Background agents are supervised by check-ins, not stopped by caps
+# 5. Background agents are supervised by check-ins, not stopped by caps
 
 - Status: Accepted
 - Date: 2026-08-10

--- a/docs/decisions/0006-self-host-deployment-plane-authorization.md
+++ b/docs/decisions/0006-self-host-deployment-plane-authorization.md
@@ -1,11 +1,11 @@
-# 4. Self-Host Authorization: Admin and Member Roles on the Deployment Plane
+# 6. Self-Host Authorization: Admin and Member Roles on the Deployment Plane
 
 - Status: Accepted
 - Date: 2026-08-10
 - Owners: server, security
-- Related: [`crates/openwave-server/src/auth.rs`](../../crates/openwave-server/src/auth.rs)
+- Related: [`crates/tidebreak-server/src/auth.rs`](../../crates/tidebreak-server/src/auth.rs)
   (token file and credential-to-principal resolution),
-  [`crates/openwave-server/src/principal.rs`](../../crates/openwave-server/src/principal.rs)
+  [`crates/tidebreak-server/src/principal.rs`](../../crates/tidebreak-server/src/principal.rs)
   (`Principal`, `AuthContext`, the fail-closed extractor),
   [record 2](0002-pre-v1-schema-and-persisted-format-mutability.md)
   (pre-1.0 format mutability, which covers the token-file change below),

--- a/docs/decisions/0007-cli-headless-feature-parity.md
+++ b/docs/decisions/0007-cli-headless-feature-parity.md
@@ -1,11 +1,11 @@
-# 5. CLI/Headless Feature Parity: the Server API Is the Product Surface
+# 7. CLI/Headless Feature Parity: the Server API Is the Product Surface
 
 - Status: Accepted
 - Date: 2026-08-10
 - Owners: cli, server, desktop
 - Related: [`docs-site/content/docs/headless.mdx`](../../docs-site/content/docs/headless.mdx)
   (current headless documentation),
-  [`docs/crates.md`](../crates.md) (crate boundaries; flags `openwave-cli` as
+  [`docs/crates.md`](../crates.md) (crate boundaries; flags `tidebreak-cli` as
   a partial baseline), record 2 (pre-v1 mutability of persisted and wire
   formats)
 - Supersedes: none
@@ -20,7 +20,7 @@ an unattended run needs to keep going.
 
 **What is true today.** The desktop app is a thin Tauri shell around an
 embedded `openwave-server`; the React UI talks to it over the same HTTP+WS API
-(~90 routes in [`crates/openwave-server/src/lib.rs`](../../crates/openwave-server/src/lib.rs))
+(~90 routes in [`crates/tidebreak-server/src/lib.rs`](../../crates/tidebreak-server/src/lib.rs))
 that `openwave serve` exposes. Chats, turns, event streaming, models,
 providers, credentials, approvals, plans, questions, permission modes, MCP
 servers, plugins, and settings are all plain HTTP — none of them go through
@@ -31,7 +31,7 @@ already headless.
 **What is not reachable headlessly.** The gaps are concentrated:
 
 - **Unattended turns die on interaction points.** Print mode auto-rejects
-  every approval ([`crates/openwave-cli/src/print.rs`](../../crates/openwave-cli/src/print.rs))
+  every approval ([`crates/tidebreak-cli/src/print.rs`](../../crates/tidebreak-cli/src/print.rs))
   and *cancels the turn* when the agent proposes a plan or asks a question —
   precisely the events a driving agent could answer if the CLI surfaced them.
 - **Setup requires raw HTTP.** There are no CLI subcommands for provider,
@@ -40,7 +40,7 @@ already headless.
 - **Host folder access has no headless consent path.** Connected folders are
   brokered by `openwave-host-broker` behind a native picker/dialog. The broker
   already models an `OperatorConfig` consent method designed for headless
-  provisioning ([`crates/openwave-host-broker/src/capability.rs`](../../crates/openwave-host-broker/src/capability.rs)),
+  provisioning ([`crates/tidebreak-host-broker/src/capability.rs`](../../crates/tidebreak-host-broker/src/capability.rs)),
   but nothing wires it up.
 - **Attachments and output export are Tauri commands.** Attaching local files
   and exporting deliverables/output revisions live in

--- a/docs/decisions/0008-checkin-needs-input.md
+++ b/docs/decisions/0008-checkin-needs-input.md
@@ -1,15 +1,15 @@
-# 5. Check-ins pause a run in `needs_input` and ride the result machinery
+# 8. Check-ins pause a run in `needs_input` and ride the result machinery
 
 - Status: Accepted
 - Date: 2026-08-10
 - Owners: agent runtime (sandbox background runs)
-- Related: [0004](0004-background-agents-checkin-supervision.md) — defines the
+- Related: [0005](0005-background-agents-checkin-supervision.md) — defines the
   two triggers this record gives a destination
 - Supersedes: —
 
 ## Context
 
-Record 0004 replaced hard caps with two escalation triggers (step cadence,
+Record 0005 replaced hard caps with two escalation triggers (step cadence,
 consecutive tool errors) but left the escalation itself unbuilt: reaching the
 cadence still ended in a forced wrap-up. The parent's `wait_for_agents` is a
 strictly fenced receipt machine — the wait settles only on `agent_run_inbox`

--- a/docs/decisions/0009-queued-turns.md
+++ b/docs/decisions/0009-queued-turns.md
@@ -1,9 +1,9 @@
-# 6. Mid-turn sends queue by default; steering is the explicit alternative
+# 9. Mid-turn sends queue by default; steering is the explicit alternative
 
 - Status: Accepted
 - Date: 2026-08-10
 - Owners: chat turn lifecycle, desktop composer
-- Related: [0005](0005-checkin-needs-input.md); `crates/openwave-core/src/db/ops/turn/queued.rs`
+- Related: [0008](0008-checkin-needs-input.md); `crates/tidebreak-core/src/db/ops/turn/queued.rs`
 - Supersedes: —
 
 ## Context

--- a/docs/decisions/0010-gateway-app-bindings.md
+++ b/docs/decisions/0010-gateway-app-bindings.md
@@ -1,6 +1,6 @@
-# 7. Gateway Connected-App Bindings for Local Apps
+# 10. Gateway Connected-App Bindings for Local Apps
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-08-10
 - Owners: core, desktop
 - Related: [`docs/local-apps.md`](../local-apps.md) (the manifest, grant, and

--- a/docs/decisions/0011-settled-folder-positions.md
+++ b/docs/decisions/0011-settled-folder-positions.md
@@ -1,4 +1,4 @@
-# 8. Settled folder positions
+# 11. Settled folder positions
 
 - Status: Accepted
 - Date: 2026-08-11

--- a/docs/decisions/0012-data-dir-listen-endpoint.md
+++ b/docs/decisions/0012-data-dir-listen-endpoint.md
@@ -1,9 +1,9 @@
-# 9. Data-dir listen endpoint for CLI attach to a running server
+# 12. Data-dir listen endpoint for CLI attach to a running server
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-08-12
 - Owners: cli, server, desktop
-- Related: [`0005-cli-headless-feature-parity.md`](0005-cli-headless-feature-parity.md)
+- Related: [`0007-cli-headless-feature-parity.md`](0007-cli-headless-feature-parity.md)
   (attach-or-embed; CLI must reach a running desktop),
   [`docs-site/content/docs/headless.mdx`](../../docs-site/content/docs/headless.mdx)
 - Supersedes: none
@@ -12,7 +12,7 @@
 
 A data directory belongs to exactly one server process. The desktop app and
 `openwave serve` both bind `openwave-server` over that directory and mint a
-per-launch bearer token. Decision 5 already says a second process must
+per-launch bearer token. Decision 7 already says a second process must
 **attach** as an HTTP+WS client rather than embed again.
 
 Today attach works for `openwave serve` because it prints the URL and token on
@@ -60,7 +60,7 @@ into its data directory; the CLI may attach by reading that file.**
 
 ## Alternatives Considered
 
-- **Do nothing / document “copy from DevTools”.** Leaves decision 5's desktop
+- **Do nothing / document “copy from DevTools”.** Leaves decision 7's desktop
   attach gap open; unusable for agents.
 - **`--server-token` on argv.** Already forbidden: process list and shell
   history.
@@ -73,7 +73,7 @@ into its data directory; the CLI may attach by reading that file.**
 - **Auto-attach whenever the lock is held (no flag).** Surprising when the
   user meant a fresh embed under another data dir; prefer explicit `--attach`
   and a lock-failure hint that names it.
-- **UDS or a second RPC.** Decision 5 keeps HTTP+WS as the product surface.
+- **UDS or a second RPC.** Decision 7 keeps HTTP+WS as the product surface.
 
 ## Consequences
 

--- a/docs/decisions/0013-computer-use-screen-capture-and-app-control.md
+++ b/docs/decisions/0013-computer-use-screen-capture-and-app-control.md
@@ -1,6 +1,6 @@
-# 10. Computer use: screen capture and app control
+# 13. Computer use: screen capture and app control
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-08-12
 - Owners: desktop / agent core
 - Related: [`docs/deferred.md`](../deferred.md) (browser surface), permission

--- a/docs/decisions/0014-shared-app-publishing-ownership.md
+++ b/docs/decisions/0014-shared-app-publishing-ownership.md
@@ -1,9 +1,9 @@
-# 11. Shared-App Publishing Is a Gateway Governance Action
+# 14. Shared-App Publishing Is a Gateway Governance Action
 
 - Status: Accepted
 - Date: 2026-08-12
 - Owners: desktop, server
-- Related: record 7 (gateway connected-app bindings for local apps),
+- Related: record 10 (gateway connected-app bindings for local apps),
   [`docs/connected-apps.md`](../connected-apps.md),
   [`docs/local-apps.md`](../local-apps.md), the model gateway's shared-apps
   design (its ADR 0036)

--- a/docs/decisions/0015-tidebreak-product-and-technical-identity.md
+++ b/docs/decisions/0015-tidebreak-product-and-technical-identity.md
@@ -1,4 +1,4 @@
-# 12. Adopt Tidebreak as the Product and Technical Identity
+# 15. Adopt Tidebreak as the Product and Technical Identity
 
 - Status: Accepted
 - Date: 2026-08-12

--- a/docs/decisions/0016-desktop-staging-channel.md
+++ b/docs/decisions/0016-desktop-staging-channel.md
@@ -1,9 +1,9 @@
-# 13. Desktop Staging Channel from Main
+# 16. Desktop Staging Channel from Main
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-08-13
 - Owners: desktop and release
-- Related: [releases](../releases.md), [decision 12](0012-tidebreak-product-and-technical-identity.md)
+- Related: [releases](../releases.md), [decision 15](0015-tidebreak-product-and-technical-identity.md)
 - Supersedes: none
 
 ## Context

--- a/docs/decisions/0017-gateway-capability-negotiation.md
+++ b/docs/decisions/0017-gateway-capability-negotiation.md
@@ -1,9 +1,9 @@
-# 14. Gateway capability negotiation, not version pinning
+# 17. Gateway capability negotiation, not version pinning
 
 - Status: Accepted
 - Date: 2026-08-13
 - Owners: gateway connector / providers
-- Related: 0007 (gateway app bindings), the model gateway's own member-catalog
+- Related: 0010 (gateway app bindings), the model gateway's own member-catalog
   contract (`GET /api/v1/me/catalog`, `surfaces`, denial codes) shipped in
   model-gateway #635/#636
 
@@ -68,3 +68,12 @@ on that boundary. Revisit if gateway deployments ever become centrally
 version-managed (a fleet where the matrix cannot rot), or if a surface
 arrives that genuinely cannot degrade — either would justify a hard minimum
 gateway version at pairing time instead.
+
+## Validation
+
+- Catalog sync tests cover both the preferred member-catalog response and the
+  legacy models/apps fallback after a 404.
+- Gateway wire fixtures accept unknown additive fields and unknown denial
+  codes without failing the whole response.
+- No client behavior branches on `gateway_version`; it remains diagnostic
+  metadata only.

--- a/docs/decisions/0018-tool-call-narration.md
+++ b/docs/decisions/0018-tool-call-narration.md
@@ -1,4 +1,4 @@
-# 15. Model-authored tool narration is display-only
+# 18. Model-authored tool narration is display-only
 
 - Status: Accepted
 - Date: 2026-08-13

--- a/docs/decisions/0019-compaction-rides-the-conversation-cache.md
+++ b/docs/decisions/0019-compaction-rides-the-conversation-cache.md
@@ -1,6 +1,6 @@
-# 15. Compaction rides the conversation's prompt cache
+# 19. Compaction rides the conversation's prompt cache
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-08-13
 - Owners: agent runtime
 - Related: `crates/tidebreak-core/src/agent/context.rs`,

--- a/docs/decisions/0020-provider-failures-preserve-account-access-detail.md
+++ b/docs/decisions/0020-provider-failures-preserve-account-access-detail.md
@@ -1,6 +1,6 @@
-# 16. Provider failures preserve account-access detail
+# 20. Provider failures preserve account-access detail
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-08-14
 - Owners: provider routing and desktop chat
 - Related: `crates/tidebreak-router/src/sse.rs`, `crates/tidebreak-server/src/event_projection.rs`

--- a/docs/decisions/0021-model-selection-and-execution-identity.md
+++ b/docs/decisions/0021-model-selection-and-execution-identity.md
@@ -1,10 +1,10 @@
-# 16. Separate Durable Model Selection from Frozen Execution Identity
+# 21. Separate Durable Model Selection from Frozen Execution Identity
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-08-14
 - Owners: model routing and turn execution
 - Related: [`docs/model-providers.md`](../model-providers.md),
-  [`0014-gateway-capability-negotiation.md`](0014-gateway-capability-negotiation.md),
+  [`0017-gateway-capability-negotiation.md`](0017-gateway-capability-negotiation.md),
   [`0002-pre-v1-schema-and-persisted-format-mutability.md`](0002-pre-v1-schema-and-persisted-format-mutability.md)
 
 ## Context

--- a/docs/decisions/0022-scoped-local-import-capability.md
+++ b/docs/decisions/0022-scoped-local-import-capability.md
@@ -1,10 +1,10 @@
-# 16. Scoped Local Import Capability for Attached CLI Publication
+# 22. Scoped Local Import Capability for Attached CLI Publication
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-08-14
 - Owners: cli, server, desktop
-- Related: [`0005-cli-headless-feature-parity.md`](0005-cli-headless-feature-parity.md),
-  [`0009-data-dir-listen-endpoint.md`](0009-data-dir-listen-endpoint.md)
+- Related: [`0007-cli-headless-feature-parity.md`](0007-cli-headless-feature-parity.md),
+  [`0012-data-dir-listen-endpoint.md`](0012-data-dir-listen-endpoint.md)
 - Supersedes: none
 
 ## Context
@@ -22,7 +22,7 @@ currently grouped with native client-executor routes, so `--attach attach`
 always receives HTTP 401. The primary bearer is valid; the missing credential
 is a capability the command can never obtain. Directly publishing caller-held
 bytes is not a native host action, but admitting it with the full
-client-executor token would collapse the boundary decision 9 protects.
+client-executor token would collapse the boundary decision 12 protects.
 
 ## Decision
 

--- a/docs/decisions/0023-background-agent-usage-accounting.md
+++ b/docs/decisions/0023-background-agent-usage-accounting.md
@@ -1,10 +1,10 @@
-# 17. Background Agent Runs Own Cumulative Usage Accounting
+# 23. Background Agent Runs Own Cumulative Usage Accounting
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-08-14
 - Owners: core storage, sandbox workers, agent-run API
 - Related: [`docs/agent-runs.md`](../agent-runs.md),
-  [`0015-compaction-rides-the-conversation-cache.md`](0015-compaction-rides-the-conversation-cache.md)
+  [`0019-compaction-rides-the-conversation-cache.md`](0019-compaction-rides-the-conversation-cache.md)
 - Supersedes: none
 
 ## Context

--- a/docs/decisions/0024-model-declared-blocked-turns.md
+++ b/docs/decisions/0024-model-declared-blocked-turns.md
@@ -1,6 +1,6 @@
-# 18. Model-Declared Blocked Turns Are Refused, Not Completed
+# 24. Model-Declared Blocked Turns Are Refused, Not Completed
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-08-14
 - Owners: agent runtime, turn lifecycle, CLI
 - Related: [`docs-site/content/docs/headless.mdx`](../../docs-site/content/docs/headless.mdx),

--- a/docs/decisions/0025-source-code-files-are-text-outputs.md
+++ b/docs/decisions/0025-source-code-files-are-text-outputs.md
@@ -1,4 +1,4 @@
-# 19. Source-code files are text outputs
+# 25. Source-code files are text outputs
 
 - Status: Proposed
 - Date: 2026-08-14

--- a/docs/decisions/0026-spreadsheets-use-a-native-read-only-workbook-surface.md
+++ b/docs/decisions/0026-spreadsheets-use-a-native-read-only-workbook-surface.md
@@ -1,4 +1,4 @@
-# 20. Spreadsheets use a native read-only workbook surface
+# 26. Spreadsheets use a native read-only workbook surface
 
 - Status: Proposed
 - Date: 2026-08-14
@@ -38,7 +38,7 @@ remain unchanged and are still the artifact exported by Tidebreak.
 
 The Tidebreak wrapper always enables read-only mode. It owns loading and error
 states, a fixed light document theme, zoom controls, formula and address
-display, citation navigation, and the visual contract with the surrounding
+display, source-reference navigation, and the visual contract with the surrounding
 document panel.
 The display projection may make semantically equivalent OOXML explicit when a
 renderer would otherwise misread it, such as expanding an empty default border
@@ -62,7 +62,7 @@ from a service. The WebAssembly binary is bundled with the application.
 ## Alternatives Considered
 
 - **Convert each workbook to PDF.** This preserves a printable appearance, but
-  a PDF page is not a workbook: cells, formulas, sheets, and range citations are
+  a PDF page is not a workbook: cells, formulas, sheets, and range references are
   no longer inspectable.
 - **Export Calc HTML and add interaction around its tables.** This produces a
   strong static rendering, including rasterized charts, but it flattens the
@@ -104,7 +104,7 @@ the read-only integration cannot satisfy.
 - A workbook with multiple sheets, merged cells, formulas, frozen panes,
   authored dimensions, comments, and charts opens as one interactive workbook
   with no office-to-PDF request.
-- A range citation activates the named or indexed sheet, selects the requested
+- A range source reference activates the named or indexed sheet, selects the requested
   address, and scrolls it into view.
 - The address/formula display follows selection while mutation gestures cannot
   change workbook contents.

--- a/docs/decisions/0027-native-authorization-for-local-mcp-commands.md
+++ b/docs/decisions/0027-native-authorization-for-local-mcp-commands.md
@@ -1,9 +1,9 @@
-# 20. Native authorization for local MCP commands
+# 27. Native authorization for local MCP commands
 
 - Status: Proposed
 - Date: 2026-08-14
 - Owners: desktop / MCP configuration
-- Related: [`0004-self-host-deployment-plane-authorization.md`](0004-self-host-deployment-plane-authorization.md), [`../host-access.md`](../host-access.md)
+- Related: [`0006-self-host-deployment-plane-authorization.md`](0006-self-host-deployment-plane-authorization.md), [`../host-access.md`](../host-access.md)
 
 ## Context
 

--- a/docs/decisions/0028-apps-have-immutable-principal-ownership.md
+++ b/docs/decisions/0028-apps-have-immutable-principal-ownership.md
@@ -1,9 +1,9 @@
-# 21. Apps Have Immutable Principal Ownership
+# 28. Apps Have Immutable Principal Ownership
 
 - Status: Proposed
 - Date: 2026-08-14
 - Owners: app runtime and storage
-- Related: 0004-self-host-deployment-plane-authorization.md, principal-scoped storage
+- Related: 0006-self-host-deployment-plane-authorization.md, principal-scoped storage
 - Supersedes: none
 
 ## Context

--- a/docs/decisions/0029-release-tags-publish-static-documentation.md
+++ b/docs/decisions/0029-release-tags-publish-static-documentation.md
@@ -1,4 +1,4 @@
-# 22. Release Tags Publish Static Documentation
+# 29. Release Tags Publish Static Documentation
 
 - Status: Proposed
 - Date: 2026-08-14

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -12,5 +12,11 @@ says `Proposed`. When a decision changes, the old record gets
 `Status: Superseded` and a pointer to its replacement rather than being
 rewritten — the value is the reasoning at the time.
 
+Records preserve the names, paths, and operational context that existed when
+the decision was accepted. In particular, records predating the Tidebreak
+rename may use the former OpenWave name. Current documentation and source code
+use Tidebreak terminology; the historical wording is not a second product or
+an active compatibility alias.
+
 [`CLAUDE.md`](../../CLAUDE.md) has the rest of the convention, including when a
 change warrants a record at all.

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -65,7 +65,7 @@ evasion, and password-manager integration are not in this plan.
 
 Desktop computer use — screen capture and consent-gated control of native
 apps — is no longer parked; it is specified by
-[decision record 10](decisions/0010-computer-use-screen-capture-and-app-control.md)
+[decision record 13](decisions/0013-computer-use-screen-capture-and-app-control.md)
 as its own capability with per-app grants. That record deliberately keeps the
 everyday browser out of its starter scope: operating the user's browser
 through the accessibility channel is not a substitute for the managed browser

--- a/docs/deliverables.md
+++ b/docs/deliverables.md
@@ -67,8 +67,8 @@ The product store therefore owns an output record whose identity is an opaque
   foreground turn or a background run, never both — recorded in two mutually
   exclusive nullable references so existing turn-produced revisions are
   unchanged and a background run can now be attributed just as precisely. Only a
-  turn producer may carry retrieval citations, which resolve against the turn's
-  evidence. Revision rows are insert-only.
+  turn producer may carry retrieval source references, which resolve against
+  the turn's evidence. Revision rows are insert-only.
 - Updating an output appends a revision and republishes the current one. The
   replaced revision keeps its own id and stays readable, so an update can no
   longer destroy the bytes it supersedes.

--- a/docs/gateway-boundary.md
+++ b/docs/gateway-boundary.md
@@ -148,7 +148,7 @@ The connector speaks a small, versioned HTTP surface on the gateway:
   draft, appending each later revision, and relaying a viewer's consent and
   the app's own operation calls. The gateway's **publish** route is
   deliberately absent: publishing is a governance action done on the
-  gateway's web surface (decision record 11), and no code path here calls it.
+  gateway's web surface (decision record 14), and no code path here calls it.
   What this host resolves instead is the address of the app's page there, so
   the author can be handed over to it.
 - `/oauth/authorize`, `/oauth/token`, `/oauth/revoke` — the flow above.

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -4,10 +4,9 @@ Tidebreak is local-first, but "local" should not mean that every agent can see
 every file on the machine. This document describes the intended boundary between
 Tidebreak's product state and user-approved access to the host computer.
 
-The design follows the same basic product split as Brightwave web plus desktop.
-The important difference at first is deployment: Tidebreak's control plane runs
-locally. The boundary is still explicit so that a self-hosted or managed control
-plane can use the same contracts later.
+Tidebreak's control plane runs locally today. The host boundary remains explicit
+so a self-hosted or managed control plane can use the same contracts later
+without widening what an agent can access on the user's computer.
 
 ## The product model
 

--- a/docs/how-tidebreak-works.md
+++ b/docs/how-tidebreak-works.md
@@ -5,7 +5,7 @@ when someone uses it, why the code has several asynchronous state machines, and
 where the unfinished edges are. It is meant to be readable before you know the
 Rust code or the history behind it.
 
-Tidebreak is pre-alpha. The runtime is substantially more complete than the
+Tidebreak is pre-1.0. The runtime is substantially more complete than the
 desktop experience, and both the schema and crate boundaries are still free to
 change.
 
@@ -147,7 +147,7 @@ billed at the model and reasoning effort chosen for the conversation. Compacting
 a long transcript is deliberately *not* one of those: it runs on the chat's own
 model so the summarization call can read the conversation's prompt cache instead
 of paying for a second full copy of the transcript — see
-[decision 0015](decisions/0015-compaction-rides-the-conversation-cache.md). Each
+[decision 0019](decisions/0019-compaction-rides-the-conversation-cache.md). Each
 role can be pinned to one model (`PUT /models/roles/{role}`, stored under
 `model.<role>`); left automatic, it resolves against an ordered list of curated
 defaults and takes the first entry whose provider is enabled and credentialed.
@@ -552,7 +552,7 @@ result rather than applying the instruction twice.
 Attaching a file does not crawl connected roots. Files enter through the
 composer, are scoped to the exact chat, and are linked to the user message that
 introduced them. They render as chips in the transcript; opening a chip uses the
-same document viewer as a citation. A source URI is identity and provenance;
+same document viewer as a response's source pill. A source URI is identity and provenance;
 Tidebreak does not fetch that URI itself. The lower-level global and project
 document APIs remain as legacy surfaces, but the desktop does not use them as a
 fallback or expose a standalone source catalog.
@@ -596,7 +596,7 @@ path.
 Readiness follows the row itself: non-empty canonical text is `readable`, and
 empty canonical text is `stored_no_text`. A real decode error fails the upload
 request instead of creating a failed background job. Source regions and parser
-fingerprints are not persisted because span citations and reparse decisions no
+fingerprints are not persisted because source locators and reparse decisions no
 longer consume them.
 
 ### 4. Retire unused blobs
@@ -608,29 +608,30 @@ but never became referenced because a later catalog transaction failed.
 
 ## How grounded sources reach a chat answer
 
-A citation is written by the model itself: an inline directive wrapping the
-cited phrase and naming a document id plus a human-scale locator — a page or
-page range, a line range, or a workbook sheet optionally narrowed to a cell
-range. The model cites the position it saw when it read the source; there is
-no server-side span resolution, no evidence store, and no opaque token
-protocol. The loop validates only shape and bounds before committing the
-message and its ordered citation records together, and exact retries reuse the
-same message and citation identities, so an ambiguous database response cannot
+The model can attach a source reference to an answer by naming a document id
+plus a human-scale locator — a page or page range, a line range, or a workbook
+sheet optionally narrowed to a cell range. It records the position it saw when
+it read the source; there is no server-side span resolution, evidence store, or
+opaque token protocol. The loop validates shape and bounds before committing
+the message and its ordered source records together. Exact retries reuse the
+same message and source identities, so an ambiguous database response cannot
 create a second historical answer.
 
-The transcript API exposes each citation as a small record: ordinal, document
-id, and locator. Clicking a citation opens the document viewer at that
-locator. The precision is deliberately coarse — the reader lands on the page
-or lines, not a highlighted span — and a locator the model gets slightly wrong
-still opens the right document. Deleting or replacing a document leaves older
-citations pointing at a source that may no longer exist; the viewer says so
-rather than rewriting history.
+The transcript API still calls these records `citations`; that is an internal
+wire and storage term, not the product presentation. The desktop shows a
+numbered **Sources** row below the response. Expanding it reveals the recorded
+locations, and opening one takes the reader to that source in the document
+viewer. The precision is deliberately coarse — the reader lands on the page or
+lines, not a highlighted span — and a locator the model gets slightly wrong
+still opens the right document. Deleting or replacing a document leaves an
+older source record pointing at something that may no longer exist; the viewer
+says so rather than rewriting history.
 
 During generation, an incremental filter recognizes directives even when a
 provider splits them across many streaming events, so partially streamed
 directive syntax never flashes through the live renderer stream; malformed or
 incomplete marker-like prose remains ordinary text. Messages written before
-this grammar render their historical directives as plain cited text.
+this grammar render their historical directives as plain text.
 
 ## The different ways to run Tidebreak
 
@@ -643,8 +644,8 @@ The browser-facing API is not exposed on a public network interface.
 The current UI is a workspace-style conversation shell, not the complete
 product. It reopens durable chats and supports conversation create/list/switch/
 rename/delete, transcript hydration, Markdown messages, file and photo
-attachments on messages with a document viewer, inline citation chips that
-open the viewer at the cited position, live and historical tool-call rendering
+attachments on messages with a document viewer, expandable source pills that
+open the viewer at the recorded position, live and historical tool-call rendering
 including exec preview images, reconnectable streaming, provider and
 web-search setup, model selection, a foreground-turn stop control, approval
 prompts, and native connected-folder attach/list/revoke from the chat. The foreground stop control sends
@@ -810,7 +811,7 @@ remembered a check, and a route-table conformance suite drives one admin and
 one member across the assembled router to keep that classification honest.
 Roles beyond the two, groups, per-capability grants, and per-user provider
 credentials are deliberately excluded — see
-[decision 4](decisions/0004-self-host-deployment-plane-authorization.md).
+[decision 6](decisions/0006-self-host-deployment-plane-authorization.md).
 
 Configuration remains deployment-scoped rather than per-user: the settings
 table configures the deployment itself, shared credentials are the point of a

--- a/docs/local-apps.md
+++ b/docs/local-apps.md
@@ -36,7 +36,7 @@ An app revision is an untrusted **bundle** and a trusted **manifest**:
   connected-app records ([connected-apps.md](connected-apps.md)) that
   contribute them, `{ folder, access }` naming a connected folder, or
   `{ gateway_app, operation_ids[] }` naming a connected app the model gateway
-  holds (record 7). The manifest — not the bundle — is what the user consents
+  holds (record 10). The manifest — not the bundle — is what the user consents
   to and what the host enforces per call.
 
   The gateway shape resolves against the signed-in gateway session: the
@@ -225,7 +225,7 @@ history is what was servable when it was used. From there the gateway stores
 everything sharing-related: the draft and its revisions, the published status,
 and the per-team grants that make it openable.
 
-**Publishing is not done here.** Decision record 11 places it on the gateway's
+**Publishing is not done here.** Decision record 14 places it on the gateway's
 own web surface, next to the publish state, the grants, and the revocation it
 belongs with. Publishing mutates gateway-owned entitlement state; every other
 mutation of that state already happens at the gateway, and a publish dialog in
@@ -239,7 +239,7 @@ publish route.
 Three properties make the registration a copy rather than a translation:
 
 - **The binding vocabulary maps.** A gateway binding already names what the
-  gateway's own shared-app manifests name — record 7 rejected the
+  gateway's own shared-app manifests name — record 10 rejected the
   translate-at-publish design, because a manifest rewritten at share time was
   never run the way its viewers will run it. Folder and local `rest_api`
   bindings are dropped rather than translated: they name capabilities that

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -365,7 +365,7 @@ the configured distribution. No long-lived AWS access key belongs in GitHub.
 Every relevant push to `main` also publishes a packaged **staging** app, a
 third desktop identity that can run beside both `cargo tauri dev` and an
 installed release. The contract is recorded in
-[decision record 13](decisions/0013-desktop-staging-channel.md).
+[decision record 16](decisions/0016-desktop-staging-channel.md).
 
 Staging is a release-profile build with a blue icon, product name
 `Tidebreak [staging]`, identifier `io.brightwave.tidebreak.staging`, keychain

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -29,7 +29,7 @@ Selecting `TIDEBREAK_PROFILE=self_host` changes three things about the server:
   nobody is empowered to configure.
 
 The deployment posture is stated in
-[decision record 4](decisions/0004-self-host-deployment-plane-authorization.md):
+[decision record 6](decisions/0006-self-host-deployment-plane-authorization.md):
 the server and its database run inside the operator's own network, and TLS
 termination and network exposure belong to the operator's fronting
 infrastructure. Tidebreak serves plain HTTP and never terminates TLS.
@@ -94,7 +94,7 @@ and connected-app sign-in and sign-out.
 That split is a property of the router rather than of individual handlers, so
 a configuration route cannot quietly land outside the gate. The reasoning, the
 rejected alternatives, and what would make us revisit it are in
-[decision record 4](decisions/0004-self-host-deployment-plane-authorization.md).
+[decision record 6](decisions/0006-self-host-deployment-plane-authorization.md).
 
 Give `admin` only to the people who actually administer the deployment: MCP
 server definitions spawn processes on the host, and the provider credentials

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -89,13 +89,13 @@ Sandbox agents never receive the definition. See
 `list_documents` discovers what the conversation can read — its own documents
 followed by the files of the project holding it — without loading content. `read_document` reads one bounded Unicode-character range; the text is
 available the moment a source is stored, because ingestion decodes
-synchronously. The model cites what it reads inline, naming the document id
-and a coarse locator — a page or page range, a line range, or a workbook
-sheet — and no reference resolution happens server-side.
+synchronously. The model can record the document id and a coarse locator — a
+page or page range, a line range, or a workbook sheet — for the **Sources** row
+below its response, and no reference resolution happens server-side.
 
 `web_extract` joins that tier from the other direction: a page it fetches is
-stored as an ordinary source of the conversation, so the model can cite the
-stored document the same way or put the page URL directly in prose, and
+stored as an ordinary source of the conversation, so the model can include the
+stored document in its **Sources** row or put the page URL directly in prose, and
 `read_document` can reach the page afterwards. See
 [Web search](web-search.md#fetched-pages-as-sources).
 
@@ -331,7 +331,8 @@ only then resolves current host policy and credentials. `web_extract` sits
 beside it on the same terms: Sensitive, with the exact page URL on the
 approval card, and routed deterministically to the configured provider when it
 implements the extract contract or to the built-in native extraction engine
-otherwise. Each page it returns is also kept as a conversation source the model can cite. Exa and Tavily both implement it, so a configured host extracts
+otherwise. Each page it returns is also kept as a conversation source the model
+can include below its response. Exa and Tavily both implement it, so a configured host extracts
 through the vendor and falls back to native — except on a rejected key, which
 surfaces for repair rather than degrading silently. Brave and SearXNG are
 search-only, so a host on either extracts natively. See

--- a/docs/web-search.md
+++ b/docs/web-search.md
@@ -306,14 +306,14 @@ accumulating duplicates.
 The row retains the final URL, sanitized title, fetch time, `text/markdown`
 media type, and extracted text. It has no original blob, parser fingerprint,
 source regions, or background work. `read_document` can open the stored text
-later, and the model may cite its document id with the lightweight locator
-grammar or include the page URL directly in prose.
+later, and the model may include its document id and lightweight locator in the
+response's **Sources** row or put the page URL directly in prose.
 
 Page content is untrusted throughout. Titles and content from every engine are
 stripped of control characters, zero-width marks, and bidirectional overrides
 in `WebExtractResponse::new`. If the page cannot be stored, the content is
-still returned and the result says plainly that it cannot be cited as a stored
-document.
+still returned and the result says plainly that it cannot be attached to the
+response as a stored source.
 
 The server's sandbox checkpoint executor invokes the same resolver and strict
 argument decoder only after it has claimed a persisted `web_search`

--- a/docs/wire-types.md
+++ b/docs/wire-types.md
@@ -118,7 +118,7 @@ worth knowing before adding types.
 ## Scope today
 
 **Generated: the whole renderer surface.** The WebSocket frame and event union, the
-tool vocabulary and previews, approval kinds, the transcript and its citations,
+tool vocabulary and previews, approval kinds, the transcript and its source records,
 all three consent surfaces, and the configuration, catalog, project, chat, and
 agent-run DTOs.
 
@@ -135,8 +135,9 @@ agent-run DTOs.
 Two generated types carry a visible override rather than being aliased, both
 written with `Omit` so the divergence is legible:
 
-- **`ChatMessage.citations`** stays optional. The server always sends it, but the
-  transcript arrives as a parsed cast with no validation, so the `?` is what
+- **`ChatMessage.citations`** stays optional. Despite the internal field name,
+  these records populate the desktop's **Sources** row. The server always sends
+  it, but the transcript arrives as a parsed cast with no validation, so the `?` is what
   forces the guard that reads it. Narrowing it would delete that guard rather
   than earn it.
 - **`ModelInfo.key`** is re-branded as `ModelSelectionKey`. The wire is honestly

--- a/legal/THIRD-PARTY-NOTICES.md
+++ b/legal/THIRD-PARTY-NOTICES.md
@@ -8,7 +8,7 @@ node scripts/generate-third-party-notices.mjs
 ```
 
 It covers every package in the resolved Cargo workspace graph that is not
-an Tidebreak crate, and every package in the desktop UI's production
+a Tidebreak crate, and every package in the desktop UI's production
 dependency graph. Development-only dependencies are excluded because they
 are not distributed.
 

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -434,7 +434,7 @@ export function renderNotices({ rustPackages, nodePackages }) {
     "```",
     "",
     "It covers every package in the resolved Cargo workspace graph that is not",
-    "an Tidebreak crate, and every package in the desktop UI's production",
+    "a Tidebreak crate, and every package in the desktop UI's production",
     "dependency graph. Development-only dependencies are excluded because they",
     "are not distributed.",
     "",


### PR DESCRIPTION
## What changed

- Add public issue and pull-request templates suitable for the soft launch.
- Point repository metadata and README navigation at the live Tidebreak website and documentation.
- Add user-facing docs for documents, source pills, and the durable agent loop.
- Replace public-facing citation language with the product’s Sources terminology while retaining internal wire names where they are compatibility contracts.
- Remove stale milestone, internal-project, and borrowed-product phrasing from current docs and source comments.
- Renumber every decision record into one chronological, collision-free sequence from 0001 through 0029 and update repository references.
- Preserve historical product vocabulary inside decision records where it describes the context at the time.

## Why

The merged security and release-documentation work resolved the deployment architecture, but the public repository still had duplicated ADR numbers, stale cross-references, incomplete product documentation, and metadata that did not point at the live site. This leaves the repository coherent for the soft launch without changing the release-controlled static docs deployment.

## Compatibility and risk

No persisted, wire, API, or release behavior changes. Source-file edits outside documentation update comments and ADR references only. The CSS custom property used for the existing source highlight is renamed consistently from an organization-specific name to `--brand-accent`.

The ADR renumbering changes repository paths. Every tracked reference was updated in the same commit, and relative Markdown links plus filename/heading numbering were checked mechanically.

## Validation

- `git diff --check`
- `cargo fmt --all --check`
- `node scripts/generate-third-party-notices.mjs --check`
- docs: `pnpm run lint`
- docs: `pnpm run types:check`
- docs: `BASE_PATH=/docs pnpm run build` — 57 static pages
- docs: `pnpm run test:vercel-output` — 2 passed
- desktop UI: `pnpm test` — 146 files, 984 tests passed
- desktop UI: `pnpm build`
- Checked 80 Markdown files for unresolved relative links.
- Checked all 29 ADR filenames for unique sequential numbers and matching headings.