### PR TITLE
fix(release): support immutable GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,12 @@
 name: Publish desktop release
 
-run-name: >-
-  ${{ github.event_name == 'release'
-    && format('Dispatch desktop {0}', github.event.release.tag_name)
-    || format('Publish desktop {0}', github.event.inputs.release_tag) }}
+run-name: Publish desktop ${{ github.event.inputs.release_tag }}
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       release_tag:
-        description: Published GitHub Release tag to build
+        description: Draft or published GitHub Release tag to build
         required: true
         type: string
 
@@ -19,47 +14,21 @@ permissions:
   contents: read
 
 concurrency:
-  # The release-event run only dispatches the real build on main. Give that
-  # short-lived run its own group so it cannot block the dispatched build.
   # Serialize production builds so two tags cannot race mutable latest.json.
-  group: >-
-    ${{ github.event_name == 'release'
-      && format('tidebreak-desktop-release-dispatch-{0}', github.run_id)
-      || 'tidebreak-desktop-production-release' }}
+  group: tidebreak-desktop-production-release
   cancel-in-progress: false
 
 jobs:
-  dispatch:
-    name: dispatch trusted main build
-    if: ${{ github.event_name == 'release' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          ref: ${{ github.sha }}
-      - name: Reject an invalid published release tag
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: node scripts/check-release-tag.mjs "$RELEASE_TAG"
-      - name: Dispatch the build from the shared main cache scope
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: >-
-          gh workflow run release.yml
-          --repo "$GITHUB_REPOSITORY"
-          --ref main
-          --field release_tag="$RELEASE_TAG"
-
   validate:
     name: validate release tag
-    if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
+      draft: ${{ steps.release.outputs.draft }}
       published_at: ${{ steps.release.outputs.published_at }}
+      release_id: ${{ steps.release.outputs.release_id }}
       sha: ${{ steps.release.outputs.sha }}
       tag: ${{ steps.release.outputs.tag }}
       version: ${{ steps.release.outputs.version }}
@@ -67,8 +36,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-          ref: refs/tags/${{ github.event.inputs.release_tag }}
-      - name: Validate the published release and derive its product version
+          ref: ${{ github.sha }}
+      - name: Validate the release and freeze its source tag
         id: release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -76,43 +45,78 @@ jobs:
         run: |
           node scripts/check-release-tag.mjs "$RELEASE_TAG"
 
-          release_json="$(gh api \
-            -H 'Accept: application/vnd.github+json' \
-            "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG")"
-          [[ "$(jq -r .tag_name <<<"$release_json")" = "$RELEASE_TAG" ]] || {
-            echo "GitHub returned metadata for a different release tag." >&2
+          release_json="$(
+            gh api --paginate \
+              -H 'Accept: application/vnd.github+json' \
+              "repos/$GITHUB_REPOSITORY/releases?per_page=100" | jq -cs \
+                --arg tag "$RELEASE_TAG" \
+                '[.[][] | select(.tag_name == $tag)]
+                 | if length == 1 then .[0] else empty end'
+          )"
+          [[ -n "$release_json" ]] || {
+            echo "Expected exactly one draft or published release tagged $RELEASE_TAG." >&2
             exit 1
           }
-          [[ "$(jq -r .draft <<<"$release_json")" = false ]] || {
-            echo "Production desktop builds require a published GitHub Release." >&2
+          [[ "$(jq -r .tag_name <<<"$release_json")" = "$RELEASE_TAG" ]] || {
+            echo "GitHub returned metadata for a different release tag." >&2
             exit 1
           }
           [[ "$(jq -r .prerelease <<<"$release_json")" = false ]] || {
             echo "Production desktop builds cannot be published from a GitHub prerelease." >&2
             exit 1
           }
-          published_at="$(jq -er \
-            '.published_at | select(type == "string" and length > 0)' \
-            <<<"$release_json")"
+
+          draft="$(jq -r .draft <<<"$release_json")"
+          release_id="$(jq -er .id <<<"$release_json")"
+          if git show-ref --verify --quiet "refs/tags/$RELEASE_TAG"; then
+            release_sha="$(git rev-list -n 1 "$RELEASE_TAG")"
+          else
+            [[ "$draft" = true ]] || {
+              echo "Published release $RELEASE_TAG is missing its Git tag." >&2
+              exit 1
+            }
+            release_sha="$GITHUB_SHA"
+            jq -n \
+              --arg ref "refs/tags/$RELEASE_TAG" \
+              --arg sha "$release_sha" \
+              '{ref: $ref, sha: $sha}' | gh api \
+                --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+                --input - >/dev/null
+          fi
+
+          published_at="$(jq -r '.published_at // empty' <<<"$release_json")"
+          if [[ "$draft" = false && -z "$published_at" ]]; then
+            echo "Published release $RELEASE_TAG has no publication timestamp." >&2
+            exit 1
+          fi
+
+          jq '{name, body, tag_name, target_commitish, prerelease}' \
+            <<<"$release_json" > "$RUNNER_TEMP/release-snapshot.json"
           {
+            echo "draft=$draft"
             echo "published_at=$published_at"
-            echo "sha=$(git rev-parse HEAD)"
+            echo "release_id=$release_id"
+            echo "sha=$release_sha"
             echo "tag=$RELEASE_TAG"
+            echo "version=${RELEASE_TAG#v}"
           } >> "$GITHUB_OUTPUT"
       - name: Require a commit from main
         env:
           RELEASE_SHA: ${{ steps.release.outputs.sha }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
         run: |
-          test "$(git rev-parse HEAD)" = "$RELEASE_SHA" || {
-            echo "The validated tag changed while resolving its commit." >&2
-            exit 1
-          }
           git fetch origin main:refs/remotes/origin/main
           git merge-base --is-ancestor "$RELEASE_SHA" origin/main || {
             echo "Release tag $RELEASE_TAG does not point to a commit on main." >&2
             exit 1
           }
+      - name: Retain the release draft snapshot
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: tidebreak-release-${{ steps.release.outputs.release_id }}-snapshot
+          path: ${{ runner.temp }}/release-snapshot.json
+          if-no-files-found: error
+          retention-days: 7
 
   build_docs:
     name: build release documentation
@@ -185,7 +189,7 @@ jobs:
 
   publish_docs:
     name: publish release documentation
-    needs: [validate, build_docs]
+    needs: [validate, build_docs, finalize_release]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment:
@@ -491,7 +495,11 @@ jobs:
   prepare_macos:
     name: prepare unsigned macOS · universal
     needs: [validate, inspect_hosted]
-    if: ${{ needs.inspect_hosted.outputs.exists != 'true' }}
+    if: >-
+      ${{
+        needs.validate.outputs.draft == 'true'
+        && needs.inspect_hosted.outputs.exists != 'true'
+      }}
     runs-on: macos-latest
     timeout-minutes: 60
     env:
@@ -624,6 +632,7 @@ jobs:
       ${{
         always()
         && needs.validate.result == 'success'
+        && needs.validate.outputs.draft == 'true'
         && needs.inspect_hosted.result == 'success'
         && needs.inspect_hosted.outputs.exists != 'true'
         && needs.prepare_macos.result == 'success'
@@ -1013,7 +1022,12 @@ jobs:
     # parks this job and `build_windows` without disturbing the rest of the
     # release gating, so resuming Windows is flipping two literals plus the
     # `windows` descriptor in scripts/create-release-manifests.mjs.
-    if: ${{ false && needs.inspect_hosted.outputs.exists != 'true' }}
+    if: >-
+      ${{
+        false
+        && needs.validate.outputs.draft == 'true'
+        && needs.inspect_hosted.outputs.exists != 'true'
+      }}
     runs-on: windows-latest
     timeout-minutes: 90
     defaults:
@@ -1133,6 +1147,7 @@ jobs:
         false
         && always()
         && needs.validate.result == 'success'
+        && needs.validate.outputs.draft == 'true'
         && needs.inspect_hosted.result == 'success'
         && needs.inspect_hosted.outputs.exists != 'true'
         && needs.prepare_windows.result == 'success'
@@ -1351,7 +1366,11 @@ jobs:
   source_sbom:
     name: generate source SBOM
     needs: [validate, inspect_hosted]
-    if: ${{ needs.inspect_hosted.outputs.exists != 'true' }}
+    if: >-
+      ${{
+        needs.validate.outputs.draft == 'true'
+        && needs.inspect_hosted.outputs.exists != 'true'
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1395,7 +1414,7 @@ jobs:
 
   publish:
     name: publish downloads.brightwave.io
-    needs: [validate, inspect_hosted, build_macos, build_windows, source_sbom]
+    needs: [validate, inspect_hosted, build_macos, build_windows, source_sbom, finalize_release]
     # `build_windows` is parked (see docs/deferred.md), so a skipped result is
     # the expected steady state; only an outright failure may block publishing.
     if: >-
@@ -1403,8 +1422,10 @@ jobs:
         always()
         && needs.validate.result == 'success'
         && needs.inspect_hosted.result == 'success'
+        && needs.finalize_release.result == 'success'
         && (
           needs.inspect_hosted.outputs.exists == 'true'
+          || needs.validate.outputs.draft != 'true'
           || (
             needs.build_macos.result == 'success'
             && needs.build_windows.result != 'failure'
@@ -1425,7 +1446,7 @@ jobs:
       TIDEBREAK_VERSION: ${{ needs.validate.outputs.version }}
       RELEASE_TAG: ${{ needs.validate.outputs.tag }}
       RELEASE_SHA: ${{ needs.validate.outputs.sha }}
-      RELEASE_PUBLISHED_AT: ${{ needs.validate.outputs.published_at }}
+      RELEASE_PUBLISHED_AT: ${{ needs.finalize_release.outputs.published_at }}
       RELEASE_BASE_URL: https://downloads.brightwave.io/tidebreak
       AWS_REGION: ${{ vars.DOWNLOADS_AWS_REGION || 'us-east-1' }}
       AWS_RELEASE_ROLE_ARN: ${{ vars.AWS_RELEASE_ROLE_ARN }}
@@ -1453,7 +1474,11 @@ jobs:
           fi
 
       - name: Download universal macOS artifacts
-        if: ${{ needs.inspect_hosted.outputs.exists != 'true' }}
+        if: >-
+          ${{
+            needs.validate.outputs.draft == 'true'
+            && needs.inspect_hosted.outputs.exists != 'true'
+          }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: tidebreak-macos-universal-${{ needs.validate.outputs.version }}
@@ -1461,11 +1486,51 @@ jobs:
 
       # Parked with the Windows build; see docs/deferred.md.
       - name: Download Windows artifacts
-        if: ${{ false && needs.inspect_hosted.outputs.exists != 'true' }}
+        if: >-
+          ${{
+            false
+            && needs.validate.outputs.draft == 'true'
+            && needs.inspect_hosted.outputs.exists != 'true'
+          }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: tidebreak-windows-x86_64-${{ needs.validate.outputs.version }}
           path: dist/windows/x86_64
+
+      - name: Recover build inputs from the immutable GitHub Release
+        if: >-
+          ${{
+            needs.validate.outputs.draft != 'true'
+            && needs.inspect_hosted.outputs.exists != 'true'
+          }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p recovery dist/macos/universal
+          gh release download "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --dir recovery
+
+          while IFS= read -r -d '' checksum; do
+            (cd recovery && sha256sum --check --strict "${checksum#recovery/}")
+          done < <(find recovery -name '*.sha256' -type f -print0)
+
+          base="Tidebreak_${TIDEBREAK_VERSION}_universal"
+          cp recovery/Tidebreak-macos-universal.dmg \
+            "dist/macos/universal/$base.dmg"
+          for suffix in app.zip app.tar.gz app.tar.gz.sig; do
+            file="$base.$suffix"
+            [[ -f "recovery/$file" ]] || {
+              echo "Immutable GitHub Release is missing recovery asset: $file" >&2
+              exit 1
+            }
+            cp "recovery/$file" "dist/macos/universal/$file"
+          done
+
+          sbom="Tidebreak_${TIDEBREAK_VERSION}_source.spdx.json"
+          cp "recovery/$sbom" "dist/$sbom"
+          cp "recovery/$sbom.sha256" "dist/$sbom.sha256"
+          (cd dist && sha256sum --check --strict "$sbom.sha256")
 
       - name: Create release manifests and checksums
         if: ${{ needs.inspect_hosted.outputs.exists != 'true' }}
@@ -1479,7 +1544,11 @@ jobs:
           --base-url "$RELEASE_BASE_URL"
 
       - name: Download the checksummed source SBOM
-        if: ${{ needs.inspect_hosted.outputs.exists != 'true' }}
+        if: >-
+          ${{
+            needs.validate.outputs.draft == 'true'
+            && needs.inspect_hosted.outputs.exists != 'true'
+          }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: tidebreak-source-sbom-${{ needs.validate.outputs.version }}
@@ -1652,17 +1721,24 @@ jobs:
           fi
 
   attach_downloads:
-    name: attach GitHub release downloads
-    needs: [validate, publish]
-    # `publish` inherits the parked `build_windows` skip through its own needs
-    # (see docs/deferred.md), and an implicit `success()` reads that whole
-    # chain — so without this guard the job skips on green runs. Only the two
-    # jobs this one actually depends on decide whether it runs.
+    name: prepare GitHub release downloads
+    needs: [validate, inspect_hosted, build_macos, build_windows, source_sbom]
+    # A published release already owns immutable assets. A draft instead needs
+    # the fresh package build and SBOM before those assets can be attached.
     if: >-
       ${{
         always()
         && needs.validate.result == 'success'
-        && needs.publish.result == 'success'
+        && needs.inspect_hosted.result == 'success'
+        && (
+          needs.validate.outputs.draft != 'true'
+          || (
+            needs.build_macos.result == 'success'
+            && needs.build_windows.result != 'failure'
+            && needs.build_windows.result != 'cancelled'
+            && needs.source_sbom.result == 'success'
+          )
+        )
       }}
     runs-on: ubuntu-latest
     permissions:
@@ -1670,71 +1746,190 @@ jobs:
     env:
       TIDEBREAK_VERSION: ${{ needs.validate.outputs.version }}
       RELEASE_TAG: ${{ needs.validate.outputs.tag }}
-      RELEASE_BASE_URL: https://downloads.brightwave.io/tidebreak
     steps:
-      # The hosted release is the only source of artifact bytes. Re-downloading
-      # it here keeps the GitHub assets a verified copy of what the CDN serves,
-      # and works the same whether this run built the release or resumed one.
-      - name: Download the published installers
+      - name: Download the verified macOS build
+        if: ${{ needs.validate.outputs.draft == 'true' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: tidebreak-macos-universal-${{ needs.validate.outputs.version }}
+          path: release-artifacts/macos
+
+      - name: Download the checksummed source SBOM
+        if: ${{ needs.validate.outputs.draft == 'true' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: tidebreak-source-sbom-${{ needs.validate.outputs.version }}
+          path: release-artifacts/sbom
+
+      - name: Prepare downloads from the verified build
+        if: ${{ needs.validate.outputs.draft == 'true' }}
         run: |
           mkdir -p downloads
-          manifest="$RUNNER_TEMP/manifest.json"
-          curl --fail --silent --show-error \
-            "$RELEASE_BASE_URL/releases/v$TIDEBREAK_VERSION/manifest.json" \
-            --output "$manifest"
-
-          while IFS=$'\t' read -r platform arch url digest; do
-            case "$platform/$arch" in
-              macos/universal) name="Tidebreak-macos-universal.dmg" ;;
-              windows/x86_64) name="Tidebreak-windows-x86_64-setup.exe" ;;
-              *) echo "Unsupported release platform: $platform/$arch" >&2; exit 1 ;;
-            esac
-            curl --fail --silent --show-error --location "$url" \
-              --output "downloads/$name"
-            printf '%s  %s\n' "$digest" "$name" > "downloads/$name.sha256"
-            (cd downloads && sha256sum --check --strict "$name.sha256")
-          done < <(jq -r \
-            '.artifacts[]
-             | select((.platform == "macos" and .format == "dmg")
-                 or (.platform == "windows" and .format == "nsis"))
-             | [.platform, .arch, .url, .sha256] | @tsv' \
-            "$manifest")
-
-          dmg_count="$(find downloads -name '*.dmg' -type f | wc -l)"
-          (( dmg_count == 1 )) || {
-            echo "Expected one macOS disk image, found $dmg_count." >&2
+          base="Tidebreak_${TIDEBREAK_VERSION}_universal"
+          source_dmg="release-artifacts/macos/$base.dmg"
+          [[ -f "$source_dmg" ]] || {
+            echo "The verified build did not contain the universal DMG." >&2
             exit 1
           }
+          cp "$source_dmg" downloads/Tidebreak-macos-universal.dmg
+          (cd downloads && sha256sum Tidebreak-macos-universal.dmg \
+            > Tidebreak-macos-universal.dmg.sha256)
 
-          # Keep the existing permanent README URL live across the transition
-          # to universal packages. Both names carry the same CDN-verified bytes;
-          # the universal name is canonical for new links.
+          for suffix in app.zip app.tar.gz app.tar.gz.sig; do
+            file="$base.$suffix"
+            [[ -f "release-artifacts/macos/$file" ]] || {
+              echo "The verified build did not contain $file." >&2
+              exit 1
+            }
+            cp "release-artifacts/macos/$file" "downloads/$file"
+            (cd downloads && sha256sum "$file" > "$file.sha256")
+          done
+
+          sbom="Tidebreak_${TIDEBREAK_VERSION}_source.spdx.json"
+          cp "release-artifacts/sbom/$sbom" "downloads/$sbom"
+          cp "release-artifacts/sbom/$sbom.sha256" "downloads/$sbom.sha256"
+          (cd downloads && sha256sum --check --strict "$sbom.sha256")
+
+      - name: Download existing immutable GitHub assets
+        if: ${{ needs.validate.outputs.draft != 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p downloads
+          gh release download "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --dir downloads
+
+      - name: Verify the complete GitHub asset set
+        run: |
           universal_dmg="downloads/Tidebreak-macos-universal.dmg"
           compatibility_dmg="downloads/Tidebreak-macos-apple-silicon.dmg"
           [[ -f "$universal_dmg" ]] || {
-            echo "The universal macOS disk image was not downloaded." >&2
+            echo "The universal macOS disk image was not prepared." >&2
             exit 1
           }
-          cp "$universal_dmg" "$compatibility_dmg"
-          (cd downloads && sha256sum "$(basename "$compatibility_dmg")" \
-            > "$(basename "$compatibility_dmg").sha256")
+          if [[ ! -f "$compatibility_dmg" ]]; then
+            cp "$universal_dmg" "$compatibility_dmg"
+            (cd downloads && sha256sum "$(basename "$compatibility_dmg")" \
+              > "$(basename "$compatibility_dmg").sha256")
+          fi
 
-          sbom="Tidebreak_${TIDEBREAK_VERSION}_source.spdx.json"
-          sbom_url="$RELEASE_BASE_URL/releases/v$TIDEBREAK_VERSION/$sbom"
-          if curl --fail --silent --show-error --head "$sbom_url" >/dev/null; then
-            curl --fail --silent --show-error "$sbom_url" \
-              --output "downloads/$sbom"
-            curl --fail --silent --show-error "$sbom_url.sha256" \
-              --output "downloads/$sbom.sha256"
-            (cd downloads && sha256sum --check --strict "$sbom.sha256")
+          while IFS= read -r -d '' file; do
+            case "$file" in
+              *.sha256) continue ;;
+            esac
+            [[ -f "$file.sha256" ]] || {
+              echo "Release asset has no checksum sidecar: ${file#downloads/}" >&2
+              exit 1
+            }
+          done < <(find downloads -type f -print0)
+          while IFS= read -r -d '' checksum; do
+            (cd downloads && sha256sum --check --strict "${checksum#downloads/}")
+          done < <(find downloads -name '*.sha256' -type f -print0)
+
+          if [[ "${{ needs.validate.outputs.draft }}" != true \
+            && "${{ needs.inspect_hosted.outputs.exists }}" != true ]]; then
+            base="Tidebreak_${TIDEBREAK_VERSION}_universal"
+            for file in \
+              "$base.app.zip" \
+              "$base.app.tar.gz" \
+              "$base.app.tar.gz.sig" \
+              "Tidebreak_${TIDEBREAK_VERSION}_source.spdx.json"; do
+              [[ -f "downloads/$file" ]] || {
+                echo "Immutable release cannot recover hosted publication without $file." >&2
+                exit 1
+              }
+            done
           fi
 
       # Version-free asset names give the README permanent one-click download
-      # links through GitHub's /releases/latest/download/ redirect.
-      - name: Attach the installers to the GitHub Release
+      # links through GitHub's /releases/latest/download/ redirect. Assets are
+      # attached while the release is still a draft; immutable releases cannot
+      # be changed after the final publication step below.
+      - name: Attach or verify the GitHub Release downloads
+        env:
+          RELEASE_DRAFT: ${{ needs.validate.outputs.draft }}
+          RELEASE_ID: ${{ needs.validate.outputs.release_id }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [[ "$RELEASE_DRAFT" = true ]]; then
+            gh release upload "$RELEASE_TAG" downloads/* \
+              --repo "$GITHUB_REPOSITORY" \
+              --clobber
+          fi
+
+          find downloads -type f -exec basename {} \; | sort \
+            > "$RUNNER_TEMP/expected-release-assets"
+          gh api --paginate \
+            "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID/assets" \
+            --jq '.[].name' | sort > "$RUNNER_TEMP/actual-release-assets"
+          diff -u \
+            "$RUNNER_TEMP/expected-release-assets" \
+            "$RUNNER_TEMP/actual-release-assets"
+
+  finalize_release:
+    name: publish immutable GitHub Release
+    needs: [validate, attach_downloads]
+    if: >-
+      ${{
+        always()
+        && needs.validate.result == 'success'
+        && needs.attach_downloads.result == 'success'
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      published_at: ${{ steps.release.outputs.published_at }}
+    steps:
+      - name: Download the frozen release metadata
+        if: ${{ needs.validate.outputs.draft == 'true' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: tidebreak-release-${{ needs.validate.outputs.release_id }}-snapshot
+          path: ${{ runner.temp }}/release-snapshot
+
+      - name: Publish or validate the immutable release
+        id: release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: >-
-          gh release upload "$RELEASE_TAG" downloads/*
-          --repo "$GITHUB_REPOSITORY"
-          --clobber
+          RELEASE_DRAFT: ${{ needs.validate.outputs.draft }}
+          RELEASE_ID: ${{ needs.validate.outputs.release_id }}
+          RELEASE_SHA: ${{ needs.validate.outputs.sha }}
+          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          tag_sha="$(gh api \
+            "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" \
+            --jq .sha)"
+          [[ "$tag_sha" = "$RELEASE_SHA" ]] || {
+            echo "Release tag $RELEASE_TAG moved after validation." >&2
+            exit 1
+          }
+
+          if [[ "$RELEASE_DRAFT" = true ]]; then
+            snapshot="$RUNNER_TEMP/release-snapshot/release-snapshot.json"
+            jq '. + {draft: false, make_latest: "true"}' "$snapshot" | gh api \
+              --method PATCH \
+              "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
+              --input - >/dev/null
+          fi
+
+          release_json="$(gh api \
+            -H 'Accept: application/vnd.github+json' \
+            "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID")"
+          [[ "$(jq -r .tag_name <<<"$release_json")" = "$RELEASE_TAG" ]] || {
+            echo "GitHub published a release for the wrong tag." >&2
+            exit 1
+          }
+          [[ "$(jq -r .draft <<<"$release_json")" = false ]] || {
+            echo "GitHub Release $RELEASE_TAG is still a draft." >&2
+            exit 1
+          }
+          [[ "$(jq -r .prerelease <<<"$release_json")" = false ]] || {
+            echo "GitHub Release $RELEASE_TAG unexpectedly became a prerelease." >&2
+            exit 1
+          }
+          published_at="$(jq -er \
+            '.published_at | select(type == "string" and length > 0)' \
+            <<<"$release_json")"
+          echo "published_at=$published_at" >> "$GITHUB_OUTPUT"

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -126,20 +126,19 @@ automatic.
    prerelease, and the notes contain the intended PRs.
    For the first release only, set `v0.1.0`, click **Generate release notes**,
    and curate the full-history result as described above.
-3. Complete the release-readiness review, then click **Publish release**.
-4. GitHub creates the tag and emits the `release.published` event. Confirm the
-   draft still has its proposed `vMAJOR.MINOR.PATCH` tag before publishing:
-   GitHub can otherwise publish an untagged release. A short-lived dispatcher
-   rejects an invalid tag before it queues a production build; for a valid tag,
-   it starts the production build from the current `main` workflow and passes
-   only that tag. Running the build from `main` gives every release the same
-   trusted compiler-cache scope; the build still queries GitHub for the
-   published release, checks out that exact tag, rejects malformed tags,
-   prereleases, drafts, or commits outside `main`, and pins all later jobs to
-   the resolved commit SHA.
-5. In parallel with the desktop release, the documentation publisher checks
-   out that validated SHA and builds `docs-site/` as a static export under
-   `/docs`. It creates an unaliased production-target deployment in the
+3. Complete the release-readiness review, but do **not** publish the draft in
+   GitHub. Immutable releases cannot accept assets after publication.
+4. Open **Actions → Publish desktop release → Run workflow**, select `main`,
+   and enter the draft's exact tag. The workflow queries that draft from the
+   trusted `main` workflow, rejects malformed tags or prereleases, creates the
+   tag at the current `main` commit when it does not already exist, and retains
+   the same tag on a retry. It snapshots the draft metadata so a later merge
+   cannot change the notes or proposed version while the build is running, and
+   pins every later job to the frozen commit SHA.
+5. In parallel with the desktop build, the documentation builder checks out
+   that validated SHA and builds `docs-site/` as a static export under `/docs`.
+   Publication waits until the GitHub Release itself has been published. It
+   then creates an unaliased production-target deployment in the
    dedicated Vercel project, smoke-tests the staged root page, nested content,
    search index, sitemap, assets, and canonical metadata, and only then
    promotes that immutable deployment to `tidebreak-docs.vercel.app`. The
@@ -147,7 +146,7 @@ automatic.
    `VERCEL_TOKEN`; its project and organization identifiers are non-secret
    workflow constants. A failed build or smoke test leaves the previous docs
    deployment serving production.
-6. The dispatched workflow first checks whether that exact tag, commit, and
+6. The workflow first checks whether that exact tag, commit, and
    publication date already have a complete immutable release on S3.
    Credential-free prerequisites — one per platform — otherwise compile the tag
    with its product version and save unsigned Cargo outputs before any signing
@@ -167,35 +166,42 @@ automatic.
    independently of the package builds. That job has no production environment,
    deployment variables, OIDC permission, or AWS role; it transfers the two
    files to the publisher through a pinned GitHub artifact action. Publication
-   waits for both the package build and source SBOM. For public repositories,
-   the publisher also records
-   Sigstore-backed SLSA-style build provenance for every immutable release file
-   (including `manifest.json`). The source-tree SBOM is deliberately published
-   as source-scoped metadata, not attested as a description of the packaged
-   installers. The publisher then uploads immutable versioned files, advances
-   the public manifests, invalidates their CDN paths, and smoke-tests the hosted
-   release. If a prior attempt already uploaded the
-   complete immutable prefix, a new dispatch validates and reuses those bytes,
-   skips the desktop build, and resumes only mutable metadata publication,
-   CDN invalidation, and smoke testing.
-9. A final job downloads every installer the immutable manifest lists back from
-   the CDN, checks them against its digests, and attaches them to the GitHub
-   Release with `.sha256` sidecars — today that is the notarized disk image as
+   waits for both the package build and source SBOM. The source-tree SBOM is
+   deliberately published as source-scoped metadata, not attested as a
+   description of the packaged installers.
+9. Before publication, a credential-free job attaches the verified build
+   outputs and their `.sha256` sidecars to the draft GitHub Release — today that
+   is the notarized disk image as
    `Tidebreak-macos-universal.dmg`, plus the byte-identical legacy
    `Tidebreak-macos-apple-silicon.dmg` alias that keeps the existing README URL
-   live through the transition. It also attaches the release SBOM and its
-   checksum when that release carries one. It would again include
-   `Tidebreak-windows-x86_64-setup.exe` if the Windows lane were unparked. It
-   holds no signing or AWS credentials. The names omit the version so that
+   live through the transition. It retains the versioned app zip, signed updater
+   archive, updater signature, source SBOM, and checksum sidecars on GitHub as
+   recovery inputs. It would again include the Windows installer and updater
+   assets if the Windows lane were unparked. This job holds no signing or AWS
+   credentials. The two DMG names omit the version so that
    `https://github.com/brightwave-inc/tidebreak/releases/latest/download/<name>`
    stays a permanent download link for the README; the release page and the
    app's own version string identify which build it is.
+10. Only after every GitHub asset is present does the workflow restore the
+    frozen title and notes and publish the draft. GitHub then locks the release
+    tag and assets. The workflow uses GitHub's resulting publication timestamp
+    to create and attest the hosted manifest, uploads immutable versioned files,
+    advances the public manifests, invalidates their CDN paths, and smoke-tests
+    the hosted release. If a prior attempt already uploaded the complete
+    immutable prefix, a new dispatch validates and reuses those bytes, skips the
+    desktop build, and resumes only mutable metadata publication, CDN
+    invalidation, and smoke testing. If GitHub publication succeeded but hosted
+    publication did not, the retry downloads and verifies the retained GitHub
+    assets, reconstructs the hosted release inputs from those immutable bytes,
+    and resumes S3/CDN publication without rebuilding signed or notarized
+    artifacts.
 
-Publishing the native draft is the only release boundary. Merging ordinary PRs
-updates the draft but never builds or ships a desktop version. A published
-GitHub Release is considered shipped only when its dispatched **Publish
-desktop release** build completes successfully; the initial dispatch run is
-not the shipping signal.
+Running **Publish desktop release** is the only release operation. Merging
+ordinary PRs updates the draft but never builds or ships a desktop version, and
+manually clicking GitHub's **Publish release** button is no longer part of the
+procedure. The GitHub Release becomes public only after its verified assets are
+attached; the release is considered fully shipped when the workflow also
+finishes hosted metadata and documentation publication successfully.
 
 ## Public desktop delivery
 
@@ -411,10 +417,11 @@ Treat the release workflow as public even while the repository is private:
 
 - Release actions are pinned to immutable commit SHAs. Dependabot is responsible
   for proposing reviewed action updates.
-- A published native GitHub Release dispatches the production build on the
-  protected `main` workflow. The build accepts only a published, non-prerelease
-  tag whose resolved commit is on `main`. It never runs with production secrets
-  for a pull request or a manually selected feature-branch workflow.
+- An explicit manual dispatch on the protected `main` workflow freezes the
+  native draft's tag before any production build. The build accepts only a
+  non-prerelease release whose resolved commit is on `main`, and it publishes
+  the GitHub Release only after attaching verified assets. It never runs with
+  production secrets for a pull request or a manually selected feature branch.
 - The jobs that build and sign check out that immutable commit SHA. The two
   AWS-credentialed jobs — the hosted-release inspection and the publisher —
   deliberately check out the dispatching `main` commit instead, so they run the

--- a/scripts/workflow-security-mutations.test.mjs
+++ b/scripts/workflow-security-mutations.test.mjs
@@ -508,7 +508,7 @@ const mutations = [
   {
     name: "README macOS download matches an uploaded asset",
     file: "README.md",
-    expected: "GitHub release publication preserves verified asset provenance",
+    expected: "GitHub release assets are attached before immutable publication",
     mutate: (source) =>
       source.replace(
         /Tidebreak-macos-[\w-]+\.dmg/,

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -520,12 +520,7 @@ test("production secrets remain isolated to the release workflow", () => {
   assert.ok(secretConsumers.includes("release.yml"));
 
   const release = workflows["release.yml"];
-  const hasPublishedReleaseTrigger =
-    /^on:\n  release:\n    types: \[published\]/m.test(release);
-  assert.ok(
-    hasPublishedReleaseTrigger || !/^  release:/m.test(release),
-    "release workflows may use only the legacy published trigger or no release trigger",
-  );
+  assert.doesNotMatch(release, /^  release:/m);
   assert.match(release, /^  workflow_dispatch:\n/m);
   assert.doesNotMatch(release, /^\s*pull_request(?:_target)?:/m);
   assert.match(release, /^permissions:\n  contents: read$/m);
@@ -1021,48 +1016,24 @@ test("sandbox images are scanned in a read-only job before the version tag is pu
   assert.equal(publish.match(/contents: write/g)?.length, 1);
 });
 
-test("release builds enter through the trusted main workflow", () => {
+test("release builds freeze a draft tag from the trusted main workflow", () => {
   const release = workflows["release.yml"];
   const validateJob = workflowJob(release, "validate");
-  if (/^  release:/m.test(release)) {
-    const dispatchJob = workflowJob(release, "dispatch");
-    assert.match(release, /gh workflow run release\.yml/);
-    assert.match(release, /--ref main/);
-    assert.match(release, /actions: write/);
-    assert.match(dispatchJob, /contents: read/);
-    assert.match(
-      dispatchJob,
-      /node scripts\/check-release-tag\.mjs "\$RELEASE_TAG"/,
-    );
-    assert.ok(
-      dispatchJob.indexOf("Reject an invalid published release tag") <
-        dispatchJob.indexOf("gh workflow run release.yml"),
-      "published release tags must be validated before dispatching a production build",
-    );
-    assert.match(
-      release,
-      /github\.event_name == 'workflow_dispatch' && github\.ref == 'refs\/heads\/main'/,
-    );
-    assert.match(
-      release,
-      /repos\/\$GITHUB_REPOSITORY\/releases\/tags\/\$RELEASE_TAG/,
-    );
-  } else {
-    assert.match(release, /^  workflow_dispatch:\n/m);
-    assert.match(validateJob, /github\.ref == 'refs\/heads\/main'/);
-    assert.match(validateJob, /permissions:\n      contents: write/);
-    assert.match(validateJob, /ref: \$\{\{ github\.sha \}\}/);
-    assert.match(validateJob, /node scripts\/check-release-tag\.mjs "\$RELEASE_TAG"/);
-    assert.match(
-      validateJob,
-      /repos\/\$GITHUB_REPOSITORY\/releases\?per_page=100/,
-    );
-    assert.match(validateJob, /select\(\.tag_name == \$tag\)/);
-    assert.match(validateJob, /refs\/tags\/\$RELEASE_TAG/);
-    assert.match(validateJob, /repos\/\$GITHUB_REPOSITORY\/git\/refs/);
-    assert.match(validateJob, /git merge-base --is-ancestor "\$RELEASE_SHA" origin\/main/);
-    assert.match(validateJob, /release-snapshot\.json/);
-  }
+  assert.doesNotMatch(release, /^  release:/m);
+  assert.match(release, /^  workflow_dispatch:\n/m);
+  assert.match(validateJob, /github\.ref == 'refs\/heads\/main'/);
+  assert.match(validateJob, /permissions:\n      contents: write/);
+  assert.match(validateJob, /ref: \$\{\{ github\.sha \}\}/);
+  assert.match(validateJob, /node scripts\/check-release-tag\.mjs "\$RELEASE_TAG"/);
+  assert.match(
+    validateJob,
+    /repos\/\$GITHUB_REPOSITORY\/releases\?per_page=100/,
+  );
+  assert.match(validateJob, /select\(\.tag_name == \$tag\)/);
+  assert.match(validateJob, /refs\/tags\/\$RELEASE_TAG/);
+  assert.match(validateJob, /repos\/\$GITHUB_REPOSITORY\/git\/refs/);
+  assert.match(validateJob, /git merge-base --is-ancestor "\$RELEASE_SHA" origin\/main/);
+  assert.match(validateJob, /release-snapshot\.json/);
   assert.match(release, /ref: \$\{\{ needs\.validate\.outputs\.sha \}\}/);
 });
 
@@ -1072,10 +1043,7 @@ test("release documentation is built from the validated tag and promoted only af
 
   assert.match(build, /^    needs: validate$/m);
   assert.doesNotMatch(build, /^    environment:/m);
-  assert.match(
-    publish,
-    /^    needs: \[validate, build_docs(?:, finalize_release)?\]$/m,
-  );
+  assert.match(publish, /^    needs: \[validate, build_docs, finalize_release\]$/m);
   assert.match(publish, /^    environment:\n      name: docs-production$/m);
   assert.match(build, /^    permissions:\n      contents: read$/m);
   assert.match(publish, /^    permissions:\n      contents: read$/m);
@@ -1585,10 +1553,7 @@ test("source SBOM generation is isolated from production credentials", () => {
   assert.match(sbomJob, /name: tidebreak-source-sbom-\$\{\{ needs\.validate\.outputs\.version \}\}/);
   assert.doesNotMatch(publishJob, /anchore\/sbom-action/);
 
-  assert.match(
-    publishJob,
-    /needs: \[validate, inspect_hosted, build_macos, build_windows, source_sbom(?:, finalize_release)?\]/,
-  );
+  assert.match(publishJob, /needs: \[validate, inspect_hosted, build_macos, build_windows, source_sbom, finalize_release\]/);
   assert.match(publishJob, /needs\.source_sbom\.result == 'success'/);
   assert.match(
     publishJob,
@@ -1619,57 +1584,51 @@ test("public releases attest provenance without treating the source SBOM as an i
   assert.ok(provenanceIndex < awsIndex);
 });
 
-test("GitHub release publication preserves verified asset provenance", () => {
+test("GitHub release assets are attached before immutable publication", () => {
   const release = workflows["release.yml"];
   const attachJob = workflowJob(release, "attach_downloads");
+  const finalizeJob = workflowJob(release, "finalize_release");
+  const publishJob = workflowJob(release, "publish");
 
+  assert.match(attachJob, /needs: \[validate, inspect_hosted, build_macos, build_windows, source_sbom\]/);
   assert.match(attachJob, /contents: write/);
   assert.doesNotMatch(attachJob, /^    environment:/m);
   assert.doesNotMatch(attachJob, /secrets\./);
   assert.doesNotMatch(attachJob, /APPLE_|TAURI_SIGNING|AWS_|DOWNLOADS_S3/);
 
-  if (/^  finalize_release:/m.test(release)) {
-    const finalizeJob = workflowJob(release, "finalize_release");
-    const publishJob = workflowJob(release, "publish");
-    assert.match(attachJob, /needs: \[validate, inspect_hosted, build_macos, build_windows, source_sbom\]/);
-    assert.match(attachJob, /name: tidebreak-macos-universal-/);
-    assert.match(attachJob, /name: tidebreak-source-sbom-/);
-    assert.match(attachJob, /gh release download "\$RELEASE_TAG"/);
-    assert.match(attachJob, /sha256sum --check --strict/);
-    assert.match(attachJob, /Tidebreak-macos-universal\.dmg/);
-    assert.match(attachJob, /Tidebreak-macos-apple-silicon\.dmg/);
-    assert.match(attachJob, /\.app\.zip/);
-    assert.match(attachJob, /\.app\.tar\.gz/);
-    assert.match(attachJob, /\.app\.tar\.gz\.sig/);
-    assert.match(attachJob, /gh release upload "\$RELEASE_TAG"/);
-    assert.match(attachJob, /if \[\[ "\$RELEASE_DRAFT" = true \]\]/);
-    assert.match(attachJob, /releases\/\$RELEASE_ID\/assets/);
-    assert.match(attachJob, /expected-release-assets/);
-    assert.match(attachJob, /actual-release-assets/);
-    assert.match(attachJob, /diff -u/);
-    assert.match(finalizeJob, /needs: \[validate, attach_downloads\]/);
-    assert.match(finalizeJob, /contents: write/);
-    assert.match(finalizeJob, /commits\/\$RELEASE_TAG/);
-    assert.match(finalizeJob, /Release tag \$RELEASE_TAG moved after validation/);
-    assert.match(finalizeJob, /draft: false/);
-    assert.match(finalizeJob, /make_latest: "true"/);
-    assert.match(finalizeJob, /published_at=\$published_at/);
-    assert.match(publishJob, /needs\.finalize_release\.result == 'success'/);
-    assert.match(
-      publishJob,
-      /RELEASE_PUBLISHED_AT: \$\{\{ needs\.finalize_release\.outputs\.published_at \}\}/,
-    );
-    assert.match(publishJob, /Recover build inputs from the immutable GitHub Release/);
-    assert.match(publishJob, /recovery\/Tidebreak-macos-universal\.dmg/);
-  } else {
-    assert.match(attachJob, /needs: \[validate, publish\]/);
-    assert.match(attachJob, /releases\/v\$TIDEBREAK_VERSION\/manifest\.json/);
-    assert.match(attachJob, /sha256sum --check --strict/);
-    assert.match(attachJob, /Tidebreak-macos-universal\.dmg/);
-    assert.match(attachJob, /Tidebreak-macos-apple-silicon\.dmg/);
-    assert.match(attachJob, /Tidebreak-windows-x86_64-setup\.exe/);
-    assert.match(attachJob, /gh release upload "\$RELEASE_TAG"/);
-  }
+  // A fresh release attaches the exact verified Actions artifacts before
+  // publication. A published retry verifies those assets and can reconstruct
+  // an incomplete hosted publication without rebuilding signed packages.
+  assert.match(attachJob, /name: tidebreak-macos-universal-/);
+  assert.match(attachJob, /name: tidebreak-source-sbom-/);
+  assert.match(attachJob, /gh release download "\$RELEASE_TAG"/);
+  assert.match(attachJob, /sha256sum --check --strict/);
+  assert.match(attachJob, /Tidebreak-macos-universal\.dmg/);
+  assert.match(attachJob, /Tidebreak-macos-apple-silicon\.dmg/);
+  assert.match(attachJob, /\.app\.zip/);
+  assert.match(attachJob, /\.app\.tar\.gz/);
+  assert.match(attachJob, /\.app\.tar\.gz\.sig/);
+  assert.match(attachJob, /gh release upload "\$RELEASE_TAG"/);
+  assert.match(attachJob, /if \[\[ "\$RELEASE_DRAFT" = true \]\]/);
+  assert.match(attachJob, /releases\/\$RELEASE_ID\/assets/);
+  assert.match(attachJob, /expected-release-assets/);
+  assert.match(attachJob, /actual-release-assets/);
+  assert.match(attachJob, /diff -u/);
+
+  assert.match(finalizeJob, /needs: \[validate, attach_downloads\]/);
+  assert.match(finalizeJob, /contents: write/);
+  assert.match(finalizeJob, /commits\/\$RELEASE_TAG/);
+  assert.match(finalizeJob, /Release tag \$RELEASE_TAG moved after validation/);
+  assert.match(finalizeJob, /draft: false/);
+  assert.match(finalizeJob, /make_latest: "true"/);
+  assert.match(finalizeJob, /published_at=\$published_at/);
+  assert.match(publishJob, /needs\.finalize_release\.result == 'success'/);
+  assert.match(
+    publishJob,
+    /RELEASE_PUBLISHED_AT: \$\{\{ needs\.finalize_release\.outputs\.published_at \}\}/,
+  );
+  assert.match(publishJob, /Recover build inputs from the immutable GitHub Release/);
+  assert.match(publishJob, /recovery\/Tidebreak-macos-universal\.dmg/);
 
   const macDownloadLink = readFileSync(repositoryFile("README.md"), "utf8")
     .match(


### PR DESCRIPTION
Prerequisite policy transition and CODEOWNERS setup landed in #2091.

## Summary

- publish verified desktop assets to the GitHub Release while it is still a draft, then publish and lock the release
- preserve updater archives, signatures, checksums, and the source SBOM as immutable recovery inputs
- resume incomplete S3/CDN publication from GitHub assets without rebuilding signed or notarized packages
- tighten the transitional release policy to the immutable-only workflow
- update the release runbook and workflow-security regression coverage

## Why

GitHub immutable releases cannot accept asset uploads after publication. The previous `release.published` flow built the desktop packages only after the release was public and then uploaded them with `--clobber`, which is incompatible with immutable releases.

The workflow now starts manually from `main` using the draft tag, freezes the source tag and release metadata, verifies the complete checksummed asset set, and publishes the GitHub Release only after those assets are attached.

## Compatibility and recovery

The permanent version-free DMG URLs remain unchanged. Versioned app updater artifacts are additionally retained on GitHub so a retry can reconstruct an incomplete hosted release from the already-published immutable bytes. Existing completed hosted releases continue through the validation-and-resume path.

The operator-facing change is that maintainers must run **Actions → Publish desktop release** for the draft instead of clicking GitHub's **Publish release** button.

## Safety and risk

- the release source must resolve to a commit on `main`
- the tag is checked again immediately before publication
- release title and notes are snapshotted and restored at publication
- every asset must have a valid checksum sidecar
- the GitHub asset-name set must exactly match the prepared set
- production credentials remain isolated from build and GitHub-asset preparation jobs
- published retries reuse immutable bytes rather than recreating signed artifacts

The main risk is operational because this changes release orchestration. The release runbook documents the new entry point and retry behavior.

## Validation

- `git diff --check`
- `actionlint .github/workflows/release.yml`
- `node scripts/workflow-security.test.mjs` — 34/34 passed
- `node scripts/workflow-security-mutations.test.mjs` — 43/43 passed
