### PR TITLE
docs: refresh product guidance and navigation

### DIFF
--- a/docs-site/AGENTS.md
+++ b/docs-site/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/docs-site/CLAUDE.md
+++ b/docs-site/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs-site/content/docs/chats.mdx
+++ b/docs-site/content/docs/chats.mdx
@@ -5,7 +5,8 @@ description: The unit of work in Tidebreak — the composer, panels, the inbox, 
 
 A chat is the unit of work. It owns its own model, permission mode, network
 policy, attached files, connected folders, and the outputs it produced.
-Nothing is global except your credentials and defaults.
+Projects, credentials, connected apps, plugins, and reusable local apps live
+outside any one chat.
 
 Start one with **New chat** in the sidebar, or ⌘N.
 
@@ -34,9 +35,14 @@ Two typed triggers:
 
 ## While a turn is running
 
-The composer stays usable. Typing and sending mid-turn **redirects** the
-active response rather than queueing a new one — the send button becomes
-**Redirect**. A separate stop button cancels the turn.
+The composer stays usable. A message sent mid-turn either joins the durable
+queue as its own follow-up or **steers** the active response at the next safe
+model boundary. Choose the default under **Settings → Agents → While an agent
+is responding**; the send button reads **Queue** or **Steer** to match.
+
+Queued messages appear above the composer. You can edit, reorder, delete,
+pause, or send one immediately. A separate stop button cancels the active
+turn.
 
 The chat header carries a context meter and an activity chip that opens the
 per-chat panels.
@@ -88,6 +94,14 @@ when reporting a problem.
 
 ## Projects
 
-The data model has an optional project that can own several chats and hold
-approvals that apply across them. It is not surfaced in the desktop app yet.
-Everything you do today lives in a chat.
+Projects organize related chats in the sidebar. Use the `+` beside
+**Projects** to create one, or move an existing chat from its row menu.
+
+A project can also hold files that every chat in it reads. Attach a file to a
+chat first, open it, then choose **Add to project**. The project's row menu
+opens **Project files**, where you can see or remove shared files. Moving a
+chat does not move its own attachments; project files are added alongside
+them.
+
+Standing approvals may be saved for one chat or for every chat in its project.
+The approval card names that scope before you confirm it.

--- a/docs-site/content/docs/connected-apps.mdx
+++ b/docs-site/content/docs/connected-apps.mdx
@@ -1,0 +1,66 @@
+---
+title: Connected apps
+description: Add MCP servers and REST APIs, understand what each surface can do, and keep credentials out of app code.
+---
+
+**Settings → Connected apps** lists the outside systems this Tidebreak profile
+can reach. There are two local kinds:
+
+- **MCP servers** expose tools directly to chats. Every call stays behind the
+  chat approval boundary.
+- **REST APIs** expose selected OpenAPI operations to [local apps](/local-apps).
+  They are not automatically added to a chat's tool list.
+
+Managed profiles can also show applications granted through their
+organization's model gateway. Those are configured by the organization rather
+than with local credentials.
+
+## Add a REST API
+
+Press **Add REST API**, then provide:
+
+| Field | What it means |
+| --- | --- |
+| **Name** | The label people see in Settings and consent sheets. |
+| **Base URL** | The HTTPS origin and path operations run against. |
+| **OpenAPI document** | A JSON OpenAPI 3.x document, fetched from an HTTPS URL or pasted directly. |
+| **Operations** | The exact `operationId` entries Tidebreak keeps from the document. |
+| **Credential** | None, a bearer token, or a custom header such as `X-Api-Key`. |
+
+Tidebreak ingests the operation catalog and keeps only the selected operation
+definitions, not the raw OpenAPI document. If you edit the connection later,
+provide the document again so the operation set can be validated against the
+new definition.
+
+Credentials go into the profile's secret store and are never displayed again.
+They are injected only by the host-side executor when a granted app invokes an
+operation; the app's HTML, the model, and the renderer never receive the value.
+
+## The REST boundary
+
+The executor refuses anything outside the stored catalog. It validates the
+HTTP method, path template, and parameters before sending a request. Requests
+must use HTTPS; loopback and private-network destinations are refused,
+redirects are not followed, and request, response, and timeout bounds are
+enforced by the host.
+
+A local app's consent sheet names the connected app and the exact operations it
+wants. If you change the base URL, operation catalog, credential reference, or
+credential placement, the old consent no longer matches and the app asks
+again.
+
+## MCP servers
+
+MCP definitions live on the same Settings page, but their behavior is
+different: their tools are advertised to the chat model and each call is
+sensitive. See [MCP servers](/mcp-servers) for transports, health, and the
+approval boundary.
+
+<Cards>
+  <Card title="Local apps" href="/local-apps">
+    See how reusable apps bind to connected operations and folders.
+  </Card>
+  <Card title="MCP servers" href="/mcp-servers">
+    Connect stdio or HTTP tool servers to chats.
+  </Card>
+</Cards>

--- a/docs-site/content/docs/how-the-agent-works.mdx
+++ b/docs-site/content/docs/how-the-agent-works.mdx
@@ -1,6 +1,6 @@
 ---
 title: How the agent works
-description: What happens during a turn, how plans and questions pause it, and how to redirect work in progress.
+description: What happens during a turn, how plans and questions pause it, and how to steer or queue work in progress.
 ---
 
 A Tidebreak turn is a durable loop: the selected model proposes the next step,
@@ -44,16 +44,18 @@ questions and pause. The question remains in the transcript and the **Inbox**
 until you answer it. Approval cards work the same way: the turn waits on a
 durable decision rather than treating a closed window as consent or refusal.
 
-## Redirecting a running turn
+## Steering or queueing a running turn
 
 If you send another message while a turn is active, Tidebreak can either queue
-it as the next turn or use it to steer the current one, depending on the send
-mode you selected. Steering is applied at a safe model boundary; it does not
-interrupt a tool halfway through and pretend the tool never ran.
+it as the next turn or use it to steer the current one. Choose the default
+under **Settings → Agents → While an agent is responding**. Steering is
+applied at a safe model boundary; it does not interrupt a tool halfway through
+and pretend the tool never ran.
 
 Use steering for corrections that matter to the current result. Queue a
 message when it is a separate follow-up you want handled after the current
-turn settles.
+turn settles. The queue is durable and can be paused, reordered, edited, or
+advanced with **Send now**.
 
 ## Background work
 

--- a/docs-site/content/docs/index.mdx
+++ b/docs-site/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: What Tidebreak is
-description: A local-first AI agent desktop app that runs on your machine with your own model keys.
+description: A local-first AI agent desktop app that runs on your machine with the models and tools you choose.
 ---
 
 Tidebreak is a desktop app for handing real work to an AI agent. You start a
@@ -25,13 +25,22 @@ formats, and behavior change frequently. Expect rough edges.
   or connect a folder on your machine that the agent can list and read.
 - **Run code in a sandbox.** The agent writes and executes scripts to analyze
   spreadsheets, render PDFs, build charts, and generate documents. Commands run
-  confined, with network access off unless you grant it.
+  inside the code-execution backend you choose. Network access is a separate
+  per-chat policy that starts open and can be narrowed to package registries,
+  exact hosts, or fully offline.
 - **Produce files, not just answers.** Anything the agent saves to its
   `output/` directory becomes a versioned output you can preview and export
   with a native save dialog.
-- **Use any model.** Anthropic, OpenAI, Google, xAI, OpenRouter, a local
-  Ollama daemon, and any OpenAI-compatible endpoint. You can switch models
-  mid-conversation without losing the thread.
+- **Build reusable local apps.** Ask for a triage view or other small tool once,
+  then reopen it from the Apps library. Its access is pinned to the exact
+  folders and connected-app operations you approve.
+- **Connect outside tools.** Add MCP servers for chat tools, or a REST API from
+  an OpenAPI document for local apps to call through Tidebreak's governed
+  executor.
+- **Use the model routes you prefer.** Anthropic, OpenAI, Google, xAI,
+  Fireworks, Together, OpenRouter, a local Ollama daemon, and any
+  OpenAI-compatible endpoint. You can switch models mid-conversation without
+  losing the thread.
 - **Decide how much rope to give it.** Every chat has a permission mode, from
   read-only planning up to full autonomy.
 
@@ -39,15 +48,15 @@ formats, and behavior change frequently. Expect rough edges.
 
 People who want an agent that can touch real data and produce real artifacts,
 and who would rather that happen on their own machine than in someone else's
-cloud. It assumes you are comfortable obtaining a model-provider credential
-and entering it in settings.
+cloud. You can sign in with a ChatGPT subscription, provide an API key, or use
+a local Ollama model.
 
 ## What it is not
 
-It is not a hosted service, and there is no account to create. It is not a
-coding assistant bound to a repository — the unit of work is a conversation
-with files attached, not a checkout. And it is not finished: several
-subsystems exist in the runtime before they have any UI.
+It is not a hosted service, and there is no Tidebreak account to create. It is
+not primarily a repository-bound coding assistant — the unit of work is a chat
+with files, folders, tools, and outputs. And it is not finished: the product is
+still pre-1.0 and its local data model can change between releases.
 
 ## Start here
 

--- a/docs-site/content/docs/installation.mdx
+++ b/docs-site/content/docs/installation.mdx
@@ -7,17 +7,18 @@ description: Download Tidebreak for macOS, or build it from source.
 
 Download the disk image and drag Tidebreak to Applications.
 
-[Download for macOS (Apple Silicon)](https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-macos-apple-silicon.dmg)
+[Download for macOS](https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-macos-universal.dmg)
 
-Releases ship an Apple Silicon (`aarch64`) build only. There is no Intel
-build; on an Intel Mac, build from source.
+Releases ship one universal build for Apple Silicon and Intel Macs. An
+Apple-Silicon-only compatibility asset is also attached to the GitHub release,
+but the universal disk image is the normal download.
 
 The macOS app is signed and notarized, so it opens without a Gatekeeper
 override. Each download has a `.sha256` sidecar on the same release if you want
 to check it:
 
 ```sh
-shasum -a 256 -c Tidebreak-macos-apple-silicon.dmg.sha256
+shasum -a 256 -c Tidebreak-macos-universal.dmg.sha256
 ```
 
 An installed macOS build keeps itself current. It checks for a newer signed

--- a/docs-site/content/docs/local-apps.mdx
+++ b/docs-site/content/docs/local-apps.mdx
@@ -1,0 +1,67 @@
+---
+title: Local apps
+description: Reopen agent-built mini-apps, review their exact capabilities, and control what they can call.
+---
+
+A local app is a small tool the agent builds once and Tidebreak keeps in the
+**Apps** library. Ask for a triage view, review console, or other focused
+interface in a chat; when the agent publishes it, the app outlives that chat
+and can be reopened from the sidebar.
+
+Apps are versioned. Publishing another revision appends to the app's history
+instead of replacing the old record in place.
+
+## What an app contains
+
+Each revision has two parts:
+
+- An HTML, CSS, and JavaScript bundle authored by the model.
+- A manifest naming the exact capabilities the app needs: selected operations
+  from REST [connected apps](/connected-apps), connected folders, or apps
+  granted through an organization's model gateway.
+
+The bundle is untrusted. The manifest is the part you review and consent to.
+Tidebreak enforces it on every call, regardless of what the app's interface
+claims it can do.
+
+## Opening and granting one
+
+Open **Apps** in the sidebar and choose an app. The first open—and any open
+after its capability set changes—shows a consent sheet before the app runs.
+Review the named folders, connected apps, and exact operations, then grant or
+decline access.
+
+Consent belongs to that app, not to a chat permission mode. You can revoke it
+from the app's detail view. If a bound connected app is reconfigured, or a new
+revision asks for more access, the existing grant stops matching and Tidebreak
+asks again.
+
+## Containment
+
+The app runs in a sandboxed, opaque-origin frame with a strict content security
+policy. It has no direct network access, cannot read Tidebreak's DOM or local
+storage, and never receives provider or connected-app credentials.
+
+When the app invokes a granted operation, it sends a message to the trusted
+host. The host checks the current manifest and consent, injects credentials at
+request time, executes the operation, bounds the result, and returns only the
+result to the frame.
+
+An app can still render misleading text—the bundle is model-authored—so treat
+its interface as presentation, not authority. The server-side manifest and
+grant are the actual boundary.
+
+## Managing apps
+
+The Apps library shows every live app, its revision count, last update, and
+whether access is granted. Open an app to run it, inspect or revoke access,
+review its revision history, or delete it.
+
+<Cards>
+  <Card title="Connected apps" href="/connected-apps">
+    Add the REST operations a local app can bind to.
+  </Card>
+  <Card title="Connected folders" href="/connected-folders">
+    Understand folder capabilities and replacement rules.
+  </Card>
+</Cards>

--- a/docs-site/content/docs/meta.json
+++ b/docs-site/content/docs/meta.json
@@ -17,6 +17,8 @@
     "permission-modes",
     "---Extending---",
     "skills-and-plugins",
+    "connected-apps",
+    "local-apps",
     "mcp-servers",
     "web-search",
     "roadmap",

--- a/docs-site/content/docs/roadmap.mdx
+++ b/docs-site/content/docs/roadmap.mdx
@@ -77,6 +77,6 @@ together, durable background runs remain local and attached.
 
 The v1 foundation still has ordinary implementation work: consolidating the
 pre-v1 schema baseline, closing the remaining self-hosted prompt-inbox ownership
-gap, enforcing Docker's strict network-off policy, surfacing the built-in
-project model, and tightening deletion and audit behavior. These are active,
-buildable slices rather than deferred promises.
+gap, enforcing Docker's strict network-off policy, and tightening deletion and
+audit behavior. These are active, buildable slices rather than deferred
+promises.

--- a/docs-site/content/docs/web-search.mdx
+++ b/docs-site/content/docs/web-search.mdx
@@ -5,7 +5,9 @@ description: Choose between your model provider's built-in search and your own s
 
 The agent has two tools that reach the public web: `web_search`, which
 searches, and `web_extract`, which fetches a specific page. Both are sensitive
-calls, so they ask for approval in Ask and Auto.
+calls. They stop for you in Ask; in Auto they are eligible for the narrow
+automatic reviewer described under [Permission modes](/permission-modes), and
+stop for you whenever that reviewer declines or cannot decide.
 
 Pages the agent fetches are added to the conversation as sources. When a
 response includes them, they appear in the expandable **Sources** row below

--- a/docs-site/src/app/(docs)/[[...slug]]/page.tsx
+++ b/docs-site/src/app/(docs)/[[...slug]]/page.tsx
@@ -43,13 +43,13 @@ export default async function Page(props: PageProps<'/[[...slug]]'>) {
 
   return (
     <>
-      <main className="min-w-0 flex-1 py-8 lg:py-10">
-        <div className="mx-auto max-w-3xl px-6">
-          <h1 className="text-3xl font-bold tracking-tight text-foreground">
+      <main id="main-content" className="min-w-0 flex-1 py-8 lg:py-12">
+        <div className="mx-auto max-w-3xl px-5 sm:px-7">
+          <h1 className="text-balance text-3xl font-semibold tracking-[-0.03em] text-foreground sm:text-4xl">
             {page.title}
           </h1>
           {page.description && (
-            <p className="mt-2 text-lg text-muted-foreground">
+            <p className="mt-3 text-pretty text-base leading-7 text-muted-foreground sm:text-lg">
               {page.description}
             </p>
           )}

--- a/docs-site/src/app/global.css
+++ b/docs-site/src/app/global.css
@@ -137,7 +137,7 @@
   }
 
   body {
-    font-family: 'Inter', sans-serif;
+    font-family: var(--font-geist-sans), system-ui, sans-serif;
     @apply bg-page-background text-foreground;
   }
 }
@@ -173,13 +173,17 @@
 }
 
 .prose code:not(pre code) {
-  font-family: ui-monospace, monospace;
+  font-family: var(--font-geist-mono), ui-monospace, monospace;
   font-size: 0.8em;
   font-weight: 450;
   background-color: color-mix(in srgb, var(--muted) 75%, transparent);
   padding: 0.2em 0.4em;
   border-radius: 0.25rem;
   border: 0.5px solid var(--border);
+}
+
+.prose :where(p, li) {
+  text-wrap: pretty;
 }
 
 .prose code:not(pre code)::before,

--- a/docs-site/src/app/layout.tsx
+++ b/docs-site/src/app/layout.tsx
@@ -1,11 +1,17 @@
-import { Inter } from 'next/font/google';
+import { Geist, Geist_Mono } from 'next/font/google';
 import { Provider } from '@/components/provider';
 import type { Metadata } from 'next';
 import { getPage, getPageImage } from '@/lib/content';
 import './global.css';
 
-const inter = Inter({
+const geistSans = Geist({
   subsets: ['latin'],
+  variable: '--font-geist-sans',
+});
+
+const geistMono = Geist_Mono({
+  subsets: ['latin'],
+  variable: '--font-geist-mono',
 });
 
 const homePage = getPage([]);
@@ -30,7 +36,12 @@ export const metadata: Metadata = {
 
 export default function Layout({ children }: LayoutProps<'/'>) {
   return (
-    <html lang="en" className={inter.className} suppressHydrationWarning>
+    <html
+      lang="en"
+      className={`${geistSans.variable} ${geistMono.variable}`}
+      data-scroll-behavior="smooth"
+      suppressHydrationWarning
+    >
       <body className="flex flex-col min-h-screen">
         <Provider>{children}</Provider>
       </body>

--- a/docs-site/src/components/docs-layout.tsx
+++ b/docs-site/src/components/docs-layout.tsx
@@ -5,8 +5,6 @@ import type { ReactNode } from 'react';
 import { Header } from './header';
 import { Sidebar, MobileSidebar } from './sidebar';
 import type { SidebarSection } from '@/lib/content';
-import { Button } from '@/components/ui/button';
-import { PanelLeft } from 'lucide-react';
 
 export function DocsShell({
   sections,
@@ -23,18 +21,18 @@ export function DocsShell({
 
   return (
     <>
-      <Header onOpenSearch={openSearch} />
+      <a
+        href="#main-content"
+        className="fixed left-4 top-3 z-[60] -translate-y-20 rounded-md bg-foreground px-3 py-2 text-sm font-medium text-background transition-transform focus:translate-y-0"
+      >
+        Skip to content
+      </a>
+      <Header
+        onOpenSearch={openSearch}
+        onOpenSidebar={() => setSidebarOpen(true)}
+      />
       <div className="mx-auto flex w-full max-w-screen-2xl flex-1 gap-0 px-2 py-2 lg:px-3">
         <Sidebar sections={sections} />
-        <Button
-          variant="outline"
-          size="icon-sm"
-          className="fixed bottom-4 left-4 z-30 rounded-full shadow-md lg:hidden"
-          onClick={() => setSidebarOpen(true)}
-          aria-label="Open sidebar"
-        >
-          <PanelLeft className="h-4 w-4" />
-        </Button>
         <MobileSidebar
           sections={sections}
           open={sidebarOpen}

--- a/docs-site/src/components/header.tsx
+++ b/docs-site/src/components/header.tsx
@@ -5,8 +5,7 @@ import { TidebreakLogo } from './logo';
 import { ThemeToggle } from './theme-toggle';
 import { SearchTrigger } from './search-trigger';
 import { Button } from '@/components/ui/button';
-import { Menu, X } from 'lucide-react';
-import { useState } from 'react';
+import { Menu } from 'lucide-react';
 
 const PRODUCT_URL = 'https://www.tidebreak.sh';
 const REPO_URL = 'https://github.com/brightwave-inc/tidebreak';
@@ -21,9 +20,13 @@ function GitHubIcon(props: React.ComponentPropsWithoutRef<'svg'>) {
   );
 }
 
-export function Header({ onOpenSearch }: { onOpenSearch: () => void }) {
-  const [mobileOpen, setMobileOpen] = useState(false);
-
+export function Header({
+  onOpenSearch,
+  onOpenSidebar,
+}: {
+  onOpenSearch: () => void;
+  onOpenSidebar: () => void;
+}) {
   return (
     <header className="sticky top-0 z-50 border-b border-border bg-background/80 backdrop-blur-lg">
       <div className="mx-auto flex h-14 max-w-screen-2xl items-center gap-4 px-4 lg:px-6">
@@ -58,36 +61,13 @@ export function Header({ onOpenSearch }: { onOpenSearch: () => void }) {
             variant="ghost"
             size="icon-sm"
             className="md:hidden"
-            onClick={() => setMobileOpen(!mobileOpen)}
-            aria-label="Toggle menu"
+            onClick={onOpenSidebar}
+            aria-label="Browse documentation"
           >
-            {mobileOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+            <Menu className="h-5 w-5" />
           </Button>
         </div>
       </div>
-
-      {mobileOpen && (
-        <div className="border-t border-border bg-background px-4 py-4 md:hidden">
-          <nav className="flex flex-col gap-2">
-            {navLinks.map((link) => (
-              <a
-                key={link.href}
-                href={link.href}
-                className="rounded-md px-3 py-2 text-sm text-muted-foreground hover:text-foreground"
-              >
-                {link.text}
-              </a>
-            ))}
-            <hr className="my-2 border-border" />
-            <Button variant="outline" size="sm" asChild className="justify-start">
-              <a href={REPO_URL} target="_blank" rel="noopener noreferrer">
-                <GitHubIcon className="h-4 w-4" />
-                GitHub
-              </a>
-            </Button>
-          </nav>
-        </div>
-      )}
     </header>
   );
 }

--- a/docs-site/src/components/page-nav.tsx
+++ b/docs-site/src/components/page-nav.tsx
@@ -22,7 +22,7 @@ export function PageNavigation({ prev, next }: PageNavProps) {
             {prev.title}
           </span>
           {prev.description && (
-            <span className="mt-1 truncate text-sm text-muted-foreground">
+            <span className="mt-1 line-clamp-2 text-sm text-muted-foreground">
               {prev.description}
             </span>
           )}
@@ -43,7 +43,7 @@ export function PageNavigation({ prev, next }: PageNavProps) {
             <ChevronRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
           </span>
           {next.description && (
-            <span className="mt-1 truncate text-sm text-muted-foreground">
+            <span className="mt-1 line-clamp-2 text-sm text-muted-foreground">
               {next.description}
             </span>
           )}

--- a/docs-site/src/components/search-trigger.tsx
+++ b/docs-site/src/components/search-trigger.tsx
@@ -17,7 +17,9 @@ export function SearchTrigger({ onClick }: { onClick: () => void }) {
 
   return (
     <button
+      type="button"
       onClick={onClick}
+      aria-label="Search documentation"
       className="inline-flex h-8 items-center gap-2 rounded-md border border-border bg-muted/50 px-3 text-sm text-muted-foreground transition-colors hover:text-foreground"
     >
       <Search className="h-3.5 w-3.5" />

--- a/docs-site/src/components/sidebar.tsx
+++ b/docs-site/src/components/sidebar.tsx
@@ -4,6 +4,12 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
 import type { SidebarSection } from '@/lib/content';
+import { X } from 'lucide-react';
+import { useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+
+const PRODUCT_URL = 'https://www.tidebreak.sh';
+const REPO_URL = 'https://github.com/brightwave-inc/tidebreak';
 
 function SidebarNav({ sections, onNavigate }: { sections: SidebarSection[]; onNavigate?: () => void }) {
   const pathname = usePathname();
@@ -66,6 +72,15 @@ export function MobileSidebar({
   open: boolean;
   onClose: () => void;
 }) {
+  useEffect(() => {
+    if (!open) return;
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') onClose();
+    }
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [open, onClose]);
+
   if (!open) return null;
 
   return (
@@ -74,11 +89,27 @@ export function MobileSidebar({
         className="fixed inset-0 z-40 bg-black/50 lg:hidden"
         onClick={onClose}
       />
-      <div className="fixed inset-y-0 left-0 z-50 w-72 overflow-y-auto bg-page-background p-6 shadow-lg lg:hidden" data-sidebar>
+      <aside
+        className="fixed inset-y-0 left-0 z-50 flex w-72 flex-col overflow-y-auto border-r border-border bg-page-background p-5 shadow-lg lg:hidden"
+        data-sidebar
+        role="dialog"
+        aria-modal="true"
+        aria-label="Documentation navigation"
+      >
+        <div className="mb-5 flex items-center justify-between">
+          <p className="text-sm font-semibold">Tidebreak Docs</p>
+          <Button variant="ghost" size="icon-sm" onClick={onClose} aria-label="Close navigation">
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
         <div className="font-[550]">
           <SidebarNav sections={sections} onNavigate={onClose} />
         </div>
-      </div>
+        <nav className="mt-8 flex gap-4 border-t border-border pt-4 text-sm text-muted-foreground" aria-label="More links">
+          <a href={PRODUCT_URL} className="hover:text-foreground">Product</a>
+          <a href={REPO_URL} className="hover:text-foreground">GitHub</a>
+        </nav>
+      </aside>
     </>
   );
 }

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -24,10 +24,6 @@ pick them up now:
   self-hosted profile.
 - Enforce the strict `network off` setting in Docker code execution, then use
   the existing egress topology to make the other network policies enforceable.
-- Give the project model its share of the desktop: optional chat organization
-  has landed, and project-scoped context is specified by
-  [decision record 1](decisions/0001-project-files-and-attachment-vocabulary.md)
-  but not yet built.
 - Make deletion of a terminal chat erase its background-run workspaces without
   waiting for the periodic reaper.
 


### PR DESCRIPTION
## What changed

- refresh stale product guidance for universal macOS packaging, Queue/Steer behavior, projects and project files, network policy defaults, and web-search approvals
- add user-facing documentation for connected apps and reusable local apps
- improve docs navigation and accessibility with a proper mobile drawer, skip link, clearer search labeling, and more readable typography/page navigation
- remove the now-shipped project-context item from the canonical deferred-scope document

## Why

The docs site had drifted behind recently shipped product behavior, and several important capabilities were either undocumented or described as future work. The mobile navigation and content typography also needed a polish pass to make the site easier to scan and operate.

## Impact and compatibility

This is a documentation and docs-site UI change only. It does not change runtime APIs, persisted data, or desktop application behavior. Risk is low and limited to the statically generated docs site.

## Validation

- `pnpm lint`
- `pnpm types:check`
- `BASE_PATH=/docs pnpm build` (19 indexed pages, 63 static routes)
- `pnpm test:vercel-output` (2/2 passing)
- `git diff --check`
- desktop and 390×844 mobile browser QA
- mobile navigation drawer, Escape/close behavior, search results, and the new Local apps page verified manually
- browser console checked with no application errors