### PR TITLE
test(security): permit isolated docs deployment CLI

### DIFF
--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1053,10 +1053,12 @@ test("release documentation is built from the validated tag and promoted only af
   assert.doesNotMatch(build, /VERCEL_TOKEN|docs-production/);
   assert.match(publish, /VERCEL_TOKEN: \$\{\{ secrets\.VERCEL_TOKEN \}\}/);
   assert.equal(
-    Object.values(docsPackage.dependencies ?? {}).includes("vercel"),
+    Object.hasOwn(docsPackage.dependencies ?? {}, "vercel"),
     false,
   );
-  assert.match(docsPackage.devDependencies.vercel, /^\d+\.\d+\.\d+$/);
+  if (Object.hasOwn(docsPackage.devDependencies ?? {}, "vercel")) {
+    assert.match(docsPackage.devDependencies.vercel, /^\d+\.\d+\.\d+$/);
+  }
   assert.match(build, /pnpm --dir docs-site install --frozen-lockfile/);
   assert.match(build, /ref: \$\{\{ needs\.validate\.outputs\.sha \}\}/);
   assert.match(build, /persist-credentials: false/);


### PR DESCRIPTION
## Summary

- Correct the release-policy assertion so it checks the `vercel` dependency key rather than package-version values.
- Permit `docs-site` to omit the duplicate Vercel devDependency while continuing to validate an exact pin if it is present.
- Preserve the existing requirement that credentialed publication installs the exact isolated `.github/vercel-cli` package.

## Why

PR #2092 removed an unused duplicate Vercel dependency from `docs-site`, but the trusted base-branch policy still required that devDependency. After #2092 was force-merged, the stale assertion began failing CI on `main`. This transitional assertion supports the already-merged isolated deployment architecture and restores the release-policy lane.

## Validation

- `node --test scripts/workflow-security.test.mjs` — 34 passed
- `node --test scripts/workflow-security-mutations.test.mjs` — 43 passed
- `git diff --check`