### PR TITLE
refactor(core): squash schema migrations into a single baseline

### DIFF
--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -1,10 +1,12 @@
 //! The database schema.
 //!
-//! Fresh pre-v1 databases are still described by [`Baseline`], and desktop
+//! Fresh pre-v1 databases are described by a single [`Baseline`]. Desktop
 //! SQLite changes bump `DESKTOP_SCHEMA_EPOCH` so disposable local data is
-//! rebuilt. Self-host databases are durable, however, so any schema change
-//! that must reach an already-recorded baseline also gets an ordered upgrade
-//! migration in this module.
+//! rebuilt. Self-host databases are durable: a renamed baseline must not
+//! recreate tables that already exist, and any later in-place baseline edit
+//! that must reach an already-recorded schema also gets an ordered upgrade
+//! migration in this module. Squash again before `1.0.0` so that release's
+//! first migration is a clean snapshot, not this public-opening chain.
 
 mod baseline;
 mod idens;
@@ -17,74 +19,7 @@ pub struct Migrator;
 #[async_trait::async_trait]
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
-        vec![Box::new(Baseline), Box::new(AddAppOwner)]
-    }
-}
-
-/// Upgrade databases that recorded the original pre-launch baseline before
-/// apps became principal-owned. Fresh databases already receive this shape
-/// from [`Baseline`], so the migration is deliberately idempotent.
-struct AddAppOwner;
-
-impl MigrationName for AddAppOwner {
-    fn name(&self) -> &str {
-        "m20260814_000002_add_app_owner"
-    }
-}
-
-#[async_trait::async_trait]
-impl MigrationTrait for AddAppOwner {
-    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        if !manager.has_column("app", "owner").await? {
-            manager
-                .alter_table(
-                    Table::alter()
-                        .table(idens::App::Table)
-                        .add_column(
-                            ColumnDef::new(idens::App::Owner)
-                                .text()
-                                .not_null()
-                                .default("local"),
-                        )
-                        .to_owned(),
-                )
-                .await?;
-        }
-        manager
-            .create_index(
-                Index::create()
-                    .if_not_exists()
-                    .name("idx_app_owner_updated")
-                    .table(idens::App::Table)
-                    .col(idens::App::Owner)
-                    .col(idens::App::UpdatedAt)
-                    .col(idens::App::Id)
-                    .to_owned(),
-            )
-            .await
-    }
-
-    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        if manager.has_column("app", "owner").await? {
-            manager
-                .drop_index(
-                    Index::drop()
-                        .if_exists()
-                        .name("idx_app_owner_updated")
-                        .table(idens::App::Table)
-                        .to_owned(),
-                )
-                .await?;
-            manager
-                .alter_table(
-                    Table::alter()
-                        .table(idens::App::Table)
-                        .drop_column(idens::App::Owner)
-                        .to_owned(),
-                )
-                .await?;
-        }
-        Ok(())
+        vec![Box::new(Baseline)]
     }
 }
 
@@ -92,13 +27,19 @@ struct Baseline;
 
 impl MigrationName for Baseline {
     fn name(&self) -> &str {
-        "m20260804_000001_baseline"
+        "m20260814_000001_baseline"
     }
 }
 
 #[async_trait::async_trait]
 impl MigrationTrait for Baseline {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // An existing self-host database already recorded an older baseline
+        // name. Re-running CREATE TABLE would fail; fold leftover upgrades
+        // into this snapshot instead and leave the rows alone.
+        if manager.has_table("app").await? {
+            return ensure_app_owner(manager).await;
+        }
         for entry in baseline::tables() {
             manager.create_table(entry.table).await?;
             for index in entry.indexes {
@@ -128,6 +69,38 @@ impl MigrationTrait for Baseline {
     }
 }
 
+/// Folded from the pre-public `add_app_owner` upgrade. Existing self-host
+/// databases that recorded the August 4 baseline may still lack the column.
+async fn ensure_app_owner(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    if !manager.has_column("app", "owner").await? {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(idens::App::Table)
+                    .add_column(
+                        ColumnDef::new(idens::App::Owner)
+                            .text()
+                            .not_null()
+                            .default("local"),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+    }
+    manager
+        .create_index(
+            Index::create()
+                .if_not_exists()
+                .name("idx_app_owner_updated")
+                .table(idens::App::Table)
+                .col(idens::App::Owner)
+                .col(idens::App::UpdatedAt)
+                .col(idens::App::Id)
+                .to_owned(),
+        )
+        .await
+}
+
 #[cfg(test)]
 mod tests {
     use sea_orm::{ConnectionTrait, Database, DbBackend, Statement};
@@ -136,15 +109,48 @@ mod tests {
     use super::Migrator;
 
     #[tokio::test]
-    async fn an_existing_baseline_app_is_backfilled_to_the_local_owner() {
+    async fn a_fresh_database_is_described_by_one_baseline() {
         let db = Database::connect("sqlite::memory:").await.unwrap();
-        Migrator::up(&db, Some(1)).await.unwrap();
-        db.execute_unprepared("DROP INDEX idx_app_owner_updated")
+        Migrator::up(&db, None).await.unwrap();
+
+        let versions = db
+            .query_all_raw(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT version FROM seaql_migrations ORDER BY version".to_owned(),
+            ))
             .await
             .unwrap();
-        db.execute_unprepared("ALTER TABLE app DROP COLUMN owner")
+        let versions: Vec<String> = versions
+            .iter()
+            .map(|row| row.try_get::<String>("", "version").unwrap())
+            .collect();
+        assert_eq!(versions, ["m20260814_000001_baseline"]);
+        assert!(db
+            .query_one_raw(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT owner FROM app LIMIT 1".to_owned(),
+            ))
             .await
-            .unwrap();
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn an_existing_pre_owner_app_is_backfilled_and_not_recreated() {
+        let db = Database::connect("sqlite::memory:").await.unwrap();
+        db.execute_unprepared(
+            "CREATE TABLE app (
+                id TEXT PRIMARY KEY NOT NULL,
+                name TEXT NOT NULL,
+                current_revision_id TEXT NOT NULL,
+                revision_count INTEGER NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                deleted_at TEXT
+            )",
+        )
+        .await
+        .unwrap();
         db.execute_unprepared(
             concat!(
                 "INSERT INTO app (id, name, current_revision_id, revision_count, created_at, updated_at, deleted_at) ",

--- a/crates/tidebreak-core/src/db/migration/baseline/mod.rs
+++ b/crates/tidebreak-core/src/db/migration/baseline/mod.rs
@@ -3,9 +3,10 @@
 //!
 //! Pre-v1 desktop databases are disposable: `tidebreak-server`'s schema-epoch
 //! guard discards a database written by an older baseline. The self-host
-//! PostgreSQL store is durable, so a baseline edit that changes an existing
-//! table must also have an ordered upgrade migration in
-//! [`crate::db::migration`].
+//! PostgreSQL store is durable, so a renamed or edited baseline must not
+//! recreate existing tables, and a later in-place edit that changes an
+//! existing table must also have an ordered upgrade migration in
+//! [`crate::db::migration`]. Squash this snapshot again before `1.0.0`.
 
 use sea_orm_migration::prelude::*;
 

--- a/crates/tidebreak-server/src/desktop_schema.rs
+++ b/crates/tidebreak-server/src/desktop_schema.rs
@@ -33,7 +33,7 @@ const VECTOR_DIRECTORY: &str = "vectors";
 const MAX_MARKER_BYTES: u64 = 1_024;
 
 /// Bump this whenever the pre-v1 schema baseline changes incompatibly.
-const DESKTOP_SCHEMA_EPOCH: u32 = 26;
+const DESKTOP_SCHEMA_EPOCH: u32 = 27;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/docs/decisions/0002-pre-v1-schema-and-persisted-format-mutability.md
+++ b/docs/decisions/0002-pre-v1-schema-and-persisted-format-mutability.md
@@ -70,7 +70,8 @@ part that has to survive to v1.
 **At `1.0.0` this inverts, in one identified place.** The fixture's failure
 message flips back from "bump the epoch" to "add an alias or write a
 migration", the baseline becomes the first entry in a real migration chain, and
-`reset_pre_v1_state` stops being reachable. The reminder lives on #1462.
+`reset_pre_v1_state` stops being reachable. The reminder lives on the
+[1.0.0 checklist](../releases.md#preparing-and-shipping-100).
 
 Deliberately excluded: this record says nothing about *wire* compatibility
 between the desktop client and server, which is a separate contract with its own

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -17,9 +17,6 @@ Several pieces are ordinary implementation work, not deferred product bets.
 They stay as open issues without a `deferred` label because a contributor can
 pick them up now:
 
-- Finish the disposable pre-v1 database baseline: consolidate the migration
-  history and remove obsolete schema paths before compatibility commitments
-  begin at 1.0.
 - Close the remaining multi-principal prompt-inbox ownership gap in the
   self-hosted profile.
 - Enforce the strict `network off` setting in Docker code execution, then use

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -547,8 +547,13 @@ its local profile until this checklist is complete:
    window.
 2. Replace the pre-v1-only guard in
    `crates/tidebreak-server/src/desktop_schema.rs` with the durable v1 lifecycle.
-   It must preserve supported data, migrate transactionally, fail safely, and
-   test upgrades from the latest 0.x state.
+   Re-squash the in-place `Baseline` into a single clean first migration and
+   invert [decision record 2](decisions/0002-pre-v1-schema-and-persisted-format-mutability.md)
+   in the same change: the journal fixture's failure message flips back to
+   "add an alias or write a migration", the baseline becomes the first entry
+   in a real migration chain, and `reset_pre_v1_state` stops being reachable.
+   The lifecycle must preserve supported data, migrate transactionally, fail
+   safely, and test upgrades from the latest 0.x state.
 3. Verify the provisioned signed, notarized, hosted macOS pipeline with clean
    install and 0.x upgrade smoke tests. Add other supported platforms before
    claiming support for them.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -547,8 +547,9 @@ its local profile until this checklist is complete:
    window.
 2. Replace the pre-v1-only guard in
    `crates/tidebreak-server/src/desktop_schema.rs` with the durable v1 lifecycle.
-   Re-squash the in-place `Baseline` into a single clean first migration and
-   invert [decision record 2](decisions/0002-pre-v1-schema-and-persisted-format-mutability.md)
+   Re-squash the in-place `Baseline` again into a single clean first
+   migration — the public-opening squash is not the last v0 edit — and invert
+   [decision record 2](decisions/0002-pre-v1-schema-and-persisted-format-mutability.md)
    in the same change: the journal fixture's failure message flips back to
    "add an alias or write a migration", the baseline becomes the first entry
    in a real migration chain, and `reset_pre_v1_state` stops being reachable.


### PR DESCRIPTION
Closes #1462.

Replaces the August 4 baseline plus the follow-up `add_app_owner` upgrade with one `Baseline` migration, `m20260814_000001_baseline`, and bumps `DESKTOP_SCHEMA_EPOCH` to 27 so disposable desktop profiles rebuild.

The table consolidations on #1462 already shipped. What was left was a two-step history that should not be the first schema entry on a public tree. This is the public-opening squash, not the end of v0. The 1.0 checklist still requires another clean snapshot before decision 0002 inverts and `reset_pre_v1_state` goes away.

Fresh databases apply that one baseline. Self-host databases that already have tables are not recreated; a missing `app.owner` is backfilled to `local`. Desktop SQLite at epoch 26 or older is reset.