### PR TITLE
fix(desktop): keep streamed reasoning on one assistant bubble

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ChatSessionReducer.test.ts
+++ b/crates/tidebreak-desktop/ui/src/ChatSessionReducer.test.ts
@@ -834,23 +834,49 @@ describe("reasoning presentation", () => {
     ]);
   });
 
-  it("opens a bubble for reasoning that follows tool activity", () => {
+  it("keeps post-tool reasoning on the existing assistant bubble", () => {
     const { state } = play([
       TURN,
       { type: "tool_call_started", call_id: "c", name: "search" },
       { type: "reasoning_delta", text: "the search found nothing" },
     ]);
-    // The empty bubble the turn opened, the call, then the reasoning that came
-    // after it — reasoning read in journal order, not hoisted above the call.
+    // The snapshot hangs the whole turn's reasoning on one assistant
+    // message. Opening a second bubble here is what made reload relocate it.
     expect(state.messages.map((message) => message.role)).toEqual([
       "assistant",
       "tool",
-      "assistant",
     ]);
-    expect(state.messages[2]).toEqual(
+    expect(state.messages[0]).toEqual(
       expect.objectContaining({
         text: "",
         reasoning: "the search found nothing",
+      }),
+    );
+  });
+
+  it("moves the turn's reasoning onto the latest assistant after more text", () => {
+    const { state } = play([
+      TURN,
+      { type: "reasoning_delta", text: "first look" },
+      { type: "text_delta", text: "trying search" },
+      { type: "tool_call_started", call_id: "c", name: "search" },
+      { type: "reasoning_delta", text: " then nothing" },
+      { type: "text_delta", text: "done" },
+    ]);
+    const assistants = state.messages.filter(
+      (message) => message.role === "assistant",
+    );
+    expect(assistants).toHaveLength(2);
+    expect(assistants[0]).toEqual(
+      expect.objectContaining({
+        text: "trying search",
+        reasoning: undefined,
+      }),
+    );
+    expect(assistants[1]).toEqual(
+      expect.objectContaining({
+        text: "done",
+        reasoning: "first look then nothing",
       }),
     );
   });

--- a/crates/tidebreak-desktop/ui/src/ChatSessionReducer.ts
+++ b/crates/tidebreak-desktop/ui/src/ChatSessionReducer.ts
@@ -34,6 +34,13 @@ export type ChatSessionState = {
   activeTurnId: string | null;
   /** Scrubbed text accumulated for the trailing assistant bubble. */
   assistantBuffer: string;
+  /**
+   * Reasoning accumulated for the open turn. The snapshot stores this on the
+   * turn's output message, so the live stream keeps one copy and paints it
+   * on the latest live assistant bubble instead of opening a new thought
+   * accordion after every tool batch.
+   */
+  reasoningBuffer: string;
   markerScrubber: AssistantSourceMarkerStreamScrubber;
   /** Tool calls streamed in the current step; discarded on interruption. */
   provisionalToolCallIds: ReadonlySet<string>;
@@ -112,6 +119,7 @@ export function initialChatSessionState(): ChatSessionState {
     busy: false,
     activeTurnId: null,
     assistantBuffer: "",
+    reasoningBuffer: "",
     markerScrubber: new AssistantSourceMarkerStreamScrubber(),
     provisionalToolCallIds: new Set(),
     hydratedMessageIds: new Set(),
@@ -169,6 +177,7 @@ export function reduceChatSessionEvent(
           compacting: false,
           contextTruncationNoted: false,
           assistantBuffer: "",
+          reasoningBuffer: "",
           markerScrubber: new AssistantSourceMarkerStreamScrubber(),
           provisionalToolCallIds: new Set(),
           messages: [
@@ -193,9 +202,13 @@ export function reduceChatSessionEvent(
         state: {
           ...state,
           assistantBuffer,
-          messages: withTrailingAssistantText(
-            state.messages,
-            assistantBuffer,
+          messages: paintTurnReasoning(
+            withTrailingAssistantText(
+              state.messages,
+              assistantBuffer,
+              deps,
+            ),
+            state.reasoningBuffer,
             deps,
           ),
         },
@@ -226,6 +239,7 @@ export function reduceChatSessionEvent(
         state: {
           ...state,
           assistantBuffer: "",
+          reasoningBuffer: "",
           provisionalToolCallIds: new Set(),
           messages,
         },
@@ -541,18 +555,12 @@ export function reduceChatSessionEvent(
     }
 
     case "reasoning_delta": {
-      // Reasoning lands on the assistant bubble it precedes, so the accordion
-      // sits where the thinking happened rather than in a fixed slot. Between
-      // tool calls there is no such bubble yet: one opens with no text, which
-      // the following text deltas then fill in.
+      const reasoningBuffer = state.reasoningBuffer + event.text;
       return {
         state: {
           ...state,
-          messages: withTrailingAssistantReasoning(
-            state.messages,
-            event.text,
-            deps,
-          ),
+          reasoningBuffer,
+          messages: paintTurnReasoning(state.messages, reasoningBuffer, deps),
         },
         effects,
       };
@@ -618,6 +626,7 @@ export function applyTerminalHydration(
     lastSeq: Math.max(state.lastSeq, hydration.lastEventSeq),
     hydratedMessageIds: hydration.messageIds,
     messages: hydration.messages,
+    reasoningBuffer: "",
     // The snapshot is authoritative when it has counts — it is rebuilt from
     // the durable turn rows. A chat with no finished turn yet leaves whatever
     // the live stream established rather than blanking the meter.
@@ -636,34 +645,56 @@ function flushMarkerTail(
   return {
     ...state,
     assistantBuffer,
-    messages: withTrailingAssistantText(state.messages, assistantBuffer, deps),
+    messages: paintTurnReasoning(
+      withTrailingAssistantText(state.messages, assistantBuffer, deps),
+      state.reasoningBuffer,
+      deps,
+    ),
   };
 }
 
-/** Extend the trailing assistant bubble's reasoning, opening one if needed. */
-function withTrailingAssistantReasoning(
+/**
+ * Keep the turn's reasoning on the latest live assistant bubble — the same
+ * place the durable snapshot attaches `ChatTerminalTurnSnapshot.reasoning`.
+ * Intermediate bubbles from earlier segments do not keep their own copy.
+ */
+function paintTurnReasoning(
   messages: ChatMessage[],
-  text: string,
+  reasoning: string,
   deps: ChatSessionDeps,
 ): ChatMessage[] {
-  const copy = [...messages];
-  const last = copy[copy.length - 1];
-  if (last?.role === "assistant" && !last.superseded) {
-    copy[copy.length - 1] = {
-      ...last,
-      reasoning: (last.reasoning ?? "") + text,
-    };
-  } else {
-    copy.push({
-      id: deps.nextId(),
-      role: "assistant",
-      text: "",
-      sources: [],
-      reasoning: text,
-      createdAt: deps.now(),
-    });
+  let lastLive = -1;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const candidate = messages[index];
+    if (candidate?.role === "assistant" && !candidate.superseded) {
+      lastLive = index;
+      break;
+    }
   }
-  return copy;
+  if (lastLive < 0) {
+    if (!reasoning) return messages;
+    return [
+      ...messages,
+      {
+        id: deps.nextId(),
+        role: "assistant",
+        text: "",
+        sources: [],
+        reasoning,
+        createdAt: deps.now(),
+      },
+    ];
+  }
+  return messages.map((message, index) => {
+    if (message.role !== "assistant" || message.superseded) return message;
+    if (index === lastLive) {
+      return message.reasoning === reasoning
+        ? message
+        : { ...message, reasoning: reasoning || undefined };
+    }
+    if (message.reasoning === undefined) return message;
+    return { ...message, reasoning: undefined };
+  });
 }
 
 function withTrailingAssistantText(

--- a/crates/tidebreak-desktop/ui/src/settings/McpPanel.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/McpPanel.test.tsx
@@ -392,8 +392,11 @@ describe("McpPanel", () => {
     await screen.findByRole("switch", { name: "Mount example-security-tools" });
     const row = mountRow("example-security-tools");
     expect(within(row).getByText("Healthy")).toBeInTheDocument();
+    // Apps load after the session check, so the switch can appear before
+    // this label. Wait for it instead of assuming the two fetches finish
+    // in lockstep.
     expect(
-      within(row).getByText(/serves: Incident API/),
+      await within(row).findByText(/serves: Incident API/),
     ).toBeInTheDocument();
     expect(
       within(row).getByRole("button", { name: /Reconnect/ }),


### PR DESCRIPTION
Closes #1715.

## Summary

- accumulate the open turn's reasoning in one buffer
- paint that buffer on the latest live assistant bubble
- do not open a new thought accordion after each tool batch

## Why

The live stream interleaved a thought accordion per reasoning segment. The durable snapshot stores reasoning on the turn's output message. Hydration therefore replaced several thoughts with one on the final bubble. The stream now uses the snapshot's shape, so the end-of-turn swap no longer relocates reasoning.

A later change can still persist per-step reasoning if we want thoughts to stay between tool batches after reload. That is a wire-type change; this fix does not invent one.

## Validation

- `pnpm test` in `crates/tidebreak-desktop/ui` — 995 passed
- `git diff --check`