### PR TITLE
docs: describe the self-host member surface as API and CLI

### DIFF
--- a/docs-site/content/docs/headless.mdx
+++ b/docs-site/content/docs/headless.mdx
@@ -430,10 +430,15 @@ query is scoped to the authenticated principal.
 
 One thing to know before using it: **settings are deployment-scoped, not
 per-user.** Enabled providers, credentials, model roles, and web-search and
-code-execution configuration are shared by everyone on the deployment, and
-anyone who can call the API can change them. The profile is for mutually
-trusting users of one operator's deployment — a household or a small team. It
-is not multi-tenant isolation.
+code-execution configuration are shared by the deployment. Only an `admin`
+token can change them; a member token receives `403` on that plane and keeps
+its own chats, projects, documents, and event stream.
+
+What a member runs is this API and the CLI with `--server` and a token from
+the operator file. The desktop app is the local Desktop profile and does not
+connect to a remote self-host deployment. The profile is for mutually trusting
+users of one operator's deployment — a household or a small team. It is not
+multi-tenant isolation.
 
 Document and blob storage on PostgreSQL, remote secret custody, object storage,
 and multi-process ownership are not finished. Treat self-hosting as

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -28,6 +28,20 @@ These are important finishing work, but they do not change the product's basic
 shape. They should be delivered as normal, reviewable slices rather than held
 in a parking label.
 
+## A client for self-host teammates
+
+The self-host profile already has named users and an admin/member split on the
+API. What a teammate runs today is that API and the `tidebreak` CLI with a
+static bearer token from the operator file. The packaged desktop app stays a
+local Desktop-profile product: it embeds its own server and does not point at
+a remote deployment.
+
+A later member client can be a desktop connection mode (URL, token, TLS
+expectations, Settings panels that degrade on a member `403`) or a hosted web
+UI the deployment serves. Either one is a second product surface, not an
+omission in the current server. Auth beyond the static token file waits on
+gateway-derived identity.
+
 ## A coworker that can work later
 
 Background agent runs make work durable, but Tidebreak does not yet schedule

--- a/docs/how-tidebreak-works.md
+++ b/docs/how-tidebreak-works.md
@@ -812,6 +812,8 @@ one member across the assembled router to keep that classification honest.
 Roles beyond the two, groups, per-capability grants, and per-user provider
 credentials are deliberately excluded — see
 [decision 6](decisions/0006-self-host-deployment-plane-authorization.md).
+Members reach that plane through the HTTP API and the CLI; the packaged
+desktop app is not a remote client for this profile.
 
 Configuration remains deployment-scoped rather than per-user: the settings
 table configures the deployment itself, shared credentials are the point of a

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -96,6 +96,28 @@ a configuration route cannot quietly land outside the gate. The reasoning, the
 rejected alternatives, and what would make us revisit it are in
 [decision record 6](decisions/0006-self-host-deployment-plane-authorization.md).
 
+### What a member runs
+
+The member surface is the HTTP API and the `tidebreak` CLI pointed at the
+deployment. Give each teammate a token from the file above and a base URL:
+
+```sh
+export TIDEBREAK_SERVER_URL=https://tidebreak.example
+export TIDEBREAK_SERVER_TOKEN=<the member token>
+cargo run -p tidebreak-cli -- --server "$TIDEBREAK_SERVER_URL" chat list
+cargo run -p tidebreak-cli -- --server "$TIDEBREAK_SERVER_URL" -p "summarize yesterday"
+```
+
+`--server` / `TIDEBREAK_SERVER_TOKEN` are the same attach path the headless
+docs describe. A member token receives `403` on deployment-plane routes, which
+is the intended degradation — not a desktop Settings panel.
+
+The packaged desktop app is the local Desktop profile. It embeds its own
+server, uses a per-launch loopback token, and does not connect to a remote
+self-host deployment. A remote-server connection mode, or a hosted web UI
+served by the deployment, is parked — see
+[What comes after v1](deferred.md#a-client-for-self-host-teammates).
+
 Give `admin` only to the people who actually administer the deployment: MCP
 server definitions spawn processes on the host, and the provider credentials
 are shared.


### PR DESCRIPTION
Closes #1872.

## Summary

- the member surface is the HTTP API and the \`tidebreak\` CLI with \`--server\`
- the packaged desktop app does not connect to a remote self-host deployment
- a remote desktop mode or hosted web UI is parked in \`docs/deferred.md\`
- the public headless page no longer says any token can change deployment settings

## Why

Decision 6 already split admin and member on the API. The leftover question was what a teammate runs. Building a remote desktop connection mode or a hosted web UI is a second product surface. Until that exists, the honest description is API-first: a token from the operator file and the CLI attach path that already works.

## Validation

- docs-only
- \`git diff --check\`