### PR TITLE
ci(release): publish the current draft when the tag is omitted

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,13 @@
 name: Publish desktop release
 
-run-name: Publish desktop ${{ github.event.inputs.release_tag }}
+run-name: Publish desktop ${{ github.event.inputs.release_tag || 'current draft' }}
 
 on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: Draft or published GitHub Release tag to build
-        required: true
+        description: Leave blank to publish the current draft. Set a tag only to retry that draft or published release.
+        required: false
         type: string
 
 permissions:
@@ -43,6 +43,25 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.event.inputs.release_tag }}
         run: |
+          if [[ -z "$RELEASE_TAG" ]]; then
+            drafts_json="$(
+              gh api --paginate \
+                -H 'Accept: application/vnd.github+json' \
+                "repos/$GITHUB_REPOSITORY/releases?per_page=100" | jq -cs \
+                  '[.[][] | select(.draft == true and .prerelease == false)]'
+            )"
+            draft_count="$(jq -r 'length' <<<"$drafts_json")"
+            if [[ "$draft_count" != 1 ]]; then
+              {
+                echo "Expected exactly one draft GitHub Release when release_tag is omitted; found $draft_count."
+                jq -r '.[].tag_name' <<<"$drafts_json"
+              } >&2
+              exit 1
+            fi
+            RELEASE_TAG="$(jq -er '.[0].tag_name' <<<"$drafts_json")"
+            echo "Using the current draft $RELEASE_TAG."
+          fi
+
           node scripts/check-release-tag.mjs "$RELEASE_TAG"
 
           release_json="$(

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -128,13 +128,15 @@ automatic.
    and curate the full-history result as described above.
 3. Complete the release-readiness review, but do **not** publish the draft in
    GitHub. Immutable releases cannot accept assets after publication.
-4. Open **Actions → Publish desktop release → Run workflow**, select `main`,
-   and enter the draft's exact tag. The workflow queries that draft from the
-   trusted `main` workflow, rejects malformed tags or prereleases, creates the
-   tag at the current `main` commit when it does not already exist, and retains
-   the same tag on a retry. It snapshots the draft metadata so a later merge
-   cannot change the notes or proposed version while the build is running, and
-   pins every later job to the frozen commit SHA.
+4. Open **Actions → Publish desktop release → Run workflow** and select
+   `main`. Leave the tag blank to publish the current draft. Enter a tag only
+   to retry that draft or an already-published release. The workflow resolves
+   a blank tag to the single non-prerelease draft, rejects a missing or
+   ambiguous draft, malformed tags, or prereleases, creates the tag at the
+   current `main` commit when it does not already exist, and retains the same
+   tag on a retry. It snapshots the draft metadata so a later merge cannot
+   change the notes or proposed version while the build is running, and pins
+   every later job to the frozen commit SHA.
 5. In parallel with the desktop build, the documentation builder checks out
    that validated SHA and builds `docs-site/` as a static export under `/docs`.
    Publication waits until the GitHub Release itself has been published. It

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1024,6 +1024,15 @@ test("release builds freeze a draft tag from the trusted main workflow", () => {
   assert.match(validateJob, /github\.ref == 'refs\/heads\/main'/);
   assert.match(validateJob, /permissions:\n      contents: write/);
   assert.match(validateJob, /ref: \$\{\{ github\.sha \}\}/);
+  assert.match(
+    release,
+    /^      release_tag:\n(?:        .*\n)+?        required: false$/m,
+  );
+  assert.match(
+    validateJob,
+    /Expected exactly one draft GitHub Release when release_tag is omitted/,
+  );
+  assert.match(validateJob, /\.draft == true and \.prerelease == false/);
   assert.match(validateJob, /node scripts\/check-release-tag\.mjs "\$RELEASE_TAG"/);
   assert.match(
     validateJob,


### PR DESCRIPTION
## Summary

- **Publish desktop release** no longer requires typing a tag. A blank dispatch resolves to the single non-prerelease GitHub draft and fails if there is not exactly one.
- An explicit tag still retries that draft or an already-published release.
- The release runbook and the workflow-security guard match the new contract.

## Why

The immutable-release flow replaced GitHub's **Publish release** button with a manual workflow dispatch. Requiring the tag made that dispatch easy to skip, which is how v0.45.0 shipped without desktop assets.

## Test plan

- [x] `node --test scripts/workflow-security.test.mjs scripts/check-release-tag.test.mjs`
- [ ] After merge: **Actions → Publish desktop release → Run workflow** on `main` with the tag left blank should select the current `v0.45.0` draft.