### PR TITLE
docs: point public URLs at tidebreak.io

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://github.com/brightwave-inc/tidebreak/security/advisories/new
     about: Please report vulnerabilities privately, not in a public issue.
   - name: Read the documentation
-    url: https://www.tidebreak.sh/docs/
+    url: https://www.tidebreak.io/docs/
     about: Installation, quickstart, permissions, providers, and troubleshooting.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -319,7 +319,7 @@ jobs:
           request /docs/search-index.json "$RUNNER_TEMP/docs-search-index.json"
           request /docs/sitemap.xml "$RUNNER_TEMP/docs-sitemap.xml"
 
-          grep -Fq 'https://www.tidebreak.sh/docs/' "$RUNNER_TEMP/docs-index.html"
+          grep -Fq 'https://www.tidebreak.io/docs/' "$RUNNER_TEMP/docs-index.html"
           grep -Fq '/docs/_next/' "$RUNNER_TEMP/docs-index.html"
           asset_path="$(grep -oE '/docs/_next/[^" ]+' \
             "$RUNNER_TEMP/docs-index.html" | head -n 1)"
@@ -366,7 +366,7 @@ jobs:
               https://tidebreak-docs.vercel.app/docs/ \
               --dump-header "$RUNNER_TEMP/docs-production-headers" \
               --output "$RUNNER_TEMP/docs-production.html" \
-              && grep -Fq 'https://www.tidebreak.sh/docs/' \
+              && grep -Fq 'https://www.tidebreak.io/docs/' \
                 "$RUNNER_TEMP/docs-production.html" \
               && grep -Eqi "content-security-policy:.*default-src 'self'" \
                 "$RUNNER_TEMP/docs-production-headers" \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.0.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/brightwave-inc/tidebreak"
-homepage = "https://www.tidebreak.sh"
+homepage = "https://www.tidebreak.io"
 authors = ["Brightwave, Inc."]
 
 [workspace.lints.clippy]

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 </p>
 
 <p align="center">
-  <a href="https://www.tidebreak.sh">Website</a> ·
-  <a href="https://www.tidebreak.sh/docs/">User documentation</a> ·
+  <a href="https://www.tidebreak.io">Website</a> ·
+  <a href="https://www.tidebreak.io/docs/">User documentation</a> ·
   <a href="https://github.com/brightwave-inc/tidebreak/releases/latest">Latest release</a> ·
   <a href="CONTRIBUTING.md">Contributing</a>
 </p>
@@ -42,8 +42,8 @@ providers without starting over. Credentials stay in the operating system's
 credential store, while chats and outputs remain in the local Tidebreak
 profile.
 
-The [website](https://www.tidebreak.sh) is the product overview. The
-[user documentation](https://www.tidebreak.sh/docs/) covers installation,
+The [website](https://www.tidebreak.io) is the product overview. The
+[user documentation](https://www.tidebreak.io/docs/) covers installation,
 configuration, permissions, connected folders, code execution, outputs, and
 the headless CLI.
 
@@ -75,7 +75,7 @@ The headless server uses the same core runtime:
 ANTHROPIC_API_KEY=sk-... cargo run -p tidebreak-cli -- serve
 ```
 
-See the [headless documentation](https://www.tidebreak.sh/docs/headless/) for
+See the [headless documentation](https://www.tidebreak.io/docs/headless/) for
 one-shot mode, HTTP API, MCP server, configuration, and self-hosting.
 
 ## Repository guide

--- a/crates/tidebreak-desktop/ui/src/MessageMarkdown.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/MessageMarkdown.test.tsx
@@ -49,10 +49,10 @@ describe("citation directives", () => {
 
 describe("safeMarkdownUrl", () => {
   it("permits only secure external links", () => {
-    expect(safeMarkdownUrl("https://tidebreak.dev/docs")).toBe(
-      "https://tidebreak.dev/docs",
+    expect(safeMarkdownUrl("https://tidebreak.io/docs")).toBe(
+      "https://tidebreak.io/docs",
     );
-    expect(safeMarkdownUrl("http://tidebreak.dev")).toBeUndefined();
+    expect(safeMarkdownUrl("http://tidebreak.io")).toBeUndefined();
     expect(safeMarkdownUrl("javascript:alert(1)")).toBeUndefined();
     expect(safeMarkdownUrl("data:text/html,unsafe")).toBeUndefined();
     expect(safeMarkdownUrl("file:///Users/example/private.txt")).toBeUndefined();
@@ -73,14 +73,14 @@ describe("MessageMarkdown", () => {
   it("renders useful Markdown without emitting embeds or unsafe links", () => {
     const markup = renderToStaticMarkup(
       <MessageMarkdown>
-        {"## Heading\n\n- `inline` item\n\n> A quote\n\n[Docs](https://tidebreak.dev/docs) [Unsafe](javascript:alert(1))\n\n![remote](https://example.com/image.png)\n\n<iframe src=\"https://example.com\"></iframe>"}
+        {"## Heading\n\n- `inline` item\n\n> A quote\n\n[Docs](https://tidebreak.io/docs) [Unsafe](javascript:alert(1))\n\n![remote](https://example.com/image.png)\n\n<iframe src=\"https://example.com\"></iframe>"}
       </MessageMarkdown>,
     );
 
     expect(markup).toContain("<h2>Heading</h2>");
     expect(markup).toContain("<code>inline</code>");
     expect(markup).toContain("<blockquote>");
-    expect(markup).toContain('href="https://tidebreak.dev/docs"');
+    expect(markup).toContain('href="https://tidebreak.io/docs"');
     expect(markup).toContain("Image omitted: remote");
     expect(markup).not.toContain("<img");
     expect(markup).not.toContain("<iframe");

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -2,7 +2,7 @@
 
 The user documentation for Tidebreak. It is a Next.js App Router site with MDX
 content, built as a static export and published at
-<https://www.tidebreak.sh/docs/>.
+<https://www.tidebreak.io/docs/>.
 
 ## Documentation boundaries
 
@@ -74,7 +74,7 @@ unset for local development. See `.env.example`.
 
 The release workflow deploys this export to the dedicated documentation
 project, then the marketing project serves it under
-`https://www.tidebreak.sh/docs/`. Canonical metadata and the sitemap point at
+`https://www.tidebreak.io/docs/`. Canonical metadata and the sitemap point at
 that public path so the raw deployment origin is not indexed as a separate
 site.
 

--- a/docs-site/src/app/(docs)/[[...slug]]/page.tsx
+++ b/docs-site/src/app/(docs)/[[...slug]]/page.tsx
@@ -9,6 +9,7 @@ import {
   stripImports,
   generateStaticParams as genParams,
 } from '@/lib/content';
+import { PUBLIC_DOCS_URL } from '@/lib/site';
 import { TableOfContents } from '@/components/toc';
 import { PageNavigation } from '@/components/page-nav';
 import type { Metadata } from 'next';
@@ -96,7 +97,7 @@ export async function generateMetadata(
     return {
       title: { absolute: 'Tidebreak Docs' },
       description: 'Documentation for Tidebreak.',
-      alternates: { canonical: 'https://www.tidebreak.sh/docs/' },
+      alternates: { canonical: PUBLIC_DOCS_URL },
     };
   }
 
@@ -108,7 +109,7 @@ export async function generateMetadata(
     title: page.title,
     description: page.description,
     alternates: {
-      canonical: `https://www.tidebreak.sh/docs/${publicPath}`,
+      canonical: new URL(publicPath, PUBLIC_DOCS_URL).toString(),
     },
     openGraph: {
       images: getPageImage(page).url,

--- a/docs-site/src/app/layout.tsx
+++ b/docs-site/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { Geist, Geist_Mono } from 'next/font/google';
 import { Provider } from '@/components/provider';
 import type { Metadata } from 'next';
 import { getPage, getPageImage } from '@/lib/content';
+import { PRODUCT_URL } from '@/lib/site';
 import './global.css';
 
 const geistSans = Geist({
@@ -18,7 +19,7 @@ const homePage = getPage([]);
 const homeImage = homePage ? getPageImage(homePage).url : '/og/image.png';
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://www.tidebreak.sh'),
+  metadataBase: new URL(PRODUCT_URL),
   title: {
     default: 'Tidebreak Docs',
     template: '%s — Tidebreak Docs',

--- a/docs-site/src/app/sitemap.ts
+++ b/docs-site/src/app/sitemap.ts
@@ -1,7 +1,6 @@
 import type { MetadataRoute } from 'next';
 import { getAllPages } from '@/lib/content';
-
-const PUBLIC_DOCS_URL = 'https://www.tidebreak.sh/docs/';
+import { PUBLIC_DOCS_URL } from '@/lib/site';
 
 export const dynamic = 'force-static';
 

--- a/docs-site/src/components/header.tsx
+++ b/docs-site/src/components/header.tsx
@@ -6,8 +6,8 @@ import { ThemeToggle } from './theme-toggle';
 import { SearchTrigger } from './search-trigger';
 import { Button } from '@/components/ui/button';
 import { Menu } from 'lucide-react';
+import { PRODUCT_URL } from '@/lib/site';
 
-const PRODUCT_URL = 'https://www.tidebreak.sh';
 const REPO_URL = 'https://github.com/brightwave-inc/tidebreak';
 
 const navLinks = [{ text: 'Product', href: PRODUCT_URL }];

--- a/docs-site/src/components/sidebar.tsx
+++ b/docs-site/src/components/sidebar.tsx
@@ -7,8 +7,8 @@ import type { SidebarSection } from '@/lib/content';
 import { X } from 'lucide-react';
 import { useEffect } from 'react';
 import { Button } from '@/components/ui/button';
+import { PRODUCT_URL } from '@/lib/site';
 
-const PRODUCT_URL = 'https://www.tidebreak.sh';
 const REPO_URL = 'https://github.com/brightwave-inc/tidebreak';
 
 function SidebarNav({ sections, onNavigate }: { sections: SidebarSection[]; onNavigate?: () => void }) {

--- a/docs-site/src/lib/site.ts
+++ b/docs-site/src/lib/site.ts
@@ -1,0 +1,2 @@
+export const PRODUCT_URL = 'https://www.tidebreak.io';
+export const PUBLIC_DOCS_URL = 'https://www.tidebreak.io/docs/';

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ deliberately parked. It is versioned with the implementation and written for
 contributors and operators.
 
 User-facing guides live in [`docs-site/content/docs/`](../docs-site/content/docs)
-and publish to [tidebreak.sh/docs](https://www.tidebreak.sh/docs/). The product
+and publish to [tidebreak.io/docs](https://www.tidebreak.io/docs/). The product
 overview and launch copy belong to the separate
 [`brightwave-inc/tidebreak-site`](https://github.com/brightwave-inc/tidebreak-site)
 repository. Keep those surfaces focused rather than copying the same product


### PR DESCRIPTION
## Summary

`www.tidebreak.io` is the public origin. `.sh` and `.dev` already 308 there.

This updates every public URL in the repository to match: Cargo homepage, README and maintainer docs, docs-site canonicals/sitemap/Product links, the GitHub issue-template docs link, and the release workflow smoke check that greps the published canonical.

Desktop channel identifiers are unchanged. `io.brightwave.tidebreak.dev`, the `tidebreak.dev` keychain service, and `tidebreak-dev://` name the debug profile, not the website.

A companion change in `brightwave-inc/tidebreak-site` updates the marketing site's Astro origin and robots sitemaps.

## Test plan

- [x] Searched the tree for leftover `https://www.tidebreak.sh` / `https://tidebreak.dev` public URLs
- [x] Built `docs-site` with `BASE_PATH=/docs` and confirmed canonicals, OG URLs, and `sitemap.xml` use `https://www.tidebreak.io`
- [ ] Let CI confirm the UI and docs-site lanes