### PR TITLE
fix(desktop): open workbooks whose packaging parts start with a UTF-8 BOM

### DIFF
--- a/crates/tidebreak-desktop/ui/src/document/readOnlyWorkbookProjection.dom.test.ts
+++ b/crates/tidebreak-desktop/ui/src/document/readOnlyWorkbookProjection.dom.test.ts
@@ -128,4 +128,54 @@ describe("projectWorkbookForReadOnlyDisplay", () => {
       D3: { dataBar: { color: "#2979ff", widthPercent: 100 } },
     });
   });
+
+  it("reads Excel packaging parts that start with a UTF-8 BOM", async () => {
+    const zip = new JSZip();
+    zip.file(
+      "xl/workbook.xml",
+      `<?xml version="1.0"?><workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Model" sheetId="1" r:id="rId1"/></sheets></workbook>`,
+    );
+    zip.file(
+      "xl/_rels/workbook.xml.rels",
+      `\uFEFF<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Target="worksheets/sheet1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/></Relationships>`,
+    );
+    zip.file(
+      "xl/worksheets/sheet1.xml",
+      `<?xml version="1.0"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData><row r="1"><c r="A1"><f>SUM(B1:B3)</f><v>42</v></c></row></sheetData></worksheet>`,
+    );
+
+    const NativeParser = globalThis.DOMParser;
+    // jsdom accepts a leading U+FEFF; the desktop webview does not.
+    class WebKitLikeParser {
+      parseFromString(xml: string, type: DOMParserSupportedType) {
+        if (xml.startsWith("\uFEFF")) {
+          return new NativeParser().parseFromString(
+            "<parsererror>XML declaration allowed only at the start of the document</parsererror>",
+            "application/xml",
+          );
+        }
+        return new NativeParser().parseFromString(xml, type);
+      }
+    }
+    globalThis.DOMParser = WebKitLikeParser as typeof DOMParser;
+    try {
+      const source = await zip.generateAsync({ type: "arraybuffer" });
+      const projection = await projectWorkbookForReadOnlyDisplay(source);
+      expect(projection.formulasBySheet).toEqual({ 0: { A1: "=SUM(B1:B3)" } });
+    } finally {
+      globalThis.DOMParser = NativeParser;
+    }
+  });
+
+  it("keeps the original workbook when a package part cannot be parsed", async () => {
+    const zip = new JSZip();
+    zip.file("xl/styles.xml", "not-xml");
+    const source = await zip.generateAsync({ type: "arraybuffer" });
+
+    const projection = await projectWorkbookForReadOnlyDisplay(source);
+
+    expect(projection.data).toBe(source);
+    expect(projection.formulasBySheet).toEqual({});
+    expect(projection.conditionalStylesBySheet).toEqual({});
+  });
 });

--- a/crates/tidebreak-desktop/ui/src/document/readOnlyWorkbookProjection.ts
+++ b/crates/tidebreak-desktop/ui/src/document/readOnlyWorkbookProjection.ts
@@ -38,12 +38,20 @@ export interface ReadOnlyWorkbookProjection {
 export async function projectWorkbookForReadOnlyDisplay(
   source: ArrayBuffer,
 ): Promise<ReadOnlyWorkbookProjection> {
+  try {
+    return await projectWorkbookDisplayCopy(source);
+  } catch {
+    // The display copy is an enhancement. A part the browser XML parser
+    // rejects must not block reading the original workbook.
+    return emptyProjection(source);
+  }
+}
+
+async function projectWorkbookDisplayCopy(
+  source: ArrayBuffer,
+): Promise<ReadOnlyWorkbookProjection> {
   if (!isZip(source)) {
-    return {
-      conditionalStylesBySheet: {},
-      data: source,
-      formulasBySheet: {},
-    };
+    return emptyProjection(source);
   }
 
   const zip = await JSZip.loadAsync(source);
@@ -580,11 +588,22 @@ function resolveZipPath(baseFile: string, target: string): string {
 }
 
 function parseXml(xml: string, path: string): XMLDocument {
-  const document = new DOMParser().parseFromString(xml, "application/xml");
+  // JSZip decodes a UTF-8 BOM into U+FEFF. WebKit then treats that mark as
+  // content before `<?xml` and refuses the part (`XML declaration allowed
+  // only at the start of the document`). Excel's packaging often writes a
+  // BOM on `[Content_Types].xml` and every `.rels` file.
+  const document = new DOMParser().parseFromString(
+    xml.replace(/^\uFEFF+/, ""),
+    "application/xml",
+  );
   if (document.getElementsByTagName("parsererror").length > 0) {
     throw new Error(`Could not parse ${path}`);
   }
   return document;
+}
+
+function emptyProjection(data: ArrayBuffer): ReadOnlyWorkbookProjection {
+  return { conditionalStylesBySheet: {}, data, formulasBySheet: {} };
 }
 
 function localElements(document: Document | Element, name: string): Element[] {


### PR DESCRIPTION
## Summary
Desktop workbook preview builds a read-only display copy by parsing OOXML in the webview. Excel often writes a UTF-8 BOM on `.rels` parts. JSZip decodes that mark to `U+FEFF`, and WebKit then rejects the XML (`XML declaration allowed only at the start of the document`). The viewer surfaced that as **This workbook could not be prepared** for ordinary generated and Excel-packaged workbooks, locally and in production.

This change strips a leading BOM before `DOMParser` so those parts parse, and if prepare still fails it opens the original bytes instead of blocking the viewer. jsdom accepts a BOM, so the new test uses a WebKit-like parser that rejects one.

## Test plan
- [x] `pnpm test -- src/document/readOnlyWorkbookProjection.dom.test.ts` (6 passed)
- [ ] Reopen a generated xlsx in the desktop app and confirm it draws instead of the prepare error