### PR TITLE
fix(desktop): remove extracted-text viewer toggle and keep PPTX sidebars inline sooner

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -156,8 +156,8 @@ export type DocumentDetail = {
   /**
    * Whether the source kept the bytes it was made from. A source with none —
    * a fetched web page, whose markup is not retained — has no original to draw,
-   * so the panel offers only the extracted text rather than a tab that can
-   * only fail.
+   * so the panel shows the extracted text rather than a viewer that can only
+   * fail.
    */
   has_original_bytes: boolean;
   updated_at: string;

--- a/crates/tidebreak-desktop/ui/src/components/document/document-details.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/document/document-details.tsx
@@ -1,7 +1,7 @@
 /**
- * `components/document/` is the reading side of a source: the extracted text,
- * the panel's view switcher below, and the viewers that need nothing more than
- * the file's characters — image, text/markdown, JSON, XML.
+ * `components/document/` is the reading side of a source: the extracted-text
+ * fallback, and the viewers that need nothing more than the file's characters
+ * — image, text/markdown, JSON, XML.
  *
  * `document/` next to it is the heavy side: the media-type dispatcher and the
  * viewers built on a document engine of their own (pdf.js, Univer), each of
@@ -34,9 +34,6 @@ import { MarkdownViewer } from "./markdown-viewer";
 const JsonViewer = lazy(() => import("./json-viewer"));
 const XmlViewer = lazy(() => import("./xml-viewer"));
 
-/** Which of a document's two views is on screen. */
-export type DocumentView = "extracted_text" | "original_doc";
-
 /**
  * A media type reduced to `type/subtype`: lowercased, parameters dropped.
  * Sources are typed by sniffing their bytes, so the stored value can carry a
@@ -49,10 +46,10 @@ export function baseMediaType(mediaType: string): string {
 /**
  * Whether any viewer can draw this format's original bytes.
  *
- * A format with no viewer is not refused: its panel drops the original view
- * and opens on the extracted text alone, which is a better floor than
- * declining to open the document at all. Keep this in step with the dispatch
- * below — a type listed here must reach a viewer there.
+ * A format with no viewer is not refused: the panel draws the extracted text
+ * instead, which is a better floor than declining to open the document at all.
+ * Keep this in step with the dispatch below — a type listed here must reach a
+ * viewer there.
  */
 export function isDocumentRenderable(mediaType: string): boolean {
   const type = baseMediaType(mediaType);
@@ -82,8 +79,7 @@ export function structuredKind(type: string): "json" | "xml" | null {
 type DocumentDetailsProps = {
   chatId: string;
   info: DocumentDetail;
-  view: DocumentView;
-  hasOriginalDocumentTab?: boolean;
+  hasOriginalDocument?: boolean;
   /** Model-authored line range to reveal in a text view. */
   targetLines?: Readonly<{ start: number; end: number }>;
   /** Page of a paginated original to open on, when opened from a citation. */
@@ -97,20 +93,19 @@ type DocumentDetailsProps = {
 };
 
 /**
- * The two ways a source is shown, and which viewer draws each format.
+ * The original file when a viewer can draw it, otherwise the extracted text.
  *
  * The original is whatever the reader imported, dispatched on media type. The
  * extracted text is what Tidebreak actually read out of it — the text of record
- * that searches and citations index into — and every source has one, which is
- * why it is the view a format with no viewer falls back to.
+ * that searches and citations index into — and is the floor for a format with
+ * no viewer.
  *
  * Adding a format is a branch here plus a case in {@link isDocumentRenderable}.
  */
 export function DocumentDetails({
   chatId,
   info,
-  view,
-  hasOriginalDocumentTab,
+  hasOriginalDocument,
   targetLines,
   targetPage,
   citationCellRange,
@@ -122,7 +117,7 @@ export function DocumentDetails({
 
   return (
     <div className="flex min-h-0 grow flex-col overflow-hidden">
-      {hasOriginalDocumentTab && view === "original_doc" && (
+      {hasOriginalDocument ? (
         <>
           {hasOriginalViewer(type) ? (
             <DocumentViewer
@@ -163,11 +158,9 @@ export function DocumentDetails({
             />
           )}
         </>
-      )}
-      {view === "extracted_text" && (
+      ) : (
         <ExtractedText info={info} targetLines={targetLines} />
       )}
-
     </div>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/components/extend/document-viewer-sidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/extend/document-viewer-sidebar.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-const INLINE_THUMBNAIL_SIDEBAR_MIN_WIDTH = 768
+const INLINE_THUMBNAIL_SIDEBAR_MIN_WIDTH = 600
 
 export function useElementWidth<TElement extends HTMLElement>() {
   const ref = React.useRef<TElement | null>(null)

--- a/crates/tidebreak-desktop/ui/src/components/extend/docx-viewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/extend/docx-viewer.tsx
@@ -1488,7 +1488,7 @@ function DocxViewerContent({
           />
         </DocumentViewerThumbnailSidebar>
         <ScrollArea
-          className="min-h-0 flex-1"
+          className="min-h-0 min-w-0 flex-1"
           style={{ backgroundColor: viewerBackgroundColor }}
           viewportClassName="px-4 py-6"
           viewportProps={{

--- a/crates/tidebreak-desktop/ui/src/components/extend/pptx-viewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/extend/pptx-viewer.tsx
@@ -1234,7 +1234,7 @@ export function PptxViewerPreview({
           ) : null}
         </DocumentViewerThumbnailSidebar>
         <ScrollArea
-          className="min-h-0 flex-1 bg-background"
+          className="min-h-0 min-w-0 flex-1 bg-background"
           viewportClassName="p-0"
           viewportProps={{
             "aria-label": "PowerPoint presentation",

--- a/crates/tidebreak-desktop/ui/src/document-detail/DocumentDetailHeader.tsx
+++ b/crates/tidebreak-desktop/ui/src/document-detail/DocumentDetailHeader.tsx
@@ -1,10 +1,8 @@
-import { AlignLeft, Check, Download, FileText, FolderPlus } from "lucide-react";
+import { Check, Download, FolderPlus } from "lucide-react";
 
 import { PanelBreadcrumb } from "@/components/PanelHeader";
 import { Button } from "@/components/ui/button";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { WithTooltip } from "@/components/ui/tooltip";
-import type { DocumentView } from "@/components/document/document-details";
 
 /**
  * The panel's header, in the two slots {@link PanelFrame} exposes: the trail
@@ -25,9 +23,6 @@ export function DocumentDetailBreadcrumb({
 }
 
 export function DocumentDetailActions({
-  view,
-  onViewChange,
-  showOriginalView = true,
   canDownload,
   downloading,
   onDownload,
@@ -36,10 +31,6 @@ export function DocumentDetailActions({
   shared,
   onAddToProject,
 }: {
-  view: DocumentView;
-  onViewChange: (view: DocumentView) => void;
-  /** Hidden for a format no viewer can draw; its panel is the extracted text. */
-  showOriginalView?: boolean;
   canDownload?: boolean;
   downloading?: boolean;
   onDownload: () => void;
@@ -85,27 +76,6 @@ export function DocumentDetailActions({
             <span className="sr-only">Download</span>
           </Button>
         </WithTooltip>
-      )}
-      {showOriginalView && (
-        <Tabs
-          value={view}
-          onValueChange={(value) => onViewChange(value as DocumentView)}
-        >
-          <TabsList className="rounded-lg bg-muted p-1">
-            <WithTooltip label="Extracted text">
-              <TabsTrigger value="extracted_text" className="h-7 w-7 px-0">
-                <AlignLeft className="size-4" />
-                <span className="sr-only">Extracted text</span>
-              </TabsTrigger>
-            </WithTooltip>
-            <WithTooltip label="Original document">
-              <TabsTrigger value="original_doc" className="h-7 w-7 px-0">
-                <FileText className="size-4" />
-                <span className="sr-only">Original document</span>
-              </TabsTrigger>
-            </WithTooltip>
-          </TabsList>
-        </Tabs>
       )}
     </div>
   );

--- a/crates/tidebreak-desktop/ui/src/document-detail/DocumentDetailHeader.tsx
+++ b/crates/tidebreak-desktop/ui/src/document-detail/DocumentDetailHeader.tsx
@@ -6,7 +6,7 @@ import { WithTooltip } from "@/components/ui/tooltip";
 
 /**
  * The panel's header, in the two slots {@link PanelFrame} exposes: the trail
- * back to the list on the left, the view switch and actions on the right.
+ * back to the list on the left, the document actions on the right.
  */
 
 export function DocumentDetailBreadcrumb({

--- a/crates/tidebreak-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
@@ -266,6 +266,7 @@ describe("DocumentDetailRoot", () => {
     );
 
     expect(await screen.findByText("Subject: quarterly numbers")).toBeVisible();
+    expect(screen.queryByRole("tab", { name: "Extracted text" })).toBeNull();
     expect(screen.queryByRole("tab", { name: "Original document" })).toBeNull();
     // Nothing is going to draw those bytes, so nothing should pull them over.
     expect(client.getChatDocumentFile).not.toHaveBeenCalled();
@@ -287,6 +288,7 @@ describe("DocumentDetailRoot", () => {
     );
 
     expect(await screen.findByText("Ownership moves.")).toBeVisible();
+    expect(screen.queryByRole("tab", { name: "Extracted text" })).toBeNull();
     expect(screen.queryByRole("tab", { name: "Original document" })).toBeNull();
     expect(client.getChatDocumentFile).not.toHaveBeenCalled();
   });
@@ -414,10 +416,9 @@ describe("DocumentDetailRoot", () => {
       locator: { kind: "lines", start: 3, end: 3 },
     });
     await openCitation(
-      // A source whose original view could be drawn, but cannot show a span:
-      // the citation lands on the extracted text, where the passage is.
       detail({ media_type: "text/plain", title: "Notes.txt", content: CITED_CONTENT }),
       "cite-1",
+      CITED_CONTENT,
     );
 
     await waitFor(() => expect(document.querySelector("mark")).not.toBeNull());
@@ -432,19 +433,20 @@ describe("DocumentDetailRoot", () => {
   it("opens the same source at the top when no citation led there", async () => {
     await openPanel(
       detail({ media_type: "text/plain", title: "Notes.txt", content: CITED_CONTENT }),
+      vi.fn(),
+      CITED_CONTENT,
     );
 
-    expect(
-      await screen.findByRole("tab", { name: "Original document", selected: true }),
-    ).toBeVisible();
+    expect(await screen.findByText(/Revenue rose 12%/)).toBeVisible();
     expect(document.querySelector("mark")).toBeNull();
+    expect(screen.queryByRole("tab", { name: "Extracted text" })).toBeNull();
+    expect(screen.queryByRole("tab", { name: "Original document" })).toBeNull();
   });
 
   const MARKDOWN_CONTENT =
     "# Café notes\n\nQuarter one was flat.\nRevenue rose **12%** in the second quarter.\n";
 
   it("marks the cited line in a rendered markdown original", async () => {
-    const user = userEvent.setup();
     seedTranscript({
       id: "cite-3",
       locator: { kind: "lines", start: 4, end: 4 },
@@ -459,7 +461,6 @@ describe("DocumentDetailRoot", () => {
       MARKDOWN_CONTENT,
     );
 
-    await user.click(await screen.findByRole("tab", { name: "Original document" }));
     await screen.findByText(/Quarter one was flat/);
 
     // The passage spans an emphasized word, which is three places in the
@@ -475,7 +476,6 @@ describe("DocumentDetailRoot", () => {
   });
 
   it("marks the cited line in an original drawn as plain text", async () => {
-    const user = userEvent.setup();
     seedTranscript({
       id: "cite-4",
       locator: { kind: "lines", start: 3, end: 3 },
@@ -485,8 +485,6 @@ describe("DocumentDetailRoot", () => {
       "cite-4",
       CITED_CONTENT,
     );
-
-    await user.click(await screen.findByRole("tab", { name: "Original document" }));
 
     await waitFor(() => expect(document.querySelector("mark")).not.toBeNull());
     const marks = Array.from(document.querySelectorAll("mark"));
@@ -521,12 +519,10 @@ describe("DocumentDetailRoot", () => {
     expect(await screen.findByText("Page 5")).toBeVisible();
   });
 
-  // The panel is already open at a citation when the next one is clicked, and
-  // two citations into one source usually want the same view — so the view a
-  // citation asks for cannot tell the second click from the first. A reader who
-  // had switched views in between used to stay where they were, and the second
-  // citation landed nowhere.
-  it("lands a second citation into a source the reader had switched views on", async () => {
+  // The panel is already open at a citation when the next one is clicked.
+  // The citation id is what tells the second click from the first; a reader
+  // who had paged away used to stay where they were.
+  it("lands a second citation into a source the reader had left", async () => {
     const user = userEvent.setup();
     seedTranscript(
       { id: "cite-6", locator: { kind: "page", page: 2 } },
@@ -539,36 +535,12 @@ describe("DocumentDetailRoot", () => {
     );
 
     expect(await screen.findByText("Page 2")).toBeVisible();
-    await user.click(screen.getByRole("tab", { name: "Extracted text" }));
+    await user.click(screen.getByRole("button", { name: "Next page" }));
+    expect(await screen.findByText("Page 3")).toBeVisible();
 
     await user.click(screen.getByRole("button", { name: "Click the second citation" }));
 
-    expect(
-      await screen.findByRole("tab", { name: "Original document", selected: true }),
-    ).toBeVisible();
     expect(await screen.findByText("Page 7")).toBeVisible();
-  });
-
-  it("draws the original from cache when the reader flips views and back", async () => {
-    const user = userEvent.setup();
-    const { client } = await openPanel(
-      detail({
-        media_type: "text/markdown",
-        title: "Report.md",
-        content: "The text of record.",
-        readable: true,
-      }),
-      vi.fn(),
-      "# Quarterly report\n",
-    );
-
-    expect(await screen.findByText("Quarterly report")).toBeVisible();
-    await user.click(screen.getByRole("tab", { name: "Extracted text" }));
-    expect(await screen.findByText("The text of record.")).toBeVisible();
-    await user.click(screen.getByRole("tab", { name: "Original document" }));
-
-    expect(await screen.findByText("Quarterly report")).toBeVisible();
-    expect(client.getChatDocumentFile).toHaveBeenCalledTimes(1);
   });
 
   it("says so when a structured source will not parse", async () => {

--- a/crates/tidebreak-desktop/ui/src/document-detail/DocumentDetailRoot.tsx
+++ b/crates/tidebreak-desktop/ui/src/document-detail/DocumentDetailRoot.tsx
@@ -9,7 +9,6 @@ import { friendlyErrorMessage } from "@/lib/utils";
 import {
   DocumentDetails,
   isDocumentRenderable,
-  type DocumentView,
 } from "@/components/document/document-details";
 import { DocumentError } from "@/components/document/error";
 import { Button } from "@/components/ui/button";
@@ -79,12 +78,10 @@ export function DocumentDetailRoot({
     };
   }, [client, chatId, documentID, reloads]);
 
-  const hasOriginalDocumentTab =
+  const hasOriginalDocument =
     info != null &&
     info.has_original_bytes &&
     isDocumentRenderable(info.media_type);
-
-  const [view, setView] = useState<DocumentView>("original_doc");
 
   const placement = useCitationPlacement(documentID, citationId);
   const paginated = info != null && isPaginatedOriginalViewer(info.media_type);
@@ -105,7 +102,7 @@ export function DocumentDetailRoot({
   // highlighted instead.
   const citationCellRange =
     placement?.kind === "sheet" &&
-    hasOriginalDocumentTab &&
+    hasOriginalDocument &&
     info != null &&
     isGridOriginalViewer(info.media_type)
       ? {
@@ -114,36 +111,6 @@ export function DocumentDetailRoot({
           ...splitCells(placement.cells),
         }
       : undefined;
-
-  // Arriving from a citation, land on whichever view can show where it points:
-  // the recorded page of a paginated original, the range of a grid one, or else
-  // the extracted text, where the passage itself is highlighted. A citation the
-  // transcript cannot resolve opens the document the same way the source list
-  // does.
-  //
-  // The original view is only worth landing on where there is one.
-  const citationView: DocumentView | null = !placement
-    ? null
-    : (citationPage != null || citationCellRange != null) &&
-        hasOriginalDocumentTab
-      ? "original_doc"
-      : citationLines
-        ? "extracted_text"
-        : null;
-
-  // Reset the view when the document changes. A format with no viewer has only
-  // the extracted text to land on.
-  //
-  // Landing is per citation rather than per resolution. Two citations into one
-  // source often want the same view, so the view alone cannot tell the second
-  // click from the first: without the citation in the dependencies, a reader who
-  // had since switched views stayed on the view they were on and the second
-  // citation landed nowhere. The citation only changes when the reader clicks
-  // one, so the transcript re-resolving the citation the panel is already open
-  // at still leaves a deliberate view switch alone.
-  useEffect(() => {
-    setView(citationView ?? (hasOriginalDocumentTab ? "original_doc" : "extracted_text"));
-  }, [documentID, hasOriginalDocumentTab, citationView, citationId]);
 
   const documentName = info ? documentTitle(info) : undefined;
 
@@ -193,9 +160,6 @@ export function DocumentDetailRoot({
       }
       headerRightSlot={
         <DocumentDetailActions
-          view={view}
-          onViewChange={setView}
-          showOriginalView={hasOriginalDocumentTab}
           canDownload={canDownload && info != null}
           downloading={downloading}
           onDownload={() => void onDownload()}
@@ -226,8 +190,7 @@ export function DocumentDetailRoot({
         <DocumentDetails
           chatId={chatId}
           info={info}
-          view={view}
-          hasOriginalDocumentTab={hasOriginalDocumentTab}
+          hasOriginalDocument={hasOriginalDocument}
           targetLines={citationLines}
           targetPage={citationPage}
           citationCellRange={citationCellRange}

--- a/crates/tidebreak-desktop/ui/src/document/DocumentViewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/DocumentViewer.tsx
@@ -4,10 +4,10 @@
  * Extend's OOXML renderers, Univer) with the parsing and control surfaces those need, and
  * the download every viewer shares (`useFileDownload`).
  *
- * `components/document/` next to it is the reading side: the extracted text,
- * the panel's view switcher, and the viewers that need nothing beyond the
- * file's characters — image, text/markdown, JSON, XML. A new format goes
- * wherever its viewer's weight puts it; both sides download the same way.
+ * `components/document/` next to it is the reading side: the extracted-text
+ * fallback, and the viewers that need nothing beyond the file's characters —
+ * image, text/markdown, JSON, XML. A new format goes wherever its viewer's
+ * weight puts it; both sides download the same way.
  */
 import { lazy, Suspense } from "react";
 import { Loader2Icon } from "lucide-react";


### PR DESCRIPTION
## Summary
Documents now open directly in their original viewer when one is available; extracted text remains the fallback only for formats with no viewer. This removes the "Original document" / "Extracted text" tab switcher from the document detail panel.

The PPTX thumbnail sidebar was also overlapping the slides at the default 50% panel split because the inline/overlay breakpoint was 768 px. The default panel is typically narrower than that, so the sidebar opened in overlay mode. Lower the breakpoint to 600 px and add `min-w-0` to the PPTX and DOCX scroll areas so the slide/page content shrinks cleanly when the sidebar is inline.

## Test plan
- [x] `pnpm test` (994 passed)
- [x] `npx tsc --noEmit`
- [ ] Open a PPTX in a default-width panel and confirm the thumbnails sit beside the slides instead of on top of them
- [ ] Open a document with a viewer and confirm no "Extracted text" tab appears