### PR TITLE
feat(ci): keep the in-flight release as a prerelease so new drafts form while it builds

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,7 @@
 name-template: "Tidebreak v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
 tag-prefix: "v"
+include-pre-releases: true
 categories:
   - title: "Breaking Changes"
     exclusive: true

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -12,6 +12,11 @@ on:
         required: true
         default: false
         type: boolean
+      update-draft:
+        description: Regenerate the release draft from merged pull requests
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -61,7 +66,11 @@ jobs:
 
   draft:
     name: update native GitHub release draft
-    if: ${{ github.event_name == 'push' }}
+    if: >-
+      ${{
+        github.event_name == 'push'
+        || (github.event_name == 'workflow_dispatch' && inputs.update-draft)
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,10 +80,12 @@ jobs:
             echo "GitHub returned metadata for a different release tag." >&2
             exit 1
           }
-          [[ "$(jq -r .prerelease <<<"$release_json")" = false ]] || {
-            echo "Production desktop builds cannot be published from a GitHub prerelease." >&2
-            exit 1
-          }
+          # A prerelease is an in-flight production build that was previously
+          # dispatched and then failed or was re-triggered. Resume it.
+          prerelease="$(jq -r .prerelease <<<"$release_json")"
+          if [[ "$prerelease" = true ]]; then
+            echo "Resuming an in-flight prerelease $RELEASE_TAG."
+          fi
 
           draft="$(jq -r .draft <<<"$release_json")"
           release_id="$(jq -er .id <<<"$release_json")"
@@ -104,7 +106,7 @@ jobs:
           fi
 
           published_at="$(jq -r '.published_at // empty' <<<"$release_json")"
-          if [[ "$draft" = false && -z "$published_at" ]]; then
+          if [[ "$draft" = false && "$prerelease" = false && -z "$published_at" ]]; then
             echo "Published release $RELEASE_TAG has no publication timestamp." >&2
             exit 1
           fi
@@ -112,13 +114,31 @@ jobs:
           jq '{name, body, tag_name, target_commitish, prerelease}' \
             <<<"$release_json" > "$RUNNER_TEMP/release-snapshot.json"
           {
-            echo "draft=$draft"
+            # The release is finalized if it was mutable when validation ran.
+            # Drafts and in-flight prereleases are both published by finalize.
+            echo "draft=$([[ "$draft" = true || "$prerelease" = true ]] && echo true || echo false)"
             echo "published_at=$published_at"
             echo "release_id=$release_id"
             echo "sha=$release_sha"
             echo "tag=$RELEASE_TAG"
             echo "version=${RELEASE_TAG#v}"
           } >> "$GITHUB_OUTPUT"
+      - name: Convert the draft to a prerelease while it builds
+        if: ${{ steps.release.outputs.draft == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ steps.release.outputs.release_id }}
+        run: |
+          # A draft keeps collecting release notes from new merges while the
+          # build runs, making the live draft drift away from the frozen notes.
+          # Mark the in-flight release as a prerelease so Release Drafter treats
+          # it as already-published and starts the next draft for any PRs that
+          # merge during this build.
+          gh api --method PATCH \
+            "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
+            -f draft=false \
+            -f prerelease=true \
+            >/dev/null
       - name: Require a commit from main
         env:
           RELEASE_SHA: ${{ steps.release.outputs.sha }}
@@ -1897,6 +1917,7 @@ jobs:
       }}
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
     outputs:
       published_at: ${{ steps.release.outputs.published_at }}
@@ -1927,7 +1948,7 @@ jobs:
 
           if [[ "$RELEASE_DRAFT" = true ]]; then
             snapshot="$RUNNER_TEMP/release-snapshot/release-snapshot.json"
-            jq '. + {draft: false, make_latest: "true"}' "$snapshot" | gh api \
+            jq '. + {draft: false, prerelease: false, make_latest: "true"}' "$snapshot" | gh api \
               --method PATCH \
               "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
               --input - >/dev/null
@@ -1952,3 +1973,13 @@ jobs:
             '.published_at | select(type == "string" and length > 0)' \
             <<<"$release_json")"
           echo "published_at=$published_at" >> "$GITHUB_OUTPUT"
+      - name: Refresh the next release draft
+        if: ${{ needs.validate.outputs.draft == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Start a new draft immediately after publishing. If any PRs merged
+          # during the build, Release Drafter already created one while the
+          # release was a prerelease; this call is idempotent and just ensures
+          # a draft exists even when the build was quiet.
+          gh workflow run release-draft.yml --ref main --field update-draft=true

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -130,13 +130,16 @@ automatic.
    GitHub. Immutable releases cannot accept assets after publication.
 4. Open **Actions → Publish desktop release → Run workflow** and select
    `main`. Leave the tag blank to publish the current draft. Enter a tag only
-   to retry that draft or an already-published release. The workflow resolves
-   a blank tag to the single non-prerelease draft, rejects a missing or
-   ambiguous draft, malformed tags, or prereleases, creates the tag at the
+   to retry that draft, an in-flight prerelease, or an already-published release.
+   The workflow resolves a blank tag to the single non-prerelease draft, rejects
+   a missing or ambiguous draft and malformed tags, creates the tag at the
    current `main` commit when it does not already exist, and retains the same
    tag on a retry. It snapshots the draft metadata so a later merge cannot
    change the notes or proposed version while the build is running, and pins
-   every later job to the frozen commit SHA.
+   every later job to the frozen commit SHA. Immediately after the snapshot, the
+   draft becomes a GitHub prerelease. This lets Release Drafter start the next
+   draft for any PRs that merge during the build, instead of appending them to
+   the in-flight release.
 5. In parallel with the desktop build, the documentation builder checks out
    that validated SHA and builds `docs-site/` as a static export under `/docs`.
    Publication waits until the GitHub Release itself has been published. It


### PR DESCRIPTION
## Summary
The immutable release workflow froze a draft's metadata and tag at dispatch time, but while the build ran Release Drafter kept updating the same draft. That made the live draft drift away from the frozen notes, and after publish no new draft existed until the next push to `main`.

Convert the in-flight release to a GitHub prerelease immediately after the snapshot. Release Drafter then treats the in-flight release as already-published and creates the next draft for any PRs that merge during the build. The release is still published from the frozen snapshot at the end, so the published notes are unchanged.

Also:
- Set `release-drafter.include-pre-releases` so the new draft uses the in-flight prerelease as its baseline instead of the previous published release.
- Allow the release workflow to resume a prerelease (for failed builds).
- Trigger the release-draft workflow after publish so a draft exists even when the build was quiet.
- Update `docs/releases.md`.

## Test plan
- [ ] Merge and dispatch the next release. Confirm the draft becomes a prerelease during the build and a new draft appears for any PRs merged in that window.
- [ ] After publish, confirm the release is no longer a prerelease/draft and the next draft is ready.
- [ ] Re-dispatch a failed release by tag and confirm the workflow resumes a prerelease.