### PR TITLE
fix(desktop): clear composer folder chips on send

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
@@ -95,6 +95,14 @@ const sessionDeps = {
 const chatListActions = useChatListStore.getState();
 const composerDraftActions = useComposerDrafts.getState();
 const firstMessageActions = useFirstMessage.getState();
+
+function rememberComposerFolder(chatId: string, rootId: string) {
+  const current =
+    useComposerDrafts.getState().attachments[chatId]?.folders ?? [];
+  if (current.includes(rootId)) return;
+  composerDraftActions.setFolders(chatId, [...current, rootId]);
+}
+
 const { signal: signalRefresh } = useRefreshSignals.getState();
 const { signal: signalTurnLifecycle } = useTurnLifecycle.getState();
 
@@ -119,7 +127,9 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   const busy = useChatSessionStore((session) => session.busy);
   const lastTurnUsage = useChatSessionStore((session) => session.lastTurnUsage);
   const [hydrated, setHydrated] = useState(false);
-  const files = useComposerAttachments(chatId).files;
+  const composerAttachments = useComposerAttachments(chatId);
+  const files = composerAttachments.files;
+  const pendingFolderIds = composerAttachments.folders;
   const [attaching, setAttaching] = useState(false);
   const [attachError, setAttachError] = useState<string | null>(null);
   const images = useImageAttachments(client, chatId);
@@ -379,6 +389,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
         ),
       () => {
         setComposerDraft("");
+        composerDraftActions.setFolders(chatId, []);
         voice.resetInputUsed();
       },
     );
@@ -512,6 +523,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
         images.clear();
         setComposerFiles(() => []);
         composerDraftActions.setSkills(chatId, []);
+        composerDraftActions.setFolders(chatId, []);
         voice.resetInputUsed();
       }
     } catch (err) {
@@ -685,11 +697,24 @@ export function ChatRoute({ chatId }: { chatId: string }) {
           }}
           folders={{
             items: folders.items,
+            pendingIds: pendingFolderIds,
             approved: folders.approved,
             working: folders.working,
             error: folders.error,
-            onAttach: nativeHost ? folders.attach : undefined,
-            onConnect: nativeHost ? folders.connectApproved : undefined,
+            onAttach: nativeHost
+              ? () => {
+                  void folders.attach().then((connected) => {
+                    if (connected) rememberComposerFolder(chatId, connected.rootId);
+                  });
+                }
+              : undefined,
+            onConnect: nativeHost
+              ? (rootId) => {
+                  void folders.connectApproved(rootId).then((connected) => {
+                    if (connected) rememberComposerFolder(chatId, connected.rootId);
+                  });
+                }
+              : undefined,
             onRemove: folders.remove,
           }}
           voice={{

--- a/crates/tidebreak-desktop/ui/src/ChatView.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatView.tsx
@@ -159,8 +159,10 @@ export function ChatView({
       onDraftChange("");
       // Pills go with the text they were attached to: accepted guidance has
       // already carried them, and leaving them behind would silently re-invoke
-      // the same skills on whatever is typed next.
+      // the same skills on whatever is typed next. Folder chips are the same
+      // draft context; the grants stay on the chat.
       useComposerDrafts.getState().setSkills(chat.id, []);
+      useComposerDrafts.getState().setFolders(chat.id, []);
       onVoiceInputAccepted();
     },
     voiceInputUsed,

--- a/crates/tidebreak-desktop/ui/src/Composer.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/Composer.test.tsx
@@ -3,10 +3,12 @@ import { describe, expect, it, vi } from "vitest";
 import {
   boundedComposerHeight,
   Composer,
+  composerFolderChips,
   imageSendBlocker,
   MAX_COMPOSER_LINES,
   shouldRestoreComposerFocus,
   shouldSubmitComposerKey,
+  type ComposerFolders,
   type ComposerImages,
 } from "./Composer";
 import {
@@ -586,5 +588,31 @@ describe("Composer", () => {
     );
 
     expect(markup).not.toContain('aria-label="Context:');
+  });
+});
+
+describe("composerFolderChips", () => {
+  const folders: ComposerFolders = {
+    items: [
+      {
+        rootId: "root-1",
+        displayName: "Downloads",
+        status: "connected",
+        statements: [],
+      },
+    ],
+    working: false,
+    error: null,
+    onRemove: vi.fn(),
+  };
+
+  it("hides standing grants once the draft has consumed them", () => {
+    expect(composerFolderChips({ ...folders, pendingIds: [] })).toEqual([]);
+  });
+
+  it("keeps a folder the draft is still holding", () => {
+    expect(
+      composerFolderChips({ ...folders, pendingIds: ["root-1"] }),
+    ).toEqual(folders.items);
   });
 });

--- a/crates/tidebreak-desktop/ui/src/Composer.tsx
+++ b/crates/tidebreak-desktop/ui/src/Composer.tsx
@@ -202,6 +202,13 @@ export type ComposerFolders = {
    * through the picker.
    */
   approved?: readonly ConnectedFolder[];
+  /**
+   * Root ids this draft is presenting as context. Standing grants stay on
+   * `items` (and on the chat); send clears this list so the chips leave with
+   * the message. Absent means every connected folder is a chip — tests and
+   * surfaces that do not distinguish a draft from a grant.
+   */
+  pendingIds?: readonly string[];
   working: boolean;
   error: string | null;
   onAttach?: () => void;
@@ -209,6 +216,16 @@ export type ComposerFolders = {
   onConnect?: (rootId: string) => void;
   onRemove: (rootId: string) => void;
 };
+
+/** The folder chips this draft is holding. Standing grants are not chips. */
+export function composerFolderChips(
+  folders: ComposerFolders,
+): ChatFolderAccess[] {
+  if (folders.pendingIds === undefined) return folders.items;
+  if (folders.pendingIds.length === 0) return [];
+  const pending = new Set(folders.pendingIds);
+  return folders.items.filter((folder) => pending.has(folder.rootId));
+}
 
 export type ComposerVoice = {
   available: boolean;
@@ -406,6 +423,7 @@ export function Composer({
   }, [resetKey]);
 
   const invokedSkills = slash?.invoked ?? [];
+  const folderChips = folders ? composerFolderChips(folders) : [];
   const atSkillCap = invokedSkills.length >= MAX_INVOKED_SKILLS;
   /** What a pick can still reach, given what this message already carries. */
   const libraryOptions = availableSlashOptions(slash?.options ?? [], invokedSkills, {
@@ -870,12 +888,12 @@ export function Composer({
           ))}
         </ul>
       )}
-      {folders && folders.items.length > 0 && (
+      {folderChips.length > 0 && folders && (
         <ul
           className="m-0 flex list-none flex-wrap gap-2 p-0"
           aria-label="Attached folders"
         >
-          {folders.items.map((folder) => (
+          {folderChips.map((folder) => (
             <FolderAttachmentChip
               key={folder.rootId}
               folder={folder}

--- a/crates/tidebreak-desktop/ui/src/ComposerDrafts.test.ts
+++ b/crates/tidebreak-desktop/ui/src/ComposerDrafts.test.ts
@@ -45,10 +45,12 @@ describe("composer draft attachments", () => {
     const store = useComposerDrafts.getState();
     store.setImages("chat-1", [READY_IMAGE, QUEUED_IMAGE]);
     store.setFiles("chat-1", [IMPORTED_FILE]);
+    store.setFolders("chat-1", ["root-1"]);
 
     // A fresh store is what the next load of the page gets.
     const restored = createComposerDraftStore().getState().attachments["chat-1"];
     expect(restored.files).toEqual([IMPORTED_FILE]);
+    expect(restored.folders).toEqual(["root-1"]);
     // The published image re-sends as-is; the queued one was a promise to
     // move bytes no storage can hold, so no chip comes back for it.
     expect(restored.images).toHaveLength(1);
@@ -60,6 +62,19 @@ describe("composer draft attachments", () => {
       // format and geometry.
       previewUrl: null,
     });
+  });
+
+  it("restores draft folder chips without implying a standing grant", () => {
+    const store = useComposerDrafts.getState();
+    store.setFolders("chat-1", ["root-1", "root-2"]);
+
+    const restored = createComposerDraftStore().getState().attachments["chat-1"];
+    expect(restored.folders).toEqual(["root-1", "root-2"]);
+    // A connected folder that was never put on this draft does not come back
+    // as a chip — send already consumed the strip.
+    expect(
+      createComposerDraftStore().getState().attachments["chat-2"],
+    ).toBeUndefined();
   });
 
   it("forgets text and attachments together, in the session too", () => {

--- a/crates/tidebreak-desktop/ui/src/ComposerDrafts.ts
+++ b/crates/tidebreak-desktop/ui/src/ComposerDrafts.ts
@@ -60,6 +60,11 @@ export type ComposerAttachmentDraft = {
   files: ImportedDocument[];
   /** Skills the next message will invoke, by catalog name, in pick order. */
   skills: string[];
+  /**
+   * Connected-folder root ids the composer is holding as this draft's
+   * context. Standing grants live on the chat; these are only the chips.
+   */
+  folders: string[];
   pendingChatId: string | null;
 };
 
@@ -67,6 +72,7 @@ export const EMPTY_ATTACHMENT_DRAFT: ComposerAttachmentDraft = {
   images: [],
   files: [],
   skills: [],
+  folders: [],
   pendingChatId: null,
 };
 
@@ -75,6 +81,7 @@ function isEmptyAttachmentDraft(draft: ComposerAttachmentDraft): boolean {
     draft.images.length === 0 &&
     draft.files.length === 0 &&
     draft.skills.length === 0 &&
+    draft.folders.length === 0 &&
     draft.pendingChatId === null
   );
 }
@@ -96,6 +103,7 @@ function storableDraft(
       .map((image) => ({ ...image, previewUrl: null })),
     files: draft.files,
     skills: draft.skills,
+    folders: draft.folders,
     pendingChatId: draft.pendingChatId,
   };
 }
@@ -123,6 +131,9 @@ function parseStoredAttachmentDraft(value: string): ComposerAttachmentDraft | nu
       files,
       skills: (Array.isArray(parsed.skills) ? parsed.skills : []).filter(
         (skill): skill is string => typeof skill === "string",
+      ),
+      folders: (Array.isArray(parsed.folders) ? parsed.folders : []).filter(
+        (folder): folder is string => typeof folder === "string",
       ),
       pendingChatId:
         typeof parsed.pendingChatId === "string" ? parsed.pendingChatId : null,
@@ -196,6 +207,7 @@ export type ComposerDraftStore = {
   setImages: (key: string, images: ImageAttachment[]) => void;
   setFiles: (key: string, files: ImportedDocument[]) => void;
   setSkills: (key: string, skills: string[]) => void;
+  setFolders: (key: string, folders: string[]) => void;
   setPendingChatId: (key: string, chatId: string | null) => void;
 };
 
@@ -241,6 +253,8 @@ export function createComposerDraftStore() {
         updateAttachments(key, (current) => ({ ...current, files })),
       setSkills: (key, skills) =>
         updateAttachments(key, (current) => ({ ...current, skills })),
+      setFolders: (key, folders) =>
+        updateAttachments(key, (current) => ({ ...current, folders })),
       setPendingChatId: (key, chatId) =>
         updateAttachments(key, (current) => ({
           ...current,

--- a/crates/tidebreak-desktop/ui/src/ComposerFolders.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ComposerFolders.dom.test.tsx
@@ -73,3 +73,58 @@ it("attaches and confirms revoking a folder from the ordinary chat composer", as
   await user.click(screen.getByRole("button", { name: "Disconnect" }));
   expect(onRemove).toHaveBeenCalledWith("root-1");
 });
+
+it("drops folder chips after send without needing a disconnect", () => {
+  render(
+    <Composer
+      activeTurnId="turn-1"
+      busy
+      cancelError={null}
+      cancelPending={false}
+      disabled={false}
+      draft=""
+      folders={{
+        items: [
+          {
+            rootId: "root-1",
+            displayName: "Downloads",
+            status: "connected",
+            statements: (["read_files", "write_files", "execute_commands"] as const).map(
+              (capability, index) => ({
+                handle: {
+                  kind: "capability_grant" as const,
+                  grant_id: `grant-${index}`,
+                },
+                level: { level: "chat" as const, chat_id: "chat-1" },
+                level_title: null,
+                verb: { kind: "capability" as const, capability },
+                resource: {
+                  kind: "host_root" as const,
+                  root_id: "root-1",
+                  display_name: null,
+                },
+                method: "folder_picker" as const,
+                granted_at: "2026-07-30T12:00:00Z",
+              }),
+            ),
+          },
+        ],
+        pendingIds: [],
+        working: false,
+        error: null,
+        onRemove: vi.fn(),
+      }}
+      onDraftChange={vi.fn()}
+      onSend={vi.fn(async () => {})}
+      onSteer={vi.fn(async () => {})}
+      onStop={vi.fn(async () => {})}
+      resetKey="chat-1"
+      steerError={null}
+      steerPending={false}
+      steerStatus={null}
+    />,
+  );
+
+  expect(screen.queryByText("Downloads")).toBeNull();
+  expect(screen.queryByLabelText("Attached folders")).toBeNull();
+});

--- a/crates/tidebreak-desktop/ui/src/useChatFolderAttachments.ts
+++ b/crates/tidebreak-desktop/ui/src/useChatFolderAttachments.ts
@@ -39,8 +39,8 @@ export type ChatFolderAttachments = {
   approved: ConnectedFolder[];
   working: boolean;
   error: string | null;
-  attach: () => void;
-  connectApproved: (rootId: string) => void;
+  attach: () => Promise<ConnectedFolder | null>;
+  connectApproved: (rootId: string) => Promise<ConnectedFolder | null>;
   remove: (rootId: string) => void;
 };
 
@@ -98,11 +98,11 @@ export function useChatFolderAttachments(
     };
   }, [chat?.id, chat?.project_id, nativeHost, folderAccess]);
 
-  async function attach() {
-    if (!chat || !nativeHost || working) return;
+  async function attach(): Promise<ConnectedFolder | null> {
+    if (!chat || !nativeHost || working) return null;
     if (!useNativePickerLatch.getState().claim(PICKER_HOLDERS.connectFolder)) {
       setError(PICKER_BUSY_MESSAGE);
-      return;
+      return null;
     }
     setWorking(true);
     setError(null);
@@ -111,8 +111,10 @@ export function useChatFolderAttachments(
       if (connected) {
         useRefreshSignals.getState().signal("folderAccess");
       }
+      return connected;
     } catch (reason) {
       setError(String(reason));
+      return null;
     } finally {
       useNativePickerLatch.getState().release(PICKER_HOLDERS.connectFolder);
       setWorking(false);
@@ -127,8 +129,10 @@ export function useChatFolderAttachments(
    * grant is the host's to make either way — this only spares the reader
    * finding a folder they have already chosen once.
    */
-  async function connectApproved(rootId: string) {
-    if (!chat || !nativeHost || working) return;
+  async function connectApproved(
+    rootId: string,
+  ): Promise<ConnectedFolder | null> {
+    if (!chat || !nativeHost || working) return null;
     setWorking(true);
     setError(null);
     try {
@@ -136,8 +140,10 @@ export function useChatFolderAttachments(
       if (connected) {
         useRefreshSignals.getState().signal("folderAccess");
       }
+      return connected;
     } catch (reason) {
       setError(String(reason));
+      return null;
     } finally {
       setWorking(false);
     }
@@ -162,8 +168,8 @@ export function useChatFolderAttachments(
     approved,
     working,
     error,
-    attach: () => void attach(),
-    connectApproved: (rootId) => void connectApproved(rootId),
+    attach,
+    connectApproved,
     remove: (rootId) => void remove(rootId),
   };
 }


### PR DESCRIPTION
## Summary

Composer folder chips looked like per-message context but were standing chat grants, so they never left after send — including in the steer box.

This keeps the grant on the chat and treats the chips as draft context:

- attaching or reconnecting a folder puts it on this draft
- send, steer, and queue drop the chips
- the Folders panel still shows connected access

## Test plan

- [x] `pnpm --dir crates/tidebreak-desktop/ui test` (full UI suite)
- [ ] Attach a folder, send a message, confirm the chips leave the composer and the folder remains in Folders
- [ ] Attach a folder, send, then steer: chips stay gone
- [ ] Disconnect still works from the chip before send