### PR TITLE
fix(ci): pass --repo to gh workflow run when refreshing the release draft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1982,4 +1982,4 @@ jobs:
           # during the build, Release Drafter already created one while the
           # release was a prerelease; this call is idempotent and just ensures
           # a draft exists even when the build was quiet.
-          gh workflow run release-draft.yml --ref main --field update-draft=true
+          gh workflow run release-draft.yml --repo "$GITHUB_REPOSITORY" --ref main --field update-draft=true


### PR DESCRIPTION
The 'publish immutable GitHub Release' job does not check out the repository, so the final step that triggers the next release draft failed with:\n\n```\nfatal: not a git repository (or any of the parent directories): .git\n```\n\nPass `--repo "$GITHUB_REPOSITORY"` to `gh workflow run` so it resolves the workflow through the API instead of requiring a local `.git` directory.\n\nRelates to the failed release run: https://github.com/brightwave-inc/tidebreak/actions/runs/31848864387/job/94925848801