### PR TITLE
fix(desktop): keep sandbox source pills next to the outcome

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ToolCardShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolCardShell.tsx
@@ -72,7 +72,10 @@ export function ToolCardShell({
           {icon}
           <span className={cn("truncate", titleClassName)}>{title}</span>
         </span>
-        {badge}
+        {/* One end cluster: a fragment would become sibling flex children,
+            so justify-between would split them and they would not share a
+            height with the outcome pill. */}
+        <span className="flex shrink-0 items-stretch gap-1">{badge}</span>
       </button>
       {expanded && (
         <div id={bodyId} className="border-t">


### PR DESCRIPTION
## Summary

Command cards show the execution backend (`Local`, `E2B`, …) next to the outcome pill. Those badges were passed as a fragment into a `justify-between` header, so they became sibling flex children: the source pill floated off the end cluster and did not share Done's height.

This wraps the badge slot in one end cluster so the source and outcome pills stay together and stretch to the same height.

## Test plan

- [ ] Open a chat with finished local `exec` calls and confirm the Local pill sits flush against Done, same height, on every row
- [ ] Confirm a card with only an outcome pill (no backend) still looks unchanged
- [ ] Confirm a running command's Running… pill still sits on the right