### PR TITLE
docs: add a compact features section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,37 +53,15 @@ the headless CLI.
 
 ## Features
 
-**Chat.** Dictate with local or cloud transcription. Queue a follow-up or
-steer the live turn. `@` attaches files and folders; `/` attaches a skill or
-saved prompt. Turns, approvals, and questions survive a restart. An inbox
-collects anything waiting on you across chats.
-
-**Documents.** Attach any file. Office, PDF, images, and text open in native
-viewers; other formats fall back to extracted text when they can be read.
-Source pills jump to the page, line, sheet, or cell the agent used. There is
-no vector index: the agent reads bounded ranges directly.
-
-**Outputs.** Files written to `output/` are versioned by filename. Restore is
-append-only. Plotly charts stay interactive. The agent can propose writing
-back into a connected folder; replacing an existing file always asks.
-
-**Models.** ChatGPT Plus or Pro, an API key (Anthropic, OpenAI, Gemini, xAI,
-Fireworks, Together, OpenRouter), or a local OpenAI-compatible endpoint
-including Ollama. Switch mid-chat. Keys stay in the OS credential store.
-
-**Execution.** Native macOS sandbox, local Docker, E2B, or Daytona. Per-chat
-network policy. Background agents one level deep. Built-in or configured web
-search (Exa, Tavily, Brave, SearXNG). Computer use (screen and app control)
-is in the product and not finished.
-
-**Permissions.** Plan, Ask, Auto, or Allow all, per chat. Folder access is
-per capability from a native picker. Standing grants are revocable. Overwrite
-of a connected file always asks.
-
-**Extensions.** Built-in skills for Word, PDF, PowerPoint, spreadsheets, and
-charts; add your own. MCP servers over stdio or HTTP. REST APIs from an
-OpenAPI document, for local apps. Ask once for a mini-app and keep it in the
-sidebar.
+| Area | What it does |
+| --- | --- |
+| **Chat** | Voice input, local or cloud. Queue a follow-up or steer the live turn. `@` attaches files and folders; `/` attaches a skill or saved prompt. Turns, approvals, and questions survive a restart. An inbox collects anything waiting on you. |
+| **Documents** | Attach any file. Office, PDF, images, and text open in native viewers; other formats fall back to extracted text when they can be read. Source pills jump to the page, line, sheet, or cell. No vector index: the agent reads bounded ranges directly. |
+| **Outputs** | Files written to `output/` are versioned by filename. Restore is append-only. Plotly charts stay interactive. The agent can write back into a connected folder; replacing an existing file always asks. |
+| **Models** | ChatGPT Plus or Pro, an API key (Anthropic, OpenAI, Gemini, xAI, Fireworks, Together, OpenRouter), or a local OpenAI-compatible endpoint including Ollama. Switch mid-chat. Keys stay in the OS credential store. |
+| **Execution** | Native macOS sandbox, local Docker, E2B, or Daytona. Per-chat network policy. Background agents one level deep. Built-in or configured web search (Exa, Tavily, Brave, SearXNG). Computer use (screen and app control) is in the product and not finished. |
+| **Permissions** | Plan, Ask, Auto, or Allow all, per chat. Folder access is per capability from a native picker. Standing grants are revocable. Overwrite of a connected file always asks. |
+| **Extensions** | Built-in skills for Word, PDF, PowerPoint, spreadsheets, and charts; add your own. MCP servers over stdio or HTTP. REST APIs from an OpenAPI document, for local apps. Ask once for a mini-app and keep it in the sidebar. |
 
 ## Run from source
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,40 @@ the headless CLI.
 > migrated. Packaged releases are currently macOS-only; Windows and Linux can
 > be built from source.
 
+## Features
+
+**Chat.** Dictate with local or cloud transcription. Queue a follow-up or
+steer the live turn. `@` attaches files and folders; `/` attaches a skill or
+saved prompt. Turns, approvals, and questions survive a restart. An inbox
+collects anything waiting on you across chats.
+
+**Documents.** Attach any file. Office, PDF, images, and text open in native
+viewers; other formats fall back to extracted text when they can be read.
+Source pills jump to the page, line, sheet, or cell the agent used. There is
+no vector index: the agent reads bounded ranges directly.
+
+**Outputs.** Files written to `output/` are versioned by filename. Restore is
+append-only. Plotly charts stay interactive. The agent can propose writing
+back into a connected folder; replacing an existing file always asks.
+
+**Models.** ChatGPT Plus or Pro, an API key (Anthropic, OpenAI, Gemini, xAI,
+Fireworks, Together, OpenRouter), or a local OpenAI-compatible endpoint
+including Ollama. Switch mid-chat. Keys stay in the OS credential store.
+
+**Execution.** Native macOS sandbox, local Docker, E2B, or Daytona. Per-chat
+network policy. Background agents one level deep. Built-in or configured web
+search (Exa, Tavily, Brave, SearXNG). Computer use (screen and app control)
+is in the product and not finished.
+
+**Permissions.** Plan, Ask, Auto, or Allow all, per chat. Folder access is
+per capability from a native picker. Standing grants are revocable. Overwrite
+of a connected file always asks.
+
+**Extensions.** Built-in skills for Word, PDF, PowerPoint, spreadsheets, and
+charts; add your own. MCP servers over stdio or HTTP. REST APIs from an
+OpenAPI document, for local apps. Ask once for a mini-app and keep it in the
+sidebar.
+
 ## Run from source
 
 Install the pinned Rust toolchain, [pnpm](https://pnpm.io), the

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ the headless CLI.
 | **Documents** | Attach any file. Office, PDF, images, and text open in native viewers; other formats fall back to extracted text when they can be read. Source pills jump to the page, line, sheet, or cell. No vector index: the agent reads bounded ranges directly. |
 | **Outputs** | Files written to `output/` are versioned by filename. Restore is append-only. Plotly charts stay interactive. The agent can write back into a connected folder; replacing an existing file always asks. |
 | **Models** | ChatGPT Plus or Pro, an API key (Anthropic, OpenAI, Gemini, xAI, Fireworks, Together, OpenRouter), or a local OpenAI-compatible endpoint including Ollama. Switch mid-chat. Keys stay in the OS credential store. |
-| **Execution** | Native macOS sandbox, local Docker, E2B, or Daytona. Per-chat network policy. Background agents one level deep. Built-in or configured web search (Exa, Tavily, Brave, SearXNG). Computer use (screen and app control) is in the product and not finished. |
+| **Execution** | Native macOS sandbox, local Docker, E2B, or Daytona. Per-chat network policy. Background agents one level deep. Built-in or configured web search (Exa, Tavily, Brave, SearXNG). Computer use: screen capture and consent-gated control of native apps. |
 | **Permissions** | Plan, Ask, Auto, or Allow all, per chat. Folder access is per capability from a native picker. Standing grants are revocable. Overwrite of a connected file always asks. |
 | **Extensions** | Built-in skills for Word, PDF, PowerPoint, spreadsheets, and charts; add your own. MCP servers over stdio or HTTP. REST APIs from an OpenAPI document, for local apps. Ask once for a mini-app and keep it in the sidebar. |
 


### PR DESCRIPTION
## Summary

Adds a compact Features section to the product README so the inventory lives next to the download and run-from-source instructions, instead of on a marketing page.

Covers chat (voice, queue/steer, `@`/`/`, durable turns, inbox), documents (any file, native viewers, source pills), outputs, models, execution, permissions, and extensions. Computer use is listed as in the product and not finished.

## Test plan

- [ ] Read the new section on GitHub's README render
- [ ] Confirm it sits between the pre-1.0 warning and Run from source
- [ ] Skim for anything that overclaims vs the current desktop app