### PR TITLE
fix(agent): keep plan mode off ask_user_questions

### DIFF
--- a/crates/tidebreak-core/src/agent/registry.rs
+++ b/crates/tidebreak-core/src/agent/registry.rs
@@ -444,7 +444,8 @@ impl ToolRegistry {
     /// orchestration tools by the class declared at registration. The
     /// orchestration pair is `Sensitive`, so a plan turn drops it by that same
     /// rule: spawned agents execute, and executing is exactly what a plan turn
-    /// must not do.
+    /// must not do. `ask_user_questions` is read-only by class but parks a
+    /// user continuation, so it is carved out by name the same way.
     #[must_use]
     pub fn specs_for_surface(
         &self,
@@ -493,6 +494,14 @@ impl ToolRegistry {
                     // decision whose accept is meaningless.
                     RegisteredTool::ForegroundClient { registered, .. }
                         if !read_only && registered.spec.name == crate::EXIT_PLAN_MODE_TOOL =>
+                    {
+                        None
+                    }
+                    // Read-only by consent class, but it parks a user
+                    // continuation a plan driver cannot answer. A missing input
+                    // belongs in the plan.
+                    RegisteredTool::ForegroundClient { registered, .. }
+                        if read_only && registered.spec.name == crate::ASK_USER_QUESTIONS_TOOL =>
                     {
                         None
                     }

--- a/crates/tidebreak-core/src/agent/tests/mod.rs
+++ b/crates/tidebreak-core/src/agent/tests/mod.rs
@@ -5670,6 +5670,135 @@ async fn plan_mode_standing_grant_does_not_bypass_the_refusal() {
         .any(|e| matches!(e, AgentEvent::ApprovalRequired { .. })));
 }
 
+/// A plan-mode turn that would ask a question must not park: a headless
+/// `--permission-mode plan` driver can decide a plan, not answer a card.
+/// The surface withholds the tool, so this provider emits it anyway — the
+/// same slip the live model made after listing folders and missing a file.
+struct PlanModeQuestionProvider;
+
+#[async_trait]
+impl ModelProvider for PlanModeQuestionProvider {
+    fn id(&self) -> ProviderId {
+        ProviderId::new("plan-mode-question")
+    }
+
+    async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+        if req.tool_choice == Some(ToolChoice::None) {
+            return Ok(stream::iter(vec![
+                ProviderEvent::TextDelta {
+                    text: "I'll list the missing file as a first step.".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                },
+            ])
+            .boxed());
+        }
+        Ok(stream::iter(vec![
+            ProviderEvent::ToolCallStarted {
+                index: 0,
+                id: "question_1".into(),
+                name: crate::ASK_USER_QUESTIONS_TOOL.into(),
+            },
+            ProviderEvent::ToolCallArgsDelta {
+                index: 0,
+                fragment: r#"{"questions":[{"id":"missing","header":"File","question":"Where is buggy_sort.py?","options":[{"id":"scratch","label":"Scratch","description":"Look in private scratch."}],"allow_free_form":true}]}"#.into(),
+            },
+            ProviderEvent::Stop {
+                reason: StopReason::ToolUse,
+            },
+        ])
+        .boxed())
+    }
+}
+
+#[tokio::test]
+async fn plan_mode_does_not_run_ask_user_questions() {
+    let db = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            db.path().join("plan-questions.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let chat = Chat {
+        id: ChatId::new(),
+        project_id: None,
+        title: None,
+        model: None,
+        reasoning_effort: None,
+        permission_mode: Some(PermissionMode::Plan),
+        network_policy: Default::default(),
+        attachment_revision: 0,
+        root_attachments: Vec::new(),
+        created_at: Utc::now(),
+    };
+    store.create_chat(&chat).await.unwrap();
+    let turn_id = TurnId::new();
+    store
+        .accept_turn(turn_id, chat.id, "fake", "find the missing file")
+        .await
+        .unwrap();
+    let lease_token = uuid::Uuid::new_v4();
+    let now = Utc::now();
+    store
+        .claim_turn_run(lease_token, now, now + chrono::Duration::minutes(1))
+        .await
+        .unwrap();
+    let mut registry = ToolRegistry::new();
+    registry.register_validated_foreground_client(
+        crate::ask_user_questions_tool_spec(),
+        ApprovalClass::ReadOnly,
+        crate::validate_ask_user_questions_arguments,
+    );
+    let agent = Agent::new(
+        Arc::new(PlanModeQuestionProvider),
+        Arc::new(registry),
+        store.clone(),
+        AgentConfig {
+            model: "fake".into(),
+            max_steps: 1,
+            ..AgentConfig::default()
+        },
+    )
+    .with_durable_steer(lease_token)
+    .with_foreground_agent_orchestration();
+    let (tx, rx) = unbounded();
+    let outcome = agent
+        .run_claimed_turn(&chat, turn_id, MessageId::new(), 1, &tx)
+        .await
+        .unwrap();
+    drop(tx);
+    let events = emitted_events(rx.collect().await);
+
+    assert!(
+        !matches!(outcome, AgentTurnOutcome::ClientToolCall { .. }),
+        "plan mode must refuse, not park: {outcome:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, AgentEvent::UserQuestionsAsked { .. })),
+        "a declined question must not emit a parked card"
+    );
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            AgentEvent::ToolCallCompleted { output, .. }
+                if output.is_error
+                    && output.content.contains("plan mode")
+                    && output.content.contains("exit_plan_mode")
+        )),
+        "the model must be told to put the missing input in the plan: {events:?}"
+    );
+    assert!(
+        store.list_tool_calls(chat.id).await.unwrap().is_empty(),
+        "a declined question must not leave a durable continuation"
+    );
+}
+
 /// The plan surface advertises only read-only registrations, so the model
 /// is never offered a tool the turn would refuse.
 #[test]
@@ -5709,15 +5838,18 @@ fn plan_surface_advertises_only_read_only_tools() {
     names.sort();
     // `update_task_plan` is read-only by consent class but still commits a
     // durable row, and a plan-mode turn is drafting a proposal the reader has
-    // not accepted. It is carved out by name rather than by class.
-    assert_eq!(
-        names,
-        vec!["ask_user_questions", "read_connected_file", "read_file"]
-    );
+    // not accepted. `ask_user_questions` is the same shape: read-only, but it
+    // parks a continuation a plan driver cannot answer. Both are carved out
+    // by name rather than by class.
+    assert_eq!(names, vec!["read_connected_file", "read_file"]);
     assert!(tools
         .specs_for_surface(true, false)
         .iter()
         .any(|spec| spec.name == crate::UPDATE_TASK_PLAN_TOOL));
+    assert!(tools
+        .specs_for_surface(true, false)
+        .iter()
+        .any(|spec| spec.name == crate::ASK_USER_QUESTIONS_TOOL));
 }
 
 /// Stands in for the server-side task-plan tool: read-only class, real write.

--- a/crates/tidebreak-core/src/agent/turn.rs
+++ b/crates/tidebreak-core/src/agent/turn.rs
@@ -1343,17 +1343,25 @@ impl Agent {
                 // plan turn refuses to spawn or wait on them at all: the
                 // read-only promise has to hold transitively, not just for
                 // this agent's own calls.
-                let plan_mode_blocks_orchestration =
-                    matches!(chat.permission_mode, Some(PermissionMode::Plan))
-                        && matches!(
-                            isolations[index],
-                            Some(CallIsolation::SandboxSpawn | CallIsolation::AgentWait)
-                        );
+                let plan_mode = matches!(chat.permission_mode, Some(PermissionMode::Plan));
+                let plan_mode_blocks_orchestration = plan_mode
+                    && matches!(
+                        isolations[index],
+                        Some(CallIsolation::SandboxSpawn | CallIsolation::AgentWait)
+                    );
+                let plan_mode_blocks_questions =
+                    plan_mode && call.name == crate::ASK_USER_QUESTIONS_TOOL;
                 if plan_mode_blocks_orchestration {
                     outputs[index] = Some(self.decline_call(
                         call,
                         events,
                         "not run: agent delegation is not available in plan mode; the chat is read-only until the reader leaves plan mode. Continue with read-only tools.".into(),
+                    ));
+                } else if plan_mode_blocks_questions {
+                    outputs[index] = Some(self.decline_call(
+                        call,
+                        events,
+                        "not run: ask_user_questions is not available in plan mode. Record missing inputs as assumptions or first steps in the plan and submit it with exit_plan_mode.".into(),
                     ));
                 } else {
                     match isolations[index].expect("an isolated call has a class") {

--- a/crates/tidebreak-core/src/plan_mode.rs
+++ b/crates/tidebreak-core/src/plan_mode.rs
@@ -2,8 +2,10 @@
 //!
 //! A plan is a continuation, not a chat message: `exit_plan_mode` parks the
 //! foreground turn the way `ask_user_questions` does, and the user's decision
-//! completes the same tool call and resumes the blocked turn. Accepting is the
-//! one place a permission mode changes as a side effect — the chat leaves
+//! completes the same tool call and resumes the blocked turn. Plan mode itself
+//! does not park on `ask_user_questions` — a missing file or choice belongs in
+//! the plan as an assumption or first step. Accepting is the one place a
+//! permission mode changes as a side effect — the chat leaves
 //! [`crate::PermissionMode::Plan`] for the execution mode the decision names,
 //! so the resumed turn re-freezes its surface with execution tools.
 
@@ -176,7 +178,7 @@ pub fn validate_exit_plan_mode_arguments(arguments: &Value) -> bool {
 pub fn exit_plan_mode_tool_spec() -> ToolSpec {
     ToolSpec::for_args::<ExitPlanModeArgs>(
         EXIT_PLAN_MODE_TOOL,
-        "Pause the current plan-mode turn and present the finished plan for the user's decision. Call it once your exploration is complete and the plan is concrete, with the full plan in Markdown. Call this tool alone, with no assistant text or sibling tools. If the user accepts, the chat leaves plan mode and you execute the plan; if they send it back, revise using their feedback and submit again.",
+        "Pause the current plan-mode turn and present the finished plan for the user's decision. Call it once your exploration is complete and the plan is concrete, with the full plan in Markdown. If a needed file, choice, or other input is missing, record it as an assumption or first step in the plan rather than asking the user separately. Call this tool alone, with no assistant text or sibling tools. If the user accepts, the chat leaves plan mode and you execute the plan; if they send it back, revise using their feedback and submit again.",
     )
 }
 
@@ -259,5 +261,13 @@ mod tests {
         assert_eq!(result["decision"], "accepted");
         assert_eq!(result["permission_mode"], "ask");
         assert!(result["note"].as_str().unwrap().contains("left plan mode"));
+    }
+
+    #[test]
+    fn missing_inputs_belong_in_the_plan() {
+        let description = exit_plan_mode_tool_spec().description;
+        assert!(description.contains("missing"));
+        assert!(description.contains("assumption or first step"));
+        assert!(description.contains("rather than asking the user separately"));
     }
 }

--- a/crates/tidebreak-server/src/foreground_prompt.rs
+++ b/crates/tidebreak-server/src/foreground_prompt.rs
@@ -267,19 +267,19 @@ pub(crate) fn compose_for_surface(
         let mut lines = if names.is_empty() {
             vec![
                 "- This chat is in plan mode: design the approach, do not carry it out.",
-                "- Use the conversation to produce a concrete plan: the intended steps, what each one touches, and any open decisions the user should settle.",
+                "- Use the conversation to produce a concrete plan: the intended steps, what each one touches, and any open decisions the user should settle. A missing file, choice, or other input is an assumption or first step in the plan, not a question to park on.",
                 "- Do not present work as done, staged, or in progress. The plan is a proposal; execution happens only after the user accepts it or switches the chat out of plan mode.",
             ]
         } else {
             vec![
                 "- This chat is in plan mode: design the approach, do not carry it out. Every tool available this turn is read-only, and requests to modify anything will be refused until the user leaves plan mode.",
-                "- Explore with the available read-only tools until you understand the task, then produce a concrete plan: the intended steps, what each one touches, and any open decisions the user should settle.",
+                "- Explore with the available read-only tools until you understand the task, then produce a concrete plan: the intended steps, what each one touches, and any open decisions the user should settle. A missing file, choice, or other input is an assumption or first step in the plan, not a question to park on.",
                 "- Do not present work as done, staged, or in progress. The plan is a proposal; execution happens only after the user accepts it or switches the chat out of plan mode.",
             ]
         };
         if has(tidebreak_core::EXIT_PLAN_MODE_TOOL) {
             lines.push(
-                "- When the plan is ready, submit it with `exit_plan_mode` and stop; the user decides from there. If they send it back, revise it with their feedback and submit again.",
+                "- When the plan is ready, submit it with `exit_plan_mode` and stop; the user decides from there. If they send it back, revise it with their feedback and submit again. If something needed is missing, write it into the plan as an assumption or first step and submit that; do not wait for a separate answer.",
             );
         }
         push_section(&mut prompt, PLAN_MODE_HEADING, &lines);
@@ -1013,6 +1013,8 @@ mod tests {
 
         assert!(plan.contains(PLAN_MODE_HEADING));
         assert!(plan.contains("do not carry it out"));
+        assert!(plan.contains("assumption or first step"));
+        assert!(plan.contains("not a question to park on"));
         assert!(!normal.contains(PLAN_MODE_HEADING));
         // The flag adds exactly one section; every tool-derived section stays
         // keyed to the surface alone.
@@ -1535,6 +1537,29 @@ mod tests {
         assert!(prompt.contains("no assistant prose and no sibling tool calls"));
         assert!(prompt.contains("correct it by emitting only `ask_user_questions`"));
         assert!(prompt.contains("wait for the user's structured answer"));
+    }
+
+    #[test]
+    fn plan_mode_sends_missing_inputs_through_exit_plan_mode() {
+        let prompt = compose_for_surface(
+            &[spec("read_file"), spec(tidebreak_core::EXIT_PLAN_MODE_TOOL)],
+            &[],
+            &[],
+            &[],
+            &NetworkPolicy::default(),
+            TIMEOUT,
+            false,
+            None,
+            None,
+            true,
+        );
+
+        assert!(prompt.contains("assumption or first step"));
+        assert!(prompt.contains("not a question to park on"));
+        assert!(prompt.contains("write it into the plan"));
+        assert!(prompt.contains("`exit_plan_mode`"));
+        assert!(!prompt.contains(USER_QUESTIONS_HEADING));
+        assert!(!prompt.contains("`ask_user_questions`"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Plan mode was parking on `ask_user_questions` when a needed file or choice was missing. A headless `--permission-mode plan` driver can only decide a plan, so that continuation halted as `questions_undriven`.

- Refuse `ask_user_questions` in plan mode with a teachable decline that points at `exit_plan_mode`, matching the existing spawn/wait isolation.
- Withhold the tool from the plan-mode surface the same way `update_task_plan` is carved out: read-only by class, but it parks a continuation a plan driver cannot answer.
- Update the plan-mode prompt and `exit_plan_mode` spec so a missing file is an assumption or first step in the plan.

## Test plan

- [x] `cargo test -p tidebreak-core --locked --lib plan_mode_does_not_run_ask_user_questions`
- [x] `cargo test -p tidebreak-core --locked --lib plan_surface_advertises_only_read_only_tools`
- [x] `cargo test -p tidebreak-server --locked --lib foreground_prompt`
- [x] `cargo clippy -p tidebreak-core --locked --all-targets -- -D warnings`
- [x] `cargo clippy -p tidebreak-server --locked --all-targets -- -D warnings`

Closes #2114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Plan mode no longer offers or processes interactive questions.
  - Missing information is now handled as documented assumptions or initial plan steps.
  - Blocked question requests are declined without creating question cards or saved tool-call records.
  - Agents receive guidance to include missing inputs in the plan or exit plan mode.

- **Tests**
  - Added coverage verifying restricted plan-mode behavior and prompt guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->