### PR TITLE
fix(cli): attach images so the next turn can see them

### DIFF
--- a/crates/tidebreak-cli/src/api/client.rs
+++ b/crates/tidebreak-cli/src/api/client.rs
@@ -481,11 +481,24 @@ impl Client {
     }
 
     /// Accept a user message and queue its turn (`202`).
-    pub async fn post_message(&self, chat: ChatId, turn_id: TurnId, content: &str) -> Result<()> {
+    ///
+    /// `attachments` are image ids returned by [`Self::attach_image`]. An empty
+    /// slice is the ordinary text-only send.
+    pub async fn post_message(
+        &self,
+        chat: ChatId,
+        turn_id: TurnId,
+        content: &str,
+        attachments: &[uuid::Uuid],
+    ) -> Result<()> {
         let response = self
             .http
             .post(format!("{}/chats/{chat}/messages", self.base))
-            .json(&serde_json::json!({ "turn_id": turn_id, "content": content }))
+            .json(&serde_json::json!({
+                "turn_id": turn_id,
+                "content": content,
+                "attachments": attachments,
+            }))
             .send()
             .await
             .map_err(request_error)?;
@@ -700,7 +713,7 @@ impl Client {
         chat: ChatId,
         media_type: &str,
         bytes: Vec<u8>,
-    ) -> Result<String> {
+    ) -> Result<uuid::Uuid> {
         let response = self
             .with_local_import(
                 self.http
@@ -720,7 +733,7 @@ impl Client {
             .map_err(request_error)?;
         value["attachment_id"]
             .as_str()
-            .map(str::to_owned)
+            .and_then(|id| uuid::Uuid::parse_str(id).ok())
             .ok_or_else(|| AgentError::msg("image publish answered without an attachment id"))
     }
 

--- a/crates/tidebreak-cli/src/outputs.rs
+++ b/crates/tidebreak-cli/src/outputs.rs
@@ -10,7 +10,10 @@
 
 use std::path::{Path, PathBuf};
 
-use tidebreak_core::{AgentError, ChatId, OutputId, OutputRevisionId, Result};
+use tidebreak_core::{
+    AgentError, ChatId, OutputId, OutputRevisionId, Result, MAX_MESSAGE_ATTACHMENTS,
+};
+use uuid::Uuid;
 
 use crate::api::client::Client;
 use crate::api::wire::{OutputPreview, OutputRevisionRow, OutputSummary};
@@ -256,10 +259,9 @@ pub async fn attach(chat: ChatId, path: PathBuf, server: Server) -> Result<()> {
             .attach_image(chat, &media_type, bytes)
             .await
             .map_err(|error| local_import_error(client, error))?;
+        record_pending_image(chat, &attachment_id)?;
         println!("{attachment_id}");
-        eprintln!(
-            "tidebreak: published {title} as an image attachment; reference it from the next turn"
-        );
+        eprintln!("tidebreak: attached {title} as {media_type}");
     } else {
         let document_id = client
             .attach_document(chat, &title, &media_type, bytes)
@@ -281,4 +283,78 @@ fn local_import_error(client: &Client, error: AgentError) -> AgentError {
     } else {
         error
     }
+}
+
+/// Image ids `tidebreak attach` published for `chat` that the next `-p` turn
+/// has not yet submitted.
+pub(crate) fn pending_image_attachments(chat: ChatId) -> Result<Vec<Uuid>> {
+    let path = pending_images_path(chat)?;
+    let Some(bytes) = std::fs::read(&path).ok() else {
+        return Ok(Vec::new());
+    };
+    let ids = serde_json::from_slice::<Vec<Uuid>>(&bytes).map_err(|error| {
+        AgentError::msg(format!(
+            "could not read pending image attachments for {chat}: {error}"
+        ))
+    })?;
+    Ok(ids.into_iter().take(MAX_MESSAGE_ATTACHMENTS).collect())
+}
+
+pub(crate) fn clear_pending_image_attachments(chat: ChatId) -> Result<()> {
+    let path = pending_images_path(chat)?;
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(AgentError::msg(format!(
+            "could not clear pending image attachments for {chat}: {error}"
+        ))),
+    }
+}
+
+fn record_pending_image(chat: ChatId, attachment_id: &Uuid) -> Result<()> {
+    let mut ids = pending_image_attachments(chat)?;
+    if ids.contains(attachment_id) {
+        return Ok(());
+    }
+    if ids.len() >= MAX_MESSAGE_ATTACHMENTS {
+        return Err(AgentError::msg(format!(
+            "a message may carry at most {MAX_MESSAGE_ATTACHMENTS} image attachments"
+        )));
+    }
+    ids.push(*attachment_id);
+    write_pending_images(chat, &ids)
+}
+
+fn write_pending_images(chat: ChatId, ids: &[Uuid]) -> Result<()> {
+    let path = pending_images_path(chat)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| {
+            AgentError::msg(format!(
+                "could not write pending image attachments for {chat}: {error}"
+            ))
+        })?;
+    }
+    let encoded = serde_json::to_vec(ids).map_err(|error| {
+        AgentError::msg(format!(
+            "could not write pending image attachments for {chat}: {error}"
+        ))
+    })?;
+    let temporary = path.with_extension("tmp");
+    let write =
+        std::fs::write(&temporary, encoded).and_then(|()| std::fs::rename(&temporary, &path));
+    if write.is_err() {
+        let _ = std::fs::remove_file(&temporary);
+    }
+    write.map_err(|error| {
+        AgentError::msg(format!(
+            "could not write pending image attachments for {chat}: {error}"
+        ))
+    })
+}
+
+fn pending_images_path(chat: ChatId) -> Result<PathBuf> {
+    Ok(crate::profile_config()?
+        .data_dir
+        .join("pending-image-attachments")
+        .join(chat.to_string()))
 }

--- a/crates/tidebreak-cli/src/print.rs
+++ b/crates/tidebreak-cli/src/print.rs
@@ -213,7 +213,13 @@ async fn one_turn(
     // Subscribe before posting: the turn can start before this returns, and the
     // socket's replay only reaches back to the cursor it was opened at.
     let mut stream = Stream::open(client, chat).await?;
-    client.post_message(chat, turn_id, prompt).await?;
+    let attachments = crate::outputs::pending_image_attachments(chat)?;
+    client
+        .post_message(chat, turn_id, prompt, &attachments)
+        .await?;
+    if !attachments.is_empty() {
+        let _ = crate::outputs::clear_pending_image_attachments(chat);
+    }
     // Installed once the turn exists, and not before. Installing it earlier
     // would swallow signals over the handshake and the post — neither of which
     // watches the interrupt, and neither of which has a turn to cancel yet.

--- a/crates/tidebreak-cli/tests/serve.rs
+++ b/crates/tidebreak-cli/tests/serve.rs
@@ -398,13 +398,22 @@ fn a_scripted_tool_using_turn_completes_in_allow_mode() {
 /// authenticate. Both lines are printed only after the listener is bound, so
 /// this also synchronizes with a server ready to accept.
 fn spawn_serve(dir: &Path) -> (Reaper, String, String) {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_tidebreak"))
+    spawn_serve_with_env(dir, &[])
+}
+
+fn spawn_serve_with_env(dir: &Path, extra_env: &[(&str, &str)]) -> (Reaper, String, String) {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_tidebreak"));
+    command
         .arg("serve")
         .env("TIDEBREAK_DATA_DIR", dir)
         .env("TIDEBREAK_KEYCHAIN_MOCK", "1")
         .env_remove("TIDEBREAK_MCP_CONFIG")
         .env_remove("TIDEBREAK_SERVER_URL")
-        .env_remove("ANTHROPIC_API_KEY")
+        .env_remove("ANTHROPIC_API_KEY");
+    for (key, value) in extra_env {
+        command.env(key, value);
+    }
+    let mut child = command
         .stdout(Stdio::piped())
         .spawn()
         .expect("spawn tidebreak serve");
@@ -746,5 +755,134 @@ fn print_mode_rejects_an_unknown_model_before_the_turn() {
     assert!(
         stderr.to_lowercase().contains("model") || stderr.to_lowercase().contains("provider"),
         "stderr: {stderr}"
+    );
+}
+
+/// A well-formed 1×1 PNG. Dimensions come from the header, so the pixels do
+/// not need to be a real decode — they just have to sniff as `image/png`.
+fn one_pixel_png() -> Vec<u8> {
+    let mut bytes = b"\x89PNG\r\n\x1a\n".to_vec();
+    let mut ihdr = Vec::new();
+    ihdr.extend_from_slice(&1u32.to_be_bytes());
+    ihdr.extend_from_slice(&1u32.to_be_bytes());
+    ihdr.extend_from_slice(&[8, 6, 0, 0, 0]);
+    bytes.extend_from_slice(&png_chunk(b"IHDR", &ihdr));
+    bytes.extend_from_slice(&png_chunk(b"IDAT", &[]));
+    bytes.extend_from_slice(&png_chunk(b"IEND", &[]));
+    bytes
+}
+
+fn png_chunk(kind: &[u8; 4], data: &[u8]) -> Vec<u8> {
+    let mut payload = kind.to_vec();
+    payload.extend_from_slice(data);
+    let mut crc = 0xffff_ffffu32;
+    for byte in &payload {
+        crc ^= u32::from(*byte);
+        for _ in 0..8 {
+            let mask = (crc & 1).wrapping_neg();
+            crc = (crc >> 1) ^ (0xedb8_8320 & mask);
+        }
+    }
+    crc = !crc;
+    let mut chunk = (data.len() as u32).to_be_bytes().to_vec();
+    chunk.extend_from_slice(&payload);
+    chunk.extend_from_slice(&crc.to_be_bytes());
+    chunk
+}
+
+fn get_json(url: &str, token: &str, path: &str) -> serde_json::Value {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            reqwest::Client::new()
+                .get(format!("{url}{path}"))
+                .bearer_auth(token)
+                .send()
+                .await
+                .expect("GET")
+                .error_for_status()
+                .expect("the route answers 2xx")
+                .json::<serde_json::Value>()
+                .await
+                .expect("JSON body")
+        })
+}
+
+/// #2115: `tidebreak attach` of an image must land on the next `-p` user
+/// message. Publishing the blob is not enough — `GET /chats/{id}/messages`
+/// has to show it.
+#[test]
+fn attaching_an_image_lands_on_the_next_print_turn() {
+    let served = tempfile::tempdir().unwrap();
+    let elsewhere = tempfile::tempdir().unwrap();
+    let script = serde_json::json!([{"text": "saw the image"}]).to_string();
+    let (_server, url, token) =
+        spawn_serve_with_env(served.path(), &[("TIDEBREAK_SCRIPTED_PROVIDER", &script)]);
+    let chat = create_chat(&url, &token);
+
+    let source = elsewhere.path().join("dashboard.png");
+    std::fs::write(&source, one_pixel_png()).unwrap();
+    let attached = Command::new(env!("CARGO_BIN_EXE_tidebreak"))
+        .args(["attach", &chat])
+        .arg(&source)
+        .arg("--server")
+        .arg(&url)
+        .env("TIDEBREAK_SERVER_TOKEN", &token)
+        .env("TIDEBREAK_DATA_DIR", elsewhere.path())
+        .env("TIDEBREAK_KEYCHAIN_MOCK", "1")
+        .env_remove("TIDEBREAK_SERVER_URL")
+        .stdin(Stdio::null())
+        .output()
+        .expect("run attach");
+    let stderr = String::from_utf8_lossy(&attached.stderr).into_owned();
+    assert!(attached.status.success(), "stderr: {stderr}");
+    let attachment_id = String::from_utf8_lossy(&attached.stdout).trim().to_owned();
+    assert!(
+        uuid::Uuid::parse_str(&attachment_id).is_ok(),
+        "the published attachment id belongs on stdout, got {attachment_id:?}"
+    );
+    assert!(
+        stderr.contains("attached") && stderr.contains("image/png"),
+        "stderr: {stderr}"
+    );
+
+    let printed = Command::new(env!("CARGO_BIN_EXE_tidebreak"))
+        .args([
+            "-p",
+            "what is in this image",
+            "--chat",
+            &chat,
+            "--permission-mode",
+            "allow",
+            "--server",
+        ])
+        .arg(&url)
+        .env("TIDEBREAK_SERVER_TOKEN", &token)
+        .env("TIDEBREAK_DATA_DIR", elsewhere.path())
+        .env("TIDEBREAK_KEYCHAIN_MOCK", "1")
+        .env_remove("TIDEBREAK_SERVER_URL")
+        .stdin(Stdio::null())
+        .output()
+        .expect("run -p after attach");
+    let stdout = String::from_utf8_lossy(&printed.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&printed.stderr).into_owned();
+    assert!(
+        printed.status.success(),
+        "stdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let transcript = get_json(&url, &token, &format!("/chats/{chat}/messages"));
+    let images = &transcript["messages"][0]["image_attachments"];
+    assert_eq!(
+        images,
+        &serde_json::json!([{
+            "attachment_id": attachment_id,
+            "media_type": "image/png",
+            "width": 1,
+            "height": 1,
+        }]),
+        "transcript: {transcript}"
     );
 }


### PR DESCRIPTION
## Summary

`tidebreak attach <chat> <image>` printed success after `POST /chats/{id}/attachments/images`, but that route only publishes identity. The next `-p` turn posted a message with no `attachments`, so `GET /chats/{id}/messages` showed `image_attachments: []` and the model never received the pixels.

Documents already land because ingest creates a chat-owned source. Images have to ride the next user message.

## Change

- After a successful image publish, remember the attachment id on the profile (`pending-image-attachments/{chat}`).
- The next `tidebreak -p` on that chat submits those ids on `POST /chats/{id}/messages` and then clears them.
- Success copy now matches documents (`attached … as image/png`) instead of telling the caller to "reference it from the next turn."

## Test

`attaching_an_image_lands_on_the_next_print_turn` attaches a PNG through the CLI, runs `-p`, and asserts `GET /chats/{id}/messages` carries the image on the user message.

Closes #2115