### PR TITLE
docs(decisions): propose code mode design records

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -62,6 +62,9 @@ an accepted boundary.
   listing claims and how entries are maintained.
 - [Model providers and cross-provider replay](model-providers.md) — provider
   tiers, switching routes mid-conversation, and flatten-on-switch.
+- [Code mode](code-mode.md) — the proposed second product surface: repos,
+  worktree workspaces, and structured sessions over external coding-agent
+  harnesses.
 
 ## Interfaces, deployment, and operations
 

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -49,7 +49,8 @@ crates/tidebreak-core/src/db/ops/code/        repo.rs, workspace.rs, session.rs,
 crates/tidebreak-harness/                     protocol translation only
   src/lib.rs       HarnessAdapter + HarnessSession traits, SessionSpec, LaunchPlan,
                    adapter registry
-  src/probe.rs     login-shell PATH resolution, version detection, auth observation
+  src/probe.rs     interactive-login shell resolution + env capture (0034),
+                   version detection, auth observation
   src/budget.rs    bounded stream-parse budgets
   src/claude/      mod.rs, parse.rs, session.rs, approvals.rs
   src/codex/  src/opencode/  src/grok/        later phases
@@ -219,7 +220,11 @@ POST/GET        /code/workspaces           {repo_id, base_ref?, title?}
 GET/PATCH       /code/workspaces/{id}
 POST            /code/workspaces/{id}/archive        {force?}
 POST            /code/workspaces/{id}/sessions       {harness, permission_mode}
-POST            /code/sessions/{id}/turns            {message}  (steer/queue if running)
+POST            /code/sessions/{id}/turns            {message}  (queued while running —
+                                                     the chat product's queue-default rule;
+                                                     steering is the explicit alternative,
+                                                     available only where the adapter's
+                                                     mid_turn_steering capability carries it)
 POST            /code/sessions/{id}/interrupt | /permission-mode | /attention | /reap
 WS              /code/sessions/{id}/events?after=    snapshot → replay → live
 WS              /code/updates                        digests, restated on connect
@@ -304,5 +309,9 @@ new `PanelContent` variants).
 Recorded in [`docs/deferred.md`](deferred.md): running a harness in a PTY;
 bundled or pinned harness binaries; checkpoint restore (the refs land in
 v1; the restore surface does not); multiple sessions per workspace;
-an in-app code editor; chat↔code convergence (one inbox, shared projects);
+an in-app code editor; chat–code convergence (the single-surface end
+state: one conversation concept with an optional workspace binding,
+engines behind the adapter contract, no user-facing mode choice); remote
+session execution (the same harness in a managed sandbox feeding the same
+journal); a supervision-first mobile client over the updates channel;
 a per-repo worktree-location override; Windows support for code mode.

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -11,8 +11,12 @@ spin up isolated **workspaces** (one worktree + branch each), and run
 **sessions** — durable conversations with external coding-agent harnesses
 (Claude Code first; Codex CLI, opencode, and Grok CLI behind it) — supervised
 through a structured UI: conversation, tool activity, approvals, per-turn
-diffs, and a pull-request flow. The modes are separate today and deliberately
-shaped to converge later ([`0030`](decisions/0030-code-mode-separate-surface.md)).
+diffs, and a pull-request flow. The two-mode split is a delivery strategy:
+the destination is one surface where context selects behavior — a
+conversation bound to a workspace behaves code-like, one without is ordinary
+chat — and the adapter contract below is the runtime interface every engine,
+eventually including Tidebreak's own internal loop, sits behind
+([`0030`](decisions/0030-code-mode-separate-surface.md)).
 
 ## Vocabulary
 

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -1,0 +1,304 @@
+# Code mode
+
+Status: proposed design, pre-implementation. The decision records
+[`0030`](decisions/0030-code-mode-separate-surface.md) through
+[`0036`](decisions/0036-code-mode-auxiliary-terminals.md) carry the decisions;
+this page carries the working design detail an implementer needs in one
+place. Where this page and a decision record disagree, the record wins.
+
+Code mode is Tidebreak's second product surface: pick a local git repository,
+spin up isolated **workspaces** (one worktree + branch each), and run
+**sessions** — durable conversations with external coding-agent harnesses
+(Claude Code first; Codex CLI, opencode, and Grok CLI behind it) — supervised
+through a structured UI: conversation, tool activity, approvals, per-turn
+diffs, and a pull-request flow. The modes are separate today and deliberately
+shaped to converge later ([`0030`](decisions/0030-code-mode-separate-surface.md)).
+
+## Vocabulary
+
+| Noun | Meaning |
+|---|---|
+| repo | A registered local git repository: root path, default base ref, branch prefix, setup/archive scripts, quick actions. |
+| workspace | One isolated unit of work on a repo. Owns exactly one git worktree and one branch for life; carries PR state. |
+| session | One durable conversation with one harness inside a workspace. V1: one active session per workspace. |
+| turn | One user→agent cycle in a session, ending in a checkpoint. |
+| harness | The external coding-agent CLI being driven (never "provider"). |
+
+## Crate and module layout
+
+Dependencies flow downward per [`docs/crates.md`](crates.md):
+`tidebreak-core` ← `tidebreak-harness` ← `tidebreak-server` ← clients.
+
+```
+crates/tidebreak-core/src/code/
+  mod.rs         RepoId, WorkspaceId, CodeSessionId, CodeTurnId, CodeApprovalId,
+                 CodeTerminalId, HarnessKind — new id types, structurally like chat ids
+  event.rs       CodeEvent, SequencedCodeEvent (conventions of src/event.rs)
+  attention.rs   AttentionState, AttentionSource, should_replace
+  caps.rs        HarnessCaps, CapLevel, HarnessTier
+  permission.rs  CodePermissionMode { Plan, Ask, Auto } and its per-mode contract
+
+crates/tidebreak-core/src/db/entities.rs      six new entities (below)
+crates/tidebreak-core/src/db/ops/code/        repo.rs, workspace.rs, session.rs,
+                                              turn.rs, journal.rs, approval.rs
+
+crates/tidebreak-harness/                     protocol translation only
+  src/lib.rs       HarnessAdapter + HarnessSession traits, SessionSpec, LaunchPlan,
+                   adapter registry
+  src/probe.rs     login-shell PATH resolution, version detection, auth observation
+  src/budget.rs    bounded stream-parse budgets
+  src/claude/      mod.rs, parse.rs, session.rs, approvals.rs
+  src/codex/  src/opencode/  src/grok/        later phases
+  src/bin/capture.rs                          dev-only, feature = "capture"
+  fixtures/<harness>/<version>/               *.ndjson + manifest.toml + *.expected.json
+
+crates/tidebreak-server/src/code/
+  mod.rs             wiring
+  session_worker.rs  per-session task: lease + spawn-epoch, adapter session, event pump
+  worktree.rs        git shell-out: repo validation, worktree add/remove/prune/self-heal
+  checkpoint.rs      hidden refs, synthetic commits via temp index, bounded diffs
+  setup_script.rs    setup/archive hooks, failure-preserves-checkout
+  recovery.rs        boot scan, fencing, orphan probe, reap
+  attention.rs       server-side attention computation, digest publication
+  approval_bridge.rs the loopback approval-prompt endpoint glue and decision routing
+  gh.rs              gh CLI shell-out: commit/push/PR/checks, graceful absence
+  terminal.rs        PTY shells, ring buffers, cursor reads (0036)
+  bus.rs             per-session broadcast + install-wide updates channel
+crates/tidebreak-server/src/routes/code/      repos, workspaces, sessions,
+                                              session_events, updates, approvals,
+                                              diffs, git, terminals, harnesses
+crates/tidebreak-server/src/scripted_harness.rs   feature-gated fake adapter
+                                              (the scripted_provider.rs pattern)
+
+crates/tidebreak-desktop/ui/src/code/         the UI family (below)
+```
+
+New dependencies, all exact-pinned and lockfile-matching: one Rust
+pseudo-terminal crate (terminals only — the harness crate must not depend on
+it, enforced by a dependency check), and the terminal-emulator UI package
+pair. Nothing else: no git library, no editor component, no diff library
+(git produces diffs; the UI styles them), no virtualization until measured.
+
+## Data model
+
+Baseline schema edit plus a `DESKTOP_SCHEMA_EPOCH` bump, per
+[`0002`](decisions/0002-pre-v1-schema-and-persisted-format-mutability.md).
+
+- **`code_repo`** — `id`, `root_path` (unique, canonical toplevel),
+  `display_name`, `default_base_ref`, `branch_prefix`, `setup_script`,
+  `archive_script`, `quick_actions` (JSON array of
+  `{name, command, auto_run_on_create}`), `created_at`.
+- **`code_workspace`** — `id`, `repo_id`, `title`, `worktree_path`,
+  `branch_name`, `base_ref`, `status`
+  (`Creating | SetupFailed | Active | Archived`), `pr` (JSON digest:
+  number, url, state, checks summary; nullable), `created_at`,
+  `archived_at`.
+- **`code_session`** — `id`, `workspace_id`, `harness_kind`,
+  `harness_version` (observed at launch), `harness_resume_ref` (the
+  harness's own session/thread id for resume), `permission_mode`,
+  `lifecycle` (`Created | Idle | Running | Fenced | Ended`), `fence_reason`
+  (JSON, nullable), `child_pid`, `spawn_epoch`, `attention_state` (JSON),
+  `attention_source`, `unrecognized_event_count`, `created_at`.
+- **`code_turn`** — `id`, `session_id`, `ordinal`, `status`
+  (`Running | Completed | Failed | Interrupted`), `user_input` (inline or
+  blob reference when large), `checkpoint_ref`, `diffstat` (JSON), `usage`
+  (JSON, as reported by the harness), `narrative` (nullable; filled
+  asynchronously, never blocks lifecycle), `started_at`, `ended_at`.
+- **`code_event`** — `(session_id, seq)` primary key, `event` (JSON),
+  `created_at`. The journal. Appends are epoch-fenced: a write carrying a
+  stale `spawn_epoch` is rejected, so a superseded worker cannot corrupt the
+  stream (the `db/ops/turn/` claim discipline applied here).
+- **`code_approval`** — `id`, `session_id`, `turn_id`, `kind` (JSON,
+  normalized classification), `harness_raw` (JSON, size-capped), `state`
+  (`Pending | Approved | Denied`), `feedback`, `requested_at`,
+  `decided_at`.
+
+Boot recovery (`code/recovery.rs`, per
+[`0032`](decisions/0032-code-workspaces-worktrees-checkpoints.md)): sessions
+recorded `Running` are probed by recorded pid. Dead → the open turn closes
+as `Interrupted` (journaled), session `Idle`, attention
+`NeedsYou { source: Lifecycle }`. Alive → `Fenced { OrphanAlive }` until an
+explicit reap. Never signal a pid not recorded at spawn; `EPERM` counts as
+alive.
+
+## The adapter contract
+
+```rust
+#[async_trait]
+pub trait HarnessAdapter: Send + Sync {
+    fn kind(&self) -> HarnessKind;
+    /// Login-shell PATH resolution, version detection, auth observation.
+    /// Never reads or stores credentials (0034).
+    async fn probe(&self, host: &HostEnv) -> HarnessProbe;
+    /// Every capability flag stated for the probed version; `Unknown` is
+    /// legal, silence is not (0031).
+    fn capabilities(&self, probe: &HarnessProbe) -> HarnessCaps;
+    /// Spawn or connect for one session. The spec carries the worktree path,
+    /// permission mode, resume ref, approval-channel wiring, and event sink.
+    async fn launch(&self, spec: SessionSpec)
+        -> Result<Box<dyn HarnessSession>, HarnessError>;
+}
+
+#[async_trait]
+pub trait HarnessSession: Send {
+    /// Feed one user turn; normalized events flow to the sink until a
+    /// terminal turn event arrives.
+    async fn run_turn(&mut self, input: TurnInput) -> Result<(), HarnessError>;
+    /// Resolve a pending approval through the harness's native channel (0033).
+    async fn decide(&mut self, approval: HarnessApprovalRef,
+                    decision: ApprovalDecision) -> Result<(), HarnessError>;
+    async fn interrupt(&mut self) -> Result<(), HarnessError>;
+    fn resume_ref(&self) -> Option<String>;
+    async fn shutdown(self: Box<Self>) -> Result<(), HarnessError>;
+}
+```
+
+Process models the trait absorbs:
+
+- **Claude Code** — one print-mode child per turn: streamed JSON output and
+  input, partial-message deltas on, resuming by the session id the stream
+  reports. Approvals via the permission-prompt tool over a loopback MCP
+  endpoint with a session-scoped token.
+- **Codex CLI** — a long-lived JSON-RPC server child (preferred; its
+  approval methods are the richer channel) or the JSONL exec mode with
+  resume, whichever the fixture spike proves stable on the installed
+  version.
+- **opencode** — a long-lived server child driven over HTTP with its event
+  stream; permissions over its permission API.
+- **Grok CLI** — best-effort tier; capabilities honestly `Unsupported` or
+  `Unknown` where its surface does not carry them.
+
+All children are pipe-based `tokio::process` with `kill_on_drop`, the
+user's environment minus Tidebreak internals
+([`0034`](decisions/0034-harness-discovery-credentials.md)), and bounded
+read budgets (fixed-size chunks, capped per tick, overflow counted and
+surfaced — parsing must be O(new bytes) and must never fall behind the
+terminal-rendering path).
+
+The exact flag strings, event schemas, and approval payload shapes per
+harness are established by the fixture-capture spike and recorded in the
+fixture manifests — deliberately not transcribed here, so this page cannot
+drift from captured reality
+([`0031`](decisions/0031-harness-adapter-boundary.md)).
+
+## The event vocabulary
+
+`CodeEvent` (journal payload; internally tagged, `#[non_exhaustive]`,
+bounded):
+
+| Variant | Carries |
+|---|---|
+| `SessionStarted` | harness kind, version, resume ref |
+| `TurnStarted` | turn id |
+| `AssistantDelta` / `AssistantMessage` | streamed or whole assistant text |
+| `ReasoningDelta` | streamed thinking text where the harness reports it |
+| `ToolStarted` | call id, name, `ToolDetail` (`Command {cmd, cwd}` \| `FileEdit {path}` \| `FileRead {path}` \| `Search {query}` \| `Other {summary}`) |
+| `ToolCompleted` | call id, outcome, bounded preview |
+| `FileChanged` | path, change kind, diffstat |
+| `ApprovalRequested` | approval id (hint; body loads from the approvals route) |
+| `ApprovalResolved` | approval id, decision |
+| `UserSteered` | the user's mid-turn message |
+| `TurnCompleted` | usage, checkpoint info |
+| `TurnFailed` | bounded error |
+| `TurnInterrupted` | — |
+| `CheckpointRecorded` | turn id, diffstat |
+| `HarnessNotice` | level, message — the visible-degradation channel |
+| `AttentionChanged` | state, source |
+
+## Server API surface
+
+```
+POST/GET        /code/repos                GET/PATCH/DELETE /code/repos/{id}
+GET             /code/harnesses            doctor    POST /code/harnesses/refresh
+
+POST/GET        /code/workspaces           {repo_id, base_ref?, title?}
+GET/PATCH       /code/workspaces/{id}
+POST            /code/workspaces/{id}/archive        {force?}
+POST            /code/workspaces/{id}/sessions       {harness, permission_mode}
+POST            /code/sessions/{id}/turns            {message}  (steer/queue if running)
+POST            /code/sessions/{id}/interrupt | /permission-mode | /attention | /reap
+WS              /code/sessions/{id}/events?after=    snapshot → replay → live
+WS              /code/updates                        digests, restated on connect
+
+GET             /code/approvals?state=pending
+POST            /code/approvals/{id}/decision        {approve | deny, feedback?}
+POST            /code/mcp/approval-prompt            loopback approval endpoint (0033)
+
+GET             /code/workspaces/{id}/files          changed files vs base, per-turn filter
+GET             /code/workspaces/{id}/diff?turn=&file=   bounded unified diff
+POST            /code/workspaces/{id}/git/commit | /git/push | /git/pr
+GET             /code/workspaces/{id}/pr             PR + checks digest (gh; graceful absence)
+POST            /code/workspaces/{id}/actions/{name} quick action; output journaled
+
+POST/GET/DELETE /code/workspaces/{id}/terminals
+GET             /code/workspaces/{id}/terminals/{tid}/read?cursor=
+POST            /code/workspaces/{id}/terminals/{tid}/write | /resize
+```
+
+The session worker is the only journal writer for its session, under a
+lease and the spawn epoch; routes submit work and read state, they never
+write the journal directly.
+
+Pull-request operations shell out to the user's `gh` (auth observed, never
+brokered — the [`0034`](decisions/0034-harness-discovery-credentials.md)
+boundary applies to `gh` exactly as to harnesses). Absent or signed-out
+`gh` degrades to copyable instructions, never to a broken button.
+
+## UI
+
+Routes (code-defined, hash history, in `ui/src/router.tsx`): `/code` (repo
+rail, doctor-driven empty state), `/code/r/$repoId` (workspace list,
+new-workspace flow, repo settings), `/code/w/$workspaceId` (the main
+surface; files, diff, and terminal open through the existing panel system —
+new `PanelContent` variants).
+
+`ui/src/code/`:
+
+- `CodeSidebar.tsx` on the existing sidebar frame and primitives: repos,
+  recent workspaces with attention badges, the mode switch back to chat.
+- `CodeUpdatesStore.ts` — one singleton store fed by `/code/updates`;
+  everything list-shaped reads from it.
+- `CodeSessionRegistry.ts` — `Map<sessionId, {store, controller, refCount}>`
+  of per-session stores from a `createCodeSessionStore()` factory; only
+  mounted session views hold event sockets. This is the chat store factory
+  generalized from one pinned instance to N.
+- `CodeSessionReducer.ts` — pure
+  `(state, SequencedCodeEvent) => {state, effects}` in the chat reducer's
+  exact shape.
+- Transcript from shared components: existing markdown rendering for
+  assistant text, existing tool-card chrome for tool events with a
+  code-mode `ToolDetail` renderer; new `CodeApprovalCard` (chat's approval
+  visual language, deny opens a feedback field), `TurnReviewCard`
+  (diffstat, duration, async narrative slot), `CodeComposer` (text,
+  permission-mode selector, interrupt), `PrCard` (status-quad chips),
+  `DiffPanel`/`FilesPanel` (server-produced unified diffs styled with the
+  semantic status tokens; per-file grouping; per-turn anchoring),
+  `TerminalPane` (ephemeral renderer over the cursor-read API; replays
+  recent bytes on mount; chunked writes on a frame budget).
+- Settings: one new section, "Coding harnesses" — the doctor.
+- Wire: generated types plus hand-written validators in
+  `ui/src/code/parsers.ts`, per [`docs/wire-types.md`](wire-types.md).
+
+## Testing
+
+- Adapter parsers: fixture replay only
+  ([`0031`](decisions/0031-harness-adapter-boundary.md)); fixtures are
+  re-captured on harness version bumps, and that procedure lives in
+  `crates/tidebreak-harness/fixtures/README.md`.
+- Orchestration and routes: driven end to end against the scripted harness
+  (turn lifecycle, WS replay, approvals round-trip including
+  deny-with-feedback, interrupt, recovery matrix).
+- Git: integration tests against throwaway temp repos.
+- UI: reducer unit tests; DOM tests for transcript, approval card, and
+  registry reference counting.
+- Live harnesses cannot run in CI. Env-gated smoke tests
+  (`TIDEBREAK_LIVE_HARNESS=1`, ignored by default) plus a per-adapter
+  manual smoke checklist cover the real thing before an adapter ships.
+
+## What v1 excludes
+
+Recorded in [`docs/deferred.md`](deferred.md): running a harness in a PTY;
+bundled or pinned harness binaries; checkpoint restore (the refs land in
+v1; the restore surface does not); multiple sessions per workspace;
+an in-app code editor; chat↔code convergence (one inbox, shared projects);
+a per-repo worktree-location override; Windows support for code mode.

--- a/docs/decisions/0030-code-mode-separate-surface.md
+++ b/docs/decisions/0030-code-mode-separate-surface.md
@@ -109,9 +109,25 @@ Gratuitous divergence — a different streaming idiom, a different settings
 mechanism, a private design language — is out of bounds without a decision
 record explaining why the shared shape cannot serve.
 
-Deliberately excluded from this record: the unification itself (one inbox, one
-project tree, chats that drive code sessions). That is a future record built
-on two proven models; this record's job is to keep it cheap.
+**The destination is one surface, and the engine slot is the primary
+abstraction.** The mode split is a delivery strategy, not the intended end
+state. The product Tidebreak is steering toward has no user-facing mode
+choice at all: a conversation bound to a repo-backed workspace behaves
+code-like, and a conversation without one is ordinary chat — context selects
+behavior. In that end state the adapter contract of
+[`0031`](0031-harness-adapter-boundary.md) is the product's runtime
+interface, and Tidebreak's internal agent loop holds no privileged seat: it
+is one engine implementation among several, selected where its capabilities
+(document work, brokered host access, outputs) are the honest best fit, with
+the same capability-flag honesty rules that govern external harnesses.
+Design choices in either mode should be tested against that destination:
+a feature that assumes the internal loop is special, or that the two
+surfaces are permanent, is going the wrong way.
+
+Deliberately excluded from this record: the unification itself (one inbox,
+one conversation concept with optional workspace binding, engines selected
+per conversation). That is a future record built on two proven models; this
+record's job is to keep it cheap.
 
 ## Alternatives Considered
 
@@ -154,11 +170,12 @@ choices (user-visible worktrees), because the two never share a data path.
 New tables are a baseline schema change and advance the desktop schema epoch
 per [`0002`](0002-pre-v1-schema-and-persisted-format-mutability.md).
 
-Revisit this decision when both models are proven and users are asking for the
-other mode's surfaces — one inbox across chats and code sessions, code
-workspaces inside chat projects, or a chat that can drive a code session. The
-convergence constraints above are the measure of whether this record did its
-job: unification should require merging structures, not translating them.
+Revisit this decision when both models are proven and the unification can
+begin: one conversation concept with an optional workspace binding, engines
+selected per conversation behind the adapter contract, and no user-facing
+mode choice. The convergence constraints above are the measure of whether
+this record did its job: unification should require merging structures, not
+translating them.
 
 ## Validation
 

--- a/docs/decisions/0030-code-mode-separate-surface.md
+++ b/docs/decisions/0030-code-mode-separate-surface.md
@@ -1,0 +1,179 @@
+# 30. Code Mode Is a Separate Surface Built for Later Convergence
+
+- Status: Proposed
+- Date: 2026-08-15
+- Owners: code mode
+- Related: [`0007-cli-headless-feature-parity.md`](0007-cli-headless-feature-parity.md),
+  [`0002-pre-v1-schema-and-persisted-format-mutability.md`](0002-pre-v1-schema-and-persisted-format-mutability.md),
+  [`docs/code-mode.md`](../code-mode.md)
+
+## Context
+
+Tidebreak's existing product is a conversation-first coworker: a chat owns a
+private scratch workspace, the foreground agent loop drives a configured model
+provider, and every capability (documents, outputs, folders, approvals) is
+shaped around that loop. The workspace path is deliberately never shown to the
+user; host files reach execution only through brokered folder grants.
+
+Coding work inverts several of those assumptions. Developers already run
+dedicated coding-agent CLIs — Claude Code, Codex CLI, Grok CLI, opencode — that
+own their own agent loops, tool sets, permission systems, and billing
+identities. What they lack is an interface: parallel sessions are a pile of
+terminal tabs, nothing distinguishes "waiting on you" from "working" from
+"done an hour ago", and reviewing what an agent actually changed means leaving
+the tool. Tidebreak wants to be that interface: pick a repository, spin up
+isolated sessions, and supervise them through a structured UI — conversation,
+tool activity, approvals, diffs, and a pull-request flow — rather than through
+raw terminals.
+
+The forces:
+
+- A coding session's engine is an external process with a foreign lifecycle,
+  not Tidebreak's own agent loop. Its workspace is a real git worktree the
+  user must be able to open, build in, and eventually merge — the opposite of
+  a hidden scratch directory.
+- The chat data model is deeply coupled to the internal loop: turns assume
+  provider steps, approvals assume the internal tool registry, documents and
+  outputs assume conversation-owned files. Overloading those types would force
+  every chat feature to answer "what does this mean for code?" from day one.
+- The two products should nevertheless become one coherent coworker over time.
+  A user who delegates a spreadsheet and a refactor should eventually get one
+  inbox, one attention surface, and one way to organize work. Divergence that
+  makes that future harder is a defect even while the modes are separate.
+- [`0007`](0007-cli-headless-feature-parity.md) establishes that the server
+  API is the product surface. A second product surface does not change that
+  rule.
+
+## Decision
+
+Tidebreak gains a second mode, **Code**, as a separate product surface whose
+internals are deliberately shaped for later convergence with chat.
+
+**Separate now:**
+
+- **Its own route family.** The desktop UI serves code mode under `/code/...`
+  with its own sidebar; the chat surface is unchanged. A persistent rail
+  affordance switches modes.
+- **Its own vocabulary.** The nouns are **repo**, **workspace**, **session**,
+  and **turn**:
+  - A *repo* is a user-registered local git repository: root path, default
+    base ref, branch prefix, setup and archive scripts, quick actions.
+  - A *workspace* is one isolated unit of work on a repo. It owns exactly one
+    git worktree and one branch for its whole life, and carries the
+    pull-request state for that branch.
+  - A *session* is one durable conversation with one external coding harness,
+    running inside a workspace. V1 permits one active session per workspace;
+    the model keeps room for follow-up and successor sessions.
+  - A *turn* is one user→agent cycle within a session, ending in a
+    checkpoint.
+  - The word *harness* names the external CLI being driven. It is not called
+    a provider — providers are model routes; a harness is a whole agent.
+  "Project" is deliberately not used: that noun already names the chat
+  product's project entity and must not acquire a second meaning.
+- **Its own tables and journal.** Code-mode state persists in new tables with
+  new id spaces. No chat table gains a code-mode column, no code table
+  references a `ChatId` or `TurnId`, and code sessions never appear in chat
+  lists or routes. The code journal is a separate table.
+- **Server-API-first.** Every code-mode capability lands as a
+  `tidebreak-server` route or WebSocket channel; the desktop UI and the CLI
+  are clients. Native-only concerns (a directory picker for repo
+  registration) follow the existing closed Tauri command allowlist rules.
+
+**Convergent by design.** Wherever the two modes need the same *kind* of
+thing, code mode adopts the chat mode's existing shape rather than inventing a
+sibling, so that a future unification is a mechanical merge instead of a
+translation layer:
+
+- The code journal uses the same event-table shape, sequencing rule,
+  journal-before-live-publication discipline, and WebSocket
+  snapshot→replay→live contract as the chat journal. A future unified journal
+  is a table merge, not a protocol negotiation.
+- The permission vocabulary reuses the chat product's mode names and meanings
+  (`Plan`, `Ask`, and an automatic tier) rather than a harness-flavored
+  synonym set.
+- The attention model introduced for code sessions
+  ([`0035`](0035-code-mode-wire-contract.md)) is defined over "a unit of
+  supervised work", not over code sessions specifically, so chat can adopt it
+  later without renaming.
+- Inbox-shaped items (pending approvals, fenced sessions, review-ready turns)
+  are modeled so they can appear in the existing cross-chat Inbox when the
+  modes align; in v1 they surface only in code-mode UI, but the wire shape is
+  not code-private in ways that would block that.
+- UI building blocks are shared components (tool cards, approval cards,
+  markdown rendering, panel system, sidebar primitives), not forks.
+- Id types are distinct (so the separation is enforceable) but structurally
+  identical to chat ids, and all wire types ride the same generated-types
+  pipeline.
+
+Gratuitous divergence — a different streaming idiom, a different settings
+mechanism, a private design language — is out of bounds without a decision
+record explaining why the shared shape cannot serve.
+
+Deliberately excluded from this record: the unification itself (one inbox, one
+project tree, chats that drive code sessions). That is a future record built
+on two proven models; this record's job is to keep it cheap.
+
+## Alternatives Considered
+
+**Extend the chat model now.** Add a session kind to chats and reuse messages,
+turns, and approvals. Rejected: a chat turn is an internal provider loop with
+provider steps and registry-bound tool calls; a code turn is a foreign process
+emitting a foreign protocol. Every shared invariant would need a carve-out,
+and each mode's changes would put the other in their blast radius exactly
+while code mode is at its most experimental.
+
+**Full separation with no convergence constraints.** Let code mode pick
+whatever shapes are locally convenient. Rejected: the modes are one product to
+the user, and every locally convenient divergence (a second streaming idiom, a
+second permission vocabulary) becomes a translation layer in the unification
+we already intend.
+
+**A separate application.** Rejected: duplicates the server, keychain,
+settings, design system, packaging, and update channel for no isolation
+benefit the route/table separation does not already provide.
+
+**Root the vocabulary in "projects".** Rejected: guaranteed collision with the
+existing project entity in code, wire types, and UI copy; code mode's natural
+root object is a git repository.
+
+**Do nothing** (leave coding workflows in terminals outside Tidebreak).
+Rejected: supervising parallel coding agents is exactly the
+attention-and-review problem Tidebreak's structured surfaces exist for.
+
+## Consequences
+
+Two products share one shell. Some duplication is accepted knowingly — code
+mode gets its own approval records, its own event enum, its own sidebar
+sections — but each duplicate is required to be shape-compatible with its chat
+counterpart, which constrains code-mode design freedom on purpose.
+
+The separation is load-bearing for safety: chat-mode invariants (brokered host
+access, hidden workspace paths) are not weakened by code mode's opposite
+choices (user-visible worktrees), because the two never share a data path.
+
+New tables are a baseline schema change and advance the desktop schema epoch
+per [`0002`](0002-pre-v1-schema-and-persisted-format-mutability.md).
+
+Revisit this decision when both models are proven and users are asking for the
+other mode's surfaces — one inbox across chats and code sessions, code
+workspaces inside chat projects, or a chat that can drive a code session. The
+convergence constraints above are the measure of whether this record did its
+job: unification should require merging structures, not translating them.
+
+## Validation
+
+- A repository check (test over the entity definitions) that no chat entity
+  references a code-mode table or id type and no code-mode entity references
+  a chat table or id type.
+- Route tests that `/code/*` routes reject chat ids and chat routes reject
+  code-mode ids rather than resolving them.
+- A UI test that the code-mode route family renders without initializing chat
+  session stores, and vice versa.
+- Convergence checks: the code events WebSocket passes the same
+  replay/reconnect test shape as the chat events route; the code permission
+  enum's variants are a subset of names shared with the chat vocabulary; code
+  inbox-shaped wire types carry no field that hard-codes a code-only id as
+  their display identity.
+- A plausible wrong implementation would pass all chat tests while quietly
+  foreign-keying code sessions into the chat `event` table; the entity check
+  above must fail it.

--- a/docs/decisions/0031-harness-adapter-boundary.md
+++ b/docs/decisions/0031-harness-adapter-boundary.md
@@ -1,0 +1,148 @@
+# 31. Harness Adapters: One Normalized Event Vocabulary Behind a Per-Harness Boundary
+
+- Status: Proposed
+- Date: 2026-08-15
+- Owners: code mode, harness integration
+- Related: [`0030-code-mode-separate-surface.md`](0030-code-mode-separate-surface.md),
+  [`0033-code-mode-approvals.md`](0033-code-mode-approvals.md),
+  [`docs/model-providers.md`](../model-providers.md),
+  [`docs/code-mode.md`](../code-mode.md)
+
+## Context
+
+Code mode drives external coding-agent CLIs — Claude Code, Codex CLI, Grok
+CLI, opencode. Each speaks its own machine-readable protocol: Claude Code
+emits a newline-delimited JSON stream in print mode and accepts streamed JSON
+input; Codex CLI has a JSONL exec mode and a long-lived JSON-RPC server mode;
+opencode exposes an HTTP server with an event stream; Grok CLI's surface is
+the youngest and least settled. All of them revise these protocols on their
+own release cadences, without notice to us.
+
+Two failure modes are known from prior art in this category and must be
+designed out:
+
+1. **Parsers written from assumption.** It is easy to write a parser against
+   what a protocol *plausibly* emits — documentation, a changelog, memory —
+   and ship code that never matches a real byte stream. Such a parser fails
+   silently: the product degrades to whatever its fallback is, and nobody
+   notices because nothing errors.
+2. **Terminal scraping.** Driving the interactive TUI through a
+   pseudo-terminal and inferring state from redrawn screen bytes caps the
+   product permanently: no structured conversation, no reliable approval
+   detection, no durable history, prompt delivery by timing heuristics.
+
+Meanwhile Tidebreak already has a written philosophy for exactly this shape of
+problem: [`docs/model-providers.md`](../model-providers.md) tiers providers,
+requires capability flags to say honestly what works where, and forbids
+silent degradation. The same philosophy applies one level up, to whole
+agents.
+
+## Decision
+
+Every harness is wrapped by an **adapter** in a dedicated crate,
+`tidebreak-harness`, that translates the harness's native machine-readable
+protocol into one normalized vocabulary, `CodeEvent`, defined in
+`tidebreak-core` alongside the domain model. Orchestration, persistence, and
+UI consume only `CodeEvent`; nothing above the adapter parses harness-native
+bytes. Harnesses are driven exclusively through their non-interactive,
+machine-readable modes — never through a pseudo-terminal
+([`0036`](0036-code-mode-auxiliary-terminals.md) covers the one PTY in the
+product, which is for the user's shells, not the harness).
+
+Three rules are part of the decision, each with an enforcement:
+
+1. **Fixtures before parsers.** A parser for a harness protocol may only be
+   written or modified against captured streams from a real CLI invocation,
+   checked into `crates/tidebreak-harness/fixtures/<harness>/<version>/`
+   together with a manifest recording the exact invocation and any redaction.
+   Every parser test replays fixtures and asserts the exact normalized event
+   sequence. A parser change with no fixture change is a review defect.
+2. **Explicit capabilities.** Each adapter states a `HarnessCaps` value for
+   every capability flag — resume, streaming deltas, structured approvals,
+   mid-turn steering, plan mode, reasoning levels, native file-change events,
+   native interrupt — as `Supported`, `Unsupported`, or `Unknown`. The struct
+   is constructed exhaustively (no `Default`), so adding a flag forces every
+   adapter to answer. An unsupported capability degrades *visibly* in the
+   product (a stated limitation, a disabled control with a reason), never
+   silently.
+3. **Version-detect, don't assume.** Adapters probe the installed CLI's
+   version and select parsing behavior accordingly. An unknown newer version
+   runs in best-effort mode with unrecognized-event *counting* — a counter
+   surfaced in the session UI and the harness doctor page — never silent
+   dropping. Raw unrecognized payloads go to a size-capped per-session debug
+   log for later fixture capture; they never enter the journal.
+
+Adapters are tiered like model providers: Claude Code is the reference tier
+and every code-mode feature must work there; Codex CLI is second; opencode
+third; Grok CLI is best-effort. A feature that cannot be expressed for a
+harness gets a per-adapter decision, even when that decision is "not
+supported here", recorded in the caps value.
+
+`CodeEvent` follows the chat journal's conventions exactly — internally
+tagged serde enum, `#[non_exhaustive]`, bounded payloads with hint events
+pointing at renderer-safe routes for anything large — so the two journals
+stay convergent per [`0030`](0030-code-mode-separate-surface.md).
+
+Deliberately excluded: a plugin or out-of-process adapter API. Adapters are
+in-tree Rust; a third-party harness lands as a PR, not a plugin, until the
+contract has survived several first-party adapters.
+
+## Alternatives Considered
+
+**Drive the interactive TUIs through a PTY and scrape output.** Rejected as a
+foundation for the reasons above: it forfeits structure permanently and makes
+approvals, resume, and steering heuristic. (A PTY escape hatch for running a
+harness interactively is separately deferred, not designed here.)
+
+**Per-harness product surfaces.** Let each harness ship its own view and
+semantics. Rejected: N harnesses × M features with no shared approval or
+attention surface, and the UI would encode protocol details the adapter
+boundary exists to contain.
+
+**Define `CodeEvent` in `tidebreak-harness`.** Rejected: the journal persists
+these events, and persistence contracts live where the store lives, in
+`tidebreak-core`. The harness crate depends on core, not the reverse.
+
+**One generic "JSON-lines adapter" configured per harness.** Rejected: the
+protocols differ structurally (NDJSON child per turn vs long-lived JSON-RPC vs
+HTTP+SSE), and a configuration language expressive enough to bridge that is a
+worse programming language.
+
+**Trust documentation instead of fixtures.** Rejected: the documented streams
+in this category have already diverged from shipped behavior within single
+release cycles, and a wrong parser fails silently.
+
+## Consequences
+
+A new crate joins the workspace with an unusual test asset: captured protocol
+fixtures that must be re-captured when harness versions move. That is a
+maintenance cost accepted deliberately — it converts "the parser silently
+rotted" into "a fixture capture is stale", which is visible and mechanical.
+Fixture capture requires a machine with the real CLIs installed and
+authenticated; CI replays fixtures but cannot capture them.
+
+The adapter boundary makes protocol drift a bounded, per-adapter event. It
+also means code mode's feature ceiling per harness is set by that harness's
+machine-readable surface; where a harness offers less than its TUI does, code
+mode says so rather than faking it.
+
+Revisit this decision if a cross-harness standard protocol emerges and at
+least two of our harnesses speak it natively, or if an adapter's protocol
+churns so fast that fixtures cannot keep up — the latter would argue for
+demoting that harness a tier, not for weakening the rules.
+
+## Validation
+
+- Fixture-replay tests per adapter asserting exact `CodeEvent` sequences,
+  including at least: a plain text turn, a tool-using turn, an approval
+  request with both outcomes, resume, interrupt, and an error/limit case.
+- A repository check that every adapter module has a corresponding fixtures
+  directory with a manifest.
+- The exhaustive-construction property of `HarnessCaps` (no `Default` impl;
+  a unit test constructs it and the compiler enforces completeness).
+- A serde round-trip and variant-stability test on `CodeEvent` mirroring the
+  chat event enum's test.
+- An unrecognized-event test: feeding a stream containing unknown event types
+  increments the surfaced counter and drops nothing else on the floor.
+- A plausible wrong implementation parses fixtures correctly but quietly
+  discards unknown lines; the counting test above must fail it.

--- a/docs/decisions/0031-harness-adapter-boundary.md
+++ b/docs/decisions/0031-harness-adapter-boundary.md
@@ -78,6 +78,14 @@ third; Grok CLI is best-effort. A feature that cannot be expressed for a
 harness gets a per-adapter decision, even when that decision is "not
 supported here", recorded in the caps value.
 
+The contract is engine-neutral on purpose. Nothing in the traits, the event
+vocabulary, or the capability flags may assume the engine is a *coding*
+agent: [`0030`](0030-code-mode-separate-surface.md) names a destination in
+which Tidebreak's own internal loop is one more implementation of this
+contract, selected where its capabilities are the best fit. A proposed
+addition to the contract that only makes sense for code is a smell to
+resolve in review, not a convenience to accept.
+
 `CodeEvent` follows the chat journal's conventions exactly — internally
 tagged serde enum, `#[non_exhaustive]`, bounded payloads with hint events
 pointing at renderer-safe routes for anything large — so the two journals

--- a/docs/decisions/0032-code-workspaces-worktrees-checkpoints.md
+++ b/docs/decisions/0032-code-workspaces-worktrees-checkpoints.md
@@ -1,0 +1,165 @@
+# 32. Workspaces: Worktrees, Branches, and Per-Turn Checkpoints via Git Shell-Out
+
+- Status: Proposed
+- Date: 2026-08-15
+- Owners: code mode
+- Related: [`0030-code-mode-separate-surface.md`](0030-code-mode-separate-surface.md),
+  [`0035-code-mode-wire-contract.md`](0035-code-mode-wire-contract.md),
+  [`docs/code-mode.md`](../code-mode.md)
+
+## Context
+
+A code-mode workspace must give a coding agent an isolated place to work on a
+real repository: the user's checkout must never be disturbed, several
+workspaces must coexist on one repo, and the result must be an ordinary branch
+the user can review, push, and merge. Git worktrees are the native mechanism
+for exactly this.
+
+Tidebreak has no git integration today — no library dependency, no shell-out,
+no repo model. Whatever this record chooses is the foundation everything else
+(diffs, review, the PR flow) stands on.
+
+Review needs more than "the diff so far": a session that runs for ten turns
+needs *turn-scoped* diffs — what did this turn change — which requires
+recording the worktree state at each turn boundary without polluting the
+branch history the user will eventually open as a pull request.
+
+Two operational realities constrain the design. First, users' git
+environments are configured: credential helpers, `core.hooksPath`, sparse
+checkout, LFS, custom drivers. An embedded git implementation sees none of
+that configuration the way the user's own `git` binary does. Second, the
+server process can crash or be killed while harness children are alive;
+recovery must never destroy user work.
+
+## Decision
+
+**Git runs as the user's own `git` binary via shell-out.** Tidebreak takes no
+git library dependency. Every git operation is a bounded, non-interactive
+subprocess (`GIT_TERMINAL_PROMPT=0`, explicit timeouts, captured output) with
+arguments built as an argv array, never a shell string.
+
+**Repos.** Registering a repo validates it with
+`git rev-parse --show-toplevel`, canonicalizes to the toplevel, and refuses
+bare repositories and nested registrations of the same toplevel. A repo
+carries: display name, default base ref, branch prefix (default
+`tidebreak/`), optional setup and archive scripts, and quick actions (named
+commands the user can run in a workspace).
+
+**Workspaces.** Creating a workspace creates a worktree and branch in one
+step: `git worktree add -b <branch> <path> <base>`, with the worktree rooted
+under the Tidebreak data directory at
+`code/worktrees/<repo-slug>/<workspace-slug>/` — never inside the user's
+repository. Branch names are the repo's prefix plus a slug of the workspace
+title, with generated two-word fallback names when untitled; a branch
+collision is a user-visible error, not an auto-suffix. After creation the
+worktree is verified (`git rev-parse --is-inside-work-tree`); a half-created
+worktree is removed and the creation fails cleanly. The setup script, if any,
+then runs inside the worktree; a setup failure preserves the checkout, marks
+the workspace `SetupFailed`, and requires an explicit user choice to continue
+anyway or destroy.
+
+**Checkpoints.** Every completed turn records the worktree's full state —
+tracked changes and untracked files — as a synthetic commit created through a
+temporary index file, referenced by a hidden ref
+`refs/tidebreak/checkpoints/<workspace>/<turn>`. The user's index, `HEAD`,
+and reflog are untouched; no visible commit appears on the branch. Checkpoints
+give three read paths: the diff of one turn
+(`checkpoint(n-1)..checkpoint(n)`), the workspace diff against base
+(`merge-base(base, HEAD)..worktree`, including uncommitted state), and a
+future restore path (out of scope here; the refs make it possible). Diffs are
+produced server-side and bounded — capped in bytes and file count, truncation
+explicitly marked — and the renderer never runs git.
+
+**Archive.** Archiving a workspace runs the archive script (same
+failure-preserves rule as setup), checks for uncommitted or unpushed work and
+requires an explicit `force` to discard any, then
+`git worktree remove` (tolerating already-gone), `git worktree prune`, and
+checkpoint-ref cleanup. The branch is kept unless the user asked to delete
+it.
+
+**Crash recovery is conservative.** Session rows persist the harness child
+pid and a per-spawn epoch. On boot, a session recorded as running is probed:
+child dead → the open turn is closed as interrupted (journaled) and the
+session is idle; child alive → the session is **fenced** — observed but not
+controlled — and only an explicit user reap resolves it. Processes are never
+killed by name or pattern, only by a pid recorded at spawn; `EPERM` from a
+signal-0 probe counts as alive; any pid-reuse doubt fences rather than kills.
+
+Deliberately excluded: checkpoint restore UX, multiple worktrees per
+workspace, and any git operation on the user's primary checkout beyond
+read-only queries against the registered repo.
+
+## Alternatives Considered
+
+**A git library (`git2`/`gix`).** Rejected: heavy exact-pinned dependencies,
+and — decisive — an embedded implementation does not see the user's git
+configuration (credential helpers, LFS, sparse settings) the way their own
+binary does. Shell-out also keeps every git operation inspectable in logs as
+a plain command.
+
+**Worktrees inside the user's repository** (e.g. `<repo>/.tidebreak/`).
+Rejected: pollutes the user's tree, their ignore files, and every tool that
+walks the repo. Data-dir placement keeps ownership and cleanup with Tidebreak.
+Known cost, accepted: some toolchains resolve paths relative to repo
+ancestry and behave differently outside it; a per-repo location override is
+deferred until that pain is real.
+
+**Visible commits per turn.** Rejected: pollutes the branch history the user
+will open as a PR, and rewriting it away (squash on archive) is exactly the
+kind of history mutation that destroys user trust when it goes wrong. Hidden
+refs record the same information out of band.
+
+**Snapshot by copying files** instead of git checkpoints. Rejected: quadratic
+in workspace size, loses rename/mode fidelity, and reimplements what git's
+object store already does content-addressed.
+
+**Kill orphaned harness children on boot.** Rejected: pid reuse makes it
+unsafe, and a wrongly killed process may take hours of agent work with it. A
+fenced card the user resolves is strictly better than a silent kill.
+
+**Do nothing** (run sessions in the user's checkout). Rejected: a single
+agent mistake contaminates the user's working state, and parallel sessions
+are impossible.
+
+## Consequences
+
+Tidebreak becomes a git citizen: it must behave well when the user's git
+config is unusual, when `git` is old, and when a repo is large. Version and
+capability checks happen at repo registration, not mid-session.
+
+Hidden refs accumulate; archive cleans a workspace's refs, and a periodic
+sweep covers refs orphaned by crashes. Checkpoint commits share the repo's
+object store, so their cost is incremental.
+
+The data-dir worktree location makes "where is my code?" a product question;
+the workspace UI must surface the path prominently (open in editor / reveal /
+copy path).
+
+Revisit this decision if per-turn checkpoints prove too slow on large repos
+(would argue for making checkpoints asynchronous or opt-out per repo), or if
+the data-dir location breaks enough real toolchains to justify the per-repo
+override now.
+
+## Validation
+
+Integration tests against throwaway temporary repositories:
+
+- create → verify → setup-script failure preserves the checkout and state;
+- checkpoint after a turn with tracked edits, untracked files, renames, and
+  mode changes; turn diff and workspace diff both correct and bounded, with
+  truncation marked when caps are exceeded;
+- the user's index and `HEAD` are byte-identical before and after a
+  checkpoint;
+- archive with uncommitted work refuses without `force`; with `force` it
+  removes worktree and refs and keeps the branch;
+- a half-created worktree (simulated failure between `worktree add` and
+  verification) is cleaned up;
+- already-removed worktrees archive without error (prune path);
+- boot recovery: dead pid closes the open turn as interrupted; a live decoy
+  process with the recorded pid fences and is never signaled; `EPERM` probes
+  count as alive.
+
+A plausible wrong implementation checkpoints only tracked files and passes
+every tracked-edit test; the untracked-file case above must fail it. Another
+passes recovery tests by killing the decoy; the never-signaled assertion
+(decoy still alive after boot) must fail it.

--- a/docs/decisions/0033-code-mode-approvals.md
+++ b/docs/decisions/0033-code-mode-approvals.md
@@ -1,0 +1,146 @@
+# 33. Code Mode Approvals Are First-Class and Deny Can Steer
+
+- Status: Proposed
+- Date: 2026-08-15
+- Owners: code mode, approvals
+- Related: [`0031-harness-adapter-boundary.md`](0031-harness-adapter-boundary.md),
+  [`0018-tool-call-narration.md`](0018-tool-call-narration.md),
+  [`docs/code-mode.md`](../code-mode.md)
+
+## Context
+
+Every harness code mode drives ships its own permission system: Claude Code
+has permission modes and a pluggable permission-prompt channel; Codex CLI has
+approval policies and sandbox levels with approval requests in its server
+protocol; opencode's server exposes a permission API. Each also ships a bypass
+flag that turns the whole system off.
+
+The temptation in this product category is documented by prior art: wrapping
+tools launch the harness with its bypass flag because surfacing approvals
+through a wrapper is hard, and the wrapper's own approval UI never gets built.
+The result is that "supervised coding agent" ships as an unsupervised one.
+
+Tidebreak's chat product already has a considered approval culture: parked
+approval cards, grant ladders, and the rule from
+[`0018`](0018-tool-call-narration.md) that a tool call cannot argue
+for its own approval. Code mode must meet that bar, not undercut it — while
+recognizing that code approvals are *foreign*: the harness, not Tidebreak,
+defines what needs approval and enforces the outcome.
+
+## Decision
+
+**No bypass by default, ever.** Tidebreak never launches a harness with its
+permission-bypass flag as a composed default. This is an enforced invariant:
+a denylist test over every adapter's argument construction (including
+user-supplied extra arguments from settings) fails the build if a bypass flag
+appears in a default launch plan. A user who wants bypass behavior can get it
+only by an explicit per-session choice that is rendered as prominently as the
+approvals it removes.
+
+**Each adapter wires the harness's native structured approval channel** into
+one normalized surface:
+
+- *Claude Code*: a Tidebreak-served permission-prompt tool over the
+  loopback MCP endpoint, passed via the harness's permission-prompt-tool and
+  MCP configuration flags with a session-scoped token. The harness's tool
+  call parks until the user decides; a deny returns the user's message as the
+  denial reason, which the model sees.
+- *Codex CLI*: the approval request/response methods of its server protocol
+  (or the equivalent in exec mode, per what the fixture spike verifies).
+- *opencode*: its server permission API.
+- *Grok CLI*: whatever structured channel its detected version offers. Absent
+  one, the adapter declares `structured_approvals: Unsupported`, and sessions
+  on that harness are restricted to permission modes that need no runtime
+  approvals — stated visibly at session creation, never silently escalated to
+  bypass.
+
+**The normalized shape.** An approval is persisted as
+`CodeApproval { kind, session, turn, state, feedback }` where `kind`
+classifies what is being asked — command execution (with command and cwd),
+file writes (with paths), network access, or other (with the harness's
+summary and the raw payload, size-capped). Classification is best-effort and
+display-oriented; the *harness's* payload is authoritative for what actually
+gets allowed, and the card renders the harness's request rather than a
+Tidebreak paraphrase — the [`0018`](0018-tool-call-narration.md)
+principle applied to foreign tools.
+
+**Deny can steer.** A decision is `Approve` or `Deny { feedback }`. Denial
+feedback travels back through the harness's channel as the denial reason, so
+"no — use the fixtures directory instead" redirects the agent in one step
+instead of stalling the turn. An undecided approval parks the session in the
+`NeedsYou` attention state; approvals survive restarts and are answerable
+after reconnect.
+
+**Permission modes reuse the chat vocabulary** (per
+[`0030`](0030-code-mode-separate-surface.md)): `Plan` maps to the harness's
+read-only or plan mode with mutations refused; `Ask` (the default) maps to
+approval-required postures where every request parks on a card; `Auto` maps
+to the harness's workspace-write posture where routine edits proceed and the
+harness's own policy still escalates sensitive actions to approval. Each
+adapter documents its exact flag mapping per mode. A mode a harness cannot
+honor is refused at session creation with the reason — never approximated.
+
+Deliberately excluded: standing grants and grant ladders for code approvals
+("always allow `cargo test`") — deferred until real usage shows which grants
+users actually repeat; Tidebreak-side sandboxing of harness processes — the
+harness's own permission system is the enforcement layer in v1.
+
+## Alternatives Considered
+
+**Bypass by default, add Tidebreak-side sandboxing later.** Rejected: it is
+the documented failure of this category, it discards the harnesses' own
+well-tested permission machinery, and "later" sandboxing of an arbitrary
+agent process is a research project, not a backlog item.
+
+**Reuse the chat approval tables and events.** Rejected: chat approvals are
+bound to the internal tool registry, call ids, judge machinery, and grant
+rungs, none of which exist for foreign tools. The *visual* language is
+shared; the data model is not (per
+[`0030`](0030-code-mode-separate-surface.md)), though the wire shape stays
+inbox-compatible for later convergence.
+
+**Approval by steering text** (answer "please don't" into the conversation).
+Rejected: not a channel, not enforceable, and unanswerable when the harness
+is mid-tool.
+
+**Tidebreak-authored allow/deny policy engine over harness requests**
+(auto-approving classes of commands). Rejected for v1: it reintroduces the
+judge problem [`0018`](0018-tool-call-narration.md) guards against,
+on foreign payloads we classify only best-effort. Revisit with standing
+grants.
+
+## Consequences
+
+The approval channel becomes part of each adapter's contract and its fixture
+suite: a harness release that changes its approval protocol breaks a fixture,
+not the user's trust.
+
+Sessions in `Ask` mode are only as responsive as the user; the attention
+system and inbox-shaped surfacing exist to make that workable. `Auto` mode's
+meaning varies by harness and the per-adapter mapping table is user-visible
+documentation.
+
+Restricting no-structured-approvals harnesses to non-approval modes narrows
+what Grok-tier harnesses can do in v1. That is the honest trade; the
+alternative was silent bypass.
+
+Revisit this decision when standing grants are designed, or if a harness
+ships an approval channel rich enough to carry Tidebreak's grant ladder
+natively.
+
+## Validation
+
+- Per-adapter fixture pairs capturing a real approval request and both
+  decision outcomes, replayed in tests.
+- An integration test against the scripted harness proving deny feedback
+  reaches the model-visible transcript of the following step.
+- The bypass denylist test over composed launch plans, including plans with
+  user-supplied extra args.
+- A restart test: an undecided approval survives a server restart and is
+  decidable after reconnect, and the session shows `NeedsYou` throughout.
+- A mode-refusal test: creating an `Ask` session on an adapter with
+  `structured_approvals: Unsupported` fails with the stated reason.
+- A plausible wrong implementation renders approval cards but resolves them
+  by writing to the database without completing the harness's channel; the
+  scripted-harness test above (the harness observes the decision) must fail
+  it.

--- a/docs/decisions/0034-harness-discovery-credentials.md
+++ b/docs/decisions/0034-harness-discovery-credentials.md
@@ -1,0 +1,132 @@
+# 34. Harness Discovery and the Credential Boundary
+
+- Status: Proposed
+- Date: 2026-08-15
+- Owners: code mode
+- Related: [`0031-harness-adapter-boundary.md`](0031-harness-adapter-boundary.md),
+  [`0033-code-mode-approvals.md`](0033-code-mode-approvals.md),
+  [`docs/code-mode.md`](../code-mode.md)
+
+## Context
+
+The coding harnesses code mode drives are products the user already has a
+relationship with: they installed them, signed into them, and pay for them
+through their own subscriptions or API keys. Some users route them through a
+managed model gateway; from the harness binary's point of view that is just
+configuration — a correctly configured `claude` works identically whether its
+traffic goes direct or through a gateway.
+
+Tidebreak's credential story is strict and simple: API keys live in the OS
+keychain, and Tidebreak never carries credential shapes beyond that. Becoming
+a broker for *other products'* credentials would be a new category of
+liability: their token formats, their refresh flows, their billing identity.
+
+There is a real platform wrinkle: GUI applications on macOS do not inherit
+the user's shell `PATH`. A harness installed via a shell profile
+(`~/.zshrc` PATH additions, version managers) is invisible to a naive
+`Command::new("claude")` from the app. This, not philosophy, is why discovery
+needs a decision.
+
+## Decision
+
+**Discovery: the user's login shell resolves the binary.** Harnesses are
+found by asking the user's own login shell
+(`$SHELL -lc 'command -v <binary>'`), so whatever the user's terminal can
+run, Tidebreak can run. Resolution results (absolute path, version) are
+cached per probe and re-probed on demand from the doctor surface. Relative
+path results are rejected; only absolute, executable paths are accepted.
+
+**Execution environment: passthrough minus Tidebreak internals.** Harness
+children run under the user's environment as the login shell provides it,
+minus Tidebreak-internal variables (anything Tidebreak-prefixed, and the
+server's own tokens). This passthrough is the entire gateway story: a
+gateway-configured harness works unchanged because its configuration —
+whatever env or config files it uses — is the user's, untouched. Tidebreak
+adds only what the adapter contract requires (working directory, the
+approval-channel wiring of [`0033`](0033-code-mode-approvals.md), and
+non-secret marker variables).
+
+**Credentials are observed, never brokered.** Tidebreak never reads, stores,
+proxies, or injects harness credentials. Each adapter implements an
+authentication *observation* — the cheapest command that distinguishes
+signed-in from signed-out — and the result is reported, with remediation
+copy that sends the user to the harness's own login flow in their terminal.
+
+**The doctor surface.** A settings section and a `GET /code/harnesses` route
+report, per harness: found or not, resolved path, detected version, adapter
+tier, capability summary, authentication status, and remediation text. The
+doctor is also where unrecognized-event counters
+([`0031`](0031-harness-adapter-boundary.md)) surface per harness.
+
+**Advanced launch configuration, bounded.** Settings may carry per-harness
+extra arguments and environment additions for unusual setups. The composed
+launch plan still passes the bypass-flag denylist of
+[`0033`](0033-code-mode-approvals.md), and extra environment cannot override
+the variables the adapter contract sets.
+
+**No bundling in v1.** Tidebreak does not install, pin, or update harness
+binaries. The existing pinned-runtime install pattern
+(`crates/tidebreak-desktop/src/node_install.rs`) is the recorded escape
+hatch if version drift becomes a support burden.
+
+Deliberately excluded: Windows discovery (login-shell semantics differ;
+Windows packaging is parked per [`docs/deferred.md`](../deferred.md)), and
+any Tidebreak-mediated harness sign-in flow.
+
+## Alternatives Considered
+
+**Bundle pinned harness binaries.** Rejected: Tidebreak would take on each
+harness's release cadence and, worse, its credential storage — a bundled
+binary does not share the user's existing login. The drift-pain escape hatch
+is recorded instead.
+
+**API-key passthrough from Tidebreak's keychain** (store an Anthropic key and
+inject it into Claude Code). Rejected: it makes Tidebreak a credential broker
+for a third-party product, forks billing identity from the user's existing
+subscription, and silently changes which account pays for a session.
+
+**Static PATH resolution from the GUI process.** Rejected on the macOS fact
+above: it would work in dev shells and fail for real users, the worst kind of
+bug.
+
+**A Tidebreak-owned gateway integration for harnesses** (Tidebreak configures
+the harness to use a gateway). Rejected for v1: passthrough already serves
+gateway users, and writing other products' config files violates the
+observation-only boundary.
+
+**Do nothing** (require the user to type absolute paths). Rejected: the
+doctor surface with login-shell resolution is strictly better and cheap.
+
+## Consequences
+
+Tidebreak's behavior depends on the user's shell environment, which is the
+point — but it means a broken shell profile breaks discovery, so probe
+failures must render as diagnosable output (the shell's stderr, bounded) in
+the doctor, not as generic errors.
+
+Authentication observation is per-adapter maintenance: a harness that changes
+its auth-status command breaks a probe, visibly, in the doctor.
+
+Because credentials are never brokered, a session's spend lands on the
+user's existing harness account, and Tidebreak can make no usage-accounting
+promises beyond what the harness reports in its own stream.
+
+Revisit this decision if harness version drift becomes a recurring support
+burden (bundling escape hatch), or if a managed-deployment story requires
+Tidebreak to *verify* rather than merely observe harness configuration.
+
+## Validation
+
+- Probe tests with shim binaries on a temporary PATH: missing binary,
+  present-but-unauthenticated, version-string variants, relative-path
+  rejection, and a shell profile that prints garbage before the answer.
+- A child-environment test: the spawned harness environment contains no
+  Tidebreak-prefixed secret variables and no keychain-derived values, while
+  preserving arbitrary user variables (the gateway-passthrough property).
+- Doctor route tests for each degraded state, including bounded stderr
+  passthrough on probe failure.
+- The composed-argv denylist test (shared with
+  [`0033`](0033-code-mode-approvals.md)) including settings-supplied extras.
+- A plausible wrong implementation resolves the binary with the GUI
+  process's own PATH and passes on developer machines; the probe tests must
+  run resolution through the shim shell to fail it.

--- a/docs/decisions/0034-harness-discovery-credentials.md
+++ b/docs/decisions/0034-harness-discovery-credentials.md
@@ -29,22 +29,28 @@ needs a decision.
 
 ## Decision
 
-**Discovery: the user's login shell resolves the binary.** Harnesses are
-found by asking the user's own login shell
-(`$SHELL -lc 'command -v <binary>'`), so whatever the user's terminal can
-run, Tidebreak can run. Resolution results (absolute path, version) are
-cached per probe and re-probed on demand from the doctor surface. Relative
-path results are rejected; only absolute, executable paths are accepted.
+**Discovery: the user's shell resolves the binary, in interactive login
+mode.** Harnesses are found by asking the user's own shell with both login
+and interactive semantics (`$SHELL -ilc 'command -v <binary>'`), because the
+two profile classes split the configuration this exists to see: zsh sources
+`.zprofile`/`.zlogin` for a login shell but `.zshrc` only when interactive —
+and version managers and gateway configuration commonly live in `.zshrc`.
+A login-only invocation would reproduce the GUI-PATH bug for exactly the
+users it was meant to fix. The probe is bounded (timeout, output delimited
+by sentinel markers so profile noise cannot forge a result) and cached;
+re-probe is on demand from the doctor surface. Relative path results are
+rejected; only absolute, executable paths are accepted.
 
-**Execution environment: passthrough minus Tidebreak internals.** Harness
-children run under the user's environment as the login shell provides it,
-minus Tidebreak-internal variables (anything Tidebreak-prefixed, and the
-server's own tokens). This passthrough is the entire gateway story: a
-gateway-configured harness works unchanged because its configuration —
-whatever env or config files it uses — is the user's, untouched. Tidebreak
-adds only what the adapter contract requires (working directory, the
-approval-channel wiring of [`0033`](0033-code-mode-approvals.md), and
-non-secret marker variables).
+**Execution environment: the probed shell's environment, minus Tidebreak
+internals.** The same probe captures the shell's resolved environment once,
+and harness children run under that snapshot — not the GUI process's
+environment, which never saw the user's profiles — minus Tidebreak-internal
+variables (anything Tidebreak-prefixed, and the server's own tokens). This
+capture is the entire gateway story: a gateway-configured harness works
+unchanged because its configuration — whatever env or config files it uses —
+is the user's, untouched. Tidebreak adds only what the adapter contract
+requires (working directory, the approval-channel wiring of
+[`0033`](0033-code-mode-approvals.md), and non-secret marker variables).
 
 **Credentials are observed, never brokered.** Tidebreak never reads, stores,
 proxies, or injects harness credentials. Each adapter implements an
@@ -119,10 +125,14 @@ Tidebreak to *verify* rather than merely observe harness configuration.
 
 - Probe tests with shim binaries on a temporary PATH: missing binary,
   present-but-unauthenticated, version-string variants, relative-path
-  rejection, and a shell profile that prints garbage before the answer.
-- A child-environment test: the spawned harness environment contains no
-  Tidebreak-prefixed secret variables and no keychain-derived values, while
-  preserving arbitrary user variables (the gateway-passthrough property).
+  rejection, and a shell profile that prints garbage before the answer
+  (the sentinel markers must survive it).
+- An environment-capture test: a variable set only in the shell's
+  interactive profile reaches the spawned child, proving the child env is
+  the shell snapshot and not the GUI process environment; and the snapshot
+  contains no Tidebreak-prefixed secret variables and no keychain-derived
+  values while preserving arbitrary user variables (the
+  gateway-passthrough property).
 - Doctor route tests for each degraded state, including bounded stderr
   passthrough on probe failure.
 - The composed-argv denylist test (shared with

--- a/docs/decisions/0035-code-mode-wire-contract.md
+++ b/docs/decisions/0035-code-mode-wire-contract.md
@@ -1,0 +1,145 @@
+# 35. Code-Mode Wire Contract: Per-Session Journals Plus One Updates Channel
+
+- Status: Proposed
+- Date: 2026-08-15
+- Owners: code mode, wire contract
+- Related: [`0030-code-mode-separate-surface.md`](0030-code-mode-separate-surface.md),
+  [`0004-chat-scoped-journal-events.md`](0004-chat-scoped-journal-events.md),
+  [`docs/wire-types.md`](../wire-types.md),
+  [`docs/code-mode.md`](../code-mode.md)
+
+## Context
+
+Code mode's defining UI problem is plural: a user runs several sessions at
+once and needs, simultaneously, (a) a full live transcript for the session
+they are looking at, and (b) a cheap, always-current summary of every other
+session — lifecycle, whether it needs them, what its pull request is doing.
+Prior art in this category tends to answer (b) badly: every session looks
+equally important, "blocked on you" is indistinguishable from "working", and
+the user becomes the polling loop.
+
+Chat mode already has a proven streaming contract for (a): a per-chat journal
+table, sequence numbers, journal-before-live-publication, and a WebSocket
+whose reconnect discipline is snapshot → replay from cursor → live
+([`0004`](0004-chat-scoped-journal-events.md),
+`crates/tidebreak-server/src/routes/events.rs`). It has no contract for (b)
+beyond per-chat metadata notices.
+
+All renderer-facing types are generated from Rust
+([`docs/wire-types.md`](../wire-types.md)); anything this record defines
+rides that pipeline.
+
+## Decision
+
+**Per-session journals, identical discipline.** Code sessions journal into
+their own table (`code_event`: session id, monotonic per-session sequence,
+event payload), written before any live publication. The per-session
+WebSocket (`/code/sessions/{id}/events?after=`) implements exactly the chat
+contract: subscribe live first, snapshot, replay `seq > after`, then live,
+with sequence-based dedupe. One socket exists per *open* session view; a
+session nobody is looking at streams to no one.
+
+**One install-wide updates channel.** A single WebSocket (`/code/updates`)
+carries unsequenced digest notices: per-session
+`{workspace, session, lifecycle, attention, title, turn count, pull-request
+state}`. Digests are restated in full on connect, so a dropped notice costs
+nothing and no cursor is needed. The channel drives the sidebar, badges,
+list views, and OS notifications for any number of sessions without a socket
+per session.
+
+**Attention is computed server-side.** So that the desktop, the CLI, and
+notifications agree — and so notifications work with no window open — every
+session carries a server-computed attention state:
+
+- `Working` — the harness is doing something.
+- `NeedsYou { prompt, source }` — an approval, question, or failure is
+  waiting on the user.
+- `Stalled { idle for }` — running but silent past a threshold.
+- `DoneUnreviewed` — finished work the user has not looked at.
+- `Fenced { reason }` — crash recovery parked it
+  ([`0032`](0032-code-workspaces-worktrees-checkpoints.md)).
+- `Manual { note }` — the user pinned a state by hand.
+
+Each automatic state carries its `source` — `Structured` (an exact protocol
+event), `Heuristic` (an inference such as idle time), or `Lifecycle` (a state
+machine fact) — and the replacement rule is fixed: a structured signal is
+never second-guessed by a heuristic on the same facts, and a `Manual` state
+is never overwritten by any automatic source, only by the user. The
+attention vocabulary is defined over "a unit of supervised work", not over
+code sessions specifically, so chat can adopt it unchanged when the modes
+converge ([`0030`](0030-code-mode-separate-surface.md)).
+
+**Journal rows are bounded.** Large payloads — diffs, file lists, raw
+harness payloads — never ride the journal. Events carry hints (ids,
+diffstats) and the renderer loads bodies from bounded GET routes, following
+the chat journal's precedent for plans and previews.
+
+**Everything is generated wire.** All types here derive into the generated
+TypeScript alongside the chat types, under the same staleness test, with
+hand-written runtime validators at the renderer boundary in the existing
+pattern.
+
+Deliberately excluded: multiplexing full event streams over one socket, and
+any renderer-side attention computation beyond display.
+
+## Alternatives Considered
+
+**One multiplexed socket carrying every session's full stream.** Rejected:
+per-session replay cursors over one connection is new protocol machinery,
+and only open views need full streams; the digest channel serves everything
+else at a fraction of the traffic.
+
+**Cursor-pull for session events** (server notifies "changed", client pulls
+from a byte or event cursor). Workable — and adopted for terminals in
+[`0036`](0036-code-mode-auxiliary-terminals.md), where bytes are ephemeral —
+but rejected for the journal: push-with-replay is the proven idiom here, and
+two streaming idioms for the same kind of durable data is a cost with no
+buyer.
+
+**Reuse the chat `event` table with a discriminator column.** Rejected: it
+foreign-keys code sessions into chat id space, exactly what
+[`0030`](0030-code-mode-separate-surface.md) forbids, and buys only a table
+name.
+
+**Poll for digests.** Rejected: N sessions × M clients polling is the
+failure mode this record exists to avoid, and restated-on-connect push is
+simpler than it looks — it is the existing metadata-notice pattern widened
+to the install.
+
+**Renderer-computed attention.** Rejected: the CLI and OS notifications need
+the same answer with no renderer running, and two implementations of "does
+this need me" will disagree in exactly the cases that matter.
+
+## Consequences
+
+The updates channel becomes a small install-wide broadcast hub in the
+server; its digests must stay cheap to compute and bounded in size, which
+the hint-shaped journal discipline already forces.
+
+Attention thresholds (the stall timer) become product tuning knobs on the
+server; changing them changes every client at once, which is the point.
+
+Because the journal is bounded and hint-shaped, some renderer views require
+a follow-up GET; view code must treat hint-then-fetch as the normal path,
+not an error path.
+
+Revisit this decision if the modes converge (the digest channel and
+attention vocabulary should then widen to chats rather than being
+reinvented), or if per-session sockets prove too heavy on very large session
+counts — the digest channel already carries the data a coarser UI would
+need.
+
+## Validation
+
+- Reconnect tests mirroring the chat events suite: replay-then-live handoff
+  with no gap and no duplicate across the seam, under concurrent writes.
+- A digest-restatement test: connect, receive full state; mutate sessions;
+  reconnect; receive full current state with no dependence on missed
+  notices.
+- The generated-types staleness test covering every new type.
+- An attention property test: no sequence of automatic transitions ever
+  replaces a `Manual` state, and a `Structured` `NeedsYou` is never
+  downgraded by a `Heuristic` source while the structured condition stands.
+- A plausible wrong implementation publishes live events before the journal
+  write commits and passes happy-path streaming tests; the reconnect test
+  must inject a crash between publish and commit to fail it.

--- a/docs/decisions/0036-code-mode-auxiliary-terminals.md
+++ b/docs/decisions/0036-code-mode-auxiliary-terminals.md
@@ -1,0 +1,122 @@
+# 36. Auxiliary Terminals Are Ephemeral Byte Streams, Never the Harness Interface
+
+- Status: Proposed
+- Date: 2026-08-15
+- Owners: code mode
+- Related: [`0031-harness-adapter-boundary.md`](0031-harness-adapter-boundary.md),
+  [`0035-code-mode-wire-contract.md`](0035-code-mode-wire-contract.md),
+  [`docs/code-mode.md`](../code-mode.md)
+
+## Context
+
+Code mode's primary interface is structured
+([`0031`](0031-harness-adapter-boundary.md)), but a workspace is a real
+checkout and the user verifying an agent's work needs a shell in it: run the
+tests, poke at state, try the build. Sending them to a separate terminal
+application with a copied path is friction exactly at the moment of review.
+
+A terminal is also the classic scope trap in this category: once a PTY
+exists, it is tempting to run the harness in it "as a fallback", and the
+structured product quietly becomes a terminal wrapper. This record draws
+that line.
+
+Terminal output is unlike journal data: it is unbounded, low-signal per
+byte, and valuable only while the shell lives. Persisting it would be
+storing noise durably.
+
+## Decision
+
+A workspace may open **auxiliary terminals**: interactive shells (the user's
+`$SHELL`) with the worktree as working directory, rendered in the workspace
+UI as a secondary surface. They exist for the user's hands, not the
+harness's.
+
+**The harness never gets a PTY.** Adapters have no pseudo-terminal API, so
+the constraint holds by construction: the only PTY code in the product lives
+in the terminal module, and the harness session contract
+([`0031`](0031-harness-adapter-boundary.md)) speaks pipes and protocols
+only.
+
+**Ephemeral by definition.** Terminal bytes live in a bounded in-memory
+ring buffer per terminal. They are not journaled, not persisted, and not
+part of any transcript; on server restart, terminals are gone and the UI
+shows "shell ended" rather than pretending continuity. Truncation (ring
+overflow) is surfaced inline in the stream, not hidden.
+
+**Cursor-pull streaming.** Deliberately unlike the journal
+([`0035`](0035-code-mode-wire-contract.md)) and matched to the data's
+nature: the server publishes only coalesced activity notices (tens of
+milliseconds granularity) on the updates channel; a client with the
+terminal open pulls bytes from a monotonic byte cursor over a plain GET,
+and writes keystrokes and resizes over plain POSTs. Reconnect and
+multi-client reads are trivially correct — a reader is just a cursor — and
+the render rate is decoupled from the producer rate. A quiet terminal costs
+nothing.
+
+**Bounded everywhere.** Terminals per workspace are capped; ring size is
+capped; read responses are capped; input writes are size-checked. The
+terminal is a convenience, not a data plane.
+
+Deliberately excluded: terminal persistence or scrollback restore across
+restarts; shared/broadcast terminals; and running any harness in a PTY —
+that idea goes to [`docs/deferred.md`](../deferred.md) as an explicitly
+rejected-for-now escape hatch, to be reconsidered only if a harness's
+machine-readable surface proves unusable.
+
+## Alternatives Considered
+
+**No terminal at all** (open the user's own terminal app at the path).
+Rejected by product decision: verification belongs next to review, and the
+cost of a bounded auxiliary surface is modest. The line drawn here — never
+the harness — is what keeps it from growing.
+
+**Journal the terminal bytes.** Rejected: unbounded, low-value durable data,
+and a transcript of a human poking at a shell is not part of the session's
+reviewable record. Anything worth keeping (a test run the agent should see)
+belongs in the conversation, said to the agent.
+
+**Push bytes over a WebSocket per terminal.** Rejected: reconnect and
+multi-client semantics need cursors anyway, backpressure on a fast producer
+is harder to reason about, and the pull model makes an idle background
+terminal free.
+
+**Run the harness interactively in the terminal as a fallback mode.**
+Rejected: it reintroduces the terminal-wrapper failure mode — no structured
+events, no real approvals, heuristic prompt delivery — through the back
+door, and its existence would sap the pressure to fix adapters when
+protocols drift.
+
+## Consequences
+
+This introduces the product's first and only pseudo-terminal dependency and
+its first terminal-emulator UI dependency, both exact-pinned; the UI cost is
+borne by the code-mode bundle. The renderer treats terminals as ephemeral
+views: closing and reopening re-fetches recent bytes from the ring rather
+than retaining renderer state.
+
+Because nothing persists, support questions of the form "what did the user
+run" have no answer by design; that is the privacy-respecting default for a
+surface that belongs to the user's hands.
+
+Revisit this decision if a harness's machine-readable surface proves
+genuinely unusable (the deferred escape hatch), or if users demonstrably
+need shared terminal state across restarts — which would argue for an
+opt-in, clearly-labeled record mode, not silent persistence.
+
+## Validation
+
+- Ring-buffer unit tests: wraparound, cursor semantics at overflow, the
+  inline truncation marker, read caps.
+- A restart test: terminals are absent after restart and the API reports
+  them ended; no terminal bytes exist anywhere durable (assert the store
+  contains none).
+- A coalescing test: a fast producer yields bounded notice frequency while
+  a pulling reader still receives every retained byte.
+- A multi-reader test: two clients at different cursors both read
+  correctly.
+- A compile-level guard that the harness crate does not depend on the PTY
+  dependency (workspace dependency check), so "the harness never gets a
+  PTY" is structural, not disciplinary.
+- A plausible wrong implementation persists ring contents to disk for crash
+  recovery and passes every streaming test; the no-durable-bytes assertion
+  must fail it.

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -252,6 +252,20 @@ purpose:
   Tidebreak data directory; toolchains that misbehave outside the repo's
   ancestry are the known cost, and the override waits for real instances of
   that pain.
+- **Remote session execution.** The adapter contract deliberately never
+  assumes a session's engine is a local child process. A later execution
+  location can run the same harness in a managed sandbox — the session
+  ingesting a sequenced remote event stream into the same journal, the
+  workspace becoming a remote clone whose results arrive as pushed branches.
+  Channels that cannot carry interactive approvals restrict the session to
+  permission modes that need none, under the same visible-capability rules
+  as any other limitation.
+- **A supervision-first mobile client.** Every code-mode capability is a
+  server route, and the updates channel (restated digests, attention,
+  approvals) is deliberately cheap enough for a phone. A mobile client that
+  fires off sessions and supervises them — approve, deny with feedback,
+  steer, review completion — is a thin client of a reachable deployment and
+  waits on the self-host member-client path above.
 - **Code mode on Windows.** Login-shell discovery and worktree pathing both
   need Windows-specific work, and Windows packaging is itself parked (see
   above).

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -240,9 +240,12 @@ purpose:
   editing to the user's editor via the worktree path. An embedded editor is
   a heavyweight dependency with its own product surface; it needs demand
   evidence first.
-- **Chat–code convergence.** One inbox across chats and code sessions,
-  code workspaces inside projects, chats that drive code sessions. The two
-  modes are built shape-compatible so this stays a mechanical merge
+- **Chat–code convergence.** The end state is one surface with no mode
+  choice: one conversation concept with an optional workspace binding, where
+  a workspace-bound conversation behaves code-like and engines — external
+  harnesses and Tidebreak's internal loop alike — sit behind the adapter
+  contract and are selected per conversation. The two modes are built
+  shape-compatible so this stays a mechanical merge
   ([record 30](decisions/0030-code-mode-separate-surface.md)); the
   convergence itself is a future record on top of two proven models.
 - **A per-repo worktree-location override.** Worktrees live under the

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -209,6 +209,50 @@ prompt server replies during an HTTP stream, propagate theme changes into app
 views, recover visibly from a transient frame-payload failure, make gateway
 sign-in restartable, and validate the external-app protocol against its SDK.
 
+## Code mode: what the first version deliberately leaves out
+
+Code mode ([`docs/code-mode.md`](code-mode.md), decision records 30–36) ships
+structured-first: harnesses are driven through their machine-readable
+protocols, and the product's answer to "the protocol doesn't carry it" is a
+visible capability gap, not a workaround. Several adjacent ideas are parked on
+purpose:
+
+- **Running a harness interactively in a PTY.** The escape-hatch version of
+  code mode — when the structured protocol breaks, fall back to a terminal
+  running the harness TUI — is rejected for now, not merely unbuilt
+  ([record 36](decisions/0036-code-mode-auxiliary-terminals.md)). Its
+  existence would sap the pressure to keep adapters honest, and it forfeits
+  approvals, resume, and durable history. Reconsider only if a harness's
+  machine-readable surface proves genuinely unusable over time.
+- **Bundled or pinned harness binaries.** Tidebreak resolves the user's own
+  installed CLIs and never brokers their credentials
+  ([record 34](decisions/0034-harness-discovery-credentials.md)). If version
+  drift becomes a recurring support burden, the pinned-runtime install
+  pattern already used for the managed Node runtime is the recorded escape
+  hatch.
+- **Checkpoint restore.** Per-turn checkpoints land with v1 as hidden refs
+  and power turn-scoped diffs; the surface that restores a workspace to an
+  earlier checkpoint waits until review flows have settled.
+- **Multiple sessions per workspace.** The data model keeps room for
+  follow-up and successor sessions in one worktree; v1 runs one active
+  session per workspace.
+- **An in-app code editor.** V1 reviews server-produced diffs and hands
+  editing to the user's editor via the worktree path. An embedded editor is
+  a heavyweight dependency with its own product surface; it needs demand
+  evidence first.
+- **Chat–code convergence.** One inbox across chats and code sessions,
+  code workspaces inside projects, chats that drive code sessions. The two
+  modes are built shape-compatible so this stays a mechanical merge
+  ([record 30](decisions/0030-code-mode-separate-surface.md)); the
+  convergence itself is a future record on top of two proven models.
+- **A per-repo worktree-location override.** Worktrees live under the
+  Tidebreak data directory; toolchains that misbehave outside the repo's
+  ancestry are the known cost, and the override waits for real instances of
+  that pain.
+- **Code mode on Windows.** Login-shell discovery and worktree pathing both
+  need Windows-specific work, and Windows packaging is itself parked (see
+  above).
+
 ## What this means for planning
 
 V1 is not a claim that Tidebreak has every kind of automation or connector. It


### PR DESCRIPTION
Proposes **Code mode** — a second product surface for driving external coding-agent CLIs (Claude Code first; Codex CLI, opencode, Grok CLI behind it) in isolated git worktrees through a structured UI: conversation, tool activity, approvals, per-turn diffs, and a pull-request flow.

Seven decision records, all `Proposed`:

- **0030** — separate surface with repo → workspace → session vocabulary, deliberately built shape-compatible with chat so later convergence is a mechanical merge rather than a translation layer
- **0031** — per-harness adapters normalize native machine-readable protocols into one `CodeEvent` vocabulary; fixtures-before-parsers, explicit capability flags, version detection with visible degradation
- **0032** — worktrees/branches/per-turn checkpoints via git shell-out (hidden refs, synthetic commits, never the user's index); conservative crash recovery that fences live orphans instead of killing them
- **0033** — approvals are first-class over each harness's native channel; deny carries feedback that steers the agent; bypass flags never in a default launch plan, lint-enforced
- **0034** — harness discovery via the user's login shell; credentials observed, never brokered; environment passthrough makes gateway-configured harnesses work unchanged
- **0035** — per-session journals with the chat journal's exact replay discipline, plus one install-wide updates channel of restated digests; server-computed attention states
- **0036** — auxiliary terminals are ephemeral byte streams for the user's shells; the harness never gets a PTY, by construction

`docs/code-mode.md` carries the working design detail in one place (crate layout, data model, adapter contract, API surface, UI plan, test strategy); `docs/deferred.md` gains a section for what v1 deliberately leaves out.

Docs-only change; no code. Not intended to merge until reviewed — implementation PRs will follow separately and reference these records.