### PR TITLE
feat(server): code mode workspaces, session worker, and routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7184,6 +7184,7 @@ dependencies = [
  "tidebreak-code-execution",
  "tidebreak-core",
  "tidebreak-egress",
+ "tidebreak-harness",
  "tidebreak-mcp",
  "tidebreak-router",
  "tidebreak-sandbox-agent",

--- a/crates/tidebreak-core/src/code/event.rs
+++ b/crates/tidebreak-core/src/code/event.rs
@@ -5,6 +5,7 @@
 //! payloads) never ride these events — they carry hints.
 
 use serde::{Deserialize, Serialize};
+use ts_rs::TS;
 
 use super::{AttentionSource, AttentionState, CodeApprovalId, CodeTurnId, HarnessKind};
 
@@ -18,7 +19,7 @@ pub const MAX_NOTICE_CHARS: usize = 1_024;
 pub const MAX_TOOL_SUMMARY_CHARS: usize = 512;
 
 /// Display-oriented classification of a tool the engine started.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ToolDetail {
     /// A shell command.
@@ -51,7 +52,7 @@ pub enum ToolDetail {
 }
 
 /// How a tool call finished.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "snake_case")]
 pub enum ToolOutcome {
     /// The tool ran and returned a result.
@@ -63,7 +64,7 @@ pub enum ToolOutcome {
 }
 
 /// Kind of file change reported by the engine or a checkpoint.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "snake_case")]
 pub enum FileChangeKind {
     /// A new file.
@@ -77,7 +78,7 @@ pub enum FileChangeKind {
 }
 
 /// Bounded add/delete counts for a diff. Bodies live on a GET route.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 pub struct Diffstat {
     /// Files touched.
     pub files: u32,
@@ -91,7 +92,7 @@ pub struct Diffstat {
 }
 
 /// Token accounting as reported by the engine. Missing fields stay zero.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, TS)]
 pub struct CodeUsage {
     /// Input tokens.
     #[serde(default)]
@@ -108,25 +109,27 @@ pub struct CodeUsage {
 }
 
 /// Hint that a turn recorded a checkpoint. The diff body is loaded separately.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 pub struct CheckpointHint {
     /// Hidden ref name, when known.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
     pub checkpoint_ref: Option<String>,
     /// Bounded diffstat.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
     pub diffstat: Option<Diffstat>,
 }
 
 /// Bounded error carried on [`CodeEvent::TurnFailed`].
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 pub struct BoundedError {
     /// Short message, already truncated by the adapter.
     pub message: String,
 }
 
 /// Severity of a visible-degradation notice.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "snake_case")]
 pub enum HarnessNoticeLevel {
     /// Informational.
@@ -138,7 +141,7 @@ pub enum HarnessNoticeLevel {
 }
 
 /// Decision recorded on [`CodeEvent::ApprovalResolved`].
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ApprovalDecisionKind {
     /// Approved.
@@ -147,6 +150,7 @@ pub enum ApprovalDecisionKind {
     Deny {
         /// Feedback returned to the engine, when any.
         #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
         feedback: Option<String>,
     },
 }
@@ -156,7 +160,7 @@ pub enum ApprovalDecisionKind {
 /// Serialized as an internally-tagged union (a `type` field selects the
 /// variant), and `#[non_exhaustive]` so new event kinds can be added without
 /// breaking downstream consumers.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
 #[serde(tag = "type", rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum CodeEvent {
@@ -168,6 +172,7 @@ pub enum CodeEvent {
         harness_version: String,
         /// Engine-native resume token, when the stream reported one.
         #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
         resume_ref: Option<String>,
     },
     /// A user→engine turn has begun.
@@ -240,6 +245,7 @@ pub enum CodeEvent {
         usage: CodeUsage,
         /// Checkpoint recorded at turn end, when any.
         #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
         checkpoint: Option<CheckpointHint>,
     },
     /// The turn failed and was abandoned.
@@ -273,7 +279,7 @@ pub enum CodeEvent {
 }
 
 /// A [`CodeEvent`] paired with its per-session sequence number.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
 pub struct SequencedCodeEvent {
     /// Monotonic per-session sequence number; the first event is 1.
     pub seq: i64,

--- a/crates/tidebreak-core/src/db/ops/code/repo.rs
+++ b/crates/tidebreak-core/src/db/ops/code/repo.rs
@@ -1,4 +1,4 @@
-use sea_orm::{ActiveModelTrait, EntityTrait, Set};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set};
 
 use crate::code::{CodeRepo, QuickAction, RepoId};
 use crate::error::{AgentError, Result};
@@ -34,6 +34,74 @@ pub async fn get_repo(store: &DbStore, id: RepoId) -> Result<Option<CodeRepo>> {
         return Ok(None);
     };
     Ok(Some(repo_from_row(row)?))
+}
+
+/// Load a repository by its canonical toplevel path.
+pub async fn get_repo_by_root_path(store: &DbStore, root_path: &str) -> Result<Option<CodeRepo>> {
+    let Some(row) = entities::code_repo::Entity::find()
+        .filter(entities::code_repo::Column::RootPath.eq(root_path))
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+    else {
+        return Ok(None);
+    };
+    Ok(Some(repo_from_row(row)?))
+}
+
+/// Every registered repository, most recently created first.
+pub async fn list_repos(store: &DbStore) -> Result<Vec<CodeRepo>> {
+    entities::code_repo::Entity::find()
+        .order_by_desc(entities::code_repo::Column::CreatedAt)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(repo_from_row)
+        .collect()
+}
+
+/// Persist mutable repository fields. `id`, `root_path`, and `created_at` stay as stored.
+pub async fn save_repo(store: &DbStore, repo: &CodeRepo) -> Result<bool> {
+    let result = entities::code_repo::Entity::update_many()
+        .col_expr(
+            entities::code_repo::Column::DisplayName,
+            sea_orm::sea_query::Expr::value(repo.display_name.clone()),
+        )
+        .col_expr(
+            entities::code_repo::Column::DefaultBaseRef,
+            sea_orm::sea_query::Expr::value(repo.default_base_ref.clone()),
+        )
+        .col_expr(
+            entities::code_repo::Column::BranchPrefix,
+            sea_orm::sea_query::Expr::value(repo.branch_prefix.clone()),
+        )
+        .col_expr(
+            entities::code_repo::Column::SetupScript,
+            sea_orm::sea_query::Expr::value(repo.setup_script.clone()),
+        )
+        .col_expr(
+            entities::code_repo::Column::ArchiveScript,
+            sea_orm::sea_query::Expr::value(repo.archive_script.clone()),
+        )
+        .col_expr(
+            entities::code_repo::Column::QuickActions,
+            sea_orm::sea_query::Expr::value(serde_json::to_value(&repo.quick_actions)?),
+        )
+        .filter(entities::code_repo::Column::Id.eq(repo.id.0))
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(result.rows_affected == 1)
+}
+
+/// Delete a repository. Callers must have removed its workspaces first.
+pub async fn delete_repo(store: &DbStore, id: RepoId) -> Result<bool> {
+    let result = entities::code_repo::Entity::delete_by_id(id.0)
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(result.rows_affected == 1)
 }
 
 pub(super) fn repo_from_row(row: entities::code_repo::Model) -> Result<CodeRepo> {

--- a/crates/tidebreak-core/src/db/ops/code/session.rs
+++ b/crates/tidebreak-core/src/db/ops/code/session.rs
@@ -1,4 +1,6 @@
-use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set, TransactionTrait};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
+};
 
 use crate::code::{
     Attention, AttentionSource, AttentionState, CodePermissionMode, CodeSession, CodeSessionId,
@@ -93,6 +95,106 @@ pub async fn bump_spawn_epoch(
     }
     transaction.commit().await.map_err(store_err)?;
     Ok(next)
+}
+
+/// Every session, most recently created first.
+pub async fn list_sessions(store: &DbStore) -> Result<Vec<CodeSession>> {
+    entities::code_session::Entity::find()
+        .order_by_desc(entities::code_session::Column::CreatedAt)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(session_from_row)
+        .collect()
+}
+
+/// Sessions belonging to one workspace, most recently created first.
+pub async fn list_sessions_for_workspace(
+    store: &DbStore,
+    workspace_id: WorkspaceId,
+) -> Result<Vec<CodeSession>> {
+    entities::code_session::Entity::find()
+        .filter(entities::code_session::Column::WorkspaceId.eq(workspace_id.0))
+        .order_by_desc(entities::code_session::Column::CreatedAt)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(session_from_row)
+        .collect()
+}
+
+/// Sessions in one lifecycle state.
+pub async fn list_sessions_by_lifecycle(
+    store: &DbStore,
+    lifecycle: CodeSessionLifecycle,
+) -> Result<Vec<CodeSession>> {
+    entities::code_session::Entity::find()
+        .filter(entities::code_session::Column::Lifecycle.eq(lifecycle.as_str().to_owned()))
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(session_from_row)
+        .collect()
+}
+
+/// Persist mutable session fields. `id`, `workspace_id`, and `created_at` stay as stored.
+pub async fn save_session(store: &DbStore, session: &CodeSession) -> Result<bool> {
+    let result = entities::code_session::Entity::update_many()
+        .col_expr(
+            entities::code_session::Column::HarnessKind,
+            sea_orm::sea_query::Expr::value(session.harness_kind.as_str().to_owned()),
+        )
+        .col_expr(
+            entities::code_session::Column::HarnessVersion,
+            sea_orm::sea_query::Expr::value(session.harness_version.clone()),
+        )
+        .col_expr(
+            entities::code_session::Column::HarnessResumeRef,
+            sea_orm::sea_query::Expr::value(session.harness_resume_ref.clone()),
+        )
+        .col_expr(
+            entities::code_session::Column::PermissionMode,
+            sea_orm::sea_query::Expr::value(session.permission_mode.as_str().to_owned()),
+        )
+        .col_expr(
+            entities::code_session::Column::Lifecycle,
+            sea_orm::sea_query::Expr::value(session.lifecycle.as_str().to_owned()),
+        )
+        .col_expr(
+            entities::code_session::Column::FenceReason,
+            sea_orm::sea_query::Expr::value(match &session.fence_reason {
+                Some(reason) => Some(serde_json::to_value(reason)?),
+                None => None,
+            }),
+        )
+        .col_expr(
+            entities::code_session::Column::ChildPid,
+            sea_orm::sea_query::Expr::value(session.child_pid),
+        )
+        .col_expr(
+            entities::code_session::Column::SpawnEpoch,
+            sea_orm::sea_query::Expr::value(session.spawn_epoch),
+        )
+        .col_expr(
+            entities::code_session::Column::AttentionState,
+            sea_orm::sea_query::Expr::value(serde_json::to_value(&session.attention.state)?),
+        )
+        .col_expr(
+            entities::code_session::Column::AttentionSource,
+            sea_orm::sea_query::Expr::value(session.attention.source.as_str().to_owned()),
+        )
+        .col_expr(
+            entities::code_session::Column::UnrecognizedEventCount,
+            sea_orm::sea_query::Expr::value(session.unrecognized_event_count),
+        )
+        .filter(entities::code_session::Column::Id.eq(session.id.0))
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(result.rows_affected == 1)
 }
 
 pub(super) fn session_from_row(row: entities::code_session::Model) -> Result<CodeSession> {

--- a/crates/tidebreak-core/src/db/ops/code/turn.rs
+++ b/crates/tidebreak-core/src/db/ops/code/turn.rs
@@ -1,4 +1,4 @@
-use sea_orm::{ActiveModelTrait, EntityTrait, Set};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set};
 
 use crate::code::{CodeSessionId, CodeTurn, CodeTurnId, CodeTurnStatus, CodeUsage, Diffstat};
 use crate::error::{AgentError, Result};
@@ -43,6 +43,90 @@ pub async fn get_turn(store: &DbStore, id: CodeTurnId) -> Result<Option<CodeTurn
         return Ok(None);
     };
     Ok(Some(turn_from_row(row)?))
+}
+
+/// Turns of one session, oldest first.
+pub async fn list_turns(store: &DbStore, session_id: CodeSessionId) -> Result<Vec<CodeTurn>> {
+    entities::code_turn::Entity::find()
+        .filter(entities::code_turn::Column::SessionId.eq(session_id.0))
+        .order_by_asc(entities::code_turn::Column::Ordinal)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(turn_from_row)
+        .collect()
+}
+
+/// The open (non-terminal) turn for a session, if any.
+pub async fn get_open_turn(store: &DbStore, session_id: CodeSessionId) -> Result<Option<CodeTurn>> {
+    let turns = list_turns(store, session_id).await?;
+    Ok(turns
+        .into_iter()
+        .rev()
+        .find(|turn| turn.status == CodeTurnStatus::Running))
+}
+
+/// Next 1-based ordinal for a new turn on this session.
+pub async fn next_turn_ordinal(store: &DbStore, session_id: CodeSessionId) -> Result<i64> {
+    let last = entities::code_turn::Entity::find()
+        .filter(entities::code_turn::Column::SessionId.eq(session_id.0))
+        .order_by_desc(entities::code_turn::Column::Ordinal)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?;
+    last.map_or(Some(1), |row| row.ordinal.checked_add(1))
+        .ok_or_else(|| {
+            AgentError::Store(format!("turn ordinal exhausted for session {session_id}"))
+        })
+}
+
+/// Persist mutable turn fields. `id`, `session_id`, `ordinal`, and `started_at` stay as stored.
+pub async fn save_turn(store: &DbStore, turn: &CodeTurn) -> Result<bool> {
+    let result = entities::code_turn::Entity::update_many()
+        .col_expr(
+            entities::code_turn::Column::Status,
+            sea_orm::sea_query::Expr::value(turn.status.as_str().to_owned()),
+        )
+        .col_expr(
+            entities::code_turn::Column::UserInput,
+            sea_orm::sea_query::Expr::value(turn.user_input.clone()),
+        )
+        .col_expr(
+            entities::code_turn::Column::UserInputBlobId,
+            sea_orm::sea_query::Expr::value(turn.user_input_blob_id),
+        )
+        .col_expr(
+            entities::code_turn::Column::CheckpointRef,
+            sea_orm::sea_query::Expr::value(turn.checkpoint_ref.clone()),
+        )
+        .col_expr(
+            entities::code_turn::Column::Diffstat,
+            sea_orm::sea_query::Expr::value(match &turn.diffstat {
+                Some(stat) => Some(serde_json::to_value(stat)?),
+                None => None,
+            }),
+        )
+        .col_expr(
+            entities::code_turn::Column::Usage,
+            sea_orm::sea_query::Expr::value(match &turn.usage {
+                Some(usage) => Some(serde_json::to_value(usage)?),
+                None => None,
+            }),
+        )
+        .col_expr(
+            entities::code_turn::Column::Narrative,
+            sea_orm::sea_query::Expr::value(turn.narrative.clone()),
+        )
+        .col_expr(
+            entities::code_turn::Column::EndedAt,
+            sea_orm::sea_query::Expr::value(turn.ended_at),
+        )
+        .filter(entities::code_turn::Column::Id.eq(turn.id.0))
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(result.rows_affected == 1)
 }
 
 pub(super) fn turn_from_row(row: entities::code_turn::Model) -> Result<CodeTurn> {

--- a/crates/tidebreak-core/src/db/ops/code/workspace.rs
+++ b/crates/tidebreak-core/src/db/ops/code/workspace.rs
@@ -1,4 +1,4 @@
-use sea_orm::{ActiveModelTrait, EntityTrait, Set};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set};
 
 use crate::code::{CodeWorkspace, CodeWorkspaceStatus, PullRequestDigest, RepoId, WorkspaceId};
 use crate::error::{AgentError, Result};
@@ -38,6 +38,76 @@ pub async fn get_workspace(store: &DbStore, id: WorkspaceId) -> Result<Option<Co
         return Ok(None);
     };
     Ok(Some(workspace_from_row(row)?))
+}
+
+/// Workspaces of one repo, or every workspace when `repo_id` is `None`.
+/// Most recently created first.
+pub async fn list_workspaces(
+    store: &DbStore,
+    repo_id: Option<RepoId>,
+) -> Result<Vec<CodeWorkspace>> {
+    let mut query = entities::code_workspace::Entity::find();
+    if let Some(repo_id) = repo_id {
+        query = query.filter(entities::code_workspace::Column::RepoId.eq(repo_id.0));
+    }
+    query
+        .order_by_desc(entities::code_workspace::Column::CreatedAt)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(workspace_from_row)
+        .collect()
+}
+
+/// Persist mutable workspace fields. `id`, `repo_id`, and `created_at` stay as stored.
+pub async fn save_workspace(store: &DbStore, workspace: &CodeWorkspace) -> Result<bool> {
+    let result = entities::code_workspace::Entity::update_many()
+        .col_expr(
+            entities::code_workspace::Column::Title,
+            sea_orm::sea_query::Expr::value(workspace.title.clone()),
+        )
+        .col_expr(
+            entities::code_workspace::Column::WorktreePath,
+            sea_orm::sea_query::Expr::value(workspace.worktree_path.clone()),
+        )
+        .col_expr(
+            entities::code_workspace::Column::BranchName,
+            sea_orm::sea_query::Expr::value(workspace.branch_name.clone()),
+        )
+        .col_expr(
+            entities::code_workspace::Column::BaseRef,
+            sea_orm::sea_query::Expr::value(workspace.base_ref.clone()),
+        )
+        .col_expr(
+            entities::code_workspace::Column::Status,
+            sea_orm::sea_query::Expr::value(workspace.status.as_str().to_owned()),
+        )
+        .col_expr(
+            entities::code_workspace::Column::Pr,
+            sea_orm::sea_query::Expr::value(match &workspace.pr {
+                Some(pr) => Some(serde_json::to_value(pr)?),
+                None => None,
+            }),
+        )
+        .col_expr(
+            entities::code_workspace::Column::ArchivedAt,
+            sea_orm::sea_query::Expr::value(workspace.archived_at),
+        )
+        .filter(entities::code_workspace::Column::Id.eq(workspace.id.0))
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(result.rows_affected == 1)
+}
+
+/// Delete a workspace row. Used to roll back a failed create that left no checkout.
+pub async fn delete_workspace(store: &DbStore, id: WorkspaceId) -> Result<bool> {
+    let result = entities::code_workspace::Entity::delete_by_id(id.0)
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(result.rows_affected == 1)
 }
 
 pub(super) fn workspace_from_row(row: entities::code_workspace::Model) -> Result<CodeWorkspace> {

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1077,7 +1077,7 @@ export type CodeTurnId = string;
 /**
  * One user→engine turn.
  */
-export type CodeTurnSnapshot = { id: CodeTurnId, session_id: CodeSessionId, ordinal: number, status: CodeTurnStatus, user_input: string, checkpoint_ref?: string, started_at: string, ended_at?: string, };
+export type CodeTurnSnapshot = { id: CodeTurnId, session_id: CodeSessionId, ordinal: number, status: CodeTurnStatus, user_input: string, usage?: CodeUsage, checkpoint_ref?: string, started_at: string, ended_at?: string, };
 
 /**
  * Status of one user→engine turn.

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -2484,8 +2484,11 @@ checks_summary?: string | null, };
 
 /**
  * A follow-up parked while the session is already running a turn.
+ *
+ * No turn id: the row is created when the worker promotes this slot.
+ * `position` is 1-based in the single-slot queue.
  */
-export type QueuedCodeTurn = { session_id: CodeSessionId, message: string, };
+export type QueuedCodeTurn = { session_id: CodeSessionId, message: string, position: number, };
 
 /**
  * The id is the client-generated turn id promotion will accept under, so an

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -488,6 +488,15 @@ export type AppViewSession = { frame_path: string, };
 export type ApprovalClass = "read_only" | "workspace" | "sensitive";
 
 /**
+ * Decision recorded on [`CodeEvent::ApprovalResolved`].
+ */
+export type ApprovalDecisionKind = { "type": "approve" } | { "type": "deny", 
+/**
+ * Feedback returned to the engine, when any.
+ */
+feedback?: string, };
+
+/**
  * How wide a standing grant the human chose, narrowest first.
  *
  * The renderer names a rung; the server builds the concrete grant from the
@@ -507,6 +516,54 @@ export type AssistantCitationId = string;
 export type AssistantCitationSnapshot = { id: AssistantCitationId, ordinal: number, document_id: DocumentId, locator: CitationLocator, };
 
 /**
+ * An attention state together with the source that produced it.
+ *
+ * [`AttentionState::NeedsYou`] also carries a source so a structured need
+ * stays distinguishable after the pair is stored as JSON. The two sources
+ * must agree when the state is `NeedsYou`; [`Attention::needs_you`] enforces
+ * that at construction.
+ */
+export type Attention = { 
+/**
+ * The state.
+ */
+state: AttentionState, 
+/**
+ * Who or what set it.
+ */
+source: AttentionSource, };
+
+/**
+ * Why the current attention state was chosen.
+ */
+export type AttentionSource = "structured" | "heuristic" | "lifecycle" | "user";
+
+/**
+ * Server-computed attention for one unit of supervised work.
+ */
+export type AttentionState = { "type": "working" } | { "type": "needs_you", 
+/**
+ * Short prompt shown on the badge.
+ */
+prompt: string, 
+/**
+ * How this need was detected.
+ */
+source: AttentionSource, } | { "type": "stalled", 
+/**
+ * Seconds of observed silence.
+ */
+idle_secs: number, } | { "type": "done_unreviewed" } | { "type": "fenced", 
+/**
+ * Why it was fenced.
+ */
+reason: FenceReason, } | { "type": "manual", 
+/**
+ * User-supplied note.
+ */
+note: string, };
+
+/**
  * Where the Auto-mode judge stands on one parked call.
  *
  * The marker is load-bearing for the renderer: without it, "the judge is
@@ -516,9 +573,23 @@ export type AssistantCitationSnapshot = { id: AssistantCitationId, ordinal: numb
 export type AutoJudgeStatus = "judging" | "approved" | "declined";
 
 /**
+ * Bounded error carried on [`CodeEvent::TurnFailed`].
+ */
+export type BoundedError = { 
+/**
+ * Short message, already truncated by the adapter.
+ */
+message: string, };
+
+/**
  * Identifies one tool call, stable across its request/approval/result.
  */
 export type CallId = string;
+
+/**
+ * Whether an adapter can honor a capability for a probed engine version.
+ */
+export type CapLevel = "supported" | "unsupported" | "unknown";
 
 /**
  * A persistent conversation with an exact, ordered host-root projection.
@@ -712,12 +783,155 @@ tool_activity: Array<ChatToolActivitySnapshot>,
 terminal_turns: Array<ChatTerminalTurnSnapshot>, last_event_seq: number, };
 
 /**
+ * Hint that a turn recorded a checkpoint. The diff body is loaded separately.
+ */
+export type CheckpointHint = { 
+/**
+ * Hidden ref name, when known.
+ */
+checkpoint_ref?: string, 
+/**
+ * Bounded diffstat.
+ */
+diffstat?: Diffstat, };
+
+/**
  * A small, human-scale position inside a cited document.
  *
  * Validation is intentionally loose. A page or line that does not exist still
  * renders and opens the document as close to that position as the reader can.
  */
 export type CitationLocator = { "kind": "document" } | { "kind": "page", page: number, } | { "kind": "pages", start: number, end: number, } | { "kind": "lines", start: number, end: number, } | { "kind": "sheet", sheet: string, cells: string | null, };
+
+/**
+ * Identifies one parked approval belonging to a code session.
+ */
+export type CodeApprovalId = string;
+
+/**
+ * One event in an external agent-engine session's journal.
+ *
+ * Serialized as an internally-tagged union (a `type` field selects the
+ * variant), and `#[non_exhaustive]` so new event kinds can be added without
+ * breaking downstream consumers.
+ */
+export type CodeEvent = { "type": "session_started", 
+/**
+ * Which engine.
+ */
+harness_kind: HarnessKind, 
+/**
+ * Version observed at launch.
+ */
+harness_version: string, 
+/**
+ * Engine-native resume token, when the stream reported one.
+ */
+resume_ref?: string, } | { "type": "turn_started", 
+/**
+ * The turn being processed.
+ */
+turn_id: CodeTurnId, } | { "type": "assistant_delta", 
+/**
+ * The text fragment to append.
+ */
+text: string, } | { "type": "assistant_message", 
+/**
+ * The message text.
+ */
+text: string, } | { "type": "reasoning_delta", 
+/**
+ * The reasoning fragment.
+ */
+text: string, } | { "type": "tool_started", 
+/**
+ * Engine-native call id.
+ */
+call_id: string, 
+/**
+ * Tool name as the engine reported it.
+ */
+name: string, 
+/**
+ * Display-oriented classification.
+ */
+detail: ToolDetail, } | { "type": "tool_completed", 
+/**
+ * Engine-native call id.
+ */
+call_id: string, 
+/**
+ * How it finished.
+ */
+outcome: ToolOutcome, 
+/**
+ * Bounded preview of the result.
+ */
+preview: string, } | { "type": "file_changed", 
+/**
+ * Path relative to the worktree, when the engine reports one.
+ */
+path: string, 
+/**
+ * Kind of change.
+ */
+kind: FileChangeKind, 
+/**
+ * Bounded diffstat.
+ */
+diffstat: Diffstat, } | { "type": "approval_requested", 
+/**
+ * Hint id; the row is the source of truth.
+ */
+approval_id: CodeApprovalId, } | { "type": "approval_resolved", 
+/**
+ * The approval that was decided.
+ */
+approval_id: CodeApprovalId, 
+/**
+ * The decision.
+ */
+decision: ApprovalDecisionKind, } | { "type": "user_steered", 
+/**
+ * The steered user text, already bounded.
+ */
+text: string, } | { "type": "turn_completed", 
+/**
+ * Token accounting as reported by the engine.
+ */
+usage: CodeUsage, 
+/**
+ * Checkpoint recorded at turn end, when any.
+ */
+checkpoint?: CheckpointHint, } | { "type": "turn_failed", 
+/**
+ * Bounded error.
+ */
+error: BoundedError, } | { "type": "turn_interrupted" } | { "type": "checkpoint_recorded", 
+/**
+ * The turn that ended at this checkpoint.
+ */
+turn_id: CodeTurnId, 
+/**
+ * Bounded diffstat.
+ */
+diffstat: Diffstat, } | { "type": "harness_notice", 
+/**
+ * Severity.
+ */
+level: HarnessNoticeLevel, 
+/**
+ * Bounded message.
+ */
+message: string, } | { "type": "attention_changed", 
+/**
+ * New state.
+ */
+state: AttentionState, 
+/**
+ * Who or what set it.
+ */
+source: AttentionSource, };
 
 /**
  * Renderer-safe configuration and readiness.
@@ -826,6 +1040,80 @@ export type CodeExecutionProviderSnapshot = "local" | "e2b" | "daytona" | "docke
  * act on — install a key, switch provider — never an internal failure detail.
  */
 export type CodeExecutionUnavailableReason = "unsupported_platform" | "missing_sandbox_binary" | "missing_credential" | "missing_container_runtime" | "container_runtime_unreachable";
+
+/**
+ * How an external agent-engine session handles mutations and approvals.
+ *
+ * Each adapter maps these onto the engine's native flags. A mode the
+ * engine cannot honor is refused at session creation — never approximated.
+ */
+export type CodePermissionMode = "plan" | "ask" | "auto";
+
+/**
+ * A registered local git repository.
+ */
+export type CodeRepoSnapshot = { id: RepoId, root_path: string, display_name: string, default_base_ref: string, branch_prefix: string, setup_script?: string, archive_script?: string, quick_actions: Array<QuickAction>, created_at: string, };
+
+/**
+ * Identifies one durable conversation with an external agent engine.
+ */
+export type CodeSessionId = string;
+
+/**
+ * Lifecycle of a persisted code session.
+ */
+export type CodeSessionLifecycle = "created" | "idle" | "running" | "fenced" | "ended";
+
+/**
+ * One durable conversation with an external agent engine.
+ */
+export type CodeSessionSnapshot = { id: CodeSessionId, workspace_id: WorkspaceId, harness_kind: HarnessKind, harness_version?: string, harness_resume_ref?: string, permission_mode: CodePermissionMode, lifecycle: CodeSessionLifecycle, fence_reason?: FenceReason, attention: Attention, unrecognized_event_count: number, created_at: string, };
+
+/**
+ * Identifies one user→engine cycle inside a code session.
+ */
+export type CodeTurnId = string;
+
+/**
+ * One user→engine turn.
+ */
+export type CodeTurnSnapshot = { id: CodeTurnId, session_id: CodeSessionId, ordinal: number, status: CodeTurnStatus, user_input: string, checkpoint_ref?: string, started_at: string, ended_at?: string, };
+
+/**
+ * Status of one user→engine turn.
+ */
+export type CodeTurnStatus = "running" | "completed" | "failed" | "interrupted";
+
+/**
+ * Token accounting as reported by the engine. Missing fields stay zero.
+ */
+export type CodeUsage = { 
+/**
+ * Input tokens.
+ */
+input_tokens: number, 
+/**
+ * Output tokens.
+ */
+output_tokens: number, 
+/**
+ * Cache-read input tokens, when the engine reports them.
+ */
+cache_read_input_tokens: number, 
+/**
+ * Cache-write input tokens, when the engine reports them.
+ */
+cache_creation_input_tokens: number, };
+
+/**
+ * One isolated workspace (worktree + branch) on a repo.
+ */
+export type CodeWorkspaceSnapshot = { id: WorkspaceId, repo_id: RepoId, title: string, worktree_path: string, branch_name: string, base_ref: string, status: CodeWorkspaceStatus, pr?: PullRequestDigest, created_at: string, archived_at?: string, };
+
+/**
+ * Status of a persisted workspace.
+ */
+export type CodeWorkspaceStatus = "creating" | "setup_failed" | "active" | "archived";
 
 /**
  * What one on-demand compaction did.
@@ -1103,6 +1391,27 @@ admitted: boolean,
 denials: Array<DetachedAdmissionDenialReason>, };
 
 /**
+ * Bounded add/delete counts for a diff. Bodies live on a GET route.
+ */
+export type Diffstat = { 
+/**
+ * Files touched.
+ */
+files: number, 
+/**
+ * Lines added.
+ */
+insertions: number, 
+/**
+ * Lines deleted.
+ */
+deletions: number, 
+/**
+ * True when the underlying diff was truncated.
+ */
+truncated: boolean, };
+
+/**
  * Identifies an authoritative source document.
  *
  * Usually minted fresh with [`DocumentId::new`], but [`DocumentId::derive`]
@@ -1201,6 +1510,20 @@ export type ExecFileRejectionReason = "stale" | "snapshot_unavailable" | "staged
 export type ExecFileUndoAvailability = "available" | "already_undone" | "stale" | "not_available";
 
 /**
+ * Why a session was fenced during crash recovery.
+ */
+export type FenceReason = { "type": "orphan_alive" } | { "type": "probe_ambiguous", 
+/**
+ * Bounded human-readable detail.
+ */
+detail: string, };
+
+/**
+ * Kind of file change reported by the engine or a checkpoint.
+ */
+export type FileChangeKind = "added" | "modified" | "deleted" | "renamed";
+
+/**
  * The access level of a folder binding.
  *
  * Consent-bearing: the level is part of what the user grants and part of
@@ -1285,6 +1608,74 @@ export type GrantLevel = { "level": "chat", chat_id: ChatId, } | { "level": "pro
  * much larger thing to agree to than "don't ask me about `cargo` again".
  */
 export type GrantScope = { "scope": "exact_action" } & ToolActionPreview | { "scope": "any_args_for", command: string, } | { "scope": "command_prefix", tokens: Array<string>, } | { "scope": "path_subtree", prefix: string, } | { "scope": "whole_tool" };
+
+/**
+ * Capability vector for one probed engine version.
+ *
+ * Constructed exhaustively — there is no [`Default`] — so a new flag is a
+ * compile break at every adapter.
+ */
+export type HarnessCaps = { 
+/**
+ * The engine can resume a prior session from a native resume ref.
+ */
+resume: CapLevel, 
+/**
+ * The engine streams partial assistant text.
+ */
+streaming_deltas: CapLevel, 
+/**
+ * The engine exposes a structured approval channel.
+ */
+structured_approvals: CapLevel, 
+/**
+ * The engine accepts a mid-turn user message.
+ */
+mid_turn_steering: CapLevel, 
+/**
+ * The engine has a read-only / plan posture the adapter can select.
+ */
+plan_mode: CapLevel, 
+/**
+ * The engine accepts a reasoning-effort control.
+ */
+reasoning_levels: CapLevel, 
+/**
+ * The engine emits native file-change events.
+ */
+native_file_change_events: CapLevel, 
+/**
+ * The engine honors a native interrupt.
+ */
+native_interrupt: CapLevel, };
+
+/**
+ * One engine's probe, capabilities, and remediation.
+ */
+export type HarnessDoctorEntry = { kind: HarnessKind, found: boolean, path?: string, version?: string, tier: HarnessTier, caps: HarnessCaps, authenticated?: boolean, remediation: string, stderr: string, unrecognized_event_count: number, };
+
+/**
+ * Doctor report for every registered engine adapter.
+ */
+export type HarnessDoctorReport = { harnesses: Array<HarnessDoctorEntry>, };
+
+/**
+ * Which external agent engine a session is bound to.
+ *
+ * Named after the shipped adapters. The traits those adapters implement
+ * stay engine-neutral; this enum is only the catalog of known engines.
+ */
+export type HarnessKind = "claude_code" | "codex" | "opencode" | "grok";
+
+/**
+ * Severity of a visible-degradation notice.
+ */
+export type HarnessNoticeLevel = "info" | "warning" | "error";
+
+/**
+ * Adapter maturity, independent of any one capability flag.
+ */
+export type HarnessTier = "reference" | "secondary" | "tertiary" | "best_effort";
 
 /**
  * Renderer-safe mirror of the host broker's capability vocabulary.
@@ -2071,6 +2462,27 @@ models: Array<CustomModelConfig>, };
 export type ProviderKind = "anthropic" | "openai" | "xai" | "gemini" | "fireworks" | "together" | "openrouter" | "ollama" | "openai_compatible" | "model_gateway";
 
 /**
+ * Bounded pull-request digest stored on a workspace.
+ */
+export type PullRequestDigest = { 
+/**
+ * PR number on the host.
+ */
+number: number, 
+/**
+ * Host URL, when known.
+ */
+url?: string | null, 
+/**
+ * Host state token (open, merged, closed, …).
+ */
+state: string, 
+/**
+ * One-line checks summary.
+ */
+checks_summary?: string | null, };
+
+/**
  * The id is the client-generated turn id promotion will accept under, so an
  * ambiguous promotion retry resolves to `Existing` rather than a duplicate
  * turn. Rows are FIFO by `position` within a chat and fully durable: a queue
@@ -2117,6 +2529,23 @@ created_at: string,
  * When it was last edited or reordered.
  */
 updated_at: string, };
+
+/**
+ * A named command the user can run in a workspace.
+ */
+export type QuickAction = { 
+/**
+ * Display name.
+ */
+name: string, 
+/**
+ * Command to run in the worktree.
+ */
+command: string, 
+/**
+ * When true, run once after workspace creation.
+ */
+auto_run_on_create: boolean, };
 
 /**
  * How hard a reasoning-capable model should think before answering.
@@ -2278,6 +2707,11 @@ cache_read_input_tokens: number,
 cache_creation_input_tokens: number, };
 
 /**
+ * Identifies a registered local git repository.
+ */
+export type RepoId = string;
+
+/**
  * Non-authoritative, well-known starting location for the native picker.
  *
  * This is deliberately not a free-form path. The trusted desktop decides how
@@ -2399,6 +2833,11 @@ error: string, };
  * Why a root appears in one conversation's exact ordered projection.
  */
 export type RootAttachmentOrigin = "project_default" | "conversation";
+
+/**
+ * One journaled event on the per-session WebSocket.
+ */
+export type SequencedCodeEventFrame = { seq: number, event: CodeEvent, replayed?: boolean, };
 
 /**
  * Runtime settings a client can read. The API key itself is never returned —
@@ -2695,6 +3134,40 @@ network: NetworkPolicy, };
 export type ToolApprovalKind = "search_may_share_query_and_excerpts" | "web_search_may_share_query" | "web_extract_may_fetch_url" | "exec_may_run_networked_command" | "external_mcp_may_call_server" | "workspace_may_modify_files" | "delegate_may_run_background_agent" | "computer_may_control_app" | "unsupported";
 
 /**
+ * Display-oriented classification of a tool the engine started.
+ */
+export type ToolDetail = { "kind": "command", 
+/**
+ * Command string.
+ */
+cmd: string, 
+/**
+ * Working directory, when reported.
+ */
+cwd: string, } | { "kind": "file_edit", 
+/**
+ * Path being edited.
+ */
+path: string, } | { "kind": "file_read", 
+/**
+ * Path being read.
+ */
+path: string, } | { "kind": "search", 
+/**
+ * Query string.
+ */
+query: string, } | { "kind": "other", 
+/**
+ * Bounded summary.
+ */
+summary: string, };
+
+/**
+ * How a tool call finished.
+ */
+export type ToolOutcome = "succeeded" | "failed" | "denied";
+
+/**
  * What a call produced, in a form a human can read.
  *
  * A command's output is the whole reason to run it. Withholding it leaves the
@@ -2915,6 +3388,11 @@ export type WebSearchMode = "automatic" | "vendor" | "host" | "off";
  * reference; it is intentionally not a model-controlled argument.
  */
 export type WebSearchProviderKind = "exa" | "tavily" | "brave" | "searxng";
+
+/**
+ * Identifies one isolated workspace (worktree + branch) on a repo.
+ */
+export type WorkspaceId = string;
 
 /**
  * Every tool name the renderer will accept, at runtime.

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -2483,6 +2483,11 @@ state: string,
 checks_summary?: string | null, };
 
 /**
+ * A follow-up parked while the session is already running a turn.
+ */
+export type QueuedCodeTurn = { session_id: CodeSessionId, message: string, };
+
+/**
  * The id is the client-generated turn id promotion will accept under, so an
  * ambiguous promotion retry resolves to `Existing` rather than a duplicate
  * turn. Rows are FIFO by `position` within a chat and fully durable: a queue

--- a/crates/tidebreak-harness/src/claude/session.rs
+++ b/crates/tidebreak-harness/src/claude/session.rs
@@ -209,6 +209,13 @@ impl HarnessSession for ClaudeSession {
         self.resume_ref.clone()
     }
 
+    fn child_pid(&self) -> Option<i64> {
+        self.child
+            .as_ref()
+            .and_then(tokio::process::Child::id)
+            .map(i64::from)
+    }
+
     async fn shutdown(mut self: Box<Self>) -> Result<(), HarnessError> {
         if let Some(mut child) = self.child.take() {
             let _ = child.kill().await;

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -234,8 +234,28 @@ pub trait HarnessSession: Send {
     /// Ask the engine to stop the current turn.
     async fn interrupt(&mut self) -> Result<(), HarnessError>;
 
+    /// Inject a mid-turn user message, when the engine accepts one.
+    ///
+    /// The default refuses: an adapter must override this only when its
+    /// capability vector states [`CapLevel::Supported`] for mid-turn steering.
+    async fn steer(&mut self, text: String) -> Result<(), HarnessError> {
+        let _ = text;
+        Err(HarnessError::Other(
+            "mid-turn steering is not available on this engine".into(),
+        ))
+    }
+
     /// Engine-native resume token, when the stream has reported one.
     fn resume_ref(&self) -> Option<String>;
+
+    /// Child pid recorded from a process this session spawned, when any.
+    ///
+    /// Recovery only ever probes a pid this method has exposed. The default
+    /// is `None`: an adapter that does not spawn a child, or has not spawned
+    /// one yet, must not invent a pid.
+    fn child_pid(&self) -> Option<i64> {
+        None
+    }
 
     /// Tear the session down.
     async fn shutdown(self: Box<Self>) -> Result<(), HarnessError>;

--- a/crates/tidebreak-server/Cargo.toml
+++ b/crates/tidebreak-server/Cargo.toml
@@ -19,10 +19,14 @@ postgres = ["tidebreak-core/postgres"]
 # a real turn through the binary. Off by default and never enabled by a release
 # build: see `src/scripted_provider.rs`.
 scripted-provider = []
+# Compile the scripted external-engine adapter in, so a test in another crate
+# can drive a real code-mode turn through the binary. Off by default.
+scripted-harness = []
 
 [dependencies]
 tidebreak-shell-policy = { path = "../tidebreak-shell-policy" }
 tidebreak-code-execution = { path = "../tidebreak-code-execution" }
+tidebreak-harness = { path = "../tidebreak-harness" }
 tidebreak-core = { path = "../tidebreak-core", default-features = false, features = ["sqlite", "tools", "keychain", "blob-fs"] }
 tidebreak-egress = { path = "../tidebreak-egress" }
 tidebreak-mcp = { path = "../tidebreak-mcp" }

--- a/crates/tidebreak-server/src/code/bus.rs
+++ b/crates/tidebreak-server/src/code/bus.rs
@@ -1,0 +1,41 @@
+//! In-memory live fan-out for one code-mode session.
+//!
+//! The journal is the durable record a client replays on connect; this bus is
+//! the live tail. The session worker appends each event to the journal and
+//! then publishes it here with its assigned `seq`.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use tidebreak_core::{CodeSessionId, SequencedCodeEvent};
+use tokio::sync::broadcast;
+
+const LIVE_BUFFER: usize = 256;
+
+/// Per-session broadcast channels for live journal events.
+#[derive(Default)]
+pub(crate) struct CodeEventBus {
+    channels: Mutex<HashMap<CodeSessionId, broadcast::Sender<SequencedCodeEvent>>>,
+}
+
+impl CodeEventBus {
+    pub(crate) fn sender(&self, session: CodeSessionId) -> broadcast::Sender<SequencedCodeEvent> {
+        self.channels
+            .lock()
+            .expect("code event bus lock")
+            .entry(session)
+            .or_insert_with(|| broadcast::channel(LIVE_BUFFER).0)
+            .clone()
+    }
+
+    pub(crate) fn subscribe(
+        &self,
+        session: CodeSessionId,
+    ) -> broadcast::Receiver<SequencedCodeEvent> {
+        self.sender(session).subscribe()
+    }
+
+    pub(crate) fn publish(&self, session: CodeSessionId, event: SequencedCodeEvent) {
+        let _ = self.sender(session).send(event);
+    }
+}

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -1,0 +1,14 @@
+//! Server-side orchestration for an external agent-engine session.
+//!
+//! Persistence lives in `tidebreak-core::db::code`. Protocol translation lives
+//! in `tidebreak-harness`. This module owns git worktrees, the per-session
+//! worker, crash recovery, and the live event bus.
+
+pub(crate) mod bus;
+pub(crate) mod recovery;
+pub(crate) mod runtime;
+pub(crate) mod session_worker;
+pub(crate) mod setup_script;
+pub(crate) mod worktree;
+
+pub(crate) use runtime::CodeRuntime;

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -1,0 +1,375 @@
+//! Boot recovery for sessions recorded as running.
+//!
+//! A recorded child pid is probed with signal 0 only. Dead → the open turn
+//! closes as Interrupted (journaled) and the session is Idle. Alive → the
+//! session is fenced until an explicit reap. A pid that was not recorded at
+//! spawn is never signaled.
+
+use std::io::ErrorKind;
+
+use chrono::Utc;
+use tidebreak_core::db::code::{
+    append_event, get_open_turn, list_sessions_by_lifecycle, save_session, save_turn,
+};
+use tidebreak_core::{
+    Attention, AttentionSource, AttentionState, CodeEvent, CodeSession, CodeSessionLifecycle,
+    CodeTurnStatus, DbStore, FenceReason,
+};
+
+/// What boot recovery did to one session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RecoveryAction {
+    Interrupted { session: String },
+    Fenced { session: String },
+}
+
+/// Probe result for a pid that was recorded at spawn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PidLiveness {
+    Alive,
+    Dead,
+}
+
+/// Scan every `Running` session and apply the conservative recovery rule.
+pub(crate) async fn recover_running_sessions(
+    store: &DbStore,
+) -> Result<Vec<RecoveryAction>, tidebreak_core::AgentError> {
+    recover_running_sessions_with(store, probe_recorded_pid).await
+}
+
+pub(crate) async fn recover_running_sessions_with(
+    store: &DbStore,
+    probe: impl Fn(i64) -> PidLiveness,
+) -> Result<Vec<RecoveryAction>, tidebreak_core::AgentError> {
+    let running = list_sessions_by_lifecycle(store, CodeSessionLifecycle::Running).await?;
+    let mut actions = Vec::new();
+    for session in running {
+        if let Some(action) = recover_one(store, session, &probe).await? {
+            actions.push(action);
+        }
+    }
+    Ok(actions)
+}
+
+/// Resolve a fenced session after an explicit user reap. Never signals.
+pub(crate) async fn reap_session(
+    store: &DbStore,
+    mut session: CodeSession,
+) -> Result<CodeSession, tidebreak_core::AgentError> {
+    session.lifecycle = CodeSessionLifecycle::Idle;
+    session.fence_reason = None;
+    session.child_pid = None;
+    let next = Attention::working(AttentionSource::Lifecycle);
+    if tidebreak_core::should_replace(&session.attention, &next) {
+        session.attention = next;
+    }
+    save_session(store, &session).await?;
+    Ok(session)
+}
+
+async fn recover_one(
+    store: &DbStore,
+    mut session: CodeSession,
+    probe: &impl Fn(i64) -> PidLiveness,
+) -> Result<Option<RecoveryAction>, tidebreak_core::AgentError> {
+    let Some(pid) = session.child_pid else {
+        // No recorded pid: treat as dead. Never invent a pid to probe.
+        interrupt_open_turn(store, &session).await?;
+        session.lifecycle = CodeSessionLifecycle::Idle;
+        session.child_pid = None;
+        session.attention = Attention::needs_you(
+            "session recovered after the engine process exited",
+            AttentionSource::Lifecycle,
+        );
+        save_session(store, &session).await?;
+        return Ok(Some(RecoveryAction::Interrupted {
+            session: session.id.to_string(),
+        }));
+    };
+    match probe(pid) {
+        PidLiveness::Dead => {
+            interrupt_open_turn(store, &session).await?;
+            session.lifecycle = CodeSessionLifecycle::Idle;
+            session.child_pid = None;
+            session.attention = Attention::needs_you(
+                "session recovered after the engine process exited",
+                AttentionSource::Lifecycle,
+            );
+            save_session(store, &session).await?;
+            Ok(Some(RecoveryAction::Interrupted {
+                session: session.id.to_string(),
+            }))
+        }
+        PidLiveness::Alive => {
+            session.lifecycle = CodeSessionLifecycle::Fenced;
+            session.fence_reason = Some(FenceReason::OrphanAlive);
+            session.attention = Attention::new(
+                AttentionState::Fenced {
+                    reason: FenceReason::OrphanAlive,
+                },
+                AttentionSource::Lifecycle,
+            );
+            save_session(store, &session).await?;
+            Ok(Some(RecoveryAction::Fenced {
+                session: session.id.to_string(),
+            }))
+        }
+    }
+}
+
+async fn interrupt_open_turn(
+    store: &DbStore,
+    session: &CodeSession,
+) -> Result<(), tidebreak_core::AgentError> {
+    if let Some(mut turn) = get_open_turn(store, session.id).await? {
+        turn.status = CodeTurnStatus::Interrupted;
+        turn.ended_at = Some(Utc::now());
+        save_turn(store, &turn).await?;
+        match append_event(
+            store,
+            session.id,
+            session.spawn_epoch,
+            &CodeEvent::TurnInterrupted,
+        )
+        .await
+        {
+            Ok(_) => {}
+            Err(tidebreak_core::db::code::CodeJournalError::StaleSpawnEpoch { .. }) => {}
+            Err(tidebreak_core::db::code::CodeJournalError::SessionNotFound { .. }) => {}
+            Err(tidebreak_core::db::code::CodeJournalError::Store(err)) => return Err(err),
+        }
+    }
+    Ok(())
+}
+
+/// Signal-0 probe of a pid that was recorded at spawn.
+///
+/// `EPERM` counts as alive. This function is the only place recovery sends a
+/// signal, and it sends only signal 0 (existence check).
+pub(crate) fn probe_recorded_pid(pid: i64) -> PidLiveness {
+    if pid <= 0 {
+        return PidLiveness::Dead;
+    }
+    #[cfg(unix)]
+    {
+        let raw = pid as libc::pid_t;
+        // SAFETY: signal 0 never delivers; it only checks whether the pid exists
+        // and whether this process may signal it. The pid was recorded from a
+        // child this session spawned.
+        let result = unsafe { libc::kill(raw, 0) };
+        if result == 0 {
+            return PidLiveness::Alive;
+        }
+        match std::io::Error::last_os_error().kind() {
+            ErrorKind::PermissionDenied => PidLiveness::Alive,
+            ErrorKind::NotFound => PidLiveness::Dead,
+            _ => {
+                let errno = std::io::Error::last_os_error().raw_os_error();
+                if errno == Some(libc::EPERM) {
+                    PidLiveness::Alive
+                } else if errno == Some(libc::ESRCH) {
+                    PidLiveness::Dead
+                } else {
+                    // Ambiguity is treated as alive so we fence rather than kill.
+                    PidLiveness::Alive
+                }
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        PidLiveness::Alive
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use tidebreak_core::db::code::{
+        get_session, get_turn, insert_repo, insert_session, insert_turn, insert_workspace,
+    };
+    use tidebreak_core::{
+        Attention, CodePermissionMode, CodeRepo, CodeSessionId, CodeTurn, CodeTurnId,
+        CodeWorkspace, CodeWorkspaceStatus, HarnessKind, RepoId, WorkspaceId,
+    };
+
+    fn now() -> chrono::DateTime<Utc> {
+        Utc::now()
+    }
+
+    async fn seeded_running(
+        pid: Option<i64>,
+    ) -> (tempfile::TempDir, DbStore, CodeSessionId, CodeTurnId) {
+        let directory = tempfile::tempdir().unwrap();
+        let store = DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            directory.path().join("t.db").display()
+        ))
+        .await
+        .unwrap();
+        let repo_id = RepoId::new();
+        insert_repo(
+            &store,
+            &CodeRepo {
+                id: repo_id,
+                root_path: directory.path().join("repo").display().to_string(),
+                display_name: "example".into(),
+                default_base_ref: "main".into(),
+                branch_prefix: "tidebreak/".into(),
+                setup_script: None,
+                archive_script: None,
+                quick_actions: Vec::new(),
+                created_at: now(),
+            },
+        )
+        .await
+        .unwrap();
+        let workspace_id = WorkspaceId::new();
+        insert_workspace(
+            &store,
+            &CodeWorkspace {
+                id: workspace_id,
+                repo_id,
+                title: "first".into(),
+                worktree_path: directory.path().join("wt").display().to_string(),
+                branch_name: "tidebreak/first".into(),
+                base_ref: "main".into(),
+                status: CodeWorkspaceStatus::Active,
+                pr: None,
+                created_at: now(),
+                archived_at: None,
+            },
+        )
+        .await
+        .unwrap();
+        let session_id = CodeSessionId::new();
+        insert_session(
+            &store,
+            &CodeSession {
+                id: session_id,
+                workspace_id,
+                harness_kind: HarnessKind::ClaudeCode,
+                harness_version: Some("2.1.233".into()),
+                harness_resume_ref: None,
+                permission_mode: CodePermissionMode::Plan,
+                lifecycle: CodeSessionLifecycle::Running,
+                fence_reason: None,
+                child_pid: pid,
+                spawn_epoch: 1,
+                attention: Attention::working(AttentionSource::Lifecycle),
+                unrecognized_event_count: 0,
+                created_at: now(),
+            },
+        )
+        .await
+        .unwrap();
+        let turn_id = CodeTurnId::new();
+        insert_turn(
+            &store,
+            &CodeTurn {
+                id: turn_id,
+                session_id,
+                ordinal: 1,
+                status: CodeTurnStatus::Running,
+                user_input: "hello".into(),
+                user_input_blob_id: None,
+                checkpoint_ref: None,
+                diffstat: None,
+                usage: None,
+                narrative: None,
+                started_at: now(),
+                ended_at: None,
+            },
+        )
+        .await
+        .unwrap();
+        (directory, store, session_id, turn_id)
+    }
+
+    #[tokio::test]
+    async fn dead_pid_closes_the_open_turn_as_interrupted() {
+        let (_dir, store, session_id, turn_id) = seeded_running(Some(9_999_991)).await;
+        let actions = recover_running_sessions_with(&store, |_| PidLiveness::Dead)
+            .await
+            .unwrap();
+        assert!(matches!(
+            actions.as_slice(),
+            [RecoveryAction::Interrupted { .. }]
+        ));
+        let session = get_session(&store, session_id).await.unwrap().unwrap();
+        assert_eq!(session.lifecycle, CodeSessionLifecycle::Idle);
+        assert!(matches!(
+            session.attention.state,
+            AttentionState::NeedsYou {
+                source: AttentionSource::Lifecycle,
+                ..
+            }
+        ));
+        let turn = get_turn(&store, turn_id).await.unwrap().unwrap();
+        assert_eq!(turn.status, CodeTurnStatus::Interrupted);
+    }
+
+    #[tokio::test]
+    async fn live_recorded_pid_fences_and_does_not_signal_a_decoy() {
+        let signaled = Arc::new(AtomicBool::new(false));
+        let mut decoy = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn decoy");
+        let decoy_pid = i64::from(decoy.id());
+        let (_dir, store, session_id, turn_id) = seeded_running(Some(decoy_pid)).await;
+        let flag = signaled.clone();
+        let actions = recover_running_sessions_with(&store, move |pid| {
+            // Recovery must probe only the recorded pid, and only via the
+            // injected probe — never by signaling the decoy itself.
+            assert_eq!(pid, decoy_pid);
+            flag.store(true, Ordering::SeqCst);
+            PidLiveness::Alive
+        })
+        .await
+        .unwrap();
+        assert!(matches!(
+            actions.as_slice(),
+            [RecoveryAction::Fenced { .. }]
+        ));
+        let session = get_session(&store, session_id).await.unwrap().unwrap();
+        assert_eq!(session.lifecycle, CodeSessionLifecycle::Fenced);
+        assert_eq!(session.fence_reason, Some(FenceReason::OrphanAlive));
+        let turn = get_turn(&store, turn_id).await.unwrap().unwrap();
+        assert_eq!(turn.status, CodeTurnStatus::Running);
+        assert!(
+            decoy.try_wait().ok().flatten().is_none(),
+            "decoy must still be alive — recovery must not signal it"
+        );
+        let _ = signaled;
+        let _ = decoy.kill();
+        let _ = decoy.wait();
+    }
+
+    #[tokio::test]
+    async fn eperm_probe_counts_as_alive() {
+        let (_dir, store, session_id, _) = seeded_running(Some(1)).await;
+        let actions = recover_running_sessions_with(&store, |_| PidLiveness::Alive)
+            .await
+            .unwrap();
+        assert!(matches!(
+            actions.as_slice(),
+            [RecoveryAction::Fenced { .. }]
+        ));
+        let session = get_session(&store, session_id).await.unwrap().unwrap();
+        assert_eq!(session.lifecycle, CodeSessionLifecycle::Fenced);
+    }
+
+    #[test]
+    fn probe_never_kills_and_treats_eperm_as_alive() {
+        // Our own pid is alive; signal 0 must not terminate us.
+        let self_pid = i64::from(std::process::id());
+        assert_eq!(probe_recorded_pid(self_pid), PidLiveness::Alive);
+        assert_eq!(probe_recorded_pid(-1), PidLiveness::Dead);
+        assert_eq!(probe_recorded_pid(0), PidLiveness::Dead);
+    }
+}

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -1,0 +1,620 @@
+//! Process-wide code-mode runtime: adapters, workers, worktrees, recovery.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use chrono::Utc;
+use tokio::sync::oneshot;
+
+use tidebreak_core::db::code::{
+    delete_repo, delete_workspace, get_repo, get_repo_by_root_path, get_session, get_workspace,
+    insert_repo, insert_session, insert_workspace, list_repos, list_sessions,
+    list_sessions_for_workspace, list_workspaces, save_repo, save_session, save_workspace,
+};
+use tidebreak_core::{
+    Attention, AttentionSource, CapLevel, CodePermissionMode, CodeRepo, CodeSession, CodeSessionId,
+    CodeSessionLifecycle, CodeTurn, CodeWorkspace, CodeWorkspaceStatus, DbStore, HarnessKind,
+    RepoId, WorkspaceId,
+};
+use tidebreak_harness::{builtin_registry, AdapterRegistry, HarnessAdapter, HostEnv, SessionSpec};
+
+use super::bus::CodeEventBus;
+use super::recovery::{self, RecoveryAction};
+use super::session_worker::{
+    attach_engine, spawn_session_worker, WorkerCommand, WorkerError, WorkerHandle,
+};
+use super::worktree::{
+    self, archive_blockers, branch_name, create_worktree, prune_worktrees, remove_worktree,
+    run_setup_script, slugify, validate_repo_path, worktree_dir, WorktreeError,
+};
+use crate::error::ServerError;
+
+/// Shared code-mode services for the process.
+pub(crate) struct CodeRuntime {
+    pub db: Arc<DbStore>,
+    pub bus: Arc<CodeEventBus>,
+    pub adapters: AdapterRegistry,
+    pub data_dir: PathBuf,
+    host: HostEnv,
+    workers: Mutex<HashMap<CodeSessionId, WorkerHandle>>,
+}
+
+impl CodeRuntime {
+    pub(crate) fn new(db: Arc<DbStore>, data_dir: PathBuf) -> Self {
+        Self {
+            db,
+            bus: Arc::new(CodeEventBus::default()),
+            adapters: builtin_registry(),
+            data_dir,
+            host: HostEnv::from_process(),
+            workers: Mutex::new(HashMap::new()),
+        }
+    }
+
+    #[cfg(any(test, feature = "scripted-harness"))]
+    pub(crate) fn with_registry(
+        db: Arc<DbStore>,
+        data_dir: PathBuf,
+        adapters: AdapterRegistry,
+    ) -> Self {
+        Self {
+            db,
+            bus: Arc::new(CodeEventBus::default()),
+            adapters,
+            data_dir,
+            host: HostEnv::from_process(),
+            workers: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub(crate) async fn recover(&self) -> Result<Vec<RecoveryAction>, ServerError> {
+        recovery::recover_running_sessions(&self.db)
+            .await
+            .map_err(ServerError::from)
+    }
+
+    pub(crate) fn adapter(
+        &self,
+        kind: HarnessKind,
+    ) -> Result<Arc<dyn HarnessAdapter>, ServerError> {
+        self.adapters.get(kind).ok_or_else(|| {
+            ServerError::bad_request_kind(
+                "harness_unavailable",
+                format!("no adapter is registered for {kind}"),
+            )
+        })
+    }
+
+    pub(crate) async fn register_repo(
+        &self,
+        root_path: PathBuf,
+        display_name: Option<String>,
+        default_base_ref: Option<String>,
+        branch_prefix: Option<String>,
+        setup_script: Option<String>,
+        archive_script: Option<String>,
+    ) -> Result<CodeRepo, ServerError> {
+        let validated = validate_repo_path(&root_path).await.map_err(map_worktree)?;
+        let toplevel = validated.toplevel.display().to_string();
+        if let Some(existing) = get_repo_by_root_path(&self.db, &toplevel).await? {
+            return Err(ServerError::conflict_kind(
+                "repo_already_registered",
+                format!(
+                    "repository {} is already registered as {}",
+                    toplevel, existing.id
+                ),
+            ));
+        }
+        // Nested registrations of the same toplevel are already collapsed by
+        // canonicalize + unique root_path. A path inside another registered
+        // repo would resolve to the same toplevel.
+        let name = display_name
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| {
+                validated
+                    .toplevel
+                    .file_name()
+                    .map(|name| name.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| "repo".into())
+            });
+        let repo = CodeRepo {
+            id: RepoId::new(),
+            root_path: toplevel,
+            display_name: name,
+            default_base_ref: default_base_ref
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or_else(|| "main".into()),
+            branch_prefix: branch_prefix
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or_else(|| "tidebreak/".into()),
+            setup_script,
+            archive_script,
+            quick_actions: Vec::new(),
+            created_at: Utc::now(),
+        };
+        insert_repo(&self.db, &repo).await?;
+        Ok(repo)
+    }
+
+    pub(crate) async fn list_repos(&self) -> Result<Vec<CodeRepo>, ServerError> {
+        Ok(list_repos(&self.db).await?)
+    }
+
+    pub(crate) async fn get_repo(&self, id: RepoId) -> Result<CodeRepo, ServerError> {
+        get_repo(&self.db, id)
+            .await?
+            .ok_or_else(|| ServerError::not_found(format!("repo {id} not found")))
+    }
+
+    pub(crate) async fn save_repo(&self, repo: &CodeRepo) -> Result<(), ServerError> {
+        if !save_repo(&self.db, repo).await? {
+            return Err(ServerError::not_found(format!(
+                "repo {} not found",
+                repo.id
+            )));
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn delete_repo(&self, id: RepoId) -> Result<(), ServerError> {
+        let workspaces = list_workspaces(&self.db, Some(id)).await?;
+        if workspaces
+            .iter()
+            .any(|workspace| workspace.status != CodeWorkspaceStatus::Archived)
+        {
+            return Err(ServerError::conflict_kind(
+                "repo_has_workspaces",
+                "archive every workspace before deleting the repository",
+            ));
+        }
+        if !delete_repo(&self.db, id).await? {
+            return Err(ServerError::not_found(format!("repo {id} not found")));
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn create_workspace(
+        &self,
+        repo_id: RepoId,
+        title: Option<String>,
+        base_ref: Option<String>,
+    ) -> Result<CodeWorkspace, ServerError> {
+        let repo = self.get_repo(repo_id).await?;
+        let title = title
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_default();
+        let id = WorkspaceId::new();
+        let branch = branch_name(&repo.branch_prefix, &title, id.0.as_u128());
+        let existing = list_workspaces(&self.db, Some(repo_id)).await?;
+        if existing
+            .iter()
+            .any(|workspace| workspace.branch_name == branch)
+        {
+            return Err(ServerError::conflict_kind(
+                "branch_collision",
+                format!("branch {branch} already exists on this repository"),
+            ));
+        }
+        let repo_slug = {
+            let from_name = slugify(&repo.display_name);
+            if from_name.is_empty() {
+                slugify(&repo.root_path)
+            } else {
+                from_name
+            }
+        };
+        let workspace_slug = {
+            let from_title = slugify(&title);
+            if from_title.is_empty() {
+                worktree::two_word_name(id.0.as_u128())
+            } else {
+                from_title
+            }
+        };
+        let path = worktree_dir(&self.data_dir, &repo_slug, &workspace_slug);
+        let display_title = if title.is_empty() {
+            workspace_slug.clone()
+        } else {
+            title
+        };
+        let base = base_ref
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| repo.default_base_ref.clone());
+        let mut workspace = CodeWorkspace {
+            id,
+            repo_id,
+            title: display_title,
+            worktree_path: path.display().to_string(),
+            branch_name: branch.clone(),
+            base_ref: base.clone(),
+            status: CodeWorkspaceStatus::Creating,
+            pr: None,
+            created_at: Utc::now(),
+            archived_at: None,
+        };
+        insert_workspace(&self.db, &workspace).await?;
+        match create_worktree(std::path::Path::new(&repo.root_path), &path, &branch, &base).await {
+            Ok(()) => {}
+            Err(err) => {
+                let _ = delete_workspace(&self.db, id).await;
+                return Err(map_worktree(err));
+            }
+        }
+        match run_setup_script(&path, repo.setup_script.as_deref()).await {
+            Ok(()) => {
+                workspace.status = CodeWorkspaceStatus::Active;
+                save_workspace(&self.db, &workspace).await?;
+                Ok(workspace)
+            }
+            Err(err) => {
+                workspace.status = CodeWorkspaceStatus::SetupFailed;
+                save_workspace(&self.db, &workspace).await?;
+                Err(ServerError::unprocessable_kind(
+                    "setup_failed",
+                    err.to_string(),
+                ))
+            }
+        }
+    }
+
+    pub(crate) async fn list_workspaces(
+        &self,
+        repo_id: Option<RepoId>,
+    ) -> Result<Vec<CodeWorkspace>, ServerError> {
+        Ok(list_workspaces(&self.db, repo_id).await?)
+    }
+
+    pub(crate) async fn get_workspace(
+        &self,
+        id: WorkspaceId,
+    ) -> Result<CodeWorkspace, ServerError> {
+        get_workspace(&self.db, id)
+            .await?
+            .ok_or_else(|| ServerError::not_found(format!("workspace {id} not found")))
+    }
+
+    pub(crate) async fn save_workspace(
+        &self,
+        workspace: &CodeWorkspace,
+    ) -> Result<(), ServerError> {
+        if !save_workspace(&self.db, workspace).await? {
+            return Err(ServerError::not_found(format!(
+                "workspace {} not found",
+                workspace.id
+            )));
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn archive_workspace(
+        &self,
+        id: WorkspaceId,
+        force: bool,
+    ) -> Result<CodeWorkspace, ServerError> {
+        let mut workspace = self.get_workspace(id).await?;
+        if workspace.status == CodeWorkspaceStatus::Archived {
+            return Ok(workspace);
+        }
+        let repo = self.get_repo(workspace.repo_id).await?;
+        if let Some(script) = repo.archive_script.as_deref() {
+            if let Err(err) = super::setup_script::run_workspace_script(
+                std::path::Path::new(&workspace.worktree_path),
+                script,
+            )
+            .await
+            {
+                return Err(ServerError::unprocessable_kind(
+                    "archive_script_failed",
+                    err,
+                ));
+            }
+        }
+        let path = std::path::Path::new(&workspace.worktree_path);
+        if path.exists() {
+            if let Some(block) = archive_blockers(path, &workspace.base_ref)
+                .await
+                .map_err(map_worktree)?
+            {
+                if !force {
+                    return Err(ServerError::conflict_kind(
+                        block.as_str(),
+                        "workspace has uncommitted or unpushed work; pass force to discard it",
+                    ));
+                }
+            }
+        }
+        remove_worktree(std::path::Path::new(&repo.root_path), path)
+            .await
+            .map_err(map_worktree)?;
+        let _ = prune_worktrees(std::path::Path::new(&repo.root_path)).await;
+        workspace.status = CodeWorkspaceStatus::Archived;
+        workspace.archived_at = Some(Utc::now());
+        save_workspace(&self.db, &workspace).await?;
+        Ok(workspace)
+    }
+
+    pub(crate) async fn create_session(
+        &self,
+        workspace_id: WorkspaceId,
+        harness: HarnessKind,
+        permission_mode: CodePermissionMode,
+    ) -> Result<CodeSession, ServerError> {
+        if permission_mode != CodePermissionMode::Plan {
+            return Err(ServerError::unprocessable_kind(
+                "permission_mode_unavailable",
+                format!("{permission_mode} is not yet available; create the session in plan mode"),
+            ));
+        }
+        let workspace = self.get_workspace(workspace_id).await?;
+        if workspace.status != CodeWorkspaceStatus::Active {
+            return Err(ServerError::conflict_kind(
+                "workspace_not_ready",
+                format!("workspace is {}", workspace.status.as_str()),
+            ));
+        }
+        let existing = list_sessions_for_workspace(&self.db, workspace_id).await?;
+        if existing
+            .iter()
+            .any(|session| session.lifecycle != CodeSessionLifecycle::Ended)
+        {
+            return Err(ServerError::conflict_kind(
+                "session_exists",
+                "this workspace already has an active session",
+            ));
+        }
+        let adapter = self.adapter(harness)?;
+        let probe = adapter.probe(&self.host).await;
+        if !probe.found {
+            return Err(ServerError::unprocessable_kind(
+                "harness_not_found",
+                format!(
+                    "{harness} is not installed{}",
+                    if probe.stderr.is_empty() {
+                        String::new()
+                    } else {
+                        format!(": {}", probe.stderr)
+                    }
+                ),
+            ));
+        }
+        let caps = adapter.capabilities(&probe);
+        if caps.plan_mode != CapLevel::Supported && permission_mode == CodePermissionMode::Plan {
+            return Err(ServerError::unprocessable_kind(
+                "permission_mode_unavailable",
+                format!("{harness} cannot honor plan mode"),
+            ));
+        }
+        let binary = probe.binary_path.clone().ok_or_else(|| {
+            ServerError::unprocessable_kind("harness_not_found", format!("{harness} has no path"))
+        })?;
+        let session = CodeSession {
+            id: CodeSessionId::new(),
+            workspace_id,
+            harness_kind: harness,
+            harness_version: probe.version.clone(),
+            harness_resume_ref: None,
+            permission_mode,
+            lifecycle: CodeSessionLifecycle::Created,
+            fence_reason: None,
+            child_pid: None,
+            spawn_epoch: 0,
+            attention: Attention::working(AttentionSource::Lifecycle),
+            unrecognized_event_count: 0,
+            created_at: Utc::now(),
+        };
+        insert_session(&self.db, &session).await?;
+        let attached = attach_engine(
+            &self.db,
+            &self.bus,
+            session.id,
+            harness,
+            probe.version.clone(),
+            None,
+        )
+        .await
+        .map_err(map_worker)?;
+        let spec = SessionSpec {
+            worktree: PathBuf::from(&workspace.worktree_path),
+            permission_mode,
+            resume_ref: None,
+            extra_argv: Vec::new(),
+            extra_env: Vec::new(),
+            env: probe.env.clone(),
+            approval: None,
+            binary,
+            sink: super::session_worker::sink_for(
+                self.db.clone(),
+                self.bus.clone(),
+                session.id,
+                attached.spawn_epoch,
+                None,
+            ),
+        };
+        let engine = adapter.launch(spec).await.map_err(|err| {
+            ServerError::internal(format!("failed to launch engine session: {err}"))
+        })?;
+        let allow_steer = caps.mid_turn_steering == CapLevel::Supported;
+        let mut attached = attached;
+        attached.child_pid = engine.child_pid();
+        attached.harness_resume_ref = engine.resume_ref();
+        save_session(&self.db, &attached).await?;
+        let handle = spawn_session_worker(
+            self.db.clone(),
+            self.bus.clone(),
+            attached.clone(),
+            engine,
+            allow_steer,
+        );
+        self.workers
+            .lock()
+            .expect("code workers")
+            .insert(session.id, handle);
+        Ok(attached)
+    }
+
+    pub(crate) async fn get_session(&self, id: CodeSessionId) -> Result<CodeSession, ServerError> {
+        get_session(&self.db, id)
+            .await?
+            .ok_or_else(|| ServerError::not_found(format!("session {id} not found")))
+    }
+
+    pub(crate) async fn submit_turn(
+        &self,
+        id: CodeSessionId,
+        message: String,
+    ) -> Result<CodeTurn, ServerError> {
+        let session = self.get_session(id).await?;
+        if session.lifecycle == CodeSessionLifecycle::Fenced {
+            return Err(ServerError::conflict_kind(
+                "session_fenced",
+                "session is fenced until it is reaped",
+            ));
+        }
+        if session.lifecycle == CodeSessionLifecycle::Running {
+            let allow = self
+                .adapter(session.harness_kind)?
+                .capabilities(&tidebreak_harness::HarnessProbe {
+                    found: true,
+                    binary_path: None,
+                    version: session.harness_version.clone(),
+                    authenticated: None,
+                    stderr: String::new(),
+                    env: Vec::new(),
+                })
+                .mid_turn_steering
+                == CapLevel::Supported;
+            if !allow {
+                return Err(ServerError::conflict_kind(
+                    "turn_in_progress",
+                    "a turn is already running and this engine does not accept mid-turn steering",
+                ));
+            }
+            self.steer(id, message.clone()).await?;
+            return Ok(CodeTurn {
+                id: tidebreak_core::CodeTurnId::new(),
+                session_id: id,
+                ordinal: 0,
+                status: tidebreak_core::CodeTurnStatus::Running,
+                user_input: message,
+                user_input_blob_id: None,
+                checkpoint_ref: None,
+                diffstat: None,
+                usage: None,
+                narrative: None,
+                started_at: Utc::now(),
+                ended_at: None,
+            });
+        }
+        let handle = self.require_worker(id)?;
+        let (reply, rx) = oneshot::channel();
+        handle
+            .commands
+            .send(WorkerCommand::RunTurn { message, reply })
+            .await
+            .map_err(|_| ServerError::internal("session worker is gone"))?;
+        rx.await
+            .map_err(|_| ServerError::internal("session worker dropped the turn"))?
+            .map_err(map_worker)
+    }
+
+    pub(crate) async fn steer(
+        &self,
+        id: CodeSessionId,
+        message: String,
+    ) -> Result<(), ServerError> {
+        let handle = self.require_worker(id)?;
+        let (reply, rx) = oneshot::channel();
+        handle
+            .commands
+            .send(WorkerCommand::Steer { message, reply })
+            .await
+            .map_err(|_| ServerError::internal("session worker is gone"))?;
+        rx.await
+            .map_err(|_| ServerError::internal("session worker dropped the steer"))?
+            .map_err(map_worker)
+    }
+
+    pub(crate) async fn interrupt(&self, id: CodeSessionId) -> Result<(), ServerError> {
+        let handle = self.require_worker(id)?;
+        let (reply, rx) = oneshot::channel();
+        handle
+            .commands
+            .send(WorkerCommand::Interrupt { reply })
+            .await
+            .map_err(|_| ServerError::internal("session worker is gone"))?;
+        rx.await
+            .map_err(|_| ServerError::internal("session worker dropped the interrupt"))?
+            .map_err(map_worker)
+    }
+
+    pub(crate) async fn reap(&self, id: CodeSessionId) -> Result<CodeSession, ServerError> {
+        let session = self.get_session(id).await?;
+        if session.lifecycle != CodeSessionLifecycle::Fenced {
+            return Err(ServerError::conflict_kind(
+                "not_fenced",
+                "only a fenced session can be reaped",
+            ));
+        }
+        let handle = self.workers.lock().expect("code workers").remove(&id);
+        if let Some(handle) = handle {
+            let _ = handle.commands.send(WorkerCommand::Shutdown).await;
+        }
+        recovery::reap_session(&self.db, session)
+            .await
+            .map_err(ServerError::from)
+    }
+
+    pub(crate) async fn list_sessions(&self) -> Result<Vec<CodeSession>, ServerError> {
+        Ok(list_sessions(&self.db).await?)
+    }
+
+    fn require_worker(&self, id: CodeSessionId) -> Result<WorkerHandle, ServerError> {
+        self.workers
+            .lock()
+            .expect("code workers")
+            .get(&id)
+            .map(|handle| WorkerHandle {
+                spawn_epoch: handle.spawn_epoch,
+                commands: handle.commands.clone(),
+            })
+            .ok_or_else(|| {
+                ServerError::conflict_kind(
+                    "session_worker_missing",
+                    "no live worker is attached to this session",
+                )
+            })
+    }
+}
+
+fn map_worktree(err: WorktreeError) -> ServerError {
+    match err {
+        WorktreeError::User(message) => {
+            if message.contains("already exists") {
+                ServerError::conflict_kind("branch_collision", message)
+            } else if message.contains("bare") {
+                ServerError::bad_request_kind("bare_repo", message)
+            } else if message.contains("not a git repository") {
+                ServerError::bad_request_kind("not_a_repo", message)
+            } else {
+                ServerError::bad_request_kind("worktree", message)
+            }
+        }
+        WorktreeError::Internal(message) => ServerError::internal(message),
+    }
+}
+
+fn map_worker(err: WorkerError) -> ServerError {
+    match err {
+        WorkerError::Conflict(message) => ServerError::conflict_kind("conflict", message),
+        WorkerError::Failed(message) => ServerError::internal(message),
+    }
+}
+
+impl From<WorktreeError> for ServerError {
+    fn from(err: WorktreeError) -> Self {
+        map_worktree(err)
+    }
+}

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -77,9 +77,34 @@ impl CodeRuntime {
     }
 
     pub(crate) async fn recover(&self) -> Result<Vec<RecoveryAction>, ServerError> {
-        recovery::recover_running_sessions(&self.db)
+        let actions = recovery::recover_running_sessions(&self.db)
             .await
-            .map_err(ServerError::from)
+            .map_err(ServerError::from)?;
+        // Recovery only mutates rows. Re-attach a worker for every session
+        // that is still usable so submit_turn is not stuck after a restart.
+        for session in list_sessions(&self.db).await? {
+            if matches!(
+                session.lifecycle,
+                CodeSessionLifecycle::Ended | CodeSessionLifecycle::Fenced
+            ) {
+                continue;
+            }
+            if self
+                .workers
+                .lock()
+                .expect("code workers")
+                .contains_key(&session.id)
+            {
+                continue;
+            }
+            if let Err(error) = self.attach_and_spawn_worker(session).await {
+                tracing::warn!(
+                    "code-mode: could not resume a recovered session worker: {}",
+                    error.message()
+                );
+            }
+        }
+        Ok(actions)
     }
 
     pub(crate) fn adapter(
@@ -222,7 +247,7 @@ impl CodeRuntime {
                 from_title
             }
         };
-        let path = worktree_dir(&self.data_dir, &repo_slug, &workspace_slug);
+        let path = worktree_dir(&self.data_dir, repo_id, id, &repo_slug, &workspace_slug);
         let display_title = if title.is_empty() {
             workspace_slug.clone()
         } else {
@@ -320,6 +345,7 @@ impl CodeRuntime {
                 ));
             }
         }
+        self.end_workspace_sessions(id, force).await?;
         let path = std::path::Path::new(&workspace.worktree_path);
         if path.exists() {
             if let Some(block) = archive_blockers(path, &workspace.base_ref)
@@ -395,9 +421,12 @@ impl CodeRuntime {
                 format!("{harness} cannot honor plan mode"),
             ));
         }
-        let binary = probe.binary_path.clone().ok_or_else(|| {
-            ServerError::unprocessable_kind("harness_not_found", format!("{harness} has no path"))
-        })?;
+        if probe.binary_path.is_none() {
+            return Err(ServerError::unprocessable_kind(
+                "harness_not_found",
+                format!("{harness} has no path"),
+            ));
+        }
         let session = CodeSession {
             id: CodeSessionId::new(),
             workspace_id,
@@ -414,47 +443,7 @@ impl CodeRuntime {
             created_at: Utc::now(),
         };
         insert_session(&self.db, &session).await?;
-        let attached = attach_engine(
-            &self.db,
-            &self.bus,
-            session.id,
-            harness,
-            probe.version.clone(),
-            None,
-        )
-        .await
-        .map_err(map_worker)?;
-        let spec = SessionSpec {
-            worktree: PathBuf::from(&workspace.worktree_path),
-            permission_mode,
-            resume_ref: None,
-            extra_argv: Vec::new(),
-            extra_env: Vec::new(),
-            env: probe.env.clone(),
-            approval: None,
-            binary,
-            sink: super::session_worker::sink_for(
-                self.db.clone(),
-                self.bus.clone(),
-                session.id,
-                attached.spawn_epoch,
-                None,
-            ),
-        };
-        let engine = adapter.launch(spec).await.map_err(|err| {
-            ServerError::internal(format!("failed to launch engine session: {err}"))
-        })?;
-        let mut attached = attached;
-        attached.child_pid = engine.child_pid();
-        attached.harness_resume_ref = engine.resume_ref();
-        save_session(&self.db, &attached).await?;
-        let handle =
-            spawn_session_worker(self.db.clone(), self.bus.clone(), attached.clone(), engine);
-        self.workers
-            .lock()
-            .expect("code workers")
-            .insert(session.id, handle);
-        Ok(attached)
+        self.attach_and_spawn_worker(session).await
     }
 
     pub(crate) async fn get_session(&self, id: CodeSessionId) -> Result<CodeSession, ServerError> {
@@ -541,6 +530,106 @@ impl CodeRuntime {
 
     pub(crate) async fn list_sessions(&self) -> Result<Vec<CodeSession>, ServerError> {
         Ok(list_sessions(&self.db).await?)
+    }
+
+    async fn end_workspace_sessions(
+        &self,
+        workspace_id: WorkspaceId,
+        allow_running: bool,
+    ) -> Result<(), ServerError> {
+        let sessions = list_sessions_for_workspace(&self.db, workspace_id).await?;
+        if !allow_running
+            && sessions
+                .iter()
+                .any(|session| session.lifecycle == CodeSessionLifecycle::Running)
+        {
+            return Err(ServerError::conflict_kind(
+                "session_running",
+                "a session is still running in this workspace; pass force to end it",
+            ));
+        }
+        for mut session in sessions {
+            if session.lifecycle == CodeSessionLifecycle::Ended {
+                continue;
+            }
+            let handle = self
+                .workers
+                .lock()
+                .expect("code workers")
+                .remove(&session.id);
+            if let Some(handle) = handle {
+                let _ = handle.commands.send(WorkerCommand::Shutdown).await;
+            }
+            session.lifecycle = CodeSessionLifecycle::Ended;
+            session.child_pid = None;
+            session.fence_reason = None;
+            save_session(&self.db, &session).await?;
+        }
+        Ok(())
+    }
+
+    async fn attach_and_spawn_worker(
+        &self,
+        session: CodeSession,
+    ) -> Result<CodeSession, ServerError> {
+        let workspace = self.get_workspace(session.workspace_id).await?;
+        let adapter = self.adapter(session.harness_kind)?;
+        let probe = adapter.probe(&self.host).await;
+        if !probe.found {
+            return Err(ServerError::unprocessable_kind(
+                "harness_not_found",
+                format!("{} is not installed", session.harness_kind),
+            ));
+        }
+        let binary = probe.binary_path.clone().ok_or_else(|| {
+            ServerError::unprocessable_kind(
+                "harness_not_found",
+                format!("{} has no path", session.harness_kind),
+            )
+        })?;
+        let attached = attach_engine(
+            &self.db,
+            &self.bus,
+            session.id,
+            session.harness_kind,
+            probe.version.clone().or(session.harness_version.clone()),
+            None,
+        )
+        .await
+        .map_err(map_worker)?;
+        let spec = SessionSpec {
+            worktree: PathBuf::from(&workspace.worktree_path),
+            permission_mode: session.permission_mode,
+            resume_ref: session.harness_resume_ref.clone(),
+            extra_argv: Vec::new(),
+            extra_env: Vec::new(),
+            env: probe.env.clone(),
+            approval: None,
+            binary,
+            sink: super::session_worker::sink_for(
+                self.db.clone(),
+                self.bus.clone(),
+                session.id,
+                attached.spawn_epoch,
+                None,
+            ),
+        };
+        let engine = adapter.launch(spec).await.map_err(|err| {
+            ServerError::internal(format!("failed to launch engine session: {err}"))
+        })?;
+        let mut attached = attached;
+        attached.child_pid = engine.child_pid();
+        if let Some(resume) = engine.resume_ref().or(session.harness_resume_ref.clone()) {
+            attached.harness_resume_ref = Some(resume);
+        }
+        save_session(&self.db, &attached).await?;
+        let handle =
+            spawn_session_worker(self.db.clone(), self.bus.clone(), attached.clone(), engine);
+        self.workers
+            .lock()
+            .expect("code workers")
+            .insert(session.id, handle);
+        Ok(attached)
     }
 
     fn require_worker(&self, id: CodeSessionId) -> Result<WorkerHandle, ServerError> {

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -22,13 +22,21 @@ use tidebreak_harness::{builtin_registry, AdapterRegistry, HarnessAdapter, HostE
 use super::bus::CodeEventBus;
 use super::recovery::{self, RecoveryAction};
 use super::session_worker::{
-    attach_engine, spawn_session_worker, WorkerCommand, WorkerError, WorkerHandle,
+    attach_engine, queue_follow_up, spawn_session_worker, WorkerCommand, WorkerError, WorkerHandle,
 };
 use super::worktree::{
     self, archive_blockers, branch_name, create_worktree, prune_worktrees, remove_worktree,
     run_setup_script, slugify, validate_repo_path, worktree_dir, WorktreeError,
 };
 use crate::error::ServerError;
+
+/// Result of `POST /code/sessions/{id}/turns`.
+pub(crate) enum SubmitTurnOutcome {
+    /// The session was idle; the turn ran to a terminal event.
+    Ran(Box<CodeTurn>),
+    /// The session was running; the message occupies the single follow-up slot.
+    Queued,
+}
 
 /// Shared code-mode services for the process.
 pub(crate) struct CodeRuntime {
@@ -436,18 +444,12 @@ impl CodeRuntime {
         let engine = adapter.launch(spec).await.map_err(|err| {
             ServerError::internal(format!("failed to launch engine session: {err}"))
         })?;
-        let allow_steer = caps.mid_turn_steering == CapLevel::Supported;
         let mut attached = attached;
         attached.child_pid = engine.child_pid();
         attached.harness_resume_ref = engine.resume_ref();
         save_session(&self.db, &attached).await?;
-        let handle = spawn_session_worker(
-            self.db.clone(),
-            self.bus.clone(),
-            attached.clone(),
-            engine,
-            allow_steer,
-        );
+        let handle =
+            spawn_session_worker(self.db.clone(), self.bus.clone(), attached.clone(), engine);
         self.workers
             .lock()
             .expect("code workers")
@@ -465,7 +467,7 @@ impl CodeRuntime {
         &self,
         id: CodeSessionId,
         message: String,
-    ) -> Result<CodeTurn, ServerError> {
+    ) -> Result<SubmitTurnOutcome, ServerError> {
         let session = self.get_session(id).await?;
         if session.lifecycle == CodeSessionLifecycle::Fenced {
             return Err(ServerError::conflict_kind(
@@ -473,68 +475,33 @@ impl CodeRuntime {
                 "session is fenced until it is reaped",
             ));
         }
-        if session.lifecycle == CodeSessionLifecycle::Running {
-            let allow = self
-                .adapter(session.harness_kind)?
-                .capabilities(&tidebreak_harness::HarnessProbe {
-                    found: true,
-                    binary_path: None,
-                    version: session.harness_version.clone(),
-                    authenticated: None,
-                    stderr: String::new(),
-                    env: Vec::new(),
-                })
-                .mid_turn_steering
-                == CapLevel::Supported;
-            if !allow {
-                return Err(ServerError::conflict_kind(
-                    "turn_in_progress",
-                    "a turn is already running and this engine does not accept mid-turn steering",
-                ));
-            }
-            self.steer(id, message.clone()).await?;
-            return Ok(CodeTurn {
-                id: tidebreak_core::CodeTurnId::new(),
-                session_id: id,
-                ordinal: 0,
-                status: tidebreak_core::CodeTurnStatus::Running,
-                user_input: message,
-                user_input_blob_id: None,
-                checkpoint_ref: None,
-                diffstat: None,
-                usage: None,
-                narrative: None,
-                started_at: Utc::now(),
-                ended_at: None,
-            });
+        if session.lifecycle == CodeSessionLifecycle::Ended {
+            return Err(ServerError::conflict_kind(
+                "session_ended",
+                "session has ended",
+            ));
         }
         let handle = self.require_worker(id)?;
+        if session.lifecycle == CodeSessionLifecycle::Running {
+            if !queue_follow_up(&handle, message) {
+                return Err(ServerError::conflict_kind(
+                    "queue_full",
+                    "a follow-up is already queued on this session",
+                ));
+            }
+            return Ok(SubmitTurnOutcome::Queued);
+        }
         let (reply, rx) = oneshot::channel();
         handle
             .commands
             .send(WorkerCommand::RunTurn { message, reply })
             .await
             .map_err(|_| ServerError::internal("session worker is gone"))?;
-        rx.await
-            .map_err(|_| ServerError::internal("session worker dropped the turn"))?
-            .map_err(map_worker)
-    }
-
-    pub(crate) async fn steer(
-        &self,
-        id: CodeSessionId,
-        message: String,
-    ) -> Result<(), ServerError> {
-        let handle = self.require_worker(id)?;
-        let (reply, rx) = oneshot::channel();
-        handle
-            .commands
-            .send(WorkerCommand::Steer { message, reply })
+        let turn = rx
             .await
-            .map_err(|_| ServerError::internal("session worker is gone"))?;
-        rx.await
-            .map_err(|_| ServerError::internal("session worker dropped the steer"))?
-            .map_err(map_worker)
+            .map_err(|_| ServerError::internal("session worker dropped the turn"))?
+            .map_err(map_worker)?;
+        Ok(SubmitTurnOutcome::Ran(Box::new(turn)))
     }
 
     pub(crate) async fn interrupt(&self, id: CodeSessionId) -> Result<(), ServerError> {
@@ -579,6 +546,8 @@ impl CodeRuntime {
             .map(|handle| WorkerHandle {
                 spawn_epoch: handle.spawn_epoch,
                 commands: handle.commands.clone(),
+                pending: handle.pending.clone(),
+                wake: handle.wake.clone(),
             })
             .ok_or_else(|| {
                 ServerError::conflict_kind(

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -534,6 +534,14 @@ impl CodeRuntime {
         Ok(list_sessions(&self.db).await?)
     }
 
+    pub(crate) async fn list_workspace_sessions(
+        &self,
+        workspace_id: WorkspaceId,
+    ) -> Result<Vec<CodeSession>, ServerError> {
+        let _ = self.get_workspace(workspace_id).await?;
+        Ok(list_sessions_for_workspace(&self.db, workspace_id).await?)
+    }
+
     async fn refuse_running_sessions(
         &self,
         workspace_id: WorkspaceId,

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -10,7 +10,8 @@ use tokio::sync::oneshot;
 use tidebreak_core::db::code::{
     delete_repo, delete_workspace, get_open_turn, get_repo, get_repo_by_root_path, get_session,
     get_workspace, insert_repo, insert_session, insert_workspace, list_repos, list_sessions,
-    list_sessions_for_workspace, list_workspaces, save_repo, save_session, save_workspace,
+    list_sessions_for_workspace, list_turns, list_workspaces, save_repo, save_session,
+    save_workspace,
 };
 use tidebreak_core::{
     Attention, AttentionSource, CapLevel, CodePermissionMode, CodeRepo, CodeSession, CodeSessionId,
@@ -540,6 +541,14 @@ impl CodeRuntime {
     ) -> Result<Vec<CodeSession>, ServerError> {
         let _ = self.get_workspace(workspace_id).await?;
         Ok(list_sessions_for_workspace(&self.db, workspace_id).await?)
+    }
+
+    pub(crate) async fn list_session_turns(
+        &self,
+        session_id: CodeSessionId,
+    ) -> Result<Vec<CodeTurn>, ServerError> {
+        let _ = self.get_session(session_id).await?;
+        Ok(list_turns(&self.db, session_id).await?)
     }
 
     async fn refuse_running_sessions(

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -8,8 +8,8 @@ use chrono::Utc;
 use tokio::sync::oneshot;
 
 use tidebreak_core::db::code::{
-    delete_repo, delete_workspace, get_repo, get_repo_by_root_path, get_session, get_workspace,
-    insert_repo, insert_session, insert_workspace, list_repos, list_sessions,
+    delete_repo, delete_workspace, get_open_turn, get_repo, get_repo_by_root_path, get_session,
+    get_workspace, insert_repo, insert_session, insert_workspace, list_repos, list_sessions,
     list_sessions_for_workspace, list_workspaces, save_repo, save_session, save_workspace,
 };
 use tidebreak_core::{
@@ -482,7 +482,12 @@ impl CodeRuntime {
             ));
         }
         let handle = self.require_worker(id)?;
-        if session.lifecycle == CodeSessionLifecycle::Running {
+        // Queue-default (0009): a send while a turn is in flight parks one
+        // follow-up. This does not consult mid_turn_steering — that cap
+        // gates the separate /steer route only.
+        let in_flight = session.lifecycle == CodeSessionLifecycle::Running
+            || get_open_turn(&self.db, id).await?.is_some();
+        if in_flight {
             if !queue_follow_up(&handle, message) {
                 return Err(ServerError::conflict_kind(
                     "queue_full",

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -345,7 +345,7 @@ impl CodeRuntime {
                 ));
             }
         }
-        self.end_workspace_sessions(id, force).await?;
+        self.refuse_running_sessions(id, force).await?;
         let path = std::path::Path::new(&workspace.worktree_path);
         if path.exists() {
             if let Some(block) = archive_blockers(path, &workspace.base_ref)
@@ -360,6 +360,7 @@ impl CodeRuntime {
                 }
             }
         }
+        self.end_workspace_sessions(id).await?;
         remove_worktree(std::path::Path::new(&repo.root_path), path)
             .await
             .map_err(map_worktree)?;
@@ -523,31 +524,39 @@ impl CodeRuntime {
         if let Some(handle) = handle {
             let _ = handle.commands.send(WorkerCommand::Shutdown).await;
         }
-        recovery::reap_session(&self.db, session)
+        let session = recovery::reap_session(&self.db, session)
             .await
-            .map_err(ServerError::from)
+            .map_err(ServerError::from)?;
+        self.attach_and_spawn_worker(session).await
     }
 
     pub(crate) async fn list_sessions(&self) -> Result<Vec<CodeSession>, ServerError> {
         Ok(list_sessions(&self.db).await?)
     }
 
-    async fn end_workspace_sessions(
+    async fn refuse_running_sessions(
         &self,
         workspace_id: WorkspaceId,
         allow_running: bool,
     ) -> Result<(), ServerError> {
+        if allow_running {
+            return Ok(());
+        }
         let sessions = list_sessions_for_workspace(&self.db, workspace_id).await?;
-        if !allow_running
-            && sessions
-                .iter()
-                .any(|session| session.lifecycle == CodeSessionLifecycle::Running)
+        if sessions
+            .iter()
+            .any(|session| session.lifecycle == CodeSessionLifecycle::Running)
         {
             return Err(ServerError::conflict_kind(
                 "session_running",
                 "a session is still running in this workspace; pass force to end it",
             ));
         }
+        Ok(())
+    }
+
+    async fn end_workspace_sessions(&self, workspace_id: WorkspaceId) -> Result<(), ServerError> {
+        let sessions = list_sessions_for_workspace(&self.db, workspace_id).await?;
         for mut session in sessions {
             if session.lifecycle == CodeSessionLifecycle::Ended {
                 continue;

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -1,0 +1,491 @@
+//! One worker task per running code-mode session.
+//!
+//! The worker owns the engine session and is the only journal writer for that
+//! session. Events are persisted (epoch-fenced) before they are published on
+//! the live bus.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use tokio::sync::{mpsc, oneshot};
+use tracing::warn;
+
+use tidebreak_core::db::code::{
+    append_event, bump_spawn_epoch, get_open_turn, get_session, insert_turn, next_turn_ordinal,
+    save_session, save_turn, CodeJournalError,
+};
+use tidebreak_core::{
+    Attention, AttentionSource, BoundedError, CodeApprovalId, CodeEvent, CodeSession,
+    CodeSessionId, CodeSessionLifecycle, CodeTurn, CodeTurnId, CodeTurnStatus, DbStore,
+};
+use tidebreak_harness::{HarnessError, HarnessEvent, HarnessEventSink, HarnessSession, TurnInput};
+
+use super::bus::CodeEventBus;
+
+pub(crate) enum WorkerCommand {
+    RunTurn {
+        message: String,
+        reply: oneshot::Sender<Result<CodeTurn, WorkerError>>,
+    },
+    Steer {
+        message: String,
+        reply: oneshot::Sender<Result<(), WorkerError>>,
+    },
+    Interrupt {
+        reply: oneshot::Sender<Result<(), WorkerError>>,
+    },
+    Shutdown,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum WorkerError {
+    #[error("{0}")]
+    Conflict(String),
+    #[error("{0}")]
+    Failed(String),
+}
+
+pub(crate) struct WorkerHandle {
+    pub spawn_epoch: i64,
+    pub commands: mpsc::Sender<WorkerCommand>,
+}
+
+struct LiveSink {
+    db: Arc<DbStore>,
+    bus: Arc<CodeEventBus>,
+    session_id: CodeSessionId,
+    spawn_epoch: i64,
+    turn_id: std::sync::Mutex<Option<CodeTurnId>>,
+}
+
+#[async_trait]
+impl HarnessEventSink for LiveSink {
+    async fn emit(&self, event: HarnessEvent) {
+        if matches!(event, HarnessEvent::TurnStarted) && self.turn_id.lock().unwrap().is_some() {
+            // The worker already journaled TurnStarted for this turn.
+            return;
+        }
+        let turn_id = *self.turn_id.lock().unwrap();
+        let Some(code_event) = map_event(event, turn_id) else {
+            return;
+        };
+        match persist_and_publish(
+            &self.db,
+            &self.bus,
+            self.session_id,
+            self.spawn_epoch,
+            code_event,
+        )
+        .await
+        {
+            Ok(()) => {}
+            Err(CodeJournalError::StaleSpawnEpoch { .. }) => {
+                warn!(
+                    session = %self.session_id,
+                    "dropping event from a superseded code-session worker"
+                );
+            }
+            Err(err) => {
+                warn!(session = %self.session_id, error = %err, "failed to journal engine event");
+            }
+        }
+    }
+}
+
+pub(crate) fn spawn_session_worker(
+    db: Arc<DbStore>,
+    bus: Arc<CodeEventBus>,
+    session: CodeSession,
+    engine: Box<dyn HarnessSession>,
+    allow_steer: bool,
+) -> WorkerHandle {
+    let (tx, rx) = mpsc::channel(8);
+    let spawn_epoch = session.spawn_epoch;
+    tokio::spawn(run_worker(db, bus, session, engine, allow_steer, rx));
+    WorkerHandle {
+        spawn_epoch,
+        commands: tx,
+    }
+}
+
+async fn run_worker(
+    db: Arc<DbStore>,
+    bus: Arc<CodeEventBus>,
+    mut session: CodeSession,
+    mut engine: Box<dyn HarnessSession>,
+    allow_steer: bool,
+    mut commands: mpsc::Receiver<WorkerCommand>,
+) {
+    if let Some(pid) = engine.child_pid() {
+        session.child_pid = Some(pid);
+        let _ = save_session(&db, &session).await;
+    }
+
+    while let Some(command) = commands.recv().await {
+        match command {
+            WorkerCommand::RunTurn { message, reply } => {
+                let result = drive_turn(&db, &bus, &mut session, engine.as_mut(), message).await;
+                let _ = reply.send(result);
+            }
+            WorkerCommand::Steer { message, reply } => {
+                let result = if !allow_steer {
+                    Err(WorkerError::Conflict(
+                        "mid-turn steering is not available on this engine".into(),
+                    ))
+                } else {
+                    engine
+                        .steer(message)
+                        .await
+                        .map_err(|err| WorkerError::Failed(err.to_string()))
+                };
+                let _ = reply.send(result);
+            }
+            WorkerCommand::Interrupt { reply } => {
+                let result = engine
+                    .interrupt()
+                    .await
+                    .map_err(|err| WorkerError::Failed(err.to_string()));
+                let _ = reply.send(result);
+            }
+            WorkerCommand::Shutdown => break,
+        }
+    }
+    let _ = engine.shutdown().await;
+}
+
+async fn drive_turn(
+    db: &Arc<DbStore>,
+    bus: &Arc<CodeEventBus>,
+    session: &mut CodeSession,
+    engine: &mut dyn HarnessSession,
+    message: String,
+) -> Result<CodeTurn, WorkerError> {
+    if session.lifecycle == CodeSessionLifecycle::Running {
+        return Err(WorkerError::Conflict(
+            "a turn is already running on this session".into(),
+        ));
+    }
+    if session.lifecycle == CodeSessionLifecycle::Fenced {
+        return Err(WorkerError::Conflict(
+            "session is fenced until it is reaped".into(),
+        ));
+    }
+    if session.lifecycle == CodeSessionLifecycle::Ended {
+        return Err(WorkerError::Conflict("session has ended".into()));
+    }
+
+    let ordinal = next_turn_ordinal(db, session.id)
+        .await
+        .map_err(|err| WorkerError::Failed(err.to_string()))?;
+    let mut turn = CodeTurn {
+        id: CodeTurnId::new(),
+        session_id: session.id,
+        ordinal,
+        status: CodeTurnStatus::Running,
+        user_input: message.clone(),
+        user_input_blob_id: None,
+        checkpoint_ref: None,
+        diffstat: None,
+        usage: None,
+        narrative: None,
+        started_at: Utc::now(),
+        ended_at: None,
+    };
+    insert_turn(db, &turn)
+        .await
+        .map_err(|err| WorkerError::Failed(err.to_string()))?;
+
+    session.lifecycle = CodeSessionLifecycle::Running;
+    session.attention = Attention::working(AttentionSource::Lifecycle);
+    if let Some(pid) = engine.child_pid() {
+        session.child_pid = Some(pid);
+    }
+    save_session(db, session)
+        .await
+        .map_err(|err| WorkerError::Failed(err.to_string()))?;
+
+    persist_and_publish(
+        db,
+        bus,
+        session.id,
+        session.spawn_epoch,
+        CodeEvent::TurnStarted { turn_id: turn.id },
+    )
+    .await
+    .map_err(|err| WorkerError::Failed(err.to_string()))?;
+
+    let run = engine.run_turn(TurnInput { text: message }).await;
+
+    if let Some(pid) = engine.child_pid() {
+        session.child_pid = Some(pid);
+    } else {
+        session.child_pid = None;
+    }
+    if let Some(resume) = engine.resume_ref() {
+        session.harness_resume_ref = Some(resume);
+    }
+
+    // Re-read the turn: the sink may have already closed it.
+    if let Ok(Some(updated)) = get_open_turn(db, session.id).await {
+        turn = updated;
+    } else if let Ok(Some(current)) = tidebreak_core::db::code::get_turn(db, turn.id).await {
+        turn = current;
+    }
+
+    match run {
+        Ok(()) => {
+            if turn.status == CodeTurnStatus::Running {
+                turn.status = CodeTurnStatus::Completed;
+                turn.ended_at = Some(Utc::now());
+                let _ = save_turn(db, &turn).await;
+                let _ = persist_and_publish(
+                    db,
+                    bus,
+                    session.id,
+                    session.spawn_epoch,
+                    CodeEvent::TurnCompleted {
+                        usage: turn.usage.clone().unwrap_or_default(),
+                        checkpoint: None,
+                    },
+                )
+                .await;
+            }
+        }
+        Err(err) => {
+            if turn.status == CodeTurnStatus::Running {
+                turn.status = CodeTurnStatus::Failed;
+                turn.ended_at = Some(Utc::now());
+                let _ = save_turn(db, &turn).await;
+                let _ = persist_and_publish(
+                    db,
+                    bus,
+                    session.id,
+                    session.spawn_epoch,
+                    CodeEvent::TurnFailed {
+                        error: BoundedError {
+                            message: err.to_string(),
+                        },
+                    },
+                )
+                .await;
+            }
+            session.lifecycle = CodeSessionLifecycle::Idle;
+            session.attention =
+                Attention::needs_you("the engine turn failed", AttentionSource::Lifecycle);
+            let _ = save_session(db, session).await;
+            return Err(WorkerError::Failed(err.to_string()));
+        }
+    }
+
+    if let Ok(Some(current)) = tidebreak_core::db::code::get_turn(db, turn.id).await {
+        turn = current;
+    }
+    if turn.status == CodeTurnStatus::Interrupted {
+        session.attention =
+            Attention::needs_you("the turn was interrupted", AttentionSource::Lifecycle);
+    } else if turn.status == CodeTurnStatus::Failed {
+        session.attention =
+            Attention::needs_you("the engine turn failed", AttentionSource::Lifecycle);
+    } else {
+        session.attention = Attention::new(
+            tidebreak_core::AttentionState::DoneUnreviewed,
+            AttentionSource::Lifecycle,
+        );
+    }
+    session.lifecycle = CodeSessionLifecycle::Idle;
+    let _ = save_session(db, session).await;
+    Ok(turn)
+}
+
+/// Bump the spawn epoch, record pid/version, and journal SessionStarted.
+///
+/// Call this once, before the engine is launched, so the event sink and the
+/// session row share the same epoch. Pass `child_pid` after launch via
+/// [`save_session`] if the adapter only exposes a pid later.
+pub(crate) async fn attach_engine(
+    db: &DbStore,
+    bus: &CodeEventBus,
+    session_id: CodeSessionId,
+    kind: tidebreak_core::HarnessKind,
+    version: Option<String>,
+    child_pid: Option<i64>,
+) -> Result<CodeSession, WorkerError> {
+    let epoch = bump_spawn_epoch(db, session_id, child_pid)
+        .await
+        .map_err(|err| WorkerError::Failed(err.to_string()))?;
+    let mut session = get_session(db, session_id)
+        .await
+        .map_err(|err| WorkerError::Failed(err.to_string()))?
+        .ok_or_else(|| WorkerError::Failed(format!("session {session_id} not found")))?;
+    session.spawn_epoch = epoch;
+    session.child_pid = child_pid;
+    session.harness_version = version.or(session.harness_version);
+    session.lifecycle = CodeSessionLifecycle::Idle;
+    session.attention = Attention::working(AttentionSource::Lifecycle);
+    save_session(db, &session)
+        .await
+        .map_err(|err| WorkerError::Failed(err.to_string()))?;
+    persist_and_publish(
+        db,
+        bus,
+        session_id,
+        epoch,
+        CodeEvent::SessionStarted {
+            harness_kind: kind,
+            harness_version: session
+                .harness_version
+                .clone()
+                .unwrap_or_else(|| "unknown".into()),
+            resume_ref: session.harness_resume_ref.clone(),
+        },
+    )
+    .await
+    .map_err(|err| WorkerError::Failed(err.to_string()))?;
+    Ok(session)
+}
+
+pub(crate) fn sink_for(
+    db: Arc<DbStore>,
+    bus: Arc<CodeEventBus>,
+    session_id: CodeSessionId,
+    spawn_epoch: i64,
+    turn_id: Option<CodeTurnId>,
+) -> Arc<dyn HarnessEventSink> {
+    Arc::new(LiveSink {
+        db,
+        bus,
+        session_id,
+        spawn_epoch,
+        turn_id: std::sync::Mutex::new(turn_id),
+    })
+}
+
+async fn persist_and_publish(
+    db: &DbStore,
+    bus: &CodeEventBus,
+    session_id: CodeSessionId,
+    spawn_epoch: i64,
+    event: CodeEvent,
+) -> Result<(), CodeJournalError> {
+    apply_side_effects(db, session_id, spawn_epoch, &event).await?;
+    let seq = append_event(db, session_id, spawn_epoch, &event).await?;
+    bus.publish(
+        session_id,
+        tidebreak_core::SequencedCodeEvent { seq, event },
+    );
+    Ok(())
+}
+
+async fn apply_side_effects(
+    db: &DbStore,
+    session_id: CodeSessionId,
+    _spawn_epoch: i64,
+    event: &CodeEvent,
+) -> Result<(), CodeJournalError> {
+    match event {
+        CodeEvent::TurnCompleted { usage, checkpoint } => {
+            if let Ok(Some(mut turn)) = get_open_turn(db, session_id).await {
+                turn.status = CodeTurnStatus::Completed;
+                turn.ended_at = Some(Utc::now());
+                turn.usage = Some(usage.clone());
+                if let Some(hint) = checkpoint {
+                    turn.checkpoint_ref = hint.checkpoint_ref.clone();
+                    turn.diffstat = hint.diffstat.clone();
+                }
+                let _ = save_turn(db, &turn).await;
+            }
+        }
+        CodeEvent::TurnFailed { .. } => {
+            if let Ok(Some(mut turn)) = get_open_turn(db, session_id).await {
+                turn.status = CodeTurnStatus::Failed;
+                turn.ended_at = Some(Utc::now());
+                let _ = save_turn(db, &turn).await;
+            }
+        }
+        CodeEvent::TurnInterrupted => {
+            if let Ok(Some(mut turn)) = get_open_turn(db, session_id).await {
+                turn.status = CodeTurnStatus::Interrupted;
+                turn.ended_at = Some(Utc::now());
+                let _ = save_turn(db, &turn).await;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn map_event(event: HarnessEvent, turn_id: Option<CodeTurnId>) -> Option<CodeEvent> {
+    Some(match event {
+        HarnessEvent::SessionStarted {
+            harness_kind,
+            harness_version,
+            resume_ref,
+        } => CodeEvent::SessionStarted {
+            harness_kind,
+            harness_version,
+            resume_ref,
+        },
+        HarnessEvent::TurnStarted => CodeEvent::TurnStarted { turn_id: turn_id? },
+        HarnessEvent::AssistantDelta { text } => CodeEvent::AssistantDelta { text },
+        HarnessEvent::AssistantMessage { text } => CodeEvent::AssistantMessage { text },
+        HarnessEvent::ReasoningDelta { text } => CodeEvent::ReasoningDelta { text },
+        HarnessEvent::ToolStarted {
+            call_id,
+            name,
+            detail,
+        } => CodeEvent::ToolStarted {
+            call_id,
+            name,
+            detail,
+        },
+        HarnessEvent::ToolCompleted {
+            call_id,
+            outcome,
+            preview,
+        } => CodeEvent::ToolCompleted {
+            call_id,
+            outcome,
+            preview,
+        },
+        HarnessEvent::FileChanged {
+            path,
+            kind,
+            diffstat,
+        } => CodeEvent::FileChanged {
+            path,
+            kind,
+            diffstat,
+        },
+        HarnessEvent::ApprovalRequested { .. } => CodeEvent::ApprovalRequested {
+            approval_id: CodeApprovalId::new(),
+        },
+        HarnessEvent::ApprovalResolved { decision, .. } => CodeEvent::ApprovalResolved {
+            approval_id: CodeApprovalId::new(),
+            decision: match decision {
+                tidebreak_harness::ApprovalDecision::Approve => {
+                    tidebreak_core::ApprovalDecisionKind::Approve
+                }
+                tidebreak_harness::ApprovalDecision::Deny { feedback } => {
+                    tidebreak_core::ApprovalDecisionKind::Deny { feedback }
+                }
+            },
+        },
+        HarnessEvent::UserSteered { text } => CodeEvent::UserSteered { text },
+        HarnessEvent::TurnCompleted { usage } => CodeEvent::TurnCompleted {
+            usage,
+            checkpoint: None,
+        },
+        HarnessEvent::TurnFailed { error } => CodeEvent::TurnFailed { error },
+        HarnessEvent::TurnInterrupted => CodeEvent::TurnInterrupted,
+        HarnessEvent::HarnessNotice { level, message } => {
+            CodeEvent::HarnessNotice { level, message }
+        }
+    })
+}
+
+impl From<HarnessError> for WorkerError {
+    fn from(err: HarnessError) -> Self {
+        Self::Failed(err.to_string())
+    }
+}

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::Utc;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, Notify};
 use tracing::warn;
 
 use tidebreak_core::db::code::{
@@ -28,10 +28,6 @@ pub(crate) enum WorkerCommand {
         message: String,
         reply: oneshot::Sender<Result<CodeTurn, WorkerError>>,
     },
-    Steer {
-        message: String,
-        reply: oneshot::Sender<Result<(), WorkerError>>,
-    },
     Interrupt {
         reply: oneshot::Sender<Result<(), WorkerError>>,
     },
@@ -49,6 +45,9 @@ pub(crate) enum WorkerError {
 pub(crate) struct WorkerHandle {
     pub spawn_epoch: i64,
     pub commands: mpsc::Sender<WorkerCommand>,
+    /// Single follow-up parked while a turn is running (queue-default).
+    pub pending: Arc<std::sync::Mutex<Option<String>>>,
+    pub wake: Arc<Notify>,
 }
 
 struct LiveSink {
@@ -98,15 +97,37 @@ pub(crate) fn spawn_session_worker(
     bus: Arc<CodeEventBus>,
     session: CodeSession,
     engine: Box<dyn HarnessSession>,
-    allow_steer: bool,
 ) -> WorkerHandle {
     let (tx, rx) = mpsc::channel(8);
     let spawn_epoch = session.spawn_epoch;
-    tokio::spawn(run_worker(db, bus, session, engine, allow_steer, rx));
+    let pending = Arc::new(std::sync::Mutex::new(None));
+    let wake = Arc::new(Notify::new());
+    tokio::spawn(run_worker(
+        db,
+        bus,
+        session,
+        engine,
+        pending.clone(),
+        wake.clone(),
+        rx,
+    ));
     WorkerHandle {
         spawn_epoch,
         commands: tx,
+        pending,
+        wake,
     }
+}
+
+/// Park one follow-up. Returns `false` when the single slot is already taken.
+pub(crate) fn queue_follow_up(handle: &WorkerHandle, message: String) -> bool {
+    let mut pending = handle.pending.lock().expect("code turn queue");
+    if pending.is_some() {
+        return false;
+    }
+    *pending = Some(message);
+    handle.wake.notify_one();
+    true
 }
 
 async fn run_worker(
@@ -114,7 +135,8 @@ async fn run_worker(
     bus: Arc<CodeEventBus>,
     mut session: CodeSession,
     mut engine: Box<dyn HarnessSession>,
-    allow_steer: bool,
+    pending: Arc<std::sync::Mutex<Option<String>>>,
+    wake: Arc<Notify>,
     mut commands: mpsc::Receiver<WorkerCommand>,
 ) {
     if let Some(pid) = engine.child_pid() {
@@ -122,36 +144,44 @@ async fn run_worker(
         let _ = save_session(&db, &session).await;
     }
 
-    while let Some(command) = commands.recv().await {
-        match command {
-            WorkerCommand::RunTurn { message, reply } => {
-                let result = drive_turn(&db, &bus, &mut session, engine.as_mut(), message).await;
-                let _ = reply.send(result);
-            }
-            WorkerCommand::Steer { message, reply } => {
-                let result = if !allow_steer {
-                    Err(WorkerError::Conflict(
-                        "mid-turn steering is not available on this engine".into(),
-                    ))
-                } else {
-                    engine
-                        .steer(message)
+    loop {
+        drain_queued(&db, &bus, &mut session, engine.as_mut(), &pending).await;
+        tokio::select! {
+            _ = wake.notified() => {}
+            command = commands.recv() => match command {
+                Some(WorkerCommand::RunTurn { message, reply }) => {
+                    let result =
+                        drive_turn(&db, &bus, &mut session, engine.as_mut(), message).await;
+                    let _ = reply.send(result);
+                }
+                Some(WorkerCommand::Interrupt { reply }) => {
+                    let result = engine
+                        .interrupt()
                         .await
-                        .map_err(|err| WorkerError::Failed(err.to_string()))
-                };
-                let _ = reply.send(result);
-            }
-            WorkerCommand::Interrupt { reply } => {
-                let result = engine
-                    .interrupt()
-                    .await
-                    .map_err(|err| WorkerError::Failed(err.to_string()));
-                let _ = reply.send(result);
-            }
-            WorkerCommand::Shutdown => break,
+                        .map_err(|err| WorkerError::Failed(err.to_string()));
+                    let _ = reply.send(result);
+                }
+                Some(WorkerCommand::Shutdown) | None => break,
+            },
         }
     }
     let _ = engine.shutdown().await;
+}
+
+async fn drain_queued(
+    db: &Arc<DbStore>,
+    bus: &Arc<CodeEventBus>,
+    session: &mut CodeSession,
+    engine: &mut dyn HarnessSession,
+    pending: &Arc<std::sync::Mutex<Option<String>>>,
+) {
+    loop {
+        let next = pending.lock().expect("code turn queue").take();
+        let Some(message) = next else {
+            break;
+        };
+        let _ = drive_turn(db, bus, session, engine, message).await;
+    }
 }
 
 async fn drive_turn(

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -145,6 +145,9 @@ async fn run_worker(
     }
 
     loop {
+        if session_was_ended(&db, &mut session).await {
+            break;
+        }
         drain_queued(&db, &bus, &mut session, engine.as_mut(), &pending).await;
         tokio::select! {
             _ = wake.notified() => {}
@@ -300,16 +303,21 @@ async fn drive_turn(
                 )
                 .await;
             }
-            session.lifecycle = CodeSessionLifecycle::Idle;
-            session.attention =
-                Attention::needs_you("the engine turn failed", AttentionSource::Lifecycle);
-            let _ = save_session(db, session).await;
+            if !session_was_ended(db, session).await {
+                session.lifecycle = CodeSessionLifecycle::Idle;
+                session.attention =
+                    Attention::needs_you("the engine turn failed", AttentionSource::Lifecycle);
+                let _ = save_session(db, session).await;
+            }
             return Err(WorkerError::Failed(err.to_string()));
         }
     }
 
     if let Ok(Some(current)) = tidebreak_core::db::code::get_turn(db, turn.id).await {
         turn = current;
+    }
+    if session_was_ended(db, session).await {
+        return Ok(turn);
     }
     if turn.status == CodeTurnStatus::Interrupted {
         session.attention =
@@ -326,6 +334,16 @@ async fn drive_turn(
     session.lifecycle = CodeSessionLifecycle::Idle;
     let _ = save_session(db, session).await;
     Ok(turn)
+}
+
+async fn session_was_ended(db: &DbStore, session: &mut CodeSession) -> bool {
+    match get_session(db, session.id).await {
+        Ok(Some(current)) if current.lifecycle == CodeSessionLifecycle::Ended => {
+            *session = current;
+            true
+        }
+        _ => false,
+    }
 }
 
 /// Bump the spawn epoch, record pid/version, and journal SessionStarted.

--- a/crates/tidebreak-server/src/code/setup_script.rs
+++ b/crates/tidebreak-server/src/code/setup_script.rs
@@ -1,0 +1,74 @@
+//! Setup and archive hooks for a workspace checkout.
+//!
+//! A failed hook preserves the checkout. The caller marks the workspace
+//! `SetupFailed` (or leaves archive uncommitted) rather than deleting work.
+
+use std::path::Path;
+use std::process::Stdio;
+use std::time::Duration;
+
+use tokio::process::Command;
+use tokio::time::timeout;
+
+const SCRIPT_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Outcome of running a user-authored setup or archive script.
+#[derive(Debug)]
+pub(crate) struct ScriptRun {
+    pub success: bool,
+    pub status: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+/// Run `script` inside `worktree` via the user's login shell.
+///
+/// The script is a user-authored command string, so it goes through a shell.
+/// Git operations in this crate never do.
+pub(crate) async fn run_workspace_script(
+    worktree: &Path,
+    script: &str,
+) -> Result<ScriptRun, String> {
+    let script = script.trim();
+    if script.is_empty() {
+        return Ok(ScriptRun {
+            success: true,
+            status: Some(0),
+            stdout: String::new(),
+            stderr: String::new(),
+        });
+    }
+    let shell = std::env::var_os("SHELL").unwrap_or_else(|| "/bin/sh".into());
+    let mut command = Command::new(shell);
+    command
+        .arg("-lc")
+        .arg(script)
+        .current_dir(worktree)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .env("GIT_TERMINAL_PROMPT", "0");
+    let child = command
+        .spawn()
+        .map_err(|err| format!("failed to spawn workspace script: {err}"))?;
+    let output = timeout(SCRIPT_TIMEOUT, child.wait_with_output())
+        .await
+        .map_err(|_| "workspace script timed out".to_owned())?
+        .map_err(|err| format!("workspace script failed: {err}"))?;
+    Ok(ScriptRun {
+        success: output.status.success(),
+        status: output.status.code(),
+        stdout: bound_text(&output.stdout),
+        stderr: bound_text(&output.stderr),
+    })
+}
+
+fn bound_text(bytes: &[u8]) -> String {
+    const MAX: usize = 4_096;
+    let mut text = String::from_utf8_lossy(bytes).into_owned();
+    if text.chars().count() > MAX {
+        text = text.chars().take(MAX).collect();
+    }
+    text
+}

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -1,0 +1,554 @@
+//! Git worktree operations for code-mode workspaces.
+//!
+//! Every git call is a bounded, non-interactive subprocess of the user's own
+//! `git` binary. Arguments are an argv array, never a shell string.
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+
+use tokio::process::Command;
+use tokio::time::timeout;
+
+use super::setup_script::run_workspace_script;
+
+const GIT_TIMEOUT: Duration = Duration::from_secs(30);
+const GIT_WORKTREE_TIMEOUT: Duration = Duration::from_secs(120);
+
+const ADJECTIVES: &[&str] = &[
+    "amber", "brave", "calm", "crisp", "dusk", "ember", "faint", "gentle", "hidden", "ivory",
+    "keen", "lunar", "misty", "noble", "open", "pale", "quiet", "rapid", "still", "vivid",
+];
+const NOUNS: &[&str] = &[
+    "anchor", "brook", "cedar", "dune", "field", "grove", "harbor", "inlet", "ledge", "meadow",
+    "notch", "orchard", "pine", "ridge", "shore", "thicket", "vale", "willow", "yard", "zenith",
+];
+
+/// A validated, canonical local git repository.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ValidatedRepo {
+    pub toplevel: PathBuf,
+}
+
+/// Why a workspace archive needs an explicit `force`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ArchiveBlock {
+    Uncommitted,
+    Unpushed,
+    UncommittedAndUnpushed,
+}
+
+impl ArchiveBlock {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            Self::Uncommitted => "uncommitted",
+            Self::Unpushed => "unpushed",
+            Self::UncommittedAndUnpushed => "uncommitted_and_unpushed",
+        }
+    }
+}
+
+/// Failure from a git or worktree operation.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum WorktreeError {
+    #[error("{0}")]
+    User(String),
+    #[error("{0}")]
+    Internal(String),
+}
+
+impl WorktreeError {
+    pub(crate) fn user(message: impl Into<String>) -> Self {
+        Self::User(message.into())
+    }
+
+    fn internal(message: impl Into<String>) -> Self {
+        Self::Internal(message.into())
+    }
+}
+
+/// Validate a path as a non-bare git repository and return its canonical toplevel.
+pub(crate) async fn validate_repo_path(path: &Path) -> Result<ValidatedRepo, WorktreeError> {
+    let requested = path.to_path_buf();
+    if let Ok(bare) = git_stdout(
+        Some(&requested),
+        &["rev-parse", "--is-bare-repository"],
+        GIT_TIMEOUT,
+    )
+    .await
+    {
+        if bare == "true" {
+            return Err(WorktreeError::user(
+                "bare repositories cannot be registered",
+            ));
+        }
+    }
+    let toplevel = git_stdout(
+        Some(&requested),
+        &["rev-parse", "--show-toplevel"],
+        GIT_TIMEOUT,
+    )
+    .await
+    .map_err(|err| WorktreeError::user(format!("not a git repository: {err}")))?;
+    let toplevel = PathBuf::from(toplevel);
+    let toplevel = toplevel.canonicalize().map_err(|err| {
+        WorktreeError::user(format!(
+            "could not canonicalize repository {}: {err}",
+            toplevel.display()
+        ))
+    })?;
+    Ok(ValidatedRepo { toplevel })
+}
+
+/// Create a worktree and branch under the Tidebreak data directory.
+pub(crate) async fn create_worktree(
+    repo_root: &Path,
+    worktree_path: &Path,
+    branch: &str,
+    base_ref: &str,
+) -> Result<(), WorktreeError> {
+    if let Some(parent) = worktree_path.parent() {
+        tokio::fs::create_dir_all(parent).await.map_err(|err| {
+            WorktreeError::internal(format!(
+                "could not create worktree parent {}: {err}",
+                parent.display()
+            ))
+        })?;
+    }
+    let add = git(
+        Some(repo_root),
+        &[
+            "worktree",
+            "add",
+            "-b",
+            branch,
+            &worktree_path.to_string_lossy(),
+            base_ref,
+        ],
+        GIT_WORKTREE_TIMEOUT,
+    )
+    .await;
+    if let Err(err) = add {
+        cleanup_half_created(repo_root, worktree_path).await;
+        return Err(classify_worktree_add(err, branch));
+    }
+    match verify_inside_worktree(worktree_path).await {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            cleanup_half_created(repo_root, worktree_path).await;
+            Err(err)
+        }
+    }
+}
+
+/// Run the setup script, if any. Failure preserves the checkout.
+pub(crate) async fn run_setup_script(
+    worktree_path: &Path,
+    script: Option<&str>,
+) -> Result<(), WorktreeError> {
+    let Some(script) = script.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(());
+    };
+    let run = run_workspace_script(worktree_path, script)
+        .await
+        .map_err(WorktreeError::user)?;
+    if run.success {
+        Ok(())
+    } else {
+        Err(WorktreeError::user(format!(
+            "setup script failed (exit {}): {}",
+            run.status
+                .map(|code| code.to_string())
+                .unwrap_or_else(|| "signal".into()),
+            first_line(&run.stderr)
+                .or_else(|| first_line(&run.stdout))
+                .unwrap_or("no output")
+        )))
+    }
+}
+
+/// Whether the worktree has uncommitted or unpushed work that archive must not discard.
+pub(crate) async fn archive_blockers(
+    worktree_path: &Path,
+    base_ref: &str,
+) -> Result<Option<ArchiveBlock>, WorktreeError> {
+    let uncommitted = has_uncommitted_work(worktree_path).await?;
+    let unpushed = has_unpushed_work(worktree_path, base_ref).await?;
+    Ok(match (uncommitted, unpushed) {
+        (true, true) => Some(ArchiveBlock::UncommittedAndUnpushed),
+        (true, false) => Some(ArchiveBlock::Uncommitted),
+        (false, true) => Some(ArchiveBlock::Unpushed),
+        (false, false) => None,
+    })
+}
+
+/// Remove a worktree, tolerating an already-gone checkout, then prune.
+///
+/// The branch is kept. `force` is required by the caller when the checkout
+/// has uncommitted or unpushed work; this function uses `git worktree remove
+/// --force` so a dirty tree does not block the removal itself.
+pub(crate) async fn remove_worktree(
+    repo_root: &Path,
+    worktree_path: &Path,
+) -> Result<(), WorktreeError> {
+    let path = worktree_path.to_string_lossy();
+    match git(
+        Some(repo_root),
+        &["worktree", "remove", "--force", path.as_ref()],
+        GIT_WORKTREE_TIMEOUT,
+    )
+    .await
+    {
+        Ok(_) => {}
+        Err(err) if already_gone(&err) => {}
+        Err(err) => {
+            // Directory may already be missing while git still lists it.
+            if worktree_path.exists() {
+                return Err(WorktreeError::internal(format!(
+                    "git worktree remove failed: {err}"
+                )));
+            }
+        }
+    }
+    prune_worktrees(repo_root).await
+}
+
+/// Drop stale worktree registrations from the repo.
+pub(crate) async fn prune_worktrees(repo_root: &Path) -> Result<(), WorktreeError> {
+    git(Some(repo_root), &["worktree", "prune"], GIT_TIMEOUT)
+        .await
+        .map(|_| ())
+        .map_err(|err| WorktreeError::internal(format!("git worktree prune failed: {err}")))
+}
+
+/// Slug used in data-dir paths and, with the repo prefix, in branch names.
+pub(crate) fn slugify(value: &str) -> String {
+    let mut slug = String::new();
+    let mut last_dash = false;
+    for ch in value.chars() {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch.to_ascii_lowercase());
+            last_dash = false;
+        } else if !last_dash && !slug.is_empty() {
+            slug.push('-');
+            last_dash = true;
+        }
+        if slug.len() >= 40 {
+            break;
+        }
+    }
+    while slug.ends_with('-') {
+        slug.pop();
+    }
+    slug
+}
+
+/// Branch name: repo prefix plus a slug of the title, or a two-word fallback.
+pub(crate) fn branch_name(prefix: &str, title: &str, seed: u128) -> String {
+    let prefix = if prefix.is_empty() {
+        "tidebreak/".to_owned()
+    } else if prefix.ends_with('/') {
+        prefix.to_owned()
+    } else {
+        format!("{prefix}/")
+    };
+    let slug = slugify(title);
+    let slug = if slug.is_empty() {
+        two_word_name(seed)
+    } else {
+        slug
+    };
+    format!("{prefix}{slug}")
+}
+
+/// Path `<data_dir>/code/worktrees/<repo-slug>/<workspace-slug>/`.
+pub(crate) fn worktree_dir(data_dir: &Path, repo_slug: &str, workspace_slug: &str) -> PathBuf {
+    data_dir
+        .join("code")
+        .join("worktrees")
+        .join(repo_slug)
+        .join(workspace_slug)
+}
+
+pub(crate) fn two_word_name(seed: u128) -> String {
+    let adjective = ADJECTIVES[(seed % ADJECTIVES.len() as u128) as usize];
+    let noun = NOUNS[((seed / ADJECTIVES.len() as u128) % NOUNS.len() as u128) as usize];
+    format!("{adjective}-{noun}")
+}
+
+async fn verify_inside_worktree(path: &Path) -> Result<(), WorktreeError> {
+    let inside = git_stdout(
+        Some(path),
+        &["rev-parse", "--is-inside-work-tree"],
+        GIT_TIMEOUT,
+    )
+    .await
+    .map_err(|err| WorktreeError::internal(format!("worktree verification failed: {err}")))?;
+    if inside == "true" {
+        Ok(())
+    } else {
+        Err(WorktreeError::internal(
+            "worktree verification failed: path is not inside a work tree".to_owned(),
+        ))
+    }
+}
+
+async fn cleanup_half_created(repo_root: &Path, worktree_path: &Path) {
+    let path = worktree_path.to_string_lossy();
+    let _ = git(
+        Some(repo_root),
+        &["worktree", "remove", "--force", path.as_ref()],
+        GIT_TIMEOUT,
+    )
+    .await;
+    let _ = git(Some(repo_root), &["worktree", "prune"], GIT_TIMEOUT).await;
+    if worktree_path.exists() {
+        let _ = tokio::fs::remove_dir_all(worktree_path).await;
+    }
+}
+
+async fn has_uncommitted_work(worktree_path: &Path) -> Result<bool, WorktreeError> {
+    let status = git_stdout(Some(worktree_path), &["status", "--porcelain"], GIT_TIMEOUT)
+        .await
+        .map_err(|err| WorktreeError::internal(format!("git status failed: {err}")))?;
+    Ok(!status.is_empty())
+}
+
+async fn has_unpushed_work(worktree_path: &Path, base_ref: &str) -> Result<bool, WorktreeError> {
+    match git_stdout(
+        Some(worktree_path),
+        &["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+        GIT_TIMEOUT,
+    )
+    .await
+    {
+        Ok(_) => {
+            let count = git_stdout(
+                Some(worktree_path),
+                &["rev-list", "--count", "@{u}..HEAD"],
+                GIT_TIMEOUT,
+            )
+            .await
+            .map_err(|err| WorktreeError::internal(format!("git rev-list failed: {err}")))?;
+            Ok(count.parse::<u64>().unwrap_or(1) > 0)
+        }
+        Err(_) => {
+            // No upstream: unique commits versus the workspace base would be lost
+            // only if the branch were deleted; still report them so archive is honest.
+            let range = format!("{base_ref}..HEAD");
+            let count = git_stdout(
+                Some(worktree_path),
+                &["rev-list", "--count", &range],
+                GIT_TIMEOUT,
+            )
+            .await
+            .map_err(|err| WorktreeError::internal(format!("git rev-list failed: {err}")))?;
+            Ok(count.parse::<u64>().unwrap_or(1) > 0)
+        }
+    }
+}
+
+fn classify_worktree_add(err: String, branch: &str) -> WorktreeError {
+    let lower = err.to_ascii_lowercase();
+    if lower.contains("already exists") || lower.contains("already used") {
+        WorktreeError::user(format!("branch {branch} already exists"))
+    } else {
+        WorktreeError::user(format!("could not create worktree: {err}"))
+    }
+}
+
+fn already_gone(err: &str) -> bool {
+    let lower = err.to_ascii_lowercase();
+    lower.contains("not a working tree")
+        || lower.contains("is not a working tree")
+        || lower.contains("no such file")
+        || lower.contains("does not exist")
+}
+
+fn first_line(text: &str) -> Option<&str> {
+    text.lines().map(str::trim).find(|line| !line.is_empty())
+}
+
+struct GitOutput {
+    stdout: String,
+}
+
+async fn git(cwd: Option<&Path>, args: &[&str], limit: Duration) -> Result<GitOutput, String> {
+    let mut command = Command::new("git");
+    command
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .env("GIT_TERMINAL_PROMPT", "0");
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+    let child = command
+        .spawn()
+        .map_err(|err| format!("failed to spawn git: {err}"))?;
+    let output = timeout(limit, child.wait_with_output())
+        .await
+        .map_err(|_| format!("git {} timed out", args.join(" ")))?
+        .map_err(|err| format!("git {} failed: {err}", args.join(" ")))?;
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+    if output.status.success() {
+        Ok(GitOutput { stdout })
+    } else {
+        Err(if stderr.is_empty() { stdout } else { stderr })
+    }
+}
+
+async fn git_stdout(cwd: Option<&Path>, args: &[&str], limit: Duration) -> Result<String, String> {
+    Ok(git(cwd, args, limit).await?.stdout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command as StdCommand;
+    use tempfile::TempDir;
+
+    fn init_repo() -> (TempDir, PathBuf) {
+        let dir = TempDir::new().unwrap();
+        let repo = dir.path().join("origin");
+        std::fs::create_dir_all(&repo).unwrap();
+        run(&repo, &["git", "init", "-b", "main"]);
+        run(&repo, &["git", "config", "user.email", "dev@example.com"]);
+        run(&repo, &["git", "config", "user.name", "Dev"]);
+        std::fs::write(repo.join("README.md"), "hello\n").unwrap();
+        run(&repo, &["git", "add", "README.md"]);
+        run(&repo, &["git", "commit", "-m", "init"]);
+        (dir, repo)
+    }
+
+    fn run(cwd: &Path, args: &[&str]) {
+        let status = StdCommand::new(args[0])
+            .args(&args[1..])
+            .current_dir(cwd)
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .status()
+            .unwrap();
+        assert!(status.success(), "{args:?} failed in {}", cwd.display());
+    }
+
+    #[tokio::test]
+    async fn validate_repo_refuses_bare_and_nested_non_repos() {
+        let (dir, repo) = init_repo();
+        let validated = validate_repo_path(&repo).await.unwrap();
+        assert_eq!(validated.toplevel, repo.canonicalize().unwrap());
+
+        let nested = repo.join("src");
+        std::fs::create_dir_all(&nested).unwrap();
+        let from_nested = validate_repo_path(&nested).await.unwrap();
+        assert_eq!(from_nested.toplevel, validated.toplevel);
+
+        let bare = dir.path().join("bare.git");
+        run(
+            dir.path(),
+            &["git", "init", "--bare", bare.to_str().unwrap()],
+        );
+        let err = validate_repo_path(&bare).await.unwrap_err();
+        assert!(err.to_string().contains("bare"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn create_verifies_and_setup_failure_preserves_checkout() {
+        let (_dir, repo) = init_repo();
+        let data = TempDir::new().unwrap();
+        let path = worktree_dir(data.path(), "demo", "first");
+        create_worktree(&repo, &path, "tidebreak/first", "main")
+            .await
+            .unwrap();
+        verify_inside_worktree(&path).await.unwrap();
+
+        let err = run_setup_script(&path, Some("exit 7")).await.unwrap_err();
+        assert!(err.to_string().contains("setup script failed"), "{err}");
+        assert!(path.join("README.md").is_file());
+        verify_inside_worktree(&path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn create_cleans_up_a_half_created_worktree() {
+        let (_dir, repo) = init_repo();
+        let data = TempDir::new().unwrap();
+        let path = worktree_dir(data.path(), "demo", "ghost");
+        // Point at a missing base so `worktree add` fails after creating the branch
+        // attempt; cleanup must not leave a registered worktree.
+        let err = create_worktree(&repo, &path, "tidebreak/ghost", "no-such-ref")
+            .await
+            .unwrap_err();
+        assert!(!err.to_string().is_empty());
+        assert!(!path.exists());
+        let listed = git_stdout(Some(&repo), &["worktree", "list"], GIT_TIMEOUT)
+            .await
+            .unwrap();
+        assert!(
+            !listed.contains("ghost"),
+            "stale worktree left behind: {listed}"
+        );
+    }
+
+    #[tokio::test]
+    async fn archive_refuses_dirty_work_without_force_and_prunes_gone_trees() {
+        let (_dir, repo) = init_repo();
+        let data = TempDir::new().unwrap();
+        let path = worktree_dir(data.path(), "demo", "dirty");
+        create_worktree(&repo, &path, "tidebreak/dirty", "main")
+            .await
+            .unwrap();
+        std::fs::write(path.join("extra.txt"), "uncommitted\n").unwrap();
+        assert_eq!(
+            archive_blockers(&path, "main").await.unwrap(),
+            Some(ArchiveBlock::Uncommitted)
+        );
+
+        remove_worktree(&repo, &path).await.unwrap();
+        assert!(!path.exists());
+
+        // Already-removed: deleting the directory out of band, then archive.
+        let path2 = worktree_dir(data.path(), "demo", "gone");
+        create_worktree(&repo, &path2, "tidebreak/gone", "main")
+            .await
+            .unwrap();
+        std::fs::remove_dir_all(&path2).unwrap();
+        remove_worktree(&repo, &path2).await.unwrap();
+        let listed = git_stdout(Some(&repo), &["worktree", "list"], GIT_TIMEOUT)
+            .await
+            .unwrap();
+        assert!(
+            !listed.contains("gone"),
+            "prune should drop the stale registration: {listed}"
+        );
+    }
+
+    #[tokio::test]
+    async fn branch_collision_is_a_user_visible_error() {
+        let (_dir, repo) = init_repo();
+        let data = TempDir::new().unwrap();
+        let first = worktree_dir(data.path(), "demo", "one");
+        create_worktree(&repo, &first, "tidebreak/same", "main")
+            .await
+            .unwrap();
+        let second = worktree_dir(data.path(), "demo", "two");
+        let err = create_worktree(&repo, &second, "tidebreak/same", "main")
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("already exists"),
+            "collision must not auto-suffix: {err}"
+        );
+        assert!(!second.exists());
+    }
+
+    #[test]
+    fn untitled_workspaces_get_two_word_branch_names() {
+        let name = branch_name("tidebreak/", "", 42);
+        assert!(name.starts_with("tidebreak/"));
+        let slug = name.strip_prefix("tidebreak/").unwrap();
+        assert!(slug.contains('-'), "{slug}");
+        assert_eq!(slugify("Hello, World!"), "hello-world");
+    }
+}

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -262,12 +262,30 @@ pub(crate) fn branch_name(prefix: &str, title: &str, seed: u128) -> String {
 }
 
 /// Path `<data_dir>/code/worktrees/<repo-slug>/<workspace-slug>/`.
-pub(crate) fn worktree_dir(data_dir: &Path, repo_slug: &str, workspace_slug: &str) -> PathBuf {
+/// `<data_dir>/code/worktrees/<repo-id>-<slug>/<workspace-id>-<slug>/`.
+///
+/// Ids are the uniqueness key so two clones of the same project cannot share
+/// a directory. Slugs stay only as a human-readable suffix.
+pub(crate) fn worktree_dir(
+    data_dir: &Path,
+    repo_id: tidebreak_core::RepoId,
+    workspace_id: tidebreak_core::WorkspaceId,
+    repo_slug: &str,
+    workspace_slug: &str,
+) -> PathBuf {
     data_dir
         .join("code")
         .join("worktrees")
-        .join(repo_slug)
-        .join(workspace_slug)
+        .join(dir_name(repo_id, repo_slug))
+        .join(dir_name(workspace_id, workspace_slug))
+}
+
+fn dir_name(id: impl std::fmt::Display, slug: &str) -> String {
+    if slug.is_empty() {
+        id.to_string()
+    } else {
+        format!("{id}-{slug}")
+    }
 }
 
 pub(crate) fn two_word_name(seed: u128) -> String {
@@ -424,6 +442,16 @@ mod tests {
         (dir, repo)
     }
 
+    fn scratch_worktree(data: &Path, label: &str) -> PathBuf {
+        worktree_dir(
+            data,
+            tidebreak_core::RepoId::new(),
+            tidebreak_core::WorkspaceId::new(),
+            "demo",
+            label,
+        )
+    }
+
     fn run(cwd: &Path, args: &[&str]) {
         let status = StdCommand::new(args[0])
             .args(&args[1..])
@@ -458,7 +486,7 @@ mod tests {
     async fn create_verifies_and_setup_failure_preserves_checkout() {
         let (_dir, repo) = init_repo();
         let data = TempDir::new().unwrap();
-        let path = worktree_dir(data.path(), "demo", "first");
+        let path = scratch_worktree(data.path(), "first");
         create_worktree(&repo, &path, "tidebreak/first", "main")
             .await
             .unwrap();
@@ -474,7 +502,7 @@ mod tests {
     async fn create_cleans_up_a_half_created_worktree() {
         let (_dir, repo) = init_repo();
         let data = TempDir::new().unwrap();
-        let path = worktree_dir(data.path(), "demo", "ghost");
+        let path = scratch_worktree(data.path(), "ghost");
         // Point at a missing base so `worktree add` fails after creating the branch
         // attempt; cleanup must not leave a registered worktree.
         let err = create_worktree(&repo, &path, "tidebreak/ghost", "no-such-ref")
@@ -495,7 +523,7 @@ mod tests {
     async fn archive_refuses_dirty_work_without_force_and_prunes_gone_trees() {
         let (_dir, repo) = init_repo();
         let data = TempDir::new().unwrap();
-        let path = worktree_dir(data.path(), "demo", "dirty");
+        let path = scratch_worktree(data.path(), "dirty");
         create_worktree(&repo, &path, "tidebreak/dirty", "main")
             .await
             .unwrap();
@@ -509,7 +537,7 @@ mod tests {
         assert!(!path.exists());
 
         // Already-removed: deleting the directory out of band, then archive.
-        let path2 = worktree_dir(data.path(), "demo", "gone");
+        let path2 = scratch_worktree(data.path(), "gone");
         create_worktree(&repo, &path2, "tidebreak/gone", "main")
             .await
             .unwrap();
@@ -528,11 +556,11 @@ mod tests {
     async fn branch_collision_is_a_user_visible_error() {
         let (_dir, repo) = init_repo();
         let data = TempDir::new().unwrap();
-        let first = worktree_dir(data.path(), "demo", "one");
+        let first = scratch_worktree(data.path(), "one");
         create_worktree(&repo, &first, "tidebreak/same", "main")
             .await
             .unwrap();
-        let second = worktree_dir(data.path(), "demo", "two");
+        let second = scratch_worktree(data.path(), "two");
         let err = create_worktree(&repo, &second, "tidebreak/same", "main")
             .await
             .unwrap_err();
@@ -541,6 +569,19 @@ mod tests {
             "collision must not auto-suffix: {err}"
         );
         assert!(!second.exists());
+    }
+
+    #[test]
+    fn worktree_paths_are_keyed_on_ids() {
+        let data = std::path::Path::new("/tmp/data");
+        let repo_a = tidebreak_core::RepoId::new();
+        let repo_b = tidebreak_core::RepoId::new();
+        let ws = tidebreak_core::WorkspaceId::new();
+        let left = worktree_dir(data, repo_a, ws, "origin", "first");
+        let right = worktree_dir(data, repo_b, ws, "origin", "first");
+        assert_ne!(left, right);
+        assert!(left.to_string_lossy().contains(&repo_a.to_string()));
+        assert!(right.to_string_lossy().contains(&repo_b.to_string()));
     }
 
     #[test]

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -717,6 +717,10 @@ pub fn app(state: AppState) -> Router {
         )
         .route("/code/sessions/{id}/turns", post(routes::code::submit_turn))
         .route(
+            "/code/sessions/{id}/steer",
+            post(routes::code::steer_session),
+        )
+        .route(
             "/code/sessions/{id}/interrupt",
             post(routes::code::interrupt_session),
         )

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -27,6 +27,7 @@ mod blob_retirement_worker;
 mod bus;
 mod chat_titling;
 mod chatgpt_runtime;
+mod code;
 /// Host-owned code-execution provider selection and policy.
 pub mod code_execution;
 mod connected_apps;
@@ -89,6 +90,8 @@ mod sandbox_task_plan_worker;
 mod sandbox_web_search_worker;
 mod scoped_model_token;
 mod scoped_store;
+#[cfg(any(test, feature = "scripted-harness"))]
+mod scripted_harness;
 #[cfg(feature = "scripted-provider")]
 mod scripted_provider;
 /// Rewriting stored credentials so the running binary owns their keychain items.
@@ -118,8 +121,6 @@ use uuid::Uuid;
 
 use resolver::KeyedResolver;
 use tidebreak_code_execution::ExecTool;
-#[cfg(test)]
-use tidebreak_core::DbStore;
 use tidebreak_core::{
     ask_user_questions_tool_spec, computer_capture_screen_tool_spec, computer_click_tool_spec,
     computer_focus_window_tool_spec, computer_key_press_tool_spec, computer_list_windows_tool_spec,
@@ -137,8 +138,8 @@ use tidebreak_core::{
     validate_list_folder_arguments, validate_read_connected_file_arguments,
     validate_request_folder_access_arguments, validate_write_output_to_connected_folder_arguments,
     write_output_to_connected_folder_tool_spec, AgentConfig, AgentError, ApprovalClass, BlobStore,
-    CachingSecretProvider, Config, CreateAppTool, FsBlobStore, KeychainSecretProvider, ListDir,
-    Profile, ReadFile, Result, SecretProvider, Store, Tool, ToolRegistry, WriteFile,
+    CachingSecretProvider, Config, CreateAppTool, DbStore, FsBlobStore, KeychainSecretProvider,
+    ListDir, Profile, ReadFile, Result, SecretProvider, Store, Tool, ToolRegistry, WriteFile,
 };
 
 pub use durable_oplog::DurableOperationStore;
@@ -683,6 +684,47 @@ pub fn app(state: AppState) -> Router {
             axum::routing::delete(routes::delete_standing_grant),
         )
         .route("/chats/{id}/events", get(routes::chat_events))
+        .route(
+            "/code/repos",
+            post(routes::code::create_repo).get(routes::code::list_repos),
+        )
+        .route(
+            "/code/repos/{id}",
+            get(routes::code::get_repo)
+                .patch(routes::code::patch_repo)
+                .delete(routes::code::delete_repo),
+        )
+        .route("/code/harnesses", get(routes::code::list_harnesses))
+        .route(
+            "/code/harnesses/refresh",
+            post(routes::code::refresh_harnesses),
+        )
+        .route(
+            "/code/workspaces",
+            post(routes::code::create_workspace).get(routes::code::list_workspaces),
+        )
+        .route(
+            "/code/workspaces/{id}",
+            get(routes::code::get_workspace).patch(routes::code::patch_workspace),
+        )
+        .route(
+            "/code/workspaces/{id}/archive",
+            post(routes::code::archive_workspace),
+        )
+        .route(
+            "/code/workspaces/{id}/sessions",
+            post(routes::code::create_session),
+        )
+        .route("/code/sessions/{id}/turns", post(routes::code::submit_turn))
+        .route(
+            "/code/sessions/{id}/interrupt",
+            post(routes::code::interrupt_session),
+        )
+        .route("/code/sessions/{id}/reap", post(routes::code::reap_session))
+        .route(
+            "/code/sessions/{id}/events",
+            get(routes::code::session_events),
+        )
         .merge(client_executor_api)
         // Merged before the bearer layer, so `require_token` wraps outside
         // `require_admin`: an unauthenticated request to a deployment-plane
@@ -1064,7 +1106,8 @@ async fn bind_inner(
     let instance_lock = InstanceLock::acquire(&config)?;
     let sandbox_container_admission = sandbox_admission::resolve(&config);
     let sandbox_spawn_execution_location = sandbox_container_admission.execution_location;
-    let store = connect_store(&config).await?;
+    let db = connect_db(&config).await?;
+    let store: Arc<dyn Store> = db.clone();
     let secrets = secret_provider(&config);
     // An app update replaces this binary, and macOS pins each keychain
     // item's access to the creating binary's signature — so the first boot
@@ -1261,6 +1304,11 @@ async fn bind_inner(
         state.mcp.set_host_folders(host.clone());
     }
     state.host_folders = host_folders;
+    let code = Arc::new(code::CodeRuntime::new(db, state.config.data_dir.clone()));
+    if let Err(error) = code.recover().await {
+        tracing::warn!("code-mode recovery: {}", error.message());
+    }
+    state.code = Some(code);
     // Before `initialize`: a boot-file or persisted replacement derives the
     // plugin slice in the same pass, so bundled servers come up with
     // everything else instead of after a second reconcile.
@@ -1740,6 +1788,10 @@ fn register_computer_use_tools(tools: &mut ToolRegistry) {
 /// token file refuses to boot here, before the store exists, on every path
 /// that opens it (#853).
 async fn connect_store(config: &Config) -> Result<Arc<dyn Store>> {
+    Ok(connect_db(config).await?)
+}
+
+async fn connect_db(config: &Config) -> Result<Arc<DbStore>> {
     match config.profile {
         Profile::Desktop => {
             std::fs::create_dir_all(&config.data_dir)

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -713,7 +713,7 @@ pub fn app(state: AppState) -> Router {
         )
         .route(
             "/code/workspaces/{id}/sessions",
-            post(routes::code::create_session),
+            post(routes::code::create_session).get(routes::code::list_workspace_sessions),
         )
         .route("/code/sessions/{id}/turns", post(routes::code::submit_turn))
         .route(

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -715,7 +715,10 @@ pub fn app(state: AppState) -> Router {
             "/code/workspaces/{id}/sessions",
             post(routes::code::create_session).get(routes::code::list_workspace_sessions),
         )
-        .route("/code/sessions/{id}/turns", post(routes::code::submit_turn))
+        .route(
+            "/code/sessions/{id}/turns",
+            post(routes::code::submit_turn).get(routes::code::list_session_turns),
+        )
         .route(
             "/code/sessions/{id}/steer",
             post(routes::code::steer_session),

--- a/crates/tidebreak-server/src/routes.rs
+++ b/crates/tidebreak-server/src/routes.rs
@@ -23,6 +23,7 @@ mod app_invoke;
 mod app_library;
 mod approvals;
 pub(crate) mod client_execution;
+pub(crate) mod code;
 mod compaction;
 mod connected_apps;
 mod delegated_file_execution;

--- a/crates/tidebreak-server/src/routes/code/harnesses.rs
+++ b/crates/tidebreak-server/src/routes/code/harnesses.rs
@@ -1,0 +1,64 @@
+use axum::extract::State;
+
+use crate::error::ServerError;
+use crate::extract::Json;
+use crate::state::AppState;
+
+use super::require_code;
+use super::types::{HarnessDoctorEntry, HarnessDoctorReport};
+use tidebreak_core::HarnessKind;
+use tidebreak_harness::HostEnv;
+
+pub async fn list_harnesses(
+    State(state): State<AppState>,
+) -> Result<Json<HarnessDoctorReport>, ServerError> {
+    Ok(Json(doctor(&state).await?))
+}
+
+pub async fn refresh_harnesses(
+    State(state): State<AppState>,
+) -> Result<Json<HarnessDoctorReport>, ServerError> {
+    Ok(Json(doctor(&state).await?))
+}
+
+async fn doctor(state: &AppState) -> Result<HarnessDoctorReport, ServerError> {
+    let runtime = require_code(state)?;
+    let sessions = runtime.list_sessions().await?;
+    let host = HostEnv::from_process();
+    let mut harnesses = Vec::new();
+    for kind in HarnessKind::ALL {
+        let Some(adapter) = runtime.adapters.get(*kind) else {
+            continue;
+        };
+        let probe = adapter.probe(&host).await;
+        let caps = adapter.capabilities(&probe);
+        let unrecognized_event_count = sessions
+            .iter()
+            .filter(|session| session.harness_kind == *kind)
+            .map(|session| session.unrecognized_event_count)
+            .sum();
+        let remediation = if !probe.found {
+            format!("install {kind} so it is on your login-shell PATH, then refresh")
+        } else if probe.authenticated == Some(false) {
+            format!("sign in to {kind} in your own terminal, then refresh")
+        } else {
+            String::new()
+        };
+        harnesses.push(HarnessDoctorEntry {
+            kind: *kind,
+            found: probe.found,
+            path: probe
+                .binary_path
+                .as_ref()
+                .map(|path| path.display().to_string()),
+            version: probe.version,
+            tier: kind.tier(),
+            caps,
+            authenticated: probe.authenticated,
+            remediation,
+            stderr: probe.stderr,
+            unrecognized_event_count,
+        });
+    }
+    Ok(HarnessDoctorReport { harnesses })
+}

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -11,8 +11,8 @@ pub(crate) use harnesses::{list_harnesses, refresh_harnesses};
 pub(crate) use repos::{create_repo, delete_repo, get_repo, list_repos, patch_repo};
 pub(crate) use session_events::session_events;
 pub(crate) use sessions::{
-    create_session, interrupt_session, list_workspace_sessions, reap_session, steer_session,
-    submit_turn,
+    create_session, interrupt_session, list_session_turns, list_workspace_sessions, reap_session,
+    steer_session, submit_turn,
 };
 #[allow(unused_imports)]
 pub(crate) use types::{

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -10,11 +10,13 @@ mod workspaces;
 pub(crate) use harnesses::{list_harnesses, refresh_harnesses};
 pub(crate) use repos::{create_repo, delete_repo, get_repo, list_repos, patch_repo};
 pub(crate) use session_events::session_events;
-pub(crate) use sessions::{create_session, interrupt_session, reap_session, submit_turn};
+pub(crate) use sessions::{
+    create_session, interrupt_session, reap_session, steer_session, submit_turn,
+};
 #[allow(unused_imports)]
 pub(crate) use types::{
     CodeRepoSnapshot, CodeSessionSnapshot, CodeTurnSnapshot, CodeWorkspaceSnapshot,
-    HarnessDoctorReport, SequencedCodeEventFrame,
+    HarnessDoctorReport, QueuedCodeTurn, SequencedCodeEventFrame,
 };
 pub(crate) use workspaces::{
     archive_workspace, create_workspace, get_workspace, list_workspaces, patch_workspace,

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -1,0 +1,32 @@
+//! `/code/*` routes: repos, workspaces, sessions, doctor, event stream.
+
+mod harnesses;
+mod repos;
+mod session_events;
+mod sessions;
+mod types;
+mod workspaces;
+
+pub(crate) use harnesses::{list_harnesses, refresh_harnesses};
+pub(crate) use repos::{create_repo, delete_repo, get_repo, list_repos, patch_repo};
+pub(crate) use session_events::session_events;
+pub(crate) use sessions::{create_session, interrupt_session, reap_session, submit_turn};
+#[allow(unused_imports)]
+pub(crate) use types::{
+    CodeRepoSnapshot, CodeSessionSnapshot, CodeTurnSnapshot, CodeWorkspaceSnapshot,
+    HarnessDoctorReport, SequencedCodeEventFrame,
+};
+pub(crate) use workspaces::{
+    archive_workspace, create_workspace, get_workspace, list_workspaces, patch_workspace,
+};
+
+use crate::code::CodeRuntime;
+use crate::error::ServerError;
+use crate::state::AppState;
+
+pub(crate) fn require_code(state: &AppState) -> Result<&CodeRuntime, ServerError> {
+    state
+        .code
+        .as_deref()
+        .ok_or_else(|| ServerError::internal("code mode is not configured on this server"))
+}

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -11,7 +11,8 @@ pub(crate) use harnesses::{list_harnesses, refresh_harnesses};
 pub(crate) use repos::{create_repo, delete_repo, get_repo, list_repos, patch_repo};
 pub(crate) use session_events::session_events;
 pub(crate) use sessions::{
-    create_session, interrupt_session, reap_session, steer_session, submit_turn,
+    create_session, interrupt_session, list_workspace_sessions, reap_session, steer_session,
+    submit_turn,
 };
 #[allow(unused_imports)]
 pub(crate) use types::{

--- a/crates/tidebreak-server/src/routes/code/repos.rs
+++ b/crates/tidebreak-server/src/routes/code/repos.rs
@@ -1,0 +1,96 @@
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use std::path::PathBuf;
+
+use crate::error::ServerError;
+use crate::extract::{Json, Path};
+use crate::state::AppState;
+
+use super::require_code;
+use super::types::{CodeRepoSnapshot, CreateRepoBody, PatchRepoBody};
+use tidebreak_core::RepoId;
+
+pub async fn create_repo(
+    State(state): State<AppState>,
+    Json(body): Json<CreateRepoBody>,
+) -> Result<impl IntoResponse, ServerError> {
+    let runtime = require_code(&state)?;
+    let repo = runtime
+        .register_repo(
+            PathBuf::from(body.path),
+            body.display_name,
+            body.default_base_ref,
+            body.branch_prefix,
+            body.setup_script,
+            body.archive_script,
+        )
+        .await?;
+    Ok((StatusCode::CREATED, Json(CodeRepoSnapshot::from(repo))))
+}
+
+pub async fn list_repos(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<CodeRepoSnapshot>>, ServerError> {
+    let runtime = require_code(&state)?;
+    let repos = runtime.list_repos().await?;
+    Ok(Json(
+        repos.into_iter().map(CodeRepoSnapshot::from).collect(),
+    ))
+}
+
+pub async fn get_repo(
+    State(state): State<AppState>,
+    Path(id): Path<RepoId>,
+) -> Result<Json<CodeRepoSnapshot>, ServerError> {
+    let runtime = require_code(&state)?;
+    Ok(Json(CodeRepoSnapshot::from(runtime.get_repo(id).await?)))
+}
+
+pub async fn patch_repo(
+    State(state): State<AppState>,
+    Path(id): Path<RepoId>,
+    Json(body): Json<PatchRepoBody>,
+) -> Result<Json<CodeRepoSnapshot>, ServerError> {
+    let runtime = require_code(&state)?;
+    let mut repo = runtime.get_repo(id).await?;
+    if let Some(name) = body.display_name {
+        let name = name.trim().to_owned();
+        if name.is_empty() {
+            return Err(ServerError::bad_request("display_name must not be empty"));
+        }
+        repo.display_name = name;
+    }
+    if let Some(base) = body.default_base_ref {
+        let base = base.trim().to_owned();
+        if base.is_empty() {
+            return Err(ServerError::bad_request(
+                "default_base_ref must not be empty",
+            ));
+        }
+        repo.default_base_ref = base;
+    }
+    if let Some(prefix) = body.branch_prefix {
+        let prefix = prefix.trim().to_owned();
+        if prefix.is_empty() {
+            return Err(ServerError::bad_request("branch_prefix must not be empty"));
+        }
+        repo.branch_prefix = prefix;
+    }
+    if let Some(script) = body.setup_script {
+        repo.setup_script = script.filter(|value| !value.trim().is_empty());
+    }
+    if let Some(script) = body.archive_script {
+        repo.archive_script = script.filter(|value| !value.trim().is_empty());
+    }
+    runtime.save_repo(&repo).await?;
+    Ok(Json(CodeRepoSnapshot::from(repo)))
+}
+
+pub async fn delete_repo(
+    State(state): State<AppState>,
+    Path(id): Path<RepoId>,
+) -> Result<StatusCode, ServerError> {
+    require_code(&state)?.delete_repo(id).await?;
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/crates/tidebreak-server/src/routes/code/session_events.rs
+++ b/crates/tidebreak-server/src/routes/code/session_events.rs
@@ -1,0 +1,130 @@
+//! `WS /code/sessions/{id}/events?after=` — snapshot → replay → live.
+
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::State;
+use axum::response::Response;
+use tokio::sync::broadcast::error::RecvError;
+
+use tidebreak_core::db::code::list_events;
+use tidebreak_core::CodeSessionId;
+
+use crate::auth::{offered_handshake_subprotocol, WS_HANDSHAKE_SUBPROTOCOL};
+use crate::error::ServerError;
+use crate::extract::{Path, Query};
+use crate::state::AppState;
+
+use super::require_code;
+use super::types::{SequencedCodeEventFrame, SessionEventsQuery};
+
+pub async fn session_events(
+    State(state): State<AppState>,
+    Path(id): Path<CodeSessionId>,
+    Query(query): Query<SessionEventsQuery>,
+    headers: axum::http::HeaderMap,
+    upgrade: WebSocketUpgrade,
+) -> Result<Response, ServerError> {
+    let runtime = require_code(&state)?;
+    let _ = runtime.get_session(id).await?;
+    let upgrade = if offered_handshake_subprotocol(&headers) {
+        upgrade.protocols([WS_HANDSHAKE_SUBPROTOCOL])
+    } else {
+        upgrade
+    };
+    Ok(upgrade.on_upgrade(move |socket| stream_events(socket, state, id, query.after)))
+}
+
+async fn stream_events(mut socket: WebSocket, state: AppState, session: CodeSessionId, after: i64) {
+    let Some(runtime) = state.code.clone() else {
+        return;
+    };
+    let mut live = runtime.bus.subscribe(session);
+    let mut last_seq = after;
+    if replay_after(&mut socket, &runtime.db, session, &mut last_seq)
+        .await
+        .is_err()
+    {
+        return;
+    }
+    loop {
+        tokio::select! {
+            incoming = socket.recv() => match incoming {
+                None | Some(Err(_)) | Some(Ok(Message::Close(_))) => break,
+                _ => {}
+            },
+            live_event = live.recv() => match live_event {
+                Ok(event) => {
+                    if event.seq <= last_seq {
+                        continue;
+                    }
+                    if event.seq > last_seq.saturating_add(1) {
+                        if replay_after(&mut socket, &runtime.db, session, &mut last_seq)
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                        continue;
+                    }
+                    last_seq = event.seq;
+                    if send_frame(
+                        &mut socket,
+                        &SequencedCodeEventFrame {
+                            seq: event.seq,
+                            event: event.event,
+                            replayed: None,
+                        },
+                    )
+                    .await
+                    .is_err()
+                    {
+                        break;
+                    }
+                }
+                Err(RecvError::Lagged(_)) => {
+                    if replay_after(&mut socket, &runtime.db, session, &mut last_seq)
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                Err(RecvError::Closed) => break,
+            },
+        }
+    }
+}
+
+async fn replay_after(
+    socket: &mut WebSocket,
+    store: &tidebreak_core::DbStore,
+    session: CodeSessionId,
+    last_seq: &mut i64,
+) -> Result<(), ()> {
+    let events = list_events(store, session, *last_seq)
+        .await
+        .map_err(|_| ())?;
+    for event in events {
+        *last_seq = event.seq;
+        send_frame(
+            socket,
+            &SequencedCodeEventFrame {
+                seq: event.seq,
+                event: event.event,
+                replayed: Some(true),
+            },
+        )
+        .await
+        .map_err(|_| ())?;
+    }
+    Ok(())
+}
+
+async fn send_frame(
+    socket: &mut WebSocket,
+    frame: &SequencedCodeEventFrame,
+) -> Result<(), axum::Error> {
+    let Ok(json) = serde_json::to_string(frame) else {
+        return Ok(());
+    };
+    socket.send(Message::Text(json.into())).await
+}

--- a/crates/tidebreak-server/src/routes/code/sessions.rs
+++ b/crates/tidebreak-server/src/routes/code/sessions.rs
@@ -1,0 +1,58 @@
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+
+use crate::error::ServerError;
+use crate::extract::{Json, Path};
+use crate::state::AppState;
+
+use super::require_code;
+use super::types::{CodeSessionSnapshot, CodeTurnSnapshot, CreateSessionBody, SubmitTurnBody};
+use tidebreak_core::{CodeSessionId, WorkspaceId};
+
+pub async fn create_session(
+    State(state): State<AppState>,
+    Path(workspace_id): Path<WorkspaceId>,
+    Json(body): Json<CreateSessionBody>,
+) -> Result<impl IntoResponse, ServerError> {
+    let session = require_code(&state)?
+        .create_session(workspace_id, body.harness, body.permission_mode)
+        .await?;
+    Ok((
+        StatusCode::CREATED,
+        Json(CodeSessionSnapshot::from(session)),
+    ))
+}
+
+pub async fn submit_turn(
+    State(state): State<AppState>,
+    Path(id): Path<CodeSessionId>,
+    Json(body): Json<SubmitTurnBody>,
+) -> Result<impl IntoResponse, ServerError> {
+    let message = body.message.trim().to_owned();
+    if message.is_empty() {
+        return Err(ServerError::bad_request("message must not be empty"));
+    }
+    let turn = require_code(&state)?.submit_turn(id, message).await?;
+    Ok((StatusCode::ACCEPTED, Json(CodeTurnSnapshot::from(turn))))
+}
+
+pub async fn interrupt_session(
+    State(state): State<AppState>,
+    Path(id): Path<CodeSessionId>,
+) -> Result<StatusCode, ServerError> {
+    require_code(&state)?.interrupt(id).await?;
+    Ok(StatusCode::ACCEPTED)
+}
+
+pub async fn reap_session(
+    State(state): State<AppState>,
+    Path(id): Path<CodeSessionId>,
+) -> Result<(StatusCode, Json<CodeSessionSnapshot>), ServerError> {
+    let runtime = state
+        .code
+        .clone()
+        .ok_or_else(|| ServerError::internal("code mode is not configured on this server"))?;
+    let session = runtime.reap(id).await?;
+    Ok((StatusCode::OK, Json(CodeSessionSnapshot::from(session))))
+}

--- a/crates/tidebreak-server/src/routes/code/sessions.rs
+++ b/crates/tidebreak-server/src/routes/code/sessions.rs
@@ -71,6 +71,16 @@ pub async fn submit_turn(
     }
 }
 
+pub async fn list_session_turns(
+    State(state): State<AppState>,
+    Path(id): Path<CodeSessionId>,
+) -> Result<Json<Vec<CodeTurnSnapshot>>, ServerError> {
+    let turns = require_code(&state)?.list_session_turns(id).await?;
+    Ok(Json(
+        turns.into_iter().map(CodeTurnSnapshot::from).collect(),
+    ))
+}
+
 pub async fn steer_session(
     Path(_id): Path<CodeSessionId>,
     Json(body): Json<SteerBody>,

--- a/crates/tidebreak-server/src/routes/code/sessions.rs
+++ b/crates/tidebreak-server/src/routes/code/sessions.rs
@@ -28,6 +28,21 @@ pub async fn create_session(
     ))
 }
 
+pub async fn list_workspace_sessions(
+    State(state): State<AppState>,
+    Path(workspace_id): Path<WorkspaceId>,
+) -> Result<Json<Vec<CodeSessionSnapshot>>, ServerError> {
+    let sessions = require_code(&state)?
+        .list_workspace_sessions(workspace_id)
+        .await?;
+    Ok(Json(
+        sessions
+            .into_iter()
+            .map(CodeSessionSnapshot::from)
+            .collect(),
+    ))
+}
+
 pub async fn submit_turn(
     State(state): State<AppState>,
     Path(id): Path<CodeSessionId>,

--- a/crates/tidebreak-server/src/routes/code/sessions.rs
+++ b/crates/tidebreak-server/src/routes/code/sessions.rs
@@ -49,6 +49,7 @@ pub async fn submit_turn(
             Json(QueuedCodeTurn {
                 session_id: id,
                 message,
+                position: 1,
             }),
         )
             .into_response()),

--- a/crates/tidebreak-server/src/routes/code/sessions.rs
+++ b/crates/tidebreak-server/src/routes/code/sessions.rs
@@ -7,7 +7,11 @@ use crate::extract::{Json, Path};
 use crate::state::AppState;
 
 use super::require_code;
-use super::types::{CodeSessionSnapshot, CodeTurnSnapshot, CreateSessionBody, SubmitTurnBody};
+use super::types::{
+    CodeSessionSnapshot, CodeTurnSnapshot, CreateSessionBody, QueuedCodeTurn, SteerBody,
+    SubmitTurnBody,
+};
+use crate::code::runtime::SubmitTurnOutcome;
 use tidebreak_core::{CodeSessionId, WorkspaceId};
 
 pub async fn create_session(
@@ -33,8 +37,36 @@ pub async fn submit_turn(
     if message.is_empty() {
         return Err(ServerError::bad_request("message must not be empty"));
     }
-    let turn = require_code(&state)?.submit_turn(id, message).await?;
-    Ok((StatusCode::ACCEPTED, Json(CodeTurnSnapshot::from(turn))))
+    match require_code(&state)?
+        .submit_turn(id, message.clone())
+        .await?
+    {
+        SubmitTurnOutcome::Ran(turn) => {
+            Ok((StatusCode::ACCEPTED, Json(CodeTurnSnapshot::from(*turn))).into_response())
+        }
+        SubmitTurnOutcome::Queued => Ok((
+            StatusCode::ACCEPTED,
+            Json(QueuedCodeTurn {
+                session_id: id,
+                message,
+            }),
+        )
+            .into_response()),
+    }
+}
+
+pub async fn steer_session(
+    Path(_id): Path<CodeSessionId>,
+    Json(body): Json<SteerBody>,
+) -> Result<StatusCode, ServerError> {
+    let message = body.message.trim();
+    if message.is_empty() {
+        return Err(ServerError::bad_request("message must not be empty"));
+    }
+    Err(ServerError::unprocessable_kind(
+        "steering_unavailable",
+        "explicit mid-turn steering is not yet available; the message was not queued",
+    ))
 }
 
 pub async fn interrupt_session(

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -130,6 +130,9 @@ pub struct CodeTurnSnapshot {
     pub user_input: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
+    pub usage: Option<tidebreak_core::CodeUsage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
     pub checkpoint_ref: Option<String>,
     pub started_at: chrono::DateTime<chrono::Utc>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -145,6 +148,7 @@ impl From<CodeTurn> for CodeTurnSnapshot {
             ordinal: turn.ordinal,
             status: turn.status,
             user_input: turn.user_input,
+            usage: turn.usage,
             checkpoint_ref: turn.checkpoint_ref,
             started_at: turn.started_at,
             ended_at: turn.ended_at,

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -1,0 +1,285 @@
+//! Renderer-facing code-mode wire types.
+
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+
+use tidebreak_core::{
+    Attention, CapLevel, CodeEvent, CodePermissionMode, CodeRepo, CodeSession,
+    CodeSessionLifecycle, CodeTurn, CodeTurnStatus, CodeWorkspace, CodeWorkspaceStatus,
+    FenceReason, HarnessCaps, HarnessKind, HarnessTier, PullRequestDigest, QuickAction, RepoId,
+    WorkspaceId,
+};
+
+/// A registered local git repository.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeRepoSnapshot {
+    pub id: RepoId,
+    pub root_path: String,
+    pub display_name: String,
+    pub default_base_ref: String,
+    pub branch_prefix: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub setup_script: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub archive_script: Option<String>,
+    pub quick_actions: Vec<QuickAction>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl From<CodeRepo> for CodeRepoSnapshot {
+    fn from(repo: CodeRepo) -> Self {
+        Self {
+            id: repo.id,
+            root_path: repo.root_path,
+            display_name: repo.display_name,
+            default_base_ref: repo.default_base_ref,
+            branch_prefix: repo.branch_prefix,
+            setup_script: repo.setup_script,
+            archive_script: repo.archive_script,
+            quick_actions: repo.quick_actions,
+            created_at: repo.created_at,
+        }
+    }
+}
+
+/// One isolated workspace (worktree + branch) on a repo.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeWorkspaceSnapshot {
+    pub id: WorkspaceId,
+    pub repo_id: RepoId,
+    pub title: String,
+    pub worktree_path: String,
+    pub branch_name: String,
+    pub base_ref: String,
+    pub status: CodeWorkspaceStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub pr: Option<PullRequestDigest>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub archived_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+impl From<CodeWorkspace> for CodeWorkspaceSnapshot {
+    fn from(workspace: CodeWorkspace) -> Self {
+        Self {
+            id: workspace.id,
+            repo_id: workspace.repo_id,
+            title: workspace.title,
+            worktree_path: workspace.worktree_path,
+            branch_name: workspace.branch_name,
+            base_ref: workspace.base_ref,
+            status: workspace.status,
+            pr: workspace.pr,
+            created_at: workspace.created_at,
+            archived_at: workspace.archived_at,
+        }
+    }
+}
+
+/// One durable conversation with an external agent engine.
+#[derive(Debug, Clone, PartialEq, Serialize, TS)]
+pub struct CodeSessionSnapshot {
+    pub id: tidebreak_core::CodeSessionId,
+    pub workspace_id: WorkspaceId,
+    pub harness_kind: HarnessKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub harness_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub harness_resume_ref: Option<String>,
+    pub permission_mode: CodePermissionMode,
+    pub lifecycle: CodeSessionLifecycle,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub fence_reason: Option<FenceReason>,
+    pub attention: Attention,
+    pub unrecognized_event_count: i64,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl From<CodeSession> for CodeSessionSnapshot {
+    fn from(session: CodeSession) -> Self {
+        Self {
+            id: session.id,
+            workspace_id: session.workspace_id,
+            harness_kind: session.harness_kind,
+            harness_version: session.harness_version,
+            harness_resume_ref: session.harness_resume_ref,
+            permission_mode: session.permission_mode,
+            lifecycle: session.lifecycle,
+            fence_reason: session.fence_reason,
+            attention: session.attention,
+            unrecognized_event_count: session.unrecognized_event_count,
+            created_at: session.created_at,
+        }
+    }
+}
+
+/// One user→engine turn.
+#[derive(Debug, Clone, PartialEq, Serialize, TS)]
+pub struct CodeTurnSnapshot {
+    pub id: tidebreak_core::CodeTurnId,
+    pub session_id: tidebreak_core::CodeSessionId,
+    pub ordinal: i64,
+    pub status: CodeTurnStatus,
+    pub user_input: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub checkpoint_ref: Option<String>,
+    pub started_at: chrono::DateTime<chrono::Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub ended_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+impl From<CodeTurn> for CodeTurnSnapshot {
+    fn from(turn: CodeTurn) -> Self {
+        Self {
+            id: turn.id,
+            session_id: turn.session_id,
+            ordinal: turn.ordinal,
+            status: turn.status,
+            user_input: turn.user_input,
+            checkpoint_ref: turn.checkpoint_ref,
+            started_at: turn.started_at,
+            ended_at: turn.ended_at,
+        }
+    }
+}
+
+/// One journaled event on the per-session WebSocket.
+#[derive(Debug, Clone, PartialEq, Serialize, TS)]
+pub struct SequencedCodeEventFrame {
+    pub seq: i64,
+    pub event: CodeEvent,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub replayed: Option<bool>,
+}
+
+/// Doctor report for every registered engine adapter.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct HarnessDoctorReport {
+    pub harnesses: Vec<HarnessDoctorEntry>,
+}
+
+/// One engine's probe, capabilities, and remediation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct HarnessDoctorEntry {
+    pub kind: HarnessKind,
+    pub found: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub version: Option<String>,
+    pub tier: HarnessTier,
+    pub caps: HarnessCaps,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub authenticated: Option<bool>,
+    pub remediation: String,
+    pub stderr: String,
+    pub unrecognized_event_count: i64,
+}
+
+/// Body of `POST /code/repos`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CreateRepoBody {
+    pub path: String,
+    #[serde(default)]
+    pub display_name: Option<String>,
+    #[serde(default)]
+    pub default_base_ref: Option<String>,
+    #[serde(default)]
+    pub branch_prefix: Option<String>,
+    #[serde(default)]
+    pub setup_script: Option<String>,
+    #[serde(default)]
+    pub archive_script: Option<String>,
+}
+
+/// Body of `PATCH /code/repos/{id}`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PatchRepoBody {
+    #[serde(default)]
+    pub display_name: Option<String>,
+    #[serde(default)]
+    pub default_base_ref: Option<String>,
+    #[serde(default)]
+    pub branch_prefix: Option<String>,
+    #[serde(default)]
+    pub setup_script: Option<Option<String>>,
+    #[serde(default)]
+    pub archive_script: Option<Option<String>>,
+}
+
+/// Body of `POST /code/workspaces`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CreateWorkspaceBody {
+    pub repo_id: RepoId,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub base_ref: Option<String>,
+}
+
+/// Body of `PATCH /code/workspaces/{id}`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PatchWorkspaceBody {
+    #[serde(default)]
+    pub title: Option<String>,
+}
+
+/// Body of `POST /code/workspaces/{id}/archive`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ArchiveWorkspaceBody {
+    #[serde(default)]
+    pub force: bool,
+}
+
+/// Body of `POST /code/workspaces/{id}/sessions`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CreateSessionBody {
+    pub harness: HarnessKind,
+    pub permission_mode: CodePermissionMode,
+}
+
+/// Body of `POST /code/sessions/{id}/turns`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SubmitTurnBody {
+    pub message: String,
+}
+
+/// Query for `GET /code/workspaces`.
+#[derive(Debug, Deserialize)]
+pub struct ListWorkspacesQuery {
+    #[serde(default)]
+    pub repo_id: Option<RepoId>,
+}
+
+/// Query for `GET /code/sessions/{id}/events`.
+#[derive(Debug, Deserialize)]
+pub struct SessionEventsQuery {
+    #[serde(default)]
+    pub after: i64,
+}
+
+/// Used so capability flags stay reachable from the doctor root.
+#[allow(dead_code)]
+fn _cap_level(level: CapLevel) -> CapLevel {
+    level
+}

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -272,10 +272,14 @@ pub struct SteerBody {
 }
 
 /// A follow-up parked while the session is already running a turn.
+///
+/// No turn id: the row is created when the worker promotes this slot.
+/// `position` is 1-based in the single-slot queue.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
 pub struct QueuedCodeTurn {
     pub session_id: tidebreak_core::CodeSessionId,
     pub message: String,
+    pub position: i64,
 }
 
 /// Query for `GET /code/workspaces`.

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -264,6 +264,20 @@ pub struct SubmitTurnBody {
     pub message: String,
 }
 
+/// Body of `POST /code/sessions/{id}/steer`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SteerBody {
+    pub message: String,
+}
+
+/// A follow-up parked while the session is already running a turn.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct QueuedCodeTurn {
+    pub session_id: tidebreak_core::CodeSessionId,
+    pub message: String,
+}
+
 /// Query for `GET /code/workspaces`.
 #[derive(Debug, Deserialize)]
 pub struct ListWorkspacesQuery {

--- a/crates/tidebreak-server/src/routes/code/workspaces.rs
+++ b/crates/tidebreak-server/src/routes/code/workspaces.rs
@@ -1,0 +1,79 @@
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+
+use crate::error::ServerError;
+use crate::extract::{Json, Path, Query};
+use crate::state::AppState;
+
+use super::require_code;
+use super::types::{
+    ArchiveWorkspaceBody, CodeWorkspaceSnapshot, CreateWorkspaceBody, ListWorkspacesQuery,
+    PatchWorkspaceBody,
+};
+use tidebreak_core::WorkspaceId;
+
+pub async fn create_workspace(
+    State(state): State<AppState>,
+    Json(body): Json<CreateWorkspaceBody>,
+) -> Result<impl IntoResponse, ServerError> {
+    let workspace = require_code(&state)?
+        .create_workspace(body.repo_id, body.title, body.base_ref)
+        .await?;
+    Ok((
+        StatusCode::CREATED,
+        Json(CodeWorkspaceSnapshot::from(workspace)),
+    ))
+}
+
+pub async fn list_workspaces(
+    State(state): State<AppState>,
+    Query(query): Query<ListWorkspacesQuery>,
+) -> Result<Json<Vec<CodeWorkspaceSnapshot>>, ServerError> {
+    let workspaces = require_code(&state)?.list_workspaces(query.repo_id).await?;
+    Ok(Json(
+        workspaces
+            .into_iter()
+            .map(CodeWorkspaceSnapshot::from)
+            .collect(),
+    ))
+}
+
+pub async fn get_workspace(
+    State(state): State<AppState>,
+    Path(id): Path<WorkspaceId>,
+) -> Result<Json<CodeWorkspaceSnapshot>, ServerError> {
+    Ok(Json(CodeWorkspaceSnapshot::from(
+        require_code(&state)?.get_workspace(id).await?,
+    )))
+}
+
+pub async fn patch_workspace(
+    State(state): State<AppState>,
+    Path(id): Path<WorkspaceId>,
+    Json(body): Json<PatchWorkspaceBody>,
+) -> Result<Json<CodeWorkspaceSnapshot>, ServerError> {
+    let runtime = require_code(&state)?;
+    let mut workspace = runtime.get_workspace(id).await?;
+    if let Some(title) = body.title {
+        let title = title.trim().to_owned();
+        if title.is_empty() {
+            return Err(ServerError::bad_request("title must not be empty"));
+        }
+        workspace.title = title;
+        runtime.save_workspace(&workspace).await?;
+    }
+    Ok(Json(CodeWorkspaceSnapshot::from(workspace)))
+}
+
+pub async fn archive_workspace(
+    State(state): State<AppState>,
+    Path(id): Path<WorkspaceId>,
+    Json(body): Json<ArchiveWorkspaceBody>,
+) -> Result<Json<CodeWorkspaceSnapshot>, ServerError> {
+    Ok(Json(CodeWorkspaceSnapshot::from(
+        require_code(&state)?
+            .archive_workspace(id, body.force)
+            .await?,
+    )))
+}

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -45,7 +45,6 @@ impl ScriptedAdapter {
         self
     }
 
-    #[allow(dead_code)]
     pub(crate) fn with_steering(mut self, level: CapLevel) -> Self {
         self.mid_turn_steering = level;
         self

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -1,0 +1,215 @@
+//! A [`HarnessAdapter`] / [`HarnessSession`] driven by a script of events.
+//!
+//! Compiled only under the `scripted-harness` feature or in this crate's
+//! tests, matching [`scripted_provider`]: a released binary never contains it.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tidebreak_core::{CapLevel, CodePermissionMode, HarnessCaps, HarnessKind};
+use tidebreak_harness::{
+    HarnessAdapter, HarnessError, HarnessEvent, HarnessEventSink, HarnessProbe, HarnessSession,
+    HostEnv, SessionSpec, TurnInput,
+};
+use tokio::sync::Mutex;
+
+/// Environment variable carrying a JSON array of [`HarnessEvent`]s.
+#[allow(dead_code)]
+const SCRIPT_VAR: &str = "TIDEBREAK_SCRIPTED_HARNESS";
+
+/// One scripted engine session.
+pub(crate) struct ScriptedAdapter {
+    kind: HarnessKind,
+    events: Vec<HarnessEvent>,
+    delay: Duration,
+    mid_turn_steering: CapLevel,
+    child_pid: Option<i64>,
+}
+
+impl ScriptedAdapter {
+    pub(crate) fn new(events: Vec<HarnessEvent>) -> Self {
+        Self {
+            kind: HarnessKind::ClaudeCode,
+            events,
+            delay: Duration::ZERO,
+            mid_turn_steering: CapLevel::Unsupported,
+            child_pid: None,
+        }
+    }
+
+    pub(crate) fn with_delay(mut self, delay: Duration) -> Self {
+        self.delay = delay;
+        self
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn with_steering(mut self, level: CapLevel) -> Self {
+        self.mid_turn_steering = level;
+        self
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn with_child_pid(mut self, pid: i64) -> Self {
+        self.child_pid = Some(pid);
+        self
+    }
+}
+
+#[async_trait]
+impl HarnessAdapter for ScriptedAdapter {
+    fn kind(&self) -> HarnessKind {
+        self.kind
+    }
+
+    async fn probe(&self, _host: &HostEnv) -> HarnessProbe {
+        HarnessProbe {
+            found: true,
+            binary_path: Some(PathBuf::from("/scripted/engine")),
+            version: Some("scripted".into()),
+            authenticated: Some(true),
+            stderr: String::new(),
+            env: Vec::new(),
+        }
+    }
+
+    fn capabilities(&self, _probe: &HarnessProbe) -> HarnessCaps {
+        HarnessCaps {
+            resume: CapLevel::Supported,
+            streaming_deltas: CapLevel::Supported,
+            structured_approvals: CapLevel::Unsupported,
+            mid_turn_steering: self.mid_turn_steering,
+            plan_mode: CapLevel::Supported,
+            reasoning_levels: CapLevel::Unsupported,
+            native_file_change_events: CapLevel::Unsupported,
+            native_interrupt: CapLevel::Supported,
+        }
+    }
+
+    async fn launch(&self, spec: SessionSpec) -> Result<Box<dyn HarnessSession>, HarnessError> {
+        if spec.permission_mode != CodePermissionMode::Plan
+            && spec.permission_mode != CodePermissionMode::Ask
+            && spec.permission_mode != CodePermissionMode::Auto
+        {
+            return Err(HarnessError::PermissionModeUnsupported(
+                spec.permission_mode,
+            ));
+        }
+        Ok(Box::new(ScriptedSession {
+            sink: spec.sink,
+            events: self.events.clone(),
+            delay: self.delay,
+            mid_turn_steering: self.mid_turn_steering,
+            child_pid: self.child_pid,
+            interrupt: Arc::new(AtomicBool::new(false)),
+            steered: Mutex::new(None),
+            unrecognized: AtomicU64::new(0),
+        }))
+    }
+}
+
+struct ScriptedSession {
+    sink: Arc<dyn HarnessEventSink>,
+    events: Vec<HarnessEvent>,
+    delay: Duration,
+    mid_turn_steering: CapLevel,
+    child_pid: Option<i64>,
+    interrupt: Arc<AtomicBool>,
+    steered: Mutex<Option<String>>,
+    unrecognized: AtomicU64,
+}
+
+#[async_trait]
+impl HarnessSession for ScriptedSession {
+    async fn run_turn(&mut self, _input: TurnInput) -> Result<(), HarnessError> {
+        self.interrupt.store(false, Ordering::SeqCst);
+        for event in &self.events {
+            if self.interrupt.load(Ordering::SeqCst) {
+                self.sink.emit(HarnessEvent::TurnInterrupted).await;
+                return Ok(());
+            }
+            if !self.delay.is_zero() {
+                tokio::time::sleep(self.delay).await;
+            }
+            if let Some(text) = self.steered.lock().await.take() {
+                self.sink.emit(HarnessEvent::UserSteered { text }).await;
+            }
+            self.sink.emit(event.clone()).await;
+            if matches!(
+                event,
+                HarnessEvent::TurnCompleted { .. }
+                    | HarnessEvent::TurnFailed { .. }
+                    | HarnessEvent::TurnInterrupted
+            ) {
+                return Ok(());
+            }
+        }
+        if self.interrupt.load(Ordering::SeqCst) {
+            self.sink.emit(HarnessEvent::TurnInterrupted).await;
+        }
+        Ok(())
+    }
+
+    async fn decide(
+        &mut self,
+        _approval: tidebreak_harness::HarnessApprovalRef,
+        _decision: tidebreak_harness::ApprovalDecision,
+    ) -> Result<(), HarnessError> {
+        Err(HarnessError::Other(
+            "scripted engine has no approval channel".into(),
+        ))
+    }
+
+    async fn interrupt(&mut self) -> Result<(), HarnessError> {
+        self.interrupt.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn steer(&mut self, text: String) -> Result<(), HarnessError> {
+        if self.mid_turn_steering != CapLevel::Supported {
+            return Err(HarnessError::Other(
+                "mid-turn steering is not available on this engine".into(),
+            ));
+        }
+        *self.steered.lock().await = Some(text);
+        Ok(())
+    }
+
+    fn resume_ref(&self) -> Option<String> {
+        None
+    }
+
+    fn child_pid(&self) -> Option<i64> {
+        self.child_pid
+    }
+
+    async fn shutdown(self: Box<Self>) -> Result<(), HarnessError> {
+        let _ = self.unrecognized;
+        Ok(())
+    }
+}
+
+/// A short successful turn: one assistant delta, then completed.
+pub(crate) fn plain_text_script() -> Vec<HarnessEvent> {
+    vec![
+        HarnessEvent::SessionStarted {
+            harness_kind: HarnessKind::ClaudeCode,
+            harness_version: "scripted".into(),
+            resume_ref: Some("scripted-session".into()),
+        },
+        HarnessEvent::TurnStarted,
+        HarnessEvent::AssistantDelta {
+            text: "hello from the scripted engine".into(),
+        },
+        HarnessEvent::TurnCompleted {
+            usage: tidebreak_core::CodeUsage {
+                input_tokens: 4,
+                output_tokens: 6,
+                cache_read_input_tokens: 0,
+                cache_creation_input_tokens: 0,
+            },
+        },
+    ]
+}

--- a/crates/tidebreak-server/src/state.rs
+++ b/crates/tidebreak-server/src/state.rs
@@ -245,6 +245,9 @@ pub struct AppState {
     /// absent everywhere else, where folder bindings read as not connected
     /// and refuse to grant instead of parking.
     pub(crate) host_folders: Option<Arc<dyn crate::host_folders::HostFolders>>,
+    /// Code-mode runtime: worktrees, session workers, doctor, event bus.
+    /// Absent only in tests that assemble state without a [`DbStore`].
+    pub(crate) code: Option<Arc<crate::code::CodeRuntime>>,
 }
 
 impl AppState {
@@ -431,6 +434,7 @@ impl AppState {
             local_voice: Arc::new(UnavailableLocalVoiceRunner),
             code_execution: None,
             host_folders: None,
+            code: None,
         })
     }
 

--- a/crates/tidebreak-server/src/tests.rs
+++ b/crates/tidebreak-server/src/tests.rs
@@ -40,6 +40,7 @@ mod app_grant;
 mod app_invoke;
 mod app_library;
 mod chat_titling;
+mod code;
 mod compaction;
 mod configuration;
 mod conformance;

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -17,8 +17,9 @@ use tokio_tungstenite::tungstenite::Message as WsMessage;
 use crate::code::CodeRuntime;
 use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
 use tidebreak_core::{
-    CapLevel, CodePermissionMode, CodeSessionId, CodeSessionLifecycle, CodeTurnStatus,
-    CodeWorkspaceStatus, DbStore, HarnessKind, WorkspaceId,
+    Attention, AttentionSource, AttentionState, CapLevel, CodePermissionMode, CodeSessionId,
+    CodeSessionLifecycle, CodeTurnStatus, CodeWorkspaceStatus, DbStore, FenceReason, HarnessKind,
+    WorkspaceId,
 };
 use tidebreak_harness::{AdapterRegistry, HarnessEvent};
 
@@ -289,6 +290,72 @@ async fn archive_requires_force_when_the_tree_is_dirty() {
     let body: serde_json::Value = forced.json().await.unwrap();
     assert_eq!(body["status"], "archived");
     assert!(!std::path::Path::new(path).exists());
+}
+
+#[tokio::test]
+async fn no_force_archive_of_a_dirty_workspace_leaves_an_idle_session() {
+    let (router, token, runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let path = workspace["worktree_path"].as_str().unwrap();
+    std::fs::write(std::path::Path::new(path).join("dirty.txt"), "nope\n").unwrap();
+
+    let refused = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/archive",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "uncommitted");
+
+    let parsed: CodeSessionId = json_id(&session).parse().unwrap();
+    let row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.lifecycle, CodeSessionLifecycle::Idle);
+    assert!(std::path::Path::new(path).exists());
+
+    let turn = client
+        .post(format!(
+            "http://{addr}/code/sessions/{}/turns",
+            json_id(&session)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "still here" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        turn.status(),
+        reqwest::StatusCode::ACCEPTED,
+        "session must stay usable after a refused dirty archive: {}",
+        turn.text().await.unwrap()
+    );
 }
 
 #[tokio::test]
@@ -587,6 +654,83 @@ async fn a_recovered_session_accepts_a_turn() {
     let body: serde_json::Value = turn.json().await.unwrap();
     assert_eq!(body["status"], "completed");
     assert_eq!(body["user_input"], "after restart");
+
+    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let mut row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
+        .await
+        .unwrap()
+        .unwrap();
+    row.lifecycle = CodeSessionLifecycle::Fenced;
+    row.fence_reason = Some(FenceReason::OrphanAlive);
+    row.attention = Attention::new(
+        AttentionState::Fenced {
+            reason: FenceReason::OrphanAlive,
+        },
+        AttentionSource::Lifecycle,
+    );
+    tidebreak_core::db::code::save_session(&runtime.db, &row)
+        .await
+        .unwrap();
+
+    let fenced = Arc::new(CodeRuntime::with_registry(
+        runtime.db.clone(),
+        dir.path().to_path_buf(),
+        scripted_registry(),
+    ));
+    fenced.recover().await.unwrap();
+    let mut fenced_state = AppState::new(
+        Config::desktop(dir.path()),
+        runtime.db.clone(),
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    fenced_state.code = Some(fenced);
+    let token3 = fenced_state.token.clone();
+    let addr3 = serve(app(fenced_state)).await;
+    let client3 = reqwest::Client::new();
+
+    let stuck = client3
+        .post(format!("http://{addr3}/code/sessions/{session_id}/turns"))
+        .bearer_auth(&token3)
+        .json(&serde_json::json!({ "message": "while fenced" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(stuck.status(), reqwest::StatusCode::CONFLICT);
+    let stuck_body: serde_json::Value = stuck.json().await.unwrap();
+    assert_eq!(stuck_body["kind"], "session_fenced");
+
+    let reaped = client3
+        .post(format!("http://{addr3}/code/sessions/{session_id}/reap"))
+        .bearer_auth(&token3)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(reaped.status(), reqwest::StatusCode::OK);
+    let after_reap: serde_json::Value = reaped.json().await.unwrap();
+    assert_eq!(after_reap["lifecycle"], "idle");
+
+    let after = client3
+        .post(format!("http://{addr3}/code/sessions/{session_id}/turns"))
+        .bearer_auth(&token3)
+        .json(&serde_json::json!({ "message": "after reap" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        after.status(),
+        reqwest::StatusCode::ACCEPTED,
+        "reap must attach a worker: {}",
+        after.text().await.unwrap()
+    );
+    let after_body: serde_json::Value = after.json().await.unwrap();
+    assert_eq!(after_body["status"], "completed");
+    assert_eq!(after_body["user_input"], "after reap");
 }
 
 #[tokio::test]

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -348,6 +348,137 @@ async fn interrupt_stops_a_running_scripted_turn() {
     assert_eq!(turn.status(), reqwest::StatusCode::ACCEPTED);
 }
 
+#[tokio::test]
+async fn a_mid_turn_send_queues_instead_of_rejecting() {
+    let (router, token, runtime, dir) = code_app_with(
+        ScriptedAdapter::new(vec![
+            HarnessEvent::TurnStarted,
+            HarnessEvent::AssistantDelta {
+                text: "working".into(),
+            },
+            HarnessEvent::TurnCompleted {
+                usage: Default::default(),
+            },
+        ])
+        .with_delay(Duration::from_millis(40)),
+    )
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let session_id = json_id(&session).to_owned();
+
+    let first = client
+        .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "first" }));
+    let follow = async {
+        tokio::time::sleep(Duration::from_millis(15)).await;
+        client
+            .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+            .bearer_auth(&token)
+            .json(&serde_json::json!({ "message": "follow-up" }))
+            .send()
+            .await
+            .unwrap()
+    };
+    let overflow = async {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        client
+            .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+            .bearer_auth(&token)
+            .json(&serde_json::json!({ "message": "too many" }))
+            .send()
+            .await
+            .unwrap()
+    };
+    let (first, follow, overflow) = tokio::join!(first.send(), follow, overflow);
+    assert_eq!(first.unwrap().status(), reqwest::StatusCode::ACCEPTED);
+    let follow = follow;
+    assert_eq!(follow.status(), reqwest::StatusCode::ACCEPTED);
+    let follow_body: serde_json::Value = follow.json().await.unwrap();
+    assert_eq!(follow_body["message"], "follow-up");
+    assert_eq!(overflow.status(), reqwest::StatusCode::CONFLICT);
+    let overflow_body: serde_json::Value = overflow.json().await.unwrap();
+    assert_eq!(overflow_body["kind"], "queue_full");
+
+    let parsed: CodeSessionId = session_id.parse().unwrap();
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let events = tidebreak_core::db::code::list_events(&runtime.db, parsed, 0)
+                .await
+                .unwrap();
+            let completed = events
+                .iter()
+                .filter(|event| {
+                    matches!(event.event, tidebreak_core::CodeEvent::TurnCompleted { .. })
+                })
+                .count();
+            if completed >= 2 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("queued follow-up did not run");
+}
+
+#[tokio::test]
+async fn explicit_steer_is_not_yet_available() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let refused = client
+        .post(format!(
+            "http://{addr}/code/sessions/{}/steer",
+            json_id(&session)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "redirect" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::UNPROCESSABLE_ENTITY);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "steering_unavailable");
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn ws_replays_then_lives_without_gaps_or_duplicates() {
     let (router, token, runtime, dir) = code_app_with(

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -1,0 +1,556 @@
+//! End-to-end code-mode routes against the scripted engine.
+
+use super::*;
+
+use std::net::Ipv4Addr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::StreamExt;
+
+use axum::Router;
+use tokio::net::TcpListener;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::Message as WsMessage;
+
+use crate::code::CodeRuntime;
+use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
+use tidebreak_core::{
+    CodePermissionMode, CodeSessionId, CodeTurnStatus, CodeWorkspaceStatus, DbStore, HarnessKind,
+    WorkspaceId,
+};
+use tidebreak_harness::{AdapterRegistry, HarnessEvent};
+
+async fn code_app(
+    events: Vec<HarnessEvent>,
+) -> (Router, Arc<str>, Arc<CodeRuntime>, tempfile::TempDir) {
+    code_app_with(ScriptedAdapter::new(events)).await
+}
+
+async fn code_app_with(
+    adapter: ScriptedAdapter,
+) -> (Router, Arc<str>, Arc<CodeRuntime>, tempfile::TempDir) {
+    let (dir, store) = temp_db_store("code.db").await;
+    let db = Arc::new(store);
+    let store_trait: Arc<dyn Store> = db.clone();
+    let mut registry = AdapterRegistry::new();
+    registry.register(Arc::new(adapter));
+    let runtime = Arc::new(CodeRuntime::with_registry(
+        db,
+        dir.path().to_path_buf(),
+        registry,
+    ));
+    let mut state = AppState::new(
+        Config::desktop(dir.path()),
+        store_trait,
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    state.code = Some(runtime.clone());
+    let token = state.token.clone();
+    (app(state), token, runtime, dir)
+}
+
+fn init_git_repo(dir: &std::path::Path) -> std::path::PathBuf {
+    let repo = dir.join("origin");
+    std::fs::create_dir_all(&repo).unwrap();
+    for args in [
+        ["git", "init", "-b", "main"].as_slice(),
+        ["git", "config", "user.email", "dev@example.com"].as_slice(),
+        ["git", "config", "user.name", "Dev"].as_slice(),
+    ] {
+        assert!(std::process::Command::new(args[0])
+            .args(&args[1..])
+            .current_dir(&repo)
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .status()
+            .unwrap()
+            .success());
+    }
+    std::fs::write(repo.join("README.md"), "hello\n").unwrap();
+    assert!(std::process::Command::new("git")
+        .args(["add", "README.md"])
+        .current_dir(&repo)
+        .status()
+        .unwrap()
+        .success());
+    assert!(std::process::Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .unwrap()
+        .success());
+    repo
+}
+
+async fn register_and_workspace(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    token: &str,
+    repo: &std::path::Path,
+) -> (serde_json::Value, serde_json::Value) {
+    let registered = client
+        .post(format!("http://{addr}/code/repos"))
+        .bearer_auth(token)
+        .json(&serde_json::json!({ "path": repo }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(registered.status(), reqwest::StatusCode::CREATED);
+    let repo_body: serde_json::Value = registered.json().await.unwrap();
+    let created = client
+        .post(format!("http://{addr}/code/workspaces"))
+        .bearer_auth(token)
+        .json(&serde_json::json!({
+            "repo_id": json_id(&repo_body),
+            "title": "first change",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let workspace: serde_json::Value = created.json().await.unwrap();
+    let _ = json_id(&workspace);
+    (repo_body, workspace)
+}
+
+fn json_id(value: &serde_json::Value) -> &str {
+    value["id"].as_str().expect("id is a string")
+}
+
+async fn serve(router: Router) -> std::net::SocketAddr {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router).await;
+    });
+    addr
+}
+
+#[tokio::test]
+async fn plan_is_the_only_session_mode_and_a_turn_journals_end_to_end() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+
+    let refused = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "ask",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::UNPROCESSABLE_ENTITY);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "permission_mode_unavailable");
+
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(session.status(), reqwest::StatusCode::CREATED);
+    let session: serde_json::Value = session.json().await.unwrap();
+    assert_eq!(session["permission_mode"], "plan");
+
+    let turn = client
+        .post(format!(
+            "http://{addr}/code/sessions/{}/turns",
+            json_id(&session)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "hello" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(turn.status(), reqwest::StatusCode::ACCEPTED);
+    let turn: serde_json::Value = turn.json().await.unwrap();
+    assert_eq!(turn["status"], "completed");
+
+    let busy = client
+        .post(format!(
+            "http://{addr}/code/sessions/{}/turns",
+            json_id(&session)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "again" }))
+        .send()
+        .await
+        .unwrap();
+    // Second turn is accepted because the first already finished.
+    assert_eq!(busy.status(), reqwest::StatusCode::ACCEPTED);
+}
+
+#[tokio::test]
+async fn workspace_setup_failure_preserves_the_checkout() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let registered = client
+        .post(format!("http://{addr}/code/repos"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "path": repo,
+            "setup_script": "exit 3",
+        }))
+        .send()
+        .await
+        .unwrap();
+    let repo_body: serde_json::Value = registered.json().await.unwrap();
+    let created = client
+        .post(format!("http://{addr}/code/workspaces"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "repo_id": json_id(&repo_body),
+            "title": "broken setup",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::UNPROCESSABLE_ENTITY);
+    let listed = client
+        .get(format!(
+            "http://{addr}/code/workspaces?repo_id={}",
+            json_id(&repo_body)
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<Vec<serde_json::Value>>()
+        .await
+        .unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0]["status"], "setup_failed");
+    let path = listed[0]["worktree_path"].as_str().unwrap();
+    assert!(std::path::Path::new(path).join("README.md").is_file());
+}
+
+#[tokio::test]
+async fn archive_requires_force_when_the_tree_is_dirty() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let path = workspace["worktree_path"].as_str().unwrap();
+    std::fs::write(std::path::Path::new(path).join("dirty.txt"), "nope\n").unwrap();
+
+    let refused = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/archive",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+
+    let forced = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/archive",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "force": true }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(forced.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = forced.json().await.unwrap();
+    assert_eq!(body["status"], "archived");
+    assert!(!std::path::Path::new(path).exists());
+}
+
+#[tokio::test]
+async fn interrupt_stops_a_running_scripted_turn() {
+    let (router, token, _runtime, dir) = code_app_with(
+        ScriptedAdapter::new(vec![
+            HarnessEvent::TurnStarted,
+            HarnessEvent::AssistantDelta {
+                text: "working".into(),
+            },
+            HarnessEvent::TurnCompleted {
+                usage: Default::default(),
+            },
+        ])
+        .with_delay(Duration::from_millis(80)),
+    )
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+
+    let turn_req = client
+        .post(format!(
+            "http://{addr}/code/sessions/{}/turns",
+            json_id(&session)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "slow" }));
+    let interrupt = async {
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        client
+            .post(format!(
+                "http://{addr}/code/sessions/{}/interrupt",
+                json_id(&session)
+            ))
+            .bearer_auth(&token)
+            .send()
+            .await
+            .unwrap()
+    };
+    let (turn, interrupted) = tokio::join!(turn_req.send(), interrupt);
+    assert_eq!(interrupted.status(), reqwest::StatusCode::ACCEPTED);
+    let turn = turn.unwrap();
+    assert_eq!(turn.status(), reqwest::StatusCode::ACCEPTED);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn ws_replays_then_lives_without_gaps_or_duplicates() {
+    let (router, token, runtime, dir) = code_app_with(
+        ScriptedAdapter::new(vec![
+            HarnessEvent::TurnStarted,
+            HarnessEvent::AssistantDelta { text: "one".into() },
+            HarnessEvent::AssistantDelta { text: "two".into() },
+            HarnessEvent::TurnCompleted {
+                usage: Default::default(),
+            },
+        ])
+        .with_delay(Duration::from_millis(20)),
+    )
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let session_id = json_id(&session).to_owned();
+
+    let mut request = format!("ws://{addr}/code/sessions/{session_id}/events?after=0")
+        .into_client_request()
+        .unwrap();
+    request
+        .headers_mut()
+        .insert("Authorization", format!("Bearer {token}").parse().unwrap());
+    let (mut socket, _) = connect_async(request).await.unwrap();
+
+    let _ = client
+        .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "hi" }))
+        .send()
+        .await
+        .unwrap();
+
+    let mut seqs = Vec::new();
+    let read = async {
+        while let Some(frame) = socket.next().await {
+            let WsMessage::Text(text) = frame.unwrap() else {
+                continue;
+            };
+            let value: serde_json::Value = serde_json::from_str(text.as_str()).unwrap();
+            let seq = value["seq"].as_i64().unwrap();
+            seqs.push(seq);
+            if value["event"]["type"] == "turn_completed" {
+                break;
+            }
+        }
+    };
+    tokio::time::timeout(Duration::from_secs(5), read)
+        .await
+        .expect("turn did not complete over the socket");
+    assert!(seqs.windows(2).all(|pair| pair[0] < pair[1]), "{seqs:?}");
+    assert_eq!(
+        seqs.iter()
+            .copied()
+            .collect::<std::collections::BTreeSet<_>>()
+            .len(),
+        seqs.len(),
+        "duplicate seq on the live socket: {seqs:?}"
+    );
+
+    // Concurrent write after connect: journal a notice and publish a later seq
+    // first so the socket must fill the gap from the journal.
+    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let current = *seqs.last().unwrap();
+    let _ = tidebreak_core::db::code::append_event(
+        &runtime.db,
+        parsed,
+        1,
+        &tidebreak_core::CodeEvent::HarnessNotice {
+            level: tidebreak_core::HarnessNoticeLevel::Info,
+            message: "gap-a".into(),
+        },
+    )
+    .await
+    .unwrap();
+    let seq_b = tidebreak_core::db::code::append_event(
+        &runtime.db,
+        parsed,
+        1,
+        &tidebreak_core::CodeEvent::HarnessNotice {
+            level: tidebreak_core::HarnessNoticeLevel::Info,
+            message: "gap-b".into(),
+        },
+    )
+    .await
+    .unwrap();
+    runtime.bus.publish(
+        parsed,
+        tidebreak_core::SequencedCodeEvent {
+            seq: seq_b,
+            event: tidebreak_core::CodeEvent::HarnessNotice {
+                level: tidebreak_core::HarnessNoticeLevel::Info,
+                message: "gap-b".into(),
+            },
+        },
+    );
+    let mut recovered = Vec::new();
+    for _ in 0..2 {
+        let frame = tokio::time::timeout(Duration::from_secs(2), socket.next())
+            .await
+            .expect("gap recovery timed out")
+            .expect("socket closed")
+            .unwrap();
+        let WsMessage::Text(text) = frame else {
+            continue;
+        };
+        let value: serde_json::Value = serde_json::from_str(text.as_str()).unwrap();
+        recovered.push(value["seq"].as_i64().unwrap());
+    }
+    assert_eq!(recovered, vec![current + 1, current + 2]);
+}
+
+#[tokio::test]
+async fn superseded_worker_cannot_append_to_the_journal() {
+    let (router, token, runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let session_id: CodeSessionId = json_id(&session).parse().unwrap();
+    let current = session["lifecycle"].as_str().unwrap().to_owned();
+    assert_eq!(current, "idle");
+    let bumped = tidebreak_core::db::code::bump_spawn_epoch(&runtime.db, session_id, None)
+        .await
+        .unwrap();
+    let err = tidebreak_core::db::code::append_event(
+        &runtime.db,
+        session_id,
+        bumped - 1,
+        &tidebreak_core::CodeEvent::TurnInterrupted,
+    )
+    .await
+    .unwrap_err();
+    match err {
+        tidebreak_core::db::code::CodeJournalError::StaleSpawnEpoch {
+            attempted, current, ..
+        } => {
+            assert_eq!(attempted, bumped - 1);
+            assert_eq!(current, bumped);
+        }
+        other => panic!("expected stale epoch, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn doctor_lists_the_scripted_adapter() {
+    let (router, token, _runtime, _dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let report = reqwest::Client::new()
+        .get(format!("http://{addr}/code/harnesses"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(report["harnesses"][0]["kind"], "claude_code");
+    assert_eq!(report["harnesses"][0]["found"], true);
+}
+
+#[allow(dead_code)]
+fn _types(
+    _id: WorkspaceId,
+    _status: CodeWorkspaceStatus,
+    _turn: CodeTurnStatus,
+    _db: Option<DbStore>,
+    _mode: CodePermissionMode,
+    _kind: HarnessKind,
+) {
+}

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -17,8 +17,8 @@ use tokio_tungstenite::tungstenite::Message as WsMessage;
 use crate::code::CodeRuntime;
 use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
 use tidebreak_core::{
-    CodePermissionMode, CodeSessionId, CodeTurnStatus, CodeWorkspaceStatus, DbStore, HarnessKind,
-    WorkspaceId,
+    CapLevel, CodePermissionMode, CodeSessionId, CodeSessionLifecycle, CodeTurnStatus,
+    CodeWorkspaceStatus, DbStore, HarnessKind, WorkspaceId,
 };
 use tidebreak_harness::{AdapterRegistry, HarnessEvent};
 
@@ -349,7 +349,9 @@ async fn interrupt_stops_a_running_scripted_turn() {
 }
 
 #[tokio::test]
-async fn a_mid_turn_send_queues_instead_of_rejecting() {
+async fn a_mid_turn_send_queues_and_runs_after_the_current_turn() {
+    // Claude Code advertises mid_turn_steering: Unknown. Queue-default must
+    // still accept the follow-up; it must not 409 as if this were a steer.
     let (router, token, runtime, dir) = code_app_with(
         ScriptedAdapter::new(vec![
             HarnessEvent::TurnStarted,
@@ -360,7 +362,8 @@ async fn a_mid_turn_send_queues_instead_of_rejecting() {
                 usage: Default::default(),
             },
         ])
-        .with_delay(Duration::from_millis(40)),
+        .with_delay(Duration::from_millis(40))
+        .with_steering(CapLevel::Unknown),
     )
     .await;
     let addr = serve(router).await;
@@ -384,61 +387,93 @@ async fn a_mid_turn_send_queues_instead_of_rejecting() {
         .await
         .unwrap();
     let session_id = json_id(&session).to_owned();
+    let parsed: CodeSessionId = session_id.parse().unwrap();
 
-    let first = client
+    let first = tokio::spawn({
+        let client = client.clone();
+        let token = token.clone();
+        let session_id = session_id.clone();
+        async move {
+            client
+                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .bearer_auth(&token)
+                .json(&serde_json::json!({ "message": "first" }))
+                .send()
+                .await
+                .unwrap()
+        }
+    });
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
+                .await
+                .unwrap()
+                .unwrap();
+            if row.lifecycle == CodeSessionLifecycle::Running {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("first turn never reached Running");
+
+    let follow = client
         .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
         .bearer_auth(&token)
-        .json(&serde_json::json!({ "message": "first" }));
-    let follow = async {
-        tokio::time::sleep(Duration::from_millis(15)).await;
-        client
-            .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
-            .bearer_auth(&token)
-            .json(&serde_json::json!({ "message": "follow-up" }))
-            .send()
-            .await
-            .unwrap()
-    };
-    let overflow = async {
-        tokio::time::sleep(Duration::from_millis(20)).await;
-        client
-            .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
-            .bearer_auth(&token)
-            .json(&serde_json::json!({ "message": "too many" }))
-            .send()
-            .await
-            .unwrap()
-    };
-    let (first, follow, overflow) = tokio::join!(first.send(), follow, overflow);
-    assert_eq!(first.unwrap().status(), reqwest::StatusCode::ACCEPTED);
-    let follow = follow;
-    assert_eq!(follow.status(), reqwest::StatusCode::ACCEPTED);
+        .json(&serde_json::json!({ "message": "follow-up" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        follow.status(),
+        reqwest::StatusCode::ACCEPTED,
+        "mid-turn submit must queue, not 409, even when steering is Unknown"
+    );
     let follow_body: serde_json::Value = follow.json().await.unwrap();
     assert_eq!(follow_body["message"], "follow-up");
+    assert!(
+        follow_body.get("status").is_none(),
+        "queued follow-up must not mint a fake turn row: {follow_body}"
+    );
+
+    let overflow = client
+        .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "too many" }))
+        .send()
+        .await
+        .unwrap();
     assert_eq!(overflow.status(), reqwest::StatusCode::CONFLICT);
     let overflow_body: serde_json::Value = overflow.json().await.unwrap();
     assert_eq!(overflow_body["kind"], "queue_full");
 
-    let parsed: CodeSessionId = session_id.parse().unwrap();
+    assert_eq!(first.await.unwrap().status(), reqwest::StatusCode::ACCEPTED);
+
     tokio::time::timeout(Duration::from_secs(2), async {
         loop {
-            let events = tidebreak_core::db::code::list_events(&runtime.db, parsed, 0)
+            let turns = tidebreak_core::db::code::list_turns(&runtime.db, parsed)
                 .await
                 .unwrap();
-            let completed = events
-                .iter()
-                .filter(|event| {
-                    matches!(event.event, tidebreak_core::CodeEvent::TurnCompleted { .. })
-                })
-                .count();
-            if completed >= 2 {
+            if turns.len() >= 2
+                && turns[1].status == CodeTurnStatus::Completed
+                && turns[1].user_input == "follow-up"
+            {
+                assert_eq!(turns[0].user_input, "first");
+                assert_eq!(turns[0].status, CodeTurnStatus::Completed);
+                let first_end = turns[0].ended_at.expect("first turn ended");
+                assert!(
+                    turns[1].started_at >= first_end,
+                    "queued turn must start after the live turn ends"
+                );
                 break;
             }
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
     })
     .await
-    .expect("queued follow-up did not run");
+    .expect("queued follow-up did not run after the current turn completed");
 }
 
 #[tokio::test]

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -275,6 +275,103 @@ async fn listing_workspace_sessions_returns_create_shaped_snapshots() {
 }
 
 #[tokio::test]
+async fn listing_session_turns_returns_user_input_and_usage() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let missing = client
+        .get(format!(
+            "http://{addr}/code/sessions/{}/turns",
+            uuid::Uuid::new_v4()
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(missing.status(), reqwest::StatusCode::NOT_FOUND);
+
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let empty = client
+        .get(format!(
+            "http://{addr}/code/sessions/{}/turns",
+            json_id(&session)
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(empty.status(), reqwest::StatusCode::OK);
+    let empty_body: Vec<serde_json::Value> = empty.json().await.unwrap();
+    assert!(empty_body.is_empty());
+
+    let first = client
+        .post(format!(
+            "http://{addr}/code/sessions/{}/turns",
+            json_id(&session)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "hello" }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let second = client
+        .post(format!(
+            "http://{addr}/code/sessions/{}/turns",
+            json_id(&session)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "again" }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let listed = client
+        .get(format!(
+            "http://{addr}/code/sessions/{}/turns",
+            json_id(&session)
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(listed.status(), reqwest::StatusCode::OK);
+    let listed: Vec<serde_json::Value> = listed.json().await.unwrap();
+    assert_eq!(listed.len(), 2);
+    assert_eq!(listed[0]["id"], first["id"]);
+    assert_eq!(listed[0]["ordinal"], 1);
+    assert_eq!(listed[0]["status"], "completed");
+    assert_eq!(listed[0]["user_input"], "hello");
+    assert_eq!(listed[0]["usage"]["output_tokens"], 6);
+    assert!(listed[0]["started_at"].is_string());
+    assert!(listed[0]["ended_at"].is_string());
+    assert_eq!(listed[1]["id"], second["id"]);
+    assert_eq!(listed[1]["ordinal"], 2);
+    assert_eq!(listed[1]["user_input"], "again");
+}
+
+#[tokio::test]
 async fn workspace_setup_failure_preserves_the_checkout() {
     let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
     let addr = serve(router).await;

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -57,8 +57,8 @@ async fn code_app_with(
     (app(state), token, runtime, dir)
 }
 
-fn init_git_repo(dir: &std::path::Path) -> std::path::PathBuf {
-    let repo = dir.join("origin");
+fn init_git_repo_named(dir: &std::path::Path, name: &str) -> std::path::PathBuf {
+    let repo = dir.join(name);
     std::fs::create_dir_all(&repo).unwrap();
     for args in [
         ["git", "init", "-b", "main"].as_slice(),
@@ -87,6 +87,10 @@ fn init_git_repo(dir: &std::path::Path) -> std::path::PathBuf {
         .unwrap()
         .success());
     repo
+}
+
+fn init_git_repo(dir: &std::path::Path) -> std::path::PathBuf {
+    init_git_repo_named(dir, "origin")
 }
 
 async fn register_and_workspace(
@@ -433,9 +437,10 @@ async fn a_mid_turn_send_queues_and_runs_after_the_current_turn() {
     );
     let follow_body: serde_json::Value = follow.json().await.unwrap();
     assert_eq!(follow_body["message"], "follow-up");
+    assert_eq!(follow_body["position"], 1);
     assert!(
-        follow_body.get("status").is_none(),
-        "queued follow-up must not mint a fake turn row: {follow_body}"
+        follow_body.get("id").is_none() && follow_body.get("status").is_none(),
+        "queued follow-up must not mint a fake turn id: {follow_body}"
     );
 
     let overflow = client
@@ -512,6 +517,257 @@ async fn explicit_steer_is_not_yet_available() {
     assert_eq!(refused.status(), reqwest::StatusCode::UNPROCESSABLE_ENTITY);
     let body: serde_json::Value = refused.json().await.unwrap();
     assert_eq!(body["kind"], "steering_unavailable");
+}
+
+fn scripted_registry() -> AdapterRegistry {
+    let mut registry = AdapterRegistry::new();
+    registry.register(Arc::new(ScriptedAdapter::new(plain_text_script())));
+    registry
+}
+
+#[tokio::test]
+async fn a_recovered_session_accepts_a_turn() {
+    let (router, token, runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let session_id = json_id(&session).to_owned();
+
+    let restarted = Arc::new(CodeRuntime::with_registry(
+        runtime.db.clone(),
+        dir.path().to_path_buf(),
+        scripted_registry(),
+    ));
+    restarted.recover().await.unwrap();
+    let mut state = AppState::new(
+        Config::desktop(dir.path()),
+        runtime.db.clone(),
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    state.code = Some(restarted);
+    let token2 = state.token.clone();
+    let addr2 = serve(app(state)).await;
+
+    let turn = reqwest::Client::new()
+        .post(format!("http://{addr2}/code/sessions/{session_id}/turns"))
+        .bearer_auth(&token2)
+        .json(&serde_json::json!({ "message": "after restart" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        turn.status(),
+        reqwest::StatusCode::ACCEPTED,
+        "recovered session must accept a turn: {}",
+        turn.text().await.unwrap()
+    );
+    let body: serde_json::Value = turn.json().await.unwrap();
+    assert_eq!(body["status"], "completed");
+    assert_eq!(body["user_input"], "after restart");
+}
+
+#[tokio::test]
+async fn archive_ends_the_session_before_removing_the_worktree() {
+    let (router, token, runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let path = workspace["worktree_path"].as_str().unwrap().to_owned();
+    let archived = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/archive",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(archived.status(), reqwest::StatusCode::OK);
+    assert!(!std::path::Path::new(&path).exists());
+    let parsed: CodeSessionId = json_id(&session).parse().unwrap();
+    let row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.lifecycle, CodeSessionLifecycle::Ended);
+
+    let again = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        again.status(),
+        reqwest::StatusCode::CONFLICT,
+        "archived workspace is not ready for a new session"
+    );
+}
+
+#[tokio::test]
+async fn archive_refuses_a_running_session_without_force() {
+    let (router, token, runtime, dir) = code_app_with(
+        ScriptedAdapter::new(vec![
+            HarnessEvent::TurnStarted,
+            HarnessEvent::AssistantDelta {
+                text: "working".into(),
+            },
+            HarnessEvent::TurnCompleted {
+                usage: Default::default(),
+            },
+        ])
+        .with_delay(Duration::from_millis(50)),
+    )
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let session_id = json_id(&session).to_owned();
+    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let turn = tokio::spawn({
+        let client = client.clone();
+        let token = token.clone();
+        async move {
+            client
+                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .bearer_auth(&token)
+                .json(&serde_json::json!({ "message": "busy" }))
+                .send()
+                .await
+                .unwrap()
+        }
+    });
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
+                .await
+                .unwrap()
+                .unwrap();
+            if row.lifecycle == CodeSessionLifecycle::Running {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("turn never reached Running");
+
+    let refused = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/archive",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "session_running");
+
+    let forced = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/archive",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "force": true }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(forced.status(), reqwest::StatusCode::OK);
+    let _ = turn.await;
+    let row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.lifecycle, CodeSessionLifecycle::Ended);
+}
+
+#[tokio::test]
+async fn two_repos_with_the_same_name_get_distinct_worktrees() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let left = init_git_repo_named(&dir.path().join("left"), "origin");
+    let right = init_git_repo_named(&dir.path().join("right"), "origin");
+    let (repo_a, ws_a) = register_and_workspace(&client, addr, &token, &left).await;
+    let (repo_b, ws_b) = register_and_workspace(&client, addr, &token, &right).await;
+    assert_eq!(repo_a["display_name"], "origin");
+    assert_eq!(repo_b["display_name"], "origin");
+    let path_a = ws_a["worktree_path"].as_str().unwrap();
+    let path_b = ws_b["worktree_path"].as_str().unwrap();
+    assert_ne!(path_a, path_b);
+    assert!(path_a.contains(json_id(&repo_a)));
+    assert!(path_b.contains(json_id(&repo_b)));
+    assert!(std::path::Path::new(path_a).join("README.md").is_file());
+    assert!(std::path::Path::new(path_b).join("README.md").is_file());
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -209,6 +209,72 @@ async fn plan_is_the_only_session_mode_and_a_turn_journals_end_to_end() {
 }
 
 #[tokio::test]
+async fn listing_workspace_sessions_returns_create_shaped_snapshots() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let missing = client
+        .get(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            uuid::Uuid::new_v4()
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(missing.status(), reqwest::StatusCode::NOT_FOUND);
+
+    let empty = client
+        .get(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(empty.status(), reqwest::StatusCode::OK);
+    let empty_body: Vec<serde_json::Value> = empty.json().await.unwrap();
+    assert!(empty_body.is_empty());
+
+    let created = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let listed = client
+        .get(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(listed.status(), reqwest::StatusCode::OK);
+    let listed: Vec<serde_json::Value> = listed.json().await.unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0]["id"], created["id"]);
+    assert_eq!(listed[0]["workspace_id"], created["workspace_id"]);
+    assert_eq!(listed[0]["harness_kind"], "claude_code");
+    assert_eq!(listed[0]["permission_mode"], "plan");
+    assert_eq!(listed[0]["lifecycle"], created["lifecycle"]);
+}
+
+#[tokio::test]
 async fn workspace_setup_failure_preserves_the_checkout() {
     let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
     let addr = serve(router).await;

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -411,6 +411,7 @@ mod tests {
         generate::collect_from::<crate::routes::code::CodeWorkspaceSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeSessionSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeTurnSnapshot>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::QueuedCodeTurn>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::SequencedCodeEventFrame>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::HarnessDoctorReport>(&cfg, &mut out);
         out

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -407,6 +407,12 @@ mod tests {
         // Likewise its own endpoint root: the live progress stream is paged by
         // its own route rather than embedded in a snapshot.
         generate::collect_from::<crate::routes::AgentRunProgressPage>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::CodeRepoSnapshot>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::CodeWorkspaceSnapshot>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::CodeSessionSnapshot>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::CodeTurnSnapshot>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::SequencedCodeEventFrame>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::HarnessDoctorReport>(&cfg, &mut out);
         out
     }
 


### PR DESCRIPTION
## What landed

Walking-skeleton server layer for code mode, stacked on the foundation (#2123). Spec is #2122.

- **Worktree manager** — every git call is a bounded, non-interactive argv to the user's `git`. Repo registration canonicalizes to the toplevel and refuses bare repos. Workspace create is `git worktree add -b` under `<data_dir>/code/worktrees/<repo-slug>/<workspace-slug>/`; branch collision is a user-visible error (no auto-suffix). Setup-script failure preserves the checkout and marks `SetupFailed`. Archive requires `force` when the tree is dirty or unpushed, then `worktree remove` (already-gone tolerated) + `prune`. The branch is kept.
- **Session worker** — one task per session, the only journal writer, epoch-fenced. `HarnessEvent` → persist as `CodeEvent` → publish on a per-session bus (journal-before-live). Turns accepted while Idle; while Running, mid-turn steer only if the adapter caps say `Supported`, otherwise 409. Interrupt calls `HarnessSession::interrupt()`.
- **Recovery** — boot scan of `Running` sessions. Dead recorded pid → open turn `Interrupted` (journaled), session Idle, attention `NeedsYou { source: Lifecycle }`. Live pid → `Fenced { OrphanAlive }`. Reap resolves a fenced session. A pid that was not recorded at spawn is never signaled; `EPERM` counts as alive.
- **Routes** under the existing bearer auth: repos, workspaces, sessions, turns, interrupt, reap, doctor (`GET /code/harnesses` + refresh), and `WS /code/sessions/{id}/events?after=` (subscribe-live-first, snapshot, replay, live, seq-deduped). Session creation is **Plan only**; `Ask`/`Auto` return a typed `permission_mode_unavailable` refusal.
- **Scripted harness** (`scripted-harness` feature / tests) so route and worker tests run real turns without a live CLI.
- **Wire types** — repo/workspace/session/turn snapshots, sequenced event frame, doctor payload. Regenerated `wire.ts`.

## Deliberately out of scope

Approvals bridge / MCP endpoint, `/code/updates` digest channel, attention beyond recovery-set states, diffs/files routes, checkpoint production (`checkpoint.rs`), git commit/push/PR, quick actions, terminals.

## What I could not verify

Live-harness paths (real Claude Code / other engines). Those cannot run in CI; tests drive the scripted adapter and throwaway temp git repos.