### PR TITLE
feat(desktop): code mode route family and session surface

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api.test.ts
+++ b/crates/tidebreak-desktop/ui/src/api.test.ts
@@ -1565,3 +1565,30 @@ describe("source download progress", () => {
     );
   });
 });
+
+describe("code workspace sessions", () => {
+  it("lists GET /code/workspaces/{id}/sessions", async () => {
+    const session = {
+      id: "sess-1",
+      workspace_id: "ws-1",
+      harness_kind: "claude_code",
+      permission_mode: "plan",
+      lifecycle: "idle",
+      attention: { state: { type: "working" }, source: "lifecycle" },
+      unrecognized_event_count: 0,
+      created_at: "2026-08-15T12:00:00.000Z",
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify([session]), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new ApiClient("http://127.0.0.1", "token");
+
+    await expect(client.listCodeWorkspaceSessions("ws-1")).resolves.toEqual([
+      session,
+    ]);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://127.0.0.1/code/workspaces/ws-1/sessions");
+    expect(init.method ?? "GET").toBe("GET");
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/api.test.ts
+++ b/crates/tidebreak-desktop/ui/src/api.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   ApiClient,
+  archiveForceKind,
+  HttpError,
   parseAgentActivityHistory,
   parseAgentRunTaskPlan,
   parseFolderAccessRequest,
@@ -1590,5 +1592,43 @@ describe("code workspace sessions", () => {
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toBe("http://127.0.0.1/code/workspaces/ws-1/sessions");
     expect(init.method ?? "GET").toBe("GET");
+  });
+
+  it("lists GET /code/sessions/{id}/turns", async () => {
+    const turn = {
+      id: "turn-1",
+      session_id: "sess-1",
+      ordinal: 1,
+      status: "completed",
+      user_input: "list the files",
+      started_at: "2026-08-15T12:00:00.000Z",
+      ended_at: "2026-08-15T12:00:02.000Z",
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify([turn]), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new ApiClient("http://127.0.0.1", "token");
+    await expect(client.listCodeSessionTurns("sess-1")).resolves.toEqual([turn]);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "http://127.0.0.1/code/sessions/sess-1/turns",
+    );
+  });
+});
+
+describe("archive force kinds", () => {
+  it("treats unpushed leftover work as a force-confirm, not a dead-end toast", () => {
+    expect(archiveForceKind(new HttpError(409, "unpushed", "unpushed"))).toBe(
+      "unpushed",
+    );
+    expect(
+      archiveForceKind(new HttpError(409, "uncommitted", "uncommitted")),
+    ).toBe("uncommitted");
+    expect(
+      archiveForceKind(
+        new HttpError(409, "both", "uncommitted_and_unpushed"),
+      ),
+    ).toBe("uncommitted_and_unpushed");
+    expect(archiveForceKind(new HttpError(409, "busy", "session_running"))).toBeNull();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -103,6 +103,7 @@ import {
 import {
   parseCodeRepo,
   parseCodeSession,
+  parseCodeSessionList,
   parseCodeTurn,
   parseCodeWorkspace,
   parseHarnessDoctorReport,
@@ -1742,6 +1743,19 @@ export class ApiClient {
         ),
       ),
       "code workspace",
+    );
+  }
+
+  async listCodeWorkspaceSessions(
+    workspaceId: string,
+  ): Promise<CodeSessionSnapshot[]> {
+    const body = await this.json<unknown>(
+      `/code/workspaces/${encodeURIComponent(workspaceId)}/sessions`,
+      { headers: this.headers() },
+    );
+    return requireParsed(
+      parseCodeSessionList(body),
+      "code workspace sessions",
     );
   }
 

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -105,6 +105,7 @@ import {
   parseCodeSession,
   parseCodeSessionList,
   parseCodeTurn,
+  parseCodeTurnList,
   parseCodeWorkspace,
   parseHarnessDoctorReport,
   parseSequencedCodeEvent,
@@ -166,8 +167,15 @@ export class HttpError extends Error {
 /** Archive is refused until the reader confirms discarding leftover work. */
 export const ARCHIVE_FORCE_KINDS = new Set([
   "uncommitted",
+  "unpushed",
   "uncommitted_and_unpushed",
 ]);
+
+/** The 409 kinds that mean archive needs an explicit force. */
+export function archiveForceKind(error: unknown): string | null {
+  if (!(error instanceof HttpError) || !error.kind) return null;
+  return ARCHIVE_FORCE_KINDS.has(error.kind) ? error.kind : null;
+}
 
 /** The server's own message for a failed response, or its status text. */
 async function throwIfNotOk(response: Response): Promise<void> {
@@ -1776,6 +1784,14 @@ export class ApiClient {
       ),
       "code session",
     );
+  }
+
+  async listCodeSessionTurns(sessionId: string): Promise<CodeTurnSnapshot[]> {
+    const body = await this.json<unknown>(
+      `/code/sessions/${encodeURIComponent(sessionId)}/turns`,
+      { headers: this.headers() },
+    );
+    return requireParsed(parseCodeTurnList(body), "code session turns");
   }
 
   async submitCodeTurn(

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -77,6 +77,14 @@ import {
   type AgentRunTaskPlan,
   type PendingChatPrompt,
   type TaskPlan,
+  type CodePermissionMode,
+  type CodeRepoSnapshot,
+  type CodeSessionSnapshot,
+  type CodeTurnSnapshot,
+  type CodeWorkspaceSnapshot,
+  type HarnessDoctorReport,
+  type HarnessKind,
+  type SequencedCodeEventFrame,
 } from "./types";
 import {
   parseAgentActivityHistory,
@@ -92,6 +100,14 @@ import {
   parseSandboxAgentCancellation,
   parseTaskPlan,
 } from "./parsers";
+import {
+  parseCodeRepo,
+  parseCodeSession,
+  parseCodeTurn,
+  parseCodeWorkspace,
+  parseHarnessDoctorReport,
+  parseSequencedCodeEvent,
+} from "../code/parsers";
 
 const WS_HANDSHAKE = "tidebreak-v1";
 const WS_TOKEN_PREFIX = "tidebreak-token.";
@@ -139,23 +155,32 @@ export class HttpError extends Error {
   constructor(
     readonly status: number,
     message: string,
+    readonly kind?: string,
   ) {
     super(message);
     this.name = "HttpError";
   }
 }
 
+/** Archive is refused until the reader confirms discarding leftover work. */
+export const ARCHIVE_FORCE_KINDS = new Set([
+  "uncommitted",
+  "uncommitted_and_unpushed",
+]);
+
 /** The server's own message for a failed response, or its status text. */
 async function throwIfNotOk(response: Response): Promise<void> {
   if (response.ok) return;
   let detail = response.statusText;
+  let kind: string | undefined;
   try {
-    const body = (await response.json()) as { message?: string };
+    const body = (await response.json()) as { message?: string; kind?: string };
     if (body.message) detail = body.message;
+    if (typeof body.kind === "string" && body.kind.length > 0) kind = body.kind;
   } catch {
     /* ignore */
   }
-  throw new HttpError(response.status, `${response.status}: ${detail}`);
+  throw new HttpError(response.status, `${response.status}: ${detail}`, kind);
 }
 
 export class ApiClient {
@@ -1576,4 +1601,247 @@ export class ApiClient {
     };
     return socket;
   }
+
+  async listCodeRepos(): Promise<CodeRepoSnapshot[]> {
+    const body = await this.json<unknown>("/code/repos", {
+      headers: this.headers(),
+    });
+    return parseList(body, parseCodeRepo, "code repos");
+  }
+
+  async createCodeRepo(body: {
+    path: string;
+    display_name?: string;
+    default_base_ref?: string;
+    branch_prefix?: string;
+    setup_script?: string;
+    archive_script?: string;
+  }): Promise<CodeRepoSnapshot> {
+    return requireParsed(
+      parseCodeRepo(
+        await this.json("/code/repos", {
+          method: "POST",
+          headers: this.headers(true),
+          body: JSON.stringify(body),
+        }),
+      ),
+      "code repo",
+    );
+  }
+
+  async getCodeRepo(repoId: string): Promise<CodeRepoSnapshot> {
+    return requireParsed(
+      parseCodeRepo(
+        await this.json(`/code/repos/${encodeURIComponent(repoId)}`, {
+          headers: this.headers(),
+        }),
+      ),
+      "code repo",
+    );
+  }
+
+  async patchCodeRepo(
+    repoId: string,
+    body: {
+      display_name?: string;
+      default_base_ref?: string;
+      branch_prefix?: string;
+      setup_script?: string | null;
+      archive_script?: string | null;
+    },
+  ): Promise<CodeRepoSnapshot> {
+    return requireParsed(
+      parseCodeRepo(
+        await this.json(`/code/repos/${encodeURIComponent(repoId)}`, {
+          method: "PATCH",
+          headers: this.headers(true),
+          body: JSON.stringify(body),
+        }),
+      ),
+      "code repo",
+    );
+  }
+
+  deleteCodeRepo(repoId: string): Promise<void> {
+    return this.json(`/code/repos/${encodeURIComponent(repoId)}`, {
+      method: "DELETE",
+      headers: this.headers(),
+    });
+  }
+
+  async getHarnessDoctor(): Promise<HarnessDoctorReport> {
+    return requireParsed(
+      parseHarnessDoctorReport(
+        await this.json("/code/harnesses", { headers: this.headers() }),
+      ),
+      "harness doctor",
+    );
+  }
+
+  async refreshHarnessDoctor(): Promise<HarnessDoctorReport> {
+    return requireParsed(
+      parseHarnessDoctorReport(
+        await this.json("/code/harnesses/refresh", {
+          method: "POST",
+          headers: this.headers(),
+        }),
+      ),
+      "harness doctor",
+    );
+  }
+
+  async listCodeWorkspaces(repoId?: string): Promise<CodeWorkspaceSnapshot[]> {
+    const query = repoId ? `?repo_id=${encodeURIComponent(repoId)}` : "";
+    const body = await this.json<unknown>(`/code/workspaces${query}`, {
+      headers: this.headers(),
+    });
+    return parseList(body, parseCodeWorkspace, "code workspaces");
+  }
+
+  async createCodeWorkspace(body: {
+    repo_id: string;
+    title?: string;
+    base_ref?: string;
+  }): Promise<CodeWorkspaceSnapshot> {
+    return requireParsed(
+      parseCodeWorkspace(
+        await this.json("/code/workspaces", {
+          method: "POST",
+          headers: this.headers(true),
+          body: JSON.stringify(body),
+        }),
+      ),
+      "code workspace",
+    );
+  }
+
+  async getCodeWorkspace(workspaceId: string): Promise<CodeWorkspaceSnapshot> {
+    return requireParsed(
+      parseCodeWorkspace(
+        await this.json(`/code/workspaces/${encodeURIComponent(workspaceId)}`, {
+          headers: this.headers(),
+        }),
+      ),
+      "code workspace",
+    );
+  }
+
+  async archiveCodeWorkspace(
+    workspaceId: string,
+    force = false,
+  ): Promise<CodeWorkspaceSnapshot> {
+    return requireParsed(
+      parseCodeWorkspace(
+        await this.json(
+          `/code/workspaces/${encodeURIComponent(workspaceId)}/archive`,
+          {
+            method: "POST",
+            headers: this.headers(true),
+            body: JSON.stringify({ force }),
+          },
+        ),
+      ),
+      "code workspace",
+    );
+  }
+
+  async createCodeSession(
+    workspaceId: string,
+    body: { harness: HarnessKind; permission_mode: CodePermissionMode },
+  ): Promise<CodeSessionSnapshot> {
+    return requireParsed(
+      parseCodeSession(
+        await this.json(
+          `/code/workspaces/${encodeURIComponent(workspaceId)}/sessions`,
+          {
+            method: "POST",
+            headers: this.headers(true),
+            body: JSON.stringify(body),
+          },
+        ),
+      ),
+      "code session",
+    );
+  }
+
+  async submitCodeTurn(
+    sessionId: string,
+    message: string,
+  ): Promise<CodeTurnSnapshot> {
+    return requireParsed(
+      parseCodeTurn(
+        await this.json(
+          `/code/sessions/${encodeURIComponent(sessionId)}/turns`,
+          {
+            method: "POST",
+            headers: this.headers(true),
+            body: JSON.stringify({ message }),
+          },
+        ),
+      ),
+      "code turn",
+    );
+  }
+
+  interruptCodeSession(sessionId: string): Promise<void> {
+    return this.json(`/code/sessions/${encodeURIComponent(sessionId)}/interrupt`, {
+      method: "POST",
+      headers: this.headers(),
+    });
+  }
+
+  async reapCodeSession(sessionId: string): Promise<CodeSessionSnapshot> {
+    return requireParsed(
+      parseCodeSession(
+        await this.json(`/code/sessions/${encodeURIComponent(sessionId)}/reap`, {
+          method: "POST",
+          headers: this.headers(),
+        }),
+      ),
+      "code session",
+    );
+  }
+
+  /** Open the per-session journal; auth via Sec-WebSocket-Protocol. */
+  openCodeEvents(
+    sessionId: string,
+    after: number,
+    onFrame: (frame: SequencedCodeEventFrame) => void,
+  ): WebSocket {
+    const url = `${this.baseUrl.replace(/^http/, "ws")}/code/sessions/${encodeURIComponent(sessionId)}/events?after=${after}`;
+    const protocols = [WS_HANDSHAKE, `${WS_TOKEN_PREFIX}${this.token}`];
+    const socket = new WebSocket(url, protocols);
+    socket.onmessage = (msg) => {
+      try {
+        const frame = parseSequencedCodeEvent(JSON.parse(String(msg.data)));
+        if (frame) onFrame(frame);
+        else console.error("dropping malformed code event frame");
+      } catch (err) {
+        console.error("bad code event frame", err);
+      }
+    };
+    return socket;
+  }
+}
+
+function requireParsed<T>(value: T | null, label: string): T {
+  if (!value) throw new Error(`${label} response contains invalid data`);
+  return value;
+}
+
+function parseList<T>(
+  body: unknown,
+  parse: (value: unknown) => T | null,
+  label: string,
+): T[] {
+  if (!Array.isArray(body)) {
+    throw new Error(`${label} response is not an array`);
+  }
+  return body.map((item, index) => {
+    const parsed = parse(item);
+    if (!parsed) {
+      throw new Error(`${label} response contains invalid data at ${index}`);
+    }
+    return parsed;
+  });
 }

--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -100,6 +100,34 @@ import {
   type TranscriptImageAttachment as WireTranscriptImageAttachment,
   type TranscriptRole,
   type ToolApprovalKind,
+  type Attention as WireAttention,
+  type AttentionSource as WireAttentionSource,
+  type AttentionState as WireAttentionState,
+  type CapLevel as WireCapLevel,
+  type CodeEvent as WireCodeEvent,
+  type CodePermissionMode as WireCodePermissionMode,
+  type CodeRepoSnapshot as WireCodeRepoSnapshot,
+  type CodeSessionId as WireCodeSessionId,
+  type CodeSessionLifecycle as WireCodeSessionLifecycle,
+  type CodeSessionSnapshot as WireCodeSessionSnapshot,
+  type CodeTurnId as WireCodeTurnId,
+  type CodeTurnSnapshot as WireCodeTurnSnapshot,
+  type CodeTurnStatus as WireCodeTurnStatus,
+  type CodeUsage as WireCodeUsage,
+  type CodeWorkspaceSnapshot as WireCodeWorkspaceSnapshot,
+  type CodeWorkspaceStatus as WireCodeWorkspaceStatus,
+  type FenceReason as WireFenceReason,
+  type HarnessCaps as WireHarnessCaps,
+  type HarnessDoctorEntry as WireHarnessDoctorEntry,
+  type HarnessDoctorReport as WireHarnessDoctorReport,
+  type HarnessKind as WireHarnessKind,
+  type HarnessNoticeLevel as WireHarnessNoticeLevel,
+  type HarnessTier as WireHarnessTier,
+  type RepoId as WireRepoId,
+  type SequencedCodeEventFrame as WireSequencedCodeEventFrame,
+  type ToolDetail as WireToolDetail,
+  type ToolOutcome as WireToolOutcome,
+  type WorkspaceId as WireWorkspaceId,
 } from "../generated/wire";
 
 export type {
@@ -931,3 +959,43 @@ export type FileDownloadProgress = {
   /** `loaded` over `total`, as 0–100. */
   percentage: number;
 };
+
+/** A registered local git repository. */
+export type CodeRepoSnapshot = WireCodeRepoSnapshot;
+export type RepoId = WireRepoId;
+
+/** One isolated worktree + branch on a repo. */
+export type CodeWorkspaceSnapshot = WireCodeWorkspaceSnapshot;
+export type WorkspaceId = WireWorkspaceId;
+export type CodeWorkspaceStatus = WireCodeWorkspaceStatus;
+
+/** One durable conversation with an external coding engine. */
+export type CodeSessionSnapshot = WireCodeSessionSnapshot;
+export type CodeSessionId = WireCodeSessionId;
+export type CodeSessionLifecycle = WireCodeSessionLifecycle;
+export type CodePermissionMode = WireCodePermissionMode;
+export type FenceReason = WireFenceReason;
+export type Attention = WireAttention;
+export type AttentionState = WireAttentionState;
+export type AttentionSource = WireAttentionSource;
+
+/** One user→engine cycle. */
+export type CodeTurnSnapshot = WireCodeTurnSnapshot;
+export type CodeTurnId = WireCodeTurnId;
+export type CodeTurnStatus = WireCodeTurnStatus;
+export type CodeUsage = WireCodeUsage;
+
+/** Journaled engine event and the sequenced WebSocket frame that carries it. */
+export type CodeEvent = WireCodeEvent;
+export type SequencedCodeEventFrame = WireSequencedCodeEventFrame;
+export type ToolDetail = WireToolDetail;
+export type ToolOutcome = WireToolOutcome;
+export type HarnessNoticeLevel = WireHarnessNoticeLevel;
+
+/** Doctor report for every registered engine. */
+export type HarnessDoctorReport = WireHarnessDoctorReport;
+export type HarnessDoctorEntry = WireHarnessDoctorEntry;
+export type HarnessKind = WireHarnessKind;
+export type HarnessTier = WireHarnessTier;
+export type HarnessCaps = WireHarnessCaps;
+export type CapLevel = WireCapLevel;

--- a/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.ts
@@ -8,15 +8,13 @@ import type {
   HarnessDoctorReport,
 } from "../api/types";
 
-const SESSION_CACHE_KEY = "tidebreak.code-sessions";
-
 /**
  * Repos, workspaces, and the last session each workspace opened.
  *
- * The walking skeleton has no `/code/updates` digest and no list-sessions
- * route, so the rail and the workspace page share this catalog. Sessions are
- * remembered after create (and across reloads) so reopening a workspace can
- * still attach its socket.
+ * The workspace page loads sessions from `GET /code/workspaces/{id}/sessions`.
+ * `rememberSession` is write-through after create/reap so the same window
+ * does not wait on another round trip. Nothing here is persisted: a reload
+ * asks the server again.
  */
 
 type CodeCatalogState = {
@@ -40,30 +38,10 @@ type CodeCatalogStore = CodeCatalogState & {
   reset: () => void;
 };
 
-function readCachedSessions(): Record<string, CodeSessionSnapshot> {
-  try {
-    const raw = window.localStorage.getItem(SESSION_CACHE_KEY);
-    if (!raw) return {};
-    const parsed = JSON.parse(raw) as unknown;
-    if (!parsed || typeof parsed !== "object") return {};
-    return parsed as Record<string, CodeSessionSnapshot>;
-  } catch {
-    return {};
-  }
-}
-
-function writeCachedSessions(sessions: Record<string, CodeSessionSnapshot>) {
-  try {
-    window.localStorage.setItem(SESSION_CACHE_KEY, JSON.stringify(sessions));
-  } catch {
-    /* ignore quota / private-mode */
-  }
-}
-
 export const useCodeCatalogStore = create<CodeCatalogStore>()((set, get) => ({
   repos: [],
   workspaces: [],
-  sessionsByWorkspace: readCachedSessions(),
+  sessionsByWorkspace: {},
   doctor: null,
   loaded: false,
   error: null,
@@ -83,17 +61,16 @@ export const useCodeCatalogStore = create<CodeCatalogStore>()((set, get) => ({
     }
   },
   rememberSession: (session) => {
-    const sessionsByWorkspace = {
-      ...get().sessionsByWorkspace,
-      [session.workspace_id]: session,
-    };
-    writeCachedSessions(sessionsByWorkspace);
-    set({ sessionsByWorkspace });
+    set({
+      sessionsByWorkspace: {
+        ...get().sessionsByWorkspace,
+        [session.workspace_id]: session,
+      },
+    });
   },
   forgetWorkspace: (workspaceId) => {
     const { [workspaceId]: _removed, ...sessionsByWorkspace } =
       get().sessionsByWorkspace;
-    writeCachedSessions(sessionsByWorkspace);
     set({
       sessionsByWorkspace,
       workspaces: get().workspaces.filter((item) => item.id !== workspaceId),
@@ -116,7 +93,6 @@ export const useCodeCatalogStore = create<CodeCatalogStore>()((set, get) => ({
     });
   },
   reset: () => {
-    writeCachedSessions({});
     set({
       repos: [],
       workspaces: [],

--- a/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.ts
@@ -1,0 +1,129 @@
+import { create } from "zustand";
+
+import type { ApiClient } from "../api/client";
+import type {
+  CodeRepoSnapshot,
+  CodeSessionSnapshot,
+  CodeWorkspaceSnapshot,
+  HarnessDoctorReport,
+} from "../api/types";
+
+const SESSION_CACHE_KEY = "tidebreak.code-sessions";
+
+/**
+ * Repos, workspaces, and the last session each workspace opened.
+ *
+ * The walking skeleton has no `/code/updates` digest and no list-sessions
+ * route, so the rail and the workspace page share this catalog. Sessions are
+ * remembered after create (and across reloads) so reopening a workspace can
+ * still attach its socket.
+ */
+
+type CodeCatalogState = {
+  repos: CodeRepoSnapshot[];
+  workspaces: CodeWorkspaceSnapshot[];
+  sessionsByWorkspace: Record<string, CodeSessionSnapshot>;
+  doctor: HarnessDoctorReport | null;
+  loaded: boolean;
+  error: string | null;
+};
+
+type CodeCatalogStore = CodeCatalogState & {
+  refresh: (client: Pick<
+    ApiClient,
+    "listCodeRepos" | "listCodeWorkspaces" | "getHarnessDoctor"
+  >) => Promise<void>;
+  rememberSession: (session: CodeSessionSnapshot) => void;
+  forgetWorkspace: (workspaceId: string) => void;
+  upsertRepo: (repo: CodeRepoSnapshot) => void;
+  upsertWorkspace: (workspace: CodeWorkspaceSnapshot) => void;
+  reset: () => void;
+};
+
+function readCachedSessions(): Record<string, CodeSessionSnapshot> {
+  try {
+    const raw = window.localStorage.getItem(SESSION_CACHE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return {};
+    return parsed as Record<string, CodeSessionSnapshot>;
+  } catch {
+    return {};
+  }
+}
+
+function writeCachedSessions(sessions: Record<string, CodeSessionSnapshot>) {
+  try {
+    window.localStorage.setItem(SESSION_CACHE_KEY, JSON.stringify(sessions));
+  } catch {
+    /* ignore quota / private-mode */
+  }
+}
+
+export const useCodeCatalogStore = create<CodeCatalogStore>()((set, get) => ({
+  repos: [],
+  workspaces: [],
+  sessionsByWorkspace: readCachedSessions(),
+  doctor: null,
+  loaded: false,
+  error: null,
+  refresh: async (client) => {
+    try {
+      const [repos, workspaces, doctor] = await Promise.all([
+        client.listCodeRepos(),
+        client.listCodeWorkspaces(),
+        client.getHarnessDoctor(),
+      ]);
+      set({ repos, workspaces, doctor, loaded: true, error: null });
+    } catch (error) {
+      set({
+        loaded: true,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  },
+  rememberSession: (session) => {
+    const sessionsByWorkspace = {
+      ...get().sessionsByWorkspace,
+      [session.workspace_id]: session,
+    };
+    writeCachedSessions(sessionsByWorkspace);
+    set({ sessionsByWorkspace });
+  },
+  forgetWorkspace: (workspaceId) => {
+    const { [workspaceId]: _removed, ...sessionsByWorkspace } =
+      get().sessionsByWorkspace;
+    writeCachedSessions(sessionsByWorkspace);
+    set({
+      sessionsByWorkspace,
+      workspaces: get().workspaces.filter((item) => item.id !== workspaceId),
+    });
+  },
+  upsertRepo: (repo) => {
+    set({
+      repos: [
+        repo,
+        ...get().repos.filter((item) => item.id !== repo.id),
+      ],
+    });
+  },
+  upsertWorkspace: (workspace) => {
+    set({
+      workspaces: [
+        workspace,
+        ...get().workspaces.filter((item) => item.id !== workspace.id),
+      ],
+    });
+  },
+  reset: () => {
+    writeCachedSessions({});
+    set({
+      repos: [],
+      workspaces: [],
+      sessionsByWorkspace: {},
+      doctor: null,
+      loaded: false,
+      error: null,
+    });
+  },
+}));

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { CodeComposer } from "./CodeComposer";
+import { PERMISSION_MODE_UNAVAILABLE_REASON } from "./labels";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CodeComposer", () => {
+  it("shows Ask and Auto as disabled with the server's unavailable reason", () => {
+    render(
+      <CodeComposer
+        running={false}
+        permissionMode="plan"
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Plan" })).toBeEnabled();
+    const ask = screen.getByRole("button", { name: /Ask/ });
+    const auto = screen.getByRole("button", { name: /Auto/ });
+    expect(ask).toBeDisabled();
+    expect(auto).toBeDisabled();
+    expect(ask).toHaveAttribute(
+      "title",
+      `Ask: ${PERMISSION_MODE_UNAVAILABLE_REASON}`,
+    );
+    expect(auto).toHaveAttribute(
+      "title",
+      `Auto: ${PERMISSION_MODE_UNAVAILABLE_REASON}`,
+    );
+    expect(
+      screen.getAllByText(PERMISSION_MODE_UNAVAILABLE_REASON),
+    ).toHaveLength(2);
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { CodeComposer } from "./CodeComposer";
@@ -36,5 +36,22 @@ describe("CodeComposer", () => {
     expect(
       screen.getAllByText(PERMISSION_MODE_UNAVAILABLE_REASON),
     ).toHaveLength(2);
+  });
+
+  it("keeps the draft when send is refused", async () => {
+    const onSend = vi.fn().mockRejectedValue(new Error("session is fenced"));
+    render(
+      <CodeComposer
+        running={false}
+        permissionMode="plan"
+        onSend={onSend}
+        onInterrupt={vi.fn()}
+      />,
+    );
+    const box = screen.getByRole("textbox", { name: "Message" });
+    fireEvent.change(box, { target: { value: "list the files" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    await waitFor(() => expect(onSend).toHaveBeenCalled());
+    expect(box).toHaveValue("list the files");
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -1,0 +1,130 @@
+import { type KeyboardEvent, useState } from "react";
+import { Square } from "lucide-react";
+
+import type { CodePermissionMode } from "../api/types";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import {
+  PERMISSION_MODE_LABELS,
+  PERMISSION_MODE_UNAVAILABLE_REASON,
+} from "./labels";
+
+/**
+ * Trimmed composer for a code session: text, send, interrupt, and the
+ * permission mode the session was created under.
+ *
+ * Plan is the only mode this phase can honor. Ask and Auto stay visible so
+ * the scale is honest, and they carry the server's "not yet available"
+ * reason rather than disappearing.
+ */
+
+const MODES: CodePermissionMode[] = ["plan", "ask", "auto"];
+
+export function CodeComposer({
+  disabled,
+  running,
+  permissionMode,
+  onSend,
+  onInterrupt,
+}: {
+  disabled?: boolean;
+  running: boolean;
+  permissionMode: CodePermissionMode;
+  onSend: (message: string) => Promise<void> | void;
+  onInterrupt: () => Promise<void> | void;
+}) {
+  const [draft, setDraft] = useState("");
+  const [sending, setSending] = useState(false);
+  const canSend = draft.trim().length > 0 && !disabled && !sending && !running;
+
+  async function send() {
+    if (!canSend) return;
+    const message = draft.trim();
+    setSending(true);
+    try {
+      await onSend(message);
+      setDraft("");
+    } finally {
+      setSending(false);
+    }
+  }
+
+  function onKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
+    if (
+      event.key === "Enter" &&
+      !event.shiftKey &&
+      !event.ctrlKey &&
+      !event.altKey &&
+      !event.metaKey &&
+      !event.nativeEvent.isComposing
+    ) {
+      event.preventDefault();
+      void send();
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2 border-t px-4 py-3">
+      <div className="flex flex-wrap items-center gap-1.5" data-testid="permission-modes">
+        {MODES.map((mode) => {
+          const available = mode === "plan";
+          const selected = permissionMode === mode;
+          return (
+            <button
+              key={mode}
+              type="button"
+              disabled={!available}
+              title={
+                available
+                  ? PERMISSION_MODE_LABELS[mode]
+                  : `${PERMISSION_MODE_LABELS[mode]}: ${PERMISSION_MODE_UNAVAILABLE_REASON}`
+              }
+              aria-pressed={selected}
+              className={cn(
+                "rounded-full border px-2.5 py-0.5 text-xs font-medium",
+                selected && "border-foreground bg-muted",
+                !available && "cursor-not-allowed opacity-50",
+              )}
+            >
+              {PERMISSION_MODE_LABELS[mode]}
+              {!available && (
+                <span className="sr-only">
+                  {PERMISSION_MODE_UNAVAILABLE_REASON}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+      <div className="flex items-end gap-2">
+        <Textarea
+          rows={2}
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          onKeyDown={onKeyDown}
+          disabled={disabled || sending}
+          placeholder={running ? "Turn in progress…" : "Message the session"}
+          aria-label="Message"
+          className="min-h-[2.75rem] resize-none"
+        />
+        {running ? (
+          <Button
+            type="button"
+            variant="destructive"
+            size="sm"
+            onClick={() => void onInterrupt()}
+            aria-label="Interrupt"
+          >
+            <Square />
+            Interrupt
+          </Button>
+        ) : (
+          <Button type="button" size="sm" disabled={!canSend} onClick={() => void send()}>
+            Send
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -45,6 +45,8 @@ export function CodeComposer({
     try {
       await onSend(message);
       setDraft("");
+    } catch {
+      // Leave the draft. A refused send has no turn to answer.
     } finally {
       setSending(false);
     }

--- a/crates/tidebreak-desktop/ui/src/code/CodeHome.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeHome.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useState, type FormEvent } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { toast } from "sonner";
+
+import { useApp } from "@/AppContext";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { RouteFrame } from "@/RouteFrame";
+import { friendlyErrorMessage } from "@/lib/utils";
+import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { CodeSidebar } from "./CodeSidebar";
+import { DoctorList } from "./DoctorList";
+import { isHarnessReady } from "./labels";
+
+/**
+ * `/code` home: the doctor when no engine is usable, otherwise repo
+ * registration and the registered list.
+ *
+ * A reader who has not installed or signed in to a harness cannot start a
+ * workspace, so the empty state is the remediation the doctor already wrote
+ * rather than a blank register form.
+ */
+
+export function CodeHome() {
+  return (
+    <RouteFrame sidebar={<CodeSidebar />}>
+      <div className="content-container min-h-0 w-full min-w-0 flex-1 overflow-auto">
+        <CodeHomeBody />
+      </div>
+    </RouteFrame>
+  );
+}
+
+function CodeHomeBody() {
+  const navigate = useNavigate();
+  const { client } = useApp();
+  const doctor = useCodeCatalogStore((state) => state.doctor);
+  const repos = useCodeCatalogStore((state) => state.repos);
+  const loaded = useCodeCatalogStore((state) => state.loaded);
+  const error = useCodeCatalogStore((state) => state.error);
+  const refresh = useCodeCatalogStore((state) => state.refresh);
+  const upsertRepo = useCodeCatalogStore((state) => state.upsertRepo);
+  const [path, setPath] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [registering, setRegistering] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+
+  useEffect(() => {
+    void refresh(client);
+  }, [client, refresh]);
+
+  const ready = doctor?.harnesses.some(isHarnessReady) ?? false;
+
+  async function onRefresh() {
+    setRefreshing(true);
+    try {
+      await refresh(client);
+    } finally {
+      setRefreshing(false);
+    }
+  }
+
+  async function register(event: FormEvent) {
+    event.preventDefault();
+    if (!path.trim()) return;
+    setRegistering(true);
+    try {
+      const repo = await client.createCodeRepo({
+        path: path.trim(),
+        display_name: displayName.trim() || undefined,
+      });
+      upsertRepo(repo);
+      setPath("");
+      setDisplayName("");
+      await navigate({ to: "/code/r/$repoId", params: { repoId: repo.id } });
+    } catch (err) {
+      toast.error(friendlyErrorMessage(err, "Could not register that repo"));
+    } finally {
+      setRegistering(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-6 py-8">
+      <div>
+        <h1 className="text-2xl font-medium tracking-tight">Code</h1>
+        <p className="text-muted-foreground text-sm">
+          Register a local git repository, then open isolated workspaces on it.
+        </p>
+      </div>
+      {error && <p className="text-sm text-critical">{error}</p>}
+      {!loaded && <p className="text-muted-foreground text-sm">Loading…</p>}
+      {doctor && !ready && (
+        <section className="flex flex-col gap-3">
+          <h2 className="text-lg font-semibold">Install a coding harness</h2>
+          <p className="text-muted-foreground text-sm">
+            No harness is installed and signed in. Code mode drives an engine
+            already on this machine — install one, sign in from your own
+            terminal, then refresh.
+          </p>
+          <DoctorList
+            report={doctor}
+            onRefresh={() => void onRefresh()}
+            refreshing={refreshing}
+          />
+        </section>
+      )}
+      {ready && (
+        <>
+          <section className="flex flex-col gap-3">
+            <h2 className="text-lg font-semibold">Register a repo</h2>
+            <form className="flex flex-col gap-3" onSubmit={register}>
+              <label className="flex flex-col gap-1 text-sm">
+                <span className="font-medium">Path</span>
+                <Input
+                  value={path}
+                  onChange={(event) => setPath(event.target.value)}
+                  placeholder="/Users/you/src/app"
+                  disabled={registering}
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-sm">
+                <span className="font-medium">Display name</span>
+                <Input
+                  value={displayName}
+                  onChange={(event) => setDisplayName(event.target.value)}
+                  disabled={registering}
+                />
+              </label>
+              <Button type="submit" disabled={registering || !path.trim()} className="self-start">
+                {registering ? "Registering…" : "Register"}
+              </Button>
+            </form>
+          </section>
+          <section className="flex flex-col gap-3">
+            <h2 className="text-lg font-semibold">Repos</h2>
+            {repos.length === 0 ? (
+              <p className="text-muted-foreground text-sm">None registered yet.</p>
+            ) : (
+              <ul className="flex flex-col gap-1">
+                {repos.map((repo) => (
+                  <li key={repo.id}>
+                    <button
+                      type="button"
+                      className="hover:bg-muted w-full rounded-md px-3 py-2 text-left text-sm"
+                      onClick={() =>
+                        void navigate({
+                          to: "/code/r/$repoId",
+                          params: { repoId: repo.id },
+                        })
+                      }
+                    >
+                      <span className="font-medium">{repo.display_name}</span>
+                      <span className="text-muted-foreground ml-2 font-mono text-xs">
+                        {repo.root_path}
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </>
+      )}
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/CodeRepoPage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeRepoPage.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+
+import { useApp } from "@/AppContext";
+import { Button } from "@/components/ui/button";
+import { RouteFrame } from "@/RouteFrame";
+import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { CodeSidebar } from "./CodeSidebar";
+import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
+import { WORKSPACE_STATUS_LABELS } from "./labels";
+
+/**
+ * One registered repo: its workspaces and the new-workspace flow.
+ */
+
+export function CodeRepoPage({ repoId }: { repoId: string }) {
+  return (
+    <RouteFrame sidebar={<CodeSidebar />}>
+      <div className="content-container min-h-0 w-full min-w-0 flex-1 overflow-auto">
+        <CodeRepoBody repoId={repoId} />
+      </div>
+    </RouteFrame>
+  );
+}
+
+function CodeRepoBody({ repoId }: { repoId: string }) {
+  const navigate = useNavigate();
+  const { client } = useApp();
+  const repos = useCodeCatalogStore((state) => state.repos);
+  const workspaces = useCodeCatalogStore((state) => state.workspaces);
+  const refresh = useCodeCatalogStore((state) => state.refresh);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    void refresh(client);
+  }, [client, refresh]);
+
+  const repo = repos.find((item) => item.id === repoId);
+  const listed = workspaces.filter((workspace) => workspace.repo_id === repoId);
+
+  if (!repo) {
+    return (
+      <p className="text-muted-foreground p-6 text-sm">Loading repo…</p>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-6 py-8">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-medium tracking-tight">{repo.display_name}</h1>
+          <p className="text-muted-foreground font-mono text-xs">{repo.root_path}</p>
+          <p className="text-muted-foreground text-xs">
+            Default base {repo.default_base_ref}
+          </p>
+        </div>
+        <Button type="button" size="sm" onClick={() => setOpen(true)}>
+          New workspace
+        </Button>
+      </div>
+      <ul className="flex flex-col gap-1">
+        {listed.length === 0 && (
+          <li className="text-muted-foreground text-sm">No workspaces yet.</li>
+        )}
+        {listed.map((workspace) => (
+          <li key={workspace.id}>
+            <button
+              type="button"
+              className="hover:bg-muted flex w-full items-center justify-between rounded-md px-3 py-2 text-left text-sm"
+              onClick={() =>
+                void navigate({
+                  to: "/code/w/$workspaceId",
+                  params: { workspaceId: workspace.id },
+                })
+              }
+            >
+              <span>
+                <span className="font-medium">{workspace.title}</span>
+                <span className="text-muted-foreground ml-2 font-mono text-xs">
+                  {workspace.branch_name}
+                </span>
+              </span>
+              <span className="text-muted-foreground text-xs">
+                {WORKSPACE_STATUS_LABELS[workspace.status]}
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+      <NewWorkspaceDialog
+        open={open}
+        onOpenChange={setOpen}
+        repos={repos}
+        defaultRepoId={repoId}
+      />
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionController.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionController.ts
@@ -1,4 +1,4 @@
-import type { SequencedCodeEventFrame } from "../api/types";
+import type { CodeTurnSnapshot, SequencedCodeEventFrame } from "../api/types";
 import {
   INITIAL_RECONNECT_DELAY_MS,
   MAX_RECONNECT_DELAY_MS,
@@ -20,6 +20,12 @@ export type CodeSessionControllerOptions = {
   getAfter: () => number;
   onEvent: (event: SequencedCodeEventFrame) => void;
   onConnectionState: (state: CodeConnectionState) => void;
+  /**
+   * Snapshot of durable turns, applied once before the first socket opens so
+   * replay can fill assistant/tool events onto turn-keyed user items.
+   */
+  hydrateTurns?: () => Promise<CodeTurnSnapshot[]>;
+  onHydrate?: (turns: CodeTurnSnapshot[]) => void;
 };
 
 /**
@@ -41,6 +47,7 @@ function isWellFormedFrame(frame: SequencedCodeEventFrame): boolean {
 
 export class CodeSessionController {
   private disposed = false;
+  private hydrated = false;
   private socket: WebSocket | null = null;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
@@ -48,6 +55,20 @@ export class CodeSessionController {
   constructor(private readonly options: CodeSessionControllerOptions) {}
 
   start(): void {
+    void this.hydrateThenConnect();
+  }
+
+  private async hydrateThenConnect(): Promise<void> {
+    if (this.options.hydrateTurns && !this.hydrated) {
+      try {
+        const turns = await this.options.hydrateTurns();
+        if (this.disposed) return;
+        this.options.onHydrate?.(turns);
+        this.hydrated = true;
+      } catch {
+        if (this.disposed) return;
+      }
+    }
     this.connect();
   }
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionController.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionController.ts
@@ -1,0 +1,114 @@
+import type { SequencedCodeEventFrame } from "../api/types";
+import {
+  INITIAL_RECONNECT_DELAY_MS,
+  MAX_RECONNECT_DELAY_MS,
+  nextReconnectDelay,
+} from "../ChatSessionController";
+
+export type CodeConnectionState = "live" | "reconnecting";
+
+export type CodeSessionControllerOptions = {
+  /**
+   * Open the session's event socket resuming after the given seq. The callback
+   * carries parsed frames; the controller decides whether they are current.
+   */
+  openSocket: (
+    after: number,
+    onFrame: (frame: SequencedCodeEventFrame) => void,
+  ) => WebSocket;
+  /** Read the resume cursor freshly on every (re)connect attempt. */
+  getAfter: () => number;
+  onEvent: (event: SequencedCodeEventFrame) => void;
+  onConnectionState: (state: CodeConnectionState) => void;
+};
+
+/**
+ * Owns one code session's event-stream connection: connect, deliver, and
+ * reconnect with the same bounded backoff as chat. Instances are single-use —
+ * releasing a registry entry disposes this controller and constructs a new
+ * one on the next acquire.
+ */
+function isWellFormedFrame(frame: SequencedCodeEventFrame): boolean {
+  return (
+    typeof frame === "object" &&
+    frame !== null &&
+    Number.isFinite(frame.seq) &&
+    typeof frame.event === "object" &&
+    frame.event !== null &&
+    typeof (frame.event as { type?: unknown }).type === "string"
+  );
+}
+
+export class CodeSessionController {
+  private disposed = false;
+  private socket: WebSocket | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
+
+  constructor(private readonly options: CodeSessionControllerOptions) {}
+
+  start(): void {
+    this.connect();
+  }
+
+  /** Close the socket and silence every callback and pending timer, forever. */
+  dispose(): void {
+    this.disposed = true;
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.socket) {
+      this.socket.close();
+      this.socket = null;
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (this.disposed || this.reconnectTimer !== null) return;
+    this.options.onConnectionState("reconnecting");
+    const delay = this.reconnectDelayMs;
+    this.reconnectDelayMs = nextReconnectDelay(this.reconnectDelayMs);
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect();
+    }, delay);
+  }
+
+  private connect(): void {
+    if (this.disposed) return;
+    let socket: WebSocket;
+    try {
+      socket = this.options.openSocket(this.options.getAfter(), (frame) => {
+        if (this.disposed || this.socket !== socket) return;
+        if (!isWellFormedFrame(frame)) {
+          console.error("dropping malformed code event frame", frame);
+          return;
+        }
+        this.options.onEvent(frame);
+      });
+    } catch {
+      this.scheduleReconnect();
+      return;
+    }
+
+    this.socket = socket;
+    socket.onopen = () => {
+      if (this.disposed || this.socket !== socket) return;
+      this.reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
+      this.options.onConnectionState("live");
+    };
+    socket.onerror = () => {
+      if (this.disposed || this.socket !== socket) return;
+      socket.close();
+      this.scheduleReconnect();
+    };
+    socket.onclose = () => {
+      if (this.socket !== socket) return;
+      this.socket = null;
+      this.scheduleReconnect();
+    };
+  }
+}
+
+export { INITIAL_RECONNECT_DELAY_MS, MAX_RECONNECT_DELAY_MS, nextReconnectDelay };

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
@@ -231,6 +231,45 @@ describe("hydrate then replay", () => {
     expect(replayed.state.lifecycle).toBe("idle");
   });
 
+  it("shows prompts from a snapshot that includes usage", () => {
+    const hydrated = hydrateCodeTurns(initialCodeSessionState(), [
+      { ...SNAPSHOT_TURN, usage: NO_USAGE },
+    ]);
+    expect(hydrated.items[0]).toMatchObject({
+      kind: "user",
+      turnId: "t1",
+      text: "list the files",
+    });
+    expect(hydrated.items[1]).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t1",
+      usage: NO_USAGE,
+    });
+  });
+
+  it("places an accepted user item above that turn's already-streamed reply", () => {
+    const streamed = play([
+      { type: "turn_started", turn_id: "t1" },
+      { type: "assistant_delta", text: "README.md" },
+      { type: "turn_completed", usage: NO_USAGE },
+    ]);
+    const accepted = applyAcceptedTurn(streamed.state, {
+      ...SNAPSHOT_TURN,
+      status: "completed",
+      usage: NO_USAGE,
+    });
+    expect(accepted.items.map((item) => item.kind)).toEqual([
+      "user",
+      "assistant",
+      "turn_boundary",
+    ]);
+    expect(accepted.items[0]).toMatchObject({
+      kind: "user",
+      turnId: "t1",
+      text: "list the files",
+    });
+  });
+
   it("converges a live accept with hydrate on the same turn id", () => {
     const accepted = applyAcceptedTurn(initialCodeSessionState(), {
       ...SNAPSHOT_TURN,

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { CodeEvent, SequencedCodeEventFrame } from "../api/types";
 import {
+  applyAcceptedTurn,
+  hydrateCodeTurns,
   initialCodeSessionState,
   reduceCodeSessionEvent,
+  userItemId,
   type CodeSessionDeps,
   type CodeSessionState,
 } from "./CodeSessionReducer";
@@ -133,6 +136,7 @@ describe("turn lifecycle", () => {
     );
     expect(state.busy).toBe(false);
     expect(state.activeTurnId).toBeNull();
+    expect(state.lifecycle).toBe("idle");
     expect(state.harnessKind).toBe("claude_code");
     expect(state.lastUsage).toEqual(NO_USAGE);
     expect(effects.at(-1)).toEqual({ type: "turn_resolved" });
@@ -154,6 +158,7 @@ describe("turn lifecycle", () => {
     const boundary = state.items[3];
     expect(boundary).toMatchObject({
       kind: "turn_boundary",
+      turnId: "t1",
       status: "completed",
       durationMs: 2500,
       usage: NO_USAGE,
@@ -168,8 +173,74 @@ describe("turn lifecycle", () => {
     expect(state.busy).toBe(false);
     expect(state.items.at(-1)).toMatchObject({
       kind: "turn_boundary",
+      turnId: "t1",
       status: "failed",
       error: "engine exited",
     });
+  });
+});
+
+const SNAPSHOT_TURN = {
+  id: "t1",
+  session_id: "sess-1",
+  ordinal: 1,
+  status: "completed" as const,
+  user_input: "list the files",
+  started_at: NOW,
+  ended_at: LATER,
+};
+
+describe("hydrate then replay", () => {
+  it("shows the user prompt after a disposed store reopens from after=0", () => {
+    const hydrated = hydrateCodeTurns(initialCodeSessionState(), [SNAPSHOT_TURN]);
+    expect(hydrated.items[0]).toEqual({
+      kind: "user",
+      id: userItemId("t1"),
+      turnId: "t1",
+      text: "list the files",
+    });
+    expect(hydrated.items[1]).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t1",
+      status: "completed",
+      durationMs: 2500,
+    });
+
+    const replayed = play(
+      [
+        { type: "turn_started", turn_id: "t1" },
+        { type: "assistant_delta", text: "README.md" },
+        { type: "turn_completed", usage: NO_USAGE },
+      ],
+      hydrated,
+    );
+    expect(replayed.state.items.filter((item) => item.kind === "user")).toHaveLength(
+      1,
+    );
+    expect(replayed.state.items[0]).toMatchObject({
+      kind: "user",
+      turnId: "t1",
+      text: "list the files",
+    });
+    expect(
+      replayed.state.items.filter((item) => item.kind === "turn_boundary"),
+    ).toHaveLength(1);
+    expect(replayed.state.items.find((item) => item.kind === "assistant")).toMatchObject({
+      text: "README.md",
+    });
+    expect(replayed.state.lifecycle).toBe("idle");
+  });
+
+  it("converges a live accept with hydrate on the same turn id", () => {
+    const accepted = applyAcceptedTurn(initialCodeSessionState(), {
+      ...SNAPSHOT_TURN,
+      status: "running",
+      ended_at: undefined,
+    });
+    const again = hydrateCodeTurns(accepted, [
+      { ...SNAPSHOT_TURN, status: "running", ended_at: undefined },
+    ]);
+    expect(again.items.filter((item) => item.kind === "user")).toHaveLength(1);
+    expect(again.items[0]?.id).toBe(userItemId("t1"));
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import type { CodeEvent, SequencedCodeEventFrame } from "../api/types";
+import {
+  initialCodeSessionState,
+  reduceCodeSessionEvent,
+  type CodeSessionDeps,
+  type CodeSessionState,
+} from "./CodeSessionReducer";
+
+const NOW = "2026-08-15T12:00:00.000Z";
+const LATER = "2026-08-15T12:00:02.500Z";
+
+const NO_USAGE = {
+  input_tokens: 10,
+  output_tokens: 4,
+  cache_read_input_tokens: 0,
+  cache_creation_input_tokens: 0,
+};
+
+function deps(): CodeSessionDeps {
+  let seq = 0;
+  return {
+    nextId: () => `c${++seq}`,
+    now: () => NOW,
+  };
+}
+
+function framed(
+  seq: number,
+  event: CodeEvent,
+  replayed = false,
+): SequencedCodeEventFrame {
+  return replayed ? { seq, event, replayed: true } : { seq, event };
+}
+
+function play(
+  events: CodeEvent[],
+  state: CodeSessionState = initialCodeSessionState(),
+  clock: CodeSessionDeps = deps(),
+) {
+  let current = { state, effects: [] as ReturnType<typeof reduceCodeSessionEvent>["effects"] };
+  events.forEach((event, index) => {
+    current = reduceCodeSessionEvent(
+      current.state,
+      framed(state.lastSeq + index + 1, event),
+      clock,
+    );
+  });
+  return current;
+}
+
+describe("seq cursor", () => {
+  it("ignores duplicate and stale events entirely", () => {
+    const clock = deps();
+    const { state } = play(
+      [
+        { type: "turn_started", turn_id: "t1" },
+        { type: "assistant_delta", text: "Hi" },
+      ],
+      initialCodeSessionState(),
+      clock,
+    );
+    const replay = reduceCodeSessionEvent(
+      state,
+      framed(state.lastSeq, { type: "assistant_delta", text: "AGAIN" }),
+      clock,
+    );
+    expect(replay.state).toBe(state);
+    expect(replay.effects).toEqual([]);
+  });
+
+  it("advances the cursor for unknown event kinds", () => {
+    const { state, effects } = reduceCodeSessionEvent(
+      initialCodeSessionState(),
+      framed(4, { type: "file_changed", path: "a.ts", kind: "modified", diffstat: {
+        files: 1,
+        insertions: 1,
+        deletions: 0,
+        truncated: false,
+      } }),
+      deps(),
+    );
+    expect(state.lastSeq).toBe(4);
+    expect(state.items).toEqual([]);
+    expect(effects).toEqual([]);
+  });
+
+  it("suppresses animation during replay", () => {
+    const { state } = reduceCodeSessionEvent(
+      initialCodeSessionState(),
+      framed(1, { type: "turn_started", turn_id: "t1" }, true),
+      deps(),
+    );
+    expect(state.animateStreaming).toBe(false);
+  });
+});
+
+describe("turn lifecycle", () => {
+  it("records deltas, tools, notices, and a completed boundary with usage", () => {
+    const clock: CodeSessionDeps = {
+      nextId: deps().nextId,
+      now: (() => {
+        let tick = 0;
+        return () => {
+          tick += 1;
+          return tick === 1 ? NOW : LATER;
+        };
+      })(),
+    };
+    const { state, effects } = play(
+      [
+        { type: "session_started", harness_kind: "claude_code", harness_version: "1.0" },
+        { type: "turn_started", turn_id: "t1" },
+        { type: "assistant_delta", text: "Hello" },
+        { type: "assistant_delta", text: " world" },
+        {
+          type: "tool_started",
+          call_id: "c1",
+          name: "Bash",
+          detail: { kind: "command", cmd: "ls", cwd: "/tmp" },
+        },
+        {
+          type: "tool_completed",
+          call_id: "c1",
+          outcome: "succeeded",
+          preview: "ok",
+        },
+        { type: "harness_notice", level: "warning", message: "degraded" },
+        { type: "turn_completed", usage: NO_USAGE },
+      ],
+      initialCodeSessionState(),
+      clock,
+    );
+    expect(state.busy).toBe(false);
+    expect(state.activeTurnId).toBeNull();
+    expect(state.harnessKind).toBe("claude_code");
+    expect(state.lastUsage).toEqual(NO_USAGE);
+    expect(effects.at(-1)).toEqual({ type: "turn_resolved" });
+    const kinds = state.items.map((item) => item.kind);
+    expect(kinds).toEqual(["assistant", "tool", "notice", "turn_boundary"]);
+    const assistant = state.items[0];
+    expect(assistant).toMatchObject({
+      kind: "assistant",
+      text: "Hello world",
+      streaming: false,
+    });
+    const tool = state.items[1];
+    expect(tool).toMatchObject({
+      kind: "tool",
+      callId: "c1",
+      status: "succeeded",
+      preview: "ok",
+    });
+    const boundary = state.items[3];
+    expect(boundary).toMatchObject({
+      kind: "turn_boundary",
+      status: "completed",
+      durationMs: 2500,
+      usage: NO_USAGE,
+    });
+  });
+
+  it("closes a failed turn with the bounded error", () => {
+    const { state } = play([
+      { type: "turn_started", turn_id: "t1" },
+      { type: "turn_failed", error: { message: "engine exited" } },
+    ]);
+    expect(state.busy).toBe(false);
+    expect(state.items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      status: "failed",
+      error: "engine exited",
+    });
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
@@ -146,7 +146,7 @@ export function applyAcceptedTurn(
     ? state.items.map((item) =>
         item.kind === "user" && item.turnId === turn.id ? user : item,
       )
-    : [...state.items, user];
+    : insertUserBeforeTurn(state.items, user, turn.id);
   const running = turn.status === "running";
   return {
     ...state,
@@ -173,7 +173,7 @@ export function hydrateCodeTurns(
           turnId: turn.id,
           status: turn.status,
           durationMs: durationMs(turn.started_at, turn.ended_at ?? null),
-          usage: null,
+          usage: turn.usage ?? null,
           error: null,
         }),
       };
@@ -416,6 +416,18 @@ function finalizeStreaming(
   return items.map((item) =>
     item.kind === kind && item.streaming ? { ...item, streaming: false } : item,
   );
+}
+
+function insertUserBeforeTurn(
+  items: CodeTranscriptItem[],
+  user: Extract<CodeTranscriptItem, { kind: "user" }>,
+  turnId: string,
+): CodeTranscriptItem[] {
+  const index = items.findIndex(
+    (item) => "turnId" in item && item.turnId === turnId,
+  );
+  if (index === -1) return [...items, user];
+  return [...items.slice(0, index), user, ...items.slice(index)];
 }
 
 function upsertTurnBoundary(

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
@@ -1,0 +1,344 @@
+import type {
+  CodeUsage,
+  HarnessKind,
+  HarnessNoticeLevel,
+  SequencedCodeEventFrame,
+  ToolDetail,
+  ToolOutcome,
+} from "../api/types";
+
+/**
+ * The pure state machine for one code session's live event stream.
+ *
+ * Chat already has this shape: a reducer owns the transcript and the seq
+ * cursor, and returns declarative effects for anything a host component must
+ * do. Code mode generalizes that to N sessions, but each session still
+ * reduces the same way so replay, reconnect, and tests stay deterministic.
+ */
+
+export type CodeToolStatus = "running" | ToolOutcome;
+
+export type CodeTranscriptItem =
+  | {
+      kind: "user";
+      id: string;
+      turnId: string | null;
+      text: string;
+    }
+  | {
+      kind: "assistant";
+      id: string;
+      turnId: string | null;
+      text: string;
+      streaming: boolean;
+    }
+  | {
+      kind: "reasoning";
+      id: string;
+      turnId: string | null;
+      text: string;
+      streaming: boolean;
+    }
+  | {
+      kind: "tool";
+      id: string;
+      turnId: string | null;
+      callId: string;
+      name: string;
+      detail: ToolDetail;
+      status: CodeToolStatus;
+      preview: string;
+    }
+  | {
+      kind: "notice";
+      id: string;
+      level: HarnessNoticeLevel;
+      message: string;
+    }
+  | {
+      kind: "turn_boundary";
+      id: string;
+      turnId: string | null;
+      status: "completed" | "failed" | "interrupted";
+      durationMs: number | null;
+      usage: CodeUsage | null;
+      error: string | null;
+    };
+
+export type CodeSessionState = {
+  /** Highest event seq applied; events at or below it are duplicates. */
+  lastSeq: number;
+  /** Whether new stream presentation should animate rather than catch up. */
+  animateStreaming: boolean;
+  items: CodeTranscriptItem[];
+  busy: boolean;
+  activeTurnId: string | null;
+  turnStartedAt: string | null;
+  assistantBuffer: string;
+  reasoningBuffer: string;
+  harnessKind: HarnessKind | null;
+  harnessVersion: string | null;
+  lastUsage: CodeUsage | null;
+};
+
+export type CodeSessionEffect =
+  | { type: "turn_began"; turnId: string }
+  | { type: "turn_resolved" };
+
+export type CodeSessionTransition = {
+  state: CodeSessionState;
+  effects: CodeSessionEffect[];
+};
+
+export type CodeSessionDeps = {
+  nextId: () => string;
+  now: () => string;
+};
+
+export function initialCodeSessionState(): CodeSessionState {
+  return {
+    lastSeq: 0,
+    animateStreaming: true,
+    items: [],
+    busy: false,
+    activeTurnId: null,
+    turnStartedAt: null,
+    assistantBuffer: "",
+    reasoningBuffer: "",
+    harnessKind: null,
+    harnessVersion: null,
+    lastUsage: null,
+  };
+}
+
+export function reduceCodeSessionEvent(
+  state: CodeSessionState,
+  framed: SequencedCodeEventFrame,
+  deps: CodeSessionDeps,
+): CodeSessionTransition {
+  if (framed.seq <= state.lastSeq) return { state, effects: [] };
+  state = {
+    ...state,
+    lastSeq: framed.seq,
+    animateStreaming: framed.replayed !== true,
+  };
+  const event = framed.event;
+  const effects: CodeSessionEffect[] = [];
+
+  switch (event.type) {
+    case "session_started":
+      return {
+        state: {
+          ...state,
+          harnessKind: event.harness_kind,
+          harnessVersion: event.harness_version,
+        },
+        effects,
+      };
+
+    case "turn_started": {
+      effects.push({ type: "turn_began", turnId: event.turn_id });
+      return {
+        state: {
+          ...state,
+          busy: true,
+          activeTurnId: event.turn_id,
+          turnStartedAt: deps.now(),
+          assistantBuffer: "",
+          reasoningBuffer: "",
+        },
+        effects,
+      };
+    }
+
+    case "assistant_delta": {
+      const assistantBuffer = state.assistantBuffer + event.text;
+      return {
+        state: {
+          ...state,
+          assistantBuffer,
+          items: upsertStreaming(
+            state.items,
+            "assistant",
+            assistantBuffer,
+            state.activeTurnId,
+            deps.nextId,
+          ),
+        },
+        effects,
+      };
+    }
+
+    case "assistant_message": {
+      return {
+        state: {
+          ...state,
+          assistantBuffer: event.text,
+          items: finalizeStreaming(
+            upsertStreaming(
+              state.items,
+              "assistant",
+              event.text,
+              state.activeTurnId,
+              deps.nextId,
+            ),
+            "assistant",
+          ),
+        },
+        effects,
+      };
+    }
+
+    case "reasoning_delta": {
+      const reasoningBuffer = state.reasoningBuffer + event.text;
+      return {
+        state: {
+          ...state,
+          reasoningBuffer,
+          items: upsertStreaming(
+            state.items,
+            "reasoning",
+            reasoningBuffer,
+            state.activeTurnId,
+            deps.nextId,
+          ),
+        },
+        effects,
+      };
+    }
+
+    case "tool_started": {
+      return {
+        state: {
+          ...state,
+          items: [
+            ...finalizeStreaming(state.items, "assistant"),
+            {
+              kind: "tool",
+              id: deps.nextId(),
+              turnId: state.activeTurnId,
+              callId: event.call_id,
+              name: event.name,
+              detail: event.detail,
+              status: "running",
+              preview: "",
+            },
+          ],
+        },
+        effects,
+      };
+    }
+
+    case "tool_completed": {
+      return {
+        state: {
+          ...state,
+          items: state.items.map((item) =>
+            item.kind === "tool" && item.callId === event.call_id
+              ? { ...item, status: event.outcome, preview: event.preview }
+              : item,
+          ),
+        },
+        effects,
+      };
+    }
+
+    case "harness_notice": {
+      return {
+        state: {
+          ...state,
+          items: [
+            ...state.items,
+            {
+              kind: "notice",
+              id: deps.nextId(),
+              level: event.level,
+              message: event.message,
+            },
+          ],
+        },
+        effects,
+      };
+    }
+
+    case "turn_completed":
+    case "turn_failed":
+    case "turn_interrupted": {
+      effects.push({ type: "turn_resolved" });
+      const status =
+        event.type === "turn_completed"
+          ? "completed"
+          : event.type === "turn_failed"
+            ? "failed"
+            : "interrupted";
+      const usage = event.type === "turn_completed" ? event.usage : null;
+      const error = event.type === "turn_failed" ? event.error.message : null;
+      return {
+        state: {
+          ...state,
+          busy: false,
+          lastUsage: usage ?? state.lastUsage,
+          assistantBuffer: "",
+          reasoningBuffer: "",
+          items: [
+            ...finalizeStreaming(
+              finalizeStreaming(state.items, "assistant"),
+              "reasoning",
+            ),
+            {
+              kind: "turn_boundary",
+              id: deps.nextId(),
+              turnId: state.activeTurnId,
+              status,
+              durationMs: durationMs(state.turnStartedAt, deps.now()),
+              usage,
+              error,
+            },
+          ],
+          activeTurnId: null,
+          turnStartedAt: null,
+        },
+        effects,
+      };
+    }
+
+    default:
+      return { state, effects };
+  }
+}
+
+function upsertStreaming(
+  items: CodeTranscriptItem[],
+  kind: "assistant" | "reasoning",
+  text: string,
+  turnId: string | null,
+  nextId: () => string,
+): CodeTranscriptItem[] {
+  const last = items[items.length - 1];
+  if (last && last.kind === kind && last.streaming) {
+    return [...items.slice(0, -1), { ...last, text }];
+  }
+  return [
+    ...items,
+    { kind, id: nextId(), turnId, text, streaming: true },
+  ];
+}
+
+function finalizeStreaming(
+  items: CodeTranscriptItem[],
+  kind: "assistant" | "reasoning",
+): CodeTranscriptItem[] {
+  return items.map((item) =>
+    item.kind === kind && item.streaming ? { ...item, streaming: false } : item,
+  );
+}
+
+function durationMs(startedAt: string | null, endedAt: string): number | null {
+  if (!startedAt) return null;
+  const start = Date.parse(startedAt);
+  const end = Date.parse(endedAt);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) {
+    return null;
+  }
+  return end - start;
+}

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
@@ -1,4 +1,7 @@
 import type {
+  CodeSessionLifecycle,
+  CodeTurnSnapshot,
+  CodeTurnStatus,
   CodeUsage,
   HarnessKind,
   HarnessNoticeLevel,
@@ -22,7 +25,7 @@ export type CodeTranscriptItem =
   | {
       kind: "user";
       id: string;
-      turnId: string | null;
+      turnId: string;
       text: string;
     }
   | {
@@ -79,6 +82,8 @@ export type CodeSessionState = {
   harnessKind: HarnessKind | null;
   harnessVersion: string | null;
   lastUsage: CodeUsage | null;
+  /** Session lifecycle as the journal last stated it. */
+  lifecycle: CodeSessionLifecycle | null;
 };
 
 export type CodeSessionEffect =
@@ -108,7 +113,86 @@ export function initialCodeSessionState(): CodeSessionState {
     harnessKind: null,
     harnessVersion: null,
     lastUsage: null,
+    lifecycle: null,
   };
+}
+
+export function userItemId(turnId: string): string {
+  return `user:${turnId}`;
+}
+
+export function boundaryItemId(turnId: string): string {
+  return `boundary:${turnId}`;
+}
+
+/**
+ * Record a turn the server accepted. Create and hydrate share this so a
+ * reopen and a live send produce the same turn-keyed user item.
+ */
+export function applyAcceptedTurn(
+  state: CodeSessionState,
+  turn: CodeTurnSnapshot,
+): CodeSessionState {
+  const user: CodeTranscriptItem = {
+    kind: "user",
+    id: userItemId(turn.id),
+    turnId: turn.id,
+    text: turn.user_input,
+  };
+  const hasUser = state.items.some(
+    (item) => item.kind === "user" && item.turnId === turn.id,
+  );
+  const items = hasUser
+    ? state.items.map((item) =>
+        item.kind === "user" && item.turnId === turn.id ? user : item,
+      )
+    : [...state.items, user];
+  const running = turn.status === "running";
+  return {
+    ...state,
+    items,
+    busy: running || state.busy,
+    activeTurnId: running ? turn.id : state.activeTurnId,
+    turnStartedAt: running ? turn.started_at : state.turnStartedAt,
+    lifecycle: running ? "running" : state.lifecycle,
+  };
+}
+
+/** Snapshot of durable turns, applied before the journal replays. */
+export function hydrateCodeTurns(
+  state: CodeSessionState,
+  turns: readonly CodeTurnSnapshot[],
+): CodeSessionState {
+  let next = state;
+  for (const turn of turns) {
+    next = applyAcceptedTurn(next, turn);
+    if (turn.status !== "running") {
+      next = {
+        ...next,
+        items: upsertTurnBoundary(next.items, {
+          turnId: turn.id,
+          status: turn.status,
+          durationMs: durationMs(turn.started_at, turn.ended_at ?? null),
+          usage: null,
+          error: null,
+        }),
+      };
+    }
+  }
+  const open = [...turns].reverse().find((turn) => turn.status === "running");
+  if (open) {
+    return {
+      ...next,
+      busy: true,
+      activeTurnId: open.id,
+      turnStartedAt: open.started_at,
+      lifecycle: "running",
+    };
+  }
+  if (turns.length > 0) {
+    return { ...next, lifecycle: next.lifecycle ?? "idle" };
+  }
+  return next;
 }
 
 export function reduceCodeSessionEvent(
@@ -143,9 +227,10 @@ export function reduceCodeSessionEvent(
           ...state,
           busy: true,
           activeTurnId: event.turn_id,
-          turnStartedAt: deps.now(),
+          turnStartedAt: state.turnStartedAt ?? deps.now(),
           assistantBuffer: "",
           reasoningBuffer: "",
+          lifecycle: "running",
         },
         effects,
       };
@@ -273,6 +358,11 @@ export function reduceCodeSessionEvent(
             : "interrupted";
       const usage = event.type === "turn_completed" ? event.usage : null;
       const error = event.type === "turn_failed" ? event.error.message : null;
+      const turnId = state.activeTurnId;
+      const finalized = finalizeStreaming(
+        finalizeStreaming(state.items, "assistant"),
+        "reasoning",
+      );
       return {
         state: {
           ...state,
@@ -280,23 +370,18 @@ export function reduceCodeSessionEvent(
           lastUsage: usage ?? state.lastUsage,
           assistantBuffer: "",
           reasoningBuffer: "",
-          items: [
-            ...finalizeStreaming(
-              finalizeStreaming(state.items, "assistant"),
-              "reasoning",
-            ),
-            {
-              kind: "turn_boundary",
-              id: deps.nextId(),
-              turnId: state.activeTurnId,
-              status,
-              durationMs: durationMs(state.turnStartedAt, deps.now()),
-              usage,
-              error,
-            },
-          ],
+          items: turnId
+            ? upsertTurnBoundary(finalized, {
+                turnId,
+                status,
+                durationMs: durationMs(state.turnStartedAt, deps.now()),
+                usage,
+                error,
+              })
+            : finalized,
           activeTurnId: null,
           turnStartedAt: null,
+          lifecycle: "idle",
         },
         effects,
       };
@@ -333,8 +418,51 @@ function finalizeStreaming(
   );
 }
 
-function durationMs(startedAt: string | null, endedAt: string): number | null {
-  if (!startedAt) return null;
+function upsertTurnBoundary(
+  items: CodeTranscriptItem[],
+  boundary: {
+    turnId: string;
+    status: Exclude<CodeTurnStatus, "running">;
+    durationMs: number | null;
+    usage: CodeUsage | null;
+    error: string | null;
+  },
+): CodeTranscriptItem[] {
+  const item: CodeTranscriptItem = {
+    kind: "turn_boundary",
+    id: boundaryItemId(boundary.turnId),
+    turnId: boundary.turnId,
+    status: boundary.status,
+    durationMs: boundary.durationMs,
+    usage: boundary.usage,
+    error: boundary.error,
+  };
+  const index = items.findIndex(
+    (candidate) =>
+      candidate.kind === "turn_boundary" && candidate.turnId === boundary.turnId,
+  );
+  if (index === -1) return [...items, item];
+  const existing = items[index];
+  if (existing && existing.kind === "turn_boundary") {
+    return [
+      ...items.slice(0, index),
+      {
+        ...item,
+        usage: boundary.usage ?? existing.usage,
+        error: boundary.error ?? existing.error,
+        durationMs: boundary.durationMs ?? existing.durationMs,
+      },
+      ...items.slice(index + 1),
+    ];
+  }
+  return items;
+}
+
+function durationMs(
+  startedAt: string | null,
+  endedAt: string | null,
+): number | null {
+  if (!startedAt || !endedAt) return null;
   const start = Date.parse(startedAt);
   const end = Date.parse(endedAt);
   if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) {

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { SequencedCodeEventFrame } from "../api/types";
+import {
+  acquireCodeSession,
+  peekCodeSession,
+  releaseCodeSession,
+  resetCodeSessionRegistry,
+} from "./CodeSessionRegistry";
+
+class FakeSocket {
+  closed = false;
+  constructor(
+    public readonly after: number,
+    public readonly emit: (frame: SequencedCodeEventFrame) => void,
+  ) {}
+  close() {
+    this.closed = true;
+  }
+}
+
+afterEach(() => {
+  resetCodeSessionRegistry();
+});
+
+describe("CodeSessionRegistry", () => {
+  it("shares one store across two acquires and closes the socket on last release", () => {
+    const sockets: FakeSocket[] = [];
+    const openSocket = (after: number, onFrame: (frame: SequencedCodeEventFrame) => void) => {
+      const socket = new FakeSocket(after, onFrame);
+      sockets.push(socket);
+      return socket as unknown as WebSocket;
+    };
+
+    const first = acquireCodeSession("s1", openSocket);
+    const second = acquireCodeSession("s1", openSocket);
+    expect(first).toBe(second);
+    expect(peekCodeSession("s1")?.refCount).toBe(2);
+    expect(sockets).toHaveLength(1);
+
+    first.getState().applyEvent(
+      { seq: 1, event: { type: "turn_started", turn_id: "t1" } },
+      { nextId: () => "id", now: () => "2026-08-15T00:00:00.000Z" },
+    );
+    expect(second.getState().busy).toBe(true);
+
+    releaseCodeSession("s1");
+    expect(sockets[0]?.closed).toBe(false);
+    expect(peekCodeSession("s1")?.refCount).toBe(1);
+
+    releaseCodeSession("s1");
+    expect(sockets[0]?.closed).toBe(true);
+    expect(peekCodeSession("s1")).toBeUndefined();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
@@ -6,6 +6,7 @@ import {
   releaseCodeSession,
   resetCodeSessionRegistry,
 } from "./CodeSessionRegistry";
+import { userItemId } from "./CodeSessionReducer";
 
 class FakeSocket {
   closed = false;
@@ -50,5 +51,62 @@ describe("CodeSessionRegistry", () => {
     releaseCodeSession("s1");
     expect(sockets[0]?.closed).toBe(true);
     expect(peekCodeSession("s1")).toBeUndefined();
+  });
+
+  it("reopen hydrates user prompts before the journal replays from after=0", async () => {
+    const sockets: FakeSocket[] = [];
+    const openSocket = (after: number, onFrame: (frame: SequencedCodeEventFrame) => void) => {
+      const socket = new FakeSocket(after, onFrame);
+      sockets.push(socket);
+      return socket as unknown as WebSocket;
+    };
+    const store = acquireCodeSession(
+      "s1",
+      openSocket,
+      { nextId: () => "id", now: () => "2026-08-15T12:00:02.500Z" },
+      async () => [
+        {
+          id: "t1",
+          session_id: "s1",
+          ordinal: 1,
+          status: "completed",
+          user_input: "list the files",
+          started_at: "2026-08-15T12:00:00.000Z",
+          ended_at: "2026-08-15T12:00:02.500Z",
+        },
+      ],
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(store.getState().items[0]).toEqual({
+      kind: "user",
+      id: userItemId("t1"),
+      turnId: "t1",
+      text: "list the files",
+    });
+    expect(sockets[0]?.after).toBe(0);
+
+    store.getState().applyEvent(
+      {
+        seq: 1,
+        event: { type: "turn_started", turn_id: "t1" },
+        replayed: true,
+      },
+      { nextId: () => "id", now: () => "2026-08-15T12:00:02.500Z" },
+    );
+    store.getState().applyEvent(
+      {
+        seq: 2,
+        event: { type: "assistant_delta", text: "README.md" },
+        replayed: true,
+      },
+      { nextId: () => "a1", now: () => "2026-08-15T12:00:02.500Z" },
+    );
+    expect(store.getState().items.filter((item) => item.kind === "user")).toHaveLength(
+      1,
+    );
+    expect(store.getState().items.find((item) => item.kind === "assistant")).toMatchObject({
+      text: "README.md",
+    });
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
@@ -1,0 +1,102 @@
+import type { ApiClient } from "../api/client";
+import type { SequencedCodeEventFrame } from "../api/types";
+import { CodeSessionController } from "./CodeSessionController";
+import {
+  createCodeSessionStore,
+  type CodeSessionStore,
+} from "./CodeSessionStore";
+import type { CodeSessionDeps } from "./CodeSessionReducer";
+
+/**
+ * Per-session stores and the sockets that feed them.
+ *
+ * Chat pins one session at a time. Code mode keeps several open: two views of
+ * the same session must share one store and one socket, and unmounting the
+ * last view must close that socket. The map is ref-counted so that contract
+ * is mechanical rather than something each page has to remember.
+ */
+
+export type CodeSessionOpenSocket = (
+  after: number,
+  onFrame: (frame: SequencedCodeEventFrame) => void,
+) => WebSocket;
+
+export type CodeSessionEntry = {
+  store: ReturnType<typeof createCodeSessionStore>;
+  controller: CodeSessionController;
+  refCount: number;
+};
+
+const registry = new Map<string, CodeSessionEntry>();
+
+const defaultDeps: CodeSessionDeps = {
+  nextId: () => {
+    nextItem += 1;
+    return `code-${nextItem}`;
+  },
+  now: () => new Date().toISOString(),
+};
+
+let nextItem = 0;
+
+export function acquireCodeSession(
+  sessionId: string,
+  openSocket: CodeSessionOpenSocket,
+  deps: CodeSessionDeps = defaultDeps,
+): ReturnType<typeof createCodeSessionStore> {
+  const existing = registry.get(sessionId);
+  if (existing) {
+    existing.refCount += 1;
+    return existing.store;
+  }
+  const store = createCodeSessionStore();
+  const controller = new CodeSessionController({
+    openSocket,
+    getAfter: () => store.getState().lastSeq,
+    onEvent: (frame) => {
+      store.getState().applyEvent(frame, deps);
+    },
+    onConnectionState: () => {},
+  });
+  registry.set(sessionId, { store, controller, refCount: 1 });
+  controller.start();
+  return store;
+}
+
+export function acquireCodeSessionFromClient(
+  sessionId: string,
+  client: Pick<ApiClient, "openCodeEvents">,
+  deps?: CodeSessionDeps,
+): ReturnType<typeof createCodeSessionStore> {
+  return acquireCodeSession(
+    sessionId,
+    (after, onFrame) => client.openCodeEvents(sessionId, after, onFrame),
+    deps,
+  );
+}
+
+export function releaseCodeSession(sessionId: string): void {
+  const existing = registry.get(sessionId);
+  if (!existing) return;
+  existing.refCount -= 1;
+  if (existing.refCount > 0) return;
+  existing.controller.dispose();
+  registry.delete(sessionId);
+}
+
+export function peekCodeSession(
+  sessionId: string,
+): CodeSessionEntry | undefined {
+  return registry.get(sessionId);
+}
+
+/** Test-only: drop every live entry without waiting for unmounts. */
+export function resetCodeSessionRegistry(): void {
+  for (const entry of registry.values()) {
+    entry.controller.dispose();
+  }
+  registry.clear();
+  nextItem = 0;
+}
+
+export type { CodeSessionStore };

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
@@ -1,11 +1,11 @@
 import type { ApiClient } from "../api/client";
-import type { SequencedCodeEventFrame } from "../api/types";
+import type { CodeTurnSnapshot, SequencedCodeEventFrame } from "../api/types";
 import { CodeSessionController } from "./CodeSessionController";
 import {
   createCodeSessionStore,
   type CodeSessionStore,
 } from "./CodeSessionStore";
-import type { CodeSessionDeps } from "./CodeSessionReducer";
+import { hydrateCodeTurns, type CodeSessionDeps } from "./CodeSessionReducer";
 
 /**
  * Per-session stores and the sockets that feed them.
@@ -43,6 +43,7 @@ export function acquireCodeSession(
   sessionId: string,
   openSocket: CodeSessionOpenSocket,
   deps: CodeSessionDeps = defaultDeps,
+  hydrateTurns?: () => Promise<CodeTurnSnapshot[]>,
 ): ReturnType<typeof createCodeSessionStore> {
   const existing = registry.get(sessionId);
   if (existing) {
@@ -57,6 +58,10 @@ export function acquireCodeSession(
       store.getState().applyEvent(frame, deps);
     },
     onConnectionState: () => {},
+    hydrateTurns,
+    onHydrate: (turns) => {
+      store.getState().update((session) => hydrateCodeTurns(session, turns));
+    },
   });
   registry.set(sessionId, { store, controller, refCount: 1 });
   controller.start();
@@ -65,13 +70,14 @@ export function acquireCodeSession(
 
 export function acquireCodeSessionFromClient(
   sessionId: string,
-  client: Pick<ApiClient, "openCodeEvents">,
+  client: Pick<ApiClient, "openCodeEvents" | "listCodeSessionTurns">,
   deps?: CodeSessionDeps,
 ): ReturnType<typeof createCodeSessionStore> {
   return acquireCodeSession(
     sessionId,
     (after, onFrame) => client.openCodeEvents(sessionId, after, onFrame),
     deps,
+    () => client.listCodeSessionTurns(sessionId),
   );
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionSend.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionSend.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createCodeSessionStore } from "./CodeSessionStore";
+import { submitAcceptedTurn } from "./CodeSessionSend";
+import { userItemId } from "./CodeSessionReducer";
+
+const TURN = {
+  id: "turn-1",
+  session_id: "sess-1",
+  ordinal: 1,
+  status: "running" as const,
+  user_input: "list the files",
+  started_at: "2026-08-15T12:00:00.000Z",
+};
+
+describe("submitAcceptedTurn", () => {
+  it("inserts a turn-keyed user item only after the server accepts", async () => {
+    const store = createCodeSessionStore();
+    await submitAcceptedTurn(store.getState().update, async () => TURN);
+    expect(store.getState().items).toEqual([
+      {
+        kind: "user",
+        id: userItemId("turn-1"),
+        turnId: "turn-1",
+        text: "list the files",
+      },
+    ]);
+  });
+
+  it("leaves the transcript empty when submit fails, so a retry cannot stack", async () => {
+    const store = createCodeSessionStore();
+    await expect(
+      submitAcceptedTurn(store.getState().update, async () => {
+        throw new Error("session is fenced");
+      }),
+    ).rejects.toThrow("session is fenced");
+    expect(store.getState().items).toEqual([]);
+  });
+});
+
+describe("retry after a failed submit", () => {
+  it("does not keep a bubble from the failed attempt", async () => {
+    const store = createCodeSessionStore();
+    const submit = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce(TURN);
+    await expect(
+      submitAcceptedTurn(store.getState().update, submit),
+    ).rejects.toThrow("offline");
+    expect(store.getState().items).toEqual([]);
+    await submitAcceptedTurn(store.getState().update, submit);
+    expect(store.getState().items).toHaveLength(1);
+    expect(store.getState().items[0]).toMatchObject({
+      kind: "user",
+      turnId: "turn-1",
+      text: "list the files",
+    });
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionSend.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionSend.test.ts
@@ -58,3 +58,50 @@ describe("retry after a failed submit", () => {
     });
   });
 });
+
+describe("accepted turn after the socket already painted", () => {
+  it("inserts the prompt above the streamed assistant reply", async () => {
+    const store = createCodeSessionStore();
+    const deps = {
+      nextId: () => "streamed",
+      now: () => "2026-08-15T12:00:02.000Z",
+    };
+    store.getState().applyEvent(
+      { seq: 1, event: { type: "turn_started", turn_id: "turn-1" } },
+      deps,
+    );
+    store.getState().applyEvent(
+      { seq: 2, event: { type: "assistant_delta", text: "README.md" } },
+      deps,
+    );
+    store.getState().applyEvent(
+      {
+        seq: 3,
+        event: {
+          type: "turn_completed",
+          usage: {
+            input_tokens: 1,
+            output_tokens: 1,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+          },
+        },
+      },
+      deps,
+    );
+    await submitAcceptedTurn(store.getState().update, async () => ({
+      ...TURN,
+      status: "completed",
+    }));
+    expect(store.getState().items.map((item) => item.kind)).toEqual([
+      "user",
+      "assistant",
+      "turn_boundary",
+    ]);
+    expect(store.getState().items[0]).toMatchObject({
+      kind: "user",
+      turnId: "turn-1",
+      text: "list the files",
+    });
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionSend.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionSend.ts
@@ -1,0 +1,19 @@
+import type { CodeTurnSnapshot } from "../api/types";
+import { applyAcceptedTurn, type CodeSessionState } from "./CodeSessionReducer";
+
+/**
+ * Insert a user turn only after the server accepts it.
+ *
+ * An optimistic bubble that survives a failed submit cannot be answered and
+ * stacks a duplicate on retry. Chat removes its optimistic item in the catch;
+ * here the cheaper mirror is to wait for the accepted snapshot, which is also
+ * the hydrate key.
+ */
+export async function submitAcceptedTurn(
+  update: (change: (session: CodeSessionState) => CodeSessionState) => void,
+  submit: () => Promise<CodeTurnSnapshot>,
+): Promise<CodeTurnSnapshot> {
+  const turn = await submit();
+  update((session) => applyAcceptedTurn(session, turn));
+  return turn;
+}

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionStore.ts
@@ -1,0 +1,55 @@
+import { create } from "zustand";
+import type { SequencedCodeEventFrame } from "../api/types";
+import {
+  initialCodeSessionState,
+  reduceCodeSessionEvent,
+  type CodeSessionDeps,
+  type CodeSessionEffect,
+  type CodeSessionState,
+} from "./CodeSessionReducer";
+
+/**
+ * One code session's state, held outside React so socket callbacks always see
+ * current truth without ref mirrors.
+ *
+ * This is the chat session store factory generalized from one pinned instance
+ * to N: the registry constructs one per open session, and nothing here is
+ * app-global.
+ */
+export type CodeSessionStore = CodeSessionState & {
+  applyEvent: (
+    framed: SequencedCodeEventFrame,
+    deps: CodeSessionDeps,
+  ) => CodeSessionEffect[];
+  update: (change: (session: CodeSessionState) => CodeSessionState) => void;
+  reset: () => void;
+};
+
+export function createCodeSessionStore() {
+  return create<CodeSessionStore>()((set, get) => ({
+    ...initialCodeSessionState(),
+    applyEvent: (framed, deps) => {
+      const { state, effects } = reduceCodeSessionEvent(
+        sessionOf(get()),
+        framed,
+        deps,
+      );
+      set(state);
+      return effects;
+    },
+    update: (change) => {
+      set(change(sessionOf(get())));
+    },
+    reset: () => {
+      set(initialCodeSessionState());
+    },
+  }));
+}
+
+function sessionOf(store: CodeSessionStore): CodeSessionState {
+  const { applyEvent, update, reset, ...session } = store;
+  void applyEvent;
+  void update;
+  void reset;
+  return session;
+}

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { cleanup, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AppContextProvider, type AppContextValue } from "@/AppContext";
+import { renderWithRouter } from "@/test/router";
+import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { CodeSidebar } from "./CodeSidebar";
+
+/**
+ * ADR 0030: the code rail must render without initializing chat session
+ * stores. This file never imports ChatSessionStore or ChatListStore.
+ */
+
+const client = {
+  listCodeRepos: vi.fn(async () => [
+    {
+      id: "repo-1",
+      root_path: "/tmp/app",
+      display_name: "app",
+      default_base_ref: "main",
+      branch_prefix: "tidebreak",
+      quick_actions: [],
+      created_at: "2026-08-15T00:00:00.000Z",
+    },
+  ]),
+  listCodeWorkspaces: vi.fn(async () => [
+    {
+      id: "ws-1",
+      repo_id: "repo-1",
+      title: "Fix login",
+      worktree_path: "/tmp/app/.worktrees/fix-login",
+      branch_name: "tidebreak/fix-login",
+      base_ref: "main",
+      status: "active" as const,
+      created_at: "2026-08-15T00:00:00.000Z",
+    },
+  ]),
+  getHarnessDoctor: vi.fn(async () => ({ harnesses: [] })),
+};
+
+const app: AppContextValue = {
+  client: client as never,
+  models: [],
+  defaultModelKey: null,
+  providers: [],
+  refreshCatalog: async () => {},
+  refreshChats: async () => {},
+  status: "",
+  setStatus: () => {},
+  newChat: () => {},
+  deleteChat: () => {},
+  startRename: () => {},
+  commitRename: () => {},
+  cancelRename: () => {},
+  newProject: async () => false,
+  deleteProject: () => {},
+  startProjectRename: () => {},
+  commitProjectRename: () => {},
+  cancelProjectRename: () => {},
+  newChatInProject: () => {},
+  moveChatToProject: () => {},
+  updateState: { status: "idle", version: null, error: null, enabled: false },
+  updateUpToDate: false,
+  checkForUpdate: async () => ({
+    status: "idle",
+    version: null,
+    error: null,
+    enabled: false,
+  }),
+  restartForUpdate: async () => {},
+};
+
+afterEach(() => {
+  cleanup();
+  useCodeCatalogStore.getState().reset();
+});
+
+describe("CodeSidebar", () => {
+  it("renders the code rail without chat stores initialized", async () => {
+    await renderWithRouter(
+      <AppContextProvider value={app}>
+        <CodeSidebar />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    expect(screen.getByRole("button", { name: "Chat" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Code" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "app" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Fix login" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "New workspace" })).toBeInTheDocument();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useRouterState } from "@tanstack/react-router";
+import { FolderGit2, MessageSquare, Plus } from "lucide-react";
+
+import { useApp } from "@/AppContext";
+import {
+  SidebarButton,
+  SidebarSectionTitle,
+  useSidebarWidth,
+} from "@/sidebar/primitives";
+import { SidebarFrame } from "@/sidebar/SidebarFrame";
+import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
+
+/**
+ * The code-mode rail: repos, recent workspaces, and the cheap switch back to
+ * chat.
+ *
+ * Built on the same frame and primitives as the chat rail so the two modes
+ * share chrome. It must not touch chat session stores — that separation is
+ * what later convergence merges rather than translates.
+ */
+
+export function CodeSidebar() {
+  const navigate = useNavigate();
+  const { client } = useApp();
+  const pathname = useRouterState({
+    select: (state) => state.location.pathname,
+  });
+  const isCompact = useSidebarWidth() === "compact";
+  const repos = useCodeCatalogStore((state) => state.repos);
+  const workspaces = useCodeCatalogStore((state) => state.workspaces);
+  const refresh = useCodeCatalogStore((state) => state.refresh);
+  const [newWorkspaceOpen, setNewWorkspaceOpen] = useState(false);
+
+  useEffect(() => {
+    void refresh(client);
+  }, [client, refresh]);
+
+  const recent = workspaces
+    .filter((workspace) => workspace.status !== "archived")
+    .slice(0, 12);
+
+  return (
+    <SidebarFrame>
+      <div className="flex shrink-0 flex-col gap-0.5">
+        <SidebarButton
+          aria-label="Chat"
+          onClick={() => void navigate({ to: "/" })}
+        >
+          <MessageSquare />
+          <span>Chat</span>
+        </SidebarButton>
+        <SidebarButton
+          aria-current={pathname === "/code" ? "page" : undefined}
+          data-active={pathname === "/code" || undefined}
+          className="data-[active]:bg-muted"
+          onClick={() => void navigate({ to: "/code" })}
+        >
+          <FolderGit2 />
+          <span>Code</span>
+        </SidebarButton>
+      </div>
+
+      {!isCompact && <SidebarSectionTitle>Repos</SidebarSectionTitle>}
+      <div className="flex shrink-0 flex-col gap-0.5">
+        {repos.map((repo) => {
+          const active = pathname === `/code/r/${repo.id}`;
+          return (
+            <SidebarButton
+              key={repo.id}
+              aria-current={active ? "page" : undefined}
+              data-active={active || undefined}
+              className="data-[active]:bg-muted"
+              onClick={() =>
+                void navigate({
+                  to: "/code/r/$repoId",
+                  params: { repoId: repo.id },
+                })
+              }
+            >
+              <FolderGit2 />
+              <span>{repo.display_name}</span>
+            </SidebarButton>
+          );
+        })}
+        {repos.length === 0 && !isCompact && (
+          <p className="px-2 py-1 text-xs text-muted-foreground">
+            No repos registered
+          </p>
+        )}
+      </div>
+
+      {!isCompact && (
+        <div className="mt-3 flex items-center justify-between px-2">
+          <SidebarSectionTitle className="px-0">Workspaces</SidebarSectionTitle>
+          <button
+            type="button"
+            className="cursor-pointer rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label="New workspace"
+            onClick={() => setNewWorkspaceOpen(true)}
+          >
+            <Plus size={14} />
+          </button>
+        </div>
+      )}
+      {isCompact && (
+        <SidebarButton
+          aria-label="New workspace"
+          onClick={() => setNewWorkspaceOpen(true)}
+        >
+          <Plus />
+          <span>New workspace</span>
+        </SidebarButton>
+      )}
+      <div className="flex min-h-0 flex-col gap-0.5">
+        {recent.map((workspace) => {
+          const active = pathname === `/code/w/${workspace.id}`;
+          return (
+            <SidebarButton
+              key={workspace.id}
+              aria-current={active ? "page" : undefined}
+              data-active={active || undefined}
+              className="data-[active]:bg-muted"
+              onClick={() =>
+                void navigate({
+                  to: "/code/w/$workspaceId",
+                  params: { workspaceId: workspace.id },
+                })
+              }
+            >
+              <FolderGit2 />
+              <span>{workspace.title}</span>
+            </SidebarButton>
+          );
+        })}
+      </div>
+
+      <NewWorkspaceDialog
+        open={newWorkspaceOpen}
+        onOpenChange={setNewWorkspaceOpen}
+        repos={repos}
+      />
+    </SidebarFrame>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CodeTranscript } from "./CodeTranscript";
+import type { CodeTranscriptItem } from "./CodeSessionReducer";
+
+afterEach(() => {
+  cleanup();
+});
+
+const items: CodeTranscriptItem[] = [
+  { kind: "user", id: "u1", turnId: "t1", text: "list the files" },
+  {
+    kind: "assistant",
+    id: "a1",
+    turnId: "t1",
+    text: "Looking at the tree.",
+    streaming: false,
+  },
+  {
+    kind: "tool",
+    id: "tool1",
+    turnId: "t1",
+    callId: "c1",
+    name: "Bash",
+    detail: { kind: "command", cmd: "ls", cwd: "/tmp" },
+    status: "succeeded",
+    preview: "README.md",
+  },
+  {
+    kind: "notice",
+    id: "n1",
+    level: "warning",
+    message: "unrecognized event dropped",
+  },
+  {
+    kind: "turn_boundary",
+    id: "b1",
+    turnId: "t1",
+    status: "completed",
+    durationMs: 1500,
+    usage: {
+      input_tokens: 12,
+      output_tokens: 3,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    },
+    error: null,
+  },
+];
+
+describe("CodeTranscript", () => {
+  it("renders assistant text, a tool card, a harness notice, and the turn boundary", () => {
+    render(<CodeTranscript items={items} />);
+    expect(screen.getByText("list the files")).toBeInTheDocument();
+    expect(screen.getByText("Looking at the tree.")).toBeInTheDocument();
+    expect(screen.getByRole("status", { name: "Bash succeeded" })).toBeInTheDocument();
+    expect(screen.getByText("unrecognized event dropped")).toBeInTheDocument();
+    expect(screen.getByText("Turn completed")).toBeInTheDocument();
+    expect(screen.getByText("1.5s")).toBeInTheDocument();
+    expect(screen.getByText("15 tokens")).toBeInTheDocument();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -1,0 +1,230 @@
+import { FileCode, FileSearch, Search, SquareTerminal, Wrench } from "lucide-react";
+
+import type { CodeUsage, ToolDetail } from "../api/types";
+import { Badge } from "@/components/ui/badge";
+import { MessageMarkdown } from "@/MessageMarkdown";
+import { ThinkingAccordion } from "@/ThinkingAccordion";
+import { ToolCardShell } from "@/ToolCardShell";
+import { cn } from "@/lib/utils";
+import type { CodeTranscriptItem } from "./CodeSessionReducer";
+
+/**
+ * The code-session transcript: markdown for assistant text, tool-card chrome
+ * for engine work, and visible harness notices.
+ *
+ * Approvals, diffs, and files stay out of this walking skeleton. What lands
+ * here is the conversation a reader can follow from the journal alone.
+ */
+
+export function CodeTranscript({ items }: { items: CodeTranscriptItem[] }) {
+  if (items.length === 0) {
+    return (
+      <p className="text-muted-foreground px-4 py-8 text-sm">
+        Send a message to start a turn.
+      </p>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-3 px-4 py-4">
+      {items.map((item) => (
+        <TranscriptItem key={item.id} item={item} />
+      ))}
+    </div>
+  );
+}
+
+function TranscriptItem({ item }: { item: CodeTranscriptItem }) {
+  switch (item.kind) {
+    case "user":
+      return (
+        <div className="ml-auto max-w-prose rounded-lg bg-muted px-3 py-2 text-sm">
+          {item.text}
+        </div>
+      );
+    case "assistant":
+      return (
+        <div className="max-w-prose text-sm">
+          <MessageMarkdown>{item.text}</MessageMarkdown>
+        </div>
+      );
+    case "reasoning":
+      return <ThinkingAccordion text={item.text} streaming={item.streaming} />;
+    case "tool":
+      return (
+        <CodeToolCard
+          name={item.name}
+          detail={item.detail}
+          status={item.status}
+          preview={item.preview}
+        />
+      );
+    case "notice":
+      return <HarnessNotice level={item.level} message={item.message} />;
+    case "turn_boundary":
+      return (
+        <TurnBoundary
+          status={item.status}
+          durationMs={item.durationMs}
+          usage={item.usage}
+          error={item.error}
+        />
+      );
+  }
+}
+
+export function CodeToolCard({
+  name,
+  detail,
+  status,
+  preview,
+}: {
+  name: string;
+  detail: ToolDetail;
+  status: "running" | "succeeded" | "failed" | "denied";
+  preview: string;
+}) {
+  const badge =
+    status === "running" ? (
+      <Badge variant="info" size="sm">
+        Running
+      </Badge>
+    ) : status === "failed" ? (
+      <Badge variant="critical" size="sm">
+        Failed
+      </Badge>
+    ) : status === "denied" ? (
+      <Badge variant="warning" size="sm">
+        Denied
+      </Badge>
+    ) : (
+      <Badge variant="success" size="sm">
+        Done
+      </Badge>
+    );
+  return (
+    <ToolCardShell
+      icon={toolIcon(detail)}
+      title={toolTitle(detail, name)}
+      titleClassName={detail.kind === "command" ? "font-mono" : undefined}
+      badge={badge}
+      defaultExpanded={status === "running"}
+      label={`${name} ${status}`}
+    >
+      <div className="text-muted-foreground space-y-1 px-2.5 pb-2 text-xs">
+        <p>{toolDetailLine(detail)}</p>
+        {preview && (
+          <pre className="bg-muted max-h-40 overflow-auto rounded-md p-2 font-mono whitespace-pre-wrap">
+            {preview}
+          </pre>
+        )}
+      </div>
+    </ToolCardShell>
+  );
+}
+
+export function HarnessNotice({
+  level,
+  message,
+}: {
+  level: "info" | "warning" | "error";
+  message: string;
+}) {
+  const tone =
+    level === "error" ? "critical" : level === "warning" ? "warning" : "info";
+  return (
+    <div
+      role="status"
+      className={cn(
+        "max-w-prose rounded-md border px-3 py-2 text-sm",
+        tone === "critical" &&
+          "border-critical-border bg-critical-background text-critical-foreground",
+        tone === "warning" &&
+          "border-warning-border bg-warning-background text-warning-foreground",
+        tone === "info" &&
+          "border-info-border bg-info-background text-info-foreground",
+      )}
+    >
+      {message}
+    </div>
+  );
+}
+
+function TurnBoundary({
+  status,
+  durationMs,
+  usage,
+  error,
+}: {
+  status: "completed" | "failed" | "interrupted";
+  durationMs: number | null;
+  usage: CodeUsage | null;
+  error: string | null;
+}) {
+  const label =
+    status === "completed"
+      ? "Turn completed"
+      : status === "failed"
+        ? "Turn failed"
+        : "Turn interrupted";
+  return (
+    <div className="text-muted-foreground flex flex-wrap items-center gap-2 text-xs">
+      <span className="font-medium">{label}</span>
+      {durationMs !== null && <span>{formatDuration(durationMs)}</span>}
+      {usage && (
+        <span>
+          {usage.input_tokens + usage.output_tokens} tokens
+        </span>
+      )}
+      {error && <span className="text-critical-foreground">{error}</span>}
+    </div>
+  );
+}
+
+function toolIcon(detail: ToolDetail) {
+  switch (detail.kind) {
+    case "command":
+      return <SquareTerminal />;
+    case "file_read":
+      return <FileSearch />;
+    case "file_edit":
+      return <FileCode />;
+    case "search":
+      return <Search />;
+    default:
+      return <Wrench />;
+  }
+}
+
+function toolTitle(detail: ToolDetail, name: string): string {
+  switch (detail.kind) {
+    case "command":
+      return detail.cmd;
+    case "file_read":
+    case "file_edit":
+      return detail.path;
+    case "search":
+      return detail.query;
+    case "other":
+      return detail.summary || name;
+  }
+}
+
+function toolDetailLine(detail: ToolDetail): string {
+  switch (detail.kind) {
+    case "command":
+      return detail.cwd ? `cwd ${detail.cwd}` : "Command";
+    case "file_read":
+      return "File read";
+    case "file_edit":
+      return "File edit";
+    case "search":
+      return "Search";
+    case "other":
+      return detail.summary;
+  }
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -18,6 +18,7 @@ import { openExternal } from "@/host";
 import { RouteFrame } from "@/RouteFrame";
 import { friendlyErrorMessage } from "@/lib/utils";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { liveCodeSession } from "./parsers";
 import { CodeComposer } from "./CodeComposer";
 import {
   acquireCodeSessionFromClient,
@@ -66,10 +67,21 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     let cancelled = false;
     void (async () => {
       try {
-        const next = await client.getCodeWorkspace(workspaceId);
+        const [next, sessions] = await Promise.all([
+          client.getCodeWorkspace(workspaceId),
+          client.listCodeWorkspaceSessions(workspaceId),
+        ]);
         if (cancelled) return;
         setWorkspace(next);
-        catalog.upsertWorkspace(next);
+        const catalogState = useCodeCatalogStore.getState();
+        catalogState.upsertWorkspace(next);
+        const live = liveCodeSession(sessions);
+        if (live) {
+          catalogState.rememberSession(live);
+          setSession(live);
+        } else if (!catalogState.sessionsByWorkspace[workspaceId]) {
+          setSession(null);
+        }
         const nextRepo = await client.getCodeRepo(next.repo_id);
         if (!cancelled) setRepo(nextRepo);
       } catch (err) {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -1,0 +1,351 @@
+import { useEffect, useRef, useState } from "react";
+import { FolderOpen } from "lucide-react";
+import { toast } from "sonner";
+
+import { ARCHIVE_FORCE_KINDS, HttpError, type ApiClient } from "../api/client";
+import type {
+  CodeRepoSnapshot,
+  CodeSessionSnapshot,
+  CodeWorkspaceSnapshot,
+  HarnessKind,
+} from "../api/types";
+import { useApp } from "@/AppContext";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ClipboardCopyButton } from "@/ClipboardCopyButton";
+import { useConfirm } from "@/components/ConfirmDialog";
+import { openExternal } from "@/host";
+import { RouteFrame } from "@/RouteFrame";
+import { friendlyErrorMessage } from "@/lib/utils";
+import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { CodeComposer } from "./CodeComposer";
+import {
+  acquireCodeSessionFromClient,
+  releaseCodeSession,
+} from "./CodeSessionRegistry";
+import { CodeSidebar } from "./CodeSidebar";
+import { CodeTranscript } from "./CodeTranscript";
+import {
+  fenceReasonText,
+  HARNESS_LABELS,
+  isHarnessReady,
+  LIFECYCLE_LABELS,
+} from "./labels";
+
+/**
+ * One workspace: header, transcript, composer, and the fence/reap path.
+ *
+ * The session store lives in the registry so two views of the same session
+ * share one socket. This page is the only mounted session view in the
+ * walking skeleton.
+ */
+
+export function CodeWorkspacePage({ workspaceId }: { workspaceId: string }) {
+  return (
+    <RouteFrame sidebar={<CodeSidebar />}>
+      <div className="content-container flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden">
+        <CodeWorkspaceBody workspaceId={workspaceId} />
+      </div>
+    </RouteFrame>
+  );
+}
+
+function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
+  const { client } = useApp();
+  const { confirm, dialog } = useConfirm();
+  const catalog = useCodeCatalogStore();
+  const [workspace, setWorkspace] = useState<CodeWorkspaceSnapshot | null>(null);
+  const [repo, setRepo] = useState<CodeRepoSnapshot | null>(null);
+  const [session, setSession] = useState<CodeSessionSnapshot | null>(
+    catalog.sessionsByWorkspace[workspaceId] ?? null,
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [starting, setStarting] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const next = await client.getCodeWorkspace(workspaceId);
+        if (cancelled) return;
+        setWorkspace(next);
+        catalog.upsertWorkspace(next);
+        const nextRepo = await client.getCodeRepo(next.repo_id);
+        if (!cancelled) setRepo(nextRepo);
+      } catch (err) {
+        if (!cancelled) {
+          setError(friendlyErrorMessage(err, "Could not load this workspace"));
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [client, workspaceId]);
+
+  async function startSession(harness: HarnessKind) {
+    setStarting(true);
+    try {
+      const created = await client.createCodeSession(workspaceId, {
+        harness,
+        permission_mode: "plan",
+      });
+      catalog.rememberSession(created);
+      setSession(created);
+    } catch (err) {
+      toast.error(friendlyErrorMessage(err, "Could not start a session"));
+    } finally {
+      setStarting(false);
+    }
+  }
+
+  async function reap() {
+    if (!session) return;
+    try {
+      const next = await client.reapCodeSession(session.id);
+      catalog.rememberSession(next);
+      setSession(next);
+    } catch (err) {
+      toast.error(friendlyErrorMessage(err, "Could not reap the session"));
+    }
+  }
+
+  async function archive() {
+    if (!workspace) return;
+    const ok = await confirm({
+      title: "Archive this workspace?",
+      description: "The worktree is removed. Uncommitted work is kept only if you cancel.",
+      confirmLabel: "Archive",
+      destructive: true,
+    });
+    if (!ok) return;
+    try {
+      await archiveWorkspace(client, workspace.id, false);
+    } catch (err) {
+      if (err instanceof HttpError && err.kind && ARCHIVE_FORCE_KINDS.has(err.kind)) {
+        const forced = await confirm({
+          title: "Discard uncommitted work?",
+          description: err.message,
+          confirmLabel: "Discard and archive",
+          destructive: true,
+        });
+        if (!forced) return;
+        try {
+          await archiveWorkspace(client, workspace.id, true);
+        } catch (forceErr) {
+          toast.error(friendlyErrorMessage(forceErr, "Could not archive"));
+        }
+        return;
+      }
+      toast.error(friendlyErrorMessage(err, "Could not archive"));
+    }
+  }
+
+  async function archiveWorkspace(
+    api: ApiClient,
+    id: string,
+    force: boolean,
+  ) {
+    const archived = await api.archiveCodeWorkspace(id, force);
+    catalog.upsertWorkspace(archived);
+    catalog.forgetWorkspace(id);
+    setWorkspace(archived);
+    toast.success("Workspace archived");
+  }
+
+  const fenced =
+    session?.lifecycle === "fenced" || session?.fence_reason !== undefined;
+  const readyHarnesses =
+    catalog.doctor?.harnesses.filter((entry) => isHarnessReady(entry)) ?? [];
+
+  return (
+    <>
+      {dialog}
+      <header className="flex shrink-0 flex-col gap-2 border-b px-4 py-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="min-w-0">
+            <h1 className="truncate text-lg font-medium">
+              {workspace?.title ?? "Workspace"}
+            </h1>
+            <p className="text-muted-foreground truncate text-xs">
+              {repo?.display_name ?? workspace?.repo_id} · {workspace?.branch_name}
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            {session && (
+              <Badge
+                variant={
+                  session.lifecycle === "running"
+                    ? "success"
+                    : session.lifecycle === "fenced"
+                      ? "warning"
+                      : "outline"
+                }
+                size="sm"
+              >
+                {LIFECYCLE_LABELS[session.lifecycle]}
+              </Badge>
+            )}
+            {workspace && workspace.status !== "archived" && (
+              <Button type="button" variant="ghost" size="xs" onClick={() => void archive()}>
+                Archive
+              </Button>
+            )}
+          </div>
+        </div>
+        {workspace && (
+          <div className="text-muted-foreground flex flex-wrap items-center gap-2 text-xs">
+            <span className="font-mono">{workspace.worktree_path}</span>
+            <ClipboardCopyButton
+              value={workspace.worktree_path}
+              label="Copy worktree path"
+              copiedAnnouncement="Copied worktree path"
+              failedAnnouncement="Could not copy worktree path"
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="2xs"
+              onClick={() => void revealPath(workspace.worktree_path)}
+            >
+              <FolderOpen />
+              Reveal
+            </Button>
+            {session && (
+              <span>
+                {HARNESS_LABELS[session.harness_kind]}
+                {session.harness_version ? ` ${session.harness_version}` : ""}
+              </span>
+            )}
+          </div>
+        )}
+      </header>
+      {error && <p className="text-critical px-4 py-2 text-sm">{error}</p>}
+      {fenced && session?.fence_reason && (
+        <div className="border-warning-border bg-warning-background text-warning-foreground mx-4 mt-3 flex flex-col gap-2 rounded-md border px-3 py-2 text-sm">
+          <p>{fenceReasonText(session.fence_reason)}</p>
+          <Button type="button" size="sm" className="self-start" onClick={() => void reap()}>
+            Reap
+          </Button>
+        </div>
+      )}
+      {!session && workspace?.status === "active" && (
+        <div className="flex flex-col gap-2 px-4 py-6">
+          <p className="text-sm">Start a Plan-mode session on this workspace.</p>
+          <div className="flex flex-wrap gap-2">
+            {readyHarnesses.map((entry) => (
+              <Button
+                key={entry.kind}
+                type="button"
+                size="sm"
+                disabled={starting}
+                onClick={() => void startSession(entry.kind)}
+              >
+                {HARNESS_LABELS[entry.kind]}
+              </Button>
+            ))}
+          </div>
+        </div>
+      )}
+      {session && (
+        <CodeSessionPane
+          key={session.id}
+          session={session}
+          client={client}
+          disabled={fenced || workspace?.status !== "active"}
+        />
+      )}
+    </>
+  );
+}
+
+function CodeSessionPane({
+  session,
+  client,
+  disabled,
+}: {
+  session: CodeSessionSnapshot;
+  client: ApiClient;
+  disabled: boolean;
+}) {
+  const store = useRegisteredCodeSession(session.id, client);
+  const items = store((state) => state.items);
+  const busy = store((state) => state.busy);
+  const harnessVersion = store((state) => state.harnessVersion);
+
+  async function send(message: string) {
+    store.getState().update((current) => ({
+      ...current,
+      items: [
+        ...current.items,
+        {
+          kind: "user",
+          id: `user-${Date.now()}`,
+          turnId: current.activeTurnId,
+          text: message,
+        },
+      ],
+    }));
+    try {
+      await client.submitCodeTurn(session.id, message);
+    } catch (err) {
+      toast.error(friendlyErrorMessage(err, "Could not send that turn"));
+    }
+  }
+
+  async function interrupt() {
+    try {
+      await client.interruptCodeSession(session.id);
+    } catch (err) {
+      toast.error(friendlyErrorMessage(err, "Could not interrupt"));
+    }
+  }
+
+  return (
+    <>
+      {harnessVersion && harnessVersion !== session.harness_version && (
+        <p className="text-muted-foreground px-4 pt-2 text-xs">
+          {HARNESS_LABELS[session.harness_kind]} {harnessVersion}
+        </p>
+      )}
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <CodeTranscript items={items} />
+      </div>
+      {session.lifecycle !== "ended" && (
+        <CodeComposer
+          running={busy || session.lifecycle === "running"}
+          disabled={disabled}
+          permissionMode={session.permission_mode}
+          onSend={send}
+          onInterrupt={interrupt}
+        />
+      )}
+    </>
+  );
+}
+
+function useRegisteredCodeSession(
+  sessionId: string,
+  client: ApiClient,
+) {
+  const storeRef = useRef<ReturnType<typeof acquireCodeSessionFromClient> | null>(
+    null,
+  );
+  if (storeRef.current === null) {
+    storeRef.current = acquireCodeSessionFromClient(sessionId, client);
+  }
+  useEffect(() => {
+    return () => {
+      releaseCodeSession(sessionId);
+      storeRef.current = null;
+    };
+  }, [sessionId, client]);
+  return storeRef.current;
+}
+
+async function revealPath(path: string): Promise<void> {
+  const fileUrl = path.startsWith("/") ? `file://${path}` : path;
+  if (!(await openExternal(fileUrl).catch(() => false))) {
+    toast.message("Copy the path to open it in the Finder.");
+  }
+}

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { FolderOpen } from "lucide-react";
 import { toast } from "sonner";
 
-import { ARCHIVE_FORCE_KINDS, HttpError, type ApiClient } from "../api/client";
+import { archiveForceKind, type ApiClient } from "../api/client";
 import type {
   CodeRepoSnapshot,
   CodeSessionSnapshot,
@@ -24,6 +24,7 @@ import {
   acquireCodeSessionFromClient,
   releaseCodeSession,
 } from "./CodeSessionRegistry";
+import { submitAcceptedTurn } from "./CodeSessionSend";
 import { CodeSidebar } from "./CodeSidebar";
 import { CodeTranscript } from "./CodeTranscript";
 import {
@@ -126,7 +127,8 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     if (!workspace) return;
     const ok = await confirm({
       title: "Archive this workspace?",
-      description: "The worktree is removed. Uncommitted work is kept only if you cancel.",
+      description:
+        "The worktree is removed. Leftover work on the branch is kept only if you cancel.",
       confirmLabel: "Archive",
       destructive: true,
     });
@@ -134,10 +136,10 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     try {
       await archiveWorkspace(client, workspace.id, false);
     } catch (err) {
-      if (err instanceof HttpError && err.kind && ARCHIVE_FORCE_KINDS.has(err.kind)) {
+      if (archiveForceKind(err)) {
         const forced = await confirm({
-          title: "Discard uncommitted work?",
-          description: err.message,
+          title: "Discard leftover work?",
+          description: err instanceof Error ? err.message : String(err),
           confirmLabel: "Discard and archive",
           destructive: true,
         });
@@ -185,18 +187,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
           </div>
           <div className="flex items-center gap-2">
             {session && (
-              <Badge
-                variant={
-                  session.lifecycle === "running"
-                    ? "success"
-                    : session.lifecycle === "fenced"
-                      ? "warning"
-                      : "outline"
-                }
-                size="sm"
-              >
-                {LIFECYCLE_LABELS[session.lifecycle]}
-              </Badge>
+              <SessionLifecycleBadge session={session} client={client} />
             )}
             {workspace && workspace.status !== "archived" && (
               <Button type="button" variant="ghost" size="xs" onClick={() => void archive()}>
@@ -271,6 +262,31 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   );
 }
 
+function SessionLifecycleBadge({
+  session,
+  client,
+}: {
+  session: CodeSessionSnapshot;
+  client: ApiClient;
+}) {
+  const store = useRegisteredCodeSession(session.id, client);
+  const lifecycle = store((state) => state.lifecycle) ?? session.lifecycle;
+  return (
+    <Badge
+      variant={
+        lifecycle === "running"
+          ? "success"
+          : lifecycle === "fenced"
+            ? "warning"
+            : "outline"
+      }
+      size="sm"
+    >
+      {LIFECYCLE_LABELS[lifecycle]}
+    </Badge>
+  );
+}
+
 function CodeSessionPane({
   session,
   client,
@@ -284,22 +300,13 @@ function CodeSessionPane({
   const items = store((state) => state.items);
   const busy = store((state) => state.busy);
   const harnessVersion = store((state) => state.harnessVersion);
+  const lifecycle = store((state) => state.lifecycle) ?? session.lifecycle;
 
   async function send(message: string) {
-    store.getState().update((current) => ({
-      ...current,
-      items: [
-        ...current.items,
-        {
-          kind: "user",
-          id: `user-${Date.now()}`,
-          turnId: current.activeTurnId,
-          text: message,
-        },
-      ],
-    }));
     try {
-      await client.submitCodeTurn(session.id, message);
+      await submitAcceptedTurn(store.getState().update, () =>
+        client.submitCodeTurn(session.id, message),
+      );
     } catch (err) {
       toast.error(friendlyErrorMessage(err, "Could not send that turn"));
     }
@@ -323,9 +330,9 @@ function CodeSessionPane({
       <div className="min-h-0 flex-1 overflow-y-auto">
         <CodeTranscript items={items} />
       </div>
-      {session.lifecycle !== "ended" && (
+      {lifecycle !== "ended" && (
         <CodeComposer
-          running={busy || session.lifecycle === "running"}
+          running={busy || lifecycle === "running"}
           disabled={disabled}
           permissionMode={session.permission_mode}
           onSend={send}

--- a/crates/tidebreak-desktop/ui/src/code/DoctorList.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DoctorList.tsx
@@ -1,0 +1,104 @@
+import type { HarnessDoctorEntry, HarnessDoctorReport } from "../api/types";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  HARNESS_LABELS,
+  HARNESS_TIER_LABELS,
+  isHarnessReady,
+} from "./labels";
+
+/**
+ * The harness doctor, shared by the code-mode empty state and Settings.
+ *
+ * Found / version / auth / remediation are the facts a reader can act on.
+ * Capability flags stay a one-line summary so the page does not become a
+ * matrix of every adapter's self-report.
+ */
+
+export function DoctorList({
+  report,
+  onRefresh,
+  refreshing,
+}: {
+  report: HarnessDoctorReport;
+  onRefresh?: () => void;
+  refreshing?: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      {onRefresh && (
+        <div className="flex justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onRefresh}
+            disabled={refreshing}
+          >
+            {refreshing ? "Refreshing…" : "Refresh"}
+          </Button>
+        </div>
+      )}
+      {report.harnesses.map((entry) => (
+        <DoctorCard key={entry.kind} entry={entry} />
+      ))}
+    </div>
+  );
+}
+
+function DoctorCard({ entry }: { entry: HarnessDoctorEntry }) {
+  const ready = isHarnessReady(entry);
+  return (
+    <Card className="gap-3 p-4">
+      <CardHeader className="justify-between">
+        <CardTitle className="text-base">{HARNESS_LABELS[entry.kind]}</CardTitle>
+        <Badge variant={ready ? "success" : "warning"} size="sm">
+          {ready ? "Ready" : entry.found ? "Sign in" : "Not found"}
+        </Badge>
+      </CardHeader>
+      <CardContent className="gap-1 text-sm">
+        <Row label="Found" value={entry.found ? "yes" : "no"} />
+        {entry.path && <Row label="Path" value={entry.path} />}
+        {entry.version && <Row label="Version" value={entry.version} />}
+        <Row label="Tier" value={HARNESS_TIER_LABELS[entry.tier]} />
+        <Row label="Capabilities" value={capsSummary(entry)} />
+        <Row
+          label="Authenticated"
+          value={
+            entry.authenticated === undefined
+              ? "unknown"
+              : entry.authenticated
+                ? "yes"
+                : "no"
+          }
+        />
+        {entry.unrecognized_event_count > 0 && (
+          <Row
+            label="Unrecognized events"
+            value={String(entry.unrecognized_event_count)}
+          />
+        )}
+        {entry.remediation && (
+          <p className="text-warning-foreground mt-2">{entry.remediation}</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <p className="text-muted-foreground">
+      <span className="text-foreground font-medium">{label}: </span>
+      {value}
+    </p>
+  );
+}
+
+function capsSummary(entry: HarnessDoctorEntry): string {
+  const supported = Object.entries(entry.caps)
+    .filter(([, level]) => level === "supported")
+    .map(([name]) => name.replaceAll("_", " "));
+  return supported.length > 0 ? supported.join(", ") : "none stated as supported";
+}

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useState, type FormEvent } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { toast } from "sonner";
+
+import type { CodeRepoSnapshot, HarnessKind } from "../api/types";
+import { useApp } from "@/AppContext";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { friendlyErrorMessage } from "@/lib/utils";
+import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { HARNESS_LABELS, isHarnessReady } from "./labels";
+
+/**
+ * Create a workspace and its first Plan-mode session, then open it.
+ *
+ * Ask and Auto are refused by the server in this phase, so the dialog does
+ * not offer them. The harness picker is the doctor: only engines that are
+ * installed (and signed in, when the doctor knows) can be chosen.
+ */
+
+export function NewWorkspaceDialog({
+  open,
+  onOpenChange,
+  repos,
+  defaultRepoId,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  repos: CodeRepoSnapshot[];
+  defaultRepoId?: string;
+}) {
+  const navigate = useNavigate();
+  const { client } = useApp();
+  const doctor = useCodeCatalogStore((state) => state.doctor);
+  const upsertWorkspace = useCodeCatalogStore((state) => state.upsertWorkspace);
+  const rememberSession = useCodeCatalogStore((state) => state.rememberSession);
+  const [repoId, setRepoId] = useState(defaultRepoId ?? repos[0]?.id ?? "");
+  const [title, setTitle] = useState("");
+  const [baseRef, setBaseRef] = useState("");
+  const [harness, setHarness] = useState<HarnessKind>("claude_code");
+  const [creating, setCreating] = useState(false);
+
+  const readyHarnesses =
+    doctor?.harnesses.filter((entry) => isHarnessReady(entry)) ?? [];
+
+  useEffect(() => {
+    if (!open) return;
+    setRepoId(defaultRepoId ?? repos[0]?.id ?? "");
+    setTitle("");
+    const selected = repos.find((repo) => repo.id === (defaultRepoId ?? repos[0]?.id));
+    setBaseRef(selected?.default_base_ref ?? "");
+    setHarness(readyHarnesses[0]?.kind ?? "claude_code");
+    // Reset against the dialog opening, not against doctor refreshes mid-open.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, defaultRepoId, repos]);
+
+  const selectedRepo = repos.find((repo) => repo.id === repoId);
+  const canCreate =
+    Boolean(repoId && title.trim() && selectedRepo && readyHarnesses.length > 0) &&
+    !creating;
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    if (!canCreate) return;
+    setCreating(true);
+    try {
+      const workspace = await client.createCodeWorkspace({
+        repo_id: repoId,
+        title: title.trim(),
+        base_ref: baseRef.trim() || undefined,
+      });
+      upsertWorkspace(workspace);
+      const session = await client.createCodeSession(workspace.id, {
+        harness,
+        permission_mode: "plan",
+      });
+      rememberSession(session);
+      onOpenChange(false);
+      await navigate({
+        to: "/code/w/$workspaceId",
+        params: { workspaceId: workspace.id },
+      });
+    } catch (error) {
+      toast.error(friendlyErrorMessage(error, "Could not create the workspace"));
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={creating ? undefined : onOpenChange}>
+      <DialogContent className="max-w-md gap-5 p-5" aria-busy={creating}>
+        <DialogHeader>
+          <DialogTitle>New workspace</DialogTitle>
+          <DialogDescription>
+            One worktree and one Plan-mode session on the selected repo.
+          </DialogDescription>
+        </DialogHeader>
+        <form className="flex flex-col gap-3" onSubmit={submit}>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-medium">Repo</span>
+            <select
+              className="h-10 rounded-md border border-border bg-background px-3 text-sm"
+              value={repoId}
+              onChange={(event) => {
+                setRepoId(event.target.value);
+                const next = repos.find((repo) => repo.id === event.target.value);
+                if (next) setBaseRef(next.default_base_ref);
+              }}
+              disabled={creating || Boolean(defaultRepoId)}
+            >
+              {repos.map((repo) => (
+                <option key={repo.id} value={repo.id}>
+                  {repo.display_name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-medium">Title</span>
+            <Input
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              disabled={creating}
+              autoFocus
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-medium">Base ref</span>
+            <Input
+              value={baseRef}
+              onChange={(event) => setBaseRef(event.target.value)}
+              disabled={creating}
+              placeholder={selectedRepo?.default_base_ref}
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-medium">Harness</span>
+            <select
+              className="h-10 rounded-md border border-border bg-background px-3 text-sm"
+              value={harness}
+              onChange={(event) => setHarness(event.target.value as HarnessKind)}
+              disabled={creating || readyHarnesses.length === 0}
+            >
+              {readyHarnesses.map((entry) => (
+                <option key={entry.kind} value={entry.kind}>
+                  {HARNESS_LABELS[entry.kind]}
+                  {entry.version ? ` ${entry.version}` : ""}
+                </option>
+              ))}
+            </select>
+          </label>
+          <p className="text-xs text-muted-foreground">
+            Permission mode is Plan. Ask and Auto are {PERMISSION_UNAVAILABLE}.
+          </p>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => onOpenChange(false)}
+              disabled={creating}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!canCreate}>
+              {creating ? "Creating…" : "Create"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+const PERMISSION_UNAVAILABLE = "not yet available";

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -1,0 +1,68 @@
+import type {
+  CodePermissionMode,
+  CodeSessionLifecycle,
+  CodeWorkspaceStatus,
+  FenceReason,
+  HarnessKind,
+  HarnessTier,
+} from "../api/types";
+
+/**
+ * Display names for the code-mode vocabulary.
+ *
+ * The wire tokens are engine and lifecycle identifiers. These strings are
+ * what the rail, the doctor, and the workspace header actually show.
+ */
+
+export const HARNESS_LABELS: Record<HarnessKind, string> = {
+  claude_code: "Claude Code",
+  codex: "Codex CLI",
+  opencode: "opencode",
+  grok: "Grok CLI",
+};
+
+export const HARNESS_TIER_LABELS: Record<HarnessTier, string> = {
+  reference: "Reference",
+  secondary: "Secondary",
+  tertiary: "Tertiary",
+  best_effort: "Best effort",
+};
+
+export const LIFECYCLE_LABELS: Record<CodeSessionLifecycle, string> = {
+  created: "Created",
+  idle: "Idle",
+  running: "Running",
+  fenced: "Fenced",
+  ended: "Ended",
+};
+
+export const WORKSPACE_STATUS_LABELS: Record<CodeWorkspaceStatus, string> = {
+  creating: "Creating",
+  setup_failed: "Setup failed",
+  active: "Active",
+  archived: "Archived",
+};
+
+export const PERMISSION_MODE_LABELS: Record<CodePermissionMode, string> = {
+  plan: "Plan",
+  ask: "Ask",
+  auto: "Auto",
+};
+
+/** The server refuses Ask and Auto until a later phase. */
+export const PERMISSION_MODE_UNAVAILABLE_REASON =
+  "not yet available; create the session in plan mode";
+
+export function fenceReasonText(reason: FenceReason): string {
+  if (reason.type === "orphan_alive") {
+    return "An engine process is still running from a previous session. Reap it before starting another turn.";
+  }
+  return reason.detail;
+}
+
+export function isHarnessReady(entry: {
+  found: boolean;
+  authenticated?: boolean;
+}): boolean {
+  return entry.found && entry.authenticated !== false;
+}

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { liveCodeSession, parseCodeSession, parseCodeSessionList } from "./parsers";
+import {
+  liveCodeSession,
+  parseCodeSession,
+  parseCodeSessionList,
+  parseCodeTurnList,
+} from "./parsers";
 
 const SESSION = {
   id: "sess-1",
@@ -30,6 +35,28 @@ describe("parseCodeSessionList", () => {
   it("rejects a non-array or a row the session parser would drop", () => {
     expect(parseCodeSessionList({ sessions: [SESSION] })).toBeNull();
     expect(parseCodeSessionList([SESSION, { ...SESSION, lifecycle: "paused" }])).toBeNull();
+  });
+});
+
+const TURN = {
+  id: "turn-1",
+  session_id: "sess-1",
+  ordinal: 1,
+  status: "completed",
+  user_input: "list the files",
+  started_at: "2026-08-15T12:00:00.000Z",
+  ended_at: "2026-08-15T12:00:02.000Z",
+};
+
+describe("parseCodeTurnList", () => {
+  it("accepts GET /code/sessions/{id}/turns", () => {
+    expect(parseCodeTurnList([TURN])).toEqual([TURN]);
+    expect(parseCodeTurnList([])).toEqual([]);
+  });
+
+  it("rejects a non-array or a row the turn parser would drop", () => {
+    expect(parseCodeTurnList({ turns: [TURN] })).toBeNull();
+    expect(parseCodeTurnList([{ ...TURN, status: "paused" }])).toBeNull();
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { liveCodeSession, parseCodeSession, parseCodeSessionList } from "./parsers";
+
+const SESSION = {
+  id: "sess-1",
+  workspace_id: "ws-1",
+  harness_kind: "claude_code",
+  permission_mode: "plan",
+  lifecycle: "idle",
+  attention: { state: { type: "working" }, source: "lifecycle" },
+  unrecognized_event_count: 0,
+  created_at: "2026-08-15T12:00:00.000Z",
+};
+
+describe("parseCodeSessionList", () => {
+  it("accepts GET /code/workspaces/{id}/sessions", () => {
+    const ended = {
+      ...SESSION,
+      id: "sess-0",
+      lifecycle: "ended",
+    };
+    expect(parseCodeSessionList([ended, SESSION])).toEqual([
+      parseCodeSession(ended),
+      parseCodeSession(SESSION),
+    ]);
+    expect(parseCodeSessionList([])).toEqual([]);
+  });
+
+  it("rejects a non-array or a row the session parser would drop", () => {
+    expect(parseCodeSessionList({ sessions: [SESSION] })).toBeNull();
+    expect(parseCodeSessionList([SESSION, { ...SESSION, lifecycle: "paused" }])).toBeNull();
+  });
+});
+
+describe("liveCodeSession", () => {
+  it("prefers the newest non-ended session", () => {
+    const ended = parseCodeSession({ ...SESSION, id: "old", lifecycle: "ended" });
+    const live = parseCodeSession(SESSION);
+    expect(ended && live).toBeTruthy();
+    expect(liveCodeSession([ended!, live!])?.id).toBe("sess-1");
+    expect(liveCodeSession([ended!])).toBeNull();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -4,6 +4,7 @@ import {
   liveCodeSession,
   parseCodeSession,
   parseCodeSessionList,
+  parseCodeTurn,
   parseCodeTurnList,
 } from "./parsers";
 
@@ -48,10 +49,23 @@ const TURN = {
   ended_at: "2026-08-15T12:00:02.000Z",
 };
 
+const USAGE = {
+  input_tokens: 12,
+  output_tokens: 3,
+  cache_read_input_tokens: 0,
+  cache_creation_input_tokens: 0,
+};
+
 describe("parseCodeTurnList", () => {
   it("accepts GET /code/sessions/{id}/turns", () => {
     expect(parseCodeTurnList([TURN])).toEqual([TURN]);
     expect(parseCodeTurnList([])).toEqual([]);
+  });
+
+  it("keeps optional usage on a completed turn", () => {
+    const withUsage = { ...TURN, usage: USAGE };
+    expect(parseCodeTurn(withUsage)).toEqual(withUsage);
+    expect(parseCodeTurnList([withUsage])).toEqual([withUsage]);
   });
 
   it("rejects a non-array or a row the turn parser would drop", () => {

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -1,0 +1,737 @@
+import type {
+  Attention,
+  AttentionSource,
+  AttentionState,
+  CapLevel,
+  CodeEvent,
+  CodePermissionMode,
+  CodeRepoSnapshot,
+  CodeSessionLifecycle,
+  CodeSessionSnapshot,
+  CodeTurnSnapshot,
+  CodeTurnStatus,
+  CodeUsage,
+  CodeWorkspaceSnapshot,
+  CodeWorkspaceStatus,
+  FenceReason,
+  HarnessCaps,
+  HarnessDoctorEntry,
+  HarnessDoctorReport,
+  HarnessKind,
+  HarnessNoticeLevel,
+  HarnessTier,
+  SequencedCodeEventFrame,
+  ToolDetail,
+  ToolOutcome,
+} from "../api/types";
+import type {
+  CodeEvent as WireCodeEvent,
+  CodeRepoSnapshot as WireCodeRepoSnapshot,
+  CodeSessionSnapshot as WireCodeSessionSnapshot,
+  CodeTurnSnapshot as WireCodeTurnSnapshot,
+  CodeWorkspaceSnapshot as WireCodeWorkspaceSnapshot,
+  HarnessCaps as WireHarnessCaps,
+  HarnessDoctorEntry as WireHarnessDoctorEntry,
+  HarnessDoctorReport as WireHarnessDoctorReport,
+  QuickAction as WireQuickAction,
+  SequencedCodeEventFrame as WireSequencedCodeEventFrame,
+  ToolDetail as WireToolDetail,
+} from "../generated/wire";
+
+/**
+ * Runtime validators for every code-mode wire type the desktop consumes.
+ *
+ * Generated types describe the JSON; these functions decide whether a payload
+ * is safe to keep. A field the server renamed or a notice that grew control
+ * characters must fail here rather than render as if it were well-formed.
+ */
+
+const HARNESS_KINDS = new Set<HarnessKind>([
+  "claude_code",
+  "codex",
+  "opencode",
+  "grok",
+]);
+const HARNESS_TIERS = new Set<HarnessTier>([
+  "reference",
+  "secondary",
+  "tertiary",
+  "best_effort",
+]);
+const CAP_LEVELS = new Set<CapLevel>(["supported", "unsupported", "unknown"]);
+const PERMISSION_MODES = new Set<CodePermissionMode>(["plan", "ask", "auto"]);
+const SESSION_LIFECYCLES = new Set<CodeSessionLifecycle>([
+  "created",
+  "idle",
+  "running",
+  "fenced",
+  "ended",
+]);
+const WORKSPACE_STATUSES = new Set<CodeWorkspaceStatus>([
+  "creating",
+  "setup_failed",
+  "active",
+  "archived",
+]);
+const TURN_STATUSES = new Set<CodeTurnStatus>([
+  "running",
+  "completed",
+  "failed",
+  "interrupted",
+]);
+const NOTICE_LEVELS = new Set<HarnessNoticeLevel>(["info", "warning", "error"]);
+const TOOL_OUTCOMES = new Set<ToolOutcome>(["succeeded", "failed", "denied"]);
+const ATTENTION_SOURCES = new Set<AttentionSource>([
+  "structured",
+  "heuristic",
+  "lifecycle",
+  "user",
+]);
+
+export function parseCodeRepo(value: unknown): CodeRepoSnapshot | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeRepoSnapshot>(value, [
+      "id",
+      "root_path",
+      "display_name",
+      "default_base_ref",
+      "branch_prefix",
+      "setup_script",
+      "archive_script",
+      "quick_actions",
+      "created_at",
+    ]) ||
+    !nonEmpty(value.id) ||
+    !nonEmpty(value.root_path) ||
+    !nonEmpty(value.display_name) ||
+    !nonEmpty(value.default_base_ref) ||
+    !nonEmpty(value.branch_prefix) ||
+    !nonEmpty(value.created_at) ||
+    !optionalString(value.setup_script) ||
+    !optionalString(value.archive_script) ||
+    !Array.isArray(value.quick_actions)
+  ) {
+    return null;
+  }
+  const quick_actions = [];
+  for (const action of value.quick_actions) {
+    const parsed = parseQuickAction(action);
+    if (!parsed) return null;
+    quick_actions.push(parsed);
+  }
+  return {
+    id: value.id,
+    root_path: value.root_path,
+    display_name: value.display_name,
+    default_base_ref: value.default_base_ref,
+    branch_prefix: value.branch_prefix,
+    ...(value.setup_script !== undefined
+      ? { setup_script: value.setup_script }
+      : {}),
+    ...(value.archive_script !== undefined
+      ? { archive_script: value.archive_script }
+      : {}),
+    quick_actions,
+    created_at: value.created_at,
+  };
+}
+
+function parseQuickAction(value: unknown): WireQuickAction | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireQuickAction>(value, [
+      "name",
+      "command",
+      "auto_run_on_create",
+    ]) ||
+    !nonEmpty(value.name) ||
+    typeof value.command !== "string" ||
+    typeof value.auto_run_on_create !== "boolean"
+  ) {
+    return null;
+  }
+  return {
+    name: value.name,
+    command: value.command,
+    auto_run_on_create: value.auto_run_on_create,
+  };
+}
+
+export function parseCodeWorkspace(
+  value: unknown,
+): CodeWorkspaceSnapshot | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeWorkspaceSnapshot>(value, [
+      "id",
+      "repo_id",
+      "title",
+      "worktree_path",
+      "branch_name",
+      "base_ref",
+      "status",
+      "pr",
+      "created_at",
+      "archived_at",
+    ]) ||
+    !nonEmpty(value.id) ||
+    !nonEmpty(value.repo_id) ||
+    !nonEmpty(value.title) ||
+    !nonEmpty(value.worktree_path) ||
+    !nonEmpty(value.branch_name) ||
+    !nonEmpty(value.base_ref) ||
+    !isMember(value.status, WORKSPACE_STATUSES) ||
+    !nonEmpty(value.created_at) ||
+    !optionalString(value.archived_at)
+  ) {
+    return null;
+  }
+  return {
+    id: value.id,
+    repo_id: value.repo_id,
+    title: value.title,
+    worktree_path: value.worktree_path,
+    branch_name: value.branch_name,
+    base_ref: value.base_ref,
+    status: value.status,
+    created_at: value.created_at,
+    ...(value.pr !== undefined ? { pr: value.pr as CodeWorkspaceSnapshot["pr"] } : {}),
+    ...(value.archived_at !== undefined ? { archived_at: value.archived_at } : {}),
+  };
+}
+
+export function parseCodeSession(value: unknown): CodeSessionSnapshot | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeSessionSnapshot>(value, [
+      "id",
+      "workspace_id",
+      "harness_kind",
+      "harness_version",
+      "harness_resume_ref",
+      "permission_mode",
+      "lifecycle",
+      "fence_reason",
+      "attention",
+      "unrecognized_event_count",
+      "created_at",
+    ]) ||
+    !nonEmpty(value.id) ||
+    !nonEmpty(value.workspace_id) ||
+    !isMember(value.harness_kind, HARNESS_KINDS) ||
+    !optionalString(value.harness_version) ||
+    !optionalString(value.harness_resume_ref) ||
+    !isMember(value.permission_mode, PERMISSION_MODES) ||
+    !isMember(value.lifecycle, SESSION_LIFECYCLES) ||
+    !isFiniteNumber(value.unrecognized_event_count) ||
+    !nonEmpty(value.created_at)
+  ) {
+    return null;
+  }
+  const attention = parseAttention(value.attention);
+  if (!attention) return null;
+  const fence_reason =
+    value.fence_reason === undefined
+      ? undefined
+      : parseFenceReason(value.fence_reason);
+  if (value.fence_reason !== undefined && !fence_reason) return null;
+  return {
+    id: value.id,
+    workspace_id: value.workspace_id,
+    harness_kind: value.harness_kind,
+    permission_mode: value.permission_mode,
+    lifecycle: value.lifecycle,
+    attention,
+    unrecognized_event_count: value.unrecognized_event_count,
+    created_at: value.created_at,
+    ...(value.harness_version !== undefined
+      ? { harness_version: value.harness_version }
+      : {}),
+    ...(value.harness_resume_ref !== undefined
+      ? { harness_resume_ref: value.harness_resume_ref }
+      : {}),
+    ...(fence_reason ? { fence_reason } : {}),
+  };
+}
+
+export function parseCodeTurn(value: unknown): CodeTurnSnapshot | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeTurnSnapshot>(value, [
+      "id",
+      "session_id",
+      "ordinal",
+      "status",
+      "user_input",
+      "checkpoint_ref",
+      "started_at",
+      "ended_at",
+    ]) ||
+    !nonEmpty(value.id) ||
+    !nonEmpty(value.session_id) ||
+    !isFiniteNumber(value.ordinal) ||
+    !isMember(value.status, TURN_STATUSES) ||
+    typeof value.user_input !== "string" ||
+    !optionalString(value.checkpoint_ref) ||
+    !nonEmpty(value.started_at) ||
+    !optionalString(value.ended_at)
+  ) {
+    return null;
+  }
+  return {
+    id: value.id,
+    session_id: value.session_id,
+    ordinal: value.ordinal,
+    status: value.status,
+    user_input: value.user_input,
+    started_at: value.started_at,
+    ...(value.checkpoint_ref !== undefined
+      ? { checkpoint_ref: value.checkpoint_ref }
+      : {}),
+    ...(value.ended_at !== undefined ? { ended_at: value.ended_at } : {}),
+  };
+}
+
+export function parseHarnessDoctorReport(
+  value: unknown,
+): HarnessDoctorReport | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireHarnessDoctorReport>(value, ["harnesses"]) ||
+    !Array.isArray(value.harnesses)
+  ) {
+    return null;
+  }
+  const harnesses: HarnessDoctorEntry[] = [];
+  for (const entry of value.harnesses) {
+    const parsed = parseHarnessDoctorEntry(entry);
+    if (!parsed) return null;
+    harnesses.push(parsed);
+  }
+  return { harnesses };
+}
+
+export function parseHarnessDoctorEntry(
+  value: unknown,
+): HarnessDoctorEntry | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireHarnessDoctorEntry>(value, [
+      "kind",
+      "found",
+      "path",
+      "version",
+      "tier",
+      "caps",
+      "authenticated",
+      "remediation",
+      "stderr",
+      "unrecognized_event_count",
+    ]) ||
+    !isMember(value.kind, HARNESS_KINDS) ||
+    typeof value.found !== "boolean" ||
+    !optionalString(value.path) ||
+    !optionalString(value.version) ||
+    !isMember(value.tier, HARNESS_TIERS) ||
+    (value.authenticated !== undefined &&
+      typeof value.authenticated !== "boolean") ||
+    typeof value.remediation !== "string" ||
+    typeof value.stderr !== "string" ||
+    !isFiniteNumber(value.unrecognized_event_count)
+  ) {
+    return null;
+  }
+  const caps = parseHarnessCaps(value.caps);
+  if (!caps) return null;
+  return {
+    kind: value.kind,
+    found: value.found,
+    tier: value.tier,
+    caps,
+    remediation: value.remediation,
+    stderr: value.stderr,
+    unrecognized_event_count: value.unrecognized_event_count,
+    ...(value.path !== undefined ? { path: value.path } : {}),
+    ...(value.version !== undefined ? { version: value.version } : {}),
+    ...(value.authenticated !== undefined
+      ? { authenticated: value.authenticated }
+      : {}),
+  };
+}
+
+function parseHarnessCaps(value: unknown): HarnessCaps | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireHarnessCaps>(value, [
+      "resume",
+      "streaming_deltas",
+      "structured_approvals",
+      "mid_turn_steering",
+      "plan_mode",
+      "reasoning_levels",
+      "native_file_change_events",
+      "native_interrupt",
+    ]) ||
+    !isMember(value.resume, CAP_LEVELS) ||
+    !isMember(value.streaming_deltas, CAP_LEVELS) ||
+    !isMember(value.structured_approvals, CAP_LEVELS) ||
+    !isMember(value.mid_turn_steering, CAP_LEVELS) ||
+    !isMember(value.plan_mode, CAP_LEVELS) ||
+    !isMember(value.reasoning_levels, CAP_LEVELS) ||
+    !isMember(value.native_file_change_events, CAP_LEVELS) ||
+    !isMember(value.native_interrupt, CAP_LEVELS)
+  ) {
+    return null;
+  }
+  return {
+    resume: value.resume,
+    streaming_deltas: value.streaming_deltas,
+    structured_approvals: value.structured_approvals,
+    mid_turn_steering: value.mid_turn_steering,
+    plan_mode: value.plan_mode,
+    reasoning_levels: value.reasoning_levels,
+    native_file_change_events: value.native_file_change_events,
+    native_interrupt: value.native_interrupt,
+  };
+}
+
+export function parseSequencedCodeEvent(
+  value: unknown,
+): SequencedCodeEventFrame | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireSequencedCodeEventFrame>(value, ["seq", "event", "replayed"]) ||
+    !isFiniteNumber(value.seq) ||
+    (value.replayed !== undefined && typeof value.replayed !== "boolean")
+  ) {
+    return null;
+  }
+  const event = parseCodeEvent(value.event);
+  if (!event) return null;
+  return {
+    seq: value.seq,
+    event,
+    ...(value.replayed !== undefined ? { replayed: value.replayed } : {}),
+  };
+}
+
+export function parseCodeEvent(value: unknown): CodeEvent | null {
+  if (
+    !isRecord(value) ||
+    typeof value.type !== "string" ||
+    value.type.length === 0
+  ) {
+    return null;
+  }
+  switch (value.type) {
+    case "session_started":
+      if (
+        !onlyKeys<Extract<WireCodeEvent, { type: "session_started" }>>(value, [
+          "type",
+          "harness_kind",
+          "harness_version",
+          "resume_ref",
+        ]) ||
+        !isMember(value.harness_kind, HARNESS_KINDS) ||
+        !nonEmpty(value.harness_version) ||
+        !optionalString(value.resume_ref)
+      ) {
+        return null;
+      }
+      return {
+        type: "session_started",
+        harness_kind: value.harness_kind,
+        harness_version: value.harness_version,
+        ...(value.resume_ref !== undefined ? { resume_ref: value.resume_ref } : {}),
+      };
+    case "turn_started":
+      if (
+        !onlyKeys<Extract<WireCodeEvent, { type: "turn_started" }>>(value, [
+          "type",
+          "turn_id",
+        ]) ||
+        !nonEmpty(value.turn_id)
+      ) {
+        return null;
+      }
+      return { type: "turn_started", turn_id: value.turn_id };
+    case "assistant_delta":
+    case "assistant_message":
+    case "reasoning_delta":
+    case "user_steered":
+      if (
+        !onlyKeys(value, ["type", "text"]) ||
+        typeof value.text !== "string"
+      ) {
+        return null;
+      }
+      return { type: value.type, text: value.text } as CodeEvent;
+    case "tool_started": {
+      if (
+        !onlyKeys<Extract<WireCodeEvent, { type: "tool_started" }>>(value, [
+          "type",
+          "call_id",
+          "name",
+          "detail",
+        ]) ||
+        !nonEmpty(value.call_id) ||
+        !nonEmpty(value.name)
+      ) {
+        return null;
+      }
+      const detail = parseToolDetail(value.detail);
+      if (!detail) return null;
+      return {
+        type: "tool_started",
+        call_id: value.call_id,
+        name: value.name,
+        detail,
+      };
+    }
+    case "tool_completed":
+      if (
+        !onlyKeys<Extract<WireCodeEvent, { type: "tool_completed" }>>(value, [
+          "type",
+          "call_id",
+          "outcome",
+          "preview",
+        ]) ||
+        !nonEmpty(value.call_id) ||
+        !isMember(value.outcome, TOOL_OUTCOMES) ||
+        typeof value.preview !== "string"
+      ) {
+        return null;
+      }
+      return {
+        type: "tool_completed",
+        call_id: value.call_id,
+        outcome: value.outcome,
+        preview: value.preview,
+      };
+    case "turn_completed": {
+      if (
+        !onlyKeys<Extract<WireCodeEvent, { type: "turn_completed" }>>(value, [
+          "type",
+          "usage",
+          "checkpoint",
+        ])
+      ) {
+        return null;
+      }
+      const usage = parseUsage(value.usage);
+      if (!usage) return null;
+      return {
+        type: "turn_completed",
+        usage,
+        ...(value.checkpoint !== undefined
+          ? {
+              checkpoint: value.checkpoint as Extract<
+                WireCodeEvent,
+                { type: "turn_completed" }
+              >["checkpoint"],
+            }
+          : {}),
+      };
+    }
+    case "turn_failed":
+      if (
+        !onlyKeys<Extract<WireCodeEvent, { type: "turn_failed" }>>(value, [
+          "type",
+          "error",
+        ]) ||
+        !isRecord(value.error) ||
+        typeof value.error.message !== "string"
+      ) {
+        return null;
+      }
+      return { type: "turn_failed", error: { message: value.error.message } };
+    case "turn_interrupted":
+      return { type: "turn_interrupted" };
+    case "harness_notice":
+      if (
+        !onlyKeys<Extract<WireCodeEvent, { type: "harness_notice" }>>(value, [
+          "type",
+          "level",
+          "message",
+        ]) ||
+        !isMember(value.level, NOTICE_LEVELS) ||
+        typeof value.message !== "string"
+      ) {
+        return null;
+      }
+      return {
+        type: "harness_notice",
+        level: value.level,
+        message: value.message,
+      };
+    case "attention_changed": {
+      if (
+        !onlyKeys<Extract<WireCodeEvent, { type: "attention_changed" }>>(value, [
+          "type",
+          "state",
+          "source",
+        ]) ||
+        !isMember(value.source, ATTENTION_SOURCES)
+      ) {
+        return null;
+      }
+      const state = parseAttentionState(value.state);
+      if (!state) return null;
+      return { type: "attention_changed", state, source: value.source };
+    }
+    default:
+      // Unknown kinds stay well-formed so a newer journal does not stall the
+      // cursor. The reducer advances seq and paints nothing.
+      return value as CodeEvent;
+  }
+}
+
+function parseToolDetail(value: unknown): ToolDetail | null {
+  if (!isRecord(value) || typeof value.kind !== "string") return null;
+  switch (value.kind) {
+    case "command":
+      if (
+        !onlyKeys<Extract<WireToolDetail, { kind: "command" }>>(value, [
+          "kind",
+          "cmd",
+          "cwd",
+        ]) ||
+        typeof value.cmd !== "string" ||
+        typeof value.cwd !== "string"
+      ) {
+        return null;
+      }
+      return { kind: "command", cmd: value.cmd, cwd: value.cwd };
+    case "file_edit":
+    case "file_read":
+      if (
+        !onlyKeys(value, ["kind", "path"]) ||
+        typeof value.path !== "string"
+      ) {
+        return null;
+      }
+      return { kind: value.kind, path: value.path } as ToolDetail;
+    case "search":
+      if (
+        !onlyKeys<Extract<WireToolDetail, { kind: "search" }>>(value, [
+          "kind",
+          "query",
+        ]) ||
+        typeof value.query !== "string"
+      ) {
+        return null;
+      }
+      return { kind: "search", query: value.query };
+    case "other":
+      if (
+        !onlyKeys<Extract<WireToolDetail, { kind: "other" }>>(value, [
+          "kind",
+          "summary",
+        ]) ||
+        typeof value.summary !== "string"
+      ) {
+        return null;
+      }
+      return { kind: "other", summary: value.summary };
+    default:
+      return null;
+  }
+}
+
+function parseUsage(value: unknown): CodeUsage | null {
+  if (
+    !isRecord(value) ||
+    !isFiniteNumber(value.input_tokens) ||
+    !isFiniteNumber(value.output_tokens) ||
+    !isFiniteNumber(value.cache_read_input_tokens) ||
+    !isFiniteNumber(value.cache_creation_input_tokens)
+  ) {
+    return null;
+  }
+  return {
+    input_tokens: value.input_tokens,
+    output_tokens: value.output_tokens,
+    cache_read_input_tokens: value.cache_read_input_tokens,
+    cache_creation_input_tokens: value.cache_creation_input_tokens,
+  };
+}
+
+function parseAttention(value: unknown): Attention | null {
+  if (!isRecord(value) || !isMember(value.source, ATTENTION_SOURCES)) {
+    return null;
+  }
+  const state = parseAttentionState(value.state);
+  if (!state) return null;
+  return { state, source: value.source };
+}
+
+function parseAttentionState(value: unknown): AttentionState | null {
+  if (!isRecord(value) || typeof value.type !== "string") return null;
+  switch (value.type) {
+    case "working":
+    case "done_unreviewed":
+      return { type: value.type };
+    case "needs_you":
+      if (
+        typeof value.prompt !== "string" ||
+        !isMember(value.source, ATTENTION_SOURCES)
+      ) {
+        return null;
+      }
+      return { type: "needs_you", prompt: value.prompt, source: value.source };
+    case "stalled":
+      if (!isFiniteNumber(value.idle_secs)) return null;
+      return { type: "stalled", idle_secs: value.idle_secs };
+    case "fenced": {
+      const reason = parseFenceReason(value.reason);
+      if (!reason) return null;
+      return { type: "fenced", reason };
+    }
+    case "manual":
+      if (typeof value.note !== "string") return null;
+      return { type: "manual", note: value.note };
+    default:
+      return null;
+  }
+}
+
+export function parseFenceReason(value: unknown): FenceReason | null {
+  if (!isRecord(value) || typeof value.type !== "string") return null;
+  if (value.type === "orphan_alive") return { type: "orphan_alive" };
+  if (value.type === "probe_ambiguous" && typeof value.detail === "string") {
+    return { type: "probe_ambiguous", detail: value.detail };
+  }
+  return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function onlyKeys<Wire>(
+  value: Record<string, unknown>,
+  allowed: readonly (keyof Wire & string)[],
+): boolean {
+  const set = new Set<string>(allowed);
+  return Object.keys(value).every((key) => set.has(key));
+}
+
+function nonEmpty(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function optionalString(value: unknown): value is string | undefined {
+  return value === undefined || typeof value === "string";
+}
+
+function isMember<T extends string>(
+  value: unknown,
+  allowed: ReadonlySet<T>,
+): value is T {
+  return typeof value === "string" && allowed.has(value as T);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -314,6 +314,18 @@ export function parseCodeTurn(value: unknown): CodeTurnSnapshot | null {
   };
 }
 
+/** `GET /code/sessions/{id}/turns` — oldest first. */
+export function parseCodeTurnList(value: unknown): CodeTurnSnapshot[] | null {
+  if (!Array.isArray(value)) return null;
+  const turns: CodeTurnSnapshot[] = [];
+  for (const item of value) {
+    const parsed = parseCodeTurn(item);
+    if (!parsed) return null;
+    turns.push(parsed);
+  }
+  return turns;
+}
+
 export function parseHarnessDoctorReport(
   value: unknown,
 ): HarnessDoctorReport | null {

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -255,6 +255,27 @@ export function parseCodeSession(value: unknown): CodeSessionSnapshot | null {
   };
 }
 
+/** `GET /code/workspaces/{id}/sessions` — newest first. */
+export function parseCodeSessionList(
+  value: unknown,
+): CodeSessionSnapshot[] | null {
+  if (!Array.isArray(value)) return null;
+  const sessions: CodeSessionSnapshot[] = [];
+  for (const item of value) {
+    const parsed = parseCodeSession(item);
+    if (!parsed) return null;
+    sessions.push(parsed);
+  }
+  return sessions;
+}
+
+/** The one session a workspace page should attach, if any. */
+export function liveCodeSession(
+  sessions: readonly CodeSessionSnapshot[],
+): CodeSessionSnapshot | null {
+  return sessions.find((session) => session.lifecycle !== "ended") ?? null;
+}
+
 export function parseCodeTurn(value: unknown): CodeTurnSnapshot | null {
   if (
     !isRecord(value) ||

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -285,6 +285,7 @@ export function parseCodeTurn(value: unknown): CodeTurnSnapshot | null {
       "ordinal",
       "status",
       "user_input",
+      "usage",
       "checkpoint_ref",
       "started_at",
       "ended_at",
@@ -300,6 +301,9 @@ export function parseCodeTurn(value: unknown): CodeTurnSnapshot | null {
   ) {
     return null;
   }
+  const usage =
+    value.usage === undefined ? undefined : parseUsage(value.usage);
+  if (value.usage !== undefined && !usage) return null;
   return {
     id: value.id,
     session_id: value.session_id,
@@ -307,6 +311,7 @@ export function parseCodeTurn(value: unknown): CodeTurnSnapshot | null {
     status: value.status,
     user_input: value.user_input,
     started_at: value.started_at,
+    ...(usage ? { usage } : {}),
     ...(value.checkpoint_ref !== undefined
       ? { checkpoint_ref: value.checkpoint_ref }
       : {}),

--- a/crates/tidebreak-desktop/ui/src/router.tsx
+++ b/crates/tidebreak-desktop/ui/src/router.tsx
@@ -21,6 +21,9 @@ import { RouteFrame } from "./RouteFrame";
 import { SettingsRoute } from "./SettingsRoute";
 import { defaultSettingsPathFor, SETTINGS_SECTIONS } from "./settings/sections";
 import { AppSidebar } from "./sidebar/AppSidebar";
+import { CodeHome } from "./code/CodeHome";
+import { CodeRepoPage } from "./code/CodeRepoPage";
+import { CodeWorkspacePage } from "./code/CodeWorkspacePage";
 
 const rootRoute = createRootRoute({ component: AppShell });
 
@@ -199,6 +202,34 @@ function ProjectRouteComponent() {
   );
 }
 
+const codeRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/code",
+  component: CodeHome,
+});
+
+const codeRepoRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/code/r/$repoId",
+  component: CodeRepoRouteComponent,
+});
+
+function CodeRepoRouteComponent() {
+  const { repoId } = codeRepoRoute.useParams();
+  return <CodeRepoPage key={repoId} repoId={repoId} />;
+}
+
+const codeWorkspaceRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/code/w/$workspaceId",
+  component: CodeWorkspaceRouteComponent,
+});
+
+function CodeWorkspaceRouteComponent() {
+  const { workspaceId } = codeWorkspaceRoute.useParams();
+  return <CodeWorkspacePage key={workspaceId} workspaceId={workspaceId} />;
+}
+
 export const settingsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/settings",
@@ -277,6 +308,9 @@ export const routeTree = rootRoute.addChildren([
   chatRoute,
   projectRoute,
   projectChatRoute,
+  codeRoute,
+  codeRepoRoute,
+  codeWorkspaceRoute,
   settingsRoute.addChildren([
     settingsIndexRoute,
     settingsMcpRedirectRoute,

--- a/crates/tidebreak-desktop/ui/src/settings/CodingHarnessesPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/CodingHarnessesPanel.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from "react";
+
+import type { ApiClient } from "../api/client";
+import type { HarnessDoctorReport } from "../api/types";
+import { DoctorList } from "@/code/DoctorList";
+import { SettingsError, SettingsPanel } from "./primitives";
+
+/**
+ * Settings: the coding-harness doctor.
+ *
+ * Found, path, version, tier, capabilities, auth, remediation, and
+ * unrecognized-event counts live here so a reader can repair an engine
+ * without opening a workspace.
+ */
+
+export function CodingHarnessesPanel({ client }: { client: ApiClient }) {
+  const [report, setReport] = useState<HarnessDoctorReport | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  async function load(refresh: boolean) {
+    if (refresh) setRefreshing(true);
+    else setLoading(true);
+    setError(null);
+    try {
+      const next = refresh
+        ? await client.refreshHarnessDoctor()
+        : await client.getHarnessDoctor();
+      setReport(next);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }
+
+  useEffect(() => {
+    void load(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [client]);
+
+  return (
+    <SettingsPanel
+      title="Coding harnesses"
+      description="Engines installed on this machine, their versions, and what they can do."
+      busy={loading || refreshing}
+    >
+      {error && <SettingsError>{error}</SettingsError>}
+      {report && (
+        <DoctorList
+          report={report}
+          onRefresh={() => void load(true)}
+          refreshing={refreshing}
+        />
+      )}
+    </SettingsPanel>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/settings/sections.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/sections.tsx
@@ -12,6 +12,7 @@ import {
   ShieldCheck,
   SquareTerminal,
   Mic,
+  Terminal,
   Waypoints,
 } from "lucide-react";
 
@@ -31,6 +32,7 @@ import { ProvidersPanel } from "./ProvidersPanel";
 import { UpdatesPanel } from "./UpdatesPanel";
 import { WebSearchPanel } from "./WebSearchPanel";
 import { VoiceTranscriptionPanel } from "./VoiceTranscriptionPanel";
+import { CodingHarnessesPanel } from "./CodingHarnessesPanel";
 
 /**
  * Each section reads what it needs from the shell context rather than being
@@ -177,6 +179,11 @@ function UpdatesSection() {
   );
 }
 
+function CodingHarnessesSection() {
+  const { client } = useApp();
+  return <CodingHarnessesPanel client={client} />;
+}
+
 export type SettingsSectionDef = {
   /** The path segment under `/settings`, and its address. */
   path: string;
@@ -233,6 +240,12 @@ export const SETTINGS_SECTIONS: SettingsSectionDef[] = [
     label: "Code execution",
     icon: SquareTerminal,
     Component: CodeExecutionSection,
+  },
+  {
+    path: "coding-harnesses",
+    label: "Coding harnesses",
+    icon: Terminal,
+    Component: CodingHarnessesSection,
   },
   {
     path: "connected-apps",

--- a/crates/tidebreak-desktop/ui/src/sidebar/AppSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/AppSidebar.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from "react";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
-import { LayoutGrid, Puzzle, SquarePen } from "lucide-react";
+import { FolderGit2, LayoutGrid, Puzzle, SquarePen } from "lucide-react";
 
 import type { Chat } from "@/api";
 import { useApp } from "@/AppContext";
@@ -63,6 +63,12 @@ export function AppSidebar({ chat }: { chat?: Chat }) {
           icon={<Puzzle />}
           active={pathname === "/plugins" || pathname.startsWith("/plugins/")}
           onClick={() => void navigate({ to: "/plugins" })}
+        />
+        <RouteButton
+          label="Code"
+          icon={<FolderGit2 />}
+          active={pathname === "/code" || pathname.startsWith("/code/")}
+          onClick={() => void navigate({ to: "/code" })}
         />
       </div>
 

--- a/crates/tidebreak-desktop/ui/src/test/router.tsx
+++ b/crates/tidebreak-desktop/ui/src/test/router.tsx
@@ -60,12 +60,30 @@ export async function renderWithRouter(
     path: "voice-transcription",
     component: () => <>{ui}</>,
   });
+  const codeRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/code",
+    component: () => <>{ui}</>,
+  });
+  const codeRepoRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/code/r/$repoId",
+    component: () => <>{ui}</>,
+  });
+  const codeWorkspaceRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/code/w/$workspaceId",
+    component: () => <>{ui}</>,
+  });
 
   const router = createRouter({
     routeTree: rootRoute.addChildren([
       homeRoute,
       chatRoute,
       appDetailRoute,
+      codeRoute,
+      codeRepoRoute,
+      codeWorkspaceRoute,
       settingsRoute.addChildren([webSearchSettingsRoute, voiceSettingsRoute]),
     ]),
     history: createMemoryHistory({ initialEntries: [initialUrl] }),


### PR DESCRIPTION
## What landed

Walking skeleton of the code-mode desktop surface, stacked on the server routes from #2124.

- Routes `/code`, `/code/r/$repoId`, `/code/w/$workspaceId` on the existing hash router, with a `CodeSidebar` built from the shared rail primitives (repos, recent workspaces, new-workspace, Chat/Code switch). Chat stores stay off this path.
- `ApiClient` methods for repos, harness doctor/refresh, workspaces, session create, turns, interrupt, and reap. Runtime validators in `ui/src/code/parsers.ts` for every wire type this surface consumes.
- `CodeSessionReducer` + per-session store factory + ref-counted `CodeSessionRegistry`. Unmounting the last view closes the socket; two views of one session share one store. The controller reuses chat's backoff/dedupe discipline against `WS /code/sessions/{id}/events?after=`.
- Workspace header (repo, branch, copyable/reveal worktree path, harness + version, lifecycle badge), transcript (`MessageMarkdown`, `ToolCardShell` + Command/FileRead/FileEdit/Search/Other, visible `HarnessNotice`, turn boundaries with duration/usage), Plan-only composer with Ask/Auto disabled and the server's "not yet available" reason, new-workspace dialog, fenced-state card with Reap, archive with force-confirm when the server reports uncommitted work.
- Settings section **Coding harnesses**: doctor (found/path/version/tier/caps/auth/remediation/unrecognized-event counts) and refresh.

## Spec and stack

- Spec #2122
- Foundation #2123
- Server #2124

## Out of scope

Approvals UI, diffs/files panels, PR flow, terminals, `/code/updates` digest store, attention badges, OS notifications, virtualization. No new npm dependencies.

## Verification

`pnpm test` (1009) and `pnpm build` green from `crates/tidebreak-desktop/ui/`. Reducer, registry, CodeSidebar (ADR 0030: renders without chat stores), transcript, and composer disabled-modes tests added.

## Could not verify

No live harness in this environment. I did not drive the running desktop app against Claude Code (or any other engine): doctor empty-state vs ready-state, worktree reveal, archive force-confirm, fence/reap, and a real turn stream still need a human with an installed, signed-in harness.

The server has no list-sessions-for-workspace route yet, so a session created in this client is remembered locally after create. Reopening a workspace from another profile still needs an explicit Start session (or a later GET).