### PR TITLE
refactor(core): stop minting ids from Default

### DIFF
--- a/crates/tidebreak-core/src/id.rs
+++ b/crates/tidebreak-core/src/id.rs
@@ -4,6 +4,11 @@
 //! say, passing a [`TurnId`] where a [`ChatId`] is expected. All ids
 //! serialize transparently (as the bare UUID string), so on the wire and in the
 //! `Store` they are indistinguishable from a plain UUID.
+//!
+//! Identity is minted only by [`id_type`]'s `new`, a typed `derive` /
+//! `from_uuid`, or an explicit `From<Uuid>`. There is no `Default`: a
+//! `..Default::default()` on a struct that happens to contain an id would
+//! otherwise invent a durable identity as a side effect.
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -29,12 +34,6 @@ macro_rules! id_type {
             #[must_use]
             pub fn as_uuid(&self) -> &Uuid {
                 &self.0
-            }
-        }
-
-        impl Default for $name {
-            fn default() -> Self {
-                Self::new()
             }
         }
 
@@ -292,12 +291,6 @@ impl RootAttachmentChangeId {
     #[must_use]
     pub const fn as_uuid(&self) -> &Uuid {
         &self.0
-    }
-}
-
-impl Default for RootAttachmentChangeId {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/crates/tidebreak-core/src/id.rs
+++ b/crates/tidebreak-core/src/id.rs
@@ -25,7 +25,11 @@ macro_rules! id_type {
 
         impl $name {
             /// Generate a fresh, random identifier.
+            ///
+            /// Not `Default`: a `..Default::default()` on a struct that
+            /// happens to contain an id would invent a durable identity.
             #[must_use]
+            #[allow(clippy::new_without_default)]
             pub fn new() -> Self {
                 Self(Uuid::new_v4())
             }
@@ -273,7 +277,10 @@ pub struct RootAttachmentChangeId(Uuid);
 
 impl RootAttachmentChangeId {
     /// Generate a fresh change identity.
+    ///
+    /// Not `Default`: see [`id_type`].
     #[must_use]
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self(Uuid::new_v4())
     }


### PR DESCRIPTION
## Summary

`id_type!` implemented `Default` as `Uuid::new_v4()`. A `..Default::default()` on any struct that happened to contain an id would invent a durable identity as a side effect. `RootAttachmentChangeId` already rejected nil on construct and deserialize, then offered the same `Default` hole.

Identity is now only minted by `new()`, a typed `derive` / `from_uuid`, or `From<Uuid>`.

## Test

- No callers of `ChatId::default()` (etc.) existed.
- `cargo test -p tidebreak-core --locked --lib id::tests`
- `cargo check --workspace --locked --all-targets`