### PR TITLE
refactor(core): make shared Store surfaces required

### DIFF
--- a/crates/tidebreak-core/src/storage/store.rs
+++ b/crates/tidebreak-core/src/storage/store.rs
@@ -73,12 +73,6 @@ fn agent_run_storage_unavailable<T>() -> Result<T> {
     ))
 }
 
-fn root_attachment_storage_unavailable<T>() -> Result<T> {
-    Err(AgentError::Store(
-        "durable root attachment storage is not implemented by this Store".into(),
-    ))
-}
-
 fn operation_log_storage_unavailable<T>() -> Result<T> {
     Err(AgentError::Store(
         "durable operation-log storage is not implemented by this Store".into(),
@@ -95,6 +89,11 @@ fn image_publication_storage_unavailable<T>() -> Result<T> {
 ///
 /// Implementations must be safe to share across threads (`Send + Sync`) and are
 /// held behind `Arc<dyn Store>`, so this trait stays object-safe.
+///
+/// A method whose only default would be `Err("… not implemented")` is
+/// required. New persistence surface lands required, or it does not land.
+/// Real defaults (owner-scoped delegates, compatibility projections) stay.
+/// See decision 0037.
 #[async_trait]
 pub trait Store: Send + Sync {
     /// Persist a new project.
@@ -144,19 +143,13 @@ pub trait Store: Send + Sync {
     /// At most one of `chat_id` and `project_id` may be present, and it must
     /// identify an existing owner. A live document's ownership is immutable:
     /// callers must delete it before recreating the same id in another corpus.
-    async fn create_document(&self, _document: &DocumentRecord) -> Result<()> {
-        document_storage_unavailable()
-    }
+    async fn create_document(&self, document: &DocumentRecord) -> Result<()>;
 
     /// Fetch an authoritative document by id, or `None` if it does not exist.
-    async fn get_document(&self, _id: DocumentId) -> Result<Option<DocumentRecord>> {
-        document_storage_unavailable()
-    }
+    async fn get_document(&self, id: DocumentId) -> Result<Option<DocumentRecord>>;
 
     /// List documents in `scope`, most-recently-created first.
-    async fn list_documents(&self, _scope: DocumentScope) -> Result<Vec<DocumentRecord>> {
-        document_storage_unavailable()
-    }
+    async fn list_documents(&self, scope: DocumentScope) -> Result<Vec<DocumentRecord>>;
 
     /// List document metadata in deterministic newest-first order.
     ///
@@ -165,12 +158,10 @@ pub trait Store: Send + Sync {
     /// order. Implementations must not load canonical text.
     async fn list_document_summaries(
         &self,
-        _scope: DocumentScope,
-        _after: Option<DocumentListCursor>,
-        _limit: u64,
-    ) -> Result<Vec<DocumentSummaryRecord>> {
-        document_storage_unavailable()
-    }
+        scope: DocumentScope,
+        after: Option<DocumentListCursor>,
+        limit: u64,
+    ) -> Result<Vec<DocumentSummaryRecord>>;
 
     /// List document ids in `scope` without requiring canonical content.
     ///
@@ -305,26 +296,20 @@ pub trait Store: Send + Sync {
     }
 
     /// Hard-delete source content.
-    async fn delete_document(&self, _id: DocumentId) -> Result<()> {
-        document_storage_unavailable()
-    }
+    async fn delete_document(&self, id: DocumentId) -> Result<()>;
 
     /// Create or replace authoritative document content.
     ///
     /// Replacements preserve `created_at` and use last-write-wins semantics.
     /// `project_id`, when present, must identify an existing project. A live
     /// document cannot move between corpora.
-    async fn upsert_document(&self, _document: &DocumentUpsert) -> Result<DocumentRecord> {
-        document_storage_unavailable()
-    }
+    async fn upsert_document(&self, document: &DocumentUpsert) -> Result<DocumentRecord>;
 
     /// Atomically accept an already-published source blob and decoded text.
     async fn accept_document_source(
         &self,
-        _document: &DocumentSourceUpsert,
-    ) -> Result<DocumentRecord> {
-        document_storage_unavailable()
-    }
+        document: &DocumentSourceUpsert,
+    ) -> Result<DocumentRecord>;
 
     /// Persist a new chat.
     ///
@@ -1081,10 +1066,8 @@ pub trait Store: Send + Sync {
     /// control; it is not renderer-selected authorization.
     async fn begin_root_attachment_change(
         &self,
-        _request: &BeginRootAttachmentChange,
-    ) -> Result<BeginRootAttachmentChangeOutcome> {
-        root_attachment_storage_unavailable()
-    }
+        request: &BeginRootAttachmentChange,
+    ) -> Result<BeginRootAttachmentChangeOutcome>;
 
     /// Atomically finish one exact change under its stable executor.
     ///
@@ -1096,21 +1079,17 @@ pub trait Store: Send + Sync {
     /// operation; arbitrary transport failures are not durable broker failures.
     async fn finish_root_attachment_change(
         &self,
-        _id: RootAttachmentChangeId,
-        _executor_id: uuid::Uuid,
-        _terminal: &RootAttachmentChangeTerminal,
-        _finished_at: chrono::DateTime<chrono::Utc>,
-    ) -> Result<FinishRootAttachmentChangeOutcome> {
-        root_attachment_storage_unavailable()
-    }
+        id: RootAttachmentChangeId,
+        executor_id: uuid::Uuid,
+        terminal: &RootAttachmentChangeTerminal,
+        finished_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<FinishRootAttachmentChangeOutcome>;
 
     /// Fetch one attachment change by exact idempotency identity.
     async fn get_root_attachment_change(
         &self,
-        _id: RootAttachmentChangeId,
-    ) -> Result<Option<RootAttachmentChange>> {
-        root_attachment_storage_unavailable()
-    }
+        id: RootAttachmentChangeId,
+    ) -> Result<Option<RootAttachmentChange>>;
 
     /// List up to `limit` awaiting changes owned by one stable native executor.
     ///
@@ -1118,11 +1097,9 @@ pub trait Store: Send + Sync {
     /// are returned in deterministic oldest-first order.
     async fn list_pending_root_attachment_changes(
         &self,
-        _executor_id: uuid::Uuid,
-        _limit: u64,
-    ) -> Result<Vec<RootAttachmentChange>> {
-        root_attachment_storage_unavailable()
-    }
+        executor_id: uuid::Uuid,
+        limit: u64,
+    ) -> Result<Vec<RootAttachmentChange>>;
 
     /// Atomically accept one foreground coordinator or sandboxed child run.
     ///

--- a/crates/tidebreak-server/src/sandbox_container_run/tests.rs
+++ b/crates/tidebreak-server/src/sandbox_container_run/tests.rs
@@ -341,6 +341,89 @@ impl Store for TerminalFaultStore {
         self.inner.list_projects().await
     }
 
+    async fn create_document(&self, document: &tidebreak_core::DocumentRecord) -> Result<()> {
+        self.inner.create_document(document).await
+    }
+
+    async fn get_document(
+        &self,
+        id: tidebreak_core::DocumentId,
+    ) -> Result<Option<tidebreak_core::DocumentRecord>> {
+        self.inner.get_document(id).await
+    }
+
+    async fn list_documents(
+        &self,
+        scope: tidebreak_core::DocumentScope,
+    ) -> Result<Vec<tidebreak_core::DocumentRecord>> {
+        self.inner.list_documents(scope).await
+    }
+
+    async fn list_document_summaries(
+        &self,
+        scope: tidebreak_core::DocumentScope,
+        after: Option<tidebreak_core::DocumentListCursor>,
+        limit: u64,
+    ) -> Result<Vec<tidebreak_core::DocumentSummaryRecord>> {
+        self.inner
+            .list_document_summaries(scope, after, limit)
+            .await
+    }
+
+    async fn delete_document(&self, id: tidebreak_core::DocumentId) -> Result<()> {
+        self.inner.delete_document(id).await
+    }
+
+    async fn upsert_document(
+        &self,
+        document: &tidebreak_core::DocumentUpsert,
+    ) -> Result<tidebreak_core::DocumentRecord> {
+        self.inner.upsert_document(document).await
+    }
+
+    async fn accept_document_source(
+        &self,
+        document: &tidebreak_core::DocumentSourceUpsert,
+    ) -> Result<tidebreak_core::DocumentRecord> {
+        self.inner.accept_document_source(document).await
+    }
+
+    async fn begin_root_attachment_change(
+        &self,
+        request: &tidebreak_core::BeginRootAttachmentChange,
+    ) -> Result<tidebreak_core::BeginRootAttachmentChangeOutcome> {
+        self.inner.begin_root_attachment_change(request).await
+    }
+
+    async fn finish_root_attachment_change(
+        &self,
+        id: tidebreak_core::RootAttachmentChangeId,
+        executor_id: Uuid,
+        terminal: &tidebreak_core::RootAttachmentChangeTerminal,
+        finished_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<tidebreak_core::FinishRootAttachmentChangeOutcome> {
+        self.inner
+            .finish_root_attachment_change(id, executor_id, terminal, finished_at)
+            .await
+    }
+
+    async fn get_root_attachment_change(
+        &self,
+        id: tidebreak_core::RootAttachmentChangeId,
+    ) -> Result<Option<tidebreak_core::RootAttachmentChange>> {
+        self.inner.get_root_attachment_change(id).await
+    }
+
+    async fn list_pending_root_attachment_changes(
+        &self,
+        executor_id: Uuid,
+        limit: u64,
+    ) -> Result<Vec<tidebreak_core::RootAttachmentChange>> {
+        self.inner
+            .list_pending_root_attachment_changes(executor_id, limit)
+            .await
+    }
+
     async fn create_chat(&self, chat: &Chat) -> Result<()> {
         self.inner.create_chat(chat).await
     }

--- a/crates/tidebreak-server/src/tests.rs
+++ b/crates/tidebreak-server/src/tests.rs
@@ -929,6 +929,38 @@ impl Store for PauseTerminalStore {
     ) -> Result<tidebreak_core::DocumentRecord> {
         self.inner.accept_document_source(source).await
     }
+    async fn begin_root_attachment_change(
+        &self,
+        request: &BeginRootAttachmentChange,
+    ) -> Result<tidebreak_core::BeginRootAttachmentChangeOutcome> {
+        self.inner.begin_root_attachment_change(request).await
+    }
+    async fn finish_root_attachment_change(
+        &self,
+        id: RootAttachmentChangeId,
+        executor_id: uuid::Uuid,
+        terminal: &tidebreak_core::RootAttachmentChangeTerminal,
+        finished_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<tidebreak_core::FinishRootAttachmentChangeOutcome> {
+        self.inner
+            .finish_root_attachment_change(id, executor_id, terminal, finished_at)
+            .await
+    }
+    async fn get_root_attachment_change(
+        &self,
+        id: RootAttachmentChangeId,
+    ) -> Result<Option<tidebreak_core::RootAttachmentChange>> {
+        self.inner.get_root_attachment_change(id).await
+    }
+    async fn list_pending_root_attachment_changes(
+        &self,
+        executor_id: uuid::Uuid,
+        limit: u64,
+    ) -> Result<Vec<tidebreak_core::RootAttachmentChange>> {
+        self.inner
+            .list_pending_root_attachment_changes(executor_id, limit)
+            .await
+    }
     async fn create_chat(&self, chat: &Chat) -> Result<()> {
         self.inner.create_chat(chat).await
     }

--- a/docs/decisions/0037-store-required-surface.md
+++ b/docs/decisions/0037-store-required-surface.md
@@ -1,0 +1,90 @@
+# 37. Store methods that both real impls provide are required
+
+- Status: Proposed
+- Date: 2026-08-15
+- Owners: persistence
+- Related: [`crates/tidebreak-core/src/storage/store.rs`](../../crates/tidebreak-core/src/storage/store.rs)
+
+## Context
+
+`Store` is one object-safe trait behind `Arc<dyn Store>`. It has grown to
+hundreds of methods. Most of those have a default body that returns
+`Err("… is not implemented by this Store")`. `DbStore` implements nearly
+every method. `MemStore` and the server test wrappers implement a small
+subset and inherit the rest as that error.
+
+The defaults were convenient: a 40-method test fake still type-checks as
+`dyn Store`. They are also how the kitchen sink grew. Every new surface
+could land as an optional method. `MemStore` and the wrappers silently
+missed it. Production was the only honest impl. A second real store
+would drown.
+
+Nothing on the trait is unused. Every error-default method is overridden
+by `DbStore`. Deleting methods is not available. The remaining choice is
+how the trait is allowed to grow.
+
+Eleven methods already have a real body on both `DbStore` and `MemStore`:
+the document catalog and the root-attachment change surface. Their
+error defaults are dead code that pretends those surfaces are optional.
+
+## Decision
+
+A `Store` method whose default is only `Err("… not implemented")` becomes
+required the moment two impls in this repository provide a real body.
+The eleven document and root-attachment methods become required now.
+
+New persistence surface still lands on this trait (object safety is not
+being reopened). It lands as a required method, or it does not land. An
+error-default is not a third option. `MemStore` and the test wrappers
+must grow with the surface they actually exercise, or they keep the
+error only by writing it in their own impl.
+
+Real defaults stay: owner-scoped delegates, compatibility projections
+(`list_document_ids` mapping `list_documents`), and the
+`*_and_append_event` unwraps. Those are behavior, not a missing impl.
+
+Capability traits (`TurnStore`, `DocumentStore`, …) composed behind the
+same `Arc<dyn Store>` are not chosen. They would split the kitchen sink,
+and they would also split every atomic operation that today touches two
+of those surfaces in one transaction. Revisit that if a second
+production impl appears.
+
+## Alternatives Considered
+
+- **Do nothing.** The next six months of features keep adding optional
+  methods. `MemStore` stays a 40-method object-safety proof that lies
+  about every newer surface. Rejected because that is how the trait
+  got to 260 methods.
+- **Make every error-default required in this change.** That is ~186
+  stubs on `MemStore` and a forwarder on every test wrapper for methods
+  those tests never call. The compile break is real; the coverage is
+  not. Rejected as a rewrite, not a growth rule.
+- **Split `Store` into capability traits now.** Object-safe composition
+  plus cross-surface transactions is a new boundary two subsystems
+  would both be held to. No second production impl exists to force it.
+- **Delete unused methods.** There are none. Every error-default is
+  implemented by `DbStore`.
+
+## Consequences
+
+- Adding a persistence method is now a compile break on every `impl
+  Store`. That is the point: the missing impl is visible in the same
+  change as the method.
+- Test wrappers that wrap `inner: Arc<dyn Store>` and do not forward
+  must grow a forward (or a stub) when a newly-required method is
+  something their tests actually invoke. Methods they never call can
+  stay as an explicit `Err` in the wrapper.
+- `MemStore` remains a partial store. It is no longer allowed to hide
+  that behind a trait default for surfaces it already implements.
+
+Revisit if a second production `Store` appears, or if a new surface
+cannot be expressed without an atomic write that the single trait
+cannot name.
+
+## Validation
+
+- `MemStore`, `DbStore`, `PauseTerminalStore`, and `TerminalFaultStore`
+  compile with the eleven methods required.
+- A new `impl Store` that omits `create_document` fails to compile.
+- Owner-scoped delegates and other real defaults still compile without
+  overrides on `MemStore`.


### PR DESCRIPTION
## Summary

Nothing on `Store` was unused. Every `Err("… not implemented")` default is overridden by `DbStore`. Deleting methods is not available.

The remaining problem is growth: new surface could land optional, and `MemStore` / the test wrappers silently missed it.

Decision 0037: a method whose only default would be that error becomes required the moment two impls in this repo provide a real body. Capability traits are not chosen — no second production impl exists, and they would split atomic writes that touch two surfaces.

This change makes the eleven document and root-attachment methods required. Those already have real bodies on both `DbStore` and `MemStore`. The error defaults were dead. Test wrappers that wrap `inner` now forward them.

Making the other ~186 error-defaults required would be ~186 stubs on `MemStore` for methods those tests never call. That is a rewrite, not this PR.

## Test

- `cargo check -p tidebreak-core -p tidebreak-server --locked --all-targets`