### PR TITLE
refactor(core): type the two AgentError payload branches

### DIFF
--- a/crates/tidebreak-core/src/error.rs
+++ b/crates/tidebreak-core/src/error.rs
@@ -70,6 +70,17 @@ pub enum AgentError {
     #[error("provider credential missing: {0}")]
     MissingCredential(String),
 
+    /// No usable connector session — never signed in, revoked, or refresh
+    /// reuse. Callers surface a reconnect affordance rather than a fault.
+    #[error("sign-in required: {0}")]
+    SignInRequired(String),
+
+    /// The authorization server refused the requested OAuth target. An
+    /// attested mint remints under a fresh context id; any other failure
+    /// is terminal.
+    #[error("attestation context rejected: {0}")]
+    InvalidTarget(String),
+
     /// A persistence failure from the `Store` / `BlobStore`.
     #[error("store error: {0}")]
     Store(String),
@@ -166,6 +177,8 @@ impl AgentError {
         match self {
             Self::Config(_) => "config",
             Self::MissingCredential(_) => "missing_credential",
+            Self::SignInRequired(_) => "authentication",
+            Self::InvalidTarget(_) => "invalid_target",
             Self::Store(_) => "store",
             Self::ProjectNotFound(_) => "not_found",
             Self::OutputFilenameTaken { .. } | Self::OutputRevisionConflict { .. } => "conflict",
@@ -306,6 +319,20 @@ mod tests {
         let info: AgentErrorInfo = (&AgentError::msg("boom")).into();
         let json = serde_json::to_string(&info).unwrap();
         assert_eq!(serde_json::from_str::<AgentErrorInfo>(&json).unwrap(), info);
+    }
+
+    #[test]
+    fn sign_in_required_shares_the_authentication_kind() {
+        let error = AgentError::SignInRequired("no session".into());
+        assert_eq!(error.kind(), "authentication");
+        assert_eq!(error.to_string(), "sign-in required: no session");
+    }
+
+    #[test]
+    fn invalid_target_is_its_own_kind() {
+        let error = AgentError::InvalidTarget("the requested target is unavailable".into());
+        assert_eq!(error.kind(), "invalid_target");
+        assert_ne!(error.kind(), "config");
     }
 
     #[test]

--- a/crates/tidebreak-server/src/connectors/chatgpt.rs
+++ b/crates/tidebreak-server/src/connectors/chatgpt.rs
@@ -52,16 +52,14 @@ const DEFAULT_TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
 const DEFAULT_REVOKE_URL: &str = "https://auth.openai.com/oauth/revoke";
 const SCOPE: &str = "openid profile email offline_access";
 const EXPIRY_LEEWAY_SECONDS: u64 = 60;
-const SIGN_IN_REQUIRED_PREFIX: &str = "chatgpt sign-in required";
-
 /// True when an operation failed because there is no usable ChatGPT session.
 #[must_use]
 pub fn is_chatgpt_sign_in_required(error: &AgentError) -> bool {
-    matches!(error, AgentError::Authentication(message) if message.starts_with(SIGN_IN_REQUIRED_PREFIX))
+    matches!(error, AgentError::SignInRequired(_))
 }
 
 fn sign_in_required(detail: &str) -> AgentError {
-    AgentError::Authentication(format!("{SIGN_IN_REQUIRED_PREFIX}: {detail}"))
+    AgentError::SignInRequired(detail.to_string())
 }
 
 fn chatgpt_error(context: &str, detail: impl std::fmt::Display) -> AgentError {

--- a/crates/tidebreak-server/src/connectors/gateway.rs
+++ b/crates/tidebreak-server/src/connectors/gateway.rs
@@ -35,18 +35,17 @@ const SCOPE: &str = "openid profile offline_access models:read inference:invoke"
 pub const SECRET_KEY: &str = "gateway.credentials_v1";
 /// Refresh an access token this close to expiry instead of using it.
 const EXPIRY_LEEWAY_SECONDS: u64 = 60;
-const SIGN_IN_REQUIRED_PREFIX: &str = "gateway sign-in required";
 
 /// True when an operation failed because there is no usable gateway session —
 /// never signed in, session revoked, or refresh-token reuse detected. Callers
 /// should surface a reconnect affordance instead of treating this as a fault.
 #[must_use]
 pub fn is_sign_in_required(error: &AgentError) -> bool {
-    matches!(error, AgentError::Authentication(_))
+    matches!(error, AgentError::SignInRequired(_))
 }
 
 fn sign_in_required(detail: &str) -> AgentError {
-    AgentError::Authentication(format!("{SIGN_IN_REQUIRED_PREFIX}: {detail}"))
+    AgentError::SignInRequired(detail.to_string())
 }
 
 fn gateway_error(context: &str, detail: impl std::fmt::Display) -> AgentError {
@@ -969,10 +968,7 @@ impl GatewayAuth {
                 let detail = error
                     .and_then(|error| error.error_description)
                     .unwrap_or_else(|| "the requested target is unavailable".to_string());
-                return Err(gateway_error(
-                    "token request",
-                    format!("invalid_target: {detail}"),
-                ));
+                return Err(AgentError::InvalidTarget(detail));
             }
             let detail = error
                 .and_then(|error| error.error_description.or(Some(error.error)))
@@ -1134,7 +1130,7 @@ struct AttestedTokens {
 /// requested target — for an attested mint, a context id pinned to a
 /// superseded session. Reminting under a fresh id recovers.
 fn is_attestation_context_rejected(error: &AgentError) -> bool {
-    matches!(error, AgentError::Config(message) if message.contains("invalid_target"))
+    matches!(error, AgentError::InvalidTarget(_))
 }
 
 impl GatewayConnection {
@@ -2119,5 +2115,19 @@ mod tests {
     fn sign_in_required_errors_are_recognizable() {
         assert!(is_sign_in_required(&sign_in_required("test")));
         assert!(!is_sign_in_required(&gateway_error("x", "y")));
+        assert!(!is_sign_in_required(&AgentError::Authentication(
+            "provider key rejected".into()
+        )));
+    }
+
+    #[test]
+    fn attestation_rejection_is_the_typed_variant_not_a_config_substring() {
+        assert!(is_attestation_context_rejected(&AgentError::InvalidTarget(
+            "the requested target is unavailable".into()
+        )));
+        assert!(!is_attestation_context_rejected(&gateway_error(
+            "token request",
+            "invalid_target: should not remint from a Config string"
+        )));
     }
 }

--- a/crates/tidebreak-server/src/mcp_config/tests.rs
+++ b/crates/tidebreak-server/src/mcp_config/tests.rs
@@ -98,8 +98,8 @@ impl SecretProvider for TestSecrets {
 #[async_trait::async_trait]
 impl GatewayEndpoints for NoGateway {
     async fn endpoint(&self, _slug: &str) -> Result<GatewayEndpointAccess> {
-        Err(AgentError::Authentication(
-            "gateway sign-in required: no gateway session is stored".to_string(),
+        Err(AgentError::SignInRequired(
+            "no gateway session is stored".to_string(),
         ))
     }
 }


### PR DESCRIPTION
## Summary

`Store(String)` / `Config(String)` / `Message(String)` are catch-alls. Almost nobody inspects the payload. Two callers did:

- Gateway attestation remint: `Config` + `contains("invalid_target")`. One wording change away from reminting forever or never recovering.
- ChatGPT sign-in: `Authentication` + `starts_with("chatgpt sign-in required")`. Gateway sign-in already used the variant alone.

Those are now `InvalidTarget` and `SignInRequired`.

`SignInRequired` keeps `kind() == "authentication"` so turn-failure classification and the reconnect affordance do not change. `InvalidTarget` is its own kind so an MCP `Config` → 400 mapper cannot swallow a remintable token error if it ever leaks.

No other stringly variants: HTTP 404s already come from typed outcomes, lease loss is already a typed store outcome, and gateway `Message` copy for model-not-granted has no consumer that reads the text.

## Test

- `cargo test -p tidebreak-core --locked --lib error::tests`
- `cargo test -p tidebreak-server --locked --lib connectors::gateway::`
- `cargo test -p tidebreak-server --locked --lib connectors::chatgpt::`
- `cargo test -p tidebreak-server --locked --lib mcp_config`