### PR TITLE
build: pin the Rust toolchain to 1.97.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,8 +36,10 @@ cargo test --workspace
 git config core.hooksPath .githooks
 ```
 
-The Rust toolchain is pinned in [`rust-toolchain.toml`](rust-toolchain.toml);
-`rustup` will pick it up automatically.
+The Rust toolchain is pinned to an exact version in
+[`rust-toolchain.toml`](rust-toolchain.toml); `rustup` will pick it up
+automatically. Bump the pin deliberately — a floating `stable` would let a
+rustup update fail the tree for everyone at once under clippy `-D warnings`.
 
 ### macOS keychain prompts
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.97.1"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

`rust-toolchain.toml` said `channel = "stable"`. CI honors that file and clippy runs `-D warnings`, so a rustup stable bump can fail every PR at once.

Pin to `1.97.1`, the version this workspace already builds with (2026-07-14). Bump it the same way as any other dependency.

## Test

- File-only change. Existing rust/workspace lanes on this PR are the verification.