### PR TITLE
feat(code): per-turn checkpoints with diff and file review

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
@@ -854,6 +854,9 @@ export function ChatRoute({ chatId }: { chatId: string }) {
         );
       case "agent":
         return <BackgroundAgentPanel chatId={chatId} runId={panel.runId} />;
+      case "files":
+      case "diff":
+        return null;
     }
   }
 

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -81,6 +81,8 @@ import {
   type CodeRepoSnapshot,
   type CodeSessionSnapshot,
   type CodeTurnSnapshot,
+  type CodeWorkspaceDiff,
+  type CodeWorkspaceFiles,
   type CodeWorkspaceSnapshot,
   type HarnessDoctorReport,
   type HarnessKind,
@@ -107,6 +109,8 @@ import {
   parseCodeTurn,
   parseCodeTurnList,
   parseCodeWorkspace,
+  parseCodeWorkspaceDiff,
+  parseCodeWorkspaceFiles,
   parseHarnessDoctorReport,
   parseSequencedCodeEvent,
 } from "../code/parsers";
@@ -1818,6 +1822,41 @@ export class ApiClient {
       method: "POST",
       headers: this.headers(),
     });
+  }
+
+  async listCodeWorkspaceFiles(
+    workspaceId: string,
+    turnId?: string,
+  ): Promise<CodeWorkspaceFiles> {
+    const query = turnId ? `?turn=${encodeURIComponent(turnId)}` : "";
+    return requireParsed(
+      parseCodeWorkspaceFiles(
+        await this.json(
+          `/code/workspaces/${encodeURIComponent(workspaceId)}/files${query}`,
+          { headers: this.headers() },
+        ),
+      ),
+      "code workspace files",
+    );
+  }
+
+  async getCodeWorkspaceDiff(
+    workspaceId: string,
+    opts: { turn?: string; file?: string } = {},
+  ): Promise<CodeWorkspaceDiff> {
+    const params = new URLSearchParams();
+    if (opts.turn) params.set("turn", opts.turn);
+    if (opts.file) params.set("file", opts.file);
+    const query = params.size > 0 ? `?${params.toString()}` : "";
+    return requireParsed(
+      parseCodeWorkspaceDiff(
+        await this.json(
+          `/code/workspaces/${encodeURIComponent(workspaceId)}/diff${query}`,
+          { headers: this.headers() },
+        ),
+      ),
+      "code workspace diff",
+    );
   }
 
   async reapCodeSession(sessionId: string): Promise<CodeSessionSnapshot> {

--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -114,7 +114,12 @@ import {
   type CodeTurnSnapshot as WireCodeTurnSnapshot,
   type CodeTurnStatus as WireCodeTurnStatus,
   type CodeUsage as WireCodeUsage,
+  type CodeWorkspaceDiff as WireCodeWorkspaceDiff,
+  type CodeWorkspaceFiles as WireCodeWorkspaceFiles,
+  type CodeFileChange as WireCodeFileChange,
   type CodeWorkspaceSnapshot as WireCodeWorkspaceSnapshot,
+  type Diffstat as WireDiffstat,
+  type FileChangeKind as WireFileChangeKind,
   type CodeWorkspaceStatus as WireCodeWorkspaceStatus,
   type FenceReason as WireFenceReason,
   type HarnessCaps as WireHarnessCaps,
@@ -984,6 +989,11 @@ export type CodeTurnSnapshot = WireCodeTurnSnapshot;
 export type CodeTurnId = WireCodeTurnId;
 export type CodeTurnStatus = WireCodeTurnStatus;
 export type CodeUsage = WireCodeUsage;
+export type Diffstat = WireDiffstat;
+export type FileChangeKind = WireFileChangeKind;
+export type CodeFileChange = WireCodeFileChange;
+export type CodeWorkspaceFiles = WireCodeWorkspaceFiles;
+export type CodeWorkspaceDiff = WireCodeWorkspaceDiff;
 
 /** Journaled engine event and the sequenced WebSocket frame that carries it. */
 export type CodeEvent = WireCodeEvent;

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
@@ -3,6 +3,7 @@ import type {
   CodeTurnSnapshot,
   CodeTurnStatus,
   CodeUsage,
+  Diffstat,
   HarnessKind,
   HarnessNoticeLevel,
   SequencedCodeEventFrame,
@@ -66,6 +67,7 @@ export type CodeTranscriptItem =
       durationMs: number | null;
       usage: CodeUsage | null;
       error: string | null;
+      diffstat: Diffstat | null;
     };
 
 export type CodeSessionState = {
@@ -175,6 +177,7 @@ export function hydrateCodeTurns(
           durationMs: durationMs(turn.started_at, turn.ended_at ?? null),
           usage: turn.usage ?? null,
           error: null,
+          diffstat: turn.diffstat ?? null,
         }),
       };
     }
@@ -346,6 +349,16 @@ export function reduceCodeSessionEvent(
       };
     }
 
+    case "checkpoint_recorded": {
+      return {
+        state: {
+          ...state,
+          items: applyDiffstat(state.items, event.turn_id, event.diffstat),
+        },
+        effects,
+      };
+    }
+
     case "turn_completed":
     case "turn_failed":
     case "turn_interrupted": {
@@ -358,6 +371,10 @@ export function reduceCodeSessionEvent(
             : "interrupted";
       const usage = event.type === "turn_completed" ? event.usage : null;
       const error = event.type === "turn_failed" ? event.error.message : null;
+      const diffstat =
+        event.type === "turn_completed"
+          ? (event.checkpoint?.diffstat ?? null)
+          : null;
       const turnId = state.activeTurnId;
       const finalized = finalizeStreaming(
         finalizeStreaming(state.items, "assistant"),
@@ -377,6 +394,7 @@ export function reduceCodeSessionEvent(
                 durationMs: durationMs(state.turnStartedAt, deps.now()),
                 usage,
                 error,
+                diffstat,
               })
             : finalized,
           activeTurnId: null,
@@ -438,6 +456,7 @@ function upsertTurnBoundary(
     durationMs: number | null;
     usage: CodeUsage | null;
     error: string | null;
+    diffstat: Diffstat | null;
   },
 ): CodeTranscriptItem[] {
   const item: CodeTranscriptItem = {
@@ -448,6 +467,7 @@ function upsertTurnBoundary(
     durationMs: boundary.durationMs,
     usage: boundary.usage,
     error: boundary.error,
+    diffstat: boundary.diffstat,
   };
   const index = items.findIndex(
     (candidate) =>
@@ -463,11 +483,24 @@ function upsertTurnBoundary(
         usage: boundary.usage ?? existing.usage,
         error: boundary.error ?? existing.error,
         durationMs: boundary.durationMs ?? existing.durationMs,
+        diffstat: boundary.diffstat ?? existing.diffstat,
       },
       ...items.slice(index + 1),
     ];
   }
   return items;
+}
+
+function applyDiffstat(
+  items: CodeTranscriptItem[],
+  turnId: string,
+  diffstat: Diffstat,
+): CodeTranscriptItem[] {
+  return items.map((item) =>
+    item.kind === "turn_boundary" && item.turnId === turnId
+      ? { ...item, diffstat }
+      : item,
+  );
 }
 
 function durationMs(

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
@@ -47,6 +47,7 @@ const items: CodeTranscriptItem[] = [
       cache_creation_input_tokens: 0,
     },
     error: null,
+    diffstat: null,
   },
 ];
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -1,22 +1,28 @@
 import { FileCode, FileSearch, Search, SquareTerminal, Wrench } from "lucide-react";
 
-import type { CodeUsage, ToolDetail } from "../api/types";
+import type { ToolDetail } from "../api/types";
 import { Badge } from "@/components/ui/badge";
 import { MessageMarkdown } from "@/MessageMarkdown";
 import { ThinkingAccordion } from "@/ThinkingAccordion";
 import { ToolCardShell } from "@/ToolCardShell";
 import { cn } from "@/lib/utils";
 import type { CodeTranscriptItem } from "./CodeSessionReducer";
+import { TurnReviewCard } from "./TurnReviewCard";
 
 /**
  * The code-session transcript: markdown for assistant text, tool-card chrome
  * for engine work, and visible harness notices.
  *
- * Approvals, diffs, and files stay out of this walking skeleton. What lands
- * here is the conversation a reader can follow from the journal alone.
+ * Approvals stay out of this surface. Turn boundaries open the Diff panel.
  */
 
-export function CodeTranscript({ items }: { items: CodeTranscriptItem[] }) {
+export function CodeTranscript({
+  items,
+  onOpenTurnDiff,
+}: {
+  items: CodeTranscriptItem[];
+  onOpenTurnDiff?: (turnId: string) => void;
+}) {
   if (items.length === 0) {
     return (
       <p className="text-muted-foreground px-4 py-8 text-sm">
@@ -27,13 +33,23 @@ export function CodeTranscript({ items }: { items: CodeTranscriptItem[] }) {
   return (
     <div className="flex flex-col gap-3 px-4 py-4">
       {items.map((item) => (
-        <TranscriptItem key={item.id} item={item} />
+        <TranscriptItem
+          key={item.id}
+          item={item}
+          onOpenTurnDiff={onOpenTurnDiff}
+        />
       ))}
     </div>
   );
 }
 
-function TranscriptItem({ item }: { item: CodeTranscriptItem }) {
+function TranscriptItem({
+  item,
+  onOpenTurnDiff,
+}: {
+  item: CodeTranscriptItem;
+  onOpenTurnDiff?: (turnId: string) => void;
+}) {
   switch (item.kind) {
     case "user":
       return (
@@ -62,11 +78,17 @@ function TranscriptItem({ item }: { item: CodeTranscriptItem }) {
       return <HarnessNotice level={item.level} message={item.message} />;
     case "turn_boundary":
       return (
-        <TurnBoundary
+        <TurnReviewCard
           status={item.status}
           durationMs={item.durationMs}
           usage={item.usage}
           error={item.error}
+          diffstat={item.diffstat}
+          onOpenDiff={
+            item.turnId && onOpenTurnDiff
+              ? () => onOpenTurnDiff(item.turnId as string)
+              : undefined
+          }
         />
       );
   }
@@ -149,37 +171,6 @@ export function HarnessNotice({
   );
 }
 
-function TurnBoundary({
-  status,
-  durationMs,
-  usage,
-  error,
-}: {
-  status: "completed" | "failed" | "interrupted";
-  durationMs: number | null;
-  usage: CodeUsage | null;
-  error: string | null;
-}) {
-  const label =
-    status === "completed"
-      ? "Turn completed"
-      : status === "failed"
-        ? "Turn failed"
-        : "Turn interrupted";
-  return (
-    <div className="text-muted-foreground flex flex-wrap items-center gap-2 text-xs">
-      <span className="font-medium">{label}</span>
-      {durationMs !== null && <span>{formatDuration(durationMs)}</span>}
-      {usage && (
-        <span>
-          {usage.input_tokens + usage.output_tokens} tokens
-        </span>
-      )}
-      {error && <span className="text-critical-foreground">{error}</span>}
-    </div>
-  );
-}
-
 function toolIcon(detail: ToolDetail) {
   switch (detail.kind) {
     case "command":
@@ -224,7 +215,4 @@ function toolDetailLine(detail: ToolDetail): string {
   }
 }
 
-function formatDuration(ms: number): string {
-  if (ms < 1000) return `${ms}ms`;
-  return `${(ms / 1000).toFixed(1)}s`;
-}
+

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { FolderOpen } from "lucide-react";
+import { FileCode, Files, FolderOpen } from "lucide-react";
 import { toast } from "sonner";
 
 import { archiveForceKind, type ApiClient } from "../api/client";
@@ -15,6 +15,9 @@ import { Button } from "@/components/ui/button";
 import { ClipboardCopyButton } from "@/ClipboardCopyButton";
 import { useConfirm } from "@/components/ConfirmDialog";
 import { openExternal } from "@/host";
+import { PanelLayout } from "@/panel/PanelLayout";
+import type { PanelContent } from "@/panel/panelTypes";
+import { useLayoutState, usePanelNav } from "@/panel/usePanelNav";
 import { RouteFrame } from "@/RouteFrame";
 import { friendlyErrorMessage } from "@/lib/utils";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
@@ -27,6 +30,8 @@ import {
 import { submitAcceptedTurn } from "./CodeSessionSend";
 import { CodeSidebar } from "./CodeSidebar";
 import { CodeTranscript } from "./CodeTranscript";
+import { DiffPanel } from "./DiffPanel";
+import { FilesPanel } from "./FilesPanel";
 import {
   fenceReasonText,
   HARNESS_LABELS,
@@ -56,6 +61,8 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const { client } = useApp();
   const { confirm, dialog } = useConfirm();
   const catalog = useCodeCatalogStore();
+  const layout = useLayoutState();
+  const { openPanel } = usePanelNav();
   const [workspace, setWorkspace] = useState<CodeWorkspaceSnapshot | null>(null);
   const [repo, setRepo] = useState<CodeRepoSnapshot | null>(null);
   const [session, setSession] = useState<CodeSessionSnapshot | null>(
@@ -189,6 +196,24 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
             {session && (
               <SessionLifecycleBadge session={session} client={client} />
             )}
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              onClick={() => openPanel({ type: "files" })}
+            >
+              <Files />
+              Files
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              onClick={() => openPanel({ type: "diff" })}
+            >
+              <FileCode />
+              Diff
+            </Button>
             {workspace && workspace.status !== "archived" && (
               <Button type="button" variant="ghost" size="xs" onClick={() => void archive()}>
                 Archive
@@ -224,42 +249,92 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         )}
       </header>
       {error && <p className="text-critical px-4 py-2 text-sm">{error}</p>}
-      {fenced && session?.fence_reason && (
-        <div className="border-warning-border bg-warning-background text-warning-foreground mx-4 mt-3 flex flex-col gap-2 rounded-md border px-3 py-2 text-sm">
-          <p>{fenceReasonText(session.fence_reason)}</p>
-          <Button type="button" size="sm" className="self-start" onClick={() => void reap()}>
-            Reap
-          </Button>
-        </div>
-      )}
-      {!session && workspace?.status === "active" && (
-        <div className="flex flex-col gap-2 px-4 py-6">
-          <p className="text-sm">Start a Plan-mode session on this workspace.</p>
-          <div className="flex flex-wrap gap-2">
-            {readyHarnesses.map((entry) => (
-              <Button
-                key={entry.kind}
-                type="button"
-                size="sm"
-                disabled={starting}
-                onClick={() => void startSession(entry.kind)}
-              >
-                {HARNESS_LABELS[entry.kind]}
-              </Button>
-            ))}
+      <PanelLayout
+        layout={layout}
+        renderChat={(visible) => (
+          <div
+            className="flex min-h-0 flex-1 flex-col overflow-hidden"
+            hidden={!visible}
+          >
+            {fenced && session?.fence_reason && (
+              <div className="border-warning-border bg-warning-background text-warning-foreground mx-4 mt-3 flex flex-col gap-2 rounded-md border px-3 py-2 text-sm">
+                <p>{fenceReasonText(session.fence_reason)}</p>
+                <Button type="button" size="sm" className="self-start" onClick={() => void reap()}>
+                  Reap
+                </Button>
+              </div>
+            )}
+            {!session && workspace?.status === "active" && (
+              <div className="flex flex-col gap-2 px-4 py-6">
+                <p className="text-sm">Start a Plan-mode session on this workspace.</p>
+                <div className="flex flex-wrap gap-2">
+                  {readyHarnesses.map((entry) => (
+                    <Button
+                      key={entry.kind}
+                      type="button"
+                      size="sm"
+                      disabled={starting}
+                      onClick={() => void startSession(entry.kind)}
+                    >
+                      {HARNESS_LABELS[entry.kind]}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            )}
+            {session && (
+              <CodeSessionPane
+                key={session.id}
+                session={session}
+                client={client}
+                disabled={fenced || workspace?.status !== "active"}
+                onOpenTurnDiff={(turnId) => openPanel({ type: "diff", turnId })}
+              />
+            )}
           </div>
-        </div>
-      )}
-      {session && (
-        <CodeSessionPane
-          key={session.id}
-          session={session}
-          client={client}
-          disabled={fenced || workspace?.status !== "active"}
-        />
-      )}
+        )}
+        renderPanel={(panel) =>
+          renderCodePanel(panel, client, workspaceId, openPanel)
+        }
+      />
     </>
   );
+}
+
+function renderCodePanel(
+  panel: PanelContent,
+  client: ApiClient,
+  workspaceId: string,
+  openPanel: (panel: PanelContent) => void,
+) {
+  switch (panel.type) {
+    case "files":
+      return (
+        <FilesPanel
+          client={client}
+          workspaceId={workspaceId}
+          turnId={panel.turnId}
+          onOpenFile={(file) =>
+            openPanel({ type: "diff", turnId: panel.turnId, file })
+          }
+        />
+      );
+    case "diff":
+      return (
+        <DiffPanel
+          client={client}
+          workspaceId={workspaceId}
+          turnId={panel.turnId}
+          file={panel.file}
+        />
+      );
+    default:
+      return (
+        <p className="text-muted-foreground px-3 py-6 text-sm">
+          This panel is not available here.
+        </p>
+      );
+  }
 }
 
 function SessionLifecycleBadge({
@@ -291,10 +366,12 @@ function CodeSessionPane({
   session,
   client,
   disabled,
+  onOpenTurnDiff,
 }: {
   session: CodeSessionSnapshot;
   client: ApiClient;
   disabled: boolean;
+  onOpenTurnDiff: (turnId: string) => void;
 }) {
   const store = useRegisteredCodeSession(session.id, client);
   const items = store((state) => state.items);
@@ -328,7 +405,7 @@ function CodeSessionPane({
         </p>
       )}
       <div className="min-h-0 flex-1 overflow-y-auto">
-        <CodeTranscript items={items} />
+        <CodeTranscript items={items} onOpenTurnDiff={onOpenTurnDiff} />
       </div>
       {lifecycle !== "ended" && (
         <CodeComposer

--- a/crates/tidebreak-desktop/ui/src/code/DiffPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DiffPanel.dom.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DiffPanel, groupUnifiedDiff } from "./DiffPanel";
+
+afterEach(() => {
+  cleanup();
+});
+
+const DIFF = `diff --git a/src/lib.rs b/src/lib.rs
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1 +1 @@
+-old
++new
+`;
+
+describe("DiffPanel", () => {
+  it("renders a grouped unified diff and a truncation notice", async () => {
+    const client = {
+      getCodeWorkspaceDiff: vi.fn().mockResolvedValue({
+        diff: DIFF,
+        truncated: true,
+        stat: { files: 1, insertions: 1, deletions: 1, truncated: true },
+        turn_id: "turn-1",
+        file: "src/lib.rs",
+      }),
+    };
+    render(
+      <DiffPanel
+        client={client}
+        workspaceId="ws-1"
+        turnId="turn-1"
+        file="src/lib.rs"
+      />,
+    );
+    expect(await screen.findByText("src/lib.rs")).toBeInTheDocument();
+    expect(screen.getByText("+new")).toBeInTheDocument();
+    expect(
+      screen.getByText("This diff was truncated. Open a single file for the rest."),
+    ).toBeInTheDocument();
+    expect(client.getCodeWorkspaceDiff).toHaveBeenCalledWith("ws-1", {
+      turn: "turn-1",
+      file: "src/lib.rs",
+    });
+  });
+});
+
+describe("groupUnifiedDiff", () => {
+  it("splits a multi-file unified diff by path", () => {
+    const groups = groupUnifiedDiff(
+      "diff --git a/a.txt b/a.txt\n+one\ndiff --git a/b.txt b/b.txt\n+two\n",
+    );
+    expect(groups.map((group) => group.path)).toEqual(["a.txt", "b.txt"]);
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/DiffPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DiffPanel.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useMemo, useState } from "react";
+
+import type { ApiClient } from "../api/client";
+import type { CodeWorkspaceDiff } from "../api/types";
+import { cn } from "@/lib/utils";
+import { friendlyErrorMessage } from "@/lib/utils";
+import { DiffstatBadge } from "./TurnReviewCard";
+
+/**
+ * Server-produced unified diff, grouped per file and tinted with the
+ * semantic status tokens. No client-side diff library.
+ */
+export function DiffPanel({
+  client,
+  workspaceId,
+  turnId,
+  file,
+}: {
+  client: Pick<ApiClient, "getCodeWorkspaceDiff">;
+  workspaceId: string;
+  turnId?: string;
+  file?: string;
+}) {
+  const [payload, setPayload] = useState<CodeWorkspaceDiff | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const next = await client.getCodeWorkspaceDiff(workspaceId, {
+          turn: turnId,
+          file,
+        });
+        if (!cancelled) {
+          setPayload(next);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(friendlyErrorMessage(err, "Could not load the diff"));
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [client, workspaceId, turnId, file]);
+
+  const groups = useMemo(
+    () => (payload ? groupUnifiedDiff(payload.diff) : []),
+    [payload],
+  );
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <header className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b px-3 py-2">
+        <div className="min-w-0">
+          <h2 className="text-sm font-medium">Diff</h2>
+          <p className="text-muted-foreground truncate text-xs">
+            {file ?? (turnId ? `Turn ${turnId}` : "Workspace vs base")}
+          </p>
+        </div>
+        {payload && <DiffstatBadge stat={payload.stat} />}
+      </header>
+      {error && <p className="text-critical px-3 py-2 text-sm">{error}</p>}
+      {payload?.truncated && (
+        <p className="text-warning-foreground bg-warning-background border-warning-border border-b px-3 py-2 text-xs">
+          This diff was truncated. Open a single file for the rest.
+        </p>
+      )}
+      <div className="min-h-0 flex-1 overflow-auto">
+        {groups.map((group) => (
+          <section key={group.path} className="border-b last:border-b-0">
+            <h3 className="bg-muted/40 truncate px-3 py-1.5 font-mono text-xs">
+              {group.path}
+            </h3>
+            <pre className="py-1 text-[11px] leading-4">
+              {group.lines.map((line, index) => (
+                <span
+                  key={`${group.path}:${index}`}
+                  className={cn(
+                    "block min-h-4 px-3",
+                    line.startsWith("+") &&
+                      !line.startsWith("+++") &&
+                      "bg-success-background text-success-foreground",
+                    line.startsWith("-") &&
+                      !line.startsWith("---") &&
+                      "bg-critical-background text-critical-foreground",
+                    line.startsWith("@@") && "text-muted-foreground",
+                  )}
+                >
+                  {line || " "}
+                </span>
+              ))}
+            </pre>
+          </section>
+        ))}
+        {payload && groups.length === 0 && !error && (
+          <p className="text-muted-foreground px-3 py-6 text-sm">No diff.</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function groupUnifiedDiff(
+  diff: string,
+): Array<{ path: string; lines: string[] }> {
+  if (!diff) return [];
+  const groups: Array<{ path: string; lines: string[] }> = [];
+  let current: { path: string; lines: string[] } | null = null;
+  for (const line of diff.split("\n")) {
+    const header = line.match(/^diff --git a\/(.+?) b\/(.+)$/);
+    if (header) {
+      current = { path: header[2] ?? header[1] ?? "file", lines: [line] };
+      groups.push(current);
+      continue;
+    }
+    if (!current) {
+      current = { path: "diff", lines: [] };
+      groups.push(current);
+    }
+    current.lines.push(line);
+  }
+  return groups.filter((group) => group.lines.length > 0);
+}

--- a/crates/tidebreak-desktop/ui/src/code/FilesPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/FilesPanel.dom.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { FilesPanel } from "./FilesPanel";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("FilesPanel", () => {
+  it("lists changed files and opens a file in the diff panel", async () => {
+    const onOpenFile = vi.fn();
+    const client = {
+      listCodeWorkspaceFiles: vi.fn().mockResolvedValue({
+        files: [
+          {
+            path: "src/lib.rs",
+            kind: "modified",
+            insertions: 3,
+            deletions: 1,
+          },
+          {
+            path: "new.txt",
+            kind: "added",
+            insertions: 1,
+            deletions: 0,
+          },
+        ],
+        truncated: false,
+        stat: { files: 2, insertions: 4, deletions: 1, truncated: false },
+      }),
+    };
+    render(
+      <FilesPanel
+        client={client}
+        workspaceId="ws-1"
+        turnId="turn-1"
+        onOpenFile={onOpenFile}
+      />,
+    );
+    expect(await screen.findByText("src/lib.rs")).toBeInTheDocument();
+    expect(screen.getByText("new.txt")).toBeInTheDocument();
+    await userEvent.setup().click(screen.getByText("src/lib.rs"));
+    expect(onOpenFile).toHaveBeenCalledWith("src/lib.rs");
+    expect(client.listCodeWorkspaceFiles).toHaveBeenCalledWith("ws-1", "turn-1");
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/FilesPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/FilesPanel.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from "react";
+
+import type { ApiClient } from "../api/client";
+import type { CodeFileChange, CodeWorkspaceFiles } from "../api/types";
+import { Badge } from "@/components/ui/badge";
+import { friendlyErrorMessage } from "@/lib/utils";
+import { DiffstatBadge } from "./TurnReviewCard";
+
+/**
+ * Changed files vs the workspace base, optionally filtered to one turn.
+ * Clicking a row opens the Diff panel at that file.
+ */
+export function FilesPanel({
+  client,
+  workspaceId,
+  turnId,
+  onOpenFile,
+}: {
+  client: Pick<ApiClient, "listCodeWorkspaceFiles">;
+  workspaceId: string;
+  turnId?: string;
+  onOpenFile: (file: string) => void;
+}) {
+  const [listing, setListing] = useState<CodeWorkspaceFiles | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const next = await client.listCodeWorkspaceFiles(workspaceId, turnId);
+        if (!cancelled) {
+          setListing(next);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(friendlyErrorMessage(err, "Could not load changed files"));
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [client, workspaceId, turnId]);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <header className="flex shrink-0 items-center justify-between gap-2 border-b px-3 py-2">
+        <h2 className="text-sm font-medium">Changed files</h2>
+        {listing && <DiffstatBadge stat={listing.stat} />}
+      </header>
+      {error && <p className="text-critical px-3 py-2 text-sm">{error}</p>}
+      {listing?.truncated && (
+        <p className="text-muted-foreground px-3 py-2 text-xs">
+          File list was truncated. Open a turn or a single file for a smaller view.
+        </p>
+      )}
+      <ul className="min-h-0 flex-1 overflow-y-auto">
+        {(listing?.files ?? []).map((file) => (
+          <li key={`${file.kind}:${file.path}`}>
+            <button
+              type="button"
+              className="hover:bg-muted/60 flex w-full items-center gap-2 px-3 py-2 text-left text-xs"
+              onClick={() => onOpenFile(file.path)}
+            >
+              <KindBadge kind={file.kind} />
+              <span className="min-w-0 flex-1 truncate font-mono" title={file.path}>
+                {fileLabel(file)}
+              </span>
+              <span className="text-muted-foreground shrink-0">
+                +{file.insertions} −{file.deletions}
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+      {listing && listing.files.length === 0 && !error && (
+        <p className="text-muted-foreground px-3 py-6 text-sm">No files changed.</p>
+      )}
+    </div>
+  );
+}
+
+function KindBadge({ kind }: { kind: CodeFileChange["kind"] }) {
+  const label =
+    kind === "added"
+      ? "A"
+      : kind === "deleted"
+        ? "D"
+        : kind === "renamed"
+          ? "R"
+          : "M";
+  return (
+    <Badge variant="outline" size="sm">
+      {label}
+    </Badge>
+  );
+}
+
+function fileLabel(file: CodeFileChange): string {
+  if (file.kind === "renamed" && file.previous_path) {
+    return `${file.previous_path} → ${file.path}`;
+  }
+  return file.path;
+}

--- a/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.dom.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { TurnReviewCard } from "./TurnReviewCard";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("TurnReviewCard", () => {
+  it("shows diffstat, duration, and opens the turn diff", async () => {
+    const onOpenDiff = vi.fn();
+    render(
+      <TurnReviewCard
+        status="completed"
+        durationMs={1500}
+        usage={{
+          input_tokens: 12,
+          output_tokens: 3,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        }}
+        error={null}
+        diffstat={{ files: 2, insertions: 10, deletions: 1, truncated: false }}
+        onOpenDiff={onOpenDiff}
+      />,
+    );
+    expect(screen.getByText("Turn completed")).toBeInTheDocument();
+    expect(screen.getByText("1.5s")).toBeInTheDocument();
+    expect(screen.getByText("2 files +10 −1")).toBeInTheDocument();
+    await userEvent.setup().click(screen.getByRole("button", { name: "Review diff" }));
+    expect(onOpenDiff).toHaveBeenCalledOnce();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.tsx
@@ -1,0 +1,74 @@
+import type { CodeUsage, Diffstat } from "../api/types";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Turn-boundary card in the code transcript: diffstat, duration, and a
+ * link that opens the Diff panel anchored to this turn.
+ *
+ * The async LLM narrative is deferred; the slot is left empty on purpose.
+ */
+export function TurnReviewCard({
+  status,
+  durationMs,
+  usage,
+  error,
+  diffstat,
+  onOpenDiff,
+}: {
+  status: "completed" | "failed" | "interrupted";
+  durationMs: number | null;
+  usage: CodeUsage | null;
+  error: string | null;
+  diffstat: Diffstat | null;
+  onOpenDiff?: () => void;
+}) {
+  const label =
+    status === "completed"
+      ? "Turn completed"
+      : status === "failed"
+        ? "Turn failed"
+        : "Turn interrupted";
+  return (
+    <section
+      className="border-border bg-card max-w-prose rounded-lg border px-3 py-2"
+      aria-label="Turn review"
+    >
+      <div className="flex flex-wrap items-center gap-2 text-xs">
+        <span className="font-medium">{label}</span>
+        {durationMs !== null && (
+          <span className="text-muted-foreground">{formatDuration(durationMs)}</span>
+        )}
+        {usage && (
+          <span className="text-muted-foreground">
+            {usage.input_tokens + usage.output_tokens} tokens
+          </span>
+        )}
+        {diffstat && <DiffstatBadge stat={diffstat} />}
+        {onOpenDiff && (
+          <Button type="button" variant="ghost" size="2xs" onClick={onOpenDiff}>
+            Review diff
+          </Button>
+        )}
+      </div>
+      {error && (
+        <p className="text-critical-foreground mt-1 text-xs">{error}</p>
+      )}
+    </section>
+  );
+}
+
+export function DiffstatBadge({ stat }: { stat: Diffstat }) {
+  return (
+    <Badge variant="outline" size="sm">
+      {stat.files} file{stat.files === 1 ? "" : "s"} +{stat.insertions} −
+      {stat.deletions}
+      {stat.truncated ? " · truncated" : ""}
+    </Badge>
+  );
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -6,6 +6,8 @@ import {
   parseCodeSessionList,
   parseCodeTurn,
   parseCodeTurnList,
+  parseCodeWorkspaceDiff,
+  parseCodeWorkspaceFiles,
 } from "./parsers";
 
 const SESSION = {
@@ -71,6 +73,53 @@ describe("parseCodeTurnList", () => {
   it("rejects a non-array or a row the turn parser would drop", () => {
     expect(parseCodeTurnList({ turns: [TURN] })).toBeNull();
     expect(parseCodeTurnList([{ ...TURN, status: "paused" }])).toBeNull();
+  });
+});
+
+describe("parseCodeWorkspaceFiles", () => {
+  const files = {
+    files: [
+      {
+        path: "src/lib.rs",
+        kind: "modified",
+        insertions: 3,
+        deletions: 1,
+      },
+    ],
+    truncated: false,
+    stat: { files: 1, insertions: 3, deletions: 1, truncated: false },
+    turn_id: "turn-1",
+  };
+
+  it("accepts GET /code/workspaces/{id}/files", () => {
+    expect(parseCodeWorkspaceFiles(files)).toEqual(files);
+  });
+
+  it("rejects a missing stat or a bad kind", () => {
+    expect(parseCodeWorkspaceFiles({ ...files, stat: { files: 1 } })).toBeNull();
+    expect(
+      parseCodeWorkspaceFiles({
+        ...files,
+        files: [{ ...files.files[0], kind: "moved" }],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("parseCodeWorkspaceDiff", () => {
+  const diff = {
+    diff: "--- a\n+++ b\n",
+    truncated: true,
+    stat: { files: 1, insertions: 1, deletions: 1, truncated: true },
+    file: "src/lib.rs",
+  };
+
+  it("accepts GET /code/workspaces/{id}/diff", () => {
+    expect(parseCodeWorkspaceDiff(diff)).toEqual(diff);
+  });
+
+  it("rejects a non-string body", () => {
+    expect(parseCodeWorkspaceDiff({ ...diff, diff: 1 })).toBeNull();
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -8,10 +8,15 @@ import type {
   CodeRepoSnapshot,
   CodeSessionLifecycle,
   CodeSessionSnapshot,
+  CodeFileChange,
   CodeTurnSnapshot,
   CodeTurnStatus,
   CodeUsage,
+  CodeWorkspaceDiff,
+  CodeWorkspaceFiles,
   CodeWorkspaceSnapshot,
+  Diffstat,
+  FileChangeKind,
   CodeWorkspaceStatus,
   FenceReason,
   HarnessCaps,
@@ -29,7 +34,11 @@ import type {
   CodeRepoSnapshot as WireCodeRepoSnapshot,
   CodeSessionSnapshot as WireCodeSessionSnapshot,
   CodeTurnSnapshot as WireCodeTurnSnapshot,
+  CodeWorkspaceDiff as WireCodeWorkspaceDiff,
+  CodeWorkspaceFiles as WireCodeWorkspaceFiles,
   CodeWorkspaceSnapshot as WireCodeWorkspaceSnapshot,
+  CodeFileChange as WireCodeFileChange,
+  Diffstat as WireDiffstat,
   HarnessCaps as WireHarnessCaps,
   HarnessDoctorEntry as WireHarnessDoctorEntry,
   HarnessDoctorReport as WireHarnessDoctorReport,
@@ -80,6 +89,12 @@ const TURN_STATUSES = new Set<CodeTurnStatus>([
   "interrupted",
 ]);
 const NOTICE_LEVELS = new Set<HarnessNoticeLevel>(["info", "warning", "error"]);
+const FILE_CHANGE_KINDS = new Set<FileChangeKind>([
+  "added",
+  "modified",
+  "deleted",
+  "renamed",
+]);
 const TOOL_OUTCOMES = new Set<ToolOutcome>(["succeeded", "failed", "denied"]);
 const ATTENTION_SOURCES = new Set<AttentionSource>([
   "structured",
@@ -287,6 +302,7 @@ export function parseCodeTurn(value: unknown): CodeTurnSnapshot | null {
       "user_input",
       "usage",
       "checkpoint_ref",
+      "diffstat",
       "started_at",
       "ended_at",
     ]) ||
@@ -304,6 +320,9 @@ export function parseCodeTurn(value: unknown): CodeTurnSnapshot | null {
   const usage =
     value.usage === undefined ? undefined : parseUsage(value.usage);
   if (value.usage !== undefined && !usage) return null;
+  const diffstat =
+    value.diffstat === undefined ? undefined : parseDiffstat(value.diffstat);
+  if (value.diffstat !== undefined && !diffstat) return null;
   return {
     id: value.id,
     session_id: value.session_id,
@@ -315,7 +334,124 @@ export function parseCodeTurn(value: unknown): CodeTurnSnapshot | null {
     ...(value.checkpoint_ref !== undefined
       ? { checkpoint_ref: value.checkpoint_ref }
       : {}),
+    ...(diffstat ? { diffstat } : {}),
     ...(value.ended_at !== undefined ? { ended_at: value.ended_at } : {}),
+  };
+}
+
+export function parseCodeWorkspaceFiles(
+  value: unknown,
+): CodeWorkspaceFiles | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeWorkspaceFiles>(value, [
+      "files",
+      "truncated",
+      "stat",
+      "turn_id",
+    ]) ||
+    !Array.isArray(value.files) ||
+    typeof value.truncated !== "boolean"
+  ) {
+    return null;
+  }
+  const files: CodeFileChange[] = [];
+  for (const item of value.files) {
+    const parsed = parseCodeFileChange(item);
+    if (!parsed) return null;
+    files.push(parsed);
+  }
+  const stat = parseDiffstat(value.stat);
+  if (!stat) return null;
+  if (value.turn_id !== undefined && !nonEmpty(value.turn_id)) return null;
+  return {
+    files,
+    truncated: value.truncated,
+    stat,
+    ...(value.turn_id !== undefined ? { turn_id: value.turn_id } : {}),
+  };
+}
+
+export function parseCodeWorkspaceDiff(
+  value: unknown,
+): CodeWorkspaceDiff | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeWorkspaceDiff>(value, [
+      "diff",
+      "truncated",
+      "stat",
+      "turn_id",
+      "file",
+    ]) ||
+    typeof value.diff !== "string" ||
+    typeof value.truncated !== "boolean" ||
+    !optionalString(value.turn_id) ||
+    !optionalString(value.file)
+  ) {
+    return null;
+  }
+  const stat = parseDiffstat(value.stat);
+  if (!stat) return null;
+  return {
+    diff: value.diff,
+    truncated: value.truncated,
+    stat,
+    ...(value.turn_id !== undefined ? { turn_id: value.turn_id } : {}),
+    ...(value.file !== undefined ? { file: value.file } : {}),
+  };
+}
+
+function parseCodeFileChange(value: unknown): CodeFileChange | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeFileChange>(value, [
+      "path",
+      "kind",
+      "insertions",
+      "deletions",
+      "previous_path",
+    ]) ||
+    typeof value.path !== "string" ||
+    !isMember(value.kind, FILE_CHANGE_KINDS) ||
+    !isFiniteNumber(value.insertions) ||
+    !isFiniteNumber(value.deletions) ||
+    !optionalString(value.previous_path)
+  ) {
+    return null;
+  }
+  return {
+    path: value.path,
+    kind: value.kind,
+    insertions: value.insertions,
+    deletions: value.deletions,
+    ...(value.previous_path !== undefined
+      ? { previous_path: value.previous_path }
+      : {}),
+  };
+}
+
+export function parseDiffstat(value: unknown): Diffstat | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireDiffstat>(value, [
+      "files",
+      "insertions",
+      "deletions",
+      "truncated",
+    ]) ||
+    !isFiniteNumber(value.files) ||
+    !isFiniteNumber(value.insertions) ||
+    !isFiniteNumber(value.deletions) ||
+    typeof value.truncated !== "boolean"
+  ) {
+    return null;
+  }
+  return {
+    files: value.files,
+    insertions: value.insertions,
+    deletions: value.deletions,
+    truncated: value.truncated,
   };
 }
 
@@ -584,6 +720,24 @@ export function parseCodeEvent(value: unknown): CodeEvent | null {
         return null;
       }
       return { type: "turn_failed", error: { message: value.error.message } };
+    case "checkpoint_recorded": {
+      if (
+        !onlyKeys<Extract<WireCodeEvent, { type: "checkpoint_recorded" }>>(
+          value,
+          ["type", "turn_id", "diffstat"],
+        ) ||
+        !nonEmpty(value.turn_id)
+      ) {
+        return null;
+      }
+      const diffstat = parseDiffstat(value.diffstat);
+      if (!diffstat) return null;
+      return {
+        type: "checkpoint_recorded",
+        turn_id: value.turn_id,
+        diffstat,
+      };
+    }
     case "turn_interrupted":
       return { type: "turn_interrupted" };
     case "harness_notice":

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1042,6 +1042,11 @@ export type CodeExecutionProviderSnapshot = "local" | "e2b" | "daytona" | "docke
 export type CodeExecutionUnavailableReason = "unsupported_platform" | "missing_sandbox_binary" | "missing_credential" | "missing_container_runtime" | "container_runtime_unreachable";
 
 /**
+ * One changed path in a workspace or turn file list.
+ */
+export type CodeFileChange = { path: string, kind: FileChangeKind, insertions: number, deletions: number, previous_path?: string, };
+
+/**
  * How an external agent-engine session handles mutations and approvals.
  *
  * Each adapter maps these onto the engine's native flags. A mode the
@@ -1077,7 +1082,7 @@ export type CodeTurnId = string;
 /**
  * One user→engine turn.
  */
-export type CodeTurnSnapshot = { id: CodeTurnId, session_id: CodeSessionId, ordinal: number, status: CodeTurnStatus, user_input: string, usage?: CodeUsage, checkpoint_ref?: string, started_at: string, ended_at?: string, };
+export type CodeTurnSnapshot = { id: CodeTurnId, session_id: CodeSessionId, ordinal: number, status: CodeTurnStatus, user_input: string, usage?: CodeUsage, checkpoint_ref?: string, diffstat?: Diffstat, started_at: string, ended_at?: string, };
 
 /**
  * Status of one user→engine turn.
@@ -1104,6 +1109,16 @@ cache_read_input_tokens: number,
  * Cache-write input tokens, when the engine reports them.
  */
 cache_creation_input_tokens: number, };
+
+/**
+ * Bounded unified diff for `GET /code/workspaces/{id}/diff`.
+ */
+export type CodeWorkspaceDiff = { diff: string, truncated: boolean, stat: Diffstat, turn_id?: CodeTurnId, file?: string, };
+
+/**
+ * Bounded changed-file list for `GET /code/workspaces/{id}/files`.
+ */
+export type CodeWorkspaceFiles = { files: Array<CodeFileChange>, truncated: boolean, stat: Diffstat, turn_id?: CodeTurnId, };
 
 /**
  * One isolated workspace (worktree + branch) on a repo.

--- a/crates/tidebreak-desktop/ui/src/panel/PanelTabs.tsx
+++ b/crates/tidebreak-desktop/ui/src/panel/PanelTabs.tsx
@@ -1,4 +1,4 @@
-import { Bot, FileText, FolderOpen, Package, Shield, X } from "lucide-react";
+import { Bot, FileCode, FileText, Files, FolderOpen, Package, Shield, X } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { panelKey, type PanelContent } from "./panelTypes";
@@ -25,6 +25,10 @@ function panelTabFallbackLabel(panel: PanelContent): string {
       return "Agents";
     case "agent":
       return "Agent";
+    case "files":
+      return "Files";
+    case "diff":
+      return "Diff";
   }
 }
 
@@ -42,6 +46,10 @@ function PanelTabIcon({ panel }: { panel: PanelContent }) {
     case "agents":
     case "agent":
       return <Bot className={className} />;
+    case "files":
+      return <Files className={className} />;
+    case "diff":
+      return <FileCode className={className} />;
   }
 }
 

--- a/crates/tidebreak-desktop/ui/src/panel/panelTypes.ts
+++ b/crates/tidebreak-desktop/ui/src/panel/panelTypes.ts
@@ -22,7 +22,11 @@ export type PanelContent =
   /** This conversation's background agents, as a table of runs. */
   | { type: "agents" }
   /** One background agent run, opened from the agents table or the transcript. */
-  | { type: "agent"; runId: string };
+  | { type: "agent"; runId: string }
+  /** Changed files in a code-mode workspace; `turnId` filters to one turn. */
+  | { type: "files"; turnId?: string }
+  /** Server-produced unified diff; `turnId`/`file` anchor within the tab. */
+  | { type: "diff"; turnId?: string; file?: string };
 
 export type PanelType = PanelContent["type"];
 

--- a/crates/tidebreak-desktop/ui/src/panel/panelUrl.test.ts
+++ b/crates/tidebreak-desktop/ui/src/panel/panelUrl.test.ts
@@ -14,6 +14,13 @@ describe("panel URLs", () => {
     expect(parsePanelSegment("permissions")).toEqual({ type: "permissions" });
     expect(parsePanelSegment("agents")).toEqual({ type: "agents" });
     expect(parsePanelSegment("agent.run-1")).toEqual({ type: "agent", runId: "run-1" });
+    expect(parsePanelSegment("files")).toEqual({ type: "files" });
+    expect(parsePanelSegment("files.turn-1")).toEqual({ type: "files", turnId: "turn-1" });
+    expect(parsePanelSegment("diff.t.turn-1.f.src%2Flib.rs")).toEqual({
+      type: "diff",
+      turnId: "turn-1",
+      file: "src/lib.rs",
+    });
     expect(parsePanelSegment("agent")).toBeNull();
     expect(parsePanelSegment("document.doc-1.cite-1")).toEqual({
       type: "document",
@@ -62,6 +69,11 @@ describe("panel URLs", () => {
       { type: "permissions" },
       { type: "agents" },
       { type: "agent", runId: "run-1" },
+      { type: "files" },
+      { type: "files", turnId: "turn-1" },
+      { type: "diff" },
+      { type: "diff", turnId: "turn-1" },
+      { type: "diff", turnId: "turn-1", file: "src/lib.rs" },
     ] as const) {
       expect(parsePanelSegment(encodePanelSegment(panel))).toEqual(panel);
     }

--- a/crates/tidebreak-desktop/ui/src/panel/panelUrl.ts
+++ b/crates/tidebreak-desktop/ui/src/panel/panelUrl.ts
@@ -48,11 +48,52 @@ export function parsePanelSegment(segment: string): PanelContent | null {
     case "agent":
       // A run id is the whole address; there is no id-less run panel.
       return id ? { type: "agent", runId: id } : null;
+    case "files":
+      return parseFilesTarget(id);
+    case "diff":
+      return parseDiffTarget(id);
     default:
       // `apps` and `plugins` were panel segments before the libraries became
       // routes of their own; those links fall back to the conversation alone.
       return null;
   }
+}
+
+function parseFilesTarget(id: string): PanelContent | null {
+  if (!id) return { type: "files" };
+  if (id.includes(".")) return null;
+  return { type: "files", turnId: id };
+}
+
+function parseDiffTarget(id: string): PanelContent | null {
+  if (!id) return { type: "diff" };
+  const parts = id.split(".");
+  let turnId: string | undefined;
+  let file: string | undefined;
+  let index = 0;
+  while (index < parts.length) {
+    const token = parts[index];
+    if (token === "t" && parts[index + 1]) {
+      turnId = parts[index + 1];
+      index += 2;
+      continue;
+    }
+    if (token === "f" && parts[index + 1]) {
+      try {
+        file = decodeURIComponent(parts.slice(index + 1).join("."));
+      } catch {
+        return null;
+      }
+      if (!file) return null;
+      break;
+    }
+    return null;
+  }
+  return {
+    type: "diff",
+    ...(turnId ? { turnId } : {}),
+    ...(file ? { file } : {}),
+  };
 }
 
 function parseDocumentTarget(id: string): PanelContent | null {
@@ -84,6 +125,14 @@ export function encodePanelSegment(panel: PanelContent): string {
       return "agents";
     case "agent":
       return `agent.${panel.runId}`;
+    case "files":
+      return panel.turnId ? `files.${panel.turnId}` : "files";
+    case "diff": {
+      const parts = ["diff"];
+      if (panel.turnId) parts.push("t", panel.turnId);
+      if (panel.file) parts.push("f", encodeURIComponent(panel.file));
+      return parts.join(".");
+    }
   }
 }
 

--- a/crates/tidebreak-desktop/ui/src/panel/usePanelNav.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/panel/usePanelNav.dom.test.tsx
@@ -128,6 +128,17 @@ describe("usePanelNav", () => {
     await waitFor(() => expect(router.state.location.search).toEqual({}));
   });
 
+  it("keeps a code workspace URL when opening files and diff", async () => {
+    const user = userEvent.setup();
+    const { router } = await mount("/code/w/ws-1");
+
+    await user.click(screen.getByText("open folders"));
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/code/w/ws-1"),
+    );
+    await waitFor(() => expect(router.state.location.search).toEqual({ tabs: "folders" }));
+  });
+
   it("toggles fullscreen on and back off, and not at all with nothing open", async () => {
     const user = userEvent.setup();
     const { router } = await mount("/c/chat-1?tabs=folders");

--- a/crates/tidebreak-desktop/ui/src/panel/usePanelNav.ts
+++ b/crates/tidebreak-desktop/ui/src/panel/usePanelNav.ts
@@ -22,13 +22,23 @@ export function useLayoutState(): LayoutState {
 export function usePanelNav() {
   const navigate = useNavigate();
   const layout = useLayoutState();
-  const { chatId } = useParams({ strict: false }) as { chatId?: string };
+  const { chatId, workspaceId } = useParams({ strict: false }) as {
+    chatId?: string;
+    workspaceId?: string;
+  };
 
   function go(next: LayoutState) {
     // Panels live beside a conversation when there is one; outside any
     // conversation the home route hosts them (the Apps library), and its bare
-    // URL is the no-tabs collapse the same way a chat's is.
-    if (chatId) {
+    // URL is the no-tabs collapse the same way a chat's is. Code workspaces
+    // host the same strip beside their transcript.
+    if (workspaceId) {
+      void navigate({
+        to: "/code/w/$workspaceId",
+        params: { workspaceId },
+        search: searchFromLayout(next),
+      });
+    } else if (chatId) {
       void navigate({
         to: "/c/$chatId",
         params: { chatId },

--- a/crates/tidebreak-desktop/ui/src/router.tsx
+++ b/crates/tidebreak-desktop/ui/src/router.tsx
@@ -222,6 +222,7 @@ function CodeRepoRouteComponent() {
 const codeWorkspaceRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/code/w/$workspaceId",
+  validateSearch: (search: Record<string, unknown>): PanelSearch => panelSearchFrom(search),
   component: CodeWorkspaceRouteComponent,
 });
 

--- a/crates/tidebreak-desktop/ui/src/test/router.tsx
+++ b/crates/tidebreak-desktop/ui/src/test/router.tsx
@@ -73,6 +73,13 @@ export async function renderWithRouter(
   const codeWorkspaceRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/code/w/$workspaceId",
+    validateSearch: (search: Record<string, unknown>): PanelSearch => ({
+      tabs: typeof search.tabs === "string" ? search.tabs : undefined,
+      active: typeof search.active === "string" ? search.active : undefined,
+      fullscreen: typeof search.fullscreen === "string" ? search.fullscreen : undefined,
+      left: typeof search.left === "string" ? search.left : undefined,
+      right: typeof search.right === "string" ? search.right : undefined,
+    }),
     component: () => <>{ui}</>,
   });
 

--- a/crates/tidebreak-server/src/code/checkpoint.rs
+++ b/crates/tidebreak-server/src/code/checkpoint.rs
@@ -1,0 +1,1015 @@
+//! Per-turn worktree checkpoints via a temporary git index.
+//!
+//! A completed turn records the worktree's full state — tracked changes and
+//! untracked files — as a synthetic commit created through a temporary index
+//! file. The user's index, `HEAD`, and reflog are untouched. The commit is
+//! referenced only by a hidden ref
+//! `refs/tidebreak/checkpoints/<workspace>/<ordinal>`.
+//!
+//! Diffs are produced here, bounded in bytes and file count, with truncation
+//! marked on the payload. The renderer never runs git.
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::process::Command;
+use tokio::time::timeout;
+use tracing::warn;
+
+use tidebreak_core::db::code::{
+    append_event, get_session, get_turn, get_workspace, list_turns, save_turn,
+};
+use tidebreak_core::{
+    CodeEvent, CodeSession, CodeTurn, CodeTurnId, CodeTurnStatus, CodeWorkspace, DbStore, Diffstat,
+    FileChangeKind, HarnessNoticeLevel, SequencedCodeEvent, WorkspaceId,
+};
+
+use super::bus::CodeEventBus;
+
+const GIT_TIMEOUT: Duration = Duration::from_secs(30);
+const GIT_SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Default bound on a unified-diff body.
+pub(crate) const MAX_DIFF_BYTES: usize = 256 * 1024;
+/// Default bound on how many files a files/diff payload includes in full.
+pub(crate) const MAX_DIFF_FILES: usize = 64;
+
+const REF_PREFIX: &str = "refs/tidebreak/checkpoints";
+
+/// Byte and file-count caps for a produced diff or file list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DiffBounds {
+    pub max_bytes: usize,
+    pub max_files: usize,
+}
+
+impl Default for DiffBounds {
+    fn default() -> Self {
+        Self {
+            max_bytes: MAX_DIFF_BYTES,
+            max_files: MAX_DIFF_FILES,
+        }
+    }
+}
+
+/// One file in a bounded workspace or turn file list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ChangedFile {
+    pub path: String,
+    pub kind: FileChangeKind,
+    pub insertions: u32,
+    pub deletions: u32,
+    pub previous_path: Option<String>,
+}
+
+/// Bounded file list for `GET /code/workspaces/{id}/files`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BoundedFiles {
+    pub files: Vec<ChangedFile>,
+    pub truncated: bool,
+    pub stat: Diffstat,
+}
+
+/// Bounded unified diff for `GET /code/workspaces/{id}/diff`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BoundedDiff {
+    pub diff: String,
+    pub truncated: bool,
+    pub stat: Diffstat,
+}
+
+/// A recorded checkpoint: hidden ref name and the turn-scoped diffstat.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RecordedCheckpoint {
+    pub checkpoint_ref: String,
+    pub diffstat: Diffstat,
+}
+
+/// Failure from a checkpoint or diff operation.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum CheckpointError {
+    #[error("{0}")]
+    User(String),
+    #[error("{0}")]
+    Internal(String),
+}
+
+impl CheckpointError {
+    fn user(message: impl Into<String>) -> Self {
+        Self::User(message.into())
+    }
+
+    fn internal(message: impl Into<String>) -> Self {
+        Self::Internal(message.into())
+    }
+}
+
+/// Hidden ref for one turn of one workspace.
+pub(crate) fn checkpoint_ref(workspace_id: WorkspaceId, ordinal: i64) -> String {
+    format!("{REF_PREFIX}/{workspace_id}/{ordinal}")
+}
+
+/// After a turn reaches `Completed`, snapshot the worktree and journal.
+///
+/// Checkpoint failure does not fail the turn: a [`CodeEvent::HarnessNotice`]
+/// is journaled and the already-recorded work stands.
+pub(crate) async fn after_turn_completed(
+    db: &Arc<DbStore>,
+    bus: &Arc<CodeEventBus>,
+    session: &CodeSession,
+    turn: &mut CodeTurn,
+) {
+    if turn.status != CodeTurnStatus::Completed || turn.checkpoint_ref.is_some() {
+        return;
+    }
+    match record_for_turn(db, session, turn).await {
+        Ok(recorded) => {
+            turn.checkpoint_ref = Some(recorded.checkpoint_ref.clone());
+            turn.diffstat = Some(recorded.diffstat.clone());
+            if let Err(err) = save_turn(db, turn).await {
+                warn!(
+                    session = %session.id,
+                    turn = %turn.id,
+                    error = %err,
+                    "failed to persist checkpoint on the turn row"
+                );
+            }
+            let _ = journal(
+                db,
+                bus,
+                session,
+                CodeEvent::CheckpointRecorded {
+                    turn_id: turn.id,
+                    diffstat: recorded.diffstat,
+                },
+            )
+            .await;
+        }
+        Err(err) => {
+            let message = truncate_notice(format!("checkpoint failed: {err}"));
+            warn!(
+                session = %session.id,
+                turn = %turn.id,
+                error = %err,
+                "checkpoint failed; turn is kept"
+            );
+            let _ = journal(
+                db,
+                bus,
+                session,
+                CodeEvent::HarnessNotice {
+                    level: HarnessNoticeLevel::Warning,
+                    message,
+                },
+            )
+            .await;
+        }
+    }
+}
+
+async fn record_for_turn(
+    db: &DbStore,
+    session: &CodeSession,
+    turn: &CodeTurn,
+) -> Result<RecordedCheckpoint, CheckpointError> {
+    let workspace = get_workspace(db, session.workspace_id)
+        .await
+        .map_err(|err| CheckpointError::internal(err.to_string()))?
+        .ok_or_else(|| CheckpointError::user("workspace not found"))?;
+    let worktree = PathBuf::from(&workspace.worktree_path);
+    let previous = previous_checkpoint_oid(&worktree, &workspace, db, turn).await?;
+    record_checkpoint(
+        &worktree,
+        workspace.id,
+        turn.ordinal,
+        previous.as_deref(),
+        &workspace.base_ref,
+    )
+    .await
+}
+
+/// Snapshot the worktree into a hidden checkpoint ref.
+///
+/// Uses a temporary index file. The user's index and `HEAD` are not written.
+pub(crate) async fn record_checkpoint(
+    worktree: &Path,
+    workspace_id: WorkspaceId,
+    ordinal: i64,
+    previous_oid: Option<&str>,
+    base_ref: &str,
+) -> Result<RecordedCheckpoint, CheckpointError> {
+    let r#ref = checkpoint_ref(workspace_id, ordinal);
+    let tree = snapshot_tree(worktree).await?;
+    let parent = match previous_oid {
+        Some(oid) => oid.to_owned(),
+        None => git_text(worktree, &["rev-parse", "HEAD"], GIT_TIMEOUT)
+            .await
+            .map_err(CheckpointError::internal)?,
+    };
+    let message = format!("checkpoint turn {ordinal}");
+    let commit = git_text(
+        worktree,
+        &["commit-tree", &tree, "-p", &parent, "-m", &message],
+        GIT_TIMEOUT,
+    )
+    .await
+    .map_err(CheckpointError::internal)?;
+    git_text(
+        worktree,
+        &["update-ref", "--no-deref", &r#ref, &commit],
+        GIT_TIMEOUT,
+    )
+    .await
+    .map_err(CheckpointError::internal)?;
+
+    let from = match previous_oid {
+        Some(oid) => oid.to_owned(),
+        None => merge_base(worktree, base_ref).await?,
+    };
+    let files = collect_changes(worktree, &from, &commit, DiffBounds::default()).await?;
+    Ok(RecordedCheckpoint {
+        checkpoint_ref: r#ref,
+        diffstat: files.stat,
+    })
+}
+
+/// Changed files between two trees or a tree and the live worktree snapshot.
+pub(crate) async fn list_changed_files(
+    worktree: &Path,
+    from: &str,
+    to: &str,
+    bounds: DiffBounds,
+) -> Result<BoundedFiles, CheckpointError> {
+    collect_changes(worktree, from, to, bounds).await
+}
+
+/// Bounded unified diff between two trees (or a live snapshot oid).
+pub(crate) async fn produce_diff(
+    worktree: &Path,
+    from: &str,
+    to: &str,
+    file: Option<&str>,
+    bounds: DiffBounds,
+) -> Result<BoundedDiff, CheckpointError> {
+    let listed = collect_changes(worktree, from, to, bounds).await?;
+    if let Some(path) = file {
+        let raw = git_bytes(
+            worktree,
+            &["diff", "--find-renames", from, to, "--", path],
+            GIT_SNAPSHOT_TIMEOUT,
+        )
+        .await
+        .map_err(CheckpointError::internal)?;
+        let (diff, body_truncated) = truncate_bytes(&raw, bounds.max_bytes);
+        let file_stat = listed
+            .files
+            .iter()
+            .find(|entry| entry.path == path || entry.previous_path.as_deref() == Some(path));
+        let stat = Diffstat {
+            files: u32::from(file_stat.is_some() || !diff.is_empty()),
+            insertions: file_stat.map(|entry| entry.insertions).unwrap_or(0),
+            deletions: file_stat.map(|entry| entry.deletions).unwrap_or(0),
+            truncated: body_truncated,
+        };
+        return Ok(BoundedDiff {
+            diff,
+            truncated: body_truncated,
+            stat,
+        });
+    }
+
+    let mut body = String::new();
+    let mut truncated = listed.truncated;
+    for (included, entry) in listed.files.iter().enumerate() {
+        if included >= bounds.max_files {
+            truncated = true;
+            break;
+        }
+        let remaining = bounds.max_bytes.saturating_sub(body.len());
+        if remaining == 0 {
+            truncated = true;
+            break;
+        }
+        let raw = git_bytes(
+            worktree,
+            &["diff", "--find-renames", from, to, "--", &entry.path],
+            GIT_SNAPSHOT_TIMEOUT,
+        )
+        .await
+        .map_err(CheckpointError::internal)?;
+        let (chunk, chunk_truncated) = truncate_bytes(&raw, remaining);
+        if !body.is_empty() && !chunk.is_empty() && !body.ends_with('\n') {
+            body.push('\n');
+        }
+        body.push_str(&chunk);
+        if chunk_truncated {
+            truncated = true;
+            break;
+        }
+    }
+    Ok(BoundedDiff {
+        diff: body,
+        truncated,
+        stat: Diffstat {
+            truncated,
+            ..listed.stat
+        },
+    })
+}
+
+/// Snapshot the current worktree (tracked + untracked) as a tree oid.
+///
+/// The user's index is never opened. A temporary index file is used and
+/// deleted before this returns.
+pub(crate) async fn snapshot_tree(worktree: &Path) -> Result<String, CheckpointError> {
+    let temp = tempfile::NamedTempFile::new().map_err(|err| {
+        CheckpointError::internal(format!("could not create temporary index: {err}"))
+    })?;
+    let index_path = temp.path().to_path_buf();
+    // `git read-tree` wants to create the index; an empty file can confuse it.
+    drop(temp);
+    let _ = tokio::fs::remove_file(&index_path).await;
+
+    let result = snapshot_tree_with_index(worktree, &index_path).await;
+    let _ = tokio::fs::remove_file(&index_path).await;
+    result
+}
+
+async fn snapshot_tree_with_index(
+    worktree: &Path,
+    index_path: &Path,
+) -> Result<String, CheckpointError> {
+    let index = index_path.to_string_lossy();
+    git_text_env(
+        worktree,
+        &["read-tree", "HEAD"],
+        &[("GIT_INDEX_FILE", index.as_ref())],
+        GIT_TIMEOUT,
+    )
+    .await
+    .map_err(CheckpointError::internal)?;
+    git_text_env(
+        worktree,
+        &["add", "-A"],
+        &[("GIT_INDEX_FILE", index.as_ref())],
+        GIT_SNAPSHOT_TIMEOUT,
+    )
+    .await
+    .map_err(CheckpointError::internal)?;
+    git_text_env(
+        worktree,
+        &["write-tree"],
+        &[("GIT_INDEX_FILE", index.as_ref())],
+        GIT_TIMEOUT,
+    )
+    .await
+    .map_err(CheckpointError::internal)
+}
+
+/// Resolve `merge-base(base_ref, HEAD)`, falling back to `base_ref`.
+pub(crate) async fn merge_base(worktree: &Path, base_ref: &str) -> Result<String, CheckpointError> {
+    match git_text(worktree, &["merge-base", base_ref, "HEAD"], GIT_TIMEOUT).await {
+        Ok(oid) if !oid.is_empty() => Ok(oid),
+        _ => git_text(worktree, &["rev-parse", base_ref], GIT_TIMEOUT)
+            .await
+            .map_err(|err| {
+                CheckpointError::user(format!("could not resolve base {base_ref}: {err}"))
+            }),
+    }
+}
+
+/// Delete every checkpoint ref belonging to one workspace.
+pub(crate) async fn delete_workspace_refs(
+    repo_root: &Path,
+    workspace_id: WorkspaceId,
+) -> Result<usize, CheckpointError> {
+    let prefix = format!("{REF_PREFIX}/{workspace_id}/");
+    let refs = list_checkpoint_refs(repo_root).await?;
+    let mut removed = 0usize;
+    for r#ref in refs {
+        if r#ref.starts_with(&prefix) {
+            delete_ref(repo_root, &r#ref).await?;
+            removed += 1;
+        }
+    }
+    Ok(removed)
+}
+
+/// Drop checkpoint refs whose workspace is no longer live (crash / leftover).
+pub(crate) async fn sweep_orphaned_refs(
+    repo_root: &Path,
+    live_workspace_ids: &[WorkspaceId],
+) -> Result<usize, CheckpointError> {
+    let live: std::collections::HashSet<String> =
+        live_workspace_ids.iter().map(ToString::to_string).collect();
+    let refs = list_checkpoint_refs(repo_root).await?;
+    let mut removed = 0usize;
+    for r#ref in refs {
+        let Some(workspace) = workspace_id_from_ref(&r#ref) else {
+            continue;
+        };
+        if !live.contains(&workspace) {
+            delete_ref(repo_root, &r#ref).await?;
+            removed += 1;
+        }
+    }
+    Ok(removed)
+}
+
+pub(crate) async fn list_checkpoint_refs(repo_root: &Path) -> Result<Vec<String>, CheckpointError> {
+    let out = git_text(
+        repo_root,
+        &[
+            "for-each-ref",
+            "--format=%(refname)",
+            &format!("{REF_PREFIX}/"),
+        ],
+        GIT_TIMEOUT,
+    )
+    .await
+    .map_err(CheckpointError::internal)?;
+    Ok(out
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToOwned::to_owned)
+        .collect())
+}
+
+/// Resolve the trees a files/diff query should compare.
+pub(crate) async fn resolve_diff_range(
+    db: &DbStore,
+    workspace: &CodeWorkspace,
+    turn_id: Option<CodeTurnId>,
+) -> Result<(PathBuf, String, String, Option<CodeTurnId>), CheckpointError> {
+    let worktree = PathBuf::from(&workspace.worktree_path);
+    if !worktree.exists() {
+        return Err(CheckpointError::user("workspace worktree is gone"));
+    }
+    match turn_id {
+        None => {
+            let from = merge_base(&worktree, &workspace.base_ref).await?;
+            let to = snapshot_tree(&worktree).await?;
+            Ok((worktree, from, to, None))
+        }
+        Some(id) => {
+            let turn = get_turn(db, id)
+                .await
+                .map_err(|err| CheckpointError::internal(err.to_string()))?
+                .ok_or_else(|| CheckpointError::user("turn not found"))?;
+            let session = get_session(db, turn.session_id)
+                .await
+                .map_err(|err| CheckpointError::internal(err.to_string()))?
+                .ok_or_else(|| CheckpointError::user("session not found"))?;
+            if session.workspace_id != workspace.id {
+                return Err(CheckpointError::user(
+                    "turn does not belong to this workspace",
+                ));
+            }
+            let to = turn
+                .checkpoint_ref
+                .clone()
+                .ok_or_else(|| CheckpointError::user("this turn has no checkpoint"))?;
+            let from = previous_checkpoint_oid(&worktree, workspace, db, &turn)
+                .await?
+                .unwrap_or(merge_base(&worktree, &workspace.base_ref).await?);
+            Ok((worktree, from, to, Some(id)))
+        }
+    }
+}
+
+async fn previous_checkpoint_oid(
+    worktree: &Path,
+    workspace: &CodeWorkspace,
+    db: &DbStore,
+    turn: &CodeTurn,
+) -> Result<Option<String>, CheckpointError> {
+    if turn.ordinal <= 1 {
+        return Ok(None);
+    }
+    let previous_ref = checkpoint_ref(workspace.id, turn.ordinal - 1);
+    if let Ok(oid) = git_text(
+        worktree,
+        &["rev-parse", "--verify", &previous_ref],
+        GIT_TIMEOUT,
+    )
+    .await
+    {
+        if !oid.is_empty() {
+            return Ok(Some(oid));
+        }
+    }
+    let turns = list_turns(db, turn.session_id)
+        .await
+        .map_err(|err| CheckpointError::internal(err.to_string()))?;
+    Ok(turns
+        .into_iter()
+        .rev()
+        .find(|candidate| candidate.ordinal < turn.ordinal && candidate.checkpoint_ref.is_some())
+        .and_then(|candidate| candidate.checkpoint_ref))
+}
+
+async fn collect_changes(
+    worktree: &Path,
+    from: &str,
+    to: &str,
+    bounds: DiffBounds,
+) -> Result<BoundedFiles, CheckpointError> {
+    let name_status = git_bytes(
+        worktree,
+        &["diff", "--name-status", "-z", "--find-renames", from, to],
+        GIT_TIMEOUT,
+    )
+    .await
+    .map_err(CheckpointError::internal)?;
+    let numstat = git_text(
+        worktree,
+        &["diff", "--numstat", "--find-renames", from, to],
+        GIT_TIMEOUT,
+    )
+    .await
+    .map_err(CheckpointError::internal)?;
+    let stats = parse_numstat(&numstat);
+    let mut files = parse_name_status(&name_status);
+    for file in &mut files {
+        if let Some((insertions, deletions)) = stats
+            .get(&file.path)
+            .or_else(|| file.previous_path.as_ref().and_then(|prev| stats.get(prev)))
+        {
+            file.insertions = *insertions;
+            file.deletions = *deletions;
+        }
+    }
+    let total_files = files.len();
+    let insertions = files
+        .iter()
+        .map(|file| file.insertions)
+        .fold(0u32, u32::saturating_add);
+    let deletions = files
+        .iter()
+        .map(|file| file.deletions)
+        .fold(0u32, u32::saturating_add);
+    let truncated = total_files > bounds.max_files;
+    if truncated {
+        files.truncate(bounds.max_files);
+    }
+    Ok(BoundedFiles {
+        files,
+        truncated,
+        stat: Diffstat {
+            files: u32::try_from(total_files).unwrap_or(u32::MAX),
+            insertions,
+            deletions,
+            truncated,
+        },
+    })
+}
+
+fn parse_name_status(raw: &[u8]) -> Vec<ChangedFile> {
+    let text = String::from_utf8_lossy(raw);
+    let mut parts = text.split('\0').filter(|part| !part.is_empty());
+    let mut files = Vec::new();
+    while let Some(status) = parts.next() {
+        let code = status.chars().next().unwrap_or('M');
+        match code {
+            'R' | 'C' => {
+                let previous = parts.next().unwrap_or("").to_owned();
+                let path = parts.next().unwrap_or("").to_owned();
+                if path.is_empty() {
+                    continue;
+                }
+                files.push(ChangedFile {
+                    path,
+                    kind: if code == 'R' {
+                        FileChangeKind::Renamed
+                    } else {
+                        FileChangeKind::Modified
+                    },
+                    insertions: 0,
+                    deletions: 0,
+                    previous_path: Some(previous).filter(|value| !value.is_empty()),
+                });
+            }
+            other => {
+                let path = parts.next().unwrap_or("").to_owned();
+                if path.is_empty() {
+                    continue;
+                }
+                let kind = match other {
+                    'A' => FileChangeKind::Added,
+                    'D' => FileChangeKind::Deleted,
+                    _ => FileChangeKind::Modified,
+                };
+                files.push(ChangedFile {
+                    path,
+                    kind,
+                    insertions: 0,
+                    deletions: 0,
+                    previous_path: None,
+                });
+            }
+        }
+    }
+    files
+}
+
+fn parse_numstat(text: &str) -> std::collections::HashMap<String, (u32, u32)> {
+    let mut out = std::collections::HashMap::new();
+    for line in text.lines() {
+        let mut cols = line.split('\t');
+        let insertions = parse_stat_count(cols.next().unwrap_or("0"));
+        let deletions = parse_stat_count(cols.next().unwrap_or("0"));
+        let path = cols.next().unwrap_or("");
+        if path.is_empty() {
+            continue;
+        }
+        let key = path
+            .split_once(" => ")
+            .map(|(_, after)| after)
+            .unwrap_or(path)
+            .to_owned();
+        out.insert(key, (insertions, deletions));
+    }
+    out
+}
+
+fn parse_stat_count(value: &str) -> u32 {
+    if value == "-" {
+        0
+    } else {
+        value.parse().unwrap_or(0)
+    }
+}
+
+fn truncate_bytes(raw: &[u8], max: usize) -> (String, bool) {
+    let text = String::from_utf8_lossy(raw);
+    if text.len() <= max {
+        return (text.into_owned(), false);
+    }
+    let mut end = max;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    (text[..end].to_owned(), true)
+}
+
+fn workspace_id_from_ref(r#ref: &str) -> Option<String> {
+    let rest = r#ref.strip_prefix(&format!("{REF_PREFIX}/"))?;
+    let (workspace, _ordinal) = rest.split_once('/')?;
+    if workspace.is_empty() {
+        None
+    } else {
+        Some(workspace.to_owned())
+    }
+}
+
+async fn delete_ref(repo_root: &Path, r#ref: &str) -> Result<(), CheckpointError> {
+    git_text(repo_root, &["update-ref", "-d", r#ref], GIT_TIMEOUT)
+        .await
+        .map(|_| ())
+        .map_err(CheckpointError::internal)
+}
+
+async fn journal(
+    db: &DbStore,
+    bus: &CodeEventBus,
+    session: &CodeSession,
+    event: CodeEvent,
+) -> Result<(), tidebreak_core::db::code::CodeJournalError> {
+    let seq = append_event(db, session.id, session.spawn_epoch, &event).await?;
+    bus.publish(session.id, SequencedCodeEvent { seq, event });
+    Ok(())
+}
+
+fn truncate_notice(message: String) -> String {
+    const MAX: usize = tidebreak_core::MAX_NOTICE_CHARS;
+    if message.chars().count() <= MAX {
+        return message;
+    }
+    message.chars().take(MAX).collect()
+}
+
+async fn git_text(cwd: &Path, args: &[&str], limit: Duration) -> Result<String, String> {
+    git_text_env(cwd, args, &[], limit).await
+}
+
+async fn git_text_env(
+    cwd: &Path,
+    args: &[&str],
+    env: &[(&str, &str)],
+    limit: Duration,
+) -> Result<String, String> {
+    let bytes = git_bytes_env(cwd, args, env, limit).await?;
+    Ok(String::from_utf8_lossy(&bytes).trim().to_owned())
+}
+
+async fn git_bytes(cwd: &Path, args: &[&str], limit: Duration) -> Result<Vec<u8>, String> {
+    git_bytes_env(cwd, args, &[], limit).await
+}
+
+async fn git_bytes_env(
+    cwd: &Path,
+    args: &[&str],
+    env: &[(&str, &str)],
+    limit: Duration,
+) -> Result<Vec<u8>, String> {
+    let mut command = Command::new("git");
+    command
+        .args(args)
+        .current_dir(cwd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_AUTHOR_NAME", "Tidebreak")
+        .env("GIT_AUTHOR_EMAIL", "tidebreak@localhost")
+        .env("GIT_COMMITTER_NAME", "Tidebreak")
+        .env("GIT_COMMITTER_EMAIL", "tidebreak@localhost");
+    for (key, value) in env {
+        command.env(key, value);
+    }
+    let child = command
+        .spawn()
+        .map_err(|err| format!("failed to spawn git: {err}"))?;
+    let output = timeout(limit, child.wait_with_output())
+        .await
+        .map_err(|_| format!("git {} timed out", args.join(" ")))?
+        .map_err(|err| format!("git {} failed: {err}", args.join(" ")))?;
+    if output.status.success() {
+        Ok(output.stdout)
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+        Err(if stderr.is_empty() { stdout } else { stderr })
+    }
+}
+
+/// Fingerprint of the user's `HEAD` and index, used to prove a checkpoint
+/// does not touch either.
+#[cfg(test)]
+pub(crate) async fn user_git_fingerprint(
+    worktree: &Path,
+) -> Result<(String, Vec<u8>), CheckpointError> {
+    let head = git_text(worktree, &["rev-parse", "HEAD"], GIT_TIMEOUT)
+        .await
+        .map_err(CheckpointError::internal)?;
+    let index_path = git_text(worktree, &["rev-parse", "--git-path", "index"], GIT_TIMEOUT)
+        .await
+        .map_err(CheckpointError::internal)?;
+    let path = worktree.join(index_path);
+    let bytes = tokio::fs::read(&path).await.unwrap_or_default();
+    Ok((head, bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::Command as StdCommand;
+    use tempfile::TempDir;
+
+    fn init_repo() -> (TempDir, PathBuf) {
+        let dir = TempDir::new().unwrap();
+        let repo = dir.path().join("origin");
+        std::fs::create_dir_all(&repo).unwrap();
+        run(&repo, &["git", "init", "-b", "main"]);
+        run(&repo, &["git", "config", "user.email", "dev@example.com"]);
+        run(&repo, &["git", "config", "user.name", "Dev"]);
+        std::fs::write(repo.join("README.md"), "hello\n").unwrap();
+        std::fs::write(repo.join("keep.txt"), "keep\n").unwrap();
+        run(&repo, &["git", "add", "README.md", "keep.txt"]);
+        run(&repo, &["git", "commit", "-m", "init"]);
+        (dir, repo)
+    }
+
+    fn add_worktree(repo: &Path, label: &str) -> PathBuf {
+        let path = repo.parent().unwrap().join(label);
+        run(
+            repo,
+            &[
+                "git",
+                "worktree",
+                "add",
+                "-b",
+                &format!("tidebreak/{label}"),
+                path.to_str().unwrap(),
+                "main",
+            ],
+        );
+        path
+    }
+
+    fn run(cwd: &Path, args: &[&str]) {
+        let status = StdCommand::new(args[0])
+            .args(&args[1..])
+            .current_dir(cwd)
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .status()
+            .unwrap();
+        assert!(status.success(), "{args:?} failed in {}", cwd.display());
+    }
+
+    fn ws() -> WorkspaceId {
+        WorkspaceId::new()
+    }
+
+    #[tokio::test]
+    async fn checkpoint_captures_untracked_renames_and_mode_changes() {
+        let (_dir, repo) = init_repo();
+        let tree = add_worktree(&repo, "cap");
+        std::fs::write(tree.join("README.md"), "hello world\n").unwrap();
+        std::fs::write(tree.join("new.txt"), "untracked\n").unwrap();
+        std::fs::rename(tree.join("keep.txt"), tree.join("kept.txt")).unwrap();
+        let mut perms = std::fs::metadata(tree.join("README.md"))
+            .unwrap()
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(tree.join("README.md"), perms).unwrap();
+
+        let before = user_git_fingerprint(&tree).await.unwrap();
+        let recorded = record_checkpoint(&tree, ws(), 1, None, "main")
+            .await
+            .unwrap();
+        let after = user_git_fingerprint(&tree).await.unwrap();
+        assert_eq!(before, after, "user index and HEAD must be byte-identical");
+        assert!(recorded.checkpoint_ref.starts_with(REF_PREFIX));
+        assert!(recorded.diffstat.files >= 2);
+
+        let head = git_text(&tree, &["rev-parse", "--abbrev-ref", "HEAD"], GIT_TIMEOUT)
+            .await
+            .unwrap();
+        assert_eq!(head, "tidebreak/cap");
+        let visible = git_text(&tree, &["log", "--oneline", "-1"], GIT_TIMEOUT)
+            .await
+            .unwrap();
+        assert!(
+            !visible.contains("checkpoint"),
+            "checkpoint must not appear on the branch: {visible}"
+        );
+
+        let from = merge_base(&tree, "main").await.unwrap();
+        let files = list_changed_files(
+            &tree,
+            &from,
+            &recorded.checkpoint_ref,
+            DiffBounds::default(),
+        )
+        .await
+        .unwrap();
+        let paths: Vec<_> = files.files.iter().map(|file| file.path.as_str()).collect();
+        assert!(paths.contains(&"new.txt"), "{paths:?}");
+        assert!(
+            files
+                .files
+                .iter()
+                .any(|file| file.kind == FileChangeKind::Renamed
+                    && (file.path == "kept.txt"
+                        || file.previous_path.as_deref() == Some("keep.txt"))),
+            "{:#?}",
+            files.files
+        );
+        assert!(
+            files
+                .files
+                .iter()
+                .any(|file| file.path == "README.md" && file.kind == FileChangeKind::Modified),
+            "{:#?}",
+            files.files
+        );
+
+        let diff = produce_diff(
+            &tree,
+            &from,
+            &recorded.checkpoint_ref,
+            None,
+            DiffBounds::default(),
+        )
+        .await
+        .unwrap();
+        assert!(diff.diff.contains("untracked"), "{}", diff.diff);
+        assert!(
+            diff.diff.contains("hello world") || diff.diff.contains("README"),
+            "{}",
+            diff.diff
+        );
+    }
+
+    #[tokio::test]
+    async fn turn_diff_is_the_range_between_checkpoints() {
+        let (_dir, repo) = init_repo();
+        let tree = add_worktree(&repo, "turns");
+        let id = ws();
+        std::fs::write(tree.join("a.txt"), "one\n").unwrap();
+        let first = record_checkpoint(&tree, id, 1, None, "main").await.unwrap();
+        std::fs::write(tree.join("b.txt"), "two\n").unwrap();
+        let first_oid = git_text(&tree, &["rev-parse", &first.checkpoint_ref], GIT_TIMEOUT)
+            .await
+            .unwrap();
+        let second = record_checkpoint(&tree, id, 2, Some(&first_oid), "main")
+            .await
+            .unwrap();
+
+        let turn2 = produce_diff(
+            &tree,
+            &first.checkpoint_ref,
+            &second.checkpoint_ref,
+            None,
+            DiffBounds::default(),
+        )
+        .await
+        .unwrap();
+        assert!(turn2.diff.contains("b.txt"), "{}", turn2.diff);
+        assert!(
+            !turn2.diff.contains("a.txt"),
+            "turn 2 must not include turn 1: {}",
+            turn2.diff
+        );
+
+        let turn1 = produce_diff(
+            &tree,
+            &merge_base(&tree, "main").await.unwrap(),
+            &first.checkpoint_ref,
+            None,
+            DiffBounds::default(),
+        )
+        .await
+        .unwrap();
+        assert!(turn1.diff.contains("a.txt"), "{}", turn1.diff);
+        assert!(!turn1.diff.contains("b.txt"), "{}", turn1.diff);
+    }
+
+    #[tokio::test]
+    async fn truncation_is_marked_when_caps_are_exceeded() {
+        let (_dir, repo) = init_repo();
+        let tree = add_worktree(&repo, "caps");
+        for i in 0..8 {
+            std::fs::write(
+                tree.join(format!("f{i}.txt")),
+                format!("{i}\n{}", "x".repeat(80)),
+            )
+            .unwrap();
+        }
+        let recorded = record_checkpoint(&tree, ws(), 1, None, "main")
+            .await
+            .unwrap();
+        let from = merge_base(&tree, "main").await.unwrap();
+        let tight = DiffBounds {
+            max_bytes: 40,
+            max_files: 2,
+        };
+        let files = list_changed_files(&tree, &from, &recorded.checkpoint_ref, tight)
+            .await
+            .unwrap();
+        assert!(files.truncated, "file-count cap must mark truncation");
+        assert_eq!(files.files.len(), 2);
+        assert!(files.stat.truncated);
+        assert!(files.stat.files >= 8);
+
+        let diff = produce_diff(&tree, &from, &recorded.checkpoint_ref, None, tight)
+            .await
+            .unwrap();
+        assert!(diff.truncated);
+        assert!(diff.diff.len() <= 80, "{}", diff.diff.len());
+    }
+
+    #[tokio::test]
+    async fn archive_removes_workspace_refs_and_sweep_drops_orphans() {
+        let (_dir, repo) = init_repo();
+        let tree = add_worktree(&repo, "gone");
+        let live = ws();
+        let dead = ws();
+        std::fs::write(tree.join("x.txt"), "x\n").unwrap();
+        record_checkpoint(&tree, live, 1, None, "main")
+            .await
+            .unwrap();
+        record_checkpoint(&tree, dead, 1, None, "main")
+            .await
+            .unwrap();
+        let listed = list_checkpoint_refs(&repo).await.unwrap();
+        assert_eq!(listed.len(), 2, "{listed:?}");
+
+        let removed = delete_workspace_refs(&repo, dead).await.unwrap();
+        assert_eq!(removed, 1);
+        let listed = list_checkpoint_refs(&repo).await.unwrap();
+        assert_eq!(listed.len(), 1);
+        assert!(listed[0].contains(&live.to_string()));
+
+        let swept = sweep_orphaned_refs(&repo, &[]).await.unwrap();
+        assert_eq!(swept, 1);
+        assert!(list_checkpoint_refs(&repo).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn snapshot_failure_does_not_write_a_ref() {
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("not-a-repo");
+        std::fs::create_dir_all(&missing).unwrap();
+        let err = record_checkpoint(&missing, ws(), 1, None, "main")
+            .await
+            .unwrap_err();
+        assert!(!err.to_string().is_empty());
+    }
+}

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -5,6 +5,7 @@
 //! worker, crash recovery, and the live event bus.
 
 pub(crate) mod bus;
+pub(crate) mod checkpoint;
 pub(crate) mod recovery;
 pub(crate) mod runtime;
 pub(crate) mod session_worker;

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -15,12 +15,16 @@ use tidebreak_core::db::code::{
 };
 use tidebreak_core::{
     Attention, AttentionSource, CapLevel, CodePermissionMode, CodeRepo, CodeSession, CodeSessionId,
-    CodeSessionLifecycle, CodeTurn, CodeWorkspace, CodeWorkspaceStatus, DbStore, HarnessKind,
-    RepoId, WorkspaceId,
+    CodeSessionLifecycle, CodeTurn, CodeTurnId, CodeWorkspace, CodeWorkspaceStatus, DbStore,
+    Diffstat, HarnessKind, RepoId, WorkspaceId,
 };
 use tidebreak_harness::{builtin_registry, AdapterRegistry, HarnessAdapter, HostEnv, SessionSpec};
 
 use super::bus::CodeEventBus;
+use super::checkpoint::{
+    delete_workspace_refs, list_changed_files, produce_diff, resolve_diff_range,
+    sweep_orphaned_refs, ChangedFile, CheckpointError, DiffBounds,
+};
 use super::recovery::{self, RecoveryAction};
 use super::session_worker::{
     attach_engine, queue_follow_up, spawn_session_worker, WorkerCommand, WorkerError, WorkerHandle,
@@ -81,6 +85,12 @@ impl CodeRuntime {
         let actions = recovery::recover_running_sessions(&self.db)
             .await
             .map_err(ServerError::from)?;
+        if let Err(error) = self.sweep_orphaned_checkpoints().await {
+            tracing::warn!(
+                "code-mode: checkpoint ref sweep failed: {}",
+                error.message()
+            );
+        }
         // Recovery only mutates rows. Re-attach a worker for every session
         // that is still usable so submit_turn is not stuck after a restart.
         for session in list_sessions(&self.db).await? {
@@ -366,6 +376,23 @@ impl CodeRuntime {
             .await
             .map_err(map_worktree)?;
         let _ = prune_worktrees(std::path::Path::new(&repo.root_path)).await;
+        if let Err(error) =
+            delete_workspace_refs(std::path::Path::new(&repo.root_path), workspace.id).await
+        {
+            tracing::warn!(
+                workspace = %workspace.id,
+                "code-mode: could not delete checkpoint refs on archive: {error}"
+            );
+        }
+        if let Err(error) = self
+            .sweep_repo_checkpoint_refs(std::path::Path::new(&repo.root_path), repo.id)
+            .await
+        {
+            tracing::warn!(
+                "code-mode: checkpoint ref sweep failed: {}",
+                error.message()
+            );
+        }
         workspace.status = CodeWorkspaceStatus::Archived;
         workspace.archived_at = Some(Utc::now());
         save_workspace(&self.db, &workspace).await?;
@@ -551,6 +578,62 @@ impl CodeRuntime {
         Ok(list_turns(&self.db, session_id).await?)
     }
 
+    pub(crate) async fn workspace_files(
+        &self,
+        workspace_id: WorkspaceId,
+        turn_id: Option<CodeTurnId>,
+    ) -> Result<(Vec<ChangedFile>, bool, Diffstat, Option<CodeTurnId>), ServerError> {
+        let workspace = self.get_workspace(workspace_id).await?;
+        let (worktree, from, to, turn) = resolve_diff_range(&self.db, &workspace, turn_id)
+            .await
+            .map_err(map_checkpoint)?;
+        let listed = list_changed_files(&worktree, &from, &to, DiffBounds::default())
+            .await
+            .map_err(map_checkpoint)?;
+        Ok((listed.files, listed.truncated, listed.stat, turn))
+    }
+
+    pub(crate) async fn workspace_diff(
+        &self,
+        workspace_id: WorkspaceId,
+        turn_id: Option<CodeTurnId>,
+        file: Option<&str>,
+    ) -> Result<(String, bool, Diffstat, Option<CodeTurnId>), ServerError> {
+        let workspace = self.get_workspace(workspace_id).await?;
+        let (worktree, from, to, turn) = resolve_diff_range(&self.db, &workspace, turn_id)
+            .await
+            .map_err(map_checkpoint)?;
+        let produced = produce_diff(&worktree, &from, &to, file, DiffBounds::default())
+            .await
+            .map_err(map_checkpoint)?;
+        Ok((produced.diff, produced.truncated, produced.stat, turn))
+    }
+
+    async fn sweep_orphaned_checkpoints(&self) -> Result<(), ServerError> {
+        for repo in list_repos(&self.db).await? {
+            self.sweep_repo_checkpoint_refs(std::path::Path::new(&repo.root_path), repo.id)
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn sweep_repo_checkpoint_refs(
+        &self,
+        repo_root: &std::path::Path,
+        repo_id: RepoId,
+    ) -> Result<(), ServerError> {
+        let live: Vec<WorkspaceId> = list_workspaces(&self.db, Some(repo_id))
+            .await?
+            .into_iter()
+            .filter(|workspace| workspace.status != CodeWorkspaceStatus::Archived)
+            .map(|workspace| workspace.id)
+            .collect();
+        sweep_orphaned_refs(repo_root, &live)
+            .await
+            .map(|_| ())
+            .map_err(map_checkpoint)
+    }
+
     async fn refuse_running_sessions(
         &self,
         workspace_id: WorkspaceId,
@@ -675,6 +758,21 @@ impl CodeRuntime {
                     "no live worker is attached to this session",
                 )
             })
+    }
+}
+
+fn map_checkpoint(err: CheckpointError) -> ServerError {
+    match err {
+        CheckpointError::User(message) => {
+            if message.contains("not found") || message.contains("gone") {
+                ServerError::not_found(message)
+            } else if message.contains("no checkpoint") {
+                ServerError::conflict_kind("no_checkpoint", message)
+            } else {
+                ServerError::bad_request_kind("checkpoint", message)
+            }
+        }
+        CheckpointError::Internal(message) => ServerError::internal(message),
     }
 }
 

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -316,6 +316,7 @@ async fn drive_turn(
     if let Ok(Some(current)) = tidebreak_core::db::code::get_turn(db, turn.id).await {
         turn = current;
     }
+    super::checkpoint::after_turn_completed(db, bus, session, &mut turn).await;
     if session_was_ended(db, session).await {
         return Ok(turn);
     }

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -712,6 +712,14 @@ pub fn app(state: AppState) -> Router {
             post(routes::code::archive_workspace),
         )
         .route(
+            "/code/workspaces/{id}/files",
+            get(routes::code::list_workspace_files),
+        )
+        .route(
+            "/code/workspaces/{id}/diff",
+            get(routes::code::get_workspace_diff),
+        )
+        .route(
             "/code/workspaces/{id}/sessions",
             post(routes::code::create_session).get(routes::code::list_workspace_sessions),
         )

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -16,11 +16,13 @@ pub(crate) use sessions::{
 };
 #[allow(unused_imports)]
 pub(crate) use types::{
-    CodeRepoSnapshot, CodeSessionSnapshot, CodeTurnSnapshot, CodeWorkspaceSnapshot,
-    HarnessDoctorReport, QueuedCodeTurn, SequencedCodeEventFrame,
+    CodeFileChange, CodeRepoSnapshot, CodeSessionSnapshot, CodeTurnSnapshot, CodeWorkspaceDiff,
+    CodeWorkspaceFiles, CodeWorkspaceSnapshot, HarnessDoctorReport, QueuedCodeTurn,
+    SequencedCodeEventFrame,
 };
 pub(crate) use workspaces::{
-    archive_workspace, create_workspace, get_workspace, list_workspaces, patch_workspace,
+    archive_workspace, create_workspace, get_workspace, get_workspace_diff, list_workspace_files,
+    list_workspaces, patch_workspace,
 };
 
 use crate::code::CodeRuntime;

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -5,9 +5,9 @@ use ts_rs::TS;
 
 use tidebreak_core::{
     Attention, CapLevel, CodeEvent, CodePermissionMode, CodeRepo, CodeSession,
-    CodeSessionLifecycle, CodeTurn, CodeTurnStatus, CodeWorkspace, CodeWorkspaceStatus,
-    FenceReason, HarnessCaps, HarnessKind, HarnessTier, PullRequestDigest, QuickAction, RepoId,
-    WorkspaceId,
+    CodeSessionLifecycle, CodeTurn, CodeTurnId, CodeTurnStatus, CodeWorkspace, CodeWorkspaceStatus,
+    Diffstat, FenceReason, FileChangeKind, HarnessCaps, HarnessKind, HarnessTier,
+    PullRequestDigest, QuickAction, RepoId, WorkspaceId,
 };
 
 /// A registered local git repository.
@@ -134,6 +134,9 @@ pub struct CodeTurnSnapshot {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub checkpoint_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub diffstat: Option<Diffstat>,
     pub started_at: chrono::DateTime<chrono::Utc>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
@@ -150,6 +153,7 @@ impl From<CodeTurn> for CodeTurnSnapshot {
             user_input: turn.user_input,
             usage: turn.usage,
             checkpoint_ref: turn.checkpoint_ref,
+            diffstat: turn.diffstat,
             started_at: turn.started_at,
             ended_at: turn.ended_at,
         }
@@ -291,6 +295,59 @@ pub struct QueuedCodeTurn {
 pub struct ListWorkspacesQuery {
     #[serde(default)]
     pub repo_id: Option<RepoId>,
+}
+
+/// Query for `GET /code/workspaces/{id}/files`.
+#[derive(Debug, Deserialize)]
+pub struct WorkspaceFilesQuery {
+    #[serde(default)]
+    pub turn: Option<CodeTurnId>,
+}
+
+/// Query for `GET /code/workspaces/{id}/diff`.
+#[derive(Debug, Deserialize)]
+pub struct WorkspaceDiffQuery {
+    #[serde(default)]
+    pub turn: Option<CodeTurnId>,
+    #[serde(default)]
+    pub file: Option<String>,
+}
+
+/// One changed path in a workspace or turn file list.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeFileChange {
+    pub path: String,
+    pub kind: FileChangeKind,
+    pub insertions: u32,
+    pub deletions: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub previous_path: Option<String>,
+}
+
+/// Bounded changed-file list for `GET /code/workspaces/{id}/files`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeWorkspaceFiles {
+    pub files: Vec<CodeFileChange>,
+    pub truncated: bool,
+    pub stat: Diffstat,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub turn_id: Option<CodeTurnId>,
+}
+
+/// Bounded unified diff for `GET /code/workspaces/{id}/diff`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeWorkspaceDiff {
+    pub diff: String,
+    pub truncated: bool,
+    pub stat: Diffstat,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub turn_id: Option<CodeTurnId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub file: Option<String>,
 }
 
 /// Query for `GET /code/sessions/{id}/events`.

--- a/crates/tidebreak-server/src/routes/code/workspaces.rs
+++ b/crates/tidebreak-server/src/routes/code/workspaces.rs
@@ -8,8 +8,9 @@ use crate::state::AppState;
 
 use super::require_code;
 use super::types::{
-    ArchiveWorkspaceBody, CodeWorkspaceSnapshot, CreateWorkspaceBody, ListWorkspacesQuery,
-    PatchWorkspaceBody,
+    ArchiveWorkspaceBody, CodeFileChange, CodeWorkspaceDiff, CodeWorkspaceFiles,
+    CodeWorkspaceSnapshot, CreateWorkspaceBody, ListWorkspacesQuery, PatchWorkspaceBody,
+    WorkspaceDiffQuery, WorkspaceFilesQuery,
 };
 use tidebreak_core::WorkspaceId;
 
@@ -76,4 +77,52 @@ pub async fn archive_workspace(
             .archive_workspace(id, body.force)
             .await?,
     )))
+}
+
+pub async fn list_workspace_files(
+    State(state): State<AppState>,
+    Path(id): Path<WorkspaceId>,
+    Query(query): Query<WorkspaceFilesQuery>,
+) -> Result<Json<CodeWorkspaceFiles>, ServerError> {
+    let (files, truncated, stat, turn_id) = require_code(&state)?
+        .workspace_files(id, query.turn)
+        .await?;
+    Ok(Json(CodeWorkspaceFiles {
+        files: files
+            .into_iter()
+            .map(|file| CodeFileChange {
+                path: file.path,
+                kind: file.kind,
+                insertions: file.insertions,
+                deletions: file.deletions,
+                previous_path: file.previous_path,
+            })
+            .collect(),
+        truncated,
+        stat,
+        turn_id,
+    }))
+}
+
+pub async fn get_workspace_diff(
+    State(state): State<AppState>,
+    Path(id): Path<WorkspaceId>,
+    Query(query): Query<WorkspaceDiffQuery>,
+) -> Result<Json<CodeWorkspaceDiff>, ServerError> {
+    let file = query
+        .file
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+    let (diff, truncated, stat, turn_id) = require_code(&state)?
+        .workspace_diff(id, query.turn, file.as_deref())
+        .await?;
+    Ok(Json(CodeWorkspaceDiff {
+        diff,
+        truncated,
+        stat,
+        turn_id,
+        file,
+    }))
 }

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -1257,6 +1257,209 @@ async fn superseded_worker_cannot_append_to_the_journal() {
 }
 
 #[tokio::test]
+async fn a_completed_turn_records_a_checkpoint_and_serves_bounded_review() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let worktree = std::path::Path::new(workspace["worktree_path"].as_str().unwrap());
+
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+
+    std::fs::write(worktree.join("added.txt"), "new file\n").unwrap();
+    std::fs::write(worktree.join("README.md"), "hello from turn\n").unwrap();
+
+    let turn = client
+        .post(format!(
+            "http://{addr}/code/sessions/{}/turns",
+            json_id(&session)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "edit the tree" }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(turn["status"], "completed");
+    let checkpoint = turn["checkpoint_ref"].as_str().expect("checkpoint_ref");
+    assert!(
+        checkpoint.contains("refs/tidebreak/checkpoints/"),
+        "{checkpoint}"
+    );
+    assert!(turn["diffstat"]["files"].as_u64().unwrap() >= 1);
+
+    let files = client
+        .get(format!(
+            "http://{addr}/code/workspaces/{}/files?turn={}",
+            json_id(&workspace),
+            json_id(&turn)
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let paths: Vec<&str> = files["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|file| file["path"].as_str())
+        .collect();
+    assert!(paths.contains(&"added.txt"), "{paths:?}");
+
+    let diff = client
+        .get(format!(
+            "http://{addr}/code/workspaces/{}/diff?turn={}&file=added.txt",
+            json_id(&workspace),
+            json_id(&turn)
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert!(
+        diff["diff"].as_str().unwrap().contains("new file"),
+        "{}",
+        diff["diff"]
+    );
+    assert_eq!(diff["truncated"], false);
+
+    let events =
+        tidebreak_core::db::code::list_events(&_runtime.db, json_id(&session).parse().unwrap(), 0)
+            .await
+            .unwrap();
+    assert!(
+        events.iter().any(|framed| {
+            matches!(
+                framed.event,
+                tidebreak_core::CodeEvent::CheckpointRecorded { .. }
+            )
+        }),
+        "expected CheckpointRecorded in {events:?}"
+    );
+
+    let archived = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/archive",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "force": true }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(archived.status(), reqwest::StatusCode::OK);
+    let leftover = std::process::Command::new("git")
+        .args([
+            "for-each-ref",
+            "--format=%(refname)",
+            "refs/tidebreak/checkpoints/",
+        ])
+        .current_dir(&repo)
+        .output()
+        .unwrap();
+    assert!(
+        leftover.status.success(),
+        "{}",
+        String::from_utf8_lossy(&leftover.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&leftover.stdout).trim().is_empty(),
+        "archive must drop checkpoint refs: {}",
+        String::from_utf8_lossy(&leftover.stdout)
+    );
+}
+
+#[tokio::test]
+async fn a_failed_checkpoint_does_not_fail_the_turn() {
+    let (router, token, runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let worktree = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+
+    // Replace the checkout with a non-repo so the snapshot fails after the
+    // engine turn has already succeeded.
+    std::fs::remove_dir_all(&worktree).unwrap();
+    std::fs::create_dir_all(&worktree).unwrap();
+    std::fs::write(worktree.join("orphan.txt"), "still here\n").unwrap();
+
+    let turn = client
+        .post(format!(
+            "http://{addr}/code/sessions/{}/turns",
+            json_id(&session)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "keep going" }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(turn["status"], "completed");
+    assert!(turn["checkpoint_ref"].is_null());
+
+    let events =
+        tidebreak_core::db::code::list_events(&runtime.db, json_id(&session).parse().unwrap(), 0)
+            .await
+            .unwrap();
+    assert!(
+        events.iter().any(|framed| {
+            matches!(
+                framed.event,
+                tidebreak_core::CodeEvent::HarnessNotice {
+                    level: tidebreak_core::HarnessNoticeLevel::Warning,
+                    ..
+                }
+            )
+        }),
+        "expected a warning notice, got {events:?}"
+    );
+}
+
+#[tokio::test]
 async fn doctor_lists_the_scripted_adapter() {
     let (router, token, _runtime, _dir) = code_app(plain_text_script()).await;
     let addr = serve(router).await;

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -414,6 +414,8 @@ mod tests {
         generate::collect_from::<crate::routes::code::QueuedCodeTurn>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::SequencedCodeEventFrame>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::HarnessDoctorReport>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::CodeWorkspaceFiles>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::CodeWorkspaceDiff>(&cfg, &mut out);
         out
     }
 


### PR DESCRIPTION
## Summary

Completed turns now leave a hidden worktree checkpoint, and the workspace UI can review those changes turn by turn.

- After a successful turn, snapshot tracked *and* untracked work through a temporary git index. The user's index and `HEAD` stay byte-identical; the snapshot lives only at `refs/tidebreak/checkpoints/<workspace>/<ordinal>`.
- Persist `checkpoint_ref` + `diffstat` on the turn row and journal `CheckpointRecorded`. A failed snapshot journals a `HarnessNotice` and leaves the turn completed.
- Serve bounded review from `GET /code/workspaces/{id}/files` and `GET /code/workspaces/{id}/diff` (byte + file-count caps, truncation marked). Turn 1 diffs from the workspace base; later turns are `checkpoint(n-1)..checkpoint(n)`. Workspace review is `merge-base(base, HEAD)` against the live tree, including uncommitted state.
- Archive deletes that workspace's checkpoint refs; boot and archive also sweep refs whose workspace is gone.
- Register `files` and `diff` panel variants. The transcript turn card shows diffstat, duration, and a link that opens the Diff panel for that turn. Files/Diff panels render the server unified-diff string with per-file grouping and status-token +/- tinting. The async narrative slot is left empty.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy -p tidebreak-server --locked --all-targets -- -D warnings`
- [x] `cargo test -p tidebreak-server --locked`
- [x] `cargo check --workspace --locked`
- [x] `pnpm test` and `pnpm build` in `crates/tidebreak-desktop/ui`
- [x] Wire types regenerated (`UPDATE_WIRE_TYPES=1`)

Temp-repo coverage includes untracked/rename/mode capture, index+HEAD identity, turn-diff correctness, truncation marking, archive/sweep ref cleanup, and checkpoint-failure-does-not-fail-turn.

Not verified in the running desktop app.