### PR TITLE
feat(code): auxiliary workspace terminals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,7 +721,7 @@ checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
 dependencies = [
  "borsh-derive",
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
 ]
 
 [[package]]
@@ -1059,6 +1059,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
@@ -1724,6 +1730,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1946,6 +1958,17 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -3490,7 +3513,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "serde",
  "winapi",
 ]
@@ -3681,13 +3704,25 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "memoffset",
 ]
@@ -4425,6 +4460,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix 0.28.0",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4609,7 +4665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -4650,7 +4706,7 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2",
@@ -5709,6 +5765,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16809bc35793b19ce4e0c53924bc0dce3937f15487997cfdaed936004180730"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "serialize-to-javascript"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5808,6 +5875,22 @@ dependencies = [
  "sigchld",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -7171,6 +7254,7 @@ dependencies = [
  "jsonschema",
  "libc",
  "plist",
+ "portable-pty",
  "reqwest 0.12.28",
  "schemars 1.2.2",
  "sea-orm",
@@ -8729,6 +8813,15 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -8914,7 +9007,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "hex",
- "nix",
+ "nix 0.29.0",
  "ordered-stream",
  "rand 0.8.6",
  "serde",

--- a/crates/tidebreak-desktop/ui/package.json
+++ b/crates/tidebreak-desktop/ui/package.json
@@ -55,6 +55,8 @@
     "@univerjs/core": "0.25.1",
     "@univerjs/preset-sheets-core": "0.25.1",
     "@univerjs/presets": "0.25.1",
+    "@xterm/addon-fit": "0.11.0",
+    "@xterm/xterm": "6.0.0",
     "ag-grid-community": "35.0.1",
     "ag-grid-react": "35.0.1",
     "class-variance-authority": "0.7.1",

--- a/crates/tidebreak-desktop/ui/pnpm-lock.yaml
+++ b/crates/tidebreak-desktop/ui/pnpm-lock.yaml
@@ -138,6 +138,12 @@ importers:
       '@univerjs/presets':
         specifier: 0.25.1
         version: 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@xterm/addon-fit':
+        specifier: 0.11.0
+        version: 0.11.0
+      '@xterm/xterm':
+        specifier: 6.0.0
+        version: 6.0.0
       ag-grid-community:
         specifier: 35.0.1
         version: 35.0.1
@@ -1388,79 +1394,66 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
@@ -1535,28 +1528,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
     resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
     resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.3':
     resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.3':
     resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
@@ -2338,6 +2327,12 @@ packages:
       react:
         optional: true
 
+  '@xterm/addon-fit@0.11.0':
+    resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/xterm@6.0.0':
+    resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
+
   acorn@8.18.0:
     resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
     engines: {node: '>=0.4.0'}
@@ -2919,28 +2914,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -6755,6 +6746,10 @@ snapshots:
   '@wendellhu/redi@1.1.1(react@19.2.7)':
     optionalDependencies:
       react: 19.2.7
+
+  '@xterm/addon-fit@0.11.0': {}
+
+  '@xterm/xterm@6.0.0': {}
 
   acorn@8.18.0: {}
 

--- a/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
@@ -856,6 +856,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
         return <BackgroundAgentPanel chatId={chatId} runId={panel.runId} />;
       case "files":
       case "diff":
+      case "terminal":
         return null;
     }
   }

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -81,6 +81,8 @@ import {
   type CodeRepoSnapshot,
   type CodeSessionSnapshot,
   type CodeTurnSnapshot,
+  type CodeTerminalRead,
+  type CodeTerminalSnapshot,
   type CodeWorkspaceDiff,
   type CodeWorkspaceFiles,
   type CodeWorkspaceSnapshot,
@@ -108,6 +110,9 @@ import {
   parseCodeSessionList,
   parseCodeTurn,
   parseCodeTurnList,
+  parseCodeTerminal,
+  parseCodeTerminalList,
+  parseCodeTerminalRead,
   parseCodeWorkspace,
   parseCodeWorkspaceDiff,
   parseCodeWorkspaceFiles,
@@ -1871,6 +1876,94 @@ export class ApiClient {
     );
   }
 
+  async listCodeTerminals(
+    workspaceId: string,
+  ): Promise<CodeTerminalSnapshot[]> {
+    const body = await this.json<unknown>(
+      `/code/workspaces/${encodeURIComponent(workspaceId)}/terminals`,
+      { headers: this.headers() },
+    );
+    return requireParsed(parseCodeTerminalList(body), "code terminals");
+  }
+
+  async createCodeTerminal(
+    workspaceId: string,
+    body: { cols?: number; rows?: number } = {},
+  ): Promise<CodeTerminalSnapshot> {
+    return requireParsed(
+      parseCodeTerminal(
+        await this.json(
+          `/code/workspaces/${encodeURIComponent(workspaceId)}/terminals`,
+          {
+            method: "POST",
+            headers: this.headers(true),
+            body: JSON.stringify(body),
+          },
+        ),
+      ),
+      "code terminal",
+    );
+  }
+
+  deleteCodeTerminal(workspaceId: string, terminalId: string): Promise<void> {
+    return this.json(
+      `/code/workspaces/${encodeURIComponent(workspaceId)}/terminals/${encodeURIComponent(terminalId)}`,
+      { method: "DELETE", headers: this.headers() },
+    );
+  }
+
+  async readCodeTerminal(
+    workspaceId: string,
+    terminalId: string,
+    cursor = 0,
+  ): Promise<CodeTerminalRead> {
+    return requireParsed(
+      parseCodeTerminalRead(
+        await this.json(
+          `/code/workspaces/${encodeURIComponent(workspaceId)}/terminals/${encodeURIComponent(terminalId)}/read?cursor=${encodeURIComponent(String(cursor))}`,
+          { headers: this.headers() },
+        ),
+      ),
+      "code terminal read",
+    );
+  }
+
+  writeCodeTerminal(
+    workspaceId: string,
+    terminalId: string,
+    data: string,
+  ): Promise<void> {
+    return this.json(
+      `/code/workspaces/${encodeURIComponent(workspaceId)}/terminals/${encodeURIComponent(terminalId)}/write`,
+      {
+        method: "POST",
+        headers: this.headers(true),
+        body: JSON.stringify({ bytes: encodeUtf8Base64(data) }),
+      },
+    );
+  }
+
+  async resizeCodeTerminal(
+    workspaceId: string,
+    terminalId: string,
+    cols: number,
+    rows: number,
+  ): Promise<CodeTerminalSnapshot> {
+    return requireParsed(
+      parseCodeTerminal(
+        await this.json(
+          `/code/workspaces/${encodeURIComponent(workspaceId)}/terminals/${encodeURIComponent(terminalId)}/resize`,
+          {
+            method: "POST",
+            headers: this.headers(true),
+            body: JSON.stringify({ cols, rows }),
+          },
+        ),
+      ),
+      "code terminal",
+    );
+  }
+
   /** Open the per-session journal; auth via Sec-WebSocket-Protocol. */
   openCodeEvents(
     sessionId: string,
@@ -1896,6 +1989,13 @@ export class ApiClient {
 function requireParsed<T>(value: T | null, label: string): T {
   if (!value) throw new Error(`${label} response contains invalid data`);
   return value;
+}
+
+function encodeUtf8Base64(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
 }
 
 function parseList<T>(

--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -117,6 +117,9 @@ import {
   type CodeWorkspaceDiff as WireCodeWorkspaceDiff,
   type CodeWorkspaceFiles as WireCodeWorkspaceFiles,
   type CodeFileChange as WireCodeFileChange,
+  type CodeTerminalActivityNotice as WireCodeTerminalActivityNotice,
+  type CodeTerminalRead as WireCodeTerminalRead,
+  type CodeTerminalSnapshot as WireCodeTerminalSnapshot,
   type CodeWorkspaceSnapshot as WireCodeWorkspaceSnapshot,
   type Diffstat as WireDiffstat,
   type FileChangeKind as WireFileChangeKind,
@@ -994,6 +997,9 @@ export type FileChangeKind = WireFileChangeKind;
 export type CodeFileChange = WireCodeFileChange;
 export type CodeWorkspaceFiles = WireCodeWorkspaceFiles;
 export type CodeWorkspaceDiff = WireCodeWorkspaceDiff;
+export type CodeTerminalSnapshot = WireCodeTerminalSnapshot;
+export type CodeTerminalRead = WireCodeTerminalRead;
+export type CodeTerminalActivityNotice = WireCodeTerminalActivityNotice;
 
 /** Journaled engine event and the sequenced WebSocket frame that carries it. */
 export type CodeEvent = WireCodeEvent;

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { FileCode, Files, FolderOpen } from "lucide-react";
+import { FileCode, Files, FolderOpen, SquareTerminal } from "lucide-react";
 import { toast } from "sonner";
 
 import { archiveForceKind, type ApiClient } from "../api/client";
@@ -32,6 +32,7 @@ import { CodeSidebar } from "./CodeSidebar";
 import { CodeTranscript } from "./CodeTranscript";
 import { DiffPanel } from "./DiffPanel";
 import { FilesPanel } from "./FilesPanel";
+import { TerminalPane } from "./TerminalPane";
 import {
   fenceReasonText,
   HARNESS_LABELS,
@@ -214,6 +215,15 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
               <FileCode />
               Diff
             </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              onClick={() => openPanel({ type: "terminal" })}
+            >
+              <SquareTerminal />
+              Terminal
+            </Button>
             {workspace && workspace.status !== "archived" && (
               <Button type="button" variant="ghost" size="xs" onClick={() => void archive()}>
                 Archive
@@ -328,6 +338,8 @@ function renderCodePanel(
           file={panel.file}
         />
       );
+    case "terminal":
+      return <TerminalPane client={client} workspaceId={workspaceId} />;
     default:
       return (
         <p className="text-muted-foreground px-3 py-6 text-sm">

--- a/crates/tidebreak-desktop/ui/src/code/TerminalPane.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TerminalPane.dom.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { TerminalPane } from "./TerminalPane";
+
+const written: string[] = [];
+const terminals: Array<{ disposed: boolean; write: (data: string, cb?: () => void) => void }> =
+  [];
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: class MockTerminal {
+    cols = 80;
+    rows = 24;
+    disposed = false;
+    write(data: string, cb?: () => void) {
+      written.push(data);
+      cb?.();
+    }
+    loadAddon() {}
+    open() {}
+    dispose() {
+      this.disposed = true;
+    }
+    onData() {
+      return { dispose() {} };
+    }
+    constructor() {
+      terminals.push(this);
+    }
+  },
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: class {
+    fit() {}
+  },
+}));
+
+vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
+
+afterEach(() => {
+  cleanup();
+  written.length = 0;
+  terminals.length = 0;
+});
+
+function encode(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+describe("TerminalPane", () => {
+  it("disposes the renderer when the pane unmounts", async () => {
+    const client = {
+      listCodeTerminals: vi.fn().mockResolvedValue([]),
+      createCodeTerminal: vi.fn().mockResolvedValue({
+        id: "term-1",
+        workspace_id: "ws-1",
+        cols: 80,
+        rows: 24,
+        ended: false,
+        created_at: "2026-08-15T12:00:00.000Z",
+      }),
+      readCodeTerminal: vi.fn().mockResolvedValue({
+        id: "term-1",
+        workspace_id: "ws-1",
+        bytes: "",
+        cursor: 0,
+        overflow: false,
+        truncated: false,
+        ended: false,
+      }),
+      writeCodeTerminal: vi.fn().mockResolvedValue(undefined),
+      resizeCodeTerminal: vi.fn().mockResolvedValue({
+        id: "term-1",
+        workspace_id: "ws-1",
+        cols: 80,
+        rows: 24,
+        ended: false,
+        created_at: "2026-08-15T12:00:00.000Z",
+      }),
+    };
+    const { unmount } = render(
+      <TerminalPane client={client} workspaceId="ws-1" />,
+    );
+    await waitFor(() => expect(client.createCodeTerminal).toHaveBeenCalled());
+    expect(terminals).toHaveLength(1);
+    expect(terminals[0]?.disposed).toBe(false);
+    unmount();
+    expect(terminals[0]?.disposed).toBe(true);
+  });
+
+  it("renders a truncation notice when the ring overflowed", async () => {
+    const client = {
+      listCodeTerminals: vi.fn().mockResolvedValue([
+        {
+          id: "term-1",
+          workspace_id: "ws-1",
+          cols: 80,
+          rows: 24,
+          ended: false,
+          created_at: "2026-08-15T12:00:00.000Z",
+        },
+      ]),
+      createCodeTerminal: vi.fn(),
+      readCodeTerminal: vi.fn().mockResolvedValue({
+        id: "term-1",
+        workspace_id: "ws-1",
+        bytes: encode("\r\n[output truncated]\r\nlater"),
+        cursor: 12,
+        overflow: true,
+        truncated: false,
+        ended: false,
+      }),
+      writeCodeTerminal: vi.fn(),
+      resizeCodeTerminal: vi.fn(),
+    };
+    render(<TerminalPane client={client} workspaceId="ws-1" />);
+    expect(await screen.findByTestId("terminal-truncated")).toHaveTextContent(
+      "Output was truncated.",
+    );
+  });
+
+  it("renders the ended-shell state", async () => {
+    const client = {
+      listCodeTerminals: vi.fn().mockResolvedValue([]),
+      createCodeTerminal: vi.fn().mockResolvedValue({
+        id: "term-1",
+        workspace_id: "ws-1",
+        cols: 80,
+        rows: 24,
+        ended: true,
+        created_at: "2026-08-15T12:00:00.000Z",
+      }),
+      readCodeTerminal: vi.fn().mockResolvedValue({
+        id: "term-1",
+        workspace_id: "ws-1",
+        bytes: "",
+        cursor: 0,
+        overflow: false,
+        truncated: false,
+        ended: true,
+      }),
+      writeCodeTerminal: vi.fn(),
+      resizeCodeTerminal: vi.fn(),
+    };
+    render(<TerminalPane client={client} workspaceId="ws-1" />);
+    expect(await screen.findByTestId("terminal-ended")).toHaveTextContent(
+      "Shell ended.",
+    );
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/TerminalPane.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TerminalPane.tsx
@@ -1,0 +1,268 @@
+import { useEffect, useRef, useState } from "react";
+import { FitAddon } from "@xterm/addon-fit";
+import { Terminal } from "@xterm/xterm";
+import "@xterm/xterm/css/xterm.css";
+
+import type { ApiClient } from "../api/client";
+import { Button } from "@/components/ui/button";
+import { friendlyErrorMessage } from "@/lib/utils";
+import {
+  resolveShellShortcut,
+  usesCommandModifier,
+} from "../ShellShortcuts";
+
+const POLL_MS = 200;
+const FRAME_BUDGET = 8 * 1024;
+const STALL_MS = 3_000;
+const TRUNCATION_TEXT = "[output truncated]";
+
+/**
+ * Ephemeral renderer over the cursor-pull terminal API.
+ *
+ * Created on open, disposed on close. Reopening re-fetches recent ring bytes
+ * rather than keeping xterm state. Writes are chunked under a frame budget;
+ * a stall surfaces a reconnect control.
+ */
+export function TerminalPane({
+  client,
+  workspaceId,
+}: {
+  client: Pick<
+    ApiClient,
+    | "listCodeTerminals"
+    | "createCodeTerminal"
+    | "readCodeTerminal"
+    | "writeCodeTerminal"
+    | "resizeCodeTerminal"
+  >;
+  workspaceId: string;
+}) {
+  const hostRef = useRef<HTMLDivElement>(null);
+  const termRef = useRef<Terminal | null>(null);
+  const fitRef = useRef<FitAddon | null>(null);
+  const tidRef = useRef<string | null>(null);
+  const cursorRef = useRef(0);
+  const pendingRef = useRef("");
+  const rafRef = useRef<number | null>(null);
+  const lastFlushRef = useRef(Date.now());
+  const [generation, setGeneration] = useState(0);
+  const [ended, setEnded] = useState(false);
+  const [overflow, setOverflow] = useState(false);
+  const [stalled, setStalled] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+    const term = new Terminal({
+      convertEol: true,
+      fontSize: 13,
+      cursorBlink: true,
+      theme: {
+        background: "#18181b",
+        foreground: "#e4e4e7",
+        cursor: "#e4e4e7",
+      },
+    });
+    const fit = new FitAddon();
+    term.loadAddon(fit);
+    term.open(host);
+    fit.fit();
+    termRef.current = term;
+    fitRef.current = fit;
+
+    const dataSub = term.onData((data) => {
+      const tid = tidRef.current;
+      if (!tid) return;
+      void client.writeCodeTerminal(workspaceId, tid, data).catch(() => {
+        // A failed keystroke is dropped; the next poll shows ended/error.
+      });
+    });
+    const command = usesCommandModifier(navigator.userAgent);
+    function onKeyDownCapture(event: KeyboardEvent) {
+      const def = resolveShellShortcut(event, {
+        editable: true,
+        modalOpen: false,
+        command,
+      });
+      if (!def) return;
+      // Let the window listener fire the app shortcut; keep it out of xterm.
+      event.stopPropagation();
+    }
+    host.addEventListener("keydown", onKeyDownCapture, true);
+
+    const onResize = () => {
+      fit.fit();
+      const tid = tidRef.current;
+      const dims = term.cols && term.rows ? { cols: term.cols, rows: term.rows } : null;
+      if (tid && dims) {
+        void client.resizeCodeTerminal(workspaceId, tid, dims.cols, dims.rows);
+      }
+    };
+    window.addEventListener("resize", onResize);
+
+    return () => {
+      window.removeEventListener("resize", onResize);
+      host.removeEventListener("keydown", onKeyDownCapture, true);
+      dataSub.dispose();
+      term.dispose();
+      termRef.current = null;
+      fitRef.current = null;
+    };
+  }, [client, workspaceId, generation]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setInterval> | undefined;
+
+    async function pull() {
+      const tid = tidRef.current;
+      if (!tid) return;
+      try {
+        const page = await client.readCodeTerminal(
+          workspaceId,
+          tid,
+          cursorRef.current,
+        );
+        if (cancelled) return;
+        cursorRef.current = page.cursor;
+        if (page.overflow) setOverflow(true);
+        if (page.ended) setEnded(true);
+        const text = decodeTerminalBytes(page.bytes);
+        if (text.includes(TRUNCATION_TEXT)) setOverflow(true);
+        if (text) enqueue(text);
+      } catch (err) {
+        if (!cancelled) {
+          setError(friendlyErrorMessage(err, "Could not read the terminal"));
+        }
+      }
+    }
+
+    async function attach() {
+      try {
+        const listed = await client.listCodeTerminals(workspaceId);
+        const live = listed.find((item) => !item.ended);
+        const cols = termRef.current?.cols;
+        const rows = termRef.current?.rows;
+        const snap =
+          live ??
+          (await client.createCodeTerminal(workspaceId, {
+            ...(cols ? { cols } : {}),
+            ...(rows ? { rows } : {}),
+          }));
+        if (cancelled) return;
+        tidRef.current = snap.id;
+        cursorRef.current = 0;
+        if (snap.ended) setEnded(true);
+        await pull();
+        timer = setInterval(() => {
+          void pull();
+        }, POLL_MS);
+      } catch (err) {
+        if (!cancelled) {
+          setError(friendlyErrorMessage(err, "Could not open a terminal"));
+        }
+      }
+    }
+
+    void attach();
+    return () => {
+      cancelled = true;
+      if (timer) clearInterval(timer);
+    };
+  }, [client, workspaceId, generation]);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      if (
+        pendingRef.current.length > FRAME_BUDGET * 8 &&
+        Date.now() - lastFlushRef.current > STALL_MS
+      ) {
+        setStalled(true);
+      }
+    }, 500);
+    return () => clearInterval(timer);
+  }, [generation]);
+
+  function enqueue(text: string) {
+    pendingRef.current += text;
+    flushSoon();
+  }
+
+  function flushSoon() {
+    if (rafRef.current != null) return;
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      const term = termRef.current;
+      if (!term) return;
+      const chunk = pendingRef.current.slice(0, FRAME_BUDGET);
+      pendingRef.current = pendingRef.current.slice(FRAME_BUDGET);
+      lastFlushRef.current = Date.now();
+      term.write(chunk, () => {
+        if (pendingRef.current) flushSoon();
+      });
+    });
+  }
+
+  function reconnect() {
+    setStalled(false);
+    setEnded(false);
+    setOverflow(false);
+    setError(null);
+    pendingRef.current = "";
+    tidRef.current = null;
+    setGeneration((value) => value + 1);
+  }
+
+  return (
+    <div
+      className="flex min-h-0 flex-1 flex-col overflow-hidden"
+      data-testid="terminal-pane"
+    >
+      <header className="flex shrink-0 items-center justify-between gap-2 border-b px-3 py-2">
+        <h2 className="text-sm font-medium">Terminal</h2>
+      </header>
+      {overflow && (
+        <p className="text-muted-foreground px-3 py-2 text-xs" data-testid="terminal-truncated">
+          Output was truncated.
+        </p>
+      )}
+      {ended && (
+        <p className="text-muted-foreground px-3 py-2 text-xs" data-testid="terminal-ended">
+          Shell ended.
+        </p>
+      )}
+      {stalled && (
+        <div className="flex items-center gap-2 px-3 py-2 text-xs">
+          <p>The terminal renderer stalled.</p>
+          <Button type="button" size="xs" onClick={reconnect}>
+            Reconnect
+          </Button>
+        </div>
+      )}
+      {error && <p className="text-critical px-3 py-2 text-sm">{error}</p>}
+      <div ref={hostRef} className="min-h-0 flex-1" data-testid="terminal-host" />
+    </div>
+  );
+}
+
+export function decodeTerminalBytes(encoded: string): string {
+  if (!encoded) return "";
+  try {
+    const binary = atob(encoded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return "";
+  }
+}
+
+export function encodeTerminalBytes(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -4,6 +4,9 @@ import {
   liveCodeSession,
   parseCodeSession,
   parseCodeSessionList,
+  parseCodeTerminal,
+  parseCodeTerminalList,
+  parseCodeTerminalRead,
   parseCodeTurn,
   parseCodeTurnList,
   parseCodeWorkspaceDiff,
@@ -120,6 +123,35 @@ describe("parseCodeWorkspaceDiff", () => {
 
   it("rejects a non-string body", () => {
     expect(parseCodeWorkspaceDiff({ ...diff, diff: 1 })).toBeNull();
+  });
+});
+
+describe("parseCodeTerminal", () => {
+  const terminal = {
+    id: "term-1",
+    workspace_id: "ws-1",
+    cols: 80,
+    rows: 24,
+    ended: false,
+    created_at: "2026-08-15T12:00:00.000Z",
+  };
+
+  it("accepts a live snapshot and a list", () => {
+    expect(parseCodeTerminal(terminal)).toEqual(terminal);
+    expect(parseCodeTerminalList([terminal])).toEqual([terminal]);
+  });
+
+  it("accepts a cursor-pull page", () => {
+    const page = {
+      id: "term-1",
+      workspace_id: "ws-1",
+      bytes: "aGVsbG8=",
+      cursor: 5,
+      overflow: false,
+      truncated: false,
+      ended: false,
+    };
+    expect(parseCodeTerminalRead(page)).toEqual(page);
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -12,6 +12,8 @@ import type {
   CodeTurnSnapshot,
   CodeTurnStatus,
   CodeUsage,
+  CodeTerminalRead,
+  CodeTerminalSnapshot,
   CodeWorkspaceDiff,
   CodeWorkspaceFiles,
   CodeWorkspaceSnapshot,
@@ -34,6 +36,8 @@ import type {
   CodeRepoSnapshot as WireCodeRepoSnapshot,
   CodeSessionSnapshot as WireCodeSessionSnapshot,
   CodeTurnSnapshot as WireCodeTurnSnapshot,
+  CodeTerminalRead as WireCodeTerminalRead,
+  CodeTerminalSnapshot as WireCodeTerminalSnapshot,
   CodeWorkspaceDiff as WireCodeWorkspaceDiff,
   CodeWorkspaceFiles as WireCodeWorkspaceFiles,
   CodeWorkspaceSnapshot as WireCodeWorkspaceSnapshot,
@@ -465,6 +469,82 @@ export function parseCodeTurnList(value: unknown): CodeTurnSnapshot[] | null {
     turns.push(parsed);
   }
   return turns;
+}
+
+export function parseCodeTerminal(value: unknown): CodeTerminalSnapshot | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeTerminalSnapshot>(value, [
+      "id",
+      "workspace_id",
+      "cols",
+      "rows",
+      "ended",
+      "created_at",
+    ]) ||
+    !nonEmpty(value.id) ||
+    !nonEmpty(value.workspace_id) ||
+    !isFiniteNumber(value.cols) ||
+    !isFiniteNumber(value.rows) ||
+    typeof value.ended !== "boolean" ||
+    !nonEmpty(value.created_at)
+  ) {
+    return null;
+  }
+  return {
+    id: value.id,
+    workspace_id: value.workspace_id,
+    cols: value.cols,
+    rows: value.rows,
+    ended: value.ended,
+    created_at: value.created_at,
+  };
+}
+
+export function parseCodeTerminalList(
+  value: unknown,
+): CodeTerminalSnapshot[] | null {
+  if (!Array.isArray(value)) return null;
+  const terminals: CodeTerminalSnapshot[] = [];
+  for (const item of value) {
+    const parsed = parseCodeTerminal(item);
+    if (!parsed) return null;
+    terminals.push(parsed);
+  }
+  return terminals;
+}
+
+export function parseCodeTerminalRead(value: unknown): CodeTerminalRead | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeTerminalRead>(value, [
+      "id",
+      "workspace_id",
+      "bytes",
+      "cursor",
+      "overflow",
+      "truncated",
+      "ended",
+    ]) ||
+    !nonEmpty(value.id) ||
+    !nonEmpty(value.workspace_id) ||
+    typeof value.bytes !== "string" ||
+    !isFiniteNumber(value.cursor) ||
+    typeof value.overflow !== "boolean" ||
+    typeof value.truncated !== "boolean" ||
+    typeof value.ended !== "boolean"
+  ) {
+    return null;
+  }
+  return {
+    id: value.id,
+    workspace_id: value.workspace_id,
+    bytes: value.bytes,
+    cursor: value.cursor,
+    overflow: value.overflow,
+    truncated: value.truncated,
+    ended: value.ended,
+  };
 }
 
 export function parseHarnessDoctorReport(

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1075,6 +1075,32 @@ export type CodeSessionLifecycle = "created" | "idle" | "running" | "fenced" | "
 export type CodeSessionSnapshot = { id: CodeSessionId, workspace_id: WorkspaceId, harness_kind: HarnessKind, harness_version?: string, harness_resume_ref?: string, permission_mode: CodePermissionMode, lifecycle: CodeSessionLifecycle, fence_reason?: FenceReason, attention: Attention, unrecognized_event_count: number, created_at: string, };
 
 /**
+ * Unsequenced activity notice published on the updates channel.
+ *
+ * Never journaled. A client that missed one just pulls from its last cursor.
+ */
+export type CodeTerminalActivityNotice = { workspace_id: WorkspaceId, terminal_id: CodeTerminalId, };
+
+/**
+ * Identifies one auxiliary terminal attached to a workspace.
+ */
+export type CodeTerminalId = string;
+
+/**
+ * Cursor-pull response for `GET /code/workspaces/{id}/terminals/{tid}/read`.
+ *
+ * `bytes` is standard base64 of the raw ring slice. `overflow` is true when
+ * the requested cursor had already fallen out of the ring; the payload then
+ * starts with the inline truncation marker.
+ */
+export type CodeTerminalRead = { id: CodeTerminalId, workspace_id: WorkspaceId, bytes: string, cursor: number, overflow: boolean, truncated: boolean, ended: boolean, };
+
+/**
+ * One live auxiliary terminal. Bytes live only in the process ring.
+ */
+export type CodeTerminalSnapshot = { id: CodeTerminalId, workspace_id: WorkspaceId, cols: number, rows: number, ended: boolean, created_at: string, };
+
+/**
  * Identifies one user→engine cycle inside a code session.
  */
 export type CodeTurnId = string;

--- a/crates/tidebreak-desktop/ui/src/panel/PanelTabs.tsx
+++ b/crates/tidebreak-desktop/ui/src/panel/PanelTabs.tsx
@@ -1,4 +1,4 @@
-import { Bot, FileCode, FileText, Files, FolderOpen, Package, Shield, X } from "lucide-react";
+import { Bot, FileCode, FileText, Files, FolderOpen, Package, Shield, SquareTerminal, X } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { panelKey, type PanelContent } from "./panelTypes";
@@ -29,6 +29,8 @@ function panelTabFallbackLabel(panel: PanelContent): string {
       return "Files";
     case "diff":
       return "Diff";
+    case "terminal":
+      return "Terminal";
   }
 }
 
@@ -50,6 +52,8 @@ function PanelTabIcon({ panel }: { panel: PanelContent }) {
       return <Files className={className} />;
     case "diff":
       return <FileCode className={className} />;
+    case "terminal":
+      return <SquareTerminal className={className} />;
   }
 }
 

--- a/crates/tidebreak-desktop/ui/src/panel/panelTypes.ts
+++ b/crates/tidebreak-desktop/ui/src/panel/panelTypes.ts
@@ -26,7 +26,9 @@ export type PanelContent =
   /** Changed files in a code-mode workspace; `turnId` filters to one turn. */
   | { type: "files"; turnId?: string }
   /** Server-produced unified diff; `turnId`/`file` anchor within the tab. */
-  | { type: "diff"; turnId?: string; file?: string };
+  | { type: "diff"; turnId?: string; file?: string }
+  /** Auxiliary workspace shell; `terminalId` pins a live PTY when known. */
+  | { type: "terminal"; terminalId?: string };
 
 export type PanelType = PanelContent["type"];
 

--- a/crates/tidebreak-desktop/ui/src/panel/panelUrl.test.ts
+++ b/crates/tidebreak-desktop/ui/src/panel/panelUrl.test.ts
@@ -21,6 +21,11 @@ describe("panel URLs", () => {
       turnId: "turn-1",
       file: "src/lib.rs",
     });
+    expect(parsePanelSegment("terminal")).toEqual({ type: "terminal" });
+    expect(parsePanelSegment("terminal.term-1")).toEqual({
+      type: "terminal",
+      terminalId: "term-1",
+    });
     expect(parsePanelSegment("agent")).toBeNull();
     expect(parsePanelSegment("document.doc-1.cite-1")).toEqual({
       type: "document",
@@ -74,6 +79,8 @@ describe("panel URLs", () => {
       { type: "diff" },
       { type: "diff", turnId: "turn-1" },
       { type: "diff", turnId: "turn-1", file: "src/lib.rs" },
+      { type: "terminal" },
+      { type: "terminal", terminalId: "term-1" },
     ] as const) {
       expect(parsePanelSegment(encodePanelSegment(panel))).toEqual(panel);
     }

--- a/crates/tidebreak-desktop/ui/src/panel/panelUrl.ts
+++ b/crates/tidebreak-desktop/ui/src/panel/panelUrl.ts
@@ -52,6 +52,8 @@ export function parsePanelSegment(segment: string): PanelContent | null {
       return parseFilesTarget(id);
     case "diff":
       return parseDiffTarget(id);
+    case "terminal":
+      return id ? { type: "terminal", terminalId: id } : { type: "terminal" };
     default:
       // `apps` and `plugins` were panel segments before the libraries became
       // routes of their own; those links fall back to the conversation alone.
@@ -133,6 +135,8 @@ export function encodePanelSegment(panel: PanelContent): string {
       if (panel.file) parts.push("f", encodeURIComponent(panel.file));
       return parts.join(".");
     }
+    case "terminal":
+      return panel.terminalId ? `terminal.${panel.terminalId}` : "terminal";
   }
 }
 

--- a/crates/tidebreak-server/Cargo.toml
+++ b/crates/tidebreak-server/Cargo.toml
@@ -93,6 +93,9 @@ dom_smoothie = { workspace = true }
 # Must move in lockstep with dom_smoothie (same major parse handoff type).
 dom_query = { workspace = true }
 zip = { workspace = true }
+# Auxiliary workspace terminals (0036). Server-only: the harness crate
+# must never depend on a PTY library.
+portable-pty = "=0.9.0"
 
 [target.'cfg(unix)'.dependencies]
 # Effective-uid account lookup (getpwuid_r) for the macOS managed-preferences

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod recovery;
 pub(crate) mod runtime;
 pub(crate) mod session_worker;
 pub(crate) mod setup_script;
+pub(crate) mod terminal;
 pub(crate) mod worktree;
 
 pub(crate) use runtime::CodeRuntime;

--- a/crates/tidebreak-server/src/code/terminal.rs
+++ b/crates/tidebreak-server/src/code/terminal.rs
@@ -1,0 +1,887 @@
+//! Auxiliary workspace terminals: a PTY plus a bounded in-memory ring.
+//!
+//! Bytes are ephemeral. They are not journaled, not persisted, and vanish
+//! when this process does. The harness crate has no PTY dependency; this
+//! module is the only place one is used.
+
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, Utc};
+use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
+use tidebreak_core::{CodeTerminalId, WorkspaceId};
+use tokio::sync::broadcast;
+
+/// Cap on live shells per workspace. A terminal is a convenience, not a data plane.
+pub const MAX_TERMINALS_PER_WORKSPACE: usize = 8;
+
+/// Retained output per terminal. Overflow drops the oldest bytes; a reader
+/// whose cursor sits behind the ring sees an inline truncation marker.
+pub const TERMINAL_RING_BYTES: usize = 256 * 1024;
+
+/// Upper bound on one cursor-pull response so a client cannot drain the ring
+/// in a single unbounded read.
+pub const MAX_TERMINAL_READ_BYTES: usize = 32 * 1024;
+
+/// Upper bound on one keystroke/write POST.
+pub const MAX_TERMINAL_WRITE_BYTES: usize = 4 * 1024;
+
+/// Activity notices are coalesced to this granularity.
+pub const TERMINAL_NOTICE_COALESCE: Duration = Duration::from_millis(32);
+
+/// Inserted at the front of a read whose cursor has fallen off the ring.
+pub const TRUNCATION_MARKER: &[u8] = b"\r\n[output truncated]\r\n";
+
+const DEFAULT_COLS: u16 = 80;
+const DEFAULT_ROWS: u16 = 24;
+const MIN_SIZE: u16 = 1;
+const MAX_SIZE: u16 = 512;
+const NOTICE_BUFFER: usize = 64;
+
+/// In-memory process-wide registry of live auxiliary terminals.
+pub(crate) struct TerminalHub {
+    inner: Mutex<HubInner>,
+    notices: broadcast::Sender<TerminalNotice>,
+}
+
+struct HubInner {
+    by_id: HashMap<CodeTerminalId, Arc<Mutex<LiveTerminal>>>,
+    by_workspace: HashMap<WorkspaceId, Vec<CodeTerminalId>>,
+}
+
+struct LiveTerminal {
+    id: CodeTerminalId,
+    workspace_id: WorkspaceId,
+    ring: ByteRing,
+    cols: u16,
+    rows: u16,
+    ended: bool,
+    created_at: DateTime<Utc>,
+    writer: Option<Box<dyn Write + Send>>,
+    master: Option<Box<dyn MasterPty + Send>>,
+    killer: Option<Box<dyn portable_pty::ChildKiller + Send + Sync>>,
+    coalesce: Coalesce,
+}
+
+struct Coalesce {
+    dirty: bool,
+    scheduled: bool,
+    quiet_until: Instant,
+}
+
+/// Unsequenced activity notice. Published on the workspace bus; never journaled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TerminalNotice {
+    pub workspace_id: WorkspaceId,
+    pub terminal_id: CodeTerminalId,
+}
+
+/// Snapshot a route can serialize.
+#[derive(Debug, Clone)]
+pub(crate) struct TerminalSnapshot {
+    pub id: CodeTerminalId,
+    pub workspace_id: WorkspaceId,
+    pub cols: u16,
+    pub rows: u16,
+    pub ended: bool,
+    pub created_at: DateTime<Utc>,
+}
+
+/// One cursor-pull response.
+#[derive(Debug, Clone)]
+pub(crate) struct TerminalRead {
+    pub data: Vec<u8>,
+    pub next_cursor: u64,
+    pub overflow: bool,
+    pub truncated: bool,
+    pub ended: bool,
+}
+
+#[derive(Debug)]
+pub(crate) enum TerminalError {
+    WorkspaceCap,
+    WriteTooLarge,
+    Ended,
+    NotFound,
+    InvalidSize,
+    Spawn(String),
+    Io(String),
+}
+
+impl TerminalHub {
+    pub(crate) fn new() -> Self {
+        let (notices, _) = broadcast::channel(NOTICE_BUFFER);
+        Self {
+            inner: Mutex::new(HubInner {
+                by_id: HashMap::new(),
+                by_workspace: HashMap::new(),
+            }),
+            notices,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn subscribe(&self) -> broadcast::Receiver<TerminalNotice> {
+        self.notices.subscribe()
+    }
+
+    pub(crate) fn open(
+        &self,
+        workspace_id: WorkspaceId,
+        cwd: &Path,
+        cols: Option<u16>,
+        rows: Option<u16>,
+    ) -> Result<TerminalSnapshot, TerminalError> {
+        let cols = clamp_size(cols.unwrap_or(DEFAULT_COLS))?;
+        let rows = clamp_size(rows.unwrap_or(DEFAULT_ROWS))?;
+        self.reserve_slot(workspace_id)?;
+        let spawned = spawn_pty(cwd, cols, rows)?;
+        let id = CodeTerminalId::new();
+        let live = LiveTerminal {
+            id,
+            workspace_id,
+            ring: ByteRing::new(TERMINAL_RING_BYTES),
+            cols,
+            rows,
+            ended: false,
+            created_at: Utc::now(),
+            writer: Some(spawned.writer),
+            master: Some(spawned.master),
+            killer: Some(spawned.killer),
+            coalesce: Coalesce::new(),
+        };
+        let handle = Arc::new(Mutex::new(live));
+        self.insert(workspace_id, id, handle.clone());
+        start_reader(handle.clone(), self.notices.clone(), spawned.reader);
+        start_reaper(handle.clone(), self.notices.clone(), spawned.child);
+        Ok(lock_snapshot(&handle))
+    }
+
+    /// Open a ring with no PTY. Used by tests that must not spawn a shell.
+    #[cfg(test)]
+    pub(crate) fn open_memory(
+        &self,
+        workspace_id: WorkspaceId,
+        cols: u16,
+        rows: u16,
+    ) -> Result<TerminalSnapshot, TerminalError> {
+        let cols = clamp_size(cols)?;
+        let rows = clamp_size(rows)?;
+        self.reserve_slot(workspace_id)?;
+        let id = CodeTerminalId::new();
+        let live = LiveTerminal {
+            id,
+            workspace_id,
+            ring: ByteRing::new(TERMINAL_RING_BYTES),
+            cols,
+            rows,
+            ended: false,
+            created_at: Utc::now(),
+            writer: None,
+            master: None,
+            killer: None,
+            coalesce: Coalesce::new(),
+        };
+        let handle = Arc::new(Mutex::new(live));
+        self.insert(workspace_id, id, handle.clone());
+        Ok(lock_snapshot(&handle))
+    }
+
+    pub(crate) fn list(&self, workspace_id: WorkspaceId) -> Vec<TerminalSnapshot> {
+        let inner = self.inner.lock().expect("terminal hub");
+        let ids = inner
+            .by_workspace
+            .get(&workspace_id)
+            .cloned()
+            .unwrap_or_default();
+        ids.iter()
+            .filter_map(|id| inner.by_id.get(id).map(lock_snapshot))
+            .collect()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get(
+        &self,
+        workspace_id: WorkspaceId,
+        id: CodeTerminalId,
+    ) -> Option<TerminalSnapshot> {
+        let inner = self.inner.lock().expect("terminal hub");
+        let handle = inner.by_id.get(&id)?;
+        let snap = lock_snapshot(handle);
+        if snap.workspace_id != workspace_id {
+            return None;
+        }
+        Some(snap)
+    }
+
+    pub(crate) fn read(
+        &self,
+        workspace_id: WorkspaceId,
+        id: CodeTerminalId,
+        cursor: u64,
+    ) -> TerminalRead {
+        let Some(handle) = self.handle(workspace_id, id) else {
+            return TerminalRead {
+                data: Vec::new(),
+                next_cursor: cursor,
+                overflow: false,
+                truncated: false,
+                ended: true,
+            };
+        };
+        let live = handle.lock().expect("terminal");
+        let (data, next_cursor, overflow, truncated) =
+            live.ring.read(cursor, MAX_TERMINAL_READ_BYTES);
+        TerminalRead {
+            data,
+            next_cursor,
+            overflow,
+            truncated,
+            ended: live.ended,
+        }
+    }
+
+    pub(crate) fn write(
+        &self,
+        workspace_id: WorkspaceId,
+        id: CodeTerminalId,
+        bytes: &[u8],
+    ) -> Result<(), TerminalError> {
+        if bytes.len() > MAX_TERMINAL_WRITE_BYTES {
+            return Err(TerminalError::WriteTooLarge);
+        }
+        let handle = self
+            .handle(workspace_id, id)
+            .ok_or(TerminalError::NotFound)?;
+        let mut live = handle.lock().expect("terminal");
+        if live.ended {
+            return Err(TerminalError::Ended);
+        }
+        if let Some(writer) = live.writer.as_mut() {
+            writer
+                .write_all(bytes)
+                .and_then(|()| writer.flush())
+                .map_err(|err| TerminalError::Io(err.to_string()))?;
+        } else {
+            // Memory-backed terminals echo writes into the ring so tests can
+            // drive the same read path the PTY reader uses.
+            live.ring.write(bytes);
+            apply_coalesce(&mut live, &handle, &self.notices, workspace_id, id);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn resize(
+        &self,
+        workspace_id: WorkspaceId,
+        id: CodeTerminalId,
+        cols: u16,
+        rows: u16,
+    ) -> Result<TerminalSnapshot, TerminalError> {
+        let cols = clamp_size(cols)?;
+        let rows = clamp_size(rows)?;
+        let handle = self
+            .handle(workspace_id, id)
+            .ok_or(TerminalError::NotFound)?;
+        let mut live = handle.lock().expect("terminal");
+        if live.ended {
+            return Err(TerminalError::Ended);
+        }
+        if let Some(master) = live.master.as_ref() {
+            master
+                .resize(PtySize {
+                    rows,
+                    cols,
+                    pixel_width: 0,
+                    pixel_height: 0,
+                })
+                .map_err(|err| TerminalError::Io(err.to_string()))?;
+        }
+        live.cols = cols;
+        live.rows = rows;
+        Ok(snapshot(&live))
+    }
+
+    pub(crate) fn close(
+        &self,
+        workspace_id: WorkspaceId,
+        id: CodeTerminalId,
+    ) -> Result<(), TerminalError> {
+        let handle = self
+            .handle(workspace_id, id)
+            .ok_or(TerminalError::NotFound)?;
+        {
+            let mut live = handle.lock().expect("terminal");
+            live.kill_and_end();
+        }
+        self.remove(workspace_id, id);
+        Ok(())
+    }
+
+    pub(crate) fn close_workspace(&self, workspace_id: WorkspaceId) {
+        let ids = {
+            let inner = self.inner.lock().expect("terminal hub");
+            inner
+                .by_workspace
+                .get(&workspace_id)
+                .cloned()
+                .unwrap_or_default()
+        };
+        for id in ids {
+            let _ = self.close(workspace_id, id);
+        }
+    }
+
+    /// Append output as if the PTY had produced it. Tests and the reader thread.
+    #[cfg(test)]
+    pub(crate) fn push_output(&self, id: CodeTerminalId, bytes: &[u8]) {
+        let handle = {
+            let inner = self.inner.lock().expect("terminal hub");
+            inner.by_id.get(&id).cloned()
+        };
+        let Some(handle) = handle else {
+            return;
+        };
+        let mut live = handle.lock().expect("terminal");
+        live.ring.write(bytes);
+        let workspace_id = live.workspace_id;
+        apply_coalesce(&mut live, &handle, &self.notices, workspace_id, id);
+    }
+
+    fn reserve_slot(&self, workspace_id: WorkspaceId) -> Result<(), TerminalError> {
+        let inner = self.inner.lock().expect("terminal hub");
+        let count = inner
+            .by_workspace
+            .get(&workspace_id)
+            .map(Vec::len)
+            .unwrap_or(0);
+        if count >= MAX_TERMINALS_PER_WORKSPACE {
+            return Err(TerminalError::WorkspaceCap);
+        }
+        Ok(())
+    }
+
+    fn insert(
+        &self,
+        workspace_id: WorkspaceId,
+        id: CodeTerminalId,
+        handle: Arc<Mutex<LiveTerminal>>,
+    ) {
+        let mut inner = self.inner.lock().expect("terminal hub");
+        inner.by_id.insert(id, handle);
+        inner.by_workspace.entry(workspace_id).or_default().push(id);
+    }
+
+    fn remove(&self, workspace_id: WorkspaceId, id: CodeTerminalId) {
+        let mut inner = self.inner.lock().expect("terminal hub");
+        inner.by_id.remove(&id);
+        if let Some(ids) = inner.by_workspace.get_mut(&workspace_id) {
+            ids.retain(|existing| *existing != id);
+            if ids.is_empty() {
+                inner.by_workspace.remove(&workspace_id);
+            }
+        }
+    }
+
+    fn handle(
+        &self,
+        workspace_id: WorkspaceId,
+        id: CodeTerminalId,
+    ) -> Option<Arc<Mutex<LiveTerminal>>> {
+        let inner = self.inner.lock().expect("terminal hub");
+        let handle = inner.by_id.get(&id)?.clone();
+        let live = handle.lock().expect("terminal");
+        if live.workspace_id != workspace_id {
+            return None;
+        }
+        drop(live);
+        Some(handle)
+    }
+}
+
+impl Default for TerminalHub {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LiveTerminal {
+    fn kill_and_end(&mut self) {
+        if let Some(mut killer) = self.killer.take() {
+            let _ = killer.kill();
+        }
+        self.writer = None;
+        self.master = None;
+        self.ended = true;
+    }
+}
+
+struct Spawned {
+    master: Box<dyn MasterPty + Send>,
+    writer: Box<dyn Write + Send>,
+    reader: Box<dyn Read + Send>,
+    child: Box<dyn portable_pty::Child + Send + Sync>,
+    killer: Box<dyn portable_pty::ChildKiller + Send + Sync>,
+}
+
+fn spawn_pty(cwd: &Path, cols: u16, rows: u16) -> Result<Spawned, TerminalError> {
+    let system = native_pty_system();
+    let pair = system
+        .openpty(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(|err| TerminalError::Spawn(err.to_string()))?;
+    let mut cmd = CommandBuilder::new(user_shell());
+    cmd.cwd(cwd);
+    let child = pair
+        .slave
+        .spawn_command(cmd)
+        .map_err(|err| TerminalError::Spawn(err.to_string()))?;
+    let killer = child.clone_killer();
+    let reader = pair
+        .master
+        .try_clone_reader()
+        .map_err(|err| TerminalError::Spawn(err.to_string()))?;
+    let writer = pair
+        .master
+        .take_writer()
+        .map_err(|err| TerminalError::Spawn(err.to_string()))?;
+    Ok(Spawned {
+        master: pair.master,
+        writer,
+        reader,
+        child,
+        killer,
+    })
+}
+
+fn user_shell() -> PathBuf {
+    if let Ok(shell) = std::env::var("SHELL") {
+        if !shell.is_empty() {
+            return PathBuf::from(shell);
+        }
+    }
+    #[cfg(windows)]
+    {
+        PathBuf::from("powershell.exe")
+    }
+    #[cfg(not(windows))]
+    {
+        PathBuf::from("/bin/sh")
+    }
+}
+
+fn start_reader(
+    handle: Arc<Mutex<LiveTerminal>>,
+    notices: broadcast::Sender<TerminalNotice>,
+    mut reader: Box<dyn Read + Send>,
+) {
+    thread::Builder::new()
+        .name("code-terminal-read".into())
+        .spawn(move || {
+            let mut buf = [0u8; 4096];
+            loop {
+                match reader.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        let mut live = handle.lock().expect("terminal");
+                        if live.ended {
+                            break;
+                        }
+                        live.ring.write(&buf[..n]);
+                        let workspace_id = live.workspace_id;
+                        let id = live.id;
+                        apply_coalesce(&mut live, &handle, &notices, workspace_id, id);
+                    }
+                    Err(_) => break,
+                }
+            }
+            if let Ok(mut live) = handle.lock() {
+                live.ended = true;
+                let workspace_id = live.workspace_id;
+                let id = live.id;
+                drop(live);
+                publish_notice(&notices, workspace_id, id);
+            }
+        })
+        .expect("code-terminal-read thread");
+}
+
+fn start_reaper(
+    handle: Arc<Mutex<LiveTerminal>>,
+    notices: broadcast::Sender<TerminalNotice>,
+    mut child: Box<dyn portable_pty::Child + Send + Sync>,
+) {
+    thread::Builder::new()
+        .name("code-terminal-wait".into())
+        .spawn(move || {
+            let _ = child.wait();
+            if let Ok(mut live) = handle.lock() {
+                if !live.ended {
+                    live.ended = true;
+                    live.writer = None;
+                    let workspace_id = live.workspace_id;
+                    let id = live.id;
+                    drop(live);
+                    publish_notice(&notices, workspace_id, id);
+                }
+            }
+        })
+        .expect("code-terminal-wait thread");
+}
+
+fn publish_notice(
+    notices: &broadcast::Sender<TerminalNotice>,
+    workspace_id: WorkspaceId,
+    terminal_id: CodeTerminalId,
+) {
+    let _ = notices.send(TerminalNotice {
+        workspace_id,
+        terminal_id,
+    });
+}
+
+fn schedule_trailing_notice(
+    handle: Arc<Mutex<LiveTerminal>>,
+    notices: broadcast::Sender<TerminalNotice>,
+    workspace_id: WorkspaceId,
+    terminal_id: CodeTerminalId,
+) {
+    thread::Builder::new()
+        .name("code-terminal-notice".into())
+        .spawn(move || {
+            thread::sleep(TERMINAL_NOTICE_COALESCE);
+            let mut live = match handle.lock() {
+                Ok(live) => live,
+                Err(_) => return,
+            };
+            if !live.coalesce.dirty {
+                live.coalesce.scheduled = false;
+                return;
+            }
+            live.coalesce.dirty = false;
+            live.coalesce.scheduled = false;
+            live.coalesce.quiet_until = Instant::now() + TERMINAL_NOTICE_COALESCE;
+            drop(live);
+            publish_notice(&notices, workspace_id, terminal_id);
+        })
+        .ok();
+}
+
+fn apply_coalesce(
+    live: &mut LiveTerminal,
+    handle: &Arc<Mutex<LiveTerminal>>,
+    notices: &broadcast::Sender<TerminalNotice>,
+    workspace_id: WorkspaceId,
+    terminal_id: CodeTerminalId,
+) {
+    match live.coalesce.mark() {
+        CoalesceAction::PublishNow => publish_notice(notices, workspace_id, terminal_id),
+        CoalesceAction::Schedule => schedule_trailing_notice(
+            Arc::clone(handle),
+            notices.clone(),
+            workspace_id,
+            terminal_id,
+        ),
+        CoalesceAction::Wait => {}
+    }
+}
+
+enum CoalesceAction {
+    PublishNow,
+    Schedule,
+    Wait,
+}
+
+impl Coalesce {
+    fn new() -> Self {
+        Self {
+            dirty: false,
+            scheduled: false,
+            quiet_until: Instant::now(),
+        }
+    }
+
+    fn mark(&mut self) -> CoalesceAction {
+        let now = Instant::now();
+        if now >= self.quiet_until {
+            self.dirty = false;
+            self.scheduled = false;
+            self.quiet_until = now + TERMINAL_NOTICE_COALESCE;
+            CoalesceAction::PublishNow
+        } else if self.scheduled {
+            self.dirty = true;
+            CoalesceAction::Wait
+        } else {
+            self.dirty = true;
+            self.scheduled = true;
+            CoalesceAction::Schedule
+        }
+    }
+}
+
+fn clamp_size(value: u16) -> Result<u16, TerminalError> {
+    if (MIN_SIZE..=MAX_SIZE).contains(&value) {
+        Ok(value)
+    } else {
+        Err(TerminalError::InvalidSize)
+    }
+}
+
+fn lock_snapshot(handle: &Arc<Mutex<LiveTerminal>>) -> TerminalSnapshot {
+    snapshot(&handle.lock().expect("terminal"))
+}
+
+fn snapshot(live: &LiveTerminal) -> TerminalSnapshot {
+    TerminalSnapshot {
+        id: live.id,
+        workspace_id: live.workspace_id,
+        cols: live.cols,
+        rows: live.rows,
+        ended: live.ended,
+        created_at: live.created_at,
+    }
+}
+
+/// Bounded circular buffer addressed by a monotonic byte cursor.
+struct ByteRing {
+    buf: Vec<u8>,
+    cap: usize,
+    start: u64,
+    len: usize,
+    head: usize,
+}
+
+impl ByteRing {
+    fn new(cap: usize) -> Self {
+        Self {
+            buf: vec![0; cap],
+            cap,
+            start: 0,
+            len: 0,
+            head: 0,
+        }
+    }
+
+    fn end(&self) -> u64 {
+        self.start + self.len as u64
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        for &byte in bytes {
+            if self.len == self.cap {
+                self.head = (self.head + 1) % self.cap;
+                self.start += 1;
+                self.len -= 1;
+            }
+            let idx = (self.head + self.len) % self.cap;
+            self.buf[idx] = byte;
+            self.len += 1;
+        }
+    }
+
+    fn read(&self, cursor: u64, max: usize) -> (Vec<u8>, u64, bool, bool) {
+        let overflow = cursor < self.start;
+        let pos = if overflow {
+            self.start
+        } else if cursor > self.end() {
+            self.end()
+        } else {
+            cursor
+        };
+        let available = (self.end() - pos) as usize;
+        let take = available.min(max);
+        let mut out = Vec::with_capacity(take + if overflow { TRUNCATION_MARKER.len() } else { 0 });
+        if overflow {
+            out.extend_from_slice(TRUNCATION_MARKER);
+        }
+        if take > 0 {
+            let offset = (pos - self.start) as usize;
+            for i in 0..take {
+                let idx = (self.head + offset + i) % self.cap;
+                out.push(self.buf[idx]);
+            }
+        }
+        (out, pos + take as u64, overflow, take < available)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn workspace() -> WorkspaceId {
+        WorkspaceId::new()
+    }
+
+    #[test]
+    fn ring_wraparound_drops_oldest_and_advances_start() {
+        let mut ring = ByteRing::new(8);
+        ring.write(b"abcdefgh");
+        assert_eq!(ring.start, 0);
+        assert_eq!(ring.end(), 8);
+        ring.write(b"ij");
+        assert_eq!(ring.start, 2);
+        assert_eq!(ring.end(), 10);
+        let (data, next, overflow, truncated) = ring.read(2, 32);
+        assert!(!overflow);
+        assert!(!truncated);
+        assert_eq!(data, b"cdefghij");
+        assert_eq!(next, 10);
+    }
+
+    #[test]
+    fn cursor_at_overflow_boundary_is_not_stale() {
+        let mut ring = ByteRing::new(4);
+        ring.write(b"abcdef");
+        // start is now 2; cursor == start is the first retained byte.
+        let (data, next, overflow, _) = ring.read(2, 32);
+        assert!(!overflow);
+        assert_eq!(data, b"cdef");
+        assert_eq!(next, 6);
+    }
+
+    #[test]
+    fn stale_cursor_gets_inline_truncation_marker() {
+        let mut ring = ByteRing::new(4);
+        ring.write(b"abcdefgh");
+        let (data, next, overflow, _) = ring.read(0, 32);
+        assert!(overflow);
+        assert!(data.starts_with(TRUNCATION_MARKER));
+        assert_eq!(&data[TRUNCATION_MARKER.len()..], b"efgh");
+        assert_eq!(next, 8);
+    }
+
+    #[test]
+    fn read_is_capped() {
+        let mut ring = ByteRing::new(64);
+        ring.write(&[b'x'; 40]);
+        let (data, next, overflow, truncated) = ring.read(0, 16);
+        assert!(!overflow);
+        assert!(truncated);
+        assert_eq!(data.len(), 16);
+        assert_eq!(next, 16);
+        let (rest, end, _, truncated_rest) = ring.read(next, 16);
+        assert!(truncated_rest);
+        assert_eq!(rest.len(), 16);
+        assert_eq!(end, 32);
+        let (tail, last, _, last_trunc) = ring.read(end, 16);
+        assert!(!last_trunc);
+        assert_eq!(tail.len(), 8);
+        assert_eq!(last, 40);
+    }
+
+    #[test]
+    fn two_readers_at_different_cursors_both_see_retained_bytes() {
+        let hub = TerminalHub::new();
+        let ws = workspace();
+        let snap = hub.open_memory(ws, 80, 24).unwrap();
+        hub.push_output(snap.id, b"hello ");
+        hub.push_output(snap.id, b"world");
+        let first = hub.read(ws, snap.id, 0);
+        assert_eq!(first.data, b"hello world");
+        let mid = hub.read(ws, snap.id, 6);
+        assert_eq!(mid.data, b"world");
+        assert_eq!(mid.next_cursor, first.next_cursor);
+    }
+
+    #[test]
+    fn fast_producer_coalesces_notices_and_reader_gets_every_byte() {
+        let hub = TerminalHub::new();
+        let ws = workspace();
+        let snap = hub.open_memory(ws, 80, 24).unwrap();
+        let mut rx = hub.subscribe();
+        let mut expected = Vec::new();
+        for i in 0..64u8 {
+            let chunk = [i];
+            expected.extend_from_slice(&chunk);
+            hub.push_output(snap.id, &chunk);
+        }
+        thread::sleep(TERMINAL_NOTICE_COALESCE + Duration::from_millis(20));
+        let mut notices = 0;
+        while rx.try_recv().is_ok() {
+            notices += 1;
+        }
+        assert!(
+            notices > 0 && notices <= 4,
+            "expected coalesced notices, got {notices}"
+        );
+        let read = hub.read(ws, snap.id, 0);
+        assert_eq!(read.data, expected);
+        assert!(!read.overflow);
+        assert!(!read.truncated);
+    }
+
+    #[test]
+    fn restart_reaps_terminals_and_leaves_no_durable_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = b"TERM_MARKER_no_durable_9f3a7c1e";
+        let ws = workspace();
+        let first = TerminalHub::new();
+        let snap = first.open_memory(ws, 80, 24).unwrap();
+        first.push_output(snap.id, marker);
+        let before = first.read(ws, snap.id, 0);
+        assert!(before.data.windows(marker.len()).any(|w| w == marker));
+        drop(first);
+
+        let second = TerminalHub::new();
+        assert!(second.list(ws).is_empty());
+        let read = second.read(ws, snap.id, 0);
+        assert!(read.ended);
+        assert!(read.data.is_empty());
+        assert!(second.get(ws, snap.id).is_none());
+        assert_no_bytes(dir.path(), marker);
+    }
+
+    #[test]
+    fn write_size_and_workspace_caps() {
+        let hub = TerminalHub::new();
+        let ws = workspace();
+        let snap = hub.open_memory(ws, 80, 24).unwrap();
+        let too_big = vec![b'a'; MAX_TERMINAL_WRITE_BYTES + 1];
+        assert!(matches!(
+            hub.write(ws, snap.id, &too_big),
+            Err(TerminalError::WriteTooLarge)
+        ));
+        for _ in 1..MAX_TERMINALS_PER_WORKSPACE {
+            hub.open_memory(ws, 80, 24).unwrap();
+        }
+        assert!(matches!(
+            hub.open_memory(ws, 80, 24),
+            Err(TerminalError::WorkspaceCap)
+        ));
+    }
+
+    fn assert_no_bytes(root: &Path, needle: &[u8]) {
+        fn walk(path: &Path, needle: &[u8]) {
+            let Ok(meta) = std::fs::metadata(path) else {
+                return;
+            };
+            if meta.is_file() {
+                let Ok(bytes) = std::fs::read(path) else {
+                    return;
+                };
+                assert!(
+                    !bytes.windows(needle.len()).any(|window| window == needle),
+                    "terminal bytes persisted at {}",
+                    path.display()
+                );
+            } else if meta.is_dir() {
+                let Ok(entries) = std::fs::read_dir(path) else {
+                    return;
+                };
+                for entry in entries.flatten() {
+                    walk(&entry.path(), needle);
+                }
+            }
+        }
+        walk(root, needle);
+    }
+}

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -740,6 +740,28 @@ pub fn app(state: AppState) -> Router {
             "/code/sessions/{id}/events",
             get(routes::code::session_events),
         )
+        .route(
+            "/code/workspaces/{id}/terminals",
+            post(routes::code::create_terminal)
+                .get(routes::code::list_terminals)
+                .delete(routes::code::close_workspace_terminals),
+        )
+        .route(
+            "/code/workspaces/{id}/terminals/{tid}",
+            axum::routing::delete(routes::code::close_terminal),
+        )
+        .route(
+            "/code/workspaces/{id}/terminals/{tid}/read",
+            get(routes::code::read_terminal),
+        )
+        .route(
+            "/code/workspaces/{id}/terminals/{tid}/write",
+            post(routes::code::write_terminal),
+        )
+        .route(
+            "/code/workspaces/{id}/terminals/{tid}/resize",
+            post(routes::code::resize_terminal),
+        )
         .merge(client_executor_api)
         // Merged before the bearer layer, so `require_token` wraps outside
         // `require_admin`: an unauthenticated request to a deployment-plane

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -4,6 +4,7 @@ mod harnesses;
 mod repos;
 mod session_events;
 mod sessions;
+mod terminals;
 mod types;
 mod workspaces;
 
@@ -14,9 +15,14 @@ pub(crate) use sessions::{
     create_session, interrupt_session, list_session_turns, list_workspace_sessions, reap_session,
     steer_session, submit_turn,
 };
+pub(crate) use terminals::{
+    close_terminal, close_workspace_terminals, create_terminal, list_terminals, read_terminal,
+    resize_terminal, write_terminal,
+};
 #[allow(unused_imports)]
 pub(crate) use types::{
-    CodeFileChange, CodeRepoSnapshot, CodeSessionSnapshot, CodeTurnSnapshot, CodeWorkspaceDiff,
+    CodeFileChange, CodeRepoSnapshot, CodeSessionSnapshot, CodeTerminalActivityNotice,
+    CodeTerminalRead, CodeTerminalSnapshot, CodeTurnSnapshot, CodeWorkspaceDiff,
     CodeWorkspaceFiles, CodeWorkspaceSnapshot, HarnessDoctorReport, QueuedCodeTurn,
     SequencedCodeEventFrame,
 };

--- a/crates/tidebreak-server/src/routes/code/terminals.rs
+++ b/crates/tidebreak-server/src/routes/code/terminals.rs
@@ -1,0 +1,179 @@
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine;
+
+use crate::code::terminal::{TerminalError, TerminalRead, TerminalSnapshot};
+use crate::error::ServerError;
+use crate::extract::{Json, Path, Query};
+use crate::state::AppState;
+use tidebreak_core::{CodeWorkspaceStatus, WorkspaceId};
+
+use super::require_code;
+use super::types::{
+    CodeTerminalRead, CodeTerminalSnapshot, CreateTerminalBody, TerminalReadQuery,
+    TerminalResizeBody, TerminalWriteBody, WorkspaceTerminalPath,
+};
+
+pub async fn create_terminal(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    Path(id): Path<WorkspaceId>,
+    Json(body): Json<CreateTerminalBody>,
+) -> Result<impl IntoResponse, ServerError> {
+    let workspace = require_code(&state)?.get_workspace(id).await?;
+    require_active(&workspace.status)?;
+    let snap = state
+        .terminals
+        .open(
+            id,
+            std::path::Path::new(&workspace.worktree_path),
+            body.cols,
+            body.rows,
+        )
+        .map_err(map_terminal)?;
+    Ok((StatusCode::CREATED, Json(snapshot_wire(snap))))
+}
+
+pub async fn list_terminals(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    Path(id): Path<WorkspaceId>,
+) -> Result<Json<Vec<CodeTerminalSnapshot>>, ServerError> {
+    let _ = require_code(&state)?.get_workspace(id).await?;
+    Ok(Json(
+        state
+            .terminals
+            .list(id)
+            .into_iter()
+            .map(snapshot_wire)
+            .collect(),
+    ))
+}
+
+pub async fn close_workspace_terminals(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    Path(id): Path<WorkspaceId>,
+) -> Result<StatusCode, ServerError> {
+    let _ = require_code(&state)?.get_workspace(id).await?;
+    state.terminals.close_workspace(id);
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub async fn close_terminal(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    Path(path): Path<WorkspaceTerminalPath>,
+) -> Result<StatusCode, ServerError> {
+    let _ = require_code(&state)?.get_workspace(path.id).await?;
+    state
+        .terminals
+        .close(path.id, path.tid)
+        .map_err(map_terminal)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub async fn read_terminal(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    Path(path): Path<WorkspaceTerminalPath>,
+    Query(query): Query<TerminalReadQuery>,
+) -> Result<Json<CodeTerminalRead>, ServerError> {
+    let _ = require_code(&state)?.get_workspace(path.id).await?;
+    Ok(Json(read_wire(
+        path.tid,
+        path.id,
+        state.terminals.read(path.id, path.tid, query.cursor),
+    )))
+}
+
+pub async fn write_terminal(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    Path(path): Path<WorkspaceTerminalPath>,
+    Json(body): Json<TerminalWriteBody>,
+) -> Result<StatusCode, ServerError> {
+    let _ = require_code(&state)?.get_workspace(path.id).await?;
+    let bytes = decode_write(&body.bytes)?;
+    state
+        .terminals
+        .write(path.id, path.tid, &bytes)
+        .map_err(map_terminal)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub async fn resize_terminal(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    Path(path): Path<WorkspaceTerminalPath>,
+    Json(body): Json<TerminalResizeBody>,
+) -> Result<Json<CodeTerminalSnapshot>, ServerError> {
+    let _ = require_code(&state)?.get_workspace(path.id).await?;
+    let snap = state
+        .terminals
+        .resize(path.id, path.tid, body.cols, body.rows)
+        .map_err(map_terminal)?;
+    Ok(Json(snapshot_wire(snap)))
+}
+
+fn require_active(status: &CodeWorkspaceStatus) -> Result<(), ServerError> {
+    if *status != CodeWorkspaceStatus::Active {
+        return Err(ServerError::conflict_kind(
+            "workspace_not_ready",
+            format!("workspace is {}", status.as_str()),
+        ));
+    }
+    Ok(())
+}
+
+fn decode_write(encoded: &str) -> Result<Vec<u8>, ServerError> {
+    BASE64.decode(encoded.trim()).map_err(|_| {
+        ServerError::bad_request_kind(
+            "invalid_terminal_bytes",
+            "write body is not standard base64",
+        )
+    })
+}
+
+fn snapshot_wire(snap: TerminalSnapshot) -> CodeTerminalSnapshot {
+    CodeTerminalSnapshot {
+        id: snap.id,
+        workspace_id: snap.workspace_id,
+        cols: snap.cols,
+        rows: snap.rows,
+        ended: snap.ended,
+        created_at: snap.created_at,
+    }
+}
+
+fn read_wire(
+    id: tidebreak_core::CodeTerminalId,
+    workspace_id: WorkspaceId,
+    read: TerminalRead,
+) -> CodeTerminalRead {
+    CodeTerminalRead {
+        id,
+        workspace_id,
+        bytes: BASE64.encode(read.data),
+        cursor: read.next_cursor,
+        overflow: read.overflow,
+        truncated: read.truncated,
+        ended: read.ended,
+    }
+}
+
+fn map_terminal(err: TerminalError) -> ServerError {
+    match err {
+        TerminalError::WorkspaceCap => ServerError::too_many_requests_kind(
+            "terminal_cap",
+            "this workspace already has as many terminals as it can keep",
+        ),
+        TerminalError::WriteTooLarge => {
+            ServerError::payload_too_large("terminal write exceeds the per-request cap")
+        }
+        TerminalError::Ended => {
+            ServerError::conflict_kind("terminal_ended", "this shell has ended")
+        }
+        TerminalError::NotFound => ServerError::not_found("terminal not found"),
+        TerminalError::InvalidSize => {
+            ServerError::bad_request_kind("invalid_terminal_size", "cols and rows must be 1..=512")
+        }
+        TerminalError::Spawn(message) | TerminalError::Io(message) => {
+            ServerError::internal(message)
+        }
+    }
+}

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -5,9 +5,9 @@ use ts_rs::TS;
 
 use tidebreak_core::{
     Attention, CapLevel, CodeEvent, CodePermissionMode, CodeRepo, CodeSession,
-    CodeSessionLifecycle, CodeTurn, CodeTurnId, CodeTurnStatus, CodeWorkspace, CodeWorkspaceStatus,
-    Diffstat, FenceReason, FileChangeKind, HarnessCaps, HarnessKind, HarnessTier,
-    PullRequestDigest, QuickAction, RepoId, WorkspaceId,
+    CodeSessionLifecycle, CodeTerminalId, CodeTurn, CodeTurnId, CodeTurnStatus, CodeWorkspace,
+    CodeWorkspaceStatus, Diffstat, FenceReason, FileChangeKind, HarnessCaps, HarnessKind,
+    HarnessTier, PullRequestDigest, QuickAction, RepoId, WorkspaceId,
 };
 
 /// A registered local git repository.
@@ -355,6 +355,84 @@ pub struct CodeWorkspaceDiff {
 pub struct SessionEventsQuery {
     #[serde(default)]
     pub after: i64,
+}
+
+/// One live auxiliary terminal. Bytes live only in the process ring.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeTerminalSnapshot {
+    pub id: CodeTerminalId,
+    pub workspace_id: WorkspaceId,
+    pub cols: u16,
+    pub rows: u16,
+    pub ended: bool,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Cursor-pull response for `GET /code/workspaces/{id}/terminals/{tid}/read`.
+///
+/// `bytes` is standard base64 of the raw ring slice. `overflow` is true when
+/// the requested cursor had already fallen out of the ring; the payload then
+/// starts with the inline truncation marker.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeTerminalRead {
+    pub id: CodeTerminalId,
+    pub workspace_id: WorkspaceId,
+    pub bytes: String,
+    pub cursor: u64,
+    pub overflow: bool,
+    pub truncated: bool,
+    pub ended: bool,
+}
+
+/// Unsequenced activity notice published on the updates channel.
+///
+/// Never journaled. A client that missed one just pulls from its last cursor.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+#[allow(dead_code)]
+pub struct CodeTerminalActivityNotice {
+    pub workspace_id: WorkspaceId,
+    pub terminal_id: CodeTerminalId,
+}
+
+/// Body of `POST /code/workspaces/{id}/terminals`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CreateTerminalBody {
+    #[serde(default)]
+    pub cols: Option<u16>,
+    #[serde(default)]
+    pub rows: Option<u16>,
+}
+
+/// Query for `GET /code/workspaces/{id}/terminals/{tid}/read`.
+#[derive(Debug, Deserialize)]
+pub struct TerminalReadQuery {
+    #[serde(default)]
+    pub cursor: u64,
+}
+
+/// Body of `POST /code/workspaces/{id}/terminals/{tid}/write`.
+///
+/// `bytes` is standard base64. Decoded length is capped by the write bound.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TerminalWriteBody {
+    pub bytes: String,
+}
+
+/// Body of `POST /code/workspaces/{id}/terminals/{tid}/resize`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TerminalResizeBody {
+    pub cols: u16,
+    pub rows: u16,
+}
+
+/// Path of a workspace-scoped terminal.
+#[derive(Debug, Deserialize)]
+pub struct WorkspaceTerminalPath {
+    pub id: WorkspaceId,
+    pub tid: CodeTerminalId,
 }
 
 /// Used so capability flags stay reachable from the doctor root.

--- a/crates/tidebreak-server/src/routes/code/workspaces.rs
+++ b/crates/tidebreak-server/src/routes/code/workspaces.rs
@@ -72,11 +72,11 @@ pub async fn archive_workspace(
     Path(id): Path<WorkspaceId>,
     Json(body): Json<ArchiveWorkspaceBody>,
 ) -> Result<Json<CodeWorkspaceSnapshot>, ServerError> {
-    Ok(Json(CodeWorkspaceSnapshot::from(
-        require_code(&state)?
-            .archive_workspace(id, body.force)
-            .await?,
-    )))
+    let archived = require_code(&state)?
+        .archive_workspace(id, body.force)
+        .await?;
+    state.terminals.close_workspace(id);
+    Ok(Json(CodeWorkspaceSnapshot::from(archived)))
 }
 
 pub async fn list_workspace_files(

--- a/crates/tidebreak-server/src/state.rs
+++ b/crates/tidebreak-server/src/state.rs
@@ -248,6 +248,8 @@ pub struct AppState {
     /// Code-mode runtime: worktrees, session workers, doctor, event bus.
     /// Absent only in tests that assemble state without a [`DbStore`].
     pub(crate) code: Option<Arc<crate::code::CodeRuntime>>,
+    /// In-memory auxiliary terminals. Ephemeral: empty after every restart.
+    pub(crate) terminals: Arc<crate::code::terminal::TerminalHub>,
 }
 
 impl AppState {
@@ -435,6 +437,7 @@ impl AppState {
             code_execution: None,
             host_folders: None,
             code: None,
+            terminals: Arc::new(crate::code::terminal::TerminalHub::new()),
         })
     }
 

--- a/crates/tidebreak-server/src/tests.rs
+++ b/crates/tidebreak-server/src/tests.rs
@@ -41,6 +41,7 @@ mod app_invoke;
 mod app_library;
 mod chat_titling;
 mod code;
+mod code_terminals;
 mod compaction;
 mod configuration;
 mod conformance;

--- a/crates/tidebreak-server/src/tests/code_terminals.rs
+++ b/crates/tidebreak-server/src/tests/code_terminals.rs
@@ -1,0 +1,359 @@
+//! Auxiliary terminal routes: cursor-pull, restart reap, no durable bytes.
+
+use super::*;
+
+use std::net::Ipv4Addr;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::Router;
+use tokio::net::TcpListener;
+
+use crate::code::CodeRuntime;
+use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
+use tidebreak_core::{DbStore, Store};
+use tidebreak_harness::AdapterRegistry;
+
+async fn terminal_app() -> (
+    Router,
+    Arc<str>,
+    Arc<CodeRuntime>,
+    tempfile::TempDir,
+    AppState,
+) {
+    let (dir, store) = temp_db_store("code-terminals.db").await;
+    let db = Arc::new(store);
+    let store_trait: Arc<dyn Store> = db.clone();
+    let mut registry = AdapterRegistry::new();
+    registry.register(Arc::new(ScriptedAdapter::new(plain_text_script())));
+    let runtime = Arc::new(CodeRuntime::with_registry(
+        db,
+        dir.path().to_path_buf(),
+        registry,
+    ));
+    let mut state = AppState::new(
+        Config::desktop(dir.path()),
+        store_trait,
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    state.code = Some(runtime.clone());
+    let token = state.token.clone();
+    (app(state.clone()), token, runtime, dir, state)
+}
+
+fn init_git_repo(dir: &std::path::Path) -> std::path::PathBuf {
+    let repo = dir.join("origin");
+    std::fs::create_dir_all(&repo).unwrap();
+    for args in [
+        ["git", "init", "-b", "main"].as_slice(),
+        ["git", "config", "user.email", "dev@example.com"].as_slice(),
+        ["git", "config", "user.name", "Dev"].as_slice(),
+    ] {
+        assert!(std::process::Command::new(args[0])
+            .args(&args[1..])
+            .current_dir(&repo)
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .status()
+            .unwrap()
+            .success());
+    }
+    std::fs::write(repo.join("README.md"), "hello\n").unwrap();
+    assert!(std::process::Command::new("git")
+        .args(["add", "README.md"])
+        .current_dir(&repo)
+        .status()
+        .unwrap()
+        .success());
+    assert!(std::process::Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(&repo)
+        .status()
+        .unwrap()
+        .success());
+    repo
+}
+
+async fn register_workspace(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    token: &str,
+    repo: &std::path::Path,
+) -> String {
+    let registered = client
+        .post(format!("http://{addr}/code/repos"))
+        .bearer_auth(token)
+        .json(&serde_json::json!({ "path": repo }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(registered.status(), reqwest::StatusCode::CREATED);
+    let repo_body: serde_json::Value = registered.json().await.unwrap();
+    let created = client
+        .post(format!("http://{addr}/code/workspaces"))
+        .bearer_auth(token)
+        .json(&serde_json::json!({
+            "repo_id": repo_body["id"].as_str().unwrap(),
+            "title": "shell",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let workspace: serde_json::Value = created.json().await.unwrap();
+    workspace["id"].as_str().unwrap().to_owned()
+}
+
+async fn serve(router: Router) -> std::net::SocketAddr {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router).await;
+    });
+    addr
+}
+
+fn b64(bytes: &[u8]) -> String {
+    use base64::Engine;
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+fn decode_b64(value: &str) -> Vec<u8> {
+    use base64::Engine;
+    base64::engine::general_purpose::STANDARD
+        .decode(value)
+        .unwrap()
+}
+
+#[tokio::test]
+async fn create_write_read_and_two_cursors() {
+    let (router, token, _runtime, dir, _state) = terminal_app().await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let workspace_id = register_workspace(&client, addr, &token, &repo).await;
+
+    let created = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{workspace_id}/terminals"
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "cols": 80, "rows": 24 }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let terminal: serde_json::Value = created.json().await.unwrap();
+    let tid = terminal["id"].as_str().unwrap();
+    assert_eq!(terminal["ended"], false);
+
+    let listed = client
+        .get(format!(
+            "http://{addr}/code/workspaces/{workspace_id}/terminals"
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(listed.status(), reqwest::StatusCode::OK);
+    let list: Vec<serde_json::Value> = listed.json().await.unwrap();
+    assert_eq!(list.len(), 1);
+
+    let payload = b"echo TERM_TWO_READERS_ok\r";
+    let written = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{workspace_id}/terminals/{tid}/write"
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "bytes": b64(payload) }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(written.status(), reqwest::StatusCode::NO_CONTENT);
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    let mut body = Vec::new();
+    let mut cursor = 0u64;
+    while tokio::time::Instant::now() < deadline {
+        let read = client
+            .get(format!(
+                "http://{addr}/code/workspaces/{workspace_id}/terminals/{tid}/read?cursor={cursor}"
+            ))
+            .bearer_auth(&token)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(read.status(), reqwest::StatusCode::OK);
+        let page: serde_json::Value = read.json().await.unwrap();
+        body.extend(decode_b64(page["bytes"].as_str().unwrap()));
+        cursor = page["cursor"].as_u64().unwrap();
+        if body
+            .windows(b"TERM_TWO_READERS_ok".len())
+            .any(|w| w == b"TERM_TWO_READERS_ok")
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(40)).await;
+    }
+    assert!(
+        body.windows(b"TERM_TWO_READERS_ok".len())
+            .any(|w| w == b"TERM_TWO_READERS_ok"),
+        "shell did not echo the written command: {:?}",
+        String::from_utf8_lossy(&body)
+    );
+
+    let late = client
+        .get(format!(
+            "http://{addr}/code/workspaces/{workspace_id}/terminals/{tid}/read?cursor={cursor}"
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    let late_page: serde_json::Value = late.json().await.unwrap();
+    assert_eq!(late_page["cursor"].as_u64().unwrap(), cursor);
+
+    let from_zero = client
+        .get(format!(
+            "http://{addr}/code/workspaces/{workspace_id}/terminals/{tid}/read?cursor=0"
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    let zero: serde_json::Value = from_zero.json().await.unwrap();
+    let zero_bytes = decode_b64(zero["bytes"].as_str().unwrap());
+    assert!(zero_bytes
+        .windows(b"TERM_TWO_READERS_ok".len())
+        .any(|w| w == b"TERM_TWO_READERS_ok"));
+}
+
+#[tokio::test]
+async fn restart_reports_ended_and_store_holds_no_terminal_bytes() {
+    let marker = b"TERM_MARKER_no_durable_9f3a7c1e";
+    let (router, token, _runtime, dir, state) = terminal_app().await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let workspace_id = register_workspace(&client, addr, &token, &repo).await;
+
+    let created = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{workspace_id}/terminals"
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let terminal: serde_json::Value = created.json().await.unwrap();
+    let tid = terminal["id"].as_str().unwrap().to_owned();
+    let parsed: tidebreak_core::CodeTerminalId = tid.parse().unwrap();
+    state.terminals.push_output(parsed, marker);
+    assert!(state
+        .terminals
+        .read(workspace_id.parse().unwrap(), parsed, 0)
+        .data
+        .windows(marker.len())
+        .any(|window| window == marker));
+
+    let (router2, token2, _runtime2, _dir2, state2) = {
+        let db = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rw",
+                dir.path().join("code-terminals.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let store_trait: Arc<dyn Store> = db.clone();
+        let mut registry = AdapterRegistry::new();
+        registry.register(Arc::new(ScriptedAdapter::new(plain_text_script())));
+        let runtime = Arc::new(CodeRuntime::with_registry(
+            db,
+            dir.path().to_path_buf(),
+            registry,
+        ));
+        let mut state = AppState::new(
+            Config::desktop(dir.path()),
+            store_trait,
+            Arc::new(FixedResolver(Arc::new(FakeProvider))),
+            Arc::new(MemSecrets::default()),
+            Arc::new(ToolRegistry::new()),
+            AgentConfig {
+                model: "fake".into(),
+                ..AgentConfig::default()
+            },
+        );
+        state.code = Some(runtime.clone());
+        let token = state.token.clone();
+        (
+            app(state.clone()),
+            token,
+            runtime,
+            dir.path().to_path_buf(),
+            state,
+        )
+    };
+    let addr2 = serve(router2).await;
+
+    let listed = client
+        .get(format!(
+            "http://{addr2}/code/workspaces/{workspace_id}/terminals"
+        ))
+        .bearer_auth(&token2)
+        .send()
+        .await
+        .unwrap();
+    let list: Vec<serde_json::Value> = listed.json().await.unwrap();
+    assert!(list.is_empty(), "restart must reap live terminals");
+
+    let read = client
+        .get(format!(
+            "http://{addr2}/code/workspaces/{workspace_id}/terminals/{tid}/read?cursor=0"
+        ))
+        .bearer_auth(&token2)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(read.status(), reqwest::StatusCode::OK);
+    let page: serde_json::Value = read.json().await.unwrap();
+    assert_eq!(page["ended"], true);
+    assert_eq!(page["bytes"].as_str().unwrap(), "");
+
+    assert_store_has_no_bytes(dir.path(), marker);
+    drop(state2);
+}
+
+fn assert_store_has_no_bytes(root: &Path, needle: &[u8]) {
+    fn walk(path: &Path, needle: &[u8]) {
+        let Ok(meta) = std::fs::metadata(path) else {
+            return;
+        };
+        if meta.is_file() {
+            let Ok(bytes) = std::fs::read(path) else {
+                return;
+            };
+            assert!(
+                !bytes.windows(needle.len()).any(|window| window == needle),
+                "terminal bytes persisted at {}",
+                path.display()
+            );
+        } else if meta.is_dir() {
+            let Ok(entries) = std::fs::read_dir(path) else {
+                return;
+            };
+            for entry in entries.flatten() {
+                walk(&entry.path(), needle);
+            }
+        }
+    }
+    walk(root, needle);
+}

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -416,6 +416,9 @@ mod tests {
         generate::collect_from::<crate::routes::code::HarnessDoctorReport>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeWorkspaceFiles>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeWorkspaceDiff>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::CodeTerminalSnapshot>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::CodeTerminalRead>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::CodeTerminalActivityNotice>(&cfg, &mut out);
         out
     }
 

--- a/legal/THIRD-PARTY-NOTICES.md
+++ b/legal/THIRD-PARTY-NOTICES.md
@@ -25,9 +25,9 @@ a stale one.
 
 ## Summary
 
-- Rust crates: 818
-- Desktop UI production packages: 497
-- Distinct license texts: 560
+- Rust crates: 827
+- Desktop UI production packages: 499
+- Distinct license texts: 569
 - Packages with no declared license: 0
 - Packages with a curated license: 28
 
@@ -636,6 +636,12 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/rust-lang/cfg-if
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-84e1bbfebd74](#l-84e1bbfebd74))
 
+### cfg_aliases 0.1.1
+
+- License: `MIT`
+- Repository: https://github.com/katharostech/cfg_aliases
+- License text: `LICENSE` ([L-48513346d335](#l-48513346d335))
+
 ### cfg_aliases 0.2.1
 
 - License: `MIT`
@@ -1026,6 +1032,12 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/allan2/dotenvy
 - License text: `LICENSE` ([L-37653ea50ac8](#l-37653ea50ac8))
 
+### downcast-rs 1.2.1
+
+- License: `MIT/Apache-2.0`
+- Repository: https://github.com/marcianx/downcast-rs
+- License text: `LICENSE-APACHE` ([L-c144680885b2](#l-c144680885b2)), `LICENSE-MIT` ([L-32979a7dea17](#l-32979a7dea17))
+
 ### dpi 0.1.2
 
 - License: `Apache-2.0 AND MIT`
@@ -1181,6 +1193,12 @@ License identifiers named across all declared expressions:
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/Diggsey/rust-field-offset
 - License text: `LICENSE-APACHE` ([L-59899c6091b5](#l-59899c6091b5)), `LICENSE-MIT` ([L-f4bc3f3c5bfd](#l-f4bc3f3c5bfd))
+
+### filedescriptor 0.8.3
+
+- License: `MIT`
+- Repository: https://github.com/wezterm/wezterm
+- License text: `LICENSE.md` ([L-0f5e2ba844a4](#l-0f5e2ba844a4))
 
 ### filetime 0.2.29
 
@@ -2182,6 +2200,12 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/mbrubeck/rust-debug-unreachable
 - License text: `LICENSE-MIT` ([L-42d8a095dbff](#l-42d8a095dbff))
 
+### nix 0.28.0
+
+- License: `MIT`
+- Repository: https://github.com/nix-rust/nix
+- License text: `LICENSE` ([L-b9b039b5058c](#l-b9b039b5058c))
+
 ### nix 0.29.0
 
 - License: `MIT`
@@ -2613,6 +2637,12 @@ License identifiers named across all declared expressions:
 - License: `Apache-2.0 OR MIT`
 - Repository: https://github.com/smol-rs/polling
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
+
+### portable-pty 0.9.0
+
+- License: `MIT`
+- Repository: https://github.com/wezterm/wezterm
+- License text: `LICENSE.md` ([L-0f5e2ba844a4](#l-0f5e2ba844a4))
 
 ### potential_utf 0.1.5
 
@@ -3256,6 +3286,12 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/jonasbb/serde_with/
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-fdd1c2117bcf](#l-fdd1c2117bcf))
 
+### serial2 0.2.38
+
+- License: `BSD-2-Clause OR Apache-2.0`
+- Repository: https://github.com/de-vri-es/serial2-rs
+- License text: `LICENSE-APACHE` ([L-948aecf4f952](#l-948aecf4f952)), `LICENSE-BSD` ([L-8b151c0d91e8](#l-8b151c0d91e8))
+
 ### serialize-to-javascript 0.1.2
 
 - License: `MIT OR Apache-2.0`
@@ -3315,6 +3351,18 @@ License identifiers named across all declared expressions:
 - License: `MIT`
 - Repository: https://github.com/oconnor663/shared_child.rs
 - License text: `LICENSE` ([L-b801c8d677ef](#l-b801c8d677ef))
+
+### shared_library 0.1.9
+
+- License: `Apache-2.0/MIT`
+- Repository: https://github.com/tomaka/shared_library/
+- License text: `LICENSE-APACHE` ([L-c144680885b2](#l-c144680885b2)), `LICENSE-MIT` ([L-1c07d19ccbe2](#l-1c07d19ccbe2))
+
+### shell-words 1.1.1
+
+- License: `MIT/Apache-2.0`
+- Repository: https://github.com/tmiasko/shell-words
+- License text: `LICENSE-APACHE` ([L-6e2add96be06](#l-6e2add96be06)), `LICENSE-MIT` ([L-104b7fa3c213](#l-104b7fa3c213))
 
 ### shlex 1.3.0
 
@@ -4718,6 +4766,12 @@ License identifiers named across all declared expressions:
 - License: `MIT`
 - Repository: https://github.com/winnow-rs/winnow
 - License text: `LICENSE-MIT` ([L-8793aa4141de](#l-8793aa4141de))
+
+### winreg 0.10.1
+
+- License: `MIT`
+- Repository: https://github.com/gentoo90/winreg-rs
+- License text: `LICENSE` ([L-d9ba37d9bbdf](#l-d9ba37d9bbdf))
 
 ### winreg 0.55.0
 
@@ -6414,6 +6468,18 @@ License identifiers named across all declared expressions:
 - License: `MIT`
 - Repository: https://github.com/wzhudev/redi.git
 - License text: `LICENSE` ([L-34fdd7429bc0](#l-34fdd7429bc0))
+
+### @xterm/addon-fit 0.11.0
+
+- License: `MIT`
+- Repository: https://github.com/xtermjs/xterm.js/tree/master/addons/addon-fit
+- License text: `LICENSE` ([L-c434897a5a6c](#l-c434897a5a6c))
+
+### @xterm/xterm 6.0.0
+
+- License: `MIT`
+- Repository: https://github.com/xtermjs/xterm.js
+- License text: `LICENSE` ([L-3474bccef5e4](#l-3474bccef5e4))
 
 ### acorn 8.18.0
 
@@ -9306,10 +9372,66 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
+### L-0f5e2ba844a4
+
+```
+MIT License
+
+Copyright (c) 2018 Wez Furlong
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
 ### L-1038b7737a0a
 
 ```
 Copyright (c) 2019-2026 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+```
+
+### L-104b7fa3c213
+
+```
+Copyright (c) 2016 Tomasz Miąsko
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
@@ -10101,6 +10223,36 @@ SOFTWARE.
 
 ```
 Copyright (c) 2014-2026 Alex Crichton
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+```
+
+### L-1c07d19ccbe2
+
+```
+Copyright (c) 2017 Pierre Krieger
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
@@ -12140,6 +12292,36 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
+### L-32979a7dea17
+
+```
+Copyright (c) 2020 Ashish Myles and contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+```
+
 ### L-32ae0b6c9e4c
 
 ```
@@ -12305,6 +12487,32 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+```
+
+### L-3474bccef5e4
+
+```
+Copyright (c) 2017-2019, The xterm.js authors (https://github.com/xtermjs/xterm.js)
+Copyright (c) 2014-2016, SourceLair Private Company (https://www.sourcelair.com)
+Copyright (c) 2012-2013, Christopher Jeffrey (https://github.com/chjj/)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 ```
 
 ### L-34fdd7429bc0
@@ -20437,6 +20645,212 @@ Apache License
    limitations under the License.
 ```
 
+### L-6e2add96be06
+
+```
+                               Apache License
+                         Version 2.0, January 2004
+                      http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+  "License" shall mean the terms and conditions for use, reproduction,
+  and distribution as defined by Sections 1 through 9 of this document.
+
+  "Licensor" shall mean the copyright owner or entity authorized by
+  the copyright owner that is granting the License.
+
+  "Legal Entity" shall mean the union of the acting entity and all
+  other entities that control, are controlled by, or are under common
+  control with that entity. For the purposes of this definition,
+  "control" means (i) the power, direct or indirect, to cause the
+  direction or management of such entity, whether by contract or
+  otherwise, or (ii) ownership of fifty percent (50%) or more of the
+  outstanding shares, or (iii) beneficial ownership of such entity.
+
+  "You" (or "Your") shall mean an individual or Legal Entity
+  exercising permissions granted by this License.
+
+  "Source" form shall mean the preferred form for making modifications,
+  including but not limited to software source code, documentation
+  source, and configuration files.
+
+  "Object" form shall mean any form resulting from mechanical
+  transformation or translation of a Source form, including but
+  not limited to compiled object code, generated documentation,
+  and conversions to other media types.
+
+  "Work" shall mean the work of authorship, whether in Source or
+  Object form, made available under the License, as indicated by a
+  copyright notice that is included in or attached to the work
+  (an example is provided in the Appendix below).
+
+  "Derivative Works" shall mean any work, whether in Source or Object
+  form, that is based on (or derived from) the Work and for which the
+  editorial revisions, annotations, elaborations, or other modifications
+  represent, as a whole, an original work of authorship. For the purposes
+  of this License, Derivative Works shall not include works that remain
+  separable from, or merely link (or bind by name) to the interfaces of,
+  the Work and Derivative Works thereof.
+
+  "Contribution" shall mean any work of authorship, including
+  the original version of the Work and any modifications or additions
+  to that Work or Derivative Works thereof, that is intentionally
+  submitted to Licensor for inclusion in the Work by the copyright owner
+  or by an individual or Legal Entity authorized to submit on behalf of
+  the copyright owner. For the purposes of this definition, "submitted"
+  means any form of electronic, verbal, or written communication sent
+  to the Licensor or its representatives, including but not limited to
+  communication on electronic mailing lists, source code control systems,
+  and issue tracking systems that are managed by, or on behalf of, the
+  Licensor for the purpose of discussing and improving the Work, but
+  excluding communication that is conspicuously marked or otherwise
+  designated in writing by the copyright owner as "Not a Contribution."
+
+  "Contributor" shall mean Licensor and any individual or Legal Entity
+  on behalf of whom a Contribution has been received by Licensor and
+  subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+  this License, each Contributor hereby grants to You a perpetual,
+  worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  copyright license to reproduce, prepare Derivative Works of,
+  publicly display, publicly perform, sublicense, and distribute the
+  Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+  this License, each Contributor hereby grants to You a perpetual,
+  worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  (except as stated in this section) patent license to make, have made,
+  use, offer to sell, sell, import, and otherwise transfer the Work,
+  where such license applies only to those patent claims licensable
+  by such Contributor that are necessarily infringed by their
+  Contribution(s) alone or by combination of their Contribution(s)
+  with the Work to which such Contribution(s) was submitted. If You
+  institute patent litigation against any entity (including a
+  cross-claim or counterclaim in a lawsuit) alleging that the Work
+  or a Contribution incorporated within the Work constitutes direct
+  or contributory patent infringement, then any patent licenses
+  granted to You under this License for that Work shall terminate
+  as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+  Work or Derivative Works thereof in any medium, with or without
+  modifications, and in Source or Object form, provided that You
+  meet the following conditions:
+
+  (a) You must give any other recipients of the Work or
+      Derivative Works a copy of this License; and
+
+  (b) You must cause any modified files to carry prominent notices
+      stating that You changed the files; and
+
+  (c) You must retain, in the Source form of any Derivative Works
+      that You distribute, all copyright, patent, trademark, and
+      attribution notices from the Source form of the Work,
+      excluding those notices that do not pertain to any part of
+      the Derivative Works; and
+
+  (d) If the Work includes a "NOTICE" text file as part of its
+      distribution, then any Derivative Works that You distribute must
+      include a readable copy of the attribution notices contained
+      within such NOTICE file, excluding those notices that do not
+      pertain to any part of the Derivative Works, in at least one
+      of the following places: within a NOTICE text file distributed
+      as part of the Derivative Works; within the Source form or
+      documentation, if provided along with the Derivative Works; or,
+      within a display generated by the Derivative Works, if and
+      wherever such third-party notices normally appear. The contents
+      of the NOTICE file are for informational purposes only and
+      do not modify the License. You may add Your own attribution
+      notices within Derivative Works that You distribute, alongside
+      or as an addendum to the NOTICE text from the Work, provided
+      that such additional attribution notices cannot be construed
+      as modifying the License.
+
+  You may add Your own copyright statement to Your modifications and
+  may provide additional or different license terms and conditions
+  for use, reproduction, or distribution of Your modifications, or
+  for any such Derivative Works as a whole, provided Your use,
+  reproduction, and distribution of the Work otherwise complies with
+  the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+  any Contribution intentionally submitted for inclusion in the Work
+  by You to the Licensor shall be under the terms and conditions of
+  this License, without any additional terms or conditions.
+  Notwithstanding the above, nothing herein shall supersede or modify
+  the terms of any separate license agreement you may have executed
+  with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+  names, trademarks, service marks, or product names of the Licensor,
+  except as required for reasonable and customary use in describing the
+  origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+  agreed to in writing, Licensor provides the Work (and each
+  Contributor provides its Contributions) on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied, including, without limitation, any warranties or conditions
+  of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+  PARTICULAR PURPOSE. You are solely responsible for determining the
+  appropriateness of using or redistributing the Work and assume any
+  risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+  whether in tort (including negligence), contract, or otherwise,
+  unless required by applicable law (such as deliberate and grossly
+  negligent acts) or agreed to in writing, shall any Contributor be
+  liable to You for damages, including any direct, indirect, special,
+  incidental, or consequential damages of any character arising as a
+  result of this License or out of the use or inability to use the
+  Work (including but not limited to damages for loss of goodwill,
+  work stoppage, computer failure or malfunction, or any and all
+  other commercial damages or losses), even if such Contributor
+  has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+  the Work or Derivative Works thereof, You may choose to offer,
+  and charge a fee for, acceptance of support, warranty, indemnity,
+  or other liability obligations and/or rights consistent with this
+  License. However, in accepting such obligations, You may act only
+  on Your own behalf and on Your sole responsibility, not on behalf
+  of any other Contributor, and only if You agree to indemnify,
+  defend, and hold each Contributor harmless for any liability
+  incurred by, or claims asserted against, such Contributor by reason
+  of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+  To apply the Apache License to your work, attach the following
+  boilerplate notice, with the fields enclosed by brackets "[]"
+  replaced with your own identifying information. (Don't include
+  the brackets!)  The text should be enclosed in the appropriate
+  comment syntax for the file format. We also recommend that a
+  file or class name and description of purpose be included on the
+  same "printed page" as the copyright notice for easier
+  identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```
+
 ### L-6e5c30d0e9f4
 
 ```
@@ -24644,6 +25058,35 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
+### L-8b151c0d91e8
+
+```
+BSD 2-Clause License
+
+Copyright (c) 2021, Maarten de Vries <maarten@de-vri.es>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
 ### L-8b6ab48f07c0
 
 ```
@@ -25925,6 +26368,24 @@ Permission is granted to anyone to use this software for any purpose, including 
 2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
 
 3. This notice may not be removed or altered from any source distribution.
+```
+
+### L-948aecf4f952
+
+```
+Copyright 2021, Maarten de Vries <maarten@de-vri.es>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 ```
 
 ### L-94b1870d380c
@@ -30854,6 +31315,30 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+```
+
+### L-c434897a5a6c
+
+```
+Copyright (c) 2019, The xterm.js authors (https://github.com/xtermjs/xterm.js)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 ```
 
 ### L-c43e20176655


### PR DESCRIPTION
## Summary

Workspace shells for verifying agent work next to review, per decision 0036. They are a user-facing convenience, not a harness interface.

- Spawn the user's `$SHELL` in a PTY with cwd set to the workspace worktree. `portable-pty` is pinned on `tidebreak-server` only; the harness crate still has the structural guard that it never depends on a PTY.
- Bytes live in a bounded in-memory ring. They are not journaled and not persisted. A server restart reaps every terminal; reconnect reports the shell ended. Ring overflow inserts an inline truncation marker.
- Caps: terminals per workspace, ring size, read response size, write size.
- Cursor-pull: `POST/GET/DELETE /code/workspaces/{id}/terminals`, `GET .../read?cursor=`, `POST .../write` and `/resize`. Activity notices are coalesced (~32ms) on an in-process bus and are never written to the journal.
- UI: `@xterm/xterm` + `@xterm/addon-fit`, a `terminal` panel variant, ephemeral renderer (create on open, dispose on close), recent-ring fetch then poll, chunked writes under a frame budget, stall reconnect, keyboard passthrough except app shortcuts.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p tidebreak-server --locked --all-targets -- -D warnings`
- [x] `cargo test -p tidebreak-server --locked --lib code::terminal`
- [x] `cargo test -p tidebreak-server --locked --lib code_terminals`
- [x] `cargo check --workspace --locked`
- [x] `pnpm test` and `pnpm build` in `crates/tidebreak-desktop/ui`
- [x] Wire types regenerated

Coverage: ring wraparound, cursor-at-overflow, truncation marker, read caps, restart reaps with no durable bytes in the store, coalesced notices while a reader still gets every retained byte, two readers at different cursors, pane dispose on unmount, truncation notice, ended-shell state.

Not verified in the running desktop app.