### PR TITLE
feat(code): commit, push, and pull-request flow for workspaces

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api.test.ts
+++ b/crates/tidebreak-desktop/ui/src/api.test.ts
@@ -1616,6 +1616,46 @@ describe("code workspace sessions", () => {
   });
 });
 
+describe("code workspace git flow", () => {
+  it("commits, pushes, and loads the PR digest", async () => {
+    const commit = {
+      sha: "abc123",
+      message: "first change\n\n1 file changed, 1 insertion(+), 0 deletions(-)",
+      stat: { files: 1, insertions: 1, deletions: 0, truncated: false },
+    };
+    const push = { branch: "tidebreak/first", remote: "origin" };
+    const digest = {
+      dirty: false,
+      unpushed: false,
+      ahead: 1,
+      has_upstream: true,
+      suggested_commit_message: commit.message,
+      gh_found: true,
+      gh_authenticated: true,
+      remediation: "",
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(commit), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(push), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(digest), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new ApiClient("http://127.0.0.1", "token");
+    await expect(client.commitCodeWorkspace("ws-1", "first change")).resolves.toEqual(commit);
+    await expect(client.pushCodeWorkspace("ws-1")).resolves.toEqual(push);
+    await expect(client.getCodeWorkspacePr("ws-1")).resolves.toEqual(digest);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "http://127.0.0.1/code/workspaces/ws-1/git/commit",
+    );
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      "http://127.0.0.1/code/workspaces/ws-1/git/push",
+    );
+    expect(fetchMock.mock.calls[2]?.[0]).toBe(
+      "http://127.0.0.1/code/workspaces/ws-1/pr",
+    );
+  });
+});
+
 describe("archive force kinds", () => {
   it("treats unpushed leftover work as a force-confirm, not a dead-end toast", () => {
     expect(archiveForceKind(new HttpError(409, "unpushed", "unpushed"))).toBe(

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -82,10 +82,14 @@ import {
   type CodeRepoSnapshot,
   type CodeSessionSnapshot,
   type CodeTurnSnapshot,
+  type CodeActionSnapshot,
+  type CodeCommitSnapshot,
+  type CodePushSnapshot,
   type CodeTerminalRead,
   type CodeTerminalSnapshot,
   type CodeWorkspaceDiff,
   type CodeWorkspaceFiles,
+  type CodeWorkspacePrSnapshot,
   type CodeWorkspaceSnapshot,
   type HarnessDoctorReport,
   type HarnessKind,
@@ -112,12 +116,16 @@ import {
   parseCodeSessionList,
   parseCodeTurn,
   parseCodeTurnList,
+  parseCodeAction,
+  parseCodeCommit,
+  parseCodePush,
   parseCodeTerminal,
   parseCodeTerminalList,
   parseCodeTerminalRead,
   parseCodeWorkspace,
   parseCodeWorkspaceDiff,
   parseCodeWorkspaceFiles,
+  parseCodeWorkspacePr,
   parseHarnessDoctorReport,
   parseSequencedCodeEvent,
 } from "../code/parsers";
@@ -1844,6 +1852,84 @@ export class ApiClient {
         ),
       ),
       "code workspace files",
+    );
+  }
+
+  async commitCodeWorkspace(
+    workspaceId: string,
+    message?: string,
+  ): Promise<CodeCommitSnapshot> {
+    return requireParsed(
+      parseCodeCommit(
+        await this.json(
+          `/code/workspaces/${encodeURIComponent(workspaceId)}/git/commit`,
+          {
+            method: "POST",
+            headers: this.headers(true),
+            body: JSON.stringify(message ? { message } : {}),
+          },
+        ),
+      ),
+      "code commit",
+    );
+  }
+
+  async pushCodeWorkspace(workspaceId: string): Promise<CodePushSnapshot> {
+    return requireParsed(
+      parseCodePush(
+        await this.json(
+          `/code/workspaces/${encodeURIComponent(workspaceId)}/git/push`,
+          { method: "POST", headers: this.headers() },
+        ),
+      ),
+      "code push",
+    );
+  }
+
+  async createCodePullRequest(
+    workspaceId: string,
+    body: { title?: string; body?: string } = {},
+  ): Promise<CodeWorkspacePrSnapshot> {
+    return requireParsed(
+      parseCodeWorkspacePr(
+        await this.json(
+          `/code/workspaces/${encodeURIComponent(workspaceId)}/git/pr`,
+          {
+            method: "POST",
+            headers: this.headers(true),
+            body: JSON.stringify(body),
+          },
+        ),
+      ),
+      "code pull request",
+    );
+  }
+
+  async getCodeWorkspacePr(
+    workspaceId: string,
+  ): Promise<CodeWorkspacePrSnapshot> {
+    return requireParsed(
+      parseCodeWorkspacePr(
+        await this.json(`/code/workspaces/${encodeURIComponent(workspaceId)}/pr`, {
+          headers: this.headers(),
+        }),
+      ),
+      "code pull request",
+    );
+  }
+
+  async runCodeWorkspaceAction(
+    workspaceId: string,
+    name: string,
+  ): Promise<CodeActionSnapshot> {
+    return requireParsed(
+      parseCodeAction(
+        await this.json(
+          `/code/workspaces/${encodeURIComponent(workspaceId)}/actions/${encodeURIComponent(name)}`,
+          { method: "POST", headers: this.headers() },
+        ),
+      ),
+      "code quick action",
     );
   }
 

--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -118,11 +118,16 @@ import {
   type CodeUsage as WireCodeUsage,
   type CodeWorkspaceDiff as WireCodeWorkspaceDiff,
   type CodeWorkspaceFiles as WireCodeWorkspaceFiles,
+  type CodeWorkspacePrSnapshot as WireCodeWorkspacePrSnapshot,
+  type CodeActionSnapshot as WireCodeActionSnapshot,
+  type CodeCommitSnapshot as WireCodeCommitSnapshot,
+  type CodePushSnapshot as WireCodePushSnapshot,
   type CodeFileChange as WireCodeFileChange,
   type CodeTerminalActivityNotice as WireCodeTerminalActivityNotice,
   type CodeTerminalRead as WireCodeTerminalRead,
   type CodeTerminalSnapshot as WireCodeTerminalSnapshot,
   type CodeWorkspaceSnapshot as WireCodeWorkspaceSnapshot,
+  type PullRequestDigest as WirePullRequestDigest,
   type Diffstat as WireDiffstat,
   type FileChangeKind as WireFileChangeKind,
   type CodeWorkspaceStatus as WireCodeWorkspaceStatus,
@@ -999,6 +1004,11 @@ export type FileChangeKind = WireFileChangeKind;
 export type CodeFileChange = WireCodeFileChange;
 export type CodeWorkspaceFiles = WireCodeWorkspaceFiles;
 export type CodeWorkspaceDiff = WireCodeWorkspaceDiff;
+export type CodeWorkspacePrSnapshot = WireCodeWorkspacePrSnapshot;
+export type CodeCommitSnapshot = WireCodeCommitSnapshot;
+export type CodePushSnapshot = WireCodePushSnapshot;
+export type CodeActionSnapshot = WireCodeActionSnapshot;
+export type PullRequestDigest = WirePullRequestDigest;
 export type CodeTerminalSnapshot = WireCodeTerminalSnapshot;
 export type CodeTerminalRead = WireCodeTerminalRead;
 export type CodeTerminalActivityNotice = WireCodeTerminalActivityNotice;

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -25,6 +25,7 @@ import { friendlyErrorMessage } from "@/lib/utils";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { liveCodeSession } from "./parsers";
 import { CodeComposer } from "./CodeComposer";
+import { PrCard } from "./PrCard";
 import {
   acquireCodeSessionFromClient,
   releaseCodeSession,
@@ -140,7 +141,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     const ok = await confirm({
       title: "Archive this workspace?",
       description:
-        "The worktree is removed. Leftover work on the branch is kept only if you cancel.",
+        "The worktree is removed. Commit, push, or create a pull request from the card on this page first if you want to keep the work.",
       confirmLabel: "Archive",
       destructive: true,
     });
@@ -151,7 +152,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
       if (archiveForceKind(err)) {
         const forced = await confirm({
           title: "Discard leftover work?",
-          description: err instanceof Error ? err.message : String(err),
+          description: `${err instanceof Error ? err.message : String(err)} Commit and push from the pull-request card on this page, or discard.`,
           confirmLabel: "Discard and archive",
           destructive: true,
         });
@@ -273,6 +274,11 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
             className="flex min-h-0 flex-1 flex-col overflow-hidden"
             hidden={!visible}
           >
+            {workspace && workspace.status !== "archived" && (
+              <div className="px-4 pt-3">
+                <PrCard client={client} workspaceId={workspace.id} />
+              </div>
+            )}
             {fenced && session?.fence_reason && (
               <div className="border-warning-border bg-warning-background text-warning-foreground mx-4 mt-3 flex flex-col gap-2 rounded-md border px-3 py-2 text-sm">
                 <p>{fenceReasonText(session.fence_reason)}</p>

--- a/crates/tidebreak-desktop/ui/src/code/PrCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PrCard.dom.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { CodeWorkspacePrSnapshot } from "../api/types";
+import { PrCardView } from "./PrCard";
+
+afterEach(() => {
+  cleanup();
+});
+
+const hostMocks = vi.hoisted(() => ({ openExternal: vi.fn() }));
+vi.mock("@/host", () => ({ openExternal: hostMocks.openExternal }));
+
+const BASE: CodeWorkspacePrSnapshot = {
+  dirty: false,
+  unpushed: false,
+  ahead: 0,
+  has_upstream: false,
+  suggested_commit_message: "first change\n\n1 file changed, 1 insertion(+), 0 deletions(-)",
+  gh_found: true,
+  gh_authenticated: true,
+  remediation: "",
+};
+
+function renderState(
+  snapshot: CodeWorkspacePrSnapshot,
+  extras: Partial<{
+    message: string;
+    onCommit: () => void;
+    onPush: () => void;
+    onCreatePr: () => void;
+  }> = {},
+) {
+  const onCommit = extras.onCommit ?? vi.fn();
+  const onPush = extras.onPush ?? vi.fn();
+  const onCreatePr = extras.onCreatePr ?? vi.fn();
+  render(
+    <PrCardView
+      snapshot={snapshot}
+      message={extras.message ?? snapshot.suggested_commit_message}
+      busy={null}
+      onMessageChange={vi.fn()}
+      onCommit={onCommit}
+      onPush={onPush}
+      onCreatePr={onCreatePr}
+    />,
+  );
+  return { onCommit, onPush, onCreatePr };
+}
+
+describe("PrCard", () => {
+  it("shows the no-commits state", () => {
+    renderState(BASE);
+    expect(screen.getByText("No commits")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Commit" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Push" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Create PR" })).toBeDisabled();
+  });
+
+  it("enables commit when the tree is dirty", async () => {
+    const { onCommit } = renderState({ ...BASE, dirty: true });
+    expect(screen.getByText("Uncommitted")).toBeInTheDocument();
+    const commit = screen.getByRole("button", { name: "Commit" });
+    expect(commit).toBeEnabled();
+    await userEvent.setup().click(commit);
+    expect(onCommit).toHaveBeenCalledOnce();
+  });
+
+  it("enables push when commits are unpushed", async () => {
+    const { onPush } = renderState({ ...BASE, unpushed: true, ahead: 1 });
+    expect(screen.getByText("Unpushed")).toBeInTheDocument();
+    const push = screen.getByRole("button", { name: "Push" });
+    expect(push).toBeEnabled();
+    await userEvent.setup().click(push);
+    expect(onPush).toHaveBeenCalledOnce();
+    expect(screen.getByRole("button", { name: "Create PR" })).toBeDisabled();
+  });
+
+  it("enables create PR after a push with no pull request", async () => {
+    const { onCreatePr } = renderState({
+      ...BASE,
+      ahead: 2,
+      has_upstream: true,
+    });
+    expect(screen.getByText("Pushed")).toBeInTheDocument();
+    const create = screen.getByRole("button", { name: "Create PR" });
+    expect(create).toBeEnabled();
+    await userEvent.setup().click(create);
+    expect(onCreatePr).toHaveBeenCalledOnce();
+  });
+
+  it("shows PR state and checks chips", () => {
+    renderState({
+      ...BASE,
+      ahead: 2,
+      has_upstream: true,
+      pr: {
+        number: 12,
+        url: "https://github.com/example/demo/pull/12",
+        state: "open",
+        checks_summary: "2 passing, 1 pending, 0 failing",
+      },
+    });
+    expect(screen.getByText("open")).toBeInTheDocument();
+    expect(screen.getByText("2 passing, 1 pending, 0 failing")).toBeInTheDocument();
+    expect(screen.getByText("#12", { exact: false })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Create PR" })).toBeDisabled();
+  });
+
+  it("shows copyable gh-absent remediation", () => {
+    renderState({
+      ...BASE,
+      gh_found: false,
+      gh_authenticated: undefined,
+      remediation:
+        "gh is not installed.\n\n  git push -u origin tidebreak/first-change\n  gh pr create --title 'first change' --body '...'\n",
+    });
+    expect(screen.getAllByText(/gh is not installed/).length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "Create PR" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Copy instructions" })).toBeInTheDocument();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/PrCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PrCard.tsx
@@ -1,0 +1,336 @@
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+import { HttpError, type ApiClient } from "../api/client";
+import type { CodeWorkspacePrSnapshot } from "../api/types";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ClipboardCopyButton } from "@/ClipboardCopyButton";
+import { Textarea } from "@/components/ui/textarea";
+import { openExternal } from "@/host";
+import { friendlyErrorMessage } from "@/lib/utils";
+
+/**
+ * Commit, push, and pull-request card on a workspace.
+ *
+ * The default commit message is generated on the server from the worktree
+ * diffstat and the workspace title. Creating a PR never merges it.
+ */
+
+export function PrCard({
+  client,
+  workspaceId,
+}: {
+  client: Pick<
+    ApiClient,
+    | "getCodeWorkspacePr"
+    | "commitCodeWorkspace"
+    | "pushCodeWorkspace"
+    | "createCodePullRequest"
+  >;
+  workspaceId: string;
+}) {
+  const [snapshot, setSnapshot] = useState<CodeWorkspacePrSnapshot | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState("");
+  const [busy, setBusy] = useState<"commit" | "push" | "pr" | null>(null);
+
+  async function reload() {
+    const next = await client.getCodeWorkspacePr(workspaceId);
+    setSnapshot(next);
+    setMessage((current) =>
+      current.trim().length === 0 ? next.suggested_commit_message : current,
+    );
+    setError(null);
+    return next;
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const next = await client.getCodeWorkspacePr(workspaceId);
+        if (cancelled) return;
+        setSnapshot(next);
+        setMessage(next.suggested_commit_message);
+        setError(null);
+      } catch (err) {
+        if (!cancelled) {
+          setError(friendlyErrorMessage(err, "Could not load pull-request status"));
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [client, workspaceId]);
+
+  async function commit() {
+    setBusy("commit");
+    try {
+      await client.commitCodeWorkspace(workspaceId, message);
+      setMessage("");
+      await reload();
+      toast.success("Committed");
+    } catch (err) {
+      toast.error(friendlyErrorMessage(err, "Could not commit"));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function push() {
+    setBusy("push");
+    try {
+      await client.pushCodeWorkspace(workspaceId);
+      await reload();
+      toast.success("Pushed");
+    } catch (err) {
+      if (err instanceof HttpError && err.kind === "git_auth_failed") {
+        toast.error(err.message);
+      } else {
+        toast.error(friendlyErrorMessage(err, "Could not push"));
+      }
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function createPr() {
+    setBusy("pr");
+    try {
+      const next = await client.createCodePullRequest(workspaceId);
+      setSnapshot(next);
+      const url = next.pr?.url;
+      if (url && !(await openExternal(url).catch(() => false))) {
+        toast.message("Copy the pull-request URL to open it.");
+      }
+      toast.success("Pull request created");
+    } catch (err) {
+      if (err instanceof HttpError && (err.kind === "gh_absent" || err.kind === "gh_signed_out")) {
+        setError(err.message);
+      } else {
+        toast.error(friendlyErrorMessage(err, "Could not create a pull request"));
+      }
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <PrCardView
+      snapshot={snapshot}
+      error={error}
+      message={message}
+      busy={busy}
+      onMessageChange={setMessage}
+      onCommit={() => void commit()}
+      onPush={() => void push()}
+      onCreatePr={() => void createPr()}
+    />
+  );
+}
+
+export function PrCardView({
+  snapshot,
+  error,
+  message,
+  busy,
+  onMessageChange,
+  onCommit,
+  onPush,
+  onCreatePr,
+}: {
+  snapshot: CodeWorkspacePrSnapshot | null;
+  error?: string | null;
+  message: string;
+  busy: "commit" | "push" | "pr" | null;
+  onMessageChange: (value: string) => void;
+  onCommit: () => void;
+  onPush: () => void;
+  onCreatePr: () => void;
+}) {
+  const ghMissing = snapshot ? !snapshot.gh_found : false;
+  const ghSignedOut = snapshot?.gh_authenticated === false;
+  const canCommit = Boolean(snapshot?.dirty) && busy === null;
+  const canPush = Boolean(snapshot?.unpushed) && busy === null;
+  const canCreatePr =
+    Boolean(snapshot) &&
+    !snapshot?.dirty &&
+    !snapshot?.unpushed &&
+    snapshot?.ahead !== 0 &&
+    !ghMissing &&
+    !ghSignedOut &&
+    !snapshot?.pr &&
+    busy === null;
+
+  return (
+    <section
+      className="border-border bg-card flex flex-col gap-3 rounded-lg border px-3 py-3"
+      aria-label="Pull request"
+    >
+      <header className="flex flex-wrap items-center justify-between gap-2">
+        <h2 className="text-sm font-medium">Pull request</h2>
+        {snapshot && <GitStateChips snapshot={snapshot} />}
+      </header>
+      {error && (
+        <p className="text-critical text-sm" role="alert">
+          {error}
+        </p>
+      )}
+      <label className="flex flex-col gap-1">
+        <span className="text-muted-foreground text-xs">Commit message</span>
+        <Textarea
+          rows={3}
+          value={message}
+          onChange={(event) => onMessageChange(event.target.value)}
+          placeholder="Describe the change"
+          disabled={busy !== null}
+        />
+      </label>
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          type="button"
+          size="sm"
+          disabled={!canCommit}
+          onClick={onCommit}
+        >
+          Commit
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          disabled={!canPush}
+          onClick={onPush}
+        >
+          Push
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          disabled={!canCreatePr}
+          onClick={onCreatePr}
+        >
+          Create PR
+        </Button>
+      </div>
+      {snapshot && (ghMissing || ghSignedOut) && (
+        <GhRemediation snapshot={snapshot} />
+      )}
+      {snapshot?.pr && <PrDigest snapshot={snapshot} />}
+    </section>
+  );
+}
+
+function GitStateChips({ snapshot }: { snapshot: CodeWorkspacePrSnapshot }) {
+  if (snapshot.pr) {
+    return (
+      <div className="flex flex-wrap items-center gap-1">
+        <Badge variant={prStateVariant(snapshot.pr.state)} size="sm">
+          {snapshot.pr.state}
+        </Badge>
+        {snapshot.pr.checks_summary && (
+          <Badge variant={checksVariant(snapshot.pr.checks_summary)} size="sm">
+            {snapshot.pr.checks_summary}
+          </Badge>
+        )}
+      </div>
+    );
+  }
+  if (snapshot.dirty) {
+    return (
+      <Badge variant="warning" size="sm">
+        Uncommitted
+      </Badge>
+    );
+  }
+  if (snapshot.unpushed) {
+    return (
+      <Badge variant="warning" size="sm">
+        Unpushed
+      </Badge>
+    );
+  }
+  if (snapshot.ahead > 0) {
+    return (
+      <Badge variant="info" size="sm">
+        Pushed
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="outline" size="sm">
+      No commits
+    </Badge>
+  );
+}
+
+function PrDigest({ snapshot }: { snapshot: CodeWorkspacePrSnapshot }) {
+  const pr = snapshot.pr;
+  if (!pr) return null;
+  return (
+    <div className="flex flex-col gap-1 text-xs">
+      <p>
+        #{pr.number}
+        {pr.url ? (
+          <>
+            {" "}
+            <a
+              href={pr.url}
+              className="text-info-foreground underline"
+              onClick={(event) => {
+                event.preventDefault();
+                void openExternal(pr.url!).catch(() => undefined);
+              }}
+            >
+              {pr.url}
+            </a>
+          </>
+        ) : null}
+      </p>
+    </div>
+  );
+}
+
+function GhRemediation({ snapshot }: { snapshot: CodeWorkspacePrSnapshot }) {
+  return (
+    <div className="border-warning-border bg-warning-background text-warning-foreground flex flex-col gap-2 rounded-md border px-3 py-2 text-xs">
+      <p>
+        {snapshot.gh_found
+          ? "gh is installed but not signed in."
+          : "gh is not installed."}{" "}
+        Copy the commands below into a terminal. Tidebreak does not store GitHub
+        credentials.
+      </p>
+      <pre className="bg-background text-foreground overflow-x-auto rounded-md p-2 font-mono whitespace-pre-wrap">
+        {snapshot.remediation}
+      </pre>
+      <ClipboardCopyButton
+        value={snapshot.remediation}
+        label="Copy instructions"
+        copiedAnnouncement="Copied pull-request instructions"
+        failedAnnouncement="Could not copy instructions"
+      />
+    </div>
+  );
+}
+
+type StatusTone = "success" | "warning" | "critical" | "info" | "outline";
+
+function prStateVariant(state: string): StatusTone {
+  const token = state.toLowerCase();
+  if (token === "open") return "success";
+  if (token === "merged") return "info";
+  if (token === "closed") return "critical";
+  return "outline";
+}
+
+function checksVariant(summary: string): StatusTone {
+  const lower = summary.toLowerCase();
+  if (/\b[1-9]\d* failing/.test(lower)) return "critical";
+  if (/\b[1-9]\d* pending/.test(lower)) return "warning";
+  if (/\b[1-9]\d* passing/.test(lower) || lower.includes("passing")) return "success";
+  return "outline";
+}

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import {
   liveCodeSession,
+  parseCodeAction,
   parseCodeApproval,
+  parseCodeCommit,
+  parseCodePush,
   parseCodeSession,
   parseCodeSessionList,
   parseCodeTerminal,
@@ -12,6 +15,7 @@ import {
   parseCodeTurnList,
   parseCodeWorkspaceDiff,
   parseCodeWorkspaceFiles,
+  parseCodeWorkspacePr,
 } from "./parsers";
 
 const SESSION = {
@@ -181,6 +185,81 @@ describe("parseCodeTerminal", () => {
       ended: false,
     };
     expect(parseCodeTerminalRead(page)).toEqual(page);
+  });
+});
+
+describe("parseCodeWorkspacePr", () => {
+  const pr = {
+    dirty: false,
+    unpushed: true,
+    ahead: 2,
+    has_upstream: false,
+    suggested_commit_message: "first change\n\n1 file changed, 1 insertion(+), 0 deletions(-)",
+    gh_found: true,
+    gh_authenticated: true,
+    remediation: "",
+    pr: {
+      number: 12,
+      url: "https://github.com/example/demo/pull/12",
+      state: "open",
+      checks_summary: "1 passing, 0 pending, 0 failing",
+    },
+  };
+
+  it("accepts GET /code/workspaces/{id}/pr", () => {
+    expect(parseCodeWorkspacePr(pr)).toEqual(pr);
+  });
+
+  it("accepts the gh-absent remediation state", () => {
+    const absent = {
+      dirty: false,
+      unpushed: false,
+      ahead: 0,
+      has_upstream: false,
+      suggested_commit_message: "Update workspace\n\n0 files changed, 0 insertions(+), 0 deletions(-)",
+      gh_found: false,
+      remediation: "gh is not installed. Install the GitHub CLI.",
+    };
+    expect(parseCodeWorkspacePr(absent)).toEqual(absent);
+  });
+
+  it("rejects a missing boolean", () => {
+    expect(parseCodeWorkspacePr({ ...pr, dirty: "yes" })).toBeNull();
+  });
+});
+
+describe("parseCodeCommit", () => {
+  it("accepts POST /code/workspaces/{id}/git/commit", () => {
+    const commit = {
+      sha: "abc123",
+      message: "first change\n\n1 file changed, 1 insertion(+), 0 deletions(-)",
+      stat: { files: 1, insertions: 1, deletions: 0, truncated: false },
+    };
+    expect(parseCodeCommit(commit)).toEqual(commit);
+    expect(parseCodeCommit({ ...commit, sha: "" })).toBeNull();
+  });
+});
+
+describe("parseCodePush", () => {
+  it("accepts POST /code/workspaces/{id}/git/push", () => {
+    expect(parseCodePush({ branch: "tidebreak/first", remote: "origin" })).toEqual({
+      branch: "tidebreak/first",
+      remote: "origin",
+    });
+  });
+});
+
+describe("parseCodeAction", () => {
+  it("accepts POST /code/workspaces/{id}/actions/{name}", () => {
+    const action = {
+      name: "echo",
+      success: true,
+      exit_code: 0,
+      stdout: "hello",
+      stderr: "",
+      timed_out: false,
+    };
+    expect(parseCodeAction(action)).toEqual(action);
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -18,7 +18,11 @@ import type {
   CodeTerminalSnapshot,
   CodeWorkspaceDiff,
   CodeWorkspaceFiles,
+  CodeWorkspacePrSnapshot,
   CodeWorkspaceSnapshot,
+  CodeActionSnapshot,
+  CodeCommitSnapshot,
+  CodePushSnapshot,
   Diffstat,
   FileChangeKind,
   CodeWorkspaceStatus,
@@ -43,8 +47,13 @@ import type {
   CodeWorkspaceDiff as WireCodeWorkspaceDiff,
   CodeWorkspaceFiles as WireCodeWorkspaceFiles,
   CodeWorkspaceSnapshot as WireCodeWorkspaceSnapshot,
+  CodeWorkspacePrSnapshot as WireCodeWorkspacePrSnapshot,
+  CodeActionSnapshot as WireCodeActionSnapshot,
+  CodeCommitSnapshot as WireCodeCommitSnapshot,
+  CodePushSnapshot as WireCodePushSnapshot,
   CodeFileChange as WireCodeFileChange,
   Diffstat as WireDiffstat,
+  PullRequestDigest as WirePullRequestDigest,
   HarnessCaps as WireHarnessCaps,
   HarnessDoctorEntry as WireHarnessDoctorEntry,
   HarnessDoctorReport as WireHarnessDoctorReport,
@@ -213,7 +222,7 @@ export function parseCodeWorkspace(
   ) {
     return null;
   }
-  return {
+  const parsed: CodeWorkspaceSnapshot = {
     id: value.id,
     repo_id: value.repo_id,
     title: value.title,
@@ -222,8 +231,145 @@ export function parseCodeWorkspace(
     base_ref: value.base_ref,
     status: value.status,
     created_at: value.created_at,
-    ...(value.pr !== undefined ? { pr: value.pr as CodeWorkspaceSnapshot["pr"] } : {}),
     ...(value.archived_at !== undefined ? { archived_at: value.archived_at } : {}),
+  };
+  if (value.pr !== undefined) {
+    const pr = parsePullRequestDigest(value.pr);
+    if (!pr) return null;
+    parsed.pr = pr;
+  }
+  return parsed;
+}
+
+export function parsePullRequestDigest(
+  value: unknown,
+): NonNullable<CodeWorkspaceSnapshot["pr"]> | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WirePullRequestDigest>(value, [
+      "number",
+      "url",
+      "state",
+      "checks_summary",
+    ]) ||
+    !isFiniteNumber(value.number) ||
+    !nonEmpty(value.state) ||
+    (value.url !== undefined && value.url !== null && typeof value.url !== "string") ||
+    (value.checks_summary !== undefined &&
+      value.checks_summary !== null &&
+      typeof value.checks_summary !== "string")
+  ) {
+    return null;
+  }
+  return {
+    number: value.number,
+    state: value.state,
+    ...(value.url ? { url: value.url } : {}),
+    ...(value.checks_summary ? { checks_summary: value.checks_summary } : {}),
+  };
+}
+
+export function parseCodeWorkspacePr(
+  value: unknown,
+): CodeWorkspacePrSnapshot | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeWorkspacePrSnapshot>(value, [
+      "dirty",
+      "unpushed",
+      "ahead",
+      "has_upstream",
+      "suggested_commit_message",
+      "pr",
+      "gh_found",
+      "gh_authenticated",
+      "remediation",
+    ]) ||
+    typeof value.dirty !== "boolean" ||
+    typeof value.unpushed !== "boolean" ||
+    !isFiniteNumber(value.ahead) ||
+    typeof value.has_upstream !== "boolean" ||
+    typeof value.suggested_commit_message !== "string" ||
+    typeof value.gh_found !== "boolean" ||
+    (value.gh_authenticated !== undefined &&
+      typeof value.gh_authenticated !== "boolean") ||
+    typeof value.remediation !== "string"
+  ) {
+    return null;
+  }
+  const parsed: CodeWorkspacePrSnapshot = {
+    dirty: value.dirty,
+    unpushed: value.unpushed,
+    ahead: value.ahead,
+    has_upstream: value.has_upstream,
+    suggested_commit_message: value.suggested_commit_message,
+    gh_found: value.gh_found,
+    remediation: value.remediation,
+    ...(value.gh_authenticated !== undefined
+      ? { gh_authenticated: value.gh_authenticated }
+      : {}),
+  };
+  if (value.pr !== undefined) {
+    const pr = parsePullRequestDigest(value.pr);
+    if (!pr) return null;
+    parsed.pr = pr;
+  }
+  return parsed;
+}
+
+export function parseCodeCommit(value: unknown): CodeCommitSnapshot | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeCommitSnapshot>(value, ["sha", "message", "stat"]) ||
+    !nonEmpty(value.sha) ||
+    typeof value.message !== "string"
+  ) {
+    return null;
+  }
+  const stat = parseDiffstat(value.stat);
+  if (!stat) return null;
+  return { sha: value.sha, message: value.message, stat };
+}
+
+export function parseCodePush(value: unknown): CodePushSnapshot | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodePushSnapshot>(value, ["branch", "remote"]) ||
+    !nonEmpty(value.branch) ||
+    !nonEmpty(value.remote)
+  ) {
+    return null;
+  }
+  return { branch: value.branch, remote: value.remote };
+}
+
+export function parseCodeAction(value: unknown): CodeActionSnapshot | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeActionSnapshot>(value, [
+      "name",
+      "success",
+      "exit_code",
+      "stdout",
+      "stderr",
+      "timed_out",
+    ]) ||
+    !nonEmpty(value.name) ||
+    typeof value.success !== "boolean" ||
+    (value.exit_code !== undefined && !isFiniteNumber(value.exit_code)) ||
+    typeof value.stdout !== "string" ||
+    typeof value.stderr !== "string" ||
+    typeof value.timed_out !== "boolean"
+  ) {
+    return null;
+  }
+  return {
+    name: value.name,
+    success: value.success,
+    stdout: value.stdout,
+    stderr: value.stderr,
+    timed_out: value.timed_out,
+    ...(value.exit_code !== undefined ? { exit_code: value.exit_code } : {}),
   };
 }
 

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -804,6 +804,11 @@ diffstat?: Diffstat, };
 export type CitationLocator = { "kind": "document" } | { "kind": "page", page: number, } | { "kind": "pages", start: number, end: number, } | { "kind": "lines", start: number, end: number, } | { "kind": "sheet", sheet: string, cells: string | null, };
 
 /**
+ * Bounded output of one named quick action. Never journaled.
+ */
+export type CodeActionSnapshot = { name: string, success: boolean, exit_code?: number, stdout: string, stderr: string, timed_out: boolean, };
+
+/**
  * `approve` or `deny`.
  */
 export type CodeApprovalDecision = "approve" | "deny";
@@ -856,6 +861,11 @@ harness_raw_json: string, state: CodeApprovalState, feedback?: string, requested
  * State of a persisted approval.
  */
 export type CodeApprovalState = "pending" | "approved" | "denied";
+
+/**
+ * Result of staging and committing the workspace worktree.
+ */
+export type CodeCommitSnapshot = { sha: string, message: string, stat: Diffstat, };
 
 /**
  * One event in an external agent-engine session's journal.
@@ -1104,6 +1114,11 @@ export type CodeFileChange = { path: string, kind: FileChangeKind, insertions: n
 export type CodePermissionMode = "plan" | "ask" | "auto";
 
 /**
+ * Result of pushing the workspace branch.
+ */
+export type CodePushSnapshot = { branch: string, remote: string, };
+
+/**
  * A registered local git repository.
  */
 export type CodeRepoSnapshot = { id: RepoId, root_path: string, display_name: string, default_base_ref: string, branch_prefix: string, setup_script?: string, archive_script?: string, quick_actions: Array<QuickAction>, created_at: string, };
@@ -1194,6 +1209,11 @@ export type CodeWorkspaceDiff = { diff: string, truncated: boolean, stat: Diffst
  * Bounded changed-file list for `GET /code/workspaces/{id}/files`.
  */
 export type CodeWorkspaceFiles = { files: Array<CodeFileChange>, truncated: boolean, stat: Diffstat, turn_id?: CodeTurnId, };
+
+/**
+ * PR + checks digest plus the local git facts the PR card needs.
+ */
+export type CodeWorkspacePrSnapshot = { dirty: boolean, unpushed: boolean, ahead: number, has_upstream: boolean, suggested_commit_message: string, pr?: PullRequestDigest, gh_found: boolean, gh_authenticated?: boolean, remediation: string, };
 
 /**
  * One isolated workspace (worktree + branch) on a repo.

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -1,0 +1,1128 @@
+//! Git commit/push and `gh` pull-request operations for a workspace.
+//!
+//! Every subprocess is bounded and non-interactive. Arguments are an argv
+//! array, never a shell string. `gh` credentials are observed, never stored.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::{Duration, Instant};
+
+use tokio::process::Command;
+use tokio::time::timeout;
+
+use tidebreak_core::{Diffstat, PullRequestDigest, QuickAction, WorkspaceId};
+
+const GIT_TIMEOUT: Duration = Duration::from_secs(30);
+const GIT_PUSH_TIMEOUT: Duration = Duration::from_secs(120);
+const GH_TIMEOUT: Duration = Duration::from_secs(30);
+const ACTION_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_OUTPUT_CHARS: usize = 4_096;
+const PR_CACHE_TTL: Duration = Duration::from_secs(20);
+
+/// Brief in-memory cache of a workspace PR digest.
+#[derive(Debug, Default)]
+pub(crate) struct PrDigestCache {
+    entries: std::sync::Mutex<HashMap<WorkspaceId, CachedPr>>,
+}
+
+#[derive(Debug, Clone)]
+struct CachedPr {
+    fetched_at: Instant,
+    digest: PullRequestDigest,
+}
+
+impl PrDigestCache {
+    pub(crate) fn get(&self, id: WorkspaceId) -> Option<PullRequestDigest> {
+        let guard = self.entries.lock().expect("pr cache");
+        let entry = guard.get(&id)?;
+        if entry.fetched_at.elapsed() > PR_CACHE_TTL {
+            return None;
+        }
+        Some(entry.digest.clone())
+    }
+
+    pub(crate) fn put(&self, id: WorkspaceId, digest: PullRequestDigest) {
+        self.entries.lock().expect("pr cache").insert(
+            id,
+            CachedPr {
+                fetched_at: Instant::now(),
+                digest,
+            },
+        );
+    }
+
+    pub(crate) fn invalidate(&self, id: WorkspaceId) {
+        self.entries.lock().expect("pr cache").remove(&id);
+    }
+}
+
+/// Failure from a git, `gh`, or quick-action operation.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum GhError {
+    #[error("nothing to commit")]
+    NothingToCommit,
+    #[error("{0}")]
+    AuthFailed(String),
+    #[error("{instructions}")]
+    GhAbsent { instructions: String },
+    #[error("{instructions}")]
+    GhSignedOut { instructions: String },
+    #[error("{0}")]
+    User(String),
+    #[error("{0}")]
+    Internal(String),
+}
+
+impl GhError {
+    fn user(message: impl Into<String>) -> Self {
+        Self::User(message.into())
+    }
+}
+
+impl From<String> for GhError {
+    fn from(message: String) -> Self {
+        Self::Internal(message)
+    }
+}
+
+/// Result of staging and committing the worktree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CommitOutcome {
+    pub sha: String,
+    pub message: String,
+    pub stat: Diffstat,
+}
+
+/// Result of pushing the workspace branch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PushOutcome {
+    pub branch: String,
+    pub remote: String,
+}
+
+/// Live git + `gh` observation for the workspace PR card.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WorkspaceGitStatus {
+    pub dirty: bool,
+    pub unpushed: bool,
+    pub ahead: u64,
+    pub has_upstream: bool,
+    pub suggested_commit_message: String,
+    pub pr: Option<PullRequestDigest>,
+    pub gh_found: bool,
+    pub gh_authenticated: Option<bool>,
+    pub remediation: String,
+}
+
+/// Outcome of one named quick action.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ActionOutcome {
+    pub name: String,
+    pub success: bool,
+    pub exit_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+    pub timed_out: bool,
+}
+
+/// Observed `gh` availability. Tokens are never read or stored.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GhObservation {
+    pub found: bool,
+    pub authenticated: Option<bool>,
+    pub binary: Option<PathBuf>,
+    pub remediation: String,
+}
+
+/// Stage every change in `worktree` and create one commit.
+pub(crate) async fn commit_all(
+    worktree: &Path,
+    title: &str,
+    message: Option<&str>,
+) -> Result<CommitOutcome, GhError> {
+    if !has_uncommitted_work(worktree).await? {
+        return Err(GhError::NothingToCommit);
+    }
+    git(worktree, &["add", "-A"], GIT_TIMEOUT).await?;
+    let stat = cached_diffstat(worktree).await?;
+    if stat.files == 0 && stat.insertions == 0 && stat.deletions == 0 {
+        return Err(GhError::NothingToCommit);
+    }
+    let message = match message.map(str::trim).filter(|value| !value.is_empty()) {
+        Some(value) => value.to_owned(),
+        None => generate_commit_message(title, &stat),
+    };
+    git(worktree, &["commit", "-m", &message], GIT_TIMEOUT)
+        .await
+        .map_err(|err| classify_git(err, "commit"))?;
+    let sha = git(worktree, &["rev-parse", "HEAD"], GIT_TIMEOUT).await?;
+    Ok(CommitOutcome { sha, message, stat })
+}
+
+/// Push the workspace branch to `origin` and set upstream.
+pub(crate) async fn push_branch(worktree: &Path, branch: &str) -> Result<PushOutcome, GhError> {
+    git(
+        worktree,
+        &["push", "-u", "origin", branch],
+        GIT_PUSH_TIMEOUT,
+    )
+    .await
+    .map_err(|err| classify_git(err, "push"))?;
+    Ok(PushOutcome {
+        branch: branch.to_owned(),
+        remote: "origin".into(),
+    })
+}
+
+/// Inspect the worktree and, when `gh` can, refresh the PR digest.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn workspace_git_status(
+    worktree: &Path,
+    workspace_id: WorkspaceId,
+    title: &str,
+    branch: &str,
+    base_ref: &str,
+    persisted: Option<PullRequestDigest>,
+    cache: &PrDigestCache,
+    gh_search_path: Option<&str>,
+) -> Result<WorkspaceGitStatus, GhError> {
+    let inspect = inspect_git(worktree, base_ref, title).await?;
+    let gh = observe_gh(gh_search_path).await;
+    let mut pr = persisted;
+    if gh.found && gh.authenticated == Some(true) {
+        if let Some(cached) = cache.get(workspace_id) {
+            pr = Some(cached);
+        } else if let Some(fresh) = load_pr_digest(worktree, &gh, gh_search_path).await? {
+            cache.put(workspace_id, fresh.clone());
+            pr = Some(fresh);
+        }
+    }
+    Ok(WorkspaceGitStatus {
+        dirty: inspect.dirty,
+        unpushed: inspect.unpushed,
+        ahead: inspect.ahead,
+        has_upstream: inspect.has_upstream,
+        suggested_commit_message: inspect.suggested_commit_message,
+        pr,
+        gh_found: gh.found,
+        gh_authenticated: gh.authenticated,
+        remediation: if gh.found && gh.authenticated == Some(true) {
+            String::new()
+        } else {
+            manual_pr_instructions(worktree, branch, title, None, &inspect.diffstat, &gh)
+        },
+    })
+}
+
+/// Create a pull request from the workspace branch. Never merges.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn create_pull_request(
+    worktree: &Path,
+    workspace_id: WorkspaceId,
+    title: &str,
+    branch: &str,
+    base_ref: &str,
+    requested_title: Option<&str>,
+    requested_body: Option<&str>,
+    cache: &PrDigestCache,
+    gh_search_path: Option<&str>,
+) -> Result<PullRequestDigest, GhError> {
+    let inspect = inspect_git(worktree, base_ref, title).await?;
+    let gh = observe_gh(gh_search_path).await;
+    require_gh(&gh, worktree, branch, title, None, &inspect.diffstat)?;
+    let pr_title = requested_title
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| generate_pr_title(title, branch));
+    let pr_body = requested_body
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or(inspect.suggested_pr_body);
+    let binary = gh.binary.clone().ok_or_else(|| GhError::GhAbsent {
+        instructions: manual_pr_instructions(
+            worktree,
+            branch,
+            title,
+            Some(&pr_body),
+            &inspect.diffstat,
+            &gh,
+        ),
+    })?;
+    let stdout = run_gh(
+        worktree,
+        &binary,
+        &[
+            "pr", "create", "--title", &pr_title, "--body", &pr_body, "--head", branch,
+        ],
+        GH_TIMEOUT,
+    )
+    .await
+    .map_err(|err| {
+        classify_gh(
+            err,
+            worktree,
+            branch,
+            title,
+            Some(&pr_body),
+            &inspect.diffstat,
+        )
+    })?;
+    cache.invalidate(workspace_id);
+    if let Some(digest) = load_pr_digest(worktree, &gh, gh_search_path).await? {
+        cache.put(workspace_id, digest.clone());
+        return Ok(digest);
+    }
+    let url = stdout
+        .lines()
+        .map(str::trim)
+        .rev()
+        .find(|line| line.starts_with("http://") || line.starts_with("https://"))
+        .map(ToOwned::to_owned);
+    let number = url.as_deref().and_then(pr_number_from_url).unwrap_or(0);
+    let digest = PullRequestDigest {
+        number,
+        url,
+        state: "open".into(),
+        checks_summary: None,
+    };
+    cache.put(workspace_id, digest.clone());
+    Ok(digest)
+}
+
+/// Run one named quick action in the worktree. Output is not journaled.
+pub(crate) async fn run_named_action(
+    worktree: &Path,
+    actions: &[QuickAction],
+    name: &str,
+) -> Result<ActionOutcome, GhError> {
+    let action = actions
+        .iter()
+        .find(|action| action.name == name)
+        .ok_or_else(|| GhError::user(format!("no quick action named {name}")))?;
+    Ok(run_action(worktree, action).await)
+}
+
+/// Run every `auto_run_on_create` action after setup. Failures are ignored.
+pub(crate) async fn run_auto_create_actions(worktree: &Path, actions: &[QuickAction]) {
+    for action in actions.iter().filter(|action| action.auto_run_on_create) {
+        let outcome = run_action(worktree, action).await;
+        if !outcome.success {
+            tracing::warn!(
+                action = %action.name,
+                timed_out = outcome.timed_out,
+                "code-mode: auto-run quick action did not succeed"
+            );
+        }
+    }
+}
+
+/// Deterministic commit subject + shortstat body. No model calls.
+pub(crate) fn generate_commit_message(title: &str, stat: &Diffstat) -> String {
+    let subject = title.trim();
+    let subject = if subject.is_empty() {
+        "Update workspace"
+    } else {
+        subject
+    };
+    format!("{subject}\n\n{}", format_shortstat(stat))
+}
+
+pub(crate) fn generate_pr_title(title: &str, branch: &str) -> String {
+    let title = title.trim();
+    if title.is_empty() {
+        branch.rsplit('/').next().unwrap_or(branch).to_owned()
+    } else {
+        title.to_owned()
+    }
+}
+
+pub(crate) fn generate_pr_body(commits: &[String], stat: &Diffstat) -> String {
+    let mut body = String::from("## Commits\n\n");
+    if commits.is_empty() {
+        body.push_str("No commits on this branch yet.\n");
+    } else {
+        for commit in commits {
+            body.push_str("- ");
+            body.push_str(commit);
+            body.push('\n');
+        }
+    }
+    body.push_str("\n## Diff\n\n");
+    body.push_str(&format_shortstat(stat));
+    body.push('\n');
+    body
+}
+
+pub(crate) fn format_shortstat(stat: &Diffstat) -> String {
+    format!(
+        "{} file{} changed, {} insertion{}(+), {} deletion{}(-)",
+        stat.files,
+        if stat.files == 1 { "" } else { "s" },
+        stat.insertions,
+        if stat.insertions == 1 { "" } else { "s" },
+        stat.deletions,
+        if stat.deletions == 1 { "" } else { "s" },
+    )
+}
+
+struct GitInspect {
+    dirty: bool,
+    unpushed: bool,
+    ahead: u64,
+    has_upstream: bool,
+    suggested_commit_message: String,
+    suggested_pr_body: String,
+    diffstat: Diffstat,
+}
+
+async fn inspect_git(worktree: &Path, base_ref: &str, title: &str) -> Result<GitInspect, GhError> {
+    let dirty = has_uncommitted_work(worktree).await?;
+    let (has_upstream, ahead_of_upstream) = match git(
+        worktree,
+        &["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+        GIT_TIMEOUT,
+    )
+    .await
+    {
+        Ok(_) => {
+            let count = git(
+                worktree,
+                &["rev-list", "--count", "@{u}..HEAD"],
+                GIT_TIMEOUT,
+            )
+            .await?;
+            (true, parse_count(&count))
+        }
+        Err(_) => (false, 0),
+    };
+    let range = format!("{base_ref}..HEAD");
+    let ahead = parse_count(&git(worktree, &["rev-list", "--count", &range], GIT_TIMEOUT).await?);
+    let unpushed = if has_upstream {
+        ahead_of_upstream > 0
+    } else {
+        ahead > 0
+    };
+    let working_stat = if dirty {
+        working_tree_diffstat(worktree).await?
+    } else {
+        Diffstat {
+            files: 0,
+            insertions: 0,
+            deletions: 0,
+            truncated: false,
+        }
+    };
+    let branch_stat = parse_shortstat(
+        &git(worktree, &["diff", "--shortstat", &range], GIT_TIMEOUT)
+            .await
+            .unwrap_or_default(),
+    );
+    let commits = commit_subjects(worktree, &range).await?;
+    Ok(GitInspect {
+        dirty,
+        unpushed,
+        ahead,
+        has_upstream,
+        suggested_commit_message: generate_commit_message(title, &working_stat),
+        suggested_pr_body: generate_pr_body(&commits, &branch_stat),
+        diffstat: branch_stat,
+    })
+}
+
+async fn has_uncommitted_work(worktree: &Path) -> Result<bool, GhError> {
+    let status = git(worktree, &["status", "--porcelain"], GIT_TIMEOUT).await?;
+    Ok(!status.is_empty())
+}
+
+async fn cached_diffstat(worktree: &Path) -> Result<Diffstat, GhError> {
+    let text = git(worktree, &["diff", "--cached", "--shortstat"], GIT_TIMEOUT).await?;
+    Ok(parse_shortstat(&text))
+}
+
+async fn working_tree_diffstat(worktree: &Path) -> Result<Diffstat, GhError> {
+    let tracked = parse_shortstat(
+        &git(worktree, &["diff", "--shortstat", "HEAD"], GIT_TIMEOUT)
+            .await
+            .unwrap_or_default(),
+    );
+    let status = git(worktree, &["status", "--porcelain"], GIT_TIMEOUT).await?;
+    let mut untracked_files = 0_u32;
+    let mut untracked_insertions = 0_u32;
+    for line in status.lines() {
+        if let Some(path) = line.strip_prefix("?? ") {
+            untracked_files += 1;
+            if let Ok(bytes) = tokio::fs::read(worktree.join(path.trim())).await {
+                untracked_insertions +=
+                    u32::try_from(String::from_utf8_lossy(&bytes).lines().count())
+                        .unwrap_or(u32::MAX);
+            }
+        }
+    }
+    Ok(Diffstat {
+        files: tracked.files.saturating_add(untracked_files),
+        insertions: tracked.insertions.saturating_add(untracked_insertions),
+        deletions: tracked.deletions,
+        truncated: tracked.truncated,
+    })
+}
+
+async fn commit_subjects(worktree: &Path, range: &str) -> Result<Vec<String>, GhError> {
+    let text = git(worktree, &["log", "--format=%h %s", range], GIT_TIMEOUT)
+        .await
+        .unwrap_or_default();
+    Ok(text
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToOwned::to_owned)
+        .collect())
+}
+
+pub(crate) fn parse_shortstat(text: &str) -> Diffstat {
+    let mut files = 0;
+    let mut insertions = 0;
+    let mut deletions = 0;
+    for part in text.split(',') {
+        let part = part.trim();
+        let mut words = part.split_whitespace();
+        let Some(n) = words.next().and_then(|value| value.parse::<u32>().ok()) else {
+            continue;
+        };
+        let rest = words.collect::<Vec<_>>().join(" ");
+        if rest.starts_with("file") {
+            files = n;
+        } else if rest.contains("insertion") {
+            insertions = n;
+        } else if rest.contains("deletion") {
+            deletions = n;
+        }
+    }
+    Diffstat {
+        files,
+        insertions,
+        deletions,
+        truncated: false,
+    }
+}
+
+fn parse_count(text: &str) -> u64 {
+    text.trim().parse().unwrap_or(0)
+}
+
+async fn observe_gh(search_path: Option<&str>) -> GhObservation {
+    let Some(binary) = find_gh(search_path) else {
+        return GhObservation {
+            found: false,
+            authenticated: None,
+            binary: None,
+            remediation: "gh is not installed. Install the GitHub CLI from https://cli.github.com/ and sign in with `gh auth login` in a terminal. Tidebreak does not store GitHub credentials.".into(),
+        };
+    };
+    match run_gh(Path::new("."), &binary, &["auth", "status"], GH_TIMEOUT).await {
+        Ok(_) => GhObservation {
+            found: true,
+            authenticated: Some(true),
+            binary: Some(binary),
+            remediation: String::new(),
+        },
+        Err(_) => GhObservation {
+            found: true,
+            authenticated: Some(false),
+            binary: Some(binary),
+            remediation: "gh is installed but not signed in. Run `gh auth login` in a terminal, then try again. Tidebreak does not store GitHub credentials.".into(),
+        },
+    }
+}
+
+fn require_gh(
+    gh: &GhObservation,
+    worktree: &Path,
+    branch: &str,
+    title: &str,
+    body: Option<&str>,
+    stat: &Diffstat,
+) -> Result<(), GhError> {
+    if !gh.found {
+        return Err(GhError::GhAbsent {
+            instructions: manual_pr_instructions(worktree, branch, title, body, stat, gh),
+        });
+    }
+    if gh.authenticated != Some(true) {
+        return Err(GhError::GhSignedOut {
+            instructions: manual_pr_instructions(worktree, branch, title, body, stat, gh),
+        });
+    }
+    Ok(())
+}
+
+fn manual_pr_instructions(
+    worktree: &Path,
+    branch: &str,
+    title: &str,
+    body: Option<&str>,
+    stat: &Diffstat,
+    gh: &GhObservation,
+) -> String {
+    let pr_title = generate_pr_title(title, branch);
+    let pr_body = body
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| generate_pr_body(&[], stat));
+    format!(
+        "{header}\n\nCreate the pull request from a terminal:\n\n  cd {worktree}\n  git push -u origin {branch}\n  gh pr create --title {title} --body {body}\n",
+        header = gh.remediation,
+        worktree = worktree.display(),
+        title = shell_single_quote(&pr_title),
+        body = shell_single_quote(&pr_body),
+    )
+}
+
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+async fn load_pr_digest(
+    worktree: &Path,
+    gh: &GhObservation,
+    _search_path: Option<&str>,
+) -> Result<Option<PullRequestDigest>, GhError> {
+    let Some(binary) = gh.binary.as_ref() else {
+        return Ok(None);
+    };
+    let view = run_gh(
+        worktree,
+        binary,
+        &["pr", "view", "--json", "number,url,state"],
+        GH_TIMEOUT,
+    )
+    .await;
+    let Ok(json) = view else {
+        return Ok(None);
+    };
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap_or(serde_json::Value::Null);
+    let number = parsed.get("number").and_then(|value| value.as_u64());
+    let Some(number) = number else {
+        return Ok(None);
+    };
+    let url = parsed
+        .get("url")
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+    let state = parsed
+        .get("state")
+        .and_then(|value| value.as_str())
+        .unwrap_or("open")
+        .to_ascii_lowercase();
+    let checks = run_gh(worktree, binary, &["pr", "checks"], GH_TIMEOUT)
+        .await
+        .unwrap_or_default();
+    Ok(Some(PullRequestDigest {
+        number,
+        url,
+        state,
+        checks_summary: summarize_checks(&checks),
+    }))
+}
+
+pub(crate) fn summarize_checks(output: &str) -> Option<String> {
+    if output.trim().is_empty() {
+        return Some("no checks".into());
+    }
+    let mut passing = 0_u32;
+    let mut failing = 0_u32;
+    let mut pending = 0_u32;
+    let mut other = 0_u32;
+    for line in output.lines() {
+        let lower = line.to_ascii_lowercase();
+        if lower.contains('\t') {
+            // skip header-ish lines that name the columns
+            if lower.starts_with("name\t") || lower.starts_with("check\t") {
+                continue;
+            }
+        } else if lower.trim().is_empty() {
+            continue;
+        }
+        if lower.contains("pass") || lower.contains("success") {
+            passing += 1;
+        } else if lower.contains("fail") || lower.contains("error") {
+            failing += 1;
+        } else if lower.contains("pend") || lower.contains("progress") || lower.contains("queued") {
+            pending += 1;
+        } else {
+            other += 1;
+        }
+    }
+    if passing + failing + pending + other == 0 {
+        return Some("no checks".into());
+    }
+    Some(format!(
+        "{passing} passing, {pending} pending, {failing} failing"
+    ))
+}
+
+fn pr_number_from_url(url: &str) -> Option<u64> {
+    url.trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .and_then(|value| value.parse().ok())
+}
+
+fn find_gh(search_path: Option<&str>) -> Option<PathBuf> {
+    let path = search_path
+        .map(ToOwned::to_owned)
+        .or_else(|| std::env::var("PATH").ok())
+        .unwrap_or_default();
+    for dir in std::env::split_paths(&path) {
+        let candidate = dir.join("gh");
+        if is_executable(&candidate) {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn is_executable(path: &Path) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        path.metadata()
+            .map(|meta| meta.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+async fn run_action(worktree: &Path, action: &QuickAction) -> ActionOutcome {
+    let script = action.command.trim();
+    if script.is_empty() {
+        return ActionOutcome {
+            name: action.name.clone(),
+            success: true,
+            exit_code: Some(0),
+            stdout: String::new(),
+            stderr: String::new(),
+            timed_out: false,
+        };
+    }
+    let shell = std::env::var_os("SHELL").unwrap_or_else(|| "/bin/sh".into());
+    let mut command = Command::new(shell);
+    command
+        .arg("-lc")
+        .arg(script)
+        .current_dir(worktree)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .env("GIT_TERMINAL_PROMPT", "0");
+    let child = match command.spawn() {
+        Ok(child) => child,
+        Err(err) => {
+            return ActionOutcome {
+                name: action.name.clone(),
+                success: false,
+                exit_code: None,
+                stdout: String::new(),
+                stderr: bound_text(&format!("failed to spawn quick action: {err}")),
+                timed_out: false,
+            };
+        }
+    };
+    match timeout(ACTION_TIMEOUT, child.wait_with_output()).await {
+        Ok(Ok(output)) => ActionOutcome {
+            name: action.name.clone(),
+            success: output.status.success(),
+            exit_code: output.status.code(),
+            stdout: bound_text(&String::from_utf8_lossy(&output.stdout)),
+            stderr: bound_text(&String::from_utf8_lossy(&output.stderr)),
+            timed_out: false,
+        },
+        Ok(Err(err)) => ActionOutcome {
+            name: action.name.clone(),
+            success: false,
+            exit_code: None,
+            stdout: String::new(),
+            stderr: bound_text(&format!("quick action failed: {err}")),
+            timed_out: false,
+        },
+        Err(_) => ActionOutcome {
+            name: action.name.clone(),
+            success: false,
+            exit_code: None,
+            stdout: String::new(),
+            stderr: "quick action timed out".into(),
+            timed_out: true,
+        },
+    }
+}
+
+fn bound_text(text: &str) -> String {
+    let mut owned = text.to_owned();
+    if owned.chars().count() > MAX_OUTPUT_CHARS {
+        owned = owned.chars().take(MAX_OUTPUT_CHARS).collect();
+    }
+    owned
+}
+
+fn classify_git(err: String, op: &str) -> GhError {
+    let lower = err.to_ascii_lowercase();
+    if lower.contains("authentication failed")
+        || lower.contains("could not read username")
+        || lower.contains("could not read password")
+        || lower.contains("permission denied")
+        || lower.contains("terminal prompts disabled")
+        || lower.contains("could not read from remote")
+        || (op == "push" && (lower.contains("403") || lower.contains("401")))
+    {
+        return GhError::AuthFailed(format!(
+            "git could not authenticate to the remote. Configure your own git credentials (a credential helper, SSH key, or token) in a terminal, then try again. Tidebreak does not store git credentials.\n\n{err}"
+        ));
+    }
+    GhError::user(format!("git {op} failed: {err}"))
+}
+
+fn classify_gh(
+    err: String,
+    worktree: &Path,
+    branch: &str,
+    title: &str,
+    body: Option<&str>,
+    stat: &Diffstat,
+) -> GhError {
+    let lower = err.to_ascii_lowercase();
+    if lower.contains("not logged") || lower.contains("not signed") || lower.contains("auth") {
+        let gh = GhObservation {
+            found: true,
+            authenticated: Some(false),
+            binary: None,
+            remediation: "gh is installed but not signed in. Run `gh auth login` in a terminal, then try again. Tidebreak does not store GitHub credentials.".into(),
+        };
+        return GhError::GhSignedOut {
+            instructions: manual_pr_instructions(worktree, branch, title, body, stat, &gh),
+        };
+    }
+    GhError::user(format!("gh failed: {err}"))
+}
+
+async fn git(cwd: &Path, args: &[&str], limit: Duration) -> Result<String, String> {
+    let mut command = Command::new("git");
+    command
+        .args(args)
+        .current_dir(cwd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .env("GIT_TERMINAL_PROMPT", "0");
+    let child = command
+        .spawn()
+        .map_err(|err| format!("failed to spawn git: {err}"))?;
+    let output = timeout(limit, child.wait_with_output())
+        .await
+        .map_err(|_| format!("git {} timed out", args.join(" ")))?
+        .map_err(|err| format!("git {} failed: {err}", args.join(" ")))?;
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+    if output.status.success() {
+        Ok(stdout)
+    } else {
+        Err(if stderr.is_empty() { stdout } else { stderr })
+    }
+}
+
+async fn run_gh(
+    cwd: &Path,
+    binary: &Path,
+    args: &[&str],
+    limit: Duration,
+) -> Result<String, String> {
+    if args
+        .iter()
+        .any(|arg| *arg == "merge" || *arg == "--merge" || *arg == "--auto" || *arg == "graphql")
+        || args.windows(2).any(|pair| pair == ["api", "graphql"])
+    {
+        return Err("refusing to run a merge or GraphQL gh command".into());
+    }
+    let mut command = Command::new(binary);
+    command
+        .args(args)
+        .current_dir(cwd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .env("GH_PROMPT_DISABLED", "1")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GH_NO_UPDATE_NOTIFIER", "1");
+    let child = command
+        .spawn()
+        .map_err(|err| format!("failed to spawn gh: {err}"))?;
+    let output = timeout(limit, child.wait_with_output())
+        .await
+        .map_err(|_| format!("gh {} timed out", args.join(" ")))?
+        .map_err(|err| format!("gh {} failed: {err}", args.join(" ")))?;
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+    if output.status.success() || args == ["pr", "checks"] {
+        // `gh pr checks` exits non-zero when checks are pending or failing;
+        // the table is still the digest we want.
+        if output.status.success() || !stdout.is_empty() {
+            return Ok(stdout);
+        }
+    }
+    Err(if stderr.is_empty() { stdout } else { stderr })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::Command as StdCommand;
+    use tempfile::TempDir;
+
+    fn init_paired_repos() -> (TempDir, PathBuf, PathBuf) {
+        let dir = TempDir::new().unwrap();
+        let bare = dir.path().join("origin.git");
+        let work = dir.path().join("work");
+        run(
+            dir.path(),
+            &["git", "init", "--bare", bare.to_str().unwrap()],
+        );
+        std::fs::create_dir_all(&work).unwrap();
+        run(&work, &["git", "init", "-b", "main"]);
+        run(&work, &["git", "config", "user.email", "dev@example.com"]);
+        run(&work, &["git", "config", "user.name", "Dev"]);
+        std::fs::write(work.join("README.md"), "hello\n").unwrap();
+        run(&work, &["git", "add", "README.md"]);
+        run(&work, &["git", "commit", "-m", "init"]);
+        run(
+            &work,
+            &["git", "remote", "add", "origin", bare.to_str().unwrap()],
+        );
+        run(&work, &["git", "push", "-u", "origin", "main"]);
+        (dir, work, bare)
+    }
+
+    fn run(cwd: &Path, args: &[&str]) {
+        let status = StdCommand::new(args[0])
+            .args(&args[1..])
+            .current_dir(cwd)
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .status()
+            .unwrap();
+        assert!(status.success(), "{args:?} failed in {}", cwd.display());
+    }
+
+    fn write_executable(path: &Path, body: &str) {
+        std::fs::write(path, body).unwrap();
+        let mut perms = std::fs::metadata(path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(path, perms).unwrap();
+    }
+
+    #[test]
+    fn generated_commit_message_is_deterministic() {
+        let stat = Diffstat {
+            files: 3,
+            insertions: 12,
+            deletions: 4,
+            truncated: false,
+        };
+        assert_eq!(
+            generate_commit_message("first change", &stat),
+            "first change\n\n3 files changed, 12 insertions(+), 4 deletions(-)"
+        );
+        assert_eq!(
+            generate_commit_message("first change", &stat),
+            generate_commit_message("first change", &stat)
+        );
+    }
+
+    #[test]
+    fn shortstat_parser_reads_git_phrasing() {
+        let stat = parse_shortstat(" 1 file changed, 1 insertion(+), 1 deletion(-)");
+        assert_eq!(
+            stat,
+            Diffstat {
+                files: 1,
+                insertions: 1,
+                deletions: 1,
+                truncated: false,
+            }
+        );
+        let only_add = parse_shortstat(" 2 files changed, 8 insertions(+)");
+        assert_eq!(only_add.insertions, 8);
+        assert_eq!(only_add.deletions, 0);
+    }
+
+    #[test]
+    fn checks_summary_counts_buckets() {
+        let table = "lint\tpass\t1s\thttps://example.test/lint\ntest\tpending\t0\thttps://example.test/test\nfmt\tfail\t2s\thttps://example.test/fmt\n";
+        assert_eq!(
+            summarize_checks(table).as_deref(),
+            Some("1 passing, 1 pending, 1 failing")
+        );
+        assert_eq!(summarize_checks("").as_deref(), Some("no checks"));
+    }
+
+    #[tokio::test]
+    async fn commit_refuses_a_clean_tree_and_commits_when_dirty() {
+        let (_dir, work, _bare) = init_paired_repos();
+        let err = commit_all(&work, "first change", None).await.unwrap_err();
+        assert!(matches!(err, GhError::NothingToCommit));
+
+        std::fs::write(work.join("extra.txt"), "line\n").unwrap();
+        let committed = commit_all(&work, "first change", None).await.unwrap();
+        assert_eq!(
+            committed.message,
+            "first change\n\n1 file changed, 1 insertion(+), 0 deletions(-)"
+        );
+        assert_eq!(committed.stat.files, 1);
+        assert!(!committed.sha.is_empty());
+
+        let again = commit_all(&work, "first change", None).await.unwrap_err();
+        assert!(matches!(again, GhError::NothingToCommit));
+    }
+
+    #[tokio::test]
+    async fn push_sends_the_branch_to_a_bare_origin() {
+        let (_dir, work, bare) = init_paired_repos();
+        run(&work, &["git", "checkout", "-b", "tidebreak/first-change"]);
+        std::fs::write(work.join("extra.txt"), "line\n").unwrap();
+        commit_all(&work, "first change", Some("custom message"))
+            .await
+            .unwrap();
+        let pushed = push_branch(&work, "tidebreak/first-change").await.unwrap();
+        assert_eq!(pushed.remote, "origin");
+        let listed = git(
+            &bare,
+            &["branch", "--list", "tidebreak/first-change"],
+            GIT_TIMEOUT,
+        )
+        .await
+        .unwrap();
+        assert!(listed.contains("tidebreak/first-change"), "{listed}");
+    }
+
+    #[tokio::test]
+    async fn gh_absent_and_signed_out_are_typed() {
+        let empty = TempDir::new().unwrap();
+        let absent = observe_gh(Some(empty.path().to_str().unwrap())).await;
+        assert!(!absent.found);
+        assert!(absent.remediation.contains("gh is not installed"));
+
+        let shim_dir = TempDir::new().unwrap();
+        write_executable(
+            &shim_dir.path().join("gh"),
+            "#!/bin/sh\nif [ \"$1\" = auth ]; then echo signed out >&2; exit 1; fi\necho unexpected >&2; exit 3\n",
+        );
+        let signed_out = observe_gh(Some(shim_dir.path().to_str().unwrap())).await;
+        assert!(signed_out.found);
+        assert_eq!(signed_out.authenticated, Some(false));
+        assert!(signed_out.remediation.contains("gh auth login"));
+    }
+
+    #[tokio::test]
+    async fn create_pr_uses_view_and_checks_and_never_merges() {
+        let (_dir, work, _bare) = init_paired_repos();
+        run(&work, &["git", "checkout", "-b", "tidebreak/first-change"]);
+        std::fs::write(work.join("extra.txt"), "line\n").unwrap();
+        commit_all(&work, "first change", None).await.unwrap();
+        push_branch(&work, "tidebreak/first-change").await.unwrap();
+
+        let shim_dir = TempDir::new().unwrap();
+        let log = shim_dir.path().join("log");
+        write_executable(
+            &shim_dir.path().join("gh"),
+            &format!(
+                r#"#!/bin/sh
+echo "$@" >> {log}
+if [ "$1" = merge ] || [ "$2" = merge ]; then echo merge-forbidden >&2; exit 2; fi
+for arg in "$@"; do
+  if [ "$arg" = --auto ]; then echo auto-forbidden >&2; exit 2; fi
+done
+if [ "$1" = auth ]; then echo logged in; exit 0; fi
+if [ "$1" = pr ] && [ "$2" = create ]; then
+  echo https://github.com/example/demo/pull/12
+  exit 0
+fi
+if [ "$1" = pr ] && [ "$2" = view ]; then
+  echo '{{"number":12,"url":"https://github.com/example/demo/pull/12","state":"OPEN"}}'
+  exit 0
+fi
+if [ "$1" = pr ] && [ "$2" = checks ]; then
+  printf 'lint\tpass\t1s\thttps://example.test/lint\n'
+  exit 0
+fi
+echo unexpected "$@" >&2
+exit 3
+"#,
+                log = log.display()
+            ),
+        );
+        let cache = PrDigestCache::default();
+        let digest = create_pull_request(
+            &work,
+            WorkspaceId::new(),
+            "first change",
+            "tidebreak/first-change",
+            "main",
+            None,
+            None,
+            &cache,
+            Some(shim_dir.path().to_str().unwrap()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(digest.number, 12);
+        assert_eq!(
+            digest.url.as_deref(),
+            Some("https://github.com/example/demo/pull/12")
+        );
+        assert_eq!(digest.state, "open");
+        assert_eq!(
+            digest.checks_summary.as_deref(),
+            Some("1 passing, 0 pending, 0 failing")
+        );
+        let logged = std::fs::read_to_string(&log).unwrap();
+        assert!(logged.contains("pr create"), "{logged}");
+        assert!(logged.contains("pr view"), "{logged}");
+        assert!(logged.contains("pr checks"), "{logged}");
+        assert!(!logged.contains("merge"), "{logged}");
+        assert!(!logged.contains("--auto"), "{logged}");
+        assert!(!logged.contains("graphql"), "{logged}");
+    }
+
+    #[tokio::test]
+    async fn quick_action_bounds_output_and_times_out() {
+        let dir = TempDir::new().unwrap();
+        let long = QuickAction {
+            name: "noise".into(),
+            command: format!("printf '%{}s' '' | tr ' ' x", MAX_OUTPUT_CHARS + 80),
+            auto_run_on_create: false,
+        };
+        let noisy = run_action(dir.path(), &long).await;
+        assert!(noisy.success, "{}", noisy.stderr);
+        assert_eq!(noisy.stdout.chars().count(), MAX_OUTPUT_CHARS);
+        assert!(!noisy.timed_out);
+
+        let sleeper = QuickAction {
+            name: "sleep".into(),
+            command: "sleep 20".into(),
+            auto_run_on_create: false,
+        };
+        let timed = run_action(dir.path(), &sleeper).await;
+        assert!(timed.timed_out);
+        assert!(!timed.success);
+        assert!(timed.stderr.contains("timed out"));
+    }
+}

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -251,11 +251,13 @@ pub(crate) async fn create_pull_request(
             &gh,
         ),
     })?;
+    let base = gh_base_branch(base_ref);
     let stdout = run_gh(
         worktree,
         &binary,
         &[
-            "pr", "create", "--title", &pr_title, "--body", &pr_body, "--head", branch,
+            "pr", "create", "--title", &pr_title, "--body", &pr_body, "--base", base, "--head",
+            branch,
         ],
         GH_TIMEOUT,
     )
@@ -354,6 +356,15 @@ pub(crate) fn generate_pr_body(commits: &[String], stat: &Diffstat) -> String {
     body.push_str(&format_shortstat(stat));
     body.push('\n');
     body
+}
+
+/// Branch name `gh pr create --base` expects: strip a remote prefix.
+pub(crate) fn gh_base_branch(base_ref: &str) -> &str {
+    let trimmed = base_ref.trim();
+    trimmed
+        .strip_prefix("refs/remotes/origin/")
+        .or_else(|| trimmed.strip_prefix("origin/"))
+        .unwrap_or(trimmed)
 }
 
 pub(crate) fn format_shortstat(stat: &Diffstat) -> String {
@@ -930,6 +941,13 @@ mod tests {
     }
 
     #[test]
+    fn gh_base_branch_strips_a_remote_prefix() {
+        assert_eq!(gh_base_branch("origin/develop"), "develop");
+        assert_eq!(gh_base_branch("refs/remotes/origin/develop"), "develop");
+        assert_eq!(gh_base_branch("main"), "main");
+    }
+
+    #[test]
     fn generated_commit_message_is_deterministic() {
         let stat = Diffstat {
             files: 3,
@@ -1075,7 +1093,7 @@ exit 3
             WorkspaceId::new(),
             "first change",
             "tidebreak/first-change",
-            "main",
+            "origin/main",
             None,
             None,
             &cache,
@@ -1095,6 +1113,11 @@ exit 3
         );
         let logged = std::fs::read_to_string(&log).unwrap();
         assert!(logged.contains("pr create"), "{logged}");
+        assert!(
+            logged.contains("--base main"),
+            "gh pr create must target the workspace base, not the host default: {logged}"
+        );
+        assert!(!logged.contains("--base origin/main"), "{logged}");
         assert!(logged.contains("pr view"), "{logged}");
         assert!(logged.contains("pr checks"), "{logged}");
         assert!(!logged.contains("merge"), "{logged}");

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -7,6 +7,7 @@
 pub(crate) mod approval_bridge;
 pub(crate) mod bus;
 pub(crate) mod checkpoint;
+pub(crate) mod gh;
 pub(crate) mod recovery;
 pub(crate) mod runtime;
 pub(crate) mod session_worker;

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -30,6 +30,9 @@ use super::checkpoint::{
     delete_workspace_refs, list_changed_files, produce_diff, resolve_diff_range,
     sweep_orphaned_refs, ChangedFile, CheckpointError, DiffBounds,
 };
+use super::gh::{
+    self, ActionOutcome, CommitOutcome, GhError, PrDigestCache, PushOutcome, WorkspaceGitStatus,
+};
 use super::recovery::{self, RecoveryAction};
 use super::session_worker::{
     attach_engine, journal_event, queue_follow_up, spawn_session_worker, WorkerCommand,
@@ -59,6 +62,9 @@ pub(crate) struct CodeRuntime {
     host: HostEnv,
     loopback_base: Mutex<Option<String>>,
     workers: Mutex<HashMap<CodeSessionId, WorkerHandle>>,
+    pr_cache: PrDigestCache,
+    #[cfg(test)]
+    gh_search_path: Mutex<Option<String>>,
 }
 
 impl CodeRuntime {
@@ -72,6 +78,9 @@ impl CodeRuntime {
             host: HostEnv::from_process(),
             loopback_base: Mutex::new(None),
             workers: Mutex::new(HashMap::new()),
+            pr_cache: PrDigestCache::default(),
+            #[cfg(test)]
+            gh_search_path: Mutex::new(None),
         }
     }
 
@@ -96,7 +105,15 @@ impl CodeRuntime {
             host: HostEnv::from_process(),
             loopback_base: Mutex::new(None),
             workers: Mutex::new(HashMap::new()),
+            pr_cache: PrDigestCache::default(),
+            #[cfg(test)]
+            gh_search_path: Mutex::new(None),
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_gh_search_path(&self, path: Option<String>) {
+        *self.gh_search_path.lock().expect("gh search path") = path;
     }
 
     pub(crate) async fn recover(&self) -> Result<Vec<RecoveryAction>, ServerError> {
@@ -309,6 +326,7 @@ impl CodeRuntime {
             Ok(()) => {
                 workspace.status = CodeWorkspaceStatus::Active;
                 save_workspace(&self.db, &workspace).await?;
+                gh::run_auto_create_actions(&path, &repo.quick_actions).await;
                 Ok(workspace)
             }
             Err(err) => {
@@ -415,6 +433,121 @@ impl CodeRuntime {
         workspace.archived_at = Some(Utc::now());
         save_workspace(&self.db, &workspace).await?;
         Ok(workspace)
+    }
+
+    pub(crate) async fn commit_workspace(
+        &self,
+        id: WorkspaceId,
+        message: Option<String>,
+    ) -> Result<CommitOutcome, ServerError> {
+        let workspace = self.require_live_workspace(id).await?;
+        gh::commit_all(
+            std::path::Path::new(&workspace.worktree_path),
+            &workspace.title,
+            message.as_deref(),
+        )
+        .await
+        .map_err(map_gh)
+    }
+
+    pub(crate) async fn push_workspace(&self, id: WorkspaceId) -> Result<PushOutcome, ServerError> {
+        let workspace = self.require_live_workspace(id).await?;
+        gh::push_branch(
+            std::path::Path::new(&workspace.worktree_path),
+            &workspace.branch_name,
+        )
+        .await
+        .map_err(map_gh)
+    }
+
+    pub(crate) async fn workspace_pr(
+        &self,
+        id: WorkspaceId,
+    ) -> Result<WorkspaceGitStatus, ServerError> {
+        let mut workspace = self.get_workspace(id).await?;
+        let gh_path = self.gh_search_path_owned();
+        let status = gh::workspace_git_status(
+            std::path::Path::new(&workspace.worktree_path),
+            workspace.id,
+            &workspace.title,
+            &workspace.branch_name,
+            &workspace.base_ref,
+            workspace.pr.clone(),
+            &self.pr_cache,
+            gh_path.as_deref(),
+        )
+        .await
+        .map_err(map_gh)?;
+        if status.pr != workspace.pr {
+            workspace.pr = status.pr.clone();
+            save_workspace(&self.db, &workspace).await?;
+        }
+        Ok(status)
+    }
+
+    pub(crate) async fn create_workspace_pr(
+        &self,
+        id: WorkspaceId,
+        title: Option<String>,
+        body: Option<String>,
+    ) -> Result<WorkspaceGitStatus, ServerError> {
+        let mut workspace = self.require_live_workspace(id).await?;
+        let gh_path = self.gh_search_path_owned();
+        let digest = gh::create_pull_request(
+            std::path::Path::new(&workspace.worktree_path),
+            workspace.id,
+            &workspace.title,
+            &workspace.branch_name,
+            &workspace.base_ref,
+            title.as_deref(),
+            body.as_deref(),
+            &self.pr_cache,
+            gh_path.as_deref(),
+        )
+        .await
+        .map_err(map_gh)?;
+        workspace.pr = Some(digest);
+        save_workspace(&self.db, &workspace).await?;
+        self.workspace_pr(id).await
+    }
+
+    pub(crate) async fn run_workspace_action(
+        &self,
+        id: WorkspaceId,
+        name: &str,
+    ) -> Result<ActionOutcome, ServerError> {
+        let workspace = self.require_live_workspace(id).await?;
+        let repo = self.get_repo(workspace.repo_id).await?;
+        gh::run_named_action(
+            std::path::Path::new(&workspace.worktree_path),
+            &repo.quick_actions,
+            name,
+        )
+        .await
+        .map_err(map_gh)
+    }
+
+    async fn require_live_workspace(&self, id: WorkspaceId) -> Result<CodeWorkspace, ServerError> {
+        let workspace = self.get_workspace(id).await?;
+        if workspace.status == CodeWorkspaceStatus::Archived {
+            return Err(ServerError::conflict_kind(
+                "workspace_not_ready",
+                "workspace is archived",
+            ));
+        }
+        if !std::path::Path::new(&workspace.worktree_path).exists() {
+            return Err(ServerError::not_found("workspace worktree is gone"));
+        }
+        Ok(workspace)
+    }
+
+    fn gh_search_path_owned(&self) -> Option<String> {
+        #[cfg(test)]
+        {
+            return self.gh_search_path.lock().expect("gh search path").clone();
+        }
+        #[cfg(not(test))]
+        None
     }
 
     pub(crate) async fn create_session(
@@ -961,6 +1094,28 @@ fn map_checkpoint(err: CheckpointError) -> ServerError {
             }
         }
         CheckpointError::Internal(message) => ServerError::internal(message),
+    }
+}
+
+fn map_gh(err: GhError) -> ServerError {
+    match err {
+        GhError::NothingToCommit => ServerError::conflict_kind(
+            "nothing_to_commit",
+            "there is nothing to commit in this workspace",
+        ),
+        GhError::AuthFailed(message) => ServerError::conflict_kind("git_auth_failed", message),
+        GhError::GhAbsent { instructions } => ServerError::conflict_kind("gh_absent", instructions),
+        GhError::GhSignedOut { instructions } => {
+            ServerError::conflict_kind("gh_signed_out", instructions)
+        }
+        GhError::User(message) => {
+            if message.contains("no quick action") {
+                ServerError::not_found(message)
+            } else {
+                ServerError::bad_request_kind("git", message)
+            }
+        }
+        GhError::Internal(message) => ServerError::internal(message),
     }
 }
 

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -720,6 +720,26 @@ pub fn app(state: AppState) -> Router {
             get(routes::code::get_workspace_diff),
         )
         .route(
+            "/code/workspaces/{id}/git/commit",
+            post(routes::code::commit_workspace),
+        )
+        .route(
+            "/code/workspaces/{id}/git/push",
+            post(routes::code::push_workspace),
+        )
+        .route(
+            "/code/workspaces/{id}/git/pr",
+            post(routes::code::create_pull_request),
+        )
+        .route(
+            "/code/workspaces/{id}/pr",
+            get(routes::code::get_workspace_pr),
+        )
+        .route(
+            "/code/workspaces/{id}/actions/{name}",
+            post(routes::code::run_workspace_action),
+        )
+        .route(
             "/code/workspaces/{id}/sessions",
             post(routes::code::create_session).get(routes::code::list_workspace_sessions),
         )

--- a/crates/tidebreak-server/src/routes/code/git.rs
+++ b/crates/tidebreak-server/src/routes/code/git.rs
@@ -1,0 +1,106 @@
+//! Commit, push, pull-request, and quick-action routes for a workspace.
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+
+use crate::error::ServerError;
+use crate::extract::{Json, Path};
+use crate::state::AppState;
+
+use super::require_code;
+use super::types::{
+    CodeActionSnapshot, CodeCommitSnapshot, CodePushSnapshot, CodeWorkspacePrSnapshot,
+    CommitWorkspaceBody, CreatePullRequestBody,
+};
+use crate::code::gh::{ActionOutcome, CommitOutcome, PushOutcome, WorkspaceGitStatus};
+use tidebreak_core::WorkspaceId;
+
+pub async fn commit_workspace(
+    State(state): State<AppState>,
+    Path(id): Path<WorkspaceId>,
+    Json(body): Json<CommitWorkspaceBody>,
+) -> Result<Json<CodeCommitSnapshot>, ServerError> {
+    let outcome = require_code(&state)?
+        .commit_workspace(id, body.message)
+        .await?;
+    Ok(Json(commit_snapshot(outcome)))
+}
+
+pub async fn push_workspace(
+    State(state): State<AppState>,
+    Path(id): Path<WorkspaceId>,
+) -> Result<Json<CodePushSnapshot>, ServerError> {
+    let outcome = require_code(&state)?.push_workspace(id).await?;
+    Ok(Json(push_snapshot(outcome)))
+}
+
+pub async fn create_pull_request(
+    State(state): State<AppState>,
+    Path(id): Path<WorkspaceId>,
+    Json(body): Json<CreatePullRequestBody>,
+) -> Result<impl IntoResponse, ServerError> {
+    let snapshot = require_code(&state)?
+        .create_workspace_pr(id, body.title, body.body)
+        .await?;
+    Ok((StatusCode::CREATED, Json(pr_snapshot(snapshot))))
+}
+
+pub async fn get_workspace_pr(
+    State(state): State<AppState>,
+    Path(id): Path<WorkspaceId>,
+) -> Result<Json<CodeWorkspacePrSnapshot>, ServerError> {
+    Ok(Json(pr_snapshot(
+        require_code(&state)?.workspace_pr(id).await?,
+    )))
+}
+
+pub async fn run_workspace_action(
+    State(state): State<AppState>,
+    Path((id, name)): Path<(WorkspaceId, String)>,
+) -> Result<Json<CodeActionSnapshot>, ServerError> {
+    let outcome = require_code(&state)?
+        .run_workspace_action(id, &name)
+        .await?;
+    Ok(Json(action_snapshot(outcome)))
+}
+
+fn commit_snapshot(outcome: CommitOutcome) -> CodeCommitSnapshot {
+    CodeCommitSnapshot {
+        sha: outcome.sha,
+        message: outcome.message,
+        stat: outcome.stat,
+    }
+}
+
+fn push_snapshot(outcome: PushOutcome) -> CodePushSnapshot {
+    CodePushSnapshot {
+        branch: outcome.branch,
+        remote: outcome.remote,
+    }
+}
+
+fn pr_snapshot(status: WorkspaceGitStatus) -> CodeWorkspacePrSnapshot {
+    CodeWorkspacePrSnapshot {
+        dirty: status.dirty,
+        unpushed: status.unpushed,
+        ahead: status.ahead,
+        has_upstream: status.has_upstream,
+        suggested_commit_message: status.suggested_commit_message,
+        pr: status.pr,
+        gh_found: status.gh_found,
+        gh_authenticated: status.gh_authenticated,
+        remediation: status.remediation,
+    }
+}
+
+fn action_snapshot(outcome: ActionOutcome) -> CodeActionSnapshot {
+    CodeActionSnapshot {
+        name: outcome.name,
+        success: outcome.success,
+        exit_code: outcome.exit_code,
+        stdout: outcome.stdout,
+        stderr: outcome.stderr,
+        timed_out: outcome.timed_out,
+    }
+}

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -1,6 +1,7 @@
 //! `/code/*` routes: repos, workspaces, sessions, doctor, event stream.
 
 mod approvals;
+mod git;
 mod harnesses;
 mod repos;
 mod session_events;
@@ -11,6 +12,9 @@ mod workspaces;
 
 pub(crate) use crate::code::approval_bridge::approval_prompt;
 pub(crate) use approvals::{decide_approval, list_approvals};
+pub(crate) use git::{
+    commit_workspace, create_pull_request, get_workspace_pr, push_workspace, run_workspace_action,
+};
 pub(crate) use harnesses::{list_harnesses, refresh_harnesses};
 pub(crate) use repos::{create_repo, delete_repo, get_repo, list_repos, patch_repo};
 pub(crate) use session_events::session_events;
@@ -24,9 +28,10 @@ pub(crate) use terminals::{
 };
 #[allow(unused_imports)]
 pub(crate) use types::{
-    CodeApprovalDecisionBody, CodeApprovalSnapshot, CodeFileChange, CodeRepoSnapshot,
-    CodeSessionSnapshot, CodeTerminalActivityNotice, CodeTerminalRead, CodeTerminalSnapshot,
-    CodeTurnSnapshot, CodeWorkspaceDiff, CodeWorkspaceFiles, CodeWorkspaceSnapshot,
+    CodeActionSnapshot, CodeApprovalDecisionBody, CodeApprovalSnapshot, CodeCommitSnapshot,
+    CodeFileChange, CodePushSnapshot, CodeRepoSnapshot, CodeSessionSnapshot,
+    CodeTerminalActivityNotice, CodeTerminalRead, CodeTerminalSnapshot, CodeTurnSnapshot,
+    CodeWorkspaceDiff, CodeWorkspaceFiles, CodeWorkspacePrSnapshot, CodeWorkspaceSnapshot,
     HarnessDoctorReport, QueuedCodeTurn, SequencedCodeEventFrame,
 };
 pub(crate) use workspaces::{

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -258,6 +258,70 @@ pub struct ArchiveWorkspaceBody {
     pub force: bool,
 }
 
+/// Body of `POST /code/workspaces/{id}/git/commit`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CommitWorkspaceBody {
+    #[serde(default)]
+    pub message: Option<String>,
+}
+
+/// Body of `POST /code/workspaces/{id}/git/pr`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CreatePullRequestBody {
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub body: Option<String>,
+}
+
+/// Result of staging and committing the workspace worktree.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeCommitSnapshot {
+    pub sha: String,
+    pub message: String,
+    pub stat: Diffstat,
+}
+
+/// Result of pushing the workspace branch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodePushSnapshot {
+    pub branch: String,
+    pub remote: String,
+}
+
+/// PR + checks digest plus the local git facts the PR card needs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeWorkspacePrSnapshot {
+    pub dirty: bool,
+    pub unpushed: bool,
+    pub ahead: u64,
+    pub has_upstream: bool,
+    pub suggested_commit_message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub pr: Option<PullRequestDigest>,
+    pub gh_found: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub gh_authenticated: Option<bool>,
+    pub remediation: String,
+}
+
+/// Bounded output of one named quick action. Never journaled.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeActionSnapshot {
+    pub name: String,
+    pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub exit_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+    pub timed_out: bool,
+}
+
 /// Body of `POST /code/workspaces/{id}/sessions`.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/tidebreak-server/src/tests.rs
+++ b/crates/tidebreak-server/src/tests.rs
@@ -41,6 +41,7 @@ mod app_invoke;
 mod app_library;
 mod chat_titling;
 mod code;
+mod code_git;
 mod code_terminals;
 mod compaction;
 mod configuration;

--- a/crates/tidebreak-server/src/tests/code_git.rs
+++ b/crates/tidebreak-server/src/tests/code_git.rs
@@ -319,6 +319,10 @@ exit 3
 
     let logged = std::fs::read_to_string(&log).unwrap();
     assert!(logged.contains("pr create"), "{logged}");
+    assert!(
+        logged.contains("--base main"),
+        "gh pr create must pass the workspace base: {logged}"
+    );
     assert!(logged.contains("pr view"), "{logged}");
     assert!(logged.contains("pr checks"), "{logged}");
     assert!(!logged.contains("merge"), "{logged}");

--- a/crates/tidebreak-server/src/tests/code_git.rs
+++ b/crates/tidebreak-server/src/tests/code_git.rs
@@ -1,0 +1,424 @@
+//! Commit, push, pull-request, and quick-action routes against temp repos.
+
+use super::*;
+
+use std::net::Ipv4Addr;
+use std::os::unix::fs::PermissionsExt;
+use std::sync::Arc;
+
+use axum::Router;
+use tokio::net::TcpListener;
+
+use crate::code::CodeRuntime;
+use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
+use tidebreak_core::{QuickAction, RepoId};
+use tidebreak_harness::AdapterRegistry;
+
+async fn code_app() -> (Router, Arc<str>, Arc<CodeRuntime>, tempfile::TempDir) {
+    let (dir, store) = temp_db_store("code-git.db").await;
+    let db = Arc::new(store);
+    let store_trait: Arc<dyn Store> = db.clone();
+    let mut registry = AdapterRegistry::new();
+    registry.register(Arc::new(ScriptedAdapter::new(plain_text_script())));
+    let runtime = Arc::new(CodeRuntime::with_registry(
+        db,
+        dir.path().to_path_buf(),
+        registry,
+    ));
+    let mut state = AppState::new(
+        Config::desktop(dir.path()),
+        store_trait,
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    state.code = Some(runtime.clone());
+    let token = state.token.clone();
+    (app(state), token, runtime, dir)
+}
+
+async fn serve(router: Router) -> std::net::SocketAddr {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router).await;
+    });
+    addr
+}
+
+fn init_paired_repo(dir: &std::path::Path) -> std::path::PathBuf {
+    let bare = dir.join("origin.git");
+    let work = dir.join("work");
+    run(dir, &["git", "init", "--bare", bare.to_str().unwrap()]);
+    std::fs::create_dir_all(&work).unwrap();
+    run(&work, &["git", "init", "-b", "main"]);
+    run(&work, &["git", "config", "user.email", "dev@example.com"]);
+    run(&work, &["git", "config", "user.name", "Dev"]);
+    std::fs::write(work.join("README.md"), "hello\n").unwrap();
+    run(&work, &["git", "add", "README.md"]);
+    run(&work, &["git", "commit", "-m", "init"]);
+    run(
+        &work,
+        &["git", "remote", "add", "origin", bare.to_str().unwrap()],
+    );
+    run(&work, &["git", "push", "-u", "origin", "main"]);
+    work
+}
+
+fn run(cwd: &std::path::Path, args: &[&str]) {
+    let status = std::process::Command::new(args[0])
+        .args(&args[1..])
+        .current_dir(cwd)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .status()
+        .unwrap();
+    assert!(status.success(), "{args:?} failed in {}", cwd.display());
+}
+
+fn write_executable(path: &std::path::Path, body: &str) {
+    std::fs::write(path, body).unwrap();
+    let mut perms = std::fs::metadata(path).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(path, perms).unwrap();
+}
+
+fn json_id(value: &serde_json::Value) -> &str {
+    value["id"].as_str().expect("id is a string")
+}
+
+async fn register_and_workspace(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    token: &str,
+    repo: &std::path::Path,
+    title: &str,
+) -> (serde_json::Value, serde_json::Value) {
+    let registered = client
+        .post(format!("http://{addr}/code/repos"))
+        .bearer_auth(token)
+        .json(&serde_json::json!({ "path": repo }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(registered.status(), reqwest::StatusCode::CREATED);
+    let repo_body: serde_json::Value = registered.json().await.unwrap();
+    let created = client
+        .post(format!("http://{addr}/code/workspaces"))
+        .bearer_auth(token)
+        .json(&serde_json::json!({
+            "repo_id": json_id(&repo_body),
+            "title": title,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    (repo_body, created.json().await.unwrap())
+}
+
+async fn error_kind(response: reqwest::Response) -> (reqwest::StatusCode, String, String) {
+    let status = response.status();
+    let body: serde_json::Value = response.json().await.unwrap();
+    (
+        status,
+        body["kind"].as_str().unwrap_or_default().to_owned(),
+        body["message"].as_str().unwrap_or_default().to_owned(),
+    )
+}
+
+#[tokio::test]
+async fn commit_and_push_use_a_bare_origin_and_refuse_a_clean_tree() {
+    let (router, token, _runtime, dir) = code_app().await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_paired_repo(dir.path());
+    let (_repo, workspace) =
+        register_and_workspace(&client, addr, &token, &repo, "first change").await;
+    let id = json_id(&workspace);
+    let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+
+    let clean = client
+        .post(format!("http://{addr}/code/workspaces/{id}/git/commit"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    let (status, kind, _) = error_kind(clean).await;
+    assert_eq!(status, reqwest::StatusCode::CONFLICT);
+    assert_eq!(kind, "nothing_to_commit");
+
+    std::fs::write(path.join("extra.txt"), "line\n").unwrap();
+    let committed = client
+        .post(format!("http://{addr}/code/workspaces/{id}/git/commit"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(committed.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = committed.json().await.unwrap();
+    assert_eq!(
+        body["message"],
+        "first change\n\n1 file changed, 1 insertion(+), 0 deletions(-)"
+    );
+    assert_eq!(body["stat"]["files"], 1);
+
+    let again = client
+        .post(format!("http://{addr}/code/workspaces/{id}/git/commit"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "unused" }))
+        .send()
+        .await
+        .unwrap();
+    let (status, kind, _) = error_kind(again).await;
+    assert_eq!(status, reqwest::StatusCode::CONFLICT);
+    assert_eq!(kind, "nothing_to_commit");
+
+    let pushed = client
+        .post(format!("http://{addr}/code/workspaces/{id}/git/push"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(pushed.status(), reqwest::StatusCode::OK);
+    let push_body: serde_json::Value = pushed.json().await.unwrap();
+    assert_eq!(push_body["remote"], "origin");
+    assert_eq!(push_body["branch"], workspace["branch_name"]);
+
+    let digest = client
+        .get(format!("http://{addr}/code/workspaces/{id}/pr"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(digest.status(), reqwest::StatusCode::OK);
+    let pr: serde_json::Value = digest.json().await.unwrap();
+    assert_eq!(pr["dirty"], false);
+    assert_eq!(pr["unpushed"], false);
+    assert!(pr["ahead"].as_u64().unwrap() >= 1);
+}
+
+#[tokio::test]
+async fn pr_create_and_view_use_path_shims_and_persist_the_digest() {
+    let (router, token, runtime, dir) = code_app().await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_paired_repo(dir.path());
+    let (_repo, workspace) =
+        register_and_workspace(&client, addr, &token, &repo, "first change").await;
+    let id = json_id(&workspace);
+    let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+    std::fs::write(path.join("extra.txt"), "line\n").unwrap();
+    let committed = client
+        .post(format!("http://{addr}/code/workspaces/{id}/git/commit"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(committed.status(), reqwest::StatusCode::OK);
+    let pushed = client
+        .post(format!("http://{addr}/code/workspaces/{id}/git/push"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(pushed.status(), reqwest::StatusCode::OK);
+
+    let empty = tempfile::TempDir::new().unwrap();
+    runtime.set_gh_search_path(Some(empty.path().display().to_string()));
+    let absent = client
+        .post(format!("http://{addr}/code/workspaces/{id}/git/pr"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    let (status, kind, message) = error_kind(absent).await;
+    assert_eq!(status, reqwest::StatusCode::CONFLICT);
+    assert_eq!(kind, "gh_absent");
+    assert!(message.contains("gh pr create"), "{message}");
+    assert!(message.contains("git push"), "{message}");
+
+    let signed_out_dir = tempfile::TempDir::new().unwrap();
+    write_executable(
+        &signed_out_dir.path().join("gh"),
+        "#!/bin/sh\nif [ \"$1\" = auth ]; then echo signed out >&2; exit 1; fi\nexit 3\n",
+    );
+    runtime.set_gh_search_path(Some(signed_out_dir.path().display().to_string()));
+    let signed_out = client
+        .post(format!("http://{addr}/code/workspaces/{id}/git/pr"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    let (status, kind, message) = error_kind(signed_out).await;
+    assert_eq!(status, reqwest::StatusCode::CONFLICT);
+    assert_eq!(kind, "gh_signed_out");
+    assert!(message.contains("gh auth login"), "{message}");
+
+    let shim_dir = tempfile::TempDir::new().unwrap();
+    let log = shim_dir.path().join("log");
+    write_executable(
+        &shim_dir.path().join("gh"),
+        &format!(
+            r#"#!/bin/sh
+echo "$@" >> {log}
+if [ "$1" = merge ] || [ "$2" = merge ]; then exit 2; fi
+if [ "$1" = auth ]; then echo logged in; exit 0; fi
+if [ "$1" = pr ] && [ "$2" = create ]; then
+  echo https://github.com/example/demo/pull/12
+  exit 0
+fi
+if [ "$1" = pr ] && [ "$2" = view ]; then
+  echo '{{"number":12,"url":"https://github.com/example/demo/pull/12","state":"OPEN"}}'
+  exit 0
+fi
+if [ "$1" = pr ] && [ "$2" = checks ]; then
+  printf 'lint\tpass\t1s\thttps://example.test/lint\n'
+  exit 0
+fi
+exit 3
+"#,
+            log = log.display()
+        ),
+    );
+    runtime.set_gh_search_path(Some(shim_dir.path().display().to_string()));
+    let created = client
+        .post(format!("http://{addr}/code/workspaces/{id}/git/pr"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let pr: serde_json::Value = created.json().await.unwrap();
+    assert_eq!(pr["pr"]["number"], 12);
+    assert_eq!(pr["pr"]["state"], "open");
+    assert_eq!(
+        pr["pr"]["checks_summary"],
+        "1 passing, 0 pending, 0 failing"
+    );
+
+    let listed = client
+        .get(format!("http://{addr}/code/workspaces/{id}"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(listed["pr"]["number"], 12);
+
+    let logged = std::fs::read_to_string(&log).unwrap();
+    assert!(logged.contains("pr create"), "{logged}");
+    assert!(logged.contains("pr view"), "{logged}");
+    assert!(logged.contains("pr checks"), "{logged}");
+    assert!(!logged.contains("merge"), "{logged}");
+    assert!(!logged.contains("graphql"), "{logged}");
+}
+
+#[tokio::test]
+async fn quick_actions_return_bounded_output_and_do_not_need_a_session() {
+    let (router, token, runtime, dir) = code_app().await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_paired_repo(dir.path());
+    let (repo_body, workspace) =
+        register_and_workspace(&client, addr, &token, &repo, "actions").await;
+    let repo_id: RepoId = json_id(&repo_body).parse().unwrap();
+    let mut stored = runtime.get_repo(repo_id).await.unwrap();
+    stored.quick_actions = vec![
+        QuickAction {
+            name: "echo".into(),
+            command: "printf 'hello-action\\n'".into(),
+            auto_run_on_create: false,
+        },
+        QuickAction {
+            name: "sleep".into(),
+            command: "sleep 20".into(),
+            auto_run_on_create: false,
+        },
+    ];
+    runtime.save_repo(&stored).await.unwrap();
+    let id = json_id(&workspace);
+
+    let echoed = client
+        .post(format!("http://{addr}/code/workspaces/{id}/actions/echo"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(echoed.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = echoed.json().await.unwrap();
+    assert_eq!(body["name"], "echo");
+    assert_eq!(body["success"], true);
+    assert!(body["stdout"].as_str().unwrap().contains("hello-action"));
+    assert_eq!(body["timed_out"], false);
+
+    let missing = client
+        .post(format!("http://{addr}/code/workspaces/{id}/actions/nope"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(missing.status(), reqwest::StatusCode::NOT_FOUND);
+
+    let timed = client
+        .post(format!("http://{addr}/code/workspaces/{id}/actions/sleep"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(timed.status(), reqwest::StatusCode::OK);
+    let timed_body: serde_json::Value = timed.json().await.unwrap();
+    assert_eq!(timed_body["timed_out"], true);
+    assert_eq!(timed_body["success"], false);
+}
+
+#[tokio::test]
+async fn auto_run_on_create_runs_after_setup() {
+    let (router, token, runtime, dir) = code_app().await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_paired_repo(dir.path());
+    let registered = client
+        .post(format!("http://{addr}/code/repos"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "path": repo }))
+        .send()
+        .await
+        .unwrap();
+    let repo_body: serde_json::Value = registered.json().await.unwrap();
+    let repo_id: RepoId = json_id(&repo_body).parse().unwrap();
+    let mut stored = runtime.get_repo(repo_id).await.unwrap();
+    stored.quick_actions = vec![QuickAction {
+        name: "stamp".into(),
+        command: "printf 'auto\\n' > stamp.txt".into(),
+        auto_run_on_create: true,
+    }];
+    runtime.save_repo(&stored).await.unwrap();
+
+    let created = client
+        .post(format!("http://{addr}/code/workspaces"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "repo_id": json_id(&repo_body),
+            "title": "auto action",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let workspace: serde_json::Value = created.json().await.unwrap();
+    let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+    let stamped = std::fs::read_to_string(path.join("stamp.txt")).unwrap();
+    assert_eq!(stamped, "auto\n");
+}

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -421,6 +421,10 @@ mod tests {
         generate::collect_from::<crate::routes::code::CodeTerminalActivityNotice>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeApprovalSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeApprovalDecisionBody>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::CodeCommitSnapshot>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::CodePushSnapshot>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::CodeWorkspacePrSnapshot>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::CodeActionSnapshot>(&cfg, &mut out);
         out
     }
 


### PR DESCRIPTION
## Summary

Workspaces can now commit, push, and open a pull request from the code-mode surface.

- `POST /code/workspaces/{id}/git/commit` stages the worktree and commits. A missing message is generated from the workspace title plus the staged shortstat. A clean tree is a typed `nothing_to_commit` 409.
- `POST /code/workspaces/{id}/git/push` pushes the workspace branch to `origin` with upstream set. Auth failures return remediation text; Tidebreak never prompts and never stores git credentials.
- `POST /code/workspaces/{id}/git/pr` creates a pull request through the user's `gh` CLI. Title and body are generated from the workspace title, commit list, and diffstat when omitted. The route never merges and never enables auto-merge.
- `GET /code/workspaces/{id}/pr` returns the local git facts plus a briefly cached `gh pr view` / `gh pr checks` digest, persisted on `code_workspace.pr` so list views can carry it.
- Absent or signed-out `gh` is a typed 409 with copyable terminal instructions. Auth is observed with `gh auth status`; tokens are never stored.
- `POST /code/workspaces/{id}/actions/{name}` runs a repo quick action in the worktree and returns bounded output. It does not write the session journal. `auto_run_on_create` actions run once after setup during workspace creation.
- The workspace page now has a `PrCard` for commit / push / create-PR, status and checks chips, and the gh-absent remediation state. Archive copy points at this card when leftover work would be discarded.

## Tests

- Temp repos with a bare `origin` remote for commit and push (no network).
- `gh` PATH shims for create / view / checks / absent / signed-out, including an assertion that merge and GraphQL are never invoked.
- Deterministic generated commit messages and nothing-to-commit refusal.
- Quick-action output bound and timeout.

Local: `cargo fmt`, `cargo clippy -p tidebreak-server --all-targets -- -D warnings`, `cargo test -p tidebreak-server --locked`, `cargo check --workspace --locked`, `pnpm test`, `pnpm build`.