### PR TITLE
feat(code): server-computed attention and the install-wide updates channel

### DIFF
--- a/crates/tidebreak-core/src/db/ops/code/journal.rs
+++ b/crates/tidebreak-core/src/db/ops/code/journal.rs
@@ -65,6 +65,20 @@ pub async fn append_event(
     Ok(seq)
 }
 
+/// Created-at of the newest journal row, if the session has any.
+pub async fn latest_event_created_at(
+    store: &DbStore,
+    session_id: CodeSessionId,
+) -> Result<Option<chrono::DateTime<Utc>>> {
+    Ok(entities::code_event::Entity::find()
+        .filter(entities::code_event::Column::SessionId.eq(session_id.0))
+        .order_by_desc(entities::code_event::Column::Seq)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+        .map(|model| model.created_at))
+}
+
 /// Events for a session with `seq > after`, in order.
 pub async fn list_events(
     store: &DbStore,

--- a/crates/tidebreak-core/src/db/ops/code/turn.rs
+++ b/crates/tidebreak-core/src/db/ops/code/turn.rs
@@ -1,4 +1,6 @@
-use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder, Set,
+};
 
 use crate::code::{CodeSessionId, CodeTurn, CodeTurnId, CodeTurnStatus, CodeUsage, Diffstat};
 use crate::error::{AgentError, Result};
@@ -56,6 +58,31 @@ pub async fn list_turns(store: &DbStore, session_id: CodeSessionId) -> Result<Ve
         .into_iter()
         .map(turn_from_row)
         .collect()
+}
+
+/// How many turns a session has recorded.
+pub async fn count_turns(store: &DbStore, session_id: CodeSessionId) -> Result<i64> {
+    let count = entities::code_turn::Entity::find()
+        .filter(entities::code_turn::Column::SessionId.eq(session_id.0))
+        .count(&store.conn)
+        .await
+        .map_err(store_err)?;
+    i64::try_from(count)
+        .map_err(|_| AgentError::Store(format!("turn count overflow for session {session_id}")))
+}
+
+/// Most recently created turn for a session, if any.
+pub async fn latest_turn(store: &DbStore, session_id: CodeSessionId) -> Result<Option<CodeTurn>> {
+    let Some(row) = entities::code_turn::Entity::find()
+        .filter(entities::code_turn::Column::SessionId.eq(session_id.0))
+        .order_by_desc(entities::code_turn::Column::Ordinal)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+    else {
+        return Ok(None);
+    };
+    Ok(Some(turn_from_row(row)?))
 }
 
 /// The open (non-terminal) turn for a session, if any.

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -94,6 +94,7 @@ import {
   type HarnessDoctorReport,
   type HarnessKind,
   type SequencedCodeEventFrame,
+  type CodeUpdateNotice,
 } from "./types";
 import {
   parseAgentActivityHistory,
@@ -128,6 +129,7 @@ import {
   parseCodeWorkspacePr,
   parseHarnessDoctorReport,
   parseSequencedCodeEvent,
+  parseCodeUpdateNotice,
 } from "../code/parsers";
 
 const WS_HANDSHAKE = "tidebreak-v1";
@@ -2071,6 +2073,39 @@ export class ApiClient {
       }
     };
     return socket;
+  }
+
+  /** Open the install-wide digest channel; auth via Sec-WebSocket-Protocol. */
+  openCodeUpdates(onNotice: (notice: CodeUpdateNotice) => void): WebSocket {
+    const url = `${this.baseUrl.replace(/^http/, "ws")}/code/updates`;
+    const protocols = [WS_HANDSHAKE, `${WS_TOKEN_PREFIX}${this.token}`];
+    const socket = new WebSocket(url, protocols);
+    socket.onmessage = (msg) => {
+      try {
+        const notice = parseCodeUpdateNotice(JSON.parse(String(msg.data)));
+        if (notice) onNotice(notice);
+        else console.error("dropping malformed code update notice");
+      } catch (err) {
+        console.error("bad code update notice", err);
+      }
+    };
+    return socket;
+  }
+
+  async setCodeAttention(
+    sessionId: string,
+    body: { clear?: boolean; note?: string },
+  ): Promise<CodeSessionSnapshot> {
+    return requireParsed(
+      parseCodeSession(
+        await this.json(`/code/sessions/${encodeURIComponent(sessionId)}/attention`, {
+          method: "POST",
+          headers: this.headers(true),
+          body: JSON.stringify(body),
+        }),
+      ),
+      "code attention",
+    );
   }
 
   async listCodeApprovals(query?: {

--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -123,11 +123,13 @@ import {
   type CodeCommitSnapshot as WireCodeCommitSnapshot,
   type CodePushSnapshot as WireCodePushSnapshot,
   type CodeFileChange as WireCodeFileChange,
+  type CodeSessionDigest as WireCodeSessionDigest,
+  type CodeUpdateNotice as WireCodeUpdateNotice,
   type CodeTerminalActivityNotice as WireCodeTerminalActivityNotice,
+  type PullRequestDigest as WirePullRequestDigest,
   type CodeTerminalRead as WireCodeTerminalRead,
   type CodeTerminalSnapshot as WireCodeTerminalSnapshot,
   type CodeWorkspaceSnapshot as WireCodeWorkspaceSnapshot,
-  type PullRequestDigest as WirePullRequestDigest,
   type Diffstat as WireDiffstat,
   type FileChangeKind as WireFileChangeKind,
   type CodeWorkspaceStatus as WireCodeWorkspaceStatus,
@@ -1012,6 +1014,8 @@ export type PullRequestDigest = WirePullRequestDigest;
 export type CodeTerminalSnapshot = WireCodeTerminalSnapshot;
 export type CodeTerminalRead = WireCodeTerminalRead;
 export type CodeTerminalActivityNotice = WireCodeTerminalActivityNotice;
+export type CodeSessionDigest = WireCodeSessionDigest;
+export type CodeUpdateNotice = WireCodeUpdateNotice;
 
 /** Journaled engine event and the sequenced WebSocket frame that carries it. */
 export type CodeApprovalSnapshot = WireCodeApprovalSnapshot;

--- a/crates/tidebreak-desktop/ui/src/code/AttentionBadge.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AttentionBadge.dom.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { Attention } from "../api/types";
+import { AttentionBadge } from "./AttentionBadge";
+
+afterEach(() => {
+  cleanup();
+});
+
+const cases: Array<{ attention: Attention; label: string; type: string }> = [
+  {
+    attention: {
+      state: { type: "needs_you", prompt: "an approval is waiting", source: "structured" },
+      source: "structured",
+    },
+    label: "an approval is waiting",
+    type: "needs_you",
+  },
+  {
+    attention: { state: { type: "stalled", idle_secs: 90 }, source: "heuristic" },
+    label: "Stalled",
+    type: "stalled",
+  },
+  {
+    attention: {
+      state: { type: "fenced", reason: { type: "orphan_alive" } },
+      source: "lifecycle",
+    },
+    label: "Fenced",
+    type: "fenced",
+  },
+  {
+    attention: { state: { type: "done_unreviewed" }, source: "lifecycle" },
+    label: "Done",
+    type: "done_unreviewed",
+  },
+  {
+    attention: { state: { type: "manual", note: "look later" }, source: "user" },
+    label: "look later",
+    type: "manual",
+  },
+];
+
+describe("AttentionBadge", () => {
+  it("renders nothing for Working", () => {
+    const { container } = render(
+      <AttentionBadge attention={{ state: { type: "working" }, source: "lifecycle" }} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it.each(cases)("renders $type with its label", ({ attention, label, type }) => {
+    render(<AttentionBadge attention={attention} />);
+    const badge = screen.getByLabelText(label);
+    expect(badge).toHaveAttribute("data-attention", type);
+  });
+
+  it("uses a compact mark with the same label", () => {
+    render(
+      <AttentionBadge
+        compact
+        attention={{
+          state: { type: "needs_you", prompt: "an approval is waiting", source: "structured" },
+          source: "structured",
+        }}
+      />,
+    );
+    expect(screen.getByLabelText("an approval is waiting")).toHaveAttribute(
+      "data-attention",
+      "needs_you",
+    );
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/AttentionBadge.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AttentionBadge.tsx
@@ -1,0 +1,81 @@
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+import type { Attention } from "../api/types";
+import { attentionLabel } from "./labels";
+
+/**
+ * Status affordance for a server-computed attention state.
+ *
+ * NeedsYou is strongest. Stalled and Fenced are distinct warnings.
+ * DoneUnreviewed is a quiet mark. Working has no badge.
+ */
+
+export function AttentionBadge({
+  attention,
+  compact = false,
+  className,
+}: {
+  attention: Attention | undefined;
+  compact?: boolean;
+  className?: string;
+}) {
+  if (!attention || attention.state.type === "working") return null;
+  const label = attentionLabel(attention);
+  const tone = attentionTone(attention);
+  if (compact) {
+    return (
+      <span
+        className={cn(
+          "inline-block size-2 shrink-0 rounded-full",
+          tone === "critical" && "bg-critical-foreground-muted",
+          tone === "warning" && "bg-warning-foreground-muted",
+          tone === "subtle" && "bg-muted-foreground/60",
+          tone === "info" && "bg-info-foreground-muted",
+          className,
+        )}
+        aria-label={label}
+        title={label}
+        data-attention={attention.state.type}
+      />
+    );
+  }
+  return (
+    <Badge
+      variant={
+        tone === "critical"
+          ? "critical"
+          : tone === "warning"
+            ? "warning"
+            : tone === "info"
+              ? "info"
+              : "outline"
+      }
+      size="sm"
+      className={className}
+      aria-label={label}
+      title={label}
+      data-attention={attention.state.type}
+    >
+      {label}
+    </Badge>
+  );
+}
+
+function attentionTone(
+  attention: Attention,
+): "critical" | "warning" | "subtle" | "info" {
+  switch (attention.state.type) {
+    case "needs_you":
+      return "critical";
+    case "stalled":
+    case "fenced":
+      return "warning";
+    case "manual":
+      return "info";
+    case "done_unreviewed":
+      return "subtle";
+    default:
+      return "subtle";
+  }
+}

--- a/crates/tidebreak-desktop/ui/src/code/CodeRepoPage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeRepoPage.tsx
@@ -4,7 +4,9 @@ import { useNavigate } from "@tanstack/react-router";
 import { useApp } from "@/AppContext";
 import { Button } from "@/components/ui/button";
 import { RouteFrame } from "@/RouteFrame";
+import { AttentionBadge } from "./AttentionBadge";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { CodeSidebar } from "./CodeSidebar";
 import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
 import { WORKSPACE_STATUS_LABELS } from "./labels";
@@ -29,6 +31,7 @@ function CodeRepoBody({ repoId }: { repoId: string }) {
   const repos = useCodeCatalogStore((state) => state.repos);
   const workspaces = useCodeCatalogStore((state) => state.workspaces);
   const refresh = useCodeCatalogStore((state) => state.refresh);
+  const digests = useCodeUpdatesStore((state) => state.byWorkspace);
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
@@ -74,13 +77,17 @@ function CodeRepoBody({ repoId }: { repoId: string }) {
                 })
               }
             >
-              <span>
+              <span className="flex min-w-0 items-center gap-2">
                 <span className="font-medium">{workspace.title}</span>
-                <span className="text-muted-foreground ml-2 font-mono text-xs">
+                <span className="text-muted-foreground font-mono text-xs">
                   {workspace.branch_name}
                 </span>
+                <AttentionBadge attention={digests[workspace.id]?.attention} compact />
               </span>
-              <span className="text-muted-foreground text-xs">
+              <span className="text-muted-foreground flex items-center gap-2 text-xs">
+                {digests[workspace.id]?.pr_state && (
+                  <span>PR #{digests[workspace.id]?.pr_state?.number}</span>
+                )}
                 {WORKSPACE_STATUS_LABELS[workspace.status]}
               </span>
             </button>

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { AppContextProvider, type AppContextValue } from "@/AppContext";
 import { renderWithRouter } from "@/test/router";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { disconnectCodeUpdates, useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { CodeSidebar } from "./CodeSidebar";
 
 /**
@@ -37,6 +38,13 @@ const client = {
     },
   ]),
   getHarnessDoctor: vi.fn(async () => ({ harnesses: [] })),
+  openCodeUpdates: vi.fn(() => {
+    return {
+      close() {},
+      addEventListener() {},
+      removeEventListener() {},
+    } as unknown as WebSocket;
+  }),
 };
 
 const app: AppContextValue = {
@@ -74,6 +82,8 @@ const app: AppContextValue = {
 afterEach(() => {
   cleanup();
   useCodeCatalogStore.getState().reset();
+  disconnectCodeUpdates();
+  useCodeUpdatesStore.getState().reset();
 });
 
 describe("CodeSidebar", () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -9,7 +9,9 @@ import {
   useSidebarWidth,
 } from "@/sidebar/primitives";
 import { SidebarFrame } from "@/sidebar/SidebarFrame";
+import { AttentionBadge } from "./AttentionBadge";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { connectCodeUpdates, useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
 
 /**
@@ -31,11 +33,14 @@ export function CodeSidebar() {
   const repos = useCodeCatalogStore((state) => state.repos);
   const workspaces = useCodeCatalogStore((state) => state.workspaces);
   const refresh = useCodeCatalogStore((state) => state.refresh);
+  const digests = useCodeUpdatesStore((state) => state.byWorkspace);
   const [newWorkspaceOpen, setNewWorkspaceOpen] = useState(false);
 
   useEffect(() => {
     void refresh(client);
   }, [client, refresh]);
+
+  useEffect(() => connectCodeUpdates(client), [client]);
 
   const recent = workspaces
     .filter((workspace) => workspace.status !== "archived")
@@ -116,6 +121,7 @@ export function CodeSidebar() {
       <div className="flex min-h-0 flex-col gap-0.5">
         {recent.map((workspace) => {
           const active = pathname === `/code/w/${workspace.id}`;
+          const digest = digests[workspace.id];
           return (
             <SidebarButton
               key={workspace.id}
@@ -131,6 +137,7 @@ export function CodeSidebar() {
             >
               <FolderGit2 />
               <span>{workspace.title}</span>
+              <AttentionBadge attention={digest?.attention} compact />
             </SidebarButton>
           );
         })}

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { Attention, CodeSessionDigest } from "../api/types";
+import {
+  noticeToAction,
+  reduceCodeUpdates,
+  shouldRequestOsAttention,
+  useCodeUpdatesStore,
+} from "./CodeUpdatesStore";
+
+const working: Attention = { state: { type: "working" }, source: "lifecycle" };
+const need: Attention = {
+  state: { type: "needs_you", prompt: "an approval is waiting", source: "structured" },
+  source: "structured",
+};
+
+function digest(overrides: Partial<CodeSessionDigest> = {}): CodeSessionDigest {
+  return {
+    workspace: "ws-1",
+    session: "sess-1",
+    lifecycle: "idle",
+    attention: working,
+    title: "first change",
+    turn_count: 0,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  useCodeUpdatesStore.getState().reset();
+  vi.restoreAllMocks();
+});
+
+describe("reduceCodeUpdates", () => {
+  it("replaces the map on snapshot and upserts a digest", () => {
+    const empty = { byWorkspace: {}, viewedWorkspaceId: null };
+    const afterSnapshot = reduceCodeUpdates(empty, {
+      type: "snapshot",
+      sessions: [digest(), digest({ workspace: "ws-2", session: "sess-2", title: "other" })],
+    });
+    expect(Object.keys(afterSnapshot.byWorkspace)).toEqual(["ws-1", "ws-2"]);
+    const afterDigest = reduceCodeUpdates(afterSnapshot, {
+      type: "digest",
+      digest: digest({ turn_count: 2, attention: need }),
+    });
+    expect(afterDigest.byWorkspace["ws-1"].turn_count).toBe(2);
+    expect(afterDigest.byWorkspace["ws-1"].attention).toEqual(need);
+    expect(afterDigest.byWorkspace["ws-2"].title).toBe("other");
+    const restated = reduceCodeUpdates(afterDigest, {
+      type: "snapshot",
+      sessions: [digest({ workspace: "ws-3", session: "sess-3" })],
+    });
+    expect(Object.keys(restated.byWorkspace)).toEqual(["ws-3"]);
+  });
+
+  it("maps notices onto reducer actions", () => {
+    expect(
+      noticeToAction({
+        type: "snapshot",
+        sessions: [digest()],
+      }),
+    ).toEqual({ type: "snapshot", sessions: [digest()] });
+    expect(
+      noticeToAction({
+        type: "digest",
+        workspace: "ws-1",
+        session: "sess-1",
+        lifecycle: "running",
+        attention: working,
+        title: "first change",
+        turn_count: 1,
+      }),
+    ).toEqual({
+      type: "digest",
+      digest: {
+        workspace: "ws-1",
+        session: "sess-1",
+        lifecycle: "running",
+        attention: working,
+        title: "first change",
+        turn_count: 1,
+      },
+    });
+    expect(
+      noticeToAction({
+        type: "terminal_activity",
+        workspace_id: "ws-1",
+        terminal_id: "term-1",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("shouldRequestOsAttention", () => {
+  it("fires only on a transition into structured NeedsYou for a workspace that is not being viewed", () => {
+    expect(shouldRequestOsAttention(working, need, "ws-1", null)).toBe(true);
+    expect(shouldRequestOsAttention(undefined, need, "ws-1", null)).toBe(true);
+    expect(shouldRequestOsAttention(need, need, "ws-1", null)).toBe(false);
+    expect(shouldRequestOsAttention(working, need, "ws-1", "ws-1")).toBe(false);
+    expect(shouldRequestOsAttention(working, need, "ws-1", "ws-other")).toBe(true);
+    expect(
+      shouldRequestOsAttention(
+        working,
+        { state: { type: "done_unreviewed" }, source: "lifecycle" },
+        "ws-1",
+        null,
+      ),
+    ).toBe(false);
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
@@ -1,0 +1,228 @@
+import { create } from "zustand";
+
+import type { ApiClient } from "../api/client";
+import type {
+  Attention,
+  CodeSessionDigest,
+  CodeSessionLifecycle,
+  CodeUpdateNotice,
+  PullRequestDigest,
+} from "../api/types";
+import {
+  INITIAL_RECONNECT_DELAY_MS,
+  MAX_RECONNECT_DELAY_MS,
+  nextReconnectDelay,
+} from "../ChatSessionController";
+import { requestUserAttention } from "../host";
+
+/**
+ * Install-wide digest store fed by `WS /code/updates`.
+ *
+ * List surfaces read lifecycle, attention, and PR state from here. The
+ * socket restates a full snapshot on every connect, so a dropped notice is
+ * cheap.
+ */
+
+export type CodeUpdatesState = {
+  byWorkspace: Record<string, CodeSessionDigest>;
+  viewedWorkspaceId: string | null;
+};
+
+export type CodeUpdatesAction =
+  | { type: "snapshot"; sessions: CodeSessionDigest[] }
+  | { type: "digest"; digest: CodeSessionDigest }
+  | { type: "view"; workspaceId: string | null }
+  | { type: "reset" };
+
+const EMPTY: CodeUpdatesState = {
+  byWorkspace: {},
+  viewedWorkspaceId: null,
+};
+
+export function reduceCodeUpdates(
+  state: CodeUpdatesState,
+  action: CodeUpdatesAction,
+): CodeUpdatesState {
+  switch (action.type) {
+    case "snapshot": {
+      const byWorkspace: Record<string, CodeSessionDigest> = {};
+      for (const digest of action.sessions) {
+        byWorkspace[digest.workspace] = digest;
+      }
+      return { ...state, byWorkspace };
+    }
+    case "digest":
+      return {
+        ...state,
+        byWorkspace: {
+          ...state.byWorkspace,
+          [action.digest.workspace]: action.digest,
+        },
+      };
+    case "view":
+      return { ...state, viewedWorkspaceId: action.workspaceId };
+    case "reset":
+      return { ...EMPTY, viewedWorkspaceId: state.viewedWorkspaceId };
+  }
+}
+
+/** True when a digest transition should poke the OS attention affordance. */
+export function shouldRequestOsAttention(
+  previous: Attention | undefined,
+  next: Attention,
+  workspaceId: string,
+  viewedWorkspaceId: string | null,
+): boolean {
+  if (viewedWorkspaceId === workspaceId) return false;
+  if (!isStructuredNeed(next)) return false;
+  return !previous || !isStructuredNeed(previous);
+}
+
+function isStructuredNeed(attention: Attention): boolean {
+  return (
+    attention.state.type === "needs_you" && attention.state.source === "structured"
+  );
+}
+
+export function noticeToAction(notice: CodeUpdateNotice): CodeUpdatesAction | null {
+  if (notice.type === "snapshot") {
+    return { type: "snapshot", sessions: notice.sessions };
+  }
+  if (notice.type === "digest") {
+    return {
+      type: "digest",
+      digest: {
+        workspace: notice.workspace,
+        session: notice.session,
+        lifecycle: notice.lifecycle,
+        attention: notice.attention,
+        title: notice.title,
+        turn_count: notice.turn_count,
+        ...(notice.pr_state !== undefined ? { pr_state: notice.pr_state } : {}),
+      },
+    };
+  }
+  return null;
+}
+
+type CodeUpdatesStore = CodeUpdatesState & {
+  apply: (action: CodeUpdatesAction) => void;
+  setViewedWorkspace: (workspaceId: string | null) => void;
+  reset: () => void;
+};
+
+export const useCodeUpdatesStore = create<CodeUpdatesStore>()((set, get) => ({
+  ...EMPTY,
+  apply: (action) => {
+    const previous = get();
+    const next = reduceCodeUpdates(previous, action);
+    if (action.type === "digest") {
+      maybeNotify(previous, action.digest);
+    }
+    set(next);
+  },
+  setViewedWorkspace: (workspaceId) => {
+    set(reduceCodeUpdates(get(), { type: "view", workspaceId }));
+  },
+  reset: () => set({ ...EMPTY }),
+}));
+
+function maybeNotify(previous: CodeUpdatesState, digest: CodeSessionDigest): void {
+  const prior = previous.byWorkspace[digest.workspace]?.attention;
+  if (
+    shouldRequestOsAttention(
+      prior,
+      digest.attention,
+      digest.workspace,
+      previous.viewedWorkspaceId,
+    )
+  ) {
+    void requestUserAttention().catch(() => {
+      // Best-effort dock bounce. The digest itself is the durable signal.
+    });
+  }
+}
+
+let activeClient: Pick<ApiClient, "openCodeUpdates"> | null = null;
+let socket: WebSocket | null = null;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
+let generation = 0;
+
+export function connectCodeUpdates(
+  client: Pick<ApiClient, "openCodeUpdates">,
+): () => void {
+  if (activeClient === client && socket) {
+    return disconnectCodeUpdates;
+  }
+  disconnectCodeUpdates();
+  activeClient = client;
+  generation += 1;
+  const born = generation;
+  open(client, born);
+  return disconnectCodeUpdates;
+}
+
+export function disconnectCodeUpdates(): void {
+  generation += 1;
+  activeClient = null;
+  if (reconnectTimer !== null) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+  if (socket) {
+    socket.onclose = null;
+    socket.onerror = null;
+    socket.close();
+    socket = null;
+  }
+  useCodeUpdatesStore.getState().reset();
+}
+
+function open(client: Pick<ApiClient, "openCodeUpdates">, born: number): void {
+  if (born !== generation) return;
+  const next = client.openCodeUpdates((notice) => {
+    if (born !== generation) return;
+    const action = noticeToAction(notice);
+    if (action) useCodeUpdatesStore.getState().apply(action);
+  });
+  socket = next;
+  next.onopen = () => {
+    if (born !== generation) return;
+    reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
+  };
+  next.onclose = () => {
+    if (born !== generation) return;
+    socket = null;
+    scheduleReconnect(client, born);
+  };
+  next.onerror = () => {
+    next.close();
+  };
+}
+
+function scheduleReconnect(
+  client: Pick<ApiClient, "openCodeUpdates">,
+  born: number,
+): void {
+  if (born !== generation) return;
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    open(client, born);
+  }, reconnectDelayMs);
+  reconnectDelayMs = nextReconnectDelay(reconnectDelayMs);
+}
+
+export function digestLifecycle(
+  digest: CodeSessionDigest | undefined,
+): CodeSessionLifecycle | undefined {
+  return digest?.lifecycle;
+}
+
+export function digestPr(
+  digest: CodeSessionDigest | undefined,
+): PullRequestDigest | undefined {
+  return digest?.pr_state;
+}
+
+export { MAX_RECONNECT_DELAY_MS };

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -22,7 +22,9 @@ import type { PanelContent } from "@/panel/panelTypes";
 import { useLayoutState, usePanelNav } from "@/panel/usePanelNav";
 import { RouteFrame } from "@/RouteFrame";
 import { friendlyErrorMessage } from "@/lib/utils";
+import { AttentionBadge } from "./AttentionBadge";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { liveCodeSession } from "./parsers";
 import { CodeComposer } from "./CodeComposer";
 import { PrCard } from "./PrCard";
@@ -76,6 +78,13 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const [error, setError] = useState<string | null>(null);
   const [starting, setStarting] = useState(false);
   const [createMode, setCreateMode] = useState<CodePermissionMode | null>(null);
+  const digest = useCodeUpdatesStore((state) => state.byWorkspace[workspaceId]);
+  const setViewedWorkspace = useCodeUpdatesStore((state) => state.setViewedWorkspace);
+
+  useEffect(() => {
+    setViewedWorkspace(workspaceId);
+    return () => setViewedWorkspace(null);
+  }, [setViewedWorkspace, workspaceId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -201,8 +210,18 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
           <div className="flex items-center gap-2">
             {session && (
               <>
+                <AttentionBadge attention={digest?.attention ?? session.attention} />
+                <AttentionPin
+                  sessionId={session.id}
+                  attention={digest?.attention ?? session.attention}
+                  client={client}
+                />
                 <PendingApprovalBadge sessionId={session.id} client={client} />
-                <SessionLifecycleBadge session={session} client={client} />
+                <SessionLifecycleBadge
+                  session={session}
+                  client={client}
+                  lifecycle={digest?.lifecycle ?? session.lifecycle}
+                />
               </>
             )}
             <Button
@@ -353,15 +372,95 @@ function renderCodePanel(
   }
 }
 
+function AttentionPin({
+  sessionId,
+  attention,
+  client,
+}: {
+  sessionId: string;
+  attention: CodeSessionSnapshot["attention"];
+  client: ApiClient;
+}) {
+  const [note, setNote] = useState("");
+  const [busy, setBusy] = useState(false);
+  const remember = useCodeCatalogStore((state) => state.rememberSession);
+
+  async function pin() {
+    const next = note.trim();
+    if (!next) return;
+    setBusy(true);
+    try {
+      const session = await client.setCodeAttention(sessionId, { note: next });
+      remember(session);
+      setNote("");
+    } catch (err) {
+      toast.error(friendlyErrorMessage(err, "Could not pin attention"));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function clear() {
+    setBusy(true);
+    try {
+      const session = await client.setCodeAttention(sessionId, { clear: true });
+      remember(session);
+    } catch (err) {
+      toast.error(friendlyErrorMessage(err, "Could not clear the pin"));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (attention.state.type === "manual") {
+    return (
+      <Button
+        type="button"
+        variant="ghost"
+        size="xs"
+        disabled={busy}
+        onClick={() => void clear()}
+      >
+        Clear pin
+      </Button>
+    );
+  }
+
+  return (
+    <form
+      className="flex items-center gap-1"
+      onSubmit={(event) => {
+        event.preventDefault();
+        void pin();
+      }}
+    >
+      <input
+        className="border-input bg-background h-6 w-36 rounded-md border px-2 text-xs"
+        value={note}
+        onChange={(event) => setNote(event.target.value)}
+        placeholder="Pin a note"
+        aria-label="Pin a note"
+        disabled={busy}
+      />
+      <Button type="submit" variant="ghost" size="xs" disabled={busy || !note.trim()}>
+        Pin
+      </Button>
+    </form>
+  );
+}
+
 function SessionLifecycleBadge({
   session,
   client,
+  lifecycle: digestLifecycle,
 }: {
   session: CodeSessionSnapshot;
   client: ApiClient;
+  lifecycle?: CodeSessionSnapshot["lifecycle"];
 }) {
   const store = useRegisteredCodeSession(session.id, client);
-  const lifecycle = store((state) => state.lifecycle) ?? session.lifecycle;
+  const fromStore = store((state) => state.lifecycle);
+  const lifecycle = digestLifecycle ?? fromStore ?? session.lifecycle;
   return (
     <Badge
       variant={

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -1,4 +1,5 @@
 import type {
+  Attention,
   CapLevel,
   CodePermissionMode,
   CodeSessionLifecycle,
@@ -80,6 +81,23 @@ export function defaultCreatePermissionMode(
   structuredApprovals: CapLevel | undefined,
 ): CodePermissionMode {
   return harnessHonorsStructuredApprovals(structuredApprovals) ? "ask" : "plan";
+}
+
+export function attentionLabel(attention: Attention): string {
+  switch (attention.state.type) {
+    case "working":
+      return "Working";
+    case "needs_you":
+      return attention.state.prompt || "Needs you";
+    case "stalled":
+      return "Stalled";
+    case "done_unreviewed":
+      return "Done";
+    case "fenced":
+      return "Fenced";
+    case "manual":
+      return attention.state.note || "Pinned";
+  }
 }
 
 export function createPermissionModes(

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -36,6 +36,9 @@ import type {
   SequencedCodeEventFrame,
   ToolDetail,
   ToolOutcome,
+  CodeSessionDigest,
+  CodeUpdateNotice,
+  PullRequestDigest,
 } from "../api/types";
 import type {
   CodeEvent as WireCodeEvent,
@@ -60,6 +63,8 @@ import type {
   QuickAction as WireQuickAction,
   SequencedCodeEventFrame as WireSequencedCodeEventFrame,
   ToolDetail as WireToolDetail,
+  CodeSessionDigest as WireCodeSessionDigest,
+  CodeUpdateNotice as WireCodeUpdateNotice,
 } from "../generated/wire";
 
 /**
@@ -1184,6 +1189,139 @@ function isMember<T extends string>(
 
 function isFiniteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
+}
+
+export function parseCodeSessionDigest(value: unknown): CodeSessionDigest | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeSessionDigest>(value, [
+      "workspace",
+      "session",
+      "lifecycle",
+      "attention",
+      "title",
+      "turn_count",
+      "pr_state",
+    ]) ||
+    !nonEmpty(value.workspace) ||
+    !nonEmpty(value.session) ||
+    !isMember(value.lifecycle, SESSION_LIFECYCLES) ||
+    typeof value.title !== "string" ||
+    !isFiniteNumber(value.turn_count)
+  ) {
+    return null;
+  }
+  const attention = parseAttention(value.attention);
+  if (!attention) return null;
+  const pr_state =
+    value.pr_state === undefined ? undefined : parsePrState(value.pr_state);
+  if (value.pr_state !== undefined && !pr_state) return null;
+  return {
+    workspace: value.workspace,
+    session: value.session,
+    lifecycle: value.lifecycle,
+    attention,
+    title: value.title,
+    turn_count: value.turn_count,
+    ...(pr_state ? { pr_state } : {}),
+  };
+}
+
+export function parseCodeUpdateNotice(value: unknown): CodeUpdateNotice | null {
+  if (!isRecord(value) || typeof value.type !== "string") return null;
+  switch (value.type) {
+    case "snapshot": {
+      if (
+        !onlyKeys<Extract<WireCodeUpdateNotice, { type: "snapshot" }>>(value, [
+          "type",
+          "sessions",
+        ]) ||
+        !Array.isArray(value.sessions)
+      ) {
+        return null;
+      }
+      const sessions: CodeSessionDigest[] = [];
+      for (const item of value.sessions) {
+        const parsed = parseCodeSessionDigest(item);
+        if (!parsed) return null;
+        sessions.push(parsed);
+      }
+      return { type: "snapshot", sessions };
+    }
+    case "digest": {
+      if (
+        !onlyKeys<Extract<WireCodeUpdateNotice, { type: "digest" }>>(value, [
+          "type",
+          "workspace",
+          "session",
+          "lifecycle",
+          "attention",
+          "title",
+          "turn_count",
+          "pr_state",
+        ]) ||
+        !nonEmpty(value.workspace) ||
+        !nonEmpty(value.session) ||
+        !isMember(value.lifecycle, SESSION_LIFECYCLES) ||
+        typeof value.title !== "string" ||
+        !isFiniteNumber(value.turn_count)
+      ) {
+        return null;
+      }
+      const attention = parseAttention(value.attention);
+      if (!attention) return null;
+      const pr_state =
+        value.pr_state === undefined ? undefined : parsePrState(value.pr_state);
+      if (value.pr_state !== undefined && !pr_state) return null;
+      return {
+        type: "digest",
+        workspace: value.workspace,
+        session: value.session,
+        lifecycle: value.lifecycle,
+        attention,
+        title: value.title,
+        turn_count: value.turn_count,
+        ...(pr_state ? { pr_state } : {}),
+      };
+    }
+    case "terminal_activity": {
+      if (
+        !onlyKeys<Extract<WireCodeUpdateNotice, { type: "terminal_activity" }>>(
+          value,
+          ["type", "workspace_id", "terminal_id"],
+        ) ||
+        !nonEmpty(value.workspace_id) ||
+        !nonEmpty(value.terminal_id)
+      ) {
+        return null;
+      }
+      return {
+        type: "terminal_activity",
+        workspace_id: value.workspace_id,
+        terminal_id: value.terminal_id,
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+function parsePrState(value: unknown): PullRequestDigest | null {
+  if (
+    !isRecord(value) ||
+    !isFiniteNumber(value.number) ||
+    typeof value.state !== "string"
+  ) {
+    return null;
+  }
+  return {
+    number: value.number,
+    state: value.state,
+    ...(typeof value.url === "string" ? { url: value.url } : {}),
+    ...(typeof value.checks_summary === "string"
+      ? { checks_summary: value.checks_summary }
+      : {}),
+  };
 }
 
 export function parseCodeApproval(value: unknown): CodeApprovalSnapshot | null {

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1124,6 +1124,11 @@ export type CodePushSnapshot = { branch: string, remote: string, };
 export type CodeRepoSnapshot = { id: RepoId, root_path: string, display_name: string, default_base_ref: string, branch_prefix: string, setup_script?: string, archive_script?: string, quick_actions: Array<QuickAction>, created_at: string, };
 
 /**
+ * Cheap per-session digest on `/code/updates`.
+ */
+export type CodeSessionDigest = { workspace: WorkspaceId, session: CodeSessionId, lifecycle: CodeSessionLifecycle, attention: Attention, title: string, turn_count: number, pr_state?: PullRequestDigest, };
+
+/**
  * Identifies one durable conversation with an external agent engine.
  */
 export type CodeSessionId = string;
@@ -1178,6 +1183,17 @@ export type CodeTurnSnapshot = { id: CodeTurnId, session_id: CodeSessionId, ordi
  * Status of one user→engine turn.
  */
 export type CodeTurnStatus = "running" | "completed" | "failed" | "interrupted";
+
+/**
+ * One unsequenced notice on `WS /code/updates`.
+ *
+ * A connect is restated as [`Self::Snapshot`]; later notices are live only.
+ */
+export type CodeUpdateNotice = { "type": "snapshot", 
+/**
+ * One row per live session.
+ */
+sessions: Array<CodeSessionDigest>, } | { "type": "digest", workspace: WorkspaceId, session: CodeSessionId, lifecycle: CodeSessionLifecycle, attention: Attention, title: string, turn_count: number, pr_state?: PullRequestDigest, } | { "type": "terminal_activity", workspace_id: WorkspaceId, terminal_id: CodeTerminalId, };
 
 /**
  * Token accounting as reported by the engine. Missing fields stay zero.

--- a/crates/tidebreak-server/src/code/attention.rs
+++ b/crates/tidebreak-server/src/code/attention.rs
@@ -1,0 +1,471 @@
+//! Server-side attention computation and digest publication.
+//!
+//! Every attention write goes through [`replace_attention`]. Digests are
+//! cheap: they are assembled from session, workspace, and turn-count rows.
+
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use tracing::warn;
+
+use tidebreak_core::db::code::{
+    count_turns, get_session, get_workspace, latest_event_created_at, latest_turn, list_approvals,
+    list_sessions, list_sessions_by_lifecycle, list_sessions_for_workspace, save_session,
+};
+use tidebreak_core::{
+    Attention, AttentionSource, AttentionState, CodeApprovalState, CodeSession, CodeSessionId,
+    CodeSessionLifecycle, CodeTurnStatus, DbStore, WorkspaceId,
+};
+
+use super::bus::{CodeEventBus, CodeLiveUpdate, SessionDigest};
+
+/// Running-but-silent threshold. A periodic sweep applies
+/// [`AttentionState::Stalled`] past this many seconds.
+pub(crate) const STALL_IDLE_SECS: u32 = 90;
+
+/// How often the stall sweep walks running sessions.
+pub(crate) const STALL_SWEEP_INTERVAL: Duration = Duration::from_secs(15);
+
+/// The only function that may write attention onto a session value.
+///
+/// `from_user` is the explicit pin/clear path: it may replace anything,
+/// including [`AttentionState::Manual`]. Automatic writes still go through
+/// [`tidebreak_core::should_replace`].
+pub(crate) fn replace_attention(
+    session: &mut CodeSession,
+    next: Attention,
+    from_user: bool,
+) -> bool {
+    if !from_user && !tidebreak_core::should_replace(&session.attention, &next) {
+        return false;
+    }
+    if session.attention == next {
+        return false;
+    }
+    session.attention = next;
+    true
+}
+
+/// Persist the session row and publish its digest. The write path for
+/// lifecycle and attention mutations that already hold the row.
+pub(crate) async fn persist_session(
+    db: &DbStore,
+    bus: &CodeEventBus,
+    session: &CodeSession,
+) -> Result<bool, tidebreak_core::AgentError> {
+    let ok = save_session(db, session).await?;
+    if ok {
+        emit_digest(db, bus, session).await;
+    }
+    Ok(ok)
+}
+
+/// Load, gate, persist, and publish. For callers that do not already hold
+/// the row (the stall sweep, the events-socket view signal, the user route).
+pub(crate) async fn apply_attention(
+    db: &DbStore,
+    bus: &CodeEventBus,
+    session_id: CodeSessionId,
+    next: Attention,
+    from_user: bool,
+) -> Result<Option<Attention>, tidebreak_core::AgentError> {
+    let Some(mut session) = get_session(db, session_id).await? else {
+        return Ok(None);
+    };
+    if !replace_attention(&mut session, next, from_user) {
+        return Ok(None);
+    }
+    persist_session(db, bus, &session).await?;
+    Ok(Some(session.attention))
+}
+
+/// Options for [`compute_attention`].
+pub(crate) struct ComputeOpts {
+    /// Treat a completed turn as already reviewed (clear / view).
+    pub reviewed: bool,
+    pub now: DateTime<Utc>,
+    pub stall_idle_secs: u32,
+}
+
+impl Default for ComputeOpts {
+    fn default() -> Self {
+        Self {
+            reviewed: false,
+            now: Utc::now(),
+            stall_idle_secs: STALL_IDLE_SECS,
+        }
+    }
+}
+
+/// Attention implied by current rows. Used to restore state after a user
+/// clear, never to second-guess a live Manual pin.
+pub(crate) async fn compute_attention(
+    db: &DbStore,
+    session: &CodeSession,
+    opts: ComputeOpts,
+) -> Result<Attention, tidebreak_core::AgentError> {
+    if session.lifecycle == CodeSessionLifecycle::Fenced {
+        if let Some(reason) = session.fence_reason.clone() {
+            return Ok(Attention::new(
+                AttentionState::Fenced { reason },
+                AttentionSource::Lifecycle,
+            ));
+        }
+    }
+    let pending = list_approvals(db, Some(CodeApprovalState::Pending), Some(session.id)).await?;
+    if !pending.is_empty() {
+        return Ok(Attention::needs_you(
+            "an approval is waiting",
+            AttentionSource::Structured,
+        ));
+    }
+    if session.lifecycle == CodeSessionLifecycle::Running {
+        let last = last_activity_at(db, session).await?;
+        let idle = opts.now.signed_duration_since(last).num_seconds().max(0) as u32;
+        if idle >= opts.stall_idle_secs {
+            return Ok(Attention::new(
+                AttentionState::Stalled { idle_secs: idle },
+                AttentionSource::Heuristic,
+            ));
+        }
+        return Ok(Attention::working(AttentionSource::Lifecycle));
+    }
+    match latest_turn(db, session.id).await? {
+        Some(turn) if turn.status == CodeTurnStatus::Failed => Ok(Attention::needs_you(
+            "the engine turn failed",
+            AttentionSource::Lifecycle,
+        )),
+        Some(turn) if turn.status == CodeTurnStatus::Interrupted => Ok(Attention::needs_you(
+            "the turn was interrupted",
+            AttentionSource::Lifecycle,
+        )),
+        Some(turn) if turn.status == CodeTurnStatus::Completed && !opts.reviewed => Ok(
+            Attention::new(AttentionState::DoneUnreviewed, AttentionSource::Lifecycle),
+        ),
+        _ => Ok(Attention::working(AttentionSource::Lifecycle)),
+    }
+}
+
+/// Mark a session as viewed: a connected events socket clears
+/// [`AttentionState::DoneUnreviewed`].
+pub(crate) async fn mark_viewed(
+    db: &DbStore,
+    bus: &CodeEventBus,
+    session_id: CodeSessionId,
+) -> Result<(), tidebreak_core::AgentError> {
+    let Some(session) = get_session(db, session_id).await? else {
+        return Ok(());
+    };
+    if !matches!(session.attention.state, AttentionState::DoneUnreviewed) {
+        return Ok(());
+    }
+    let _ = apply_attention(
+        db,
+        bus,
+        session_id,
+        Attention::working(AttentionSource::Lifecycle),
+        false,
+    )
+    .await?;
+    Ok(())
+}
+
+/// User pin (`note`) or clear (restore computed, treating the session as
+/// reviewed so DoneUnreviewed does not bounce back).
+pub(crate) async fn user_set_attention(
+    db: &DbStore,
+    bus: &CodeEventBus,
+    session_id: CodeSessionId,
+    clear: bool,
+    note: Option<String>,
+) -> Result<CodeSession, tidebreak_core::AgentError> {
+    let Some(mut session) = get_session(db, session_id).await? else {
+        return Err(tidebreak_core::AgentError::Store(format!(
+            "session {session_id} not found"
+        )));
+    };
+    let next = if clear {
+        compute_attention(
+            db,
+            &session,
+            ComputeOpts {
+                reviewed: true,
+                ..ComputeOpts::default()
+            },
+        )
+        .await?
+    } else {
+        Attention::manual(note.unwrap_or_default())
+    };
+    replace_attention(&mut session, next, true);
+    persist_session(db, bus, &session).await?;
+    Ok(session)
+}
+
+/// Walk running sessions and apply [`AttentionState::Stalled`] when silent.
+pub(crate) async fn sweep_stalled(
+    db: &DbStore,
+    bus: &CodeEventBus,
+    idle_secs: u32,
+) -> Result<(), tidebreak_core::AgentError> {
+    let now = Utc::now();
+    let running = list_sessions_by_lifecycle(db, CodeSessionLifecycle::Running).await?;
+    for session in running {
+        let last = last_activity_at(db, &session).await?;
+        let idle = now.signed_duration_since(last).num_seconds().max(0) as u32;
+        if idle < idle_secs {
+            continue;
+        }
+        let next = Attention::new(
+            AttentionState::Stalled { idle_secs: idle },
+            AttentionSource::Heuristic,
+        );
+        let _ = apply_attention(db, bus, session.id, next, false).await?;
+    }
+    Ok(())
+}
+
+/// Activity on a running session clears a stall.
+pub(crate) async fn note_activity(
+    db: &DbStore,
+    bus: &CodeEventBus,
+    session_id: CodeSessionId,
+) -> Result<(), tidebreak_core::AgentError> {
+    let Some(session) = get_session(db, session_id).await? else {
+        return Ok(());
+    };
+    if session.lifecycle != CodeSessionLifecycle::Running {
+        return Ok(());
+    }
+    if !matches!(session.attention.state, AttentionState::Stalled { .. }) {
+        return Ok(());
+    }
+    let _ = apply_attention(
+        db,
+        bus,
+        session_id,
+        Attention::working(AttentionSource::Lifecycle),
+        false,
+    )
+    .await?;
+    Ok(())
+}
+
+pub(crate) async fn emit_digest(db: &DbStore, bus: &CodeEventBus, session: &CodeSession) {
+    match build_digest(db, session).await {
+        Ok(digest) => bus.publish_update(CodeLiveUpdate::Digest(digest)),
+        Err(err) => warn!(
+            session = %session.id,
+            error = %err,
+            "failed to build a code-session digest"
+        ),
+    }
+}
+
+pub(crate) async fn emit_workspace_digests(
+    db: &DbStore,
+    bus: &CodeEventBus,
+    workspace_id: WorkspaceId,
+) {
+    match list_sessions_for_workspace(db, workspace_id).await {
+        Ok(sessions) => {
+            for session in sessions {
+                emit_digest(db, bus, &session).await;
+            }
+        }
+        Err(err) => warn!(
+            workspace = %workspace_id,
+            error = %err,
+            "failed to list sessions for a workspace digest"
+        ),
+    }
+}
+
+pub(crate) async fn list_digests(
+    db: &DbStore,
+) -> Result<Vec<SessionDigest>, tidebreak_core::AgentError> {
+    let mut out = Vec::new();
+    for session in list_sessions(db).await? {
+        if session.lifecycle == CodeSessionLifecycle::Ended {
+            continue;
+        }
+        out.push(build_digest(db, &session).await?);
+    }
+    Ok(out)
+}
+
+async fn build_digest(
+    db: &DbStore,
+    session: &CodeSession,
+) -> Result<SessionDigest, tidebreak_core::AgentError> {
+    let workspace = get_workspace(db, session.workspace_id)
+        .await?
+        .ok_or_else(|| {
+            tidebreak_core::AgentError::Store(format!(
+                "workspace {} missing for session {}",
+                session.workspace_id, session.id
+            ))
+        })?;
+    let turn_count = count_turns(db, session.id).await?;
+    Ok(SessionDigest {
+        workspace: session.workspace_id,
+        session: session.id,
+        lifecycle: session.lifecycle,
+        attention: session.attention.clone(),
+        title: workspace.title,
+        turn_count,
+        pr_state: workspace.pr,
+    })
+}
+
+async fn last_activity_at(
+    db: &DbStore,
+    session: &CodeSession,
+) -> Result<DateTime<Utc>, tidebreak_core::AgentError> {
+    if let Some(at) = latest_event_created_at(db, session.id).await? {
+        return Ok(at);
+    }
+    if let Some(turn) = latest_turn(db, session.id).await? {
+        return Ok(turn.started_at);
+    }
+    Ok(session.created_at)
+}
+
+/// Abort the stall sweep when the runtime is dropped.
+pub(crate) struct StallSweepGuard(Option<tokio::task::JoinHandle<()>>);
+
+impl StallSweepGuard {
+    pub(crate) fn spawn(db: std::sync::Arc<DbStore>, bus: std::sync::Arc<CodeEventBus>) -> Self {
+        let handle = tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(STALL_SWEEP_INTERVAL);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                if let Err(err) = sweep_stalled(&db, &bus, STALL_IDLE_SECS).await {
+                    warn!(error = %err, "code-mode stall sweep failed");
+                }
+            }
+        });
+        Self(Some(handle))
+    }
+}
+
+impl Drop for StallSweepGuard {
+    fn drop(&mut self) {
+        if let Some(handle) = self.0.take() {
+            handle.abort();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tidebreak_core::{should_replace, FenceReason, WorkspaceId};
+
+    fn auto_working() -> Attention {
+        Attention::working(AttentionSource::Lifecycle)
+    }
+
+    fn structured_need() -> Attention {
+        Attention::needs_you("approve this", AttentionSource::Structured)
+    }
+
+    fn heuristic_stall() -> Attention {
+        Attention::new(
+            AttentionState::Stalled { idle_secs: 30 },
+            AttentionSource::Heuristic,
+        )
+    }
+
+    fn session_with(attention: Attention) -> CodeSession {
+        CodeSession {
+            id: CodeSessionId::new(),
+            workspace_id: WorkspaceId::new(),
+            harness_kind: tidebreak_core::HarnessKind::ClaudeCode,
+            harness_version: None,
+            harness_resume_ref: None,
+            permission_mode: tidebreak_core::CodePermissionMode::Plan,
+            lifecycle: CodeSessionLifecycle::Idle,
+            fence_reason: None,
+            child_pid: None,
+            spawn_epoch: 1,
+            attention,
+            unrecognized_event_count: 0,
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn chokepoint_never_lets_automatic_replace_manual() {
+        let mut session = session_with(Attention::manual("hold"));
+        for next in [
+            auto_working(),
+            Attention::working(AttentionSource::Structured),
+            heuristic_stall(),
+            structured_need(),
+            Attention::new(AttentionState::DoneUnreviewed, AttentionSource::Lifecycle),
+            Attention::new(
+                AttentionState::Fenced {
+                    reason: FenceReason::OrphanAlive,
+                },
+                AttentionSource::Lifecycle,
+            ),
+        ] {
+            assert!(
+                !replace_attention(&mut session, next.clone(), false),
+                "automatic {:?} must not replace Manual",
+                next.source
+            );
+            assert!(matches!(
+                session.attention.state,
+                AttentionState::Manual { .. }
+            ));
+        }
+        assert!(replace_attention(
+            &mut session,
+            Attention::manual("updated"),
+            true
+        ));
+        assert!(replace_attention(&mut session, auto_working(), true));
+        assert_eq!(session.attention.state, AttentionState::Working);
+    }
+
+    #[test]
+    fn chokepoint_holds_structured_need_against_heuristic() {
+        let mut session = session_with(structured_need());
+        assert!(!replace_attention(&mut session, heuristic_stall(), false));
+        assert!(!replace_attention(
+            &mut session,
+            Attention::needs_you("maybe idle?", AttentionSource::Heuristic),
+            false
+        ));
+        assert!(replace_attention(&mut session, auto_working(), false));
+    }
+
+    #[test]
+    fn chokepoint_agrees_with_should_replace() {
+        let currents = [
+            auto_working(),
+            structured_need(),
+            heuristic_stall(),
+            Attention::manual("pin"),
+            Attention::new(AttentionState::DoneUnreviewed, AttentionSource::Lifecycle),
+        ];
+        let nexts = [
+            auto_working(),
+            structured_need(),
+            heuristic_stall(),
+            Attention::manual("other"),
+            Attention::working(AttentionSource::User),
+        ];
+        for current in &currents {
+            for next in &nexts {
+                let mut session = session_with(current.clone());
+                let applied = replace_attention(&mut session, next.clone(), false);
+                let expected = should_replace(current, next) && current != next;
+                assert_eq!(applied, expected, "current={current:?} next={next:?}");
+            }
+        }
+    }
+}

--- a/crates/tidebreak-server/src/code/bus.rs
+++ b/crates/tidebreak-server/src/code/bus.rs
@@ -1,21 +1,59 @@
-//! In-memory live fan-out for one code-mode session.
+//! In-memory live fan-out for one code-mode session plus the install-wide
+//! updates channel.
 //!
 //! The journal is the durable record a client replays on connect; this bus is
 //! the live tail. The session worker appends each event to the journal and
 //! then publishes it here with its assigned `seq`.
+//!
+//! `/code/updates` is unsequenced: a dropped notice costs nothing because the
+//! full digest is restated on every connect.
 
 use std::collections::HashMap;
 use std::sync::Mutex;
 
-use tidebreak_core::{CodeSessionId, SequencedCodeEvent};
+use tidebreak_core::{
+    Attention, CodeSessionId, CodeSessionLifecycle, PullRequestDigest, SequencedCodeEvent,
+    WorkspaceId,
+};
 use tokio::sync::broadcast;
 
 const LIVE_BUFFER: usize = 256;
+const UPDATES_BUFFER: usize = 256;
 
-/// Per-session broadcast channels for live journal events.
-#[derive(Default)]
+/// Cheap per-session digest published on `/code/updates`.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct SessionDigest {
+    pub workspace: WorkspaceId,
+    pub session: CodeSessionId,
+    pub lifecycle: CodeSessionLifecycle,
+    pub attention: Attention,
+    pub title: String,
+    pub turn_count: i64,
+    pub pr_state: Option<PullRequestDigest>,
+}
+
+/// One unsequenced notice on the install-wide updates channel.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum CodeLiveUpdate {
+    /// Cheap per-session digest, computed from rows.
+    Digest(SessionDigest),
+}
+
+/// Per-session broadcast channels for live journal events, plus the
+/// install-wide digest channel.
 pub(crate) struct CodeEventBus {
     channels: Mutex<HashMap<CodeSessionId, broadcast::Sender<SequencedCodeEvent>>>,
+    updates: broadcast::Sender<CodeLiveUpdate>,
+}
+
+impl Default for CodeEventBus {
+    fn default() -> Self {
+        let (updates, _) = broadcast::channel(UPDATES_BUFFER);
+        Self {
+            channels: Mutex::new(HashMap::new()),
+            updates,
+        }
+    }
 }
 
 impl CodeEventBus {
@@ -37,5 +75,13 @@ impl CodeEventBus {
 
     pub(crate) fn publish(&self, session: CodeSessionId, event: SequencedCodeEvent) {
         let _ = self.sender(session).send(event);
+    }
+
+    pub(crate) fn subscribe_updates(&self) -> broadcast::Receiver<CodeLiveUpdate> {
+        self.updates.subscribe()
+    }
+
+    pub(crate) fn publish_update(&self, update: CodeLiveUpdate) {
+        let _ = self.updates.send(update);
     }
 }

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -5,6 +5,7 @@
 //! worker, crash recovery, and the live event bus.
 
 pub(crate) mod approval_bridge;
+pub(crate) mod attention;
 pub(crate) mod bus;
 pub(crate) mod checkpoint;
 pub(crate) mod gh;

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -9,12 +9,15 @@ use std::io::ErrorKind;
 
 use chrono::Utc;
 use tidebreak_core::db::code::{
-    append_event, get_open_turn, list_sessions_by_lifecycle, save_session, save_turn,
+    append_event, get_open_turn, list_sessions_by_lifecycle, save_turn,
 };
 use tidebreak_core::{
     Attention, AttentionSource, AttentionState, CodeEvent, CodeSession, CodeSessionLifecycle,
     CodeTurnStatus, DbStore, FenceReason,
 };
+
+use super::attention::{persist_session, replace_attention};
+use super::bus::CodeEventBus;
 
 /// What boot recovery did to one session.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -33,18 +36,20 @@ pub(crate) enum PidLiveness {
 /// Scan every `Running` session and apply the conservative recovery rule.
 pub(crate) async fn recover_running_sessions(
     store: &DbStore,
+    bus: &CodeEventBus,
 ) -> Result<Vec<RecoveryAction>, tidebreak_core::AgentError> {
-    recover_running_sessions_with(store, probe_recorded_pid).await
+    recover_running_sessions_with(store, bus, probe_recorded_pid).await
 }
 
 pub(crate) async fn recover_running_sessions_with(
     store: &DbStore,
+    bus: &CodeEventBus,
     probe: impl Fn(i64) -> PidLiveness,
 ) -> Result<Vec<RecoveryAction>, tidebreak_core::AgentError> {
     let running = list_sessions_by_lifecycle(store, CodeSessionLifecycle::Running).await?;
     let mut actions = Vec::new();
     for session in running {
-        if let Some(action) = recover_one(store, session, &probe).await? {
+        if let Some(action) = recover_one(store, bus, session, &probe).await? {
             actions.push(action);
         }
     }
@@ -54,21 +59,24 @@ pub(crate) async fn recover_running_sessions_with(
 /// Resolve a fenced session after an explicit user reap. Never signals.
 pub(crate) async fn reap_session(
     store: &DbStore,
+    bus: &CodeEventBus,
     mut session: CodeSession,
 ) -> Result<CodeSession, tidebreak_core::AgentError> {
     session.lifecycle = CodeSessionLifecycle::Idle;
     session.fence_reason = None;
     session.child_pid = None;
-    let next = Attention::working(AttentionSource::Lifecycle);
-    if tidebreak_core::should_replace(&session.attention, &next) {
-        session.attention = next;
-    }
-    save_session(store, &session).await?;
+    replace_attention(
+        &mut session,
+        Attention::working(AttentionSource::Lifecycle),
+        false,
+    );
+    persist_session(store, bus, &session).await?;
     Ok(session)
 }
 
 async fn recover_one(
     store: &DbStore,
+    bus: &CodeEventBus,
     mut session: CodeSession,
     probe: &impl Fn(i64) -> PidLiveness,
 ) -> Result<Option<RecoveryAction>, tidebreak_core::AgentError> {
@@ -77,11 +85,15 @@ async fn recover_one(
         interrupt_open_turn(store, &session).await?;
         session.lifecycle = CodeSessionLifecycle::Idle;
         session.child_pid = None;
-        session.attention = Attention::needs_you(
-            "session recovered after the engine process exited",
-            AttentionSource::Lifecycle,
+        replace_attention(
+            &mut session,
+            Attention::needs_you(
+                "session recovered after the engine process exited",
+                AttentionSource::Lifecycle,
+            ),
+            false,
         );
-        save_session(store, &session).await?;
+        persist_session(store, bus, &session).await?;
         return Ok(Some(RecoveryAction::Interrupted {
             session: session.id.to_string(),
         }));
@@ -91,11 +103,15 @@ async fn recover_one(
             interrupt_open_turn(store, &session).await?;
             session.lifecycle = CodeSessionLifecycle::Idle;
             session.child_pid = None;
-            session.attention = Attention::needs_you(
-                "session recovered after the engine process exited",
-                AttentionSource::Lifecycle,
+            replace_attention(
+                &mut session,
+                Attention::needs_you(
+                    "session recovered after the engine process exited",
+                    AttentionSource::Lifecycle,
+                ),
+                false,
             );
-            save_session(store, &session).await?;
+            persist_session(store, bus, &session).await?;
             Ok(Some(RecoveryAction::Interrupted {
                 session: session.id.to_string(),
             }))
@@ -103,13 +119,17 @@ async fn recover_one(
         PidLiveness::Alive => {
             session.lifecycle = CodeSessionLifecycle::Fenced;
             session.fence_reason = Some(FenceReason::OrphanAlive);
-            session.attention = Attention::new(
-                AttentionState::Fenced {
-                    reason: FenceReason::OrphanAlive,
-                },
-                AttentionSource::Lifecycle,
+            replace_attention(
+                &mut session,
+                Attention::new(
+                    AttentionState::Fenced {
+                        reason: FenceReason::OrphanAlive,
+                    },
+                    AttentionSource::Lifecycle,
+                ),
+                false,
             );
-            save_session(store, &session).await?;
+            persist_session(store, bus, &session).await?;
             Ok(Some(RecoveryAction::Fenced {
                 session: session.id.to_string(),
             }))
@@ -293,7 +313,8 @@ mod tests {
     #[tokio::test]
     async fn dead_pid_closes_the_open_turn_as_interrupted() {
         let (_dir, store, session_id, turn_id) = seeded_running(Some(9_999_991)).await;
-        let actions = recover_running_sessions_with(&store, |_| PidLiveness::Dead)
+        let bus = crate::code::bus::CodeEventBus::default();
+        let actions = recover_running_sessions_with(&store, &bus, |_| PidLiveness::Dead)
             .await
             .unwrap();
         assert!(matches!(
@@ -323,7 +344,8 @@ mod tests {
         let decoy_pid = i64::from(decoy.id());
         let (_dir, store, session_id, turn_id) = seeded_running(Some(decoy_pid)).await;
         let flag = signaled.clone();
-        let actions = recover_running_sessions_with(&store, move |pid| {
+        let bus = crate::code::bus::CodeEventBus::default();
+        let actions = recover_running_sessions_with(&store, &bus, move |pid| {
             // Recovery must probe only the recorded pid, and only via the
             // injected probe — never by signaling the decoy itself.
             assert_eq!(pid, decoy_pid);
@@ -339,6 +361,12 @@ mod tests {
         let session = get_session(&store, session_id).await.unwrap().unwrap();
         assert_eq!(session.lifecycle, CodeSessionLifecycle::Fenced);
         assert_eq!(session.fence_reason, Some(FenceReason::OrphanAlive));
+        assert!(matches!(
+            session.attention.state,
+            AttentionState::Fenced {
+                reason: FenceReason::OrphanAlive
+            }
+        ));
         let turn = get_turn(&store, turn_id).await.unwrap().unwrap();
         assert_eq!(turn.status, CodeTurnStatus::Running);
         assert!(
@@ -351,9 +379,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fenced_recovery_does_not_overwrite_a_manual_pin() {
+        let (_dir, store, session_id, _) = seeded_running(Some(1)).await;
+        let mut session = get_session(&store, session_id).await.unwrap().unwrap();
+        session.attention = Attention::manual("hold");
+        tidebreak_core::db::code::save_session(&store, &session)
+            .await
+            .unwrap();
+        let bus = crate::code::bus::CodeEventBus::default();
+        let actions = recover_running_sessions_with(&store, &bus, |_| PidLiveness::Alive)
+            .await
+            .unwrap();
+        assert!(matches!(
+            actions.as_slice(),
+            [RecoveryAction::Fenced { .. }]
+        ));
+        let session = get_session(&store, session_id).await.unwrap().unwrap();
+        assert_eq!(session.lifecycle, CodeSessionLifecycle::Fenced);
+        assert!(
+            matches!(session.attention.state, AttentionState::Manual { .. }),
+            "Fenced recovery must go through should_replace: {:?}",
+            session.attention
+        );
+    }
+
+    #[tokio::test]
     async fn eperm_probe_counts_as_alive() {
         let (_dir, store, session_id, _) = seeded_running(Some(1)).await;
-        let actions = recover_running_sessions_with(&store, |_| PidLiveness::Alive)
+        let bus = crate::code::bus::CodeEventBus::default();
+        let actions = recover_running_sessions_with(&store, &bus, |_| PidLiveness::Alive)
             .await
             .unwrap();
         assert!(matches!(

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use chrono::Utc;
@@ -11,7 +12,7 @@ use tidebreak_core::db::code::{
     delete_repo, delete_workspace, get_approval, get_open_turn, get_repo, get_repo_by_root_path,
     get_session, get_workspace, insert_repo, insert_session, insert_workspace, list_approvals,
     list_repos, list_sessions, list_sessions_for_workspace, list_turns, list_workspaces,
-    save_approval, save_repo, save_session, save_workspace,
+    save_approval, save_repo, save_workspace,
 };
 use tidebreak_core::{
     ApprovalDecisionKind, Attention, AttentionSource, CapLevel, CodeApproval, CodeApprovalId,
@@ -65,6 +66,8 @@ pub(crate) struct CodeRuntime {
     pr_cache: PrDigestCache,
     #[cfg(test)]
     gh_search_path: Mutex<Option<String>>,
+    stall_sweep: Mutex<Option<super::attention::StallSweepGuard>>,
+    stall_started: AtomicBool,
 }
 
 impl CodeRuntime {
@@ -81,6 +84,8 @@ impl CodeRuntime {
             pr_cache: PrDigestCache::default(),
             #[cfg(test)]
             gh_search_path: Mutex::new(None),
+            stall_sweep: Mutex::new(None),
+            stall_started: AtomicBool::new(false),
         }
     }
 
@@ -108,6 +113,8 @@ impl CodeRuntime {
             pr_cache: PrDigestCache::default(),
             #[cfg(test)]
             gh_search_path: Mutex::new(None),
+            stall_sweep: Mutex::new(None),
+            stall_started: AtomicBool::new(false),
         }
     }
 
@@ -117,7 +124,8 @@ impl CodeRuntime {
     }
 
     pub(crate) async fn recover(&self) -> Result<Vec<RecoveryAction>, ServerError> {
-        let actions = recovery::recover_running_sessions(&self.db)
+        self.ensure_stall_sweep();
+        let actions = recovery::recover_running_sessions(&self.db, &self.bus)
             .await
             .map_err(ServerError::from)?;
         if let Err(error) = self.sweep_orphaned_checkpoints().await {
@@ -366,6 +374,7 @@ impl CodeRuntime {
                 workspace.id
             )));
         }
+        super::attention::emit_workspace_digests(&self.db, &self.bus, workspace.id).await;
         Ok(())
     }
 
@@ -480,7 +489,7 @@ impl CodeRuntime {
         .map_err(map_gh)?;
         if status.pr != workspace.pr {
             workspace.pr = status.pr.clone();
-            save_workspace(&self.db, &workspace).await?;
+            self.save_workspace(&workspace).await?;
         }
         Ok(status)
     }
@@ -507,7 +516,7 @@ impl CodeRuntime {
         .await
         .map_err(map_gh)?;
         workspace.pr = Some(digest);
-        save_workspace(&self.db, &workspace).await?;
+        self.save_workspace(&workspace).await?;
         self.workspace_pr(id).await
     }
 
@@ -692,10 +701,36 @@ impl CodeRuntime {
         if let Some(handle) = handle {
             let _ = handle.commands.send(WorkerCommand::Shutdown).await;
         }
-        let session = recovery::reap_session(&self.db, session)
+        let session = recovery::reap_session(&self.db, &self.bus, session)
             .await
             .map_err(ServerError::from)?;
         self.attach_and_spawn_worker(session).await
+    }
+
+    pub(crate) async fn set_attention(
+        &self,
+        id: CodeSessionId,
+        clear: bool,
+        note: Option<String>,
+    ) -> Result<CodeSession, ServerError> {
+        let _ = self.get_session(id).await?;
+        super::attention::user_set_attention(&self.db, &self.bus, id, clear, note)
+            .await
+            .map_err(ServerError::from)
+    }
+
+    pub(crate) async fn mark_session_viewed(&self, id: CodeSessionId) -> Result<(), ServerError> {
+        super::attention::mark_viewed(&self.db, &self.bus, id)
+            .await
+            .map_err(ServerError::from)
+    }
+
+    fn ensure_stall_sweep(&self) {
+        if self.stall_started.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let guard = super::attention::StallSweepGuard::spawn(self.db.clone(), self.bus.clone());
+        *self.stall_sweep.lock().expect("stall sweep") = Some(guard);
     }
 
     pub(crate) async fn list_sessions(&self) -> Result<Vec<CodeSession>, ServerError> {
@@ -812,7 +847,7 @@ impl CodeRuntime {
             session.lifecycle = CodeSessionLifecycle::Ended;
             session.child_pid = None;
             session.fence_reason = None;
-            save_session(&self.db, &session).await?;
+            super::attention::persist_session(&self.db, &self.bus, &session).await?;
         }
         Ok(())
     }
@@ -873,7 +908,7 @@ impl CodeRuntime {
         if let Some(resume) = engine.resume_ref().or(session.harness_resume_ref.clone()) {
             attached.harness_resume_ref = Some(resume);
         }
-        save_session(&self.db, &attached).await?;
+        super::attention::persist_session(&self.db, &self.bus, &attached).await?;
         let handle = spawn_session_worker(
             self.db.clone(),
             self.bus.clone(),
@@ -892,9 +927,12 @@ impl CodeRuntime {
         )
         .await?;
         if !pending.is_empty() {
-            attached.attention =
-                Attention::needs_you("an approval is waiting", AttentionSource::Structured);
-            save_session(&self.db, &attached).await?;
+            super::attention::replace_attention(
+                &mut attached,
+                Attention::needs_you("an approval is waiting", AttentionSource::Structured),
+                false,
+            );
+            super::attention::persist_session(&self.db, &self.bus, &attached).await?;
         }
         Ok(attached)
     }
@@ -1040,16 +1078,14 @@ impl CodeRuntime {
         )
         .await?;
         if still_pending.is_empty() {
-            if let Ok(Some(mut current)) = get_session(&self.db, approval.session_id).await {
-                if matches!(
-                    current.attention.state,
-                    tidebreak_core::AttentionState::NeedsYou { .. }
-                ) && current.attention.source == AttentionSource::Structured
-                {
-                    current.attention = Attention::working(AttentionSource::Lifecycle);
-                    let _ = save_session(&self.db, &current).await;
-                }
-            }
+            let _ = super::attention::apply_attention(
+                &self.db,
+                &self.bus,
+                approval.session_id,
+                Attention::working(AttentionSource::Lifecycle),
+                false,
+            )
+            .await;
         }
         Ok(approval)
     }

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -104,11 +104,14 @@ impl LiveSink {
         if insert_approval(&self.db, &approval).await.is_err() {
             return;
         }
-        if let Ok(Some(mut session)) = get_session(&self.db, self.session_id).await {
-            session.attention =
-                Attention::needs_you("an approval is waiting", AttentionSource::Structured);
-            let _ = save_session(&self.db, &session).await;
-        }
+        let _ = super::attention::apply_attention(
+            &self.db,
+            &self.bus,
+            self.session_id,
+            Attention::needs_you("an approval is waiting", AttentionSource::Structured),
+            false,
+        )
+        .await;
         let _ = persist_and_publish(
             &self.db,
             &self.bus,
@@ -366,11 +369,15 @@ async fn drive_turn(
     sink.set_turn(turn.id);
 
     session.lifecycle = CodeSessionLifecycle::Running;
-    session.attention = Attention::working(AttentionSource::Lifecycle);
+    super::attention::replace_attention(
+        session,
+        Attention::working(AttentionSource::Lifecycle),
+        false,
+    );
     if let Some(pid) = engine.child_pid() {
         session.child_pid = Some(pid);
     }
-    save_session(db, session)
+    super::attention::persist_session(db, bus, session)
         .await
         .map_err(|err| WorkerError::Failed(err.to_string()))?;
 
@@ -459,9 +466,12 @@ async fn drive_turn(
             }
             if !session_was_ended(db, session).await {
                 session.lifecycle = CodeSessionLifecycle::Idle;
-                session.attention =
-                    Attention::needs_you("the engine turn failed", AttentionSource::Lifecycle);
-                let _ = save_session(db, session).await;
+                super::attention::replace_attention(
+                    session,
+                    Attention::needs_you("the engine turn failed", AttentionSource::Lifecycle),
+                    false,
+                );
+                let _ = super::attention::persist_session(db, bus, session).await;
             }
             return Err(WorkerError::Failed(err.to_string()));
         }
@@ -475,19 +485,29 @@ async fn drive_turn(
         return Ok(turn);
     }
     if turn.status == CodeTurnStatus::Interrupted {
-        session.attention =
-            Attention::needs_you("the turn was interrupted", AttentionSource::Lifecycle);
+        super::attention::replace_attention(
+            session,
+            Attention::needs_you("the turn was interrupted", AttentionSource::Lifecycle),
+            false,
+        );
     } else if turn.status == CodeTurnStatus::Failed {
-        session.attention =
-            Attention::needs_you("the engine turn failed", AttentionSource::Lifecycle);
+        super::attention::replace_attention(
+            session,
+            Attention::needs_you("the engine turn failed", AttentionSource::Lifecycle),
+            false,
+        );
     } else {
-        session.attention = Attention::new(
-            tidebreak_core::AttentionState::DoneUnreviewed,
-            AttentionSource::Lifecycle,
+        super::attention::replace_attention(
+            session,
+            Attention::new(
+                tidebreak_core::AttentionState::DoneUnreviewed,
+                AttentionSource::Lifecycle,
+            ),
+            false,
         );
     }
     session.lifecycle = CodeSessionLifecycle::Idle;
-    let _ = save_session(db, session).await;
+    let _ = super::attention::persist_session(db, bus, session).await;
     Ok(turn)
 }
 
@@ -525,8 +545,12 @@ pub(crate) async fn attach_engine(
     session.child_pid = child_pid;
     session.harness_version = version.or(session.harness_version);
     session.lifecycle = CodeSessionLifecycle::Idle;
-    session.attention = Attention::working(AttentionSource::Lifecycle);
-    save_session(db, &session)
+    super::attention::replace_attention(
+        &mut session,
+        Attention::working(AttentionSource::Lifecycle),
+        false,
+    );
+    super::attention::persist_session(db, bus, &session)
         .await
         .map_err(|err| WorkerError::Failed(err.to_string()))?;
     persist_and_publish(
@@ -583,11 +607,28 @@ async fn persist_and_publish(
 ) -> Result<(), CodeJournalError> {
     apply_side_effects(db, session_id, spawn_epoch, &event).await?;
     let seq = append_event(db, session_id, spawn_epoch, &event).await?;
+    if is_activity(&event) {
+        let _ = super::attention::note_activity(db, bus, session_id).await;
+    }
     bus.publish(
         session_id,
         tidebreak_core::SequencedCodeEvent { seq, event },
     );
     Ok(())
+}
+
+fn is_activity(event: &CodeEvent) -> bool {
+    matches!(
+        event,
+        CodeEvent::AssistantDelta { .. }
+            | CodeEvent::AssistantMessage { .. }
+            | CodeEvent::ReasoningDelta { .. }
+            | CodeEvent::ToolStarted { .. }
+            | CodeEvent::ToolCompleted { .. }
+            | CodeEvent::FileChanged { .. }
+            | CodeEvent::ApprovalRequested { .. }
+            | CodeEvent::UserSteered { .. }
+    )
 }
 
 async fn apply_side_effects(

--- a/crates/tidebreak-server/src/code/terminal.rs
+++ b/crates/tidebreak-server/src/code/terminal.rs
@@ -124,7 +124,6 @@ impl TerminalHub {
         }
     }
 
-    #[cfg(test)]
     pub(crate) fn subscribe(&self) -> broadcast::Receiver<TerminalNotice> {
         self.notices.subscribe()
     }

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -757,9 +757,14 @@ pub fn app(state: AppState) -> Router {
         )
         .route("/code/sessions/{id}/reap", post(routes::code::reap_session))
         .route(
+            "/code/sessions/{id}/attention",
+            post(routes::code::set_attention),
+        )
+        .route(
             "/code/sessions/{id}/events",
             get(routes::code::session_events),
         )
+        .route("/code/updates", get(routes::code::code_updates))
         .route(
             "/code/workspaces/{id}/terminals",
             post(routes::code::create_terminal)

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -8,6 +8,7 @@ mod session_events;
 mod sessions;
 mod terminals;
 mod types;
+mod updates;
 mod workspaces;
 
 pub(crate) use crate::code::approval_bridge::approval_prompt;
@@ -20,7 +21,7 @@ pub(crate) use repos::{create_repo, delete_repo, get_repo, list_repos, patch_rep
 pub(crate) use session_events::session_events;
 pub(crate) use sessions::{
     create_session, interrupt_session, list_session_turns, list_workspace_sessions, reap_session,
-    steer_session, submit_turn,
+    set_attention, steer_session, submit_turn,
 };
 pub(crate) use terminals::{
     close_terminal, close_workspace_terminals, create_terminal, list_terminals, read_terminal,
@@ -29,11 +30,12 @@ pub(crate) use terminals::{
 #[allow(unused_imports)]
 pub(crate) use types::{
     CodeActionSnapshot, CodeApprovalDecisionBody, CodeApprovalSnapshot, CodeCommitSnapshot,
-    CodeFileChange, CodePushSnapshot, CodeRepoSnapshot, CodeSessionSnapshot,
+    CodeFileChange, CodePushSnapshot, CodeRepoSnapshot, CodeSessionDigest, CodeSessionSnapshot,
     CodeTerminalActivityNotice, CodeTerminalRead, CodeTerminalSnapshot, CodeTurnSnapshot,
-    CodeWorkspaceDiff, CodeWorkspaceFiles, CodeWorkspacePrSnapshot, CodeWorkspaceSnapshot,
-    HarnessDoctorReport, QueuedCodeTurn, SequencedCodeEventFrame,
+    CodeUpdateNotice, CodeWorkspaceDiff, CodeWorkspaceFiles, CodeWorkspacePrSnapshot,
+    CodeWorkspaceSnapshot, HarnessDoctorReport, QueuedCodeTurn, SequencedCodeEventFrame,
 };
+pub(crate) use updates::code_updates;
 pub(crate) use workspaces::{
     archive_workspace, create_workspace, get_workspace, get_workspace_diff, list_workspace_files,
     list_workspaces, patch_workspace,

--- a/crates/tidebreak-server/src/routes/code/session_events.rs
+++ b/crates/tidebreak-server/src/routes/code/session_events.rs
@@ -38,6 +38,7 @@ async fn stream_events(mut socket: WebSocket, state: AppState, session: CodeSess
         return;
     };
     let mut live = runtime.bus.subscribe(session);
+    let _ = runtime.mark_session_viewed(session).await;
     let mut last_seq = after;
     if replay_after(&mut socket, &runtime.db, session, &mut last_seq)
         .await

--- a/crates/tidebreak-server/src/routes/code/sessions.rs
+++ b/crates/tidebreak-server/src/routes/code/sessions.rs
@@ -8,8 +8,8 @@ use crate::state::AppState;
 
 use super::require_code;
 use super::types::{
-    CodeSessionSnapshot, CodeTurnSnapshot, CreateSessionBody, QueuedCodeTurn, SteerBody,
-    SubmitTurnBody,
+    CodeSessionSnapshot, CodeTurnSnapshot, CreateSessionBody, QueuedCodeTurn, SetAttentionBody,
+    SteerBody, SubmitTurnBody,
 };
 use crate::code::runtime::SubmitTurnOutcome;
 use tidebreak_core::{CodeSessionId, WorkspaceId};
@@ -101,6 +101,17 @@ pub async fn interrupt_session(
 ) -> Result<StatusCode, ServerError> {
     require_code(&state)?.interrupt(id).await?;
     Ok(StatusCode::ACCEPTED)
+}
+
+pub async fn set_attention(
+    State(state): State<AppState>,
+    Path(id): Path<CodeSessionId>,
+    Json(body): Json<SetAttentionBody>,
+) -> Result<Json<CodeSessionSnapshot>, ServerError> {
+    let session = require_code(&state)?
+        .set_attention(id, body.clear, body.note)
+        .await?;
+    Ok(Json(CodeSessionSnapshot::from(session)))
 }
 
 pub async fn reap_session(

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -521,6 +521,91 @@ pub struct CodeTerminalActivityNotice {
     pub terminal_id: CodeTerminalId,
 }
 
+/// Cheap per-session digest on `/code/updates`.
+#[derive(Debug, Clone, PartialEq, Serialize, TS)]
+pub struct CodeSessionDigest {
+    pub workspace: WorkspaceId,
+    pub session: tidebreak_core::CodeSessionId,
+    pub lifecycle: CodeSessionLifecycle,
+    pub attention: Attention,
+    pub title: String,
+    pub turn_count: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub pr_state: Option<PullRequestDigest>,
+}
+
+impl From<crate::code::bus::SessionDigest> for CodeSessionDigest {
+    fn from(digest: crate::code::bus::SessionDigest) -> Self {
+        Self {
+            workspace: digest.workspace,
+            session: digest.session,
+            lifecycle: digest.lifecycle,
+            attention: digest.attention,
+            title: digest.title,
+            turn_count: digest.turn_count,
+            pr_state: digest.pr_state,
+        }
+    }
+}
+
+/// One unsequenced notice on `WS /code/updates`.
+///
+/// A connect is restated as [`Self::Snapshot`]; later notices are live only.
+#[derive(Debug, Clone, PartialEq, Serialize, TS)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CodeUpdateNotice {
+    /// Full current digest of every non-ended session.
+    Snapshot {
+        /// One row per live session.
+        sessions: Vec<CodeSessionDigest>,
+    },
+    /// One session's current digest.
+    Digest {
+        workspace: WorkspaceId,
+        session: tidebreak_core::CodeSessionId,
+        lifecycle: CodeSessionLifecycle,
+        attention: Attention,
+        title: String,
+        turn_count: i64,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        pr_state: Option<PullRequestDigest>,
+    },
+    /// Coalesced terminal activity. Not restated on connect.
+    TerminalActivity {
+        workspace_id: WorkspaceId,
+        terminal_id: CodeTerminalId,
+    },
+}
+
+impl CodeUpdateNotice {
+    pub(crate) fn digest(digest: crate::code::bus::SessionDigest) -> Self {
+        let wire = CodeSessionDigest::from(digest);
+        Self::Digest {
+            workspace: wire.workspace,
+            session: wire.session,
+            lifecycle: wire.lifecycle,
+            attention: wire.attention,
+            title: wire.title,
+            turn_count: wire.turn_count,
+            pr_state: wire.pr_state,
+        }
+    }
+}
+
+/// Body of `POST /code/sessions/{id}/attention`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SetAttentionBody {
+    /// Drop a Manual pin and restore computed state.
+    #[serde(default)]
+    pub clear: bool,
+    /// Pin a Manual note. Ignored when `clear` is true.
+    #[serde(default)]
+    pub note: Option<String>,
+}
+
 /// Body of `POST /code/workspaces/{id}/terminals`.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/tidebreak-server/src/routes/code/updates.rs
+++ b/crates/tidebreak-server/src/routes/code/updates.rs
@@ -1,0 +1,108 @@
+//! `WS /code/updates` — install-wide digest channel, restated on connect.
+
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::State;
+use axum::response::Response;
+use tokio::sync::broadcast::error::RecvError;
+
+use crate::auth::{offered_handshake_subprotocol, WS_HANDSHAKE_SUBPROTOCOL};
+use crate::code::attention::list_digests;
+use crate::code::bus::CodeLiveUpdate;
+use crate::error::ServerError;
+use crate::state::AppState;
+
+use super::require_code;
+use super::types::{CodeSessionDigest, CodeUpdateNotice};
+
+pub async fn code_updates(
+    State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
+    upgrade: WebSocketUpgrade,
+) -> Result<Response, ServerError> {
+    let _ = require_code(&state)?;
+    let upgrade = if offered_handshake_subprotocol(&headers) {
+        upgrade.protocols([WS_HANDSHAKE_SUBPROTOCOL])
+    } else {
+        upgrade
+    };
+    Ok(upgrade.on_upgrade(move |socket| stream_updates(socket, state)))
+}
+
+async fn stream_updates(mut socket: WebSocket, state: AppState) {
+    let Some(runtime) = state.code.clone() else {
+        return;
+    };
+    let mut live = runtime.bus.subscribe_updates();
+    let mut terminals = state.terminals.subscribe();
+    match list_digests(&runtime.db).await {
+        Ok(sessions) => {
+            let notice = CodeUpdateNotice::Snapshot {
+                sessions: sessions.into_iter().map(CodeSessionDigest::from).collect(),
+            };
+            if send_notice(&mut socket, &notice).await.is_err() {
+                return;
+            }
+        }
+        Err(_) => return,
+    }
+    loop {
+        tokio::select! {
+            incoming = socket.recv() => match incoming {
+                None | Some(Err(_)) | Some(Ok(Message::Close(_))) => break,
+                _ => {}
+            },
+            update = live.recv() => match update {
+                Ok(CodeLiveUpdate::Digest(digest)) => {
+                    if send_notice(&mut socket, &CodeUpdateNotice::digest(digest))
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                Err(RecvError::Lagged(_)) => {
+                    match list_digests(&runtime.db).await {
+                        Ok(sessions) => {
+                            let notice = CodeUpdateNotice::Snapshot {
+                                sessions: sessions
+                                    .into_iter()
+                                    .map(CodeSessionDigest::from)
+                                    .collect(),
+                            };
+                            if send_notice(&mut socket, &notice).await.is_err() {
+                                break;
+                            }
+                        }
+                        Err(_) => break,
+                    }
+                }
+                Err(RecvError::Closed) => break,
+            },
+            notice = terminals.recv() => match notice {
+                Ok(notice) => {
+                    if send_notice(
+                        &mut socket,
+                        &CodeUpdateNotice::TerminalActivity {
+                            workspace_id: notice.workspace_id,
+                            terminal_id: notice.terminal_id,
+                        },
+                    )
+                    .await
+                    .is_err()
+                    {
+                        break;
+                    }
+                }
+                Err(RecvError::Lagged(_)) => {}
+                Err(RecvError::Closed) => break,
+            },
+        }
+    }
+}
+
+async fn send_notice(socket: &mut WebSocket, notice: &CodeUpdateNotice) -> Result<(), axum::Error> {
+    let Ok(json) = serde_json::to_string(notice) else {
+        return Ok(());
+    };
+    socket.send(Message::Text(json.into())).await
+}

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -1967,6 +1967,359 @@ async fn oversized_write_approval_is_still_decidable() {
     assert_eq!(seen[0].1, ApprovalDecision::Approve);
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn updates_channel_restates_the_full_digest_on_reconnect() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let session_id = json_id(&session);
+
+    let mut request = format!("ws://{addr}/code/updates")
+        .into_client_request()
+        .unwrap();
+    request
+        .headers_mut()
+        .insert("Authorization", format!("Bearer {token}").parse().unwrap());
+    let (mut socket, _) = connect_async(request).await.unwrap();
+    let first = next_json(&mut socket).await;
+    assert_eq!(first["type"], "snapshot");
+    let sessions = first["sessions"].as_array().expect("snapshot sessions");
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0]["session"], session_id);
+    assert_eq!(sessions[0]["workspace"], json_id(&workspace));
+    assert_eq!(sessions[0]["title"], "first change");
+    assert_eq!(sessions[0]["turn_count"], 0);
+
+    let _ = client
+        .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "hi" }))
+        .send()
+        .await
+        .unwrap();
+
+    let mut saw_turn = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while tokio::time::Instant::now() < deadline {
+        let notice = tokio::time::timeout(Duration::from_millis(500), next_json(&mut socket))
+            .await
+            .ok();
+        let Some(notice) = notice else {
+            continue;
+        };
+        if notice["type"] == "digest" && notice["turn_count"] == 1 {
+            saw_turn = true;
+            break;
+        }
+    }
+    assert!(saw_turn, "live digest must carry the new turn count");
+    drop(socket);
+
+    let mut request = format!("ws://{addr}/code/updates")
+        .into_client_request()
+        .unwrap();
+    request
+        .headers_mut()
+        .insert("Authorization", format!("Bearer {token}").parse().unwrap());
+    let (mut socket, _) = connect_async(request).await.unwrap();
+    let restated = next_json(&mut socket).await;
+    assert_eq!(restated["type"], "snapshot");
+    let sessions = restated["sessions"].as_array().expect("restated sessions");
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0]["session"], session_id);
+    assert_eq!(sessions[0]["turn_count"], 1);
+    assert_eq!(sessions[0]["attention"]["state"]["type"], "done_unreviewed");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn attention_follows_approval_completion_and_view() {
+    let adapter = ScriptedAdapter::new(approval_script())
+        .with_approvals(CapLevel::Supported)
+        .with_delay(Duration::from_millis(20));
+    let (router, token, runtime, dir) = code_app_with(adapter).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "ask",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let session_id = json_id(&session).to_owned();
+
+    let turn = tokio::spawn({
+        let client = client.clone();
+        let token = token.clone();
+        let session_id = session_id.clone();
+        async move {
+            client
+                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .bearer_auth(&token)
+                .json(&serde_json::json!({ "message": "write it" }))
+                .send()
+                .await
+                .unwrap()
+        }
+    });
+
+    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let approval = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let listed = client
+                .get(format!("http://{addr}/code/approvals?state=pending"))
+                .bearer_auth(&token)
+                .send()
+                .await
+                .unwrap();
+            let body: Vec<serde_json::Value> = listed.json().await.unwrap();
+            if let Some(row) = body.into_iter().next() {
+                let session = tidebreak_core::db::code::get_session(&runtime.db, parsed)
+                    .await
+                    .unwrap()
+                    .unwrap();
+                if matches!(
+                    session.attention.state,
+                    AttentionState::NeedsYou {
+                        source: AttentionSource::Structured,
+                        ..
+                    }
+                ) {
+                    return row;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("pending structured NeedsYou never appeared");
+
+    let decided = client
+        .post(format!(
+            "http://{addr}/code/approvals/{}/decision",
+            approval["id"].as_str().unwrap()
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "decision": "approve" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(decided.status(), reqwest::StatusCode::OK);
+
+    let after_decision = tidebreak_core::db::code::get_session(&runtime.db, parsed)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        !matches!(
+            after_decision.attention.state,
+            AttentionState::NeedsYou {
+                source: AttentionSource::Structured,
+                ..
+            }
+        ),
+        "decision must lift structured NeedsYou, got {:?}",
+        after_decision.attention
+    );
+
+    let finished = turn.await.unwrap();
+    assert_eq!(finished.status(), reqwest::StatusCode::ACCEPTED);
+    let row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.attention.state, AttentionState::DoneUnreviewed);
+
+    let mut request = format!("ws://{addr}/code/sessions/{session_id}/events?after=0")
+        .into_client_request()
+        .unwrap();
+    request
+        .headers_mut()
+        .insert("Authorization", format!("Bearer {token}").parse().unwrap());
+    let (_socket, _) = connect_async(request).await.unwrap();
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
+                .await
+                .unwrap()
+                .unwrap();
+            if row.attention.state == AttentionState::Working {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("viewing the session must clear DoneUnreviewed");
+}
+
+#[tokio::test]
+async fn stall_sweep_marks_a_silent_running_session() {
+    let (router, token, runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let parsed: CodeSessionId = json_id(&session).parse().unwrap();
+    let mut row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
+        .await
+        .unwrap()
+        .unwrap();
+    row.lifecycle = CodeSessionLifecycle::Running;
+    tidebreak_core::db::code::save_session(&runtime.db, &row)
+        .await
+        .unwrap();
+
+    crate::code::attention::sweep_stalled(&runtime.db, &runtime.bus, 0)
+        .await
+        .unwrap();
+    let row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        matches!(row.attention.state, AttentionState::Stalled { .. }),
+        "{:?}",
+        row.attention
+    );
+}
+
+#[tokio::test]
+async fn user_can_pin_and_clear_attention() {
+    let (router, token, runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let session_id = json_id(&session);
+
+    let pinned = client
+        .post(format!(
+            "http://{addr}/code/sessions/{session_id}/attention"
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "note": "look at this later" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(pinned.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = pinned.json().await.unwrap();
+    assert_eq!(body["attention"]["state"]["type"], "manual");
+    assert_eq!(body["attention"]["state"]["note"], "look at this later");
+    assert_eq!(body["attention"]["source"], "user");
+
+    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let mut row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
+        .await
+        .unwrap()
+        .unwrap();
+    row.lifecycle = CodeSessionLifecycle::Running;
+    tidebreak_core::db::code::save_session(&runtime.db, &row)
+        .await
+        .unwrap();
+    crate::code::attention::sweep_stalled(&runtime.db, &runtime.bus, 0)
+        .await
+        .unwrap();
+    let row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        matches!(row.attention.state, AttentionState::Manual { .. }),
+        "Manual must survive the stall sweep"
+    );
+
+    let cleared = client
+        .post(format!(
+            "http://{addr}/code/sessions/{session_id}/attention"
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "clear": true }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(cleared.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = cleared.json().await.unwrap();
+    assert_ne!(body["attention"]["state"]["type"], "manual");
+}
+
+async fn next_json(
+    socket: &mut tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+) -> serde_json::Value {
+    loop {
+        let Some(frame) = socket.next().await else {
+            panic!("updates socket closed");
+        };
+        let WsMessage::Text(text) = frame.expect("ws frame") else {
+            continue;
+        };
+        return serde_json::from_str(text.as_str()).unwrap();
+    }
+}
+
 #[tokio::test]
 async fn doctor_lists_the_scripted_adapter() {
     let (router, token, _runtime, _dir) = code_app(plain_text_script()).await;

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -419,6 +419,8 @@ mod tests {
         generate::collect_from::<crate::routes::code::CodeTerminalSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeTerminalRead>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeTerminalActivityNotice>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::CodeSessionDigest>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::CodeUpdateNotice>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeApprovalSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeApprovalDecisionBody>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeCommitSnapshot>(&cfg, &mut out);


### PR DESCRIPTION
## Summary

Attention is computed on the server from real session signals and published on one install-wide updates channel, so the sidebar, workspace lists, and the workspace header agree without per-session sockets.

- Every attention write goes through one chokepoint that enforces `should_replace`: Manual is never overwritten automatically, and a structured `NeedsYou` is not downgraded by a heuristic stall.
- Automatic states come from live facts: `Working` while a turn runs, `NeedsYou{Structured}` on a pending approval, `NeedsYou{Lifecycle}` on a failed or interrupted turn, `Stalled` from a periodic sweep of silent running sessions, `DoneUnreviewed` after a completed turn, `Fenced` from recovery.
- `POST /code/sessions/{id}/attention` pins a Manual note or clears it back to the computed state. Connecting the session-events socket after completion clears `DoneUnreviewed`.
- `WS /code/updates` restates a full digest snapshot on connect (`workspace`, `session`, `lifecycle`, `attention`, `title`, `turn_count`, `pr_state`) and then publishes cheap row-backed notices. Terminal activity is forwarded as workspace-scoped notices, not per-byte.
- List surfaces read lifecycle/attention/PR from `CodeUpdatesStore`. Sidebar and repo list rows get attention badges. The workspace header can pin or clear a Manual note.
- A transition into `NeedsYou{Structured}` for a workspace the user is not viewing uses the existing desktop `request_user_attention` command. A richer OS notification is out of scope here.

## Tests

- Digest restatement on reconnect, including the turn count and `DoneUnreviewed` after a completed turn.
- Scripted-harness attention path: pending approval → structured `NeedsYou`; decision lifts it; completion → `DoneUnreviewed`; events-socket view clears it.
- Stall sweep on a silent running session; Manual survives both the sweep and fenced recovery.
- Replacement property at the persist chokepoint (Manual vs automatic, structured vs heuristic).
- Badge rendering per state, updates-store reducer, and not-viewing gating for the attention trigger.

Local: `cargo fmt`, `cargo clippy -p tidebreak-server --all-targets --locked -- -D warnings`, `cargo test -p tidebreak-server --locked --lib`, `cargo check --workspace --locked`, `pnpm test`, `pnpm build`. Rebased onto `origin/main` after #2136.