### PR TITLE
docs: mark code mode implemented and accept records 0030-0036

### DIFF
--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -1,10 +1,17 @@
 # Code mode
 
-Status: proposed design, pre-implementation. The decision records
+Status: implemented (first version). The decision records
 [`0030`](decisions/0030-code-mode-separate-surface.md) through
-[`0036`](decisions/0036-code-mode-auxiliary-terminals.md) carry the decisions;
-this page carries the working design detail an implementer needs in one
-place. Where this page and a decision record disagree, the record wins.
+[`0036`](decisions/0036-code-mode-auxiliary-terminals.md) carry the decisions
+and are accepted; this page carries the working design detail in one place.
+Where this page and a decision record disagree, the record wins. The first
+version ships the full surface described here — repos, workspaces, sessions,
+approvals, checkpoints and review, auxiliary terminals, the git/PR flow, the
+updates channel, and adapters for Claude Code (reference tier), Codex CLI,
+opencode, and Grok CLI (the last currently refuses every permission mode:
+its captured 1.0.4 print surface honors none of them, and honesty beats
+approximation) — with the deliberately parked scope recorded in
+[`docs/deferred.md`](deferred.md).
 
 Code mode is Tidebreak's second product surface: pick a local git repository,
 spin up isolated **workspaces** (one worktree + branch each), and run

--- a/docs/decisions/0030-code-mode-separate-surface.md
+++ b/docs/decisions/0030-code-mode-separate-surface.md
@@ -1,6 +1,6 @@
 # 30. Code Mode Is a Separate Surface Built for Later Convergence
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-08-15
 - Owners: code mode
 - Related: [`0007-cli-headless-feature-parity.md`](0007-cli-headless-feature-parity.md),

--- a/docs/decisions/0031-harness-adapter-boundary.md
+++ b/docs/decisions/0031-harness-adapter-boundary.md
@@ -1,6 +1,6 @@
 # 31. Harness Adapters: One Normalized Event Vocabulary Behind a Per-Harness Boundary
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-08-15
 - Owners: code mode, harness integration
 - Related: [`0030-code-mode-separate-surface.md`](0030-code-mode-separate-surface.md),

--- a/docs/decisions/0032-code-workspaces-worktrees-checkpoints.md
+++ b/docs/decisions/0032-code-workspaces-worktrees-checkpoints.md
@@ -1,6 +1,6 @@
 # 32. Workspaces: Worktrees, Branches, and Per-Turn Checkpoints via Git Shell-Out
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-08-15
 - Owners: code mode
 - Related: [`0030-code-mode-separate-surface.md`](0030-code-mode-separate-surface.md),

--- a/docs/decisions/0033-code-mode-approvals.md
+++ b/docs/decisions/0033-code-mode-approvals.md
@@ -1,6 +1,6 @@
 # 33. Code Mode Approvals Are First-Class and Deny Can Steer
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-08-15
 - Owners: code mode, approvals
 - Related: [`0031-harness-adapter-boundary.md`](0031-harness-adapter-boundary.md),

--- a/docs/decisions/0034-harness-discovery-credentials.md
+++ b/docs/decisions/0034-harness-discovery-credentials.md
@@ -1,6 +1,6 @@
 # 34. Harness Discovery and the Credential Boundary
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-08-15
 - Owners: code mode
 - Related: [`0031-harness-adapter-boundary.md`](0031-harness-adapter-boundary.md),

--- a/docs/decisions/0035-code-mode-wire-contract.md
+++ b/docs/decisions/0035-code-mode-wire-contract.md
@@ -1,6 +1,6 @@
 # 35. Code-Mode Wire Contract: Per-Session Journals Plus One Updates Channel
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-08-15
 - Owners: code mode, wire contract
 - Related: [`0030-code-mode-separate-surface.md`](0030-code-mode-separate-surface.md),

--- a/docs/decisions/0036-code-mode-auxiliary-terminals.md
+++ b/docs/decisions/0036-code-mode-auxiliary-terminals.md
@@ -1,6 +1,6 @@
 # 36. Auxiliary Terminals Are Ephemeral Byte Streams, Never the Harness Interface
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-08-15
 - Owners: code mode
 - Related: [`0031-harness-adapter-boundary.md`](0031-harness-adapter-boundary.md),


### PR DESCRIPTION
The first version of code mode is fully merged (#2123, #2124, #2125, #2130, #2131, #2133, #2134, #2135, #2136, #2137, #2138 on the #2122 design). This flips records 0030–0036 from Proposed to Accepted — merging was the acceptance, and the implementation now exists against them — and updates `docs/code-mode.md` from "proposed design, pre-implementation" to implemented, noting the Grok adapter's honest refuse-all-permission-modes state (its captured 1.0.4 print surface honors none of them).

Docs-only.