### PR TITLE
fix(desktop): replace native workspace selects with the shared Select

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -18,6 +18,13 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { friendlyErrorMessage } from "@/lib/utils";
 import { PermissionModePicker } from "./CodeComposer";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
@@ -128,25 +135,29 @@ export function NewWorkspaceDialog({
           </DialogDescription>
         </DialogHeader>
         <form className="flex flex-col gap-3" onSubmit={submit}>
-          <label className="flex flex-col gap-1 text-sm">
+          <div className="flex flex-col gap-1 text-sm">
             <span className="font-medium">Repo</span>
-            <select
-              className="h-10 rounded-md border border-border bg-background px-3 text-sm"
-              value={repoId}
-              onChange={(event) => {
-                setRepoId(event.target.value);
-                const next = repos.find((repo) => repo.id === event.target.value);
+            <Select
+              value={repoId || undefined}
+              onValueChange={(value) => {
+                setRepoId(value);
+                const next = repos.find((repo) => repo.id === value);
                 if (next) setBaseRef(next.default_base_ref);
               }}
-              disabled={creating || Boolean(defaultRepoId)}
+              disabled={creating || Boolean(defaultRepoId) || repos.length === 0}
             >
-              {repos.map((repo) => (
-                <option key={repo.id} value={repo.id}>
-                  {repo.display_name}
-                </option>
-              ))}
-            </select>
-          </label>
+              <SelectTrigger aria-label="Repo">
+                <SelectValue placeholder="No repos" />
+              </SelectTrigger>
+              <SelectContent scrollButtons={false}>
+                {repos.map((repo) => (
+                  <SelectItem key={repo.id} value={repo.id}>
+                    {repo.display_name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
           <label className="flex flex-col gap-1 text-sm">
             <span className="font-medium">Title</span>
             <Input
@@ -165,22 +176,26 @@ export function NewWorkspaceDialog({
               placeholder={selectedRepo?.default_base_ref}
             />
           </label>
-          <label className="flex flex-col gap-1 text-sm">
+          <div className="flex flex-col gap-1 text-sm">
             <span className="font-medium">Harness</span>
-            <select
-              className="h-10 rounded-md border border-border bg-background px-3 text-sm"
-              value={harness}
-              onChange={(event) => setHarness(event.target.value as HarnessKind)}
+            <Select
+              value={readyHarnesses.some((entry) => entry.kind === harness) ? harness : undefined}
+              onValueChange={(value) => setHarness(value as HarnessKind)}
               disabled={creating || readyHarnesses.length === 0}
             >
-              {readyHarnesses.map((entry) => (
-                <option key={entry.kind} value={entry.kind}>
-                  {HARNESS_LABELS[entry.kind]}
-                  {entry.version ? ` ${entry.version}` : ""}
-                </option>
-              ))}
-            </select>
-          </label>
+              <SelectTrigger aria-label="Harness">
+                <SelectValue placeholder="No ready harness" />
+              </SelectTrigger>
+              <SelectContent scrollButtons={false}>
+                {readyHarnesses.map((entry) => (
+                  <SelectItem key={entry.kind} value={entry.kind}>
+                    {HARNESS_LABELS[entry.kind]}
+                    {entry.version ? ` ${entry.version}` : ""}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
           <div className="flex flex-col gap-1 text-sm">
             <span className="font-medium">Permission mode</span>
             <PermissionModePicker

--- a/crates/tidebreak-desktop/ui/src/components/ui/select.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/ui/select.tsx
@@ -25,7 +25,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-10 w-full cursor-pointer items-center justify-between rounded-md border border-border bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       size === "sm" && "h-8 px-2 py-1 text-xs",
       className,
     )}
@@ -82,7 +82,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-96 min-w-32 overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+        "relative z-[60] max-h-96 min-w-32 overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className,


### PR DESCRIPTION
## Summary

The new-workspace **Repo** and **Harness** fields were the last native `<select>` elements in the desktop UI. Opening them drew the macOS system menu over the dialog instead of the in-app picker used everywhere else.

They now use the existing shadcn/Radix `Select` — the same control as settings model/provider pickers, web search, voice, and document zoom.

The shared trigger and menu also line up with nearby inputs: `border-border`, pointer cursor, menu shadow, and a z-index above dialogs so the list is usable inside this form.

## Test plan

- [x] `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit`
- [x] `pnpm --dir crates/tidebreak-desktop/ui test` (1076 passed)
- [ ] Open **New workspace** and confirm Repo / Harness open an in-app menu (no OS popup)
- [ ] Pick a different repo and harness; Create still uses those values
- [ ] Settings model/provider selects still open and pick as before

Could not drive the running desktop app in this session.