### PR TITLE
fix(desktop): show calculated values for uncached spreadsheet formulas

### DIFF
--- a/crates/tidebreak-desktop/ui/src/document/readOnlyWorkbookFormulaEngine.ts
+++ b/crates/tidebreak-desktop/ui/src/document/readOnlyWorkbookFormulaEngine.ts
@@ -1,0 +1,108 @@
+import workbookWasmUrl from "@dukelib/sheets-wasm/duke_sheets_wasm_bg.wasm?url";
+
+export type EvaluatedFormulaValue =
+  | { type: "boolean"; value: boolean }
+  | { type: "error"; value: string }
+  | { type: "number"; value: number }
+  | { type: "text"; value: string };
+
+export type EvaluatedFormulaMap = Record<string, EvaluatedFormulaValue>;
+
+type DukeModule = typeof import("@dukelib/sheets-wasm");
+
+let dukeModule: Promise<DukeModule> | null = null;
+
+function loadDuke(): Promise<DukeModule> {
+  dukeModule ??= import("@dukelib/sheets-wasm").then(async (mod) => {
+    await mod.default({ module_or_path: workbookWasmUrl });
+    return mod;
+  });
+  return dukeModule;
+}
+
+/**
+ * Evaluate formula cells that have no authored cached result.
+ *
+ * The read-only viewer paints cached `<v>` values and may skip its own
+ * calculation (too many formulas, or a dangling sheet reference anywhere in
+ * the book). Agent-built workbooks often ship live formulas and no cache, so
+ * the display copy has to compute those results itself.
+ */
+export async function evaluateUncachedFormulasWithDuke(
+  source: ArrayBuffer,
+  cells: ReadonlyArray<{ address: string; sheetIndex: number }>,
+): Promise<EvaluatedFormulaMap | null> {
+  if (cells.length === 0) return null;
+
+  const { Workbook } = await loadDuke();
+  const workbook = Workbook.fromBytes(new Uint8Array(source));
+  try {
+    workbook.calculate();
+    const values: EvaluatedFormulaMap = {};
+    for (const cell of cells) {
+      const parsed = parseA1(cell.address);
+      if (!parsed) continue;
+      try {
+        const evaluated = readEvaluatedValue(
+          workbook.getSheet(cell.sheetIndex).getCalculatedValueAt(
+            parsed.row,
+            parsed.col,
+          ),
+        );
+        if (evaluated) values[formulaValueKey(cell.sheetIndex, cell.address)] = evaluated;
+      } catch {
+        // A missing or unreadable sheet must not abort the rest of the bake.
+      }
+    }
+    return Object.keys(values).length > 0 ? values : null;
+  } finally {
+    workbook.free();
+  }
+}
+
+export function formulaValueKey(sheetIndex: number, address: string): string {
+  return `${sheetIndex}:${address}`;
+}
+
+function readEvaluatedValue(value: {
+  asBoolean: () => boolean | undefined;
+  asError: () => string | undefined;
+  asNumber: () => number | undefined;
+  asText: () => string | undefined;
+  is_boolean: boolean;
+  is_empty: boolean;
+  is_error: boolean;
+  is_number: boolean;
+  is_text: boolean;
+}): EvaluatedFormulaValue | null {
+  if (value.is_empty) return null;
+  if (value.is_number) {
+    const number = value.asNumber();
+    return number === undefined || !Number.isFinite(number)
+      ? null
+      : { type: "number", value: number };
+  }
+  if (value.is_boolean) {
+    return { type: "boolean", value: Boolean(value.asBoolean()) };
+  }
+  if (value.is_error) {
+    const error = value.asError()?.trim();
+    return error ? { type: "error", value: error } : null;
+  }
+  if (value.is_text) {
+    const text = value.asText();
+    return text === undefined ? null : { type: "text", value: text };
+  }
+  return null;
+}
+
+function parseA1(address: string): { col: number; row: number } | null {
+  const match = address.replaceAll("$", "").match(/^([A-Z]+)(\d+)$/i);
+  if (!match?.[1] || !match[2]) return null;
+  let col = 0;
+  for (const letter of match[1].toUpperCase()) {
+    col = col * 26 + letter.charCodeAt(0) - 64;
+  }
+  const row = Number(match[2]) - 1;
+  return row >= 0 ? { col: col - 1, row } : null;
+}

--- a/crates/tidebreak-desktop/ui/src/document/readOnlyWorkbookProjection.dom.test.ts
+++ b/crates/tidebreak-desktop/ui/src/document/readOnlyWorkbookProjection.dom.test.ts
@@ -1,11 +1,32 @@
 // @vitest-environment jsdom
 
 import JSZip from "jszip";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const formulaEngine = vi.hoisted(() => ({
+  evaluateUncachedFormulasWithDuke: vi.fn<
+    (
+      source: ArrayBuffer,
+      cells: ReadonlyArray<{ address: string; sheetIndex: number }>,
+    ) => Promise<Record<string, { type: string; value: boolean | number | string }> | null>
+  >(async () => null),
+}));
+
+vi.mock("./readOnlyWorkbookFormulaEngine", () => ({
+  evaluateUncachedFormulasWithDuke:
+    formulaEngine.evaluateUncachedFormulasWithDuke,
+  formulaValueKey: (sheetIndex: number, address: string) =>
+    `${sheetIndex}:${address}`,
+}));
 
 import { projectWorkbookForReadOnlyDisplay } from "./readOnlyWorkbookProjection";
 
 describe("projectWorkbookForReadOnlyDisplay", () => {
+  beforeEach(() => {
+    formulaEngine.evaluateUncachedFormulasWithDuke.mockReset();
+    formulaEngine.evaluateUncachedFormulasWithDuke.mockResolvedValue(null);
+  });
+
   it("renders cached values while retaining original formulas for inspection", async () => {
     const zip = new JSZip();
     zip.file(
@@ -41,6 +62,82 @@ describe("projectWorkbookForReadOnlyDisplay", () => {
       "42",
     );
     expect(cells[1]?.getElementsByTagNameNS("*", "f")).toHaveLength(1);
+  });
+
+  it("does not treat an empty cached value as a formula result", async () => {
+    const zip = new JSZip();
+    zip.file(
+      "xl/workbook.xml",
+      `<?xml version="1.0"?><workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Model" sheetId="1" r:id="rId1"/></sheets></workbook>`,
+    );
+    zip.file(
+      "xl/_rels/workbook.xml.rels",
+      `<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Target="worksheets/sheet1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/></Relationships>`,
+    );
+    zip.file(
+      "xl/worksheets/sheet1.xml",
+      `<?xml version="1.0"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData><row r="2"><c r="B2"><f>Assumptions!B6/4</f><v/></c></row></sheetData></worksheet>`,
+    );
+
+    const source = await zip.generateAsync({ type: "arraybuffer" });
+    const projection = await projectWorkbookForReadOnlyDisplay(source);
+    const projectedZip = await JSZip.loadAsync(projection.data);
+    const sheetXml = await projectedZip
+      .file("xl/worksheets/sheet1.xml")!
+      .async("string");
+    const document = new DOMParser().parseFromString(
+      sheetXml,
+      "application/xml",
+    );
+    const cell = document.getElementsByTagNameNS("*", "c")[0];
+
+    expect(projection.formulasBySheet).toEqual({
+      0: { B2: "=Assumptions!B6/4" },
+    });
+    expect(cell?.getElementsByTagNameNS("*", "f")).toHaveLength(1);
+    expect(cell?.getElementsByTagNameNS("*", "v")).toHaveLength(0);
+  });
+
+  it("bakes calculated results into formula cells that have no cached value", async () => {
+    formulaEngine.evaluateUncachedFormulasWithDuke.mockResolvedValue({
+      "0:B2": { type: "number", value: 25.6 },
+    });
+
+    const zip = new JSZip();
+    zip.file(
+      "xl/workbook.xml",
+      `<?xml version="1.0"?><workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="FCF Model" sheetId="1" r:id="rId1"/></sheets></workbook>`,
+    );
+    zip.file(
+      "xl/_rels/workbook.xml.rels",
+      `<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Target="worksheets/sheet1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/></Relationships>`,
+    );
+    zip.file(
+      "xl/worksheets/sheet1.xml",
+      `<?xml version="1.0"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData><row r="2"><c r="B2"><f>Assumptions!$B$6/4</f></c></row></sheetData></worksheet>`,
+    );
+
+    const source = await zip.generateAsync({ type: "arraybuffer" });
+    const projection = await projectWorkbookForReadOnlyDisplay(source);
+    const projectedZip = await JSZip.loadAsync(projection.data);
+    const sheetXml = await projectedZip
+      .file("xl/worksheets/sheet1.xml")!
+      .async("string");
+    const document = new DOMParser().parseFromString(
+      sheetXml,
+      "application/xml",
+    );
+    const cell = document.getElementsByTagNameNS("*", "c")[0];
+
+    expect(formulaEngine.evaluateUncachedFormulasWithDuke).toHaveBeenCalledWith(
+      source,
+      [{ address: "B2", sheetIndex: 0 }],
+    );
+    expect(projection.formulasBySheet).toEqual({
+      0: { B2: "=Assumptions!$B$6/4" },
+    });
+    expect(cell?.getElementsByTagNameNS("*", "f")).toHaveLength(0);
+    expect(cell?.getElementsByTagNameNS("*", "v")[0]?.textContent).toBe("25.6");
   });
 
   it("preserves border indices by expanding empty OOXML border records", async () => {

--- a/crates/tidebreak-desktop/ui/src/document/readOnlyWorkbookProjection.dom.test.ts
+++ b/crates/tidebreak-desktop/ui/src/document/readOnlyWorkbookProjection.dom.test.ts
@@ -226,6 +226,37 @@ describe("projectWorkbookForReadOnlyDisplay", () => {
     });
   });
 
+  it("projects data bars from baked formula results, not empty cached values", async () => {
+    formulaEngine.evaluateUncachedFormulasWithDuke.mockResolvedValue({
+      "0:D1": { type: "number", value: 0 },
+      "0:D2": { type: "number", value: 0.5 },
+      "0:D3": { type: "number", value: 1 },
+    });
+
+    const zip = new JSZip();
+    zip.file(
+      "xl/workbook.xml",
+      `<?xml version="1.0"?><workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Dashboard" sheetId="1" r:id="rId1"/></sheets></workbook>`,
+    );
+    zip.file(
+      "xl/_rels/workbook.xml.rels",
+      `<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Target="worksheets/sheet1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/></Relationships>`,
+    );
+    zip.file(
+      "xl/worksheets/sheet1.xml",
+      `<?xml version="1.0"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData><row r="1"><c r="D1"><f>A1</f><v/></c></row><row r="2"><c r="D2"><f>A2</f><v/></c></row><row r="3"><c r="D3"><f>A3</f><v/></c></row></sheetData><conditionalFormatting sqref="D1:D3"><cfRule type="dataBar" priority="1"><dataBar><cfvo type="min"/><cfvo type="max"/><color rgb="FF2979FF"/></dataBar></cfRule></conditionalFormatting></worksheet>`,
+    );
+
+    const source = await zip.generateAsync({ type: "arraybuffer" });
+    const projection = await projectWorkbookForReadOnlyDisplay(source);
+
+    expect(projection.conditionalStylesBySheet[0]).toMatchObject({
+      D1: { dataBar: { color: "#2979ff", widthPercent: 0 } },
+      D2: { dataBar: { color: "#2979ff", widthPercent: 50 } },
+      D3: { dataBar: { color: "#2979ff", widthPercent: 100 } },
+    });
+  });
+
   it("reads Excel packaging parts that start with a UTF-8 BOM", async () => {
     const zip = new JSZip();
     zip.file(

--- a/crates/tidebreak-desktop/ui/src/document/readOnlyWorkbookProjection.ts
+++ b/crates/tidebreak-desktop/ui/src/document/readOnlyWorkbookProjection.ts
@@ -82,11 +82,6 @@ async function projectWorkbookDisplayCopy(
         const document = parseXml(await entry.async("string"), path);
         const formulas: Record<string, string> = {};
         const uncached: { address: string; cell: Element }[] = [];
-        const conditionalStyles = projectConditionalStyles(document);
-
-        if (Object.keys(conditionalStyles).length > 0) {
-          conditionalStylesBySheet[sheetIndex] = conditionalStyles;
-        }
 
         for (const cell of localElements(document, "c")) {
           const formula = localChild(cell, "f");
@@ -151,6 +146,11 @@ async function projectWorkbookDisplayCopy(
       }
     }
 
+    const conditionalStyles = projectConditionalStyles(sheet.document);
+    if (Object.keys(conditionalStyles).length > 0) {
+      conditionalStylesBySheet[sheet.sheetIndex] = conditionalStyles;
+    }
+
     if (sheetChanged) {
       zip.file(sheet.path, new XMLSerializer().serializeToString(sheet.document));
       changed = true;
@@ -179,11 +179,8 @@ function projectConditionalStyles(
 
   for (const cell of localElements(document, "c")) {
     const address = cell.getAttribute("r")?.replaceAll("$", "").toUpperCase();
-    const rawValue = localChild(cell, "v")?.textContent;
-    const value =
-      rawValue === null || rawValue === undefined
-        ? Number.NaN
-        : Number(rawValue);
+    const rawValue = cellCachedValue(cell);
+    const value = rawValue === null ? Number.NaN : Number(rawValue);
     if (address && Number.isFinite(value)) numericValues.set(address, value);
   }
 

--- a/crates/tidebreak-desktop/ui/src/document/readOnlyWorkbookProjection.ts
+++ b/crates/tidebreak-desktop/ui/src/document/readOnlyWorkbookProjection.ts
@@ -1,5 +1,12 @@
 import JSZip from "jszip";
 
+import {
+  evaluateUncachedFormulasWithDuke,
+  formulaValueKey,
+  type EvaluatedFormulaMap,
+  type EvaluatedFormulaValue,
+} from "./readOnlyWorkbookFormulaEngine";
+
 const OFFICE_DOCUMENT_RELATIONSHIPS =
   "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
 const DRAWINGML =
@@ -32,8 +39,10 @@ export interface ReadOnlyWorkbookProjection {
  * Excel stores both a formula and its last calculated value. Browser formula
  * engines cannot reproduce every Excel function, but a viewer does not need
  * to: it can paint the cached result with the cell's original number format
- * and keep the formula separately for inspection. The source bytes are never
- * changed or written back.
+ * and keep the formula separately for inspection. Formula cells with no
+ * authored cache are calculated into the display copy so they still paint
+ * when the viewer skips its own engine. The source bytes are never changed
+ * or written back.
  */
 export async function projectWorkbookForReadOnlyDisplay(
   source: ArrayBuffer,
@@ -64,45 +73,89 @@ async function projectWorkbookDisplayCopy(
   let changed = await normalizeEmptyBorders(zip);
   if (await normalizeImplicitChartSeriesColors(zip)) changed = true;
 
-  await Promise.all(
-    sheetPaths.map(async (path, sheetIndex) => {
-      const entry = zip.file(path);
-      if (!entry) return;
+  const parsedSheets = (
+    await Promise.all(
+      sheetPaths.map(async (path, sheetIndex) => {
+        const entry = zip.file(path);
+        if (!entry) return null;
 
-      const document = parseXml(await entry.async("string"), path);
-      const formulas: Record<string, string> = {};
-      const conditionalStyles = projectConditionalStyles(document);
-      let sheetChanged = false;
+        const document = parseXml(await entry.async("string"), path);
+        const formulas: Record<string, string> = {};
+        const uncached: { address: string; cell: Element }[] = [];
+        const conditionalStyles = projectConditionalStyles(document);
 
-      if (Object.keys(conditionalStyles).length > 0) {
-        conditionalStylesBySheet[sheetIndex] = conditionalStyles;
-      }
-
-      for (const cell of localElements(document, "c")) {
-        const formula = localChild(cell, "f");
-        if (!formula) continue;
-
-        const address = cell.getAttribute("r");
-        const formulaText = formula.textContent?.trim();
-        if (address && formulaText) formulas[address] = `=${formulaText}`;
-
-        // Only replace formulas that have an authored cached result. Formulas
-        // without one still go through the workbook engine as a best effort.
-        if (localChild(cell, "v")) {
-          cell.removeChild(formula);
-          sheetChanged = true;
+        if (Object.keys(conditionalStyles).length > 0) {
+          conditionalStylesBySheet[sheetIndex] = conditionalStyles;
         }
-      }
 
-      if (Object.keys(formulas).length > 0) {
-        formulasBySheet[sheetIndex] = formulas;
-      }
-      if (sheetChanged) {
-        zip.file(path, new XMLSerializer().serializeToString(document));
-        changed = true;
-      }
-    }),
+        for (const cell of localElements(document, "c")) {
+          const formula = localChild(cell, "f");
+          if (!formula) continue;
+
+          const address = cell.getAttribute("r")?.replaceAll("$", "").toUpperCase();
+          const formulaText = formula.textContent?.trim();
+          if (address && formulaText) formulas[address] = `=${formulaText}`;
+
+          // An empty `<v>` is not a cached result. openpyxl and uncalculated
+          // Excel files emit one; treating it as authored would strip the
+          // formula and leave a blank cell.
+          if (address && !cellCachedValue(cell)) {
+            uncached.push({ address, cell });
+          }
+        }
+
+        if (Object.keys(formulas).length > 0) {
+          formulasBySheet[sheetIndex] = formulas;
+        }
+
+        return { document, path, sheetIndex, uncached };
+      }),
+    )
+  ).filter((sheet): sheet is ParsedSheet => sheet !== null);
+
+  const uncachedCells = parsedSheets.flatMap((sheet) =>
+    sheet.uncached.map((cell) => ({
+      address: cell.address,
+      sheetIndex: sheet.sheetIndex,
+    })),
   );
+  const evaluated = await evaluateUncachedFormulas(source, uncachedCells);
+
+  for (const sheet of parsedSheets) {
+    let sheetChanged = false;
+
+    if (evaluated) {
+      for (const { address, cell } of sheet.uncached) {
+        const value = evaluated[formulaValueKey(sheet.sheetIndex, address)];
+        if (!value) continue;
+        writeCachedFormulaValue(sheet.document, cell, value);
+        sheetChanged = true;
+      }
+    }
+
+    for (const cell of localElements(sheet.document, "c")) {
+      const formula = localChild(cell, "f");
+      if (!formula) continue;
+
+      // Only replace formulas that have an authored or baked cached result.
+      // Formulas still without one stay in the display copy as a best effort.
+      if (cellCachedValue(cell)) {
+        cell.removeChild(formula);
+        sheetChanged = true;
+        continue;
+      }
+      const emptyValue = localChild(cell, "v");
+      if (emptyValue) {
+        cell.removeChild(emptyValue);
+        sheetChanged = true;
+      }
+    }
+
+    if (sheetChanged) {
+      zip.file(sheet.path, new XMLSerializer().serializeToString(sheet.document));
+      changed = true;
+    }
+  }
 
   if (!changed) {
     return { conditionalStylesBySheet, data: source, formulasBySheet };
@@ -604,6 +657,70 @@ function parseXml(xml: string, path: string): XMLDocument {
 
 function emptyProjection(data: ArrayBuffer): ReadOnlyWorkbookProjection {
   return { conditionalStylesBySheet: {}, data, formulasBySheet: {} };
+}
+
+interface ParsedSheet {
+  document: XMLDocument;
+  path: string;
+  sheetIndex: number;
+  uncached: { address: string; cell: Element }[];
+}
+
+async function evaluateUncachedFormulas(
+  source: ArrayBuffer,
+  cells: ReadonlyArray<{ address: string; sheetIndex: number }>,
+): Promise<EvaluatedFormulaMap | null> {
+  if (cells.length === 0) return null;
+  try {
+    return await evaluateUncachedFormulasWithDuke(source, cells);
+  } catch {
+    return null;
+  }
+}
+
+function cellCachedValue(cell: Element): string | null {
+  const raw = localChild(cell, "v")?.textContent?.trim();
+  return raw ? raw : null;
+}
+
+function writeCachedFormulaValue(
+  document: XMLDocument,
+  cell: Element,
+  value: EvaluatedFormulaValue,
+): void {
+  const existing = localChild(cell, "v");
+  if (existing) cell.removeChild(existing);
+
+  switch (value.type) {
+    case "number":
+      cell.removeAttribute("t");
+      break;
+    case "boolean":
+      cell.setAttribute("t", "b");
+      break;
+    case "error":
+      cell.setAttribute("t", "e");
+      break;
+    case "text":
+      cell.setAttribute("t", "str");
+      break;
+  }
+
+  const cached = namespacedSibling(document, cell, "v");
+  cached.textContent = serializedFormulaValue(value);
+  cell.appendChild(cached);
+}
+
+function serializedFormulaValue(value: EvaluatedFormulaValue): string {
+  switch (value.type) {
+    case "boolean":
+      return value.value ? "1" : "0";
+    case "error":
+    case "text":
+      return value.value;
+    case "number":
+      return String(value.value);
+  }
 }
 
 function localElements(document: Document | Element, name: string): Element[] {


### PR DESCRIPTION
## Summary

Formula cells in the native workbook viewer showed a live formula in the formula bar and a blank grid. Agent-built workbooks typically write the formula and no Excel cached result, and two display-copy mistakes then hid the value:

- An empty `<v>` was treated as an authored cache, so the formula was stripped and the cell stayed empty.
- The canvas worker skips calculation above 1,000 formulas, or if any formula in the book points at a missing sheet. Remaining uncached cells never painted.

The display copy now evaluates those uncached formulas with the bundled Duke engine, writes the results as cached values, and still keeps the original formula for the formula bar. Source bytes are unchanged.

## Why

A generated FCF model (cross-sheet `INDEX` / `ROUNDUP` / `ROW`) is a normal Tidebreak deliverable. The viewer already prefers Excel's cached result so unsupported functions do not become `#VALUE!`. That path assumed a real cache. Without one, review showed empty revenue and FCF columns.

## Tests

- Empty `<v>` is no longer treated as a cached result; the formula stays in the display copy.
- A calculated number is baked into an uncached formula cell and the formula is retained for inspection.

Local: `pnpm exec vitest run src/document/readOnlyWorkbookProjection.dom.test.ts src/document/NativeSpreadsheetViewer.dom.test.tsx src/document/SpreadsheetViewer.dom.test.tsx`, `pnpm exec tsc --noEmit`.

Not verified in the running desktop app.