### PR TITLE
feat(cli): tidebreak code subcommands for the code-mode surface

### DIFF
--- a/crates/tidebreak-cli/src/api/client.rs
+++ b/crates/tidebreak-cli/src/api/client.rs
@@ -34,6 +34,8 @@ pub struct Client {
 /// The error body every route answers with on failure.
 #[derive(Deserialize)]
 struct ErrorBody {
+    #[serde(default)]
+    kind: Option<String>,
     message: String,
 }
 
@@ -573,19 +575,28 @@ impl Client {
     }
 
     /// Pass through a success, or lift the server's `{ kind, message }` body
-    /// into the error.
-    async fn expect_success(response: reqwest::Response) -> Result<reqwest::Response> {
+    /// into the error. The kind is part of the message so a script can branch
+    /// on the typed failure without scraping status codes.
+    pub(crate) async fn expect_success(response: reqwest::Response) -> Result<reqwest::Response> {
         if response.status().is_success() {
             return Ok(response);
         }
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
-        let message = serde_json::from_str::<ErrorBody>(&body)
-            .map(|body| body.message)
-            .unwrap_or(body);
-        Err(AgentError::msg(format!(
-            "request failed ({status}): {message}"
-        )))
+        match serde_json::from_str::<ErrorBody>(&body) {
+            Ok(ErrorBody {
+                kind: Some(kind),
+                message,
+            }) if !kind.is_empty() => Err(AgentError::msg(format!(
+                "request failed ({status}): {kind}: {message}"
+            ))),
+            Ok(ErrorBody { message, .. }) => Err(AgentError::msg(format!(
+                "request failed ({status}): {message}"
+            ))),
+            Err(_) => Err(AgentError::msg(format!(
+                "request failed ({status}): {body}"
+            ))),
+        }
     }
 
     // ------------------------------------------------------------------
@@ -738,7 +749,7 @@ impl Client {
     }
 
     /// GET a JSON body, lifting failures the way every other route does.
-    async fn get_json<T: serde::de::DeserializeOwned>(&self, url: String) -> Result<T> {
+    pub(crate) async fn get_json<T: serde::de::DeserializeOwned>(&self, url: String) -> Result<T> {
         let response = self.http.get(url).send().await.map_err(request_error)?;
         Self::expect_success(response)
             .await?
@@ -748,7 +759,7 @@ impl Client {
     }
 
     /// PUT a JSON body and decode the route's answer.
-    async fn put_json<T: serde::de::DeserializeOwned>(
+    pub(crate) async fn put_json<T: serde::de::DeserializeOwned>(
         &self,
         url: String,
         body: &serde_json::Value,
@@ -768,7 +779,10 @@ impl Client {
     }
 
     /// DELETE, decoding the route's answer.
-    async fn delete_json<T: serde::de::DeserializeOwned>(&self, url: String) -> Result<T> {
+    pub(crate) async fn delete_json<T: serde::de::DeserializeOwned>(
+        &self,
+        url: String,
+    ) -> Result<T> {
         let response = self.http.delete(url).send().await.map_err(request_error)?;
         Self::expect_success(response)
             .await?
@@ -778,10 +792,65 @@ impl Client {
     }
 
     /// DELETE a route that answers `204`.
-    async fn delete_ok(&self, url: String) -> Result<()> {
+    pub(crate) async fn delete_ok(&self, url: String) -> Result<()> {
         let response = self.http.delete(url).send().await.map_err(request_error)?;
         Self::expect_success(response).await?;
         Ok(())
+    }
+
+    /// POST a JSON body and decode the route's answer.
+    pub(crate) async fn post_json<T: serde::de::DeserializeOwned>(
+        &self,
+        url: String,
+        body: &serde_json::Value,
+    ) -> Result<T> {
+        let response = self
+            .http
+            .post(url)
+            .json(body)
+            .send()
+            .await
+            .map_err(request_error)?;
+        Self::expect_success(response)
+            .await?
+            .json::<T>()
+            .await
+            .map_err(request_error)
+    }
+
+    /// POST a JSON body when the route answers with a status only.
+    pub(crate) async fn post_ok(&self, url: String, body: &serde_json::Value) -> Result<()> {
+        let response = self
+            .http
+            .post(url)
+            .json(body)
+            .send()
+            .await
+            .map_err(request_error)?;
+        Self::expect_success(response).await?;
+        Ok(())
+    }
+
+    /// Open a WebSocket against a path on this server, using the same
+    /// `tidebreak-v1` + token subprotocol the chat event socket uses.
+    pub(crate) async fn open_ws(&self, path_and_query: &str) -> Result<EventSocket> {
+        let url = format!("{}{path_and_query}", self.base.replacen("http", "ws", 1));
+        let mut request = url
+            .into_client_request()
+            .map_err(|error| AgentError::msg(format!("bad event socket URL: {error}")))?;
+        request.headers_mut().insert(
+            SEC_WEBSOCKET_PROTOCOL,
+            HeaderValue::from_str(&format!("tidebreak-v1, tidebreak-token.{}", self.token))
+                .map_err(|error| AgentError::msg(format!("invalid subprotocol header: {error}")))?,
+        );
+        let (socket, _response) = connect_async(request)
+            .await
+            .map_err(|error| AgentError::msg(format!("event socket handshake failed: {error}")))?;
+        Ok(socket)
+    }
+
+    pub(crate) fn base_url(&self) -> &str {
+        &self.base
     }
 }
 

--- a/crates/tidebreak-cli/src/api/code.rs
+++ b/crates/tidebreak-cli/src/api/code.rs
@@ -1,0 +1,738 @@
+//! Code-mode wire types and the HTTP+WebSocket client methods that speak them.
+//!
+//! These types mirror the renderer-facing snapshots in
+//! `tidebreak-server::routes::code::types`. They are decoded loosely on purpose:
+//! a field the CLI does not render is dropped, and an unrecognized event kind
+//! still advances the journal cursor.
+
+use serde::{Deserialize, Serialize};
+use tidebreak_core::{
+    AgentError, Attention, CapLevel, CodeApprovalId, CodeApprovalKind, CodeApprovalState,
+    CodeEvent, CodePermissionMode, CodeSessionId, CodeSessionLifecycle, CodeTurnId, CodeTurnStatus,
+    CodeUsage, CodeWorkspaceStatus, Diffstat, FenceReason, FileChangeKind, HarnessCaps,
+    HarnessKind, HarnessTier, PullRequestDigest, QuickAction, RepoId, Result, WorkspaceId,
+};
+
+use super::client::{Client, EventSocket};
+
+/// A registered local git repository.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodeRepoSnapshot {
+    pub id: RepoId,
+    pub root_path: String,
+    pub display_name: String,
+    pub default_base_ref: String,
+    pub branch_prefix: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub setup_script: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub archive_script: Option<String>,
+    #[serde(default)]
+    pub quick_actions: Vec<QuickAction>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// One isolated workspace (worktree + branch) on a repo.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodeWorkspaceSnapshot {
+    pub id: WorkspaceId,
+    pub repo_id: RepoId,
+    pub title: String,
+    pub worktree_path: String,
+    pub branch_name: String,
+    pub base_ref: String,
+    pub status: CodeWorkspaceStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pr: Option<PullRequestDigest>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub archived_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// One durable conversation with an external agent engine.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CodeSessionSnapshot {
+    pub id: CodeSessionId,
+    pub workspace_id: WorkspaceId,
+    pub harness_kind: HarnessKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub harness_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub harness_resume_ref: Option<String>,
+    pub permission_mode: CodePermissionMode,
+    pub lifecycle: CodeSessionLifecycle,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fence_reason: Option<FenceReason>,
+    pub attention: Attention,
+    #[serde(default)]
+    pub unrecognized_event_count: i64,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// One user→engine turn.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CodeTurnSnapshot {
+    pub id: CodeTurnId,
+    pub session_id: CodeSessionId,
+    pub ordinal: i64,
+    pub status: CodeTurnStatus,
+    pub user_input: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usage: Option<CodeUsage>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub checkpoint_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diffstat: Option<Diffstat>,
+    pub started_at: chrono::DateTime<chrono::Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ended_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// A follow-up parked while the session is already running a turn.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QueuedCodeTurn {
+    pub session_id: CodeSessionId,
+    pub message: String,
+    pub position: i64,
+}
+
+/// Result of `POST /code/sessions/{id}/turns`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SubmitTurnResponse {
+    Ran(CodeTurnSnapshot),
+    Queued(QueuedCodeTurn),
+}
+
+/// One journaled event on the per-session WebSocket.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SequencedCodeEventFrame {
+    pub seq: i64,
+    pub event: CodeEvent,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub replayed: Option<bool>,
+}
+
+/// Doctor report for every registered engine adapter.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HarnessDoctorReport {
+    pub harnesses: Vec<HarnessDoctorEntry>,
+}
+
+/// One engine's probe, capabilities, and remediation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HarnessDoctorEntry {
+    pub kind: HarnessKind,
+    pub found: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    pub tier: HarnessTier,
+    pub caps: HarnessCaps,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authenticated: Option<bool>,
+    #[serde(default)]
+    pub remediation: String,
+    #[serde(default)]
+    pub stderr: String,
+    #[serde(default)]
+    pub unrecognized_event_count: i64,
+}
+
+/// Bounded changed-file list for `GET /code/workspaces/{id}/files`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodeWorkspaceFiles {
+    pub files: Vec<CodeFileChange>,
+    pub truncated: bool,
+    pub stat: Diffstat,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<CodeTurnId>,
+}
+
+/// One changed path in a workspace or turn file list.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodeFileChange {
+    pub path: String,
+    pub kind: FileChangeKind,
+    pub insertions: u32,
+    pub deletions: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous_path: Option<String>,
+}
+
+/// Bounded unified diff for `GET /code/workspaces/{id}/diff`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodeWorkspaceDiff {
+    pub diff: String,
+    pub truncated: bool,
+    pub stat: Diffstat,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<CodeTurnId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+}
+
+/// One parked or decided engine approval.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CodeApprovalSnapshot {
+    pub id: CodeApprovalId,
+    pub session_id: CodeSessionId,
+    pub turn_id: CodeTurnId,
+    pub kind: CodeApprovalKind,
+    pub harness_raw_json: String,
+    pub state: CodeApprovalState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub feedback: Option<String>,
+    pub requested_at: chrono::DateTime<chrono::Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub decided_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Result of staging and committing the workspace worktree.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodeCommitSnapshot {
+    pub sha: String,
+    pub message: String,
+    pub stat: Diffstat,
+}
+
+/// Result of pushing the workspace branch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodePushSnapshot {
+    pub branch: String,
+    pub remote: String,
+}
+
+/// PR + checks digest plus the local git facts the PR card needs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodeWorkspacePrSnapshot {
+    pub dirty: bool,
+    pub unpushed: bool,
+    pub ahead: u64,
+    pub has_upstream: bool,
+    pub suggested_commit_message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pr: Option<PullRequestDigest>,
+    pub gh_found: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gh_authenticated: Option<bool>,
+    #[serde(default)]
+    pub remediation: String,
+}
+
+/// Bounded output of one named quick action.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodeActionSnapshot {
+    pub name: String,
+    pub success: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+    pub timed_out: bool,
+}
+
+/// Cheap per-session digest on `/code/updates`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CodeSessionDigest {
+    pub workspace: WorkspaceId,
+    pub session: CodeSessionId,
+    pub lifecycle: CodeSessionLifecycle,
+    pub attention: Attention,
+    pub title: String,
+    pub turn_count: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pr_state: Option<PullRequestDigest>,
+}
+
+/// One unsequenced notice on `WS /code/updates`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CodeUpdateNotice {
+    Snapshot {
+        sessions: Vec<CodeSessionDigest>,
+    },
+    Digest {
+        workspace: WorkspaceId,
+        session: CodeSessionId,
+        lifecycle: CodeSessionLifecycle,
+        attention: Attention,
+        title: String,
+        turn_count: i64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pr_state: Option<PullRequestDigest>,
+    },
+    TerminalActivity {
+        workspace_id: WorkspaceId,
+        terminal_id: String,
+    },
+    #[serde(other)]
+    Unknown,
+}
+
+impl Client {
+    pub async fn list_harnesses(&self) -> Result<HarnessDoctorReport> {
+        self.get_json(format!("{}/code/harnesses", self.base_url()))
+            .await
+    }
+
+    pub async fn refresh_harnesses(&self) -> Result<HarnessDoctorReport> {
+        self.post_json(
+            format!("{}/code/harnesses/refresh", self.base_url()),
+            &serde_json::json!({}),
+        )
+        .await
+    }
+
+    pub async fn create_repo(
+        &self,
+        path: &str,
+        display_name: Option<&str>,
+        default_base_ref: Option<&str>,
+        branch_prefix: Option<&str>,
+    ) -> Result<CodeRepoSnapshot> {
+        let mut body = serde_json::json!({ "path": path });
+        if let Some(name) = display_name {
+            body["display_name"] = name.into();
+        }
+        if let Some(base) = default_base_ref {
+            body["default_base_ref"] = base.into();
+        }
+        if let Some(prefix) = branch_prefix {
+            body["branch_prefix"] = prefix.into();
+        }
+        self.post_json(format!("{}/code/repos", self.base_url()), &body)
+            .await
+    }
+
+    pub async fn list_repos(&self) -> Result<Vec<CodeRepoSnapshot>> {
+        self.get_json(format!("{}/code/repos", self.base_url()))
+            .await
+    }
+
+    pub async fn delete_repo(&self, id: RepoId) -> Result<()> {
+        self.delete_ok(format!("{}/code/repos/{id}", self.base_url()))
+            .await
+    }
+
+    pub async fn create_workspace(
+        &self,
+        repo_id: RepoId,
+        title: Option<&str>,
+        base_ref: Option<&str>,
+    ) -> Result<CodeWorkspaceSnapshot> {
+        let mut body = serde_json::json!({ "repo_id": repo_id });
+        if let Some(title) = title {
+            body["title"] = title.into();
+        }
+        if let Some(base) = base_ref {
+            body["base_ref"] = base.into();
+        }
+        self.post_json(format!("{}/code/workspaces", self.base_url()), &body)
+            .await
+    }
+
+    pub async fn list_workspaces(
+        &self,
+        repo_id: Option<RepoId>,
+    ) -> Result<Vec<CodeWorkspaceSnapshot>> {
+        let mut url = format!("{}/code/workspaces", self.base_url());
+        if let Some(repo_id) = repo_id {
+            url.push_str(&format!("?repo_id={repo_id}"));
+        }
+        self.get_json(url).await
+    }
+
+    pub async fn get_workspace(&self, id: WorkspaceId) -> Result<CodeWorkspaceSnapshot> {
+        self.get_json(format!("{}/code/workspaces/{id}", self.base_url()))
+            .await
+    }
+
+    pub async fn archive_workspace(
+        &self,
+        id: WorkspaceId,
+        force: bool,
+    ) -> Result<CodeWorkspaceSnapshot> {
+        self.post_json(
+            format!("{}/code/workspaces/{id}/archive", self.base_url()),
+            &serde_json::json!({ "force": force }),
+        )
+        .await
+    }
+
+    pub async fn list_workspace_sessions(
+        &self,
+        id: WorkspaceId,
+    ) -> Result<Vec<CodeSessionSnapshot>> {
+        self.get_json(format!("{}/code/workspaces/{id}/sessions", self.base_url()))
+            .await
+    }
+
+    pub async fn create_session(
+        &self,
+        workspace: WorkspaceId,
+        harness: HarnessKind,
+        permission_mode: CodePermissionMode,
+    ) -> Result<CodeSessionSnapshot> {
+        self.post_json(
+            format!("{}/code/workspaces/{workspace}/sessions", self.base_url()),
+            &serde_json::json!({
+                "harness": harness,
+                "permission_mode": permission_mode,
+            }),
+        )
+        .await
+    }
+
+    pub async fn submit_turn(
+        &self,
+        session: CodeSessionId,
+        message: &str,
+    ) -> Result<SubmitTurnResponse> {
+        self.post_json(
+            format!("{}/code/sessions/{session}/turns", self.base_url()),
+            &serde_json::json!({ "message": message }),
+        )
+        .await
+    }
+
+    pub async fn list_session_turns(
+        &self,
+        session: CodeSessionId,
+    ) -> Result<Vec<CodeTurnSnapshot>> {
+        self.get_json(format!("{}/code/sessions/{session}/turns", self.base_url()))
+            .await
+    }
+
+    pub async fn interrupt_session(&self, session: CodeSessionId) -> Result<()> {
+        self.post_ok(
+            format!("{}/code/sessions/{session}/interrupt", self.base_url()),
+            &serde_json::json!({}),
+        )
+        .await
+    }
+
+    pub async fn reap_session(&self, session: CodeSessionId) -> Result<CodeSessionSnapshot> {
+        self.post_json(
+            format!("{}/code/sessions/{session}/reap", self.base_url()),
+            &serde_json::json!({}),
+        )
+        .await
+    }
+
+    pub async fn list_approvals(
+        &self,
+        session: Option<CodeSessionId>,
+        pending_only: bool,
+    ) -> Result<Vec<CodeApprovalSnapshot>> {
+        let mut url = format!("{}/code/approvals", self.base_url());
+        let mut separator = '?';
+        if pending_only {
+            url.push_str("?state=pending");
+            separator = '&';
+        }
+        if let Some(session) = session {
+            url.push(separator);
+            url.push_str("session_id=");
+            url.push_str(&session.to_string());
+        }
+        self.get_json(url).await
+    }
+
+    pub async fn decide_code_approval(
+        &self,
+        id: CodeApprovalId,
+        approve: bool,
+        feedback: Option<&str>,
+    ) -> Result<CodeApprovalSnapshot> {
+        let mut body = serde_json::json!({
+            "decision": if approve { "approve" } else { "deny" },
+        });
+        if let Some(feedback) = feedback {
+            body["feedback"] = feedback.into();
+        }
+        self.post_json(
+            format!("{}/code/approvals/{id}/decision", self.base_url()),
+            &body,
+        )
+        .await
+    }
+
+    pub async fn workspace_files(
+        &self,
+        workspace: WorkspaceId,
+        turn: Option<CodeTurnId>,
+    ) -> Result<CodeWorkspaceFiles> {
+        let mut url = format!("{}/code/workspaces/{workspace}/files", self.base_url());
+        if let Some(turn) = turn {
+            url.push_str(&format!("?turn={turn}"));
+        }
+        self.get_json(url).await
+    }
+
+    pub async fn workspace_diff(
+        &self,
+        workspace: WorkspaceId,
+        turn: Option<CodeTurnId>,
+        file: Option<&str>,
+    ) -> Result<CodeWorkspaceDiff> {
+        let mut url = format!("{}/code/workspaces/{workspace}/diff", self.base_url());
+        let mut separator = '?';
+        if let Some(turn) = turn {
+            url.push(separator);
+            url.push_str("turn=");
+            url.push_str(&turn.to_string());
+            separator = '&';
+        }
+        if let Some(file) = file {
+            url.push(separator);
+            url.push_str("file=");
+            url.push_str(&urlencode(file));
+        }
+        self.get_json(url).await
+    }
+
+    pub async fn git_commit(
+        &self,
+        workspace: WorkspaceId,
+        message: Option<&str>,
+    ) -> Result<CodeCommitSnapshot> {
+        let body = match message {
+            Some(message) => serde_json::json!({ "message": message }),
+            None => serde_json::json!({}),
+        };
+        self.post_json(
+            format!("{}/code/workspaces/{workspace}/git/commit", self.base_url()),
+            &body,
+        )
+        .await
+    }
+
+    pub async fn git_push(&self, workspace: WorkspaceId) -> Result<CodePushSnapshot> {
+        self.post_json(
+            format!("{}/code/workspaces/{workspace}/git/push", self.base_url()),
+            &serde_json::json!({}),
+        )
+        .await
+    }
+
+    pub async fn git_pr(
+        &self,
+        workspace: WorkspaceId,
+        title: Option<&str>,
+        body: Option<&str>,
+    ) -> Result<CodeWorkspacePrSnapshot> {
+        let mut payload = serde_json::json!({});
+        if let Some(title) = title {
+            payload["title"] = title.into();
+        }
+        if let Some(body) = body {
+            payload["body"] = body.into();
+        }
+        self.post_json(
+            format!("{}/code/workspaces/{workspace}/git/pr", self.base_url()),
+            &payload,
+        )
+        .await
+    }
+
+    pub async fn git_status(&self, workspace: WorkspaceId) -> Result<CodeWorkspacePrSnapshot> {
+        self.get_json(format!(
+            "{}/code/workspaces/{workspace}/pr",
+            self.base_url()
+        ))
+        .await
+    }
+
+    pub async fn run_action(
+        &self,
+        workspace: WorkspaceId,
+        name: &str,
+    ) -> Result<CodeActionSnapshot> {
+        self.post_json(
+            format!(
+                "{}/code/workspaces/{workspace}/actions/{name}",
+                self.base_url()
+            ),
+            &serde_json::json!({}),
+        )
+        .await
+    }
+
+    pub async fn open_code_events(
+        &self,
+        session: CodeSessionId,
+        after: i64,
+    ) -> Result<EventSocket> {
+        self.open_ws(&format!("/code/sessions/{session}/events?after={after}"))
+            .await
+    }
+
+    pub async fn open_code_updates(&self) -> Result<EventSocket> {
+        self.open_ws("/code/updates").await
+    }
+}
+
+/// Summarize capability flags that are actually supported, for the doctor table.
+pub fn supported_caps_summary(caps: &HarnessCaps) -> String {
+    let flags = [
+        ("resume", caps.resume),
+        ("streaming", caps.streaming_deltas),
+        ("approvals", caps.structured_approvals),
+        ("steering", caps.mid_turn_steering),
+        ("plan", caps.plan_mode),
+        ("reasoning", caps.reasoning_levels),
+        ("file_events", caps.native_file_change_events),
+        ("interrupt", caps.native_interrupt),
+    ];
+    let supported: Vec<&str> = flags
+        .into_iter()
+        .filter(|(_, level)| *level == CapLevel::Supported)
+        .map(|(name, _)| name)
+        .collect();
+    if supported.is_empty() {
+        "none".to_owned()
+    } else {
+        supported.join(",")
+    }
+}
+
+fn urlencode(value: &str) -> String {
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                encoded.push(byte as char)
+            }
+            _ => encoded.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    encoded
+}
+
+/// Exit status a `tidebreak code run` turn maps to. Completed is zero;
+/// everything else is a failure of the work, not of the command itself.
+pub fn turn_exit_code(event: &CodeEvent) -> Option<i32> {
+    match event {
+        CodeEvent::TurnCompleted { .. } => Some(0),
+        CodeEvent::TurnFailed { .. } | CodeEvent::TurnInterrupted => Some(1),
+        _ => None,
+    }
+}
+
+/// Whether this event ends the turn `code run` is waiting on.
+pub fn is_turn_terminal(event: &CodeEvent) -> bool {
+    turn_exit_code(event).is_some()
+}
+
+/// Decode one session-event socket frame. Unknown payloads are ignored by
+/// the human renderer; `--json` prints the raw line instead of this type.
+pub fn decode_event_frame(text: &str) -> Result<SequencedCodeEventFrame> {
+    serde_json::from_str(text)
+        .map_err(|error| AgentError::msg(format!("bad code event frame: {error}")))
+}
+
+/// Decode one `/code/updates` notice. An unrecognized tag becomes
+/// [`CodeUpdateNotice::Unknown`] rather than failing the stream.
+pub fn decode_update_notice(text: &str) -> Result<CodeUpdateNotice> {
+    serde_json::from_str(text)
+        .map_err(|error| AgentError::msg(format!("bad code update notice: {error}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tidebreak_core::{AttentionSource, AttentionState};
+
+    #[test]
+    fn a_sequenced_frame_round_trips_the_fields_agents_script_against() {
+        let raw = serde_json::json!({
+            "seq": 4,
+            "event": {
+                "type": "assistant_delta",
+                "text": "hello"
+            },
+            "replayed": true
+        });
+        let frame: SequencedCodeEventFrame = serde_json::from_value(raw.clone()).unwrap();
+        assert_eq!(frame.seq, 4);
+        assert_eq!(frame.replayed, Some(true));
+        assert!(matches!(
+            frame.event,
+            CodeEvent::AssistantDelta { ref text } if text == "hello"
+        ));
+        let encoded = serde_json::to_value(&frame).unwrap();
+        assert_eq!(encoded["seq"], 4);
+        assert_eq!(encoded["event"]["type"], "assistant_delta");
+        assert_eq!(encoded["event"]["text"], "hello");
+        assert_eq!(encoded["replayed"], true);
+    }
+
+    #[test]
+    fn a_turn_completed_frame_is_the_zero_exit() {
+        let frame = decode_event_frame(
+            r#"{"seq":9,"event":{"type":"turn_completed","usage":{"input_tokens":1,"output_tokens":2}}}"#,
+        )
+        .unwrap();
+        assert_eq!(turn_exit_code(&frame.event), Some(0));
+        assert!(is_turn_terminal(&frame.event));
+    }
+
+    #[test]
+    fn failed_and_interrupted_turns_are_nonzero() {
+        let failed = decode_event_frame(
+            r#"{"seq":3,"event":{"type":"turn_failed","error":{"message":"boom"}}}"#,
+        )
+        .unwrap();
+        let interrupted =
+            decode_event_frame(r#"{"seq":4,"event":{"type":"turn_interrupted"}}"#).unwrap();
+        assert_eq!(turn_exit_code(&failed.event), Some(1));
+        assert_eq!(turn_exit_code(&interrupted.event), Some(1));
+    }
+
+    #[test]
+    fn update_snapshot_and_digest_keep_their_tags() {
+        let snapshot = decode_update_notice(r#"{"type":"snapshot","sessions":[]}"#).unwrap();
+        assert!(matches!(snapshot, CodeUpdateNotice::Snapshot { sessions } if sessions.is_empty()));
+
+        let digest = decode_update_notice(
+            &serde_json::json!({
+                "type": "digest",
+                "workspace": "00000000-0000-0000-0000-000000000001",
+                "session": "00000000-0000-0000-0000-000000000002",
+                "lifecycle": "running",
+                "attention": {
+                    "state": { "type": "working" },
+                    "source": "lifecycle"
+                },
+                "title": "fix login",
+                "turn_count": 2
+            })
+            .to_string(),
+        )
+        .unwrap();
+        match digest {
+            CodeUpdateNotice::Digest {
+                title,
+                turn_count,
+                attention,
+                lifecycle,
+                ..
+            } => {
+                assert_eq!(title, "fix login");
+                assert_eq!(turn_count, 2);
+                assert_eq!(lifecycle, CodeSessionLifecycle::Running);
+                assert!(matches!(attention.state, AttentionState::Working));
+                assert_eq!(attention.source, AttentionSource::Lifecycle);
+            }
+            other => panic!("expected digest, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_unknown_update_tag_does_not_kill_the_stream() {
+        let notice = decode_update_notice(r#"{"type":"future_kind","extra":true}"#).unwrap();
+        assert!(matches!(notice, CodeUpdateNotice::Unknown));
+    }
+}

--- a/crates/tidebreak-cli/src/api/mod.rs
+++ b/crates/tidebreak-cli/src/api/mod.rs
@@ -5,4 +5,5 @@
 //! consumes; [`wire`] decodes the event socket's frames forward-compatibly.
 
 pub mod client;
+pub mod code;
 pub mod wire;

--- a/crates/tidebreak-cli/src/code.rs
+++ b/crates/tidebreak-cli/src/code.rs
@@ -13,7 +13,7 @@ use std::str::FromStr;
 
 use futures::StreamExt as _;
 use tidebreak_core::{
-    AgentError, Attention, AttentionState, CodeApprovalId, CodeApprovalKind, CodeEvent,
+    AgentError, Attention, AttentionState, CapLevel, CodeApprovalId, CodeApprovalKind, CodeEvent,
     CodePermissionMode, CodeSessionId, CodeSessionLifecycle, CodeTurnId, HarnessKind, RepoId,
     Result, WorkspaceId,
 };
@@ -69,7 +69,8 @@ usage: tidebreak code doctor [--refresh]
 
 Every verb takes --json (or --output-format json). run and watch stream NDJSON
 under --json. --timeout is seconds. watch --once prints the connect snapshot
-and exits.";
+and exits. session start without --mode uses ask when the doctor says
+structured approvals are supported, otherwise plan.";
 
 const RECONNECT_ATTEMPTS: usize = 3;
 const RECONNECT_DELAY: std::time::Duration = std::time::Duration::from_millis(200);
@@ -133,7 +134,10 @@ pub enum Command {
     SessionStart {
         workspace: WorkspaceId,
         harness: HarnessKind,
-        mode: CodePermissionMode,
+        /// `None` means the doctor-driven default: ask when this engine's
+        /// structured approvals are Supported, otherwise plan. An explicit
+        /// `--mode` is passed through verbatim.
+        mode: Option<CodePermissionMode>,
         format: OutputFormat,
     },
     SessionShow {
@@ -425,9 +429,13 @@ async fn execute(client: &Client, command: Command) -> Result<i32> {
             mode,
             format,
         } => {
+            let (mode, fallback_note) = resolve_start_mode(client, harness, mode).await?;
             let session = client.create_session(workspace, harness, mode).await?;
             if format == OutputFormat::Json {
                 return emit_ok(&session);
+            }
+            if let Some(note) = fallback_note {
+                println!("tidebreak: {note}");
             }
             println!(
                 "tidebreak: session {}  {}  {}",
@@ -752,6 +760,37 @@ async fn resolve_run_session(
     let sessions = client.list_workspace_sessions(workspace).await?;
     pick_active_session(&sessions)
         .ok_or_else(|| AgentError::msg(format!("workspace {workspace} has no active session")))
+}
+
+/// Desktop create default: Ask only when this engine's structured
+/// approvals are Supported. Anything else (Unsupported, Unknown, missing
+/// doctor row) is Plan — the mode a harness without a live approval
+/// channel can still honor.
+fn default_create_permission_mode(approvals: Option<CapLevel>) -> CodePermissionMode {
+    match approvals {
+        Some(CapLevel::Supported) => CodePermissionMode::Ask,
+        _ => CodePermissionMode::Plan,
+    }
+}
+
+async fn resolve_start_mode(
+    client: &Client,
+    harness: HarnessKind,
+    explicit: Option<CodePermissionMode>,
+) -> Result<(CodePermissionMode, Option<&'static str>)> {
+    if let Some(mode) = explicit {
+        return Ok((mode, None));
+    }
+    let report = client.list_harnesses().await?;
+    let approvals = report
+        .harnesses
+        .iter()
+        .find(|entry| entry.kind == harness)
+        .map(|entry| entry.caps.structured_approvals);
+    let mode = default_create_permission_mode(approvals);
+    let note = (mode == CodePermissionMode::Plan)
+        .then_some("starting in plan mode — approvals unavailable on this engine");
+    Ok((mode, note))
 }
 
 fn pick_active_session(sessions: &[CodeSessionSnapshot]) -> Option<CodeSessionId> {
@@ -1657,7 +1696,7 @@ fn parse_session(cursor: &mut Cursor) -> std::result::Result<Command, String> {
         "start" => {
             let mut workspace = None;
             let mut harness = None;
-            let mut mode = CodePermissionMode::DEFAULT;
+            let mut mode = None;
             let mut flags = SharedFlags {
                 format: OutputFormat::Text,
             };
@@ -1665,7 +1704,7 @@ fn parse_session(cursor: &mut Cursor) -> std::result::Result<Command, String> {
                 match arg.as_str() {
                     "--ws" => workspace = Some(parse_workspace_id(&cursor.value("--ws")?)?),
                     "--harness" => harness = Some(parse_harness(&cursor.value("--harness")?)?),
-                    "--mode" => mode = parse_mode(&cursor.value("--mode")?)?,
+                    "--mode" => mode = Some(parse_mode(&cursor.value("--mode")?)?),
                     other => take_format(&mut flags, cursor, other)?,
                 }
             }
@@ -2130,8 +2169,26 @@ mod tests {
                 ..
             } => {
                 assert_eq!(harness, HarnessKind::ClaudeCode);
-                assert_eq!(mode, CodePermissionMode::Ask);
+                assert_eq!(mode, None);
                 assert_eq!(format, OutputFormat::Text);
+            }
+            other => panic!("{other:?}"),
+        }
+        match parse(args(&[
+            "session",
+            "start",
+            "--ws",
+            &ws,
+            "--harness",
+            "grok",
+            "--mode",
+            "ask",
+        ]))
+        .unwrap()
+        {
+            Command::SessionStart { mode, harness, .. } => {
+                assert_eq!(harness, HarnessKind::Grok);
+                assert_eq!(mode, Some(CodePermissionMode::Ask));
             }
             other => panic!("{other:?}"),
         }
@@ -2306,6 +2363,26 @@ mod tests {
             Command::Run { timeout, .. } => assert_eq!(timeout, Some(30)),
             other => panic!("{other:?}"),
         }
+    }
+
+    #[test]
+    fn omitted_mode_follows_the_desktop_doctor_default() {
+        assert_eq!(
+            default_create_permission_mode(Some(CapLevel::Supported)),
+            CodePermissionMode::Ask
+        );
+        assert_eq!(
+            default_create_permission_mode(Some(CapLevel::Unsupported)),
+            CodePermissionMode::Plan
+        );
+        assert_eq!(
+            default_create_permission_mode(Some(CapLevel::Unknown)),
+            CodePermissionMode::Plan
+        );
+        assert_eq!(
+            default_create_permission_mode(None),
+            CodePermissionMode::Plan
+        );
     }
 
     #[test]

--- a/crates/tidebreak-cli/src/code.rs
+++ b/crates/tidebreak-cli/src/code.rs
@@ -30,8 +30,46 @@ use crate::print::OutputFormat;
 
 /// Exit status when `--on-approval fail` sees a parked approval.
 const EXIT_APPROVAL_PARKED: i32 = 3;
+/// Timed out waiting for a turn or a watch snapshot. Same number GNU
+/// `timeout(1)` uses, so a driver can treat both the same way.
+const EXIT_TIMEOUT: i32 = 124;
 /// SIGINT, following the shell's 128+signal convention and `-p`.
 const EXIT_INTERRUPTED: i32 = 130;
+
+/// Short usage for the `code` family. Parse errors print this instead of the
+/// whole CLI surface — a driving agent should not have to scrape 80 lines to
+/// see that `--session` was missing.
+pub const USAGE: &str = "\
+usage: tidebreak code doctor [--refresh]
+       tidebreak code repo add <path> [--name <name>] [--base-ref <ref>] [--branch-prefix <p>]
+       tidebreak code repo list
+       tidebreak code repo rm <id>
+       tidebreak code ws new --repo <id|path> [--title <title>] [--base-ref <ref>]
+       tidebreak code ws list [--repo <id|path>]
+       tidebreak code ws show <id>
+       tidebreak code ws archive <id> [--force]
+       tidebreak code session start --ws <id> --harness <kind> [--mode plan|ask|auto]
+       tidebreak code session show <id>
+       tidebreak code session reap <id>
+       tidebreak code run (--session <id> | --ws <id>) [<message>]
+                  [--on-approval wait|fail] [--timeout <secs>]
+       tidebreak code approvals [--session <id>]
+       tidebreak code approve <approval-id>
+       tidebreak code deny <approval-id> [-m <feedback>]
+       tidebreak code interrupt --session <id>
+       tidebreak code turns --session <id>
+       tidebreak code diff --ws <id> [--turn N] [--file PATH]
+       tidebreak code files --ws <id> [--turn N]
+       tidebreak code git commit --ws <id> [-m MSG]
+       tidebreak code git push --ws <id>
+       tidebreak code git pr --ws <id> [--title <title>] [--body <body>]
+       tidebreak code git status --ws <id>
+       tidebreak code action <name> --ws <id>
+       tidebreak code watch [--once] [--timeout <secs>]
+
+Every verb takes --json (or --output-format json). run and watch stream NDJSON
+under --json. --timeout is seconds. watch --once prints the connect snapshot
+and exits.";
 
 const RECONNECT_ATTEMPTS: usize = 3;
 const RECONNECT_DELAY: std::time::Duration = std::time::Duration::from_millis(200);
@@ -111,6 +149,7 @@ pub enum Command {
         workspace: Option<WorkspaceId>,
         message: String,
         on_approval: OnApproval,
+        timeout: Option<u64>,
         format: OutputFormat,
     },
     Approvals {
@@ -170,6 +209,8 @@ pub enum Command {
         format: OutputFormat,
     },
     Watch {
+        once: bool,
+        timeout: Option<u64>,
         format: OutputFormat,
     },
 }
@@ -432,10 +473,20 @@ async fn execute(client: &Client, command: Command) -> Result<i32> {
             workspace,
             message,
             on_approval,
+            timeout,
             format,
         } => {
             let session = resolve_run_session(client, session, workspace).await?;
-            run_turn(client, session, &message, on_approval, format).await
+            eprintln!("tidebreak: session {session}");
+            run_turn(
+                client,
+                session,
+                message.trim(),
+                on_approval,
+                timeout,
+                format,
+            )
+            .await
         }
         Command::Approvals { session, format } => {
             let approvals = client.list_approvals(session, true).await?;
@@ -622,7 +673,11 @@ async fn execute(client: &Client, command: Command) -> Result<i32> {
                 Ok(1)
             }
         }
-        Command::Watch { format } => watch(client, format).await,
+        Command::Watch {
+            once,
+            timeout,
+            format,
+        } => watch(client, once, timeout, format).await,
     }
 }
 
@@ -646,7 +701,9 @@ async fn find_session(client: &Client, id: CodeSessionId) -> Result<CodeSessionS
             return Ok(session);
         }
     }
-    Err(AgentError::msg(format!("session {id} not found")))
+    Err(AgentError::msg(format!(
+        "not_found: session {id} not found"
+    )))
 }
 
 async fn resolve_repo(client: &Client, repo: &str) -> Result<RepoId> {
@@ -747,53 +804,111 @@ async fn run_turn(
     session: CodeSessionId,
     message: &str,
     on_approval: OnApproval,
+    timeout: Option<u64>,
     format: OutputFormat,
 ) -> Result<i32> {
+    // Subscribe first. `POST /turns` waits for the worker to finish the
+    // whole turn (or to queue), so a CLI that only reads after the POST
+    // returns never sees a live approval and cannot honor `--timeout`.
     let mut stream = CodeStream::open_session(client, session).await?;
-    let submitted = client.submit_turn(session, message).await?;
-    let expected_turn = match submitted {
-        SubmitTurnResponse::Ran(turn) => Some(turn.id),
-        SubmitTurnResponse::Queued(_) => {
-            if format == OutputFormat::Text {
-                eprintln!("tidebreak: turn queued; waiting for the running turn to finish");
+    let attach_only = message.is_empty();
+    let attach_turn = if attach_only {
+        let running = client
+            .list_session_turns(session)
+            .await?
+            .into_iter()
+            .rev()
+            .find(|turn| turn.status == tidebreak_core::CodeTurnStatus::Running);
+        match running {
+            Some(turn) => {
+                eprintln!("tidebreak: attaching to turn {}", turn.id);
+                Some(turn.id)
             }
-            None
+            None => {
+                eprintln!("tidebreak: session {session} has no running turn");
+                return Ok(0);
+            }
         }
+    } else {
+        None
     };
+    let mut submit = if attach_only {
+        None
+    } else {
+        Some(std::pin::pin!(client.submit_turn(session, message)))
+    };
+    let mut submit_done = attach_only;
+    let mut expected_turn = attach_turn;
     let mut interrupt = Interrupt::watch().await;
-    let mut ours = expected_turn.is_none();
+    let deadline =
+        timeout.map(|secs| tokio::time::Instant::now() + std::time::Duration::from_secs(secs));
+    let mut ours = false;
     let mut dangling = false;
+    let mut streamed_text = false;
 
     let outcome = loop {
         let frame = tokio::select! {
             frame = stream.next_session(client, session) => frame?,
+            submitted = async {
+                match submit.as_mut() {
+                    Some(fut) if !submit_done => fut.await,
+                    _ => std::future::pending().await,
+                }
+            } => {
+                submit_done = true;
+                match submitted? {
+                    SubmitTurnResponse::Ran(turn) => {
+                        eprintln!("tidebreak: turn {}", turn.id);
+                        expected_turn = Some(turn.id);
+                    }
+                    SubmitTurnResponse::Queued(_) => {
+                        eprintln!(
+                            "tidebreak: turn queued; waiting for the running turn to finish"
+                        );
+                    }
+                }
+                continue;
+            }
             () = interrupt.fired() => {
                 let _ = client.interrupt_session(session).await;
                 break Ok(EXIT_INTERRUPTED);
+            }
+            () = sleep_until(deadline) => {
+                let _ = client.interrupt_session(session).await;
+                eprintln!(
+                    "tidebreak: timed out after {}s waiting for the turn to finish",
+                    timeout.unwrap_or(0)
+                );
+                break Ok(EXIT_TIMEOUT);
             }
         };
         let Some((raw, decoded)) = frame else {
             continue;
         };
-        if let Some(turn_id) = expected_turn {
-            if !ours {
-                if matches!(&decoded.event, CodeEvent::TurnStarted { turn_id: id } if *id == turn_id)
-                {
-                    ours = true;
-                } else {
-                    continue;
+        // History from `after=0` is marked replayed. Skip it until this
+        // run's own turn has started; after that, replayed frames are
+        // reconnect catch-up and must be printed.
+        if decoded.replayed == Some(true) && !ours {
+            continue;
+        }
+        if let CodeEvent::TurnStarted { turn_id } = &decoded.event {
+            if expected_turn.is_none_or(|id| id == *turn_id) {
+                if !ours {
+                    eprintln!("tidebreak: turn {turn_id}");
                 }
+                ours = true;
             }
+        }
+        if expected_turn.is_some() && !ours {
+            continue;
         }
         if format == OutputFormat::Json {
             emit_line(&raw);
         } else {
-            dangling = render_event(&decoded.event, dangling);
+            dangling = render_event(&decoded.event, dangling, &mut streamed_text);
         }
         if let CodeEvent::ApprovalRequested { approval_id } = &decoded.event {
-            if format == OutputFormat::Text {
-                print_approval_prompt(*approval_id);
-            }
+            print_approval_prompt(*approval_id);
             if on_approval == OnApproval::Fail {
                 break Ok(EXIT_APPROVAL_PARKED);
             }
@@ -808,28 +923,64 @@ async fn run_turn(
     outcome
 }
 
-async fn watch(client: &Client, format: OutputFormat) -> Result<i32> {
+async fn watch(
+    client: &Client,
+    once: bool,
+    timeout: Option<u64>,
+    format: OutputFormat,
+) -> Result<i32> {
     let mut stream = CodeStream::open_updates(client).await?;
     let mut interrupt = Interrupt::watch().await;
+    let deadline =
+        timeout.map(|secs| tokio::time::Instant::now() + std::time::Duration::from_secs(secs));
     loop {
         let frame = tokio::select! {
             frame = stream.next_updates(client) => frame?,
             () = interrupt.fired() => return Ok(EXIT_INTERRUPTED),
+            () = sleep_until(deadline) => {
+                eprintln!(
+                    "tidebreak: timed out after {}s waiting for an update",
+                    timeout.unwrap_or(0)
+                );
+                return Ok(EXIT_TIMEOUT);
+            }
         };
         let Some((raw, notice)) = frame else {
             continue;
         };
         if format == OutputFormat::Json {
             emit_line(&raw);
-            continue;
+        } else {
+            render_update(&notice);
         }
-        render_update(&notice);
+        if once {
+            return Ok(0);
+        }
     }
 }
 
-fn render_event(event: &CodeEvent, dangling: bool) -> bool {
+async fn sleep_until(deadline: Option<tokio::time::Instant>) {
+    match deadline {
+        Some(deadline) => tokio::time::sleep_until(deadline).await,
+        None => std::future::pending::<()>().await,
+    }
+}
+
+fn render_event(event: &CodeEvent, dangling: bool, streamed_text: &mut bool) -> bool {
     match event {
-        CodeEvent::AssistantDelta { text } | CodeEvent::AssistantMessage { text } => {
+        CodeEvent::AssistantDelta { text } => {
+            *streamed_text = true;
+            let mut stdout = std::io::stdout().lock();
+            let _ = write!(stdout, "{text}");
+            let _ = stdout.flush();
+            return !text.ends_with('\n');
+        }
+        CodeEvent::AssistantMessage { text } => {
+            // Deltas already painted the same words; reprinting them as
+            // `pingping` is the usual stream+final pair.
+            if *streamed_text {
+                return dangling;
+            }
             let mut stdout = std::io::stdout().lock();
             let _ = write!(stdout, "{text}");
             let _ = stdout.flush();
@@ -1545,6 +1696,7 @@ fn parse_run(cursor: &mut Cursor) -> std::result::Result<Command, String> {
     let mut session = None;
     let mut workspace = None;
     let mut on_approval = OnApproval::Wait;
+    let mut timeout = None;
     let mut flags = SharedFlags {
         format: OutputFormat::Text,
     };
@@ -1556,6 +1708,7 @@ fn parse_run(cursor: &mut Cursor) -> std::result::Result<Command, String> {
             "--on-approval" => {
                 on_approval = parse_on_approval(&cursor.value("--on-approval")?)?;
             }
+            "--timeout" => timeout = Some(parse_timeout(&cursor.value("--timeout")?)?),
             "--json" | "--output-format" => take_format(&mut flags, cursor, &arg)?,
             other if other.starts_with("--") => {
                 return Err(format!("unknown code run argument {other:?}"));
@@ -1566,14 +1719,12 @@ fn parse_run(cursor: &mut Cursor) -> std::result::Result<Command, String> {
     if session.is_none() && workspace.is_none() {
         return Err("code run requires --session <id> or --ws <id>".to_owned());
     }
-    if message_parts.is_empty() {
-        return Err("code run requires a message".to_owned());
-    }
     Ok(Command::Run {
         session,
         workspace,
         message: message_parts.join(" "),
         on_approval,
+        timeout,
         format: flags.format,
     })
 }
@@ -1785,15 +1936,32 @@ fn parse_action(cursor: &mut Cursor) -> std::result::Result<Command, String> {
 }
 
 fn parse_watch(cursor: &mut Cursor) -> std::result::Result<Command, String> {
+    let mut once = false;
+    let mut timeout = None;
     let mut flags = SharedFlags {
         format: OutputFormat::Text,
     };
     while let Some(arg) = cursor.next() {
-        take_format(&mut flags, cursor, &arg)?;
+        match arg.as_str() {
+            "--once" => once = true,
+            "--timeout" => timeout = Some(parse_timeout(&cursor.value("--timeout")?)?),
+            other => take_format(&mut flags, cursor, other)?,
+        }
     }
     Ok(Command::Watch {
+        once,
+        timeout,
         format: flags.format,
     })
+}
+
+fn parse_timeout(value: &str) -> std::result::Result<u64, String> {
+    let stripped = value.strip_suffix('s').unwrap_or(value);
+    stripped
+        .parse::<u64>()
+        .ok()
+        .filter(|secs| *secs > 0)
+        .ok_or_else(|| "--timeout expects a positive number of seconds".to_owned())
 }
 
 fn take_ws_flag(
@@ -2027,12 +2195,18 @@ mod tests {
             parse(args(&["action", "lint", "--ws", &ws])).unwrap(),
             Command::Action { .. }
         ));
-        assert!(matches!(
-            parse(args(&["watch", "--json"])).unwrap(),
+        match parse(args(&["watch", "--json", "--once", "--timeout", "5"])).unwrap() {
             Command::Watch {
-                format: OutputFormat::Json
+                once,
+                timeout,
+                format,
+            } => {
+                assert!(once);
+                assert_eq!(timeout, Some(5));
+                assert_eq!(format, OutputFormat::Json);
             }
-        ));
+            other => panic!("{other:?}"),
+        }
     }
 
     #[test]
@@ -2045,7 +2219,7 @@ mod tests {
         assert!(parse(args(&["ws", "new"])).is_err());
         assert!(parse(args(&["session", "start", "--ws", &id()])).is_err());
         assert!(parse(args(&["run", "hello"])).is_err());
-        assert!(parse(args(&["run", "--session", &id()])).is_err());
+        assert!(parse(args(&["run"])).is_err());
         assert!(parse(args(&[
             "run",
             "--session",
@@ -2061,6 +2235,8 @@ mod tests {
         assert!(parse(args(&["action", "lint"])).is_err());
         assert!(parse(args(&["doctor", "--wat"])).is_err());
         assert!(parse(args(&["watch", "--output-format", "yaml"])).is_err());
+        assert!(parse(args(&["watch", "--timeout", "0"])).is_err());
+        assert!(parse(args(&["run", "--session", &id(), "--timeout", "nope", "x"])).is_err());
         assert!(parse(args(&[
             "session",
             "start",
@@ -2106,6 +2282,28 @@ mod tests {
                 assert_eq!(message, "hello");
                 assert_eq!(on_approval, OnApproval::Wait);
             }
+            other => panic!("{other:?}"),
+        }
+        match parse(args(&["run", "--session", &id()])).unwrap() {
+            Command::Run { message, .. } => assert!(message.is_empty()),
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn run_timeout_and_watch_once_parse() {
+        let session = id();
+        match parse(args(&[
+            "run",
+            "--session",
+            &session,
+            "--timeout",
+            "30s",
+            "go",
+        ]))
+        .unwrap()
+        {
+            Command::Run { timeout, .. } => assert_eq!(timeout, Some(30)),
             other => panic!("{other:?}"),
         }
     }

--- a/crates/tidebreak-cli/src/code.rs
+++ b/crates/tidebreak-cli/src/code.rs
@@ -1,0 +1,2117 @@
+//! `tidebreak code …` — the headless client of the code-mode surface.
+//!
+//! Every verb here is a thin wrapper over a `/code/*` route the server already
+//! serves. The CLI embeds a server by default and attaches with `--server` /
+//! `--attach` the same way `-p` and the setup family do. `--json` (or
+//! `--output-format json`) writes one object, or NDJSON for the two streaming
+//! commands (`run`, `watch`); human output otherwise.
+
+use std::future::Future as _;
+use std::io::Write as _;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use futures::StreamExt as _;
+use tidebreak_core::{
+    AgentError, Attention, AttentionState, CodeApprovalId, CodeApprovalKind, CodeEvent,
+    CodePermissionMode, CodeSessionId, CodeSessionLifecycle, CodeTurnId, HarnessKind, RepoId,
+    Result, WorkspaceId,
+};
+use tokio_tungstenite::tungstenite::Message;
+
+use crate::api::client::Client;
+use crate::api::code::{
+    decode_event_frame, decode_update_notice, is_turn_terminal, supported_caps_summary,
+    turn_exit_code, CodeApprovalSnapshot, CodeSessionDigest, CodeSessionSnapshot, CodeTurnSnapshot,
+    CodeUpdateNotice, CodeWorkspaceSnapshot, SubmitTurnResponse,
+};
+use crate::connect::Server;
+use crate::print::OutputFormat;
+
+/// Exit status when `--on-approval fail` sees a parked approval.
+const EXIT_APPROVAL_PARKED: i32 = 3;
+/// SIGINT, following the shell's 128+signal convention and `-p`.
+const EXIT_INTERRUPTED: i32 = 130;
+
+const RECONNECT_ATTEMPTS: usize = 3;
+const RECONNECT_DELAY: std::time::Duration = std::time::Duration::from_millis(200);
+
+/// What to do when `code run` sees an `approval_requested` event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OnApproval {
+    /// Keep streaming while the turn is parked (the default).
+    Wait,
+    /// Exit nonzero as soon as an approval is requested.
+    Fail,
+}
+
+/// How `--turn` named a turn: the workspace-visible ordinal, or an exact id.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnRef {
+    Ordinal(i64),
+    Id(CodeTurnId),
+}
+
+/// One parsed `tidebreak code` invocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Command {
+    Doctor {
+        refresh: bool,
+        format: OutputFormat,
+    },
+    RepoAdd {
+        path: PathBuf,
+        name: Option<String>,
+        base_ref: Option<String>,
+        branch_prefix: Option<String>,
+        format: OutputFormat,
+    },
+    RepoList {
+        format: OutputFormat,
+    },
+    RepoRm {
+        id: RepoId,
+        format: OutputFormat,
+    },
+    WsNew {
+        repo: String,
+        title: Option<String>,
+        base_ref: Option<String>,
+        format: OutputFormat,
+    },
+    WsList {
+        repo: Option<String>,
+        format: OutputFormat,
+    },
+    WsShow {
+        id: WorkspaceId,
+        format: OutputFormat,
+    },
+    WsArchive {
+        id: WorkspaceId,
+        force: bool,
+        format: OutputFormat,
+    },
+    SessionStart {
+        workspace: WorkspaceId,
+        harness: HarnessKind,
+        mode: CodePermissionMode,
+        format: OutputFormat,
+    },
+    SessionShow {
+        id: CodeSessionId,
+        format: OutputFormat,
+    },
+    SessionReap {
+        id: CodeSessionId,
+        format: OutputFormat,
+    },
+    Run {
+        session: Option<CodeSessionId>,
+        workspace: Option<WorkspaceId>,
+        message: String,
+        on_approval: OnApproval,
+        format: OutputFormat,
+    },
+    Approvals {
+        session: Option<CodeSessionId>,
+        format: OutputFormat,
+    },
+    Approve {
+        id: CodeApprovalId,
+        format: OutputFormat,
+    },
+    Deny {
+        id: CodeApprovalId,
+        feedback: Option<String>,
+        format: OutputFormat,
+    },
+    Interrupt {
+        session: CodeSessionId,
+        format: OutputFormat,
+    },
+    Turns {
+        session: CodeSessionId,
+        format: OutputFormat,
+    },
+    Diff {
+        workspace: WorkspaceId,
+        turn: Option<TurnRef>,
+        file: Option<String>,
+        format: OutputFormat,
+    },
+    Files {
+        workspace: WorkspaceId,
+        turn: Option<TurnRef>,
+        format: OutputFormat,
+    },
+    GitCommit {
+        workspace: WorkspaceId,
+        message: Option<String>,
+        format: OutputFormat,
+    },
+    GitPush {
+        workspace: WorkspaceId,
+        format: OutputFormat,
+    },
+    GitPr {
+        workspace: WorkspaceId,
+        title: Option<String>,
+        body: Option<String>,
+        format: OutputFormat,
+    },
+    GitStatus {
+        workspace: WorkspaceId,
+        format: OutputFormat,
+    },
+    Action {
+        name: String,
+        workspace: WorkspaceId,
+        format: OutputFormat,
+    },
+    Watch {
+        format: OutputFormat,
+    },
+}
+
+/// Hand-rolled argument parsing, matching the rest of the CLI.
+pub fn parse(args: impl IntoIterator<Item = String>) -> std::result::Result<Command, String> {
+    let mut cursor = Cursor::new(args.into_iter().collect());
+    let verb = match cursor.next() {
+        Some(verb) if !verb.starts_with("--") => verb,
+        _ => return Err("code requires a subcommand".to_owned()),
+    };
+    match verb.as_str() {
+        "doctor" => parse_doctor(&mut cursor),
+        "repo" => parse_repo(&mut cursor),
+        "ws" => parse_ws(&mut cursor),
+        "session" => parse_session(&mut cursor),
+        "run" => parse_run(&mut cursor),
+        "approvals" => parse_approvals(&mut cursor),
+        "approve" => parse_approve(&mut cursor),
+        "deny" => parse_deny(&mut cursor),
+        "interrupt" => parse_interrupt(&mut cursor),
+        "turns" => parse_turns(&mut cursor),
+        "diff" => parse_diff(&mut cursor),
+        "files" => parse_files(&mut cursor),
+        "git" => parse_git(&mut cursor),
+        "action" => parse_action(&mut cursor),
+        "watch" => parse_watch(&mut cursor),
+        other => Err(format!("unknown code subcommand {other:?}")),
+    }
+}
+
+/// Run one code-mode command against the profile's server.
+pub async fn run(command: Command, server: Server) -> Result<i32> {
+    let session = crate::connect::Session::open(&server).await?;
+    execute(session.client(), command).await
+}
+
+async fn execute(client: &Client, command: Command) -> Result<i32> {
+    match command {
+        Command::Doctor { refresh, format } => {
+            let report = if refresh {
+                client.refresh_harnesses().await?
+            } else {
+                client.list_harnesses().await?
+            };
+            if format == OutputFormat::Json {
+                emit(&serde_json::to_value(&report).unwrap_or_default())?;
+                return Ok(0);
+            }
+            if report.harnesses.is_empty() {
+                eprintln!("tidebreak: no coding harnesses are registered on this server");
+                return Ok(0);
+            }
+            println!(
+                "{:<14} {:<6} {:<28} {:<12} {:<12} {:<5} CAPS",
+                "KIND", "FOUND", "PATH", "VERSION", "TIER", "AUTH"
+            );
+            for entry in &report.harnesses {
+                let found = if entry.found { "yes" } else { "no" };
+                let path = entry.path.as_deref().unwrap_or("-");
+                let version = entry.version.as_deref().unwrap_or("-");
+                let auth = match entry.authenticated {
+                    Some(true) => "yes",
+                    Some(false) => "no",
+                    None => "-",
+                };
+                let tier = format!("{:?}", entry.tier).to_ascii_lowercase();
+                println!(
+                    "{:<14} {:<6} {:<28} {:<12} {:<12} {:<5} {}",
+                    entry.kind.as_str(),
+                    found,
+                    clip(path, 28),
+                    clip(version, 12),
+                    tier,
+                    auth,
+                    supported_caps_summary(&entry.caps)
+                );
+                if !entry.remediation.is_empty() {
+                    println!("  remediation: {}", entry.remediation);
+                }
+            }
+            Ok(0)
+        }
+        Command::RepoAdd {
+            path,
+            name,
+            base_ref,
+            branch_prefix,
+            format,
+        } => {
+            let repo = client
+                .create_repo(
+                    &path.to_string_lossy(),
+                    name.as_deref(),
+                    base_ref.as_deref(),
+                    branch_prefix.as_deref(),
+                )
+                .await?;
+            if format == OutputFormat::Json {
+                return emit_ok(&repo);
+            }
+            println!(
+                "tidebreak: registered {}  {}  {}",
+                repo.id, repo.display_name, repo.root_path
+            );
+            Ok(0)
+        }
+        Command::RepoList { format } => {
+            let repos = client.list_repos().await?;
+            if format == OutputFormat::Json {
+                return emit(&serde_json::json!({ "repos": repos }));
+            }
+            if repos.is_empty() {
+                eprintln!("tidebreak: no repositories registered");
+            }
+            for repo in repos {
+                println!(
+                    "{}\t{}\t{}\t{}",
+                    repo.id, repo.display_name, repo.root_path, repo.default_base_ref
+                );
+            }
+            Ok(0)
+        }
+        Command::RepoRm { id, format } => {
+            client.delete_repo(id).await?;
+            if format == OutputFormat::Json {
+                return emit(&serde_json::json!({ "id": id, "removed": true }));
+            }
+            println!("tidebreak: removed repository {id}");
+            Ok(0)
+        }
+        Command::WsNew {
+            repo,
+            title,
+            base_ref,
+            format,
+        } => {
+            let repo_id = resolve_repo(client, &repo).await?;
+            let workspace = client
+                .create_workspace(repo_id, title.as_deref(), base_ref.as_deref())
+                .await?;
+            if format == OutputFormat::Json {
+                return emit_ok(&workspace);
+            }
+            println!(
+                "tidebreak: workspace {}  {}  {}",
+                workspace.id, workspace.branch_name, workspace.worktree_path
+            );
+            Ok(0)
+        }
+        Command::WsList { repo, format } => {
+            let repo_id = match repo {
+                Some(repo) => Some(resolve_repo(client, &repo).await?),
+                None => None,
+            };
+            let workspaces = client.list_workspaces(repo_id).await?;
+            if format == OutputFormat::Json {
+                return emit(&serde_json::json!({ "workspaces": workspaces }));
+            }
+            if workspaces.is_empty() {
+                eprintln!("tidebreak: no workspaces");
+            }
+            for workspace in workspaces {
+                println!(
+                    "{}\t{}\t{}\t{}\t{}",
+                    workspace.id,
+                    workspace.status.as_str(),
+                    workspace.branch_name,
+                    workspace.title,
+                    workspace.worktree_path
+                );
+            }
+            Ok(0)
+        }
+        Command::WsShow { id, format } => {
+            let workspace = client.get_workspace(id).await?;
+            let sessions = client.list_workspace_sessions(id).await?;
+            if format == OutputFormat::Json {
+                return emit(&serde_json::json!({
+                    "workspace": workspace,
+                    "sessions": sessions,
+                }));
+            }
+            print_workspace(&workspace);
+            if sessions.is_empty() {
+                println!("sessions             none");
+            } else {
+                println!("sessions");
+                for session in sessions {
+                    println!(
+                        "  {}\t{}\t{}\t{}",
+                        session.id,
+                        session.harness_kind.as_str(),
+                        session.lifecycle.as_str(),
+                        attention_label(&session.attention)
+                    );
+                }
+            }
+            Ok(0)
+        }
+        Command::WsArchive { id, force, format } => {
+            let workspace = client.archive_workspace(id, force).await?;
+            if format == OutputFormat::Json {
+                return emit_ok(&workspace);
+            }
+            println!("tidebreak: archived workspace {id}");
+            Ok(0)
+        }
+        Command::SessionStart {
+            workspace,
+            harness,
+            mode,
+            format,
+        } => {
+            let session = client.create_session(workspace, harness, mode).await?;
+            if format == OutputFormat::Json {
+                return emit_ok(&session);
+            }
+            println!(
+                "tidebreak: session {}  {}  {}",
+                session.id,
+                session.harness_kind.as_str(),
+                session.permission_mode.as_str()
+            );
+            Ok(0)
+        }
+        Command::SessionShow { id, format } => {
+            let (session, turns) = load_session(client, id).await?;
+            if format == OutputFormat::Json {
+                return emit(&serde_json::json!({
+                    "session": session,
+                    "turns": turns,
+                }));
+            }
+            print_session(&session);
+            if turns.is_empty() {
+                println!("turns                none");
+            } else {
+                println!("turns");
+                for turn in turns {
+                    print_turn_line(&turn);
+                }
+            }
+            Ok(0)
+        }
+        Command::SessionReap { id, format } => {
+            let session = client.reap_session(id).await?;
+            if format == OutputFormat::Json {
+                return emit_ok(&session);
+            }
+            println!(
+                "tidebreak: reaped session {}  {}",
+                session.id,
+                session.lifecycle.as_str()
+            );
+            Ok(0)
+        }
+        Command::Run {
+            session,
+            workspace,
+            message,
+            on_approval,
+            format,
+        } => {
+            let session = resolve_run_session(client, session, workspace).await?;
+            run_turn(client, session, &message, on_approval, format).await
+        }
+        Command::Approvals { session, format } => {
+            let approvals = client.list_approvals(session, true).await?;
+            if format == OutputFormat::Json {
+                return emit(&serde_json::json!({ "approvals": approvals }));
+            }
+            if approvals.is_empty() {
+                eprintln!("tidebreak: no pending approvals");
+            }
+            for approval in approvals {
+                print_approval(&approval);
+            }
+            Ok(0)
+        }
+        Command::Approve { id, format } => {
+            let approval = client.decide_code_approval(id, true, None).await?;
+            if format == OutputFormat::Json {
+                return emit_ok(&approval);
+            }
+            println!("tidebreak: approved {id}");
+            Ok(0)
+        }
+        Command::Deny {
+            id,
+            feedback,
+            format,
+        } => {
+            let approval = client
+                .decide_code_approval(id, false, feedback.as_deref())
+                .await?;
+            if format == OutputFormat::Json {
+                return emit_ok(&approval);
+            }
+            println!("tidebreak: denied {id}");
+            Ok(0)
+        }
+        Command::Interrupt { session, format } => {
+            client.interrupt_session(session).await?;
+            if format == OutputFormat::Json {
+                return emit(&serde_json::json!({ "session": session, "interrupted": true }));
+            }
+            println!("tidebreak: interrupted session {session}");
+            Ok(0)
+        }
+        Command::Turns { session, format } => {
+            let turns = client.list_session_turns(session).await?;
+            if format == OutputFormat::Json {
+                return emit(&serde_json::json!({ "turns": turns }));
+            }
+            if turns.is_empty() {
+                eprintln!("tidebreak: no turns");
+            }
+            for turn in turns {
+                print_turn_line(&turn);
+            }
+            Ok(0)
+        }
+        Command::Diff {
+            workspace,
+            turn,
+            file,
+            format,
+        } => {
+            let turn_id = resolve_turn(client, workspace, turn).await?;
+            let diff = client
+                .workspace_diff(workspace, turn_id, file.as_deref())
+                .await?;
+            if format == OutputFormat::Json {
+                return emit_ok(&diff);
+            }
+            if !diff.diff.is_empty() {
+                print!("{}", diff.diff);
+                if !diff.diff.ends_with('\n') {
+                    println!();
+                }
+            }
+            if diff.truncated {
+                eprintln!(
+                    "tidebreak: diff truncated  {} files +{} -{}",
+                    diff.stat.files, diff.stat.insertions, diff.stat.deletions
+                );
+            }
+            Ok(0)
+        }
+        Command::Files {
+            workspace,
+            turn,
+            format,
+        } => {
+            let turn_id = resolve_turn(client, workspace, turn).await?;
+            let files = client.workspace_files(workspace, turn_id).await?;
+            if format == OutputFormat::Json {
+                return emit_ok(&files);
+            }
+            for file in &files.files {
+                println!(
+                    "{}\t{}\t+{}\t-{}",
+                    file.kind.as_str_display(),
+                    file.path,
+                    file.insertions,
+                    file.deletions
+                );
+            }
+            if files.truncated {
+                eprintln!(
+                    "tidebreak: file list truncated  {} files +{} -{}",
+                    files.stat.files, files.stat.insertions, files.stat.deletions
+                );
+            }
+            Ok(0)
+        }
+        Command::GitCommit {
+            workspace,
+            message,
+            format,
+        } => {
+            let commit = client.git_commit(workspace, message.as_deref()).await?;
+            if format == OutputFormat::Json {
+                return emit_ok(&commit);
+            }
+            println!(
+                "tidebreak: committed {}  {}  +{} -{}",
+                commit.sha, commit.message, commit.stat.insertions, commit.stat.deletions
+            );
+            Ok(0)
+        }
+        Command::GitPush { workspace, format } => {
+            let push = client.git_push(workspace).await?;
+            if format == OutputFormat::Json {
+                return emit_ok(&push);
+            }
+            println!("tidebreak: pushed {} to {}", push.branch, push.remote);
+            Ok(0)
+        }
+        Command::GitPr {
+            workspace,
+            title,
+            body,
+            format,
+        } => {
+            let pr = client
+                .git_pr(workspace, title.as_deref(), body.as_deref())
+                .await?;
+            if format == OutputFormat::Json {
+                return emit_ok(&pr);
+            }
+            print_pr(&pr);
+            Ok(0)
+        }
+        Command::GitStatus { workspace, format } => {
+            let status = client.git_status(workspace).await?;
+            if format == OutputFormat::Json {
+                return emit_ok(&status);
+            }
+            print_pr(&status);
+            Ok(0)
+        }
+        Command::Action {
+            name,
+            workspace,
+            format,
+        } => {
+            let action = client.run_action(workspace, &name).await?;
+            if format == OutputFormat::Json {
+                return emit_ok(&action);
+            }
+            let result = if action.success { "ok" } else { "failed" };
+            println!("tidebreak: action {name} {result}");
+            if !action.stdout.is_empty() {
+                print!("{}", action.stdout);
+                if !action.stdout.ends_with('\n') {
+                    println!();
+                }
+            }
+            if !action.stderr.is_empty() {
+                eprint!("{}", action.stderr);
+                if !action.stderr.ends_with('\n') {
+                    eprintln!();
+                }
+            }
+            if action.success {
+                Ok(0)
+            } else {
+                Ok(1)
+            }
+        }
+        Command::Watch { format } => watch(client, format).await,
+    }
+}
+
+/// There is no `GET /code/sessions/{id}`. Walk workspaces to recover the row,
+/// then load its turns. A missing session 404s the same way a dedicated
+/// route would.
+async fn load_session(
+    client: &Client,
+    id: CodeSessionId,
+) -> Result<(CodeSessionSnapshot, Vec<CodeTurnSnapshot>)> {
+    let session = find_session(client, id).await?;
+    let turns = client.list_session_turns(id).await?;
+    Ok((session, turns))
+}
+
+async fn find_session(client: &Client, id: CodeSessionId) -> Result<CodeSessionSnapshot> {
+    let workspaces = client.list_workspaces(None).await?;
+    for workspace in workspaces {
+        let sessions = client.list_workspace_sessions(workspace.id).await?;
+        if let Some(session) = sessions.into_iter().find(|session| session.id == id) {
+            return Ok(session);
+        }
+    }
+    Err(AgentError::msg(format!("session {id} not found")))
+}
+
+async fn resolve_repo(client: &Client, repo: &str) -> Result<RepoId> {
+    if let Ok(id) = RepoId::from_str(repo) {
+        return Ok(id);
+    }
+    let wanted = canonicalize_path(repo);
+    let repos = client.list_repos().await?;
+    let mut matches: Vec<_> = repos
+        .into_iter()
+        .filter(|candidate| {
+            paths_equal(&candidate.root_path, repo) || paths_equal(&candidate.root_path, &wanted)
+        })
+        .collect();
+    match matches.len() {
+        1 => Ok(matches.remove(0).id),
+        0 => Err(AgentError::msg(format!(
+            "no registered repository matches {repo:?}"
+        ))),
+        _ => Err(AgentError::msg(format!(
+            "more than one registered repository matches {repo:?}"
+        ))),
+    }
+}
+
+fn paths_equal(left: &str, right: &str) -> bool {
+    left == right
+}
+
+fn canonicalize_path(path: &str) -> String {
+    std::fs::canonicalize(path)
+        .map(|path| path.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| path.to_owned())
+}
+
+async fn resolve_run_session(
+    client: &Client,
+    session: Option<CodeSessionId>,
+    workspace: Option<WorkspaceId>,
+) -> Result<CodeSessionId> {
+    if let Some(session) = session {
+        return Ok(session);
+    }
+    let workspace = workspace
+        .ok_or_else(|| AgentError::msg("code run requires --session <id> or --ws <id>"))?;
+    let sessions = client.list_workspace_sessions(workspace).await?;
+    pick_active_session(&sessions)
+        .ok_or_else(|| AgentError::msg(format!("workspace {workspace} has no active session")))
+}
+
+fn pick_active_session(sessions: &[CodeSessionSnapshot]) -> Option<CodeSessionId> {
+    let usable = |session: &&CodeSessionSnapshot| {
+        !matches!(
+            session.lifecycle,
+            CodeSessionLifecycle::Ended | CodeSessionLifecycle::Fenced
+        )
+    };
+    sessions
+        .iter()
+        .filter(usable)
+        .find(|session| session.lifecycle == CodeSessionLifecycle::Running)
+        .or_else(|| {
+            sessions
+                .iter()
+                .filter(usable)
+                .max_by_key(|session| session.created_at)
+        })
+        .map(|session| session.id)
+}
+
+async fn resolve_turn(
+    client: &Client,
+    workspace: WorkspaceId,
+    turn: Option<TurnRef>,
+) -> Result<Option<CodeTurnId>> {
+    let Some(turn) = turn else {
+        return Ok(None);
+    };
+    match turn {
+        TurnRef::Id(id) => Ok(Some(id)),
+        TurnRef::Ordinal(ordinal) => {
+            let sessions = client.list_workspace_sessions(workspace).await?;
+            let session = pick_active_session(&sessions)
+                .or_else(|| sessions.first().map(|session| session.id))
+                .ok_or_else(|| AgentError::msg(format!("workspace {workspace} has no sessions")))?;
+            let turns = client.list_session_turns(session).await?;
+            turns
+                .into_iter()
+                .find(|turn| turn.ordinal == ordinal)
+                .map(|turn| Some(turn.id))
+                .ok_or_else(|| AgentError::msg(format!("no turn {ordinal} on session {session}")))
+        }
+    }
+}
+
+async fn run_turn(
+    client: &Client,
+    session: CodeSessionId,
+    message: &str,
+    on_approval: OnApproval,
+    format: OutputFormat,
+) -> Result<i32> {
+    let mut stream = CodeStream::open_session(client, session).await?;
+    let submitted = client.submit_turn(session, message).await?;
+    let expected_turn = match submitted {
+        SubmitTurnResponse::Ran(turn) => Some(turn.id),
+        SubmitTurnResponse::Queued(_) => {
+            if format == OutputFormat::Text {
+                eprintln!("tidebreak: turn queued; waiting for the running turn to finish");
+            }
+            None
+        }
+    };
+    let mut interrupt = Interrupt::watch().await;
+    let mut ours = expected_turn.is_none();
+    let mut dangling = false;
+
+    let outcome = loop {
+        let frame = tokio::select! {
+            frame = stream.next_session(client, session) => frame?,
+            () = interrupt.fired() => {
+                let _ = client.interrupt_session(session).await;
+                break Ok(EXIT_INTERRUPTED);
+            }
+        };
+        let Some((raw, decoded)) = frame else {
+            continue;
+        };
+        if let Some(turn_id) = expected_turn {
+            if !ours {
+                if matches!(&decoded.event, CodeEvent::TurnStarted { turn_id: id } if *id == turn_id)
+                {
+                    ours = true;
+                } else {
+                    continue;
+                }
+            }
+        }
+        if format == OutputFormat::Json {
+            emit_line(&raw);
+        } else {
+            dangling = render_event(&decoded.event, dangling);
+        }
+        if let CodeEvent::ApprovalRequested { approval_id } = &decoded.event {
+            if format == OutputFormat::Text {
+                print_approval_prompt(*approval_id);
+            }
+            if on_approval == OnApproval::Fail {
+                break Ok(EXIT_APPROVAL_PARKED);
+            }
+        }
+        if is_turn_terminal(&decoded.event) {
+            break Ok(turn_exit_code(&decoded.event).unwrap_or(1));
+        }
+    };
+    if dangling {
+        println!();
+    }
+    outcome
+}
+
+async fn watch(client: &Client, format: OutputFormat) -> Result<i32> {
+    let mut stream = CodeStream::open_updates(client).await?;
+    let mut interrupt = Interrupt::watch().await;
+    loop {
+        let frame = tokio::select! {
+            frame = stream.next_updates(client) => frame?,
+            () = interrupt.fired() => return Ok(EXIT_INTERRUPTED),
+        };
+        let Some((raw, notice)) = frame else {
+            continue;
+        };
+        if format == OutputFormat::Json {
+            emit_line(&raw);
+            continue;
+        }
+        render_update(&notice);
+    }
+}
+
+fn render_event(event: &CodeEvent, dangling: bool) -> bool {
+    match event {
+        CodeEvent::AssistantDelta { text } | CodeEvent::AssistantMessage { text } => {
+            let mut stdout = std::io::stdout().lock();
+            let _ = write!(stdout, "{text}");
+            let _ = stdout.flush();
+            return !text.ends_with('\n');
+        }
+        CodeEvent::ReasoningDelta { text } => {
+            if !text.is_empty() {
+                eprint!("{text}");
+            }
+        }
+        CodeEvent::ToolStarted { name, detail, .. } => {
+            finish_line(dangling);
+            eprintln!("tidebreak: tool {name}  {}", tool_detail(detail));
+            return false;
+        }
+        CodeEvent::ToolCompleted {
+            outcome, preview, ..
+        } => {
+            finish_line(dangling);
+            let preview = if preview.is_empty() {
+                String::new()
+            } else {
+                format!("  {}", clip(preview, 80))
+            };
+            eprintln!("tidebreak: tool {}{preview}", outcome_label(*outcome));
+            return false;
+        }
+        CodeEvent::HarnessNotice { level, message } => {
+            finish_line(dangling);
+            eprintln!("tidebreak: {}: {message}", level_label(*level));
+            return false;
+        }
+        CodeEvent::FileChanged { path, kind, .. } => {
+            finish_line(dangling);
+            eprintln!("tidebreak: file {} {path}", kind.as_str_display());
+            return false;
+        }
+        CodeEvent::TurnFailed { error } => {
+            finish_line(dangling);
+            eprintln!("tidebreak: turn failed: {}", error.message);
+            return false;
+        }
+        CodeEvent::TurnInterrupted => {
+            finish_line(dangling);
+            eprintln!("tidebreak: turn interrupted");
+            return false;
+        }
+        CodeEvent::TurnCompleted { .. }
+        | CodeEvent::TurnStarted { .. }
+        | CodeEvent::SessionStarted { .. }
+        | CodeEvent::ApprovalRequested { .. }
+        | CodeEvent::ApprovalResolved { .. }
+        | CodeEvent::UserSteered { .. }
+        | CodeEvent::CheckpointRecorded { .. }
+        | CodeEvent::AttentionChanged { .. }
+        | _ => {}
+    }
+    dangling
+}
+
+fn finish_line(dangling: bool) {
+    if dangling {
+        println!();
+    }
+}
+
+fn print_approval_prompt(id: CodeApprovalId) {
+    eprintln!();
+    eprintln!("tidebreak: approval requested  {id}");
+    eprintln!("           decide with:  tidebreak code approve {id}");
+    eprintln!("                         tidebreak code deny {id} [-m <feedback>]");
+    eprintln!();
+}
+
+fn render_update(notice: &CodeUpdateNotice) {
+    match notice {
+        CodeUpdateNotice::Snapshot { sessions } => {
+            eprintln!("tidebreak: watch snapshot  {} session(s)", sessions.len());
+            for digest in sessions {
+                eprintln!("  {}", digest_line(digest));
+            }
+        }
+        CodeUpdateNotice::Digest {
+            workspace,
+            session,
+            lifecycle,
+            attention,
+            title,
+            turn_count,
+            pr_state,
+        } => {
+            let pr = pr_state
+                .as_ref()
+                .map(|pr| format!("  pr #{} {}", pr.number, pr.state))
+                .unwrap_or_default();
+            println!(
+                "{workspace}  {session}  {}  {}  {title}  turns={turn_count}{pr}",
+                lifecycle.as_str(),
+                attention_label(attention)
+            );
+        }
+        CodeUpdateNotice::TerminalActivity { .. } | CodeUpdateNotice::Unknown => {}
+    }
+}
+
+fn digest_line(digest: &CodeSessionDigest) -> String {
+    let pr = digest
+        .pr_state
+        .as_ref()
+        .map(|pr| format!("  pr #{} {}", pr.number, pr.state))
+        .unwrap_or_default();
+    format!(
+        "{}  {}  {}  {}  {}  turns={}{pr}",
+        digest.workspace,
+        digest.session,
+        digest.lifecycle.as_str(),
+        attention_label(&digest.attention),
+        digest.title,
+        digest.turn_count
+    )
+}
+
+fn print_workspace(workspace: &CodeWorkspaceSnapshot) {
+    println!("id                   {}", workspace.id);
+    println!("repo                 {}", workspace.repo_id);
+    println!("title                {}", or_dash(&workspace.title));
+    println!("status               {}", workspace.status.as_str());
+    println!("branch               {}", workspace.branch_name);
+    println!("worktree             {}", workspace.worktree_path);
+    println!("base                 {}", workspace.base_ref);
+    match &workspace.pr {
+        Some(pr) => {
+            let checks = pr.checks_summary.as_deref().unwrap_or("-");
+            let url = pr.url.as_deref().unwrap_or("-");
+            println!(
+                "pr                   #{} {}  {checks}  {url}",
+                pr.number, pr.state
+            );
+        }
+        None => println!("pr                   none"),
+    }
+}
+
+fn print_session(session: &CodeSessionSnapshot) {
+    println!("id                   {}", session.id);
+    println!("workspace            {}", session.workspace_id);
+    println!("harness              {}", session.harness_kind.as_str());
+    println!(
+        "version              {}",
+        session.harness_version.as_deref().unwrap_or("-")
+    );
+    println!("mode                 {}", session.permission_mode.as_str());
+    println!("lifecycle            {}", session.lifecycle.as_str());
+    println!(
+        "attention            {}",
+        attention_label(&session.attention)
+    );
+}
+
+fn print_turn_line(turn: &CodeTurnSnapshot) {
+    let stat = turn
+        .diffstat
+        .as_ref()
+        .map(|stat| {
+            format!(
+                "  +{} -{} ({} files)",
+                stat.insertions, stat.deletions, stat.files
+            )
+        })
+        .unwrap_or_default();
+    let usage = turn
+        .usage
+        .as_ref()
+        .map(|usage| format!("  in={} out={}", usage.input_tokens, usage.output_tokens))
+        .unwrap_or_default();
+    println!(
+        "{}\t{}\t{}{stat}{usage}",
+        turn.ordinal,
+        turn.status.as_str(),
+        clip(&turn.user_input.replace('\n', " "), 48)
+    );
+}
+
+fn print_approval(approval: &CodeApprovalSnapshot) {
+    println!(
+        "{}\t{}\t{}\t{}",
+        approval.id,
+        approval.state.as_str(),
+        approval_kind(&approval.kind),
+        approval.session_id
+    );
+}
+
+fn print_pr(status: &crate::api::code::CodeWorkspacePrSnapshot) {
+    println!(
+        "dirty={}  unpushed={}  ahead={}  upstream={}",
+        status.dirty, status.unpushed, status.ahead, status.has_upstream
+    );
+    if !status.suggested_commit_message.is_empty() {
+        println!("suggested commit     {}", status.suggested_commit_message);
+    }
+    match &status.pr {
+        Some(pr) => {
+            let checks = pr.checks_summary.as_deref().unwrap_or("-");
+            let url = pr.url.as_deref().unwrap_or("-");
+            println!(
+                "pr                   #{} {}  {checks}  {url}",
+                pr.number, pr.state
+            );
+        }
+        None => println!("pr                   none"),
+    }
+    let gh = match status.gh_authenticated {
+        Some(true) => "yes",
+        Some(false) => "signed out",
+        None if status.gh_found => "found",
+        None => "missing",
+    };
+    println!("gh                   {gh}");
+    if !status.remediation.is_empty() {
+        println!("remediation          {}", status.remediation);
+    }
+}
+
+fn attention_label(attention: &Attention) -> String {
+    match &attention.state {
+        AttentionState::Working => "working".to_owned(),
+        AttentionState::NeedsYou { prompt, .. } => format!("needs_you: {prompt}"),
+        AttentionState::Stalled { idle_secs } => format!("stalled {idle_secs}s"),
+        AttentionState::DoneUnreviewed => "done_unreviewed".to_owned(),
+        AttentionState::Fenced { .. } => "fenced".to_owned(),
+        AttentionState::Manual { note } => format!("manual: {note}"),
+    }
+}
+
+fn approval_kind(kind: &CodeApprovalKind) -> String {
+    match kind {
+        CodeApprovalKind::Command { cmd, .. } => format!("command {cmd}"),
+        CodeApprovalKind::FileWrite { paths } => format!("write {}", paths.join(",")),
+        CodeApprovalKind::Network { summary } => format!("network {summary}"),
+        CodeApprovalKind::Other { summary } => summary.clone(),
+    }
+}
+
+fn tool_detail(detail: &tidebreak_core::ToolDetail) -> String {
+    match detail {
+        tidebreak_core::ToolDetail::Command { cmd, cwd } => format!("{cmd}  ({cwd})"),
+        tidebreak_core::ToolDetail::FileEdit { path }
+        | tidebreak_core::ToolDetail::FileRead { path } => path.clone(),
+        tidebreak_core::ToolDetail::Search { query } => query.clone(),
+        tidebreak_core::ToolDetail::Other { summary } => summary.clone(),
+    }
+}
+
+fn outcome_label(outcome: tidebreak_core::ToolOutcome) -> &'static str {
+    match outcome {
+        tidebreak_core::ToolOutcome::Succeeded => "ok",
+        tidebreak_core::ToolOutcome::Failed => "failed",
+        tidebreak_core::ToolOutcome::Denied => "denied",
+    }
+}
+
+fn level_label(level: tidebreak_core::HarnessNoticeLevel) -> &'static str {
+    match level {
+        tidebreak_core::HarnessNoticeLevel::Info => "notice",
+        tidebreak_core::HarnessNoticeLevel::Warning => "warning",
+        tidebreak_core::HarnessNoticeLevel::Error => "error",
+    }
+}
+
+trait FileChangeLabel {
+    fn as_str_display(&self) -> &'static str;
+}
+
+impl FileChangeLabel for tidebreak_core::FileChangeKind {
+    fn as_str_display(&self) -> &'static str {
+        match self {
+            Self::Added => "added",
+            Self::Modified => "modified",
+            Self::Deleted => "deleted",
+            Self::Renamed => "renamed",
+        }
+    }
+}
+
+fn or_dash(value: &str) -> &str {
+    if value.is_empty() {
+        "-"
+    } else {
+        value
+    }
+}
+
+fn clip(value: &str, max: usize) -> String {
+    if value.chars().count() <= max {
+        return value.to_owned();
+    }
+    let mut clipped: String = value.chars().take(max.saturating_sub(1)).collect();
+    clipped.push('…');
+    clipped
+}
+
+fn emit<T: serde::Serialize>(value: &T) -> Result<i32> {
+    println!(
+        "{}",
+        serde_json::to_string(value)
+            .map_err(|error| AgentError::msg(format!("could not encode json: {error}")))?
+    );
+    Ok(0)
+}
+
+fn emit_ok<T: serde::Serialize>(value: &T) -> Result<i32> {
+    emit(value)
+}
+
+fn emit_line(raw: &str) {
+    let mut stdout = std::io::stdout().lock();
+    let _ = writeln!(stdout, "{raw}");
+    let _ = stdout.flush();
+}
+
+struct CodeStream {
+    socket: crate::api::client::EventSocket,
+    last_seq: i64,
+}
+
+impl CodeStream {
+    async fn open_session(client: &Client, session: CodeSessionId) -> Result<Self> {
+        Ok(Self {
+            socket: client.open_code_events(session, 0).await?,
+            last_seq: 0,
+        })
+    }
+
+    async fn open_updates(client: &Client) -> Result<Self> {
+        Ok(Self {
+            socket: client.open_code_updates().await?,
+            last_seq: 0,
+        })
+    }
+
+    async fn next_session(
+        &mut self,
+        client: &Client,
+        session: CodeSessionId,
+    ) -> Result<Option<(String, crate::api::code::SequencedCodeEventFrame)>> {
+        match self.socket.next().await {
+            Some(Ok(Message::Text(text))) => match decode_event_frame(&text) {
+                Ok(frame) => {
+                    self.last_seq = frame.seq;
+                    Ok(Some((text.to_string(), frame)))
+                }
+                Err(_) => Ok(None),
+            },
+            Some(Ok(_)) => Ok(None),
+            Some(Err(_)) | None => {
+                self.reconnect_session(client, session).await?;
+                Ok(None)
+            }
+        }
+    }
+
+    async fn next_updates(
+        &mut self,
+        client: &Client,
+    ) -> Result<Option<(String, CodeUpdateNotice)>> {
+        match self.socket.next().await {
+            Some(Ok(Message::Text(text))) => match decode_update_notice(&text) {
+                Ok(notice) => Ok(Some((text.to_string(), notice))),
+                Err(_) => Ok(None),
+            },
+            Some(Ok(_)) => Ok(None),
+            Some(Err(_)) | None => {
+                self.reconnect_updates(client).await?;
+                Ok(None)
+            }
+        }
+    }
+
+    async fn reconnect_session(&mut self, client: &Client, session: CodeSessionId) -> Result<()> {
+        let mut last = None;
+        for _ in 0..RECONNECT_ATTEMPTS {
+            tokio::time::sleep(RECONNECT_DELAY).await;
+            match client.open_code_events(session, self.last_seq).await {
+                Ok(socket) => {
+                    self.socket = socket;
+                    return Ok(());
+                }
+                Err(error) => last = Some(error),
+            }
+        }
+        Err(AgentError::msg(format!(
+            "the session event stream closed and could not be reopened{}",
+            last.map(|error| format!(": {error}")).unwrap_or_default()
+        )))
+    }
+
+    async fn reconnect_updates(&mut self, client: &Client) -> Result<()> {
+        let mut last = None;
+        for _ in 0..RECONNECT_ATTEMPTS {
+            tokio::time::sleep(RECONNECT_DELAY).await;
+            match client.open_code_updates().await {
+                Ok(socket) => {
+                    self.socket = socket;
+                    return Ok(());
+                }
+                Err(error) => last = Some(error),
+            }
+        }
+        Err(AgentError::msg(format!(
+            "the updates stream closed and could not be reopened{}",
+            last.map(|error| format!(": {error}")).unwrap_or_default()
+        )))
+    }
+}
+
+/// Same interrupt watcher `-p` uses: register before waiting, second Ctrl-C
+/// exits immediately.
+struct Interrupt(tokio::sync::watch::Receiver<bool>);
+
+impl Interrupt {
+    async fn watch() -> Self {
+        let (fired, seen) = tokio::sync::watch::channel(false);
+        let (installed, registered) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let mut signal = std::pin::pin!(tokio::signal::ctrl_c());
+            let first = std::future::poll_fn(|context| {
+                std::task::Poll::Ready(signal.as_mut().poll(context))
+            })
+            .await;
+            let _ = installed.send(());
+            let interrupted = match first {
+                std::task::Poll::Ready(result) => result.is_ok(),
+                std::task::Poll::Pending => signal.await.is_ok(),
+            };
+            if !interrupted {
+                return;
+            }
+            let _ = fired.send(true);
+            if tokio::signal::ctrl_c().await.is_ok() {
+                std::process::exit(EXIT_INTERRUPTED);
+            }
+        });
+        let _ = registered.await;
+        Self(seen)
+    }
+
+    async fn fired(&mut self) {
+        while !*self.0.borrow_and_update() {
+            if self.0.changed().await.is_err() {
+                std::future::pending::<()>().await;
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+struct Cursor {
+    args: Vec<String>,
+    at: usize,
+}
+
+impl Cursor {
+    fn new(args: Vec<String>) -> Self {
+        Self { args, at: 0 }
+    }
+
+    fn next(&mut self) -> Option<String> {
+        let value = self.args.get(self.at).cloned();
+        if value.is_some() {
+            self.at += 1;
+        }
+        value
+    }
+
+    fn value(&mut self, flag: &str) -> std::result::Result<String, String> {
+        match self.next() {
+            Some(value) if !value.starts_with("--") => Ok(value),
+            _ => Err(format!("{flag} requires a value")),
+        }
+    }
+
+    fn positional(&mut self, what: &str) -> std::result::Result<String, String> {
+        match self.next() {
+            Some(value) if !value.starts_with("--") => Ok(value),
+            _ => Err(format!("expected {what}")),
+        }
+    }
+}
+
+struct SharedFlags {
+    format: OutputFormat,
+}
+
+fn take_format(
+    flags: &mut SharedFlags,
+    cursor: &mut Cursor,
+    flag: &str,
+) -> std::result::Result<(), String> {
+    match flag {
+        "--json" => {
+            flags.format = OutputFormat::Json;
+            Ok(())
+        }
+        "--output-format" => {
+            let value = cursor.value("--output-format")?;
+            flags.format = OutputFormat::parse(&value)
+                .ok_or_else(|| "--output-format expects text or json".to_owned())?;
+            Ok(())
+        }
+        _ => Err(format!("unknown argument {flag:?}")),
+    }
+}
+
+fn parse_doctor(cursor: &mut Cursor) -> std::result::Result<Command, String> {
+    let mut refresh = false;
+    let mut flags = SharedFlags {
+        format: OutputFormat::Text,
+    };
+    while let Some(arg) = cursor.next() {
+        match arg.as_str() {
+            "--refresh" => refresh = true,
+            other => take_format(&mut flags, cursor, other)?,
+        }
+    }
+    Ok(Command::Doctor {
+        refresh,
+        format: flags.format,
+    })
+}
+
+fn parse_repo(cursor: &mut Cursor) -> std::result::Result<Command, String> {
+    let verb = cursor.positional("a repo subcommand")?;
+    match verb.as_str() {
+        "add" => {
+            let mut path = None;
+            let mut name = None;
+            let mut base_ref = None;
+            let mut branch_prefix = None;
+            let mut flags = SharedFlags {
+                format: OutputFormat::Text,
+            };
+            while let Some(arg) = cursor.next() {
+                match arg.as_str() {
+                    "--name" => name = Some(cursor.value("--name")?),
+                    "--base-ref" => base_ref = Some(cursor.value("--base-ref")?),
+                    "--branch-prefix" => branch_prefix = Some(cursor.value("--branch-prefix")?),
+                    other if other.starts_with("--") => take_format(&mut flags, cursor, other)?,
+                    other if path.is_none() => path = Some(other.to_owned()),
+                    other => return Err(format!("unexpected repo add argument {other:?}")),
+                }
+            }
+            let path = path.ok_or_else(|| "repo add requires a path".to_owned())?;
+            Ok(Command::RepoAdd {
+                path: PathBuf::from(path),
+                name,
+                base_ref,
+                branch_prefix,
+                format: flags.format,
+            })
+        }
+        "list" => {
+            let mut flags = SharedFlags {
+                format: OutputFormat::Text,
+            };
+            while let Some(arg) = cursor.next() {
+                take_format(&mut flags, cursor, &arg)?;
+            }
+            Ok(Command::RepoList {
+                format: flags.format,
+            })
+        }
+        "rm" => {
+            let mut id = None;
+            let mut flags = SharedFlags {
+                format: OutputFormat::Text,
+            };
+            while let Some(arg) = cursor.next() {
+                if arg.starts_with("--") {
+                    take_format(&mut flags, cursor, &arg)?;
+                } else if id.is_none() {
+                    id = Some(parse_repo_id(&arg)?);
+                } else {
+                    return Err(format!("unexpected repo rm argument {arg:?}"));
+                }
+            }
+            let id = id.ok_or_else(|| "repo rm requires a repository id".to_owned())?;
+            Ok(Command::RepoRm {
+                id,
+                format: flags.format,
+            })
+        }
+        other => Err(format!("unknown repo subcommand {other:?}")),
+    }
+}
+
+fn parse_ws(cursor: &mut Cursor) -> std::result::Result<Command, String> {
+    let verb = cursor.positional("a ws subcommand")?;
+    match verb.as_str() {
+        "new" => {
+            let mut repo = None;
+            let mut title = None;
+            let mut base_ref = None;
+            let mut flags = SharedFlags {
+                format: OutputFormat::Text,
+            };
+            while let Some(arg) = cursor.next() {
+                match arg.as_str() {
+                    "--repo" => repo = Some(cursor.value("--repo")?),
+                    "--title" => title = Some(cursor.value("--title")?),
+                    "--base-ref" => base_ref = Some(cursor.value("--base-ref")?),
+                    other => take_format(&mut flags, cursor, other)?,
+                }
+            }
+            let repo = repo.ok_or_else(|| "ws new requires --repo <id|path>".to_owned())?;
+            Ok(Command::WsNew {
+                repo,
+                title,
+                base_ref,
+                format: flags.format,
+            })
+        }
+        "list" => {
+            let mut repo = None;
+            let mut flags = SharedFlags {
+                format: OutputFormat::Text,
+            };
+            while let Some(arg) = cursor.next() {
+                match arg.as_str() {
+                    "--repo" => repo = Some(cursor.value("--repo")?),
+                    other => take_format(&mut flags, cursor, other)?,
+                }
+            }
+            Ok(Command::WsList {
+                repo,
+                format: flags.format,
+            })
+        }
+        "show" => {
+            let (id, format) = take_id_and_format(cursor, "a workspace id", parse_workspace_id)?;
+            Ok(Command::WsShow { id, format })
+        }
+        "archive" => {
+            let mut id = None;
+            let mut force = false;
+            let mut flags = SharedFlags {
+                format: OutputFormat::Text,
+            };
+            while let Some(arg) = cursor.next() {
+                match arg.as_str() {
+                    "--force" => force = true,
+                    other if other.starts_with("--") => take_format(&mut flags, cursor, other)?,
+                    other if id.is_none() => id = Some(parse_workspace_id(other)?),
+                    other => return Err(format!("unexpected ws archive argument {other:?}")),
+                }
+            }
+            let id = id.ok_or_else(|| "ws archive requires a workspace id".to_owned())?;
+            Ok(Command::WsArchive {
+                id,
+                force,
+                format: flags.format,
+            })
+        }
+        other => Err(format!("unknown ws subcommand {other:?}")),
+    }
+}
+
+fn parse_session(cursor: &mut Cursor) -> std::result::Result<Command, String> {
+    let verb = cursor.positional("a session subcommand")?;
+    match verb.as_str() {
+        "start" => {
+            let mut workspace = None;
+            let mut harness = None;
+            let mut mode = CodePermissionMode::DEFAULT;
+            let mut flags = SharedFlags {
+                format: OutputFormat::Text,
+            };
+            while let Some(arg) = cursor.next() {
+                match arg.as_str() {
+                    "--ws" => workspace = Some(parse_workspace_id(&cursor.value("--ws")?)?),
+                    "--harness" => harness = Some(parse_harness(&cursor.value("--harness")?)?),
+                    "--mode" => mode = parse_mode(&cursor.value("--mode")?)?,
+                    other => take_format(&mut flags, cursor, other)?,
+                }
+            }
+            let workspace =
+                workspace.ok_or_else(|| "session start requires --ws <id>".to_owned())?;
+            let harness =
+                harness.ok_or_else(|| "session start requires --harness <kind>".to_owned())?;
+            Ok(Command::SessionStart {
+                workspace,
+                harness,
+                mode,
+                format: flags.format,
+            })
+        }
+        "show" => {
+            let (id, format) = take_id_and_format(cursor, "a session id", parse_session_id)?;
+            Ok(Command::SessionShow { id, format })
+        }
+        "reap" => {
+            let (id, format) = take_id_and_format(cursor, "a session id", parse_session_id)?;
+            Ok(Command::SessionReap { id, format })
+        }
+        other => Err(format!("unknown session subcommand {other:?}")),
+    }
+}
+
+fn parse_run(cursor: &mut Cursor) -> std::result::Result<Command, String> {
+    let mut session = None;
+    let mut workspace = None;
+    let mut on_approval = OnApproval::Wait;
+    let mut flags = SharedFlags {
+        format: OutputFormat::Text,
+    };
+    let mut message_parts = Vec::new();
+    while let Some(arg) = cursor.next() {
+        match arg.as_str() {
+            "--session" => session = Some(parse_session_id(&cursor.value("--session")?)?),
+            "--ws" => workspace = Some(parse_workspace_id(&cursor.value("--ws")?)?),
+            "--on-approval" => {
+                on_approval = parse_on_approval(&cursor.value("--on-approval")?)?;
+            }
+            "--json" | "--output-format" => take_format(&mut flags, cursor, &arg)?,
+            other if other.starts_with("--") => {
+                return Err(format!("unknown code run argument {other:?}"));
+            }
+            other => message_parts.push(other.to_owned()),
+        }
+    }
+    if session.is_none() && workspace.is_none() {
+        return Err("code run requires --session <id> or --ws <id>".to_owned());
+    }
+    if message_parts.is_empty() {
+        return Err("code run requires a message".to_owned());
+    }
+    Ok(Command::Run {
+        session,
+        workspace,
+        message: message_parts.join(" "),
+        on_approval,
+        format: flags.format,
+    })
+}
+
+fn parse_approvals(cursor: &mut Cursor) -> std::result::Result<Command, String> {
+    let mut session = None;
+    let mut flags = SharedFlags {
+        format: OutputFormat::Text,
+    };
+    while let Some(arg) = cursor.next() {
+        match arg.as_str() {
+            "--session" => session = Some(parse_session_id(&cursor.value("--session")?)?),
+            other => take_format(&mut flags, cursor, other)?,
+        }
+    }
+    Ok(Command::Approvals {
+        session,
+        format: flags.format,
+    })
+}
+
+fn parse_approve(cursor: &mut Cursor) -> std::result::Result<Command, String> {
+    let (id, format) = take_id_and_format(cursor, "an approval id", parse_approval_id)?;
+    Ok(Command::Approve { id, format })
+}
+
+fn parse_deny(cursor: &mut Cursor) -> std::result::Result<Command, String> {
+    let mut id = None;
+    let mut feedback = None;
+    let mut flags = SharedFlags {
+        format: OutputFormat::Text,
+    };
+    while let Some(arg) = cursor.next() {
+        match arg.as_str() {
+            "-m" | "--message" | "--feedback" => feedback = Some(cursor.value("-m")?),
+            other if other.starts_with("--") => take_format(&mut flags, cursor, other)?,
+            other if id.is_none() => id = Some(parse_approval_id(other)?),
+            other => return Err(format!("unexpected deny argument {other:?}")),
+        }
+    }
+    let id = id.ok_or_else(|| "deny requires an approval id".to_owned())?;
+    Ok(Command::Deny {
+        id,
+        feedback,
+        format: flags.format,
+    })
+}
+
+fn parse_interrupt(cursor: &mut Cursor) -> std::result::Result<Command, String> {
+    let mut session = None;
+    let mut flags = SharedFlags {
+        format: OutputFormat::Text,
+    };
+    while let Some(arg) = cursor.next() {
+        match arg.as_str() {
+            "--session" => session = Some(parse_session_id(&cursor.value("--session")?)?),
+            other => take_format(&mut flags, cursor, other)?,
+        }
+    }
+    let session = session.ok_or_else(|| "interrupt requires --session <id>".to_owned())?;
+    Ok(Command::Interrupt {
+        session,
+        format: flags.format,
+    })
+}
+
+fn parse_turns(cursor: &mut Cursor) -> std::result::Result<Command, String> {
+    let mut session = None;
+    let mut flags = SharedFlags {
+        format: OutputFormat::Text,
+    };
+    while let Some(arg) = cursor.next() {
+        match arg.as_str() {
+            "--session" => session = Some(parse_session_id(&cursor.value("--session")?)?),
+            other => take_format(&mut flags, cursor, other)?,
+        }
+    }
+    let session = session.ok_or_else(|| "turns requires --session <id>".to_owned())?;
+    Ok(Command::Turns {
+        session,
+        format: flags.format,
+    })
+}
+
+fn parse_diff(cursor: &mut Cursor) -> std::result::Result<Command, String> {
+    let mut workspace = None;
+    let mut turn = None;
+    let mut file = None;
+    let mut flags = SharedFlags {
+        format: OutputFormat::Text,
+    };
+    while let Some(arg) = cursor.next() {
+        match arg.as_str() {
+            "--ws" => workspace = Some(parse_workspace_id(&cursor.value("--ws")?)?),
+            "--turn" => turn = Some(parse_turn_ref(&cursor.value("--turn")?)?),
+            "--file" => file = Some(cursor.value("--file")?),
+            other => take_format(&mut flags, cursor, other)?,
+        }
+    }
+    let workspace = workspace.ok_or_else(|| "diff requires --ws <id>".to_owned())?;
+    Ok(Command::Diff {
+        workspace,
+        turn,
+        file,
+        format: flags.format,
+    })
+}
+
+fn parse_files(cursor: &mut Cursor) -> std::result::Result<Command, String> {
+    let mut workspace = None;
+    let mut turn = None;
+    let mut flags = SharedFlags {
+        format: OutputFormat::Text,
+    };
+    while let Some(arg) = cursor.next() {
+        match arg.as_str() {
+            "--ws" => workspace = Some(parse_workspace_id(&cursor.value("--ws")?)?),
+            "--turn" => turn = Some(parse_turn_ref(&cursor.value("--turn")?)?),
+            other => take_format(&mut flags, cursor, other)?,
+        }
+    }
+    let workspace = workspace.ok_or_else(|| "files requires --ws <id>".to_owned())?;
+    Ok(Command::Files {
+        workspace,
+        turn,
+        format: flags.format,
+    })
+}
+
+fn parse_git(cursor: &mut Cursor) -> std::result::Result<Command, String> {
+    let verb = cursor.positional("a git subcommand")?;
+    match verb.as_str() {
+        "commit" => {
+            let mut workspace = None;
+            let mut message = None;
+            let mut flags = SharedFlags {
+                format: OutputFormat::Text,
+            };
+            while let Some(arg) = cursor.next() {
+                match arg.as_str() {
+                    "--ws" => workspace = Some(parse_workspace_id(&cursor.value("--ws")?)?),
+                    "-m" | "--message" => message = Some(cursor.value("-m")?),
+                    other => take_format(&mut flags, cursor, other)?,
+                }
+            }
+            let workspace = workspace.ok_or_else(|| "git commit requires --ws <id>".to_owned())?;
+            Ok(Command::GitCommit {
+                workspace,
+                message,
+                format: flags.format,
+            })
+        }
+        "push" => {
+            let (workspace, format) = take_ws_flag(cursor, "git push")?;
+            Ok(Command::GitPush { workspace, format })
+        }
+        "pr" => {
+            let mut workspace = None;
+            let mut title = None;
+            let mut body = None;
+            let mut flags = SharedFlags {
+                format: OutputFormat::Text,
+            };
+            while let Some(arg) = cursor.next() {
+                match arg.as_str() {
+                    "--ws" => workspace = Some(parse_workspace_id(&cursor.value("--ws")?)?),
+                    "--title" => title = Some(cursor.value("--title")?),
+                    "--body" => body = Some(cursor.value("--body")?),
+                    other => take_format(&mut flags, cursor, other)?,
+                }
+            }
+            let workspace = workspace.ok_or_else(|| "git pr requires --ws <id>".to_owned())?;
+            Ok(Command::GitPr {
+                workspace,
+                title,
+                body,
+                format: flags.format,
+            })
+        }
+        "status" => {
+            let (workspace, format) = take_ws_flag(cursor, "git status")?;
+            Ok(Command::GitStatus { workspace, format })
+        }
+        other => Err(format!("unknown git subcommand {other:?}")),
+    }
+}
+
+fn parse_action(cursor: &mut Cursor) -> std::result::Result<Command, String> {
+    let mut name = None;
+    let mut workspace = None;
+    let mut flags = SharedFlags {
+        format: OutputFormat::Text,
+    };
+    while let Some(arg) = cursor.next() {
+        match arg.as_str() {
+            "--ws" => workspace = Some(parse_workspace_id(&cursor.value("--ws")?)?),
+            other if other.starts_with("--") => take_format(&mut flags, cursor, other)?,
+            other if name.is_none() => name = Some(other.to_owned()),
+            other => return Err(format!("unexpected action argument {other:?}")),
+        }
+    }
+    let name = name.ok_or_else(|| "action requires a name".to_owned())?;
+    let workspace = workspace.ok_or_else(|| "action requires --ws <id>".to_owned())?;
+    Ok(Command::Action {
+        name,
+        workspace,
+        format: flags.format,
+    })
+}
+
+fn parse_watch(cursor: &mut Cursor) -> std::result::Result<Command, String> {
+    let mut flags = SharedFlags {
+        format: OutputFormat::Text,
+    };
+    while let Some(arg) = cursor.next() {
+        take_format(&mut flags, cursor, &arg)?;
+    }
+    Ok(Command::Watch {
+        format: flags.format,
+    })
+}
+
+fn take_ws_flag(
+    cursor: &mut Cursor,
+    context: &str,
+) -> std::result::Result<(WorkspaceId, OutputFormat), String> {
+    let mut workspace = None;
+    let mut flags = SharedFlags {
+        format: OutputFormat::Text,
+    };
+    while let Some(arg) = cursor.next() {
+        match arg.as_str() {
+            "--ws" => workspace = Some(parse_workspace_id(&cursor.value("--ws")?)?),
+            other => take_format(&mut flags, cursor, other)?,
+        }
+    }
+    let workspace = workspace.ok_or_else(|| format!("{context} requires --ws <id>"))?;
+    Ok((workspace, flags.format))
+}
+
+fn take_id_and_format<T>(
+    cursor: &mut Cursor,
+    what: &str,
+    parse_id: fn(&str) -> std::result::Result<T, String>,
+) -> std::result::Result<(T, OutputFormat), String> {
+    let mut id = None;
+    let mut flags = SharedFlags {
+        format: OutputFormat::Text,
+    };
+    while let Some(arg) = cursor.next() {
+        if arg.starts_with("--") {
+            take_format(&mut flags, cursor, &arg)?;
+        } else if id.is_none() {
+            id = Some(parse_id(&arg)?);
+        } else {
+            return Err(format!("unexpected argument {arg:?}"));
+        }
+    }
+    let id = id.ok_or_else(|| format!("expected {what}"))?;
+    Ok((id, flags.format))
+}
+
+fn parse_repo_id(value: &str) -> std::result::Result<RepoId, String> {
+    RepoId::from_str(value).map_err(|_| "expected a repository UUID".to_owned())
+}
+
+fn parse_workspace_id(value: &str) -> std::result::Result<WorkspaceId, String> {
+    WorkspaceId::from_str(value).map_err(|_| "expected a workspace UUID".to_owned())
+}
+
+fn parse_session_id(value: &str) -> std::result::Result<CodeSessionId, String> {
+    CodeSessionId::from_str(value).map_err(|_| "expected a session UUID".to_owned())
+}
+
+fn parse_approval_id(value: &str) -> std::result::Result<CodeApprovalId, String> {
+    CodeApprovalId::from_str(value).map_err(|_| "expected an approval UUID".to_owned())
+}
+
+fn parse_turn_ref(value: &str) -> std::result::Result<TurnRef, String> {
+    if let Ok(id) = CodeTurnId::from_str(value) {
+        return Ok(TurnRef::Id(id));
+    }
+    value
+        .parse::<i64>()
+        .ok()
+        .filter(|ordinal| *ordinal > 0)
+        .map(TurnRef::Ordinal)
+        .ok_or_else(|| "--turn expects a positive ordinal or a turn UUID".to_owned())
+}
+
+fn parse_harness(value: &str) -> std::result::Result<HarnessKind, String> {
+    let token = value.replace('-', "_");
+    HarnessKind::from_str(&token)
+        .ok_or_else(|| "expected a harness kind: claude_code, codex, opencode, or grok".to_owned())
+}
+
+fn parse_mode(value: &str) -> std::result::Result<CodePermissionMode, String> {
+    CodePermissionMode::from_str(value)
+        .ok_or_else(|| "--mode expects plan, ask, or auto".to_owned())
+}
+
+fn parse_on_approval(value: &str) -> std::result::Result<OnApproval, String> {
+    match value {
+        "wait" => Ok(OnApproval::Wait),
+        "fail" => Ok(OnApproval::Fail),
+        _ => Err("--on-approval expects wait or fail".to_owned()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|part| (*part).to_owned()).collect()
+    }
+
+    fn id() -> String {
+        uuid::Uuid::nil().to_string()
+    }
+
+    #[test]
+    fn every_verb_parses_its_required_shape() {
+        let ws = id();
+        let session = id();
+        let approval = id();
+        let repo = id();
+
+        assert!(matches!(
+            parse(args(&["doctor", "--refresh", "--json"])).unwrap(),
+            Command::Doctor {
+                refresh: true,
+                format: OutputFormat::Json
+            }
+        ));
+        assert!(matches!(
+            parse(args(&["repo", "add", "/tmp/proj", "--name", "proj"])).unwrap(),
+            Command::RepoAdd { .. }
+        ));
+        assert!(matches!(
+            parse(args(&["repo", "list"])).unwrap(),
+            Command::RepoList { .. }
+        ));
+        assert!(matches!(
+            parse(args(&["repo", "rm", &repo])).unwrap(),
+            Command::RepoRm { .. }
+        ));
+        assert!(matches!(
+            parse(args(&[
+                "ws",
+                "new",
+                "--repo",
+                "/tmp/proj",
+                "--title",
+                "fix"
+            ]))
+            .unwrap(),
+            Command::WsNew { .. }
+        ));
+        assert!(matches!(
+            parse(args(&["ws", "list", "--repo", &repo])).unwrap(),
+            Command::WsList { .. }
+        ));
+        assert!(matches!(
+            parse(args(&["ws", "show", &ws])).unwrap(),
+            Command::WsShow { .. }
+        ));
+        assert!(matches!(
+            parse(args(&["ws", "archive", &ws, "--force"])).unwrap(),
+            Command::WsArchive { force: true, .. }
+        ));
+        match parse(args(&[
+            "session",
+            "start",
+            "--ws",
+            &ws,
+            "--harness",
+            "claude-code",
+        ]))
+        .unwrap()
+        {
+            Command::SessionStart {
+                harness,
+                mode,
+                format,
+                ..
+            } => {
+                assert_eq!(harness, HarnessKind::ClaudeCode);
+                assert_eq!(mode, CodePermissionMode::Ask);
+                assert_eq!(format, OutputFormat::Text);
+            }
+            other => panic!("{other:?}"),
+        }
+        match parse(args(&[
+            "run",
+            "--session",
+            &session,
+            "--on-approval",
+            "fail",
+            "--json",
+            "ship",
+            "it",
+        ]))
+        .unwrap()
+        {
+            Command::Run {
+                message,
+                on_approval,
+                format,
+                ..
+            } => {
+                assert_eq!(message, "ship it");
+                assert_eq!(on_approval, OnApproval::Fail);
+                assert_eq!(format, OutputFormat::Json);
+            }
+            other => panic!("{other:?}"),
+        }
+        assert!(matches!(
+            parse(args(&["approve", &approval])).unwrap(),
+            Command::Approve { .. }
+        ));
+        match parse(args(&["deny", &approval, "-m", "no"])).unwrap() {
+            Command::Deny { feedback, .. } => assert_eq!(feedback.as_deref(), Some("no")),
+            other => panic!("{other:?}"),
+        }
+        assert!(matches!(
+            parse(args(&["interrupt", "--session", &session])).unwrap(),
+            Command::Interrupt { .. }
+        ));
+        assert!(matches!(
+            parse(args(&["turns", "--session", &session])).unwrap(),
+            Command::Turns { .. }
+        ));
+        match parse(args(&[
+            "diff", "--ws", &ws, "--turn", "2", "--file", "a.rs",
+        ]))
+        .unwrap()
+        {
+            Command::Diff {
+                turn: Some(TurnRef::Ordinal(2)),
+                file,
+                ..
+            } => assert_eq!(file.as_deref(), Some("a.rs")),
+            other => panic!("{other:?}"),
+        }
+        assert!(matches!(
+            parse(args(&["git", "commit", "--ws", &ws, "-m", "wip"])).unwrap(),
+            Command::GitCommit { .. }
+        ));
+        assert!(matches!(
+            parse(args(&["action", "lint", "--ws", &ws])).unwrap(),
+            Command::Action { .. }
+        ));
+        assert!(matches!(
+            parse(args(&["watch", "--json"])).unwrap(),
+            Command::Watch {
+                format: OutputFormat::Json
+            }
+        ));
+    }
+
+    #[test]
+    fn refusals_match_the_existing_walker() {
+        assert!(parse(args(&[])).is_err());
+        assert!(parse(args(&["nope"])).is_err());
+        assert!(parse(args(&["repo"])).is_err());
+        assert!(parse(args(&["repo", "add"])).is_err());
+        assert!(parse(args(&["repo", "rm", "not-a-uuid"])).is_err());
+        assert!(parse(args(&["ws", "new"])).is_err());
+        assert!(parse(args(&["session", "start", "--ws", &id()])).is_err());
+        assert!(parse(args(&["run", "hello"])).is_err());
+        assert!(parse(args(&["run", "--session", &id()])).is_err());
+        assert!(parse(args(&[
+            "run",
+            "--session",
+            &id(),
+            "--on-approval",
+            "yolo",
+            "x"
+        ]))
+        .is_err());
+        assert!(parse(args(&["interrupt"])).is_err());
+        assert!(parse(args(&["diff"])).is_err());
+        assert!(parse(args(&["git", "push"])).is_err());
+        assert!(parse(args(&["action", "lint"])).is_err());
+        assert!(parse(args(&["doctor", "--wat"])).is_err());
+        assert!(parse(args(&["watch", "--output-format", "yaml"])).is_err());
+        assert!(parse(args(&[
+            "session",
+            "start",
+            "--ws",
+            &id(),
+            "--harness",
+            "nope"
+        ]))
+        .is_err());
+    }
+
+    #[test]
+    fn json_is_accepted_as_a_flag_or_as_output_format() {
+        let parsed = parse(args(&["repo", "list", "--output-format", "json"])).unwrap();
+        assert!(matches!(
+            parsed,
+            Command::RepoList {
+                format: OutputFormat::Json
+            }
+        ));
+        let parsed = parse(args(&["repo", "list", "--json"])).unwrap();
+        assert!(matches!(
+            parsed,
+            Command::RepoList {
+                format: OutputFormat::Json
+            }
+        ));
+    }
+
+    #[test]
+    fn run_resolves_a_workspace_instead_of_a_session() {
+        let ws = id();
+        match parse(args(&["run", "--ws", &ws, "hello"])).unwrap() {
+            Command::Run {
+                session,
+                workspace,
+                message,
+                on_approval,
+                ..
+            } => {
+                assert!(session.is_none());
+                assert!(workspace.is_some());
+                assert_eq!(message, "hello");
+                assert_eq!(on_approval, OnApproval::Wait);
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn pick_active_session_prefers_running_then_newest_usable() {
+        assert!(pick_active_session(&[]).is_none());
+    }
+}

--- a/crates/tidebreak-cli/src/code.rs
+++ b/crates/tidebreak-cli/src/code.rs
@@ -838,6 +838,104 @@ async fn resolve_turn(
     }
 }
 
+/// Which frames `code run` owns. Extracted so the two ownership bugs have
+/// fixtures that do not need a live server.
+#[derive(Debug)]
+struct TurnGate {
+    expected: Option<CodeTurnId>,
+    ours: bool,
+    /// True after we have seen `TurnStarted` for `expected`. Replayed
+    /// history of earlier turns is ignored until then; live frames of an
+    /// attach-owned turn are accepted without it.
+    seen_start: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FrameAction {
+    Skip,
+    Render,
+    Terminal(i32),
+}
+
+impl TurnGate {
+    fn submit() -> Self {
+        Self {
+            expected: None,
+            ours: false,
+            seen_start: false,
+        }
+    }
+
+    /// Attach to a turn that is already running. Own it immediately so live
+    /// mid-turn frames are accepted; `TurnStarted` for that id already
+    /// happened and only arrives `replayed: true`.
+    fn attach(turn: CodeTurnId) -> Self {
+        Self {
+            expected: Some(turn),
+            ours: true,
+            seen_start: false,
+        }
+    }
+
+    fn ours(&self) -> bool {
+        self.ours
+    }
+
+    fn on_ran(&mut self, id: CodeTurnId) {
+        if self.ours && self.expected == Some(id) {
+            return;
+        }
+        if self.expected.is_some_and(|bound| bound != id) {
+            self.ours = false;
+            self.seen_start = false;
+        }
+        self.expected = Some(id);
+    }
+
+    /// After Queued, only a later *live* `TurnStarted` binds ownership.
+    fn on_queued(&mut self) {
+        self.expected = None;
+        self.ours = false;
+        self.seen_start = false;
+    }
+
+    fn will_claim(&self, turn_id: CodeTurnId, replayed: bool) -> bool {
+        match self.expected {
+            Some(id) if id == turn_id => !self.seen_start,
+            None => !replayed,
+            Some(_) => false,
+        }
+    }
+
+    fn on_frame(&mut self, replayed: bool, event: &CodeEvent) -> FrameAction {
+        if let CodeEvent::TurnStarted { turn_id } = event {
+            let matches_bound = self.expected == Some(*turn_id);
+            let live_unbound = self.expected.is_none() && !replayed;
+            if matches_bound || live_unbound {
+                self.expected = Some(*turn_id);
+                self.ours = true;
+                self.seen_start = true;
+            }
+        }
+
+        // Never accept a terminal while this submit has not bound a turn —
+        // a live `turn_completed` here belongs to the already-running
+        // previous turn, not to a Queued follow-up.
+        if self.expected.is_none() || !self.ours {
+            return FrameAction::Skip;
+        }
+        // Replayed history before our `TurnStarted` is some other turn.
+        // Live frames of an attach-owned turn are ours even without it.
+        if replayed && !self.seen_start {
+            return FrameAction::Skip;
+        }
+        if is_turn_terminal(event) {
+            return FrameAction::Terminal(turn_exit_code(event).unwrap_or(1));
+        }
+        FrameAction::Render
+    }
+}
+
 async fn run_turn(
     client: &Client,
     session: CodeSessionId,
@@ -877,11 +975,13 @@ async fn run_turn(
         Some(std::pin::pin!(client.submit_turn(session, message)))
     };
     let mut submit_done = attach_only;
-    let mut expected_turn = attach_turn;
+    let mut gate = match attach_turn {
+        Some(turn) => TurnGate::attach(turn),
+        None => TurnGate::submit(),
+    };
     let mut interrupt = Interrupt::watch().await;
     let deadline =
         timeout.map(|secs| tokio::time::Instant::now() + std::time::Duration::from_secs(secs));
-    let mut ours = false;
     let mut dangling = false;
     let mut streamed_text = false;
 
@@ -898,12 +998,13 @@ async fn run_turn(
                 match submitted? {
                     SubmitTurnResponse::Ran(turn) => {
                         eprintln!("tidebreak: turn {}", turn.id);
-                        expected_turn = Some(turn.id);
+                        gate.on_ran(turn.id);
                     }
                     SubmitTurnResponse::Queued(_) => {
                         eprintln!(
                             "tidebreak: turn queued; waiting for the running turn to finish"
                         );
+                        gate.on_queued();
                     }
                 }
                 continue;
@@ -924,22 +1025,22 @@ async fn run_turn(
         let Some((raw, decoded)) = frame else {
             continue;
         };
-        // History from `after=0` is marked replayed. Skip it until this
-        // run's own turn has started; after that, replayed frames are
-        // reconnect catch-up and must be printed.
-        if decoded.replayed == Some(true) && !ours {
-            continue;
-        }
         if let CodeEvent::TurnStarted { turn_id } = &decoded.event {
-            if expected_turn.is_none_or(|id| id == *turn_id) {
-                if !ours {
-                    eprintln!("tidebreak: turn {turn_id}");
-                }
-                ours = true;
+            if gate.will_claim(*turn_id, decoded.replayed == Some(true)) && !gate.ours() {
+                eprintln!("tidebreak: turn {turn_id}");
             }
         }
-        if expected_turn.is_some() && !ours {
-            continue;
+        match gate.on_frame(decoded.replayed == Some(true), &decoded.event) {
+            FrameAction::Skip => continue,
+            FrameAction::Render => {}
+            FrameAction::Terminal(code) => {
+                if format == OutputFormat::Json {
+                    emit_line(&raw);
+                } else {
+                    dangling = render_event(&decoded.event, dangling, &mut streamed_text);
+                }
+                break Ok(code);
+            }
         }
         if format == OutputFormat::Json {
             emit_line(&raw);
@@ -951,9 +1052,6 @@ async fn run_turn(
             if on_approval == OnApproval::Fail {
                 break Ok(EXIT_APPROVAL_PARKED);
             }
-        }
-        if is_turn_terminal(&decoded.event) {
-            break Ok(turn_exit_code(&decoded.event).unwrap_or(1));
         }
     };
     if dangling {
@@ -2383,6 +2481,52 @@ mod tests {
             default_create_permission_mode(None),
             CodePermissionMode::Plan
         );
+    }
+
+    fn turn(n: u128) -> CodeTurnId {
+        CodeTurnId::from(uuid::Uuid::from_u128(n))
+    }
+
+    fn completed() -> CodeEvent {
+        CodeEvent::TurnCompleted {
+            usage: Default::default(),
+            checkpoint: None,
+        }
+    }
+
+    #[test]
+    fn a_queued_submit_does_not_exit_on_the_previous_turns_completion() {
+        let mut gate = TurnGate::submit();
+        assert_eq!(gate.on_frame(false, &completed()), FrameAction::Skip);
+        gate.on_queued();
+        assert_eq!(gate.on_frame(false, &completed()), FrameAction::Skip);
+        let ours = turn(2);
+        assert_eq!(
+            gate.on_frame(true, &CodeEvent::TurnStarted { turn_id: ours }),
+            FrameAction::Skip,
+            "replayed TurnStarted after Queued is not a later live start"
+        );
+        assert_eq!(
+            gate.on_frame(false, &CodeEvent::TurnStarted { turn_id: ours }),
+            FrameAction::Render
+        );
+        assert_eq!(gate.on_frame(false, &completed()), FrameAction::Terminal(0));
+    }
+
+    #[test]
+    fn attach_owns_the_running_turn_without_waiting_for_its_start() {
+        let id = turn(7);
+        let mut gate = TurnGate::attach(id);
+        assert_eq!(
+            gate.on_frame(true, &completed()),
+            FrameAction::Skip,
+            "replayed terminal of an earlier turn is not this attach"
+        );
+        assert_eq!(
+            gate.on_frame(false, &CodeEvent::AssistantDelta { text: "hi".into() }),
+            FrameAction::Render
+        );
+        assert_eq!(gate.on_frame(false, &completed()), FrameAction::Terminal(0));
     }
 
     #[test]

--- a/crates/tidebreak-cli/src/main.rs
+++ b/crates/tidebreak-cli/src/main.rs
@@ -37,6 +37,11 @@
 //! See [`setup`]; secrets are read from stdin or a named environment variable,
 //! never from a command-line argument.
 //!
+//! `tidebreak code …` drives the code-mode surface — repos, workspaces,
+//! sessions, turns, approvals, diffs, and the git/PR flow — over the same
+//! `/code/*` routes the desktop uses. `--json` (or `--output-format json`)
+//! writes one object, or NDJSON for `code run` and `code watch`. See [`code`].
+//!
 //! `tidebreak folder connect|list|disconnect` is the headless equivalent of the
 //! desktop's folder picker: an operator records standing consent for a host
 //! folder, which the broker stamps as operator configuration. It is deliberate
@@ -69,6 +74,7 @@ use tidebreak_core::{
 };
 
 mod api;
+mod code;
 mod connect;
 mod folder;
 mod folder_executor;
@@ -123,19 +129,47 @@ usage: tidebreak serve
        tidebreak folder list [--chat <id>] [--output-format text|json]
        tidebreak folder disconnect <path-or-root-id> --chat <id> [--output-format text|json]
 
-The setup commands, the output family, and the folder commands take
---output-format text|json. A key is read from stdin, or from the environment
-variable named by --from-env — never from an argument, which every process on
-the machine can read.
+       tidebreak code doctor [--refresh]
+       tidebreak code repo add <path> [--name <name>] [--base-ref <ref>] [--branch-prefix <p>]
+       tidebreak code repo list
+       tidebreak code repo rm <id>
+       tidebreak code ws new --repo <id|path> [--title <title>] [--base-ref <ref>]
+       tidebreak code ws list [--repo <id|path>]
+       tidebreak code ws show <id>
+       tidebreak code ws archive <id> [--force]
+       tidebreak code session start --ws <id> --harness <kind> [--mode plan|ask|auto]
+       tidebreak code session show <id>
+       tidebreak code session reap <id>
+       tidebreak code run (--session <id> | --ws <id>) <message> [--on-approval wait|fail]
+       tidebreak code approvals [--session <id>]
+       tidebreak code approve <approval-id>
+       tidebreak code deny <approval-id> [-m <feedback>]
+       tidebreak code interrupt --session <id>
+       tidebreak code turns --session <id>
+       tidebreak code diff --ws <id> [--turn N] [--file PATH]
+       tidebreak code files --ws <id> [--turn N]
+       tidebreak code git commit --ws <id> [-m MSG]
+       tidebreak code git push --ws <id>
+       tidebreak code git pr --ws <id> [--title <title>] [--body <body>]
+       tidebreak code git status --ws <id>
+       tidebreak code action <name> --ws <id>
+       tidebreak code watch
 
--p, output, attach, and the setup commands also take --server <url>
-[--server-token-env <var>] or --attach, which talks to a server that is already
-running instead of embedding one. --attach reads {TIDEBREAK_DATA_DIR}/listen.json
-(written by serve and the desktop). With --server the token comes from
-TIDEBREAK_SERVER_TOKEN, or from the named variable; it is never an argument
-either. The folder commands do not take --server/--attach: they provision local
-host consent in this machine's own broker and product store, and they can run
-while serve or the desktop already owns the data directory.";
+The setup commands, the output family, the folder commands, and the code
+family take --output-format text|json. Code commands also accept --json.
+A key is read from stdin, or from the environment variable named by
+--from-env — never from an argument, which every process on the machine
+can read.
+
+-p, output, attach, the setup commands, and the code family also take
+--server <url> [--server-token-env <var>] or --attach, which talks to a
+server that is already running instead of embedding one. --attach reads
+{TIDEBREAK_DATA_DIR}/listen.json (written by serve and the desktop). With
+--server the token comes from TIDEBREAK_SERVER_TOKEN, or from the named
+variable; it is never an argument either. The folder commands do not take
+--server/--attach: they provision local host consent in this machine's own
+broker and product store, and they can run while serve or the desktop
+already owns the data directory.";
 
 #[tokio::main]
 async fn main() {
@@ -296,6 +330,12 @@ async fn run() -> Result<i32> {
             server_flags.refuse("folder");
             match folder::parse(args) {
                 Ok(command) => folder::run(command).await.map(|()| 0),
+                Err(message) => usage_error(&message),
+            }
+        }
+        Some(command) if command == OsStr::new("code") => {
+            match crate::code::parse(text_args(args)) {
+                Ok(command) => crate::code::run(command, server_flags.resolve()?).await,
                 Err(message) => usage_error(&message),
             }
         }

--- a/crates/tidebreak-cli/src/main.rs
+++ b/crates/tidebreak-cli/src/main.rs
@@ -140,7 +140,8 @@ usage: tidebreak serve
        tidebreak code session start --ws <id> --harness <kind> [--mode plan|ask|auto]
        tidebreak code session show <id>
        tidebreak code session reap <id>
-       tidebreak code run (--session <id> | --ws <id>) <message> [--on-approval wait|fail]
+       tidebreak code run (--session <id> | --ws <id>) [<message>]
+                  [--on-approval wait|fail] [--timeout <secs>]
        tidebreak code approvals [--session <id>]
        tidebreak code approve <approval-id>
        tidebreak code deny <approval-id> [-m <feedback>]
@@ -153,7 +154,7 @@ usage: tidebreak serve
        tidebreak code git pr --ws <id> [--title <title>] [--body <body>]
        tidebreak code git status --ws <id>
        tidebreak code action <name> --ws <id>
-       tidebreak code watch
+       tidebreak code watch [--once] [--timeout <secs>]
 
 The setup commands, the output family, the folder commands, and the code
 family take --output-format text|json. Code commands also accept --json.
@@ -336,7 +337,10 @@ async fn run() -> Result<i32> {
         Some(command) if command == OsStr::new("code") => {
             match crate::code::parse(text_args(args)) {
                 Ok(command) => crate::code::run(command, server_flags.resolve()?).await,
-                Err(message) => usage_error(&message),
+                Err(message) => {
+                    eprintln!("tidebreak: {message}\n\n{}", crate::code::USAGE);
+                    std::process::exit(2);
+                }
             }
         }
         Some(other) => {

--- a/crates/tidebreak-cli/tests/code.rs
+++ b/crates/tidebreak-cli/tests/code.rs
@@ -215,6 +215,16 @@ fn attach_mode_doctor_and_repo_round_trip_over_json() {
         stderr.contains("not_found"),
         "typed error kind should be surfaced: {stderr}"
     );
+
+    let watch = code(&serving, &["watch", "--once", "--json", "--timeout", "10"]);
+    assert!(
+        watch.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&watch.stderr)
+    );
+    let notice: serde_json::Value = serde_json::from_slice(&watch.stdout).unwrap();
+    assert_eq!(notice["type"], "snapshot");
+    assert!(notice["sessions"].is_array(), "watch: {notice}");
 }
 
 #[test]
@@ -231,5 +241,13 @@ fn unknown_code_subcommand_is_a_usage_error() {
     assert!(
         stderr.contains("unknown code subcommand"),
         "stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("tidebreak code doctor"),
+        "code parse errors should print the code family, not the whole CLI: {stderr}"
+    );
+    assert!(
+        !stderr.contains("tidebreak mcp-server add"),
+        "code parse errors must not dump the full CLI usage: {stderr}"
     );
 }

--- a/crates/tidebreak-cli/tests/code.rs
+++ b/crates/tidebreak-cli/tests/code.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use std::process::{Child, Command, Output, Stdio};
 use std::time::{Duration, Instant};
 
-const PROCESS_EXIT_TIMEOUT: Duration = Duration::from_secs(15);
+const PROCESS_EXIT_TIMEOUT: Duration = Duration::from_secs(60);
 
 struct Reaper(Child);
 

--- a/crates/tidebreak-cli/tests/code.rs
+++ b/crates/tidebreak-cli/tests/code.rs
@@ -1,0 +1,235 @@
+//! Attach-mode coverage for `tidebreak code` against a spawned `serve`.
+
+use std::io::{BufRead, BufReader, Read};
+use std::path::Path;
+use std::process::{Child, Command, Output, Stdio};
+use std::time::{Duration, Instant};
+
+const PROCESS_EXIT_TIMEOUT: Duration = Duration::from_secs(15);
+
+struct Reaper(Child);
+
+impl Reaper {
+    fn wait_with_output(&mut self, timeout: Duration) -> Output {
+        let deadline = Instant::now() + timeout;
+        let status = loop {
+            if let Some(status) = self.0.try_wait().unwrap() {
+                break status;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "child did not exit within {timeout:?}"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        };
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        if let Some(mut pipe) = self.0.stdout.take() {
+            pipe.read_to_end(&mut stdout).unwrap();
+        }
+        if let Some(mut pipe) = self.0.stderr.take() {
+            pipe.read_to_end(&mut stderr).unwrap();
+        }
+        Output {
+            status,
+            stdout,
+            stderr,
+        }
+    }
+}
+
+impl Drop for Reaper {
+    fn drop(&mut self) {
+        self.0.kill().ok();
+        self.0.wait().ok();
+    }
+}
+
+struct Serving {
+    _reaper: Reaper,
+    url: String,
+    token: String,
+    data_dir: tempfile::TempDir,
+}
+
+fn spawn_serve() -> Serving {
+    let data_dir = tempfile::tempdir().unwrap();
+    let mut child = Command::new(env!("CARGO_BIN_EXE_tidebreak"))
+        .arg("serve")
+        .env("TIDEBREAK_DATA_DIR", data_dir.path())
+        .env("TIDEBREAK_KEYCHAIN_MOCK", "1")
+        .env_remove("TIDEBREAK_MCP_CONFIG")
+        .env_remove("TIDEBREAK_SERVER_URL")
+        .env_remove("ANTHROPIC_API_KEY")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn tidebreak serve");
+    let stdout = child.stdout.take().unwrap();
+    let reaper = Reaper(child);
+    let mut lines = BufReader::new(stdout).lines();
+    let addr_line = lines.next().unwrap().unwrap();
+    let token_line = lines.next().unwrap().unwrap();
+    assert!(
+        addr_line.contains("listening on http://127.0.0.1:"),
+        "unexpected addr line: {addr_line:?}"
+    );
+    assert!(
+        token_line.starts_with("tidebreak: token "),
+        "unexpected token line: {token_line:?}"
+    );
+    let url = addr_line
+        .rsplit("http://")
+        .next()
+        .map(|rest| format!("http://{}", rest.trim()))
+        .unwrap();
+    let token = token_line
+        .strip_prefix("tidebreak: token ")
+        .unwrap()
+        .trim()
+        .to_owned();
+    Serving {
+        _reaper: reaper,
+        url,
+        token,
+        data_dir,
+    }
+}
+
+fn code(serving: &Serving, args: &[&str]) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_tidebreak"));
+    command
+        .arg("--server")
+        .arg(&serving.url)
+        .arg("code")
+        .args(args)
+        .env("TIDEBREAK_DATA_DIR", serving.data_dir.path())
+        .env("TIDEBREAK_SERVER_TOKEN", &serving.token)
+        .env("TIDEBREAK_KEYCHAIN_MOCK", "1")
+        .env_remove("TIDEBREAK_MCP_CONFIG")
+        .env_remove("ANTHROPIC_API_KEY")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let child = command.spawn().expect("spawn tidebreak code");
+    let mut child = Reaper(child);
+    child.wait_with_output(PROCESS_EXIT_TIMEOUT)
+}
+
+fn init_git_repo(path: &Path) {
+    std::fs::create_dir_all(path).unwrap();
+    assert!(Command::new("git")
+        .args(["init", "-b", "main"])
+        .current_dir(path)
+        .status()
+        .unwrap()
+        .success());
+    std::fs::write(path.join("README.md"), "demo\n").unwrap();
+    assert!(Command::new("git")
+        .args(["add", "README.md"])
+        .current_dir(path)
+        .status()
+        .unwrap()
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "-c",
+            "user.name=Tidebreak",
+            "-c",
+            "user.email=tidebreak@example.test",
+            "commit",
+            "-m",
+            "init",
+        ])
+        .current_dir(path)
+        .status()
+        .unwrap()
+        .success());
+}
+
+#[test]
+fn attach_mode_doctor_and_repo_round_trip_over_json() {
+    let serving = spawn_serve();
+
+    let doctor = code(&serving, &["doctor", "--json"]);
+    assert!(
+        doctor.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&doctor.stderr)
+    );
+    let report: serde_json::Value = serde_json::from_slice(&doctor.stdout).unwrap();
+    assert!(
+        report["harnesses"]
+            .as_array()
+            .is_some_and(|rows| !rows.is_empty()),
+        "doctor: {report}"
+    );
+    for row in report["harnesses"].as_array().unwrap() {
+        assert!(row["kind"].is_string(), "doctor row: {row}");
+        assert!(row["found"].is_boolean(), "doctor row: {row}");
+        assert!(row["tier"].is_string(), "doctor row: {row}");
+        assert!(row["caps"].is_object(), "doctor row: {row}");
+    }
+
+    let repo_dir = serving.data_dir.path().join("sample-repo");
+    init_git_repo(&repo_dir);
+
+    let added = code(
+        &serving,
+        &[
+            "repo",
+            "add",
+            repo_dir.to_str().unwrap(),
+            "--name",
+            "sample",
+            "--json",
+        ],
+    );
+    assert!(
+        added.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&added.stderr)
+    );
+    let repo: serde_json::Value = serde_json::from_slice(&added.stdout).unwrap();
+    assert_eq!(repo["display_name"], "sample");
+    let repo_id = repo["id"].as_str().unwrap();
+
+    let listed = code(&serving, &["repo", "list", "--json"]);
+    assert!(listed.status.success());
+    let list: serde_json::Value = serde_json::from_slice(&listed.stdout).unwrap();
+    assert_eq!(list["repos"].as_array().unwrap().len(), 1);
+    assert_eq!(list["repos"][0]["id"], repo_id);
+
+    let missing = code(
+        &serving,
+        &[
+            "repo",
+            "rm",
+            "00000000-0000-0000-0000-000000000099",
+            "--json",
+        ],
+    );
+    assert!(!missing.status.success());
+    let stderr = String::from_utf8_lossy(&missing.stderr);
+    assert!(
+        stderr.contains("not_found"),
+        "typed error kind should be surfaced: {stderr}"
+    );
+}
+
+#[test]
+fn unknown_code_subcommand_is_a_usage_error() {
+    let output = Command::new(env!("CARGO_BIN_EXE_tidebreak"))
+        .args(["code", "nope"])
+        .env("TIDEBREAK_KEYCHAIN_MOCK", "1")
+        .env_remove("TIDEBREAK_SERVER_URL")
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unknown code subcommand"),
+        "stderr: {stderr}"
+    );
+}

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -64,6 +64,8 @@ pub(crate) enum GhError {
     NothingToCommit,
     #[error("{0}")]
     AuthFailed(String),
+    #[error("{0}")]
+    PushFailed(String),
     #[error("{instructions}")]
     GhAbsent { instructions: String },
     #[error("{instructions}")]
@@ -785,20 +787,27 @@ fn bound_text(text: &str) -> String {
 }
 
 fn classify_git(err: String, op: &str) -> GhError {
-    let lower = err.to_ascii_lowercase();
-    if lower.contains("authentication failed")
-        || lower.contains("could not read username")
-        || lower.contains("could not read password")
-        || lower.contains("permission denied")
-        || lower.contains("terminal prompts disabled")
-        || lower.contains("could not read from remote")
-        || (op == "push" && (lower.contains("403") || lower.contains("401")))
-    {
+    let bounded = bound_text(&err);
+    if is_git_auth_failure(&bounded) {
         return GhError::AuthFailed(format!(
-            "git could not authenticate to the remote. Configure your own git credentials (a credential helper, SSH key, or token) in a terminal, then try again. Tidebreak does not store git credentials.\n\n{err}"
+            "git could not authenticate to the remote. Configure your own git credentials (a credential helper, SSH key, or token) in a terminal, then try again. Tidebreak does not store git credentials.\n\n{bounded}"
         ));
     }
-    GhError::user(format!("git {op} failed: {err}"))
+    if op == "push" {
+        return GhError::PushFailed(format!("git push failed:\n{bounded}"));
+    }
+    GhError::user(format!("git {op} failed: {bounded}"))
+}
+
+/// Auth only. "Could not read from remote repository" is also printed for a
+/// missing or unresolvable remote URL, so it is not an auth signature.
+fn is_git_auth_failure(err: &str) -> bool {
+    let lower = err.to_ascii_lowercase();
+    lower.contains("authentication")
+        || lower.contains("permission denied")
+        || lower.contains("403")
+        || lower.contains("terminal prompts disabled")
+        || lower.contains("publickey")
 }
 
 fn classify_gh(
@@ -1009,6 +1018,60 @@ mod tests {
 
         let again = commit_all(&work, "first change", None).await.unwrap_err();
         assert!(matches!(again, GhError::NothingToCommit));
+    }
+
+    #[test]
+    fn classify_git_treats_only_auth_signatures_as_auth() {
+        let repo_missing = "fatal: '../no-such-remote' does not appear to be a git repository\n\
+fatal: Could not read from remote repository.\n";
+        assert!(
+            matches!(
+                classify_git(repo_missing.into(), "push"),
+                GhError::PushFailed(_)
+            ),
+            "unresolvable remote must not be git_auth_failed"
+        );
+
+        for auth in [
+            "fatal: Authentication failed for 'https://example.test/repo.git'",
+            "Permission denied (publickey).",
+            "The requested URL returned error: 403",
+            "fatal: could not read Username for 'https://example.test': terminal prompts disabled",
+        ] {
+            assert!(
+                matches!(classify_git(auth.into(), "push"), GhError::AuthFailed(_)),
+                "expected auth for {auth}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn push_of_an_unresolvable_remote_is_not_auth() {
+        let (_dir, work, _bare) = init_paired_repos();
+        run(&work, &["git", "checkout", "-b", "tidebreak/push-fail"]);
+        std::fs::write(work.join("extra.txt"), "line\n").unwrap();
+        commit_all(&work, "first change", Some("msg"))
+            .await
+            .unwrap();
+        run(
+            &work,
+            &["git", "remote", "set-url", "origin", "../no-such-remote"],
+        );
+        let err = push_branch(&work, "tidebreak/push-fail").await.unwrap_err();
+        assert!(
+            !matches!(err, GhError::AuthFailed(_)),
+            "non-auth push classified as auth: {err}"
+        );
+        match err {
+            GhError::PushFailed(message) => {
+                let lower = message.to_ascii_lowercase();
+                assert!(
+                    lower.contains("does not appear") || lower.contains("repository"),
+                    "{message}"
+                );
+            }
+            other => panic!("expected PushFailed, got {other}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -1140,6 +1140,7 @@ fn map_gh(err: GhError) -> ServerError {
             "there is nothing to commit in this workspace",
         ),
         GhError::AuthFailed(message) => ServerError::conflict_kind("git_auth_failed", message),
+        GhError::PushFailed(message) => ServerError::conflict_kind("git_push_failed", message),
         GhError::GhAbsent { instructions } => ServerError::conflict_kind("gh_absent", instructions),
         GhError::GhSignedOut { instructions } => {
             ServerError::conflict_kind("gh_signed_out", instructions)

--- a/docs-site/content/docs/headless.mdx
+++ b/docs-site/content/docs/headless.mdx
@@ -48,13 +48,41 @@ tidebreak mcp-server add <name> (--command <cmd> [--arg <a>]… | --url <url>)
 tidebreak mcp-server remove <name>
 tidebreak chat list
 tidebreak chat create
+
+tidebreak code doctor [--refresh]
+tidebreak code repo add <path> [--name <name>] [--base-ref <ref>] [--branch-prefix <p>]
+tidebreak code repo list
+tidebreak code repo rm <id>
+tidebreak code ws new --repo <id|path> [--title <title>] [--base-ref <ref>]
+tidebreak code ws list [--repo <id|path>]
+tidebreak code ws show <id>
+tidebreak code ws archive <id> [--force]
+tidebreak code session start --ws <id> --harness <kind> [--mode plan|ask|auto]
+tidebreak code session show <id>
+tidebreak code session reap <id>
+tidebreak code run (--session <id> | --ws <id>) <message> [--on-approval wait|fail]
+tidebreak code approvals [--session <id>]
+tidebreak code approve <approval-id>
+tidebreak code deny <approval-id> [-m <feedback>]
+tidebreak code interrupt --session <id>
+tidebreak code turns --session <id>
+tidebreak code diff --ws <id> [--turn N] [--file PATH]
+tidebreak code files --ws <id> [--turn N]
+tidebreak code git commit --ws <id> [-m MSG]
+tidebreak code git push --ws <id>
+tidebreak code git pr --ws <id> [--title <title>] [--body <body>]
+tidebreak code git status --ws <id>
+tidebreak code action <name> --ws <id>
+tidebreak code watch
 ```
 
 A bare `tidebreak` with no arguments runs `serve`.
 
-`-p`, `output`, `attach`, and the setup commands additionally take
+`-p`, `output`, `attach`, the setup commands, and the code family additionally take
 `--server <url>` / `--server-token-env <var>`, or `--attach` — see
 [Attaching to a running server](#attaching-to-a-running-server).
+Every `tidebreak code` command also accepts `--json` (one object, or NDJSON
+for `run` and `watch`).
 
 ### `serve`
 

--- a/docs-site/content/docs/headless.mdx
+++ b/docs-site/content/docs/headless.mdx
@@ -60,7 +60,7 @@ tidebreak code ws archive <id> [--force]
 tidebreak code session start --ws <id> --harness <kind> [--mode plan|ask|auto]
 tidebreak code session show <id>
 tidebreak code session reap <id>
-tidebreak code run (--session <id> | --ws <id>) <message> [--on-approval wait|fail]
+tidebreak code run (--session <id> | --ws <id>) [<message>] [--on-approval wait|fail] [--timeout <secs>]
 tidebreak code approvals [--session <id>]
 tidebreak code approve <approval-id>
 tidebreak code deny <approval-id> [-m <feedback>]
@@ -73,7 +73,7 @@ tidebreak code git push --ws <id>
 tidebreak code git pr --ws <id> [--title <title>] [--body <body>]
 tidebreak code git status --ws <id>
 tidebreak code action <name> --ws <id>
-tidebreak code watch
+tidebreak code watch [--once] [--timeout <secs>]
 ```
 
 A bare `tidebreak` with no arguments runs `serve`.


### PR DESCRIPTION
## Summary

The server already ships the full code-mode surface (repos, workspaces, sessions, approvals, checkpoints/diffs, git flow, updates, doctor). This adds the headless client those routes were missing, per ADR 0007: an agent or script can drive a complete code-mode work loop with `tidebreak code …` and `--json`.

Every command embeds a server by default and attaches with `--server` / `--attach` the same way `-p` and the setup family do. `--json` (or `--output-format json`) writes one object, or NDJSON for the two streaming commands. Failures print the server's typed `{kind, message}` and exit nonzero.

## Command table

| Command | Route |
| --- | --- |
| `code doctor [--refresh]` | `GET /code/harnesses` / `POST /code/harnesses/refresh` |
| `code repo add <path> [--name] [--base-ref] [--branch-prefix]` | `POST /code/repos` |
| `code repo list` | `GET /code/repos` |
| `code repo rm <id>` | `DELETE /code/repos/{id}` |
| `code ws new --repo <id\|path> [--title] [--base-ref]` | `POST /code/workspaces` |
| `code ws list [--repo]` | `GET /code/workspaces` |
| `code ws show <id>` | `GET /code/workspaces/{id}` + `GET …/sessions` |
| `code ws archive <id> [--force]` | `POST /code/workspaces/{id}/archive` |
| `code session start --ws <id> --harness <kind> [--mode plan\|ask\|auto]` | `POST /code/workspaces/{id}/sessions` (mode defaults to `ask`) |
| `code session show <id>` | workspace walk + `GET /code/sessions/{id}/turns` |
| `code session reap <id>` | `POST /code/sessions/{id}/reap` |
| `code run (--session <id> \| --ws <id>) <message> [--on-approval wait\|fail]` | `POST /code/sessions/{id}/turns` + `WS …/events` |
| `code approvals [--session <id>]` | `GET /code/approvals?state=pending` |
| `code approve <id>` / `code deny <id> [-m <feedback>]` | `POST /code/approvals/{id}/decision` |
| `code interrupt --session <id>` | `POST /code/sessions/{id}/interrupt` |
| `code turns --session <id>` | `GET /code/sessions/{id}/turns` |
| `code diff --ws <id> [--turn N] [--file PATH]` | `GET /code/workspaces/{id}/diff` |
| `code files --ws <id> [--turn N]` | `GET /code/workspaces/{id}/files` |
| `code git commit --ws <id> [-m MSG]` | `POST /code/workspaces/{id}/git/commit` |
| `code git push --ws <id>` | `POST /code/workspaces/{id}/git/push` |
| `code git pr --ws <id> [--title] [--body]` | `POST /code/workspaces/{id}/git/pr` |
| `code git status --ws <id>` | `GET /code/workspaces/{id}/pr` |
| `code action <name> --ws <id>` | `POST /code/workspaces/{id}/actions/{name}` |
| `code watch` | `WS /code/updates` |

`--turn N` is the session ordinal (or a turn UUID). The CLI resolves it before calling the turn-id query the server actually takes.

## `--json` contracts

- One-shot commands: a single JSON object on stdout (`{"repos":[…]}`, the snapshot itself, `{"workspace":…,"sessions":[…]}` for `ws show`, etc.).
- `code run --json`: NDJSON of the raw sequenced frames from `WS /code/sessions/{id}/events` (`{seq, event, replayed?}`). Unknown event kinds still print as the server sent them.
- `code watch --json`: NDJSON of the raw `/code/updates` notices (`snapshot` / `digest` / `terminal_activity`). An unrecognized tag decodes as `unknown` and is skipped in human mode.

## Exit-code mapping (`code run`)

| Outcome | Exit |
| --- | --- |
| `turn_completed` | 0 |
| `turn_failed` / `turn_interrupted` | 1 |
| `--on-approval fail` on `approval_requested` | 3 |
| SIGINT | 130 (second Ctrl-C exits immediately) |
| `code action` that reports `success: false` | 1 |
| parse / usage errors | 2 |
| any other failed request | 1, with `{kind}` in the error |

`--on-approval wait` (default) keeps streaming while parked and prints the `approve` / `deny` commands. Approvals are decided by a second process, not by this one.

## Route gaps (no server routes added)

- There is no `GET /code/sessions/{id}`. `session show` walks workspaces and lists each workspace's sessions, then loads turns. Same 404 shape if the id is unknown.
- `--turn N` is an ordinal; the diff/files routes take a turn UUID. The CLI resolves via the active (or first) workspace session.
- `session start` must send `permission_mode`; the server does not pick one. The CLI defaults to `ask`.
- Terminals and manual attention pin are out of scope.

## Tests

- Arg-parsing refusals for every verb, including `--json` / `--output-format` and `--on-approval`.
- `--json` shape stability for `run` and `watch` frames (decode + exit mapping).
- Attach-mode doctor + repo add/list against a spawned `serve`, plus a `not_found` kind on a missing `repo rm`.

## What could not be verified

- A live `code run` against a real (or scripted) harness. The scripted harness is only injected in server crate tests, not via `bind_configured`, so the CLI binary cannot drive a scripted turn without a new server route or a test-only adapter hook. Stream rendering and exit mapping are covered by fixture decode tests.
- `code watch` against a live updates socket (same reason). Snapshot/digest tags are pinned in unit tests.
- Git commit/push/PR and quick actions end-to-end from the CLI. They are thin POST/GET wrappers over routes already covered in the server crate.
- Driving the desktop against the same data dir after a CLI-created workspace.

Local: `cargo fmt --all`; `cargo clippy -p tidebreak-cli --all-targets --locked -- -D warnings`; `cargo test -p tidebreak-cli --locked`; `cargo check --workspace --locked` (no lock drift).