### PR TITLE
feat(code): source palette for adding repos with clone support

### DIFF
--- a/crates/tidebreak-desktop/native-only-commands.txt
+++ b/crates/tidebreak-desktop/native-only-commands.txt
@@ -27,6 +27,7 @@ server_info: hands the renderer the embedded server's address and per-launch tok
 request_user_attention: native window attention hint when a parked question needs the user.
 
 # OS pickers, drops, and save dialogs
+pick_code_directory: native directory picker for code-mode repo registration and clone destinations; grant-free — the path is handed to the server for validation (ADR 0030).
 attach_chat_files: opens the OS file picker; only the native shell can turn a user's file choice into readable paths.
 attach_dropped_chat_files: claims the operating-system drop this window received and routes the dropped paths through the same ingest.
 export_library_document: writes a source document's bytes wherever the native save dialog sends them.

--- a/crates/tidebreak-desktop/src/host_access.rs
+++ b/crates/tidebreak-desktop/src/host_access.rs
@@ -1152,15 +1152,46 @@ async fn confirm_folder_widening(
         .map_err(|_| "folder permission prompt closed unexpectedly".to_owned())
 }
 
+/// Grant-free directory picker for code-mode repo registration and clone
+/// destinations. The path is returned as a string; the server validates it.
+#[tauri::command]
+pub(crate) async fn pick_code_directory(
+    app: AppHandle,
+    state: State<'_, HostAccess>,
+) -> Result<Option<String>, String> {
+    let _picker = state
+        .picker
+        .try_lock()
+        .map_err(|_| "a folder picker is already open".to_owned())?;
+    let path = pick_folder_titled(&app, None, "Choose a folder").await?;
+    let Some(path) = path else {
+        return Ok(None);
+    };
+    if !path.is_absolute() {
+        return Err("the folder picker returned an invalid path".to_owned());
+    }
+    Ok(Some(path.to_string_lossy().into_owned()))
+}
+
 pub(super) async fn pick_folder(
     app: &AppHandle,
     starting_directory: Option<PathBuf>,
 ) -> Result<Option<PathBuf>, String> {
+    pick_folder_titled(
+        app,
+        starting_directory,
+        "Choose a folder Tidebreak can read",
+    )
+    .await
+}
+
+async fn pick_folder_titled(
+    app: &AppHandle,
+    starting_directory: Option<PathBuf>,
+    title: &str,
+) -> Result<Option<PathBuf>, String> {
     let (tx, rx) = oneshot::channel();
-    let mut picker = app
-        .dialog()
-        .file()
-        .set_title("Choose a folder Tidebreak can read");
+    let mut picker = app.dialog().file().set_title(title);
     if let Some(starting_directory) = starting_directory {
         picker = picker.set_directory(starting_directory);
     }

--- a/crates/tidebreak-desktop/src/lib.rs
+++ b/crates/tidebreak-desktop/src/lib.rs
@@ -610,6 +610,7 @@ pub fn run() {
             client_execution::computer_use::computer_use_state,
             client_execution::computer_use::stop_computer_use_control,
             client_execution::computer_use::resume_computer_use_control,
+            host_access::pick_code_directory,
             host_access::connect_folder,
             host_access::connect_approved_folder,
             host_access::list_approved_folders,

--- a/crates/tidebreak-desktop/ui/src/ProviderIcons.tsx
+++ b/crates/tidebreak-desktop/ui/src/ProviderIcons.tsx
@@ -52,6 +52,24 @@ export function GeminiIcon(props: IconProps) {
   );
 }
 
+/**
+ * opencode. The mark is monochrome in its own brand usage, so it takes the
+ * surrounding text color.
+ */
+export function OpenCodeIcon(props: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M12 2.4 19.6 6.8v10.4L12 21.6 4.4 17.2V6.8L12 2.4zm0 2.3L6.4 7.9v8.2L12 19.3l5.6-3.2V7.9L12 4.7zm0 3.1a4.2 4.2 0 1 1 0 8.4 4.2 4.2 0 0 1 0-8.4zm0 1.8a2.4 2.4 0 1 0 .001 4.801A2.4 2.4 0 0 0 12 6.5z" />
+    </svg>
+  );
+}
+
 export function XaiIcon(props: IconProps) {
   return (
     <svg

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -91,6 +91,8 @@ import {
   type CodeWorkspaceFiles,
   type CodeWorkspacePrSnapshot,
   type CodeWorkspaceSnapshot,
+  type CodeCloneDefaults,
+  type CodeCloneJobSnapshot,
   type HarnessDoctorReport,
   type HarnessKind,
   type SequencedCodeEventFrame,
@@ -112,6 +114,8 @@ import {
 } from "./parsers";
 import {
   parseCodeApproval,
+  parseCodeCloneDefaults,
+  parseCodeCloneJob,
   parseCodeRepo,
   parseCodeSession,
   parseCodeSessionList,
@@ -1697,6 +1701,46 @@ export class ApiClient {
       method: "DELETE",
       headers: this.headers(),
     });
+  }
+
+  async getCodeCloneDefaults(): Promise<CodeCloneDefaults> {
+    return requireParsed(
+      parseCodeCloneDefaults(
+        await this.json("/code/repos/clone-defaults", {
+          headers: this.headers(),
+        }),
+      ),
+      "clone defaults",
+    );
+  }
+
+  async startCodeClone(body: {
+    url?: string;
+    github?: string;
+    parent_dir: string;
+    name?: string;
+  }): Promise<CodeCloneJobSnapshot> {
+    return requireParsed(
+      parseCodeCloneJob(
+        await this.json("/code/repos/clone", {
+          method: "POST",
+          headers: this.headers(true),
+          body: JSON.stringify(body),
+        }),
+      ),
+      "clone job",
+    );
+  }
+
+  async getCodeCloneJob(jobId: string): Promise<CodeCloneJobSnapshot> {
+    return requireParsed(
+      parseCodeCloneJob(
+        await this.json(`/code/repos/clone/${encodeURIComponent(jobId)}`, {
+          headers: this.headers(),
+        }),
+      ),
+      "clone job",
+    );
   }
 
   async getHarnessDoctor(): Promise<HarnessDoctorReport> {

--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -125,6 +125,8 @@ import {
   type CodeFileChange as WireCodeFileChange,
   type CodeSessionDigest as WireCodeSessionDigest,
   type CodeUpdateNotice as WireCodeUpdateNotice,
+  type CodeCloneDefaults as WireCodeCloneDefaults,
+  type CodeCloneJobSnapshot as WireCodeCloneJobSnapshot,
   type CodeTerminalActivityNotice as WireCodeTerminalActivityNotice,
   type PullRequestDigest as WirePullRequestDigest,
   type CodeTerminalRead as WireCodeTerminalRead,
@@ -1016,6 +1018,8 @@ export type CodeTerminalRead = WireCodeTerminalRead;
 export type CodeTerminalActivityNotice = WireCodeTerminalActivityNotice;
 export type CodeSessionDigest = WireCodeSessionDigest;
 export type CodeUpdateNotice = WireCodeUpdateNotice;
+export type CodeCloneDefaults = WireCodeCloneDefaults;
+export type CodeCloneJobSnapshot = WireCodeCloneJobSnapshot;
 
 /** Journaled engine event and the sequenced WebSocket frame that carries it. */
 export type CodeApprovalSnapshot = WireCodeApprovalSnapshot;

--- a/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.dom.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AppContextProvider, type AppContextValue } from "@/AppContext";
+import { renderWithRouter } from "@/test/router";
+import { AddRepoPalette } from "./AddRepoPalette";
+import { useCodeUpdatesStore } from "./CodeUpdatesStore";
+
+afterEach(() => {
+  cleanup();
+  useCodeUpdatesStore.getState().reset();
+});
+
+function app(overrides: Partial<AppContextValue["client"]> = {}): AppContextValue {
+  return {
+    client: {
+      getCodeCloneDefaults: vi.fn(async () => ({
+        parent_dir: "/tmp/src",
+        gh_found: false,
+        gh_remediation: "gh is not installed. Install the GitHub CLI.",
+      })),
+      startCodeClone: vi.fn(),
+      getCodeRepo: vi.fn(),
+      createCodeRepo: vi.fn(),
+      ...overrides,
+    } as never,
+    models: [],
+    defaultModelKey: null,
+    providers: [],
+    refreshCatalog: async () => {},
+    refreshChats: async () => {},
+    status: "",
+    setStatus: () => {},
+    newChat: () => {},
+    deleteChat: () => {},
+    startRename: () => {},
+    commitRename: () => {},
+    cancelRename: () => {},
+    newProject: async () => false,
+    deleteProject: () => {},
+    startProjectRename: () => {},
+    commitProjectRename: () => {},
+    cancelProjectRename: () => {},
+    newChatInProject: () => {},
+    moveChatToProject: () => {},
+    updateState: { status: "idle", version: null, error: null, enabled: false },
+    updateUpToDate: false,
+    checkForUpdate: async () => ({
+      status: "idle",
+      version: null,
+      error: null,
+      enabled: false,
+    }),
+    restartForUpdate: async () => {},
+  };
+}
+
+async function renderPalette(value: AppContextValue = app()) {
+  return renderWithRouter(
+    <AppContextProvider value={value}>
+      <AddRepoPalette open onOpenChange={vi.fn()} />
+    </AppContextProvider>,
+    { initialUrl: "/code" },
+  );
+}
+
+describe("AddRepoPalette", () => {
+  it("filters sources and selects with the keyboard", async () => {
+    await renderPalette();
+    const search = await screen.findByPlaceholderText("Filter sources");
+    fireEvent.change(search, { target: { value: "git" } });
+    expect(screen.getByRole("option", { name: /Git URL/ })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /Local folder/ })).not.toBeInTheDocument();
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Enter" });
+    expect(await screen.findByText("Clone from a remote URL into a parent folder.")).toBeInTheDocument();
+  });
+
+  it("goes back a stage on Backspace and closes on Escape", async () => {
+    const onOpenChange = vi.fn();
+    await renderWithRouter(
+      <AppContextProvider value={app()}>
+        <AddRepoPalette open onOpenChange={onOpenChange} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+    fireEvent.click(await screen.findByRole("option", { name: /GitHub repository/ }));
+    expect(await screen.findByText("Clone an owner/repo from GitHub.")).toBeInTheDocument();
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Backspace" });
+    expect(await screen.findByRole("option", { name: /Local folder/ })).toBeInTheDocument();
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("shows the gh-absent hint on the GitHub form", async () => {
+    await renderPalette();
+    fireEvent.click(await screen.findByRole("option", { name: /GitHub repository/ }));
+    expect(await screen.findByTestId("gh-absent-hint")).toHaveTextContent(
+      "gh is not installed",
+    );
+  });
+
+  it("drives clone progress to done and shows an error tail with retry", async () => {
+    const started = vi.fn(async () => ({
+      id: "job-1",
+      phase: "starting",
+      done: false,
+    }));
+    const getRepo = vi.fn(async () => ({
+      id: "repo-1",
+      root_path: "/tmp/src/demo",
+      display_name: "demo",
+      default_base_ref: "main",
+      branch_prefix: "tidebreak/",
+      quick_actions: [],
+      created_at: "2026-08-17T00:00:00.000Z",
+    }));
+    await renderPalette(
+      app({
+        startCodeClone: started,
+        getCodeRepo: getRepo,
+      }),
+    );
+    fireEvent.click(await screen.findByRole("option", { name: /Git URL/ }));
+    fireEvent.change(screen.getByPlaceholderText("https://example.com/acme/app.git"), {
+      target: { value: "/tmp/origin.git" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Clone" }));
+    await waitFor(() => expect(started).toHaveBeenCalled());
+    expect(await screen.findByTestId("clone-phase")).toHaveTextContent("starting");
+    useCodeUpdatesStore.getState().apply({
+      type: "clone_progress",
+      job: { id: "job-1", phase: "receiving objects", percent: 40, done: false },
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("clone-phase")).toHaveTextContent("receiving objects"),
+    );
+    useCodeUpdatesStore.getState().apply({
+      type: "clone_progress",
+      job: {
+        id: "job-1",
+        phase: "failed",
+        done: true,
+        error: "fatal: repository not found",
+      },
+    });
+    expect(await screen.findByText("fatal: repository not found")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(screen.getByPlaceholderText("https://example.com/acme/app.git")).toBeInTheDocument();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.tsx
@@ -1,0 +1,669 @@
+import { useEffect, useMemo, useState, type KeyboardEvent } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { Folder, GitBranch, Link2 } from "lucide-react";
+
+import type { CodeCloneDefaults, CodeCloneJobSnapshot } from "../api/types";
+import { useApp } from "@/AppContext";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  OptionListbox,
+  optionElementId,
+  type OptionRow,
+} from "@/components/OptionListbox";
+import { Progress } from "@/components/ui/progress";
+import { SearchInput } from "@/components/SearchInput";
+import { hasNativeHost, pickCodeDirectory } from "@/host";
+import { friendlyErrorMessage } from "@/lib/utils";
+import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { useCodeUpdatesStore } from "./CodeUpdatesStore";
+
+type Stage = "sources" | "local" | "git_url" | "github" | "progress";
+type SourceKey = "local" | "git_url" | "github";
+
+const SOURCES: OptionRow[] = [
+  {
+    key: "local",
+    label: "Local folder",
+    description: "Browse a folder on disk",
+    icon: Folder,
+  },
+  {
+    key: "git_url",
+    label: "Git URL",
+    description: "Clone from a remote URL",
+    icon: Link2,
+  },
+  {
+    key: "github",
+    label: "GitHub repository",
+    description: "Clone owner/repo",
+    icon: GitBranch,
+  },
+];
+
+/**
+ * Keyboard-first dialog for registering or cloning a repo.
+ *
+ * Stages stay inside one dialog: source list, a small form, then clone
+ * progress. Backspace returns a stage; Escape closes.
+ */
+export function AddRepoPalette({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const navigate = useNavigate();
+  const { client } = useApp();
+  const upsertRepo = useCodeCatalogStore((state) => state.upsertRepo);
+  const cloneJobs = useCodeUpdatesStore((state) => state.cloneJobs);
+  const [stage, setStage] = useState<Stage>("sources");
+  const [query, setQuery] = useState("");
+  const [active, setActive] = useState(0);
+  const [path, setPath] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [url, setUrl] = useState("");
+  const [github, setGithub] = useState("");
+  const [parentDir, setParentDir] = useState("");
+  const [cloneName, setCloneName] = useState("");
+  const [defaults, setDefaults] = useState<CodeCloneDefaults | null>(null);
+  const [jobId, setJobId] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const job = jobId ? cloneJobs[jobId] : undefined;
+  const rows = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return SOURCES;
+    return SOURCES.filter(
+      (row) =>
+        row.label.toLowerCase().includes(needle) ||
+        (row.description ?? "").toLowerCase().includes(needle),
+    );
+  }, [query]);
+
+  useEffect(() => {
+    if (!open) return;
+    setStage("sources");
+    setQuery("");
+    setActive(0);
+    setPath("");
+    setDisplayName("");
+    setUrl("");
+    setGithub("");
+    setCloneName("");
+    setJobId(null);
+    setBusy(false);
+    setError(null);
+    void client.getCodeCloneDefaults().then((next) => {
+      setDefaults(next);
+      setParentDir(next.parent_dir ?? "");
+    });
+  }, [open, client]);
+
+  useEffect(() => {
+    if (active >= rows.length) setActive(0);
+  }, [active, rows.length]);
+
+  useEffect(() => {
+    if (!job || stage !== "progress") return;
+    if (job.done && job.repo_id) {
+      void (async () => {
+        try {
+          const repo = await client.getCodeRepo(job.repo_id!);
+          upsertRepo(repo);
+          onOpenChange(false);
+          await navigate({
+            to: "/code/r/$repoId",
+            params: { repoId: repo.id },
+          });
+        } catch (err) {
+          setError(friendlyErrorMessage(err, "Cloned, but could not open the repo"));
+        }
+      })();
+    }
+  }, [job, stage, client, upsertRepo, navigate, onOpenChange]);
+
+  function goBack() {
+    if (stage === "sources") {
+      onOpenChange(false);
+      return;
+    }
+    if (stage === "progress") {
+      setStage(github.trim() ? "github" : url.trim() ? "git_url" : "sources");
+      setJobId(null);
+      setError(null);
+      return;
+    }
+    setStage("sources");
+    setError(null);
+  }
+
+  async function pickDirectory(into: "path" | "parent") {
+    const picked = await pickCodeDirectory();
+    if (!picked) return;
+    if (into === "path") setPath(picked);
+    else setParentDir(picked);
+  }
+
+  async function registerLocal() {
+    if (!path.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const repo = await client.createCodeRepo({
+        path: path.trim(),
+        display_name: displayName.trim() || undefined,
+      });
+      upsertRepo(repo);
+      onOpenChange(false);
+      await navigate({ to: "/code/r/$repoId", params: { repoId: repo.id } });
+    } catch (err) {
+      setError(friendlyErrorMessage(err, "Could not register that repo"));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function startClone(body: {
+    url?: string;
+    github?: string;
+    parent_dir: string;
+    name?: string;
+  }) {
+    if (!body.parent_dir.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const started = await client.startCodeClone({
+        ...body,
+        parent_dir: body.parent_dir.trim(),
+        name: body.name?.trim() || undefined,
+      });
+      useCodeUpdatesStore.getState().apply({
+        type: "clone_progress",
+        job: started,
+      });
+      setJobId(started.id);
+      setStage("progress");
+    } catch (err) {
+      setError(friendlyErrorMessage(err, "Could not start the clone"));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function selectSource(index: number) {
+    const row = rows[index];
+    if (!row) return;
+    setActive(index);
+    if (row.key === "local") {
+      setStage("local");
+      if (hasNativeHost()) void pickDirectory("path");
+      return;
+    }
+    if (row.key === "git_url") setStage("git_url");
+    if (row.key === "github") setStage("github");
+  }
+
+  function onKeyDown(event: KeyboardEvent) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      onOpenChange(false);
+      return;
+    }
+    if (event.key === "Backspace") {
+      const target = event.target as HTMLElement | null;
+      const typing =
+        target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement;
+      if (typing && target.value.length > 0) return;
+      event.preventDefault();
+      goBack();
+      return;
+    }
+    if (stage !== "sources") return;
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActive((current) => Math.min(current + 1, Math.max(rows.length - 1, 0)));
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActive((current) => Math.max(current - 1, 0));
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      selectSource(active);
+    }
+  }
+
+  const title =
+    stage === "local"
+      ? "Local folder"
+      : stage === "git_url"
+        ? "Git URL"
+        : stage === "github"
+          ? "GitHub repository"
+          : stage === "progress"
+            ? "Cloning"
+            : "Add a repo";
+
+  return (
+    <Dialog open={open} onOpenChange={busy ? undefined : onOpenChange}>
+      <DialogContent
+        className="max-w-md gap-4 p-5"
+        onKeyDown={onKeyDown}
+        aria-busy={busy}
+      >
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>
+            {stage === "sources"
+              ? "Register a local checkout or clone a remote."
+              : stage === "local"
+                ? "Pick a folder or paste its path."
+                : stage === "git_url"
+                  ? "Clone from a remote URL into a parent folder."
+                  : stage === "github"
+                    ? "Clone an owner/repo from GitHub."
+                    : "Cloning into the chosen folder."}
+          </DialogDescription>
+        </DialogHeader>
+
+        {stage === "sources" && (
+          <div className="flex flex-col gap-2">
+            <SearchInput
+              value={query}
+              onValueChange={setQuery}
+              placeholder="Filter sources"
+              size="sm"
+              aria-controls="add-repo-sources"
+              aria-activedescendant={
+                rows[active]
+                  ? optionElementId("add-repo-sources", active)
+                  : undefined
+              }
+            />
+            <OptionListbox
+              listId="add-repo-sources"
+              label="Sources"
+              rows={rows}
+              activeIndex={active}
+              onPick={selectSource}
+              onHighlight={setActive}
+            />
+          </div>
+        )}
+
+        {stage === "local" && (
+          <LocalStage
+            path={path}
+            displayName={displayName}
+            busy={busy}
+            error={error}
+            onPath={setPath}
+            onDisplayName={setDisplayName}
+            onBrowse={() => void pickDirectory("path")}
+            onSubmit={() => void registerLocal()}
+          />
+        )}
+
+        {stage === "git_url" && (
+          <GitUrlStage
+            url={url}
+            parentDir={parentDir}
+            name={cloneName}
+            busy={busy}
+            error={error}
+            onUrl={setUrl}
+            onParentDir={setParentDir}
+            onName={setCloneName}
+            onBrowse={() => void pickDirectory("parent")}
+            onSubmit={() =>
+              void startClone({
+                url,
+                parent_dir: parentDir,
+                name: cloneName,
+              })
+            }
+          />
+        )}
+
+        {stage === "github" && (
+          <GithubStage
+            github={github}
+            parentDir={parentDir}
+            name={cloneName}
+            defaults={defaults}
+            busy={busy}
+            error={error}
+            onGithub={setGithub}
+            onParentDir={setParentDir}
+            onName={setCloneName}
+            onBrowse={() => void pickDirectory("parent")}
+            onSubmit={() =>
+              void startClone({
+                github,
+                parent_dir: parentDir,
+                name: cloneName,
+              })
+            }
+          />
+        )}
+
+        {stage === "progress" && (
+          <ProgressStage
+            job={job}
+            error={error ?? job?.error}
+            onRetry={() => {
+              setStage(github.trim() ? "github" : "git_url");
+              setJobId(null);
+              setError(null);
+            }}
+          />
+        )}
+
+        <footer className="text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+          <Hint keys={["↑", "↓"]} label="Navigate" />
+          <Hint keys={["Enter"]} label="Select" />
+          <Hint keys={["Backspace"]} label="Back" />
+          <Hint keys={["Esc"]} label="Close" />
+        </footer>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function LocalStage({
+  path,
+  displayName,
+  busy,
+  error,
+  onPath,
+  onDisplayName,
+  onBrowse,
+  onSubmit,
+}: {
+  path: string;
+  displayName: string;
+  busy: boolean;
+  error: string | null;
+  onPath: (value: string) => void;
+  onDisplayName: (value: string) => void;
+  onBrowse: () => void;
+  onSubmit: () => void;
+}) {
+  return (
+    <form
+      className="flex flex-col gap-3"
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSubmit();
+      }}
+    >
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-medium">Path</span>
+        <div className="flex gap-2">
+          <Input
+            value={path}
+            onChange={(event) => onPath(event.target.value)}
+            placeholder="/Users/you/src/app"
+            disabled={busy}
+            autoFocus
+          />
+          {hasNativeHost() && (
+            <Button type="button" variant="outline" onClick={onBrowse} disabled={busy}>
+              Browse
+            </Button>
+          )}
+        </div>
+      </label>
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-medium">Display name</span>
+        <Input
+          value={displayName}
+          onChange={(event) => onDisplayName(event.target.value)}
+          disabled={busy}
+        />
+      </label>
+      {error && <p className="text-sm text-critical">{error}</p>}
+      <Button type="submit" disabled={busy || !path.trim()} className="self-start">
+        {busy ? "Registering…" : "Register"}
+      </Button>
+    </form>
+  );
+}
+
+function GitUrlStage({
+  url,
+  parentDir,
+  name,
+  busy,
+  error,
+  onUrl,
+  onParentDir,
+  onName,
+  onBrowse,
+  onSubmit,
+}: {
+  url: string;
+  parentDir: string;
+  name: string;
+  busy: boolean;
+  error: string | null;
+  onUrl: (value: string) => void;
+  onParentDir: (value: string) => void;
+  onName: (value: string) => void;
+  onBrowse: () => void;
+  onSubmit: () => void;
+}) {
+  return (
+    <form
+      className="flex flex-col gap-3"
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSubmit();
+      }}
+    >
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-medium">URL</span>
+        <Input
+          value={url}
+          onChange={(event) => onUrl(event.target.value)}
+          placeholder="https://example.com/acme/app.git"
+          disabled={busy}
+          autoFocus
+        />
+      </label>
+      <ParentDirField
+        value={parentDir}
+        busy={busy}
+        onChange={onParentDir}
+        onBrowse={onBrowse}
+      />
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-medium">Name</span>
+        <Input
+          value={name}
+          onChange={(event) => onName(event.target.value)}
+          placeholder="optional folder name"
+          disabled={busy}
+        />
+      </label>
+      {error && <p className="text-sm text-critical">{error}</p>}
+      <Button
+        type="submit"
+        disabled={busy || !url.trim() || !parentDir.trim()}
+        className="self-start"
+      >
+        {busy ? "Starting…" : "Clone"}
+      </Button>
+    </form>
+  );
+}
+
+function GithubStage({
+  github,
+  parentDir,
+  name,
+  defaults,
+  busy,
+  error,
+  onGithub,
+  onParentDir,
+  onName,
+  onBrowse,
+  onSubmit,
+}: {
+  github: string;
+  parentDir: string;
+  name: string;
+  defaults: CodeCloneDefaults | null;
+  busy: boolean;
+  error: string | null;
+  onGithub: (value: string) => void;
+  onParentDir: (value: string) => void;
+  onName: (value: string) => void;
+  onBrowse: () => void;
+  onSubmit: () => void;
+}) {
+  const ghHint =
+    defaults && (!defaults.gh_found || defaults.gh_authenticated === false)
+      ? defaults.gh_remediation
+      : null;
+  return (
+    <form
+      className="flex flex-col gap-3"
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSubmit();
+      }}
+    >
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-medium">Repository</span>
+        <Input
+          value={github}
+          onChange={(event) => onGithub(event.target.value)}
+          placeholder="owner/repo"
+          disabled={busy}
+          autoFocus
+        />
+      </label>
+      {ghHint && (
+        <p className="text-muted-foreground text-xs" data-testid="gh-absent-hint">
+          {ghHint} You can still clone over HTTPS.
+        </p>
+      )}
+      <ParentDirField
+        value={parentDir}
+        busy={busy}
+        onChange={onParentDir}
+        onBrowse={onBrowse}
+      />
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-medium">Name</span>
+        <Input
+          value={name}
+          onChange={(event) => onName(event.target.value)}
+          placeholder="optional folder name"
+          disabled={busy}
+        />
+      </label>
+      {error && <p className="text-sm text-critical">{error}</p>}
+      <Button
+        type="submit"
+        disabled={busy || !github.trim() || !parentDir.trim()}
+        className="self-start"
+      >
+        {busy ? "Starting…" : "Clone"}
+      </Button>
+    </form>
+  );
+}
+
+function ParentDirField({
+  value,
+  busy,
+  onChange,
+  onBrowse,
+}: {
+  value: string;
+  busy: boolean;
+  onChange: (value: string) => void;
+  onBrowse: () => void;
+}) {
+  return (
+    <label className="flex flex-col gap-1 text-sm">
+      <span className="font-medium">Destination folder</span>
+      <div className="flex gap-2">
+        <Input
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          placeholder="/Users/you/src"
+          disabled={busy}
+        />
+        {hasNativeHost() && (
+          <Button type="button" variant="outline" onClick={onBrowse} disabled={busy}>
+            Browse
+          </Button>
+        )}
+      </div>
+    </label>
+  );
+}
+
+function ProgressStage({
+  job,
+  error,
+  onRetry,
+}: {
+  job: CodeCloneJobSnapshot | undefined;
+  error: string | null | undefined;
+  onRetry: () => void;
+}) {
+  const failed = Boolean(error) || job?.done === true && Boolean(job.error);
+  const percent = job?.percent ?? (job?.done && !job.error ? 100 : 0);
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-sm" data-testid="clone-phase">
+        {job?.phase ?? "starting"}
+      </p>
+      <Progress value={percent} />
+      {failed && (
+        <>
+          <pre className="bg-muted max-h-32 overflow-auto rounded-md p-2 text-xs whitespace-pre-wrap">
+            {error ?? job?.error}
+          </pre>
+          <Button type="button" variant="outline" className="self-start" onClick={onRetry}>
+            Retry
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Hint({ keys, label }: { keys: string[]; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      {keys.map((key) => (
+        <kbd
+          key={key}
+          className="inline-flex h-5 min-w-5 items-center justify-center rounded border bg-muted/60 px-1 font-sans text-2xs leading-none font-medium text-foreground/80"
+        >
+          {key}
+        </kbd>
+      ))}
+      <span>{label}</span>
+    </span>
+  );
+}
+
+export type { SourceKey };
+export { SOURCES };

--- a/crates/tidebreak-desktop/ui/src/code/CodeHome.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeHome.tsx
@@ -1,13 +1,11 @@
-import { useEffect, useState, type FormEvent } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
-import { toast } from "sonner";
 
 import { useApp } from "@/AppContext";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { RouteFrame } from "@/RouteFrame";
-import { friendlyErrorMessage } from "@/lib/utils";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { AddRepoPalette } from "./AddRepoPalette";
 import { CodeSidebar } from "./CodeSidebar";
 import { DoctorList } from "./DoctorList";
 import { isHarnessReady } from "./labels";
@@ -39,10 +37,7 @@ function CodeHomeBody() {
   const loaded = useCodeCatalogStore((state) => state.loaded);
   const error = useCodeCatalogStore((state) => state.error);
   const refresh = useCodeCatalogStore((state) => state.refresh);
-  const upsertRepo = useCodeCatalogStore((state) => state.upsertRepo);
-  const [path, setPath] = useState("");
-  const [displayName, setDisplayName] = useState("");
-  const [registering, setRegistering] = useState(false);
+  const [addOpen, setAddOpen] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
 
   useEffect(() => {
@@ -57,26 +52,6 @@ function CodeHomeBody() {
       await refresh(client);
     } finally {
       setRefreshing(false);
-    }
-  }
-
-  async function register(event: FormEvent) {
-    event.preventDefault();
-    if (!path.trim()) return;
-    setRegistering(true);
-    try {
-      const repo = await client.createCodeRepo({
-        path: path.trim(),
-        display_name: displayName.trim() || undefined,
-      });
-      upsertRepo(repo);
-      setPath("");
-      setDisplayName("");
-      await navigate({ to: "/code/r/$repoId", params: { repoId: repo.id } });
-    } catch (err) {
-      toast.error(friendlyErrorMessage(err, "Could not register that repo"));
-    } finally {
-      setRegistering(false);
     }
   }
 
@@ -108,29 +83,13 @@ function CodeHomeBody() {
       {ready && (
         <>
           <section className="flex flex-col gap-3">
-            <h2 className="text-lg font-semibold">Register a repo</h2>
-            <form className="flex flex-col gap-3" onSubmit={register}>
-              <label className="flex flex-col gap-1 text-sm">
-                <span className="font-medium">Path</span>
-                <Input
-                  value={path}
-                  onChange={(event) => setPath(event.target.value)}
-                  placeholder="/Users/you/src/app"
-                  disabled={registering}
-                />
-              </label>
-              <label className="flex flex-col gap-1 text-sm">
-                <span className="font-medium">Display name</span>
-                <Input
-                  value={displayName}
-                  onChange={(event) => setDisplayName(event.target.value)}
-                  disabled={registering}
-                />
-              </label>
-              <Button type="submit" disabled={registering || !path.trim()} className="self-start">
-                {registering ? "Registering…" : "Register"}
-              </Button>
-            </form>
+            <h2 className="text-lg font-semibold">Add a repo</h2>
+            <p className="text-muted-foreground text-sm">
+              Browse a local folder, or clone from a git URL or GitHub.
+            </p>
+            <Button type="button" className="self-start" onClick={() => setAddOpen(true)}>
+              Add repo
+            </Button>
           </section>
           <section className="flex flex-col gap-3">
             <h2 className="text-lg font-semibold">Repos</h2>
@@ -162,6 +121,7 @@ function CodeHomeBody() {
           </section>
         </>
       )}
+      <AddRepoPalette open={addOpen} onOpenChange={setAddOpen} />
     </div>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
@@ -38,6 +38,10 @@ const client = {
     },
   ]),
   getHarnessDoctor: vi.fn(async () => ({ harnesses: [] })),
+  getCodeCloneDefaults: vi.fn(async () => ({
+    gh_found: false,
+    gh_remediation: "gh is not installed.",
+  })),
   openCodeUpdates: vi.fn(() => {
     return {
       close() {},

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -12,6 +12,7 @@ import { SidebarFrame } from "@/sidebar/SidebarFrame";
 import { AttentionBadge } from "./AttentionBadge";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { connectCodeUpdates, useCodeUpdatesStore } from "./CodeUpdatesStore";
+import { AddRepoPalette } from "./AddRepoPalette";
 import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
 
 /**
@@ -35,6 +36,7 @@ export function CodeSidebar() {
   const refresh = useCodeCatalogStore((state) => state.refresh);
   const digests = useCodeUpdatesStore((state) => state.byWorkspace);
   const [newWorkspaceOpen, setNewWorkspaceOpen] = useState(false);
+  const [addRepoOpen, setAddRepoOpen] = useState(false);
 
   useEffect(() => {
     void refresh(client);
@@ -67,7 +69,25 @@ export function CodeSidebar() {
         </SidebarButton>
       </div>
 
-      {!isCompact && <SidebarSectionTitle>Repos</SidebarSectionTitle>}
+      {!isCompact && (
+        <div className="flex items-center justify-between px-2">
+          <SidebarSectionTitle className="px-0">Repos</SidebarSectionTitle>
+          <button
+            type="button"
+            className="cursor-pointer rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label="Add repo"
+            onClick={() => setAddRepoOpen(true)}
+          >
+            <Plus size={14} />
+          </button>
+        </div>
+      )}
+      {isCompact && (
+        <SidebarButton aria-label="Add repo" onClick={() => setAddRepoOpen(true)}>
+          <Plus />
+          <span>Add repo</span>
+        </SidebarButton>
+      )}
       <div className="flex shrink-0 flex-col gap-0.5">
         {repos.map((repo) => {
           const active = pathname === `/code/r/${repo.id}`;
@@ -148,6 +168,7 @@ export function CodeSidebar() {
         onOpenChange={setNewWorkspaceOpen}
         repos={repos}
       />
+      <AddRepoPalette open={addRepoOpen} onOpenChange={setAddRepoOpen} />
     </SidebarFrame>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.test.ts
@@ -33,7 +33,7 @@ afterEach(() => {
 
 describe("reduceCodeUpdates", () => {
   it("replaces the map on snapshot and upserts a digest", () => {
-    const empty = { byWorkspace: {}, viewedWorkspaceId: null };
+    const empty = { byWorkspace: {}, cloneJobs: {}, viewedWorkspaceId: null };
     const afterSnapshot = reduceCodeUpdates(empty, {
       type: "snapshot",
       sessions: [digest(), digest({ workspace: "ws-2", session: "sess-2", title: "other" })],
@@ -88,6 +88,23 @@ describe("reduceCodeUpdates", () => {
         terminal_id: "term-1",
       }),
     ).toBeNull();
+    expect(
+      noticeToAction({
+        type: "clone_progress",
+        job: "job-1",
+        phase: "receiving objects",
+        percent: 40,
+        done: false,
+      }),
+    ).toEqual({
+      type: "clone_progress",
+      job: {
+        id: "job-1",
+        phase: "receiving objects",
+        percent: 40,
+        done: false,
+      },
+    });
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
@@ -3,6 +3,7 @@ import { create } from "zustand";
 import type { ApiClient } from "../api/client";
 import type {
   Attention,
+  CodeCloneJobSnapshot,
   CodeSessionDigest,
   CodeSessionLifecycle,
   CodeUpdateNotice,
@@ -25,17 +26,20 @@ import { requestUserAttention } from "../host";
 
 export type CodeUpdatesState = {
   byWorkspace: Record<string, CodeSessionDigest>;
+  cloneJobs: Record<string, CodeCloneJobSnapshot>;
   viewedWorkspaceId: string | null;
 };
 
 export type CodeUpdatesAction =
   | { type: "snapshot"; sessions: CodeSessionDigest[] }
   | { type: "digest"; digest: CodeSessionDigest }
+  | { type: "clone_progress"; job: CodeCloneJobSnapshot }
   | { type: "view"; workspaceId: string | null }
   | { type: "reset" };
 
 const EMPTY: CodeUpdatesState = {
   byWorkspace: {},
+  cloneJobs: {},
   viewedWorkspaceId: null,
 };
 
@@ -57,6 +61,14 @@ export function reduceCodeUpdates(
         byWorkspace: {
           ...state.byWorkspace,
           [action.digest.workspace]: action.digest,
+        },
+      };
+    case "clone_progress":
+      return {
+        ...state,
+        cloneJobs: {
+          ...state.cloneJobs,
+          [action.job.id]: action.job,
         },
       };
     case "view":
@@ -99,6 +111,19 @@ export function noticeToAction(notice: CodeUpdateNotice): CodeUpdatesAction | nu
         title: notice.title,
         turn_count: notice.turn_count,
         ...(notice.pr_state !== undefined ? { pr_state: notice.pr_state } : {}),
+      },
+    };
+  }
+  if (notice.type === "clone_progress") {
+    return {
+      type: "clone_progress",
+      job: {
+        id: notice.job,
+        phase: notice.phase,
+        done: notice.done,
+        ...(notice.percent !== undefined ? { percent: notice.percent } : {}),
+        ...(notice.error !== undefined ? { error: notice.error } : {}),
+        ...(notice.repo_id !== undefined ? { repo_id: notice.repo_id } : {}),
       },
     };
   }

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -42,7 +42,6 @@ import { TerminalPane } from "./TerminalPane";
 import {
   fenceReasonText,
   HARNESS_LABELS,
-  isHarnessReady,
   LIFECYCLE_LABELS,
 } from "./labels";
 
@@ -191,8 +190,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
 
   const fenced =
     session?.lifecycle === "fenced" || session?.fence_reason !== undefined;
-  const readyHarnesses =
-    catalog.doctor?.harnesses.filter((entry) => isHarnessReady(entry)) ?? [];
+  const doctorHarnesses = catalog.doctor?.harnesses ?? [];
 
   return (
     <>
@@ -308,7 +306,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
             )}
             {!session && workspace?.status === "active" && (
               <StartSessionPrompt
-                harnesses={readyHarnesses}
+                harnesses={doctorHarnesses}
                 starting={starting}
                 selectedMode={createMode}
                 onSelectMode={setCreateMode}

--- a/crates/tidebreak-desktop/ui/src/code/HarnessPicker.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/HarnessPicker.dom.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { HarnessDoctorEntry } from "../api/types";
+import { renderWithRouter } from "@/test/router";
+import { HarnessPicker } from "./HarnessPicker";
+
+afterEach(() => {
+  cleanup();
+});
+
+const CAPS = {
+  resume: "supported",
+  streaming_deltas: "supported",
+  mid_turn_steering: "unsupported",
+  plan_mode: "supported",
+  reasoning_levels: "unknown",
+  native_file_change_events: "unsupported",
+  native_interrupt: "supported",
+  structured_approvals: "supported",
+} as const;
+
+function entry(
+  overrides: Partial<HarnessDoctorEntry> & Pick<HarnessDoctorEntry, "kind">,
+): HarnessDoctorEntry {
+  return {
+    found: true,
+    version: "9.9.9",
+    path: "/opt/harness",
+    tier: "reference",
+    caps: { ...CAPS },
+    remediation: "",
+    stderr: "",
+    unrecognized_event_count: 0,
+    ...overrides,
+  };
+}
+
+describe("HarnessPicker", () => {
+  it("selects a ready row and dims unusable ones", async () => {
+    const onChange = vi.fn();
+    await renderWithRouter(
+      <HarnessPicker
+        harnesses={[
+          entry({ kind: "claude_code" }),
+          entry({ kind: "codex", found: false }),
+          entry({
+            kind: "grok",
+            caps: { ...CAPS, plan_mode: "unsupported", structured_approvals: "unsupported" },
+          }),
+        ]}
+        value="claude_code"
+        onChange={onChange}
+      />,
+    );
+    expect(screen.getByRole("option", { name: /Claude Code/ })).toBeEnabled();
+    expect(screen.getByRole("option", { name: /Not installed/ })).toBeDisabled();
+    expect(screen.getByRole("option", { name: /Not available yet/ })).toBeDisabled();
+    fireEvent.click(screen.getByRole("option", { name: /Claude Code/ }));
+    expect(onChange).toHaveBeenCalledWith("claude_code");
+  });
+
+  it("moves with the keyboard and never renders doctor version strings", async () => {
+    const onChange = vi.fn();
+    await renderWithRouter(
+      <HarnessPicker
+        harnesses={[
+          entry({ kind: "claude_code", version: "2.1.233" }),
+          entry({ kind: "codex", version: "0.80.0" }),
+        ]}
+        value="claude_code"
+        onChange={onChange}
+      />,
+    );
+    const list = screen.getByRole("listbox", { name: "Harness" });
+    expect(list.textContent).not.toMatch(/2\.1\.233|0\.80\.0|\/opt\/harness/);
+    fireEvent.keyDown(list, { key: "ArrowDown" });
+    fireEvent.keyDown(list, { key: "Enter" });
+    expect(onChange).toHaveBeenCalledWith("codex");
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/HarnessPicker.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/HarnessPicker.tsx
@@ -1,0 +1,157 @@
+import type { ComponentType, KeyboardEvent } from "react";
+import { useEffect, useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+
+import type { HarnessDoctorEntry, HarnessKind } from "../api/types";
+import {
+  ClaudeIcon,
+  OpenAIIcon,
+  OpenCodeIcon,
+  XaiIcon,
+} from "../ProviderIcons";
+import { cn } from "@/lib/utils";
+import {
+  HARNESS_LABELS,
+  HARNESS_SUBTITLES,
+  harnessUnusableReason,
+} from "./labels";
+
+const HARNESS_ICONS: Record<
+  HarnessKind,
+  ComponentType<{ className?: string }>
+> = {
+  claude_code: ClaudeIcon,
+  codex: OpenAIIcon,
+  opencode: OpenCodeIcon,
+  grok: XaiIcon,
+};
+
+/**
+ * Branded harness picker: logo, product name, one-line subtitle.
+ *
+ * Ready rows are selectable. Unusable rows are dimmed with a short reason
+ * and a quiet link to the doctor. Versions and capability flags stay off
+ * this surface.
+ */
+export function HarnessPicker({
+  harnesses,
+  value,
+  onChange,
+  disabled,
+}: {
+  harnesses: HarnessDoctorEntry[];
+  value: HarnessKind | null;
+  onChange: (kind: HarnessKind) => void;
+  disabled?: boolean;
+}) {
+  const navigate = useNavigate();
+  const harnessesPath: string = "/settings/coding-harnesses";
+  const [active, setActive] = useState(() =>
+    Math.max(
+      0,
+      harnesses.findIndex((entry) => {
+        if (value) return entry.kind === value;
+        return !harnessUnusableReason(entry);
+      }),
+    ),
+  );
+
+  useEffect(() => {
+    const next = harnesses.findIndex((entry) => {
+      if (value) return entry.kind === value;
+      return !harnessUnusableReason(entry);
+    });
+    if (next >= 0) setActive(next);
+  }, [harnesses, value]);
+
+  function move(delta: number) {
+    if (harnesses.length === 0) return;
+    setActive((current) => {
+      const next = (current + delta + harnesses.length) % harnesses.length;
+      return next;
+    });
+  }
+
+  function pick(index: number) {
+    const entry = harnesses[index];
+    if (!entry || harnessUnusableReason(entry) || disabled) return;
+    onChange(entry.kind);
+  }
+
+  function onKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      move(1);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      move(-1);
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      pick(active);
+    }
+  }
+
+  return (
+    <div
+      role="listbox"
+      aria-label="Harness"
+      tabIndex={disabled ? -1 : 0}
+      className="flex flex-col gap-0.5 rounded-md border border-border p-1"
+      onKeyDown={onKeyDown}
+    >
+      {harnesses.map((entry, index) => {
+        const reason = harnessUnusableReason(entry);
+        const selected = value === entry.kind;
+        const Icon = HARNESS_ICONS[entry.kind];
+        return (
+          <button
+            key={entry.kind}
+            type="button"
+            role="option"
+            aria-selected={selected}
+            aria-disabled={Boolean(reason) || undefined}
+            disabled={disabled || Boolean(reason)}
+            className={cn(
+              "flex w-full items-start gap-2.5 rounded-sm px-2 py-1.5 text-left text-sm",
+              index === active && "bg-accent text-accent-foreground",
+              reason && "opacity-50",
+              selected && !reason && "ring-1 ring-border",
+            )}
+            onMouseEnter={() => setActive(index)}
+            onClick={() => pick(index)}
+          >
+            <Icon className="mt-0.5 size-4 shrink-0" />
+            <span className="flex min-w-0 flex-col">
+              <span className="truncate font-medium">
+                {HARNESS_LABELS[entry.kind]}
+              </span>
+              <span className="truncate text-xs text-muted-foreground">
+                {reason ?? HARNESS_SUBTITLES[entry.kind]}
+              </span>
+              {reason && (
+                <span
+                  role="link"
+                  tabIndex={0}
+                  className="text-muted-foreground mt-0.5 w-fit cursor-pointer text-xs underline-offset-2 hover:underline"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    void navigate({ to: harnessesPath });
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      void navigate({ to: harnessesPath });
+                    }
+                  }}
+                >
+                  Coding harnesses
+                </span>
+              )}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -28,11 +28,11 @@ import {
 import { friendlyErrorMessage } from "@/lib/utils";
 import { PermissionModePicker } from "./CodeComposer";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { HarnessPicker } from "./HarnessPicker";
 import {
   createPermissionModes,
   defaultCreatePermissionMode,
-  HARNESS_LABELS,
-  isHarnessReady,
+  harnessUnusableReason,
 } from "./labels";
 
 /**
@@ -40,8 +40,8 @@ import {
  *
  * Permission mode defaults to Ask when the doctor reports structured
  * approvals, otherwise Plan — create always has a mode the harness can honor.
- * The harness picker is the doctor: only engines that are installed (and
- * signed in, when the doctor knows) can be chosen.
+ * The harness picker lists every doctor entry. Ready rows are selectable;
+ * unusable ones stay visible and dimmed.
  */
 
 export function NewWorkspaceDialog({
@@ -69,8 +69,10 @@ export function NewWorkspaceDialog({
   );
   const [creating, setCreating] = useState(false);
 
-  const readyHarnesses =
-    doctor?.harnesses.filter((entry) => isHarnessReady(entry)) ?? [];
+  const allHarnesses = doctor?.harnesses ?? [];
+  const readyHarnesses = allHarnesses.filter(
+    (entry) => !harnessUnusableReason(entry),
+  );
 
   useEffect(() => {
     if (!open) return;
@@ -178,23 +180,12 @@ export function NewWorkspaceDialog({
           </label>
           <div className="flex flex-col gap-1 text-sm">
             <span className="font-medium">Harness</span>
-            <Select
-              value={readyHarnesses.some((entry) => entry.kind === harness) ? harness : undefined}
-              onValueChange={(value) => setHarness(value as HarnessKind)}
-              disabled={creating || readyHarnesses.length === 0}
-            >
-              <SelectTrigger aria-label="Harness">
-                <SelectValue placeholder="No ready harness" />
-              </SelectTrigger>
-              <SelectContent scrollButtons={false}>
-                {readyHarnesses.map((entry) => (
-                  <SelectItem key={entry.kind} value={entry.kind}>
-                    {HARNESS_LABELS[entry.kind]}
-                    {entry.version ? ` ${entry.version}` : ""}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <HarnessPicker
+              harnesses={allHarnesses}
+              value={harness}
+              onChange={setHarness}
+              disabled={creating}
+            />
           </div>
           <div className="flex flex-col gap-1 text-sm">
             <span className="font-medium">Permission mode</span>

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { HarnessDoctorEntry } from "../api/types";
+import { renderWithRouter } from "@/test/router";
 import { StartSessionPrompt } from "./StartSessionPrompt";
 
 afterEach(() => {
@@ -35,9 +36,9 @@ function entry(
 }
 
 describe("StartSessionPrompt", () => {
-  it("defaults to Ask and posts Ask when the doctor supports structured approvals", () => {
+  it("defaults to Ask and posts Ask when the doctor supports structured approvals", async () => {
     const onStart = vi.fn();
-    render(
+    await renderWithRouter(
       <StartSessionPrompt
         harnesses={[entry("claude_code", "supported")]}
         starting={false}
@@ -50,13 +51,13 @@ describe("StartSessionPrompt", () => {
       "aria-pressed",
       "true",
     );
-    fireEvent.click(screen.getByRole("button", { name: "Claude Code" }));
+    fireEvent.click(screen.getByRole("option", { name: /Claude Code/ }));
     expect(onStart).toHaveBeenCalledWith("claude_code", "ask");
   });
 
-  it("falls back to Plan when structured approvals are not supported", () => {
+  it("falls back to Plan when structured approvals are not supported", async () => {
     const onStart = vi.fn();
-    render(
+    await renderWithRouter(
       <StartSessionPrompt
         harnesses={[entry("claude_code", "unsupported")]}
         starting={false}
@@ -71,13 +72,13 @@ describe("StartSessionPrompt", () => {
       "aria-pressed",
       "true",
     );
-    fireEvent.click(screen.getByRole("button", { name: "Claude Code" }));
+    fireEvent.click(screen.getByRole("option", { name: /Claude Code/ }));
     expect(onStart).toHaveBeenCalledWith("claude_code", "plan");
   });
 
-  it("posts Plan for a harness that cannot honor a selected Ask mode", () => {
+  it("posts Plan for a harness that cannot honor a selected Ask mode", async () => {
     const onStart = vi.fn();
-    render(
+    await renderWithRouter(
       <StartSessionPrompt
         harnesses={[
           entry("claude_code", "supported"),
@@ -89,7 +90,7 @@ describe("StartSessionPrompt", () => {
         onStart={onStart}
       />,
     );
-    fireEvent.click(screen.getByRole("button", { name: "Codex CLI" }));
+    fireEvent.click(screen.getByRole("option", { name: /Codex CLI/ }));
     expect(onStart).toHaveBeenCalledWith("codex", "plan");
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
@@ -3,12 +3,12 @@ import type {
   HarnessDoctorEntry,
   HarnessKind,
 } from "../api/types";
-import { Button } from "@/components/ui/button";
 import { PermissionModePicker } from "./CodeComposer";
+import { HarnessPicker } from "./HarnessPicker";
 import {
   createPermissionModes,
   defaultCreatePermissionMode,
-  HARNESS_LABELS,
+  harnessUnusableReason,
 } from "./labels";
 
 /**
@@ -29,7 +29,8 @@ export function StartSessionPrompt({
   onSelectMode: (mode: CodePermissionMode) => void;
   onStart: (harness: HarnessKind, mode: CodePermissionMode) => void;
 }) {
-  const anyAsk = harnesses.some((entry) =>
+  const usable = harnesses.filter((entry) => !harnessUnusableReason(entry));
+  const anyAsk = usable.some((entry) =>
     createPermissionModes(entry.caps.structured_approvals).includes("ask"),
   );
   const defaultMode: CodePermissionMode = anyAsk ? "ask" : "plan";
@@ -46,22 +47,16 @@ export function StartSessionPrompt({
         availableModes={availableModes}
         onChange={onSelectMode}
       />
-      <div className="flex flex-wrap gap-2">
-        {harnesses.map((entry) => {
-          const posted = modeForHarness(entry, mode);
-          return (
-            <Button
-              key={entry.kind}
-              type="button"
-              size="sm"
-              disabled={starting}
-              onClick={() => onStart(entry.kind, posted)}
-            >
-              {HARNESS_LABELS[entry.kind]}
-            </Button>
-          );
-        })}
-      </div>
+      <HarnessPicker
+        harnesses={harnesses}
+        value={null}
+        disabled={starting}
+        onChange={(kind) => {
+          const entry = harnesses.find((item) => item.kind === kind);
+          if (!entry) return;
+          onStart(entry.kind, modeForHarness(entry, mode));
+        }}
+      />
     </div>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/code/labels.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   createPermissionModes,
   defaultCreatePermissionMode,
+  harnessUnusableReason,
 } from "./labels";
 
 describe("create-time permission mode", () => {
@@ -17,5 +18,35 @@ describe("create-time permission mode", () => {
     expect(defaultCreatePermissionMode(undefined)).toBe("plan");
     expect(createPermissionModes("unsupported")).toEqual(["plan"]);
     expect(createPermissionModes("unknown")).toEqual(["plan"]);
+  });
+});
+
+describe("harnessUnusableReason", () => {
+  it("names the one reason a picker row cannot be chosen", () => {
+    expect(
+      harnessUnusableReason({
+        found: false,
+        caps: { plan_mode: "supported", structured_approvals: "supported" },
+      }),
+    ).toBe("Not installed");
+    expect(
+      harnessUnusableReason({
+        found: true,
+        authenticated: false,
+        caps: { plan_mode: "supported", structured_approvals: "supported" },
+      }),
+    ).toBe("Sign in via your terminal");
+    expect(
+      harnessUnusableReason({
+        found: true,
+        caps: { plan_mode: "unsupported", structured_approvals: "unsupported" },
+      }),
+    ).toBe("Not available yet");
+    expect(
+      harnessUnusableReason({
+        found: true,
+        caps: { plan_mode: "supported", structured_approvals: "unsupported" },
+      }),
+    ).toBeNull();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -23,6 +23,14 @@ export const HARNESS_LABELS: Record<HarnessKind, string> = {
   grok: "Grok CLI",
 };
 
+/** One-line product gloss for the picker. Not how the adapter works. */
+export const HARNESS_SUBTITLES: Record<HarnessKind, string> = {
+  claude_code: "Anthropic's coding agent",
+  codex: "OpenAI's coding agent",
+  opencode: "Open-source coding agent",
+  grok: "xAI's coding agent",
+};
+
 export const HARNESS_TIER_LABELS: Record<HarnessTier, string> = {
   reference: "Reference",
   secondary: "Secondary",
@@ -67,6 +75,31 @@ export function isHarnessReady(entry: {
   authenticated?: boolean;
 }): boolean {
   return entry.found && entry.authenticated !== false;
+}
+
+/** True when create can post at least one permission mode this engine honors. */
+export function harnessHonorsAnyCreateMode(entry: {
+  caps: { plan_mode: CapLevel; structured_approvals: CapLevel };
+}): boolean {
+  return (
+    entry.caps.plan_mode === "supported" ||
+    harnessHonorsStructuredApprovals(entry.caps.structured_approvals)
+  );
+}
+
+/**
+ * Why a picker row is not selectable. Ready rows return null.
+ * Versions, paths, and capability names stay on the doctor.
+ */
+export function harnessUnusableReason(entry: {
+  found: boolean;
+  authenticated?: boolean;
+  caps: { plan_mode: CapLevel; structured_approvals: CapLevel };
+}): string | null {
+  if (!entry.found) return "Not installed";
+  if (entry.authenticated === false) return "Sign in via your terminal";
+  if (!harnessHonorsAnyCreateMode(entry)) return "Not available yet";
+  return null;
 }
 
 /** Ask/Auto need a structured approval channel. Plan does not. */

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -4,10 +4,13 @@ import {
   liveCodeSession,
   parseCodeAction,
   parseCodeApproval,
+  parseCodeCloneDefaults,
+  parseCodeCloneJob,
   parseCodeCommit,
   parseCodePush,
   parseCodeSession,
   parseCodeSessionList,
+  parseCodeUpdateNotice,
   parseCodeTerminal,
   parseCodeTerminalList,
   parseCodeTerminalRead,
@@ -270,5 +273,48 @@ describe("liveCodeSession", () => {
     expect(ended && live).toBeTruthy();
     expect(liveCodeSession([ended!, live!])?.id).toBe("sess-1");
     expect(liveCodeSession([ended!])).toBeNull();
+  });
+});
+
+describe("clone wire parsers", () => {
+  it("accepts a clone job snapshot and defaults payload", () => {
+    const job = {
+      id: "job-1",
+      phase: "receiving objects",
+      percent: 40,
+      done: false,
+    };
+    expect(parseCodeCloneJob(job)).toEqual(job);
+    expect(
+      parseCodeCloneDefaults({
+        parent_dir: "/tmp/src",
+        gh_found: false,
+        gh_remediation: "gh is not installed.",
+      }),
+    ).toEqual({
+      parent_dir: "/tmp/src",
+      gh_found: false,
+      gh_remediation: "gh is not installed.",
+    });
+  });
+
+  it("accepts a clone_progress update notice", () => {
+    expect(
+      parseCodeUpdateNotice({
+        type: "clone_progress",
+        job: "job-1",
+        phase: "done",
+        percent: 100,
+        done: true,
+        repo_id: "repo-1",
+      }),
+    ).toEqual({
+      type: "clone_progress",
+      job: "job-1",
+      phase: "done",
+      percent: 100,
+      done: true,
+      repo_id: "repo-1",
+    });
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -38,6 +38,8 @@ import type {
   ToolOutcome,
   CodeSessionDigest,
   CodeUpdateNotice,
+  CodeCloneDefaults,
+  CodeCloneJobSnapshot,
   PullRequestDigest,
 } from "../api/types";
 import type {
@@ -65,6 +67,8 @@ import type {
   ToolDetail as WireToolDetail,
   CodeSessionDigest as WireCodeSessionDigest,
   CodeUpdateNotice as WireCodeUpdateNotice,
+  CodeCloneDefaults as WireCodeCloneDefaults,
+  CodeCloneJobSnapshot as WireCodeCloneJobSnapshot,
 } from "../generated/wire";
 
 /**
@@ -127,6 +131,65 @@ const ATTENTION_SOURCES = new Set<AttentionSource>([
   "lifecycle",
   "user",
 ]);
+
+export function parseCodeCloneJob(value: unknown): CodeCloneJobSnapshot | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeCloneJobSnapshot>(value, [
+      "id",
+      "phase",
+      "percent",
+      "done",
+      "error",
+      "repo_id",
+    ]) ||
+    !nonEmpty(value.id) ||
+    typeof value.phase !== "string" ||
+    typeof value.done !== "boolean" ||
+    (value.percent !== undefined && !isFiniteNumber(value.percent)) ||
+    !optionalString(value.error) ||
+    !optionalString(value.repo_id)
+  ) {
+    return null;
+  }
+  return {
+    id: value.id,
+    phase: value.phase,
+    done: value.done,
+    ...(value.percent !== undefined ? { percent: value.percent } : {}),
+    ...(value.error !== undefined ? { error: value.error } : {}),
+    ...(value.repo_id !== undefined ? { repo_id: value.repo_id } : {}),
+  };
+}
+
+export function parseCodeCloneDefaults(
+  value: unknown,
+): CodeCloneDefaults | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeCloneDefaults>(value, [
+      "parent_dir",
+      "gh_found",
+      "gh_authenticated",
+      "gh_remediation",
+    ]) ||
+    !optionalString(value.parent_dir) ||
+    typeof value.gh_found !== "boolean" ||
+    typeof value.gh_remediation !== "string" ||
+    (value.gh_authenticated !== undefined &&
+      typeof value.gh_authenticated !== "boolean")
+  ) {
+    return null;
+  }
+  return {
+    gh_found: value.gh_found,
+    gh_remediation: value.gh_remediation,
+    ...(value.parent_dir !== undefined ? { parent_dir: value.parent_dir } : {}),
+    ...(value.gh_authenticated !== undefined
+      ? { gh_authenticated: value.gh_authenticated }
+      : {}),
+  };
+}
 
 export function parseCodeRepo(value: unknown): CodeRepoSnapshot | null {
   if (
@@ -1282,6 +1345,31 @@ export function parseCodeUpdateNotice(value: unknown): CodeUpdateNotice | null {
         title: value.title,
         turn_count: value.turn_count,
         ...(pr_state ? { pr_state } : {}),
+      };
+    }
+    case "clone_progress": {
+      if (
+        !onlyKeys<Extract<WireCodeUpdateNotice, { type: "clone_progress" }>>(
+          value,
+          ["type", "job", "phase", "percent", "done", "error", "repo_id"],
+        ) ||
+        !nonEmpty(value.job) ||
+        typeof value.phase !== "string" ||
+        typeof value.done !== "boolean" ||
+        (value.percent !== undefined && !isFiniteNumber(value.percent)) ||
+        !optionalString(value.error) ||
+        !optionalString(value.repo_id)
+      ) {
+        return null;
+      }
+      return {
+        type: "clone_progress",
+        job: value.job,
+        phase: value.phase,
+        done: value.done,
+        ...(value.percent !== undefined ? { percent: value.percent } : {}),
+        ...(value.error !== undefined ? { error: value.error } : {}),
+        ...(value.repo_id !== undefined ? { repo_id: value.repo_id } : {}),
       };
     }
     case "terminal_activity": {

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -863,6 +863,16 @@ harness_raw_json: string, state: CodeApprovalState, feedback?: string, requested
 export type CodeApprovalState = "pending" | "approved" | "denied";
 
 /**
+ * Remembered clone destination plus observed `gh` status.
+ */
+export type CodeCloneDefaults = { parent_dir?: string, gh_found: boolean, gh_authenticated?: boolean, gh_remediation: string, };
+
+/**
+ * Snapshot of an in-flight or finished clone job.
+ */
+export type CodeCloneJobSnapshot = { id: string, phase: string, percent?: number, done: boolean, error?: string, repo_id?: RepoId, };
+
+/**
  * Result of staging and committing the workspace worktree.
  */
 export type CodeCommitSnapshot = { sha: string, message: string, stat: Diffstat, };
@@ -1193,7 +1203,7 @@ export type CodeUpdateNotice = { "type": "snapshot",
 /**
  * One row per live session.
  */
-sessions: Array<CodeSessionDigest>, } | { "type": "digest", workspace: WorkspaceId, session: CodeSessionId, lifecycle: CodeSessionLifecycle, attention: Attention, title: string, turn_count: number, pr_state?: PullRequestDigest, } | { "type": "terminal_activity", workspace_id: WorkspaceId, terminal_id: CodeTerminalId, };
+sessions: Array<CodeSessionDigest>, } | { "type": "digest", workspace: WorkspaceId, session: CodeSessionId, lifecycle: CodeSessionLifecycle, attention: Attention, title: string, turn_count: number, pr_state?: PullRequestDigest, } | { "type": "terminal_activity", workspace_id: WorkspaceId, terminal_id: CodeTerminalId, } | { "type": "clone_progress", job: string, phase: string, percent?: number, done: boolean, error?: string, repo_id?: RepoId, };
 
 /**
  * Token accounting as reported by the engine. Missing fields stay zero.

--- a/crates/tidebreak-desktop/ui/src/host.ts
+++ b/crates/tidebreak-desktop/ui/src/host.ts
@@ -20,6 +20,13 @@ export function hasNativeHost(): boolean {
   return isTauri();
 }
 
+/** Native directory picker for code-mode repo registration and clone destinations. */
+export async function pickCodeDirectory(): Promise<string | null> {
+  if (!isTauri()) return null;
+  const path = await invoke<string | null>("pick_code_directory");
+  return path ?? null;
+}
+
 /** Best-effort only; durable pending-question polling remains authoritative. */
 export async function requestUserAttention(): Promise<void> {
   if (!isTauri()) return;

--- a/crates/tidebreak-server/src/code/bus.rs
+++ b/crates/tidebreak-server/src/code/bus.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 
 use tidebreak_core::{
-    Attention, CodeSessionId, CodeSessionLifecycle, PullRequestDigest, SequencedCodeEvent,
+    Attention, CodeSessionId, CodeSessionLifecycle, PullRequestDigest, RepoId, SequencedCodeEvent,
     WorkspaceId,
 };
 use tokio::sync::broadcast;
@@ -32,11 +32,24 @@ pub(crate) struct SessionDigest {
     pub pr_state: Option<PullRequestDigest>,
 }
 
+/// Progress of one in-flight `git clone` job.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct CloneProgress {
+    pub job: String,
+    pub phase: String,
+    pub percent: Option<u8>,
+    pub done: bool,
+    pub error: Option<String>,
+    pub repo_id: Option<RepoId>,
+}
+
 /// One unsequenced notice on the install-wide updates channel.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum CodeLiveUpdate {
     /// Cheap per-session digest, computed from rows.
     Digest(SessionDigest),
+    /// Clone job progress. Not restated on connect.
+    CloneProgress(CloneProgress),
 }
 
 /// Per-session broadcast channels for live journal events, plus the

--- a/crates/tidebreak-server/src/code/clone.rs
+++ b/crates/tidebreak-server/src/code/clone.rs
@@ -1,0 +1,510 @@
+//! Bounded `git clone` jobs for adding a remote repository.
+//!
+//! The user's own `git` binary does the work. Arguments are an argv array,
+//! never a shell string. Credential helpers may authenticate; the process
+//! never prompts and never stores secrets.
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, BufReader};
+use tokio::process::Command;
+use tokio::time::timeout;
+use uuid::Uuid;
+
+use tidebreak_core::{RepoId, Store};
+
+use super::bus::{CloneProgress, CodeLiveUpdate};
+use super::gh::{self, resolve_github_clone_url};
+use super::runtime::CodeRuntime;
+use crate::error::ServerError;
+use crate::routes::code::{CodeCloneDefaults, CodeCloneJobSnapshot};
+
+const CLONE_TIMEOUT: Duration = Duration::from_secs(900);
+const MAX_STDERR_CHARS: usize = 4_096;
+pub(crate) const CLONE_PARENT_DIR_SETTING: &str = "code_clone_parent_dir";
+
+/// In-memory clone jobs for this process. Not journaled; a restart drops them.
+#[derive(Debug, Default)]
+pub(crate) struct CloneJobs {
+    jobs: Mutex<std::collections::HashMap<Uuid, CloneJob>>,
+}
+
+#[derive(Debug, Clone)]
+struct CloneJob {
+    id: Uuid,
+    phase: String,
+    percent: Option<u8>,
+    done: bool,
+    error: Option<String>,
+    repo_id: Option<RepoId>,
+}
+
+impl CloneJobs {
+    fn snapshot(&self, id: Uuid) -> Option<CodeCloneJobSnapshot> {
+        self.jobs
+            .lock()
+            .expect("clone jobs")
+            .get(&id)
+            .map(CloneJob::to_snapshot)
+    }
+
+    fn insert(&self, job: CloneJob) {
+        self.jobs.lock().expect("clone jobs").insert(job.id, job);
+    }
+
+    fn apply(&self, id: Uuid, update: impl FnOnce(&mut CloneJob)) -> Option<CloneJob> {
+        let mut guard = self.jobs.lock().expect("clone jobs");
+        let job = guard.get_mut(&id)?;
+        update(job);
+        Some(job.clone())
+    }
+}
+
+impl CloneJob {
+    fn to_snapshot(&self) -> CodeCloneJobSnapshot {
+        CodeCloneJobSnapshot {
+            id: self.id.to_string(),
+            phase: self.phase.clone(),
+            percent: self.percent,
+            done: self.done,
+            error: self.error.clone(),
+            repo_id: self.repo_id,
+        }
+    }
+}
+
+/// Body fields after the route has rejected an empty or mixed source.
+pub(crate) struct CloneRequest {
+    pub url: Option<String>,
+    pub github: Option<String>,
+    pub parent_dir: String,
+    pub name: Option<String>,
+}
+
+impl CodeRuntime {
+    pub(crate) async fn clone_defaults(&self) -> Result<CodeCloneDefaults, ServerError> {
+        let parent_dir = read_clone_parent_dir(&*self.db).await?;
+        let gh = gh::observe_gh(self.gh_search_path().as_deref()).await;
+        Ok(CodeCloneDefaults {
+            parent_dir,
+            gh_found: gh.found,
+            gh_authenticated: gh.authenticated,
+            gh_remediation: gh.remediation,
+        })
+    }
+
+    pub(crate) fn get_clone_job(&self, id: Uuid) -> Result<CodeCloneJobSnapshot, ServerError> {
+        self.clone_jobs
+            .snapshot(id)
+            .ok_or_else(|| ServerError::not_found(format!("clone job {id} not found")))
+    }
+
+    /// Validate, remember the parent, return a job id, and spawn the clone.
+    pub(crate) async fn start_clone(
+        self: &std::sync::Arc<Self>,
+        request: CloneRequest,
+    ) -> Result<CodeCloneJobSnapshot, ServerError> {
+        let parent = PathBuf::from(request.parent_dir.trim());
+        validate_parent_dir(&parent).await?;
+        let source = resolve_clone_source(&request, self.gh_search_path()).await?;
+        let name = request
+            .name
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| infer_clone_name(&source));
+        if name.is_empty()
+            || name.contains('/')
+            || name.contains('\\')
+            || name == "."
+            || name == ".."
+        {
+            return Err(ServerError::bad_request_kind(
+                "clone_invalid_name",
+                "name must be a single path segment",
+            ));
+        }
+        let target = parent.join(&name);
+        if target.exists() {
+            return Err(ServerError::conflict_kind(
+                "clone_target_exists",
+                format!("destination {} already exists", target.display()),
+            ));
+        }
+        write_clone_parent_dir(&*self.db, &parent).await?;
+
+        let id = Uuid::new_v4();
+        let job = CloneJob {
+            id,
+            phase: "starting".into(),
+            percent: None,
+            done: false,
+            error: None,
+            repo_id: None,
+        };
+        self.clone_jobs.insert(job.clone());
+        self.publish_clone(&job);
+
+        let runtime = std::sync::Arc::clone(self);
+        tokio::spawn(async move {
+            runtime.run_clone(id, source, target).await;
+        });
+        Ok(job.to_snapshot())
+    }
+
+    async fn run_clone(self: std::sync::Arc<Self>, id: Uuid, url: String, target: PathBuf) {
+        match clone_into(&url, &target, |phase, percent| {
+            self.touch_clone(id, |job| {
+                job.phase = phase.to_owned();
+                job.percent = Some(percent);
+            });
+        })
+        .await
+        {
+            Ok(()) => match self
+                .register_repo(target, None, None, None, None, None)
+                .await
+            {
+                Ok(repo) => {
+                    self.touch_clone(id, |job| {
+                        job.phase = "done".into();
+                        job.percent = Some(100);
+                        job.done = true;
+                        job.repo_id = Some(repo.id);
+                    });
+                }
+                Err(error) => {
+                    self.fail_clone(id, error.message());
+                }
+            },
+            Err(error) => self.fail_clone(id, error),
+        }
+    }
+
+    fn touch_clone(&self, id: Uuid, update: impl FnOnce(&mut CloneJob)) {
+        if let Some(job) = self.clone_jobs.apply(id, update) {
+            self.publish_clone(&job);
+        }
+    }
+
+    fn fail_clone(&self, id: Uuid, error: impl Into<String>) {
+        let error = bound_stderr(&error.into());
+        self.touch_clone(id, |job| {
+            job.phase = "failed".into();
+            job.done = true;
+            job.error = Some(error);
+        });
+    }
+
+    fn publish_clone(&self, job: &CloneJob) {
+        self.bus
+            .publish_update(CodeLiveUpdate::CloneProgress(CloneProgress {
+                job: job.id.to_string(),
+                phase: job.phase.clone(),
+                percent: job.percent,
+                done: job.done,
+                error: job.error.clone(),
+                repo_id: job.repo_id,
+            }));
+    }
+
+    fn gh_search_path(&self) -> Option<String> {
+        #[cfg(test)]
+        {
+            return self.gh_search_path.lock().expect("gh search path").clone();
+        }
+        #[cfg(not(test))]
+        None
+    }
+}
+
+async fn resolve_clone_source(
+    request: &CloneRequest,
+    gh_search_path: Option<String>,
+) -> Result<String, ServerError> {
+    let url = request
+        .url
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let github = request
+        .github
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    match (url, github) {
+        (Some(_), Some(_)) => Err(ServerError::bad_request_kind(
+            "clone_invalid_source",
+            "provide url or github, not both",
+        )),
+        (None, None) => Err(ServerError::bad_request_kind(
+            "clone_invalid_source",
+            "provide url or github",
+        )),
+        (Some(url), None) => Ok(url.to_owned()),
+        (None, Some(github)) => {
+            if !valid_github_slug(github) {
+                return Err(ServerError::bad_request_kind(
+                    "clone_invalid_source",
+                    "github must be owner/repo",
+                ));
+            }
+            resolve_github_clone_url(github, gh_search_path.as_deref())
+                .await
+                .map_err(|err| {
+                    ServerError::bad_request_kind("clone_github_unresolved", err.to_string())
+                })
+        }
+    }
+}
+
+async fn validate_parent_dir(parent: &Path) -> Result<(), ServerError> {
+    if parent.as_os_str().is_empty() {
+        return Err(ServerError::bad_request_kind(
+            "clone_parent_missing",
+            "parent_dir must not be empty",
+        ));
+    }
+    let meta = match tokio::fs::metadata(parent).await {
+        Ok(meta) => meta,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Err(ServerError::bad_request_kind(
+                "clone_parent_missing",
+                format!("parent_dir {} does not exist", parent.display()),
+            ));
+        }
+        Err(err) => {
+            return Err(ServerError::bad_request_kind(
+                "clone_parent_unusable",
+                format!("could not read parent_dir {}: {err}", parent.display()),
+            ));
+        }
+    };
+    if !meta.is_dir() {
+        return Err(ServerError::bad_request_kind(
+            "clone_parent_not_dir",
+            format!("parent_dir {} is not a directory", parent.display()),
+        ));
+    }
+    Ok(())
+}
+
+async fn clone_into(
+    url: &str,
+    target: &Path,
+    mut on_progress: impl FnMut(&str, u8),
+) -> Result<(), String> {
+    let mut command = Command::new("git");
+    command
+        .args(["clone", "--progress", "--", url])
+        .arg(target)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_ASKPASS", "")
+        .env("GCM_INTERACTIVE", "never");
+    let mut child = command
+        .spawn()
+        .map_err(|err| format!("failed to spawn git: {err}"))?;
+    let stderr = child.stderr.take().ok_or("git stderr was not piped")?;
+    let mut reader = BufReader::new(stderr);
+    let mut tail = String::new();
+    let run = async {
+        loop {
+            let Some(line) = read_progress_line(&mut reader).await? else {
+                break;
+            };
+            append_tail(&mut tail, &line);
+            if let Some((phase, percent)) = parse_clone_progress_line(&line) {
+                on_progress(&phase, percent);
+            }
+        }
+        child
+            .wait()
+            .await
+            .map_err(|err| format!("git clone failed: {err}"))
+    };
+    let status = timeout(CLONE_TIMEOUT, run)
+        .await
+        .map_err(|_| "git clone timed out".to_owned())??;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(if tail.trim().is_empty() {
+            format!("git clone failed (exit {})", status.code().unwrap_or(-1))
+        } else {
+            tail
+        })
+    }
+}
+
+/// Parse a `git clone --progress` stderr line into a phase name and percent.
+pub(crate) fn parse_clone_progress_line(line: &str) -> Option<(String, u8)> {
+    let line = line.trim();
+    let percent_at = line.find('%')?;
+    let before = &line[..percent_at];
+    let digits: String = before
+        .chars()
+        .rev()
+        .take_while(|ch| ch.is_ascii_digit())
+        .collect::<String>()
+        .chars()
+        .rev()
+        .collect();
+    if digits.is_empty() {
+        return None;
+    }
+    let percent: u8 = digits.parse().ok()?;
+    let without_remote = line.strip_prefix("remote:").map(str::trim).unwrap_or(line);
+    let phase = without_remote
+        .split_once(':')
+        .map(|(head, _)| head.trim())
+        .unwrap_or("cloning")
+        .to_ascii_lowercase();
+    let phase = if phase.is_empty() {
+        "cloning".into()
+    } else {
+        phase
+    };
+    Some((phase, percent.min(100)))
+}
+
+/// Last path segment of a git URL, minus a trailing `.git`.
+pub(crate) fn infer_clone_name(url: &str) -> String {
+    let trimmed = url.trim().trim_end_matches('/');
+    let trimmed = trimmed.strip_suffix(".git").unwrap_or(trimmed);
+    let segment = trimmed
+        .rsplit(['/', ':'])
+        .find(|part| !part.is_empty())
+        .unwrap_or("repo");
+    segment.to_owned()
+}
+
+pub(crate) fn valid_github_slug(value: &str) -> bool {
+    let Some((owner, repo)) = value.split_once('/') else {
+        return false;
+    };
+    if owner.is_empty() || repo.is_empty() || repo.contains('/') {
+        return false;
+    }
+    slug_part(owner) && slug_part(repo)
+}
+
+fn slug_part(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' || ch == '.')
+}
+
+async fn read_clone_parent_dir(store: &dyn Store) -> Result<Option<String>, ServerError> {
+    Ok(store
+        .get_setting(CLONE_PARENT_DIR_SETTING)
+        .await?
+        .and_then(|value| {
+            value
+                .as_str()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(ToOwned::to_owned)
+        }))
+}
+
+async fn write_clone_parent_dir(store: &dyn Store, parent: &Path) -> Result<(), ServerError> {
+    store
+        .set_setting(
+            CLONE_PARENT_DIR_SETTING,
+            &serde_json::json!(parent.display().to_string()),
+        )
+        .await?;
+    Ok(())
+}
+
+async fn read_progress_line<R: AsyncReadExt + Unpin>(
+    reader: &mut BufReader<R>,
+) -> Result<Option<String>, String> {
+    let mut buf = Vec::new();
+    loop {
+        let mut byte = [0u8; 1];
+        match reader.read(&mut byte).await {
+            Ok(0) => {
+                if buf.is_empty() {
+                    return Ok(None);
+                }
+                break;
+            }
+            Ok(_) => {
+                if byte[0] == b'\n' || byte[0] == b'\r' {
+                    if buf.is_empty() {
+                        continue;
+                    }
+                    break;
+                }
+                buf.push(byte[0]);
+            }
+            Err(err) => return Err(format!("git clone stderr: {err}")),
+        }
+    }
+    Ok(Some(String::from_utf8_lossy(&buf).into_owned()))
+}
+
+fn append_tail(tail: &mut String, line: &str) {
+    if !tail.is_empty() {
+        tail.push('\n');
+    }
+    tail.push_str(line);
+    *tail = bound_stderr(tail);
+}
+
+fn bound_stderr(text: &str) -> String {
+    let mut owned = text.to_owned();
+    if owned.chars().count() > MAX_STDERR_CHARS {
+        owned = owned
+            .chars()
+            .rev()
+            .take(MAX_STDERR_CHARS)
+            .collect::<String>();
+        owned = owned.chars().rev().collect();
+    }
+    owned
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn progress_parser_reads_git_percent_lines() {
+        assert_eq!(
+            parse_clone_progress_line("Receiving objects:  45% (45/100)"),
+            Some(("receiving objects".into(), 45))
+        );
+        assert_eq!(
+            parse_clone_progress_line("remote: Compressing objects: 100% (50/50), done."),
+            Some(("compressing objects".into(), 100))
+        );
+        assert_eq!(parse_clone_progress_line("Cloning into 'foo'..."), None);
+    }
+
+    #[test]
+    fn clone_name_strips_git_suffix_and_path() {
+        assert_eq!(infer_clone_name("https://github.com/acme/demo.git"), "demo");
+        assert_eq!(infer_clone_name("git@github.com:acme/demo.git"), "demo");
+        assert_eq!(infer_clone_name("/tmp/origin.git"), "origin");
+    }
+
+    #[test]
+    fn github_slug_requires_owner_repo() {
+        assert!(valid_github_slug("acme/demo"));
+        assert!(valid_github_slug("acme.inc/my_repo-1"));
+        assert!(!valid_github_slug("acme"));
+        assert!(!valid_github_slug("acme/demo/extra"));
+        assert!(!valid_github_slug("acme/de mo"));
+    }
+}

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -126,6 +126,50 @@ pub(crate) struct ActionOutcome {
     pub timed_out: bool,
 }
 
+/// Resolve `owner/repo` to a clone URL.
+///
+/// When `gh` is signed in, the URL is whatever `gh repo view --json url`
+/// reports. Otherwise the HTTPS GitHub URL is constructed. Credentials are
+/// never read or stored.
+pub(crate) async fn resolve_github_clone_url(
+    owner_repo: &str,
+    search_path: Option<&str>,
+) -> Result<String, GhError> {
+    let gh = observe_gh(search_path).await;
+    if gh.found && gh.authenticated == Some(true) {
+        let binary = gh.binary.as_ref().ok_or_else(|| GhError::GhAbsent {
+            instructions: gh.remediation.clone(),
+        })?;
+        let json = run_gh(
+            Path::new("."),
+            binary,
+            &["repo", "view", owner_repo, "--json", "url"],
+            GH_TIMEOUT,
+        )
+        .await
+        .map_err(|err| GhError::user(format!("could not resolve {owner_repo}: {err}")))?;
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json).unwrap_or(serde_json::Value::Null);
+        let url = parsed
+            .get("url")
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| GhError::user(format!("gh did not report a url for {owner_repo}")))?;
+        return Ok(github_clone_url(url));
+    }
+    Ok(format!("https://github.com/{owner_repo}.git"))
+}
+
+fn github_clone_url(url: &str) -> String {
+    let trimmed = url.trim().trim_end_matches('/');
+    if trimmed.ends_with(".git") {
+        trimmed.to_owned()
+    } else {
+        format!("{trimmed}.git")
+    }
+}
+
 /// Observed `gh` availability. Tokens are never read or stored.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct GhObservation {
@@ -523,7 +567,7 @@ fn parse_count(text: &str) -> u64 {
     text.trim().parse().unwrap_or(0)
 }
 
-async fn observe_gh(search_path: Option<&str>) -> GhObservation {
+pub(crate) async fn observe_gh(search_path: Option<&str>) -> GhObservation {
     let Some(binary) = find_gh(search_path) else {
         return GhObservation {
             found: false,
@@ -1147,5 +1191,35 @@ exit 3
         assert!(timed.timed_out);
         assert!(!timed.success);
         assert!(timed.stderr.contains("timed out"));
+    }
+
+    #[tokio::test]
+    async fn resolve_github_uses_gh_url_when_signed_in() {
+        let shim_dir = TempDir::new().unwrap();
+        write_executable(
+            &shim_dir.path().join("gh"),
+            r#"#!/bin/sh
+if [ "$1" = auth ]; then exit 0; fi
+if [ "$1" = repo ] && [ "$2" = view ]; then
+  echo '{"url":"https://github.com/acme/demo"}'
+  exit 0
+fi
+echo unexpected "$@" >&2
+exit 3
+"#,
+        );
+        let url = resolve_github_clone_url("acme/demo", Some(shim_dir.path().to_str().unwrap()))
+            .await
+            .unwrap();
+        assert_eq!(url, "https://github.com/acme/demo.git");
+    }
+
+    #[tokio::test]
+    async fn resolve_github_constructs_https_when_gh_is_absent() {
+        let empty = TempDir::new().unwrap();
+        let url = resolve_github_clone_url("acme/demo", Some(empty.path().to_str().unwrap()))
+            .await
+            .unwrap();
+        assert_eq!(url, "https://github.com/acme/demo.git");
     }
 }

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod approval_bridge;
 pub(crate) mod attention;
 pub(crate) mod bus;
 pub(crate) mod checkpoint;
+pub(crate) mod clone;
 pub(crate) mod gh;
 pub(crate) mod recovery;
 pub(crate) mod runtime;

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -31,6 +31,7 @@ use super::checkpoint::{
     delete_workspace_refs, list_changed_files, produce_diff, resolve_diff_range,
     sweep_orphaned_refs, ChangedFile, CheckpointError, DiffBounds,
 };
+use super::clone::CloneJobs;
 use super::gh::{
     self, ActionOutcome, CommitOutcome, GhError, PrDigestCache, PushOutcome, WorkspaceGitStatus,
 };
@@ -64,8 +65,9 @@ pub(crate) struct CodeRuntime {
     loopback_base: Mutex<Option<String>>,
     workers: Mutex<HashMap<CodeSessionId, WorkerHandle>>,
     pr_cache: PrDigestCache,
+    pub(crate) clone_jobs: CloneJobs,
     #[cfg(test)]
-    gh_search_path: Mutex<Option<String>>,
+    pub(crate) gh_search_path: Mutex<Option<String>>,
     stall_sweep: Mutex<Option<super::attention::StallSweepGuard>>,
     stall_started: AtomicBool,
 }
@@ -82,6 +84,7 @@ impl CodeRuntime {
             loopback_base: Mutex::new(None),
             workers: Mutex::new(HashMap::new()),
             pr_cache: PrDigestCache::default(),
+            clone_jobs: CloneJobs::default(),
             #[cfg(test)]
             gh_search_path: Mutex::new(None),
             stall_sweep: Mutex::new(None),
@@ -111,6 +114,7 @@ impl CodeRuntime {
             loopback_base: Mutex::new(None),
             workers: Mutex::new(HashMap::new()),
             pr_cache: PrDigestCache::default(),
+            clone_jobs: CloneJobs::default(),
             #[cfg(test)]
             gh_search_path: Mutex::new(None),
             stall_sweep: Mutex::new(None),

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -689,6 +689,12 @@ pub fn app(state: AppState) -> Router {
             post(routes::code::create_repo).get(routes::code::list_repos),
         )
         .route(
+            "/code/repos/clone-defaults",
+            get(routes::code::clone_defaults),
+        )
+        .route("/code/repos/clone", post(routes::code::start_clone))
+        .route("/code/repos/clone/{job}", get(routes::code::get_clone_job))
+        .route(
             "/code/repos/{id}",
             get(routes::code::get_repo)
                 .patch(routes::code::patch_repo)

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -17,7 +17,10 @@ pub(crate) use git::{
     commit_workspace, create_pull_request, get_workspace_pr, push_workspace, run_workspace_action,
 };
 pub(crate) use harnesses::{list_harnesses, refresh_harnesses};
-pub(crate) use repos::{create_repo, delete_repo, get_repo, list_repos, patch_repo};
+pub(crate) use repos::{
+    clone_defaults, create_repo, delete_repo, get_clone_job, get_repo, list_repos, patch_repo,
+    start_clone,
+};
 pub(crate) use session_events::session_events;
 pub(crate) use sessions::{
     create_session, interrupt_session, list_session_turns, list_workspace_sessions, reap_session,
@@ -29,11 +32,12 @@ pub(crate) use terminals::{
 };
 #[allow(unused_imports)]
 pub(crate) use types::{
-    CodeActionSnapshot, CodeApprovalDecisionBody, CodeApprovalSnapshot, CodeCommitSnapshot,
-    CodeFileChange, CodePushSnapshot, CodeRepoSnapshot, CodeSessionDigest, CodeSessionSnapshot,
-    CodeTerminalActivityNotice, CodeTerminalRead, CodeTerminalSnapshot, CodeTurnSnapshot,
-    CodeUpdateNotice, CodeWorkspaceDiff, CodeWorkspaceFiles, CodeWorkspacePrSnapshot,
-    CodeWorkspaceSnapshot, HarnessDoctorReport, QueuedCodeTurn, SequencedCodeEventFrame,
+    CodeActionSnapshot, CodeApprovalDecisionBody, CodeApprovalSnapshot, CodeCloneDefaults,
+    CodeCloneJobSnapshot, CodeCommitSnapshot, CodeFileChange, CodePushSnapshot, CodeRepoSnapshot,
+    CodeSessionDigest, CodeSessionSnapshot, CodeTerminalActivityNotice, CodeTerminalRead,
+    CodeTerminalSnapshot, CodeTurnSnapshot, CodeUpdateNotice, CodeWorkspaceDiff,
+    CodeWorkspaceFiles, CodeWorkspacePrSnapshot, CodeWorkspaceSnapshot, HarnessDoctorReport,
+    QueuedCodeTurn, SequencedCodeEventFrame,
 };
 pub(crate) use updates::code_updates;
 pub(crate) use workspaces::{

--- a/crates/tidebreak-server/src/routes/code/repos.rs
+++ b/crates/tidebreak-server/src/routes/code/repos.rs
@@ -2,14 +2,26 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use std::path::PathBuf;
+use std::sync::Arc;
+use uuid::Uuid;
 
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
 use crate::state::AppState;
 
 use super::require_code;
-use super::types::{CodeRepoSnapshot, CreateRepoBody, PatchRepoBody};
+use super::types::{
+    CloneRepoBody, CodeCloneDefaults, CodeCloneJobSnapshot, CodeRepoSnapshot, CreateRepoBody,
+    PatchRepoBody,
+};
 use tidebreak_core::RepoId;
+
+fn require_code_arc(state: &AppState) -> Result<Arc<crate::code::CodeRuntime>, ServerError> {
+    state
+        .code
+        .clone()
+        .ok_or_else(|| ServerError::internal("code mode is not configured on this server"))
+}
 
 pub async fn create_repo(
     State(state): State<AppState>,
@@ -93,4 +105,33 @@ pub async fn delete_repo(
 ) -> Result<StatusCode, ServerError> {
     require_code(&state)?.delete_repo(id).await?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+pub async fn clone_defaults(
+    State(state): State<AppState>,
+) -> Result<Json<CodeCloneDefaults>, ServerError> {
+    Ok(Json(require_code(&state)?.clone_defaults().await?))
+}
+
+pub async fn start_clone(
+    State(state): State<AppState>,
+    Json(body): Json<CloneRepoBody>,
+) -> Result<(StatusCode, Json<CodeCloneJobSnapshot>), ServerError> {
+    let runtime = require_code_arc(&state)?;
+    let job = runtime
+        .start_clone(crate::code::clone::CloneRequest {
+            url: body.url,
+            github: body.github,
+            parent_dir: body.parent_dir,
+            name: body.name,
+        })
+        .await?;
+    Ok((StatusCode::ACCEPTED, Json(job)))
+}
+
+pub async fn get_clone_job(
+    State(state): State<AppState>,
+    Path(job): Path<Uuid>,
+) -> Result<Json<CodeCloneJobSnapshot>, ServerError> {
+    Ok(Json(require_code(&state)?.get_clone_job(job)?))
 }

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -198,6 +198,49 @@ pub struct HarnessDoctorEntry {
     pub unrecognized_event_count: i64,
 }
 
+/// Body of `POST /code/repos/clone`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CloneRepoBody {
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub github: Option<String>,
+    pub parent_dir: String,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
+/// Snapshot of an in-flight or finished clone job.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeCloneJobSnapshot {
+    pub id: String,
+    pub phase: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub percent: Option<u8>,
+    pub done: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub repo_id: Option<RepoId>,
+}
+
+/// Remembered clone destination plus observed `gh` status.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeCloneDefaults {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub parent_dir: Option<String>,
+    pub gh_found: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub gh_authenticated: Option<bool>,
+    pub gh_remediation: String,
+}
+
 /// Body of `POST /code/repos`.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -577,9 +620,35 @@ pub enum CodeUpdateNotice {
         workspace_id: WorkspaceId,
         terminal_id: CodeTerminalId,
     },
+    /// Progress of one `git clone` job. Not restated on connect.
+    CloneProgress {
+        job: String,
+        phase: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        percent: Option<u8>,
+        done: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        error: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        repo_id: Option<RepoId>,
+    },
 }
 
 impl CodeUpdateNotice {
+    pub(crate) fn clone_progress(progress: crate::code::bus::CloneProgress) -> Self {
+        Self::CloneProgress {
+            job: progress.job,
+            phase: progress.phase,
+            percent: progress.percent,
+            done: progress.done,
+            error: progress.error,
+            repo_id: progress.repo_id,
+        }
+    }
+
     pub(crate) fn digest(digest: crate::code::bus::SessionDigest) -> Self {
         let wire = CodeSessionDigest::from(digest);
         Self::Digest {

--- a/crates/tidebreak-server/src/routes/code/updates.rs
+++ b/crates/tidebreak-server/src/routes/code/updates.rs
@@ -60,6 +60,14 @@ async fn stream_updates(mut socket: WebSocket, state: AppState) {
                         break;
                     }
                 }
+                Ok(CodeLiveUpdate::CloneProgress(progress)) => {
+                    if send_notice(&mut socket, &CodeUpdateNotice::clone_progress(progress))
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
                 Err(RecvError::Lagged(_)) => {
                     match list_digests(&runtime.db).await {
                         Ok(sessions) => {

--- a/crates/tidebreak-server/src/tests.rs
+++ b/crates/tidebreak-server/src/tests.rs
@@ -41,6 +41,7 @@ mod app_invoke;
 mod app_library;
 mod chat_titling;
 mod code;
+mod code_clone;
 mod code_git;
 mod code_terminals;
 mod compaction;

--- a/crates/tidebreak-server/src/tests/code_clone.rs
+++ b/crates/tidebreak-server/src/tests/code_clone.rs
@@ -1,0 +1,351 @@
+//! Clone-job routes against a local bare origin. No network.
+
+use super::*;
+
+use std::net::Ipv4Addr;
+use std::os::unix::fs::PermissionsExt;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::Router;
+use futures::StreamExt;
+use tokio::net::TcpListener;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::Message as WsMessage;
+
+use crate::code::CodeRuntime;
+use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
+use tidebreak_harness::AdapterRegistry;
+
+async fn code_app() -> (Router, Arc<str>, Arc<CodeRuntime>, tempfile::TempDir) {
+    let (dir, store) = temp_db_store("code-clone.db").await;
+    let db = Arc::new(store);
+    let store_trait: Arc<dyn Store> = db.clone();
+    let mut registry = AdapterRegistry::new();
+    registry.register(Arc::new(ScriptedAdapter::new(plain_text_script())));
+    let runtime = Arc::new(CodeRuntime::with_registry(
+        db,
+        dir.path().to_path_buf(),
+        registry,
+    ));
+    let mut state = AppState::new(
+        Config::desktop(dir.path()),
+        store_trait,
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    state.code = Some(runtime.clone());
+    let token = state.token.clone();
+    (app(state), token, runtime, dir)
+}
+
+async fn serve(router: Router) -> std::net::SocketAddr {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router).await;
+    });
+    addr
+}
+
+fn init_bare_origin(dir: &std::path::Path) -> std::path::PathBuf {
+    let bare = dir.join("origin.git");
+    let work = dir.join("seed");
+    run(dir, &["git", "init", "--bare", bare.to_str().unwrap()]);
+    std::fs::create_dir_all(&work).unwrap();
+    run(&work, &["git", "init", "-b", "main"]);
+    run(&work, &["git", "config", "user.email", "dev@example.com"]);
+    run(&work, &["git", "config", "user.name", "Dev"]);
+    std::fs::write(work.join("README.md"), "hello\n").unwrap();
+    run(&work, &["git", "add", "README.md"]);
+    run(&work, &["git", "commit", "-m", "init"]);
+    run(
+        &work,
+        &["git", "remote", "add", "origin", bare.to_str().unwrap()],
+    );
+    run(&work, &["git", "push", "-u", "origin", "main"]);
+    bare
+}
+
+fn run(cwd: &std::path::Path, args: &[&str]) {
+    let status = std::process::Command::new(args[0])
+        .args(&args[1..])
+        .current_dir(cwd)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .status()
+        .unwrap();
+    assert!(status.success(), "{args:?} failed in {}", cwd.display());
+}
+
+fn write_executable(path: &std::path::Path, body: &str) {
+    std::fs::write(path, body).unwrap();
+    let mut perms = std::fs::metadata(path).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(path, perms).unwrap();
+}
+
+async fn wait_job(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    token: &str,
+    job_id: &str,
+) -> serde_json::Value {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+    loop {
+        let response = client
+            .get(format!("http://{addr}/code/repos/clone/{job_id}"))
+            .bearer_auth(token)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let body: serde_json::Value = response.json().await.unwrap();
+        if body["done"].as_bool() == Some(true) {
+            return body;
+        }
+        if tokio::time::Instant::now() > deadline {
+            panic!("clone job did not finish: {body}");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+async fn next_json(
+    socket: &mut tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+) -> serde_json::Value {
+    loop {
+        let Some(frame) = socket.next().await else {
+            panic!("updates socket closed");
+        };
+        let WsMessage::Text(text) = frame.expect("ws frame") else {
+            continue;
+        };
+        return serde_json::from_str(text.as_str()).unwrap();
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn clone_from_a_local_origin_registers_the_repo() {
+    let (router, token, _runtime, dir) = code_app().await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let origin = init_bare_origin(dir.path());
+    let parent = dir.path().join("checkouts");
+    std::fs::create_dir_all(&parent).unwrap();
+
+    let mut request = format!("ws://{addr}/code/updates")
+        .into_client_request()
+        .unwrap();
+    request
+        .headers_mut()
+        .insert("Authorization", format!("Bearer {token}").parse().unwrap());
+    let (mut socket, _) = connect_async(request).await.unwrap();
+    let snapshot = next_json(&mut socket).await;
+    assert_eq!(snapshot["type"], "snapshot");
+
+    let started = client
+        .post(format!("http://{addr}/code/repos/clone"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "url": origin,
+            "parent_dir": parent,
+            "name": "demo",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(started.status(), reqwest::StatusCode::ACCEPTED);
+    let job: serde_json::Value = started.json().await.unwrap();
+    let job_id = job["id"].as_str().expect("job id");
+
+    let mut saw_progress = false;
+    let mut done = None;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+    while tokio::time::Instant::now() < deadline {
+        let notice = tokio::time::timeout(Duration::from_millis(500), next_json(&mut socket))
+            .await
+            .ok();
+        let Some(notice) = notice else {
+            continue;
+        };
+        if notice["type"] == "clone_progress" && notice["job"] == job_id {
+            saw_progress = true;
+            if notice["done"].as_bool() == Some(true) {
+                done = Some(notice);
+                break;
+            }
+        }
+    }
+    assert!(saw_progress, "updates channel must carry clone_progress");
+    let done = done.expect("terminal clone_progress notice");
+    assert!(done["error"].is_null());
+    let repo_id = done["repo_id"].as_str().expect("registered repo id");
+
+    let finished = wait_job(&client, addr, &token, job_id).await;
+    assert_eq!(finished["repo_id"], repo_id);
+    assert_eq!(finished["done"], true);
+
+    let listed = client
+        .get(format!("http://{addr}/code/repos"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<Vec<serde_json::Value>>()
+        .await
+        .unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0]["id"], repo_id);
+    assert!(
+        listed[0]["root_path"]
+            .as_str()
+            .unwrap()
+            .ends_with("checkouts/demo"),
+        "{}",
+        listed[0]["root_path"]
+    );
+
+    let defaults = client
+        .get(format!("http://{addr}/code/repos/clone-defaults"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(
+        defaults["parent_dir"].as_str().unwrap(),
+        parent.to_str().unwrap()
+    );
+}
+
+#[tokio::test]
+async fn clone_rejects_bad_url_existing_target_and_unusable_parent() {
+    let (router, token, _runtime, dir) = code_app().await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let origin = init_bare_origin(dir.path());
+    let parent = dir.path().join("checkouts");
+    std::fs::create_dir_all(&parent).unwrap();
+
+    let missing = client
+        .post(format!("http://{addr}/code/repos/clone"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "url": origin,
+            "parent_dir": dir.path().join("no-such-parent"),
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(missing.status(), reqwest::StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = missing.json().await.unwrap();
+    assert_eq!(body["kind"], "clone_parent_missing");
+
+    let file_parent = dir.path().join("not-a-dir");
+    std::fs::write(&file_parent, "nope\n").unwrap();
+    let dirty = client
+        .post(format!("http://{addr}/code/repos/clone"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "url": origin,
+            "parent_dir": file_parent,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(dirty.status(), reqwest::StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = dirty.json().await.unwrap();
+    assert_eq!(body["kind"], "clone_parent_not_dir");
+
+    std::fs::create_dir_all(parent.join("demo")).unwrap();
+    let exists = client
+        .post(format!("http://{addr}/code/repos/clone"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "url": origin,
+            "parent_dir": parent,
+            "name": "demo",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(exists.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = exists.json().await.unwrap();
+    assert_eq!(body["kind"], "clone_target_exists");
+
+    let started = client
+        .post(format!("http://{addr}/code/repos/clone"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "url": dir.path().join("missing-origin.git"),
+            "parent_dir": parent,
+            "name": "bad",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(started.status(), reqwest::StatusCode::ACCEPTED);
+    let job: serde_json::Value = started.json().await.unwrap();
+    let finished = wait_job(&client, addr, &token, job["id"].as_str().unwrap()).await;
+    assert_eq!(finished["done"], true);
+    assert!(
+        finished["error"].as_str().unwrap().contains("git"),
+        "{finished}"
+    );
+    assert!(finished["repo_id"].is_null());
+}
+
+#[tokio::test]
+async fn github_clone_uses_the_url_gh_reports_when_signed_in() {
+    let (router, token, runtime, dir) = code_app().await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let origin = init_bare_origin(dir.path());
+    let parent = dir.path().join("checkouts");
+    std::fs::create_dir_all(&parent).unwrap();
+
+    let shim_dir = tempfile::TempDir::new().unwrap();
+    write_executable(
+        &shim_dir.path().join("gh"),
+        &format!(
+            r#"#!/bin/sh
+if [ "$1" = auth ]; then exit 0; fi
+if [ "$1" = repo ] && [ "$2" = view ]; then
+  printf '{{"url":"{url}"}}\n'
+  exit 0
+fi
+echo unexpected "$@" >&2
+exit 3
+"#,
+            url = origin.display()
+        ),
+    );
+    runtime.set_gh_search_path(Some(shim_dir.path().display().to_string()));
+
+    let started = client
+        .post(format!("http://{addr}/code/repos/clone"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "github": "acme/demo",
+            "parent_dir": parent,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(started.status(), reqwest::StatusCode::ACCEPTED);
+    let job: serde_json::Value = started.json().await.unwrap();
+    let finished = wait_job(&client, addr, &token, job["id"].as_str().unwrap()).await;
+    assert_eq!(finished["done"], true, "{finished}");
+    assert!(finished["error"].is_null(), "{finished}");
+    assert!(finished["repo_id"].is_string());
+}

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -427,6 +427,8 @@ mod tests {
         generate::collect_from::<crate::routes::code::CodePushSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeWorkspacePrSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeActionSnapshot>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::CodeCloneJobSnapshot>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::CodeCloneDefaults>(&cfg, &mut out);
         out
     }
 


### PR DESCRIPTION
## What

Code mode no longer asks for a bare path when adding a repo. The home empty state and the sidebar add affordance open a keyboard-first **source palette**:

- **Local folder** — native directory picker (or a pasted path) then the existing registration route.
- **Git URL** — clone into a remembered parent directory, with an optional folder name.
- **GitHub repository** — `owner/repo`. When `gh` is signed in, the clone URL is whatever `gh repo view --json url` reports. When `gh` is absent or signed out, the same form still clones over HTTPS and shows the existing graceful-absence hint inline.

Unserved providers are omitted, not teased. Stages stay in one dialog (list → form → progress); Backspace goes back, Escape closes.

The new-workspace and start-session harness pickers use the same visual language: logo, product name, one-line subtitle. Ready rows are selectable. Unusable rows (not installed, signed out, or — like Grok today — refusing every permission mode) are dimmed with one short reason and a quiet link to Coding harnesses. Versions, paths, and capability flags stay on the doctor.

## Clone-job contract

- `POST /code/repos/clone` `{url | github, parent_dir, name?}` validates that `parent_dir` exists and the target does not, then returns a job id immediately (`202`).
- Clone is `git clone --progress` as an argv array with `GIT_TERMINAL_PROMPT=0` and a finite timeout. The user's own credential helpers may authenticate; Tidebreak never prompts and never stores secrets.
- Progress publishes as unsequenced `clone_progress` notices on `/code/updates` (`job`, `phase`, `percent`, `done`, bounded `error`, `repo_id` on success). `GET /code/repos/clone/{job}` is the poller.
- Success auto-registers through the existing repo path. `GET /code/repos/clone-defaults` returns the remembered parent directory plus observed `gh` status.

## Native command

`pick_code_directory` is a grant-free OS folder picker for registration and clone destinations (ADR 0030). The path is returned as a string; the server validates it. Allowlisted in `native-only-commands.txt`.

## Tests

- Server: local bare-origin clone (no network), progress notices, typed failures (missing/unusable parent, existing target, bad URL), `gh` shim resolve signed-in and absent, auto-register on success.
- UI: palette keyboard (arrows / Enter / Backspace / Esc), filter, gh-absent hint, progress-to-error retry; harness picker ready vs dimmed, keyboard selection, no version strings from the doctor payload.

## What could not be verified

Did not drive the running desktop app or a real native folder picker. Clone coverage is local-git and `gh` shims only — no live GitHub network clone.