### PR TITLE
test(harness): close the remaining environment leak in the probe relative-path test

### DIFF
--- a/crates/tidebreak-harness/src/probe.rs
+++ b/crates/tidebreak-harness/src/probe.rs
@@ -275,13 +275,28 @@ async fn run_interactive_login_shell(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::os::unix::fs::PermissionsExt;
 
     fn write_exec(path: &Path, body: &str) {
-        std::fs::write(path, body).unwrap();
-        let mut perms = std::fs::metadata(path).unwrap().permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(path, perms).unwrap();
+        // Write a sibling inode, fsync, then rename over `path` so execve
+        // never sees a file that still has a writer (Linux ETXTBSY).
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let staging = path.with_extension("writing");
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o755)
+            .open(&staging)
+            .unwrap();
+        file.write_all(body.as_bytes()).unwrap();
+        file.sync_all().unwrap();
+        drop(file);
+        std::fs::rename(&staging, path).unwrap();
+        if let Some(parent) = path.parent() {
+            let dir = std::fs::File::open(parent).unwrap();
+            dir.sync_all().unwrap();
+        }
     }
 
     /// Shim that prints profile noise, honors `-ilc`/`-c`, then evals the script.
@@ -329,39 +344,62 @@ eval "$cmd"
         assert!(matches!(err, ProbeError::NotFound(_)));
     }
 
+    async fn diagnose_probe_shim(host: &HostEnv) -> String {
+        let script = "printf '%s\\n' 'TIDEBREAK_PROBE_BEGIN_diag'; command -v claude || true; \
+             printf '%s\\n' 'TIDEBREAK_PROBE_ENV_diag'; \
+             if env -0 >/dev/null 2>&1; then env -0; else env; fi; \
+             printf '\\n%s\\n' 'TIDEBREAK_PROBE_END_diag'";
+        match run_interactive_login_shell(host, script).await {
+            Ok(out) => format!(
+                "shim status_ok={} stdout={:?} stderr={:?}",
+                out.status_ok, out.stdout, out.stderr
+            ),
+            Err(err) => format!("shim spawn failed: {err}"),
+        }
+    }
+
     #[tokio::test]
     async fn relative_path_is_rejected() {
         let dir = tempfile::tempdir().unwrap();
         let empty_path = dir.path().join("empty-path");
+        let home = dir.path().join("home");
+        let tmp = dir.path().join("tmp");
         std::fs::create_dir(&empty_path).unwrap();
+        std::fs::create_dir(&home).unwrap();
+        std::fs::create_dir(&tmp).unwrap();
         let shell = dir.path().join("shell");
-        // Dedicated shim: honor `-ilc`/`-c`, then replace `command -v` with a
-        // hardcoded relative path. Do not eval the host `command` builtin or
-        // inherit PATH — both vary across runners.
+        // Closed-world fake shell: exact `-ilc`/`-c` matches, peel sentinels
+        // with simple POSIX expansions, print a relative path. Never eval the
+        // probe script or call host `command`/`env` — those differ by /bin/sh.
         write_exec(
             &shell,
             r#"#!/bin/sh
 cmd=
 while [ $# -gt 0 ]; do
   case "$1" in
-    -c) shift; cmd=$1; break ;;
-    -*c)
-      rest=${1#*c}
+    -c|-ilc|-lic|-icl|-lci|-cil|-cli)
       shift
-      if [ -n "$rest" ]; then cmd=$rest; else cmd=$1; fi
+      cmd=$1
       break
       ;;
-    -*) shift ;;
-    *) break ;;
+    -i|-l|-il|-li)
+      shift
+      ;;
+    *)
+      break
+      ;;
   esac
 done
-# Never invoke the host `command` builtin: rewrite the probe's
-# `command -v claude || true` to a relative path we control.
-prefix="${cmd%%command -v *}"
-suffix="${cmd#*command -v claude || true}"
-eval "$prefix"
+begin_tail=${cmd#*TIDEBREAK_PROBE_BEGIN_}
+begin_tok=${begin_tail%%[!0-9a-f]*}
+env_tail=${cmd#*TIDEBREAK_PROBE_ENV_}
+env_tok=${env_tail%%[!0-9a-f]*}
+end_tail=${cmd#*TIDEBREAK_PROBE_END_}
+end_tok=${end_tail%%[!0-9a-f]*}
+printf '%s\n' "TIDEBREAK_PROBE_BEGIN_${begin_tok}"
 printf '%s\n' "claude"
-eval "true$suffix"
+printf '%s\n' "TIDEBREAK_PROBE_ENV_${env_tok}"
+printf '\n%s\n' "TIDEBREAK_PROBE_END_${end_tok}"
 "#,
         );
         let host = HostEnv {
@@ -369,16 +407,20 @@ eval "true$suffix"
             env: vec![
                 ("SHELL".into(), shell.as_os_str().to_owned()),
                 ("PATH".into(), empty_path.as_os_str().to_owned()),
+                ("HOME".into(), home.as_os_str().to_owned()),
+                ("TMPDIR".into(), tmp.as_os_str().to_owned()),
+                ("LANG".into(), "C".into()),
+                ("LC_ALL".into(), "C".into()),
             ],
             clear_env: true,
         };
-        let err = resolve_binary(&host, "claude").await.unwrap_err();
-        match err {
-            ProbeError::RelativePath { name, path } => {
-                assert_eq!(name, "claude");
-                assert_eq!(path, "claude");
-            }
-            other => panic!("expected RelativePath, got {other:?}"),
+        match resolve_binary(&host, "claude").await {
+            Err(ProbeError::RelativePath { name, path })
+                if name == "claude" && path == "claude" => {}
+            other => panic!(
+                "expected RelativePath {{ name: \"claude\", path: \"claude\" }}, got {other:?}; {}",
+                diagnose_probe_shim(&host).await
+            ),
         }
     }
 


### PR DESCRIPTION
## Summary

`probe::tests::relative_path_is_rejected` failed the workspace `test` lane on unrelated PRs after the #2130 hermetic shim. The panic at `probe.rs:381` was not a sentinel-parse leak. CI log from #2143:

```
expected RelativePath, got Shell("Text file busy (os error 26)")
```

Two remaining host inputs:

1. **Write-then-exec race.** The test wrote the fake shell and immediately `execve`'d it. On Linux that is `ETXTBSY` when a writer still holds the inode. `write_exec` now creates a sibling file with mode `0755`, `fsync`s, then `rename`s over the dest so the executed inode never had an open writer.
2. **Host `/bin/sh` dialect.** The previous shim rewrote `command -v claude || true` with `${var%%…}` / `${var#*… || true}` and `eval`'d the rest, which then called `env` on an empty `PATH`. Ubuntu's `/bin/sh` is dash; macOS is bash-as-sh. The new shim is the `SHELL` under test (`#!/bin/sh`), matches `-ilc`/`-c` by exact flags, peels `TIDEBREAK_PROBE_*` tokens with hex-only POSIX expansions, and prints a relative `claude`. It never evals the probe script and never calls host `command` or `env`.

`clear_env` is still on. The child env is only `SHELL`, `PATH` (empty dir), `HOME`, `TMPDIR`, `LANG=C`, and `LC_ALL=C`. Failure now dumps shim stdout/stderr (or the spawn error) instead of a bare `panic`.

Product `probe_shell` / `resolve_binary` behavior is unchanged. This was a test hermeticity bug, not a product bug.

Refs #2132

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy -p tidebreak-harness --all-targets --locked --no-deps -- -D warnings` (bare `-p` without `--no-deps` lints `tidebreak-core` as a dep and hits pre-existing unused-code warnings on this tree)
- [x] `cargo test -p tidebreak-harness --locked` (69 passed)
- [x] `cargo check --workspace --locked`
- [x] `relative_path_is_rejected` 200/200 on the built test binary (macOS)
- [x] Fake-shell script 200/200 under `/bin/dash` with empty `PATH` and `env -i`
- [x] Same script 50/50 under `/bin/sh` and `/bin/bash`