### PR TITLE
fix(code): classify HTTP 401 push rejections as auth failures

### DIFF
--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -850,6 +850,7 @@ fn is_git_auth_failure(err: &str) -> bool {
     lower.contains("authentication")
         || lower.contains("permission denied")
         || lower.contains("403")
+        || lower.contains("401")
         || lower.contains("terminal prompts disabled")
         || lower.contains("publickey")
 }
@@ -1080,6 +1081,7 @@ fatal: Could not read from remote repository.\n";
             "fatal: Authentication failed for 'https://example.test/repo.git'",
             "Permission denied (publickey).",
             "The requested URL returned error: 403",
+            "The requested URL returned error: 401",
             "fatal: could not read Username for 'https://example.test': terminal prompts disabled",
         ] {
             assert!(


### PR DESCRIPTION
## Summary

A leftover from #2142: tightening `is_git_auth_failure` dropped `401` when the overly broad "could not read from remote" needle came out. Git's HTTP transport reports credential rejection as `The requested URL returned error: 401` with none of the remaining auth signatures, so a real 401 classified as `git_push_failed` and skipped the credential remediation.

This adds `401` next to the existing `403`. The unresolvable-remote fixture (`does not appear to be a git repository` / `Could not read from remote repository`) still does not match.

## Test

`classify_git_treats_only_auth_signatures_as_auth` now includes the 401 HTTP string and still asserts the unresolvable-remote stderr is `PushFailed`.