### PR TITLE
fix(desktop): keep chat header clear of macOS traffic lights

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
@@ -884,7 +884,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   return (
     <RouteFrame sidebar={<AppSidebar chat={chat} />}>
       <div className="relative mr-2 flex min-h-0 min-w-0 flex-1 flex-col">
-        <header className="mt-2 flex h-9 w-full shrink-0 items-center justify-between gap-2 pl-4 pr-1">
+        <header className="window-chrome-row mt-2 flex h-9 w-full shrink-0 items-center justify-between gap-2 pr-1">
           <ChatHeaderTitle chat={chat} />
           <div className="relative z-20 flex shrink-0 items-center gap-2 self-start">
             <ChatStatusChip

--- a/crates/tidebreak-desktop/ui/src/sidebar/primitives.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/primitives.tsx
@@ -38,12 +38,12 @@ export function Sidebar({ className, children, ...props }: ComponentProps<"div">
           className,
         )}
         style={{
-          flex: isCompact ? "0 0 calc(var(--spacing) * 14)" : "var(--sidebar-expanded-flex)",
+          flex: isCompact ? "0 0 var(--sidebar-compact-width)" : "var(--sidebar-expanded-flex)",
           // Above 1600px, --sidebar-expanded-flex sets flex-shrink to 1 so the
           // rail can grow with the window. Without a min-width floor, that same
           // shrink lets a second open content panel squeeze the rail down to a
           // sliver instead of taking space from the panels themselves.
-          minWidth: isCompact ? "calc(var(--spacing) * 14)" : "var(--sidebar-expanded-min)",
+          minWidth: isCompact ? "var(--sidebar-compact-width)" : "var(--sidebar-expanded-min)",
         }}
         data-sidebar={width}
       >

--- a/crates/tidebreak-desktop/ui/src/styles.css
+++ b/crates/tidebreak-desktop/ui/src/styles.css
@@ -75,6 +75,10 @@
   --sidebar-expanded-min: calc(var(--spacing) * 56);
   --sidebar-expanded-max: calc(var(--spacing) * 80);
   --sidebar-expanded-flex: 0 0 var(--sidebar-expanded-min);
+  --sidebar-compact-width: calc(var(--spacing) * 14);
+  /* macOS overlay traffic lights at trafficLightPosition (16, 20), plus a
+     gap before the history buttons. The compact rail is narrower than this. */
+  --mac-traffic-light-inset: 84px;
 
   --shadow-sm: 0 0px 8px 0px oklch(0 0 0 / 0.06);
   --shadow: 0 0px 8px 0px oklch(0 0 0 / 0.07);
@@ -1625,7 +1629,7 @@ body {
 }
 
 .titlebar.is-mac-overlay {
-  padding-left: 84px;
+  padding-left: var(--mac-traffic-light-inset);
 }
 
 .titlebar-nav {
@@ -1645,11 +1649,13 @@ body {
    the drag target, but the optional history buttons disappear until the rail
    is expanded rather than spilling over the routed header. */
 .app-shell:has([data-sidebar="compact"]) .titlebar {
-  width: calc(var(--spacing) * 14);
+  width: var(--sidebar-compact-width);
   padding-inline: 0.25rem;
 }
 
 .app-shell:has([data-sidebar="compact"]) .titlebar.is-mac-overlay {
+  /* Cover the overflowing lights so the window still drags there. */
+  width: var(--mac-traffic-light-inset);
   padding-left: 0;
 }
 
@@ -1657,6 +1663,21 @@ body {
   .titlebar.is-mac-overlay
   .titlebar-nav {
   display: none;
+}
+
+/* Chrome that shares the traffic-light row (the chat breadcrumb) has to start
+   after the cluster when the rail cannot contain it. The extra inset is only
+   the overflow past the rail — the same 84px line the expanded history
+   buttons already use. */
+.window-chrome-row {
+  padding-left: 1rem;
+}
+
+.app-shell:has([data-sidebar="compact"]):has(.titlebar.is-mac-overlay)
+  .window-chrome-row {
+  padding-left: calc(
+    var(--mac-traffic-light-inset) - var(--sidebar-compact-width)
+  );
 }
 
 /* Full-window surfaces that replace the shell (boot and error screens, the


### PR DESCRIPTION
## Summary

The compact sidebar is narrower than the macOS overlay traffic-light cluster, so the chat breadcrumb (`Chats / …`) sat under the lights.

When the rail is collapsed on the overlay titlebar, the chat chrome row now starts at the same 84px line the expanded history buttons already use. The drag strip widens to cover the overflowing lights so the window still moves from that corner.

## Validation

- CSS inset: compact rail (56px) vs traffic-light reserve (84px) leaves 28px of header padding, matching the expanded history-button start
- Did not drive the native macOS window in this session