### PR TITLE
fix(desktop): stabilize the pending-approval badge selector

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -483,9 +483,14 @@ function PendingApprovalBadge({
   client: ApiClient;
 }) {
   const store = useRegisteredCodeSession(sessionId, client);
-  const pending = store((state) =>
-    state.items.filter((item) => item.kind === "approval" && item.state === "pending"),
-  ).length;
+  // The selector must return a primitive: zustand v5 re-renders whenever the
+  // snapshot is not referentially stable, so a fresh array here loops forever.
+  const pending = store(
+    (state) =>
+      state.items.filter(
+        (item) => item.kind === "approval" && item.state === "pending",
+      ).length,
+  );
   if (pending === 0) return null;
   return (
     <Badge variant="warning" size="sm" data-testid="pending-approval-badge">


### PR DESCRIPTION
Opening a workspace with a live session (e.g. immediately after creating one) crashed with React's **Maximum update depth exceeded**.

`PendingApprovalBadge` selected `state.items.filter(...)` from the zustand session store and applied `.length` outside the selector. zustand v5 compares snapshots by reference, so the freshly allocated array made every snapshot check look like a change and re-rendered forever.

The fix moves `.length` inside the selector so the snapshot is a primitive. This was the only unstable selector in the UI (audited `(state) =>` selectors across `ui/src`).

No new test: the badge is a private component of `CodeWorkspacePage`, and reproducing the loop requires mounting the full page with a mocked client and session registry — scaffolding far heavier than the one-line invariant it would pin. UI suite passes (170 files / 1088 tests).