### PR TITLE
feat(code): grok sessions in unsupervised Auto, and a dropdown harness picker

### DIFF
--- a/crates/tidebreak-cli/src/api/code.rs
+++ b/crates/tidebreak-cli/src/api/code.rs
@@ -582,6 +582,7 @@ pub fn supported_caps_summary(caps: &HarnessCaps) -> String {
         ("approvals", caps.structured_approvals),
         ("steering", caps.mid_turn_steering),
         ("plan", caps.plan_mode),
+        ("auto", caps.auto_mode),
         ("reasoning", caps.reasoning_levels),
         ("file_events", caps.native_file_change_events),
         ("interrupt", caps.native_interrupt),

--- a/crates/tidebreak-cli/src/code.rs
+++ b/crates/tidebreak-cli/src/code.rs
@@ -14,8 +14,8 @@ use std::str::FromStr;
 use futures::StreamExt as _;
 use tidebreak_core::{
     AgentError, Attention, AttentionState, CapLevel, CodeApprovalId, CodeApprovalKind, CodeEvent,
-    CodePermissionMode, CodeSessionId, CodeSessionLifecycle, CodeTurnId, HarnessKind, RepoId,
-    Result, WorkspaceId,
+    CodePermissionMode, CodeSessionId, CodeSessionLifecycle, CodeTurnId, HarnessCaps, HarnessKind,
+    RepoId, Result, WorkspaceId,
 };
 use tokio_tungstenite::tungstenite::Message;
 
@@ -762,13 +762,18 @@ async fn resolve_run_session(
         .ok_or_else(|| AgentError::msg(format!("workspace {workspace} has no active session")))
 }
 
-/// Desktop create default: Ask only when this engine's structured
-/// approvals are Supported. Anything else (Unsupported, Unknown, missing
-/// doctor row) is Plan — the mode a harness without a live approval
-/// channel can still honor.
-fn default_create_permission_mode(approvals: Option<CapLevel>) -> CodePermissionMode {
-    match approvals {
-        Some(CapLevel::Supported) => CodePermissionMode::Ask,
+/// Desktop create default: Ask when this engine's structured approvals are
+/// Supported; else Plan when it has a plan posture; else Auto when that is
+/// the only posture it honors (grok-tier — unsupervised, and said so). A
+/// missing doctor row defaults to Plan and lets the server refuse.
+fn default_create_permission_mode(caps: Option<&HarnessCaps>) -> CodePermissionMode {
+    match caps {
+        Some(caps) if caps.structured_approvals == CapLevel::Supported => CodePermissionMode::Ask,
+        Some(caps)
+            if caps.plan_mode != CapLevel::Supported && caps.auto_mode == CapLevel::Supported =>
+        {
+            CodePermissionMode::Auto
+        }
         _ => CodePermissionMode::Plan,
     }
 }
@@ -782,14 +787,21 @@ async fn resolve_start_mode(
         return Ok((mode, None));
     }
     let report = client.list_harnesses().await?;
-    let approvals = report
+    let caps = report
         .harnesses
         .iter()
         .find(|entry| entry.kind == harness)
-        .map(|entry| entry.caps.structured_approvals);
-    let mode = default_create_permission_mode(approvals);
-    let note = (mode == CodePermissionMode::Plan)
-        .then_some("starting in plan mode — approvals unavailable on this engine");
+        .map(|entry| &entry.caps);
+    let mode = default_create_permission_mode(caps);
+    let note = match mode {
+        CodePermissionMode::Plan => {
+            Some("starting in plan mode — approvals unavailable on this engine")
+        }
+        CodePermissionMode::Auto => Some(
+            "starting in auto mode — this engine has no approval channel; every action proceeds without asking",
+        ),
+        CodePermissionMode::Ask => None,
+    };
     Ok((mode, note))
 }
 
@@ -2465,16 +2477,57 @@ mod tests {
 
     #[test]
     fn omitted_mode_follows_the_desktop_doctor_default() {
+        fn caps(
+            structured_approvals: CapLevel,
+            plan_mode: CapLevel,
+            auto_mode: CapLevel,
+        ) -> HarnessCaps {
+            HarnessCaps {
+                resume: CapLevel::Supported,
+                streaming_deltas: CapLevel::Supported,
+                structured_approvals,
+                mid_turn_steering: CapLevel::Unknown,
+                plan_mode,
+                auto_mode,
+                reasoning_levels: CapLevel::Unknown,
+                native_file_change_events: CapLevel::Unknown,
+                native_interrupt: CapLevel::Supported,
+            }
+        }
+        // Approval-carrying engines default to Ask.
         assert_eq!(
-            default_create_permission_mode(Some(CapLevel::Supported)),
+            default_create_permission_mode(Some(&caps(
+                CapLevel::Supported,
+                CapLevel::Supported,
+                CapLevel::Supported,
+            ))),
             CodePermissionMode::Ask
         );
+        // No approvals but a plan posture: Plan.
         assert_eq!(
-            default_create_permission_mode(Some(CapLevel::Unsupported)),
+            default_create_permission_mode(Some(&caps(
+                CapLevel::Unsupported,
+                CapLevel::Supported,
+                CapLevel::Unsupported,
+            ))),
             CodePermissionMode::Plan
         );
+        // Grok-tier: unsupervised Auto is the only honored posture.
         assert_eq!(
-            default_create_permission_mode(Some(CapLevel::Unknown)),
+            default_create_permission_mode(Some(&caps(
+                CapLevel::Unsupported,
+                CapLevel::Unsupported,
+                CapLevel::Supported,
+            ))),
+            CodePermissionMode::Auto
+        );
+        // Unknown everywhere, or no doctor row: Plan, and the server refuses.
+        assert_eq!(
+            default_create_permission_mode(Some(&caps(
+                CapLevel::Unknown,
+                CapLevel::Unknown,
+                CapLevel::Unknown,
+            ))),
             CodePermissionMode::Plan
         );
         assert_eq!(

--- a/crates/tidebreak-core/src/code/caps.rs
+++ b/crates/tidebreak-core/src/code/caps.rs
@@ -61,6 +61,13 @@ pub struct HarnessCaps {
     pub mid_turn_steering: CapLevel,
     /// The engine has a read-only / plan posture the adapter can select.
     pub plan_mode: CapLevel,
+    /// The engine has a workspace-write / auto posture the adapter can select.
+    ///
+    /// Whether that posture is supervised is a separate question:
+    /// with `structured_approvals` supported, sensitive actions still park on
+    /// approval cards; without it, Auto runs unsupervised and the product
+    /// states so where the mode is chosen (decision 0038).
+    pub auto_mode: CapLevel,
     /// The engine accepts a reasoning-effort control.
     pub reasoning_levels: CapLevel,
     /// The engine emits native file-change events.
@@ -82,6 +89,7 @@ mod tests {
             structured_approvals: CapLevel::Unknown,
             mid_turn_steering: CapLevel::Unknown,
             plan_mode: CapLevel::Supported,
+            auto_mode: CapLevel::Unknown,
             reasoning_levels: CapLevel::Unknown,
             native_file_change_events: CapLevel::Unknown,
             native_interrupt: CapLevel::Supported,

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -40,6 +40,7 @@ import { FilesPanel } from "./FilesPanel";
 import { StartSessionPrompt } from "./StartSessionPrompt";
 import { TerminalPane } from "./TerminalPane";
 import {
+  createPermissionModes,
   fenceReasonText,
   HARNESS_LABELS,
   LIFECYCLE_LABELS,
@@ -520,7 +521,17 @@ function CodeSessionPane({
   );
   const [decidingId, setDecidingId] = useState<string | null>(null);
   const [approvalError, setApprovalError] = useState<string | undefined>();
-  const availableModes: CodePermissionMode[] = ["plan", "ask", "auto"];
+  const doctorEntry = useCodeCatalogStore(
+    (state) =>
+      state.doctor?.harnesses.find(
+        (entry) => entry.kind === session.harness_kind,
+      ) ?? null,
+  );
+  // Doctor caps decide what this engine's picker offers; without a doctor
+  // row yet, show everything and let the server refuse.
+  const availableModes: CodePermissionMode[] = doctorEntry
+    ? createPermissionModes(doctorEntry.caps)
+    : ["plan", "ask", "auto"];
 
   useEffect(() => {
     let cancelled = false;

--- a/crates/tidebreak-desktop/ui/src/code/HarnessPicker.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/HarnessPicker.dom.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, screen } from "@testing-library/react";
+import { cleanup, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { HarnessDoctorEntry } from "../api/types";
@@ -15,6 +16,7 @@ const CAPS = {
   streaming_deltas: "supported",
   mid_turn_steering: "unsupported",
   plan_mode: "supported",
+  auto_mode: "supported",
   reasoning_levels: "unknown",
   native_file_change_events: "unsupported",
   native_interrupt: "supported",
@@ -38,45 +40,57 @@ function entry(
 }
 
 describe("HarnessPicker", () => {
-  it("selects a ready row and dims unusable ones", async () => {
+  it("is a dropdown: ready rows select, unusable rows are disabled with a reason", async () => {
+    const user = userEvent.setup();
     const onChange = vi.fn();
     await renderWithRouter(
       <HarnessPicker
         harnesses={[
           entry({ kind: "claude_code" }),
-          entry({ kind: "codex", found: false }),
+          entry({ kind: "codex" }),
+          entry({ kind: "opencode", found: false }),
+        ]}
+        value="claude_code"
+        onChange={onChange}
+      />,
+    );
+    const trigger = screen.getByRole("combobox", { name: "Harness" });
+    expect(trigger).toHaveTextContent("Claude Code");
+    await user.click(trigger);
+    expect(
+      screen.getByRole("option", { name: /Not installed/ }),
+    ).toHaveAttribute("aria-disabled", "true");
+    await user.click(screen.getByRole("option", { name: /Codex CLI/ }));
+    expect(onChange).toHaveBeenCalledWith("codex");
+  });
+
+  it("keeps an Auto-only engine selectable and never renders doctor strings", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    await renderWithRouter(
+      <HarnessPicker
+        harnesses={[
+          entry({ kind: "claude_code", version: "2.1.233" }),
           entry({
             kind: "grok",
-            caps: { ...CAPS, plan_mode: "unsupported", structured_approvals: "unsupported" },
+            version: "1.0.4",
+            caps: {
+              ...CAPS,
+              plan_mode: "unsupported",
+              structured_approvals: "unsupported",
+            },
           }),
         ]}
         value="claude_code"
         onChange={onChange}
       />,
     );
-    expect(screen.getByRole("option", { name: /Claude Code/ })).toBeEnabled();
-    expect(screen.getByRole("option", { name: /Not installed/ })).toBeDisabled();
-    expect(screen.getByRole("option", { name: /Not available yet/ })).toBeDisabled();
-    fireEvent.click(screen.getByRole("option", { name: /Claude Code/ }));
-    expect(onChange).toHaveBeenCalledWith("claude_code");
-  });
-
-  it("moves with the keyboard and never renders doctor version strings", async () => {
-    const onChange = vi.fn();
-    await renderWithRouter(
-      <HarnessPicker
-        harnesses={[
-          entry({ kind: "claude_code", version: "2.1.233" }),
-          entry({ kind: "codex", version: "0.80.0" }),
-        ]}
-        value="claude_code"
-        onChange={onChange}
-      />,
-    );
-    const list = screen.getByRole("listbox", { name: "Harness" });
-    expect(list.textContent).not.toMatch(/2\.1\.233|0\.80\.0|\/opt\/harness/);
-    fireEvent.keyDown(list, { key: "ArrowDown" });
-    fireEvent.keyDown(list, { key: "Enter" });
-    expect(onChange).toHaveBeenCalledWith("codex");
+    await user.click(screen.getByRole("combobox", { name: "Harness" }));
+    const listbox = screen.getByRole("listbox");
+    expect(listbox.textContent).not.toMatch(/2\.1\.233|1\.0\.4|\/opt\/harness/);
+    const grokRow = screen.getByRole("option", { name: /Grok CLI/ });
+    expect(grokRow).not.toHaveAttribute("aria-disabled", "true");
+    await user.click(grokRow);
+    expect(onChange).toHaveBeenCalledWith("grok");
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/HarnessPicker.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/HarnessPicker.tsx
@@ -1,5 +1,4 @@
-import type { ComponentType, KeyboardEvent } from "react";
-import { useEffect, useState } from "react";
+import type { ComponentType } from "react";
 import { useNavigate } from "@tanstack/react-router";
 
 import type { HarnessDoctorEntry, HarnessKind } from "../api/types";
@@ -9,7 +8,13 @@ import {
   OpenCodeIcon,
   XaiIcon,
 } from "../ProviderIcons";
-import { cn } from "@/lib/utils";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import {
   HARNESS_LABELS,
   HARNESS_SUBTITLES,
@@ -27,11 +32,12 @@ const HARNESS_ICONS: Record<
 };
 
 /**
- * Branded harness picker: logo, product name, one-line subtitle.
+ * Branded harness dropdown: logo, product name, one-line subtitle per row.
  *
- * Ready rows are selectable. Unusable rows are dimmed with a short reason
- * and a quiet link to the doctor. Versions and capability flags stay off
- * this surface.
+ * Ready rows are selectable. Unusable rows stay listed, disabled, with a
+ * short reason in place of the subtitle; a quiet link to the doctor appears
+ * under the control while any row is unusable. Versions and capability
+ * flags stay off this surface.
  */
 export function HarnessPicker({
   harnesses,
@@ -46,112 +52,62 @@ export function HarnessPicker({
 }) {
   const navigate = useNavigate();
   const harnessesPath: string = "/settings/coding-harnesses";
-  const [active, setActive] = useState(() =>
-    Math.max(
-      0,
-      harnesses.findIndex((entry) => {
-        if (value) return entry.kind === value;
-        return !harnessUnusableReason(entry);
-      }),
-    ),
-  );
-
-  useEffect(() => {
-    const next = harnesses.findIndex((entry) => {
-      if (value) return entry.kind === value;
-      return !harnessUnusableReason(entry);
-    });
-    if (next >= 0) setActive(next);
-  }, [harnesses, value]);
-
-  function move(delta: number) {
-    if (harnesses.length === 0) return;
-    setActive((current) => {
-      const next = (current + delta + harnesses.length) % harnesses.length;
-      return next;
-    });
-  }
-
-  function pick(index: number) {
-    const entry = harnesses[index];
-    if (!entry || harnessUnusableReason(entry) || disabled) return;
-    onChange(entry.kind);
-  }
-
-  function onKeyDown(event: KeyboardEvent<HTMLDivElement>) {
-    if (event.key === "ArrowDown") {
-      event.preventDefault();
-      move(1);
-    } else if (event.key === "ArrowUp") {
-      event.preventDefault();
-      move(-1);
-    } else if (event.key === "Enter") {
-      event.preventDefault();
-      pick(active);
-    }
-  }
+  const selected = harnesses.find((entry) => entry.kind === value);
+  const SelectedIcon = selected ? HARNESS_ICONS[selected.kind] : null;
+  const anyUnusable = harnesses.some((entry) => harnessUnusableReason(entry));
 
   return (
-    <div
-      role="listbox"
-      aria-label="Harness"
-      tabIndex={disabled ? -1 : 0}
-      className="flex flex-col gap-0.5 rounded-md border border-border p-1"
-      onKeyDown={onKeyDown}
-    >
-      {harnesses.map((entry, index) => {
-        const reason = harnessUnusableReason(entry);
-        const selected = value === entry.kind;
-        const Icon = HARNESS_ICONS[entry.kind];
-        return (
-          <button
-            key={entry.kind}
-            type="button"
-            role="option"
-            aria-selected={selected}
-            aria-disabled={Boolean(reason) || undefined}
-            disabled={disabled || Boolean(reason)}
-            className={cn(
-              "flex w-full items-start gap-2.5 rounded-sm px-2 py-1.5 text-left text-sm",
-              index === active && "bg-accent text-accent-foreground",
-              reason && "opacity-50",
-              selected && !reason && "ring-1 ring-border",
+    <div className="flex flex-col gap-1">
+      <Select
+        value={value ?? undefined}
+        onValueChange={(next) => onChange(next as HarnessKind)}
+        disabled={disabled || harnesses.length === 0}
+      >
+        <SelectTrigger aria-label="Harness">
+          <SelectValue placeholder="No harness detected">
+            {selected && SelectedIcon && (
+              <span className="flex items-center gap-2">
+                <SelectedIcon className="size-4 shrink-0" />
+                <span className="truncate">{HARNESS_LABELS[selected.kind]}</span>
+              </span>
             )}
-            onMouseEnter={() => setActive(index)}
-            onClick={() => pick(index)}
-          >
-            <Icon className="mt-0.5 size-4 shrink-0" />
-            <span className="flex min-w-0 flex-col">
-              <span className="truncate font-medium">
-                {HARNESS_LABELS[entry.kind]}
-              </span>
-              <span className="truncate text-xs text-muted-foreground">
-                {reason ?? HARNESS_SUBTITLES[entry.kind]}
-              </span>
-              {reason && (
-                <span
-                  role="link"
-                  tabIndex={0}
-                  className="text-muted-foreground mt-0.5 w-fit cursor-pointer text-xs underline-offset-2 hover:underline"
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    void navigate({ to: harnessesPath });
-                  }}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter" || event.key === " ") {
-                      event.preventDefault();
-                      event.stopPropagation();
-                      void navigate({ to: harnessesPath });
-                    }
-                  }}
-                >
-                  Coding harnesses
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent scrollButtons={false}>
+          {harnesses.map((entry) => {
+            const reason = harnessUnusableReason(entry);
+            const Icon = HARNESS_ICONS[entry.kind];
+            return (
+              <SelectItem
+                key={entry.kind}
+                value={entry.kind}
+                disabled={Boolean(reason)}
+              >
+                <span className="flex items-center gap-2.5">
+                  <Icon className="size-4 shrink-0" />
+                  <span className="flex min-w-0 flex-col text-left">
+                    <span className="truncate font-medium">
+                      {HARNESS_LABELS[entry.kind]}
+                    </span>
+                    <span className="text-muted-foreground truncate text-xs">
+                      {reason ?? HARNESS_SUBTITLES[entry.kind]}
+                    </span>
+                  </span>
                 </span>
-              )}
-            </span>
-          </button>
-        );
-      })}
+              </SelectItem>
+            );
+          })}
+        </SelectContent>
+      </Select>
+      {anyUnusable && (
+        <button
+          type="button"
+          className="text-muted-foreground w-fit cursor-pointer text-xs underline-offset-2 hover:underline"
+          onClick={() => void navigate({ to: harnessesPath })}
+        >
+          Coding harnesses
+        </button>
+      )}
     </div>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -30,9 +30,11 @@ import { PermissionModePicker } from "./CodeComposer";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { HarnessPicker } from "./HarnessPicker";
 import {
+  autoIsUnsupervised,
   createPermissionModes,
   defaultCreatePermissionMode,
   harnessUnusableReason,
+  UNSUPERVISED_AUTO_NOTE,
 } from "./labels";
 
 /**
@@ -92,15 +94,17 @@ export function NewWorkspaceDialog({
 
   const selectedRepo = repos.find((repo) => repo.id === repoId);
   const selectedHarness = readyHarnesses.find((entry) => entry.kind === harness);
-  const availableModes = createPermissionModes(
-    selectedHarness?.caps.structured_approvals,
-  );
+  const availableModes = selectedHarness
+    ? createPermissionModes(selectedHarness.caps)
+    : [];
   const postedMode =
     permissionMode && availableModes.includes(permissionMode)
       ? permissionMode
-      : defaultCreatePermissionMode(selectedHarness?.caps.structured_approvals);
+      : selectedHarness
+        ? defaultCreatePermissionMode(selectedHarness.caps)
+        : "plan";
   const canCreate =
-    Boolean(repoId && selectedRepo && readyHarnesses.length > 0) && !creating;
+    Boolean(repoId && selectedRepo && selectedHarness) && !creating;
 
   async function submit(event: FormEvent) {
     event.preventDefault();
@@ -198,6 +202,13 @@ export function NewWorkspaceDialog({
               availableModes={availableModes}
               onChange={setPermissionMode}
             />
+            {postedMode === "auto" &&
+              selectedHarness &&
+              autoIsUnsupervised(selectedHarness.caps) && (
+                <p className="text-warning-foreground text-xs">
+                  {UNSUPERVISED_AUTO_NOTE}
+                </p>
+              )}
           </div>
           <DialogFooter>
             <Button

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, screen } from "@testing-library/react";
+import { cleanup, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { HarnessDoctorEntry } from "../api/types";
 import { renderWithRouter } from "@/test/router";
+import { UNSUPERVISED_AUTO_NOTE } from "./labels";
 import { StartSessionPrompt } from "./StartSessionPrompt";
 
 afterEach(() => {
@@ -15,6 +17,7 @@ const CAPS = {
   streaming_deltas: "supported",
   mid_turn_steering: "unsupported",
   plan_mode: "supported",
+  auto_mode: "supported",
   reasoning_levels: "unknown",
   native_file_change_events: "unsupported",
   native_interrupt: "supported",
@@ -22,13 +25,13 @@ const CAPS = {
 
 function entry(
   kind: HarnessDoctorEntry["kind"],
-  structuredApprovals: HarnessDoctorEntry["caps"]["structured_approvals"],
+  caps: Partial<HarnessDoctorEntry["caps"]>,
 ): HarnessDoctorEntry {
   return {
     kind,
     found: true,
     tier: "reference",
-    caps: { ...CAPS, structured_approvals: structuredApprovals },
+    caps: { ...CAPS, structured_approvals: "supported", ...caps },
     remediation: "",
     stderr: "",
     unrecognized_event_count: 0,
@@ -37,10 +40,11 @@ function entry(
 
 describe("StartSessionPrompt", () => {
   it("defaults to Ask and posts Ask when the doctor supports structured approvals", async () => {
+    const user = userEvent.setup();
     const onStart = vi.fn();
     await renderWithRouter(
       <StartSessionPrompt
-        harnesses={[entry("claude_code", "supported")]}
+        harnesses={[entry("claude_code", {})]}
         starting={false}
         selectedMode={null}
         onSelectMode={vi.fn()}
@@ -51,38 +55,47 @@ describe("StartSessionPrompt", () => {
       "aria-pressed",
       "true",
     );
-    fireEvent.click(screen.getByRole("option", { name: /Claude Code/ }));
+    await user.click(screen.getByRole("button", { name: "Start session" }));
     expect(onStart).toHaveBeenCalledWith("claude_code", "ask");
   });
 
   it("falls back to Plan when structured approvals are not supported", async () => {
+    const user = userEvent.setup();
     const onStart = vi.fn();
     await renderWithRouter(
       <StartSessionPrompt
-        harnesses={[entry("claude_code", "unsupported")]}
+        harnesses={[
+          entry("claude_code", {
+            structured_approvals: "unsupported",
+            auto_mode: "unsupported",
+          }),
+        ]}
         starting={false}
         selectedMode={null}
         onSelectMode={vi.fn()}
         onStart={onStart}
       />,
     );
-    const ask = screen.getByRole("button", { name: /Ask/ });
-    expect(ask).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Ask/ })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Plan" })).toHaveAttribute(
       "aria-pressed",
       "true",
     );
-    fireEvent.click(screen.getByRole("option", { name: /Claude Code/ }));
+    await user.click(screen.getByRole("button", { name: "Start session" }));
     expect(onStart).toHaveBeenCalledWith("claude_code", "plan");
   });
 
-  it("posts Plan for a harness that cannot honor a selected Ask mode", async () => {
+  it("switches an Auto-only engine to unsupervised Auto and says so", async () => {
+    const user = userEvent.setup();
     const onStart = vi.fn();
     await renderWithRouter(
       <StartSessionPrompt
         harnesses={[
-          entry("claude_code", "supported"),
-          entry("codex", "unsupported"),
+          entry("claude_code", {}),
+          entry("grok", {
+            plan_mode: "unsupported",
+            structured_approvals: "unsupported",
+          }),
         ]}
         starting={false}
         selectedMode="ask"
@@ -90,7 +103,16 @@ describe("StartSessionPrompt", () => {
         onStart={onStart}
       />,
     );
-    fireEvent.click(screen.getByRole("option", { name: /Codex CLI/ }));
-    expect(onStart).toHaveBeenCalledWith("codex", "plan");
+    expect(screen.queryByText(UNSUPERVISED_AUTO_NOTE)).toBeNull();
+    await user.click(screen.getByRole("combobox", { name: "Harness" }));
+    await user.click(screen.getByRole("option", { name: /Grok CLI/ }));
+    // The selected Ask is not honorable here; the mode follows the engine.
+    expect(screen.getByRole("button", { name: "Auto" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByText(UNSUPERVISED_AUTO_NOTE)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+    expect(onStart).toHaveBeenCalledWith("grok", "auto");
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
@@ -1,20 +1,28 @@
+import { useState } from "react";
+
 import type {
   CodePermissionMode,
   HarnessDoctorEntry,
   HarnessKind,
 } from "../api/types";
+import { Button } from "@/components/ui/button";
 import { PermissionModePicker } from "./CodeComposer";
 import { HarnessPicker } from "./HarnessPicker";
 import {
+  autoIsUnsupervised,
   createPermissionModes,
   defaultCreatePermissionMode,
   harnessUnusableReason,
+  UNSUPERVISED_AUTO_NOTE,
 } from "./labels";
 
 /**
- * Create-time harness + permission mode. Defaults to Ask when any ready
- * harness reports structured approvals, otherwise Plan, so create always
- * posts a mode the selected engine can honor.
+ * Create-time harness + permission mode for a workspace with no session.
+ *
+ * The harness dropdown defaults to the first ready engine; the mode list and
+ * default follow the selected engine's own capability flags, so start always
+ * posts a mode that engine can honor. Unsupervised Auto says so before the
+ * session exists (decision 0038).
  */
 export function StartSessionPrompt({
   harnesses,
@@ -29,43 +37,44 @@ export function StartSessionPrompt({
   onSelectMode: (mode: CodePermissionMode) => void;
   onStart: (harness: HarnessKind, mode: CodePermissionMode) => void;
 }) {
-  const usable = harnesses.filter((entry) => !harnessUnusableReason(entry));
-  const anyAsk = usable.some((entry) =>
-    createPermissionModes(entry.caps.structured_approvals).includes("ask"),
-  );
-  const defaultMode: CodePermissionMode = anyAsk ? "ask" : "plan";
-  const mode = selectedMode ?? defaultMode;
-  const availableModes: CodePermissionMode[] = anyAsk
-    ? ["plan", "ask", "auto"]
-    : ["plan"];
+  const [picked, setPicked] = useState<HarnessKind | null>(null);
+  const ready = harnesses.filter((entry) => !harnessUnusableReason(entry));
+  const selected =
+    harnesses.find((entry) => entry.kind === picked && !harnessUnusableReason(entry)) ??
+    ready[0];
+  const availableModes = selected ? createPermissionModes(selected.caps) : [];
+  const mode: CodePermissionMode =
+    selectedMode && availableModes.includes(selectedMode)
+      ? selectedMode
+      : selected
+        ? defaultCreatePermissionMode(selected.caps)
+        : "plan";
 
   return (
     <div className="flex flex-col gap-3 px-4 py-6">
       <p className="text-sm">Start a session on this workspace.</p>
+      <HarnessPicker
+        harnesses={harnesses}
+        value={selected?.kind ?? null}
+        disabled={starting}
+        onChange={setPicked}
+      />
       <PermissionModePicker
         value={mode}
         availableModes={availableModes}
         onChange={onSelectMode}
       />
-      <HarnessPicker
-        harnesses={harnesses}
-        value={null}
-        disabled={starting}
-        onChange={(kind) => {
-          const entry = harnesses.find((item) => item.kind === kind);
-          if (!entry) return;
-          onStart(entry.kind, modeForHarness(entry, mode));
-        }}
-      />
+      {mode === "auto" && selected && autoIsUnsupervised(selected.caps) && (
+        <p className="text-warning-foreground text-xs">{UNSUPERVISED_AUTO_NOTE}</p>
+      )}
+      <Button
+        type="button"
+        className="w-fit"
+        disabled={starting || !selected}
+        onClick={() => selected && onStart(selected.kind, mode)}
+      >
+        {starting ? "Starting…" : "Start session"}
+      </Button>
     </div>
   );
-}
-
-function modeForHarness(
-  entry: HarnessDoctorEntry,
-  selected: CodePermissionMode,
-): CodePermissionMode {
-  const available = createPermissionModes(entry.caps.structured_approvals);
-  if (available.includes(selected)) return selected;
-  return defaultCreatePermissionMode(entry.caps.structured_approvals);
 }

--- a/crates/tidebreak-desktop/ui/src/code/labels.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.test.ts
@@ -1,23 +1,52 @@
 import { describe, expect, it } from "vitest";
 
+import type { ModeCaps } from "./labels";
 import {
+  autoIsUnsupervised,
   createPermissionModes,
   defaultCreatePermissionMode,
   harnessUnusableReason,
 } from "./labels";
 
+function caps(
+  plan_mode: ModeCaps["plan_mode"],
+  structured_approvals: ModeCaps["structured_approvals"],
+  auto_mode: ModeCaps["auto_mode"],
+): ModeCaps {
+  return { plan_mode, structured_approvals, auto_mode };
+}
+
 describe("create-time permission mode", () => {
   it("defaults to Ask when the doctor reports structured approvals", () => {
-    expect(defaultCreatePermissionMode("supported")).toBe("ask");
-    expect(createPermissionModes("supported")).toEqual(["plan", "ask", "auto"]);
+    expect(defaultCreatePermissionMode(caps("supported", "supported", "supported"))).toBe(
+      "ask",
+    );
+    expect(
+      createPermissionModes(caps("supported", "supported", "supported")),
+    ).toEqual(["plan", "ask", "auto"]);
   });
 
   it("falls back to Plan when structured approvals are not supported", () => {
-    expect(defaultCreatePermissionMode("unsupported")).toBe("plan");
-    expect(defaultCreatePermissionMode("unknown")).toBe("plan");
-    expect(defaultCreatePermissionMode(undefined)).toBe("plan");
-    expect(createPermissionModes("unsupported")).toEqual(["plan"]);
-    expect(createPermissionModes("unknown")).toEqual(["plan"]);
+    expect(
+      defaultCreatePermissionMode(caps("supported", "unsupported", "unsupported")),
+    ).toBe("plan");
+    expect(
+      defaultCreatePermissionMode(caps("supported", "unknown", "unknown")),
+    ).toBe("plan");
+    expect(
+      createPermissionModes(caps("supported", "unsupported", "unsupported")),
+    ).toEqual(["plan"]);
+  });
+
+  it("offers only unsupervised Auto for a grok-shaped engine", () => {
+    const grok = caps("unsupported", "unsupported", "supported");
+    expect(createPermissionModes(grok)).toEqual(["auto"]);
+    expect(defaultCreatePermissionMode(grok)).toBe("auto");
+    expect(autoIsUnsupervised(grok)).toBe(true);
+    // Supervised Auto rides the approval channel and needs no statement.
+    expect(autoIsUnsupervised(caps("supported", "supported", "supported"))).toBe(
+      false,
+    );
   });
 });
 
@@ -26,26 +55,33 @@ describe("harnessUnusableReason", () => {
     expect(
       harnessUnusableReason({
         found: false,
-        caps: { plan_mode: "supported", structured_approvals: "supported" },
+        caps: caps("supported", "supported", "supported"),
       }),
     ).toBe("Not installed");
     expect(
       harnessUnusableReason({
         found: true,
         authenticated: false,
-        caps: { plan_mode: "supported", structured_approvals: "supported" },
+        caps: caps("supported", "supported", "supported"),
       }),
     ).toBe("Sign in via your terminal");
     expect(
       harnessUnusableReason({
         found: true,
-        caps: { plan_mode: "unsupported", structured_approvals: "unsupported" },
+        caps: caps("unsupported", "unsupported", "unsupported"),
       }),
     ).toBe("Not available yet");
     expect(
       harnessUnusableReason({
         found: true,
-        caps: { plan_mode: "supported", structured_approvals: "unsupported" },
+        caps: caps("supported", "unsupported", "unsupported"),
+      }),
+    ).toBeNull();
+    // An Auto-only engine is usable, not "Not available yet".
+    expect(
+      harnessUnusableReason({
+        found: true,
+        caps: caps("unsupported", "unsupported", "supported"),
       }),
     ).toBeNull();
   });

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -1,10 +1,10 @@
 import type {
   Attention,
-  CapLevel,
   CodePermissionMode,
   CodeSessionLifecycle,
   CodeWorkspaceStatus,
   FenceReason,
+  HarnessCaps,
   HarnessKind,
   HarnessTier,
 } from "../api/types";
@@ -63,6 +63,16 @@ export const PERMISSION_MODE_LABELS: Record<CodePermissionMode, string> = {
 export const PERMISSION_MODE_UNAVAILABLE_REASON =
   "this harness cannot honor that mode";
 
+/** Stated wherever unsupervised Auto is offered (decision 0038). */
+export const UNSUPERVISED_AUTO_NOTE =
+  "This engine has no approval channel: in Auto, every action runs without asking.";
+
+/** The capability flags the mode policy reads. */
+export type ModeCaps = Pick<
+  HarnessCaps,
+  "plan_mode" | "structured_approvals" | "auto_mode"
+>;
+
 export function fenceReasonText(reason: FenceReason): string {
   if (reason.type === "orphan_alive") {
     return "An engine process is still running from a previous session. Reap it before starting another turn.";
@@ -78,13 +88,8 @@ export function isHarnessReady(entry: {
 }
 
 /** True when create can post at least one permission mode this engine honors. */
-export function harnessHonorsAnyCreateMode(entry: {
-  caps: { plan_mode: CapLevel; structured_approvals: CapLevel };
-}): boolean {
-  return (
-    entry.caps.plan_mode === "supported" ||
-    harnessHonorsStructuredApprovals(entry.caps.structured_approvals)
-  );
+export function harnessHonorsAnyCreateMode(entry: { caps: ModeCaps }): boolean {
+  return createPermissionModes(entry.caps).length > 0;
 }
 
 /**
@@ -94,7 +99,7 @@ export function harnessHonorsAnyCreateMode(entry: {
 export function harnessUnusableReason(entry: {
   found: boolean;
   authenticated?: boolean;
-  caps: { plan_mode: CapLevel; structured_approvals: CapLevel };
+  caps: ModeCaps;
 }): string | null {
   if (!entry.found) return "Not installed";
   if (entry.authenticated === false) return "Sign in via your terminal";
@@ -102,18 +107,33 @@ export function harnessUnusableReason(entry: {
   return null;
 }
 
-/** Ask/Auto need a structured approval channel. Plan does not. */
-export function harnessHonorsStructuredApprovals(
-  structuredApprovals: CapLevel | undefined,
-): boolean {
-  return structuredApprovals === "supported";
+/**
+ * True when this engine's Auto runs with nobody to ask (decision 0038):
+ * it has an auto posture but no approval channel to escalate through.
+ */
+export function autoIsUnsupervised(caps: ModeCaps): boolean {
+  return caps.auto_mode === "supported" && caps.structured_approvals !== "supported";
 }
 
-/** Create default: Ask when the doctor says the harness can honor it, else Plan. */
-export function defaultCreatePermissionMode(
-  structuredApprovals: CapLevel | undefined,
-): CodePermissionMode {
-  return harnessHonorsStructuredApprovals(structuredApprovals) ? "ask" : "plan";
+/**
+ * Create default: Ask when the engine carries approvals, else Plan when it
+ * has one, else Auto when that is the only posture it honors. An engine
+ * honoring nothing still answers Plan — create is disabled before it posts.
+ */
+export function defaultCreatePermissionMode(caps: ModeCaps): CodePermissionMode {
+  if (caps.structured_approvals === "supported") return "ask";
+  if (caps.plan_mode === "supported") return "plan";
+  if (caps.auto_mode === "supported") return "auto";
+  return "plan";
+}
+
+/** The modes create may post for this engine, each on its own flag. */
+export function createPermissionModes(caps: ModeCaps): CodePermissionMode[] {
+  const modes: CodePermissionMode[] = [];
+  if (caps.plan_mode === "supported") modes.push("plan");
+  if (caps.structured_approvals === "supported") modes.push("ask");
+  if (caps.auto_mode === "supported") modes.push("auto");
+  return modes;
 }
 
 export function attentionLabel(attention: Attention): string {
@@ -131,12 +151,4 @@ export function attentionLabel(attention: Attention): string {
     case "manual":
       return attention.state.note || "Pinned";
   }
-}
-
-export function createPermissionModes(
-  structuredApprovals: CapLevel | undefined,
-): CodePermissionMode[] {
-  return harnessHonorsStructuredApprovals(structuredApprovals)
-    ? ["plan", "ask", "auto"]
-    : ["plan"];
 }

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -844,6 +844,7 @@ function parseHarnessCaps(value: unknown): HarnessCaps | null {
       "structured_approvals",
       "mid_turn_steering",
       "plan_mode",
+      "auto_mode",
       "reasoning_levels",
       "native_file_change_events",
       "native_interrupt",
@@ -853,6 +854,7 @@ function parseHarnessCaps(value: unknown): HarnessCaps | null {
     !isMember(value.structured_approvals, CAP_LEVELS) ||
     !isMember(value.mid_turn_steering, CAP_LEVELS) ||
     !isMember(value.plan_mode, CAP_LEVELS) ||
+    !isMember(value.auto_mode, CAP_LEVELS) ||
     !isMember(value.reasoning_levels, CAP_LEVELS) ||
     !isMember(value.native_file_change_events, CAP_LEVELS) ||
     !isMember(value.native_interrupt, CAP_LEVELS)
@@ -865,6 +867,7 @@ function parseHarnessCaps(value: unknown): HarnessCaps | null {
     structured_approvals: value.structured_approvals,
     mid_turn_steering: value.mid_turn_steering,
     plan_mode: value.plan_mode,
+    auto_mode: value.auto_mode,
     reasoning_levels: value.reasoning_levels,
     native_file_change_events: value.native_file_change_events,
     native_interrupt: value.native_interrupt,

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1773,6 +1773,15 @@ mid_turn_steering: CapLevel,
  */
 plan_mode: CapLevel, 
 /**
+ * The engine has a workspace-write / auto posture the adapter can select.
+ *
+ * Whether that posture is supervised is a separate question:
+ * with `structured_approvals` supported, sensitive actions still park on
+ * approval cards; without it, Auto runs unsupervised and the product
+ * states so where the mode is chosen (decision 0038).
+ */
+auto_mode: CapLevel, 
+/**
  * The engine accepts a reasoning-effort control.
  */
 reasoning_levels: CapLevel, 

--- a/crates/tidebreak-harness/fixtures/grok/1.0.4/manifest.toml
+++ b/crates/tidebreak-harness/fixtures/grok/1.0.4/manifest.toml
@@ -33,15 +33,17 @@ scenarios = [
 ]
 
 [permission_mode_mapping]
-# No Tidebreak permission mode is honored on 1.0.4 print mode.
-# Ask/Auto: no structured approval channel in streaming-json.
+# Auto is the default headless posture: no permission flags composed, the
+# engine executes routine work unprompted, and nothing escalates — offered
+# as unsupervised Auto and stated at selection (decision 0038).
+# Ask: no structured approval channel in streaming-json.
 # Plan: `--permission-mode plan` and `--sandbox read-only` both wrote
 # files in captured turns. `--deny Edit/Write/Bash` did refuse those
 # tools (see permission-denied) but is not composed as a Plan stand-in.
 # `--always-approve` / `--yolo` / `bypassPermissions` are denylisted.
 Plan = "refused"
 Ask = "refused"
-Auto = "refused"
+Auto = "default headless posture (no permission flags composed)"
 
 [redaction]
 notes = """
@@ -66,6 +68,7 @@ verified = [
   "--permission-mode plan wrote note.txt; --sandbox read-only wrote sandboxed.txt",
   "--deny Edit --deny Write --deny Bash failed write + run_terminal_command (Denied by permission policy)",
   "ACP: grok agent stdio initialize + session/new returned sessionId; no request_permission captured",
+  "re-probed 2026-08-17 on 1.0.4 (d846eb93): default headless (no permission flags) ran the write tool unprompted and the file landed; --permission-mode plan wrote again",
 ]
 not_verified = [
   "ACP session/request_permission request/response pair",

--- a/crates/tidebreak-harness/src/claude/mod.rs
+++ b/crates/tidebreak-harness/src/claude/mod.rs
@@ -69,6 +69,14 @@ impl HarnessAdapter for ClaudeCodeAdapter {
             },
             mid_turn_steering: CapLevel::Unknown,
             plan_mode: CapLevel::Supported,
+            // `--permission-mode acceptEdits`; supervised by the approval
+            // channel, so it carries the same version gate — unsupervised
+            // Auto has not been probed on other versions.
+            auto_mode: if version_is_2_1_233(_probe.version.as_deref()) {
+                CapLevel::Supported
+            } else {
+                CapLevel::Unknown
+            },
             reasoning_levels: CapLevel::Unknown,
             native_file_change_events: CapLevel::Unknown,
             native_interrupt: CapLevel::Supported,

--- a/crates/tidebreak-harness/src/codex/mod.rs
+++ b/crates/tidebreak-harness/src/codex/mod.rs
@@ -76,6 +76,9 @@ impl HarnessAdapter for CodexAdapter {
             // `turn/steer` exists in the generated schema; not captured.
             mid_turn_steering: CapLevel::Unknown,
             plan_mode: CapLevel::Supported,
+            // `thread/start` sandbox workspace-write + approvalPolicy
+            // on-request; supervised by the captured approval channel.
+            auto_mode: CapLevel::Supported,
             reasoning_levels: CapLevel::Supported,
             native_file_change_events: CapLevel::Unknown,
             native_interrupt: CapLevel::Supported,

--- a/crates/tidebreak-harness/src/grok/mod.rs
+++ b/crates/tidebreak-harness/src/grok/mod.rs
@@ -81,6 +81,11 @@ impl HarnessAdapter for GrokAdapter {
             // `--permission-mode plan` and `--sandbox read-only` both
             // wrote files in captured 1.0.4 turns.
             plan_mode: CapLevel::Unsupported,
+            // The default headless posture (no permission flags composed)
+            // executed a write tool unprompted — re-probed 2026-08-17 on
+            // 1.0.4 (d846eb93). Unsupervised: nothing escalates, which the
+            // product states where the mode is chosen (decision 0038).
+            auto_mode: CapLevel::Supported,
             // `--reasoning-effort` is documented and was used on capture.
             reasoning_levels: CapLevel::Supported,
             native_file_change_events: CapLevel::Unknown,
@@ -270,15 +275,17 @@ mod tests {
         assert_eq!(caps.reasoning_levels, CapLevel::Supported);
         assert_eq!(caps.structured_approvals, CapLevel::Unsupported);
         assert_eq!(caps.plan_mode, CapLevel::Unsupported);
+        assert_eq!(caps.auto_mode, CapLevel::Supported);
         assert_eq!(caps.mid_turn_steering, CapLevel::Unsupported);
         assert_eq!(caps.native_file_change_events, CapLevel::Unknown);
     }
 
     #[test]
-    fn every_permission_mode_is_refused() {
-        for mode in CodePermissionMode::ALL {
-            let err = refuse_unhonored_mode(*mode).unwrap_err();
-            assert!(matches!(err, HarnessError::PermissionModeUnsupported(m) if m == *mode));
+    fn auto_is_honored_and_plan_and_ask_are_refused() {
+        assert!(refuse_unhonored_mode(CodePermissionMode::Auto).is_ok());
+        for mode in [CodePermissionMode::Plan, CodePermissionMode::Ask] {
+            let err = refuse_unhonored_mode(mode).unwrap_err();
+            assert!(matches!(err, HarnessError::PermissionModeUnsupported(m) if m == mode));
         }
     }
 

--- a/crates/tidebreak-harness/src/grok/session.rs
+++ b/crates/tidebreak-harness/src/grok/session.rs
@@ -57,17 +57,26 @@ impl GrokSession {
     }
 }
 
-/// 1.0.4 print mode cannot honor any Tidebreak permission mode.
+/// 1.0.4 honors Auto only, as its default headless posture.
 ///
-/// Ask/Auto need a structured approval channel. Headless `streaming-json`
-/// has none (`grok agent stdio` ACP was probed; no request/response pair
-/// was captured). Plan's `--permission-mode plan` and `--sandbox read-only`
-/// both wrote files in captured turns. Composing `--always-approve` /
-/// `--yolo` / `bypassPermissions` is forbidden. Composing `--deny` rules
-/// as a stand-in for Plan would approximate a posture the engine's own
-/// plan/read-only flags did not honor.
+/// Auto composes no permission flags: the default print-mode posture
+/// executes routine work unprompted (re-probed 2026-08-17 — a write tool
+/// ran without asking), which is exactly an unsupervised workspace-write
+/// auto. Ask needs a structured approval channel and headless
+/// `streaming-json` has none (`grok agent stdio` ACP was probed; no
+/// request/response pair was captured). Plan's `--permission-mode plan`
+/// and `--sandbox read-only` both wrote files in captured and re-probed
+/// turns. Composing `--always-approve` / `--yolo` / `bypassPermissions`
+/// is forbidden. Composing `--deny` rules as a stand-in for Plan would
+/// approximate a posture the engine's own plan/read-only flags did not
+/// honor.
 pub(crate) fn refuse_unhonored_mode(mode: CodePermissionMode) -> Result<(), HarnessError> {
-    Err(HarnessError::PermissionModeUnsupported(mode))
+    match mode {
+        CodePermissionMode::Auto => Ok(()),
+        CodePermissionMode::Plan | CodePermissionMode::Ask => {
+            Err(HarnessError::PermissionModeUnsupported(mode))
+        }
+    }
 }
 
 /// Argv for one print-mode child. The prompt lives in `prompt_file`, never

--- a/crates/tidebreak-harness/src/opencode/mod.rs
+++ b/crates/tidebreak-harness/src/opencode/mod.rs
@@ -78,6 +78,9 @@ impl HarnessAdapter for OpencodeAdapter {
             // OpenAPI; not captured.
             mid_turn_steering: CapLevel::Unknown,
             plan_mode: CapLevel::Supported,
+            // Workspace-write ruleset with sensitive actions still asking
+            // over the permission API; supervised Auto.
+            auto_mode: CapLevel::Supported,
             reasoning_levels: CapLevel::Unknown,
             // session.diff was empty arrays; file.edited was not seen.
             native_file_change_events: CapLevel::Unknown,

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -1108,20 +1108,26 @@ fn refuse_unhonored_mode(
     mode: CodePermissionMode,
     caps: &tidebreak_core::HarnessCaps,
 ) -> Result<(), ServerError> {
+    // Each mode stands on its own capability flag (decision 0038): Auto is
+    // never derived from the approval channel, so an engine whose only
+    // honest posture is unsupervised Auto can still be driven.
     let ok = match mode {
         CodePermissionMode::Plan => caps.plan_mode == CapLevel::Supported,
-        CodePermissionMode::Ask | CodePermissionMode::Auto => {
-            caps.structured_approvals == CapLevel::Supported
-        }
+        CodePermissionMode::Ask => caps.structured_approvals == CapLevel::Supported,
+        CodePermissionMode::Auto => caps.auto_mode == CapLevel::Supported,
     };
     if ok {
         return Ok(());
     }
     let reason = match mode {
         CodePermissionMode::Plan => format!("{harness} cannot honor plan mode"),
-        CodePermissionMode::Ask | CodePermissionMode::Auto => format!(
+        CodePermissionMode::Ask => format!(
             "{harness} cannot honor {mode}: structured approvals are {}",
             caps.structured_approvals.as_str()
+        ),
+        CodePermissionMode::Auto => format!(
+            "{harness} cannot honor {mode}: an auto posture is {}",
+            caps.auto_mode.as_str()
         ),
     };
     Err(ServerError::unprocessable_kind(

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -75,6 +75,7 @@ pub(crate) struct ScriptedAdapter {
     delay: Duration,
     mid_turn_steering: CapLevel,
     structured_approvals: CapLevel,
+    auto_mode: CapLevel,
     child_pid: Option<i64>,
     approver: Arc<ScriptedApprover>,
 }
@@ -87,13 +88,24 @@ impl ScriptedAdapter {
             delay: Duration::ZERO,
             mid_turn_steering: CapLevel::Unsupported,
             structured_approvals: CapLevel::Unsupported,
+            auto_mode: CapLevel::Unsupported,
             child_pid: None,
             approver: Arc::new(ScriptedApprover::default()),
         }
     }
 
+    /// Sets the approval channel and, with it, the supervised auto posture —
+    /// the coupling every real approval-carrying adapter has.
     pub(crate) fn with_approvals(mut self, level: CapLevel) -> Self {
         self.structured_approvals = level;
+        self.auto_mode = level;
+        self
+    }
+
+    /// Overrides the auto posture independently of the approval channel,
+    /// for exercising the mode gate's per-flag refusals.
+    pub(crate) fn with_auto_mode(mut self, level: CapLevel) -> Self {
+        self.auto_mode = level;
         self
     }
 
@@ -143,6 +155,7 @@ impl HarnessAdapter for ScriptedAdapter {
             structured_approvals: self.structured_approvals,
             mid_turn_steering: self.mid_turn_steering,
             plan_mode: CapLevel::Supported,
+            auto_mode: self.auto_mode,
             reasoning_levels: CapLevel::Unsupported,
             native_file_change_events: CapLevel::Unsupported,
             native_interrupt: CapLevel::Supported,

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -173,6 +173,69 @@ async fn serve(router: Router) -> std::net::SocketAddr {
     addr
 }
 
+/// Auto is gated by its own capability flag (decision 0038): an engine with
+/// a live approval channel but no auto posture refuses Auto, and an engine
+/// whose only honest posture is unsupervised Auto creates an Auto session.
+/// A wrong implementation deriving Auto from the approval flag passes
+/// neither arm.
+#[tokio::test]
+async fn auto_stands_on_its_own_capability_flag() {
+    let adapter = ScriptedAdapter::new(plain_text_script())
+        .with_approvals(CapLevel::Supported)
+        .with_auto_mode(CapLevel::Unsupported);
+    let (router, token, _runtime, dir) = code_app_with(adapter).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let refused = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "auto",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::UNPROCESSABLE_ENTITY);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "permission_mode_unavailable");
+    assert!(
+        body["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("auto posture"),
+        "{}",
+        body["message"]
+    );
+
+    let adapter = ScriptedAdapter::new(plain_text_script()).with_auto_mode(CapLevel::Supported);
+    let (router, token, _runtime, dir) = code_app_with(adapter).await;
+    let addr = serve(router).await;
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let created = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "auto",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let session: serde_json::Value = created.json().await.unwrap();
+    assert_eq!(session["permission_mode"], "auto");
+}
+
 #[tokio::test]
 async fn plan_is_the_only_session_mode_and_a_turn_journals_end_to_end() {
     let (router, token, _runtime, dir) = code_app(plain_text_script()).await;

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -8,10 +8,12 @@ Where this page and a decision record disagree, the record wins. The first
 version ships the full surface described here — repos, workspaces, sessions,
 approvals, checkpoints and review, auxiliary terminals, the git/PR flow, the
 updates channel, and adapters for Claude Code (reference tier), Codex CLI,
-opencode, and Grok CLI (the last currently refuses every permission mode:
-its captured 1.0.4 print surface honors none of them, and honesty beats
-approximation) — with the deliberately parked scope recorded in
-[`docs/deferred.md`](deferred.md).
+opencode, and Grok CLI (the last honors Auto only, as its default headless
+posture: its captured 1.0.4 plan and sandbox flags do not confine and it has
+no approval channel, so Auto runs unsupervised and the product says so where
+the mode is chosen — see
+[`0038`](decisions/0038-auto-is-a-declared-capability.md)) — with the
+deliberately parked scope recorded in [`docs/deferred.md`](deferred.md).
 
 Code mode is Tidebreak's second product surface: pick a local git repository,
 spin up isolated **workspaces** (one worktree + branch each), and run
@@ -177,8 +179,10 @@ Process models the trait absorbs:
   version.
 - **opencode** — a long-lived server child driven over HTTP with its event
   stream; permissions over its permission API.
-- **Grok CLI** — best-effort tier; capabilities honestly `Unsupported` or
-  `Unknown` where its surface does not carry them.
+- **Grok CLI** — best-effort tier; one print-mode child per turn; honors
+  Auto only, as its default headless posture (unsupervised — see
+  [`0038`](decisions/0038-auto-is-a-declared-capability.md)); capabilities
+  honestly `Unsupported` or `Unknown` where its surface does not carry them.
 
 All children are pipe-based `tokio::process` with `kill_on_drop`, the
 user's environment minus Tidebreak internals

--- a/docs/decisions/0038-auto-is-a-declared-capability.md
+++ b/docs/decisions/0038-auto-is-a-declared-capability.md
@@ -1,0 +1,132 @@
+# 38. Auto Is a Declared Capability, and Unsupervised Auto Is Stated
+
+- Status: Accepted
+- Date: 2026-08-17
+- Owners: code mode, approvals
+- Related: [`0031-harness-adapter-boundary.md`](0031-harness-adapter-boundary.md),
+  [`0033-code-mode-approvals.md`](0033-code-mode-approvals.md),
+  [`crates/tidebreak-harness/fixtures/grok/1.0.4/manifest.toml`](../../crates/tidebreak-harness/fixtures/grok/1.0.4/manifest.toml)
+
+## Context
+
+[`0033`](0033-code-mode-approvals.md) maps Tidebreak's three permission modes
+onto each harness and rules that a mode a harness cannot honor is refused at
+session creation — never approximated, never silently escalated to bypass.
+For harnesses without a structured approval channel it says sessions "are
+restricted to permission modes that need no runtime approvals".
+
+The implementation came out stricter than that sentence: `Ask` and `Auto`
+both required `structured_approvals: Supported`, and `Plan` required
+`plan_mode: Supported`. For Grok CLI 1.0.4 the capture found no approval
+channel *and* a plan flag that does not confine (`--permission-mode plan`
+and `--sandbox read-only` both wrote files), so every mode was refused and
+the engine was listed but unusable.
+
+What the strict reading missed is that `Auto` needs no runtime approvals to
+be honored. Re-probed on the same build (1.0.4 d846eb93, 2026-08-17): the
+default headless posture — `--prompt-file` + `--output-format
+streaming-json`, **no permission flags composed** — executes write tools
+without prompting. That *is* a workspace-write auto posture. What it lacks
+is the escalation half of 0033's Auto gloss ("the harness's own policy still
+escalates sensitive actions"), because there is nothing to escalate to.
+
+So the real question is not whether Grok can run — it can, today, with no
+bypass flag — but how the product distinguishes *supervised* Auto (routine
+edits proceed, sensitive actions park on approval cards) from *unsupervised*
+Auto (everything proceeds), without hardcoding harness names into policy.
+
+## Decision
+
+**`Auto` is gated by its own capability flag.** `HarnessCaps` gains
+`auto_mode: CapLevel`: whether the adapter can select a workspace-write /
+auto posture for this engine version. Session creation refuses each mode on
+its own flag — `Plan` on `plan_mode`, `Ask` on `structured_approvals`,
+`Auto` on `auto_mode`. No mode is ever derived from another mode's flag.
+
+**Whether Auto is supervised is read from `structured_approvals`.** The two
+flags together describe the posture honestly: `auto_mode: Supported` +
+`structured_approvals: Supported` is 0033's supervised Auto;
+`auto_mode: Supported` + `structured_approvals: Unsupported` is unsupervised
+Auto — every action the engine takes proceeds, nothing parks. Surfaces that
+offer the mode (the create dialog, the start-session prompt, the CLI) must
+state the unsupervised variant visibly at selection time. That satisfies
+0033's "stated visibly at session creation, never silently escalated":
+the statement is the product's, made where the choice is made.
+
+**Grok CLI 1.0.4 declares `auto_mode: Supported` and maps Auto to its
+default headless posture**, composing no permission flags at all. `Plan` and
+`Ask` stay refused on this version: the plan flag does not confine, and
+there is still no approval channel. The bypass denylist is untouched —
+`--always-approve`, `--yolo`, and `bypassPermissions` remain forbidden in
+composed plans; unsupervised Auto is the engine's own default, not a flag we
+add.
+
+**Existing adapters keep their behavior.** Claude Code, Codex CLI, and
+opencode declare `auto_mode` exactly where their Auto worked before — for
+Claude that means the same version gate as its approval channel, since
+unsupervised Auto has not been probed there and `Unknown` is the honest
+answer on unverified versions.
+
+Deliberately excluded: offering a synthetic Plan for Grok out of `--deny`
+rules (a posture the engine's own plan flag failed to honor — captured
+denials exist, but composing them would be the approximation 0033 forbids);
+and driving Grok over ACP (`grok agent stdio`) for structured approvals — no
+`session/request_permission` pair has been captured, so it stays
+`not_verified` in the manifest.
+
+## Alternatives Considered
+
+**Keep Grok fully refused (do nothing).** Honest but strictly worse than
+honest Auto: the engine executes unsupervised by default in every terminal
+its user already runs it in; Tidebreak refusing to drive it protects nothing
+and forfeits the workspace isolation, checkpoints, and review surface that
+are the product's actual safety contribution.
+
+**Derive Auto from `structured_approvals || best_effort_tier`** or hardcode
+the grok kind in the server gate. Rejected: policy keyed on harness identity
+rots the moment a version changes behavior; capability flags are the
+established carrier ([`0031`](0031-harness-adapter-boundary.md)) and the
+caps struct has no `Default` precisely so a new flag forces every adapter to
+answer.
+
+**Synthesize Plan from `--deny Edit --deny Write --deny Bash`.** The denials
+individually worked in capture, but a composed denylist is an enumeration —
+every tool not on it still runs. Presenting that as "Plan: mutations
+refused" would promise more than the engine enforces.
+
+**Adopt ACP and build a real approval channel for Grok.** The right end
+state if Grok's ACP ships a capturable `session/request_permission`
+round-trip; not buildable today on fixtures-before-parsers grounds.
+
+## Consequences
+
+`HarnessCaps` changes shape, which ripples through the wire snapshot, the
+generated renderer types, the CLI doctor summary, and every caps literal in
+tests — a compile-time sweep by design.
+
+Unsupervised Auto puts real weight on the statement at selection time and on
+what Tidebreak itself provides around an unsupervised engine: worktree
+isolation, per-turn checkpoints, diffs, and review before merge. Those, not
+runtime approvals, are the supervision story for Grok-tier engines.
+
+Revisit when a Grok version honors its plan flag (unlock `Plan` from a new
+capture), or ships a capturable approval channel (unlock `Ask`, and Auto
+becomes supervised), or if usage shows unsupervised Auto being chosen
+without understanding — the visible statement is the mitigation, and if it
+fails the mode should be demoted behind an explicit setting.
+
+## Validation
+
+- Adapter tests: Grok accepts `Auto` and still refuses `Plan` and `Ask`;
+  the composed Auto launch plan contains no permission or bypass flags (the
+  existing denylist test extended to the Auto plan).
+- A server mode-refusal test: `Auto` on an adapter with
+  `auto_mode: Unsupported` fails with the stated reason even when
+  `structured_approvals: Supported` — this is the case a plausible wrong
+  implementation (deriving Auto from approvals) would still pass without.
+- UI: the mode list is computed from the three flags, and the unsupervised
+  statement renders exactly when `auto_mode` is supported while
+  `structured_approvals` is not.
+- The Grok fixture manifest records the 2026-08-17 re-probe: default
+  headless executed a write tool unprompted; `--permission-mode plan` wrote
+  again.


### PR DESCRIPTION
Two changes to the code-mode surface, driven end to end through the CLI.

## Grok support (decision 0038, included)

Grok CLI was listed but unusable: every permission mode was refused. Re-probed live on the exact installed build (1.0.4 d846eb93, 2026-08-17):

- the **default headless posture** (`--prompt-file` + `--output-format streaming-json`, no permission flags composed) executes write tools unprompted — that *is* a workspace-write auto posture, reached without any bypass flag;
- `--permission-mode plan` still writes files, so Plan stays refused;
- there is still no approval channel, so Ask stays refused.

The carrier is a new capability flag, **`HarnessCaps.auto_mode`** — session creation now refuses each mode on its own flag instead of deriving Auto from the approval channel. Existing adapters keep exactly their previous behavior (Claude's auto rides the same version gate as its approvals). Grok declares `auto_mode: Supported` and maps Auto to the default posture; the bypass denylist is untouched. Everywhere unsupervised Auto is offered — create dialog, start-session prompt, CLI default-mode note — the product states it: *"This engine has no approval channel: in Auto, every action runs without asking."* ADR 0038 records the decision, the alternatives (synthetic `--deny` Plan, ACP approvals, harness-name policy), and what would unlock Plan/Ask. The grok fixture manifest gains the dated re-probe entries.

## Dropdown harness picker

`HarnessPicker` becomes a real `Select` dropdown: branded rows with subtitle, unusable rows disabled with their reason, and a doctor link under the control while any row is unusable. `StartSessionPrompt` gains an explicit **Start session** button (rows no longer double as one) and follows the selected engine's caps for the mode list and default. The mid-session composer's mode list is now doctor-caps-driven too.

## Verified by driving the CLI

- `code doctor`: grok now reports `resume,streaming,auto,reasoning,interrupt`.
- `session start --harness grok` (no mode) → defaults to auto and prints the unsupervised note; `--mode plan` / `--mode ask` → 422 with precise reasons; explicit `--mode auto` works.
- Real grok turns: a trivial reply and a file-write task both completed; `code files` shows the tracked change.
- Regression: claude_code, codex, and opencode each started with their default mode and completed a turn.

## Tests

- Grok adapter: auto honored, plan/ask refused; caps assertions; launch-plan denylist unchanged.
- Server: `auto_stands_on_its_own_capability_flag` — Auto refused when `auto_mode` is unsupported *even with approvals supported* (the case a derive-from-approvals implementation would pass), and an Auto-only engine creates an auto session.
- CLI: default-mode ladder (ask → plan → auto) unit-tested.
- UI: labels policy tests incl. the grok shape and the unsupervised statement; dropdown and start-prompt dom tests rewritten (`tsc`, 1089 tests, `pnpm build` all green).

Not verified live: the dropdown in the running desktop app (dom tests cover it).