### PR TITLE
feat(desktop): experimental settings section, with code mode opt-in

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -22,6 +22,7 @@ import {
   prependReplacementChat,
 } from "./ChatDeletion";
 import { useChatListStore } from "./ChatListStore";
+import { useExperimentalFlags } from "./experimental";
 import { connectOutputs } from "./deliverables";
 import { useProjectListStore } from "./ProjectListStore";
 import { useComposerDrafts } from "./ComposerDrafts";
@@ -198,6 +199,9 @@ export function AppShell() {
         if (!cancelled) setBootError(String(err));
       }
     })();
+    // Loads apart from the catalog on purpose: a flags failure keeps the
+    // opted-out defaults instead of taking down the shell.
+    void useExperimentalFlags.getState().refresh(client);
     return () => {
       cancelled = true;
     };

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -374,6 +374,7 @@ export class ApiClient {
     sandbox_agent_checkin_steps?: number;
     sandbox_agent_error_checkin?: number;
     model_visibility_overrides?: Record<string, ModelVisibility>;
+    code_mode_enabled?: boolean;
     compaction?: {
       threshold_fraction?: number;
       target_fraction?: number;

--- a/crates/tidebreak-desktop/ui/src/code/CodeModeGate.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeModeGate.tsx
@@ -1,0 +1,48 @@
+import { useNavigate } from "@tanstack/react-router";
+import type { ReactNode } from "react";
+import { FlaskConical } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { useExperimentalFlags } from "@/experimental";
+import { RouteFrame } from "@/RouteFrame";
+import { AppSidebar } from "@/sidebar/AppSidebar";
+
+/**
+ * Keeps the code-mode pages behind the experimental opt-in.
+ *
+ * The routes still resolve — a deep link or a stale history entry lands on
+ * this explanation rather than a dead end — but nothing code-mode renders
+ * until the reader has flipped the switch. Until the flags load the gate
+ * shows nothing rather than flashing a surface it may be about to hide.
+ */
+export function CodeModeGate({ children }: { children: ReactNode }) {
+  const navigate = useNavigate();
+  const loaded = useExperimentalFlags((state) => state.loaded);
+  const enabled = useExperimentalFlags((state) => state.codeModeEnabled);
+  if (enabled) return <>{children}</>;
+  return (
+    <RouteFrame sidebar={<AppSidebar />}>
+      <div className="content-container flex w-full flex-1 items-center justify-center">
+        {loaded && (
+          <div className="flex max-w-sm flex-col items-center gap-3 text-center">
+            <FlaskConical className="text-muted-foreground size-6" />
+            <h1 className="text-lg font-medium">Code mode is experimental</h1>
+            <p className="text-muted-foreground text-sm">
+              Drive coding agents like Claude Code in isolated workspaces on
+              your repositories. Turn it on to try it.
+            </p>
+            <Button
+              type="button"
+              onClick={() => {
+                const experimentalPath: string = "/settings/experimental";
+                void navigate({ to: experimentalPath });
+              }}
+            >
+              Open experimental settings
+            </Button>
+          </div>
+        )}
+      </div>
+    </RouteFrame>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/experimental.ts
+++ b/crates/tidebreak-desktop/ui/src/experimental.ts
@@ -1,0 +1,36 @@
+import { create } from "zustand";
+
+import type { ApiClient } from "./api";
+
+/**
+ * Experimental feature flags, read from `/settings` once the shell has a
+ * client and rewritten by the Experimental settings panel.
+ *
+ * Surfaces gate on the flag *and* `loaded`: until the fetch lands the app
+ * behaves as opted out, so an experimental surface never flashes into a rail
+ * it is about to leave. There is exactly one answer in the tree at a time —
+ * panels that toggle a flag write it back here instead of refetching.
+ */
+
+type ExperimentalFlagsStore = {
+  loaded: boolean;
+  codeModeEnabled: boolean;
+  refresh: (client: ApiClient) => Promise<void>;
+  setCodeModeEnabled: (enabled: boolean) => void;
+};
+
+export const useExperimentalFlags = create<ExperimentalFlagsStore>()((set) => ({
+  loaded: false,
+  codeModeEnabled: false,
+  refresh: async (client) => {
+    try {
+      const settings = await client.getSettings();
+      set({ loaded: true, codeModeEnabled: settings.code_mode_enabled });
+    } catch {
+      // A failed read keeps the opted-out default; the flags load again with
+      // the next shell boot, and nothing user-facing breaks meanwhile.
+      set({ loaded: true });
+    }
+  },
+  setCodeModeEnabled: (enabled) => set({ codeModeEnabled: enabled }),
+}));

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -3051,7 +3051,13 @@ model_visibility_overrides: { [key in string]: ModelVisibility },
  * enabled. Read at boot; turning it off unregisters the tools on the next
  * launch.
  */
-computer_use_enabled: boolean, };
+computer_use_enabled: boolean, 
+/**
+ * Whether the experimental code-mode surface is shown. Opt-in: default
+ * off, flipped in Settings → Experimental. The flag gates the desktop's
+ * navigation and pages, not the `/code/*` routes themselves.
+ */
+code_mode_enabled: boolean, };
 
 /**
  * Renderer-safe progress of the current sign-in attempt.

--- a/crates/tidebreak-desktop/ui/src/router.tsx
+++ b/crates/tidebreak-desktop/ui/src/router.tsx
@@ -22,6 +22,7 @@ import { SettingsRoute } from "./SettingsRoute";
 import { defaultSettingsPathFor, SETTINGS_SECTIONS } from "./settings/sections";
 import { AppSidebar } from "./sidebar/AppSidebar";
 import { CodeHome } from "./code/CodeHome";
+import { CodeModeGate } from "./code/CodeModeGate";
 import { CodeRepoPage } from "./code/CodeRepoPage";
 import { CodeWorkspacePage } from "./code/CodeWorkspacePage";
 
@@ -205,7 +206,11 @@ function ProjectRouteComponent() {
 const codeRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/code",
-  component: CodeHome,
+  component: () => (
+    <CodeModeGate>
+      <CodeHome />
+    </CodeModeGate>
+  ),
 });
 
 const codeRepoRoute = createRoute({
@@ -216,7 +221,11 @@ const codeRepoRoute = createRoute({
 
 function CodeRepoRouteComponent() {
   const { repoId } = codeRepoRoute.useParams();
-  return <CodeRepoPage key={repoId} repoId={repoId} />;
+  return (
+    <CodeModeGate>
+      <CodeRepoPage key={repoId} repoId={repoId} />
+    </CodeModeGate>
+  );
 }
 
 const codeWorkspaceRoute = createRoute({
@@ -228,7 +237,11 @@ const codeWorkspaceRoute = createRoute({
 
 function CodeWorkspaceRouteComponent() {
   const { workspaceId } = codeWorkspaceRoute.useParams();
-  return <CodeWorkspacePage key={workspaceId} workspaceId={workspaceId} />;
+  return (
+    <CodeModeGate>
+      <CodeWorkspacePage key={workspaceId} workspaceId={workspaceId} />
+    </CodeModeGate>
+  );
 }
 
 export const settingsRoute = createRoute({

--- a/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.dom.test.tsx
@@ -35,6 +35,7 @@ describe("AgentsPanel", () => {
       },
       model_visibility_overrides: {},
       computer_use_enabled: true,
+      code_mode_enabled: false,
     };
     const putSettings = vi.fn().mockResolvedValue({
       ...settings,

--- a/crates/tidebreak-desktop/ui/src/settings/ExperimentalPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/ExperimentalPanel.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { toast } from "sonner";
+
+import type { ApiClient } from "../api";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { useExperimentalFlags } from "@/experimental";
+import { friendlyErrorMessage } from "@/lib/utils";
+import { SettingsError, SettingsPanel, SettingsSection } from "./primitives";
+
+/**
+ * Features that are usable but not settled: each row is one opt-in switch.
+ *
+ * The panel is the writer of record for the experimental flags store — the
+ * toggle persists through `PUT /settings` first and only then updates the
+ * store, so a rail never shows a surface the server did not accept.
+ */
+export function ExperimentalPanel({ client }: { client: ApiClient }) {
+  const navigate = useNavigate();
+  const codeModeEnabled = useExperimentalFlags((state) => state.codeModeEnabled);
+  const setCodeModeEnabled = useExperimentalFlags(
+    (state) => state.setCodeModeEnabled,
+  );
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // The shell seeds the store at boot; re-reading on mount keeps the panel
+  // honest after another window changed the flag.
+  useEffect(() => {
+    void useExperimentalFlags.getState().refresh(client);
+  }, [client]);
+
+  async function toggleCodeMode(enabled: boolean) {
+    setSaving(true);
+    setError(null);
+    try {
+      const settings = await client.putSettings({ code_mode_enabled: enabled });
+      setCodeModeEnabled(settings.code_mode_enabled);
+    } catch (err) {
+      setError(friendlyErrorMessage(err, "Could not save the setting"));
+      toast.error("Could not save the setting");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <SettingsPanel
+      title="Experimental"
+      description="Features that work but are still settling. Each is off until you turn it on, and turning one off hides it again without deleting anything."
+      busy={saving}
+    >
+      <SettingsSection>
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex flex-col gap-1">
+            <span className="font-bold">Code mode</span>
+            <span className="text-muted-foreground text-sm">
+              Drive coding agents — Claude Code, Codex CLI, opencode, Grok CLI —
+              in isolated worktree workspaces on your repositories, with
+              approvals, per-turn diffs, and a pull-request flow.
+            </span>
+          </div>
+          <Switch
+            aria-label="Code mode"
+            checked={codeModeEnabled}
+            disabled={saving}
+            onCheckedChange={(checked) => void toggleCodeMode(checked)}
+          />
+        </div>
+        {codeModeEnabled && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="self-start"
+            onClick={() => void navigate({ to: "/code" })}
+          >
+            Open code mode
+          </Button>
+        )}
+        {error && <SettingsError>{error}</SettingsError>}
+      </SettingsSection>
+    </SettingsPanel>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/settings/sections.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/sections.tsx
@@ -4,6 +4,7 @@ import {
   Blocks,
   Bot,
   Cpu,
+  FlaskConical,
   Gauge,
   Globe,
   KeyRound,
@@ -33,6 +34,7 @@ import { UpdatesPanel } from "./UpdatesPanel";
 import { WebSearchPanel } from "./WebSearchPanel";
 import { VoiceTranscriptionPanel } from "./VoiceTranscriptionPanel";
 import { CodingHarnessesPanel } from "./CodingHarnessesPanel";
+import { ExperimentalPanel } from "./ExperimentalPanel";
 
 /**
  * Each section reads what it needs from the shell context rather than being
@@ -184,6 +186,11 @@ function CodingHarnessesSection() {
   return <CodingHarnessesPanel client={client} />;
 }
 
+function ExperimentalSection() {
+  const { client } = useApp();
+  return <ExperimentalPanel client={client} />;
+}
+
 export type SettingsSectionDef = {
   /** The path segment under `/settings`, and its address. */
   path: string;
@@ -200,6 +207,9 @@ export type SettingsSectionDef = {
   /** Kept out of the rail on an unmanaged profile, same deep-link contract:
    * the route resolves and the panel renders its not-connected state. */
   unmanagedHidden?: boolean;
+  /** Kept out of the rail until the code-mode experiment is enabled, same
+   * deep-link contract: the route resolves either way. */
+  codeModeOnly?: boolean;
 };
 
 /**
@@ -246,6 +256,7 @@ export const SETTINGS_SECTIONS: SettingsSectionDef[] = [
     label: "Coding harnesses",
     icon: Terminal,
     Component: CodingHarnessesSection,
+    codeModeOnly: true,
   },
   {
     path: "connected-apps",
@@ -260,6 +271,12 @@ export const SETTINGS_SECTIONS: SettingsSectionDef[] = [
     Component: PermissionsSection,
   },
   { path: "appearance", label: "Appearance", icon: Palette, Component: AppearanceSection },
+  {
+    path: "experimental",
+    label: "Experimental",
+    icon: FlaskConical,
+    Component: ExperimentalSection,
+  },
   { path: "updates", label: "Updates", icon: RefreshCw, Component: UpdatesSection },
 ];
 
@@ -272,10 +289,17 @@ export const SETTINGS_SECTIONS: SettingsSectionDef[] = [
  * where settings opens. An unmanaged profile has no gateway at all — policy
  * is the only gateway source, and connecting happens from the gateway's own
  * page — so the Model Gateway section is dropped from its rail instead.
+ * Sections belonging to the code-mode experiment leave the rail while it is
+ * opted out.
  */
-export function settingsSectionsFor(managed: boolean): SettingsSectionDef[] {
-  return SETTINGS_SECTIONS.filter((section) =>
-    managed ? !section.managedHidden : !section.unmanagedHidden,
+export function settingsSectionsFor(
+  managed: boolean,
+  codeModeEnabled = false,
+): SettingsSectionDef[] {
+  return SETTINGS_SECTIONS.filter(
+    (section) =>
+      (managed ? !section.managedHidden : !section.unmanagedHidden) &&
+      (!section.codeModeOnly || codeModeEnabled),
   );
 }
 

--- a/crates/tidebreak-desktop/ui/src/sidebar/AppSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/AppSidebar.tsx
@@ -5,6 +5,7 @@ import { FolderGit2, LayoutGrid, Puzzle, SquarePen } from "lucide-react";
 import type { Chat } from "@/api";
 import { useApp } from "@/AppContext";
 import { useChatListStore } from "@/ChatListStore";
+import { useExperimentalFlags } from "@/experimental";
 import { ChatsSection } from "./ChatsSection";
 import { InboxButton } from "./InboxButton";
 import { ProjectsSection } from "./ProjectsSection";
@@ -31,6 +32,7 @@ export function AppSidebar({ chat }: { chat?: Chat }) {
   const deletingChatId = useChatListStore((state) => state.deletingChatId);
   const pathname = useRouterState({ select: (state) => state.location.pathname });
   const isCompact = useSidebarWidth() === "compact";
+  const codeModeEnabled = useExperimentalFlags((state) => state.codeModeEnabled);
 
   return (
     <SidebarFrame>
@@ -64,12 +66,16 @@ export function AppSidebar({ chat }: { chat?: Chat }) {
           active={pathname === "/plugins" || pathname.startsWith("/plugins/")}
           onClick={() => void navigate({ to: "/plugins" })}
         />
-        <RouteButton
-          label="Code"
-          icon={<FolderGit2 />}
-          active={pathname === "/code" || pathname.startsWith("/code/")}
-          onClick={() => void navigate({ to: "/code" })}
-        />
+        {/* Experimental and opt-in: the rail lists Code only after the reader
+            enables it under Settings → Experimental. */}
+        {codeModeEnabled && (
+          <RouteButton
+            label="Code"
+            icon={<FolderGit2 />}
+            active={pathname === "/code" || pathname.startsWith("/code/")}
+            onClick={() => void navigate({ to: "/code" })}
+          />
+        )}
       </div>
 
       <ProjectsSection activeChatId={chat?.id} />

--- a/crates/tidebreak-desktop/ui/src/sidebar/SettingsSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/SettingsSidebar.tsx
@@ -1,6 +1,7 @@
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 import { ArrowLeft, PanelLeftOpen } from "lucide-react";
 
+import { useExperimentalFlags } from "@/experimental";
 import { useManagedPolicy } from "@/managedPolicy";
 import { settingsSectionsFor } from "@/settings/sections";
 import { useUiStore } from "@/UiStore";
@@ -22,7 +23,8 @@ export function SettingsSidebar({ onBack }: { onBack: () => void }) {
   const isCompact = useSidebarWidth() === "compact";
   const pathname = useRouterState({ select: (state) => state.location.pathname });
   const { managed } = useManagedPolicy();
-  const sections = settingsSectionsFor(managed);
+  const codeModeEnabled = useExperimentalFlags((state) => state.codeModeEnabled);
+  const sections = settingsSectionsFor(managed, codeModeEnabled);
 
   return (
     <Sidebar>

--- a/crates/tidebreak-server/src/routes.rs
+++ b/crates/tidebreak-server/src/routes.rs
@@ -15,6 +15,11 @@ pub(crate) const MODEL_VISIBILITY_OVERRIDES_SETTING: &str = "models.visibility_o
 /// Master switch for the computer-use capability (screen capture + app
 /// control). Default on; setting it false unregisters the tools at boot.
 pub(crate) const COMPUTER_USE_ENABLED_SETTING: &str = "computer_use.enabled";
+/// Opt-in switch for the experimental code-mode surface. Default off: the
+/// desktop hides the surface until the reader enables it in Settings →
+/// Experimental. The `/code/*` routes keep serving either way — the flag
+/// gates discovery, not data.
+pub(crate) const CODE_MODE_ENABLED_SETTING: &str = "code_mode.enabled";
 
 mod agent_runs;
 mod app_gateway_page;

--- a/crates/tidebreak-server/src/routes/settings.rs
+++ b/crates/tidebreak-server/src/routes/settings.rs
@@ -143,6 +143,10 @@ pub struct Settings {
     /// enabled. Read at boot; turning it off unregisters the tools on the next
     /// launch.
     pub computer_use_enabled: bool,
+    /// Whether the experimental code-mode surface is shown. Opt-in: default
+    /// off, flipped in Settings → Experimental. The flag gates the desktop's
+    /// navigation and pages, not the `/code/*` routes themselves.
+    pub code_mode_enabled: bool,
 }
 
 /// The reader's last explicit per-chat choices — what an unspecified field of
@@ -190,6 +194,10 @@ pub struct SettingsUpdate {
     /// at the next boot (the tools register or not then).
     #[serde(default)]
     pub computer_use_enabled: Option<bool>,
+    /// Opt in to (or back out of) the experimental code-mode surface. Absent
+    /// leaves it unchanged; applies immediately.
+    #[serde(default)]
+    pub code_mode_enabled: Option<bool>,
 }
 
 /// Partial update for [`CompactionSettings`]. Absent fields leave the current
@@ -334,6 +342,15 @@ pub async fn put_settings(
             )
             .await?;
     }
+    if let Some(enabled) = body.code_mode_enabled {
+        state
+            .store
+            .set_setting(
+                crate::routes::CODE_MODE_ENABLED_SETTING,
+                &serde_json::json!(enabled),
+            )
+            .await?;
+    }
     Ok(Json(
         read_settings(&state, &auth.principal.owner_id()).await?,
     ))
@@ -352,6 +369,7 @@ async fn read_settings(state: &AppState, owner: &OwnerId) -> Result<Settings, Se
         compaction: read_compaction_settings(&*state.store).await?,
         model_visibility_overrides: read_model_visibility_overrides(&*state.store).await?,
         computer_use_enabled: read_computer_use_enabled(&*state.store).await?,
+        code_mode_enabled: read_code_mode_enabled(&*state.store).await?,
     })
 }
 
@@ -363,6 +381,16 @@ pub(crate) async fn read_computer_use_enabled(store: &dyn Store) -> tidebreak_co
         .await?
         .and_then(|value| value.as_bool())
         .unwrap_or(true))
+}
+
+/// Whether the experimental code-mode surface is shown. Default **off** —
+/// the surface is opt-in, and only an explicit `true` reveals it.
+pub(crate) async fn read_code_mode_enabled(store: &dyn Store) -> tidebreak_core::Result<bool> {
+    Ok(store
+        .get_setting(crate::routes::CODE_MODE_ENABLED_SETTING)
+        .await?
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false))
 }
 
 /// The largest number of stored visibility deviations.

--- a/crates/tidebreak-server/src/tests/configuration.rs
+++ b/crates/tidebreak-server/src/tests/configuration.rs
@@ -93,6 +93,9 @@ async fn settings_default_then_update_roundtrips() {
     assert_eq!(settings["compaction"]["target_fraction"], 0.25);
     assert_eq!(settings["compaction"]["min_threshold_tokens"], 50000);
     assert_eq!(settings["compaction"]["protect_recent_messages"], 5);
+    // Code mode is experimental and opt-in: the surface must not appear
+    // until the reader flips it, so the default is the decision.
+    assert_eq!(settings["code_mode_enabled"], false);
 
     // PUT a model, and it comes back.
     let response = router
@@ -114,7 +117,8 @@ async fn settings_default_then_update_roundtrips() {
                             "target_fraction": 0.3,
                             "min_threshold_tokens": 40000,
                             "protect_recent_messages": 8
-                        }
+                        },
+                        "code_mode_enabled": true
                     })
                     .to_string(),
                 ))
@@ -132,6 +136,7 @@ async fn settings_default_then_update_roundtrips() {
     assert_eq!(settings["compaction"]["target_fraction"], 0.3);
     assert_eq!(settings["compaction"]["min_threshold_tokens"], 40000);
     assert_eq!(settings["compaction"]["protect_recent_messages"], 8);
+    assert_eq!(settings["code_mode_enabled"], true);
 
     // GET reflects the update.
     let response = router


### PR DESCRIPTION
Code mode sat in every profile's rail while it is still an experiment. This adds a **Settings → Experimental** section and puts code mode behind its switch, off by default.

## What changed

**Server**
- New runtime setting `code_mode_enabled` on `GET/PUT /settings` (key `code_mode.enabled`), **default false** — the default is pinned in the settings round-trip test, since "ships opt-in" is the decision that would otherwise be easy to lose.

**Desktop**
- New **Experimental** settings section (flask icon, between Appearance and Updates) with the Code mode switch and a jump into the surface once enabled. Copy states the contract: off by default, turning one off hides it without deleting anything.
- The app rail lists **Code** only while opted in. The `/code` routes still resolve — a deep link or stale history entry lands on a short "Code mode is experimental" explanation with a button to the Experimental panel, per the same deep-link contract the settings rail already follows.
- The **Coding harnesses** settings section leaves the rail with the flag (its route also still resolves).
- Flags load once at shell boot into a small store (`useExperimentalFlags`); until they load the app behaves as opted out, so the rail never flashes an entry it is about to hide. The panel persists through `PUT /settings` first and only then updates the store.

**Deliberately not gated**: the `/code/*` routes and the `tidebreak code` CLI. The flag gates discovery, not data — existing workspaces and sessions survive an opt-out untouched, there is no engine-lifecycle edge case on toggle, and invoking `tidebreak code` is already an explicit act.

## Driven over the wire

Against a fresh profile with `tidebreak serve`: `GET /settings` answers `code_mode_enabled: false` by default; `PUT {"code_mode_enabled": true}` persists and reads back; toggling back off leaves `computer_use_enabled` and the rest untouched; `tidebreak code doctor` keeps working while opted out.

Not verified live: the desktop rail/gate rendering (covered by `tsc`, the 1089-test suite, and `pnpm build`).