### PR TITLE
feat(desktop): widen the sidebar and make it resizable

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
@@ -8,7 +8,7 @@ import { usePendingPrompts } from "./PendingPrompts";
 import { useProjectListStore } from "./ProjectListStore";
 import { useRefreshSignals } from "./RefreshSignals";
 import { useChatsSectionState } from "./sidebar/ChatsSection";
-import { useUiStore } from "./UiStore";
+import { SIDEBAR_DEFAULT_WIDTH, useUiStore } from "./UiStore";
 
 /**
  * The shell and the routing around it, exercised the way the app runs: boot
@@ -273,7 +273,7 @@ beforeEach(() => {
     savingProjectTitle: false,
     expandedProjectIds: [],
   });
-  useUiStore.setState({ sidebarCollapsed: false });
+  useUiStore.setState({ sidebarCollapsed: false, sidebarWidth: SIDEBAR_DEFAULT_WIDTH });
   // Module-level chrome state survives a render, so a test that collapsed or
   // filtered the list would otherwise decide the next one's rail.
   useChatsSectionState.setState({ collapsed: false, filtering: false, query: "" });

--- a/crates/tidebreak-desktop/ui/src/UiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/UiStore.ts
@@ -1,10 +1,22 @@
 import { create } from "zustand";
 
 const SIDEBAR_COLLAPSED_KEY = "tidebreak.sidebar-collapsed";
+const SIDEBAR_WIDTH_KEY = "tidebreak.sidebar-width";
 const MODEL_MENU_NOT_CONNECTED_KEY = "tidebreak.model-menu-not-connected-collapsed";
 const ACTIVE_TURN_SEND_MODE_KEY = "tidebreak.composer.sendMode";
 
 export type ActiveTurnSendMode = "queue" | "steer";
+
+/** Expanded rail width bounds, in CSS pixels. */
+export const SIDEBAR_MIN_WIDTH = 200;
+export const SIDEBAR_MAX_WIDTH = 480;
+/** Default expanded width — a touch wider than the old fixed 224px rail. */
+export const SIDEBAR_DEFAULT_WIDTH = 280;
+
+export function clampSidebarWidth(width: number): number {
+  if (!Number.isFinite(width)) return SIDEBAR_DEFAULT_WIDTH;
+  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, Math.round(width)));
+}
 
 function readStoredSidebarCollapsed(): boolean {
   try {
@@ -17,6 +29,24 @@ function readStoredSidebarCollapsed(): boolean {
 function storeSidebarCollapsed(collapsed: boolean): void {
   try {
     window.localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(collapsed));
+  } catch {
+    // Preference persistence is best-effort.
+  }
+}
+
+function readStoredSidebarWidth(): number {
+  try {
+    const raw = window.localStorage.getItem(SIDEBAR_WIDTH_KEY);
+    if (raw == null) return SIDEBAR_DEFAULT_WIDTH;
+    return clampSidebarWidth(Number(raw));
+  } catch {
+    return SIDEBAR_DEFAULT_WIDTH;
+  }
+}
+
+function storeSidebarWidth(width: number): void {
+  try {
+    window.localStorage.setItem(SIDEBAR_WIDTH_KEY, String(width));
   } catch {
     // Preference persistence is best-effort.
   }
@@ -58,7 +88,7 @@ function storeActiveTurnSendMode(mode: ActiveTurnSendMode): void {
 
 /**
  * Chrome state that belongs to no conversation and does not deserve a URL:
- * whether the sidebar is showing.
+ * whether the sidebar is showing, and how wide the expanded rail is.
  *
  * Where the workspace is pointed used to live here too. It is in the URL now,
  * because a layout that cannot be linked at cannot be the target of a citation.
@@ -66,6 +96,13 @@ function storeActiveTurnSendMode(mode: ActiveTurnSendMode): void {
 export type UiStore = {
   sidebarCollapsed: boolean;
   toggleSidebar: () => void;
+  /** Expanded rail width in CSS pixels. Ignored while the rail is compact. */
+  sidebarWidth: number;
+  /**
+   * Set the expanded rail width. Pass `{ persist: false }` while dragging so
+   * localStorage is only written once the pointer is up.
+   */
+  setSidebarWidth: (width: number, options?: { persist?: boolean }) => void;
   /**
    * Whether the model picker's "Not connected" section is folded away. Open by
    * default — the section exists to be noticed once — and remembered after
@@ -87,6 +124,12 @@ export function createUiStore() {
         storeSidebarCollapsed(sidebarCollapsed);
         return { sidebarCollapsed };
       }),
+    sidebarWidth: readStoredSidebarWidth(),
+    setSidebarWidth: (width, options) => {
+      const sidebarWidth = clampSidebarWidth(width);
+      if (options?.persist !== false) storeSidebarWidth(sidebarWidth);
+      set({ sidebarWidth });
+    },
     modelMenuNotConnectedCollapsed: readStoredNotConnectedCollapsed(),
     toggleModelMenuNotConnected: () =>
       set((state) => {

--- a/crates/tidebreak-desktop/ui/src/sidebar/primitives.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/primitives.tsx
@@ -1,4 +1,12 @@
-import { forwardRef, useState, type ComponentProps } from "react";
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ComponentProps,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
 import { Slot } from "@radix-ui/react-slot";
 
 import {
@@ -8,7 +16,12 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import { useUiStore } from "@/UiStore";
+import {
+  SIDEBAR_DEFAULT_WIDTH,
+  SIDEBAR_MAX_WIDTH,
+  SIDEBAR_MIN_WIDTH,
+  useUiStore,
+} from "@/UiStore";
 
 /**
  * The navigation rail, in two widths.
@@ -16,7 +29,7 @@ import { useUiStore } from "@/UiStore";
  * Compact keeps the rail rather than hiding it: a sidebar that disappears takes
  * the way back with it, and the reader is left hunting for a control to bring
  * it back. Collapsed here means icons only, still reachable, with each item's
- * name in a tooltip.
+ * name in a tooltip. Expanded width is reader-chosen and remembered.
  */
 export type SidebarWidth = "compact" | "expanded";
 
@@ -24,30 +37,151 @@ export function useSidebarWidth(): SidebarWidth {
   return useUiStore((state) => (state.sidebarCollapsed ? "compact" : "expanded"));
 }
 
+/**
+ * Publish the expanded rail width onto the shell so chrome that sits over the
+ * rail (the titlebar) can track it without reading the store itself.
+ */
+function useSyncSidebarWidthCssVar(widthPx: number, isCompact: boolean) {
+  useEffect(() => {
+    const shell = document.querySelector<HTMLElement>(".app-shell");
+    if (!shell) return;
+    if (isCompact) {
+      shell.style.removeProperty("--sidebar-expanded-width");
+      return;
+    }
+    shell.style.setProperty("--sidebar-expanded-width", `${widthPx}px`);
+  }, [widthPx, isCompact]);
+}
+
+/**
+ * Drag handle on the rail's trailing edge. Double-click restores the default
+ * width. Lives outside react-resizable-panels so the rail stays independent of
+ * the conversation/panel split beside it.
+ */
+function SidebarResizeHandle({
+  onDraggingChange,
+}: {
+  onDraggingChange: (dragging: boolean) => void;
+}) {
+  const sidebarWidth = useUiStore((state) => state.sidebarWidth);
+  const setSidebarWidth = useUiStore((state) => state.setSidebarWidth);
+  const dragRef = useRef<{ pointerId: number; startX: number; startWidth: number } | null>(
+    null,
+  );
+  const [dragging, setDragging] = useState(false);
+
+  const endDrag = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current;
+      if (!drag || drag.pointerId !== event.pointerId) return;
+      dragRef.current = null;
+      setDragging(false);
+      onDraggingChange(false);
+      // Commit the live width once; moves during the drag skipped persistence.
+      setSidebarWidth(useUiStore.getState().sidebarWidth);
+      try {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      } catch {
+        // Capture may already be released.
+      }
+      document.body.style.removeProperty("cursor");
+      document.body.style.removeProperty("user-select");
+    },
+    [onDraggingChange, setSidebarWidth],
+  );
+
+  const onPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    dragRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startWidth: sidebarWidth,
+    };
+    setDragging(true);
+    onDraggingChange(true);
+    event.currentTarget.setPointerCapture(event.pointerId);
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+  };
+
+  const onPointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    setSidebarWidth(drag.startWidth + (event.clientX - drag.startX), { persist: false });
+  };
+
+  const onDoubleClick = () => {
+    setSidebarWidth(SIDEBAR_DEFAULT_WIDTH);
+  };
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize sidebar"
+      aria-valuemin={SIDEBAR_MIN_WIDTH}
+      aria-valuemax={SIDEBAR_MAX_WIDTH}
+      aria-valuenow={sidebarWidth}
+      tabIndex={0}
+      className="group absolute top-0 right-0 z-20 hidden h-full w-2 translate-x-1/2 cursor-col-resize touch-none md:block"
+      data-dragging={dragging || undefined}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+      onDoubleClick={onDoubleClick}
+      onKeyDown={(event) => {
+        const step = event.shiftKey ? 32 : 16;
+        if (event.key === "ArrowLeft") {
+          event.preventDefault();
+          setSidebarWidth(sidebarWidth - step);
+        } else if (event.key === "ArrowRight") {
+          event.preventDefault();
+          setSidebarWidth(sidebarWidth + step);
+        } else if (event.key === "Home") {
+          event.preventDefault();
+          setSidebarWidth(SIDEBAR_MIN_WIDTH);
+        } else if (event.key === "End") {
+          event.preventDefault();
+          setSidebarWidth(SIDEBAR_MAX_WIDTH);
+        }
+      }}
+    >
+      <div className="absolute top-0 right-1 bottom-0 w-[0.5px] bg-border transition-all group-hover:w-px group-hover:translate-x-[0.5px] group-hover:bg-foreground/35 group-hover:delay-75 group-data-[dragging]:bg-foreground/75" />
+      <div className="absolute top-1/2 right-0 h-6 w-2 -translate-y-1/2 cursor-col-resize rounded-full border-[0.5px] border-border bg-background opacity-0 shadow transition duration-200 group-hover:opacity-100 group-hover:delay-75 group-data-[dragging]:opacity-100 group-data-[dragging]:border-foreground/10 group-data-[dragging]:bg-foreground" />
+    </div>
+  );
+}
+
 export function Sidebar({ className, children, ...props }: ComponentProps<"div">) {
   const width = useSidebarWidth();
   const isCompact = width === "compact";
+  const sidebarWidthPx = useUiStore((state) => state.sidebarWidth);
+  const [resizing, setResizing] = useState(false);
+  useSyncSidebarWidthCssVar(sidebarWidthPx, isCompact);
 
   return (
     <TooltipProvider>
       <div
         {...props}
         className={cn(
-          "relative flex flex-col overflow-hidden transition-all duration-200",
-          isCompact && "shrink-0",
+          "relative flex shrink-0 flex-col overflow-hidden",
+          // Animate collapse/expand, but not live drags — easing lags the pointer.
+          !isCompact && !resizing && "transition-[flex-basis,min-width,width] duration-200",
           className,
         )}
         style={{
-          flex: isCompact ? "0 0 var(--sidebar-compact-width)" : "var(--sidebar-expanded-flex)",
-          // Above 1600px, --sidebar-expanded-flex sets flex-shrink to 1 so the
-          // rail can grow with the window. Without a min-width floor, that same
-          // shrink lets a second open content panel squeeze the rail down to a
-          // sliver instead of taking space from the panels themselves.
-          minWidth: isCompact ? "var(--sidebar-compact-width)" : "var(--sidebar-expanded-min)",
+          flex: isCompact
+            ? "0 0 var(--sidebar-compact-width)"
+            : `0 0 ${sidebarWidthPx}px`,
+          minWidth: isCompact ? "var(--sidebar-compact-width)" : `${sidebarWidthPx}px`,
+          width: isCompact ? undefined : sidebarWidthPx,
         }}
         data-sidebar={width}
       >
         {children}
+        {!isCompact && <SidebarResizeHandle onDraggingChange={setResizing} />}
       </div>
     </TooltipProvider>
   );

--- a/crates/tidebreak-desktop/ui/src/styles.css
+++ b/crates/tidebreak-desktop/ui/src/styles.css
@@ -71,10 +71,10 @@
   --container-margin: 0.5rem;
   --container-border: 1px;
 
-  /* Sidebar rail: a fixed 224px until the window is wide enough to spend more. */
-  --sidebar-expanded-min: calc(var(--spacing) * 56);
-  --sidebar-expanded-max: calc(var(--spacing) * 80);
-  --sidebar-expanded-flex: 0 0 var(--sidebar-expanded-min);
+  /* Sidebar rail: reader-resizable; JS sets --sidebar-expanded-width on the shell. */
+  --sidebar-expanded-min: 200px;
+  --sidebar-expanded-max: 480px;
+  --sidebar-expanded-width: 280px;
   --sidebar-compact-width: calc(var(--spacing) * 14);
   /* macOS overlay traffic lights at trafficLightPosition (16, 20), plus a
      gap before the history buttons. The compact rail is narrower than this. */
@@ -250,15 +250,6 @@
   --shadow-lg: var(--shadow-lg);
   --shadow-xl: var(--shadow-lg);
   --shadow-2xl: var(--shadow-lg);
-}
-
-/* Above 1600px the sidebar is allowed to grow with the window rather than
-   leaving an increasingly wide gutter beside a fixed rail. */
-@media (min-width: 1600px) {
-  :root {
-    --sidebar-expanded-flex: 0 1
-      clamp(var(--sidebar-expanded-min), 15%, var(--sidebar-expanded-max));
-  }
 }
 
 * {
@@ -1619,7 +1610,7 @@ body {
   left: 0;
   z-index: 40;
   display: flex;
-  width: var(--sidebar-expanded-min);
+  width: var(--sidebar-expanded-width);
   height: 40px;
   align-items: center;
   gap: 0.5rem;


### PR DESCRIPTION
## Summary
- Raise the expanded sidebar default from 224px to 280px.
- Add a trailing-edge drag handle (with keyboard support and double-click reset) so the rail width can be resized between 200–480px.
- Remember the chosen width in localStorage and keep the overlaid titlebar aligned with the rail.

## Test plan
- [ ] Expand the sidebar and confirm it opens wider than before (~280px).
- [ ] Drag the right edge to resize; width should track the pointer without lag.
- [ ] Reload the app and confirm the chosen width is restored.
- [ ] Double-click the handle to reset to the default width.
- [ ] Collapse and expand again; preferred expanded width should return.
- [ ] Confirm the titlebar/history controls still sit over the rail at the new width (macOS overlay titlebar included).
- [ ] Open a content panel beside chat and confirm the sidebar resize remains independent of the chat/panel split.