### PR TITLE
fix(desktop): navigate after archive and repair the code pane height chain

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.ts
@@ -32,7 +32,7 @@ type CodeCatalogStore = CodeCatalogState & {
     "listCodeRepos" | "listCodeWorkspaces" | "getHarnessDoctor"
   >) => Promise<void>;
   rememberSession: (session: CodeSessionSnapshot) => void;
-  forgetWorkspace: (workspaceId: string) => void;
+  forgetWorkspaceSession: (workspaceId: string) => void;
   upsertRepo: (repo: CodeRepoSnapshot) => void;
   upsertWorkspace: (workspace: CodeWorkspaceSnapshot) => void;
   reset: () => void;
@@ -68,13 +68,10 @@ export const useCodeCatalogStore = create<CodeCatalogStore>()((set, get) => ({
       },
     });
   },
-  forgetWorkspace: (workspaceId) => {
+  forgetWorkspaceSession: (workspaceId) => {
     const { [workspaceId]: _removed, ...sessionsByWorkspace } =
       get().sessionsByWorkspace;
-    set({
-      sessionsByWorkspace,
-      workspaces: get().workspaces.filter((item) => item.id !== workspaceId),
-    });
+    set({ sessionsByWorkspace });
   },
   upsertRepo: (repo) => {
     set({

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -44,7 +44,7 @@ export function CodeTranscript({
     );
   }
   return (
-    <div className="flex flex-col gap-3 px-4 py-4">
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-3 px-4 py-4">
       {items.map((item) => (
         <TranscriptItem
           key={item.id}

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -1,0 +1,206 @@
+// @vitest-environment jsdom
+import type { ReactNode } from "react";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+
+import { AppContextProvider, type AppContextValue } from "@/AppContext";
+import type { PanelSearch } from "@/panel/panelUrl";
+import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { disconnectCodeUpdates, useCodeUpdatesStore } from "./CodeUpdatesStore";
+import { CodeWorkspacePage } from "./CodeWorkspacePage";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), message: vi.fn() },
+}));
+
+// The resize library lays out from real element measurements, which jsdom does
+// not provide; left alone it registers no regions and renders nothing.
+vi.mock("react-resizable-panels", () => ({
+  PanelGroup: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Panel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PanelResizeHandle: () => <div />,
+}));
+
+const WORKSPACE = {
+  id: "ws-1",
+  repo_id: "repo-1",
+  title: "Fix login",
+  worktree_path: "/tmp/app/.worktrees/fix-login",
+  branch_name: "tidebreak/fix-login",
+  base_ref: "main",
+  status: "active" as const,
+  created_at: "2026-08-15T00:00:00.000Z",
+};
+
+const REPO = {
+  id: "repo-1",
+  root_path: "/tmp/app",
+  display_name: "app",
+  default_base_ref: "main",
+  branch_prefix: "tidebreak",
+  quick_actions: [],
+  created_at: "2026-08-15T00:00:00.000Z",
+};
+
+function makeClient() {
+  return {
+    getCodeWorkspace: vi.fn(async () => WORKSPACE),
+    listCodeWorkspaceSessions: vi.fn(async () => []),
+    getCodeRepo: vi.fn(async () => REPO),
+    archiveCodeWorkspace: vi.fn(async () => ({
+      ...WORKSPACE,
+      status: "archived" as const,
+    })),
+    getCodeWorkspacePr: vi.fn(async () => ({
+      dirty: false,
+      unpushed: false,
+      ahead: 0,
+      has_upstream: false,
+      suggested_commit_message: "",
+      gh_found: true,
+      gh_authenticated: true,
+      remediation: "",
+    })),
+    listCodeRepos: vi.fn(async () => [REPO]),
+    listCodeWorkspaces: vi.fn(async () => [WORKSPACE]),
+    getHarnessDoctor: vi.fn(async () => ({ harnesses: [] })),
+    getCodeCloneDefaults: vi.fn(async () => ({
+      gh_found: false,
+      gh_remediation: "gh is not installed.",
+    })),
+    openCodeUpdates: vi.fn(
+      () =>
+        ({
+          close() {},
+          addEventListener() {},
+          removeEventListener() {},
+        }) as unknown as WebSocket,
+    ),
+  };
+}
+
+function appContext(client: ReturnType<typeof makeClient>): AppContextValue {
+  return {
+    client: client as never,
+    models: [],
+    defaultModelKey: null,
+    providers: [],
+    refreshCatalog: async () => {},
+    refreshChats: async () => {},
+    status: "",
+    setStatus: () => {},
+    newChat: () => {},
+    deleteChat: () => {},
+    startRename: () => {},
+    commitRename: () => {},
+    cancelRename: () => {},
+    newProject: async () => false,
+    deleteProject: () => {},
+    startProjectRename: () => {},
+    commitProjectRename: () => {},
+    cancelProjectRename: () => {},
+    newChatInProject: () => {},
+    moveChatToProject: () => {},
+    updateState: { status: "idle", version: null, error: null, enabled: false },
+    updateUpToDate: false,
+    checkForUpdate: async () => ({
+      status: "idle",
+      version: null,
+      error: null,
+      enabled: false,
+    }),
+    restartForUpdate: async () => {},
+  };
+}
+
+/**
+ * The workspace route renders the page under test; the repo route renders a
+ * marker instead, so an assertion can tell the two apart the way the running
+ * app does.
+ */
+async function mountWorkspace(client: ReturnType<typeof makeClient>) {
+  const rootRoute = createRootRoute();
+  const codeRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/code",
+    component: () => <p>code index</p>,
+  });
+  const codeRepoRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/code/r/$repoId",
+    component: () => <p>repo page</p>,
+  });
+  const codeWorkspaceRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/code/w/$workspaceId",
+    validateSearch: (search: Record<string, unknown>): PanelSearch => ({
+      tabs: typeof search.tabs === "string" ? search.tabs : undefined,
+      active: typeof search.active === "string" ? search.active : undefined,
+      fullscreen:
+        typeof search.fullscreen === "string" ? search.fullscreen : undefined,
+      left: typeof search.left === "string" ? search.left : undefined,
+      right: typeof search.right === "string" ? search.right : undefined,
+    }),
+    component: function WorkspaceRoute() {
+      const { workspaceId } = codeWorkspaceRoute.useParams();
+      return (
+        <AppContextProvider value={appContext(client)}>
+          <CodeWorkspacePage workspaceId={workspaceId} />
+        </AppContextProvider>
+      );
+    },
+  });
+
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([
+      codeRoute,
+      codeRepoRoute,
+      codeWorkspaceRoute,
+    ]),
+    history: createMemoryHistory({ initialEntries: ["/code/w/ws-1"] }),
+  });
+  await router.load();
+  const result = render(<RouterProvider router={router as never} />);
+  return { ...result, router };
+}
+
+afterEach(() => {
+  cleanup();
+  useCodeCatalogStore.getState().reset();
+  disconnectCodeUpdates();
+  useCodeUpdatesStore.getState().reset();
+});
+
+describe("CodeWorkspacePage", () => {
+  it("leaves the archived workspace for its repo", async () => {
+    const client = makeClient();
+    const { router } = await mountWorkspace(client);
+    const user = userEvent.setup();
+
+    expect(
+      await screen.findByRole("heading", { name: "Fix login" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Archive" }));
+    const confirmation = await screen.findByRole("alertdialog");
+    await user.click(
+      within(confirmation).getByRole("button", { name: "Archive" }),
+    );
+
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/code/r/repo-1"),
+    );
+    expect(client.archiveCodeWorkspace).toHaveBeenCalledWith("ws-1", false);
+    expect(
+      screen.queryByRole("heading", { name: "Fix login" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
 import { FileCode, Files, FolderOpen, SquareTerminal } from "lucide-react";
 import { toast } from "sonner";
 
@@ -67,6 +68,7 @@ export function CodeWorkspacePage({ workspaceId }: { workspaceId: string }) {
 function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const { client } = useApp();
   const { confirm, dialog } = useConfirm();
+  const navigate = useNavigate();
   const catalog = useCodeCatalogStore();
   const layout = useLayoutState();
   const { openPanel } = usePanelNav();
@@ -183,10 +185,25 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     force: boolean,
   ) {
     const archived = await api.archiveCodeWorkspace(id, force);
+    // The archived row stays in the catalog — the rail filters archived
+    // workspaces out and the repo page lists them with their status — but the
+    // session it held is gone with the worktree.
     catalog.upsertWorkspace(archived);
-    catalog.forgetWorkspace(id);
+    catalog.forgetWorkspaceSession(id);
     setWorkspace(archived);
     toast.success("Workspace archived");
+    // This page is addressed by the workspace that was just archived, so
+    // staying here leaves the reader on a dead worktree. The repo lists it
+    // again, archived and labelled.
+    if (archived.repo_id) {
+      await navigate({
+        to: "/code/r/$repoId",
+        params: { repoId: archived.repo_id },
+        replace: true,
+      });
+    } else {
+      await navigate({ to: "/code", replace: true });
+    }
   }
 
   const fenced =
@@ -288,8 +305,12 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
       <PanelLayout
         layout={layout}
         renderChat={(visible) => (
+          // The panel slot this sits in is a plain block, so nothing stretches
+          // the pane to the slot's height — `flex-1` resolves to nothing and
+          // the transcript never becomes a scroller. It claims the height
+          // itself, the same way `.chat-pane` does.
           <div
-            className="flex min-h-0 flex-1 flex-col overflow-hidden"
+            className="flex h-full min-h-0 flex-col overflow-hidden"
             hidden={!visible}
           >
             {workspace && workspace.status !== "archived" && (
@@ -533,6 +554,18 @@ function CodeSessionPane({
     ? createPermissionModes(doctorEntry.caps)
     : ["plan", "ask", "auto"];
 
+  // `items` is a fresh array on every streamed delta, so keying the fetch on it
+  // would list approvals again for every token of a turn. Only an approval
+  // appearing or changing state can change what the list would return.
+  const approvalKey = useMemo(
+    () =>
+      items
+        .filter((item) => item.kind === "approval")
+        .map((item) => `${item.approvalId}:${item.state}`)
+        .join(","),
+    [items],
+  );
+
   useEffect(() => {
     let cancelled = false;
     void (async () => {
@@ -549,7 +582,7 @@ function CodeSessionPane({
     return () => {
       cancelled = true;
     };
-  }, [client, session.id, items]);
+  }, [client, session.id, approvalKey]);
 
   async function send(message: string) {
     try {


### PR DESCRIPTION
Four fixes on the code workspace page.

**Archiving left the reader on the workspace it removed.** The page is
addressed by `/code/w/$workspaceId`, and archiving never changed the route, so
after the worktree was gone the page stayed pinned to it. The catalog
bookkeeping also cancelled itself out: `upsertWorkspace(archived)` was
immediately undone by `forgetWorkspace` dropping the same row from the list.

Archiving now replaces the location with the workspace's repo — which already
lists archived workspaces with a status label — and falls back to `/code` when
no repo id is available. Both entry points, plain and forced, funnel through
the same call. The catalog keeps the archived row (the rail filters archived
workspaces out on its own) and drops only the session entry, so
`forgetWorkspace` narrows to `forgetWorkspaceSession`; it had no other caller.

Whether an archived workspace stays readable by deep link is a separate
product question, so no redirect guard is added here.

**The pane never claimed its height.** It asked for `flex-1`, but the slot it
sits in is a `react-resizable-panels` `Panel`, which renders a plain block —
nothing stretched the pane, so its height went content-driven, the transcript
scroller never became a scroll container, and the composer was pushed past the
bottom of the window. It takes `h-full` instead, the same way `.chat-pane`
does. That reason is now written down at all three sites that have hit it.

**The transcript had no centering column.** It was full-width, so on a wide
window items hugged the left edge while the `ml-auto` user bubble sat far
right. The container is bounded to the same 48rem column chat uses. Bubble
styling and class names are deliberately untouched — a broader convergence
pass is separate work.

**Approvals refetched on every delta.** The effect listed `items` in its
dependency array, and that array is fresh on every reducer event, so
`GET /code/approvals` fired for every streamed token of a turn. It is keyed on
the approval ids and their states instead, which is what actually changes the
response.

One DOM test covers the archive navigation: it drives the confirm dialog and
asserts the router lands on the repo route with the workspace page unmounted.
It fails without the navigation fix. The height and width changes are
CSS-mechanical and have no test.

Verified with `pnpm test` (171 files, 1090 tests) and `pnpm build`. Not driven
in the running app.