### PR TITLE
fix(server): NUL-delimited numstat parsing and panic-free truncation

### DIFF
--- a/crates/tidebreak-harness/src/budget.rs
+++ b/crates/tidebreak-harness/src/budget.rs
@@ -43,6 +43,9 @@ pub struct BudgetTick {
 #[derive(Debug, Default)]
 pub struct StreamLineBuffer {
     pending: String,
+    /// Whether the line currently being buffered has already hit the cap, so
+    /// the rest of it is dropped until its newline arrives.
+    overflowing: bool,
     /// Total overflow chunks observed over the life of the buffer.
     pub overflow_chunks: u64,
 }
@@ -55,44 +58,55 @@ impl StreamLineBuffer {
     }
 
     /// Push `bytes` (lossy UTF-8) and take any complete lines.
+    ///
+    /// A line longer than `budget.max_partial_line` is emitted truncated at
+    /// its cap once its newline arrives, and the bytes beyond the cap are
+    /// counted as overflow. The stream keeps flowing either way: one oversized
+    /// line must never stop later lines from being delivered.
     pub fn push(&mut self, bytes: &[u8], budget: StreamBudget) -> BudgetTick {
-        let mut overflow_chunks = 0;
         let incoming = String::from_utf8_lossy(bytes);
-        if self.pending.len().saturating_add(incoming.len()) > budget.max_partial_line {
-            overflow_chunks += 1;
-            self.overflow_chunks += 1;
-            let room = budget.max_partial_line.saturating_sub(self.pending.len());
-            self.pending.push_str(&incoming[..incoming.len().min(room)]);
-            // Drop the rest of this chunk but keep looking for a newline so a
-            // later delimiter can flush the capped prefix.
-            if let Some(idx) = incoming.find('\n') {
-                let _ = idx;
-            } else {
-                return BudgetTick {
-                    lines: Vec::new(),
-                    overflow_chunks,
-                };
-            }
-        } else {
-            self.pending.push_str(&incoming);
-        }
-
+        let mut rest: &str = incoming.as_ref();
         let mut lines = Vec::new();
-        while let Some(idx) = self.pending.find('\n') {
-            let mut line = self.pending.drain(..=idx).collect::<String>();
-            if line.ends_with('\n') {
-                line.pop();
-                if line.ends_with('\r') {
-                    line.pop();
+        let mut overflow_chunks = 0;
+
+        while !rest.is_empty() {
+            let (segment, tail) = match rest.find('\n') {
+                Some(idx) => (&rest[..idx], Some(&rest[idx + 1..])),
+                None => (rest, None),
+            };
+
+            if self.overflowing {
+                if !segment.is_empty() {
+                    overflow_chunks += 1;
+                    self.overflow_chunks += 1;
+                }
+            } else {
+                let room = budget.max_partial_line.saturating_sub(self.pending.len());
+                if segment.len() > room {
+                    let end = crate::text::floor_char_boundary(segment, room);
+                    self.pending.push_str(&segment[..end]);
+                    self.overflowing = true;
+                    overflow_chunks += 1;
+                    self.overflow_chunks += 1;
+                } else {
+                    self.pending.push_str(segment);
                 }
             }
-            lines.push(line);
+
+            match tail {
+                Some(tail) => {
+                    let mut line = std::mem::take(&mut self.pending);
+                    if line.ends_with('\r') {
+                        line.pop();
+                    }
+                    lines.push(line);
+                    self.overflowing = false;
+                    rest = tail;
+                }
+                None => rest = "",
+            }
         }
-        if self.pending.len() > budget.max_partial_line {
-            self.pending.truncate(budget.max_partial_line);
-            overflow_chunks += 1;
-            self.overflow_chunks += 1;
-        }
+
         BudgetTick {
             lines,
             overflow_chunks,
@@ -133,5 +147,40 @@ mod tests {
         assert!(tick.overflow_chunks >= 1);
         assert_eq!(buf.overflow_chunks, tick.overflow_chunks);
         assert!(buf.pending().len() <= 8);
+    }
+
+    #[test]
+    fn an_oversized_line_does_not_wedge_the_stream() {
+        let budget = StreamBudget {
+            chunk_size: 8,
+            max_chunks_per_tick: 1,
+            max_partial_line: 8,
+        };
+        let mut buf = StreamLineBuffer::new();
+
+        // An oversized line arriving in pieces, then a normal line behind it.
+        assert!(buf.push(b"aaaaaaaaaabbbb", budget).lines.is_empty());
+        assert!(buf.push(b"cccccccccc", budget).lines.is_empty());
+        let tick = buf.push(b"dddd\nnormal\n", budget);
+        assert_eq!(tick.lines, ["aaaaaaaa", "normal"]);
+        assert!(buf.overflow_chunks >= 1);
+        assert!(buf.pending().is_empty());
+
+        // And the buffer keeps working afterwards.
+        let tick = buf.push(b"after\n", budget);
+        assert_eq!(tick.lines, ["after"]);
+    }
+
+    #[test]
+    fn a_character_straddling_the_cap_is_dropped_not_split() {
+        let budget = StreamBudget {
+            chunk_size: 8,
+            max_chunks_per_tick: 1,
+            // "é" is two bytes, so a cap of 5 lands inside the third one.
+            max_partial_line: 5,
+        };
+        let mut buf = StreamLineBuffer::new();
+        let tick = buf.push("ééé\nplain\n".as_bytes(), budget);
+        assert_eq!(tick.lines, ["éé", "plain"]);
     }
 }

--- a/crates/tidebreak-harness/src/claude/parse.rs
+++ b/crates/tidebreak-harness/src/claude/parse.rs
@@ -346,9 +346,7 @@ impl ClaudeStreamParser {
     fn count_unrecognized(&mut self, label: &str, payload: impl std::fmt::Display) {
         self.unrecognized += 1;
         let mut rendered = payload.to_string();
-        if rendered.len() > MAX_UNRECOGNIZED_LOG {
-            rendered.truncate(MAX_UNRECOGNIZED_LOG);
-        }
+        crate::text::truncate_on_char_boundary(&mut rendered, MAX_UNRECOGNIZED_LOG);
         tracing::debug!(
             target: "tidebreak_harness::claude",
             unrecognized = self.unrecognized,

--- a/crates/tidebreak-harness/src/codex/parse.rs
+++ b/crates/tidebreak-harness/src/codex/parse.rs
@@ -424,9 +424,7 @@ impl CodexStreamParser {
     fn count_unrecognized(&mut self, label: &str, payload: impl std::fmt::Display) {
         self.unrecognized += 1;
         let mut rendered = payload.to_string();
-        if rendered.len() > MAX_UNRECOGNIZED_LOG {
-            rendered.truncate(MAX_UNRECOGNIZED_LOG);
-        }
+        crate::text::truncate_on_char_boundary(&mut rendered, MAX_UNRECOGNIZED_LOG);
         tracing::debug!(
             target: "tidebreak_harness::codex",
             unrecognized = self.unrecognized,

--- a/crates/tidebreak-harness/src/grok/parse.rs
+++ b/crates/tidebreak-harness/src/grok/parse.rs
@@ -274,9 +274,7 @@ impl GrokStreamParser {
     fn count_unrecognized(&mut self, label: &str, payload: impl std::fmt::Display) {
         self.unrecognized += 1;
         let mut rendered = payload.to_string();
-        if rendered.len() > MAX_UNRECOGNIZED_LOG {
-            rendered.truncate(MAX_UNRECOGNIZED_LOG);
-        }
+        crate::text::truncate_on_char_boundary(&mut rendered, MAX_UNRECOGNIZED_LOG);
         tracing::debug!(
             target: "tidebreak_harness::grok",
             unrecognized = self.unrecognized,

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -27,6 +27,7 @@ pub mod grok;
 pub mod launch;
 pub mod opencode;
 pub mod probe;
+mod text;
 
 pub use budget::{BudgetTick, StreamBudget, StreamLineBuffer};
 pub use launch::{validate_launch_plan, BypassFlagError, LaunchPlan};

--- a/crates/tidebreak-harness/src/opencode/parse.rs
+++ b/crates/tidebreak-harness/src/opencode/parse.rs
@@ -538,9 +538,7 @@ impl OpencodeStreamParser {
     fn count_unrecognized(&mut self, label: &str, payload: impl std::fmt::Display) {
         self.unrecognized += 1;
         let mut rendered = payload.to_string();
-        if rendered.len() > MAX_UNRECOGNIZED_LOG {
-            rendered.truncate(MAX_UNRECOGNIZED_LOG);
-        }
+        crate::text::truncate_on_char_boundary(&mut rendered, MAX_UNRECOGNIZED_LOG);
         tracing::debug!(
             target: "tidebreak_harness::opencode",
             unrecognized = self.unrecognized,

--- a/crates/tidebreak-harness/src/probe.rs
+++ b/crates/tidebreak-harness/src/probe.rs
@@ -262,9 +262,7 @@ async fn run_interactive_login_shell(
         .map_err(|err| ProbeError::Shell(err.to_string()))?;
     let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
     let mut stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-    if stderr.len() > MAX_STDERR_BYTES {
-        stderr.truncate(MAX_STDERR_BYTES);
-    }
+    crate::text::truncate_on_char_boundary(&mut stderr, MAX_STDERR_BYTES);
     Ok(ShellOutput {
         stdout,
         stderr,

--- a/crates/tidebreak-harness/src/text.rs
+++ b/crates/tidebreak-harness/src/text.rs
@@ -1,0 +1,56 @@
+//! Byte-capped text handling that never splits a character.
+//!
+//! Engine stdout, shell stderr, and unrecognized payloads are all capped by
+//! byte length before they are logged or buffered. `String::truncate` panics
+//! when the cap lands inside a multi-byte character, so every cap in this
+//! crate goes through the helpers here instead.
+
+/// Largest index at or below `max_bytes` that is a character boundary of
+/// `text`. Returns `text.len()` when the cap is not reached.
+pub(crate) fn floor_char_boundary(text: &str, max_bytes: usize) -> usize {
+    if max_bytes >= text.len() {
+        return text.len();
+    }
+    let mut end = max_bytes;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    end
+}
+
+/// Shorten `text` to at most `max_bytes`, cutting on a character boundary.
+pub(crate) fn truncate_on_char_boundary(text: &mut String, max_bytes: usize) {
+    let end = floor_char_boundary(text, max_bytes);
+    text.truncate(end);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cap_landing_inside_a_character_drops_that_character() {
+        // "é" is two bytes, so a cap of 2 lands between them.
+        let mut text = String::from("aéb");
+        truncate_on_char_boundary(&mut text, 2);
+        assert_eq!(text, "a");
+
+        // A three-byte character straddling the cap from either side.
+        let mut text = String::from("a€b");
+        truncate_on_char_boundary(&mut text, 3);
+        assert_eq!(text, "a");
+        let mut text = String::from("a€b");
+        truncate_on_char_boundary(&mut text, 4);
+        assert_eq!(text, "a€");
+
+        // Caps at or past the end leave the string alone.
+        let mut text = String::from("a€b");
+        truncate_on_char_boundary(&mut text, 64);
+        assert_eq!(text, "a€b");
+
+        // A cap that cannot fit even the first character yields nothing.
+        let mut text = String::from("€");
+        truncate_on_char_boundary(&mut text, 1);
+        assert!(text.is_empty());
+    }
+}

--- a/crates/tidebreak-server/src/code/checkpoint.rs
+++ b/crates/tidebreak-server/src/code/checkpoint.rs
@@ -524,9 +524,9 @@ async fn collect_changes(
     )
     .await
     .map_err(CheckpointError::internal)?;
-    let numstat = git_text(
+    let numstat = git_bytes(
         worktree,
-        &["diff", "--numstat", "--find-renames", from, to],
+        &["diff", "--numstat", "-z", "--find-renames", from, to],
         GIT_TIMEOUT,
     )
     .await
@@ -615,22 +615,34 @@ fn parse_name_status(raw: &[u8]) -> Vec<ChangedFile> {
     files
 }
 
-fn parse_numstat(text: &str) -> std::collections::HashMap<String, (u32, u32)> {
+/// Parse `git diff --numstat -z`, keyed by post-image path.
+///
+/// `-z` is what makes the keys line up with `--name-status -z`: without it git
+/// quotes and C-escapes any path outside ASCII, and collapses a rename into a
+/// single `old => new` field. Neither form ever matches a name-status path, so
+/// those files would silently carry zero insertions and deletions.
+///
+/// The NUL-delimited record is `<added>\t<deleted>\t<path>\0`, except for a
+/// rename or copy, where the path column is empty and the pre-image and
+/// post-image paths follow as two further NUL-terminated fields.
+fn parse_numstat(raw: &[u8]) -> std::collections::HashMap<String, (u32, u32)> {
+    let text = String::from_utf8_lossy(raw);
     let mut out = std::collections::HashMap::new();
-    for line in text.lines() {
-        let mut cols = line.split('\t');
+    let mut parts = text.split('\0').filter(|part| !part.is_empty());
+    while let Some(record) = parts.next() {
+        // A path may itself contain a tab, so only split off the two counts.
+        let mut cols = record.splitn(3, '\t');
         let insertions = parse_stat_count(cols.next().unwrap_or("0"));
         let deletions = parse_stat_count(cols.next().unwrap_or("0"));
         let path = cols.next().unwrap_or("");
         if path.is_empty() {
-            continue;
+            let (Some(_previous), Some(current)) = (parts.next(), parts.next()) else {
+                break;
+            };
+            out.insert(current.to_owned(), (insertions, deletions));
+        } else {
+            out.insert(path.to_owned(), (insertions, deletions));
         }
-        let key = path
-            .split_once(" => ")
-            .map(|(_, after)| after)
-            .unwrap_or(path)
-            .to_owned();
-        out.insert(key, (insertions, deletions));
     }
     out
 }
@@ -895,6 +907,64 @@ mod tests {
             "{}",
             diff.diff
         );
+    }
+
+    #[tokio::test]
+    async fn line_counts_survive_renames_and_non_ascii_paths() {
+        let (_dir, repo) = init_repo();
+        let body: String = (1..=12).map(|i| format!("line {i}\n")).collect();
+        std::fs::create_dir_all(repo.join("src")).unwrap();
+        std::fs::write(repo.join("src/alpha.rs"), &body).unwrap();
+        run(&repo, &["git", "add", "src/alpha.rs"]);
+        run(&repo, &["git", "commit", "-m", "alpha"]);
+
+        let tree = add_worktree(&repo, "numstat");
+        // A rename with one added line, and a path outside ASCII. Non-`-z`
+        // numstat renders the first as `src/{alpha.rs => beta.rs}` and quotes
+        // and escapes the second, so neither matched its name-status entry.
+        std::fs::rename(tree.join("src/alpha.rs"), tree.join("src/beta.rs")).unwrap();
+        std::fs::write(tree.join("src/beta.rs"), format!("{body}line 13\n")).unwrap();
+        std::fs::write(tree.join("café.txt"), "un\ndeux\n").unwrap();
+
+        let recorded = record_checkpoint(&tree, ws(), 1, None, "main")
+            .await
+            .unwrap();
+        let from = merge_base(&tree, "main").await.unwrap();
+        let files = list_changed_files(
+            &tree,
+            &from,
+            &recorded.checkpoint_ref,
+            DiffBounds::default(),
+        )
+        .await
+        .unwrap();
+
+        let renamed = files
+            .files
+            .iter()
+            .find(|file| file.path == "src/beta.rs")
+            .unwrap_or_else(|| panic!("{:#?}", files.files));
+        assert_eq!(renamed.kind, FileChangeKind::Renamed);
+        assert_eq!(renamed.previous_path.as_deref(), Some("src/alpha.rs"));
+        assert_eq!((renamed.insertions, renamed.deletions), (1, 0));
+
+        // Matched by kind rather than by name: macOS and Linux disagree on the
+        // Unicode normalization of the path, but not on its line counts.
+        let accented = files
+            .files
+            .iter()
+            .find(|file| file.kind == FileChangeKind::Added)
+            .unwrap_or_else(|| panic!("{:#?}", files.files));
+        assert!(accented.path.contains("caf"), "{}", accented.path);
+        assert!(
+            !accented.path.starts_with('"'),
+            "path must not be quoted: {}",
+            accented.path
+        );
+        assert_eq!((accented.insertions, accented.deletions), (2, 0));
+
+        assert_eq!(files.stat.insertions, 3);
+        assert_eq!(files.stat.deletions, 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Three byte-level defects in code mode's git and stream-parsing paths.

## Numstat counts lost on renames and non-ASCII paths

`parse_numstat` read `git diff --numstat` without `-z`, while `parse_name_status`
used it. Without `-z` git renders a same-directory rename as
`src/{alpha.rs => beta.rs}` and quotes and C-escapes any path outside ASCII, so
those records never matched the name-status path they were meant to annotate and
the file kept zero insertions and deletions. That flowed into the journaled
`CheckpointRecorded`, the diffstat badge, and the generated commit message.

Both commands now run with `-z`. The parser handles the NUL-delimited rename
form — the counts are followed by an empty path column, then the pre-image and
post-image paths as two further NUL-terminated fields — and splits the counts off
with `splitn(3, '\t')` so a tab inside a path cannot truncate it.

## `String::truncate` on non-character boundaries

`String::truncate` panics when the byte cap lands inside a multi-byte character.
Five caps applied it directly to engine- or shell-controlled text: the
login-shell stderr capture in `probe.rs` and the `MAX_UNRECOGNIZED_LOG` payload
log in each of the four adapters — the code whose entire job is surviving input
it does not recognize. All five now go through one helper that floors the cap to
a character boundary (`str::floor_char_boundary` is still unstable).

## Oversized line wedged a session's stream

`StreamLineBuffer::push` had the same panic and a worse failure behind it. On
overflow it kept a capped prefix that contained no newline and dropped the rest
of the chunk, so the pending buffer stayed permanently full: no line ever
completed again, and every later line on that session was silently lost. It now
drops bytes only until the oversized line's newline arrives, emits that line
truncated at the cap, and resumes normally. Overflow accounting is unchanged.

## Tests

Three, each a reproduction that fails without the corresponding fix:

- a checkpoint over a same-directory rename and a non-ASCII filename, asserting
  the per-file and total line counts (verified failing on the old parser with
  `(0, 0)` for both files);
- a cap landing inside two- and three-byte characters, which panicked before;
- an oversized line followed by a normal line, asserting the normal line still
  comes through and the buffer keeps working afterwards.
