### PR TITLE
fix(server): preserve worktrees on failed archive scripts and fence session saves

### DIFF
--- a/crates/tidebreak-core/src/db/ops/code/session.rs
+++ b/crates/tidebreak-core/src/db/ops/code/session.rs
@@ -141,6 +141,18 @@ pub async fn list_sessions_by_lifecycle(
 }
 
 /// Persist mutable session fields. `id`, `workspace_id`, and `created_at` stay as stored.
+///
+/// The write is fenced on `spawn_epoch`, the same way journal appends are: a
+/// caller holding an epoch older than the stored row is a superseded worker
+/// unwinding, and its write is dropped rather than allowed to regress the row.
+/// Without the fence such a worker writes its own epoch back over a newer
+/// spawn's — un-fencing itself, making the live worker the stale one, and
+/// silently dropping everything the live worker appends afterwards. The same
+/// fence keeps a superseded worker from regressing lifecycle, attention, or
+/// the recorded child pid.
+///
+/// Returns `false` when nothing was written: either the row is gone or the
+/// caller has been superseded.
 pub async fn save_session(store: &DbStore, session: &CodeSession) -> Result<bool> {
     let result = entities::code_session::Entity::update_many()
         .col_expr(
@@ -191,10 +203,24 @@ pub async fn save_session(store: &DbStore, session: &CodeSession) -> Result<bool
             sea_orm::sea_query::Expr::value(session.unrecognized_event_count),
         )
         .filter(entities::code_session::Column::Id.eq(session.id.0))
+        .filter(entities::code_session::Column::SpawnEpoch.lte(session.spawn_epoch))
         .exec(&store.conn)
         .await
         .map_err(store_err)?;
-    Ok(result.rows_affected == 1)
+    if result.rows_affected != 1 {
+        // Rare, and invisible without a word: distinguish a superseded writer
+        // from a row that is simply gone.
+        if let Some(current) = get_session(store, session.id).await? {
+            tracing::warn!(
+                session = %session.id,
+                attempted = session.spawn_epoch,
+                current = current.spawn_epoch,
+                "dropping a session write from a superseded code-session worker"
+            );
+        }
+        return Ok(false);
+    }
+    Ok(true)
 }
 
 pub(super) fn session_from_row(row: entities::code_session::Model) -> Result<CodeSession> {

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -8,7 +8,7 @@ use crate::code::{
 use crate::db::code::{
     append_event, bump_spawn_epoch, get_approval, get_repo, get_session, get_turn, get_workspace,
     insert_approval, insert_repo, insert_session, insert_turn, insert_workspace, list_events,
-    set_workspace_title_if, CodeJournalError,
+    save_session, set_workspace_title_if, CodeJournalError,
 };
 use chrono::Utc;
 
@@ -180,6 +180,40 @@ async fn entity_graph_round_trips() {
     .unwrap();
     let approval = get_approval(&store, approval_id).await.unwrap().unwrap();
     assert_eq!(approval.state, CodeApprovalState::Pending);
+}
+
+/// A worker that has been superseded still holds a snapshot of the row and
+/// writes it on the way out. If that write lands, it puts the old epoch back:
+/// the outgoing worker un-fences itself, the live worker becomes the stale one,
+/// and everything the live worker appends is dropped while the session still
+/// reads as healthy.
+#[tokio::test]
+async fn a_superseded_worker_cannot_regress_the_session_row() {
+    let (_dir, store, session_id, _) = seeded_session().await;
+    let outgoing = get_session(&store, session_id).await.unwrap().unwrap();
+    assert_eq!(
+        bump_spawn_epoch(&store, session_id, Some(99))
+            .await
+            .unwrap(),
+        1
+    );
+    let mut live = get_session(&store, session_id).await.unwrap().unwrap();
+    live.lifecycle = CodeSessionLifecycle::Running;
+    assert!(save_session(&store, &live).await.unwrap());
+
+    let mut unwinding = outgoing;
+    unwinding.lifecycle = CodeSessionLifecycle::Ended;
+    unwinding.child_pid = None;
+    assert!(!save_session(&store, &unwinding).await.unwrap());
+
+    let row = get_session(&store, session_id).await.unwrap().unwrap();
+    assert_eq!(row.spawn_epoch, 1);
+    assert_eq!(row.lifecycle, CodeSessionLifecycle::Running);
+    assert_eq!(row.child_pid, Some(99));
+    // The live worker is still the one that owns the journal.
+    append_event(&store, session_id, 1, &CodeEvent::TurnInterrupted)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -42,7 +42,7 @@ use super::session_worker::{
 };
 use super::worktree::{
     self, archive_blockers, branch_name, create_worktree, prune_worktrees, remove_worktree,
-    run_setup_script, slugify, validate_repo_path, worktree_dir, WorktreeError,
+    run_archive_script, run_setup_script, slugify, validate_repo_path, worktree_dir, WorktreeError,
 };
 use crate::error::ServerError;
 
@@ -467,19 +467,8 @@ impl CodeRuntime {
             return Ok(workspace);
         }
         let repo = self.get_repo(workspace.repo_id).await?;
-        if let Some(script) = repo.archive_script.as_deref() {
-            if let Err(err) = super::setup_script::run_workspace_script(
-                std::path::Path::new(&workspace.worktree_path),
-                script,
-            )
-            .await
-            {
-                return Err(ServerError::unprocessable_kind(
-                    "archive_script_failed",
-                    err,
-                ));
-            }
-        }
+        // Blockers first: a refused archive must leave the workspace exactly as
+        // it was, and running the hook script is not "exactly as it was".
         self.refuse_running_sessions(id, force).await?;
         let path = std::path::Path::new(&workspace.worktree_path);
         if path.exists() {
@@ -493,6 +482,17 @@ impl CodeRuntime {
                         "workspace has uncommitted or unpushed work; pass force to discard it",
                     ));
                 }
+            }
+            // Decision 0032: the archive script obeys the same
+            // failure-preserves rule as setup. A script that backs up or
+            // pushes state and exits non-zero must stop the archive, not have
+            // its checkout removed underneath it. A worktree that is already
+            // gone has nothing to run the script against.
+            if let Err(err) = run_archive_script(path, repo.archive_script.as_deref()).await {
+                return Err(ServerError::unprocessable_kind(
+                    "archive_script_failed",
+                    err.to_string(),
+                ));
             }
         }
         self.end_workspace_sessions(id).await?;
@@ -777,9 +777,16 @@ impl CodeRuntime {
             ));
         }
         let handle = self.workers.lock().expect("code workers").remove(&id);
-        if let Some(handle) = handle {
-            let _ = handle.commands.send(WorkerCommand::Shutdown).await;
-        }
+        let session = match handle {
+            // The outgoing worker writes its own final state as it stops, and
+            // the new spawn must not be started against a row it is still
+            // moving. Wait for it, then reap the row as it stands now.
+            Some(handle) => {
+                Self::shut_down_worker(id, handle).await;
+                self.get_session(id).await?
+            }
+            None => session,
+        };
         let session = recovery::reap_session(&self.db, &self.bus, session)
             .await
             .map_err(ServerError::from)?;
@@ -921,7 +928,12 @@ impl CodeRuntime {
                 .expect("code workers")
                 .remove(&session.id);
             if let Some(handle) = handle {
-                let _ = handle.commands.send(WorkerCommand::Shutdown).await;
+                Self::shut_down_worker(session.id, handle).await;
+                // The worker writes its own final state on the way out. End the
+                // row as it stands now, not the snapshot taken before it left.
+                if let Some(current) = get_session(&self.db, session.id).await? {
+                    session = current;
+                }
             }
             session.lifecycle = CodeSessionLifecycle::Ended;
             session.child_pid = None;
@@ -929,6 +941,39 @@ impl CodeRuntime {
             super::attention::persist_session(&self.db, &self.bus, &session).await?;
         }
         Ok(())
+    }
+
+    /// Ask a superseded worker to stop, and wait for it to finish unwinding.
+    ///
+    /// The worker drops its command receiver as its last act — after the engine
+    /// is shut down and its final writes have landed — so the sender seeing the
+    /// receiver close is the completion signal. A `Shutdown` delivered while a
+    /// turn is running only ends that turn, so keep asking until the receiver is
+    /// gone. The wait is bounded: a wedged worker must not block an archive or a
+    /// reap, and the epoch fence on the session row keeps its late writes
+    /// harmless either way.
+    async fn shut_down_worker(id: CodeSessionId, handle: WorkerHandle) {
+        const GRACE: std::time::Duration = std::time::Duration::from_secs(5);
+        const RETRY: std::time::Duration = std::time::Duration::from_millis(50);
+        let commands = handle.commands.clone();
+        drop(handle);
+        let stopped = tokio::time::timeout(GRACE, async {
+            while commands.send(WorkerCommand::Shutdown).await.is_ok() {
+                tokio::select! {
+                    _ = commands.closed() => return,
+                    _ = tokio::time::sleep(RETRY) => {}
+                }
+            }
+            commands.closed().await;
+        })
+        .await
+        .is_ok();
+        if !stopped {
+            tracing::warn!(
+                session = %id,
+                "code-mode: session worker did not stop in time; continuing without it"
+            );
+        }
     }
 
     async fn attach_and_spawn_worker(

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -927,18 +927,17 @@ impl CodeRuntime {
                 .lock()
                 .expect("code workers")
                 .remove(&session.id);
-            if let Some(handle) = handle {
-                Self::shut_down_worker(session.id, handle).await;
-                // The worker writes its own final state on the way out. End the
-                // row as it stands now, not the snapshot taken before it left.
-                if let Some(current) = get_session(&self.db, session.id).await? {
-                    session = current;
-                }
-            }
+            // Mark the row ended before asking the worker to stop. A worker
+            // interrupted mid-turn re-reads the row on its way round the loop
+            // and leaves on its own when it finds the session ended, so one
+            // `Shutdown` is enough however busy it was.
             session.lifecycle = CodeSessionLifecycle::Ended;
             session.child_pid = None;
             session.fence_reason = None;
             super::attention::persist_session(&self.db, &self.bus, &session).await?;
+            if let Some(handle) = handle {
+                Self::shut_down_worker(session.id, handle).await;
+            }
         }
         Ok(())
     }
@@ -947,23 +946,24 @@ impl CodeRuntime {
     ///
     /// The worker drops its command receiver as its last act — after the engine
     /// is shut down and its final writes have landed — so the sender seeing the
-    /// receiver close is the completion signal. A `Shutdown` delivered while a
-    /// turn is running only ends that turn, so keep asking until the receiver is
-    /// gone. The wait is bounded: a wedged worker must not block an archive or a
-    /// reap, and the epoch fence on the session row keeps its late writes
-    /// harmless either way.
+    /// receiver close is exactly "the worker is gone". One `Shutdown` is enough:
+    /// an idle worker leaves the loop on it, and a worker mid-turn interrupts
+    /// the turn and then leaves at the top of the next iteration because the
+    /// caller marked the session ended first. Resending would only replay
+    /// `interrupt` into an engine that is already stopping.
+    ///
+    /// The wait is bounded so an engine that never returns cannot hold an
+    /// archive or a reap open; the epoch fence on the session row keeps a late
+    /// writer harmless either way.
     async fn shut_down_worker(id: CodeSessionId, handle: WorkerHandle) {
         const GRACE: std::time::Duration = std::time::Duration::from_secs(5);
-        const RETRY: std::time::Duration = std::time::Duration::from_millis(50);
         let commands = handle.commands.clone();
         drop(handle);
+        // Send and wait under one deadline: a worker that has stopped draining
+        // its commands would otherwise park the send itself once the channel
+        // filled up.
         let stopped = tokio::time::timeout(GRACE, async {
-            while commands.send(WorkerCommand::Shutdown).await.is_ok() {
-                tokio::select! {
-                    _ = commands.closed() => return,
-                    _ = tokio::time::sleep(RETRY) => {}
-                }
-            }
+            let _ = commands.send(WorkerCommand::Shutdown).await;
             commands.closed().await;
         })
         .await

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -146,6 +146,25 @@ pub(crate) async fn run_setup_script(
     worktree_path: &Path,
     script: Option<&str>,
 ) -> Result<(), WorktreeError> {
+    run_hook_script(worktree_path, script, "setup").await
+}
+
+/// Run the archive script, if any. Failure preserves the checkout, so the
+/// caller must not remove the worktree when this returns an error.
+pub(crate) async fn run_archive_script(
+    worktree_path: &Path,
+    script: Option<&str>,
+) -> Result<(), WorktreeError> {
+    run_hook_script(worktree_path, script, "archive").await
+}
+
+/// A non-zero exit is a failure, not a completed run: `run_workspace_script`
+/// only reports `Err` when the script could not be spawned or timed out.
+async fn run_hook_script(
+    worktree_path: &Path,
+    script: Option<&str>,
+    label: &str,
+) -> Result<(), WorktreeError> {
     let Some(script) = script.map(str::trim).filter(|value| !value.is_empty()) else {
         return Ok(());
     };
@@ -156,7 +175,7 @@ pub(crate) async fn run_setup_script(
         Ok(())
     } else {
         Err(WorktreeError::user(format!(
-            "setup script failed (exit {}): {}",
+            "{label} script failed (exit {}): {}",
             run.status
                 .map(|code| code.to_string())
                 .unwrap_or_else(|| "signal".into()),

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -1099,6 +1099,92 @@ async fn a_recovered_session_accepts_a_turn() {
     assert_eq!(after_body["user_input"], "after reap");
 }
 
+/// Decision 0032: the archive script obeys the same failure-preserves rule as
+/// setup. A script whose job is to back the workspace up must be able to stop
+/// the archive by failing, and a refused archive must not have run it at all.
+#[tokio::test]
+async fn a_failing_archive_script_preserves_the_worktree() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let registered = client
+        .post(format!("http://{addr}/code/repos"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "path": repo,
+            "archive_script": "echo ran >> .archive-ran; exit 4",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(registered.status(), reqwest::StatusCode::CREATED);
+    let repo_body: serde_json::Value = registered.json().await.unwrap();
+    let created = client
+        .post(format!("http://{addr}/code/workspaces"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "repo_id": json_id(&repo_body),
+            "title": "backed up on archive",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let workspace: serde_json::Value = created.json().await.unwrap();
+    let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+    std::fs::write(path.join("dirty.txt"), "nope\n").unwrap();
+
+    let refused = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/archive",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    assert!(
+        !path.join(".archive-ran").exists(),
+        "a refused archive must not run the archive script"
+    );
+
+    let failed = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/archive",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "force": true }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(failed.status(), reqwest::StatusCode::UNPROCESSABLE_ENTITY);
+    let body: serde_json::Value = failed.json().await.unwrap();
+    assert_eq!(body["kind"], "archive_script_failed");
+    assert!(path.join(".archive-ran").is_file());
+    assert!(
+        path.join("dirty.txt").is_file(),
+        "a failed archive script must leave the worktree on disk"
+    );
+    let listed = client
+        .get(format!(
+            "http://{addr}/code/workspaces?repo_id={}",
+            json_id(&repo_body)
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<Vec<serde_json::Value>>()
+        .await
+        .unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0]["status"], "active");
+}
+
 #[tokio::test]
 async fn archive_ends_the_session_before_removing_the_worktree() {
     let (router, token, runtime, dir) = code_app(plain_text_script()).await;


### PR DESCRIPTION
Three fixes on the code-mode archive and worker-supersession paths.

## A failing archive script no longer destroys the worktree

`archive_workspace` treated `run_workspace_script` returning `Ok(_)` as
success, but that function only reports `Err` when the script cannot be
spawned or times out — a non-zero exit comes back as `Ok(ScriptRun { success:
false, .. })`. An archive script whose job is to back up or push state could
fail and the archive proceeded to `git worktree remove` anyway, taking the
work with it. The setup path checks `run.success`; the archive path never
ported the check, though decision 0032 states the archive hook obeys the same
failure-preserves rule.

Archive now aborts with `archive_script_failed` and leaves the checkout on
disk when the script fails. Setup and archive share one implementation
(`run_hook_script`) so the two cannot drift apart again.

The script also ran *before* the force and running-session checks, so an
archive that was subsequently refused had already executed it — a refused
archive could push, tag, or upload. Blockers are now evaluated first, and the
script only runs against a worktree that still exists (an already-removed
worktree archives without error, and has nothing to back up).

## `save_session` cannot be regressed by a superseded worker

The update carried no predicate but the row id, so it wrote `spawn_epoch`
unconditionally. Archive and reap send `Shutdown` and re-attach; the outgoing
worker keeps its own `CodeSession` snapshot and writes it while unwinding,
putting its stale epoch back over the new one. That un-fences the worker that
is leaving and makes the live worker the stale one: its appends fail
`StaleSpawnEpoch` and are dropped, so the session goes permanently silent
while the UI still shows it healthy.

The save is now fenced on `spawn_epoch` the same way journal appends are — the
write lands only if the caller is at least as new as the stored row. Fencing
the whole update, not just the epoch column, also stops a superseded worker
from regressing lifecycle, attention, or the recorded child pid. The dropped
write is logged rather than passing silently.

## Archive and reap wait for the outgoing worker

Both removed the handle, sent `Shutdown`, and continued without waiting, so a
new engine could be launched into the same worktree while the old one was
still shutting down. Both now wait for the worker to finish: the worker drops
its command receiver as its last act, after the engine is shut down, so the
sender observing that close is exactly \"the worker is gone\".

One `Shutdown` is enough. An idle worker leaves its loop on it; a worker
mid-turn treats it as an interrupt and then leaves at the top of the next
iteration, because `end_workspace_sessions` marks the row ended *before* it
asks the worker to stop and the worker already re-reads the row there
(`session_was_ended`). Send and wait share one deadline, so neither a wedged
engine nor a worker that has stopped draining its commands can hold an archive
open; the epoch fence keeps a late writer harmless if one is left behind.

## Tests

- `a_failing_archive_script_preserves_the_worktree` — a refused archive has
  not run the script, and a forced archive whose script exits non-zero
  surfaces `archive_script_failed`, keeps the worktree, and leaves the
  workspace active.
- `a_superseded_worker_cannot_regress_the_session_row` — a save from an older
  epoch is rejected and leaves epoch, lifecycle, and child pid alone, and the
  live worker can still append.

Verified locally on the rebased branch: `cargo fmt --check`, clippy on both
crates with `--all-targets`, `cargo test -p tidebreak-server` (967 passed),
`cargo test -p tidebreak-core` (671 passed), and `cargo test -p
tidebreak-desktop` (152 passed, 0.6s). The force-archive-during-a-turn test
runs in 0.44s, so the shutdown wait resolves on worker exit rather than on its
timeout.