### PR TITLE
feat(desktop): mode-scoped shortcuts, Cmd+N creates a workspace in code mode

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
@@ -4,6 +4,9 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useChatListStore } from "./ChatListStore";
+import { useCodeCatalogStore } from "./code/CodeCatalogStore";
+import { useCodeUiStore } from "./code/CodeUiStore";
+import { useExperimentalFlags } from "./experimental";
 import { usePendingPrompts } from "./PendingPrompts";
 import { useProjectListStore } from "./ProjectListStore";
 import { useRefreshSignals } from "./RefreshSignals";
@@ -59,6 +62,24 @@ const createProject = vi.fn(async (title: string) => ({
   root_attachments: [],
   created_at: "2026-08-13T12:00:00Z",
 }));
+const getSettings = vi.fn(async () => ({
+  model: null,
+  has_api_key: false,
+  code_mode_enabled: false,
+}));
+const listCodeRepos = vi.fn(async () => [
+  {
+    id: "repo-1",
+    root_path: "/tmp/app",
+    display_name: "app",
+    default_base_ref: "main",
+    branch_prefix: "tidebreak",
+    quick_actions: [],
+    created_at: "2026-08-16T00:00:00.000Z",
+  },
+]);
+const listCodeWorkspaces = vi.fn(async () => [] as unknown[]);
+const getHarnessDoctor = vi.fn(async () => ({ harnesses: [] }));
 const listPendingUserQuestions = vi.fn(async () => [] as unknown[]);
 const listPendingFolderAccessRequests = vi.fn(async () => [] as unknown[]);
 const listInbox = vi.fn(async () => [] as unknown[]);
@@ -106,9 +127,14 @@ vi.mock("./api", () => ({
     gatewaySignIn = vi.fn(async () => ({ authorization_url: "http://gw/authorize" }));
     listModels = vi.fn(async () => ({ models: [], roles: [] }));
     listProviders = vi.fn(async () => ({ providers: [] }));
-    getSettings = vi.fn(async () => ({
-      model: null,
-      has_api_key: false,
+    getSettings = getSettings;
+    listCodeRepos = listCodeRepos;
+    listCodeWorkspaces = listCodeWorkspaces;
+    getHarnessDoctor = getHarnessDoctor;
+    openCodeUpdates = vi.fn(() => ({
+      close() {},
+      addEventListener() {},
+      removeEventListener() {},
     }));
     listChats = listChats;
     createChat = createChat;
@@ -259,6 +285,23 @@ beforeEach(() => {
   getPolicy.mockClear();
   getPolicy.mockResolvedValue(unmanaged);
   getGatewayStatus.mockClear();
+  getSettings.mockClear();
+  getSettings.mockResolvedValue({
+    model: null,
+    has_api_key: false,
+    code_mode_enabled: false,
+  });
+  listCodeRepos.mockClear();
+  listCodeWorkspaces.mockClear();
+  // Code mode is opt-in and its catalog outlives a render, so a test that
+  // turned it on must not decide the next one's routes.
+  useExperimentalFlags.setState({ loaded: false, codeModeEnabled: false });
+  useCodeCatalogStore.getState().reset();
+  useCodeUiStore.setState({
+    newWorkspaceOpen: false,
+    newWorkspaceRepoId: undefined,
+    addRepoOpen: false,
+  });
   usePendingPrompts.setState({ chatId: null, userQuestions: [], folderAccess: [] });
   // The stores outlive a test file's renders, so a chat list left behind would
   // decide the next test's routing before its own boot ever ran.
@@ -585,7 +628,9 @@ describe("app shell", () => {
     await mountApp();
 
     expect(await screen.findByText("Sign in to continue")).toBeInTheDocument();
-    await user.keyboard("{Meta>}n{/Meta}");
+    // Ctrl is the command modifier under jsdom's non-mac user agent; pressing
+    // Meta here would prove nothing, because nothing is bound to it.
+    await user.keyboard("{Control>}n{/Control}");
 
     expect(createChat).not.toHaveBeenCalled();
     expect(listInbox).not.toHaveBeenCalled();
@@ -636,4 +681,39 @@ describe("app shell", () => {
     );
     expect(screen.getByRole("button", { name: "Research" })).toBeInTheDocument();
   });
+
+  it(
+    "opens a workspace rather than a chat for Cmd+N in code mode",
+    { timeout: 15000 },
+    async () => {
+      // Shell shortcuts are mode-scoped, and the mode is the route family. The
+      // regression this pins is Cmd+N on a /code route creating a chat and
+      // navigating the reader out of the mode they were working in.
+      getSettings.mockResolvedValue({
+        model: null,
+        has_api_key: false,
+        code_mode_enabled: true,
+      });
+      const user = userEvent.setup();
+      const { router } = await mountApp({ at: "/code" });
+
+      // The registered repo means the rail and the catalog are both up.
+      expect(
+        await screen.findByRole("button", { name: "app" }),
+      ).toBeInTheDocument();
+
+      // jsdom reports a non-mac user agent, so the platform's command modifier
+      // here is Ctrl — the same chord the app takes as Cmd on macOS.
+      await user.keyboard("{Control>}n{/Control}");
+
+      const dialog = await screen.findByRole("dialog");
+      expect(
+        within(dialog).getByText(
+          "One worktree and one session on the selected repo.",
+        ),
+      ).toBeInTheDocument();
+      expect(createChat).not.toHaveBeenCalled();
+      expect(router.state.location.pathname).toBe("/code");
+    },
+  );
 });

--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { Outlet, useNavigate } from "@tanstack/react-router";
+import { Outlet, useNavigate, useRouter } from "@tanstack/react-router";
 import { isTauri } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { toast } from "sonner";
@@ -22,6 +22,8 @@ import {
   prependReplacementChat,
 } from "./ChatDeletion";
 import { useChatListStore } from "./ChatListStore";
+import { useCodeUiStore } from "./code/CodeUiStore";
+import { codeRepoIdFromPath, shellShortcutMode } from "./code/routes";
 import { useExperimentalFlags } from "./experimental";
 import { connectOutputs } from "./deliverables";
 import { useProjectListStore } from "./ProjectListStore";
@@ -39,7 +41,11 @@ import { Titlebar } from "./Titlebar";
 import { WindowDragStrip } from "./WindowDragStrip";
 import { useActiveChatId } from "./useActiveChatId";
 import { useChatPromptWatcher } from "./useChatPromptWatcher";
-import { useShellShortcuts, type ShellShortcutHandlers } from "./ShellShortcuts";
+import {
+  useShellShortcuts,
+  type ShellShortcutHandlers,
+  type ShellShortcutMode,
+} from "./ShellShortcuts";
 import { ShortcutsDialog } from "./ShortcutsDialog";
 import { useUiStore } from "./UiStore";
 import { UPDATE_CHECK_REQUESTED_EVENT, useDesktopUpdates } from "./updates";
@@ -67,15 +73,17 @@ function GatedShellHooks({
   client,
   chatId,
   shortcuts,
+  shortcutMode,
 }: {
   client: ApiClient;
   chatId: string | null;
   shortcuts: ShellShortcutHandlers;
+  shortcutMode: () => ShellShortcutMode;
 }) {
   // Watched here rather than in the conversation, so that the agent parking a
   // turn on a question is noticed whatever screen the reader is on.
   useChatPromptWatcher(client, chatId);
-  useShellShortcuts(shortcuts);
+  useShellShortcuts(shortcuts, shortcutMode);
   return null;
 }
 
@@ -116,6 +124,12 @@ export function AppShell() {
   const desktopUpdates = useDesktopUpdates();
   const desktopNavigation = useDesktopNavigation();
   const zoom = useInterfaceZoom();
+  // Read at keydown rather than subscribed to: which mode a shortcut fires in
+  // is the route's answer, and the shell has no other reason to re-render on
+  // every navigation.
+  const router = useRouter();
+  const currentShortcutMode = () =>
+    shellShortcutMode(router.state.location.pathname);
 
   // The native "Check for Updates…" menu item lands the reader on the
   // Updates settings panel and runs the same explicit check the panel's
@@ -142,8 +156,9 @@ export function AppShell() {
 
   // Shell shortcuts are defined here because these actions outlive any one
   // route: toggling the frame, starting a chat, reaching the composer, and
-  // scaling the window all work wherever the reader is. They are installed
-  // below the gate, by GatedShellHooks.
+  // scaling the window all work wherever the reader is. Mode-scoped ones act
+  // on whichever half of the app the route is in. They are installed below the
+  // gate, by GatedShellHooks.
   const shellShortcuts: ShellShortcutHandlers = {
     "history-back": () => {
       if (desktopNavigation.canGoBack) desktopNavigation.goBack();
@@ -153,6 +168,12 @@ export function AppShell() {
     },
     "toggle-sidebar": () => useUiStore.getState().toggleSidebar(),
     "new-chat": () => void onNewChat(),
+    "code-new-workspace": () => {
+      const { pathname } = router.state.location;
+      useCodeUiStore
+        .getState()
+        .startNewWorkspace(codeRepoIdFromPath(pathname));
+    },
     "focus-composer": focusComposer,
     "zoom-in": zoom.zoomIn,
     "zoom-out": zoom.zoomOut,
@@ -601,6 +622,7 @@ export function AppShell() {
         client={client}
         chatId={openChatId}
         shortcuts={shellShortcuts}
+        shortcutMode={currentShortcutMode}
       />
       <AppContextProvider
         value={{

--- a/crates/tidebreak-desktop/ui/src/ShellShortcuts.test.ts
+++ b/crates/tidebreak-desktop/ui/src/ShellShortcuts.test.ts
@@ -9,6 +9,7 @@ import {
   shortcutKeycaps,
   usesCommandModifier,
   type ShellShortcutAction,
+  type ShellShortcutMode,
 } from "./ShellShortcuts";
 
 function keyEvent(overrides: Partial<KeyboardEvent>): KeyboardEvent {
@@ -23,9 +24,15 @@ function keyEvent(overrides: Partial<KeyboardEvent>): KeyboardEvent {
   } as KeyboardEvent;
 }
 
-/** The default context: a mac-style keyboard, nothing in the way. */
+/** The default context: a mac-style keyboard in chat, nothing in the way. */
 function context(overrides: Partial<Parameters<typeof resolveShellShortcut>[1]> = {}) {
-  return { editable: true, modalOpen: false, command: true, ...overrides };
+  return {
+    editable: true,
+    modalOpen: false,
+    command: true,
+    mode: "chat" as ShellShortcutMode,
+    ...overrides,
+  };
 }
 
 describe("shell shortcut resolution", () => {
@@ -58,6 +65,23 @@ describe("shell shortcut resolution", () => {
       const resolved = resolveShellShortcut(keyEvent(event), context());
       expect(resolved?.id).toBe(id);
     }
+  });
+
+  it("gives Cmd+N to whichever mode the reader is in", () => {
+    // One chord, two modes: a conversation in chat, a workspace in code. The
+    // regression this pins is Cmd+N in code mode creating a chat and taking
+    // the reader out of the mode they were working in.
+    const cmdN = keyEvent({ key: "n", code: "KeyN" });
+    expect(resolveShellShortcut(cmdN, context({ mode: "chat" }))?.id).toBe(
+      "new-chat",
+    );
+    expect(resolveShellShortcut(cmdN, context({ mode: "code" }))?.id).toBe(
+      "code-new-workspace",
+    );
+    // Unscoped shortcuts are the frame's and act the same on both sides.
+    expect(
+      resolveShellShortcut(keyEvent({}), context({ mode: "code" }))?.id,
+    ).toBe("toggle-sidebar");
   });
 
   it("leaves Alt+Arrow to the field the reader is typing in", () => {
@@ -150,6 +174,7 @@ describe("shell shortcut resolution", () => {
       editable: false,
       modalOpen: true,
       command: true,
+      mode: "chat",
     });
     expect(resolved).toBeNull();
   });
@@ -173,8 +198,44 @@ describe("shortcut help", () => {
   it("files every shortcut under a heading the dialog renders", () => {
     // A shortcut grouped under a heading nobody lists would vanish from the
     // help while still firing — the exact drift the dialog exists to prevent.
-    const listed = groupedShellShortcuts().flatMap(({ items }) => items);
-    expect(listed).toHaveLength(SHELL_SHORTCUTS.length);
-    expect(new Set(listed)).toEqual(new Set(SHELL_SHORTCUTS));
+    // Per mode, because the help lists what fires where it is being read.
+    for (const mode of ["chat", "code"] as ShellShortcutMode[]) {
+      const listed = groupedShellShortcuts(mode).flatMap(({ items }) => items);
+      const live = SHELL_SHORTCUTS.filter(
+        (def) => def.scope === undefined || def.scope === mode,
+      );
+      expect(listed).toHaveLength(live.length);
+      expect(new Set(listed)).toEqual(new Set(live));
+    }
+  });
+});
+
+describe("shortcut table", () => {
+  it("binds each chord to one action per mode", () => {
+    // Scoping makes it possible for two definitions to share a chord, which is
+    // the point — and also the way a shortcut silently stops firing, because
+    // resolution takes the first match in table order. Sharing is allowed only
+    // across modes; within one, a chord means exactly one thing.
+    const owners = new Map<string, ShellShortcutAction>();
+    for (const def of SHELL_SHORTCUTS) {
+      const modes: ShellShortcutMode[] = def.scope
+        ? [def.scope]
+        : ["chat", "code"];
+      // "any" shift matches held and unheld alike, so it occupies both.
+      const shifts = def.shift === "any" ? [true, false] : [def.shift ?? false];
+      const keys = def.codes
+        ? def.codes.map((code) => `code:${code}`)
+        : def.keys.map((key) => `key:${key}`);
+      for (const mode of modes) {
+        for (const shift of shifts) {
+          for (const key of keys) {
+            const chord = [mode, def.mod, def.alt ?? false, shift, key].join("|");
+            const owner = owners.get(chord);
+            expect(owner, `${chord} is bound twice`).toBeUndefined();
+            owners.set(chord, def.id);
+          }
+        }
+      }
+    }
   });
 });

--- a/crates/tidebreak-desktop/ui/src/ShellShortcuts.ts
+++ b/crates/tidebreak-desktop/ui/src/ShellShortcuts.ts
@@ -13,6 +13,7 @@ export type ShellShortcutAction =
   | "history-forward"
   | "toggle-sidebar"
   | "new-chat"
+  | "code-new-workspace"
   | "focus-composer"
   | "zoom-in"
   | "zoom-out"
@@ -20,13 +21,29 @@ export type ShellShortcutAction =
   | "reload-app"
   | "show-shortcuts";
 
+/**
+ * Which half of the app a shortcut belongs to.
+ *
+ * Chat and code are two modes of one app, and the same chord means the thing
+ * the reader is looking at: Cmd+N starts a conversation in chat and a
+ * workspace in code. Mode is derived from the route family rather than stored,
+ * so the shortcut and the screen can never disagree about which one is up.
+ */
+export type ShellShortcutMode = "chat" | "code";
+
 /** The heading a shortcut sits under in the help dialog. */
-export type ShellShortcutGroup = "Navigation" | "Chat" | "View" | "Help";
+export type ShellShortcutGroup =
+  | "Navigation"
+  | "Chat"
+  | "Code"
+  | "View"
+  | "Help";
 
 /** Group headings in the order the help dialog lists them. */
 export const SHELL_SHORTCUT_GROUPS: readonly ShellShortcutGroup[] = [
   "Navigation",
   "Chat",
+  "Code",
   "View",
   "Help",
 ];
@@ -74,6 +91,13 @@ export type ShellShortcutDef = ShellShortcutBinding & {
   /** Which heading the help dialog files it under. */
   group: ShellShortcutGroup;
   /**
+   * The mode the shortcut belongs to, or every mode when absent. Two
+   * definitions may share a chord only across scopes — that is the whole point
+   * of the field, and the only way one chord can mean the right thing on both
+   * sides of the app.
+   */
+  scope?: ShellShortcutMode;
+  /**
    * Whether the shortcut may fire while focus is in a text field. Chorded
    * combos (mod+key) are safe there — they are not something a reader types —
    * so the composer's own focus never swallows them.
@@ -111,6 +135,20 @@ export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
     mod: true,
     description: "Start a new chat",
     group: "Chat",
+    scope: "chat",
+    allowInEditable: true,
+  },
+  {
+    // Cmd+N is "make me a new one of what I am looking at". In code mode the
+    // unit of work is a workspace — a worktree and a branch — so making a chat
+    // here would both do the wrong thing and navigate the reader out of the
+    // mode they were working in.
+    id: "code-new-workspace",
+    codes: ["KeyN"],
+    mod: true,
+    description: "New workspace",
+    group: "Code",
+    scope: "code",
     allowInEditable: true,
   },
   {
@@ -231,14 +269,17 @@ function shortcutKeyLabel(def: ShellShortcutDef): string {
  * The shortcuts under their headings, in the order the help dialog lists them.
  *
  * Grouping lives here rather than in the dialog so a shortcut cannot go missing
- * from the help by being filed under a heading nobody renders.
+ * from the help by being filed under a heading nobody renders. Filtered to the
+ * mode the reader is in: listing every scope would show two Cmd+N rows, only
+ * one of which is true where the dialog is being read.
  */
-export function groupedShellShortcuts(): Array<{
+export function groupedShellShortcuts(mode: ShellShortcutMode): Array<{
   group: ShellShortcutGroup;
   items: ShellShortcutDef[];
 }> {
   const byGroup = new Map<ShellShortcutGroup, ShellShortcutDef[]>();
   for (const def of SHELL_SHORTCUTS) {
+    if (!inScope(def, mode)) continue;
     const items = byGroup.get(def.group) ?? [];
     items.push(def);
     byGroup.set(def.group, items);
@@ -247,6 +288,11 @@ export function groupedShellShortcuts(): Array<{
     const items = byGroup.get(group);
     return items ? [{ group, items }] : [];
   });
+}
+
+/** Whether a definition is live in a mode — an unscoped one is live in all. */
+function inScope(def: ShellShortcutDef, mode: ShellShortcutMode): boolean {
+  return def.scope === undefined || def.scope === mode;
 }
 
 type ShortcutKeyEvent = Pick<
@@ -294,14 +340,23 @@ export function isEditableTarget(target: EventTarget | null): boolean {
  *
  * A modal dialog on screen suppresses every shell shortcut: the reader is
  * mid-decision, and toggling the frame or starting a new chat behind the
- * dialog would be a surprise. Kept pure so the guard is testable without a DOM.
+ * dialog would be a surprise. `mode` decides which scoped definitions are live,
+ * and is required rather than defaulted so every caller has to say which half
+ * of the app the key was pressed in. Kept pure so the guard is testable without
+ * a DOM.
  */
 export function resolveShellShortcut(
   event: ShortcutKeyEvent,
-  context: { editable: boolean; modalOpen: boolean; command: boolean },
+  context: {
+    editable: boolean;
+    modalOpen: boolean;
+    command: boolean;
+    mode: ShellShortcutMode;
+  },
 ): ShellShortcutDef | null {
   if (context.modalOpen) return null;
   for (const def of SHELL_SHORTCUTS) {
+    if (!inScope(def, context.mode)) continue;
     if (!matchesShellShortcut(event, def, context.command)) continue;
     if (context.editable && !def.allowInEditable) return null;
     return def;
@@ -325,10 +380,18 @@ export type ShellShortcutHandlers = Record<ShellShortcutAction, () => void>;
  *
  * Handlers are read through a ref so the listener registers once and never has
  * to be torn down and rebound as the callbacks change identity between renders.
+ * `mode` is a getter for the same reason, and because the mode is read from the
+ * route: asking for it at keydown keeps the shell out of a re-render on every
+ * navigation.
  */
-export function useShellShortcuts(handlers: ShellShortcutHandlers): void {
+export function useShellShortcuts(
+  handlers: ShellShortcutHandlers,
+  mode: () => ShellShortcutMode,
+): void {
   const handlersRef = useRef(handlers);
   handlersRef.current = handlers;
+  const modeRef = useRef(mode);
+  modeRef.current = mode;
 
   useEffect(() => {
     const command = usesCommandModifier(navigator.userAgent);
@@ -338,6 +401,7 @@ export function useShellShortcuts(handlers: ShellShortcutHandlers): void {
         editable: isEditableTarget(event.target),
         modalOpen: hasOpenModalDialog(document),
         command,
+        mode: modeRef.current(),
       });
       if (!def) return;
       event.preventDefault();

--- a/crates/tidebreak-desktop/ui/src/ShortcutsDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/ShortcutsDialog.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useMemo } from "react";
+import { useRouterState } from "@tanstack/react-router";
 
 import {
   Dialog,
@@ -8,6 +9,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
+import { shellShortcutMode } from "./code/routes";
 import {
   groupedShellShortcuts,
   shortcutKeycaps,
@@ -50,7 +52,9 @@ function ShortcutRow({
  *
  * Rendering from the table the listener matches on is the point: a hand-written
  * second copy would drift the first time a binding changed, and a help dialog
- * that misstates the keys is worse than no dialog at all.
+ * that misstates the keys is worse than no dialog at all. Listed for the mode
+ * the route is in, for the same reason: Cmd+N is one row, and which one is true
+ * depends on where the reader pressed it.
  */
 export function ShortcutsDialog({
   open,
@@ -60,7 +64,10 @@ export function ShortcutsDialog({
   onOpenChange: (open: boolean) => void;
 }) {
   const command = useMemo(() => usesCommandModifier(navigator.userAgent), []);
-  const groups = useMemo(() => groupedShellShortcuts(), []);
+  const mode = useRouterState({
+    select: (state) => shellShortcutMode(state.location.pathname),
+  });
+  const groups = useMemo(() => groupedShellShortcuts(mode), [mode]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/crates/tidebreak-desktop/ui/src/code/CodeRepoPage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeRepoPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useNavigate } from "@tanstack/react-router";
 
 import { useApp } from "@/AppContext";
@@ -8,7 +8,7 @@ import { AttentionBadge } from "./AttentionBadge";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { CodeSidebar } from "./CodeSidebar";
-import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
+import { useCodeUiStore } from "./CodeUiStore";
 import { WORKSPACE_STATUS_LABELS } from "./labels";
 
 /**
@@ -32,7 +32,9 @@ function CodeRepoBody({ repoId }: { repoId: string }) {
   const workspaces = useCodeCatalogStore((state) => state.workspaces);
   const refresh = useCodeCatalogStore((state) => state.refresh);
   const digests = useCodeUpdatesStore((state) => state.byWorkspace);
-  const [open, setOpen] = useState(false);
+  // The dialog itself is mounted once, by the rail this page renders beside
+  // it, so that Cmd+N and the buttons all drive the same one.
+  const startNewWorkspace = useCodeUiStore((state) => state.startNewWorkspace);
 
   useEffect(() => {
     void refresh(client);
@@ -57,7 +59,11 @@ function CodeRepoBody({ repoId }: { repoId: string }) {
             Default base {repo.default_base_ref}
           </p>
         </div>
-        <Button type="button" size="sm" onClick={() => setOpen(true)}>
+        <Button
+          type="button"
+          size="sm"
+          onClick={() => startNewWorkspace(repoId)}
+        >
           New workspace
         </Button>
       </div>
@@ -96,12 +102,6 @@ function CodeRepoBody({ repoId }: { repoId: string }) {
           </li>
         ))}
       </ul>
-      <NewWorkspaceDialog
-        open={open}
-        onOpenChange={setOpen}
-        repos={repos}
-        defaultRepoId={repoId}
-      />
     </div>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 import { FolderGit2, MessageSquare, Plus } from "lucide-react";
 
@@ -11,6 +11,7 @@ import {
 import { SidebarFrame } from "@/sidebar/SidebarFrame";
 import { AttentionBadge } from "./AttentionBadge";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { useCodeUiStore } from "./CodeUiStore";
 import { connectCodeUpdates, useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { AddRepoPalette } from "./AddRepoPalette";
 import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
@@ -22,6 +23,10 @@ import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
  * Built on the same frame and primitives as the chat rail so the two modes
  * share chrome. It must not touch chat session stores — that separation is
  * what later convergence merges rather than translates.
+ *
+ * It also hosts code mode's two dialogs. The rail is on screen for every
+ * `/code` route, so mounting them here is what makes them reachable from the
+ * keyboard anywhere in the mode without a second instance per page.
  */
 
 export function CodeSidebar() {
@@ -35,8 +40,16 @@ export function CodeSidebar() {
   const workspaces = useCodeCatalogStore((state) => state.workspaces);
   const refresh = useCodeCatalogStore((state) => state.refresh);
   const digests = useCodeUpdatesStore((state) => state.byWorkspace);
-  const [newWorkspaceOpen, setNewWorkspaceOpen] = useState(false);
-  const [addRepoOpen, setAddRepoOpen] = useState(false);
+  const newWorkspaceOpen = useCodeUiStore((state) => state.newWorkspaceOpen);
+  const newWorkspaceRepoId = useCodeUiStore(
+    (state) => state.newWorkspaceRepoId,
+  );
+  const addRepoOpen = useCodeUiStore((state) => state.addRepoOpen);
+  const startNewWorkspace = useCodeUiStore((state) => state.startNewWorkspace);
+  const setNewWorkspaceOpen = useCodeUiStore(
+    (state) => state.setNewWorkspaceOpen,
+  );
+  const setAddRepoOpen = useCodeUiStore((state) => state.setAddRepoOpen);
 
   useEffect(() => {
     void refresh(client);
@@ -123,7 +136,7 @@ export function CodeSidebar() {
             type="button"
             className="cursor-pointer rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
             aria-label="New workspace"
-            onClick={() => setNewWorkspaceOpen(true)}
+            onClick={() => startNewWorkspace()}
           >
             <Plus size={14} />
           </button>
@@ -132,7 +145,7 @@ export function CodeSidebar() {
       {isCompact && (
         <SidebarButton
           aria-label="New workspace"
-          onClick={() => setNewWorkspaceOpen(true)}
+          onClick={() => startNewWorkspace()}
         >
           <Plus />
           <span>New workspace</span>
@@ -169,6 +182,7 @@ export function CodeSidebar() {
         open={newWorkspaceOpen}
         onOpenChange={setNewWorkspaceOpen}
         repos={repos}
+        defaultRepoId={newWorkspaceRepoId}
       />
       <AddRepoPalette open={addRepoOpen} onOpenChange={setAddRepoOpen} />
     </SidebarFrame>

--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -1,0 +1,49 @@
+import { create } from "zustand";
+
+import { useCodeCatalogStore } from "./CodeCatalogStore";
+
+/**
+ * Code mode's dialog state, held outside the components that draw it.
+ *
+ * The new-workspace flow is reachable from three places — the rail, a repo
+ * page, and Cmd+N — and only one of them is a component the shell can see. A
+ * store lets the shortcut open the dialog without the shell importing code
+ * mode's surfaces, and keeps a single dialog instance rather than one per
+ * button that opens it.
+ */
+export type CodeUiStore = {
+  newWorkspaceOpen: boolean;
+  /** The repo the dialog opens locked to, when it was opened from one. */
+  newWorkspaceRepoId: string | undefined;
+  addRepoOpen: boolean;
+  /**
+   * Ask for a workspace, from a repo page or from anywhere in code mode.
+   *
+   * With nothing registered the new-workspace dialog is a form the reader
+   * cannot submit, so the request lands on repo registration instead — that is
+   * the step actually in their way.
+   */
+  startNewWorkspace: (repoId?: string) => void;
+  setNewWorkspaceOpen: (open: boolean) => void;
+  setAddRepoOpen: (open: boolean) => void;
+};
+
+export const useCodeUiStore = create<CodeUiStore>()((set) => ({
+  newWorkspaceOpen: false,
+  newWorkspaceRepoId: undefined,
+  addRepoOpen: false,
+  startNewWorkspace: (repoId) => {
+    const { repos } = useCodeCatalogStore.getState();
+    if (repos.length === 0) {
+      set({ addRepoOpen: true });
+      return;
+    }
+    // A repo the catalog does not know would lock the form to nothing and
+    // leave the reader a dialog they cannot submit; free choice is the safe
+    // fallback.
+    const known = repos.some((repo) => repo.id === repoId) ? repoId : undefined;
+    set({ newWorkspaceOpen: true, newWorkspaceRepoId: known });
+  },
+  setNewWorkspaceOpen: (open) => set({ newWorkspaceOpen: open }),
+  setAddRepoOpen: (open) => set({ addRepoOpen: open }),
+}));

--- a/crates/tidebreak-desktop/ui/src/code/TerminalPane.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TerminalPane.tsx
@@ -84,6 +84,9 @@ export function TerminalPane({
         editable: true,
         modalOpen: false,
         command,
+        // The terminal only exists inside a workspace, so the chords reaching
+        // it are always code mode's.
+        mode: "code",
       });
       if (!def) return;
       // Let the window listener fire the app shortcut; keep it out of xterm.

--- a/crates/tidebreak-desktop/ui/src/code/routes.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/routes.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { codeRepoIdFromPath, isCodeRoute, shellShortcutMode } from "./routes";
+
+describe("code routes", () => {
+  it("reads mode and repo from the path the reader is on", () => {
+    // Mode-scoped shortcuts hang off these answers, so a path family read
+    // wrongly here sends Cmd+N to the other half of the app — or locks the
+    // new-workspace dialog to something that is not a repo.
+    expect(isCodeRoute("/code")).toBe(true);
+    expect(isCodeRoute("/code/w/ws-1")).toBe(true);
+    expect(isCodeRoute("/codex")).toBe(false);
+    expect(shellShortcutMode("/c/chat-1")).toBe("chat");
+    expect(shellShortcutMode("/code/r/repo-1")).toBe("code");
+
+    expect(codeRepoIdFromPath("/code/r/repo-1")).toBe("repo-1");
+    expect(codeRepoIdFromPath("/code/w/ws-1")).toBeUndefined();
+    expect(codeRepoIdFromPath("/code")).toBeUndefined();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/routes.ts
+++ b/crates/tidebreak-desktop/ui/src/code/routes.ts
@@ -1,0 +1,31 @@
+import type { ShellShortcutMode } from "@/ShellShortcuts";
+
+/**
+ * Which mode a path is in, decided by the route family alone.
+ *
+ * Code mode is a place in the URL, not a flag someone can leave set: the rail,
+ * the shortcuts, and anything else that behaves differently on the two sides of
+ * the app read it from here so they cannot come to disagree. Kept free of
+ * imports beyond a type so the shell can ask without pulling code mode in.
+ */
+
+/** Whether a path belongs to code mode. */
+export function isCodeRoute(pathname: string): boolean {
+  return pathname === "/code" || pathname.startsWith("/code/");
+}
+
+/** The shortcut scope a path puts the reader in. */
+export function shellShortcutMode(pathname: string): ShellShortcutMode {
+  return isCodeRoute(pathname) ? "code" : "chat";
+}
+
+/**
+ * The repo a path is showing, when it is showing one.
+ *
+ * Lets a shortcut fired on a repo page open the same repo-locked flow the
+ * page's own button does, rather than a form asking which repo again.
+ */
+export function codeRepoIdFromPath(pathname: string): string | undefined {
+  const match = /^\/code\/r\/([^/]+)$/.exec(pathname);
+  return match?.[1];
+}

--- a/crates/tidebreak-desktop/ui/src/sidebar/AppSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/AppSidebar.tsx
@@ -5,6 +5,7 @@ import { FolderGit2, LayoutGrid, Puzzle, SquarePen } from "lucide-react";
 import type { Chat } from "@/api";
 import { useApp } from "@/AppContext";
 import { useChatListStore } from "@/ChatListStore";
+import { isCodeRoute } from "@/code/routes";
 import { useExperimentalFlags } from "@/experimental";
 import { ChatsSection } from "./ChatsSection";
 import { InboxButton } from "./InboxButton";
@@ -72,7 +73,7 @@ export function AppSidebar({ chat }: { chat?: Chat }) {
           <RouteButton
             label="Code"
             icon={<FolderGit2 />}
-            active={pathname === "/code" || pathname.startsWith("/code/")}
+            active={isCodeRoute(pathname)}
             onClick={() => void navigate({ to: "/code" })}
           />
         )}


### PR DESCRIPTION
Cmd+N was globally bound to `new-chat`. Pressed in code mode it created a
chat and navigated the reader out of the mode they were working in, which is
never what the key meant there: the unit of work in code mode is a workspace
— a worktree and a branch, per ADR 0030.

**The rule this establishes: shell shortcuts are mode-scoped, and the mode
derives from the route family.** Anything under `/code` is code mode,
everything else is chat. A definition may declare `scope: "chat" | "code"`,
or leave it out to stay live in both — Cmd+B still toggles the sidebar
everywhere. Two definitions may share a chord only across scopes, which is
what lets Cmd+N mean "new chat" on one side and "new workspace" on the other.

- `resolveShellShortcut` takes the mode as a **required** context field, so
  every caller has to say which half of the app the key was pressed in rather
  than silently resolving against the wrong table. The terminal pane, which
  builds its own context to keep shell chords out of xterm, says `"code"`.
- The help dialog lists the shortcuts for the mode it is being read in.
  Listing every scope would show two conflicting Cmd+N rows, and a help dialog
  that misstates the keys is worse than none.
- The shell reads the mode inside the keydown handler through the router
  rather than subscribing to it, so the root frame does not re-render on every
  navigation.
- The inline `/code` path check in the chat rail is now `isCodeRoute`, shared
  with the mode derivation.

Code mode's dialogs move out of component state into a small store, so the
shell can open the new-workspace flow without importing code-mode surfaces,
and there is one dialog instance in the rail rather than one per page that
opens it. The rail is mounted on every `/code` route, so the shortcut is
reachable anywhere in the mode. Two edges the store handles: with nothing
registered it opens repo registration instead, because the new-workspace form
would be one the reader cannot submit; fired on a repo page it preselects
that repo, matching the page's own button, and ignores a repo id the catalog
does not know.

No native menu accelerator: a native Cmd+N would consume the key
window-globally and defeat the scoping.

Tests: Cmd+N resolves to the right action in each mode; an invariant that no
two definitions share a chord within one mode (sharing across modes is the
feature, and the same table order that makes it work is how a shortcut could
silently stop firing); the help-grouping check is now per mode. One DOM test
drives a `/code` route and pins that the chord opens the workspace dialog and
does not create a chat. The gated-shell guard beside it pressed Meta, which
is bound to nothing under jsdom's non-mac user agent — it now presses the
modifier that platform actually uses, so it proves something.

Verified with `pnpm test` and `pnpm build` in `crates/tidebreak-desktop/ui`;
the shortcut was not exercised in the running desktop app.
